### PR TITLE
Fix #1878: Guard OAuth dialog against wrong-provider auth prompts

### DIFF
--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppDialogs.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppDialogs.ts
@@ -52,6 +52,7 @@ export interface AppDialogsParams {
   recordingIntegrationRef: React.MutableRefObject<RecordingIntegration | null>;
   runtime: {
     getActiveModelName: () => string;
+    getActiveProviderName: () => string;
     getCliOAuthManager: () => unknown;
   };
   consoleMessages: ConsoleMessageItem[];
@@ -208,7 +209,11 @@ function useDialogsAuthProviders(
   } = p;
   const auth = useAuthCommand(settings, appState);
   const isOAuthCodeDialogOpen = appState.openDialogs.oauthCode;
-  useOAuthOrchestration({ appDispatch, isOAuthCodeDialogOpen });
+  useOAuthOrchestration({
+    appDispatch,
+    isOAuthCodeDialogOpen,
+    getActiveProviderName: runtime.getActiveProviderName,
+  });
   const editor = useEditorSettings(settings, appState, addItem);
   const provider = useProviderDialog({
     addMessage: (msg) =>

--- a/packages/cli/src/ui/hooks/useOAuthOrchestration.spec.ts
+++ b/packages/cli/src/ui/hooks/useOAuthOrchestration.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '../../test-utils/render.js';
+import { useOAuthOrchestration } from './useOAuthOrchestration.js';
+import type { AppAction } from '../reducers/appReducer.js';
+
+const OAUTH_POLL_MS = 100;
+
+describe('useOAuthOrchestration', () => {
+  let appDispatch: React.Dispatch<AppAction>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    appDispatch = vi.fn();
+    delete (global as Record<string, unknown>).__oauth_needs_code;
+    delete (global as Record<string, unknown>).__oauth_provider;
+    delete (global as Record<string, unknown>).__oauth_browser_auth_complete;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (global as Record<string, unknown>).__oauth_needs_code;
+    delete (global as Record<string, unknown>).__oauth_provider;
+    delete (global as Record<string, unknown>).__oauth_browser_auth_complete;
+  });
+
+  describe('provider guard (Issue #1878)', () => {
+    it('does not dispatch OPEN_DIALOG when __oauth_provider differs from active provider', () => {
+      const getActiveProviderName = vi.fn().mockReturnValue('codex');
+      (global as Record<string, unknown>).__oauth_needs_code = true;
+      (global as Record<string, unknown>).__oauth_provider = 'anthropic';
+
+      renderHook(() =>
+        useOAuthOrchestration({
+          appDispatch,
+          isOAuthCodeDialogOpen: false,
+          getActiveProviderName,
+        }),
+      );
+
+      vi.advanceTimersByTime(OAUTH_POLL_MS * 3);
+
+      expect(appDispatch).not.toHaveBeenCalled();
+      expect((global as Record<string, unknown>).__oauth_needs_code).toBe(true);
+    });
+
+    it('dispatches OPEN_DIALOG and clears flag when pending provider matches active provider', () => {
+      const getActiveProviderName = vi.fn().mockReturnValue('anthropic');
+      (global as Record<string, unknown>).__oauth_needs_code = true;
+      (global as Record<string, unknown>).__oauth_provider = 'anthropic';
+
+      renderHook(() =>
+        useOAuthOrchestration({
+          appDispatch,
+          isOAuthCodeDialogOpen: false,
+          getActiveProviderName,
+        }),
+      );
+
+      vi.advanceTimersByTime(OAUTH_POLL_MS * 3);
+
+      expect(appDispatch).toHaveBeenCalledWith({
+        type: 'OPEN_DIALOG',
+        payload: 'oauthCode',
+      });
+      expect((global as Record<string, unknown>).__oauth_needs_code).toBe(
+        false,
+      );
+    });
+
+    it('dispatches OPEN_DIALOG when __oauth_provider is absent (legacy compatibility)', () => {
+      const getActiveProviderName = vi.fn().mockReturnValue('codex');
+      (global as Record<string, unknown>).__oauth_needs_code = true;
+
+      renderHook(() =>
+        useOAuthOrchestration({
+          appDispatch,
+          isOAuthCodeDialogOpen: false,
+          getActiveProviderName,
+        }),
+      );
+
+      vi.advanceTimersByTime(OAUTH_POLL_MS * 3);
+
+      expect(appDispatch).toHaveBeenCalledWith({
+        type: 'OPEN_DIALOG',
+        payload: 'oauthCode',
+      });
+      expect((global as Record<string, unknown>).__oauth_needs_code).toBe(
+        false,
+      );
+    });
+
+    it('does not crash when getActiveProviderName throws', () => {
+      const getActiveProviderName = vi.fn().mockImplementation(() => {
+        throw new Error('runtime not initialized');
+      });
+      (global as Record<string, unknown>).__oauth_needs_code = true;
+      (global as Record<string, unknown>).__oauth_provider = 'anthropic';
+
+      renderHook(() =>
+        useOAuthOrchestration({
+          appDispatch,
+          isOAuthCodeDialogOpen: false,
+          getActiveProviderName,
+        }),
+      );
+
+      vi.advanceTimersByTime(OAUTH_POLL_MS * 3);
+
+      expect(appDispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches OPEN_DIALOG when getActiveProviderName is not provided (backward compatibility)', () => {
+      (global as Record<string, unknown>).__oauth_needs_code = true;
+      (global as Record<string, unknown>).__oauth_provider = 'anthropic';
+
+      renderHook(() =>
+        useOAuthOrchestration({
+          appDispatch,
+          isOAuthCodeDialogOpen: false,
+        }),
+      );
+
+      vi.advanceTimersByTime(OAUTH_POLL_MS * 3);
+
+      expect(appDispatch).toHaveBeenCalledWith({
+        type: 'OPEN_DIALOG',
+        payload: 'oauthCode',
+      });
+    });
+  });
+
+  describe('auto-dismiss on browser auth complete', () => {
+    it('dispatches CLOSE_DIALOG when dialog is open and __oauth_browser_auth_complete is true', () => {
+      (global as Record<string, unknown>).__oauth_browser_auth_complete = true;
+
+      renderHook(() =>
+        useOAuthOrchestration({
+          appDispatch,
+          isOAuthCodeDialogOpen: true,
+        }),
+      );
+
+      vi.advanceTimersByTime(OAUTH_POLL_MS * 3);
+
+      expect(appDispatch).toHaveBeenCalledWith({
+        type: 'CLOSE_DIALOG',
+        payload: 'oauthCode',
+      });
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useOAuthOrchestration.ts
+++ b/packages/cli/src/ui/hooks/useOAuthOrchestration.ts
@@ -22,25 +22,46 @@ import type { AppAction } from '../reducers/appReducer.js';
 interface UseOAuthOrchestrationOptions {
   appDispatch: React.Dispatch<AppAction>;
   isOAuthCodeDialogOpen: boolean;
+  getActiveProviderName?: () => string;
+}
+
+function oauthProviderMatchesActive(
+  getActiveProviderName: (() => string) | undefined,
+): boolean {
+  const pendingProvider = (global as Record<string, unknown>).__oauth_provider;
+  if (typeof pendingProvider !== 'string') {
+    return true;
+  }
+  if (!getActiveProviderName) {
+    return true;
+  }
+  let activeProviderName: string;
+  try {
+    activeProviderName = getActiveProviderName();
+  } catch {
+    return false;
+  }
+  return pendingProvider === activeProviderName;
 }
 
 export function useOAuthOrchestration({
   appDispatch,
   isOAuthCodeDialogOpen,
+  getActiveProviderName,
 }: UseOAuthOrchestrationOptions): void {
-  // Check for OAuth code needed flag
   useEffect(() => {
     const checkOAuthFlag = setInterval(() => {
       if ((global as Record<string, unknown>).__oauth_needs_code === true) {
-        // Clear the flag
+        if (!oauthProviderMatchesActive(getActiveProviderName)) {
+          return;
+        }
         (global as Record<string, unknown>).__oauth_needs_code = false;
-        // Open the OAuth code dialog
         appDispatch({ type: 'OPEN_DIALOG', payload: 'oauthCode' });
       }
-    }, 100); // Check every 100ms
+    }, 100);
 
     return () => clearInterval(checkOAuthFlag);
-  }, [appDispatch]);
+  }, [appDispatch, getActiveProviderName]);
 
   // Auto-dismiss OAuth dialog when auth completes via browser callback
   // Issue #1404: Dialog should automatically hide after auth completes


### PR DESCRIPTION
## TLDR

Prevents the OAuth code dialog from opening when the pending auth provider (`__oauth_provider`) does not match the currently active provider. This fixes the bug where users on Codex saw an Anthropic/Claude auth prompt instead of Codex auth.

## Dive Deeper

**Root cause**: `useOAuthOrchestration` polls `global.__oauth_needs_code` every 100ms and unconditionally opens the `oauthCode` dialog when the flag is `true`. However, `AnthropicOAuthProvider.armPendingAuthDialog()` sets both `__oauth_needs_code=true` and `__oauth_provider="anthropic"`. When the active provider is Codex (which uses its own device/local callback flow), the hook still saw the flag and showed the wrong dialog.

**Fix**: Added an optional `getActiveProviderName` parameter to `useOAuthOrchestration`. Before dispatching `OPEN_DIALOG`, the hook now checks if `global.__oauth_provider` (when present) matches the active provider name. If they differ, the dialog is suppressed and the flag is left intact (the owning provider will clear it). Backward compatibility is preserved: when `__oauth_provider` is absent (legacy/caller-set-only) or `getActiveProviderName` is not supplied, the dialog opens as before.

**Changes**:
- `packages/cli/src/ui/hooks/useOAuthOrchestration.ts`: Added `getActiveProviderName` option and `oauthProviderMatchesActive` guard function. If pending provider differs from active, the hook skips `OPEN_DIALOG` and does not clear the flag.
- `packages/cli/src/ui/containers/AppContainer/hooks/useAppDialogs.ts`: Passes `runtime.getActiveProviderName` to `useOAuthOrchestration`. Also adds `getActiveProviderName` to the `AppDialogsParams.runtime` type.
- `packages/cli/src/ui/hooks/useOAuthOrchestration.spec.ts`: Behavioral tests covering: (1) provider mismatch suppresses dialog, (2) provider match opens dialog, (3) absent `__oauth_provider` opens dialog (legacy), (4) `getActiveProviderName` throwing does not crash, (5) omitting `getActiveProviderName` opens dialog (backward compat), (6) auto-dismiss on browser auth complete still works.

## Reviewer Test Plan

1. Switch to a Codex provider/profile
2. Trigger any auth flow that sets `__oauth_needs_code=true` with `__oauth_provider="anthropic"`
3. Verify that the Claude auth dialog does NOT appear
4. Switch to an Anthropic provider and trigger auth - verify the code dialog DOES appear

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1878