### PR TITLE
Fix provider-aware rate limit messages (Fixes #1398)

### DIFF
--- a/packages/a2a-server/src/agent/task-support.test.ts
+++ b/packages/a2a-server/src/agent/task-support.test.ts
@@ -4,8 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
-import { applyReplacement } from './task-support.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  GeminiEventType,
+  type ServerGeminiStreamEvent,
+} from '@vybestack/llxprt-code-core';
+import {
+  applyReplacement,
+  handleStreamError,
+  type TaskStreamContext,
+} from './task-support.js';
+import { CoderAgentEvent } from '../types.js';
+import type { StateChange } from '../types.js';
 
 describe('applyReplacement', () => {
   describe('isNewFile behavior', () => {
@@ -95,5 +105,47 @@ describe('applyReplacement', () => {
         applyReplacement('price: $100 price: $200', '$', '€', false, 2),
       ).toBe('price: €100 price: €200');
     });
+  });
+});
+
+describe('handleStreamError', () => {
+  it('formats Anthropic rate-limit errors without Gemini fallback guidance', () => {
+    const publishedUpdates: Array<{ error?: string }> = [];
+    const context: TaskStreamContext = {
+      taskState: 'working',
+      providerName: 'anthropic',
+      currentModel: 'claude-opus-4-6',
+      cancelPendingTools: vi.fn(),
+      setTaskStateAndPublishUpdate: vi.fn(
+        (_state, _msg, _text, _parts, _final, error) => {
+          publishedUpdates.push({ error });
+        },
+      ),
+    };
+    const stateChange: StateChange = {
+      kind: CoderAgentEvent.StateChangeEvent,
+    };
+    const event: ServerGeminiStreamEvent & {
+      type: typeof GeminiEventType.Error;
+    } = {
+      type: GeminiEventType.Error,
+      value: {
+        error: {
+          message: 'Rate limit exceeded',
+          status: 429,
+        },
+      },
+    };
+
+    handleStreamError(event, context, stateChange);
+
+    expect(publishedUpdates[0]?.error).toContain(
+      'Anthropic rate limit exceeded',
+    );
+    expect(publishedUpdates[0]?.error).not.toContain('gemini');
+    expect(publishedUpdates[0]?.error).not.toContain('gemini-2.5-flash');
+    expect(publishedUpdates[0]?.error).not.toContain('AI Studio');
+    expect(publishedUpdates[0]?.error).not.toContain('Gemini Code Assist');
+    expect(publishedUpdates[0]?.error).not.toContain('Switching to the');
   });
 });

--- a/packages/a2a-server/src/agent/task-support.ts
+++ b/packages/a2a-server/src/agent/task-support.ts
@@ -514,6 +514,8 @@ function deleteCompletedConfirmation(
  */
 export interface TaskStreamContext {
   taskState: TaskState;
+  currentModel?: string;
+  providerName?: string;
   cancelPendingTools: (reason: string) => void;
   setTaskStateAndPublishUpdate: (
     state: TaskState,
@@ -526,6 +528,19 @@ export interface TaskStreamContext {
   ) => void;
 }
 
+function getErrorFallbackModel(context: TaskStreamContext): string | undefined {
+  const normalizedProviderName = context.providerName?.trim().toLowerCase();
+  if (
+    normalizedProviderName !== undefined &&
+    normalizedProviderName !== '' &&
+    normalizedProviderName !== 'gemini'
+  ) {
+    return undefined;
+  }
+
+  return context.currentModel;
+}
+
 /**
  * Handles stream idle timeout events by cancelling pending tools
  * and publishing an input-required state update.
@@ -535,6 +550,7 @@ export function handleStreamIdleTimeout(
     type: typeof GeminiEventType.StreamIdleTimeout;
   },
   context: TaskStreamContext,
+
   stateChange: StateChange,
   traceId?: string,
 ): void {
@@ -552,7 +568,12 @@ export function handleStreamIdleTimeout(
     'Task timed out waiting for model response.',
     undefined,
     true,
-    parseAndFormatApiError(event.value.error),
+    parseAndFormatApiError(
+      event.value.error,
+      undefined,
+      getErrorFallbackModel(context),
+      context.providerName,
+    ),
     traceId,
   );
 }
@@ -598,7 +619,12 @@ export function handleStreamError(
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime boundary: error.message may be undefined in malformed payloads despite type definitions
     event.value.error.message ?? 'Unknown error from LLM stream';
   logger.error('[Task] Received error event from LLM stream:', errorMessage);
-  const errMessage = parseAndFormatApiError(event.value.error);
+  const errMessage = parseAndFormatApiError(
+    event.value.error,
+    undefined,
+    getErrorFallbackModel(context),
+    context.providerName,
+  );
   context.cancelPendingTools(`LLM stream error: ${errorMessage}`);
   context.setTaskStateAndPublishUpdate(
     context.taskState,

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -681,8 +681,11 @@ export class Task {
   }
 
   private createStreamContext() {
+    const providerName = this.config.getProvider()?.trim();
     return {
       taskState: this.taskState,
+      currentModel: this.modelInfo?.model ?? this.config.getModel(),
+      providerName: providerName === '' ? undefined : providerName,
       cancelPendingTools: this.cancelPendingTools.bind(this),
       setTaskStateAndPublishUpdate:
         this.setTaskStateAndPublishUpdate.bind(this),

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -32,6 +32,10 @@ import { handleSlashCommand } from './nonInteractiveCliCommands.js';
 import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
 import { processResponseTurns } from './nonInteractiveCliSupport.js';
+import {
+  getActiveProviderNameForApiError,
+  getErrorFallbackModel,
+} from './utils/apiErrorFormatting.js';
 
 interface RunNonInteractiveParams {
   config: Config;
@@ -304,7 +308,15 @@ export async function runNonInteractive(
     });
   } catch (error) {
     if (!jsonOutput) {
-      debugLogger.error(parseAndFormatApiError(error));
+      const providerName = getActiveProviderNameForApiError(config);
+      debugLogger.error(
+        parseAndFormatApiError(
+          error,
+          undefined,
+          getErrorFallbackModel(config, providerName),
+          providerName,
+        ),
+      );
     }
     throw error;
   } finally {

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/streamUtils.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/streamUtils.test.ts
@@ -11,7 +11,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { FinishReason } from '@google/genai';
 import type { Part } from '@google/genai';
-import { UnauthorizedError } from '@vybestack/llxprt-code-core';
+import {
+  UnauthorizedError,
+  parseAndFormatApiError,
+} from '@vybestack/llxprt-code-core';
 import type { Config } from '@vybestack/llxprt-code-core';
 import type { LoadedSettings } from '../../../../config/settings.js';
 import type { HistoryItemWithoutId } from '../../../types.js';
@@ -31,6 +34,7 @@ import {
   getCurrentProfileName,
   SYSTEM_NOTICE_EVENT,
 } from '../streamUtils.js';
+import { getActiveProviderNameForApiError } from '../../../../utils/apiErrorFormatting.js';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -493,16 +497,65 @@ describe('processSlashCommandResult', () => {
 
 // ─── handleSubmissionError ────────────────────────────────────────────────────
 
+describe('getActiveProviderNameForApiError', () => {
+  const makeConfig = (
+    activeProvider: unknown,
+    providerManagerName?: string,
+  ): Config =>
+    ({
+      getProviderManager: vi.fn(() =>
+        providerManagerName === undefined
+          ? undefined
+          : { getActiveProviderName: vi.fn(() => providerManagerName) },
+      ),
+      getSettingsService: vi.fn(() => ({
+        get: vi.fn(() => activeProvider),
+      })),
+    }) as unknown as Config;
+
+  it('prefers the provider manager active provider when available', () => {
+    const result = getActiveProviderNameForApiError(
+      makeConfig('profile-name', 'anthropic'),
+    );
+    expect(result).toBe('anthropic');
+  });
+
+  it('falls back to activeProvider setting when provider manager is unavailable', () => {
+    const result = getActiveProviderNameForApiError(makeConfig('openai'));
+    expect(result).toBe('openai');
+  });
+
+  it('treats blank provider manager and setting values as unknown provider', () => {
+    const result = getActiveProviderNameForApiError(makeConfig('   ', ''));
+    expect(result).toBeUndefined();
+  });
+});
+
 describe('handleSubmissionError', () => {
   const mockAddItem = vi.fn();
   const mockOnAuthError = vi.fn();
-  const mockConfig = {
-    getModel: vi.fn(() => 'test-model'),
-  } as unknown as Config;
+  const mockParseAndFormatApiError = vi.mocked(parseAndFormatApiError);
+  const makeConfig = (
+    activeProvider: unknown,
+    providerManagerName?: string,
+  ): Config =>
+    ({
+      getModel: vi.fn(() => 'test-model'),
+      getProviderManager: vi.fn(() =>
+        providerManagerName === undefined
+          ? undefined
+          : { getActiveProviderName: vi.fn(() => providerManagerName) },
+      ),
+      getSettingsService: vi.fn(() => ({
+        get: vi.fn(() => activeProvider),
+      })),
+    }) as unknown as Config;
+  const mockConfig = makeConfig(undefined);
 
   beforeEach(() => {
     mockAddItem.mockClear();
     mockOnAuthError.mockClear();
+    mockParseAndFormatApiError.mockClear();
   });
 
   it('calls onAuthError and returns true for UnauthorizedError', () => {
@@ -531,6 +584,54 @@ describe('handleSubmissionError', () => {
     expect(mockAddItem).toHaveBeenCalledOnce();
     const itemArg = mockAddItem.mock.calls[0][0];
     expect(itemArg.type).toBe('error');
+  });
+
+  it('passes Anthropic provider without Gemini fallback model', () => {
+    handleSubmissionError(
+      new Error('Rate limited'),
+      mockAddItem,
+      makeConfig('anthropic'),
+      mockOnAuthError,
+      Date.now(),
+    );
+    expect(mockParseAndFormatApiError).toHaveBeenCalledWith(
+      'Error: Rate limited',
+      undefined,
+      undefined,
+      'anthropic',
+    );
+  });
+
+  it('passes Gemini provider with fallback model', () => {
+    handleSubmissionError(
+      new Error('Rate limited'),
+      mockAddItem,
+      makeConfig('Gemini'),
+      mockOnAuthError,
+      Date.now(),
+    );
+    expect(mockParseAndFormatApiError).toHaveBeenCalledWith(
+      'Error: Rate limited',
+      undefined,
+      'test-model',
+      'Gemini',
+    );
+  });
+
+  it('treats blank active provider as default Gemini behavior', () => {
+    handleSubmissionError(
+      new Error('Rate limited'),
+      mockAddItem,
+      makeConfig('   '),
+      mockOnAuthError,
+      Date.now(),
+    );
+    expect(mockParseAndFormatApiError).toHaveBeenCalledWith(
+      'Error: Rate limited',
+      undefined,
+      'test-model',
+      undefined,
+    );
   });
 
   it('does not add error item for AbortError (swallows it)', () => {

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useStreamEventHandlers.watchdog.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useStreamEventHandlers.watchdog.test.ts
@@ -62,6 +62,76 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
     vi.useRealTimers();
   });
 
+  it('formats stream error events with Anthropic provider guidance', () => {
+    const pendingHistoryItemRef = {
+      current: null as HistoryItemWithoutId | null,
+    };
+    const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
+    const anthropicConfig = {
+      getModel: vi.fn(() => 'claude-opus-4-6'),
+      getMaxSessionTurns: vi.fn(() => 42),
+      getEphemeralSetting: vi.fn(() => undefined),
+      getProviderManager: vi.fn(() => ({
+        getActiveProviderName: vi.fn(() => 'anthropic'),
+      })),
+      getSettingsService: vi.fn(() => ({
+        get: vi.fn(() => 'profile-name'),
+      })),
+    } as unknown as Config;
+
+    const { result } = renderHook(() =>
+      useStreamEventHandlers({
+        config: anthropicConfig,
+        settings: mockSettings,
+        addItem: mockAddItem,
+        onDebugMessage: vi.fn(),
+        onCancelSubmit: vi.fn(),
+        sanitizeContent: (text: string) => ({ text, blocked: false }),
+        flushPendingHistoryItem: vi.fn(),
+        pendingHistoryItemRef,
+        thinkingBlocksRef: { current: [] as ThinkingBlock[] },
+        turnCancelledRef: { current: false },
+        queuedSubmissionsRef,
+        setPendingHistoryItem: vi.fn(),
+        setIsResponding: vi.fn(),
+        setThought,
+        setLastGeminiActivityTime,
+        scheduleToolCalls: mockScheduleToolCalls,
+        abortActiveStream,
+        handleShellCommand: vi.fn(() => false),
+        handleSlashCommand: vi.fn().mockResolvedValue(false),
+        logger: null,
+        shellModeActive: false,
+        loopDetectedRef: { current: false },
+        lastProfileNameRef: { current: undefined as string | undefined },
+      }),
+    );
+
+    result.current.handleErrorEvent(
+      {
+        error: {
+          message: 'Rate limit exceeded',
+          status: 429,
+        },
+      },
+      123,
+    );
+
+    expect(mockAddItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.ERROR,
+        text: expect.stringContaining('Anthropic rate limit exceeded'),
+      }),
+      123,
+    );
+    const errorItem = mockAddItem.mock.calls[0][0] as { text: string };
+    expect(errorItem.text).not.toContain('gemini-2.5-flash');
+    expect(errorItem.text).not.toContain('AI Studio');
+    expect(errorItem.text).not.toContain('Gemini Code Assist');
+    expect(errorItem.text).not.toContain('Switching to the');
+    expect(queuedSubmissionsRef.current).toStrictEqual([]);
+  });
+
   it('aborts a stalled stream after partial content without scheduling buffered tool calls', async () => {
     const pendingHistoryItemRef = {
       current: null as HistoryItemWithoutId | null,

--- a/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
@@ -38,6 +38,10 @@ import {
 import { findLastSafeSplitPoint } from '../../utils/markdownUtilities.js';
 import { SHELL_COMMAND_NAME, SHELL_NAME } from '../../constants.js';
 import { type UseHistoryManagerReturn } from '../useHistoryManager.js';
+import {
+  getActiveProviderNameForApiError,
+  getErrorFallbackModel,
+} from '../../../utils/apiErrorFormatting.js';
 
 // ─── Re-exported constant ────────────────────────────────────────────────────
 
@@ -390,13 +394,16 @@ export function handleSubmissionError(
   }
   const isAbortError = error instanceof Error && error.name === 'AbortError';
   if (!isAbortError) {
+    const providerName = getActiveProviderNameForApiError(config);
+    const fallbackModel = getErrorFallbackModel(config, providerName);
     addItem(
       {
         type: MessageType.ERROR,
         text: parseAndFormatApiError(
           getErrorMessage(error) || 'Unknown error',
           undefined,
-          config.getModel(),
+          fallbackModel,
+          providerName,
         ),
       },
       timestamp,

--- a/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
@@ -49,6 +49,10 @@ import {
   getCurrentProfileName,
   buildFinishReasonMessage,
 } from './streamUtils.js';
+import {
+  getActiveProviderNameForApiError,
+  getErrorFallbackModel,
+} from '../../../utils/apiErrorFormatting.js';
 import { StreamProcessingStatus } from './types.js';
 import {
   processContentEvent,
@@ -302,13 +306,16 @@ function useErrorEventHandler(deps: StreamEventHandlerDeps) {
         flushPendingHistoryItem(userMessageTimestamp);
         setPendingHistoryItem(null);
       }
+      const providerName = getActiveProviderNameForApiError(config);
+      const fallbackModel = getErrorFallbackModel(config, providerName);
       addItem(
         {
           type: MessageType.ERROR,
           text: parseAndFormatApiError(
             eventValue.error,
             undefined,
-            config.getModel(),
+            fallbackModel,
+            providerName,
           ),
         },
         userMessageTimestamp,

--- a/packages/cli/src/utils/apiErrorFormatting.test.ts
+++ b/packages/cli/src/utils/apiErrorFormatting.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Config } from '@vybestack/llxprt-code-core';
+import {
+  getActiveProviderNameForApiError,
+  getErrorFallbackModel,
+} from './apiErrorFormatting.js';
+
+function makeConfig(options: {
+  model?: string;
+  configProvider?: string;
+  settingsProvider?: unknown;
+  managerProvider?: string;
+  throwFromManager?: boolean;
+  throwFromSettings?: boolean;
+}): Config {
+  return {
+    getModel: vi.fn(() => options.model ?? 'test-model'),
+    getProvider: vi.fn(() => options.configProvider),
+    getProviderManager: vi.fn(() => {
+      if (options.throwFromManager === true) {
+        throw new Error('provider manager unavailable');
+      }
+      return options.managerProvider === undefined
+        ? undefined
+        : { getActiveProviderName: vi.fn(() => options.managerProvider) };
+    }),
+    getSettingsService: vi.fn(() => {
+      if (options.throwFromSettings === true) {
+        throw new Error('settings unavailable');
+      }
+      return { get: vi.fn(() => options.settingsProvider) };
+    }),
+  } as unknown as Config;
+}
+
+describe('apiErrorFormatting', () => {
+  describe('getActiveProviderNameForApiError', () => {
+    it('uses provider manager active provider before settings', () => {
+      const config = makeConfig({
+        managerProvider: 'anthropic',
+        settingsProvider: 'profile-name',
+      });
+      expect(getActiveProviderNameForApiError(config)).toBe('anthropic');
+    });
+
+    it('falls back to activeProvider setting when provider manager is blank', () => {
+      const config = makeConfig({
+        managerProvider: '   ',
+        settingsProvider: 'openai',
+      });
+      expect(getActiveProviderNameForApiError(config)).toBe('openai');
+    });
+
+    it('returns undefined when provider context is unavailable', () => {
+      const config = makeConfig({
+        throwFromManager: true,
+        throwFromSettings: true,
+      });
+      expect(getActiveProviderNameForApiError(config)).toBeUndefined();
+    });
+  });
+
+  it('uses config provider before settings when provider manager is blank', () => {
+    const config = makeConfig({
+      managerProvider: '   ',
+      configProvider: 'anthropic',
+      settingsProvider: 'profile-name',
+    });
+    expect(getActiveProviderNameForApiError(config)).toBe('anthropic');
+  });
+
+  describe('getErrorFallbackModel', () => {
+    it('returns model for unknown provider', () => {
+      const config = makeConfig({ model: 'gemini-2.5-pro' });
+      expect(getErrorFallbackModel(config, undefined)).toBe('gemini-2.5-pro');
+    });
+
+    it('returns model for Gemini provider regardless of case or whitespace', () => {
+      const config = makeConfig({ model: 'gemini-2.5-pro' });
+      expect(getErrorFallbackModel(config, ' Gemini ')).toBe('gemini-2.5-pro');
+    });
+
+    it('returns model for blank provider as unknown provider', () => {
+      const config = makeConfig({ model: 'gemini-2.5-pro' });
+      expect(getErrorFallbackModel(config, '   ')).toBe('gemini-2.5-pro');
+    });
+
+    it('does not return model for non-Gemini provider', () => {
+      const config = makeConfig({ model: 'claude-opus-4-6' });
+      expect(getErrorFallbackModel(config, 'anthropic')).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/utils/apiErrorFormatting.ts
+++ b/packages/cli/src/utils/apiErrorFormatting.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core';
+
+export function getActiveProviderNameForApiError(
+  config: Config,
+): string | undefined {
+  const activeProvider = getActiveProviderNameFromProviderManager(config);
+  if (activeProvider !== undefined) {
+    return activeProvider;
+  }
+
+  const configuredProvider = getProviderNameFromConfig(config);
+  if (configuredProvider !== undefined) {
+    return configuredProvider;
+  }
+
+  return getActiveProviderNameFromSettings(config);
+}
+
+export function getErrorFallbackModel(
+  config: Config,
+  providerName: string | undefined,
+): string | undefined {
+  const trimmedProviderName = providerName?.trim().toLowerCase();
+  const normalizedProviderName =
+    trimmedProviderName === '' ? undefined : trimmedProviderName;
+  if (
+    normalizedProviderName !== undefined &&
+    normalizedProviderName !== 'gemini'
+  ) {
+    return undefined;
+  }
+
+  try {
+    return config.getModel();
+  } catch {
+    return undefined;
+  }
+}
+
+function getActiveProviderNameFromProviderManager(
+  config: Config,
+): string | undefined {
+  try {
+    const activeProvider = config.getProviderManager()?.getActiveProviderName();
+    return normalizeProviderName(activeProvider);
+  } catch {
+    return undefined;
+  }
+}
+
+function getProviderNameFromConfig(config: Config): string | undefined {
+  try {
+    return normalizeProviderName(config.getProvider());
+  } catch {
+    return undefined;
+  }
+}
+
+function getActiveProviderNameFromSettings(config: Config): string | undefined {
+  try {
+    const configuredProvider = config
+      .getSettingsService()
+      .get('activeProvider');
+    return normalizeProviderName(configuredProvider);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeProviderName(providerName: unknown): string | undefined {
+  if (typeof providerName !== 'string') {
+    return undefined;
+  }
+  const trimmed = providerName.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -13,6 +13,10 @@ import {
   isFatalToolError,
   type Config,
 } from '@vybestack/llxprt-code-core';
+import {
+  getActiveProviderNameForApiError,
+  getErrorFallbackModel,
+} from './apiErrorFormatting.js';
 
 /**
  * Extracts a string error message from an unknown error type
@@ -69,7 +73,13 @@ export function handleError(
   config: Config,
   customErrorCode?: string | number,
 ): never {
-  const errorMessage = parseAndFormatApiError(error);
+  const providerName = getActiveProviderNameForApiError(config);
+  const errorMessage = parseAndFormatApiError(
+    error,
+    undefined,
+    getErrorFallbackModel(config, providerName),
+    providerName,
+  );
 
   console.error(errorMessage);
 

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -383,4 +383,295 @@ describe('parseAndFormatApiError', () => {
     expect(result).not.toContain('Gemini Code Assist');
     expect(result).not.toContain('Switching to the');
   });
+
+  // ── Provider-aware rate limit messages (issue #1398) ──────────────────────
+
+  describe('provider-aware rate limit messaging (issue #1398)', () => {
+    const rateLimitErrorMessage =
+      'got status: 429 Too Many Requests. {"error":{"code":429,"message":"Rate limit exceeded","status":"RESOURCE_EXHAUSTED"}}';
+
+    it('should return Anthropic-specific rate limit message for native Anthropic 429 payload', () => {
+      const anthropicPayload =
+        'got status: 429 Too Many Requests. {"error":{"code":429,"message":"This request would exceed your account rate limit. Please try again later.","status":"rate_limit_error"}}';
+      const result = parseAndFormatApiError(
+        anthropicPayload,
+        undefined,
+        'claude-opus-4-6',
+        'anthropic',
+      );
+      expect(result).toContain(
+        'This request would exceed your account rate limit',
+      );
+      expect(result).toContain('Anthropic rate limit exceeded');
+      expect(result).toContain('retries rate-limited requests with backoff');
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should append Anthropic guidance for native Anthropic rate_limit_error payloads without numeric code', () => {
+      const result = parseAndFormatApiError(
+        'got status: 429 Too Many Requests. {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account rate limit. Please try again later."},"request_id":"req_011CY6xKsGweWtbaspTSdMBd"}',
+        undefined,
+        'claude-opus-4-6',
+        'anthropic',
+      );
+      expect(result).toContain(
+        'This request would exceed your account rate limit. Please try again later.',
+      );
+      expect(result).toContain('Anthropic rate limit exceeded');
+      expect(result).toContain('backoff');
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should return Anthropic-specific rate limit message for anthropic provider on 429', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'claude-opus-4-6',
+        'anthropic',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).toContain('Anthropic');
+      expect(result).toContain('retry');
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('Switching to the');
+      expect(result).not.toContain('/model');
+    });
+
+    it('should return generic rate limit message for unknown non-Gemini provider on 429', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'gpt-4o',
+        'openai',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).toContain('Rate limit exceeded');
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('flash');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should preserve existing Gemini rate limit behavior when providerName is gemini', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'gemini-2.5-pro',
+        'gemini',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).toContain('Rate limit exceeded. Please wait a moment');
+      expect(result).toContain('/model to switch to a different model');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should preserve default behavior without providerName even for Claude model names', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'claude-opus-4-6',
+      );
+      expect(result).toContain('Rate limit exceeded. Please wait a moment');
+      expect(result).toContain('/model to switch to a different model');
+      expect(result).not.toContain('Anthropic rate limit exceeded');
+    });
+
+    it('should preserve existing Gemini rate limit behavior when providerName is undefined', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'gemini-2.5-pro',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).toContain('Rate limit exceeded. Please wait a moment');
+      expect(result).toContain('/model to switch to a different model');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should preserve existing Gemini rate limit behavior when providerName has mixed case', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'gemini-2.5-pro',
+        'Gemini',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).toContain('Rate limit exceeded. Please wait a moment');
+      expect(result).toContain('/model to switch to a different model');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should preserve existing Gemini rate limit behavior when providerName is blank', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'gemini-2.5-pro',
+        '   ',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).toContain('Rate limit exceeded. Please wait a moment');
+      expect(result).toContain('/model to switch to a different model');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should show Anthropic-specific message for 429 StructuredError with anthropic provider', () => {
+      const error: StructuredError = {
+        message: 'Rate limit exceeded',
+        status: 429,
+      };
+      const result = parseAndFormatApiError(
+        error,
+        undefined,
+        undefined,
+        'anthropic',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429)]',
+      );
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).toContain('retry');
+    });
+
+    it('should return Anthropic-specific rate limit message for Anthropic-backed aliases', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'claude-opus-4-6',
+        'work-anthropic-alias',
+      );
+      expect(result).toContain('Anthropic rate limit exceeded');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+    });
+
+    it('should show provider-aware guidance for non-structured object 429 errors', () => {
+      const result = parseAndFormatApiError(
+        { response: { status: 429 } },
+        undefined,
+        'claude-opus-4-6',
+        'anthropic',
+      );
+      expect(result).toContain(
+        '[API Error: An unknown error occurred. (Status: 429)]',
+      );
+      expect(result).toContain('Anthropic rate limit exceeded');
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should show non-Gemini rate limit message when anthropic provider encounters Google Pro quota error', () => {
+      const proQuotaError =
+        'got status: 429 Too Many Requests. {"error":{"code":429,"message":"Quota exceeded for quota metric \'Gemini 2.5 Pro Requests\' and limit \'RequestsPerDay\' of service \'generativelanguage.googleapis.com\' for consumer \'project_number:123456789\'.","status":"RESOURCE_EXHAUSTED"}}';
+      const result = parseAndFormatApiError(
+        proQuotaError,
+        undefined,
+        'claude-opus-4-6',
+        'anthropic',
+      );
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('Switching to the');
+      expect(result).toContain('retry');
+    });
+
+    it('should not reference Gemini for Anthropic provider on Anthropic-style rate_limit_error StructuredError', () => {
+      const error: StructuredError = {
+        message:
+          'This request would exceed your accounts rate limit. Please try again later.',
+        status: 429,
+      };
+      const result = parseAndFormatApiError(
+        error,
+        undefined,
+        'claude-opus-4-6',
+        'anthropic',
+      );
+      expect(result).toContain('[API Error:');
+      expect(result).toContain('429');
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('gemini-2.5-flash');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should maintain backward compatibility when providerName is not provided', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'gemini-2.5-pro',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).toContain('Rate limit exceeded. Please wait a moment');
+    });
+
+    it('should handle codex provider without Gemini references', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'gpt-5.2',
+        'codex',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('Switching to the');
+    });
+
+    it('should handle deepseek provider without Gemini references', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'deepseek-chat',
+        'deepseek',
+      );
+      expect(result).toContain(
+        '[API Error: Rate limit exceeded (Status: 429, RESOURCE_EXHAUSTED)]',
+      );
+      expect(result).not.toContain('gemini');
+      expect(result).not.toContain('AI Studio');
+      expect(result).not.toContain('Gemini Code Assist');
+      expect(result).not.toContain('Switching to the');
+    });
+  });
 });

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -527,6 +527,18 @@ describe('parseAndFormatApiError', () => {
       expect(result).not.toContain('Switching to the');
     });
 
+    it('should preserve explicit Gemini provider behavior for Claude model names', () => {
+      const result = parseAndFormatApiError(
+        rateLimitErrorMessage,
+        undefined,
+        'claude-opus-4-6',
+        'gemini',
+      );
+      expect(result).toContain('Rate limit exceeded. Please wait a moment');
+      expect(result).toContain('/model to switch to a different model');
+      expect(result).not.toContain('Anthropic rate limit exceeded');
+    });
+
     it('should preserve existing Gemini rate limit behavior when providerName is blank', () => {
       const result = parseAndFormatApiError(
         rateLimitErrorMessage,

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -26,8 +26,17 @@ const PAID_TIER_THANKS =
 const PAID_TIER_AUTH_HINT = `consider using /auth to switch to using a paid API key from AI Studio at ${AI_STUDIO_KEY_URL}`;
 
 // Provider-neutral rate limit message (used when no Google-specific quota detector matches)
-const GENERIC_RATE_LIMIT_MESSAGE =
+const GEMINI_RATE_LIMIT_MESSAGE =
   '\nRate limit exceeded. Please wait a moment and retry, or use /model to switch to a different model.';
+
+const getRateLimitErrorMessageAnthropicFree = () =>
+  '\nAnthropic rate limit exceeded. LLxprt Code retries rate-limited requests with backoff when possible. Please wait before retrying manually.';
+
+const getRateLimitErrorMessageAnthropicPaid = () =>
+  '\nAnthropic rate limit exceeded. LLxprt Code retries rate-limited requests with backoff when possible. Please wait before retrying manually or check your Anthropic plan limits.';
+
+const getRateLimitErrorMessageGeneric = () =>
+  '\nRate limit exceeded. LLxprt Code retries rate-limited requests with backoff when possible. Please wait before retrying manually.';
 
 // Google Free Tier message functions
 const getRateLimitErrorMessageGoogleProQuotaFree = (
@@ -118,14 +127,52 @@ function getErrorCodeFromUnknown(error: unknown): string | undefined {
   return undefined;
 }
 
+function normalizeProviderName(providerName?: string): string | undefined {
+  const trimmedProviderName = providerName?.trim().toLowerCase();
+  return trimmedProviderName === '' ? undefined : trimmedProviderName;
+}
+
+function getProviderFamily(
+  providerName?: string,
+  currentModel?: string,
+): string | undefined {
+  const normalizedProviderName = normalizeProviderName(providerName);
+  if (normalizedProviderName === undefined) {
+    return undefined;
+  }
+
+  const normalizedModelName = currentModel?.trim().toLowerCase() ?? '';
+  if (
+    normalizedProviderName.includes('anthropic') ||
+    normalizedModelName.startsWith('anthropic:') ||
+    normalizedModelName.startsWith('claude')
+  ) {
+    return 'anthropic';
+  }
+
+  return normalizedProviderName;
+}
+
 function getRateLimitMessage(
   error?: unknown,
   userTier?: UserTierId,
   currentModel?: string,
+  providerName?: string,
 ): string {
   // Determine if user is on a paid tier (Legacy or Standard) - default to FREE if not specified
   const isPaidTier =
     userTier === UserTierId.LEGACY || userTier === UserTierId.STANDARD;
+  const providerFamily = getProviderFamily(providerName, currentModel);
+
+  if (providerFamily === 'anthropic') {
+    return isPaidTier
+      ? getRateLimitErrorMessageAnthropicPaid()
+      : getRateLimitErrorMessageAnthropicFree();
+  }
+
+  if (providerFamily !== undefined && providerFamily !== 'gemini') {
+    return getRateLimitErrorMessageGeneric();
+  }
 
   if (isProQuotaExceededError(error)) {
     return isPaidTier
@@ -148,7 +195,7 @@ function getRateLimitMessage(
       : getRateLimitErrorMessageGoogleGenericQuotaFree();
   }
 
-  return GENERIC_RATE_LIMIT_MESSAGE;
+  return GEMINI_RATE_LIMIT_MESSAGE;
 }
 
 function formatStreamInterruptedError(error: unknown): string {
@@ -172,11 +219,12 @@ function formatStructuredApiError(
   error: StructuredError,
   userTier?: UserTierId,
   currentModel?: string,
+  providerName?: string,
 ): string {
   const status = getErrorStatus(error);
   let text = `[API Error: ${formatErrorMessageWithStatus(error.message, status)}]`;
   if (status === 429) {
-    text += getRateLimitMessage(error, userTier, currentModel);
+    text += getRateLimitMessage(error, userTier, currentModel, providerName);
   }
   return text;
 }
@@ -185,6 +233,7 @@ function formatStringApiError(
   error: string,
   userTier?: UserTierId,
   currentModel?: string,
+  providerName?: string,
 ): string {
   const jsonStart = error.indexOf('{');
   if (jsonStart === -1) {
@@ -195,6 +244,7 @@ function formatStringApiError(
     error.substring(jsonStart),
     userTier,
     currentModel,
+    providerName,
   );
   return parsedMessage ?? `[API Error: ${error}]`;
 }
@@ -203,6 +253,7 @@ function formatEmbeddedJsonApiError(
   jsonString: string,
   userTier?: UserTierId,
   currentModel?: string,
+  providerName?: string,
 ): string | undefined {
   const parsedError = parseApiErrorJson(jsonString);
   if (parsedError === undefined) {
@@ -219,10 +270,30 @@ function formatEmbeddedJsonApiError(
       : undefined,
   );
   let text = `[API Error: ${finalMessage}${statusSuffix}]`;
-  if (parsedError.error.code === 429) {
-    text += getRateLimitMessage(parsedError, userTier, currentModel);
+  if (isRateLimitApiError(parsedError)) {
+    text += getRateLimitMessage(
+      parsedError,
+      userTier,
+      currentModel,
+      providerName,
+    );
   }
   return text;
+}
+
+function isRateLimitApiError(error: ApiError): boolean {
+  if (error.error.code === 429) {
+    return true;
+  }
+
+  if (
+    error.error.status === 'RESOURCE_EXHAUSTED' ||
+    error.error.status === 'rate_limit_error'
+  ) {
+    return true;
+  }
+
+  return 'type' in error.error && error.error.type === 'rate_limit_error';
 }
 
 function parseApiErrorJson(jsonString: string): ApiError | undefined {
@@ -247,6 +318,7 @@ export function parseAndFormatApiError(
   error: unknown,
   userTier?: UserTierId,
   currentModel?: string,
+  providerName?: string,
 ): string {
   const errorCode = getErrorCodeFromUnknown(error);
   if (errorCode === STREAM_INTERRUPTED_ERROR_CODE) {
@@ -254,16 +326,26 @@ export function parseAndFormatApiError(
   }
 
   if (isStructuredError(error)) {
-    return formatStructuredApiError(error, userTier, currentModel);
+    return formatStructuredApiError(
+      error,
+      userTier,
+      currentModel,
+      providerName,
+    );
   }
 
   if (typeof error === 'string') {
-    return formatStringApiError(error, userTier, currentModel);
+    return formatStringApiError(error, userTier, currentModel, providerName);
   }
 
-  const fallbackStatusSuffix = buildStatusSuffix(getErrorStatus(error));
+  const fallbackStatus = getErrorStatus(error);
+  const fallbackStatusSuffix = buildStatusSuffix(fallbackStatus);
   if (fallbackStatusSuffix) {
-    return `[API Error: An unknown error occurred.${fallbackStatusSuffix}]`;
+    let text = `[API Error: An unknown error occurred.${fallbackStatusSuffix}]`;
+    if (fallbackStatus === 429) {
+      text += getRateLimitMessage(error, userTier, currentModel, providerName);
+    }
+    return text;
   }
 
   return '[API Error: An unknown error occurred.]';

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -141,6 +141,10 @@ function getProviderFamily(
     return undefined;
   }
 
+  if (normalizedProviderName === 'gemini') {
+    return normalizedProviderName;
+  }
+
   const normalizedModelName = currentModel?.trim().toLowerCase() ?? '';
   if (
     normalizedProviderName.includes('anthropic') ||


### PR DESCRIPTION
## TLDR

Fixes provider-aware API rate-limit error formatting so Anthropic and other explicit non-Gemini providers no longer receive Gemini/flash fallback guidance on 429 errors. Gemini/default behavior remains backward compatible.

## Dive Deeper

This change threads active provider context into API error formatting across interactive CLI stream errors, submission errors, non-interactive CLI errors, generic CLI error handling, and A2A stream error handling.

Core error parsing now accepts an optional provider name, routes Anthropic rate-limit errors to Anthropic-specific retry/backoff guidance, routes other explicit non-Gemini providers to generic retry/backoff guidance, and preserves existing Gemini/default messaging when provider context is Gemini, blank, or omitted. It also recognizes native Anthropic rate_limit_error payloads that do not include a numeric error code.

A shared CLI helper centralizes provider lookup and fallback-model selection so non-Gemini providers do not receive a Gemini fallback model in error-formatting paths.

## Reviewer Test Plan

Reviewers can validate by configuring an Anthropic provider and forcing or simulating a 429/rate_limit_error response. The displayed error should mention Anthropic rate limiting and retry/backoff guidance, and should not mention gemini-2.5-flash, AI Studio, Gemini Code Assist, or switching to a Gemini model.

For Gemini/default behavior, simulate a Gemini 429 and confirm existing Gemini quota guidance and fallback-model behavior remains unchanged.

Verification run locally:

- npm run test: root test command completed core and CLI tests but was terminated with SIGTERM before the A2A workspace in two attempts; A2A workspace tests were then run separately and passed.
- npm test --workspace @vybestack/llxprt-code-a2a-server: passed.
- npm run lint: passed.
- npm run typecheck: passed.
- npm run format: passed.
- npm run build: passed.
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else": passed.

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      |   |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

## Linked issues / bugs

Fixes #1398
