### PR TITLE
Fix #2002: todopause still doesn't pause the system from telling the model it has todos and to keep going

### DIFF
--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -167,6 +167,7 @@ export class MessageStreamOrchestrator {
       loopDetector.reset(ctx.prompt_id);
       setLastPromptId(ctx.prompt_id);
       resetCurrentSequenceModel();
+      await todoContinuationService.clearPausedState();
 
       const hookOutput = await agentHookManager.fireBeforeAgentHookSafe(
         ctx.prompt_id,

--- a/packages/agents/src/core/TodoContinuationService.test.ts
+++ b/packages/agents/src/core/TodoContinuationService.test.ts
@@ -17,14 +17,25 @@ import { TodoReminderService } from '@vybestack/llxprt-code-core/services/todo-r
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { Todo } from '@vybestack/llxprt-code-tools';
 
-// Mock TodoStore so readTodoSnapshot doesn't hit the filesystem
-const { todoStoreReadMock, mockTodoStoreConstructor } = vi.hoisted(() => {
+// Mock TodoStore so persisted todo state doesn't hit the filesystem
+const {
+  todoStoreReadMock,
+  todoStoreReadPausedMock,
+  todoStoreWritePausedMock,
+  mockTodoStoreConstructor,
+} = vi.hoisted(() => {
   const readMock = vi.fn();
+  const readPausedMock = vi.fn();
+  const writePausedMock = vi.fn();
   const constructorMock = vi.fn().mockImplementation(() => ({
     readTodos: readMock,
+    readPausedState: readPausedMock,
+    writePausedState: writePausedMock,
   }));
   return {
     todoStoreReadMock: readMock,
+    todoStoreReadPausedMock: readPausedMock,
+    todoStoreWritePausedMock: writePausedMock,
     mockTodoStoreConstructor: constructorMock,
   };
 });
@@ -108,8 +119,12 @@ describe('TodoContinuationService', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     todoStoreReadMock.mockResolvedValue([]);
+    todoStoreReadPausedMock.mockResolvedValue(false);
+    todoStoreWritePausedMock.mockResolvedValue(undefined);
     mockTodoStoreConstructor.mockImplementation(() => ({
       readTodos: todoStoreReadMock,
+      readPausedState: todoStoreReadPausedMock,
+      writePausedState: todoStoreWritePausedMock,
     }));
 
     vi.mocked(TodoReminderService).mockImplementation(
@@ -493,6 +508,25 @@ describe('TodoContinuationService', () => {
       ).toHaveBeenCalledWith(pendingTodo);
     });
 
+    it('suppresses reminders and active todos when todo continuation is paused', async () => {
+      todoStoreReadMock.mockResolvedValue([pendingTodo]);
+      todoStoreReadPausedMock.mockResolvedValue(true);
+
+      const result = await service.getTodoReminderForCurrentState();
+
+      expect(result).toStrictEqual({
+        reminder: null,
+        todos: [pendingTodo],
+        activeTodos: [],
+      });
+      expect(
+        vi.mocked(reminderService.getUpdateActiveTodoReminder),
+      ).not.toHaveBeenCalled();
+      expect(
+        vi.mocked(reminderService.getCreateListReminder),
+      ).not.toHaveBeenCalled();
+    });
+
     it('returns escalated reminder when escalate flag is set', async () => {
       todoStoreReadMock.mockResolvedValue([pendingTodo]);
       const result = await service.getTodoReminderForCurrentState({
@@ -558,6 +592,25 @@ describe('TodoContinuationService', () => {
       expect(arr).toHaveLength(2);
       expect(arr[0]).toStrictEqual({ text: 'single part' });
       expect(arr[1].text).toBe('Reminder');
+    });
+  });
+
+  describe('applyPendingReminder', () => {
+    it('returns the original request and resets pending reminder state when paused', async () => {
+      const request = [{ text: 'original request' }];
+      service.toolCallReminderLevel = 'base';
+      service.toolActivityCount = 5;
+      todoStoreReadPausedMock.mockResolvedValue(true);
+
+      const result = await service.applyPendingReminder(request);
+
+      expect(result).toBe(request);
+      expect(service.toolCallReminderLevel).toBe('none');
+      expect(service.toolActivityCount).toBe(0);
+      expect(todoStoreReadMock).not.toHaveBeenCalled();
+      expect(
+        vi.mocked(reminderService.getUpdateActiveTodoReminder),
+      ).not.toHaveBeenCalled();
     });
   });
 
@@ -887,6 +940,46 @@ describe('TodoContinuationService', () => {
       todoStoreReadMock.mockRejectedValue(new Error('disk error'));
       const result = await service.readTodoSnapshot();
       expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('readPausedState', () => {
+    it('reads paused state from the store using config session id', async () => {
+      todoStoreReadPausedMock.mockResolvedValue(true);
+
+      const result = await service.readPausedState();
+
+      expect(result).toBe(true);
+      expect(mockTodoStoreConstructor).toHaveBeenCalledWith(
+        'test-session',
+        expect.anything(),
+      );
+    });
+
+    it('returns false on error', async () => {
+      todoStoreReadPausedMock.mockRejectedValue(new Error('disk error'));
+
+      const result = await service.readPausedState();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearPausedState', () => {
+    it('writes false to paused state for the current session', async () => {
+      await service.clearPausedState();
+
+      expect(todoStoreWritePausedMock).toHaveBeenCalledWith(false);
+      expect(mockTodoStoreConstructor).toHaveBeenCalledWith(
+        'test-session',
+        expect.anything(),
+      );
+    });
+
+    it('does not throw when clearing paused state fails', async () => {
+      todoStoreWritePausedMock.mockRejectedValue(new Error('disk error'));
+
+      await expect(service.clearPausedState()).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/agents/src/core/TodoContinuationService.ts
+++ b/packages/agents/src/core/TodoContinuationService.ts
@@ -206,6 +206,26 @@ export class TodoContinuationService {
     }
   }
 
+  async readPausedState(): Promise<boolean> {
+    try {
+      const sessionId = this.config.getSessionId();
+      const store = new TodoStore(sessionId, DEFAULT_AGENT_ID);
+      return await store.readPausedState();
+    } catch {
+      return false;
+    }
+  }
+
+  async clearPausedState(): Promise<void> {
+    try {
+      const sessionId = this.config.getSessionId();
+      const store = new TodoStore(sessionId, DEFAULT_AGENT_ID);
+      await store.writePausedState(false);
+    } catch {
+      // Clearing paused task-list state failed; do not block the new prompt.
+    }
+  }
+
   getActiveTodos(todos: Todo[]): Todo[] {
     const inProgress = todos.filter((todo) => todo.status === 'in_progress');
     const pending = todos.filter((todo) => todo.status === 'pending');
@@ -245,6 +265,10 @@ export class TodoContinuationService {
     activeTodos: Todo[];
   }> {
     const todos = options?.todoSnapshot ?? (await this.readTodoSnapshot());
+    if (await this.readPausedState()) {
+      return { reminder: null, todos, activeTodos: [] };
+    }
+
     const activeTodos = options?.activeTodos ?? this.getActiveTodos(todos);
 
     let reminder: string | null = null;
@@ -394,6 +418,12 @@ export class TodoContinuationService {
 
   async applyPendingReminder(request: PartListUnion): Promise<PartListUnion> {
     if (this.toolCallReminderLevel === 'none') return request;
+
+    if (await this.readPausedState()) {
+      this.toolCallReminderLevel = 'none';
+      this.toolActivityCount = 0;
+      return request;
+    }
 
     const reminderResult = await this.getTodoReminderForCurrentState({
       todoSnapshot: this.lastTodoSnapshot,

--- a/packages/agents/src/core/client.test.ts
+++ b/packages/agents/src/core/client.test.ts
@@ -96,13 +96,24 @@ vi.mock('@vybestack/llxprt-code-core/services/complexity-analyzer.js', () => ({
     }),
   })),
 }));
-const { todoStoreReadMock, mockTodoStoreConstructor } = vi.hoisted(() => {
+const {
+  todoStoreReadMock,
+  todoStoreReadPausedMock,
+  todoStoreWritePausedMock,
+  mockTodoStoreConstructor,
+} = vi.hoisted(() => {
   const readMock = vi.fn();
+  const readPausedMock = vi.fn();
+  const writePausedMock = vi.fn();
   const constructorMock = vi.fn().mockImplementation(() => ({
     readTodos: readMock,
+    readPausedState: readPausedMock,
+    writePausedState: writePausedMock,
   }));
   return {
     todoStoreReadMock: readMock,
+    todoStoreReadPausedMock: readPausedMock,
+    todoStoreWritePausedMock: writePausedMock,
     mockTodoStoreConstructor: constructorMock,
   };
 });
@@ -341,10 +352,16 @@ describe('Gemini Client (client.ts)', () => {
     vi.mocked(uiTelemetryService.setLastPromptTokenCount).mockClear();
     mockTodoStoreConstructor.mockReset();
     todoStoreReadMock.mockReset();
+    todoStoreReadPausedMock.mockReset();
+    todoStoreWritePausedMock.mockReset();
     mockTodoStoreConstructor.mockImplementation(() => ({
       readTodos: todoStoreReadMock,
+      readPausedState: todoStoreReadPausedMock,
+      writePausedState: todoStoreWritePausedMock,
     }));
     todoStoreReadMock.mockResolvedValue([]);
+    todoStoreReadPausedMock.mockResolvedValue(false);
+    todoStoreWritePausedMock.mockResolvedValue(undefined);
 
     // Re-setup prompts mocks after reset
     vi.mocked(getCoreSystemPromptAsync).mockResolvedValue(
@@ -1175,6 +1192,99 @@ sub memory
           part.text.includes('System Note'),
       );
       expect(reminderPart).toBeDefined();
+    });
+
+    it('does not retry with pending todos when paused for the current prompt', async () => {
+      todoStoreReadMock.mockResolvedValue([
+        {
+          id: 'todo-1',
+          content: 'Blocked task',
+          status: 'pending',
+        },
+      ]);
+      todoStoreReadPausedMock.mockResolvedValue(true);
+      client['lastPromptId'] = 'prompt-paused-current';
+
+      const forwardedRequests: Part[][] = [];
+      mockTurnRunFn.mockReset();
+      mockTurnRunFn.mockImplementation((req: PartListUnion) => {
+        forwardedRequests.push(req as Part[]);
+        return (async function* () {
+          yield {
+            type: GeminiEventType.Content,
+            value: 'Waiting for user input',
+          };
+          yield {
+            type: GeminiEventType.Finished,
+            value: { reason: 'STOP' },
+          };
+        })();
+      });
+
+      vi.spyOn(client['config'], 'getIdeMode').mockReturnValue(false);
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Continue the task' }],
+        new AbortController().signal,
+        'prompt-paused-current',
+      );
+      await fromAsync(stream);
+
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+      expect(todoStoreWritePausedMock).not.toHaveBeenCalled();
+      expect(forwardedRequests).toHaveLength(1);
+      expect(JSON.stringify(forwardedRequests[0])).not.toContain('System Note');
+    });
+
+    it('clears paused state at the start of a new prompt', async () => {
+      mockTurnRunFn.mockReset();
+      mockTurnRunFn.mockImplementation(() =>
+        (async function* () {
+          yield {
+            type: GeminiEventType.Content,
+            value: 'Started new work',
+          };
+          yield {
+            type: GeminiEventType.Finished,
+            value: { reason: 'STOP' },
+          };
+        })(),
+      );
+
+      vi.spyOn(client['config'], 'getIdeMode').mockReturnValue(false);
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'New request' }],
+        new AbortController().signal,
+        'prompt-new-after-pause',
+      );
+      await fromAsync(stream);
+
+      expect(todoStoreWritePausedMock).toHaveBeenCalledWith(false);
     });
 
     it('does not retry after todo_pause', async () => {


### PR DESCRIPTION
## TLDR

Fixes #2002 by making the agents todo continuation path honor the persisted paused state written by todo_pause. When a turn is paused, pending/in-progress todos no longer trigger follow-up todo reminder system notes for the rest of that prompt, preventing repeated todo_pause loops.

## Dive Deeper

This PR adds paused-state awareness to TodoContinuationService:

- Reads the persisted todo paused flag from the same LocalTodoStore/session used by todo tools.
- Suppresses todo reminder generation and returns no active todos while paused, while preserving the current todo snapshot for state visibility.
- Skips pending reminder injection when paused and resets reminder counters so no stale System Note is appended after todo_pause.
- Clears the persisted paused state only when MessageStreamOrchestrator starts a new user prompt, so pause applies to the rest of the current turn without disabling todo continuation forever.

Regression coverage was added for both the service-level behavior and the client/orchestrator flow, including same-prompt pause suppression and new-prompt pause clearing.

## Reviewer Test Plan

Suggested validation:

1. Run the focused agents tests for TodoContinuationService and client stream behavior.
2. Exercise a prompt that creates sample todos and calls todo_pause; confirm the agent returns control instead of continuing to receive unfinished-todo reminders in the same turn.
3. Send a new prompt after the paused turn; confirm todo continuation behavior is available again.
4. Run the project verification suite before merge.

Useful commands:

    npm run test --workspace @vybestack/llxprt-code-agents -- TodoContinuationService.test.ts client.test.ts
    npm run typecheck --workspace @vybestack/llxprt-code-agents
    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load synthetic "write me a haiku and nothing else"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | -   | -   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2002
