### PR TITLE
Support V2 settings format (Fixes #1613)

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -1373,12 +1373,15 @@ The following settings remain at the top level of the `settings.json` file.
   - **Properties:**
     - **`contextPercentageThreshold`** (number): A value between 0 and 1 that specifies the token threshold for compression as a percentage of the model's total token limit. For example, a value of `0.6` will trigger compression when the chat history exceeds 60% of the token limit. This is equivalent to `model.compressionThreshold`.
   - **Example:**
+
     ```json
     "model": {
       "compressionThreshold": 0.6
     }
     ```
+
   - **Legacy example:**
+
     ```json
     "chatCompression": {
       "contextPercentageThreshold": 0.6
@@ -1427,6 +1430,7 @@ The following settings remain at the top level of the `settings.json` file.
   - **Default:** `{"screenReader": false, "enableLoadingPhrases": true}`
 
   - **Example:**
+
     ```json
     "ui": {
       "accessibility": {
@@ -1435,7 +1439,9 @@ The following settings remain at the top level of the `settings.json` file.
       }
     }
     ```
+
   - **Legacy example:**
+
     ```json
     "accessibility": {
       "screenReader": true,

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -2,7 +2,9 @@
 
 This page covers `settings.json` — the persistent configuration file. You can also edit settings interactively with the `/settings` command during a session.
 
-For session-level settings (the `/set` command), profiles, and reasoning configuration, see [Settings and Profiles](../settings-and-profiles.md).
+For session-level settings (the `/set` command), profiles, reasoning configuration, and V2 namespaced settings compatibility, see [Settings and Profiles](../settings-and-profiles.md).
+
+Unknown top-level keys in settings files are intentionally accepted and preserved for forward/backward compatibility with extensions, migrations, and older configuration files. Unknown nested keys inside strict built-in sections are still rejected during validation.
 
 ## Configuration layers
 
@@ -227,6 +229,51 @@ In addition to a project settings file, a project's `.llxprt` directory can cont
   - **Values:** `"text"`, `"json"`
 
 #### `ui`
+
+- **`ui.accessibility.enableLoadingPhrases`** (boolean):
+  - **Description:** Enable loading phrases during operations.
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`ui.accessibility.screenReader`** (boolean):
+  - **Description:** Render output in plain-text to be more screen reader accessible
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
+- **`ui.checkpointing.enabled`** (boolean):
+  - **Description:** Enable session checkpointing for recovery
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
+- **`ui.fileFiltering.respectGitIgnore`** (boolean):
+  - **Description:** Respect .gitignore files when searching
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`ui.fileFiltering.respectLlxprtIgnore`** (boolean):
+  - **Description:** Respect .llxprtignore files when searching
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`ui.fileFiltering.enableRecursiveFileSearch`** (boolean):
+  - **Description:** Enable recursive file search functionality
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`ui.fileFiltering.enableFuzzySearch`** (boolean):
+  - **Description:** Enable fuzzy search when searching for files.
+  - **Default:** `true`
+  - **Requires restart:** Yes
+
+- **`ui.fileFiltering.maxFileCount`** (number):
+  - **Description:** Maximum number of files to index during file search. Prevents OOM on large projects.
+  - **Default:** `20000`
+  - **Requires restart:** Yes
+
+- **`ui.fileFiltering.searchTimeout`** (number):
+  - **Description:** Timeout in milliseconds for file search operations.
+  - **Default:** `5000`
+  - **Requires restart:** Yes
 
 - **`ui.theme`** (string):
   - **Description:** The color theme for the UI.
@@ -622,8 +669,8 @@ In addition to a project settings file, a project's `.llxprt` directory can cont
 
 #### `model`
 
-- **`model`** (string):
-  - **Description:** The Gemini model to use for conversations.
+- **`model`** (string | object):
+  - **Description:** The model to use for conversations. V2 settings may use { name, compressionThreshold }; compressionThreshold maps to chatCompression.contextPercentageThreshold.
   - **Default:** `undefined`
 
 #### `hasSeenIdeIntegrationNudge`
@@ -648,8 +695,16 @@ In addition to a project settings file, a project's `.llxprt` directory can cont
 
 #### `chatCompression`
 
-- **`chatCompression`** (object):
-  - **Description:** Chat compression settings.
+- **`chatCompression.contextPercentageThreshold`** (number):
+  - **Description:** Fraction of context-limit that triggers history compression (0.0–1.0).
+  - **Default:** `undefined`
+
+- **`chatCompression.strategy`** (string):
+  - **Description:** Legacy compression strategy selector.
+  - **Default:** `undefined`
+
+- **`chatCompression.profile`** (string):
+  - **Description:** Legacy compression profile selector.
   - **Default:** `undefined`
 
 #### `experimental`
@@ -1021,21 +1076,9 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
   - **Description:** The Gemini model to use for conversations.
   - **Default:** `undefined`
 
-- **`model.maxSessionTurns`** (number):
-  - **Description:** Maximum number of user/model/tool turns to keep in a session. -1 means unlimited.
-  - **Default:** `-1`
-
-- **`model.summarizeToolOutput`** (object):
-  - **Description:** Settings for summarizing tool output.
+- **`model.compressionThreshold`** (number):
+  - **Description:** V2 setting for the token threshold that triggers chat history compression, expressed as a percentage of the model context limit. This maps to legacy `chatCompression.contextPercentageThreshold`.
   - **Default:** `undefined`
-
-- **`model.chatCompression`** (object):
-  - **Description:** Chat compression settings.
-  - **Default:** `undefined`
-
-- **`model.skipNextSpeakerCheck`** (boolean):
-  - **Description:** Skip the next speaker check.
-  - **Default:** `false`
 
 #### `context`
 
@@ -1325,12 +1368,17 @@ The following settings remain at the top level of the `settings.json` file.
     "loadMemoryFromIncludeDirectories": true
     ```
 
-- **`chatCompression`** (object):
-  - **Description:** Controls the settings for chat history compression, both automatic and
-    when manually invoked through the /compress command.
+- **`chatCompression`** (object, legacy compatibility):
+  - **Description:** Legacy root setting for chat history compression, both automatic and when manually invoked through the /compress command. New V2 configuration should use `model.compressionThreshold`.
   - **Properties:**
-    - **`contextPercentageThreshold`** (number): A value between 0 and 1 that specifies the token threshold for compression as a percentage of the model's total token limit. For example, a value of `0.6` will trigger compression when the chat history exceeds 60% of the token limit.
+    - **`contextPercentageThreshold`** (number): A value between 0 and 1 that specifies the token threshold for compression as a percentage of the model's total token limit. For example, a value of `0.6` will trigger compression when the chat history exceeds 60% of the token limit. This is equivalent to `model.compressionThreshold`.
   - **Example:**
+    ```json
+    "model": {
+      "compressionThreshold": 0.6
+    }
+    ```
+  - **Legacy example:**
     ```json
     "chatCompression": {
       "contextPercentageThreshold": 0.6
@@ -1371,8 +1419,8 @@ The following settings remain at the top level of the `settings.json` file.
     ```
   - **Note:** When set, the specified profile will be loaded automatically each time LLxprt Code starts
 
-- **`accessibility`** (object):
-  - **Description:** Configures accessibility features for the CLI.
+- **`ui.accessibility`** (object):
+  - **Description:** V2 namespace for accessibility features for the CLI. Root `accessibility` remains accepted for legacy compatibility.
   - **Properties:**
     - **`screenReader`** (boolean): Enables screen reader mode, which adjusts the TUI for better compatibility with screen readers. This can also be enabled with the `--screen-reader` command-line flag, which will take precedence over the setting.
     - **`enableLoadingPhrases`** (boolean): Enables the display of loading phrases during operations.
@@ -1380,19 +1428,20 @@ The following settings remain at the top level of the `settings.json` file.
 
   - **Example:**
     ```json
+    "ui": {
+      "accessibility": {
+        "screenReader": true,
+        "enableLoadingPhrases": false
+      }
+    }
+    ```
+  - **Legacy example:**
+    ```json
     "accessibility": {
       "screenReader": true,
       "enableLoadingPhrases": false
     }
     ```
-
-#### Additional Dialog Settings
-
-The following settings are available in the `/settings` dialog:
-
-- **`enableAutoUpdateNotification`** (boolean):
-  - **Description:** Enable update notification prompts.
-  - **Default:** `true`
 
 - **`enablePromptCompletion`** (boolean):
   - **Description:** Enable AI-powered prompt completion suggestions while typing. Provides intelligent autocomplete based on context and command history.

--- a/docs/settings-and-profiles.md
+++ b/docs/settings-and-profiles.md
@@ -66,6 +66,67 @@ At startup:
 llxprt --set context-limit=100000 --set streaming=disabled
 ```
 
+## Settings File Compatibility
+
+Persistent settings files accept both legacy flat keys and the V2 namespaced shape for settings that have moved under a clearer namespace. Existing files continue to work; new writes for mapped UI primitive keys use the V2 path.
+
+```json
+{
+  "ui": {
+    "accessibility": {
+      "screenReader": true,
+      "enableLoadingPhrases": false
+    },
+    "checkpointing": {
+      "enabled": true
+    },
+    "fileFiltering": {
+      "respectGitIgnore": true,
+      "respectLlxprtIgnore": true,
+      "enableRecursiveFileSearch": true,
+      "enableFuzzySearch": false
+    }
+  }
+}
+```
+
+Backward-compatible mappings:
+
+| Legacy path       | V2 path written by settings updates |
+| ----------------- | ----------------------------------- |
+| `accessibility.*` | `ui.accessibility.*`                |
+| `checkpointing.*` | `ui.checkpointing.*`                |
+| `fileFiltering.*` | `ui.fileFiltering.*`                |
+
+When both legacy and V2 locations are present in the same settings layer, the V2 value wins. Normal scope precedence still applies across settings files.
+
+This is the complete V2 compatibility mapping currently supported by LLxprt. Other root-level settings remain in their existing locations until they get an explicit namespaced compatibility path.
+
+Model settings have one compatibility exception: the legacy `model` setting is a string and remains supported as-is for model selection. V2 files may also use an object when they need compression settings next to the model name:
+
+```json
+{
+  "model": {
+    "name": "gpt-4.1",
+    "compressionThreshold": 0.7
+  }
+}
+```
+
+`compressionThreshold` must be a number from 0 to 1.
+
+`model.name` is normalized back to the active model string, and `model.compressionThreshold` maps to the legacy runtime shape `chatCompression.contextPercentageThreshold`. Existing files using `"model": "gpt-4.1"` and/or `chatCompression.contextPercentageThreshold` continue to work.
+
+Merged runtime settings keep `model` as the active model string for existing callers and also expose the V2 object fields as `modelConfig` for code that needs the full namespaced model configuration.
+
+```json
+{
+  "chatCompression": {
+    "contextPercentageThreshold": 0.7
+  }
+}
+```
+
 ### Core Settings
 
 | Setting                 | Description                                    | Default          |

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -15,7 +15,7 @@ import {
   type MCPServerConfig,
 } from '@vybestack/llxprt-code-core';
 
-import { type Settings } from './settings.js';
+import { type MergedSettings, type Settings } from './settings.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
 import { resolveMcpServers } from './mcpServerConfig.js';
 import { type CliArgs } from './cliArgParser.js';
@@ -109,15 +109,17 @@ async function bootstrapAndLoadProfile(
 /** Steps 7-8: Resolve approval mode and provider/model, sync to SettingsService */
 function resolveApprovalAndProvider(
   argv: CliArgs,
-  profileMergedSettings: Settings,
+  profileMergedSettings: MergedSettings,
   context: ContextResolutionResult,
   profileResult: ProfileLoadResult,
   runtimeState: BootstrapRuntimeState,
 ) {
+  const securitySettings = (profileMergedSettings as Partial<MergedSettings>)
+    .security;
   const approvalMode = resolveApprovalMode({
     cliApprovalMode: argv.approvalMode,
     cliYolo: argv.yolo,
-    disableYoloMode: profileMergedSettings.security?.disableYoloMode,
+    disableYoloMode: securitySettings?.disableYoloMode,
     secureModeEnabled: profileMergedSettings.admin?.secureModeEnabled,
     trustedFolder: context.trustedFolder,
   });
@@ -144,7 +146,7 @@ function resolveApprovalAndProvider(
 async function resolveConfigBuildPieces(
   argv: CliArgs,
   settings: Settings,
-  profileMergedSettings: Settings,
+  profileMergedSettings: MergedSettings,
   profileResult: ProfileLoadResult,
   runtimeState: BootstrapRuntimeState,
   cwd: string,

--- a/packages/cli/src/config/profileResolution.ts
+++ b/packages/cli/src/config/profileResolution.ts
@@ -11,7 +11,7 @@ import {
   debugLogger,
   type Profile,
 } from '@vybestack/llxprt-code-core';
-import type { Settings } from './settings.js';
+import type { MergedSettings, Settings } from './settings.js';
 import type { CliArgs } from './cliArgParser.js';
 import type { BootstrapProfileArgs } from './profileBootstrap.js';
 
@@ -24,7 +24,7 @@ export interface ProfilePreparationResult {
   readonly profileModel: string | undefined;
   readonly profileModelParams: Record<string, unknown> | undefined;
   readonly profileBaseUrl: string | undefined;
-  readonly profileMergedSettings: Settings;
+  readonly profileMergedSettings: MergedSettings;
 }
 
 export interface ProfileResolutionInput {
@@ -42,7 +42,7 @@ export interface ProfileResolutionResult {
 }
 
 export interface ProfileLoadResult {
-  readonly profileMergedSettings: Settings;
+  readonly profileMergedSettings: MergedSettings;
   readonly profileModel: string | undefined;
   readonly profileProvider: string | undefined;
   readonly profileModelParams: Record<string, unknown> | undefined;
@@ -95,12 +95,12 @@ export function prepareProfileForApplication(
   const loadSummary = `Loaded ${profileSource === 'inline' ? 'inline profile from --profile' : `profile ${profileSource}`}: provider=${profile.provider}, model=${profile.model}, hasEphemeralSettings=${!!ephemeralSettings}`;
   logger.debug(() => loadSummary);
 
-  let profileMergedSettings = baseSettings;
+  let profileMergedSettings: MergedSettings = baseSettings as MergedSettings;
   if (argv.provider === undefined && ephemeralSettings) {
     profileMergedSettings = {
       ...baseSettings,
       ...ephemeralSettings,
-    } as Settings;
+    } as MergedSettings;
     logger.debug(
       () =>
         `Merged ephemeral settings from ${profileSource === 'inline' ? 'inline profile' : `profile '${profileSource}'`}`,
@@ -255,7 +255,7 @@ export async function loadAndPrepareProfile(input: {
     profileExplicitlySpecified,
   } = input;
 
-  let profileMergedSettings = settings;
+  let profileMergedSettings: MergedSettings = settings as MergedSettings;
   let profileModel: string | undefined;
   let profileProvider: string | undefined;
   let profileModelParams: Record<string, unknown> | undefined;

--- a/packages/cli/src/config/settings-schema/schema-extensions.ts
+++ b/packages/cli/src/config/settings-schema/schema-extensions.ts
@@ -172,12 +172,17 @@ export const EXTENSION_SETTINGS_SCHEMA = {
     showInDialog: true,
   },
   model: {
-    type: 'string',
+    type: 'union',
+    refs: ['ModelName', 'ModelConfig'],
     label: 'Model',
     category: 'General',
     requiresRestart: false,
-    default: undefined as string | undefined,
-    description: 'The Gemini model to use for conversations.',
+    default: undefined as
+      | string
+      | { name?: string; compressionThreshold?: number }
+      | undefined,
+    description:
+      'The model to use for conversations. V2 settings may use { name, compressionThreshold }; compressionThreshold maps to chatCompression.contextPercentageThreshold.',
     showInDialog: false,
   },
   hasSeenIdeIntegrationNudge: {
@@ -213,8 +218,42 @@ export const EXTENSION_SETTINGS_SCHEMA = {
     category: 'General',
     requiresRestart: false,
     default: undefined as ChatCompressionSettings | undefined,
-    description: 'Chat compression settings.',
+    description:
+      'Legacy chat compression settings. V2 model.compressionThreshold maps to contextPercentageThreshold.',
     showInDialog: false,
+    properties: {
+      contextPercentageThreshold: {
+        type: 'number',
+        label: 'Context Percentage Threshold',
+        category: 'General',
+        requiresRestart: false,
+        default: undefined,
+        description:
+          'Fraction of context-limit that triggers history compression (0.0–1.0).',
+        showInDialog: false,
+        minimum: 0,
+        maximum: 1,
+      },
+      strategy: {
+        type: 'string',
+        label: 'Compression Strategy',
+        category: 'General',
+        requiresRestart: false,
+        default: undefined,
+        description: 'Legacy compression strategy selector.',
+        showInDialog: false,
+      },
+      profile: {
+        type: 'string',
+        label: 'Compression Profile',
+        category: 'General',
+        requiresRestart: false,
+        default: undefined,
+        description: 'Legacy compression profile selector.',
+        showInDialog: false,
+      },
+    },
+    additionalProperties: false,
   },
 
   experimental: {

--- a/packages/cli/src/config/settings-schema/schema-ui.ts
+++ b/packages/cli/src/config/settings-schema/schema-ui.ts
@@ -1,6 +1,7 @@
 import { type WittyPhraseStyle } from '../../ui/constants/phrasesCollections.js';
 import type { MemoryImportFormat } from './types.js';
 import type { CustomTheme } from '../../ui/themes/theme.js';
+import { CORE_SETTINGS_SCHEMA } from './schema-core.js';
 
 export const UI_SETTINGS_SCHEMA = {
   ui: {
@@ -12,6 +13,9 @@ export const UI_SETTINGS_SCHEMA = {
     description: 'User interface settings.',
     showInDialog: false,
     properties: {
+      accessibility: CORE_SETTINGS_SCHEMA.accessibility,
+      checkpointing: CORE_SETTINGS_SCHEMA.checkpointing,
+      fileFiltering: CORE_SETTINGS_SCHEMA.fileFiltering,
       theme: {
         type: 'string',
         label: 'Theme',

--- a/packages/cli/src/config/settings-schema/types.ts
+++ b/packages/cli/src/config/settings-schema/types.ts
@@ -10,7 +10,8 @@ export type SettingsType =
   | 'number'
   | 'array'
   | 'object'
-  | 'enum';
+  | 'enum'
+  | 'union';
 
 export type SettingsValue =
   | boolean
@@ -46,6 +47,10 @@ export interface SettingCollectionDefinition {
    * For example, a JSON schema generator can use this to point to a shared definition.
    */
   ref?: string;
+  /**
+   * For union settings, references the allowed schema alternatives.
+   */
+  refs?: readonly string[];
 }
 
 export enum MergeStrategy {
@@ -80,9 +85,14 @@ export interface SettingDefinition {
    */
   items?: SettingCollectionDefinition;
   /**
+   * For union settings, references the allowed schema alternatives.
+   */
+  refs?: readonly string[];
+  /**
    * For map-like objects without explicit `properties`, describes the shape of the values.
    */
-  additionalProperties?: SettingCollectionDefinition;
+  additionalProperties?: SettingCollectionDefinition | false;
+
   /**
    * Optional reference identifier for generators that emit a `$ref`.
    */

--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -85,15 +85,6 @@ describe('settings-validation', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should accept unknown top-level keys (passthrough for migration)', () => {
-      const validSettings = {
-        unknownKey: 'some value',
-        anotherUnknown: 123,
-      };
-      const result = validateSettings(validSettings);
-      expect(result.success).toBe(true);
-    });
-
     it('should accept complex valid settings', () => {
       const validSettings = {
         enableAutoUpdate: false,
@@ -249,6 +240,142 @@ describe('settings-validation', () => {
       // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
       if (!result.error) throw new Error('unreachable: narrowing failed');
       expect(result.error.issues.length).toBeGreaterThan(1);
+    });
+
+    it('should accept V2 nested ui compatibility namespaces', () => {
+      const validSettings = {
+        ui: {
+          accessibility: { screenReader: true },
+          checkpointing: { enabled: true },
+          fileFiltering: {
+            respectGitIgnore: true,
+            enableFuzzySearch: false,
+          },
+        },
+      };
+
+      const result = validateSettings(validSettings);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid V2 nested ui compatibility paths', () => {
+      const invalidSettings = {
+        ui: {
+          accessibility: { screenReader: 'yes' },
+          checkpointing: { enabled: 'yes' },
+          fileFiltering: { enableFuzzySearch: 'no' },
+        },
+      };
+
+      const result = validateSettings(invalidSettings);
+
+      expect(result.success).toBe(false);
+      // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
+      if (!result.error) throw new Error('unreachable: narrowing failed');
+      expect(result.error.issues.map((issue) => issue.path)).toStrictEqual(
+        expect.arrayContaining([
+          ['ui', 'accessibility', 'screenReader'],
+          ['ui', 'checkpointing', 'enabled'],
+          ['ui', 'fileFiltering', 'enableFuzzySearch'],
+        ]),
+      );
+    });
+
+    it('should accept model object compatibility settings', () => {
+      const validSettings = {
+        model: {
+          name: 'provider-model',
+          compressionThreshold: 0.7,
+        },
+      };
+
+      const result = validateSettings(validSettings);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject model compression thresholds outside the 0 to 1 range', () => {
+      expect(
+        validateSettings({ model: { compressionThreshold: -0.1 } }).success,
+      ).toBe(false);
+      expect(
+        validateSettings({ model: { compressionThreshold: 1.1 } }).success,
+      ).toBe(false);
+      expect(
+        validateSettings({
+          chatCompression: { contextPercentageThreshold: 1.1 },
+        }).success,
+      ).toBe(false);
+    });
+
+    it('should reject invalid model object compatibility settings', () => {
+      const invalidSettings = {
+        model: {
+          name: 123,
+          compressionThreshold: '0.7',
+          extra: true,
+        },
+      };
+
+      const result = validateSettings(invalidSettings);
+
+      expect(result.success).toBe(false);
+      // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
+      if (!result.error) throw new Error('unreachable: narrowing failed');
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    });
+
+    it('should validate legacy chatCompression fields and reject unknown nested keys', () => {
+      const validSettings = {
+        chatCompression: {
+          contextPercentageThreshold: 0.5,
+          strategy: 'high-density',
+          profile: 'balanced',
+        },
+      };
+      const invalidSettings = {
+        chatCompression: { compressionThreshold: 0.5 },
+      };
+
+      expect(validateSettings(validSettings).success).toBe(true);
+      expect(validateSettings(invalidSettings).success).toBe(false);
+    });
+
+    it('should include guidance for mistaken compression paths', () => {
+      const result = validateSettings({
+        chatCompression: { compressionThreshold: 0.5 },
+        model: { chatCompression: { contextPercentageThreshold: 0.5 } },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+
+      const message = formatValidationError(result.error!, '/settings.json');
+      expect(message).toContain(
+        'Use model.compressionThreshold instead of chatCompression.compressionThreshold.',
+      );
+      expect(message).toContain(
+        'model.chatCompression is not supported. Use model.compressionThreshold.',
+      );
+    });
+
+    it('should include guidance for invalid root compatibility paths', () => {
+      const result = validateSettings({
+        accessibility: { screenReader: 'yes' },
+        chatCompression: { contextPercentageThreshold: '0.5' },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+
+      const message = formatValidationError(result.error!, '/settings.json');
+      expect(message).toContain(
+        'Use ui.accessibility.* for V2 settings; root accessibility.* remains accepted for legacy compatibility.',
+      );
+      expect(message).toContain(
+        'Use model.compressionThreshold for V2 settings; root chatCompression.contextPercentageThreshold remains accepted for legacy compatibility.',
+      );
     });
 
     it('should validate mcpServers with type field for all transport types', () => {

--- a/packages/cli/src/config/settings-validation.ts
+++ b/packages/cli/src/config/settings-validation.ts
@@ -49,6 +49,24 @@ function buildStringJsonSchema(def: JsonSchemaLike): z.ZodTypeAny {
   return z.string();
 }
 
+function applyNumberBounds(
+  schema: z.ZodNumber,
+  def: { minimum?: unknown; maximum?: unknown },
+): z.ZodNumber {
+  let boundedSchema = schema;
+  if (typeof def.minimum === 'number') {
+    boundedSchema = boundedSchema.min(def.minimum);
+  }
+  if (typeof def.maximum === 'number') {
+    boundedSchema = boundedSchema.max(def.maximum);
+  }
+  return boundedSchema;
+}
+
+function buildNumberJsonSchema(def: JsonSchemaLike): z.ZodTypeAny {
+  return applyNumberBounds(z.number(), def);
+}
+
 function buildBooleanJsonSchema(def: JsonSchemaLike): z.ZodTypeAny {
   if ('const' in def) {
     return z.literal(def.const as never);
@@ -114,7 +132,7 @@ function buildZodSchemaFromJsonSchema(def: unknown): z.ZodTypeAny {
     case 'string':
       return buildStringJsonSchema(def);
     case 'number':
-      return z.number();
+      return buildNumberJsonSchema(def);
     case 'boolean':
       return buildBooleanJsonSchema(def);
     case 'array':
@@ -176,14 +194,16 @@ function buildObjectShapeFromProperties(
 /**
  * Builds a Zod schema for primitive types (string, number, boolean).
  */
-function buildPrimitiveSchema(
-  type: 'string' | 'number' | 'boolean',
-): z.ZodTypeAny {
-  switch (type) {
+function buildPrimitiveSchema(definition: {
+  type: 'string' | 'number' | 'boolean';
+  minimum?: number;
+  maximum?: number;
+}): z.ZodTypeAny {
+  switch (definition.type) {
     case 'string':
       return z.string();
     case 'number':
-      return z.number();
+      return applyNumberBounds(z.number(), definition);
     case 'boolean':
       return z.boolean();
     default:
@@ -210,12 +230,23 @@ function buildZodSchemaFromDefinition(
   if (definition.ref && definition.ref in REF_SCHEMAS) {
     return REF_SCHEMAS[definition.ref].optional();
   }
+  if (definition.type === 'union' && definition.refs) {
+    return unionJsonSchemas(
+      definition.refs.map((ref) => REF_SCHEMAS[ref] ?? z.unknown()),
+    ).optional();
+  }
 
   switch (definition.type) {
     case 'string':
     case 'number':
     case 'boolean':
-      baseSchema = buildPrimitiveSchema(definition.type);
+      baseSchema = buildPrimitiveSchema(
+        definition as {
+          type: 'string' | 'number' | 'boolean';
+          minimum?: number;
+          maximum?: number;
+        },
+      );
       break;
 
     case 'enum': {
@@ -237,17 +268,23 @@ function buildZodSchemaFromDefinition(
         const shape = buildObjectShapeFromProperties(definition.properties);
         baseSchema = z.object(shape).passthrough();
 
-        if (definition.additionalProperties) {
+        if (definition.additionalProperties === false) {
+          baseSchema = z.object(shape).strict();
+        } else if (definition.additionalProperties) {
           const additionalSchema = buildZodSchemaFromCollection(
             definition.additionalProperties,
           );
           baseSchema = z.object(shape).catchall(additionalSchema);
         }
-      } else if (definition.additionalProperties) {
-        const valueSchema = buildZodSchemaFromCollection(
-          definition.additionalProperties,
-        );
-        baseSchema = z.record(z.string(), valueSchema);
+      } else if (definition.additionalProperties !== undefined) {
+        const additionalProperties = definition.additionalProperties;
+        baseSchema =
+          additionalProperties === false
+            ? z.record(z.string(), z.never())
+            : z.record(
+                z.string(),
+                buildZodSchemaFromCollection(additionalProperties),
+              );
       } else {
         baseSchema = z.record(z.string(), z.unknown());
       }
@@ -275,7 +312,13 @@ function buildZodSchemaFromCollection(
     case 'string':
     case 'number':
     case 'boolean':
-      return buildPrimitiveSchema(collection.type);
+      return buildPrimitiveSchema(
+        collection as {
+          type: 'string' | 'number' | 'boolean';
+          minimum?: number;
+          maximum?: number;
+        },
+      );
 
     case 'enum': {
       return buildEnumSchema(collection.options);
@@ -294,6 +337,10 @@ function buildZodSchemaFromCollection(
         return z.object(shape).passthrough();
       }
       return z.record(z.string(), z.unknown());
+    case 'union':
+      return unionJsonSchemas(
+        (collection.refs ?? []).map((ref) => REF_SCHEMAS[ref] ?? z.unknown()),
+      );
 
     default:
       return z.unknown();
@@ -328,6 +375,41 @@ export function validateSettings(data: unknown): {
   return result;
 }
 
+function getValidationGuidance(
+  path: string,
+  message?: string,
+): string | undefined {
+  if (
+    path === 'chatCompression' &&
+    message?.includes('compressionThreshold') === true
+  ) {
+    return 'Use model.compressionThreshold instead of chatCompression.compressionThreshold.';
+  }
+  if (path === 'model' && message?.includes('chatCompression') === true) {
+    return 'model.chatCompression is not supported. Use model.compressionThreshold.';
+  }
+
+  switch (path) {
+    case 'accessibility':
+    case 'accessibility.screenReader':
+    case 'accessibility.enableLoadingPhrases':
+      return 'Use ui.accessibility.* for V2 settings; root accessibility.* remains accepted for legacy compatibility.';
+    case 'chatCompression':
+    case 'chatCompression.contextPercentageThreshold':
+      return 'Use model.compressionThreshold for V2 settings; root chatCompression.contextPercentageThreshold remains accepted for legacy compatibility.';
+    case 'chatCompression.compressionThreshold':
+      return 'Use model.compressionThreshold instead of chatCompression.compressionThreshold.';
+    case 'model.chatCompression':
+      return 'model.chatCompression is not supported. Use model.compressionThreshold.';
+    case 'model.compressionThreshold':
+      return 'model.compressionThreshold must be a number between 0 and 1.';
+    case 'model':
+      return 'Use either a model name string or { name, compressionThreshold }.';
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Format a Zod error into a helpful error message for end users.
  */
@@ -359,6 +441,11 @@ export function formatValidationError(
       const received = issue.received;
       lines.push(`Expected: ${expected}, but received: ${received}`);
     }
+    const guidance = getValidationGuidance(path, issue.message);
+    if (guidance) {
+      lines.push(`Guidance: ${guidance}`);
+    }
+
     lines.push('');
   }
 

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -63,6 +63,8 @@ import {
   type Settings,
   loadEnvironment,
 } from './settings';
+import { getV2NamespacedSettingPath } from './settingsMerge.js';
+
 import { FatalConfigError, LLXPRT_DIR } from '@vybestack/llxprt-code-core';
 
 const MOCK_WORKSPACE_DIR = '/mock/workspace';
@@ -780,6 +782,373 @@ describe('Settings Loading and Merging', () => {
       });
     });
 
+    it('should map V2 model.compressionThreshold to chatCompression without changing model string selection', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettingsContent = {
+        model: {
+          name: 'user-model',
+          compressionThreshold: 0.5,
+        },
+      };
+      const workspaceSettingsContent = {
+        model: 'workspace-model',
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.model).toBe('workspace-model');
+      expect(settings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.5,
+      });
+      expect(settings.merged.modelConfig).toStrictEqual({
+        name: 'workspace-model',
+        compressionThreshold: 0.5,
+      });
+    });
+
+    it('should let higher-precedence model.compressionThreshold override legacy chatCompression', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettingsContent = {
+        chatCompression: { contextPercentageThreshold: 0.5 },
+      };
+      const workspaceSettingsContent = {
+        model: {
+          name: 'workspace-model',
+          compressionThreshold: 0.8,
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.model).toBe('workspace-model');
+      expect(settings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.8,
+      });
+    });
+
+    it('should preserve legacy chatCompression when lower-precedence model.compressionThreshold exists', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettingsContent = {
+        model: { compressionThreshold: 0.5 },
+      };
+      const workspaceSettingsContent = {
+        chatCompression: { contextPercentageThreshold: 0.8 },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.8,
+      });
+    });
+
+    it('should preserve legacy chatCompression strategy and profile fields', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        chatCompression: {
+          contextPercentageThreshold: 0.5,
+          strategy: 'high-density',
+          profile: 'balanced',
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.user.settings.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.5,
+        strategy: 'high-density',
+        profile: 'balanced',
+      });
+      expect(settings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.5,
+        strategy: 'high-density',
+        profile: 'balanced',
+      });
+    });
+
+    it('should keep workspace and user model precedence over system model settings', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const systemSettingsContent = {
+        model: 'system-model',
+      };
+      const systemDefaultsContent = {
+        model: 'system-default-model',
+      };
+      const userSettingsContent = {
+        model: 'user-model',
+      };
+      const workspaceSettingsContent = {
+        model: { name: 'workspace-model' },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === '/mock/system/settings.json')
+            return JSON.stringify(systemSettingsContent);
+          if (p === '/mock/system/system-defaults.json')
+            return JSON.stringify(systemDefaultsContent);
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.model).toBe('workspace-model');
+    });
+
+    it('should keep user model precedence over system model settings when workspace model is absent', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const systemSettingsContent = {
+        model: { name: 'system-model' },
+      };
+      const systemDefaultsContent = {
+        model: { name: 'system-default-model' },
+      };
+      const userSettingsContent = {
+        model: 'user-model',
+      };
+      const workspaceSettingsContent = {};
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === '/mock/system/settings.json')
+            return JSON.stringify(systemSettingsContent);
+          if (p === '/mock/system/system-defaults.json')
+            return JSON.stringify(systemDefaultsContent);
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.model).toBe('user-model');
+    });
+
+    it('should use system model precedence over systemDefaults when user and workspace are absent', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const systemSettingsContent = {
+        model: 'system-model',
+      };
+      const systemDefaultsContent = {
+        model: { name: 'system-default-model' },
+      };
+      const userSettingsContent = {};
+      const workspaceSettingsContent = {};
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === '/mock/system/settings.json')
+            return JSON.stringify(systemSettingsContent);
+          if (p === '/mock/system/system-defaults.json')
+            return JSON.stringify(systemDefaultsContent);
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.model).toBe('system-model');
+    });
+
+    it('should use systemDefaults model when no higher precedence model exists', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const systemSettingsContent = {};
+      const systemDefaultsContent = {
+        model: 'system-default-model',
+      };
+      const userSettingsContent = {};
+      const workspaceSettingsContent = {};
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === '/mock/system/settings.json')
+            return JSON.stringify(systemSettingsContent);
+          if (p === '/mock/system/system-defaults.json')
+            return JSON.stringify(systemDefaultsContent);
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.model).toBe('system-default-model');
+    });
+
+    it('should read V2 namespaced UI settings into their top-level compatibility sections', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        ui: {
+          accessibility: { screenReader: true },
+          checkpointing: { enabled: true },
+          fileFiltering: { enableFuzzySearch: false },
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.accessibility).toMatchObject({
+        enableLoadingPhrases: true,
+        screenReader: true,
+      });
+      expect(settings.merged.checkpointing).toStrictEqual({ enabled: true });
+      expect(settings.merged.fileFiltering).toMatchObject({
+        enableFuzzySearch: false,
+        respectGitIgnore: true,
+      });
+    });
+
+    it('should prefer V2 namespaced values over legacy top-level values in the same settings layer', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        accessibility: { screenReader: false },
+        checkpointing: { enabled: false },
+        fileFiltering: { enableFuzzySearch: true },
+        ui: {
+          accessibility: { screenReader: true },
+          checkpointing: { enabled: true },
+          fileFiltering: { enableFuzzySearch: false },
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.accessibility.screenReader).toBe(true);
+      expect(settings.merged.checkpointing.enabled).toBe(true);
+      expect(settings.merged.fileFiltering.enableFuzzySearch).toBe(false);
+    });
+
+    it('should keep layer precedence when merging legacy top-level and V2 namespaced settings', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          p === USER_SETTINGS_PATH || p === MOCK_WORKSPACE_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        ui: {
+          accessibility: { screenReader: true },
+          checkpointing: { enabled: true },
+          fileFiltering: { enableFuzzySearch: false },
+        },
+      };
+      const workspaceSettingsContent = {
+        accessibility: { screenReader: false },
+        checkpointing: { enabled: false },
+        fileFiltering: { enableFuzzySearch: true },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.accessibility.screenReader).toBe(false);
+      expect(settings.merged.checkpointing.enabled).toBe(false);
+      expect(settings.merged.fileFiltering.enableFuzzySearch).toBe(true);
+    });
+
+    it('should map legacy V2-compatible setting paths to namespaced write paths', () => {
+      expect(getV2NamespacedSettingPath('accessibility.screenReader')).toBe(
+        'ui.accessibility.screenReader',
+      );
+      expect(getV2NamespacedSettingPath('checkpointing.enabled')).toBe(
+        'ui.checkpointing.enabled',
+      );
+      expect(
+        getV2NamespacedSettingPath('fileFiltering.enableFuzzySearch'),
+      ).toBe('ui.fileFiltering.enableFuzzySearch');
+      expect(getV2NamespacedSettingPath('ui.theme')).toBe('ui.theme');
+      expect(getV2NamespacedSettingPath('chatCompression.enabled')).toBe(
+        'chatCompression.enabled',
+      );
+      expect(
+        getV2NamespacedSettingPath(
+          'chatCompression.contextPercentageThreshold',
+        ),
+      ).toBe('model.compressionThreshold');
+    });
+
     it('should merge includeDirectories from all scopes', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true);
       const systemSettingsContent = {
@@ -1429,7 +1798,7 @@ describe('Settings Loading and Merging', () => {
 
       // Verify migrated value (inverted: disableLoadingPhrases=true → enableLoadingPhrases=false)
       expect(
-        (settings.user.settings.accessibility as Record<string, unknown>)[
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
           'enableLoadingPhrases'
         ],
       ).toBe(false);
@@ -1457,7 +1826,7 @@ describe('Settings Loading and Merging', () => {
 
       // Verify migrated value (inverted: disableFuzzySearch=true → enableFuzzySearch=false)
       expect(
-        (settings.user.settings.fileFiltering as Record<string, unknown>)[
+        (settings.user.settings.ui?.fileFiltering as Record<string, unknown>)[
           'enableFuzzySearch'
         ],
       ).toBe(false);
@@ -1512,6 +1881,250 @@ describe('Settings Loading and Merging', () => {
       );
       expect(loadedSettings.systemDefaults.settings.ui?.theme).toBe('default');
       expect(loadedSettings.merged.ui.theme).toBe('matrix');
+    });
+
+    it('setValue should write V2-compatible settings to namespaced paths', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(false);
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(
+        SettingScope.User,
+        'accessibility.screenReader',
+        true,
+      );
+      expect(loadedSettings.user.settings.accessibility).toBeUndefined();
+      expect(loadedSettings.user.settings.ui?.accessibility).toStrictEqual({
+        screenReader: true,
+      });
+      expect(loadedSettings.merged.accessibility.screenReader).toBe(true);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        USER_SETTINGS_PATH,
+        JSON.stringify(
+          { ui: { accessibility: { screenReader: true } } },
+          null,
+          2,
+        ),
+        'utf-8',
+      );
+    });
+
+    it('setValue should write additional V2-compatible settings to namespaced paths', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(false);
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(SettingScope.User, 'checkpointing.enabled', true);
+      expect(loadedSettings.user.settings.checkpointing).toBeUndefined();
+      expect(loadedSettings.user.settings.ui?.checkpointing).toStrictEqual({
+        enabled: true,
+      });
+      expect(loadedSettings.merged.checkpointing.enabled).toBe(true);
+
+      loadedSettings.setValue(
+        SettingScope.User,
+        'fileFiltering.enableFuzzySearch',
+        false,
+      );
+      expect(loadedSettings.user.settings.fileFiltering).toBeUndefined();
+      expect(loadedSettings.user.settings.ui?.fileFiltering).toStrictEqual({
+        enableFuzzySearch: false,
+      });
+      expect(loadedSettings.merged.fileFiltering.enableFuzzySearch).toBe(false);
+    });
+
+    it('setValue should write chatCompression threshold updates to V2 model path', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(false);
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(
+        SettingScope.User,
+        'chatCompression.contextPercentageThreshold',
+        0.7,
+      );
+      expect(loadedSettings.user.settings.chatCompression).toBeUndefined();
+      expect(
+        (
+          loadedSettings.user.settings.model as {
+            compressionThreshold?: number;
+          }
+        ).compressionThreshold,
+      ).toBe(0.7);
+      expect(loadedSettings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.7,
+      });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        USER_SETTINGS_PATH,
+        JSON.stringify({ model: { compressionThreshold: 0.7 } }, null, 2),
+        'utf-8',
+      );
+    });
+
+    it('setValue should remove duplicate legacy leaves when writing V2 paths', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify({
+              accessibility: {
+                screenReader: false,
+                enableLoadingPhrases: true,
+              },
+              checkpointing: { enabled: false },
+              fileFiltering: { enableFuzzySearch: true },
+              chatCompression: {
+                contextPercentageThreshold: 0.5,
+                strategy: 'high-density',
+                profile: 'balanced',
+              },
+            });
+          }
+          return '{}';
+        },
+      );
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(
+        SettingScope.User,
+        'accessibility.screenReader',
+        true,
+      );
+      loadedSettings.setValue(SettingScope.User, 'checkpointing.enabled', true);
+      loadedSettings.setValue(
+        SettingScope.User,
+        'fileFiltering.enableFuzzySearch',
+        false,
+      );
+      loadedSettings.setValue(
+        SettingScope.User,
+        'chatCompression.contextPercentageThreshold',
+        0.8,
+      );
+
+      expect(loadedSettings.user.settings.accessibility).toStrictEqual({
+        enableLoadingPhrases: true,
+      });
+      expect(loadedSettings.user.settings.checkpointing).toBeUndefined();
+      expect(loadedSettings.user.settings.fileFiltering).toBeUndefined();
+      expect(loadedSettings.user.settings.chatCompression).toStrictEqual({
+        strategy: 'high-density',
+        profile: 'balanced',
+      });
+      expect(loadedSettings.user.settings.ui?.accessibility).toStrictEqual({
+        screenReader: true,
+      });
+      expect(loadedSettings.user.settings.ui?.checkpointing).toStrictEqual({
+        enabled: true,
+      });
+      expect(loadedSettings.user.settings.ui?.fileFiltering).toStrictEqual({
+        enableFuzzySearch: false,
+      });
+      expect(loadedSettings.user.settings.model).toStrictEqual({
+        compressionThreshold: 0.8,
+      });
+    });
+
+    it('setValue should preserve an existing V2 model object when setting the legacy model name', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        model: { compressionThreshold: 0.7 },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(SettingScope.User, 'model', 'updated-model');
+
+      expect(loadedSettings.user.settings.model).toStrictEqual({
+        name: 'updated-model',
+        compressionThreshold: 0.7,
+      });
+      expect(loadedSettings.merged.model).toBe('updated-model');
+      expect(loadedSettings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.7,
+      });
+    });
+
+    it('setValue should support direct V2 model.compressionThreshold writes and preserve name', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        model: { name: 'existing-model' },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(
+        SettingScope.User,
+        'model.compressionThreshold',
+        0.8,
+      );
+
+      expect(loadedSettings.user.settings.model).toStrictEqual({
+        name: 'existing-model',
+        compressionThreshold: 0.8,
+      });
+      expect(loadedSettings.merged.model).toBe('existing-model');
+      expect(loadedSettings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.8,
+      });
+    });
+
+    it('setValue should support direct V2 model.name writes and preserve compressionThreshold', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        model: { compressionThreshold: 0.7 },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(SettingScope.User, 'model.name', 'updated-model');
+
+      expect(loadedSettings.user.settings.model).toStrictEqual({
+        name: 'updated-model',
+        compressionThreshold: 0.7,
+      });
+      expect(loadedSettings.merged.model).toBe('updated-model');
+      expect(loadedSettings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.7,
+      });
     });
   });
 

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -2061,6 +2061,40 @@ describe('Settings Loading and Merging', () => {
       });
     });
 
+    it('setValue should replace an existing V2 model object when setting a model object', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) => p === USER_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        model: { name: 'existing-model', compressionThreshold: 0.7 },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+      const loadedSettings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      loadedSettings.setValue(SettingScope.User, 'model', {
+        name: 'replacement-model',
+        compressionThreshold: 0.5,
+      });
+
+      expect(loadedSettings.user.settings.model).toStrictEqual({
+        name: 'replacement-model',
+        compressionThreshold: 0.5,
+      });
+      expect(loadedSettings.merged.model).toBe('replacement-model');
+      expect(loadedSettings.merged.chatCompression).toStrictEqual({
+        contextPercentageThreshold: 0.5,
+      });
+    });
+
     it('setValue should support direct V2 model.compressionThreshold writes and preserve name', () => {
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) => p === USER_SETTINGS_PATH,

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -20,7 +20,7 @@ import {
   type MergedSettings,
   type MemoryImportFormat,
 } from './settingsSchema.js';
-import { mergeSettings } from './settingsMerge.js';
+import { getV2NamespacedSettingPath, mergeSettings } from './settingsMerge.js';
 export { loadSettings } from './settingsLoader.js';
 export { migrateDeprecatedSettings } from './settingsMigrations.js';
 import {
@@ -196,35 +196,86 @@ export class LoadedSettings {
     value: Settings[K] | unknown,
   ): void {
     const settingsFile = this.forScope(scope);
+    const resolvedKey =
+      typeof key === 'string' ? getV2NamespacedSettingPath(key) : key;
+    const settingsRecord = settingsFile.settings as Record<string, unknown>;
+    const legacyPath = typeof key === 'string' ? key.split('.') : undefined;
+    const shouldRemoveLegacyPath =
+      typeof key === 'string' &&
+      typeof resolvedKey === 'string' &&
+      resolvedKey !== key &&
+      legacyPath !== undefined;
 
-    // Handle nested paths like 'ui.ideMode'
-    if (typeof key === 'string' && key.includes('.')) {
-      const parts = key.split('.');
-      const topLevel = parts[0] as keyof Settings;
-      const nested = parts.slice(1).join('.');
-
-      // Ensure the top-level object exists
-      const settingsRecord = settingsFile.settings as Record<string, unknown>;
-      const existingTopLevel = settingsRecord[topLevel];
-      if (typeof existingTopLevel !== 'object' || existingTopLevel === null) {
-        settingsRecord[topLevel] = {};
-      }
-
-      // Navigate to the nested property
-      let current = settingsRecord[topLevel] as Record<string, unknown>;
-      const nestedParts = nested.split('.');
-      for (let i = 0; i < nestedParts.length - 1; i++) {
-        current[nestedParts[i]] ??= {};
-        current = current[nestedParts[i]] as Record<string, unknown>;
-      }
-      current[nestedParts[nestedParts.length - 1]] = value;
+    if (
+      resolvedKey === 'model' &&
+      typeof settingsRecord.model === 'object' &&
+      settingsRecord.model !== null &&
+      !Array.isArray(settingsRecord.model)
+    ) {
+      this.setNestedValue(settingsRecord, ['model', 'name'], value);
+    } else if (typeof resolvedKey === 'string' && resolvedKey.includes('.')) {
+      this.setNestedValue(settingsRecord, resolvedKey.split('.'), value);
     } else {
-      settingsFile.settings[key as K] = value as Settings[K];
+      settingsFile.settings[resolvedKey as K] = value as Settings[K];
+    }
+
+    if (shouldRemoveLegacyPath) {
+      this.deleteNestedValue(settingsRecord, legacyPath);
     }
 
     this._merged = this.computeMergedSettings();
     saveSettings(settingsFile);
     coreEvents.emitSettingsChanged();
+  }
+
+  private setNestedValue(
+    settingsRecord: Record<string, unknown>,
+    parts: string[],
+    value: unknown,
+  ): void {
+    let current = settingsRecord;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      const existing = current[part];
+      if (
+        typeof existing !== 'object' ||
+        existing === null ||
+        Array.isArray(existing)
+      ) {
+        current[part] = {};
+      }
+      current = current[part] as Record<string, unknown>;
+    }
+    current[parts[parts.length - 1]] = value;
+  }
+
+  private deleteNestedValue(
+    settingsRecord: Record<string, unknown>,
+    parts: string[],
+  ): boolean {
+    const [part, ...rest] = parts;
+    if (!part || !(part in settingsRecord)) {
+      return Object.keys(settingsRecord).length === 0;
+    }
+
+    if (rest.length === 0) {
+      delete settingsRecord[part];
+      return Object.keys(settingsRecord).length === 0;
+    }
+
+    const existing = settingsRecord[part];
+    if (
+      typeof existing !== 'object' ||
+      existing === null ||
+      Array.isArray(existing)
+    ) {
+      return Object.keys(settingsRecord).length === 0;
+    }
+
+    if (this.deleteNestedValue(existing as Record<string, unknown>, rest)) {
+      delete settingsRecord[part];
+    }
+    return Object.keys(settingsRecord).length === 0;
   }
 
   // Provider keyfile methods for llxprt multi-provider support

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -212,7 +212,15 @@ export class LoadedSettings {
       settingsRecord.model !== null &&
       !Array.isArray(settingsRecord.model)
     ) {
-      this.setNestedValue(settingsRecord, ['model', 'name'], value);
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+      ) {
+        settingsRecord.model = value;
+      } else {
+        this.setNestedValue(settingsRecord, ['model', 'name'], value);
+      }
     } else if (typeof resolvedKey === 'string' && resolvedKey.includes('.')) {
       this.setNestedValue(settingsRecord, resolvedKey.split('.'), value);
     } else {

--- a/packages/cli/src/config/settingsMerge.ts
+++ b/packages/cli/src/config/settingsMerge.ts
@@ -25,6 +25,31 @@ const LEGACY_UI_KEYS = [
   'hasSeenIdeIntegrationNudge',
 ] as const;
 
+export const V2_NAMESPACE_MAPPINGS = {
+  accessibility: 'ui',
+  checkpointing: 'ui',
+  fileFiltering: 'ui',
+} as const satisfies Partial<Record<keyof Settings, keyof Settings>>;
+
+const V2_WRITE_PATH_MAPPINGS = {
+  'chatCompression.contextPercentageThreshold': 'model.compressionThreshold',
+} as const satisfies Record<string, string>;
+
+export type V2NamespacedSettingKey = keyof typeof V2_NAMESPACE_MAPPINGS;
+
+export function getV2NamespacedSettingPath(key: string): string {
+  if (Object.prototype.hasOwnProperty.call(V2_WRITE_PATH_MAPPINGS, key)) {
+    return V2_WRITE_PATH_MAPPINGS[key as keyof typeof V2_WRITE_PATH_MAPPINGS];
+  }
+
+  const [topLevel, ...nestedParts] = key.split('.');
+  if (!Object.prototype.hasOwnProperty.call(V2_NAMESPACE_MAPPINGS, topLevel)) {
+    return key;
+  }
+  const namespace = V2_NAMESPACE_MAPPINGS[topLevel as V2NamespacedSettingKey];
+  return [namespace, topLevel, ...nestedParts].join('.');
+}
+
 type SettingsLayer = Partial<Settings>;
 type MergeLayers = {
   schemaDefaults: SettingsLayer;
@@ -80,6 +105,36 @@ function extractLegacyUiKeys(settings: SettingsLayer): Record<string, unknown> {
   return legacy;
 }
 
+function getObjectSettingValue(
+  settings: SettingsLayer,
+  key: keyof Settings,
+): object | undefined {
+  const value: unknown = settings[key];
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value
+    : undefined;
+}
+
+function extractV2NestedKeys(
+  settings: SettingsLayer,
+  namespace: keyof Settings,
+): Record<string, unknown> {
+  const namespacedSettings = getObjectSettingValue(settings, namespace) as
+    | Record<string, unknown>
+    | undefined;
+  const nested: Record<string, unknown> = {};
+  for (const [key, mappedNamespace] of Object.entries(V2_NAMESPACE_MAPPINGS)) {
+    if (mappedNamespace !== namespace) {
+      continue;
+    }
+    const value = namespacedSettings?.[key];
+    if (value !== undefined) {
+      nested[key] = value;
+    }
+  }
+  return nested;
+}
+
 function getPrioritizedTheme({
   schemaDefaults,
   systemDefaults,
@@ -102,12 +157,16 @@ function mergeUiSettings(layers: MergeLayers): MergedSettings['ui'] {
   const ui = {
     ...(schemaDefaults.ui ?? {}),
     ...extractLegacyUiKeys(systemDefaults),
+    ...extractV2NestedKeys(systemDefaults, 'ui'),
     ...(systemDefaults.ui ?? {}),
     ...extractLegacyUiKeys(user),
+    ...extractV2NestedKeys(user, 'ui'),
     ...(user.ui ?? {}),
     ...extractLegacyUiKeys(workspace),
+    ...extractV2NestedKeys(workspace, 'ui'),
     ...(workspace.ui ?? {}),
     ...extractLegacyUiKeys(system),
+    ...extractV2NestedKeys(system, 'ui'),
     ...(system.ui ?? {}),
     customThemes: {
       ...(systemDefaults.ui?.customThemes ?? {}),
@@ -169,6 +228,128 @@ function mergeObjectSection<K extends keyof Settings>(
   } as NonNullable<Settings[K]>;
 }
 
+function getModelSettings(settings: SettingsLayer):
+  | {
+      name?: unknown;
+      compressionThreshold?: unknown;
+    }
+  | undefined {
+  const model: unknown = settings.model;
+  return typeof model === 'object' && model !== null && !Array.isArray(model)
+    ? (model as { name?: unknown; compressionThreshold?: unknown })
+    : undefined;
+}
+
+function getModelName(settings: SettingsLayer): string | undefined {
+  const model = settings.model;
+  if (typeof model === 'string') {
+    return model;
+  }
+  const name = getModelSettings(settings)?.name;
+  return typeof name === 'string' ? name : undefined;
+}
+
+function getModelCompressionThreshold(
+  settings: SettingsLayer,
+): number | undefined {
+  const threshold = getModelSettings(settings)?.compressionThreshold;
+  return typeof threshold === 'number' ? threshold : undefined;
+}
+
+function getModelCompressionSettings(
+  settings: SettingsLayer,
+): { contextPercentageThreshold: number } | undefined {
+  const threshold = getModelCompressionThreshold(settings);
+  return threshold === undefined
+    ? undefined
+    : { contextPercentageThreshold: threshold };
+}
+
+function getChatCompressionSettings(
+  settings: SettingsLayer,
+): Record<string, unknown> {
+  const chatCompression: unknown = settings.chatCompression;
+  return {
+    ...(typeof chatCompression === 'object' &&
+    chatCompression !== null &&
+    !Array.isArray(chatCompression)
+      ? chatCompression
+      : {}),
+    ...(getModelCompressionSettings(settings) ?? {}),
+  };
+}
+
+function getPrioritizedModel(layers: MergeLayers): string | undefined {
+  return [
+    getModelName(layers.workspace),
+    getModelName(layers.user),
+    getModelName(layers.system),
+    getModelName(layers.systemDefaults),
+    getModelName(layers.schemaDefaults),
+  ].find((model) => model !== undefined);
+}
+
+function getPrioritizedModelCompressionThreshold(
+  layers: MergeLayers,
+): number | undefined {
+  return [
+    getModelCompressionThreshold(layers.workspace),
+    getModelCompressionThreshold(layers.user),
+    getModelCompressionThreshold(layers.system),
+    getModelCompressionThreshold(layers.systemDefaults),
+    getModelCompressionThreshold(layers.schemaDefaults),
+  ].find((threshold) => threshold !== undefined);
+}
+
+function getPrioritizedModelConfig(
+  layers: MergeLayers,
+): MergedSettings['modelConfig'] | undefined {
+  const name = getPrioritizedModel(layers);
+  const compressionThreshold = getPrioritizedModelCompressionThreshold(layers);
+  if (name === undefined && compressionThreshold === undefined) {
+    return undefined;
+  }
+  return {
+    ...(name === undefined ? {} : { name }),
+    ...(compressionThreshold === undefined ? {} : { compressionThreshold }),
+  };
+}
+
+function getV2NestedObjectSection<K extends V2NamespacedSettingKey>(
+  settings: SettingsLayer,
+  key: K,
+): object | undefined {
+  const namespace = V2_NAMESPACE_MAPPINGS[key];
+  const namespacedSettings = getObjectSettingValue(settings, namespace) as
+    | Record<string, unknown>
+    | undefined;
+  const value = namespacedSettings?.[key];
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value
+    : undefined;
+}
+
+function mergeV2CompatibleObjectSection<K extends V2NamespacedSettingKey>(
+  key: K,
+  schemaDefaults: SettingsLayer,
+  systemDefaults: SettingsLayer,
+  user: SettingsLayer,
+  workspace: SettingsLayer,
+  system: SettingsLayer,
+): NonNullable<Settings[K]> {
+  return {
+    ...((schemaDefaults[key] as object | undefined) ?? {}),
+    ...((systemDefaults[key] as object | undefined) ?? {}),
+    ...(getV2NestedObjectSection(systemDefaults, key) ?? {}),
+    ...((user[key] as object | undefined) ?? {}),
+    ...(getV2NestedObjectSection(user, key) ?? {}),
+    ...((workspace[key] as object | undefined) ?? {}),
+    ...(getV2NestedObjectSection(workspace, key) ?? {}),
+    ...((system[key] as object | undefined) ?? {}),
+    ...(getV2NestedObjectSection(system, key) ?? {}),
+  } as NonNullable<Settings[K]>;
+}
+
 function mergeBaseSettings(layers: MergeLayers): Partial<MergedSettings> {
   const { schemaDefaults, systemDefaults, user, workspace, system } = layers;
   return {
@@ -177,7 +358,9 @@ function mergeBaseSettings(layers: MergeLayers): Partial<MergedSettings> {
     ...user,
     ...workspace,
     ...system,
-  };
+    model: getPrioritizedModel(layers),
+    modelConfig: getPrioritizedModelConfig(layers),
+  } as Partial<MergedSettings>;
 }
 
 function applyCoreMergedSections(
@@ -200,14 +383,15 @@ function applyCoreMergedSections(
     ...(workspace.includeDirectories ?? []),
     ...(system.includeDirectories ?? []),
   ];
-  merged.chatCompression = mergeObjectSection(
-    'chatCompression',
-    {},
-    systemDefaults,
-    user,
-    workspace,
-    system,
-  );
+  merged.chatCompression = {
+    ...getChatCompressionSettings(systemDefaults),
+    ...getChatCompressionSettings(user),
+    ...getChatCompressionSettings(workspace),
+    ...getChatCompressionSettings(system),
+  };
+
+  merged.model = getPrioritizedModel(layers);
+  merged.modelConfig = getPrioritizedModelConfig(layers);
   merged.coreToolSettings = schemaDefaults.coreToolSettings ?? {};
 }
 
@@ -218,6 +402,18 @@ function applySchemaBackedSections(
   const { schemaDefaults, systemDefaults, user, workspace, system } = layers;
   for (const key of ['security', 'telemetry', 'mcp', 'tools'] as const) {
     merged[key] = mergeObjectSection(
+      key,
+      schemaDefaults,
+      systemDefaults,
+      user,
+      workspace,
+      system,
+    );
+  }
+  for (const key of Object.keys(
+    V2_NAMESPACE_MAPPINGS,
+  ) as V2NamespacedSettingKey[]) {
+    merged[key] = mergeV2CompatibleObjectSection(
       key,
       schemaDefaults,
       systemDefaults,

--- a/packages/cli/src/config/settingsMerge.ts
+++ b/packages/cli/src/config/settingsMerge.ts
@@ -389,9 +389,6 @@ function applyCoreMergedSections(
     ...getChatCompressionSettings(workspace),
     ...getChatCompressionSettings(system),
   };
-
-  merged.model = getPrioritizedModel(layers);
-  merged.modelConfig = getPrioritizedModelConfig(layers);
   merged.coreToolSettings = schemaDefaults.coreToolSettings ?? {};
 }
 

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -15,6 +15,8 @@ import {
   getEnableHooks,
   getEnableHooksUI,
 } from './settingsSchema.js';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 describe('SettingsSchema', () => {
   describe('SETTINGS_SCHEMA', () => {
@@ -275,43 +277,102 @@ describe('SettingsSchema', () => {
       expect(SETTINGS_SCHEMA.defaultDisabledTools.requiresRestart).toBe(true);
     });
 
+    it('should represent model as an explicit string-or-object union', () => {
+      expect(SETTINGS_SCHEMA.model.type).toBe('union');
+      expect(SETTINGS_SCHEMA.model.refs).toStrictEqual([
+        'ModelName',
+        'ModelConfig',
+      ]);
+      expect(SETTINGS_SCHEMA_DEFINITIONS.ModelName).toMatchObject({
+        type: 'string',
+      });
+      expect(SETTINGS_SCHEMA_DEFINITIONS.ModelConfig).toMatchObject({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          compressionThreshold: { type: 'number', minimum: 0, maximum: 1 },
+        },
+      });
+    });
+
+    it('should keep generated JSON schema model union consistent with schema definitions', () => {
+      const generatedSchema = JSON.parse(
+        readFileSync(
+          resolve(process.cwd(), '../../schemas/settings.schema.json'),
+          'utf8',
+        ),
+      ) as {
+        properties: { model: { anyOf?: Array<{ $ref: string }> } };
+      };
+
+      expect(generatedSchema.properties.model.anyOf).toStrictEqual([
+        { $ref: '#/$defs/ModelName' },
+        { $ref: '#/$defs/ModelConfig' },
+      ]);
+      const modelConfig = (
+        generatedSchema as unknown as {
+          $defs: {
+            ModelConfig: {
+              properties: {
+                compressionThreshold: { minimum?: number; maximum?: number };
+              };
+            };
+          };
+        }
+      ).$defs.ModelConfig;
+      expect(modelConfig.properties.compressionThreshold).toMatchObject({
+        minimum: 0,
+        maximum: 1,
+      });
+    });
+
     it('has JSON schema definitions for every referenced ref', () => {
       const schema = getSettingsSchema();
       const referenced = new Set<string>();
       const missing: string[] = [];
 
-      const visitDefinition = (definition: SettingDefinition) => {
-        if (definition.ref) {
-          referenced.add(definition.ref);
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- verifying all refs are defined at runtime
-          if (SETTINGS_SCHEMA_DEFINITIONS[definition.ref] === undefined) {
-            missing.push(definition.ref);
-          }
+      const recordReference = (ref: string): void => {
+        referenced.add(ref);
+        if (!(ref in SETTINGS_SCHEMA_DEFINITIONS)) {
+          missing.push(ref);
         }
+      };
+
+      const visitRefs = (refs: readonly string[] | undefined): void => {
+        for (const ref of refs ?? []) {
+          recordReference(ref);
+        }
+      };
+
+      const visitDefinition = (definition: SettingDefinition): void => {
+        if (definition.ref) {
+          recordReference(definition.ref);
+        }
+        visitRefs(definition.refs);
+
         if (definition.properties) {
           Object.values(definition.properties).forEach(visitDefinition);
         }
         if (definition.items) {
           visitCollection(definition.items);
         }
-        if (definition.additionalProperties) {
-          visitCollection(definition.additionalProperties);
+        if (definition.additionalProperties !== undefined) {
+          const additionalProperties = definition.additionalProperties;
+          if (additionalProperties !== false) {
+            visitCollection(additionalProperties);
+          }
         }
       };
 
-      const visitCollection = (collection: SettingCollectionDefinition) => {
+      const visitCollection = (
+        collection: SettingCollectionDefinition,
+      ): void => {
         if (collection.ref) {
-          referenced.add(collection.ref);
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- verifying all refs are defined at runtime
-          if (SETTINGS_SCHEMA_DEFINITIONS[collection.ref] === undefined) {
-            missing.push(collection.ref);
-          }
-          return;
+          recordReference(collection.ref);
         }
+        visitRefs(collection.refs);
+
         if (collection.properties) {
-          Object.values(collection.properties).forEach(visitDefinition);
-        }
-        if (collection.type === 'array' && collection.properties) {
           Object.values(collection.properties).forEach(visitDefinition);
         }
       };

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -314,6 +314,20 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
     description: 'Accepts either a boolean flag or a string command name.',
     anyOf: [{ type: 'boolean' }, { type: 'string' }],
   },
+  ModelName: {
+    type: 'string',
+    description: 'Model name string.',
+  },
+  ModelConfig: {
+    type: 'object',
+    description:
+      'V2 model configuration object with optional name and compressionThreshold.',
+    additionalProperties: false,
+    properties: {
+      name: { type: 'string' },
+      compressionThreshold: { type: 'number', minimum: 0, maximum: 1 },
+    },
+  },
   BooleanOrLspConfig: {
     description:
       'Set to true to enable LSP with defaults, false to disable, or provide an object to configure LSP servers and diagnostics behavior.',
@@ -410,7 +424,13 @@ export type Settings = InferSettings<SettingsSchemaType>;
  * Settings type for the merged settings object. Sub-objects that are
  * always populated by mergeSettings() are marked as required.
  */
-export type MergedSettings = Settings & {
+export type MergedSettings = Omit<Settings, 'model'> & {
+  model?: string;
+  modelConfig?: {
+    name?: string;
+    compressionThreshold?: number;
+  };
+
   ui: NonNullable<Settings['ui']>;
   security: NonNullable<Settings['security']>;
   telemetry: NonNullable<Settings['telemetry']>;

--- a/packages/cli/src/utils/dynamicSettings.ts
+++ b/packages/cli/src/utils/dynamicSettings.ts
@@ -17,6 +17,7 @@ const allowedTypes = [
   'array',
   'object',
   'enum',
+  'union',
 ] as const;
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -164,6 +164,22 @@ describe('SettingsUtils', () => {
         expect(value).toBe(false);
       });
 
+      it('should read V2 namespaced storage for legacy schema keys', () => {
+        const settings = {
+          ui: { accessibility: { enableLoadingPhrases: false } },
+        };
+        const mergedSettings = {
+          accessibility: { enableLoadingPhrases: true },
+        };
+
+        const value = getEffectiveValue(
+          'accessibility.enableLoadingPhrases',
+          settings,
+          mergedSettings,
+        );
+        expect(value).toBe(false);
+      });
+
       it('should return undefined for invalid settings', () => {
         const settings = {};
         const mergedSettings = {};
@@ -480,6 +496,33 @@ describe('SettingsUtils', () => {
         };
         expect(
           settingExistsInScope('accessibility.enableLoadingPhrases', settings),
+        ).toBe(true);
+      });
+
+      it('should return true for V2 namespaced settings that map to legacy schema keys', () => {
+        const settings = {
+          ui: {
+            accessibility: { enableLoadingPhrases: true },
+            checkpointing: { enabled: true },
+            fileFiltering: { enableFuzzySearch: false },
+          },
+          model: { compressionThreshold: 0.7 },
+        };
+
+        expect(
+          settingExistsInScope('accessibility.enableLoadingPhrases', settings),
+        ).toBe(true);
+        expect(settingExistsInScope('checkpointing.enabled', settings)).toBe(
+          true,
+        );
+        expect(
+          settingExistsInScope('fileFiltering.enableFuzzySearch', settings),
+        ).toBe(true);
+        expect(
+          settingExistsInScope(
+            'chatCompression.contextPercentageThreshold',
+            settings,
+          ),
         ).toBe(true);
       });
 

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -15,6 +15,7 @@ import type {
   SettingsSchema,
 } from '../config/settingsSchema.js';
 import { SETTINGS_SCHEMA } from '../config/settingsSchema.js';
+import { getV2NamespacedSettingPath } from '../config/settingsMerge.js';
 
 // The schema is now nested, but many parts of the UI and logic work better
 // with a flattened structure and dot-notation keys. This section flattens the
@@ -168,6 +169,28 @@ export function getNestedValue(
   return undefined;
 }
 
+function getSettingStoragePaths(key: string): string[][] {
+  const legacyPath = key.split('.');
+  const namespacedKey = getV2NamespacedSettingPath(key);
+  if (namespacedKey === key) {
+    return [legacyPath];
+  }
+  return [namespacedKey.split('.'), legacyPath];
+}
+
+function getSettingValueFromStoragePaths(
+  settings: Record<string, unknown>,
+  key: string,
+): unknown {
+  for (const path of getSettingStoragePaths(key)) {
+    const value = getNestedValue(settings, path);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Get the effective value for a setting, considering inheritance from higher scopes
  * Always returns a value (never undefined) - falls back to default if not set anywhere
@@ -182,16 +205,20 @@ export function getEffectiveValue(
     return undefined;
   }
 
-  const path = key.split('.');
-
   // Check the current scope's settings first
-  let value = getNestedValue(settings as Record<string, unknown>, path);
+  let value = getSettingValueFromStoragePaths(
+    settings as Record<string, unknown>,
+    key,
+  );
   if (value !== undefined) {
     return value as SettingDefinition['default'];
   }
 
   // Check the merged settings for an inherited value
-  value = getNestedValue(mergedSettings as Record<string, unknown>, path);
+  value = getSettingValueFromStoragePaths(
+    mergedSettings as Record<string, unknown>,
+    key,
+  );
   if (value !== undefined) {
     return value as SettingDefinition['default'];
   }
@@ -338,9 +365,12 @@ export function settingExistsInScope(
   key: string,
   scopeSettings: Settings,
 ): boolean {
-  const path = key.split('.');
-  const value = getNestedValue(scopeSettings as Record<string, unknown>, path);
-  return value !== undefined;
+  return (
+    getSettingValueFromStoragePaths(
+      scopeSettings as Record<string, unknown>,
+      key,
+    ) !== undefined
+  );
 }
 
 /**

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -4,7 +4,7 @@
   "title": "LLxprt Code Settings",
   "description": "Configuration file schema for LLxprt Code settings. This schema enables IDE completion for `settings.json`.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "$schema": {
       "title": "Schema",
@@ -256,6 +256,99 @@
       "default": {},
       "type": "object",
       "properties": {
+        "accessibility": {
+          "title": "Accessibility",
+          "description": "Accessibility settings.",
+          "markdownDescription": "Accessibility settings.\n\n- Category: `Accessibility`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "enableLoadingPhrases": {
+              "title": "Enable Loading Phrases",
+              "description": "Enable loading phrases during operations.",
+              "markdownDescription": "Enable loading phrases during operations.\n\n- Category: `Accessibility`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "screenReader": {
+              "title": "Screen Reader Mode",
+              "description": "Render output in plain-text to be more screen reader accessible",
+              "markdownDescription": "Render output in plain-text to be more screen reader accessible\n\n- Category: `Accessibility`\n- Requires restart: `yes`\n- Default: `false`",
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "checkpointing": {
+          "title": "Checkpointing",
+          "description": "Session checkpointing settings.",
+          "markdownDescription": "Session checkpointing settings.\n\n- Category: `Checkpointing`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable Checkpointing",
+              "description": "Enable session checkpointing for recovery",
+              "markdownDescription": "Enable session checkpointing for recovery\n\n- Category: `Checkpointing`\n- Requires restart: `yes`\n- Default: `false`",
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "fileFiltering": {
+          "title": "File Filtering",
+          "description": "Settings for git-aware file filtering.",
+          "markdownDescription": "Settings for git-aware file filtering.\n\n- Category: `File Filtering`\n- Requires restart: `yes`\n- Default: `{}`",
+          "default": {},
+          "type": "object",
+          "properties": {
+            "respectGitIgnore": {
+              "title": "Respect .gitignore",
+              "description": "Respect .gitignore files when searching",
+              "markdownDescription": "Respect .gitignore files when searching\n\n- Category: `File Filtering`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "respectLlxprtIgnore": {
+              "title": "Respect .llxprtignore",
+              "description": "Respect .llxprtignore files when searching",
+              "markdownDescription": "Respect .llxprtignore files when searching\n\n- Category: `File Filtering`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "enableRecursiveFileSearch": {
+              "title": "Enable Recursive File Search",
+              "description": "Enable recursive file search functionality",
+              "markdownDescription": "Enable recursive file search functionality\n\n- Category: `File Filtering`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "enableFuzzySearch": {
+              "title": "Enable Fuzzy Search",
+              "description": "Enable fuzzy search when searching for files.",
+              "markdownDescription": "Enable fuzzy search when searching for files.\n\n- Category: `File Filtering`\n- Requires restart: `yes`\n- Default: `true`",
+              "default": true,
+              "type": "boolean"
+            },
+            "maxFileCount": {
+              "title": "Max File Count",
+              "description": "Maximum number of files to index during file search. Prevents OOM on large projects.",
+              "markdownDescription": "Maximum number of files to index during file search. Prevents OOM on large projects.\n\n- Category: `File Filtering`\n- Requires restart: `yes`\n- Default: `20000`",
+              "default": 20000,
+              "type": "number"
+            },
+            "searchTimeout": {
+              "title": "Search Timeout (ms)",
+              "description": "Timeout in milliseconds for file search operations.",
+              "markdownDescription": "Timeout in milliseconds for file search operations.\n\n- Category: `File Filtering`\n- Requires restart: `yes`\n- Default: `5000`",
+              "default": 5000,
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
         "theme": {
           "title": "Theme",
           "description": "The color theme for the UI.",
@@ -921,9 +1014,16 @@
     },
     "model": {
       "title": "Model",
-      "description": "The Gemini model to use for conversations.",
-      "markdownDescription": "The Gemini model to use for conversations.\n\n- Category: `General`\n- Requires restart: `no`",
-      "type": "string"
+      "description": "The model to use for conversations. V2 settings may use { name, compressionThreshold }; compressionThreshold maps to chatCompression.contextPercentageThreshold.",
+      "markdownDescription": "The model to use for conversations. V2 settings may use { name, compressionThreshold }; compressionThreshold maps to chatCompression.contextPercentageThreshold.\n\n- Category: `General`\n- Requires restart: `no`",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModelName"
+        },
+        {
+          "$ref": "#/$defs/ModelConfig"
+        }
+      ]
     },
     "hasSeenIdeIntegrationNudge": {
       "title": "Has Seen IDE Integration Nudge",
@@ -948,10 +1048,32 @@
     },
     "chatCompression": {
       "title": "Chat Compression",
-      "description": "Chat compression settings.",
-      "markdownDescription": "Chat compression settings.\n\n- Category: `General`\n- Requires restart: `no`",
+      "description": "Legacy chat compression settings. V2 model.compressionThreshold maps to contextPercentageThreshold.",
+      "markdownDescription": "Legacy chat compression settings. V2 model.compressionThreshold maps to contextPercentageThreshold.\n\n- Category: `General`\n- Requires restart: `no`",
       "type": "object",
-      "additionalProperties": true
+      "properties": {
+        "contextPercentageThreshold": {
+          "title": "Context Percentage Threshold",
+          "description": "Fraction of context-limit that triggers history compression (0.0–1.0).",
+          "markdownDescription": "Fraction of context-limit that triggers history compression (0.0–1.0).\n\n- Category: `General`\n- Requires restart: `no`",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "strategy": {
+          "title": "Compression Strategy",
+          "description": "Legacy compression strategy selector.",
+          "markdownDescription": "Legacy compression strategy selector.\n\n- Category: `General`\n- Requires restart: `no`",
+          "type": "string"
+        },
+        "profile": {
+          "title": "Compression Profile",
+          "description": "Legacy compression profile selector.",
+          "markdownDescription": "Legacy compression profile selector.\n\n- Category: `General`\n- Requires restart: `no`",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     },
     "experimental": {
       "title": "Experimental",
@@ -1719,6 +1841,25 @@
           "type": "string"
         }
       ]
+    },
+    "ModelName": {
+      "type": "string",
+      "description": "Model name string."
+    },
+    "ModelConfig": {
+      "type": "object",
+      "description": "V2 model configuration object with optional name and compressionThreshold.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "compressionThreshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
     },
     "BooleanOrLspConfig": {
       "description": "Set to true to enable LSP with defaults, false to disable, or provide an object to configure LSP servers and diagnostics behavior.",

--- a/scripts/generate-settings-doc.ts
+++ b/scripts/generate-settings-doc.ts
@@ -181,6 +181,21 @@ function formatDescription(definition: SettingDefinition) {
 }
 
 function formatType(definition: SettingDefinition): string {
+  if (definition.type === 'union' && definition.refs) {
+    return definition.refs
+      .map((ref) => {
+        switch (ref) {
+          case 'ModelName':
+            return 'string';
+          case 'ModelConfig':
+            return 'object';
+          default:
+            return ref;
+        }
+      })
+      .join(' | ');
+  }
+
   switch (definition.ref) {
     case 'StringOrStringArray':
       return 'string | string[]';

--- a/scripts/generate-settings-schema.ts
+++ b/scripts/generate-settings-schema.ts
@@ -116,7 +116,7 @@ function buildSchemaObject(schema: SettingsSchemaType): JsonSchema {
     description:
       'Configuration file schema for LLxprt Code settings. This schema enables IDE completion for `settings.json`.',
     type: 'object',
-    additionalProperties: false,
+    additionalProperties: true,
     properties: {},
   };
 
@@ -156,7 +156,9 @@ function buildSettingSchema(
 
   const schemaShape = definition.ref
     ? buildRefSchema(definition.ref, defs)
-    : buildSchemaForType(definition, pathSegments, defs);
+    : definition.type === 'union' && definition.refs
+      ? buildUnionSchema(definition.refs, defs)
+      : buildSchemaForType(definition, pathSegments, defs);
 
   return { ...base, ...schemaShape };
 }
@@ -296,6 +298,13 @@ function buildInlineObjectSchema(
     properties: childSchemas,
     additionalProperties: false,
   };
+}
+
+function buildUnionSchema(
+  refs: readonly string[],
+  defs: Map<string, JsonSchema>,
+): JsonSchema {
+  return { anyOf: refs.map((ref) => buildRefSchema(ref, defs)) };
 }
 
 function buildRefSchema(


### PR DESCRIPTION
## TLDR

Adds V2 hierarchical settings compatibility while keeping existing flat settings working. Mapped settings now read both legacy and V2 paths, write new updates to V2 storage paths, validate V2 shapes, and document the supported compatibility mappings.

## Dive Deeper

This PR implements V2 settings support for the currently supported LLxprt mappings:

- accessibility settings are accepted at ui.accessibility and still read from legacy accessibility.
- checkpointing settings are accepted at ui.checkpointing and still read from legacy checkpointing.
- file filtering settings are accepted at ui.fileFiltering and still read from legacy fileFiltering.
- chatCompression.contextPercentageThreshold remains accepted and maps to V2 model.compressionThreshold.
- model can remain a legacy string or use the V2 object shape with name and compressionThreshold.

Notable behavior:

- Same-layer V2 values win over same-layer legacy values for mapped keys.
- Normal scope precedence is preserved across system defaults, user, workspace, and system settings.
- Merged runtime settings keep model as the active model string for existing callers and expose modelConfig for V2 object fields.
- setValue writes mapped settings to V2 paths and removes duplicate legacy leaves from the same settings file, while preserving unrelated legacy siblings such as chatCompression strategy/profile.
- Runtime validation and generated JSON schema enforce compression threshold bounds from 0 to 1.
- Generated schema/root validation intentionally allow unknown top-level keys for compatibility, while known nested compatibility objects are validated.
- Settings documentation and generated configuration docs now describe the supported V2 format and legacy compatibility behavior.

## Reviewer Test Plan

Suggested validation steps:

1. Create or edit a settings file containing V2 values such as ui.accessibility.screenReader, ui.checkpointing.enabled, ui.fileFiltering.enableFuzzySearch, and model.compressionThreshold; confirm the CLI loads them into the expected runtime settings.
2. Create or edit a settings file with legacy accessibility, checkpointing, fileFiltering, and chatCompression.contextPercentageThreshold values; confirm they continue to load.
3. Put both a legacy and V2 equivalent in the same settings file and confirm the V2 value wins.
4. Use settings update flows that call setValue for accessibility.screenReader or chatCompression.contextPercentageThreshold and confirm the file is written using ui.accessibility.screenReader or model.compressionThreshold without leaving duplicate legacy leaves.
5. Try invalid V2 values such as model.compressionThreshold greater than 1 or ui.accessibility.screenReader as a string and confirm validation reports the nested path with guidance.

Verification run locally:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      |   |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

## Linked issues / bugs

Fixes #1613
