### PR TITLE
Fix #1730: Add semantic response outcome metadata (Fixes #1730)

### DIFF
--- a/packages/core/src/core/MessageConverter.ts
+++ b/packages/core/src/core/MessageConverter.ts
@@ -32,6 +32,7 @@ import {
   isThoughtPart,
   type UsageMetadataWithCache,
 } from './geminiChatTypes.js';
+import { getResponseTextFromParts } from '../utils/generateContentResponseUtilities.js';
 
 const logger = new DebugLogger('llxprt:core:message-converter');
 
@@ -463,12 +464,7 @@ export function convertIContentToResponse(
       },
     ],
     get text() {
-      return (
-        parts
-          .filter((p) => 'text' in p && !isThoughtPart(p))
-          .map((p) => p.text)
-          .join('') || ''
-      );
+      return getResponseTextFromParts(parts) ?? '';
     },
     functionCalls: parts
       .filter((p) => 'functionCall' in p)

--- a/packages/core/src/core/MessageStreamOrchestrator.ts
+++ b/packages/core/src/core/MessageStreamOrchestrator.ts
@@ -10,6 +10,7 @@ import {
   type ServerGeminiStreamEvent,
   GeminiEventType,
   DEFAULT_AGENT_ID,
+  type ServerGeminiFinishedOutcome,
 } from './turn.js';
 import type { Config } from '../config/config.js';
 import type { GeminiChat } from './geminiChat.js';
@@ -74,6 +75,7 @@ export interface IterationResult {
   hadThinking: boolean;
   hadContent: boolean;
   deferredEvents: ServerGeminiStreamEvent[];
+  outcome?: ServerGeminiFinishedOutcome;
 }
 
 interface PostTurnResult {
@@ -382,6 +384,7 @@ export class MessageStreamOrchestrator {
     let hadContent = false;
     let hadToolCallsThisTurn = hadToolCallsPrior;
     const deferredEvents: ServerGeminiStreamEvent[] = [];
+    let finishedOutcome: ServerGeminiFinishedOutcome | undefined;
 
     for await (const event of turn.run(iterRequest, signal)) {
       if (loopDetector.addAndCheck(event)) {
@@ -392,6 +395,7 @@ export class MessageStreamOrchestrator {
           hadThinking,
           hadContent,
           deferredEvents,
+          outcome: finishedOutcome,
         });
       }
 
@@ -405,6 +409,8 @@ export class MessageStreamOrchestrator {
         todoPauseSeen = true;
       if (event.type === GeminiEventType.Thought) hadThinking = true;
       if (event.type === GeminiEventType.Content) hadContent = true;
+      if (event.type === GeminiEventType.Finished && event.value.outcome)
+        finishedOutcome = event.value.outcome;
       this._handleTodoToolCall(event, todoContinuationService);
       if (event.type === GeminiEventType.Content && event.value)
         ctx.responseChunks.push(event.value);
@@ -435,6 +441,7 @@ export class MessageStreamOrchestrator {
       hadThinking,
       hadContent,
       deferredEvents,
+      outcome: finishedOutcome,
     };
   }
 
@@ -465,8 +472,12 @@ export class MessageStreamOrchestrator {
       return yield* this._finishWithToolCalls(iter.deferredEvents, ctx);
     }
 
+    // Prefer authoritative Finished outcome when available, fallback to event-inferred flags
+    const hadVisible = iter.outcome?.hadVisibleOutput ?? iter.hadContent;
+    const hadThinking = iter.outcome?.hadThinking ?? iter.hadThinking;
+
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider stream and tool-call runtime payloads.
-    if (iter.hadThinking && !iter.hadContent && !iter.hadToolCallsThisTurn) {
+    if (hadThinking && !hadVisible && !iter.hadToolCallsThisTurn) {
       const newRetry = retryCount + 1;
       this.deps.logger.debug(
         () =>

--- a/packages/core/src/core/StreamProcessor.ts
+++ b/packages/core/src/core/StreamProcessor.ts
@@ -48,6 +48,7 @@ import {
   InvalidStreamError,
   EmptyStreamError,
   isSchemaDepthError,
+  isThoughtPart,
   type UsageMetadataWithCache,
 } from './geminiChatTypes.js';
 import type { ResponseOutcome } from '../utils/generateContentResponseUtilities.js';
@@ -812,9 +813,7 @@ export class StreamProcessor {
           isActionable: acc.outcome.isActionable || chunkOutcome.isActionable,
         };
         acc.modelResponseParts.push(
-          ...(includeThoughts
-            ? parts
-            : parts.filter((p) => p.thought !== true)),
+          ...(includeThoughts ? parts : parts.filter((p) => !isThoughtPart(p))),
         );
       }
     }

--- a/packages/core/src/core/StreamProcessor.ts
+++ b/packages/core/src/core/StreamProcessor.ts
@@ -48,9 +48,10 @@ import {
   InvalidStreamError,
   EmptyStreamError,
   isSchemaDepthError,
-  isThoughtPart,
   type UsageMetadataWithCache,
 } from './geminiChatTypes.js';
+import type { ResponseOutcome } from '../utils/generateContentResponseUtilities.js';
+import { analyzeResponseOutcome } from '../utils/generateContentResponseUtilities.js';
 import { hasCycleInSchema } from '../tools/tools.js';
 import { isStructuredError } from '../utils/quotaErrorDetection.js';
 import {
@@ -766,18 +767,19 @@ export class StreamProcessor {
 
   private _createStreamAccumulator(): {
     modelResponseParts: Part[];
-    hasToolCall: boolean;
+    outcome: ResponseOutcome;
     finishReason: FinishReason | undefined;
-    hasTextResponse: boolean;
-    hasThinkingResponse: boolean;
     allChunks: GenerateContentResponse[];
   } {
     return {
       modelResponseParts: [],
-      hasToolCall: false,
+      outcome: {
+        hasVisibleText: false,
+        hasThinking: false,
+        hasToolCalls: false,
+        isActionable: false,
+      },
       finishReason: undefined,
-      hasTextResponse: false,
-      hasThinkingResponse: false,
       allChunks: [],
     };
   }
@@ -786,10 +788,8 @@ export class StreamProcessor {
     chunk: GenerateContentResponse,
     acc: {
       modelResponseParts: Part[];
-      hasToolCall: boolean;
+      outcome: ResponseOutcome;
       finishReason: FinishReason | undefined;
-      hasTextResponse: boolean;
-      hasThinkingResponse: boolean;
       allChunks: GenerateContentResponse[];
     },
     includeThoughts: boolean,
@@ -803,22 +803,14 @@ export class StreamProcessor {
     if (isValidResponse(chunk)) {
       const parts = chunk.candidates?.[0]?.content?.parts;
       if (parts !== undefined) {
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (parts.some((p) => p.functionCall !== undefined))
-          acc.hasToolCall = true;
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (
-          parts.some(
-            (p) =>
-              p.text !== undefined &&
-              typeof p.text === 'string' &&
-              p.text.trim() !== '' &&
-              !isThoughtPart(p),
-          )
-        )
-          acc.hasTextResponse = true;
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (parts.some((p) => isThoughtPart(p))) acc.hasThinkingResponse = true;
+        const chunkOutcome = analyzeResponseOutcome(parts);
+        acc.outcome = {
+          hasVisibleText:
+            acc.outcome.hasVisibleText || chunkOutcome.hasVisibleText,
+          hasThinking: acc.outcome.hasThinking || chunkOutcome.hasThinking,
+          hasToolCalls: acc.outcome.hasToolCalls || chunkOutcome.hasToolCalls,
+          isActionable: acc.outcome.isActionable || chunkOutcome.isActionable,
+        };
         acc.modelResponseParts.push(
           ...(includeThoughts
             ? parts
@@ -849,10 +841,8 @@ export class StreamProcessor {
   private async _finalizeStreamProcessing(
     acc: {
       modelResponseParts: Part[];
-      hasToolCall: boolean;
+      outcome: ResponseOutcome;
       finishReason: FinishReason | undefined;
-      hasTextResponse: boolean;
-      hasThinkingResponse: boolean;
       allChunks: GenerateContentResponse[];
     },
     userInput: Content | Content[],
@@ -865,16 +855,16 @@ export class StreamProcessor {
     if (isMissingFinishReason(acc.finishReason)) {
       this.logger.debug(
         () =>
-          `[stream:terminal] stream ended without finishReason (hasToolCall=${String(acc.hasToolCall)}, hasTextResponse=${String(acc.hasTextResponse)}, hasThinkingResponse=${String(acc.hasThinkingResponse)}, responseTextLength=${responseText.length})`,
+          `[stream:terminal] stream ended without finishReason (hasToolCall=${String(acc.outcome.hasToolCalls)}, hasTextResponse=${String(acc.outcome.hasVisibleText)}, hasThinkingResponse=${String(acc.outcome.hasThinking)}, responseTextLength=${responseText.length})`,
       );
     } else {
       this.logger.debug(
         () => `[stream:terminal] finalized stream with finishReason`,
         {
           finishReason: acc.finishReason,
-          hasToolCall: acc.hasToolCall,
-          hasTextResponse: acc.hasTextResponse,
-          hasThinkingResponse: acc.hasThinkingResponse,
+          hasToolCall: acc.outcome.hasToolCalls,
+          hasTextResponse: acc.outcome.hasVisibleText,
+          hasThinkingResponse: acc.outcome.hasThinking,
           responseTextLength: responseText.length,
           chunkCount: acc.allChunks.length,
         },
@@ -883,9 +873,7 @@ export class StreamProcessor {
 
     this._validateStreamCompletion(
       userInput,
-      acc.hasToolCall,
-      acc.hasTextResponse,
-      acc.hasThinkingResponse,
+      acc.outcome,
       acc.finishReason,
       responseText,
     );
@@ -934,9 +922,7 @@ export class StreamProcessor {
    */
   private _validateStreamCompletion(
     userInput: Content | Content[],
-    hasToolCall: boolean,
-    hasTextResponse: boolean,
-    hasThinkingResponse: boolean,
+    outcome: ResponseOutcome,
     finishReason: FinishReason | undefined,
     responseText: string,
   ): void {
@@ -945,9 +931,9 @@ export class StreamProcessor {
       : isFunctionResponse(userInput);
 
     const validationContext = {
-      hasToolCall,
-      hasTextResponse,
-      hasThinkingResponse,
+      hasToolCall: outcome.hasToolCalls,
+      hasTextResponse: outcome.hasVisibleText,
+      hasThinkingResponse: outcome.hasThinking,
       finishReason,
       responseTextLength: responseText.length,
       isToolContinuationInput,
@@ -959,17 +945,17 @@ export class StreamProcessor {
     );
 
     const hasMissingFinishAndNoText =
-      isMissingFinishReason(finishReason) && !hasTextResponse;
+      isMissingFinishReason(finishReason) && !outcome.hasVisibleText;
     const isEmptyResponse = responseText === '';
     const noRelevantContent =
-      !hasToolCall && !isToolContinuationInput && !hasThinkingResponse;
+      !outcome.hasToolCalls && !isToolContinuationInput && !outcome.hasThinking;
     const isInvalidResponse =
       noRelevantContent && (hasMissingFinishAndNoText || isEmptyResponse);
 
     if (isInvalidResponse) {
       this._throwMissingResponseError(
         finishReason,
-        hasTextResponse,
+        outcome.hasVisibleText,
         validationContext,
       );
     }

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -11,6 +11,7 @@ import type {
   ServerGeminiToolCallRequestEvent,
   ServerGeminiErrorEvent,
   ServerGeminiStreamEvent,
+  ServerGeminiFinishedEvent,
 } from './turn.js';
 import { Turn, GeminiEventType, DEFAULT_AGENT_ID } from './turn.js';
 import type {
@@ -51,7 +52,37 @@ vi.mock('../utils/generateContentResponseUtilities', () => ({
       .map((part) => part.text)
       .join('') ?? undefined,
   getFunctionCalls: (resp: GenerateContentResponse) => resp.functionCalls ?? [],
+  analyzeResponseOutcome: (parts: Part[]) => {
+    let hasVisibleText = false;
+    let hasThinking = false;
+    let hasToolCalls = false;
+    for (const part of parts) {
+      const isThinking = (part as { thought?: boolean }).thought === true;
+      if (isThinking) hasThinking = true;
+      if (part.functionCall !== undefined) hasToolCalls = true;
+      if (
+        !isThinking &&
+        typeof part.text === 'string' &&
+        part.text.trim() !== ''
+      )
+        hasVisibleText = true;
+    }
+    return {
+      hasVisibleText,
+      hasThinking,
+      hasToolCalls,
+      isActionable: hasVisibleText || hasToolCalls,
+    };
+  },
 }));
+
+const findFinishedEvent = (
+  events: ServerGeminiStreamEvent[],
+): ServerGeminiFinishedEvent | undefined =>
+  events.find(
+    (event): event is ServerGeminiFinishedEvent =>
+      event.type === GeminiEventType.Finished,
+  );
 
 describe('Turn', () => {
   let turn: Turn;
@@ -576,6 +607,11 @@ describe('Turn', () => {
               thoughtsTokenCount: 5,
               toolUsePromptTokenCount: 2,
             },
+            outcome: {
+              hadVisibleOutput: true,
+              hadThinking: false,
+              hadToolCalls: false,
+            },
           },
         },
       ]);
@@ -618,7 +654,15 @@ describe('Turn', () => {
         },
         {
           type: GeminiEventType.Finished,
-          value: { reason: 'MAX_TOKENS', usageMetadata: undefined },
+          value: {
+            reason: 'MAX_TOKENS',
+            usageMetadata: undefined,
+            outcome: {
+              hadVisibleOutput: true,
+              hadThinking: false,
+              hadToolCalls: false,
+            },
+          },
         },
       ]);
     });
@@ -656,7 +700,15 @@ describe('Turn', () => {
         },
         {
           type: GeminiEventType.Finished,
-          value: { reason: 'SAFETY', usageMetadata: undefined },
+          value: {
+            reason: 'SAFETY',
+            usageMetadata: undefined,
+            outcome: {
+              hadVisibleOutput: true,
+              hadThinking: false,
+              hadToolCalls: false,
+            },
+          },
         },
       ]);
     });
@@ -747,7 +799,15 @@ describe('Turn', () => {
         },
         {
           type: GeminiEventType.Finished,
-          value: { reason: 'OTHER', usageMetadata: undefined },
+          value: {
+            reason: 'OTHER',
+            usageMetadata: undefined,
+            outcome: {
+              hadVisibleOutput: true,
+              hadThinking: false,
+              hadToolCalls: false,
+            },
+          },
         },
       ]);
     });
@@ -1069,6 +1129,323 @@ describe('Turn', () => {
         // consume stream
       }
       expect(turn.getDebugResponses()).toStrictEqual([resp1, resp2]);
+    });
+    describe('Finished event outcome', () => {
+      it('should include outcome with hadVisibleOutput true for text-only response', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: { parts: [{ text: 'Hello world' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: true,
+          hadThinking: false,
+          hadToolCalls: false,
+        });
+      });
+
+      it('should include outcome with hadThinking true for thinking-only response', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    parts: [{ text: 'internal reasoning', thought: true }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Think about it' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: false,
+          hadThinking: true,
+          hadToolCalls: false,
+        });
+      });
+
+      it('should include outcome with hadToolCalls true for tool-call response', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    parts: [
+                      {
+                        functionCall: {
+                          name: 'read_file',
+                          args: { path: '/tmp/x' },
+                        },
+                      },
+                    ],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Read a file' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: false,
+          hadThinking: false,
+          hadToolCalls: true,
+        });
+      });
+
+      it('should include cumulative visible-output outcome when finish reason is in a later chunk', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [{ content: { parts: [{ text: 'Hello world' }] } }],
+            } as GenerateContentResponse,
+          };
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [{ content: { parts: [] }, finishReason: 'STOP' }],
+            } as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: true,
+          hadThinking: false,
+          hadToolCalls: false,
+        });
+      });
+
+      it('should include cumulative thinking outcome when finish reason is in a later chunk', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    parts: [{ text: 'internal reasoning', thought: true }],
+                  },
+                },
+              ],
+            } as unknown as GenerateContentResponse,
+          };
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [{ content: { parts: [] }, finishReason: 'STOP' }],
+            } as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Think about it' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: false,
+          hadThinking: true,
+          hadToolCalls: false,
+        });
+      });
+
+      it('should include cumulative tool-call outcome when finish reason is in a later chunk', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    parts: [
+                      {
+                        functionCall: {
+                          name: 'read_file',
+                          args: { path: '/tmp/x' },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            } as unknown as GenerateContentResponse,
+          };
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [{ content: { parts: [] }, finishReason: 'STOP' }],
+            } as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Read a file' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: false,
+          hadThinking: false,
+          hadToolCalls: true,
+        });
+      });
+
+      it('should reset cumulative outcome after retry events', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                { content: { parts: [{ text: 'discarded text' }] } },
+              ],
+            } as GenerateContentResponse,
+          };
+          yield { type: StreamEventType.RETRY };
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: {
+                    parts: [{ text: 'internal reasoning', thought: true }],
+                  },
+                },
+              ],
+            } as unknown as GenerateContentResponse,
+          };
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [{ content: { parts: [] }, finishReason: 'STOP' }],
+            } as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Think about it' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: false,
+          hadThinking: true,
+          hadToolCalls: false,
+        });
+      });
+
+      it('should not emit content for whitespace-only text', async () => {
+        const mockResponseStream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: {
+              candidates: [
+                {
+                  content: { parts: [{ text: '   ' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as GenerateContentResponse,
+          };
+        })();
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        const events: ServerGeminiStreamEvent[] = [];
+        for await (const event of turn.run(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+        )) {
+          events.push(event);
+        }
+
+        expect(
+          events.some((event) => event.type === GeminiEventType.Content),
+        ).toBe(false);
+        const finishedEvent = findFinishedEvent(events);
+        expect(finishedEvent).toBeDefined();
+        expect(finishedEvent?.value.outcome).toStrictEqual({
+          hadVisibleOutput: false,
+          hadThinking: false,
+          hadToolCalls: false,
+        });
+      });
     });
   });
 

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -26,6 +26,8 @@ import type { ToolErrorType } from '../tools/tool-error.js';
 import {
   getResponseText,
   getFunctionCalls,
+  analyzeResponseOutcome,
+  type ResponseOutcome,
 } from '../utils/generateContentResponseUtilities.js';
 import { reportError } from '../utils/errorReporting.js';
 import {
@@ -262,11 +264,18 @@ export type ServerGeminiMaxSessionTurnsEvent = {
   type: GeminiEventType.MaxSessionTurns;
 };
 
+export type ServerGeminiFinishedOutcome = {
+  hadVisibleOutput: boolean;
+  hadThinking: boolean;
+  hadToolCalls: boolean;
+};
+
 export type ServerGeminiFinishedEvent = {
   type: GeminiEventType.Finished;
   value: {
     reason: FinishReason;
     usageMetadata?: GenerateContentResponseUsageMetadata;
+    outcome?: ServerGeminiFinishedOutcome;
   };
 };
 
@@ -394,7 +403,9 @@ export class Turn {
     text: string | undefined,
     usageMetadata: GenerateContentResponseUsageMetadata | undefined,
     traceId: string | undefined,
+    cumulativeOutcome: ResponseOutcome,
   ): Generator<ServerGeminiStreamEvent> {
+    const outcome = cumulativeOutcome;
     this.logger.debug(() => `[stream:turn] emitting Finished event`, {
       finishReason,
       traceId,
@@ -402,6 +413,7 @@ export class Turn {
       toolCallCount: functionCalls.length,
       textLength: text?.length ?? 0,
       hasUsageMetadata: Boolean(usageMetadata),
+      outcome,
     });
     this.finishReason = finishReason;
     yield {
@@ -409,6 +421,11 @@ export class Turn {
       value: {
         reason: finishReason,
         usageMetadata,
+        outcome: {
+          hadVisibleOutput: outcome.hasVisibleText,
+          hadThinking: outcome.hasThinking,
+          hadToolCalls: outcome.hasToolCalls,
+        },
       },
     };
   }
@@ -432,6 +449,7 @@ export class Turn {
   private *processStreamChunk(
     resp: GenerateContentResponse,
     traceId: string | undefined,
+    cumulativeOutcome: ResponseOutcome,
   ): Generator<ServerGeminiStreamEvent> {
     this.debugResponses.push(resp);
 
@@ -452,8 +470,9 @@ export class Turn {
       }
     }
 
+    const chunkOutcome = analyzeResponseOutcome(allParts);
     const text = getResponseText(resp);
-    if (text) {
+    if (chunkOutcome.hasVisibleText && text !== undefined) {
       yield { type: GeminiEventType.Content, value: text, traceId };
 
       // Emit citation event if conditions are met
@@ -487,6 +506,7 @@ export class Turn {
         text,
         resp.usageMetadata,
         traceId,
+        cumulativeOutcome,
       );
     } else {
       this.logNoFinishReason(
@@ -499,6 +519,15 @@ export class Turn {
     }
   }
 
+  private createEmptyResponseOutcome(): ResponseOutcome {
+    return {
+      hasVisibleText: false,
+      hasThinking: false,
+      hasToolCalls: false,
+      isActionable: false,
+    };
+  }
+
   private async *consumeStreamEvents(
     streamIterator: AsyncIterator<StreamEvent>,
     timeoutController: AbortController,
@@ -506,6 +535,7 @@ export class Turn {
     effectiveTimeoutMs: number,
     idleFlag: { timedOut: boolean },
   ): AsyncGenerator<ServerGeminiStreamEvent> {
+    let cumulativeOutcome = this.createEmptyResponseOutcome();
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/too-many-break-or-continue-in-loop -- Turn events cross provider/runtime boundaries despite declared types.
     while (true) {
       // Use watchdog if timeout > 0, otherwise call iterator.next() directly
@@ -542,6 +572,7 @@ export class Turn {
 
       // Handle the RETRY event
       if (streamEvent.type === StreamEventType.RETRY) {
+        cumulativeOutcome = this.createEmptyResponseOutcome();
         yield { type: GeminiEventType.Retry };
         continue;
       }
@@ -573,8 +604,24 @@ export class Turn {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Turn events cross provider/runtime boundaries despite declared types.
       if (resp === null || resp === undefined) continue;
 
+      const parts = resp.candidates?.[0]?.content?.parts ?? [];
+      const chunkOutcome = analyzeResponseOutcome(parts);
+      cumulativeOutcome = {
+        hasVisibleText:
+          cumulativeOutcome.hasVisibleText || chunkOutcome.hasVisibleText,
+        hasThinking: cumulativeOutcome.hasThinking || chunkOutcome.hasThinking,
+        hasToolCalls:
+          cumulativeOutcome.hasToolCalls || chunkOutcome.hasToolCalls,
+        isActionable:
+          cumulativeOutcome.isActionable || chunkOutcome.isActionable,
+      };
+
       const traceId = resp.responseId ?? undefined;
-      yield* this.processStreamChunk(resp, traceId as string);
+      yield* this.processStreamChunk(
+        resp,
+        traceId as string,
+        cumulativeOutcome,
+      );
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,6 +135,8 @@ export {
   convertToFunctionResponse,
   extractAgentIdFromMetadata,
   createErrorResponse,
+  analyzeResponseOutcome,
+  type ResponseOutcome,
 } from './utils/generateContentResponseUtilities.js';
 export * from './utils/filesearch/fileSearch.js';
 export * from './utils/secure-browser-launcher.js';

--- a/packages/core/src/utils/generateContentResponseUtilities.test.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.test.ts
@@ -19,6 +19,7 @@ import {
   limitFunctionResponsePart,
   limitStringOutput,
   toParts,
+  analyzeResponseOutcome,
 } from './generateContentResponseUtilities.js';
 import type {
   GenerateContentResponse,
@@ -74,6 +75,102 @@ const minimalMockResponse = (
 });
 
 describe('generateContentResponseUtilities', () => {
+  describe('analyzeResponseOutcome', () => {
+    it('should detect visible text', () => {
+      const outcome = analyzeResponseOutcome([{ text: 'Hello' }]);
+      expect(outcome).toStrictEqual({
+        hasVisibleText: true,
+        hasThinking: false,
+        hasToolCalls: false,
+        isActionable: true,
+      });
+    });
+
+    it('should treat whitespace-only text as not visible', () => {
+      const outcome = analyzeResponseOutcome([{ text: '   ' }]);
+      expect(outcome).toStrictEqual({
+        hasVisibleText: false,
+        hasThinking: false,
+        hasToolCalls: false,
+        isActionable: false,
+      });
+    });
+
+    it('should detect thought parts as thinking only', () => {
+      const outcome = analyzeResponseOutcome([
+        { text: 'thinking...', thought: true },
+      ]);
+      expect(outcome).toStrictEqual({
+        hasVisibleText: false,
+        hasThinking: true,
+        hasToolCalls: false,
+        isActionable: false,
+      });
+    });
+
+    it('should detect tool calls', () => {
+      const outcome = analyzeResponseOutcome([
+        { functionCall: { name: 'testFunc', args: {} } },
+      ]);
+      expect(outcome).toStrictEqual({
+        hasVisibleText: false,
+        hasThinking: false,
+        hasToolCalls: true,
+        isActionable: true,
+      });
+    });
+
+    it('should detect mixed parts', () => {
+      const outcome = analyzeResponseOutcome([
+        { text: 'Hello' },
+        { text: 'thinking...', thought: true },
+        { functionCall: { name: 'func', args: {} } },
+      ]);
+      expect(outcome).toStrictEqual({
+        hasVisibleText: true,
+        hasThinking: true,
+        hasToolCalls: true,
+        isActionable: true,
+      });
+    });
+
+    it('should return all false for empty parts', () => {
+      const outcome = analyzeResponseOutcome([]);
+      expect(outcome).toStrictEqual({
+        hasVisibleText: false,
+        hasThinking: false,
+        hasToolCalls: false,
+        isActionable: false,
+      });
+    });
+
+    it('should not count thought text as visible text', () => {
+      const outcome = analyzeResponseOutcome([
+        { text: 'thinking only', thought: true },
+        { text: '' },
+      ]);
+      expect(outcome.hasVisibleText).toBe(false);
+      expect(outcome.hasThinking).toBe(true);
+      expect(outcome.isActionable).toBe(false);
+    });
+
+    it('should detect tool calls independently from thought status', () => {
+      const outcome = analyzeResponseOutcome([
+        {
+          text: 'thinking while calling',
+          thought: true,
+          functionCall: { name: 'testFunc', args: {} },
+        },
+      ]);
+      expect(outcome).toStrictEqual({
+        hasVisibleText: false,
+        hasThinking: true,
+        hasToolCalls: true,
+        isActionable: true,
+      });
+    });
+  });
+
   describe('getResponseText', () => {
     it('should return undefined for no candidates', () => {
       expect(getResponseText(minimalMockResponse(undefined))).toBeUndefined();
@@ -111,6 +208,20 @@ describe('generateContentResponseUtilities', () => {
       ]);
       expect(getResponseText(response)).toBeUndefined();
     });
+    it('should filter out thought parts using canonical isThoughtPart', () => {
+      const response = mockResponse([
+        { text: 'thinking...', thought: true } as Part,
+        mockTextPart('visible'),
+        { text: 'more thinking', thought: true } as Part,
+      ]);
+      expect(getResponseText(response)).toBe('visible');
+    });
+    it('should return undefined when only thought parts exist', () => {
+      const response = mockResponse([
+        { text: 'thinking...', thought: true } as Part,
+      ]);
+      expect(getResponseText(response)).toBeUndefined();
+    });
   });
 
   describe('getResponseTextFromParts', () => {
@@ -142,6 +253,22 @@ describe('generateContentResponseUtilities', () => {
         getResponseTextFromParts([
           mockFunctionCallPart('testFunc'),
           mockFunctionCallPart('anotherFunc'),
+        ]),
+      ).toBeUndefined();
+    });
+    it('should filter out thought parts using canonical isThoughtPart', () => {
+      expect(
+        getResponseTextFromParts([
+          { text: 'thinking...', thought: true } as Part,
+          mockTextPart('visible'),
+          { text: 'more thinking', thought: true } as Part,
+        ]),
+      ).toBe('visible');
+    });
+    it('should return undefined when only thought parts exist', () => {
+      expect(
+        getResponseTextFromParts([
+          { text: 'thinking...', thought: true } as Part,
         ]),
       ).toBeUndefined();
     });

--- a/packages/core/src/utils/generateContentResponseUtilities.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.ts
@@ -20,7 +20,56 @@ import {
   type ToolCallResponseInfo,
 } from '../index.js';
 import { DEFAULT_AGENT_ID } from '../core/turn.js';
+import { isThoughtPart } from '../core/geminiChatTypes.js';
 import { DebugLogger } from '../debug/index.js';
+
+/**
+ * Canonical outcome of a model response, derived from its parts.
+ * Single source of truth for whether a response produced visible text,
+ * thinking content, tool calls, or any actionable output.
+ */
+export interface ResponseOutcome {
+  hasVisibleText: boolean;
+  hasThinking: boolean;
+  hasToolCalls: boolean;
+  isActionable: boolean;
+}
+
+/**
+ * Analyze response parts to determine the canonical outcome.
+ * This is the single authoritative function for detecting visible text,
+ * thinking content, and tool calls — eliminating ad-hoc duplication
+ * across StreamProcessor, turn.ts, MessageConverter, and client.ts.
+ */
+export function analyzeResponseOutcome(parts: Part[]): ResponseOutcome {
+  let hasVisibleText = false;
+  let hasThinking = false;
+  let hasToolCalls = false;
+
+  for (const part of parts) {
+    const isThinking = isThoughtPart(part);
+    if (isThinking) {
+      hasThinking = true;
+    }
+    if (part.functionCall !== undefined) {
+      hasToolCalls = true;
+    }
+    if (
+      !isThinking &&
+      typeof part.text === 'string' &&
+      part.text.trim() !== ''
+    ) {
+      hasVisibleText = true;
+    }
+  }
+
+  return {
+    hasVisibleText,
+    hasThinking,
+    hasToolCalls,
+    isActionable: hasVisibleText || hasToolCalls,
+  };
+}
 
 const toolSchedulerLogger = new DebugLogger('llxprt:core:tool-scheduler');
 
@@ -31,25 +80,16 @@ export function getResponseText(
   if (!parts) {
     return undefined;
   }
-
-  // Filter out thought parts - thinking content should only go through Thought events,
-  // not be duplicated in Content events. Model context path handles thinking separately
-  // via IContent blocks and reasoning ephemerals. (fixes #721 duplicate thinking)
-  const textSegments = parts
-    .filter((part) => (part as { thought?: boolean }).thought !== true)
-    .map((part) => part.text)
-    .filter((text): text is string => typeof text === 'string');
-
-  if (textSegments.length === 0) {
-    return undefined;
-  }
-  return textSegments.join('');
+  return getResponseTextFromParts(parts);
 }
 
 export function getResponseTextFromParts(parts: Part[]): string | undefined {
-  // Filter out thought parts - same as getResponseText (fixes #721)
+  // Filter out thought parts - thinking content should only go through Thought events,
+  // not be duplicated in Content events. Model context path handles thinking separately
+  // via IContent blocks and reasoning ephemerals. Uses canonical isThoughtPart
+  // from geminiChatTypes for consistent filtering. (fixes #721, #1730)
   const textSegments = parts
-    .filter((part) => (part as { thought?: boolean }).thought !== true)
+    .filter((part) => !isThoughtPart(part))
     .map((part) => part.text)
     .filter((text): text is string => typeof text === 'string');
 


### PR DESCRIPTION
## TLDR

Centralizes response outcome detection so visible output, thinking, and tool calls are classified consistently across streaming layers. Finished events now carry semantic outcome metadata that reflects the whole turn, including split streaming chunks and retry boundaries.

## Dive Deeper

This adds a canonical response outcome helper in the core response utilities and routes existing visible-output decisions through it where this issue identified duplicated logic.

Key changes:

- Adds analyzeResponseOutcome and ResponseOutcome for canonical hasVisibleText, hasThinking, hasToolCalls, and isActionable classification.
- Refactors response text extraction and IContent conversion to use shared thought filtering semantics.
- Updates StreamProcessor validation to use the canonical outcome instead of ad hoc text/thinking/tool booleans.
- Adds Finished event outcome metadata with hadVisibleOutput, hadThinking, and hadToolCalls.
- Accumulates Turn outcome across streamed chunks so a terminal finish-reason-only chunk still reports earlier visible text, thinking, or tool calls correctly.
- Resets the cumulative Turn outcome when a provider retry event occurs so discarded partial attempts do not leak into the final semantic outcome.
- Updates MessageStreamOrchestrator to prefer Finished outcome metadata while retaining fallback to legacy event flags when outcome is unavailable.

Anthropic terminal metadata buffering was intentionally not changed. The current stop-reason mapping path already handles the immediate fragility without introducing provider-stream buffering or extra latency risk.

## Reviewer Test Plan

Recommended review focus:

1. Inspect packages/core/src/utils/generateContentResponseUtilities.ts for canonical outcome semantics.
2. Inspect packages/core/src/core/turn.ts to verify Finished outcome is cumulative across streamed chunks and reset across retry events.
3. Inspect packages/core/src/core/MessageStreamOrchestrator.ts to verify outcome metadata is preferred with backwards-compatible fallback.
4. Run focused tests:

    cd packages/core
    npm test -- turn.test.ts generateContentResponseUtilities.test.ts

5. Run the full repository verification commands listed below.

Verification run locally:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      |   |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

## Linked issues / bugs

Fixes #1730
