### PR TITLE
Fix PTY focus routing for live shells (Fixes #1894)

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -2615,9 +2615,7 @@ describe('InputPrompt', () => {
   });
 
   it('should still allow input when shell is not focused', async () => {
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />, {
-      shellFocus: false,
-    });
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
 
     await act(async () => {
       stdin.write('a');
@@ -2625,6 +2623,20 @@ describe('InputPrompt', () => {
     await waitFor(() => expect(mockBuffer.handleInput).toHaveBeenCalled());
     unmount();
   });
+
+  it('should not process typed keys when embedded shell is focused', async () => {
+    props.isEmbeddedShellFocused = true;
+    props.focus = true;
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+
+    await act(async () => {
+      stdin.write('a');
+    });
+
+    expect(mockBuffer.handleInput).not.toHaveBeenCalled();
+    unmount();
+  });
+
   describe('command queuing while streaming', () => {
     beforeEach(() => {
       props.streamingState = StreamingState.Responding;

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1729,7 +1729,9 @@ const useRuntimeState = (
     pendingLargePastesRef,
     nextPlaceholderIdRef,
   });
-  useKeypress(state.handleInput, { isActive: true });
+  useKeypress(state.handleInput, {
+    isActive: props.isEmbeddedShellFocused !== true,
+  });
   return state;
 };
 

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ToolMessageProps } from './ToolMessage.js';
 import { ToolMessage } from './ToolMessage.js';
 import { StreamingState, ToolCallStatus } from '../../types.js';
@@ -13,7 +14,25 @@ import { StreamingContext } from '../../contexts/StreamingContext.js';
 import { renderWithProviders } from '../../../test-utils/render.js';
 import { Colors } from '../../colors.js';
 import { TOOL_STATUS } from '../../constants.js';
-import type { AnsiOutput } from '@vybestack/llxprt-code-core';
+import type { AnsiOutput, Config } from '@vybestack/llxprt-code-core';
+
+const isActivePtyMock = vi.hoisted(() => vi.fn());
+const getLastActivePtyIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@vybestack/llxprt-code-core', async () => {
+  const actual = await vi.importActual<
+    typeof import('@vybestack/llxprt-code-core')
+  >('@vybestack/llxprt-code-core');
+
+  return {
+    ...actual,
+    ShellExecutionService: {
+      ...actual.ShellExecutionService,
+      isActivePty: isActivePtyMock,
+      getLastActivePtyId: getLastActivePtyIdMock,
+    },
+  };
+});
 
 vi.mock('../GeminiRespondingSpinner.js', () => ({
   GeminiRespondingSpinner: ({
@@ -43,6 +62,10 @@ vi.mock('../../utils/MarkdownDisplay.js', () => ({
   MarkdownDisplay: function MockMarkdownDisplay({ text }: { text: string }) {
     return <Text color={Colors.Foreground}>MockMarkdown:{text}</Text>;
   },
+}));
+vi.mock('../ShellInputPrompt.js', () => ({
+  ShellInputPrompt: ({ focus }: { focus: boolean }) =>
+    focus ? React.createElement(Text, null, 'MockShellInput') : null,
 }));
 
 const renderWithContext = (
@@ -204,5 +227,141 @@ describe('<ToolMessage />', () => {
       StreamingState.Idle,
     );
     expect(lastFrame()).toMatchSnapshot();
+  });
+
+  describe('shell focus state for completed shell with live PTY', () => {
+    const shellConfig = {
+      getEnableInteractiveShell: () => true,
+    } as unknown as Config;
+
+    beforeEach(() => {
+      isActivePtyMock.mockReturnValue(false);
+      getLastActivePtyIdMock.mockReturnValue(null);
+    });
+
+    it('shows focused indicator for executing shell with matching ptyId', () => {
+      getLastActivePtyIdMock.mockReturnValue(42);
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...baseProps}
+          name="Shell"
+          status={ToolCallStatus.Executing}
+          ptyId={42}
+          activeShellPtyId={42}
+          embeddedShellFocused={true}
+          config={shellConfig}
+        />,
+        StreamingState.Idle,
+      );
+      expect(lastFrame()).toContain('Focused');
+    });
+
+    it('shows focusable indicator for executing shell even when not focused', () => {
+      getLastActivePtyIdMock.mockReturnValue(42);
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...baseProps}
+          name="Shell"
+          status={ToolCallStatus.Executing}
+          ptyId={42}
+          activeShellPtyId={42}
+          embeddedShellFocused={false}
+          config={shellConfig}
+        />,
+        StreamingState.Idle,
+      );
+      expect(lastFrame()).toContain('Tab/Ctrl+F to focus');
+      expect(lastFrame()).not.toContain('Focused');
+    });
+
+    it('shows focused indicator for completed shell when PTY is still alive and embeddedShellFocused is true', () => {
+      getLastActivePtyIdMock.mockReturnValue(42);
+      isActivePtyMock.mockReturnValue(true);
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...baseProps}
+          name="Shell"
+          status={ToolCallStatus.Success}
+          ptyId={42}
+          activeShellPtyId={42}
+          embeddedShellFocused={true}
+          config={shellConfig}
+        />,
+        StreamingState.Idle,
+      );
+      expect(lastFrame()).toContain('Focused');
+    });
+
+    it('does not show focused indicator for completed shell when PTY is dead', () => {
+      getLastActivePtyIdMock.mockReturnValue(42);
+      isActivePtyMock.mockReturnValue(false);
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...baseProps}
+          name="Shell"
+          status={ToolCallStatus.Success}
+          ptyId={42}
+          activeShellPtyId={42}
+          embeddedShellFocused={true}
+          config={shellConfig}
+        />,
+        StreamingState.Idle,
+      );
+      expect(lastFrame()).not.toContain('Focused');
+      expect(lastFrame()).not.toContain('Tab/Ctrl+F to focus');
+    });
+
+    it('does not show focused indicator for non-shell tool', () => {
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...baseProps}
+          name="ReadFile"
+          status={ToolCallStatus.Success}
+          ptyId={42}
+          embeddedShellFocused={true}
+          config={shellConfig}
+        />,
+        StreamingState.Idle,
+      );
+      expect(lastFrame()).not.toContain('Focused');
+      expect(lastFrame()).not.toContain('Tab/Ctrl+F to focus');
+    });
+
+    it('shows focusable indicator for completed shell when PTY is alive but not focused', () => {
+      getLastActivePtyIdMock.mockReturnValue(42);
+      isActivePtyMock.mockReturnValue(true);
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...baseProps}
+          name="Shell"
+          status={ToolCallStatus.Success}
+          ptyId={42}
+          activeShellPtyId={42}
+          embeddedShellFocused={false}
+          config={shellConfig}
+        />,
+        StreamingState.Idle,
+      );
+      expect(lastFrame()).toContain('Tab/Ctrl+F to focus');
+      expect(lastFrame()).not.toContain('Focused');
+    });
+
+    it('shows ShellInputPrompt for completed shell when PTY alive and focused', () => {
+      getLastActivePtyIdMock.mockReturnValue(42);
+      isActivePtyMock.mockReturnValue(true);
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...baseProps}
+          name="Shell"
+          status={ToolCallStatus.Success}
+          ptyId={42}
+          activeShellPtyId={42}
+          embeddedShellFocused={true}
+          config={shellConfig}
+        />,
+        StreamingState.Idle,
+      );
+      expect(lastFrame()).toContain('MockShellInput');
+    });
   });
 });

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -137,17 +137,22 @@ function computeShellFocusState(
   const isThisShellTargeted =
     ptyId === activeShellPtyId ||
     (activeShellPtyId == null && isLastActiveShellTarget);
+  const isPtyAlive =
+    ptyId !== undefined && ShellExecutionService.isActivePty(ptyId);
+  const isExecuting = status === ToolCallStatus.Executing;
+  const isActiveOrAlive = isExecuting || isPtyAlive;
   const isThisShellFocused =
     isShellTool &&
-    status === ToolCallStatus.Executing &&
     isThisShellTargeted &&
-    embeddedShellFocused === true;
+    embeddedShellFocused === true &&
+    isActiveOrAlive;
 
+  const interactiveShellEnabled = config?.getEnableInteractiveShell() === true;
   const isThisShellFocusable =
     isShellTool &&
-    status === ToolCallStatus.Executing &&
-    config?.getEnableInteractiveShell() === true &&
-    isThisShellTargeted;
+    interactiveShellEnabled &&
+    isThisShellTargeted &&
+    isActiveOrAlive;
 
   return {
     isShellTool,

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolMessage.test.tsx.snap
@@ -1,0 +1,38 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<ToolMessage /> > renders AnsiOutputText for AnsiOutput results 1`] = `
+"│                                                                              │
+│ ✓                                                                            │
+│ test-tool A tool for testing                                                 │
+│                                                                              │
+│    hello                                                                     │"
+`;
+
+exports[`<ToolMessage /> > renders DiffRenderer for diff results 1`] = `
+"│                                                                              │
+│ ✓                                                                            │
+│ test-tool A tool for testing                                                 │
+│                                                                              │
+│    MockDiff:--- a/file.txt                                                   │
+│    +++ b/file.txt                                                            │
+│    @@ -1 +1 @@                                                               │
+│    -old                                                                      │
+│    +new                                                                      │"
+`;
+
+exports[`<ToolMessage /> > renders emphasis correctly 1`] = `
+"│                                                                              │
+│ ✓                                                                            │
+│ test-tool A tool for testing                                                 │
+│  ←                                                                           │
+│                                                                              │
+│    MockMarkdown:Test result                                                  │"
+`;
+
+exports[`<ToolMessage /> > renders emphasis correctly 2`] = `
+"│                                                                              │
+│ ✓                                                                            │
+│ test-tool A tool for testing                                                 │
+│                                                                              │
+│    MockMarkdown:Test result                                                  │"
+`;

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.test.ts
@@ -16,6 +16,7 @@ const setMouseEventsActiveMock = vi.hoisted(() => vi.fn());
 const disableMouseEventsMock = vi.hoisted(() => vi.fn());
 const enableMouseEventsMock = vi.hoisted(() => vi.fn());
 const getLastActivePtyIdMock = vi.hoisted(() => vi.fn());
+const isActivePtyMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../hooks/useKeypress.js', async () => {
   const actual = await vi.importActual<
@@ -44,6 +45,7 @@ vi.mock('@vybestack/llxprt-code-core', async () => {
     ...actual,
     ShellExecutionService: {
       getLastActivePtyId: getLastActivePtyIdMock,
+      isActivePty: isActivePtyMock,
     },
     DebugLogger: class {
       log(): void {
@@ -148,6 +150,7 @@ describe('useKeybindings', () => {
     vi.clearAllMocks();
     isMouseEventsActiveMock.mockReturnValue(false);
     getLastActivePtyIdMock.mockReturnValue(null);
+    isActivePtyMock.mockReturnValue(false);
   });
 
   it('copy mode consumes keypress before exit handling', () => {
@@ -320,6 +323,7 @@ describe('useKeybindings', () => {
 
   it('toggles embedded shell focus when interactive shell is enabled and a pty exists', () => {
     const harness = createHarness();
+    isActivePtyMock.mockReturnValue(true);
 
     renderUseKeybindings(harness, {
       shell: {
@@ -338,6 +342,74 @@ describe('useKeybindings', () => {
     expect(harness.setEmbeddedShellFocused).toHaveBeenCalledWith(
       expect.any(Function),
     );
+  });
+
+  it('does not toggle shell focus when activeShellPtyId is nonzero but isActivePty returns false (stale PTY)', () => {
+    const harness = createHarness();
+    // activeShellPtyId is a nonzero id that is no longer alive
+    isActivePtyMock.mockReturnValue(false);
+
+    renderUseKeybindings(harness, {
+      shell: {
+        activeShellPtyId: 42,
+        setEmbeddedShellFocused: harness.setEmbeddedShellFocused,
+        getEnableInteractiveShell: () => true,
+      },
+    });
+
+    const handler = getRegisteredHandler();
+
+    act(() => {
+      handler({ ctrl: true, name: 'f' } as Key);
+    });
+
+    expect(harness.setEmbeddedShellFocused).not.toHaveBeenCalled();
+  });
+
+  it('toggles embedded shell focus when activeShellPtyId is null but lastActivePtyId is alive', () => {
+    const harness = createHarness();
+    getLastActivePtyIdMock.mockReturnValue(99);
+    isActivePtyMock.mockReturnValue(true);
+
+    renderUseKeybindings(harness, {
+      shell: {
+        activeShellPtyId: null,
+        setEmbeddedShellFocused: harness.setEmbeddedShellFocused,
+        getEnableInteractiveShell: () => true,
+      },
+    });
+
+    const handler = getRegisteredHandler();
+
+    act(() => {
+      handler({ ctrl: true, name: 'f' } as Key);
+    });
+
+    expect(harness.setEmbeddedShellFocused).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+  });
+
+  it('does not toggle shell focus when lastActivePtyId points to a dead PTY', () => {
+    const harness = createHarness();
+    getLastActivePtyIdMock.mockReturnValue(99);
+    isActivePtyMock.mockReturnValue(false);
+
+    renderUseKeybindings(harness, {
+      shell: {
+        activeShellPtyId: null,
+        setEmbeddedShellFocused: harness.setEmbeddedShellFocused,
+        getEnableInteractiveShell: () => true,
+      },
+    });
+
+    const handler = getRegisteredHandler();
+
+    act(() => {
+      handler({ ctrl: true, name: 'f' } as Key);
+    });
+
+    expect(harness.setEmbeddedShellFocused).not.toHaveBeenCalled();
   });
 
   it('runs /ide status command only when IDE mode and context are both present', () => {

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useKeybindings.ts
@@ -233,8 +233,13 @@ function handleIdeAndShellKeys(
   ) {
     const lastPtyId = ShellExecutionService.getLastActivePtyId();
     const hasActiveShellPty =
-      shell.activeShellPtyId !== null && shell.activeShellPtyId !== 0;
-    const hasLastPty = lastPtyId !== null && lastPtyId !== 0;
+      shell.activeShellPtyId !== null &&
+      shell.activeShellPtyId !== 0 &&
+      ShellExecutionService.isActivePty(shell.activeShellPtyId);
+    const hasLastPty =
+      lastPtyId !== null &&
+      lastPtyId !== 0 &&
+      ShellExecutionService.isActivePty(lastPtyId);
     const hasActivePty = hasActiveShellPty || hasLastPty;
     debug.log(
       'Ctrl+F: activeShellPtyId=%s, lastActivePtyId=%s, will toggle=%s',

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useShellFocusAutoReset.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useShellFocusAutoReset.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '../../../../test-utils/render.js';
+import { useShellFocusAutoReset } from './useShellFocusAutoReset.js';
+import { ToolCallStatus } from '../../../types.js';
+import { SHELL_COMMAND_NAME } from '../../../constants.js';
+import type { HistoryItemWithoutId } from '../../../types.js';
+
+const isActivePtyMock = vi.hoisted(() => vi.fn());
+const getLastActivePtyIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@vybestack/llxprt-code-core', async () => {
+  const actual = await vi.importActual<
+    typeof import('@vybestack/llxprt-code-core')
+  >('@vybestack/llxprt-code-core');
+
+  return {
+    ...actual,
+    ShellExecutionService: {
+      ...actual.ShellExecutionService,
+      isActivePty: isActivePtyMock,
+      getLastActivePtyId: getLastActivePtyIdMock,
+    },
+    DebugLogger: class {
+      log(): void {}
+    },
+  };
+});
+
+describe('useShellFocusAutoReset', () => {
+  let setEmbeddedShellFocused: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setEmbeddedShellFocused = vi.fn();
+    isActivePtyMock.mockReturnValue(false);
+    getLastActivePtyIdMock.mockReturnValue(null);
+  });
+
+  const shellToolExecuting = (
+    name = SHELL_COMMAND_NAME,
+    ptyId?: number,
+  ): HistoryItemWithoutId => ({
+    type: 'tool_group',
+    tools: [
+      {
+        callId: 'call-1',
+        name,
+        description: 'test shell',
+        resultDisplay: undefined,
+        status: ToolCallStatus.Executing,
+        confirmationDetails: undefined,
+        ...(ptyId !== undefined ? { ptyId } : {}),
+      },
+    ],
+  });
+
+  const shellToolCompleted = (
+    name = SHELL_COMMAND_NAME,
+    ptyId?: number,
+  ): HistoryItemWithoutId => ({
+    type: 'tool_group',
+    tools: [
+      {
+        callId: 'call-1',
+        name,
+        description: 'test shell',
+        resultDisplay: undefined,
+        status: ToolCallStatus.Success,
+        confirmationDetails: undefined,
+        ...(ptyId !== undefined ? { ptyId } : {}),
+      },
+    ],
+  });
+
+  it('should not reset when a shell tool is executing', () => {
+    renderHook(() =>
+      useShellFocusAutoReset({
+        pendingHistoryItems: [shellToolExecuting()],
+        embeddedShellFocused: true,
+        setEmbeddedShellFocused,
+      }),
+    );
+
+    expect(setEmbeddedShellFocused).not.toHaveBeenCalled();
+  });
+
+  it('should not reset when embedded shell is not focused', () => {
+    renderHook(() =>
+      useShellFocusAutoReset({
+        pendingHistoryItems: [shellToolCompleted()],
+        embeddedShellFocused: false,
+        setEmbeddedShellFocused,
+      }),
+    );
+
+    expect(setEmbeddedShellFocused).not.toHaveBeenCalled();
+  });
+
+  it('should report anyShellExecuting true when a shell is executing', () => {
+    const { result } = renderHook(() =>
+      useShellFocusAutoReset({
+        pendingHistoryItems: [shellToolExecuting()],
+        embeddedShellFocused: true,
+        setEmbeddedShellFocused,
+      }),
+    );
+
+    expect(result.current.anyShellExecuting).toBe(true);
+  });
+
+  it('should report anyShellExecuting false when no shell is executing', () => {
+    const { result } = renderHook(() =>
+      useShellFocusAutoReset({
+        pendingHistoryItems: [shellToolCompleted()],
+        embeddedShellFocused: false,
+        setEmbeddedShellFocused,
+      }),
+    );
+
+    expect(result.current.anyShellExecuting).toBe(false);
+  });
+
+  it('should reset when no shell executing, focused, and no live PTY', () => {
+    getLastActivePtyIdMock.mockReturnValue(null);
+
+    renderHook(() =>
+      useShellFocusAutoReset({
+        pendingHistoryItems: [shellToolCompleted()],
+        embeddedShellFocused: true,
+        setEmbeddedShellFocused,
+      }),
+    );
+
+    expect(setEmbeddedShellFocused).toHaveBeenCalledWith(false);
+  });
+
+  it('should not reset when no shell executing, focused, but a live PTY exists', () => {
+    getLastActivePtyIdMock.mockReturnValue(42);
+    isActivePtyMock.mockReturnValue(true);
+
+    renderHook(() =>
+      useShellFocusAutoReset({
+        pendingHistoryItems: [shellToolCompleted()],
+        embeddedShellFocused: true,
+        setEmbeddedShellFocused,
+      }),
+    );
+
+    expect(setEmbeddedShellFocused).not.toHaveBeenCalled();
+  });
+
+  it('should reset when no shell executing, focused, and last active PTY is no longer alive', () => {
+    getLastActivePtyIdMock.mockReturnValue(42);
+    isActivePtyMock.mockReturnValue(false);
+
+    renderHook(() =>
+      useShellFocusAutoReset({
+        pendingHistoryItems: [shellToolCompleted()],
+        embeddedShellFocused: true,
+        setEmbeddedShellFocused,
+      }),
+    );
+
+    expect(setEmbeddedShellFocused).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useShellFocusAutoReset.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useShellFocusAutoReset.ts
@@ -7,7 +7,10 @@
 import { useEffect, useMemo } from 'react';
 import { ToolCallStatus, type HistoryItemWithoutId } from '../../../types.js';
 import { SHELL_COMMAND_NAME, SHELL_NAME } from '../../../constants.js';
-import { DebugLogger } from '@vybestack/llxprt-code-core';
+import {
+  DebugLogger,
+  ShellExecutionService,
+} from '@vybestack/llxprt-code-core';
 
 const debug = new DebugLogger('llxprt:ui:appcontainer');
 
@@ -20,9 +23,11 @@ interface UseShellFocusAutoResetParams {
 /**
  * @hook useShellFocusAutoReset
  * @description Resets embedded shell focus when no shell tool is executing
+ * AND no live PTY still exists. Preserves focus when a PTY remains alive
+ * so users can continue typing into the embedded terminal.
  * @inputs pendingHistoryItems, embeddedShellFocused, setEmbeddedShellFocused
  * @outputs activeShellExecuting flag
- * @sideEffects Updates focus state when execution ends
+ * @sideEffects Updates focus state when execution ends and PTY is dead
  */
 export function useShellFocusAutoReset({
   pendingHistoryItems,
@@ -45,8 +50,14 @@ export function useShellFocusAutoReset({
 
   useEffect(() => {
     if (embeddedShellFocused && !anyShellExecuting) {
-      debug.log('Auto-resetting embeddedShellFocused: no shell executing');
-      setEmbeddedShellFocused(false);
+      const lastActivePtyId = ShellExecutionService.getLastActivePtyId();
+      const hasLivePty =
+        lastActivePtyId !== null &&
+        ShellExecutionService.isActivePty(lastActivePtyId);
+      if (!hasLivePty) {
+        debug.log('Auto-resetting embeddedShellFocused: no shell executing');
+        setEmbeddedShellFocused(false);
+      }
     }
   }, [embeddedShellFocused, anyShellExecuting, setEmbeddedShellFocused]);
 

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.tsx
@@ -18,12 +18,18 @@ import {
 
 const mockIsBinary = vi.hoisted(() => vi.fn());
 const mockShellExecutionService = vi.hoisted(() => vi.fn());
+const mockIsActivePty = vi.hoisted(() => vi.fn());
+const mockGetLastActivePtyId = vi.hoisted(() => vi.fn());
 vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
   return {
     ...original,
-    ShellExecutionService: { execute: mockShellExecutionService },
+    ShellExecutionService: {
+      execute: mockShellExecutionService,
+      isActivePty: mockIsActivePty,
+      getLastActivePtyId: mockGetLastActivePtyId,
+    },
     isBinary: mockIsBinary,
   };
 });
@@ -119,6 +125,8 @@ describe('useShellCommandProcessor', () => {
     );
     mockIsBinary.mockReturnValue(false);
     vi.mocked(fs.existsSync).mockReturnValue(false);
+    mockIsActivePty.mockReturnValue(false);
+    mockGetLastActivePtyId.mockReturnValue(null);
 
     mockShellExecutionService.mockImplementation(
       (_cmd, _cwd, callback, _signal, _usePty, _config) => {
@@ -629,6 +637,101 @@ describe('useShellCommandProcessor', () => {
 
       const finalHistoryItem = addItemToHistoryMock.mock.calls[1][0];
       expect(finalHistoryItem.tools[0].resultDisplay).not.toContain('WARNING');
+    });
+  });
+
+  describe('shellCleanup focus preservation', () => {
+    it('should not clear shell input focus when PTY is still alive after completion', async () => {
+      mockIsActivePty.mockReturnValue(true);
+      mockGetLastActivePtyId.mockReturnValue(12345);
+
+      const { result } = renderProcessorHook();
+
+      act(() => {
+        result.current.handleShellCommand(
+          'echo "live"',
+          new AbortController().signal,
+        );
+      });
+      const execPromise = onExecMock.mock.calls[0][0];
+
+      act(() => {
+        resolveExecutionPromise(createMockServiceResult({ output: 'live' }));
+      });
+      await act(async () => await execPromise);
+
+      expect(setShellInputFocusedMock).toHaveBeenCalledWith(true);
+      expect(setShellInputFocusedMock).not.toHaveBeenCalledWith(false);
+    });
+
+    it('should clear shell input focus when no PTY remains alive after completion', async () => {
+      mockIsActivePty.mockReturnValue(false);
+      mockGetLastActivePtyId.mockReturnValue(null);
+
+      const { result } = renderProcessorHook();
+
+      act(() => {
+        result.current.handleShellCommand(
+          'echo "done"',
+          new AbortController().signal,
+        );
+      });
+      const execPromise = onExecMock.mock.calls[0][0];
+
+      act(() => {
+        resolveExecutionPromise(createMockServiceResult({ output: 'done' }));
+      });
+      await act(async () => await execPromise);
+
+      expect(setShellInputFocusedMock).toHaveBeenCalledWith(true);
+      expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
+    });
+
+    it('should clear shell input focus when PTY was alive but has since died', async () => {
+      mockGetLastActivePtyId.mockReturnValue(12345);
+      mockIsActivePty.mockReturnValue(false);
+
+      const { result } = renderProcessorHook();
+
+      act(() => {
+        result.current.handleShellCommand(
+          'echo "dead"',
+          new AbortController().signal,
+        );
+      });
+      const execPromise = onExecMock.mock.calls[0][0];
+
+      act(() => {
+        resolveExecutionPromise(createMockServiceResult({ output: 'dead' }));
+      });
+      await act(async () => await execPromise);
+
+      expect(setShellInputFocusedMock).toHaveBeenCalledWith(true);
+      expect(setShellInputFocusedMock).toHaveBeenCalledWith(false);
+    });
+
+    it('should not clear focus on synchronous error when PTY is still alive', async () => {
+      mockIsActivePty.mockReturnValue(true);
+      mockGetLastActivePtyId.mockReturnValue(12345);
+      const testError = new Error('Synchronous spawn error');
+      mockShellExecutionService.mockImplementation(() => {
+        throw testError;
+      });
+
+      const { result } = renderProcessorHook();
+
+      act(() => {
+        result.current.handleShellCommand(
+          'a-command',
+          new AbortController().signal,
+        );
+      });
+      const execPromise = onExecMock.mock.calls[0][0];
+
+      await act(async () => await execPromise);
+
+      expect(setShellInputFocusedMock).toHaveBeenCalledWith(true);
+      expect(setShellInputFocusedMock).not.toHaveBeenCalledWith(false);
     });
   });
 });

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -372,7 +372,13 @@ function shellCleanup(
     fs.unlinkSync(pwdFilePath);
   }
   setActiveShellPtyId(null);
-  setShellInputFocused(false);
+  const lastActivePtyId = ShellExecutionService.getLastActivePtyId();
+  const ptyAlive =
+    lastActivePtyId !== null &&
+    ShellExecutionService.isActivePty(lastActivePtyId);
+  if (!ptyAlive) {
+    setShellInputFocused(false);
+  }
   resolve();
 }
 


### PR DESCRIPTION
## TLDR

Fixes Ctrl+F embedded PTY focus routing on Linux by making shell focus decisions live-PTY aware and preventing the main input prompt from consuming keyboard input while the embedded shell is focused.

## Dive Deeper

This PR fixes the focus handoff for interactive shell PTYs in several connected paths:

- The main InputPrompt keypress handler is inactive while embedded shell focus is active, so typed keys no longer continue into the message input box.
- Ctrl+F focus toggling now verifies that the active or last-active PTY is still alive before focusing it.
- Shell focus auto-reset and shell command cleanup preserve focus while a PTY remains alive after command completion.
- ToolMessage shell focus rendering can keep ShellInputPrompt available for a targeted live PTY even after the tool status is no longer Executing.
- Added regression coverage for live PTY focus preservation, stale PTY rejection, cleanup behavior, and input routing.

## Reviewer Test Plan

Recommended validation:

1. Run npm run test, npm run lint, npm run typecheck, npm run format, npm run build.
2. Run node scripts/start.js --profile-load synthetic "write me a haiku and nothing else".
3. On Linux, start an interactive shell PTY in llxprt-code, press Ctrl+F, and type into the terminal. Verify typed keys go to the PTY instead of the message input.
4. Let the shell tool transition out of Executing while the PTY remains alive, then press Ctrl+F and type again. Verify focus and ShellInputPrompt still target the live PTY.
5. Verify Ctrl+F does not focus a stale/dead PTY after the PTY exits.

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      |   |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

Verification completed on macOS:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load synthetic "write me a haiku and nothing else"

## Linked issues / bugs

Fixes #1894
