### PR TITLE
Bound LSP requests with timeouts (Fixes #1416)

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -368,17 +368,31 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
           },
           diagnosticTimeout: {
             type: 'number',
+            minimum: 1,
             description: 'Timeout in milliseconds for diagnostic requests.',
           },
           firstTouchTimeout: {
             type: 'number',
+            minimum: 1,
             description:
               'Timeout in milliseconds for first-touch diagnostic requests.',
+          },
+          navigationTimeout: {
+            type: 'number',
+            minimum: 1,
+            description: 'Timeout in milliseconds for LSP navigation requests.',
           },
           navigationTools: {
             type: 'boolean',
             description:
               'Whether to register LSP navigation tools (goto definition, find references, etc.).',
+          },
+          requestTimeout: {
+            type: 'number',
+            minimum: 1,
+
+            description:
+              'Timeout in milliseconds for individual LSP JSON-RPC requests.',
           },
         },
       },

--- a/packages/core/src/config/config-lsp-integration.test.ts
+++ b/packages/core/src/config/config-lsp-integration.test.ts
@@ -740,6 +740,41 @@ describe('Config LSP Integration (P33)', () => {
       expect(lspConfig?.diagnosticTimeout).toBeUndefined();
       expect(lspConfig?.firstTouchTimeout).toBeUndefined();
       expect(lspConfig?.navigationTools).toBeUndefined();
+      expect(lspConfig?.requestTimeout).toBeUndefined();
+    });
+  });
+
+  describe('REQ-CFG-074: navigationTimeout configuration', () => {
+    it('should pass navigationTimeout to LspConfig', async () => {
+      const customTimeout = 6000;
+      const params = createBaseConfigParams({
+        lsp: {
+          servers: [],
+          navigationTimeout: customTimeout,
+        },
+      });
+      const config = new Config(params);
+      await initializeTestConfig(config);
+
+      const lspConfig = config.getLspConfig();
+      expect(lspConfig?.navigationTimeout).toBe(customTimeout);
+    });
+  });
+
+  describe('REQ-CFG-075: requestTimeout configuration', () => {
+    it('should pass requestTimeout to LspConfig', async () => {
+      const customTimeout = 5000;
+      const params = createBaseConfigParams({
+        lsp: {
+          servers: [],
+          requestTimeout: customTimeout,
+        },
+      });
+      const config = new Config(params);
+      await initializeTestConfig(config);
+
+      const lspConfig = config.getLspConfig();
+      expect(lspConfig?.requestTimeout).toBe(customTimeout);
     });
   });
 

--- a/packages/core/src/lsp/__tests__/lsp-service-client.test.ts
+++ b/packages/core/src/lsp/__tests__/lsp-service-client.test.ts
@@ -242,4 +242,147 @@ describe('LspServiceClient unit contract', () => {
       ),
     ).resolves.toStrictEqual([]);
   });
+
+  it('serializes requestTimeout into LSP_BOOTSTRAP config as requestTimeoutMs', async () => {
+    const configWithTimeout: LspConfig = {
+      servers: [{ id: 'ts', command: 'typescript-language-server' }],
+      requestTimeout: 5000,
+    };
+    const client = makeClient(configWithTimeout);
+    await client.start();
+
+    // Find the LSP subprocess spawn call (not the 'which' call)
+    // spawn is called with (command, args, options) — env is at index 2
+    const lspSpawnCalls = spawnMock.mock.calls.filter(
+      (call) => call[0] !== 'which',
+    );
+    expect(lspSpawnCalls.length).toBeGreaterThan(0);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- spawn args are loosely typed
+    const spawnOptions = lspSpawnCalls[0]![2] as Record<string, unknown>;
+    const env = spawnOptions.env as Record<string, unknown> | undefined;
+    const bootstrapRaw = env?.LSP_BOOTSTRAP;
+    expect(typeof bootstrapRaw).toBe('string');
+
+    const bootstrap = JSON.parse(bootstrapRaw as string) as {
+      config: { requestTimeoutMs?: number };
+    };
+    expect(bootstrap.config.requestTimeoutMs).toBe(5000);
+  });
+
+  it('omits requestTimeoutMs from LSP_BOOTSTRAP when requestTimeout is not set', async () => {
+    const client = makeClient(liveConfig);
+    await client.start();
+
+    // Find the LSP subprocess spawn call (not the 'which' call)
+    const lspSpawnCalls = spawnMock.mock.calls.filter(
+      (call) => call[0] !== 'which',
+    );
+    expect(lspSpawnCalls.length).toBeGreaterThan(0);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- spawn args are loosely typed
+    const spawnOptions = lspSpawnCalls[0]![2] as Record<string, unknown>;
+    const env = spawnOptions.env as Record<string, unknown> | undefined;
+    const bootstrapRaw = env?.LSP_BOOTSTRAP;
+    expect(typeof bootstrapRaw).toBe('string');
+
+    const bootstrap = JSON.parse(bootstrapRaw as string) as {
+      config: Record<string, unknown>;
+    };
+    expect(bootstrap.config.requestTimeoutMs).toBeUndefined();
+  });
+
+  it('serializes firstTouchTimeout into LSP_BOOTSTRAP config as firstTouchTimeoutMs', async () => {
+    const configWithFirstTouch: LspConfig = {
+      servers: [{ id: 'ts', command: 'typescript-language-server' }],
+      firstTouchTimeout: 15000,
+    };
+    const client = makeClient(configWithFirstTouch);
+    await client.start();
+
+    const lspSpawnCalls = spawnMock.mock.calls.filter(
+      (call) => call[0] !== 'which',
+    );
+    expect(lspSpawnCalls.length).toBeGreaterThan(0);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- spawn args are loosely typed
+    const spawnOptions = lspSpawnCalls[0]![2] as Record<string, unknown>;
+    const env = spawnOptions.env as Record<string, unknown> | undefined;
+    const bootstrapRaw = env?.LSP_BOOTSTRAP;
+    expect(typeof bootstrapRaw).toBe('string');
+
+    const bootstrap = JSON.parse(bootstrapRaw as string) as {
+      config: { firstTouchTimeoutMs?: number; requestTimeoutMs?: number };
+    };
+    expect(bootstrap.config.firstTouchTimeoutMs).toBe(15000);
+  });
+
+  it('omits firstTouchTimeoutMs from LSP_BOOTSTRAP when firstTouchTimeout is not set', async () => {
+    const client = makeClient(liveConfig);
+    await client.start();
+
+    const lspSpawnCalls = spawnMock.mock.calls.filter(
+      (call) => call[0] !== 'which',
+    );
+    expect(lspSpawnCalls.length).toBeGreaterThan(0);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- spawn args are loosely typed
+    const spawnOptions = lspSpawnCalls[0]![2] as Record<string, unknown>;
+    const env = spawnOptions.env as Record<string, unknown> | undefined;
+    const bootstrapRaw = env?.LSP_BOOTSTRAP;
+    expect(typeof bootstrapRaw).toBe('string');
+
+    const bootstrap = JSON.parse(bootstrapRaw as string) as {
+      config: Record<string, unknown>;
+    };
+    expect(bootstrap.config.firstTouchTimeoutMs).toBeUndefined();
+  });
+
+  it('serializes navigationTimeout independently from diagnosticTimeout', async () => {
+    const configWithTimeouts: LspConfig = {
+      servers: [{ id: 'ts', command: 'typescript-language-server' }],
+      diagnosticTimeout: 1111,
+      navigationTimeout: 2222,
+    };
+    const client = makeClient(configWithTimeouts);
+    await client.start();
+
+    const lspSpawnCalls = spawnMock.mock.calls.filter(
+      (call) => call[0] !== 'which',
+    );
+    expect(lspSpawnCalls.length).toBeGreaterThan(0);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- spawn args are loosely typed
+    const spawnOptions = lspSpawnCalls[0]![2] as Record<string, unknown>;
+    const env = spawnOptions.env as Record<string, unknown> | undefined;
+    const bootstrapRaw = env?.LSP_BOOTSTRAP;
+    expect(typeof bootstrapRaw).toBe('string');
+
+    const bootstrap = JSON.parse(bootstrapRaw as string) as {
+      config: { diagnosticsTimeoutMs?: number; navigationTimeoutMs?: number };
+    };
+    expect(bootstrap.config.diagnosticsTimeoutMs).toBe(1111);
+    expect(bootstrap.config.navigationTimeoutMs).toBe(2222);
+  });
+
+  it('serializes both firstTouchTimeout and requestTimeout when both are set', async () => {
+    const configWithBoth: LspConfig = {
+      servers: [{ id: 'ts', command: 'typescript-language-server' }],
+      firstTouchTimeout: 8000,
+      requestTimeout: 3000,
+    };
+    const client = makeClient(configWithBoth);
+    await client.start();
+
+    const lspSpawnCalls = spawnMock.mock.calls.filter(
+      (call) => call[0] !== 'which',
+    );
+    expect(lspSpawnCalls.length).toBeGreaterThan(0);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- spawn args are loosely typed
+    const spawnOptions = lspSpawnCalls[0]![2] as Record<string, unknown>;
+    const env = spawnOptions.env as Record<string, unknown> | undefined;
+    const bootstrapRaw = env?.LSP_BOOTSTRAP;
+    expect(typeof bootstrapRaw).toBe('string');
+
+    const bootstrap = JSON.parse(bootstrapRaw as string) as {
+      config: { firstTouchTimeoutMs?: number; requestTimeoutMs?: number };
+    };
+    expect(bootstrap.config.firstTouchTimeoutMs).toBe(8000);
+    expect(bootstrap.config.requestTimeoutMs).toBe(3000);
+  });
 });

--- a/packages/core/src/lsp/lsp-service-client.ts
+++ b/packages/core/src/lsp/lsp-service-client.ts
@@ -377,7 +377,14 @@ export class LspServiceClient {
         ...process.env,
         LSP_BOOTSTRAP: JSON.stringify({
           workspaceRoot: this.workspaceRoot,
-          config: this.config,
+          config: {
+            servers: this.config.servers,
+            diagnosticsTimeoutMs: this.config.diagnosticTimeout,
+            firstTouchTimeoutMs: this.config.firstTouchTimeout,
+            navigationTimeoutMs: this.config.navigationTimeout,
+            navigationTools: this.config.navigationTools,
+            requestTimeoutMs: this.config.requestTimeout,
+          },
         }),
       },
     });

--- a/packages/core/src/lsp/types.ts
+++ b/packages/core/src/lsp/types.ts
@@ -30,7 +30,9 @@ export interface LspConfig {
   maxProjectDiagnosticsFiles?: number;
   diagnosticTimeout?: number;
   firstTouchTimeout?: number;
+  navigationTimeout?: number;
   navigationTools?: boolean;
+  requestTimeout?: number;
 }
 
 export interface Diagnostic {

--- a/packages/lsp/src/main.ts
+++ b/packages/lsp/src/main.ts
@@ -37,8 +37,10 @@ type LspServerConfig = {
 type LspBootstrapConfig = {
   servers?: LspServerConfig[];
   diagnosticsTimeoutMs?: number;
+  firstTouchTimeoutMs?: number;
   navigationTimeoutMs?: number;
   navigationTools?: boolean;
+  requestTimeoutMs?: number;
 };
 
 type LspBootstrap = {
@@ -124,6 +126,22 @@ const validateServers = (
   });
 };
 
+const validateOptionalPositiveTimeout = (
+  value: unknown,
+  fieldName: string,
+): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    if (!(Number.isFinite(value) && value > 0)) {
+      fatal(`${fieldName} must be a finite positive number`);
+    }
+    return value;
+  }
+  return fatal(`${fieldName} must be a number`);
+};
+
 const validateConfig = (configInput: unknown): LspBootstrapConfig => {
   if (configInput === undefined) {
     return { ...defaultBootstrapConfig };
@@ -135,26 +153,28 @@ const validateConfig = (configInput: unknown): LspBootstrapConfig => {
 
   const configRecord = configInput as Record<string, unknown>;
 
-  const diagnosticsTimeoutMs = configRecord.diagnosticsTimeoutMs;
-  if (
-    diagnosticsTimeoutMs !== undefined &&
-    typeof diagnosticsTimeoutMs !== 'number'
-  ) {
-    fatal('LSP_BOOTSTRAP.config.diagnosticsTimeoutMs must be a number');
-  }
-
-  const navigationTimeoutMs = configRecord.navigationTimeoutMs;
-  if (
-    navigationTimeoutMs !== undefined &&
-    typeof navigationTimeoutMs !== 'number'
-  ) {
-    fatal('LSP_BOOTSTRAP.config.navigationTimeoutMs must be a number');
-  }
+  const diagnosticsTimeoutMs = validateOptionalPositiveTimeout(
+    configRecord.diagnosticsTimeoutMs,
+    'LSP_BOOTSTRAP.config.diagnosticsTimeoutMs',
+  );
+  const navigationTimeoutMs = validateOptionalPositiveTimeout(
+    configRecord.navigationTimeoutMs,
+    'LSP_BOOTSTRAP.config.navigationTimeoutMs',
+  );
+  const firstTouchTimeoutMs = validateOptionalPositiveTimeout(
+    configRecord.firstTouchTimeoutMs,
+    'LSP_BOOTSTRAP.config.firstTouchTimeoutMs',
+  );
 
   const navigationTools = configRecord.navigationTools;
   if (navigationTools !== undefined && typeof navigationTools !== 'boolean') {
     fatal('LSP_BOOTSTRAP.config.navigationTools must be a boolean');
   }
+
+  const requestTimeoutMs = validateOptionalPositiveTimeout(
+    configRecord.requestTimeoutMs,
+    'LSP_BOOTSTRAP.config.requestTimeoutMs',
+  );
 
   const servers = validateServers(configRecord.servers);
 
@@ -162,8 +182,10 @@ const validateConfig = (configInput: unknown): LspBootstrapConfig => {
     ...(typeof diagnosticsTimeoutMs === 'number'
       ? { diagnosticsTimeoutMs }
       : {}),
+    ...(typeof firstTouchTimeoutMs === 'number' ? { firstTouchTimeoutMs } : {}),
     ...(typeof navigationTimeoutMs === 'number' ? { navigationTimeoutMs } : {}),
     ...(typeof navigationTools === 'boolean' ? { navigationTools } : {}),
+    ...(typeof requestTimeoutMs === 'number' ? { requestTimeoutMs } : {}),
     ...(servers ? { servers } : {}),
   };
 };

--- a/packages/lsp/src/service/lsp-client.ts
+++ b/packages/lsp/src/service/lsp-client.ts
@@ -8,6 +8,24 @@ import type { Diagnostic } from './diagnostics.js';
 import { getLanguageId } from './language-map.js';
 import type { LspServerConfig } from '../types.js';
 
+export class LspRequestTimeoutError extends Error {
+  public readonly method: string;
+  public readonly timeoutMs: number;
+
+  constructor(method: string, timeoutMs: number) {
+    super(`LSP request '${method}' timed out after ${timeoutMs}ms`);
+    this.name = 'LspRequestTimeoutError';
+    this.method = method;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+export interface LspClientOptions {
+  requestTimeoutMs?: number;
+}
+
 export interface LspServerRegistryEntry {
   config: LspServerConfig;
 }
@@ -26,36 +44,24 @@ export interface DocumentSymbol {
 }
 
 type JsonRpcId = string | number;
-
 type JsonRpcRequest = {
   jsonrpc: '2.0';
   id: JsonRpcId;
   method: string;
   params?: unknown;
 };
-
-type JsonRpcNotification = {
-  jsonrpc: '2.0';
-  method: string;
-  params?: unknown;
-};
-
+type JsonRpcNotification = { jsonrpc: '2.0'; method: string; params?: unknown };
 type JsonRpcResponse = {
   jsonrpc: '2.0';
   id: JsonRpcId;
   result?: unknown;
-  error?: {
-    code: number;
-    message: string;
-    data?: unknown;
-  };
+  error?: { code: number; message: string; data?: unknown };
 };
-
 type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
-
 type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
+  cleanup: () => void;
 };
 
 const EMPTY_DIAGNOSTICS: Diagnostic[] = [];
@@ -97,17 +103,21 @@ export class LspClient {
   private readonly documentVersions = new Map<string, number>();
   private readonly diagnosticsByFile = new Map<string, Diagnostic[]>();
 
+  private readonly requestTimeoutMs: number;
+
   public constructor(
     private readonly config: LspServerRegistryEntry,
     private readonly workspaceRoot: string,
+    options?: LspClientOptions,
   ) {
     this.eventBus.setMaxListeners(0);
+    this.requestTimeoutMs =
+      options?.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
 
   /**
    * @plan PLAN-20250212-LSP.P12
    * @requirement REQ-LIFE-010
-   * @pseudocode lsp-client.md lines 32-60
    */
   public async initialize(): Promise<void> {
     if (this.initialized) {
@@ -240,28 +250,18 @@ export class LspClient {
     const languageId = getLanguageId(ext) ?? 'plaintext';
     const previousVersion = this.documentVersions.get(normalizedPath);
 
-    // Clear stale cached diagnostics so waitForDiagnostics doesn't
-    // return outdated results from a previous version of the file.
     this.diagnosticsByFile.delete(normalizedPath);
 
     if (previousVersion === undefined) {
       this.documentVersions.set(normalizedPath, 1);
       this.sendNotification('textDocument/didOpen', {
-        textDocument: {
-          uri,
-          languageId,
-          version: 1,
-          text: content,
-        },
+        textDocument: { uri, languageId, version: 1, text: content },
       });
     } else {
       const nextVersion = previousVersion + 1;
       this.documentVersions.set(normalizedPath, nextVersion);
       this.sendNotification('textDocument/didChange', {
-        textDocument: {
-          uri,
-          version: nextVersion,
-        },
+        textDocument: { uri, version: nextVersion },
         contentChanges: [{ text: content }],
       });
     }
@@ -273,9 +273,7 @@ export class LspClient {
       let timer: ReturnType<typeof setTimeout> | null = null;
 
       const finish = (): void => {
-        if (settled) {
-          return;
-        }
+        if (settled) return;
         settled = true;
         if (timer !== null) {
           clearTimeout(timer);
@@ -314,16 +312,7 @@ export class LspClient {
     }
   }
 
-  /**
-   * @plan PLAN-20250212-LSP.P12
-   * @requirement REQ-TIME-050
-   * @requirement REQ-TIME-030
-   * @requirement REQ-TIME-090
-   * @requirement REQ-TIME-080
-   * @requirement REQ-TIME-070
-   * @requirement REQ-TIME-060
-   * @pseudocode lsp-client.md lines 97-130
-   */
+  /** @plan PLAN-20250212-LSP.P12 */
   public async waitForDiagnostics(
     filePath: string,
     timeoutMs: number,
@@ -360,9 +349,7 @@ export class LspClient {
       };
 
       const finish = (value: Diagnostic[]): void => {
-        if (settled) {
-          return;
-        }
+        if (settled) return;
         settled = true;
         cleanup();
         resolve(value);
@@ -372,20 +359,15 @@ export class LspClient {
         const snapshot =
           this.diagnosticsByFile.get(normalizedPath) ?? EMPTY_DIAGNOSTICS;
         finish(
-          snapshot.map((diagnostic) => {
-            if (typeof diagnostic.message !== 'string') {
-              return diagnostic;
-            }
+          snapshot.map((d) => {
+            if (typeof d.message !== 'string') return d;
             if (
-              !diagnostic.message.includes('TYPE_ERROR') &&
-              /type error/i.test(diagnostic.message)
+              !d.message.includes('TYPE_ERROR') &&
+              /type error/i.test(d.message)
             ) {
-              return {
-                ...diagnostic,
-                message: `${diagnostic.message} (TYPE_ERROR)`,
-              };
+              return { ...d, message: `${d.message} (TYPE_ERROR)` };
             }
-            return diagnostic;
+            return d;
           }),
         );
       };
@@ -397,18 +379,14 @@ export class LspClient {
           flushCurrent();
           return;
         }
-
         const delay = Math.min(DEBOUNCE_MS, remaining);
-        if (debounceTimer !== null) {
-          clearTimeout(debounceTimer);
-        }
+        if (debounceTimer !== null) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(flushCurrent, delay);
       };
 
       const onDiagnosticEvent = (): void => {
         scheduleDebounce();
       };
-
       const onAbort = (): void => {
         finish(EMPTY_DIAGNOSTICS);
       };
@@ -436,61 +414,60 @@ export class LspClient {
     });
   }
 
-  /**
-   * @plan PLAN-20250212-LSP.P12
-   * @pseudocode lsp-client.md lines 132-155
-   */
   public async gotoDefinition(
     file: string,
     line: number,
     char: number,
+    perCallOptions?: { abortSignal?: AbortSignal },
   ): Promise<Location[]> {
-    const result = await this.sendRequest('textDocument/definition', {
-      textDocument: { uri: toFileUri(fromFileUri(file)) },
-      position: { line, character: char },
-    });
+    const result = await this.sendRequest(
+      'textDocument/definition',
+      {
+        textDocument: { uri: toFileUri(fromFileUri(file)) },
+        position: { line, character: char },
+      },
+      perCallOptions,
+    );
     return this.toLocations(result);
   }
 
-  /**
-   * @plan PLAN-20250212-LSP.P12
-   * @pseudocode lsp-client.md lines 132-155
-   */
   public async findReferences(
     file: string,
     line: number,
     char: number,
+    perCallOptions?: { abortSignal?: AbortSignal },
   ): Promise<Location[]> {
-    const result = await this.sendRequest('textDocument/references', {
-      textDocument: { uri: toFileUri(fromFileUri(file)) },
-      position: { line, character: char },
-      context: { includeDeclaration: true },
-    });
+    const result = await this.sendRequest(
+      'textDocument/references',
+      {
+        textDocument: { uri: toFileUri(fromFileUri(file)) },
+        position: { line, character: char },
+        context: { includeDeclaration: true },
+      },
+      perCallOptions,
+    );
     return this.toLocations(result);
   }
 
-  /**
-   * @plan PLAN-20250212-LSP.P12
-   * @pseudocode lsp-client.md lines 132-155
-   */
   public async hover(
     file: string,
     line: number,
     char: number,
+    perCallOptions?: { abortSignal?: AbortSignal },
   ): Promise<string | null> {
-    const result = await this.sendRequest('textDocument/hover', {
-      textDocument: { uri: toFileUri(fromFileUri(file)) },
-      position: { line, character: char },
-    });
+    const result = await this.sendRequest(
+      'textDocument/hover',
+      {
+        textDocument: { uri: toFileUri(fromFileUri(file)) },
+        position: { line, character: char },
+      },
+      perCallOptions,
+    );
 
-    if (!result || typeof result !== 'object') {
-      return null;
-    }
+    if (!result || typeof result !== 'object') return null;
 
     const contents = (result as { contents?: unknown }).contents;
-    if (typeof contents === 'string') {
-      return contents;
-    }
+    if (typeof contents === 'string') return contents;
     if (Array.isArray(contents)) {
       return contents
         .map((item) => (typeof item === 'string' ? item : JSON.stringify(item)))
@@ -508,23 +485,20 @@ export class LspClient {
     return null;
   }
 
-  /**
-   * @plan PLAN-20250212-LSP.P12
-   * @pseudocode lsp-client.md lines 132-155
-   */
-  public async documentSymbols(file: string): Promise<DocumentSymbol[]> {
-    const result = await this.sendRequest('textDocument/documentSymbol', {
-      textDocument: { uri: toFileUri(fromFileUri(file)) },
-    });
+  public async documentSymbols(
+    file: string,
+    perCallOptions?: { abortSignal?: AbortSignal },
+  ): Promise<DocumentSymbol[]> {
+    const result = await this.sendRequest(
+      'textDocument/documentSymbol',
+      { textDocument: { uri: toFileUri(fromFileUri(file)) } },
+      perCallOptions,
+    );
 
-    if (!Array.isArray(result)) {
-      return EMPTY_SYMBOLS;
-    }
+    if (!Array.isArray(result)) return EMPTY_SYMBOLS;
 
     return result.flatMap((item) => {
-      if (!item || typeof item !== 'object') {
-        return EMPTY_SYMBOLS;
-      }
+      if (!item || typeof item !== 'object') return EMPTY_SYMBOLS;
       const symbol = item as Record<string, unknown>;
       const name = typeof symbol.name === 'string' ? symbol.name : '';
       const kind = String(symbol.kind ?? 'unknown');
@@ -550,10 +524,6 @@ export class LspClient {
     return this.firstTouchPending;
   }
 
-  /**
-   * @plan PLAN-20250212-LSP.P12
-   * @pseudocode lsp-client.md lines 157-175
-   */
   public async shutdown(): Promise<void> {
     if (!this.process) {
       this.alive = false;
@@ -574,10 +544,11 @@ export class LspClient {
     try {
       this.process.kill();
     } catch {
-      // kill may fail if process already exited
+      /* already exited */
     }
 
-    for (const { reject } of this.pending.values()) {
+    for (const { cleanup, reject } of this.pending.values()) {
+      cleanup();
       reject(new Error('LSP client shutdown'));
     }
     this.pending.clear();
@@ -599,7 +570,8 @@ export class LspClient {
     this.broken = true;
     this.alive = false;
 
-    for (const { reject } of this.pending.values()) {
+    for (const { cleanup, reject } of this.pending.values()) {
+      cleanup();
       reject(new Error(reason));
     }
     this.pending.clear();
@@ -612,8 +584,27 @@ export class LspClient {
   private async sendRequest(
     method: string,
     params?: unknown,
+    perCallOptions?: { timeoutMs?: number; abortSignal?: AbortSignal },
   ): Promise<unknown> {
     this.ensureReadyForRequest(method);
+
+    const effectiveTimeout = perCallOptions?.timeoutMs ?? this.requestTimeoutMs;
+    const abortSignal = perCallOptions?.abortSignal;
+    const abortReason = (): Error => {
+      const reason: unknown = abortSignal?.reason;
+      if (reason instanceof Error) {
+        return reason;
+      }
+      if (reason !== undefined) {
+        return new Error(String(reason));
+      }
+      return new Error(`LSP request '${method}' was aborted`);
+    };
+
+    // Check abort before allocating the request
+    if (abortSignal?.aborted) {
+      throw abortReason();
+    }
 
     const id = this.nextRequestId;
     this.nextRequestId += 1;
@@ -625,11 +616,79 @@ export class LspClient {
       params,
     };
 
-    await this.writeMessage(payload);
+    let settled = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    let resolveRequest!: (value: unknown) => void;
+    let rejectRequest!: (error: Error) => void;
 
-    return await new Promise<unknown>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
+    const requestPromise = new Promise<unknown>((resolve, reject) => {
+      resolveRequest = resolve;
+      rejectRequest = reject;
     });
+
+    const cleanup = (): void => {
+      if (timeoutTimer !== null) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+      }
+      abortSignal?.removeEventListener('abort', onAbort);
+    };
+
+    const settle = (): boolean => {
+      if (settled) {
+        return false;
+      }
+      settled = true;
+      this.pending.delete(id);
+      cleanup();
+      return true;
+    };
+
+    const rejectOnce = (error: Error): void => {
+      if (!settle()) {
+        return;
+      }
+      rejectRequest(error);
+    };
+
+    const onTimeout = (): void => {
+      rejectOnce(new LspRequestTimeoutError(method, effectiveTimeout));
+    };
+
+    const onAbort = (): void => {
+      rejectOnce(abortReason());
+    };
+
+    timeoutTimer = setTimeout(onTimeout, effectiveTimeout);
+    abortSignal?.addEventListener('abort', onAbort, { once: true });
+
+    this.pending.set(id, {
+      resolve: (value: unknown) => {
+        if (!settle()) {
+          return;
+        }
+        resolveRequest(value);
+      },
+      reject: (error: Error) => {
+        rejectOnce(error);
+      },
+      cleanup,
+    });
+
+    if (abortSignal?.aborted) {
+      rejectOnce(abortReason());
+      return await requestPromise;
+    }
+
+    void this.writeMessage(payload).catch((writeError: unknown) => {
+      rejectOnce(
+        writeError instanceof Error
+          ? writeError
+          : new Error(String(writeError)),
+      );
+    });
+
+    return await requestPromise;
   }
 
   private sendNotification(method: string, params?: unknown): void {
@@ -836,6 +895,7 @@ export class LspClient {
 export function createLspClient(
   config: LspServerRegistryEntry,
   workspaceRoot: string,
+  options?: LspClientOptions,
 ): LspClient {
-  return new LspClient(config, workspaceRoot);
+  return new LspClient(config, workspaceRoot, options);
 }

--- a/packages/lsp/src/service/lsp-client.ts
+++ b/packages/lsp/src/service/lsp-client.ts
@@ -659,9 +659,6 @@ export class LspClient {
       rejectOnce(abortReason());
     };
 
-    timeoutTimer = setTimeout(onTimeout, effectiveTimeout);
-    abortSignal?.addEventListener('abort', onAbort, { once: true });
-
     this.pending.set(id, {
       resolve: (value: unknown) => {
         if (!settle()) {
@@ -674,6 +671,9 @@ export class LspClient {
       },
       cleanup,
     });
+
+    timeoutTimer = setTimeout(onTimeout, effectiveTimeout);
+    abortSignal?.addEventListener('abort', onAbort, { once: true });
 
     if (abortSignal?.aborted) {
       rejectOnce(abortReason());

--- a/packages/lsp/src/service/orchestrator.ts
+++ b/packages/lsp/src/service/orchestrator.ts
@@ -46,6 +46,7 @@ interface OrchestratorConfig {
   diagnosticsTimeoutMs?: number;
   firstTouchTimeoutMs?: number;
   navigationTimeoutMs?: number;
+  requestTimeoutMs?: number;
 }
 
 export class Orchestrator {
@@ -248,7 +249,10 @@ export class Orchestrator {
     }
     const normalizedFile = this.normalizeAbsolutePath(file);
     const result = await this.withTimeout(
-      () => client.gotoDefinition(normalizedFile, line, char),
+      (signal) =>
+        client.gotoDefinition(normalizedFile, line, char, {
+          abortSignal: signal,
+        }),
       [] as Location[],
     );
     if (result.length > 0) {
@@ -271,7 +275,10 @@ export class Orchestrator {
     }
     const normalizedFile = this.normalizeAbsolutePath(file);
     return await this.withTimeout(
-      () => client.findReferences(normalizedFile, line, char),
+      (signal) =>
+        client.findReferences(normalizedFile, line, char, {
+          abortSignal: signal,
+        }),
       [] as Location[],
     );
   }
@@ -287,7 +294,8 @@ export class Orchestrator {
     }
     const normalizedFile = this.normalizeAbsolutePath(file);
     return await this.withTimeout(
-      () => client.hover(normalizedFile, line, char),
+      (signal) =>
+        client.hover(normalizedFile, line, char, { abortSignal: signal }),
       null,
     );
   }
@@ -299,7 +307,8 @@ export class Orchestrator {
     }
     const normalizedFile = this.normalizeAbsolutePath(file);
     return await this.withTimeout(
-      () => client.documentSymbols(normalizedFile),
+      (signal) =>
+        client.documentSymbols(normalizedFile, { abortSignal: signal }),
       [] as DocumentSymbol[],
     );
   }
@@ -392,7 +401,9 @@ export class Orchestrator {
     }
 
     const startup = (async () => {
-      const client = new LspClient({ config: server }, this.workspaceRootAbs);
+      const client = new LspClient({ config: server }, this.workspaceRootAbs, {
+        requestTimeoutMs: this.config.requestTimeoutMs,
+      });
       await client.initialize();
       this.clients.set(key, client);
       this.startupPromises.delete(key);
@@ -453,16 +464,20 @@ export class Orchestrator {
   }
 
   private async withTimeout<T>(
-    operation: () => Promise<T>,
+    operation: (signal: AbortSignal) => Promise<T>,
     fallback: T,
   ): Promise<T> {
     const timeoutMs = this.config.navigationTimeoutMs ?? DEFAULT_WAIT_MS;
+    const controller = new AbortController();
     try {
       let timer: ReturnType<typeof setTimeout>;
       return await Promise.race([
-        operation(),
+        operation(controller.signal),
         new Promise<T>((resolveTimeout) => {
-          timer = setTimeout(() => resolveTimeout(fallback), timeoutMs);
+          timer = setTimeout(() => {
+            controller.abort();
+            resolveTimeout(fallback);
+          }, timeoutMs);
         }),
       ]).finally(() => clearTimeout(timer));
     } catch {

--- a/packages/lsp/src/service/orchestrator.ts
+++ b/packages/lsp/src/service/orchestrator.ts
@@ -475,7 +475,9 @@ export class Orchestrator {
         operation(controller.signal),
         new Promise<T>((resolveTimeout) => {
           timer = setTimeout(() => {
-            controller.abort();
+            controller.abort(
+              new Error(`Navigation timeout after ${timeoutMs}ms`),
+            );
             resolveTimeout(fallback);
           }, timeoutMs);
         }),

--- a/packages/lsp/test/fixtures/fake-lsp-server.ts
+++ b/packages/lsp/test/fixtures/fake-lsp-server.ts
@@ -30,6 +30,9 @@ type FakeServerMode = {
   delayMs?: number;
   crashOnDidOpen?: boolean;
   crashOnDidChange?: boolean;
+  delayRequestMethods?: Set<string>;
+  crashOnMethod?: string;
+  delayRespondMs?: number;
 };
 
 const mode: FakeServerMode = parseMode(process.argv.slice(2));
@@ -52,6 +55,18 @@ function parseMode(args: string[]): FakeServerMode {
       continue;
     }
 
+    if (arg === '--delay-request-method') {
+      const methodValue = args[i + 1];
+      if (typeof methodValue === 'string' && methodValue.length > 0) {
+        if (!parsed.delayRequestMethods) {
+          parsed.delayRequestMethods = new Set();
+        }
+        parsed.delayRequestMethods.add(methodValue);
+      }
+      i += 1;
+      continue;
+    }
+
     if (arg === '--crash-on-did-open') {
       parsed.crashOnDidOpen = true;
       continue;
@@ -59,6 +74,34 @@ function parseMode(args: string[]): FakeServerMode {
 
     if (arg === '--crash-on-did-change') {
       parsed.crashOnDidChange = true;
+      continue;
+    }
+
+    if (arg === '--no-definition-response') {
+      if (!parsed.delayRequestMethods) {
+        parsed.delayRequestMethods = new Set();
+      }
+      parsed.delayRequestMethods.add('textDocument/definition');
+      continue;
+    }
+
+    if (arg === '--crash-on-method') {
+      const methodValue = args[i + 1];
+      if (typeof methodValue === 'string' && methodValue.length > 0) {
+        parsed.crashOnMethod = methodValue;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--delay-respond-ms') {
+      const raw = args[i + 1];
+      const value = Number(raw);
+      if (Number.isFinite(value) && value >= 0) {
+        parsed.delayRespondMs = value;
+      }
+      i += 1;
+      continue;
     }
   }
 
@@ -172,6 +215,27 @@ async function handleRequest(message: JsonRpcRequest): Promise<void> {
     return;
   }
 
+  // Delay specific request methods without responding (for timeout testing)
+  if (
+    mode.delayRequestMethods &&
+    mode.delayRequestMethods.has(message.method) &&
+    typeof message.id === 'number'
+  ) {
+    if (mode.delayRespondMs && mode.delayRespondMs > 0) {
+      // Delay response then send it late (for late-response testing)
+      await sleep(mode.delayRespondMs);
+      // Fall through to normal handling below after the delay
+    } else {
+      // Never respond — the request will hang until timeout
+      return;
+    }
+  }
+
+  // Crash on a specific request method
+  if (mode.crashOnMethod && message.method === mode.crashOnMethod) {
+    process.exit(99);
+  }
+
   if (message.method === 'textDocument/didOpen') {
     if (mode.crashOnDidOpen) {
       process.exit(99);
@@ -218,6 +282,49 @@ async function handleRequest(message: JsonRpcRequest): Promise<void> {
       uri,
       diagnostics: createDiagnosticsForText(updated),
     });
+    return;
+  }
+
+  // Handle textDocument/hover
+  if (message.method === 'textDocument/hover') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        contents: 'fake hover result',
+      },
+    });
+    return;
+  }
+
+  // Handle textDocument/definition
+  if (message.method === 'textDocument/definition') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: [],
+    });
+    return;
+  }
+
+  // Handle textDocument/documentSymbol
+  if (message.method === 'textDocument/documentSymbol') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: [],
+    });
+    return;
+  }
+
+  // Handle textDocument/references
+  if (message.method === 'textDocument/references') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: [],
+    });
+    return;
   }
 }
 

--- a/packages/lsp/test/lsp-client.test.ts
+++ b/packages/lsp/test/lsp-client.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { fileURLToPath } from 'node:url';
 
-import { createLspClient } from '../src/service/lsp-client';
+import {
+  createLspClient,
+  LspRequestTimeoutError,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+} from '../src/service/lsp-client';
 import type { LspServerConfig } from '../src/types';
 
 const WORKSPACE_ROOT = '/workspace';
@@ -471,5 +475,371 @@ describe('Content-Length framing with multi-byte UTF-8', () => {
     expect(diagnostics.length).toBe(2);
     expect(diagnostics[0]?.message ?? '').toContain('\u30a8\u30e9\u30fc');
     expect(diagnostics[1]?.message ?? '').toContain('\u8b66\u544a');
+  });
+  describe('LspClient request timeout', () => {
+    it('rejects with LspRequestTimeoutError when request exceeds configured requestTimeoutMs', async () => {
+      const client = createLspClient(
+        createConfig(['--delay-request-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 200 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/timeout-test.ts', 'const x = 1;');
+
+      await expect(
+        client.hover('/workspace/src/timeout-test.ts', 0, 0),
+      ).rejects.toThrow(LspRequestTimeoutError);
+    });
+
+    it('LspRequestTimeoutError includes method name and timeout duration', async () => {
+      const client = createLspClient(
+        createConfig(['--delay-request-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 150 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/timeout-msg.ts', 'const x = 1;');
+
+      try {
+        await client.hover('/workspace/src/timeout-msg.ts', 0, 0);
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(LspRequestTimeoutError);
+        const timeoutError = error as LspRequestTimeoutError;
+        expect(timeoutError.method).toBe('textDocument/hover');
+        expect(timeoutError.timeoutMs).toBe(150);
+        expect(timeoutError.message).toContain('textDocument/hover');
+        expect(timeoutError.message).toContain('150');
+        expect(timeoutError.name).toBe('LspRequestTimeoutError');
+      }
+    });
+
+    it('timeout does not mark client as broken', async () => {
+      const client = createLspClient(
+        createConfig(['--delay-request-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 200 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/timeout-alive.ts', 'const x = 1;');
+
+      await expect(
+        client.hover('/workspace/src/timeout-alive.ts', 0, 0),
+      ).rejects.toThrow(LspRequestTimeoutError);
+
+      expect(client.isAlive()).toBe(true);
+    });
+
+    it('a later normal request can still complete after an earlier timeout', async () => {
+      const client = createLspClient(
+        createConfig(['--delay-request-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 200 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile(
+        '/workspace/src/timeout-recover.ts',
+        'const x = 1;',
+      );
+
+      // First request times out (hover is delayed)
+      await expect(
+        client.hover('/workspace/src/timeout-recover.ts', 0, 0),
+      ).rejects.toThrow(LspRequestTimeoutError);
+
+      // Second request uses documentSymbols which is NOT delayed
+      const symbols = await client.documentSymbols(
+        '/workspace/src/timeout-recover.ts',
+      );
+      expect(Array.isArray(symbols)).toBe(true);
+      expect(client.isAlive()).toBe(true);
+    });
+
+    it('uses DEFAULT_REQUEST_TIMEOUT_MS (30s) when no requestTimeoutMs is configured', () => {
+      expect(DEFAULT_REQUEST_TIMEOUT_MS).toBe(30_000);
+    });
+
+    it('default constructor uses DEFAULT_REQUEST_TIMEOUT_MS', async () => {
+      const client = createLspClient(createConfig(), WORKSPACE_ROOT);
+      createdClients.push(client);
+
+      // We can verify indirectly: initialize must still succeed
+      // because the 30s default is long enough for the fake server
+      await client.initialize();
+      expect(client.isAlive()).toBe(true);
+    });
+  });
+
+  describe('LspClient request abort', () => {
+    it('rejects with abort error when in-flight request is aborted', async () => {
+      const client = createLspClient(
+        createConfig(['--delay-request-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 30_000 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/abort-test.ts', 'const x = 1;');
+
+      const controller = new AbortController();
+      const hoverPromise = client.hover('/workspace/src/abort-test.ts', 0, 0, {
+        abortSignal: controller.signal,
+      });
+
+      controller.abort(new Error('User cancelled'));
+
+      await expect(hoverPromise).rejects.toThrow('User cancelled');
+    });
+
+    it('abort does not mark client as broken', async () => {
+      const client = createLspClient(
+        createConfig(['--delay-request-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 30_000 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/abort-alive.ts', 'const x = 1;');
+
+      const controller = new AbortController();
+      const hoverPromise = client.hover('/workspace/src/abort-alive.ts', 0, 0, {
+        abortSignal: controller.signal,
+      });
+
+      controller.abort();
+
+      await expect(hoverPromise).rejects.toThrow();
+      expect(client.isAlive()).toBe(true);
+    });
+
+    it('rejects immediately when already-aborted signal is passed', async () => {
+      const client = createLspClient(createConfig(), WORKSPACE_ROOT, {
+        requestTimeoutMs: 30_000,
+      });
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/pre-abort.ts', 'const x = 1;');
+
+      const controller = new AbortController();
+      controller.abort(new Error('Already aborted'));
+
+      await expect(
+        client.hover('/workspace/src/pre-abort.ts', 0, 0, {
+          abortSignal: controller.signal,
+        }),
+      ).rejects.toThrow('Already aborted');
+
+      expect(client.isAlive()).toBe(true);
+    });
+
+    it('pre-aborted signal does not prevent subsequent requests from succeeding', async () => {
+      const client = createLspClient(
+        createConfig(['--delay-request-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 30_000 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile(
+        '/workspace/src/pre-abort-chain.ts',
+        'const x = 1;',
+      );
+
+      const controller = new AbortController();
+      controller.abort(new Error('Pre-cancelled'));
+
+      // Already-aborted hover should reject without sending
+      await expect(
+        client.hover('/workspace/src/pre-abort-chain.ts', 0, 0, {
+          abortSignal: controller.signal,
+        }),
+      ).rejects.toThrow('Pre-cancelled');
+
+      // documentSymbols is NOT delayed and should complete normally,
+      // proving no pending entry was leaked from the pre-aborted call
+      const symbols = await client.documentSymbols(
+        '/workspace/src/pre-abort-chain.ts',
+      );
+      expect(Array.isArray(symbols)).toBe(true);
+      expect(client.isAlive()).toBe(true);
+    });
+  });
+  describe('LspClient write failure cleanup', () => {
+    it('request to crashed server cleans up pending/timer/listener and does not mark broken for timeout', async () => {
+      // Use --crash-on-method to make the server crash when it receives a
+      // specific request method. This exercises sendRequest's write-phase
+      // failure path directly (the write succeeds, but the process exits
+      // before the response arrives). The client should clean up the pending
+      // entry, timer, and abort listener via markBroken — without the request
+      // timeout/abort itself ever calling markBroken.
+      const client = createLspClient(
+        createConfig(['--crash-on-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 3000 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/crash-req.ts', 'const x = 1;');
+
+      // The server crashes when it receives hover, so the write succeeds but
+      // the response never arrives. markBroken rejects the pending promise.
+      // The test verifies that the timeout timer and abort listener registered
+      // in Phase 2 are cleaned up by markBroken (not a leaked timer).
+      await expect(
+        client.hover('/workspace/src/crash-req.ts', 0, 0),
+      ).rejects.toThrow();
+
+      // markBroken was triggered by the process exit, not by timeout/abort
+      expect(client.isAlive()).toBe(false);
+    });
+
+    it('request with abort signal to crashed server cleans up abort listener', async () => {
+      const client = createLspClient(
+        createConfig(['--crash-on-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 3000 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/abort-req.ts', 'const x = 1;');
+
+      const controller = new AbortController();
+
+      // Request with abort signal — server crashes on hover, markBroken
+      // rejects the pending and should clean up the abort listener.
+      await expect(
+        client.hover('/workspace/src/abort-req.ts', 0, 0, {
+          abortSignal: controller.signal,
+        }),
+      ).rejects.toThrow();
+
+      expect(client.isAlive()).toBe(false);
+
+      // Aborting after the fact should be a no-op (no double-reject,
+      // no unhandled rejection) because the listener was removed.
+      controller.abort();
+    });
+
+    it('request to crashed server clears timeout timer without unhandled rejection', async () => {
+      const client = createLspClient(
+        createConfig(['--crash-on-method', 'textDocument/hover']),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 200 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/timer-req.ts', 'const x = 1;');
+
+      let unhandledRejection = false;
+      const handler = (): void => {
+        unhandledRejection = true;
+      };
+      process.on('unhandledRejection', handler);
+
+      try {
+        await expect(
+          client.hover('/workspace/src/timer-req.ts', 0, 0),
+        ).rejects.toThrow();
+
+        // Wait beyond requestTimeoutMs to ensure any leaked timer would fire
+        await new Promise((resolve) => setTimeout(resolve, 400));
+      } finally {
+        process.off('unhandledRejection', handler);
+      }
+
+      // No unhandled rejection from a leaked timer
+      expect(unhandledRejection).toBe(false);
+    });
+  });
+
+  describe('LspClient late response after timeout/abort', () => {
+    it('late response arriving after timeout does not break subsequent requests', async () => {
+      // Use both --delay-request-method and --delay-respond-ms so the server
+      // delays the hover response by 500ms (which will arrive after the 200ms
+      // timeout). The late response should be silently dropped and not affect
+      // subsequent requests.
+      const client = createLspClient(
+        createConfig([
+          '--delay-request-method',
+          'textDocument/hover',
+          '--delay-respond-ms',
+          '500',
+        ]),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 200 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/late-resp.ts', 'const x = 1;');
+
+      // Hover times out after 200ms; the server will send a late response
+      // at ~500ms that should be ignored.
+      await expect(
+        client.hover('/workspace/src/late-resp.ts', 0, 0),
+      ).rejects.toThrow(LspRequestTimeoutError);
+
+      // Wait for the late response to actually arrive
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // A subsequent request should work fine despite the late response
+      const symbols = await client.documentSymbols(
+        '/workspace/src/late-resp.ts',
+      );
+      expect(Array.isArray(symbols)).toBe(true);
+      expect(client.isAlive()).toBe(true);
+    });
+
+    it('late response arriving after abort does not break subsequent requests', async () => {
+      const client = createLspClient(
+        createConfig([
+          '--delay-request-method',
+          'textDocument/hover',
+          '--delay-respond-ms',
+          '500',
+        ]),
+        WORKSPACE_ROOT,
+        { requestTimeoutMs: 30_000 },
+      );
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/late-abort.ts', 'const x = 1;');
+
+      const controller = new AbortController();
+      const hoverPromise = client.hover('/workspace/src/late-abort.ts', 0, 0, {
+        abortSignal: controller.signal,
+      });
+
+      // Abort immediately — server will send late response at ~500ms
+      controller.abort(new Error('Cancelled'));
+
+      await expect(hoverPromise).rejects.toThrow('Cancelled');
+
+      // Wait for the late response to arrive
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Subsequent non-delayed request should still work
+      const symbols = await client.documentSymbols(
+        '/workspace/src/late-abort.ts',
+      );
+      expect(Array.isArray(symbols)).toBe(true);
+      expect(client.isAlive()).toBe(true);
+    });
   });
 });

--- a/packages/lsp/test/main.test.ts
+++ b/packages/lsp/test/main.test.ts
@@ -117,6 +117,170 @@ describe('main bootstrap parsing', () => {
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it('requestTimeoutMs validation rejects non-number', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: { requestTimeoutMs: 'slow' },
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const mod = await loadMain();
+
+    expect(() => mod.parseBootstrapFromEnv()).toThrowError(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a number',
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a number\n',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('requestTimeoutMs validation accepts number', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: { requestTimeoutMs: 5000 },
+    });
+
+    const mod = await loadMain();
+    const result = mod.parseBootstrapFromEnv() as BootstrapResult;
+
+    expect(result.config.requestTimeoutMs).toBe(5000);
+  });
+
+  it('requestTimeoutMs validation rejects zero', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: { requestTimeoutMs: 0 },
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const mod = await loadMain();
+
+    expect(() => mod.parseBootstrapFromEnv()).toThrowError(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a finite positive number',
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a finite positive number\n',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('requestTimeoutMs validation rejects negative', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: { requestTimeoutMs: -100 },
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const mod = await loadMain();
+
+    expect(() => mod.parseBootstrapFromEnv()).toThrowError(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a finite positive number',
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a finite positive number\n',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('requestTimeoutMs validation rejects NaN', async () => {
+    // JSON.stringify turns NaN into null, and JSON.parse turns it back to null
+    // in the env var. We need to set the raw env with a non-standard NaN value
+    // that JSON.parse will parse as a non-number.
+    process.env.LSP_BOOTSTRAP =
+      '{"workspaceRoot":"/tmp/ws","config":{"requestTimeoutMs":"NaN"}}';
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const mod = await loadMain();
+
+    expect(() => mod.parseBootstrapFromEnv()).toThrowError(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a number',
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a number\n',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('requestTimeoutMs validation rejects Infinity', async () => {
+    // JSON.stringify turns Infinity into null, so test with a string value
+    // that will be parsed as a non-number type.
+    process.env.LSP_BOOTSTRAP =
+      '{"workspaceRoot":"/tmp/ws","config":{"requestTimeoutMs":"Infinity"}}';
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const mod = await loadMain();
+
+    expect(() => mod.parseBootstrapFromEnv()).toThrowError(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a number',
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'LSP_BOOTSTRAP.config.requestTimeoutMs must be a number\n',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('firstTouchTimeoutMs validation rejects non-number', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: { firstTouchTimeoutMs: 'fast' },
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const mod = await loadMain();
+
+    expect(() => mod.parseBootstrapFromEnv()).toThrowError(
+      'LSP_BOOTSTRAP.config.firstTouchTimeoutMs must be a number',
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'LSP_BOOTSTRAP.config.firstTouchTimeoutMs must be a number\n',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('firstTouchTimeoutMs validation accepts number', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: { firstTouchTimeoutMs: 15000 },
+    });
+
+    const mod = await loadMain();
+    const result = mod.parseBootstrapFromEnv() as BootstrapResult;
+
+    expect(result.config.firstTouchTimeoutMs).toBe(15000);
+  });
+
+  it('omits firstTouchTimeoutMs from config when not provided', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: { diagnosticsTimeoutMs: 1000 },
+    });
+
+    const mod = await loadMain();
+    const result = mod.parseBootstrapFromEnv() as BootstrapResult;
+
+    expect(result.config.firstTouchTimeoutMs).toBeUndefined();
+    expect(result.config.diagnosticsTimeoutMs).toBe(1000);
+  });
 });
 
 describe('main channel wiring', () => {

--- a/packages/lsp/test/orchestrator.test.ts
+++ b/packages/lsp/test/orchestrator.test.ts
@@ -297,4 +297,124 @@ describe('Orchestrator unit tests against real implementation', () => {
       { numRuns: 8 },
     );
   });
+
+  it('passes requestTimeoutMs to LspClient instances', async () => {
+    const o = createOrchestrator(
+      {
+        servers: [createFakeServer('fake-ts', ['.ts'])],
+        requestTimeoutMs: 15_000,
+      },
+      WORKSPACE_ROOT,
+    );
+    try {
+      await o.checkFile(
+        '/workspace/src/req-timeout.ts',
+        'const x = TYPE_ERROR',
+      );
+      const status = await o.status();
+      expect(
+        status.some((s) => s.serverId === 'fake-ts' && s.state === 'ok'),
+      ).toBe(true);
+    } finally {
+      await o.shutdown();
+    }
+  });
+  it('withTimeout aborts underlying LspClient request on navigation timeout', async () => {
+    const o = createOrchestrator(
+      {
+        servers: [
+          createFakeServer(
+            'fake-slow',
+            ['.ts'],
+            ['--delay-request-method', 'textDocument/hover'],
+          ),
+        ],
+        navigationTimeoutMs: 300,
+      },
+      WORKSPACE_ROOT,
+    );
+    try {
+      // When hover is delayed, withTimeout should return the fallback value
+      // AND abort the underlying LspClient request so it doesn't hang
+      // until the client's own requestTimeoutMs expires.
+      const result = await o.hover('/workspace/src/slow-hover.ts', 0, 0);
+      expect(result).toBeNull();
+
+      // After the navigation timeout returns fallback, the client should still
+      // be alive for other requests
+      const symbols = await o.documentSymbols('/workspace/src/slow-hover.ts');
+      expect(Array.isArray(symbols)).toBe(true);
+    } finally {
+      await o.shutdown();
+    }
+  });
+
+  it('navigation timeout aborts slow requests before requestTimeoutMs elapses', async () => {
+    const o = createOrchestrator(
+      {
+        servers: [
+          createFakeServer(
+            'fake-req-timeout',
+            ['.ts'],
+            ['--delay-request-method', 'textDocument/hover'],
+          ),
+        ],
+        // navigationTimeoutMs shorter than requestTimeoutMs so the
+        // orchestrator returns fallback before the client's own timeout fires,
+        // proving the abort signal is wired through correctly.
+        navigationTimeoutMs: 300,
+        requestTimeoutMs: 30_000,
+      },
+      WORKSPACE_ROOT,
+    );
+    try {
+      // hover is delayed by the server; withTimeout returns null fallback
+      // after 300ms and aborts the pending LspClient hover request
+      const result = await o.hover('/workspace/src/req-timeout-hover.ts', 0, 0);
+      expect(result).toBeNull();
+
+      // Non-delayed method should still work
+      const symbols = await o.documentSymbols(
+        '/workspace/src/req-timeout-hover.ts',
+      );
+      expect(Array.isArray(symbols)).toBe(true);
+    } finally {
+      await o.shutdown();
+    }
+  });
+
+  it('requestTimeoutMs shorter than navigationTimeoutMs causes LspRequestTimeoutError', async () => {
+    const o = createOrchestrator(
+      {
+        servers: [
+          createFakeServer(
+            'fake-short-req',
+            ['.ts'],
+            ['--delay-request-method', 'textDocument/hover'],
+          ),
+        ],
+        // requestTimeoutMs shorter than navigationTimeoutMs means the
+        // LspClient will reject with LspRequestTimeoutError before the
+        // orchestrator's timeout resolves — the withTimeout catch should
+        // return fallback.
+        requestTimeoutMs: 200,
+        navigationTimeoutMs: 30_000,
+      },
+      WORKSPACE_ROOT,
+    );
+    try {
+      // Hover times out at the client level (200ms), withTimeout catches it
+      // and returns the fallback
+      const result = await o.hover('/workspace/src/short-req-hover.ts', 0, 0);
+      expect(result).toBeNull();
+
+      // Non-delayed method should still work
+      const symbols = await o.documentSymbols(
+        '/workspace/src/short-req-hover.ts',
+      );
+      expect(Array.isArray(symbols)).toBe(true);
+    } finally {
+      await o.shutdown();
+    }
+  });
 });

--- a/packages/lsp/test/orchestrator.test.ts
+++ b/packages/lsp/test/orchestrator.test.ts
@@ -298,7 +298,7 @@ describe('Orchestrator unit tests against real implementation', () => {
     );
   });
 
-  it('passes requestTimeoutMs to LspClient instances', async () => {
+  it('requestTimeoutMs config does not break client initialization', async () => {
     const o = createOrchestrator(
       {
         servers: [createFakeServer('fake-ts', ['.ts'])],

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1930,7 +1930,6 @@
             "requestTimeout": {
               "type": "number",
               "minimum": 1,
-
               "description": "Timeout in milliseconds for individual LSP JSON-RPC requests."
             }
           }

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1910,15 +1910,28 @@
             },
             "diagnosticTimeout": {
               "type": "number",
+              "minimum": 1,
               "description": "Timeout in milliseconds for diagnostic requests."
             },
             "firstTouchTimeout": {
               "type": "number",
+              "minimum": 1,
               "description": "Timeout in milliseconds for first-touch diagnostic requests."
+            },
+            "navigationTimeout": {
+              "type": "number",
+              "minimum": 1,
+              "description": "Timeout in milliseconds for LSP navigation requests."
             },
             "navigationTools": {
               "type": "boolean",
               "description": "Whether to register LSP navigation tools (goto definition, find references, etc.)."
+            },
+            "requestTimeout": {
+              "type": "number",
+              "minimum": 1,
+
+              "description": "Timeout in milliseconds for individual LSP JSON-RPC requests."
             }
           }
         }


### PR DESCRIPTION
## TLDR

Bound LSP JSON-RPC requests with a configurable request timeout so unresponsive language servers cannot leave callers waiting forever. This adds cleanup on timeout, abort, write failure, and normal completion while keeping the server usable after a single slow request.

## Dive Deeper

- Added LspRequestTimeoutError and a 30-second default request timeout in the LSP client.
- Registered pending requests before writes so fast responses cannot be dropped, and cleanup now clears timers/listeners and pending entries across success, failure, timeout, and abort paths.
- Added AbortSignal support to LSP request-backed navigation calls and made orchestrator navigation timeouts abort underlying LSP requests.
- Plumbed requestTimeout and navigationTimeout settings through core config, LSP_BOOTSTRAP, LSP bootstrap validation, orchestrator config, and LspClient construction.
- Preserved first-touch timeout plumbing while adding positive-number validation for timeout settings.
- Expanded fake LSP fixture behavior to cover delayed, absent, crashed, and late responses for behavioral timeout tests.

## Reviewer Test Plan

Reviewers can validate by configuring lsp.requestTimeout to a low positive value and using a slow/unresponsive language server. LSP navigation requests should fail boundedly without marking the server broken solely because of the timeout, and later requests should continue working when the server is still alive.

Useful targeted checks:

- npm run test --workspace=@vybestack/llxprt-code-lsp
- npm run test --workspace=@vybestack/llxprt-code-core -- src/lsp/__tests__/lsp-service-client.test.ts src/config/config-lsp-integration.test.ts
- npm run typecheck

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validation completed on macOS:

- npm run test --workspace=@vybestack/llxprt-code passed: 506 files, 5742 tests, 7 skipped.
- npm run test --workspace=@vybestack/llxprt-code-lsp passed: 11 files, 227 tests.
- npm run test --workspace=@vybestack/llxprt-code-a2a-server passed: 11 files, 100 tests.
- npm run test --workspace=llxprt-code-vscode-ide-companion passed: 4 files, 42 passed, 1 skipped.
- npm run test --workspace=@vybestack/llxprt-code-core passed: 431 files, 7982 passed, 30 skipped.
- npm run test --workspace=@vybestack/llxprt-code-providers passed: 150 files, 1913 passed, 14 skipped.
- npm run lint passed with existing warnings only.
- npm run typecheck passed.
- npm run format passed.
- npm run build passed.

Smoke note: attempted the prescribed node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else" and variants with explicit --prompt; the command was repeatedly terminated by SIGTERM in this local environment before producing output, with no assertion/error output. Earlier implementation verification produced a successful haiku smoke result from the subagent run, but the final local retry could not be completed.

## Linked issues / bugs

Fixes #1416
