### PR TITLE
fix(core): Centralize Anthropic OAuth token classification (Fixes #276)

### DIFF
--- a/packages/core/src/providers/BaseProvider.ts
+++ b/packages/core/src/providers/BaseProvider.ts
@@ -409,6 +409,18 @@ export abstract class BaseProvider implements IProvider {
   protected abstract supportsOAuth(): boolean;
 
   /**
+   * Classify whether a given auth token is an OAuth token.
+   * Default implementation always returns false; providers that support
+   * token-prefix-based OAuth detection (e.g., Anthropic) should override.
+   *
+   * @param _authToken - The resolved auth token string
+   * @returns true if the token should be treated as an OAuth token
+   */
+  protected classifyOAuthToken(_authToken: string): boolean {
+    return false;
+  }
+
+  /**
    * @plan PLAN-20251018-STATELESSPROVIDER2.P06
    * @requirement REQ-SP2-001
    * @pseudocode base-provider-call-contract.md lines 1-3

--- a/packages/core/src/providers/anthropic/AnthropicProvider.issue276.test.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.issue276.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Tests for issue #276: AnthropicProvider OAuth token behavior through public APIs
+ *
+ * Verifies that AnthropicProvider behaves correctly with OAuth tokens vs API keys
+ * through public APIs only (getModels, generateChatCompletion).
+ * OAuth tokens (sk-ant-oat*) trigger: hardcoded model list, tool name prefixing,
+ * OAuth beta headers, SDK authToken construction. API keys trigger: API-fetched
+ * models, no tool prefixing, no OAuth headers, SDK apiKey construction.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AnthropicProvider } from './AnthropicProvider.js';
+import type { IContent } from '../../services/history/IContent.js';
+import { TEST_PROVIDER_CONFIG } from '../test-utils/providerTestConfig.js';
+import {
+  createProviderWithRuntime,
+  createRuntimeConfigStub,
+} from '../../test-utils/runtime.js';
+import {
+  createProviderCallOptions,
+  type ProviderCallOptionsInit,
+} from '../../test-utils/providerCallOptions.js';
+import type { ProviderRuntimeContext } from '../../runtime/providerRuntimeContext.js';
+import type { SettingsService } from '../../settings/SettingsService.js';
+import {
+  clearActiveProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '../../runtime/providerRuntimeContext.js';
+import { OAUTH_MODELS } from './AnthropicModelData.js';
+
+vi.mock('../../tools/ToolFormatter.js', () => ({
+  ToolFormatter: vi.fn().mockImplementation(() => ({
+    toProviderFormat: vi.fn((tools: unknown[]) => tools),
+    fromProviderFormat: vi.fn((rawToolCall: unknown) => [rawToolCall]),
+    convertGeminiToAnthropic: vi.fn(() => []),
+    convertGeminiToFormat: vi.fn(() => undefined),
+  })),
+}));
+
+vi.mock('../../core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn(
+    async () => "You are Claude Code, Anthropic's official CLI for Claude.",
+  ),
+}));
+
+vi.mock('../../utils/retry.js', () => ({
+  getErrorStatus: vi.fn(() => undefined),
+  isNetworkTransientError: vi.fn(() => false),
+}));
+
+/**
+ * Track Anthropic SDK constructor calls so we can assert on authToken vs apiKey
+ * without touching protected methods or using type assertions.
+ */
+const sdkConstructorCalls: Array<Record<string, unknown>> = [];
+
+const mockBetaModelsList = vi.fn();
+
+const mockMessagesCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation((opts: Record<string, unknown>) => {
+    sdkConstructorCalls.push({ ...opts });
+    return {
+      _options: opts,
+      messages: {
+        create: mockMessagesCreate,
+      },
+      beta: {
+        models: {
+          list: mockBetaModelsList,
+        },
+      },
+    };
+  }),
+}));
+
+/** Create a non-streaming response from Anthropic SDK */
+function nonStreamingResponse(text = 'response') {
+  return {
+    content: [{ type: 'text', text }],
+    usage: { input_tokens: 10, output_tokens: 5 },
+  };
+}
+
+function toStringRecord(value: unknown): Record<string, string> | undefined {
+  if (value === null || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const entries = Object.entries(value);
+  if (entries.every(([, entryValue]) => typeof entryValue === 'string')) {
+    return Object.fromEntries(entries);
+  }
+
+  return undefined;
+}
+
+function lastSdkConstructorOptions(): {
+  authToken?: string;
+  apiKey?: string;
+  defaultHeaders?: Record<string, string>;
+  dangerouslyAllowBrowser?: boolean;
+} {
+  const last = sdkConstructorCalls[sdkConstructorCalls.length - 1];
+  return {
+    authToken: typeof last.authToken === 'string' ? last.authToken : undefined,
+    apiKey: typeof last.apiKey === 'string' ? last.apiKey : undefined,
+    defaultHeaders: toStringRecord(last.defaultHeaders),
+    dangerouslyAllowBrowser:
+      typeof last.dangerouslyAllowBrowser === 'boolean'
+        ? last.dangerouslyAllowBrowser
+        : undefined,
+  };
+}
+
+function resetSdkTracking() {
+  sdkConstructorCalls.length = 0;
+}
+
+describe('Issue #276: OAuth token behavior through public APIs', () => {
+  let runtimeContext: ProviderRuntimeContext;
+  let settingsService: SettingsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSdkTracking();
+    mockBetaModelsList.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          id: 'claude-sonnet-4-5-20250929',
+          display_name: 'Claude Sonnet 4.5',
+        };
+      },
+    });
+
+    const result = createProviderWithRuntime<AnthropicProvider>(
+      ({ settingsService: svc }) => {
+        svc.set('auth-key', 'test-api-key');
+        svc.set('activeProvider', 'anthropic');
+        svc.setProviderSetting('anthropic', 'streaming', 'disabled');
+        return new AnthropicProvider(
+          'test-api-key',
+          undefined,
+          TEST_PROVIDER_CONFIG,
+        );
+      },
+      {
+        runtimeId: 'anthropic.issue276.test',
+        metadata: { source: 'AnthropicProvider.issue276.test.ts' },
+      },
+    );
+
+    runtimeContext = result.runtime;
+    settingsService = result.settingsService;
+    runtimeContext.config ??= createRuntimeConfigStub(settingsService);
+    runtimeContext.config.getEphemeralSettings = () => ({
+      ...settingsService.getAllGlobalSettings(),
+      ...settingsService.getProviderSettings('anthropic'),
+    });
+
+    setActiveProviderRuntimeContext(runtimeContext);
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  const buildCallOptions = (
+    contents: IContent[],
+    overrides: Omit<ProviderCallOptionsInit, 'providerName' | 'contents'> = {},
+  ) =>
+    createProviderCallOptions({
+      providerName: 'anthropic',
+      contents,
+      settings: settingsService,
+      runtime: runtimeContext,
+      config: runtimeContext.config,
+      ...overrides,
+    });
+
+  describe('getModels: OAuth token returns hardcoded model list', () => {
+    it('returns the OAUTH_MODELS list when authenticated with an OAuth token', async () => {
+      const oauthProvider = new AnthropicProvider(
+        'sk-ant-oat-test-token',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      const models = await oauthProvider.getModels();
+
+      const oauthModelIds = OAUTH_MODELS.map((m) => m.id);
+      const returnedModelIds = models.map((m) => m.id);
+      expect(returnedModelIds).toStrictEqual(oauthModelIds);
+      models.forEach((model) => {
+        expect(model.provider).toBe('anthropic');
+      });
+    });
+
+    it('does not call client.beta.models.list when using an OAuth token', async () => {
+      const oauthProvider = new AnthropicProvider(
+        'sk-ant-oat-test-token',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      await oauthProvider.getModels();
+
+      expect(mockBetaModelsList).not.toHaveBeenCalled();
+    });
+
+    it('fetches models from the API when authenticated with a regular API key', async () => {
+      const apiProvider = new AnthropicProvider(
+        'test-api-key',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      const models = await apiProvider.getModels();
+
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.some((m) => m.id === 'claude-sonnet-4-5-20250929')).toBe(
+        true,
+      );
+      const oauthModelIds = OAUTH_MODELS.map((m) => m.id);
+      const returnedModelIds = models.map((m) => m.id);
+
+      expect(returnedModelIds).not.toStrictEqual(oauthModelIds);
+    });
+
+    it('calls client.beta.models.list when using a regular API key', async () => {
+      const apiProvider = new AnthropicProvider(
+        'test-api-key',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      await apiProvider.getModels();
+
+      expect(mockBetaModelsList).toHaveBeenCalled();
+    });
+
+    it('returns default models with empty-string auth token when no auth is available', async () => {
+      const noAuthProvider = new AnthropicProvider(
+        '',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      const models = await noAuthProvider.getModels();
+      expect(models.length).toBeGreaterThan(0);
+      models.forEach((model) => {
+        expect(model.provider).toBe('anthropic');
+      });
+    });
+  });
+
+  describe('generateChatCompletion: SDK construction uses correct auth mode', () => {
+    it('constructs SDK with authToken and no apiKey for OAuth tokens, plus OAuth beta defaultHeaders', async () => {
+      const oauthProvider = new AnthropicProvider(
+        'sk-ant-oat-test-token',
+        undefined,
+        {
+          ...TEST_PROVIDER_CONFIG,
+          getEphemeralSettings: () => ({
+            streaming: 'disabled',
+          }),
+        },
+      );
+
+      const callOptions = buildCallOptions(
+        [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Test OAuth' }],
+          },
+        ],
+        {
+          resolved: {
+            authToken: 'sk-ant-oat-test-token',
+            model: 'claude-sonnet-4-5-20250929',
+          },
+        },
+      );
+
+      mockMessagesCreate.mockResolvedValueOnce(nonStreamingResponse());
+
+      const generator = oauthProvider.generateChatCompletion(callOptions);
+      await generator.next();
+
+      const sdkOpts = lastSdkConstructorOptions();
+      expect(sdkOpts.authToken).toBe('sk-ant-oat-test-token');
+      expect(sdkOpts.apiKey).toBeUndefined();
+
+      expect(sdkOpts.defaultHeaders).toBeDefined();
+      const betaHeader = sdkOpts.defaultHeaders?.['anthropic-beta'];
+      expect(typeof betaHeader === 'string').toBe(true);
+      expect(betaHeader).toContain('oauth-2025-04-20');
+    });
+
+    it('constructs SDK with apiKey and no authToken for regular API keys, without OAuth beta headers', async () => {
+      const apiProvider = new AnthropicProvider('test-api-key', undefined, {
+        ...TEST_PROVIDER_CONFIG,
+        getEphemeralSettings: () => ({
+          streaming: 'disabled',
+        }),
+      });
+
+      const callOptions = buildCallOptions(
+        [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Test API key' }],
+          },
+        ],
+        {
+          resolved: {
+            authToken: 'test-api-key',
+            model: 'claude-sonnet-4-5-20250929',
+          },
+        },
+      );
+
+      mockMessagesCreate.mockResolvedValueOnce(nonStreamingResponse());
+
+      const generator = apiProvider.generateChatCompletion(callOptions);
+      await generator.next();
+
+      const sdkOpts = lastSdkConstructorOptions();
+      expect(sdkOpts.apiKey).toBe('test-api-key');
+      expect(sdkOpts.authToken).toBeUndefined();
+
+      const betaHeader = sdkOpts.defaultHeaders?.['anthropic-beta'];
+      expect(
+        typeof betaHeader === 'string' &&
+          betaHeader.includes('oauth-2025-04-20'),
+      ).toBe(false);
+    });
+  });
+
+  describe('generateChatCompletion: OAuth token prefixes tool names', () => {
+    it('sends tool names prefixed with llxprt_ when using an OAuth token', async () => {
+      const oauthProvider = new AnthropicProvider(
+        'sk-ant-oat-test-token',
+        undefined,
+        {
+          ...TEST_PROVIDER_CONFIG,
+          getEphemeralSettings: () => ({
+            streaming: 'disabled',
+          }),
+        },
+      );
+
+      const callOptions = buildCallOptions(
+        [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Test' }],
+          },
+        ],
+        {
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: 'read_file',
+                  description: 'Read a file',
+                  parametersJsonSchema: { type: 'object', properties: {} },
+                },
+              ],
+            },
+          ],
+          resolved: {
+            authToken: 'sk-ant-oat-test-token',
+            model: 'claude-sonnet-4-5-20250929',
+          },
+        },
+      );
+
+      mockMessagesCreate.mockResolvedValueOnce(nonStreamingResponse());
+
+      const generator = oauthProvider.generateChatCompletion(callOptions);
+      await generator.next();
+
+      const call = mockMessagesCreate.mock.calls[0];
+      expect(call).toBeDefined();
+      const requestBody = call[0];
+      expect(requestBody.tools).toBeDefined();
+      expect(requestBody.tools[0].name).toBe('llxprt_read_file');
+    });
+
+    it('sends tool names without prefix when using a regular API key', async () => {
+      const apiProvider = new AnthropicProvider('test-api-key', undefined, {
+        ...TEST_PROVIDER_CONFIG,
+        getEphemeralSettings: () => ({
+          streaming: 'disabled',
+        }),
+      });
+
+      const callOptions = buildCallOptions(
+        [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Test' }],
+          },
+        ],
+        {
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: 'read_file',
+                  description: 'Read a file',
+                  parametersJsonSchema: { type: 'object', properties: {} },
+                },
+              ],
+            },
+          ],
+          resolved: {
+            authToken: 'test-api-key',
+            model: 'claude-sonnet-4-5-20250929',
+          },
+        },
+      );
+
+      mockMessagesCreate.mockResolvedValueOnce(nonStreamingResponse());
+
+      const generator = apiProvider.generateChatCompletion(callOptions);
+      await generator.next();
+
+      const call =
+        mockMessagesCreate.mock.calls[mockMessagesCreate.mock.calls.length - 1];
+      expect(call).toBeDefined();
+      const requestBody = call[0];
+      expect(requestBody.tools).toBeDefined();
+      expect(requestBody.tools[0].name).toBe('read_file');
+    });
+  });
+
+  describe('generateChatCompletion: OAuth token sets beta header in API call', () => {
+    it('includes oauth-2025-04-20 in anthropic-beta header for OAuth requests', async () => {
+      const oauthProvider = new AnthropicProvider(
+        'sk-ant-oat-test-token',
+        undefined,
+        {
+          ...TEST_PROVIDER_CONFIG,
+          getEphemeralSettings: () => ({
+            streaming: 'disabled',
+          }),
+        },
+      );
+
+      const callOptions = buildCallOptions(
+        [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Test' }],
+          },
+        ],
+        {
+          resolved: {
+            authToken: 'sk-ant-oat-test-token',
+            model: 'claude-sonnet-4-5-20250929',
+          },
+        },
+      );
+
+      mockMessagesCreate.mockResolvedValueOnce(nonStreamingResponse());
+
+      const generator = oauthProvider.generateChatCompletion(callOptions);
+      await generator.next();
+
+      const call = mockMessagesCreate.mock.calls[0];
+      const options = call[1];
+      expect(options?.headers).toBeDefined();
+      const headers = options.headers;
+      const betaHeader = headers['anthropic-beta'];
+      expect(
+        typeof betaHeader === 'string' &&
+          betaHeader.includes('oauth-2025-04-20'),
+      ).toBe(true);
+    });
+
+    it('does not include oauth-2025-04-20 in anthropic-beta header for API key requests', async () => {
+      const apiProvider = new AnthropicProvider('test-api-key', undefined, {
+        ...TEST_PROVIDER_CONFIG,
+        getEphemeralSettings: () => ({
+          streaming: 'disabled',
+        }),
+      });
+
+      settingsService.setProviderSetting('anthropic', 'prompt-caching', 'off');
+
+      const callOptions = buildCallOptions(
+        [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Test' }],
+          },
+        ],
+        {
+          resolved: {
+            authToken: 'test-api-key',
+            model: 'claude-sonnet-4-5-20250929',
+          },
+        },
+      );
+
+      mockMessagesCreate.mockResolvedValueOnce(nonStreamingResponse());
+
+      const generator = apiProvider.generateChatCompletion(callOptions);
+      await generator.next();
+
+      const call =
+        mockMessagesCreate.mock.calls[mockMessagesCreate.mock.calls.length - 1];
+      const allOptions = call[1];
+      const headers = allOptions?.headers;
+      const betaHeader = headers?.['anthropic-beta'];
+      const betaIncludesOAuth =
+        typeof betaHeader === 'string' &&
+        betaHeader.includes('oauth-2025-04-20');
+      expect(betaIncludesOAuth).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/providers/anthropic/AnthropicProvider.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.ts
@@ -85,6 +85,14 @@ export class AnthropicProvider extends BaseProvider {
     return true;
   }
 
+  /**
+   * Classify whether a given auth token is an Anthropic OAuth token.
+   * Anthropic OAuth tokens start with the 'sk-ant-oat' prefix.
+   */
+  protected override classifyOAuthToken(authToken: string): boolean {
+    return authToken.startsWith('sk-ant-oat');
+  }
+
   // @plan PLAN-20251023-STATELESS-HARDENING.P08
   // Create loggers on-demand to avoid instance state
   // @requirement REQ-SP4-002: Eliminate provider-level caching
@@ -117,7 +125,7 @@ export class AnthropicProvider extends BaseProvider {
   }
 
   private instantiateClient(authToken: string, baseURL?: string): Anthropic {
-    const isOAuthToken = authToken.startsWith('sk-ant-oat');
+    const isOAuthToken = this.classifyOAuthToken(authToken);
     const clientConfig: Record<string, unknown> = {
       dangerouslyAllowBrowser: true,
     };
@@ -237,7 +245,7 @@ export class AnthropicProvider extends BaseProvider {
     }
 
     // Check if using OAuth - the models.list endpoint doesn't work with OAuth tokens
-    const isOAuthToken = authToken.startsWith('sk-ant-oat');
+    const isOAuthToken = this.classifyOAuthToken(authToken);
 
     if (isOAuthToken) {
       // For OAuth, return only the working models
@@ -522,7 +530,7 @@ export class AnthropicProvider extends BaseProvider {
       options,
       options.resolved.telemetry,
     );
-    const isOAuth = authToken.startsWith('sk-ant-oat');
+    const isOAuth = this.classifyOAuthToken(authToken);
 
     const requestContext = await this.prepareRequestContext(options, isOAuth);
 


### PR DESCRIPTION
## TLDR

Centralizes Anthropic OAuth token classification through the BaseProvider hook and updates AnthropicProvider to use that hook for SDK construction, model listing, and generation behavior.

## Dive Deeper

This keeps the Anthropic-specific OAuth behavior that issue #276 identifies as necessary while removing repeated token-prefix checks from the provider flow.

Changes included:

- Added a protected BaseProvider token-classification hook that defaults to non-OAuth.
- Overrode the hook in AnthropicProvider for Anthropic OAuth tokens.
- Updated AnthropicProvider client construction, model listing, and generation paths to use the hook.
- Added behavioral issue #276 coverage through public APIs only:
  - OAuth tokens use SDK authToken configuration and OAuth beta headers.
  - API keys use SDK apiKey configuration and omit OAuth beta headers.
  - OAuth model listing returns hardcoded OAuth models.
  - API-key model listing fetches models through the Anthropic SDK.
  - OAuth generation prefixes tool names.
  - API-key generation does not prefix tool names.

The existing Anthropic usage-info token validation remains unchanged because it is a usage endpoint guard outside AnthropicProvider authentication/generation/model-listing flow scope.

## Reviewer Test Plan

Recommended validation:

1. Review AnthropicProvider and BaseProvider changes to confirm the only AnthropicProvider token-prefix check is in the centralized Anthropic override.
2. Run the focused core test from packages/core:

   npm run test -- AnthropicProvider.issue276.test.ts

3. Run the full verification suite listed below.
4. For manual behavior, exercise Anthropic with both OAuth and API-key auth and verify model listing and generation preserve their existing mode-specific behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load waferglm5 "write me a haiku and nothing else"

The smoke command exited 0. The selected smoke profile reported an external OpenAI 401 Invalid API key error, which is unrelated to AnthropicProvider issue #276.

## Linked issues / bugs

Fixes #276
