### PR TITLE
fix: enforce complexity cap 25 (Fixes #1914)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -233,7 +233,7 @@ export default tseslint.config(
       'no-unneeded-ternary': 'error',
 
       // Complexity limits
-      complexity: ['warn', 15],
+      complexity: ['error', 25],
       'max-lines': [
         'error',
         { max: 800, skipBlankLines: true, skipComments: true },
@@ -583,7 +583,7 @@ export default tseslint.config(
   {
     files: ['packages/a2a-server/src/agent/task.ts'],
     rules: {
-      complexity: ['error', 15],
+      complexity: ['error', 25],
     },
   },
   // ============================================================================
@@ -772,7 +772,7 @@ export default tseslint.config(
           ],
         },
       ],
-      complexity: ['error', 15],
+      complexity: ['error', 25],
       'max-lines': [
         'error',
         { max: 800, skipBlankLines: true, skipComments: true },
@@ -815,7 +815,7 @@ export default tseslint.config(
           ],
         },
       ],
-      complexity: ['error', 15],
+      complexity: ['error', 25],
       'max-lines-per-function': ['error', 80],
     },
   },
@@ -835,7 +835,7 @@ export default tseslint.config(
           ],
         },
       ],
-      complexity: ['error', 15],
+      complexity: ['error', 25],
       'max-lines-per-function': ['error', 80],
     },
   },

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
@@ -109,7 +109,7 @@ describe('prepareTurnForQuery', () => {
     expect(thinkingBlocksRef.current).toStrictEqual([existingThinkingBlock]);
   });
 
-  it('falls back to the default runtime id when session id is unavailable', async () => {
+  it('preserves Config method binding when preparing a turn', async () => {
     const callOrder: string[] = [];
     const handler = {
       reset: vi.fn(() => {
@@ -121,17 +121,28 @@ describe('prepareTurnForQuery', () => {
       ensureBucketsAuthenticated: vi.fn(async () => {
         callOrder.push('ensure');
       }),
-      resetSession: vi.fn(),
     };
     const config = {
-      getBucketFailoverHandler: () => handler,
-      getSessionId: () => undefined,
+      sessionId: 'bound-runtime',
+      getBucketFailoverHandler(this: {
+        bucketFailoverHandler: typeof handler;
+      }) {
+        return this.bucketFailoverHandler;
+      },
+      getSessionId(this: { sessionId: string }) {
+        return this.sessionId;
+      },
+      bucketFailoverHandler: handler,
     } as unknown as Config;
 
     await prepareTurnForQuery(false, config, vi.fn(), vi.fn(), {
-      current: [],
+      current: [existingThinkingBlock],
     } as { current: ThinkingBlock[] });
 
-    expect(callOrder).toContain('invalidate:default');
+    expect(callOrder).toStrictEqual([
+      'reset',
+      'invalidate:bound-runtime',
+      'ensure',
+    ]);
   });
 });

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStream.ts
@@ -41,6 +41,13 @@ import { useGeminiStreamOrchestration } from './useGeminiStreamOrchestration.js'
  * Resets or carries-over per-turn state depending on whether this is a new
  * prompt or a continuation. Also handles bucket failover reset/reauth.
  */
+function bindOptionalConfigMethod<T extends (...args: never[]) => unknown>(
+  method: T | undefined,
+  config: Config,
+): T | undefined {
+  return method?.bind(config) as T | undefined;
+}
+
 export async function prepareTurnForQuery(
   isContinuation: boolean,
   config: Config,
@@ -48,9 +55,10 @@ export async function prepareTurnForQuery(
   setThought: (t: null) => void,
   thinkingBlocksRef: React.MutableRefObject<ThinkingBlock[]>,
 ): Promise<void> {
-  const getBucketFailoverHandler = config.getBucketFailoverHandler as
-    | Config['getBucketFailoverHandler']
-    | undefined;
+  const getBucketFailoverHandler = bindOptionalConfigMethod(
+    config.getBucketFailoverHandler,
+    config,
+  );
 
   if (!isContinuation) {
     startNewPrompt();
@@ -62,9 +70,10 @@ export async function prepareTurnForQuery(
     // This ensures tokens updated by other processes are picked up
     const handler = getBucketFailoverHandler?.();
     if (handler?.invalidateAuthCache) {
-      const getRuntimeSessionId = config.getSessionId as
-        | (() => string | undefined)
-        | undefined;
+      const getRuntimeSessionId = bindOptionalConfigMethod(
+        config.getSessionId,
+        config,
+      );
       const runtimeId = getRuntimeSessionId?.() ?? 'default';
       handler.invalidateAuthCache(runtimeId);
     }

--- a/scripts/tests/tmux-harness.test.js
+++ b/scripts/tests/tmux-harness.test.js
@@ -1,0 +1,499 @@
+/**
+ * Unit tests for pure functions in scripts/tmux-harness.js.
+ *
+ * These functions are imported via dynamic import since the source is ESM.
+ * The refactoring goal (issue #1914) is to reduce cyclomatic complexity
+ * without changing behavior, so these tests guard against regressions.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+async function importHarness() {
+  return import('../tmux-harness.js');
+}
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+describe('parseArgs', () => {
+  it('returns defaults with empty argv', async () => {
+    const { parseArgs } = await importHarness();
+    const opts = parseArgs([]);
+    expect(opts.scenario).toBeUndefined();
+    expect(opts.scriptPath).toBeUndefined();
+    expect(opts.outDir).toBeUndefined();
+    expect(opts.cols).toBeUndefined();
+    expect(opts.rows).toBeUndefined();
+    expect(opts.initialWaitMs).toBeUndefined();
+    expect(opts.historyLimit).toBeUndefined();
+    expect(opts.scrollbackLines).toBeUndefined();
+    expect(opts.yolo).toBe(false);
+    expect(opts.keepSession).toBe(false);
+    expect(opts.assert).toBe(false);
+  });
+
+  it('parses --scenario haiku', async () => {
+    const { parseArgs } = await importHarness();
+    const opts = parseArgs(['--scenario', 'haiku']);
+    expect(opts.scenario).toBe('haiku');
+  });
+
+  it('parses --scenario scrollback', async () => {
+    const { parseArgs } = await importHarness();
+    const opts = parseArgs(['--scenario', 'scrollback']);
+    expect(opts.scenario).toBe('scrollback');
+  });
+
+  it('rejects invalid --scenario', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--scenario', 'bogus'])).toThrow(
+      'Invalid --scenario: bogus',
+    );
+  });
+
+  it('parses --script path', async () => {
+    const { parseArgs } = await importHarness();
+    const opts = parseArgs(['--script', '/tmp/test.json']);
+    expect(opts.scriptPath).toBe('/tmp/test.json');
+  });
+
+  it('parses --out-dir path', async () => {
+    const { parseArgs } = await importHarness();
+    const opts = parseArgs(['--out-dir', '/tmp/out']);
+    expect(opts.outDir).toBe('/tmp/out');
+  });
+
+  it('parses numeric flags: --cols --rows --initial-wait-ms --history-limit --scrollback-lines', async () => {
+    const { parseArgs } = await importHarness();
+    const opts = parseArgs([
+      '--cols',
+      '160',
+      '--rows',
+      '50',
+      '--initial-wait-ms',
+      '3000',
+      '--history-limit',
+      '99999',
+      '--scrollback-lines',
+      '5000',
+    ]);
+    expect(opts.cols).toBe(160);
+    expect(opts.rows).toBe(50);
+    expect(opts.initialWaitMs).toBe(3000);
+    expect(opts.historyLimit).toBe(99999);
+    expect(opts.scrollbackLines).toBe(5000);
+  });
+
+  it('rejects invalid --cols (zero)', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--cols', '0'])).toThrow(/Invalid --cols/);
+  });
+
+  it('rejects invalid --cols (negative)', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--cols', '-5'])).toThrow(
+      /Missing value for --cols/,
+    );
+  });
+
+  it('rejects invalid --rows (NaN)', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--rows', 'abc'])).toThrow(/Invalid --rows/);
+  });
+
+  it('rejects negative --initial-wait-ms', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--initial-wait-ms', '-1'])).toThrow(
+      /Missing value for --initial-wait-ms/,
+    );
+  });
+
+  it('rejects zero --history-limit', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--history-limit', '0'])).toThrow(
+      /Invalid --history-limit/,
+    );
+  });
+
+  it('rejects zero --scrollback-lines', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--scrollback-lines', '0'])).toThrow(
+      /Invalid --scrollback-lines/,
+    );
+  });
+
+  it('parses boolean flags: --yolo --keep-session --assert', async () => {
+    const { parseArgs } = await importHarness();
+    const opts = parseArgs(['--yolo', '--keep-session', '--assert']);
+    expect(opts.yolo).toBe(true);
+    expect(opts.keepSession).toBe(true);
+    expect(opts.assert).toBe(true);
+  });
+
+  it('rejects unknown args', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--bogus'])).toThrow('Unknown args');
+  });
+
+  it('rejects missing value for --script', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--script'])).toThrow('Missing value for --script');
+  });
+
+  it('rejects flag-like value for --script', async () => {
+    const { parseArgs } = await importHarness();
+    expect(() => parseArgs(['--script', '--yolo'])).toThrow(
+      'Missing value for --script',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildStartArgs
+// ---------------------------------------------------------------------------
+describe('buildStartArgs', () => {
+  it('returns the default command when no script command is provided', async () => {
+    const { buildStartArgs } = await importHarness();
+    expect(buildStartArgs(null, false)).toEqual(['node', 'scripts/start.js']);
+  });
+
+  it('appends --yolo to a copied script start command without mutating the script', async () => {
+    const { buildStartArgs } = await importHarness();
+    const script = { startCommand: ['node', 'scripts/start.js'] };
+
+    expect(buildStartArgs(script, true)).toEqual([
+      'node',
+      'scripts/start.js',
+      '--yolo',
+    ]);
+    expect(script.startCommand).toEqual(['node', 'scripts/start.js']);
+  });
+
+  it('does not duplicate --yolo when already present', async () => {
+    const { buildStartArgs } = await importHarness();
+    const script = { startCommand: ['node', 'scripts/start.js', '--yolo'] };
+
+    expect(buildStartArgs(script, true)).toEqual([
+      'node',
+      'scripts/start.js',
+      '--yolo',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compileMatcher / matchText / formatMatcher
+// ---------------------------------------------------------------------------
+describe('compileMatcher', () => {
+  it('creates contains matcher', async () => {
+    const { compileMatcher } = await importHarness();
+    const m = compileMatcher({ contains: 'hello' });
+    expect(m.kind).toBe('contains');
+    expect(m.value).toBe('hello');
+  });
+
+  it('creates regex matcher', async () => {
+    const { compileMatcher } = await importHarness();
+    const m = compileMatcher({ regex: 'h.llo', regexFlags: 'i' });
+    expect(m.kind).toBe('regex');
+    expect(m.value.test('HELLO')).toBe(true);
+  });
+
+  it('creates regex matcher without flags', async () => {
+    const { compileMatcher } = await importHarness();
+    const m = compileMatcher({ regex: 'hello' });
+    expect(m.kind).toBe('regex');
+    expect(m.value.flags).toBe('');
+  });
+
+  it('throws on missing both contains and regex', async () => {
+    const { compileMatcher } = await importHarness();
+    expect(() => compileMatcher({})).toThrow('Matcher requires');
+  });
+});
+
+describe('matchText', () => {
+  it('matches contains', async () => {
+    const { matchText } = await importHarness();
+    expect(matchText('hello world', { kind: 'contains', value: 'world' })).toBe(
+      true,
+    );
+    expect(matchText('hello world', { kind: 'contains', value: 'xyz' })).toBe(
+      false,
+    );
+  });
+
+  it('matches regex', async () => {
+    const { matchText } = await importHarness();
+    expect(
+      matchText('hello', {
+        kind: 'regex',
+        value: /^hel/,
+      }),
+    ).toBe(true);
+    expect(
+      matchText('hello', {
+        kind: 'regex',
+        value: /^xyz/,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('formatMatcher', () => {
+  it('formats contains matcher', async () => {
+    const { formatMatcher } = await importHarness();
+    expect(formatMatcher({ kind: 'contains', value: 'foo' })).toBe(
+      'contains "foo"',
+    );
+  });
+
+  it('formats regex matcher', async () => {
+    const { formatMatcher } = await importHarness();
+    const re = /test/gi;
+    expect(formatMatcher({ kind: 'regex', value: re })).toBe(
+      `regex /${re.source}/${re.flags}`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countMatches
+// ---------------------------------------------------------------------------
+describe('countMatches', () => {
+  it('counts substring occurrences', async () => {
+    const { countMatches } = await importHarness();
+    expect(countMatches('abcabcabc', { kind: 'contains', value: 'abc' })).toBe(
+      3,
+    );
+  });
+
+  it('counts overlapping substrings (non-overlapping)', async () => {
+    const { countMatches } = await importHarness();
+    expect(countMatches('aaa', { kind: 'contains', value: 'aa' })).toBe(1);
+  });
+
+  it('returns 0 for empty needle', async () => {
+    const { countMatches } = await importHarness();
+    expect(countMatches('abc', { kind: 'contains', value: '' })).toBe(0);
+  });
+
+  it('counts regex matches (adds g flag if missing)', async () => {
+    const { countMatches } = await importHarness();
+    expect(
+      countMatches('a1b2c3', {
+        kind: 'regex',
+        value: /\d/,
+      }),
+    ).toBe(3);
+  });
+
+  it('counts regex matches with existing g flag', async () => {
+    const { countMatches } = await importHarness();
+    expect(
+      countMatches('a1b2c3', {
+        kind: 'regex',
+        value: /\d/g,
+      }),
+    ).toBe(3);
+  });
+
+  it('returns 0 for no regex matches', async () => {
+    const { countMatches } = await importHarness();
+    expect(
+      countMatches('abc', {
+        kind: 'regex',
+        value: /\d/,
+      }),
+    ).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeLabel
+// ---------------------------------------------------------------------------
+describe('sanitizeLabel', () => {
+  it('replaces non-alphanumeric chars with underscore', async () => {
+    const { sanitizeLabel } = await importHarness();
+    expect(sanitizeLabel('hello world!')).toBe('hello_world');
+  });
+
+  it('strips leading/trailing underscores', async () => {
+    const { sanitizeLabel } = await importHarness();
+    expect(sanitizeLabel('_foo_')).toBe('foo');
+  });
+
+  it('keeps dots, dashes, underscores', async () => {
+    const { sanitizeLabel } = await importHarness();
+    expect(sanitizeLabel('my-label_v1.0')).toBe('my-label_v1.0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deepCloneJson / applyMacroArgs
+// ---------------------------------------------------------------------------
+describe('deepCloneJson', () => {
+  it('deep clones a value', async () => {
+    const { deepCloneJson } = await importHarness();
+    const obj = { a: [1, 2], b: 'c' };
+    const clone = deepCloneJson(obj);
+    expect(clone).toEqual(obj);
+    expect(clone).not.toBe(obj);
+    clone.a.push(3);
+    expect(obj.a).toEqual([1, 2]);
+  });
+});
+
+describe('applyMacroArgs', () => {
+  it('replaces exact variable reference', async () => {
+    const { applyMacroArgs } = await importHarness();
+    expect(applyMacroArgs('${NAME}', { NAME: 'hello' })).toBe('hello');
+  });
+
+  it('interpolates within a string', async () => {
+    const { applyMacroArgs } = await importHarness();
+    expect(applyMacroArgs('prefix-${NAME}-suffix', { NAME: 'val' })).toBe(
+      'prefix-val-suffix',
+    );
+  });
+
+  it('leaves unknown variables untouched', async () => {
+    const { applyMacroArgs } = await importHarness();
+    expect(applyMacroArgs('${MISSING}', { NAME: 'hello' })).toBe('${MISSING}');
+  });
+
+  it('applies recursively to arrays', async () => {
+    const { applyMacroArgs } = await importHarness();
+    expect(applyMacroArgs(['${A}', '${B}'], { A: '1', B: '2' })).toEqual([
+      '1',
+      '2',
+    ]);
+  });
+
+  it('applies recursively to objects', async () => {
+    const { applyMacroArgs } = await importHarness();
+    expect(applyMacroArgs({ key: '${A}' }, { A: '1' })).toEqual({ key: '1' });
+  });
+
+  it('returns non-string primitives unchanged', async () => {
+    const { applyMacroArgs } = await importHarness();
+    expect(applyMacroArgs(42, {})).toBe(42);
+    expect(applyMacroArgs(null, {})).toBe(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandScriptMacros
+// ---------------------------------------------------------------------------
+describe('expandScriptMacros', () => {
+  it('returns steps unchanged when macros is null', async () => {
+    const { expandScriptMacros } = await importHarness();
+    const steps = [{ type: 'wait', ms: 100 }];
+    expect(expandScriptMacros(steps, null)).toEqual(steps);
+  });
+
+  it('returns steps unchanged when macros is undefined', async () => {
+    const { expandScriptMacros } = await importHarness();
+    const steps = [{ type: 'wait', ms: 100 }];
+    expect(expandScriptMacros(steps, undefined)).toEqual(steps);
+  });
+
+  it('expands a macro step', async () => {
+    const { expandScriptMacros } = await importHarness();
+    const steps = [
+      { type: 'macro', name: 'greet', args: { NAME: 'world' } },
+      { type: 'wait', ms: 100 },
+    ];
+    const macros = {
+      greet: [{ type: 'line', text: 'Hello ${NAME}' }],
+    };
+    const result = expandScriptMacros(steps, macros);
+    expect(result).toEqual([
+      { type: 'line', text: 'Hello world' },
+      { type: 'wait', ms: 100 },
+    ]);
+  });
+
+  it('detects macro cycles', async () => {
+    const { expandScriptMacros } = await importHarness();
+    const steps = [{ type: 'macro', name: 'a' }];
+    const macros = {
+      a: [{ type: 'macro', name: 'b' }],
+      b: [{ type: 'macro', name: 'a' }],
+    };
+    expect(() => expandScriptMacros(steps, macros)).toThrow('Macro cycle');
+  });
+
+  it('rejects non-array steps', async () => {
+    const { expandScriptMacros } = await importHarness();
+    expect(() => expandScriptMacros('bad', {})).toThrow('must be an array');
+  });
+
+  it('rejects non-object macros', async () => {
+    const { expandScriptMacros } = await importHarness();
+    expect(() => expandScriptMacros([], 42)).toThrow('must be an object');
+  });
+
+  it('rejects empty-named macro', async () => {
+    const { expandScriptMacros } = await importHarness();
+    const steps = [{ type: 'macro', name: '  ' }];
+    expect(() => expandScriptMacros(steps, {})).toThrow('non-empty');
+  });
+
+  it('rejects non-array macro template', async () => {
+    const { expandScriptMacros } = await importHarness();
+    const steps = [{ type: 'macro', name: 'bad' }];
+    const macros = { bad: 'not-array' };
+    expect(() => expandScriptMacros(steps, macros)).toThrow('must be an array');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseToolConfirmationOptions
+// ---------------------------------------------------------------------------
+describe('parseToolConfirmationOptions', () => {
+  it('parses numbered options with Yes/No/Modify labels', async () => {
+    const { parseToolConfirmationOptions } = await importHarness();
+    const screen = [
+      '1. Yes, allow once',
+      '2. Yes, allow always',
+      '3. No, deny',
+    ].join('\n');
+    const options = parseToolConfirmationOptions(screen);
+    expect(options).toHaveLength(3);
+    expect(options[0]).toEqual({
+      number: 1,
+      label: 'Yes, allow once',
+      selected: false,
+    });
+  });
+
+  it('detects selected option with bullet', async () => {
+    const { parseToolConfirmationOptions } = await importHarness();
+    const screen = '  ●1. Yes, allow once\n  2. No, deny';
+    const options = parseToolConfirmationOptions(screen);
+    expect(options[0].selected).toBe(true);
+    expect(options[1].selected).toBe(false);
+  });
+
+  it('ignores options that do not start with yes/no/modify', async () => {
+    const { parseToolConfirmationOptions } = await importHarness();
+    const screen = '1. Maybe later\n2. Yes, allow once';
+    const options = parseToolConfirmationOptions(screen);
+    expect(options).toHaveLength(1);
+    expect(options[0].label).toBe('Yes, allow once');
+  });
+
+  it('returns empty array for no matches', async () => {
+    const { parseToolConfirmationOptions } = await importHarness();
+    const options = parseToolConfirmationOptions('nothing here');
+    expect(options).toEqual([]);
+  });
+
+  it('handles box-drawing characters in line', async () => {
+    const { parseToolConfirmationOptions } = await importHarness();
+    const screen = '│ 1. Yes, allow once │\n│ 2. No, deny         │';
+    const options = parseToolConfirmationOptions(screen);
+    expect(options).toHaveLength(2);
+  });
+});

--- a/scripts/tests/tmux-harness.test.js
+++ b/scripts/tests/tmux-harness.test.js
@@ -179,6 +179,20 @@ describe('buildStartArgs', () => {
       '--yolo',
     ]);
   });
+
+  it('rejects invalid script start commands', async () => {
+    const { buildStartArgs } = await importHarness();
+    const message =
+      'Invalid script.startCommand: expected non-empty array of strings';
+
+    expect(() => buildStartArgs({ startCommand: [] }, false)).toThrow(message);
+    expect(() => buildStartArgs({ startCommand: 'node' }, false)).toThrow(
+      message,
+    );
+    expect(() => buildStartArgs({ startCommand: ['node', 42] }, false)).toThrow(
+      message,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -221,6 +235,14 @@ describe('matchText', () => {
     expect(matchText('hello world', { kind: 'contains', value: 'xyz' })).toBe(
       false,
     );
+  });
+
+  it('resets stateful regex matchers before each test', async () => {
+    const { matchText } = await importHarness();
+    const matcher = { kind: 'regex', value: /hello/g };
+
+    expect(matchText('hello', matcher)).toBe(true);
+    expect(matchText('hello', matcher)).toBe(true);
   });
 
   it('matches regex', async () => {

--- a/scripts/tmux-harness.js
+++ b/scripts/tmux-harness.js
@@ -16,8 +16,9 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = [...argv];
   const opts = {
     scenario: undefined, // haiku | scrollback
@@ -82,44 +83,31 @@ function parseArgs(argv) {
     throw new Error(`Unknown args: ${args.join(' ')}`);
   }
 
-  if (
-    opts.cols !== undefined &&
-    (!Number.isFinite(opts.cols) || opts.cols <= 0)
-  ) {
-    throw new Error(`Invalid --cols: ${opts.cols}`);
-  }
-  if (
-    opts.rows !== undefined &&
-    (!Number.isFinite(opts.rows) || opts.rows <= 0)
-  ) {
-    throw new Error(`Invalid --rows: ${opts.rows}`);
-  }
+  validatePositiveFinite(opts.cols, '--cols');
+  validatePositiveFinite(opts.rows, '--rows');
+  validateNonNegativeFinite(opts.initialWaitMs, '--initial-wait-ms');
+  validatePositiveFinite(opts.historyLimit, '--history-limit');
+  validatePositiveFinite(opts.scrollbackLines, '--scrollback-lines');
   if (
     opts.scenario !== undefined &&
     !['haiku', 'scrollback'].includes(opts.scenario)
   ) {
     throw new Error(`Invalid --scenario: ${opts.scenario}`);
   }
-  if (
-    opts.initialWaitMs !== undefined &&
-    (!Number.isFinite(opts.initialWaitMs) || opts.initialWaitMs < 0)
-  ) {
-    throw new Error(`Invalid --initial-wait-ms: ${opts.initialWaitMs}`);
-  }
-  if (
-    opts.historyLimit !== undefined &&
-    (!Number.isFinite(opts.historyLimit) || opts.historyLimit <= 0)
-  ) {
-    throw new Error(`Invalid --history-limit: ${opts.historyLimit}`);
-  }
-  if (
-    opts.scrollbackLines !== undefined &&
-    (!Number.isFinite(opts.scrollbackLines) || opts.scrollbackLines <= 0)
-  ) {
-    throw new Error(`Invalid --scrollback-lines: ${opts.scrollbackLines}`);
-  }
 
   return opts;
+}
+
+function validatePositiveFinite(value, flag) {
+  if (value !== undefined && (!Number.isFinite(value) || value <= 0)) {
+    throw new Error(`Invalid ${flag}: ${value}`);
+  }
+}
+
+function validateNonNegativeFinite(value, flag) {
+  if (value !== undefined && (!Number.isFinite(value) || value < 0)) {
+    throw new Error(`Invalid ${flag}: ${value}`);
+  }
 }
 
 function runTmux(args, options = {}) {
@@ -209,7 +197,7 @@ function captureScrollback(sessionName, scrollbackLines) {
   ]);
 }
 
-function compileMatcher(step) {
+export function compileMatcher(step) {
   if (typeof step.contains === 'string') {
     return { kind: 'contains', value: step.contains };
   }
@@ -222,21 +210,21 @@ function compileMatcher(step) {
   );
 }
 
-function matchText(text, matcher) {
+export function matchText(text, matcher) {
   if (matcher.kind === 'contains') {
     return text.includes(matcher.value);
   }
   return matcher.value.test(text);
 }
 
-function formatMatcher(matcher) {
+export function formatMatcher(matcher) {
   if (matcher.kind === 'contains') {
     return `contains "${matcher.value}"`;
   }
   return `regex /${matcher.value.source}/${matcher.value.flags}`;
 }
 
-function countMatches(text, matcher) {
+export function countMatches(text, matcher) {
   if (matcher.kind === 'contains') {
     if (matcher.value.length === 0) {
       return 0;
@@ -259,15 +247,15 @@ function countMatches(text, matcher) {
   return Array.from(text.matchAll(re)).length;
 }
 
-function sanitizeLabel(label) {
+export function sanitizeLabel(label) {
   return label.replace(/[^a-z0-9._-]+/gi, '_').replace(/^_+|_+$/g, '');
 }
 
-function deepCloneJson(value) {
+export function deepCloneJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function applyMacroArgs(value, args) {
+export function applyMacroArgs(value, args) {
   if (typeof value === 'string') {
     const exact = value.match(/^\$\{([A-Za-z0-9_]+)\}$/);
     if (exact) {
@@ -298,7 +286,7 @@ function applyMacroArgs(value, args) {
   return value;
 }
 
-function expandScriptMacros(steps, macros) {
+export function expandScriptMacros(steps, macros) {
   if (!Array.isArray(steps)) {
     throw new Error(`script.steps must be an array`);
   }
@@ -347,7 +335,7 @@ function expandScriptMacros(steps, macros) {
   return expand(steps, []);
 }
 
-function parseToolConfirmationOptions(screen) {
+export function parseToolConfirmationOptions(screen) {
   const options = [];
   const lines = screen.split('\n');
   for (const rawLine of lines) {
@@ -449,6 +437,388 @@ function isShellModeActive(sessionName) {
   return screen.includes('shell mode enabled');
 }
 
+function resolveScopeAndScrollback(step, defaults) {
+  const scope = step.scope === 'scrollback' ? 'scrollback' : 'screen';
+  const scrollbackLines = Number(
+    step.scrollbackLines ?? defaults.scrollbackLines,
+  );
+  return { scope, scrollbackLines };
+}
+
+async function executeWaitStep(step) {
+  const ms = Number(step.ms ?? 0);
+  if (!Number.isFinite(ms) || ms < 0) {
+    throw new Error(`Invalid wait.ms`);
+  }
+  await sleep(ms);
+}
+
+async function executeLineStep(step, sessionName, sendKeys, defaults) {
+  if (typeof step.text !== 'string') {
+    throw new Error(`Invalid line.text`);
+  }
+  const postTypeMs = Number(step.postTypeMs ?? defaults.postTypeMs);
+
+  const submitKeys = (() => {
+    if (Array.isArray(step.submitKeys)) return step.submitKeys;
+    const treatAsShell =
+      step.text.startsWith('!') || isShellModeActive(sessionName);
+    return treatAsShell ? defaults.shellSubmitKeys : defaults.submitKeys;
+  })();
+
+  runTmux(['send-keys', '-t', sessionName, '-l', step.text]);
+  await sleep(postTypeMs);
+  await sendKeys(submitKeys);
+}
+
+async function executeKeyStep(step, sendKeys) {
+  if (typeof step.key !== 'string') {
+    throw new Error(`Invalid key.key`);
+  }
+  await sendKeys([step.key]);
+}
+
+async function executeKeysStep(step, sendKeys) {
+  if (
+    !Array.isArray(step.keys) ||
+    step.keys.some((k) => typeof k !== 'string')
+  ) {
+    throw new Error(`Invalid keys.keys`);
+  }
+  await sendKeys(step.keys);
+}
+
+async function executeSelectToolOptionStep(step, sessionName, sendKeys) {
+  const matcher = compileMatcher(step);
+  const screen = captureScreen(sessionName);
+  const options = parseToolConfirmationOptions(screen);
+  if (options.length === 0) {
+    throw new Error(`No tool confirmation options found on screen`);
+  }
+
+  const currentIndex = options.findIndex((option) => option.selected);
+  const startIndex = currentIndex === -1 ? 0 : currentIndex;
+  const targetIndex = options.findIndex((option) =>
+    matchText(option.label, matcher),
+  );
+  if (targetIndex === -1) {
+    throw new Error(
+      `No tool option matches ${formatMatcher(matcher)} (options: ${options.map((o) => o.label).join(', ')})`,
+    );
+  }
+
+  const delta = targetIndex - startIndex;
+  if (delta > 0) {
+    await sendKeys(Array.from({ length: delta }, () => 'Down'));
+  } else if (delta < 0) {
+    await sendKeys(Array.from({ length: -delta }, () => 'Up'));
+  }
+}
+
+async function executeCopyModeStep(step, sessionName) {
+  if (step.enter) {
+    runTmux(['copy-mode', '-t', `${sessionName}:0.0`]);
+  }
+  if (step.exit) {
+    runTmux(['send-keys', '-t', `${sessionName}:0.0`, '-X', 'cancel']);
+  }
+
+  const repeatAction = async (action, count) => {
+    const n = Number(count);
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new Error(`Invalid copyMode count`);
+    }
+    for (let idx = 0; idx < n; idx += 1) {
+      runTmux(['send-keys', '-t', `${sessionName}:0.0`, '-X', action]);
+      await sleep(80);
+    }
+  };
+
+  if (step.pageUp) await repeatAction('page-up', step.pageUp);
+  if (step.pageDown) await repeatAction('page-down', step.pageDown);
+  if (step.up) await repeatAction('cursor-up', step.up);
+  if (step.down) await repeatAction('cursor-down', step.down);
+}
+
+async function executeCaptureStep(step, i, sessionName, outDir, defaults) {
+  const label = typeof step.label === 'string' ? step.label : `capture_${i}`;
+  const scrollbackLines = Number(
+    step.scrollbackLines ?? defaults.scrollbackLines,
+  );
+  const safe = sanitizeLabel(`${String(i).padStart(3, '0')}-${label}`);
+
+  if (step.scope === 'screen') {
+    const screen = captureScreen(sessionName);
+    await fs.writeFile(path.join(outDir, `${safe}-screen.txt`), screen, 'utf8');
+  } else if (step.scope === 'scrollback') {
+    const scrollback = captureScrollback(sessionName, scrollbackLines);
+    await fs.writeFile(
+      path.join(outDir, `${safe}-scrollback.txt`),
+      scrollback,
+      'utf8',
+    );
+  } else {
+    await captureArtifacts({
+      sessionName,
+      outDir,
+      label: safe,
+      scrollbackLines,
+    });
+  }
+}
+
+async function executeWaitForStep(step, i, sessionName, defaults) {
+  const matcher = compileMatcher(step);
+  const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
+  const pollMs = Number(step.pollMs ?? defaults.pollMs);
+  const { scope, scrollbackLines } = resolveScopeAndScrollback(step, defaults);
+  await waitFor({
+    sessionName,
+    scope,
+    matcher,
+    timeoutMs,
+    pollMs,
+    scrollbackLines,
+    description: `step ${i} (${formatMatcher(matcher)})`,
+  });
+}
+
+async function executeWaitForNotStep(step, i, sessionName, defaults) {
+  const matcher = compileMatcher(step);
+  const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
+  const pollMs = Number(step.pollMs ?? defaults.pollMs);
+  const { scope, scrollbackLines } = resolveScopeAndScrollback(step, defaults);
+  await waitForNot({
+    sessionName,
+    scope,
+    matcher,
+    timeoutMs,
+    pollMs,
+    scrollbackLines,
+    description: `step ${i} (${formatMatcher(matcher)})`,
+  });
+}
+
+async function executeExpectStep(step, sessionName, defaults) {
+  const matcher = compileMatcher(step);
+  const { scope, scrollbackLines } = resolveScopeAndScrollback(step, defaults);
+  const text =
+    scope === 'scrollback'
+      ? captureScrollback(sessionName, scrollbackLines)
+      : captureScreen(sessionName);
+
+  if (step.lineNumber !== undefined) {
+    const n = Number(step.lineNumber);
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new Error(`Invalid expect.lineNumber`);
+    }
+    const lines = text.split('\n');
+    const line = lines[n - 1] ?? '';
+    if (!matchText(line, matcher)) {
+      throw new Error(
+        `Expected ${formatMatcher(matcher)} on ${scope} line ${n}`,
+      );
+    }
+  } else if (!matchText(text, matcher)) {
+    throw new Error(`Expected ${formatMatcher(matcher)} in ${scope}`);
+  }
+}
+
+async function executeExpectCountStep(step, sessionName, defaults) {
+  const matcher = compileMatcher(step);
+  const { scope, scrollbackLines } = resolveScopeAndScrollback(step, defaults);
+  const text =
+    scope === 'scrollback'
+      ? captureScrollback(sessionName, scrollbackLines)
+      : captureScreen(sessionName);
+  const count = countMatches(text, matcher);
+
+  if (step.equals !== undefined && count !== Number(step.equals)) {
+    throw new Error(`Expected count == ${step.equals} but got ${count}`);
+  }
+  if (step.atLeast !== undefined && count < Number(step.atLeast)) {
+    throw new Error(`Expected count >= ${step.atLeast} but got ${count}`);
+  }
+  if (step.atMost !== undefined && count > Number(step.atMost)) {
+    throw new Error(`Expected count <= ${step.atMost} but got ${count}`);
+  }
+}
+
+async function sendApprovalChoice(choice, sendKeys) {
+  if (choice === 'once') {
+    await sendKeys(['Enter']);
+  } else if (choice === 'always') {
+    await sendKeys(['Down', 'Enter']);
+  } else if (choice === 'no') {
+    await sendKeys(['Down', 'Down', 'Enter']);
+  } else {
+    throw new Error(`Invalid approval choice: ${choice}`);
+  }
+}
+
+async function executeApproveShellStep(
+  step,
+  i,
+  sessionName,
+  sendKeys,
+  defaults,
+) {
+  const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
+  await waitFor({
+    sessionName,
+    scope: 'screen',
+    matcher: { kind: 'contains', value: 'Shell Command Execution' },
+    timeoutMs,
+    pollMs: 200,
+    scrollbackLines: defaults.scrollbackLines,
+    description: `step ${i} (shell confirmation dialog)`,
+  });
+
+  await sendApprovalChoice(step.choice ?? 'once', sendKeys);
+}
+
+async function executeApproveToolStep(
+  step,
+  i,
+  sessionName,
+  sendKeys,
+  defaults,
+) {
+  const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
+  const confirmMatcher = step.confirmation
+    ? compileMatcher(step.confirmation)
+    : { kind: 'contains', value: 'Yes, allow once' };
+
+  await waitFor({
+    sessionName,
+    scope: 'screen',
+    matcher: confirmMatcher,
+    timeoutMs,
+    pollMs: 200,
+    scrollbackLines: defaults.scrollbackLines,
+    description: `step ${i} (tool confirmation)`,
+  });
+
+  const choice = step.choice ?? 'once';
+  if (choice === 'always') {
+    const screen = captureScreen(sessionName);
+    if (!screen.includes('Yes, allow always')) {
+      throw new Error(
+        `Requested choice "always" but no "Yes, allow always" option is visible`,
+      );
+    }
+    await sendKeys(['Down', 'Enter']);
+  } else {
+    await sendApprovalChoice(choice, sendKeys);
+  }
+}
+
+function executeHistorySampleStep(step, i, sessionName, scriptState) {
+  scriptState.historySamples.push({
+    tMs: Date.now(),
+    historySize: getHistorySize(sessionName),
+    label: typeof step.label === 'string' ? step.label : `sample_${i}`,
+  });
+}
+
+function executeExpectHistoryDeltaStep(step, scriptState) {
+  const fromLabel = step.fromLabel ?? step.from;
+  const toLabel = step.toLabel ?? step.to;
+  if (typeof fromLabel !== 'string' || fromLabel.trim().length === 0) {
+    throw new Error(`Invalid expectHistoryDelta.fromLabel`);
+  }
+  if (typeof toLabel !== 'string' || toLabel.trim().length === 0) {
+    throw new Error(`Invalid expectHistoryDelta.toLabel`);
+  }
+
+  const fromSample = scriptState.historySamples.find(
+    (sample) => sample.label === fromLabel,
+  );
+  const toSample = [...scriptState.historySamples]
+    .reverse()
+    .find((sample) => sample.label === toLabel);
+
+  if (!fromSample) {
+    throw new Error(
+      `Missing historySample "${fromLabel}" for expectHistoryDelta`,
+    );
+  }
+  if (!toSample) {
+    throw new Error(
+      `Missing historySample "${toLabel}" for expectHistoryDelta`,
+    );
+  }
+
+  const delta = toSample.historySize - fromSample.historySize;
+
+  if (step.equals !== undefined && delta !== Number(step.equals)) {
+    throw new Error(
+      `Expected history delta == ${step.equals} but got ${delta}`,
+    );
+  }
+  if (step.atLeast !== undefined && delta < Number(step.atLeast)) {
+    throw new Error(
+      `Expected history delta >= ${step.atLeast} but got ${delta}`,
+    );
+  }
+  if (step.atMost !== undefined && delta > Number(step.atMost)) {
+    throw new Error(
+      `Expected history delta <= ${step.atMost} but got ${delta}`,
+    );
+  }
+}
+
+async function executeWaitForExitStep(step, sessionName) {
+  const timeoutMs = Number(step.timeoutMs ?? 15000);
+  const exited = await waitForPaneDead(sessionName, timeoutMs);
+  if (!exited) {
+    throw new Error(`Timed out waiting for exit`);
+  }
+}
+
+async function executeStepDispatch(
+  step,
+  i,
+  { sessionName, outDir, sendKeys, scriptState, defaults },
+) {
+  switch (step.type) {
+    case 'wait':
+      return executeWaitStep(step);
+    case 'line':
+      return executeLineStep(step, sessionName, sendKeys, defaults);
+    case 'key':
+      return executeKeyStep(step, sendKeys);
+    case 'keys':
+      return executeKeysStep(step, sendKeys);
+    case 'selectToolOption':
+      return executeSelectToolOptionStep(step, sessionName, sendKeys);
+    case 'copyMode':
+      return executeCopyModeStep(step, sessionName);
+    case 'capture':
+      return executeCaptureStep(step, i, sessionName, outDir, defaults);
+    case 'waitFor':
+      return executeWaitForStep(step, i, sessionName, defaults);
+    case 'waitForNot':
+      return executeWaitForNotStep(step, i, sessionName, defaults);
+    case 'expect':
+      return executeExpectStep(step, sessionName, defaults);
+    case 'expectCount':
+      return executeExpectCountStep(step, sessionName, defaults);
+    case 'approveShell':
+      return executeApproveShellStep(step, i, sessionName, sendKeys, defaults);
+    case 'approveTool':
+      return executeApproveToolStep(step, i, sessionName, sendKeys, defaults);
+    case 'historySample':
+      return executeHistorySampleStep(step, i, sessionName, scriptState);
+    case 'expectHistoryDelta':
+      return executeExpectHistoryDeltaStep(step, scriptState);
+    case 'waitForExit':
+      return executeWaitForExitStep(step, sessionName);
+    default:
+      throw new Error(`Unknown step.type: ${step.type}`);
+  }
+}
+
 async function runScriptSteps({ sessionName, outDir, steps, defaults }) {
   const scriptState = {
     historySamples: [],
@@ -468,355 +838,13 @@ async function runScriptSteps({ sessionName, outDir, steps, defaults }) {
     }
 
     try {
-      switch (step.type) {
-        case 'wait': {
-          const ms = Number(step.ms ?? 0);
-          if (!Number.isFinite(ms) || ms < 0) {
-            throw new Error(`Invalid wait.ms`);
-          }
-          await sleep(ms);
-          break;
-        }
-        case 'line': {
-          if (typeof step.text !== 'string') {
-            throw new Error(`Invalid line.text`);
-          }
-          const postTypeMs = Number(step.postTypeMs ?? defaults.postTypeMs);
-
-          const submitKeys = (() => {
-            if (Array.isArray(step.submitKeys)) return step.submitKeys;
-            const treatAsShell =
-              step.text.startsWith('!') || isShellModeActive(sessionName);
-            return treatAsShell
-              ? defaults.shellSubmitKeys
-              : defaults.submitKeys;
-          })();
-
-          runTmux(['send-keys', '-t', sessionName, '-l', step.text]);
-          await sleep(postTypeMs);
-          await sendKeys(submitKeys);
-          break;
-        }
-        case 'key': {
-          if (typeof step.key !== 'string') {
-            throw new Error(`Invalid key.key`);
-          }
-          await sendKeys([step.key]);
-          break;
-        }
-        case 'keys': {
-          if (
-            !Array.isArray(step.keys) ||
-            step.keys.some((k) => typeof k !== 'string')
-          ) {
-            throw new Error(`Invalid keys.keys`);
-          }
-          await sendKeys(step.keys);
-          break;
-        }
-        case 'selectToolOption': {
-          const matcher = compileMatcher(step);
-          const screen = captureScreen(sessionName);
-          const options = parseToolConfirmationOptions(screen);
-          if (options.length === 0) {
-            throw new Error(`No tool confirmation options found on screen`);
-          }
-
-          const currentIndex = options.findIndex((option) => option.selected);
-          const startIndex = currentIndex === -1 ? 0 : currentIndex;
-          const targetIndex = options.findIndex((option) =>
-            matchText(option.label, matcher),
-          );
-          if (targetIndex === -1) {
-            throw new Error(
-              `No tool option matches ${formatMatcher(matcher)} (options: ${options.map((o) => o.label).join(', ')})`,
-            );
-          }
-
-          const delta = targetIndex - startIndex;
-          if (delta > 0) {
-            await sendKeys(Array.from({ length: delta }, () => 'Down'));
-          } else if (delta < 0) {
-            await sendKeys(Array.from({ length: -delta }, () => 'Up'));
-          }
-          break;
-        }
-        case 'copyMode': {
-          if (step.enter) {
-            runTmux(['copy-mode', '-t', `${sessionName}:0.0`]);
-          }
-          if (step.exit) {
-            runTmux(['send-keys', '-t', `${sessionName}:0.0`, '-X', 'cancel']);
-          }
-
-          const repeatAction = async (action, count) => {
-            const n = Number(count);
-            if (!Number.isFinite(n) || n <= 0) {
-              throw new Error(`Invalid copyMode count`);
-            }
-            for (let idx = 0; idx < n; idx += 1) {
-              runTmux(['send-keys', '-t', `${sessionName}:0.0`, '-X', action]);
-              await sleep(80);
-            }
-          };
-
-          if (step.pageUp) await repeatAction('page-up', step.pageUp);
-          if (step.pageDown) await repeatAction('page-down', step.pageDown);
-          if (step.up) await repeatAction('cursor-up', step.up);
-          if (step.down) await repeatAction('cursor-down', step.down);
-          break;
-        }
-        case 'capture': {
-          const label =
-            typeof step.label === 'string' ? step.label : `capture_${i}`;
-          const scrollbackLines = Number(
-            step.scrollbackLines ?? defaults.scrollbackLines,
-          );
-          const safe = sanitizeLabel(`${String(i).padStart(3, '0')}-${label}`);
-
-          if (step.scope === 'screen') {
-            const screen = captureScreen(sessionName);
-            await fs.writeFile(
-              path.join(outDir, `${safe}-screen.txt`),
-              screen,
-              'utf8',
-            );
-          } else if (step.scope === 'scrollback') {
-            const scrollback = captureScrollback(sessionName, scrollbackLines);
-            await fs.writeFile(
-              path.join(outDir, `${safe}-scrollback.txt`),
-              scrollback,
-              'utf8',
-            );
-          } else {
-            await captureArtifacts({
-              sessionName,
-              outDir,
-              label: safe,
-              scrollbackLines,
-            });
-          }
-          break;
-        }
-        case 'waitFor': {
-          const matcher = compileMatcher(step);
-          const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
-          const pollMs = Number(step.pollMs ?? defaults.pollMs);
-          const scope = step.scope === 'scrollback' ? 'scrollback' : 'screen';
-          const scrollbackLines = Number(
-            step.scrollbackLines ?? defaults.scrollbackLines,
-          );
-          await waitFor({
-            sessionName,
-            scope,
-            matcher,
-            timeoutMs,
-            pollMs,
-            scrollbackLines,
-            description: `step ${i} (${formatMatcher(matcher)})`,
-          });
-          break;
-        }
-        case 'waitForNot': {
-          const matcher = compileMatcher(step);
-          const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
-          const pollMs = Number(step.pollMs ?? defaults.pollMs);
-          const scope = step.scope === 'scrollback' ? 'scrollback' : 'screen';
-          const scrollbackLines = Number(
-            step.scrollbackLines ?? defaults.scrollbackLines,
-          );
-          await waitForNot({
-            sessionName,
-            scope,
-            matcher,
-            timeoutMs,
-            pollMs,
-            scrollbackLines,
-            description: `step ${i} (${formatMatcher(matcher)})`,
-          });
-          break;
-        }
-        case 'expect': {
-          const matcher = compileMatcher(step);
-          const scope = step.scope === 'scrollback' ? 'scrollback' : 'screen';
-          const scrollbackLines = Number(
-            step.scrollbackLines ?? defaults.scrollbackLines,
-          );
-          const text =
-            scope === 'scrollback'
-              ? captureScrollback(sessionName, scrollbackLines)
-              : captureScreen(sessionName);
-
-          if (step.lineNumber !== undefined) {
-            const n = Number(step.lineNumber);
-            if (!Number.isFinite(n) || n <= 0) {
-              throw new Error(`Invalid expect.lineNumber`);
-            }
-            const lines = text.split('\n');
-            const line = lines[n - 1] ?? '';
-            if (!matchText(line, matcher)) {
-              throw new Error(
-                `Expected ${formatMatcher(matcher)} on ${scope} line ${n}`,
-              );
-            }
-          } else if (!matchText(text, matcher)) {
-            throw new Error(`Expected ${formatMatcher(matcher)} in ${scope}`);
-          }
-          break;
-        }
-        case 'expectCount': {
-          const matcher = compileMatcher(step);
-          const scope = step.scope === 'scrollback' ? 'scrollback' : 'screen';
-          const scrollbackLines = Number(
-            step.scrollbackLines ?? defaults.scrollbackLines,
-          );
-          const text =
-            scope === 'scrollback'
-              ? captureScrollback(sessionName, scrollbackLines)
-              : captureScreen(sessionName);
-          const count = countMatches(text, matcher);
-
-          if (step.equals !== undefined && count !== Number(step.equals)) {
-            throw new Error(
-              `Expected count == ${step.equals} but got ${count}`,
-            );
-          }
-          if (step.atLeast !== undefined && count < Number(step.atLeast)) {
-            throw new Error(
-              `Expected count >= ${step.atLeast} but got ${count}`,
-            );
-          }
-          if (step.atMost !== undefined && count > Number(step.atMost)) {
-            throw new Error(
-              `Expected count <= ${step.atMost} but got ${count}`,
-            );
-          }
-          break;
-        }
-        case 'approveShell': {
-          const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
-          await waitFor({
-            sessionName,
-            scope: 'screen',
-            matcher: { kind: 'contains', value: 'Shell Command Execution' },
-            timeoutMs,
-            pollMs: 200,
-            scrollbackLines: defaults.scrollbackLines,
-            description: `step ${i} (shell confirmation dialog)`,
-          });
-
-          const choice = step.choice ?? 'once';
-          if (choice === 'once') {
-            await sendKeys(['Enter']);
-          } else if (choice === 'always') {
-            await sendKeys(['Down', 'Enter']);
-          } else if (choice === 'no') {
-            await sendKeys(['Down', 'Down', 'Enter']);
-          } else {
-            throw new Error(`Invalid approveShell.choice`);
-          }
-          break;
-        }
-        case 'approveTool': {
-          const timeoutMs = Number(step.timeoutMs ?? defaults.timeoutMs);
-          const confirmMatcher = step.confirmation
-            ? compileMatcher(step.confirmation)
-            : { kind: 'contains', value: 'Yes, allow once' };
-
-          await waitFor({
-            sessionName,
-            scope: 'screen',
-            matcher: confirmMatcher,
-            timeoutMs,
-            pollMs: 200,
-            scrollbackLines: defaults.scrollbackLines,
-            description: `step ${i} (tool confirmation)`,
-          });
-
-          const choice = step.choice ?? 'once';
-          if (choice === 'once') {
-            await sendKeys(['Enter']);
-          } else if (choice === 'always') {
-            const screen = captureScreen(sessionName);
-            if (!screen.includes('Yes, allow always')) {
-              throw new Error(
-                `Requested choice "always" but no "Yes, allow always" option is visible`,
-              );
-            }
-            await sendKeys(['Down', 'Enter']);
-          } else if (choice === 'no') {
-            await sendKeys(['Down', 'Down', 'Enter']);
-          } else {
-            throw new Error(`Invalid approveTool.choice`);
-          }
-          break;
-        }
-        case 'historySample': {
-          scriptState.historySamples.push({
-            tMs: Date.now(),
-            historySize: getHistorySize(sessionName),
-            label: typeof step.label === 'string' ? step.label : `sample_${i}`,
-          });
-          break;
-        }
-        case 'expectHistoryDelta': {
-          const fromLabel = step.fromLabel ?? step.from;
-          const toLabel = step.toLabel ?? step.to;
-          if (typeof fromLabel !== 'string' || fromLabel.trim().length === 0) {
-            throw new Error(`Invalid expectHistoryDelta.fromLabel`);
-          }
-          if (typeof toLabel !== 'string' || toLabel.trim().length === 0) {
-            throw new Error(`Invalid expectHistoryDelta.toLabel`);
-          }
-
-          const fromSample = scriptState.historySamples.find(
-            (sample) => sample.label === fromLabel,
-          );
-          const toSample = [...scriptState.historySamples]
-            .reverse()
-            .find((sample) => sample.label === toLabel);
-
-          if (!fromSample) {
-            throw new Error(
-              `Missing historySample "${fromLabel}" for expectHistoryDelta`,
-            );
-          }
-          if (!toSample) {
-            throw new Error(
-              `Missing historySample "${toLabel}" for expectHistoryDelta`,
-            );
-          }
-
-          const delta = toSample.historySize - fromSample.historySize;
-
-          if (step.equals !== undefined && delta !== Number(step.equals)) {
-            throw new Error(
-              `Expected history delta == ${step.equals} but got ${delta}`,
-            );
-          }
-          if (step.atLeast !== undefined && delta < Number(step.atLeast)) {
-            throw new Error(
-              `Expected history delta >= ${step.atLeast} but got ${delta}`,
-            );
-          }
-          if (step.atMost !== undefined && delta > Number(step.atMost)) {
-            throw new Error(
-              `Expected history delta <= ${step.atMost} but got ${delta}`,
-            );
-          }
-          break;
-        }
-        case 'waitForExit': {
-          const timeoutMs = Number(step.timeoutMs ?? 15000);
-          const exited = await waitForPaneDead(sessionName, timeoutMs);
-          if (!exited) {
-            throw new Error(`Timed out waiting for exit`);
-          }
-          break;
-        }
-        default:
-          throw new Error(`Unknown step.type: ${step.type}`);
-      }
+      await executeStepDispatch(step, i, {
+        sessionName,
+        outDir,
+        sendKeys,
+        scriptState,
+        defaults,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const stepLabel = sanitizeLabel(
@@ -947,77 +975,105 @@ async function runScenarioScrollback({
   };
 }
 
-async function main() {
-  const options = parseArgs(process.argv.slice(2));
-  const sessionName = `llxprt_tmux_${Date.now().toString(16)}`;
-  const outDir = options.outDir
-    ? path.resolve(process.cwd(), options.outDir)
-    : path.join(os.tmpdir(), `llxprt-tmux-harness-${Date.now()}`);
-  await fs.mkdir(outDir, { recursive: true });
-
-  const script = options.scriptPath
-    ? await (async () => {
-        const scriptPath = path.resolve(process.cwd(), options.scriptPath);
-        try {
-          return JSON.parse(await fs.readFile(scriptPath, 'utf8'));
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          throw new Error(
-            `Failed to parse script file ${scriptPath}: ${message}`,
-          );
-        }
-      })()
-    : null;
-
-  if (script?.steps) {
-    script.steps = expandScriptMacros(script.steps, script.macros);
+async function loadScript(scriptPath) {
+  if (!scriptPath) return null;
+  const resolved = path.resolve(process.cwd(), scriptPath);
+  try {
+    return JSON.parse(await fs.readFile(resolved, 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse script file ${resolved}: ${message}`);
   }
+}
 
-  const tmuxCols = options.cols ?? script?.tmux?.cols ?? 120;
-  const tmuxRows = options.rows ?? script?.tmux?.rows ?? 40;
-  const initialWaitMs =
-    options.initialWaitMs ?? script?.tmux?.initialWaitMs ?? 6000;
-  const historyLimit =
-    options.historyLimit ?? script?.tmux?.historyLimit ?? 50000;
+function resolveTmuxConfig(options, script) {
+  return {
+    cols: options.cols ?? script?.tmux?.cols ?? 120,
+    rows: options.rows ?? script?.tmux?.rows ?? 40,
+    initialWaitMs: options.initialWaitMs ?? script?.tmux?.initialWaitMs ?? 6000,
+    historyLimit: options.historyLimit ?? script?.tmux?.historyLimit ?? 50000,
+    scrollbackLines:
+      options.scrollbackLines ?? script?.tmux?.scrollbackLines ?? 2000,
+  };
+}
 
+function startTmuxSession(sessionName, startArgs, tmuxConfig) {
   // Ensure no stale session with the same name (unlikely, but safe).
   tryTmux(['kill-session', '-t', sessionName]);
 
-  // Start LLxprt in interactive mode (no piped stdin).
-  const startArgs = Array.isArray(script?.startCommand)
-    ? script.startCommand
-    : ['node', 'scripts/start.js'];
-  const shouldYolo = Boolean(options.yolo || script?.yolo);
-  if (shouldYolo && !startArgs.includes('--yolo')) {
-    startArgs.push('--yolo');
-  }
   runTmux([
     'new-session',
     '-d',
     '-s',
     sessionName,
     '-x',
-    String(tmuxCols),
+    String(tmuxConfig.cols),
     '-y',
-    String(tmuxRows),
+    String(tmuxConfig.rows),
     ...startArgs,
   ]);
-  // Keep the session around after the command exits so we can capture the final
-  // screen and scrollback even if /quit exits quickly.
   runTmux(['set-option', '-t', `${sessionName}:0`, 'remain-on-exit', 'on']);
   runTmux([
     'set-option',
     '-t',
     `${sessionName}:0`,
     'history-limit',
-    String(historyLimit),
+    String(tmuxConfig.historyLimit),
   ]);
+}
 
-  // Let Ink render the initial UI.
-  await sleep(initialWaitMs);
+export function buildStartArgs(script, shouldYolo) {
+  const startArgs = Array.isArray(script?.startCommand)
+    ? [...script.startCommand]
+    : ['node', 'scripts/start.js'];
+  if (shouldYolo && !startArgs.includes('--yolo')) {
+    startArgs.push('--yolo');
+  }
+  return startArgs;
+}
 
-  const typeLineAndSubmit = async (
+async function runScenario({
+  scenario,
+  script,
+  sessionName,
+  typeLineAndSubmit,
+  outDir,
+  tmuxConfig,
+}) {
+  if (script?.steps) {
+    await runScriptSteps({
+      sessionName,
+      outDir,
+      steps: script.steps,
+      defaults: {
+        postTypeMs: 600,
+        submitKeys: ['Enter'],
+        shellSubmitKeys: ['Enter'],
+        timeoutMs: 15000,
+        pollMs: 250,
+        scrollbackLines: tmuxConfig.scrollbackLines,
+      },
+    });
+    return { kind: 'script' };
+  }
+
+  if (scenario === 'haiku') {
+    return await runScenarioHaiku({ sessionName, typeLineAndSubmit });
+  }
+
+  if (scenario === 'scrollback') {
+    return await runScenarioScrollback({
+      sessionName,
+      typeLineAndSubmit,
+      outDir,
+    });
+  }
+
+  throw new Error(`Unhandled scenario: ${scenario}`);
+}
+
+function makeTypeLineAndSubmit(sessionName) {
+  return async (
     line,
     { postTypeMs = 600, enterRepeats = 1, escapeBeforeEnter = false } = {},
   ) => {
@@ -1032,88 +1088,186 @@ async function main() {
       await sleep(150);
     }
   };
+}
+
+async function handleScenarioError({
+  error,
+  sessionName,
+  outDir,
+  options,
+  script,
+  scenario,
+}) {
+  const message = error instanceof Error ? error.message : String(error);
+  const scrollbackLines =
+    options.scrollbackLines ?? script?.tmux?.scrollbackLines ?? 2000;
+  try {
+    await captureArtifacts({
+      sessionName,
+      outDir,
+      label: 'error-final',
+      scrollbackLines,
+    });
+  } catch {
+    // ignore
+  }
+  try {
+    await fs.writeFile(
+      path.join(outDir, 'error.json'),
+      JSON.stringify({ message }, null, 2),
+      'utf8',
+    );
+  } catch {
+    // ignore
+  }
+  if (!options.keepSession) {
+    tryTmux(['kill-session', '-t', sessionName]);
+  }
+  console.error(
+    [
+      `tmux session: ${sessionName}`,
+      `artifacts: ${outDir}`,
+      `scenario: ${script?.steps ? 'script' : scenario}`,
+    ].join('\n'),
+  );
+}
+
+async function captureFinalArtifacts({
+  sessionName,
+  outDir,
+  scenario,
+  tmuxConfig,
+}) {
+  const screen = captureScreen(sessionName);
+  const scrollbackLines =
+    scenario === 'scrollback' ? 20000 : tmuxConfig.scrollbackLines;
+  const scrollback = captureScrollback(sessionName, scrollbackLines);
+  await fs.writeFile(path.join(outDir, 'screen.txt'), screen, 'utf8');
+  await fs.writeFile(path.join(outDir, 'scrollback.txt'), scrollback, 'utf8');
+  return { screen, scrollback, scrollbackLines };
+}
+
+async function assertScrollbackResults({
+  scenarioResult,
+  baselineScrollback,
+  options,
+  outDir,
+  tmuxConfig,
+}) {
+  const sentinelCount =
+    baselineScrollback.match(new RegExp(scenarioResult.sentinel, 'g'))
+      ?.length ?? 0;
+  const tipsCount =
+    baselineScrollback.match(/Tips for getting started:/g)?.length ?? 0;
+
+  const historyDelta =
+    scenarioResult.historySamples.length >= 2
+      ? scenarioResult.historySamples.at(-1).historySize -
+        scenarioResult.historySamples[0].historySize
+      : 0;
+
+  await fs.writeFile(
+    path.join(outDir, 'metrics.json'),
+    JSON.stringify(
+      {
+        scenario: 'scrollback',
+        tmux: {
+          cols: tmuxConfig.cols,
+          rows: tmuxConfig.rows,
+        },
+        counts: {
+          sentinel: scenarioResult.sentinel,
+          sentinelCount,
+          tipsCount,
+        },
+        history: {
+          deltaDuringCopyMode: historyDelta,
+          samplesFile: 'history-samples.json',
+        },
+        captures: scenarioResult.captures ?? null,
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  if (!options.assert) return null;
+
+  if (sentinelCount < 1) {
+    return new Error(
+      `Scrollback output missing: expected sentinelCount >= 1 but got ${sentinelCount} (sentinel: "${scenarioResult.sentinel}")`,
+    );
+  }
+  if (historyDelta !== 0) {
+    return new Error(
+      `Scrollback redraw detected: expected history delta == 0 but got ${historyDelta}`,
+    );
+  }
+  if (tipsCount > 1) {
+    return new Error(
+      `Scrollback redraw detected: expected tipsCount <= 1 but got ${tipsCount}`,
+    );
+  }
+  return null;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const sessionName = `llxprt_tmux_${Date.now().toString(16)}`;
+  const outDir = options.outDir
+    ? path.resolve(process.cwd(), options.outDir)
+    : path.join(os.tmpdir(), `llxprt-tmux-harness-${Date.now()}`);
+  await fs.mkdir(outDir, { recursive: true });
+
+  const script = await loadScript(options.scriptPath);
+  if (script?.steps) {
+    script.steps = expandScriptMacros(script.steps, script.macros);
+  }
+
+  const tmuxConfig = resolveTmuxConfig(options, script);
+  const shouldYolo = Boolean(options.yolo || script?.yolo);
+  const startArgs = buildStartArgs(script, shouldYolo);
+  startTmuxSession(sessionName, startArgs, tmuxConfig);
+
+  // Let Ink render the initial UI.
+  await sleep(tmuxConfig.initialWaitMs);
+
+  const typeLineAndSubmit = makeTypeLineAndSubmit(sessionName);
 
   let scenarioResult;
   const scenario = options.scenario ?? 'haiku';
   try {
-    if (script?.steps) {
-      await runScriptSteps({
-        sessionName,
-        outDir,
-        steps: script.steps,
-        defaults: {
-          postTypeMs: 600,
-          submitKeys: ['Enter'],
-          shellSubmitKeys: ['Enter'],
-          timeoutMs: 15000,
-          pollMs: 250,
-          scrollbackLines:
-            options.scrollbackLines ?? script?.tmux?.scrollbackLines ?? 2000,
-        },
-      });
-      scenarioResult = { kind: 'script' };
-    } else if (scenario === 'haiku') {
-      scenarioResult = await runScenarioHaiku({
-        sessionName,
-        typeLineAndSubmit,
-      });
-    } else if (scenario === 'scrollback') {
-      scenarioResult = await runScenarioScrollback({
-        sessionName,
-        typeLineAndSubmit,
-        outDir,
-      });
-    } else {
-      throw new Error(`Unhandled scenario: ${scenario}`);
-    }
+    scenarioResult = await runScenario({
+      scenario,
+      script,
+      sessionName,
+      typeLineAndSubmit,
+      outDir,
+      options,
+      tmuxConfig,
+    });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const scrollbackLines =
-      options.scrollbackLines ?? script?.tmux?.scrollbackLines ?? 2000;
-    try {
-      await captureArtifacts({
-        sessionName,
-        outDir,
-        label: 'error-final',
-        scrollbackLines,
-      });
-    } catch {
-      // ignore
-    }
-    try {
-      await fs.writeFile(
-        path.join(outDir, 'error.json'),
-        JSON.stringify({ message }, null, 2),
-        'utf8',
-      );
-    } catch {
-      // ignore
-    }
-    if (!options.keepSession) {
-      tryTmux(['kill-session', '-t', sessionName]);
-    }
-    console.error(
-      [
-        `tmux session: ${sessionName}`,
-        `artifacts: ${outDir}`,
-        `scenario: ${script?.steps ? 'script' : scenario}`,
-      ].join('\n'),
-    );
+    await handleScenarioError({
+      error,
+      sessionName,
+      outDir,
+      options,
+      script,
+      scenario,
+    });
     throw error;
   }
 
   // Give the process time to exit cleanly (pane should become "dead").
   const exited = await waitForPaneDead(sessionName, 15000);
 
-  // Capture both visible screen and some scrollback for inspection.
-  const screen = captureScreen(sessionName);
-  const scrollbackLines =
-    scenario === 'scrollback'
-      ? 20000
-      : (options.scrollbackLines ?? script?.tmux?.scrollbackLines ?? 2000);
-  const scrollback = captureScrollback(sessionName, scrollbackLines);
-  await fs.writeFile(path.join(outDir, 'screen.txt'), screen, 'utf8');
-  await fs.writeFile(path.join(outDir, 'scrollback.txt'), scrollback, 'utf8');
+  const { scrollback } = await captureFinalArtifacts({
+    sessionName,
+    outDir,
+    scenario,
+    tmuxConfig,
+  });
 
   let assertionError = null;
   if (scenarioResult?.kind === 'scrollback') {
@@ -1124,61 +1278,13 @@ async function main() {
         )
       : scrollback;
 
-    const sentinelCount =
-      baselineScrollback.match(new RegExp(scenarioResult.sentinel, 'g'))
-        ?.length ?? 0;
-    const tipsCount =
-      baselineScrollback.match(/Tips for getting started:/g)?.length ?? 0;
-
-    const historyDelta =
-      scenarioResult.historySamples.length >= 2
-        ? scenarioResult.historySamples.at(-1).historySize -
-          scenarioResult.historySamples[0].historySize
-        : 0;
-
-    await fs.writeFile(
-      path.join(outDir, 'metrics.json'),
-      JSON.stringify(
-        {
-          scenario: 'scrollback',
-          tmux: {
-            cols: tmuxCols,
-            rows: tmuxRows,
-          },
-          counts: {
-            sentinel: scenarioResult.sentinel,
-            sentinelCount,
-            tipsCount,
-          },
-          history: {
-            deltaDuringCopyMode: historyDelta,
-            samplesFile: 'history-samples.json',
-          },
-          captures: scenarioResult.captures ?? null,
-        },
-        null,
-        2,
-      ),
-      'utf8',
-    );
-
-    if (options.assert) {
-      if (sentinelCount < 1) {
-        assertionError = new Error(
-          `Scrollback output missing: expected sentinelCount >= 1 but got ${sentinelCount} (sentinel: "${scenarioResult.sentinel}")`,
-        );
-      }
-      if (!assertionError && historyDelta !== 0) {
-        assertionError = new Error(
-          `Scrollback redraw detected: expected history delta == 0 but got ${historyDelta}`,
-        );
-      }
-      if (!assertionError && tipsCount > 1) {
-        assertionError = new Error(
-          `Scrollback redraw detected: expected tipsCount <= 1 but got ${tipsCount}`,
-        );
-      }
-    }
+    assertionError = await assertScrollbackResults({
+      scenarioResult,
+      baselineScrollback,
+      options,
+      outDir,
+      tmuxConfig,
+    });
   }
 
   // Tear down so we don't leak sessions.
@@ -1199,7 +1305,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tmux-harness.js
+++ b/scripts/tmux-harness.js
@@ -214,6 +214,8 @@ export function matchText(text, matcher) {
   if (matcher.kind === 'contains') {
     return text.includes(matcher.value);
   }
+  matcher.value.lastIndex = 0;
+
   return matcher.value.test(text);
 }
 
@@ -1023,9 +1025,19 @@ function startTmuxSession(sessionName, startArgs, tmuxConfig) {
 }
 
 export function buildStartArgs(script, shouldYolo) {
-  const startArgs = Array.isArray(script?.startCommand)
-    ? [...script.startCommand]
-    : ['node', 'scripts/start.js'];
+  const command = script?.startCommand;
+  if (
+    command !== undefined &&
+    (!Array.isArray(command) ||
+      command.length === 0 ||
+      command.some((item) => typeof item !== 'string'))
+  ) {
+    throw new Error(
+      'Invalid script.startCommand: expected non-empty array of strings',
+    );
+  }
+
+  const startArgs = command ? [...command] : ['node', 'scripts/start.js'];
   if (shouldYolo && !startArgs.includes('--yolo')) {
     startArgs.push('--yolo');
   }


### PR DESCRIPTION
## TLDR

Promotes ESLint cyclomatic complexity enforcement to error at cap 25 and clears the current cap-25 offenders. While verifying the interactive path with the tmux harness, this also fixes an unhandled promise rejection caused by detached Config method calls losing their binding.

## Dive Deeper

- Changes all active ESLint complexity rules from cap 15 to error at cap 25.
- Refactors scripts/tmux-harness.js into focused helpers so scripts lint passes with complexity as an error at cap 25.
- Adds unit coverage for the tmux harness helpers and start command argument handling.
- Fixes prepareTurnForQuery so Config methods that depend on this are bound before use, while still tolerating older test doubles that do not provide bucket failover methods.
- Adds regression coverage proving Config method binding is preserved when preparing a turn.
- Reproduced the interactive Debug Console failure through the tmux harness before the fix, then verified the waferglm5 prompt no longer emits bucketFailoverHandler or Unhandled Promise Rejection after the fix.

## Reviewer Test Plan

Recommended reviewer checks:

1. Run npm run lint and confirm there are zero errors, including zero complexity diagnostics at cap 25.
2. Run npm run test, npm run typecheck, npm run format, and npm run build.
3. Run node scripts/start.js --profile-load waferglm5 "write me a haiku and nothing else".
4. Optionally exercise the tmux harness with a waferglm5 scripted prompt and assert the scrollback does not contain bucketFailoverHandler or Unhandled Promise Rejection.

Validation performed on this branch:

- npm run test --workspaces --if-present -- --reporter=dot
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load waferglm5 "write me a haiku and nothing else"
- Focused tmux harness verification for the interactive bucketFailoverHandler crash

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      | [OK]  |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

## Linked issues / bugs

Fixes #1914
