### PR TITLE
Fix subagent PromptConfig initialMessages contract (Fixes #1788)

### DIFF
--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -1002,14 +1002,13 @@ describe('subagent.ts', () => {
         );
       });
 
-      it('should use initialMessages instead of systemPrompt if provided', async () => {
+      it('should always start with empty chat history when using systemPrompt', async () => {
         const { config } = await createMockConfig();
         vi.mocked(GeminiChat).mockClear();
 
-        const initialMessages: Content[] = [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-        ];
-        const promptConfig: PromptConfig = { initialMessages };
+        const promptConfig: PromptConfig = {
+          systemPrompt: 'You are a subagent.',
+        };
         const context = new ContextState();
 
         // Model stops immediately
@@ -1030,14 +1029,36 @@ describe('subagent.ts', () => {
         await scope.runNonInteractive(context);
 
         const callArgs = vi.mocked(GeminiChat).mock.calls[0];
-        const generationConfig = getGenerationConfigFromMock();
         const history = callArgs[3];
 
-        const systemInstruction = generationConfig.systemInstruction as string;
-        // Environment context should now be in system instruction
-        expect(systemInstruction).toContain('Env Context');
-        // History should only contain initialMessages, not environment context
-        expect(history).toStrictEqual([...initialMessages]);
+        // GeminiChat constructor history is always empty;
+        // runtime initial messages are generated separately by buildInitialMessages
+        expect(history).toStrictEqual([]);
+      });
+
+      it('should reject with required error when PromptConfig lacks systemPrompt', async () => {
+        const { config } = await createMockConfig();
+        const { overrides } = createRuntimeOverrides();
+
+        // Bypass TypeScript's required systemPrompt via cast to simulate
+        // a runtime-malformed PromptConfig that bypassed compile-time checks
+        const malformedPromptConfig = {} as unknown as PromptConfig;
+
+        const scope = await SubAgentScope.create(
+          'test-agent',
+          config,
+          malformedPromptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          undefined,
+          undefined,
+          overrides,
+        );
+
+        await expect(
+          scope.runNonInteractive(new ContextState()),
+        ).rejects.toThrow('PromptConfig must have `systemPrompt` defined.');
+        expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
       });
 
       it('should substitute placeholders for missing template variables', async () => {
@@ -1100,30 +1121,43 @@ describe('subagent.ts', () => {
         expect(systemInstruction).toContain('Session <missing:sessionId>');
       });
 
-      it('should validate that systemPrompt and initialMessages are mutually exclusive', async () => {
+      it('should always include outputConfig instructions in system instruction when systemPrompt is used', async () => {
         const { config } = await createMockConfig();
-        const promptConfig: PromptConfig = {
-          systemPrompt: 'System',
-          initialMessages: [{ role: 'user', parts: [{ text: 'Hi' }] }],
+        vi.mocked(GeminiChat).mockClear();
+
+        const promptConfig: PromptConfig = { systemPrompt: 'Do the task.' };
+        const outputConfig: OutputConfig = {
+          outputs: {
+            result1: 'The first result',
+          },
         };
         const context = new ContextState();
 
+        // Model stops immediately
+        mockSendMessageStream.mockImplementation(createMockStream(['stop']));
+
         const { overrides } = createRuntimeOverrides();
-        const agent = await SubAgentScope.create(
-          'TestAgent',
+        const scope = await SubAgentScope.create(
+          'test-agent',
           config,
           promptConfig,
           defaultModelConfig,
           defaultRunConfig,
           undefined,
-          undefined,
+          outputConfig,
           overrides,
         );
 
-        await expect(agent.runNonInteractive(context)).rejects.toThrow(
-          'PromptConfig cannot have both `systemPrompt` and `initialMessages` defined.',
-        );
-        expect(agent.output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+        await scope.runNonInteractive(context);
+
+        const generationConfig = getGenerationConfigFromMock();
+        const systemInstruction = generationConfig.systemInstruction as string;
+
+        // systemPrompt-based PromptConfig must always include output instructions
+        expect(systemInstruction).toContain('self_emitvalue');
+        expect(systemInstruction).toContain('result1');
+        // And non-interactive rules must always be present
+        expect(systemInstruction).toContain('non-interactive');
       });
 
       it('should pass interactionMode subagent when building system prompt', async () => {

--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -1057,7 +1057,9 @@ describe('subagent.ts', () => {
 
         await expect(
           scope.runNonInteractive(new ContextState()),
-        ).rejects.toThrow('PromptConfig must have `systemPrompt` defined.');
+        ).rejects.toThrow(
+          'PromptConfig.systemPrompt must be a non-empty string.',
+        );
         expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
       });
 

--- a/packages/core/src/core/subagentRuntimeSetup.test.ts
+++ b/packages/core/src/core/subagentRuntimeSetup.test.ts
@@ -427,7 +427,7 @@ describe('subagentRuntimeSetup', () => {
       };
 
       await expect(createChatObject(params)).rejects.toThrow(
-        'PromptConfig must have `systemPrompt` defined.',
+        'PromptConfig.systemPrompt must be a non-empty string.',
       );
     });
 
@@ -458,7 +458,69 @@ describe('subagentRuntimeSetup', () => {
       };
 
       await expect(createChatObject(params)).rejects.toThrow(
-        'PromptConfig must have `systemPrompt` defined.',
+        'PromptConfig.systemPrompt must be a non-empty string.',
+      );
+    });
+
+    it('should throw when systemPrompt is whitespace-only', async () => {
+      const whitespacePromptConfig = {
+        systemPrompt: '   \t\n  ',
+      } as CreateChatObjectParams['promptConfig'];
+
+      const params: CreateChatObjectParams = {
+        promptConfig: whitespacePromptConfig,
+        modelConfig: { model: 'test-model', temp: 0, top_p: 1 },
+        outputConfig: undefined,
+        toolConfig: undefined,
+        runtimeContext: {
+          state: {
+            sessionId: 'test-session',
+            provider: 'gemini',
+            model: 'test',
+          },
+          tools: { listToolNames: () => [], getToolMetadata: () => undefined },
+        },
+        contentGenerator: {},
+        environmentContextLoader: async () => [],
+        foregroundConfig: {
+          getMcpClientManager: () => ({ getMcpInstructions: () => undefined }),
+        } as unknown as CreateChatObjectParams['foregroundConfig'],
+        context: { get: () => undefined, get_keys: () => [], set: () => {} },
+      };
+
+      await expect(createChatObject(params)).rejects.toThrow(
+        'PromptConfig.systemPrompt must be a non-empty string.',
+      );
+    });
+
+    it('should throw when systemPrompt is a non-string type', async () => {
+      const numericPromptConfig = {
+        systemPrompt: 42,
+      } as unknown as CreateChatObjectParams['promptConfig'];
+
+      const params: CreateChatObjectParams = {
+        promptConfig: numericPromptConfig,
+        modelConfig: { model: 'test-model', temp: 0, top_p: 1 },
+        outputConfig: undefined,
+        toolConfig: undefined,
+        runtimeContext: {
+          state: {
+            sessionId: 'test-session',
+            provider: 'gemini',
+            model: 'test',
+          },
+          tools: { listToolNames: () => [], getToolMetadata: () => undefined },
+        },
+        contentGenerator: {},
+        environmentContextLoader: async () => [],
+        foregroundConfig: {
+          getMcpClientManager: () => ({ getMcpInstructions: () => undefined }),
+        } as unknown as CreateChatObjectParams['foregroundConfig'],
+        context: { get: () => undefined, get_keys: () => [], set: () => {} },
+      };
+
+      await expect(createChatObject(params)).rejects.toThrow(
+        'PromptConfig.systemPrompt must be a non-empty string.',
       );
     });
   });

--- a/packages/core/src/core/subagentRuntimeSetup.test.ts
+++ b/packages/core/src/core/subagentRuntimeSetup.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import type { CreateChatObjectParams } from './subagentRuntimeSetup.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let convertMetadataToFunctionDeclaration: any;
@@ -24,6 +25,8 @@ let buildChatSystemPrompt: any;
 let createSchedulerConfig: any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let createEmojiFilter: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createChatObject: any;
 
 describe('subagentRuntimeSetup', () => {
   beforeAll(async () => {
@@ -38,6 +41,7 @@ describe('subagentRuntimeSetup', () => {
     buildChatSystemPrompt = mod.buildChatSystemPrompt;
     createSchedulerConfig = mod.createSchedulerConfig;
     createEmojiFilter = mod.createEmojiFilter;
+    createChatObject = mod.createChatObject;
   }, 30000); // Increase timeout for dynamic import during full test suite runs
 
   describe('convertMetadataToFunctionDeclaration', () => {
@@ -348,8 +352,6 @@ describe('subagentRuntimeSetup', () => {
     it('should template systemPrompt and add non-interactive rules', () => {
       const promptConfig = {
         systemPrompt: 'You are a ${role}.',
-        goal_prompt: 'Do something.',
-        behaviour_prompts: [],
       };
       const context = {
         get: (k: string) => (k === 'role' ? 'tester' : ''),
@@ -364,8 +366,6 @@ describe('subagentRuntimeSetup', () => {
     it('should add output instructions when outputConfig has outputs', () => {
       const promptConfig = {
         systemPrompt: 'Hello',
-        goal_prompt: 'Do something.',
-        behaviour_prompts: [],
       };
       const outputConfig = { outputs: { summary: 'A summary' } };
       const context = { get: () => '', get_keys: () => [], set: () => {} };
@@ -374,14 +374,92 @@ describe('subagentRuntimeSetup', () => {
       expect(result).toContain('summary');
     });
 
-    it('should return empty string when no systemPrompt', () => {
+    it('should always append non-interactive rules even without outputConfig', () => {
       const promptConfig = {
-        goal_prompt: 'Do something.',
-        behaviour_prompts: [],
+        systemPrompt: 'Do the task.',
       };
       const context = { get: () => '', get_keys: () => [], set: () => {} };
       const result = buildChatSystemPrompt(promptConfig, undefined, context);
-      expect(result).toBe('');
+      expect(result).toContain('non-interactive');
+      expect(result).toContain('stop calling tools');
+    });
+
+    it('should always append output instructions and non-interactive rules when outputConfig has outputs', () => {
+      const promptConfig = {
+        systemPrompt: 'Be helpful.',
+      };
+      const outputConfig = { outputs: { result: 'The answer' } };
+      const context = { get: () => '', get_keys: () => [], set: () => {} };
+      const result = buildChatSystemPrompt(promptConfig, outputConfig, context);
+      expect(result).toContain('self_emitvalue');
+      expect(result).toContain("emit the 'result' key");
+      expect(result).toContain('non-interactive');
+      expect(result).toContain('stop calling tools');
+    });
+  });
+
+  describe('createChatObject', () => {
+    it('should throw when PromptConfig lacks systemPrompt', async () => {
+      // Bypass TypeScript's required systemPrompt via cast to simulate
+      // a runtime-malformed PromptConfig that bypassed compile-time checks
+      const malformedPromptConfig =
+        {} as CreateChatObjectParams['promptConfig'];
+
+      const params: CreateChatObjectParams = {
+        promptConfig: malformedPromptConfig,
+        modelConfig: { model: 'test-model', temp: 0, top_p: 1 },
+        outputConfig: undefined,
+        toolConfig: undefined,
+        runtimeContext: {
+          state: {
+            sessionId: 'test-session',
+            provider: 'gemini',
+            model: 'test',
+          },
+          tools: { listToolNames: () => [], getToolMetadata: () => undefined },
+        },
+        contentGenerator: {},
+        environmentContextLoader: async () => [],
+        foregroundConfig: {
+          getMcpClientManager: () => ({ getMcpInstructions: () => undefined }),
+        } as unknown as CreateChatObjectParams['foregroundConfig'],
+        context: { get: () => undefined, get_keys: () => [], set: () => {} },
+      };
+
+      await expect(createChatObject(params)).rejects.toThrow(
+        'PromptConfig must have `systemPrompt` defined.',
+      );
+    });
+
+    it('should throw when systemPrompt is an empty string', async () => {
+      const emptyPromptConfig = {
+        systemPrompt: '',
+      } as CreateChatObjectParams['promptConfig'];
+
+      const params: CreateChatObjectParams = {
+        promptConfig: emptyPromptConfig,
+        modelConfig: { model: 'test-model', temp: 0, top_p: 1 },
+        outputConfig: undefined,
+        toolConfig: undefined,
+        runtimeContext: {
+          state: {
+            sessionId: 'test-session',
+            provider: 'gemini',
+            model: 'test',
+          },
+          tools: { listToolNames: () => [], getToolMetadata: () => undefined },
+        },
+        contentGenerator: {},
+        environmentContextLoader: async () => [],
+        foregroundConfig: {
+          getMcpClientManager: () => ({ getMcpInstructions: () => undefined }),
+        } as unknown as CreateChatObjectParams['foregroundConfig'],
+        context: { get: () => undefined, get_keys: () => [], set: () => {} },
+      };
+
+      await expect(createChatObject(params)).rejects.toThrow(
+        'PromptConfig must have `systemPrompt` defined.',
+      );
     });
   });
 

--- a/packages/core/src/core/subagentRuntimeSetup.ts
+++ b/packages/core/src/core/subagentRuntimeSetup.ts
@@ -498,8 +498,11 @@ export async function createChatObject(
   const { foregroundConfig: config, context } = params;
   const logger = new DebugLogger('llxprt:subagent');
 
-  if (!promptConfig.systemPrompt) {
-    throw new Error('PromptConfig must have `systemPrompt` defined.');
+  if (
+    typeof promptConfig.systemPrompt !== 'string' ||
+    promptConfig.systemPrompt.trim().length === 0
+  ) {
+    throw new Error('PromptConfig.systemPrompt must be a non-empty string.');
   }
 
   const startHistory: Content[] = [];

--- a/packages/core/src/core/subagentRuntimeSetup.ts
+++ b/packages/core/src/core/subagentRuntimeSetup.ts
@@ -350,10 +350,6 @@ export function buildChatSystemPrompt(
   outputConfig: OutputConfig | undefined,
   context: ContextState,
 ): string {
-  if (!promptConfig.systemPrompt) {
-    return '';
-  }
-
   let finalPrompt = templateString(promptConfig.systemPrompt, context);
 
   if (outputConfig?.outputs) {
@@ -502,21 +498,16 @@ export async function createChatObject(
   const { foregroundConfig: config, context } = params;
   const logger = new DebugLogger('llxprt:subagent');
 
-  if (!promptConfig.systemPrompt && !promptConfig.initialMessages) {
-    throw new Error(
-      'PromptConfig must have either `systemPrompt` or `initialMessages` defined.',
-    );
-  }
-  if (promptConfig.systemPrompt && promptConfig.initialMessages) {
-    throw new Error(
-      'PromptConfig cannot have both `systemPrompt` and `initialMessages` defined.',
-    );
+  if (!promptConfig.systemPrompt) {
+    throw new Error('PromptConfig must have `systemPrompt` defined.');
   }
 
-  const startHistory = [...(promptConfig.initialMessages ?? [])];
-  const personaPrompt = promptConfig.systemPrompt
-    ? buildChatSystemPrompt(promptConfig, outputConfig, context)
-    : '';
+  const startHistory: Content[] = [];
+  const personaPrompt = buildChatSystemPrompt(
+    promptConfig,
+    outputConfig,
+    context,
+  );
 
   const runtimeDecls = buildRuntimeFunctionDeclarations(
     runtimeContext.tools,

--- a/packages/core/src/core/subagentTypes.ts
+++ b/packages/core/src/core/subagentTypes.ts
@@ -12,7 +12,7 @@
  * Extracted from subagent.ts as part of Issue #1581.
  */
 
-import type { Content, FunctionDeclaration, Part } from '@google/genai';
+import type { FunctionDeclaration, Part } from '@google/genai';
 import type {
   AgentRuntimeContext,
   ReadonlySettingsSnapshot,
@@ -68,19 +68,17 @@ export interface OutputObject {
 
 /**
  * Configures the initial prompt for the subagent.
+ * The subagent always operates in non-interactive mode with a systemPrompt
+ * that receives outputConfig instructions and non-interactive rules appended
+ * automatically by buildChatSystemPrompt.
  */
 export interface PromptConfig {
   /**
    * A single system prompt string that defines the subagent's persona and instructions.
-   * Note: Use either `systemPrompt` or `initialMessages`, but not both.
+   * Required. The system prompt is templated against the context state and
+   * automatically receives appended outputConfig instructions and non-interactive rules.
    */
-  systemPrompt?: string;
-
-  /**
-   * An array of user/model content pairs to seed the chat history for few-shot prompting.
-   * Note: Use either `systemPrompt` or `initialMessages`, but not both.
-   */
-  initialMessages?: Content[];
+  systemPrompt: string;
 }
 
 /**


### PR DESCRIPTION
## TLDR

Removes the unused core subagent initialMessages prompt path so subagents always require systemPrompt and always receive the output-variable and non-interactive instructions that createChatObject registers tools for.

## Dive Deeper

The core subagent PromptConfig previously allowed two mutually exclusive setup modes: systemPrompt or initialMessages. Production callers use systemPrompt, while the initialMessages branch could register self_emitvalue through outputConfig without adding the matching instructions because buildChatSystemPrompt returned an empty string without systemPrompt.

This PR simplifies the core subagent contract by:

- Making core subagent PromptConfig.systemPrompt required.
- Removing core subagent PromptConfig.initialMessages.
- Always building the persona/system prompt through buildChatSystemPrompt.
- Always starting GeminiChat with empty constructor history for the core subagent path.
- Preserving the separate packages/core/src/agents initialMessages support for the declarative agents framework.
- Updating tests to cover the new required-systemPrompt runtime validation and the always-present output/non-interactive instructions.

## Reviewer Test Plan

Reviewers can validate by running:

    npm exec vitest run packages/core/src/core/subagentRuntimeSetup.test.ts packages/core/src/core/subagent.test.ts -- --pool=forks --poolOptions.forks.singleFork=true
    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build

The required smoke command was also attempted:

    node scripts/start.js --profile-load waferglm5 "write me a haiku and nothing else"

It reached build status successfully and then timed out locally with signal 15 after no response. The waferglm5 profile file on this machine is an empty JSON object, so this appears environment/profile related rather than a regression in this subagent PromptConfig change.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1788
