### PR TITLE
Validate promoted lint rules (Fixes #1915)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -898,10 +898,10 @@ export default tseslint.config(
   //
   // Error-level max-lines and max-lines-per-function rules on the four new
   // modules ensure they never grow past their design targets. The coordinator
-  // file (subagent.ts) uses 'warn' during the decomposition (Phases 1-4) and
-  // will be promoted to 'error' in Phase 5 once the file is thin enough.
-  // These rules target files that don't exist yet — ESLint silently ignores
-  // unmatched globs, so CI stays green during Phase 0.
+  // file (subagent.ts) was promoted from 'warn' to 'error' in Phase 5 (Issue
+  // #1915) once the file was thin enough to comply. These rules target files
+  // that don't exist yet — ESLint silently ignores unmatched globs, so CI
+  // stays green during Phase 0.
   {
     files: [
       'packages/core/src/core/subagentTypes.ts',
@@ -921,13 +921,13 @@ export default tseslint.config(
       ],
     },
   },
-  // subagent.ts coordinator: warn during decomposition, promoted to error in Phase 5
+  // subagent.ts coordinator: promoted from warn to error in Phase 5 (Issue #1915)
   {
     files: ['packages/core/src/core/subagent.ts'],
     ignores: ['**/*.test.ts'],
     rules: {
       'max-lines': [
-        'warn',
+        'error',
         { max: 800, skipBlankLines: true, skipComments: true },
       ],
       'max-lines-per-function': [

--- a/project-plans/issue1569d/MAX_LINES_OFFENDERS.md
+++ b/project-plans/issue1569d/MAX_LINES_OFFENDERS.md
@@ -1,5 +1,26 @@
 # Issue #1569d — max-lines offenders
 
+## Phase 5 C5-MLF / C5-CogC / C5-ML Validation Summary (Issue #1915)
+
+Validated on branch `issue1915` that promoted production-only size and
+cognitive-complexity rules remain at zero diagnostics:
+
+- **Scope**: `packages/core/src` and `packages/cli/src`, excluding
+  `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, and `__tests__`
+- **Rules & caps**:
+  - `max-lines`: error, cap 800 (skipBlankLines, skipComments)
+  - `max-lines-per-function`: error, cap 80 (skipBlankLines, skipComments)
+  - `sonarjs/cognitive-complexity`: error, cap 30
+- **Result**: 0 diagnostics across all three rules in production-only files
+- **eslint.config.js change**: `subagent.ts` coordinator `max-lines` override
+  promoted from `warn` to `error` (file now compliant at <800 counted lines)
+
+The historical offender table below is retained from the Phase 5 C5-PREP
+inventory. It was captured when `max-lines` was at warning level and includes
+test files and counts that do not reflect the current production-only status.
+
+---
+
 Captured for Phase 5 C5-PREP after enabling global `max-lines` warning policy:
 
 - Rule config: `max-lines: ["warn", { max: 800, skipBlankLines: true, skipComments: true }]`


### PR DESCRIPTION
## TLDR

Validates the promoted production size and cognitive-complexity lint rules for issue #1915 and completes the remaining subagent.ts max-lines promotion from warn to error.

## Dive Deeper

This PR confirms the production-only rule set remains clean for packages/core/src and packages/cli/src while excluding test/spec files and __tests__ directories.

Changes included:

- Promoted the packages/core/src/core/subagent.ts max-lines override from warn to error.
- Updated the related ESLint comments to reflect that Phase 5 promotion is complete.
- Added an issue #1915 validation note to project-plans/issue1569d/MAX_LINES_OFFENDERS.md.
- Documented that the older offender table is historical Phase 5 C5-PREP inventory and includes tests/older counts.

Targeted validation result:

    max-lines: 0 production diagnostics
    max-lines-per-function: 0 production diagnostics
    sonarjs/cognitive-complexity: 0 production diagnostics

## Reviewer Test Plan

Run the targeted production-only lint scan and filter for the three promoted rules:

    npm exec -- eslint "packages/core/src/**/*.{ts,tsx}" "packages/cli/src/**/*.{ts,tsx}" --ignore-pattern "**/*.test.ts" --ignore-pattern "**/*.test.tsx" --ignore-pattern "**/*.spec.ts" --ignore-pattern "**/*.spec.tsx" --ignore-pattern "**/__tests__/**" --format json --output-file /tmp/issue1915-eslint-production.json

Then filter the JSON for max-lines, max-lines-per-function, and sonarjs/cognitive-complexity and confirm zero hits.

Full verification run for this branch:

    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load waferglm5 "write me a haiku and nothing else"

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      |   |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

## Linked issues / bugs

Fixes #1915
Related to #1569
