### PR TITLE
Remove duplicate subagent factory propagation (Fixes #1962)

### DIFF
--- a/packages/core/src/core/subagentOrchestrator.test.ts
+++ b/packages/core/src/core/subagentOrchestrator.test.ts
@@ -460,18 +460,14 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
     expect(result.dispose).toBeTypeOf('function');
   });
 
-  it('passes the foreground content generator factory into provider-backed subagent runtimes', async () => {
+  it('forwards providerManager to loader for provider-backed subagent runtimes', async () => {
     const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
     const loadProfile = vi.fn().mockResolvedValue(profile);
 
     const providerManager = { getActiveProvider: vi.fn() };
-    const contentGeneratorFactory = {
-      createContentGenerator: vi.fn(),
-    };
     const config = {
       ...makeForegroundConfig(),
       getProviderManager: () => providerManager,
-      getContentGeneratorFactory: () => contentGeneratorFactory,
     } as unknown as Config;
 
     const runtimeBundle = createRuntimeBundle('provider-backed');
@@ -504,7 +500,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
     );
     expect(
       loaderArgs.profile.contentGeneratorConfig.contentGeneratorFactory,
-    ).toBe(contentGeneratorFactory);
+    ).toBeUndefined();
   });
 
   it('seeds default disabled tools into subagent runtime settings when profile omits disabled tools', async () => {

--- a/packages/core/src/core/subagentOrchestrator.ts
+++ b/packages/core/src/core/subagentOrchestrator.ts
@@ -727,15 +727,6 @@ export class SubagentOrchestrator {
         : undefined;
     if (providerManager) {
       contentGeneratorConfig.providerManager = providerManager;
-      const contentGeneratorFactory =
-        typeof this.options.foregroundConfig.getContentGeneratorFactory ===
-        'function'
-          ? this.options.foregroundConfig.getContentGeneratorFactory()
-          : undefined;
-      if (contentGeneratorFactory) {
-        contentGeneratorConfig.contentGeneratorFactory =
-          contentGeneratorFactory;
-      }
     }
 
     const toolRegistry: ToolRegistry | undefined =

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -85,6 +85,21 @@ describe('activate', () => {
       displayName: 'VS Code',
     }));
 
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            extensions: [
+              {
+                versions: [{ version: '1.1.0' }],
+              },
+            ],
+          },
+        ],
+      }),
+    } as Response);
+
     context = {
       subscriptions: [],
       environmentVariableCollection: {


### PR DESCRIPTION
## TLDR

Removes redundant provider content generator factory propagation from SubagentOrchestrator so AgentRuntimeLoader remains the single hydration boundary for provider-backed isolated runtimes.

## Dive Deeper

SubagentOrchestrator still forwards the active provider manager into the runtime loader profile, but no longer reads the foreground content generator factory or copies it into the content generator config. The runtime loader keeps responsibility for hydrating provider-backed content generator inputs from runtime profile/config and preserving the existing missing-factory fast-fail path.

The SubagentOrchestrator runtime assembly test now asserts the orchestrator contract directly: providerManager is forwarded, while contentGeneratorConfig.contentGeneratorFactory remains unset. Existing AgentRuntimeLoader tests continue to cover factory hydration from Config and the missing-factory failure case.

## Reviewer Test Plan

Run the targeted runtime tests:

    npx vitest run packages/core/src/core/subagentOrchestrator.test.ts packages/core/src/runtime/AgentRuntimeLoader.test.ts

Run the full local verification gates:

    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
    node scripts/tmux-harness.js --script scripts/tmux-script.subagent-haiku-repro.json --assert

Also inspect packages/core/src/core/subagentOrchestrator.ts to confirm there is no foreground content generator factory propagation in createRuntimeBundle.

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      | [OK]  |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

## Linked issues / bugs

Fixes #1962
