### PR TITLE
Fix load balancer subagent runtime profiles (Fixes #1970)

### DIFF
--- a/packages/cli/src/runtime/__tests__/profileApplication.lb.test.ts
+++ b/packages/cli/src/runtime/__tests__/profileApplication.lb.test.ts
@@ -14,7 +14,12 @@
  * @pseudocode consumer-migration.md lines 10-15
  */
 
+/* eslint-disable max-lines -- Load-balancer profile application behavior is intentionally grouped in one regression suite. */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import type { LoadBalancingProvider } from '@vybestack/llxprt-code-providers';
 import type { Profile, LoadBalancerProfile } from '@vybestack/llxprt-code-core';
 
@@ -89,6 +94,12 @@ const isCliStatelessProviderModeEnabledMock = vi
 const isCliRuntimeStatelessReadyMock = vi
   .fn<() => boolean>()
   .mockReturnValue(true);
+const createProviderKeyStorageMock =
+  vi.fn<() => { getKey: (name: string) => Promise<string | null> }>();
+
+const keyStorageStub = {
+  getKey: vi.fn<(name: string) => Promise<string | null>>(),
+};
 
 // Stub objects
 const configStub = {
@@ -246,6 +257,8 @@ beforeEach(() => {
     providerManager: providerManagerStub,
     profileManager: profileManagerStub,
   });
+  keyStorageStub.getKey.mockResolvedValue(null);
+  createProviderKeyStorageMock.mockReturnValue(keyStorageStub);
   getActiveProviderOrThrowMock.mockReturnValue({ name: 'gemini' });
   isCliStatelessProviderModeEnabledMock.mockReturnValue(true);
   isCliRuntimeStatelessReadyMock.mockReturnValue(true);
@@ -265,6 +278,7 @@ vi.mock('../runtimeSettings.js', () => ({
   clearActiveModelParam: clearActiveModelParamMock,
   getActiveModelParams: getActiveModelParamsMock,
   setEphemeralSetting: setEphemeralSettingMock,
+  createProviderKeyStorage: createProviderKeyStorageMock,
   getCliRuntimeServices: getCliRuntimeServicesMock,
   getActiveProviderOrThrow: getActiveProviderOrThrowMock,
   isCliStatelessProviderModeEnabled: isCliStatelessProviderModeEnabledMock,
@@ -822,4 +836,224 @@ describe('Phase 2: Load Balancing Profile Detection (type: loadbalancer format)'
       expect(result.modelName).toBe('test-model');
     });
   });
+
+  describe('auth-key-name resolution in sub-profiles (issue #1970)', () => {
+    it('resolves auth-key-name from secure storage into sub-profile authToken', async () => {
+      keyStorageStub.getKey.mockImplementation(async (name: string) => {
+        if (name === 'chutes') return 'resolved-chutes-api-key';
+        if (name === 'openrouter') return 'resolved-openrouter-api-key';
+        return null;
+      });
+
+      const lbProfile: LoadBalancerProfile = {
+        version: 1,
+        type: 'loadbalancer',
+        policy: 'roundrobin',
+        profiles: ['zai', 'ollamaglm51'],
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      };
+
+      const mockLoadProfile = vi.fn(
+        async (profileName: string): Promise<Profile> => {
+          if (profileName === 'zai') {
+            return {
+              version: 1,
+              provider: 'Chutes.ai',
+              model: 'model-zai',
+              modelParams: {},
+              ephemeralSettings: {
+                'auth-key-name': 'chutes',
+                'base-url': 'https://chutes.ai/v1',
+              },
+            };
+          }
+          return {
+            version: 1,
+            provider: 'OpenRouter',
+            model: 'model-glm51',
+            modelParams: {},
+            ephemeralSettings: {
+              'auth-key-name': 'openrouter',
+              'base-url': 'https://openrouter.ai/v1',
+            },
+          };
+        },
+      );
+      profileManagerStub.loadProfile = mockLoadProfile;
+
+      const { getLBProvider } = wrapRegisterProviderToCaptureLB();
+
+      await applyProfileWithGuards(lbProfile, {
+        profileName: 'glm',
+      });
+
+      const lbProvider = getLBProvider();
+      expect(lbProvider).not.toBeNull();
+      expect(createProviderKeyStorageMock).toHaveBeenCalled();
+      expect(keyStorageStub.getKey).toHaveBeenCalledWith('chutes');
+      expect(keyStorageStub.getKey).toHaveBeenCalledWith('openrouter');
+
+      // Verify the resolved auth tokens are wired into the config
+      const config = (
+        lbProvider as unknown as {
+          config: { subProfiles: Array<{ authToken?: string; name: string }> };
+        }
+      ).config;
+      const subProfiles = config.subProfiles;
+      const zaiSub = subProfiles.find((sp) => sp.name === 'zai');
+      const ollamaSub = subProfiles.find((sp) => sp.name === 'ollamaglm51');
+      expect(zaiSub?.authToken).toBe('resolved-chutes-api-key');
+      expect(ollamaSub?.authToken).toBe('resolved-openrouter-api-key');
+    });
+
+    it('prefers explicit auth-key over auth-key-name', async () => {
+      keyStorageStub.getKey.mockResolvedValue('resolved-from-storage');
+
+      const lbProfile: LoadBalancerProfile = {
+        version: 1,
+        type: 'loadbalancer',
+        policy: 'roundrobin',
+        profiles: ['explicitKey'],
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      };
+
+      const mockLoadProfile = vi.fn(
+        async (): Promise<Profile> => ({
+          version: 1,
+          provider: 'gemini',
+          model: 'gemini-flash',
+          modelParams: {},
+          ephemeralSettings: {
+            'auth-key': 'explicit-direct-key',
+            'auth-key-name': 'chutes',
+          },
+        }),
+      );
+      profileManagerStub.loadProfile = mockLoadProfile;
+
+      const { getLBProvider } = wrapRegisterProviderToCaptureLB();
+
+      await applyProfileWithGuards(lbProfile, {
+        profileName: 'myLB',
+      });
+
+      const lbProvider = getLBProvider();
+      expect(lbProvider).not.toBeNull();
+      const config = (
+        lbProvider as unknown as {
+          config: { subProfiles: Array<{ authToken?: string; name: string }> };
+        }
+      ).config;
+      expect(keyStorageStub.getKey).not.toHaveBeenCalled();
+      expect(config.subProfiles[0]?.authToken).toBe('explicit-direct-key');
+    });
+
+    it('warns and continues when auth-key-name references a missing key', async () => {
+      keyStorageStub.getKey.mockResolvedValue(null);
+
+      const lbProfile: LoadBalancerProfile = {
+        version: 1,
+        type: 'loadbalancer',
+        policy: 'roundrobin',
+        profiles: ['missingKeyProfile'],
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      };
+
+      const mockLoadProfile = vi.fn(
+        async (): Promise<Profile> => ({
+          version: 1,
+          provider: 'gemini',
+          model: 'gemini-flash',
+          modelParams: {},
+          ephemeralSettings: {
+            'auth-key-name': 'nonexistent-key',
+          },
+        }),
+      );
+      profileManagerStub.loadProfile = mockLoadProfile;
+
+      const { getLBProvider } = wrapRegisterProviderToCaptureLB();
+
+      // Should not throw, registration should succeed
+      await applyProfileWithGuards(lbProfile, {
+        profileName: 'myLB',
+      });
+
+      const lbProvider = getLBProvider();
+      expect(lbProvider).not.toBeNull();
+      const config = (
+        lbProvider as unknown as {
+          config: { subProfiles: Array<{ authToken?: string; name: string }> };
+        }
+      ).config;
+      // authToken should be undefined (no crash, just missing)
+      expect(config.subProfiles[0]?.authToken).toBeUndefined();
+    });
+
+    it('resolves auth-key-name and falls back to auth-keyfile when named key missing', async () => {
+      keyStorageStub.getKey.mockResolvedValue(null);
+      const tempDir = await fs.mkdtemp(
+        path.join(tmpdir(), 'llxprt-lb-keyfile-'),
+      );
+      const keyfilePath = path.join(tempDir, 'api-key.txt');
+      await fs.writeFile(keyfilePath, 'resolved-from-keyfile\n');
+
+      try {
+        const lbProfile: LoadBalancerProfile = {
+          version: 1,
+          type: 'loadbalancer',
+          policy: 'roundrobin',
+          profiles: ['fallbackProfile'],
+          provider: '',
+          model: '',
+          modelParams: {},
+          ephemeralSettings: {},
+        };
+
+        const mockLoadProfile = vi.fn(
+          async (): Promise<Profile> => ({
+            version: 1,
+            provider: 'gemini',
+            model: 'gemini-flash',
+            modelParams: {},
+            ephemeralSettings: {
+              'auth-key-name': 'missing-key',
+              'auth-keyfile': keyfilePath,
+            },
+          }),
+        );
+        profileManagerStub.loadProfile = mockLoadProfile;
+
+        const { getLBProvider } = wrapRegisterProviderToCaptureLB();
+
+        await applyProfileWithGuards(lbProfile, {
+          profileName: 'myLB',
+        });
+
+        const lbProvider = getLBProvider();
+        expect(lbProvider).not.toBeNull();
+        const config = (
+          lbProvider as unknown as {
+            config: {
+              subProfiles: Array<{ authToken?: string; name: string }>;
+            };
+          }
+        ).config;
+        expect(config.subProfiles[0]?.authToken).toBe('resolved-from-keyfile');
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
 });
+
+/* eslint-enable max-lines */

--- a/packages/cli/src/runtime/profile-application/loadBalancerProfile.ts
+++ b/packages/cli/src/runtime/profile-application/loadBalancerProfile.ts
@@ -19,6 +19,7 @@ import * as fs from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import type { getCliRuntimeServices } from '../runtimeSettings.js';
+import { createProviderKeyStorage } from '../runtimeSettings.js';
 import {
   getProfileEphemeralSettings,
   getProfileModel,
@@ -70,8 +71,38 @@ async function resolveSubProfileAuthToken(
   deps: LoadBalancerResolutionDeps,
 ): Promise<string | undefined> {
   const authToken = getStringValue(subProfileEphemeralSettings, 'auth-key');
-  if (authToken !== undefined || authKeyfile === undefined) {
+  if (authToken !== undefined) {
     return authToken;
+  }
+
+  const authKeyName = getStringValue(
+    subProfileEphemeralSettings,
+    'auth-key-name',
+  );
+  if (authKeyName !== undefined) {
+    try {
+      const resolvedKey = await createProviderKeyStorage().getKey(authKeyName);
+      if (resolvedKey && resolvedKey.trim() !== '') {
+        deps.lbLogger.debug(
+          () =>
+            `Resolved auth-key-name '${authKeyName}' for sub-profile ${profileName}`,
+        );
+        return resolvedKey.trim();
+      }
+      deps.lbLogger.warn(
+        () =>
+          `Key '${authKeyName}' not found in secure storage for sub-profile ${profileName}; falling back.`,
+      );
+    } catch (error) {
+      deps.lbLogger.warn(
+        () =>
+          `Failed to resolve auth-key-name '${authKeyName}' for sub-profile ${profileName}: ${error}`,
+      );
+    }
+  }
+
+  if (authKeyfile === undefined) {
+    return undefined;
   }
   try {
     const keyfilePath = authKeyfile.startsWith('~')

--- a/packages/core/src/core/subagentOrchestrator.test.ts
+++ b/packages/core/src/core/subagentOrchestrator.test.ts
@@ -976,6 +976,11 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
     expect(loaderArgs.profile.settings.tools?.allowed).toStrictEqual([
       'read_file',
     ]);
+    const modelConfig = scopeFactory.mock.calls[0][3];
+    expect(modelConfig.model).toBe('claude-sonnet-4');
+    expect(modelConfig.temp).toBe(0.2);
+    expect(modelConfig.top_p).toBe(0.8);
+
     expect(loaderArgs.profile.contentGeneratorConfig.model).toBe(
       'claude-sonnet-4',
     );
@@ -991,5 +996,101 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
       'claude-sonnet-4',
     );
     expect(settingsService.getProviderSettings('').model).toBeUndefined();
+  });
+
+  it('rejects load balancer subagent profiles without referenced profiles', async () => {
+    const emptyLoadBalancerSubagent: SubagentConfig = {
+      name: 'empty-lb-helper',
+      profile: 'empty-lb',
+      systemPrompt: 'Do not launch.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const emptyLoadBalancerProfile: Profile = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: [],
+      provider: '',
+      model: '',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(emptyLoadBalancerSubagent);
+    const loadProfile = vi.fn().mockResolvedValue(emptyLoadBalancerProfile);
+    const runtimeLoader = vi.fn().mockResolvedValue(createRuntimeBundle());
+    const scopeFactory = vi.fn<typeof SubAgentScope.create>();
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager: { loadSubagent } as unknown as SubagentManager,
+      profileManager: { loadProfile } as unknown as ProfileManager,
+      foregroundConfig: makeForegroundConfig(),
+      scopeFactory,
+      runtimeLoader,
+    });
+
+    await expect(
+      orchestrator.launch({ name: emptyLoadBalancerSubagent.name }),
+    ).rejects.toThrow(/must reference a profile/);
+    expect(runtimeLoader).not.toHaveBeenCalled();
+    expect(scopeFactory).not.toHaveBeenCalled();
+  });
+
+  it('rejects nested load balancer profiles for subagent runtime resolution', async () => {
+    const nestedLoadBalancerSubagent: SubagentConfig = {
+      name: 'nested-lb-helper',
+      profile: 'outer-lb',
+      systemPrompt: 'Do not launch.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const outerLoadBalancerProfile: Profile = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['inner-lb'],
+      provider: '',
+      model: '',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    const innerLoadBalancerProfile: Profile = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['anthropic-fast'],
+      provider: '',
+      model: '',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(nestedLoadBalancerSubagent);
+    const loadProfile = vi.fn(async (profileName: string) => {
+      if (profileName === 'outer-lb') {
+        return outerLoadBalancerProfile;
+      }
+      if (profileName === 'inner-lb') {
+        return innerLoadBalancerProfile;
+      }
+      throw new Error(`unexpected profile ${profileName}`);
+    });
+    const runtimeLoader = vi.fn().mockResolvedValue(createRuntimeBundle());
+    const scopeFactory = vi.fn<typeof SubAgentScope.create>();
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager: { loadSubagent } as unknown as SubagentManager,
+      profileManager: { loadProfile } as unknown as ProfileManager,
+      foregroundConfig: makeForegroundConfig(),
+      scopeFactory,
+      runtimeLoader,
+    });
+
+    await expect(
+      orchestrator.launch({ name: nestedLoadBalancerSubagent.name }),
+    ).rejects.toThrow(/cannot use nested load balancer profile 'inner-lb'/);
+    expect(runtimeLoader).not.toHaveBeenCalled();
+    expect(scopeFactory).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/core/subagentOrchestrator.test.ts
+++ b/packages/core/src/core/subagentOrchestrator.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable max-lines, eslint-comments/disable-enable-pair -- Subagent orchestrator regression coverage intentionally lives with existing runtime assembly tests. */
+
 import { describe, expect, it, vi } from 'vitest';
 import type { SubagentManager } from '../config/subagentManager.js';
 import type { ProfileManager } from '../config/profileManager.js';
@@ -795,6 +797,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
     expect(settingsService.getCurrentProfileName()).toBe(
       keyNameSubagent.profile,
     );
+
     expect(settingsService.get('auth-key-name')).toBe('chutesminimax');
   });
 
@@ -888,5 +891,105 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
 
     expect(disposeSpy).toHaveBeenCalledTimes(1);
     expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('launches load balancer profile subagents with a concrete runtime provider and model', async () => {
+    const loadBalancerSubagent: SubagentConfig = {
+      name: 'typescript-helper',
+      profile: 'typescript-lb',
+      systemPrompt: 'Write TypeScript carefully.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const loadBalancerProfile: Profile = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['anthropic-fast', 'openai-fallback'],
+      provider: '',
+      model: '',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    const anthropicProfile: Profile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'claude-sonnet-4',
+      modelParams: {
+        temperature: 0.2,
+        top_p: 0.8,
+      },
+      ephemeralSettings: {
+        'auth-key': 'anthropic-key',
+        'compression-threshold': 0.66,
+        'tools.allowed': ['read_file'],
+      },
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(loadBalancerSubagent);
+    const loadProfile = vi.fn(async (profileName: string) => {
+      if (profileName === 'typescript-lb') {
+        return loadBalancerProfile;
+      }
+      if (profileName === 'anthropic-fast') {
+        return anthropicProfile;
+      }
+      throw new Error(`unexpected profile ${profileName}`);
+    });
+
+    const providerManager = { getActiveProvider: vi.fn() };
+    const config = {
+      ...makeForegroundConfig(),
+      getProviderManager: () => providerManager,
+    } as unknown as Config;
+    const runtimeBundle = createRuntimeBundle('load-balancer');
+    const runtimeLoader = vi.fn().mockResolvedValue(runtimeBundle);
+    const scope = {
+      runtimeContext: runtimeBundle.runtimeContext,
+      getAgentId: () => 'typescript-helper-1',
+    } as unknown as SubAgentScopeInstance;
+    const scopeFactory = vi
+      .fn<typeof SubAgentScope.create>()
+      .mockResolvedValue(scope);
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager: { loadSubagent } as unknown as SubagentManager,
+      profileManager: { loadProfile } as unknown as ProfileManager,
+      foregroundConfig: config,
+      scopeFactory,
+      runtimeLoader,
+    });
+
+    const result = await orchestrator.launch({
+      name: loadBalancerSubagent.name,
+    });
+
+    const loaderArgs = runtimeLoader.mock.calls[0][0];
+    const settingsService = loaderArgs.profile.providerRuntime.settingsService;
+
+    expect(result.profile).toBe(loadBalancerProfile);
+    expect(loaderArgs.profile.state.provider).toBe('anthropic');
+    expect(loaderArgs.profile.state.model).toBe('claude-sonnet-4');
+    expect(loaderArgs.profile.settings.compressionThreshold).toBe(0.66);
+    expect(loaderArgs.profile.settings.tools?.allowed).toStrictEqual([
+      'read_file',
+    ]);
+    expect(loaderArgs.profile.contentGeneratorConfig.model).toBe(
+      'claude-sonnet-4',
+    );
+    expect(loaderArgs.profile.contentGeneratorConfig.apiKey).toBe(
+      'anthropic-key',
+    );
+    expect(loaderArgs.profile.contentGeneratorConfig.providerManager).toBe(
+      providerManager,
+    );
+    expect(settingsService.getCurrentProfileName()).toBe('typescript-lb');
+    expect(settingsService.get('activeProvider')).toBe('anthropic');
+    expect(settingsService.getProviderSettings('anthropic').model).toBe(
+      'claude-sonnet-4',
+    );
+    expect(settingsService.getProviderSettings('').model).toBeUndefined();
   });
 });

--- a/packages/core/src/core/subagentOrchestrator.ts
+++ b/packages/core/src/core/subagentOrchestrator.ts
@@ -12,6 +12,7 @@ import type { SubagentManager } from '../config/subagentManager.js';
 import type { ProfileManager } from '../config/profileManager.js';
 import type { SubagentConfig } from '../config/types.js';
 import type { Profile } from '../types/modelParams.js';
+import { isLoadBalancerProfile } from '../types/modelParams.js';
 import { SubAgentScope } from './subagent.js';
 import type {
   ModelConfig,
@@ -49,6 +50,10 @@ type RuntimeLoader = (
 ) => Promise<AgentRuntimeLoaderResult>;
 
 type ScopeFactory = typeof SubAgentScope.create;
+
+type RuntimeProfileResolution = {
+  effectiveProfile: Profile;
+};
 
 const createAbortError = (message: string): Error => {
   const error = new Error(message);
@@ -183,12 +188,17 @@ export class SubagentOrchestrator {
       signal,
       'Subagent launch aborted while loading profile.',
     );
+    const runtimeProfile = await this.resolveRuntimeProfile(profile);
+    this.throwIfAborted(
+      signal,
+      'Subagent launch aborted while resolving runtime profile.',
+    );
 
     const promptConfig = this.buildPromptConfig(
       subagent.systemPrompt,
       request.behaviourPrompts,
     );
-    const modelConfig = this.buildModelConfig(profile);
+    const modelConfig = this.buildModelConfig(runtimeProfile.effectiveProfile);
     const runConfig = this.buildRunConfig(profile, request.runConfig);
     this.throwIfAborted(
       signal,
@@ -197,7 +207,7 @@ export class SubagentOrchestrator {
 
     const agentRuntimeId = this.createRuntimeId(subagent.name);
     const runtimeResult = await this.createRuntimeBundle(
-      { subagent, profile, modelConfig, agentRuntimeId },
+      { subagent, runtimeProfile, modelConfig, agentRuntimeId },
       signal,
     );
     this.throwIfAborted(
@@ -331,6 +341,31 @@ export class SubagentOrchestrator {
     }
 
     return runConfig;
+  }
+
+  private async resolveRuntimeProfile(
+    profile: Profile,
+  ): Promise<RuntimeProfileResolution> {
+    if (!isLoadBalancerProfile(profile)) {
+      return { effectiveProfile: profile };
+    }
+
+    const firstProfileName = profile.profiles[0];
+    if (!firstProfileName) {
+      throw new Error(
+        'Load balancer subagent profile must reference a profile.',
+      );
+    }
+
+    const effectiveProfile =
+      await this.options.profileManager.loadProfile(firstProfileName);
+    if (isLoadBalancerProfile(effectiveProfile)) {
+      throw new Error(
+        `Load balancer subagent profile cannot use nested load balancer profile '${firstProfileName}'.`,
+      );
+    }
+
+    return { effectiveProfile };
   }
 
   private baseSessionId(): string {
@@ -689,25 +724,30 @@ export class SubagentOrchestrator {
   private async createRuntimeBundle(
     params: {
       subagent: SubagentConfig;
-      profile: Profile;
+      runtimeProfile: RuntimeProfileResolution;
       modelConfig: ModelConfig;
       agentRuntimeId: string;
     },
     signal?: AbortSignal,
   ): Promise<AgentRuntimeLoaderResult> {
-    const { profile, modelConfig, agentRuntimeId, subagent } = params;
+    const { runtimeProfile, modelConfig, agentRuntimeId, subagent } = params;
+    const { effectiveProfile } = runtimeProfile;
 
     this.throwIfAborted(
       signal,
       'Subagent launch aborted before runtime state.',
     );
     const runtimeState = this.createRuntimeState(
-      profile,
+      effectiveProfile,
       modelConfig,
       agentRuntimeId,
     );
     const settingsService = new SettingsService();
-    this.populateSettingsService(settingsService, profile, subagent.profile);
+    this.populateSettingsService(
+      settingsService,
+      effectiveProfile,
+      subagent.profile,
+    );
 
     const providerRuntime: ProviderRuntimeContext =
       createProviderRuntimeContext({
@@ -720,9 +760,9 @@ export class SubagentOrchestrator {
         },
       });
 
-    const settingsSnapshot = this.createSettingsSnapshot(profile);
+    const settingsSnapshot = this.createSettingsSnapshot(effectiveProfile);
     const contentGeneratorConfig = this.buildContentGeneratorConfig(
-      profile,
+      effectiveProfile,
       modelConfig,
     );
     const providerManager =

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -487,13 +487,17 @@ export class LoadBalancingProvider implements IProvider {
   }
 
   /**
-   * Get default model (stub for Phase 1)
-   * Will be implemented in later phases to return first sub-profile's model
+   * Get the model that can satisfy provider-level runtime normalization before
+   * the request is delegated to a concrete sub-profile.
    */
   getDefaultModel(): string {
-    // Stub implementation - returns empty string
-    // Later phases will return the first sub-profile's model or a sensible default
-    return '';
+    const firstSubProfile = this.config.subProfiles[0];
+
+    if (isResolvedSubProfile(firstSubProfile)) {
+      return firstSubProfile.model;
+    }
+
+    return firstSubProfile.modelId ?? '';
   }
 
   /**

--- a/packages/providers/src/__tests__/LoadBalancingProvider.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.test.ts
@@ -150,6 +150,25 @@ describe('LoadBalancingProvider - Phase 1: Skeleton Implementation', () => {
       expect(result).toBe('gemini-flash');
     });
 
+    it('returns the first resolved sub-profile model as the default model', () => {
+      const resolvedSubProfile: ResolvedSubProfile = {
+        name: 'resolved-1',
+        providerName: 'anthropic',
+        model: 'claude-opus-4',
+        ephemeralSettings: {},
+        modelParams: {},
+      };
+      const lbConfig: LoadBalancingProviderConfig = {
+        profileName: 'resolved-default-test',
+        strategy: 'round-robin',
+        subProfiles: [resolvedSubProfile],
+      };
+
+      const provider = new LoadBalancingProvider(lbConfig, providerManager);
+
+      expect(provider.getDefaultModel()).toBe('claude-opus-4');
+    });
+
     it('uses the first sub-profile model as runtime default for foreground load-balancer calls', () => {
       const lbConfig: LoadBalancingProviderConfig = {
         profileName: 'glm',

--- a/packages/providers/src/__tests__/LoadBalancingProvider.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.test.ts
@@ -17,7 +17,7 @@
 /* eslint-disable max-lines -- Phase 5: large behavioral coverage file retained together to avoid fragmenting related scenarios. */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import type { IProvider } from '../IProvider.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
 import { ProviderManager } from '../ProviderManager.js';
 import { SettingsService } from '@vybestack/llxprt-code-core/settings/SettingsService.js';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
@@ -147,7 +147,49 @@ describe('LoadBalancingProvider - Phase 1: Skeleton Implementation', () => {
       expect(typeof provider.getDefaultModel).toBe('function');
 
       const result = provider.getDefaultModel();
-      expect(typeof result).toBe('string');
+      expect(result).toBe('gemini-flash');
+    });
+
+    it('uses the first sub-profile model as runtime default for foreground load-balancer calls', () => {
+      const lbConfig: LoadBalancingProviderConfig = {
+        profileName: 'glm',
+        strategy: 'round-robin',
+        subProfiles: [
+          {
+            name: 'anthropic-fast',
+            providerName: 'anthropic',
+            modelId: 'claude-sonnet-4',
+          },
+        ],
+      };
+      const configWithoutGlobalModel = createRuntimeConfigStub(
+        settingsService,
+        {
+          getModel: () => undefined,
+        },
+      );
+      const localProviderManager = new ProviderManager({
+        settingsService,
+        config: configWithoutGlobalModel,
+      });
+      const provider = new LoadBalancingProvider(
+        lbConfig,
+        localProviderManager,
+      );
+      localProviderManager.registerProvider(provider);
+      settingsService.set('activeProvider', 'anthropic');
+
+      const normalized = localProviderManager.normalizeRuntimeInputs(
+        {
+          contents: [],
+          settings: settingsService,
+          config: configWithoutGlobalModel,
+          resolved: { authToken: 'token' },
+        } satisfies GenerateChatOptions,
+        'load-balancer',
+      );
+
+      expect(normalized.resolved?.model).toBe('claude-sonnet-4');
     });
 
     it('should have getServerTools method that returns an array', () => {


### PR DESCRIPTION
## TLDR

Fixes load-balancer-profile subagent launches by resolving a concrete member profile for runtime assembly instead of passing the load-balancer profile's intentionally empty provider and model into runtime state.

## Dive Deeper

Load balancer profiles intentionally store empty provider and model fields and list concrete profile names in their profiles array. SubagentOrchestrator previously used those empty fields directly when creating AgentRuntimeState and runtime settings, which caused RuntimeStateError provider.missing before the subagent could run.

This change keeps the originally requested load-balancer profile as the launch result identity, but resolves the first referenced standard profile as the effective runtime profile. That effective profile now supplies:

- runtime state provider and model
- isolated SettingsService provider/model/auth/compression/tool values
- loader settings snapshot
- content generator config model and API key

ProviderManager is still forwarded to the runtime bundle, so the load-balancing layer remains available for provider-backed execution. The fix does not invent fallback providers or models; invalid empty/nested load-balancer references fail explicitly.

Issue #1972 is related to subagent compression/auth behavior, but this PR does not claim to fix it. The focused change may help load-balancer subagents preserve concrete compression/auth settings, but it does not change compression provider resolution.

## Reviewer Test Plan

Suggested reviewer validation:

1. Configure a subagent to use a load-balancer profile whose first member is a standard profile.
2. Launch it through the task tool.
3. Confirm launch no longer fails with RuntimeStateError provider.missing.
4. Confirm runtime settings come from the concrete member profile while the subagent still reports the requested load-balancer profile identity.

Validated locally:

- npx vitest run packages/core/src/core/subagentOrchestrator.test.ts
- npx eslint packages/core/src/core/subagentOrchestrator.ts packages/core/src/core/subagentOrchestrator.test.ts
- npm run test
- npm run lint
- npm run build
- npm run typecheck after build
- npm run typecheck --workspace @vybestack/llxprt-code-core before and after the focused changes
- node scripts/start.js --profile-load synthetic "write me a haiku and nothing else" completed with exit 0 after npm install refreshed workspace links; the model call itself returned a synthetic-provider 402 insufficient credits error, recorded in the local client error report.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1970
Related to #1972
