### PR TITLE
Hydrate provider factories for subagent runtimes (Fixes #1956)

### DIFF
--- a/packages/core/src/runtime/AgentRuntimeLoader.test.ts
+++ b/packages/core/src/runtime/AgentRuntimeLoader.test.ts
@@ -30,6 +30,8 @@ import type {
   ContentGenerator,
   ContentGeneratorConfig,
 } from '../core/contentGenerator.js';
+import type { RuntimeContentGeneratorFactory } from './contracts/RuntimeContentGeneratorFactory.js';
+import type { RuntimeProviderManager } from './contracts/RuntimeProviderManager.js';
 
 function createTestConfig(): Config {
   const settingsService = new SettingsService();
@@ -269,5 +271,156 @@ describe('AgentRuntimeLoader', () => {
       description: 'Alpha tool for testing.',
     });
     expect(bundle.toolsView.getToolMetadata('beta')).toBeUndefined();
+  });
+
+  it('hydrates contentGeneratorFactory from Config when providerManager is present but factory is missing from snapshot', async () => {
+    const factoryGenerator: ContentGenerator = {
+      generateContent: vi.fn(async () => ({ candidates: [] })),
+      generateContentStream: vi.fn(async function* () {
+        yield { candidates: [] };
+      }),
+      countTokens: vi.fn(async () => ({ totalTokens: 0 })),
+      embedContent: vi.fn(async () => ({ embeddings: [] })),
+    };
+
+    const factory: RuntimeContentGeneratorFactory<ContentGenerator> = {
+      createContentGenerator: vi.fn(() => factoryGenerator),
+    };
+
+    const fakeManager: RuntimeProviderManager = {
+      getActiveProvider: vi.fn(),
+      getActiveProviderName: vi.fn(),
+      setActiveProvider: vi.fn(),
+      getAvailableModels: vi.fn(async () => []),
+      getProviderNames: () => [],
+      listProviders: () => [],
+      getProviderByName: vi.fn(),
+      registerProvider: vi.fn(),
+      prepareStatelessProviderInvocation: vi.fn(),
+      getProviderMetrics: () => ({}),
+      getSessionTokenUsage: () => ({
+        input: 0,
+        output: 0,
+        cache: 0,
+        tool: 0,
+        thought: 0,
+        total: 0,
+      }),
+      getServerToolsProvider: () => null,
+      setServerToolsProvider: vi.fn(),
+      setConfig: vi.fn(),
+      hasActiveProvider: () => true,
+      accumulateSessionTokens: vi.fn(),
+    };
+
+    const configWithFactory = new Config({
+      sessionId: 'test-session',
+      targetDir: '/tmp/test-agent-runtime-loader',
+      settingsService: new SettingsService(),
+    } as unknown as import('../config/config.js').ConfigParameters);
+    configWithFactory.setContentGeneratorFactory(factory);
+    configWithFactory.setProviderManager(fakeManager);
+
+    const contentConfigWithManager: ContentGeneratorConfig = {
+      model: 'gemini-2.0-pro',
+      providerManager: fakeManager,
+    };
+
+    const bundle = await loadAgentRuntime({
+      profile: {
+        config: configWithFactory,
+        state: runtimeState,
+        settings: settingsSnapshot,
+        providerRuntime,
+        contentGeneratorConfig: contentConfigWithManager,
+      },
+      overrides: {
+        providerAdapter,
+        telemetryAdapter,
+        toolsView,
+      },
+    });
+
+    expect(bundle.contentGenerator).toBe(factoryGenerator);
+    expect(factory.createContentGenerator).toHaveBeenCalledWith(fakeManager);
+  });
+
+  it('succeeds without hydration when providerManager is absent', async () => {
+    const simpleConfig = createContentGeneratorConfig();
+    const bundle = await loadAgentRuntime({
+      profile: {
+        config,
+        state: runtimeState,
+        settings: settingsSnapshot,
+        providerRuntime,
+        contentGeneratorConfig: simpleConfig,
+      },
+      overrides: {
+        providerAdapter,
+        telemetryAdapter,
+        toolsView,
+      },
+    });
+
+    expect(bundle.contentGenerator).toBeDefined();
+    expect(bundle.contentGenerator.generateContent).toBeDefined();
+  });
+
+  it('throws when providerManager is present but contentGeneratorFactory is missing and Config has no factory', async () => {
+    const fakeManager: RuntimeProviderManager = {
+      getActiveProvider: vi.fn(),
+      getActiveProviderName: vi.fn(),
+      setActiveProvider: vi.fn(),
+      getAvailableModels: vi.fn(async () => []),
+      getProviderNames: () => [],
+      listProviders: () => [],
+      getProviderByName: vi.fn(),
+      registerProvider: vi.fn(),
+      prepareStatelessProviderInvocation: vi.fn(),
+      getProviderMetrics: () => ({}),
+      getSessionTokenUsage: () => ({
+        input: 0,
+        output: 0,
+        cache: 0,
+        tool: 0,
+        thought: 0,
+        total: 0,
+      }),
+      getServerToolsProvider: () => null,
+      setServerToolsProvider: vi.fn(),
+      setConfig: vi.fn(),
+      hasActiveProvider: () => true,
+      accumulateSessionTokens: vi.fn(),
+    };
+
+    const configNoFactory = new Config({
+      sessionId: 'test-session',
+      targetDir: '/tmp/test-agent-runtime-loader',
+      settingsService: new SettingsService(),
+    } as unknown as import('../config/config.js').ConfigParameters);
+
+    const contentConfigWithManagerOnly: ContentGeneratorConfig = {
+      model: 'gemini-2.0-pro',
+      providerManager: fakeManager,
+    };
+
+    await expect(
+      loadAgentRuntime({
+        profile: {
+          config: configNoFactory,
+          state: runtimeState,
+          settings: settingsSnapshot,
+          providerRuntime,
+          contentGeneratorConfig: contentConfigWithManagerOnly,
+        },
+        overrides: {
+          providerAdapter,
+          telemetryAdapter,
+          toolsView,
+        },
+      }),
+    ).rejects.toThrow(
+      'Provider content generator factory is required when a provider manager is configured',
+    );
   });
 });

--- a/packages/core/src/runtime/AgentRuntimeLoader.ts
+++ b/packages/core/src/runtime/AgentRuntimeLoader.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import { HistoryService } from '../services/history/HistoryService.js';
 import type { Config } from '../config/config.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
@@ -79,6 +77,32 @@ const defaultContentGeneratorFactory: ContentGeneratorFactory = (
   config,
   sessionId,
 ) => createContentGenerator(contentConfig, config, sessionId);
+
+function hydrateContentGeneratorConfig(
+  profile: AgentRuntimeProfileSnapshot,
+  contentConfig: ContentGeneratorConfig,
+): ContentGeneratorConfig {
+  const providerManager =
+    contentConfig.providerManager ??
+    profile.providerManager ??
+    profile.config.getProviderManager();
+  const configFactory =
+    providerManager == null
+      ? undefined
+      : profile.config.getContentGeneratorFactory();
+  const contentGeneratorFactory =
+    contentConfig.contentGeneratorFactory ?? configFactory;
+
+  if (providerManager == null) {
+    return contentConfig;
+  }
+
+  return {
+    ...contentConfig,
+    providerManager,
+    ...(contentGeneratorFactory == null ? {} : { contentGeneratorFactory }),
+  };
+}
 
 type ToolGovernance = {
   allowed: Set<string>;
@@ -251,10 +275,16 @@ export async function loadAgentRuntime(
         'AgentRuntimeLoader requires contentGeneratorConfig when no contentGenerator override is supplied.',
       );
     }
+
+    const hydratedConfig = hydrateContentGeneratorConfig(
+      profile,
+      contentConfig,
+    );
+
     const factory =
       overrides.contentGeneratorFactory ?? defaultContentGeneratorFactory;
     contentGenerator = await factory(
-      contentConfig,
+      hydratedConfig,
       profile.config,
       profile.state.sessionId,
     );


### PR DESCRIPTION
## TLDR

Hydrates provider-backed content generator configuration during isolated agent runtime loading so Task/subagent invocations can reuse the provider content generator factory stored on Config when the ContentGeneratorConfig snapshot only carries a provider manager.

## Dive Deeper

Issue #1956 reported Task failures after the provider package split because createContentGenerator now requires a provider-owned factory whenever a provider manager is configured. Some subagent runtime paths pass a ContentGeneratorConfig snapshot with the provider manager but without the factory, even though Config already has that factory.

This change adds AgentRuntimeLoader hydration before content generator creation:

- preserve snapshot-provided provider manager and factory when present
- fall back to the profile provider manager or Config provider manager
- fall back to Config content generator factory when a provider manager exists
- preserve the existing error when no provider factory is available anywhere

The fix stays within core runtime contracts and does not introduce a core dependency on the providers package.

## Reviewer Test Plan

Recommended validation:

1. Run the AgentRuntimeLoader test file and confirm the new provider-manager hydration cases pass.
2. Exercise a Task/subagent invocation from a provider-manager backed CLI profile and confirm it no longer fails with the provider factory required error.
3. Confirm the no-factory case still fails with the existing explicit error.

Verified locally:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load waferglm5 "write me a haiku and nothing else"

Smoke command exited 0. The configured waferglm5 provider returned an OpenAI 401 Invalid API key error in the generated runtime error report, which is external credential state rather than the provider factory regression.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1956
