### PR TITLE
Consolidate auth key settings (Fixes #1560)

### DIFF
--- a/packages/agents/src/core/chatSession.runtime.test.ts
+++ b/packages/agents/src/core/chatSession.runtime.test.ts
@@ -74,7 +74,7 @@ describe('ChatSession runtime context', () => {
     config = new Config(createConfigParams(settingsService));
 
     settingsService.set('providers.stub.base-url', 'https://stub.example.com');
-    settingsService.set('providers.stub.apiKey', 'stub-api-key');
+    settingsService.set('providers.stub.auth-key', 'stub-api-key');
     settingsService.set('providers.stub.model', 'stub-model');
 
     providerRuntime = createProviderRuntimeContext({

--- a/packages/agents/src/core/chatSession.thinking-toolcalls.test.ts
+++ b/packages/agents/src/core/chatSession.thinking-toolcalls.test.ts
@@ -96,7 +96,7 @@ describe('Issue #1150: Thinking blocks must be attached to tool call messages', 
     settingsService = new SettingsService();
     config = new Config(createConfigParams(settingsService));
 
-    settingsService.set('providers.anthropic.apiKey', 'test-api-key');
+    settingsService.set('providers.anthropic.auth-key', 'test-api-key');
     settingsService.set(
       'providers.anthropic.model',
       'claude-sonnet-4-5-20250929',

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -810,16 +810,11 @@ export class ChatSession {
   ): void {
     this.copyProfileSettingAliases(profileSettings, provider, ephemerals, [
       { sourceKey: 'auth-key', globalKey: 'auth-key', providerKey: 'auth-key' },
-      { sourceKey: 'auth-key', providerKey: 'apiKey' },
-      { sourceKey: 'apiKey', globalKey: 'auth-key', providerKey: 'apiKey' },
-      { sourceKey: 'apiKey', providerKey: 'auth-key' },
       {
         sourceKey: 'auth-keyfile',
         globalKey: 'auth-keyfile',
         providerKey: 'auth-keyfile',
       },
-      { sourceKey: 'auth-keyfile', providerKey: 'apiKeyfile' },
-      { sourceKey: 'apiKeyfile', providerKey: 'apiKeyfile' },
       {
         sourceKey: 'auth-key-name',
         globalKey: 'auth-key-name',
@@ -962,7 +957,6 @@ export class ChatSession {
     const providerSettings = profileSettings.getProviderSettings(provider);
     const directAuth = this.getStringSettingFromValues([
       providerSettings['auth-key'],
-      providerSettings.apiKey,
       profileSettings.get('auth-key'),
     ]);
     if (directAuth) {
@@ -982,7 +976,6 @@ export class ChatSession {
 
     const keyFile = this.getStringSettingFromValues([
       providerSettings['auth-keyfile'],
-      providerSettings.apiKeyfile,
       profileSettings.get('auth-keyfile'),
     ]);
     if (keyFile) {

--- a/packages/agents/src/core/subagentOrchestrator.ts
+++ b/packages/agents/src/core/subagentOrchestrator.ts
@@ -474,7 +474,7 @@ export class SubagentOrchestrator {
     ]);
     if (authKey) {
       service.set('auth-key', authKey);
-      service.set(`providers.${provider}.apiKey`, authKey);
+      service.set(`providers.${provider}.auth-key`, authKey);
     }
     const authKeyName = this.getStringSetting(profile.ephemeralSettings, [
       'auth-key-name',
@@ -489,16 +489,16 @@ export class SubagentOrchestrator {
     if (authKeyfile) {
       const expandedKeyfile = authKeyfile.replace(/^~(?=$|[\\/])/, homedir());
       service.set('auth-keyfile', expandedKeyfile);
-      service.set(`providers.${provider}.apiKeyfile`, expandedKeyfile);
-      const apiKey = service.get(`providers.${provider}.apiKey`);
+      service.set(`providers.${provider}.auth-keyfile`, expandedKeyfile);
+      const authKey = service.get(`providers.${provider}.auth-key`);
       const shouldLoadApiKeyfile =
         // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        apiKey === undefined ||
-        apiKey === null ||
-        apiKey === '' ||
-        apiKey === false ||
-        apiKey === 0 ||
-        (typeof apiKey === 'number' && Number.isNaN(apiKey));
+        authKey === undefined ||
+        authKey === null ||
+        authKey === '' ||
+        authKey === false ||
+        authKey === 0 ||
+        (typeof authKey === 'number' && Number.isNaN(authKey));
       if (shouldLoadApiKeyfile) {
         this.tryLoadApiKeyFromKeyfile(provider, expandedKeyfile, service);
       }
@@ -515,7 +515,7 @@ export class SubagentOrchestrator {
       if (fs.existsSync(resolvedPath)) {
         const content = fs.readFileSync(resolvedPath, 'utf8').trim();
         if (content !== '') {
-          service.set(`providers.${provider}.apiKey`, content);
+          service.set(`providers.${provider}.auth-key`, content);
         }
       }
     } catch (error) {

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -211,11 +211,11 @@ export class AuthPrecedenceResolver {
         ? settingsService.getProviderSettings(providerKey)
         : undefined;
     const providerAuthKey = this.normalizeAuthValue(
-      providerSettings?.['auth-key'] ?? providerSettings?.apiKey,
+      providerSettings?.['auth-key'],
     );
     if (providerAuthKey !== undefined) return providerAuthKey;
     const providerAuthKeyfile = this.normalizeAuthValue(
-      providerSettings?.['auth-keyfile'] ?? providerSettings?.apiKeyfile,
+      providerSettings?.['auth-keyfile'],
     );
     return this.resolveKeyFileAuth(providerAuthKeyfile);
   }

--- a/packages/cli/src/integration-tests/provider-switching.integration.test.ts
+++ b/packages/cli/src/integration-tests/provider-switching.integration.test.ts
@@ -104,25 +104,25 @@ describe('Runtime Provider Switching Integration', () => {
     const setResult = await setProviderApiKey('key-for-provider-a');
     expect(setResult.success).toBe(true);
     expect(
-      config.getSettingsService().getProviderSettings('providerA').apiKey,
+      config.getSettingsService().getProviderSettings('providerA')['auth-key'],
     ).toBe('key-for-provider-a');
     expect(config.getEphemeralSetting('auth-key')).toBe('key-for-provider-a');
 
     await switchActiveProvider('providerB');
     expect(
-      config.getSettingsService().getProviderSettings('providerA').apiKey,
+      config.getSettingsService().getProviderSettings('providerA')['auth-key'],
     ).toBeUndefined();
     expect(config.getEphemeralSetting('auth-key')).toBeUndefined();
 
     const resultB = await setProviderApiKey('key-for-provider-b');
     expect(resultB.success).toBe(true);
     expect(
-      config.getSettingsService().getProviderSettings('providerB').apiKey,
+      config.getSettingsService().getProviderSettings('providerB')['auth-key'],
     ).toBe('key-for-provider-b');
 
     await switchActiveProvider('providerA');
     expect(
-      config.getSettingsService().getProviderSettings('providerB').apiKey,
+      config.getSettingsService().getProviderSettings('providerB')['auth-key'],
     ).toBeUndefined();
   });
 

--- a/packages/cli/src/providers/providerManagerInstance.test.ts
+++ b/packages/cli/src/providers/providerManagerInstance.test.ts
@@ -163,8 +163,8 @@ describe('bindOpenAIAliasIdentity', () => {
     provider.setRuntimeSettingsService(settingsService);
 
     settingsService.set('activeProvider', 'Synthetic');
-    settingsService.setProviderSetting('openai', 'apiKey', 'sk-openai');
-    settingsService.setProviderSetting('Synthetic', 'apiKey', 'sk-alias');
+    settingsService.setProviderSetting('openai', 'auth-key', 'sk-openai');
+    settingsService.setProviderSetting('Synthetic', 'auth-key', 'sk-alias');
 
     const resolver = provider as unknown as {
       getAuthToken(): Promise<string>;

--- a/packages/cli/src/providers/providerManagerInstance.ts
+++ b/packages/cli/src/providers/providerManagerInstance.ts
@@ -441,9 +441,9 @@ function resolveOpenaiSettings(
   const openaiSettings = openaiProviderSettings?.openai as
     | Record<string, unknown>
     | undefined;
-  const openaiProviderApiKey =
-    (openaiSettings?.apiKey as string | undefined) ??
-    (openaiSettings?.['auth-key'] as string | undefined);
+  const openaiProviderApiKey = openaiSettings?.['auth-key'] as
+    | string
+    | undefined;
 
   const openaiApiKey = resolveOpenaiApiKey(
     ephemeralAuthKey,

--- a/packages/cli/src/runtime/__tests__/authKeyName.test.ts
+++ b/packages/cli/src/runtime/__tests__/authKeyName.test.ts
@@ -537,7 +537,6 @@ describe('API key precedence and named key resolution @plan:PLAN-20260211-SECURE
 
       const providerSettings =
         settingsService.getProviderSettings('test-provider');
-      providerSettings.apiKeyfile = '/tmp/test-provider.key';
       providerSettings['auth-keyfile'] = '/tmp/test-provider.key';
 
       await runtimeMod.updateActiveProviderApiKey(null);
@@ -545,7 +544,7 @@ describe('API key precedence and named key resolution @plan:PLAN-20260211-SECURE
       expect(config.getEphemeralSetting('auth-key-name')).toBeUndefined();
       expect(config.getEphemeralSetting('auth-keyfile')).toBeUndefined();
       expect(
-        settingsService.getProviderSettings('test-provider').apiKeyfile,
+        settingsService.getProviderSettings('test-provider')['auth-keyfile'],
       ).toBeUndefined();
       expect(
         settingsService.getProviderSettings('test-provider')['auth-keyfile'],

--- a/packages/cli/src/runtime/__tests__/profileApplication.test.ts
+++ b/packages/cli/src/runtime/__tests__/profileApplication.test.ts
@@ -1181,11 +1181,11 @@ describe('STEP 2 workflow: pre-switch auth wiring', () => {
 
     await applyProfileWithGuards(profile);
 
-    expect(settingsServiceStub.getProviderSettings('anthropic')['apiKey']).toBe(
-      'keyfile-api-key',
-    );
     expect(
-      settingsServiceStub.getProviderSettings('anthropic')['apiKeyfile'],
+      settingsServiceStub.getProviderSettings('anthropic')['auth-key'],
+    ).toBe('keyfile-api-key');
+    expect(
+      settingsServiceStub.getProviderSettings('anthropic')['auth-keyfile'],
     ).toBeDefined();
   });
 

--- a/packages/cli/src/runtime/__tests__/runtimeIsolation.test.ts
+++ b/packages/cli/src/runtime/__tests__/runtimeIsolation.test.ts
@@ -227,7 +227,7 @@ describe('CLI runtime isolation', () => {
       runtimeA.handle.config.getEphemeralSetting('custom-headers'),
     ).toStrictEqual({ 'x-runtime': runtimeA.id });
     expect(aSecondarySettings.temperature).toBe(0.6);
-    expect(aSecondarySettings.apiKey).toBe('alpha-updated-key');
+    expect(aSecondarySettings['auth-key']).toBe('alpha-updated-key');
     expect(aSecondarySettings['base-url']).toBe(
       'https://alpha.isolated.example.com',
     );
@@ -253,7 +253,7 @@ describe('CLI runtime isolation', () => {
       runtimeB.handle.config.getEphemeralSetting('custom-headers'),
     ).toStrictEqual({ 'x-runtime': runtimeB.id });
     expect(bSecondarySettings.temperature).toBe(0.4);
-    expect(bSecondarySettings.apiKey).toBe('beta-updated-key');
+    expect(bSecondarySettings['auth-key']).toBe('beta-updated-key');
     expect(bSecondarySettings['base-url']).toBe(
       'https://beta.isolated.example.com',
     );
@@ -514,7 +514,7 @@ async function bootstrapRuntimeFixture(options: {
       );
       settingsService.setProviderSetting(
         options.primaryProvider,
-        'apiKey',
+        'auth-key',
         `${options.id}-initial-key`,
       );
       config.setProvider(options.primaryProvider);

--- a/packages/cli/src/runtime/profileApplication.ts
+++ b/packages/cli/src/runtime/profileApplication.ts
@@ -474,9 +474,9 @@ function createProviderSetters(
     settingsService.setProviderSetting(targetProviderName, key, value);
   };
   return {
-    setProviderApiKey: (apiKey) => setProviderSetting('apiKey', apiKey),
+    setProviderApiKey: (apiKey) => setProviderSetting('auth-key', apiKey),
     setProviderApiKeyfile: (filePath) =>
-      setProviderSetting('apiKeyfile', filePath),
+      setProviderSetting('auth-keyfile', filePath),
     setProviderBaseUrl: (baseUrl) => setProviderSetting('base-url', baseUrl),
   };
 }
@@ -494,7 +494,14 @@ function sanitizeSensitiveModelParams(sanitizedProfile: Profile): void {
   );
   propagateModelParamToEphemeral(sanitizedProfile, ['base-url'], 'base-url');
   const sanitizedModelParams = getProfileModelParams(sanitizedProfile);
-  for (const key of ['apiKey', 'api-key', 'apiKeyfile', 'api-keyfile']) {
+  for (const key of [
+    'auth-key',
+    'apiKey',
+    'api-key',
+    'auth-keyfile',
+    'apiKeyfile',
+    'api-keyfile',
+  ]) {
     if (key in sanitizedModelParams) {
       delete sanitizedModelParams[key as keyof ModelParams];
     }

--- a/packages/cli/src/runtime/providerMutations.ts
+++ b/packages/cli/src/runtime/providerMutations.ts
@@ -268,9 +268,7 @@ export async function updateActiveProviderApiKey(
   });
 
   if (!trimmed) {
-    settingsService.setProviderSetting(providerName, 'apiKey', undefined);
     settingsService.setProviderSetting(providerName, 'auth-key', undefined);
-    settingsService.setProviderSetting(providerName, 'apiKeyfile', undefined);
     settingsService.setProviderSetting(providerName, 'auth-keyfile', undefined);
     config.setEphemeralSetting('auth-key', undefined);
     config.setEphemeralSetting('auth-keyfile', undefined);
@@ -293,8 +291,7 @@ export async function updateActiveProviderApiKey(
     };
   }
 
-  settingsService.setProviderSetting(providerName, 'apiKey', trimmed);
-  settingsService.setProviderSetting(providerName, 'apiKeyfile', undefined);
+  settingsService.setProviderSetting(providerName, 'auth-key', trimmed);
   settingsService.setProviderSetting(providerName, 'auth-keyfile', undefined);
   config.setEphemeralSetting('auth-key', trimmed);
   config.setEphemeralSetting('auth-keyfile', undefined);

--- a/packages/core/src/integration-tests/settings-remediation.test.ts
+++ b/packages/core/src/integration-tests/settings-remediation.test.ts
@@ -96,11 +96,11 @@ describe('Settings Remediation Integration', () => {
      * @and No file operations occur
      */
     it('should update provider settings through integration', () => {
-      settingsService.setProviderSetting('openai', 'apiKey', 'test-key-123');
+      settingsService.setProviderSetting('openai', 'auth-key', 'test-key-123');
       settingsService.setProviderSetting('openai', 'model', 'gpt-4');
 
       const providerSettings = settingsService.getProviderSettings('openai');
-      expect(providerSettings.apiKey).toBe('test-key-123');
+      expect(providerSettings['auth-key']).toBe('test-key-123');
       expect(providerSettings.model).toBe('gpt-4');
     });
 
@@ -421,8 +421,8 @@ describe('Settings Remediation Integration', () => {
       config.setEphemeralSetting('model', 'gpt-4');
       config.setEphemeralSetting('temperature', 0.7);
 
-      settingsService.setProviderSetting('openai', 'apiKey', 'key-1');
-      settingsService.setProviderSetting('anthropic', 'apiKey', 'key-2');
+      settingsService.setProviderSetting('openai', 'auth-key', 'key-1');
+      settingsService.setProviderSetting('anthropic', 'auth-key', 'key-2');
 
       config.setEphemeralSetting('model', 'gpt-4-turbo');
 
@@ -435,8 +435,8 @@ describe('Settings Remediation Integration', () => {
 
       expect(allGlobalSettings.model).toBe('gpt-4-turbo');
       expect(allGlobalSettings.temperature).toBe(0.7);
-      expect(openaiSettings.apiKey).toBe('key-1');
-      expect(anthropicSettings.apiKey).toBe('key-2');
+      expect(openaiSettings['auth-key']).toBe('key-1');
+      expect(anthropicSettings['auth-key']).toBe('key-2');
 
       expect(events).toHaveLength(6);
       expect(events[0].type).toBe('global-change');
@@ -462,13 +462,13 @@ describe('Settings Remediation Integration', () => {
      */
     it('should support legacy promise-based interface', async () => {
       config.setEphemeralSetting('model', 'test-model');
-      settingsService.setProviderSetting('openai', 'apiKey', 'test-key');
+      settingsService.setProviderSetting('openai', 'auth-key', 'test-key');
 
       const globalSettings = await settingsService.getSettings();
       const providerSettings = await settingsService.getSettings('openai');
 
-      expect(globalSettings.providers.openai.apiKey).toBe('test-key');
-      expect(providerSettings.apiKey).toBe('test-key');
+      expect(globalSettings.providers.openai['auth-key']).toBe('test-key');
+      expect(providerSettings['auth-key']).toBe('test-key');
 
       await settingsService.updateSettings({ model: 'updated-model' });
       await settingsService.updateSettings('openai', { model: 'gpt-4' });
@@ -487,18 +487,20 @@ describe('Settings Remediation Integration', () => {
     it('should provide comprehensive diagnostics', async () => {
       config.setEphemeralSetting('model', 'test-model');
       config.setEphemeralSetting('temperature', 0.8);
-      settingsService.setProviderSetting('openai', 'apiKey', 'test-key');
+      settingsService.setProviderSetting('openai', 'auth-key', 'test-key');
       settingsService.setProviderSetting('openai', 'model', 'gpt-4');
       settingsService.set('activeProvider', 'openai');
 
       const diagnostics = await settingsService.getDiagnosticsData();
 
       expect(diagnostics.provider).toBe('openai');
-      expect(diagnostics.providerSettings.apiKey).toBe('test-key');
+      expect(diagnostics.providerSettings['auth-key']).toBe('test-key');
       expect(diagnostics.providerSettings.model).toBe('gpt-4');
       expect(diagnostics.ephemeralSettings.model).toBe('test-model');
       expect(diagnostics.ephemeralSettings.temperature).toBe(0.8);
-      expect(diagnostics.allSettings.providers.openai.apiKey).toBe('test-key');
+      expect(diagnostics.allSettings.providers.openai['auth-key']).toBe(
+        'test-key',
+      );
     });
   });
 });

--- a/packages/providers/src/BaseProvider.test.ts
+++ b/packages/providers/src/BaseProvider.test.ts
@@ -803,4 +803,114 @@ describe('BaseProvider', () => {
       );
     });
   });
+
+  describe('BaseProvider — model params defensive stripping', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      originalEnv = { ...process.env };
+      delete process.env.TEST_API_KEY;
+      resetSettingsService();
+      registerSettingsService(new SettingsService());
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+      vi.restoreAllMocks();
+      clearActiveProviderRuntimeContext();
+    });
+
+    it('strips legacy apiKey from additionalSettings', async () => {
+      const settingsService = getSettingsService();
+      settingsService.setProviderSetting('test', 'apiKey', 'leaked-legacy-key');
+      settingsService.setProviderSetting('test', 'model', 'gpt-4');
+      settingsService.setProviderSetting('test', 'enabled', true);
+
+      const config: BaseProviderConfig = { name: 'test' };
+      const provider = new TestProvider(config);
+
+      const params = await (
+        provider as unknown as {
+          getModelParamsFromSettings(): Promise<
+            Record<string, unknown> | undefined
+          >;
+        }
+      ).getModelParamsFromSettings();
+
+      expect(params?.apiKey).toBeUndefined();
+    });
+
+    it('strips legacy apiKeyfile from additionalSettings', async () => {
+      const settingsService = getSettingsService();
+      settingsService.setProviderSetting(
+        'test',
+        'apiKeyfile',
+        '/path/to/keyfile',
+      );
+      settingsService.setProviderSetting('test', 'model', 'gpt-4');
+      settingsService.setProviderSetting('test', 'enabled', true);
+
+      const config: BaseProviderConfig = { name: 'test' };
+      const provider = new TestProvider(config);
+
+      const params = await (
+        provider as unknown as {
+          getModelParamsFromSettings(): Promise<
+            Record<string, unknown> | undefined
+          >;
+        }
+      ).getModelParamsFromSettings();
+
+      expect(params?.apiKeyfile).toBeUndefined();
+    });
+
+    it('strips legacy api-key and api-keyfile from additionalSettings', async () => {
+      const settingsService = getSettingsService();
+      settingsService.setProviderSetting('test', 'api-key', 'leaked-key');
+      settingsService.setProviderSetting(
+        'test',
+        'api-keyfile',
+        '/path/to/keyfile',
+      );
+      settingsService.setProviderSetting('test', 'model', 'gpt-4');
+      settingsService.setProviderSetting('test', 'enabled', true);
+
+      const config: BaseProviderConfig = { name: 'test' };
+      const provider = new TestProvider(config);
+
+      const params = await (
+        provider as unknown as {
+          getModelParamsFromSettings(): Promise<
+            Record<string, unknown> | undefined
+          >;
+        }
+      ).getModelParamsFromSettings();
+
+      expect(params?.['api-key']).toBeUndefined();
+      expect(params?.['api-keyfile']).toBeUndefined();
+    });
+
+    it('preserves non-sensitive custom params alongside stripping', async () => {
+      const settingsService = getSettingsService();
+      settingsService.setProviderSetting('test', 'apiKey', 'leaked');
+      settingsService.setProviderSetting('test', 'model', 'gpt-4');
+      settingsService.setProviderSetting('test', 'enabled', true);
+      settingsService.setProviderSetting('test', 'customParam', 'keep-me');
+
+      const config: BaseProviderConfig = { name: 'test' };
+      const provider = new TestProvider(config);
+
+      const params = await (
+        provider as unknown as {
+          getModelParamsFromSettings(): Promise<
+            Record<string, unknown> | undefined
+          >;
+        }
+      ).getModelParamsFromSettings();
+
+      expect(params?.apiKey).toBeUndefined();
+      expect(params?.customParam).toBe('keep-me');
+    });
+  });
 });

--- a/packages/providers/src/BaseProvider.ts
+++ b/packages/providers/src/BaseProvider.ts
@@ -904,14 +904,14 @@ export abstract class BaseProvider implements IProvider {
    * Get API key from SettingsService if available
    */
   protected async getApiKeyFromSettings(): Promise<string | undefined> {
-    return this.getProviderSetting('apiKey');
+    return this.getProviderSetting('auth-key');
   }
 
   /**
    * Set API key in SettingsService if available
    */
   protected async setApiKeyInSettings(apiKey: string): Promise<void> {
-    await this.setProviderSetting('apiKey', apiKey);
+    await this.setProviderSetting('auth-key', apiKey);
   }
 
   /**
@@ -956,11 +956,19 @@ export abstract class BaseProvider implements IProvider {
       // Extract model parameters from settings, excluding standard fields
       const {
         enabled: _enabled,
-        apiKey: _apiKey,
+        'auth-key': _authKey,
+        'auth-keyfile': _authKeyfile,
         'base-url': _baseUrl,
         model: _model,
         maxTokens,
         temperature,
+        // Defensive: strip legacy sensitive aliases that should never reach
+        // the model params pass-through, even if present in imported/malformed
+        // provider settings data.
+        apiKey: _legacyApiKey,
+        apiKeyfile: _legacyApiKeyfile,
+        'api-key': _legacyApiKeyDash,
+        'api-keyfile': _legacyApiKeyfileDash,
         ...additionalSettings
       } = settings;
 
@@ -1060,7 +1068,8 @@ function isFalsyLikeValue(value: unknown): boolean {
 
 export interface ProviderSettings {
   enabled: boolean;
-  apiKey?: string;
+  'auth-key'?: string;
+  'auth-keyfile'?: string;
   baseUrl?: string;
   model?: string;
   maxTokens?: number;

--- a/packages/providers/src/ProviderManager.ts
+++ b/packages/providers/src/ProviderManager.ts
@@ -529,7 +529,7 @@ export class ProviderManager implements IProviderManager {
       baseURL: this.resolveBaseURLField(rawOptions, providerSettings),
       authToken:
         rawOptions.resolved?.authToken ??
-        (providerSettings.apiKey as string | undefined),
+        (providerSettings['auth-key'] as string | undefined),
       telemetry: {
         ...rawOptions.resolved?.telemetry,
         runtimeId,

--- a/packages/providers/src/__tests__/ProviderManager.guard.test.ts
+++ b/packages/providers/src/__tests__/ProviderManager.guard.test.ts
@@ -97,7 +97,7 @@ describe('ProviderManager runtime guard plumbing', () => {
     manager.registerProvider(provider);
     settingsService.set('activeProvider', provider.name);
     settingsService.setProviderSetting(provider.name, 'model', 'stub-model');
-    settingsService.setProviderSetting(provider.name, 'apiKey', 'stub-key');
+    settingsService.setProviderSetting(provider.name, 'auth-key', 'stub-key');
     settingsService.setProviderSetting(
       provider.name,
       'base-url',
@@ -143,7 +143,7 @@ describe('ProviderManager runtime guard plumbing', () => {
     manager.registerProvider(provider);
     settingsService.set('activeProvider', provider.name);
     settingsService.setProviderSetting(provider.name, 'model', 'stub-model');
-    settingsService.setProviderSetting(provider.name, 'apiKey', 'stub-key');
+    settingsService.setProviderSetting(provider.name, 'auth-key', 'stub-key');
     settingsService.setProviderSetting(
       provider.name,
       'base-url',
@@ -174,7 +174,7 @@ describe('ProviderManager runtime guard plumbing', () => {
     const settingsService = new SettingsService();
     settingsService.set('streaming', 'enabled');
     settingsService.setProviderSetting('openai', 'temperature', 0.5);
-    settingsService.setProviderSetting('openai', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('openai', 'auth-key', 'test-key');
     const config = createRuntimeConfigStub(settingsService);
     const manager = new ProviderManager({ settingsService, config });
 
@@ -285,7 +285,7 @@ describe('ProviderManager.normalizeRuntimeInputs', () => {
 
     settingsService.set('activeProvider', 'stub-provider');
     settingsService.setProviderSetting('stub-provider', 'model', 'test-model');
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
     settingsService.setProviderSetting(
       'stub-provider',
       'base-url',
@@ -325,7 +325,7 @@ describe('ProviderManager.normalizeRuntimeInputs', () => {
 
     settingsService.set('activeProvider', 'stub-provider');
     settingsService.setProviderSetting('stub-provider', 'model', 'test-model');
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
 
     const normalized = manager.normalizeRuntimeInputs(
       {
@@ -537,7 +537,7 @@ describe('ProviderManager.normalizeRuntimeInputs', () => {
 
     settingsService.set('activeProvider', provider.name);
     settingsService.setProviderSetting(provider.name, 'model', 'test-model');
-    settingsService.setProviderSetting(provider.name, 'apiKey', 'test-key');
+    settingsService.setProviderSetting(provider.name, 'auth-key', 'test-key');
 
     const normalized = manager.normalizeRuntimeInputs(
       {
@@ -566,7 +566,7 @@ describe('ProviderManager.normalizeRuntimeInputs', () => {
 
     settingsService.set('activeProvider', 'stub-provider');
     settingsService.setProviderSetting('stub-provider', 'model', 'test-model');
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
     settingsService.setProviderSetting(
       'stub-provider',
       'base-url',
@@ -609,7 +609,7 @@ describe('ProviderManager.normalizeRuntimeInputs empty/whitespace fallback seman
       'model',
       'settings-model',
     );
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
     settingsService.setProviderSetting(
       'stub-provider',
       'base-url',
@@ -645,7 +645,7 @@ describe('ProviderManager.normalizeRuntimeInputs empty/whitespace fallback seman
       'model',
       'settings-model',
     );
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
     settingsService.setProviderSetting(
       'stub-provider',
       'base-url',
@@ -680,7 +680,7 @@ describe('ProviderManager.normalizeRuntimeInputs empty/whitespace fallback seman
 
     settingsService.set('activeProvider', 'stub-provider');
     settingsService.setProviderSetting('stub-provider', 'model', 'test-model');
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
 
     const normalized = manager.normalizeRuntimeInputs(
       {
@@ -712,7 +712,7 @@ describe('ProviderManager.normalizeRuntimeInputs empty/whitespace fallback seman
 
     settingsService.set('activeProvider', 'stub-provider');
     settingsService.setProviderSetting('stub-provider', 'model', 'test-model');
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
 
     const normalized = manager.normalizeRuntimeInputs(
       {
@@ -805,7 +805,7 @@ describe('ProviderManager.normalizeRuntimeInputs empty/whitespace fallback seman
 
     settingsService.set('activeProvider', 'stub-provider');
     settingsService.setProviderSetting('stub-provider', 'model', 'test-model');
-    settingsService.setProviderSetting('stub-provider', 'apiKey', 'test-key');
+    settingsService.setProviderSetting('stub-provider', 'auth-key', 'test-key');
     // Intentionally set base-url to empty string
     settingsService.setProviderSetting('stub-provider', 'base-url', '');
 

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -674,8 +674,10 @@ export class GeminiProvider extends BaseProvider {
 
       const reservedKeys = new Set([
         'enabled',
+        'auth-key',
         'apiKey',
         'api-key',
+        'auth-keyfile',
         'apiKeyfile',
         'api-keyfile',
         'base-url',

--- a/packages/providers/src/openai-vercel/OpenAIVercelProvider.test.ts
+++ b/packages/providers/src/openai-vercel/OpenAIVercelProvider.test.ts
@@ -567,7 +567,7 @@ describe('Authentication (REQ-OAV-003)', () => {
       );
       settingsService.setProviderSetting(
         'openaivercel',
-        'apiKey',
+        'auth-key',
         'keyfile-api-key',
       );
       settingsService.set('auth-key', 'keyfile-api-key');

--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -440,8 +440,10 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
 
       const reservedKeys = new Set([
         'enabled',
+        'auth-key',
         'apiKey',
         'api-key',
+        'auth-keyfile',
         'apiKeyfile',
         'api-keyfile',
         'base-url',

--- a/packages/providers/src/provider-manager-behavior.test.ts
+++ b/packages/providers/src/provider-manager-behavior.test.ts
@@ -137,7 +137,7 @@ describe('ProviderManager behavioral tests', () => {
       const config = createTestConfig(settingsService);
       const manager = new ProviderManager({ settingsService, config });
       settingsService.set('activeProvider', 'fake');
-      settingsService.setProviderSetting('fake', 'apiKey', 'test-key');
+      settingsService.setProviderSetting('fake', 'auth-key', 'test-key');
       manager.registerProvider(provider);
       const providers = manager.listProviders();
       expect(providers).toContain('fake');
@@ -162,7 +162,7 @@ describe('ProviderManager behavioral tests', () => {
       const settingsService = new SettingsService();
       const config = createTestConfig(settingsService);
       const manager = new ProviderManager({ settingsService, config });
-      settingsService.setProviderSetting('fake', 'apiKey', 'test-key');
+      settingsService.setProviderSetting('fake', 'auth-key', 'test-key');
       manager.registerProvider(provider);
       manager.setActiveProvider('fake');
       expect(manager.getActiveProviderName()).toBe('fake');
@@ -200,7 +200,7 @@ describe('ProviderManager behavioral tests', () => {
       const settingsService = new SettingsService();
       const config = createTestConfig(settingsService);
       const manager = new ProviderManager({ settingsService, config });
-      settingsService.setProviderSetting('fake', 'apiKey', 'test-key');
+      settingsService.setProviderSetting('fake', 'auth-key', 'test-key');
       manager.registerProvider(provider);
       manager.setActiveProvider('fake');
       expect(manager.hasActiveProvider()).toBe(true);

--- a/packages/settings/src/__tests__/settingsRegistry.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.test.ts
@@ -99,9 +99,30 @@ describe('getSettingSpec — spec lookup', () => {
     expect(spec?.category).toBe('cli-behavior');
   });
 
-  it('returns a spec with category provider-config for apiKey', () => {
-    const spec = getSettingSpec('apiKey');
+  it('resolves apiKey alias to auth-key canonical spec', () => {
+    const spec = getSettingSpec('auth-key');
     expect(spec?.category).toBe('provider-config');
+    expect(spec?.aliases).toContain('apiKey');
+  });
+
+  it('resolves auth-key canonical spec directly', () => {
+    const spec = getSettingSpec('auth-key');
+    expect(spec?.category).toBe('provider-config');
+    expect(spec?.persistToProfile).toBe(true);
+  });
+
+  it('resolves auth-keyfile canonical spec with apiKeyfile alias', () => {
+    const spec = getSettingSpec('auth-keyfile');
+    expect(spec?.category).toBe('provider-config');
+    expect(spec?.aliases).toContain('apiKeyfile');
+  });
+
+  it('resolves apiKey to auth-key via resolveAlias', () => {
+    expect(resolveAlias('apiKey')).toBe('auth-key');
+  });
+
+  it('resolves apiKeyfile to auth-keyfile via resolveAlias', () => {
+    expect(resolveAlias('apiKeyfile')).toBe('auth-keyfile');
   });
 
   it('returns a spec with type enum for compression.strategy', () => {
@@ -287,9 +308,42 @@ describe('getProfilePersistableKeys — profile persistence', () => {
     expect(keys).toContain('reasoning.enabled');
   });
 
-  it('does not include apiKey (persistToProfile: false)', () => {
+  it('auth-key is persistable to profile (canonical)', () => {
     const keys = getProfilePersistableKeys();
-    expect(keys).not.toContain('apiKey');
+    expect(keys).toContain('auth-key');
+  });
+
+  it('auth-keyfile is persistable to profile (canonical)', () => {
+    const keys = getProfilePersistableKeys();
+    expect(keys).toContain('auth-keyfile');
+  });
+
+  it('apiKey alias resolves to auth-key spec via getSettingSpec', () => {
+    const spec = getSettingSpec('apiKey');
+    expect(spec).toBeDefined();
+    expect(spec?.key).toBe('auth-key');
+    expect(spec?.category).toBe('provider-config');
+    expect(spec?.aliases).toContain('apiKey');
+  });
+
+  it('apiKeyfile alias resolves to auth-keyfile spec via getSettingSpec', () => {
+    const spec = getSettingSpec('apiKeyfile');
+    expect(spec).toBeDefined();
+    expect(spec?.key).toBe('auth-keyfile');
+    expect(spec?.category).toBe('provider-config');
+    expect(spec?.aliases).toContain('apiKeyfile');
+  });
+
+  it('api-key alias resolves to auth-key spec via getSettingSpec', () => {
+    const spec = getSettingSpec('api-key');
+    expect(spec).toBeDefined();
+    expect(spec?.key).toBe('auth-key');
+  });
+
+  it('api-keyfile alias resolves to auth-keyfile spec via getSettingSpec', () => {
+    const spec = getSettingSpec('api-keyfile');
+    expect(spec).toBeDefined();
+    expect(spec?.key).toBe('auth-keyfile');
   });
 });
 
@@ -345,14 +399,19 @@ describe('getAutocompleteSuggestions — completion options', () => {
 });
 
 describe('getProtectedSettingKeys — protected/hidden keys', () => {
-  it('includes apiKey in protected keys', () => {
+  it('includes auth-key in protected keys', () => {
+    const keys = getProtectedSettingKeys();
+    expect(keys).toContain('auth-key');
+  });
+
+  it('includes apiKey alias in protected keys', () => {
     const keys = getProtectedSettingKeys();
     expect(keys).toContain('apiKey');
   });
 
-  it('includes auth-key in protected keys', () => {
+  it('includes auth-keyfile in protected keys', () => {
     const keys = getProtectedSettingKeys();
-    expect(keys).toContain('auth-key');
+    expect(keys).toContain('auth-keyfile');
   });
 
   it('includes model in protected keys', () => {
@@ -367,14 +426,24 @@ describe('getProtectedSettingKeys — protected/hidden keys', () => {
 });
 
 describe('getProviderConfigKeys — provider config key enumeration', () => {
-  it('includes apiKey', () => {
+  it('includes auth-key canonical', () => {
+    const keys = getProviderConfigKeys();
+    expect(keys).toContain('auth-key');
+  });
+
+  it('includes apiKey alias', () => {
     const keys = getProviderConfigKeys();
     expect(keys).toContain('apiKey');
   });
 
-  it('includes api-key alias', () => {
+  it('includes auth-keyfile canonical', () => {
     const keys = getProviderConfigKeys();
-    expect(keys).toContain('api-key');
+    expect(keys).toContain('auth-keyfile');
+  });
+
+  it('includes apiKeyfile alias', () => {
+    const keys = getProviderConfigKeys();
+    expect(keys).toContain('apiKeyfile');
   });
 
   it('includes base-url', () => {
@@ -437,7 +506,13 @@ describe('getDirectSettingSpecs — direct setting specifications', () => {
     expect(found).toBeUndefined();
   });
 
-  it('excludes apiKey (provider-config category)', () => {
+  it('excludes auth-key (provider-config category)', () => {
+    const specs = getDirectSettingSpecs();
+    const found = specs.find((s) => s.value === 'auth-key');
+    expect(found).toBeUndefined();
+  });
+
+  it('excludes apiKey alias from direct setting specs', () => {
     const specs = getDirectSettingSpecs();
     const found = specs.find((s) => s.value === 'apiKey');
     expect(found).toBeUndefined();

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -338,7 +338,8 @@ export class ProfileManager {
       } satisfies ModelParams,
       ephemeralSettings: {
         'base-url': optionalString(providerSettings['base-url']),
-        'auth-key': optionalString(providerSettings.apiKey),
+        'auth-key': optionalString(providerSettings['auth-key']),
+        'auth-keyfile': optionalString(providerSettings['auth-keyfile']),
         'prompt-caching': optionalPromptCaching(
           providerSettings['prompt-caching'],
         ),
@@ -381,7 +382,8 @@ export class ProfileManager {
           temperature: profile.modelParams.temperature,
           maxTokens: profile.modelParams.max_tokens,
           'base-url': profile.ephemeralSettings['base-url'],
-          apiKey: profile.ephemeralSettings['auth-key'],
+          'auth-key': profile.ephemeralSettings['auth-key'],
+          'auth-keyfile': profile.ephemeralSettings['auth-keyfile'],
           'prompt-caching': profile.ephemeralSettings['prompt-caching'],
           'include-folder-structure':
             profile.ephemeralSettings['include-folder-structure'],

--- a/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
+++ b/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
@@ -283,4 +283,63 @@ describe('ProfileManager — save and load with SettingsService', () => {
     await pm.load('load-target', mockSettingsService);
     expect(appliedData['currentProfile']).toBe('load-target');
   });
+
+  it('save persists auth-keyfile in ephemeralSettings', async () => {
+    const mockSettingsService = {
+      exportForProfile: async () => ({
+        defaultProvider: 'openai',
+        providers: {
+          openai: {
+            model: 'gpt-4',
+            'auth-key': 'sk-secret',
+            'auth-keyfile': '/path/to/keyfile',
+          },
+        },
+        tools: { allowed: [], disabled: [] },
+      }),
+      setCurrentProfileName: (_name: string | null) => {},
+    };
+
+    await pm.save('authfile-profile', mockSettingsService);
+
+    const filePath = path.join(tempDir, 'authfile-profile.json');
+    const content = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(content);
+    expect(parsed.ephemeralSettings['auth-key']).toBe('sk-secret');
+    expect(parsed.ephemeralSettings['auth-keyfile']).toBe('/path/to/keyfile');
+  });
+
+  it('load round-trips auth-keyfile back to settings', async () => {
+    const profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: {
+        'auth-key': 'sk-roundtrip',
+        'auth-keyfile': '/roundtrip/keyfile',
+      },
+    };
+    await pm.saveProfile('rt-keyfile', profile);
+
+    let importedData: Record<string, unknown> | undefined;
+    const mockSettingsService = {
+      setCurrentProfileName: () => {},
+      importFromProfile: async (data: unknown) => {
+        importedData = data as Record<string, unknown>;
+      },
+      set: () => {},
+    };
+
+    await pm.load('rt-keyfile', mockSettingsService);
+
+    expect(importedData).toBeDefined();
+    const imported = importedData as Record<string, unknown>;
+    const providers = imported.providers as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(providers.openai['auth-key']).toBe('sk-roundtrip');
+    expect(providers.openai['auth-keyfile']).toBe('/roundtrip/keyfile');
+  });
 });

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -70,32 +70,18 @@ const HEADER_PRESERVE_SET = new Set([
 
 export const SETTINGS_REGISTRY: readonly SettingSpec[] = [
   {
-    key: 'apiKey',
-    aliases: ['api-key'],
+    key: 'auth-key',
+    aliases: ['apiKey', 'api-key'],
     category: 'provider-config',
     description: 'Provider API authentication key',
-    type: 'string',
-    persistToProfile: false,
-  },
-  {
-    key: 'auth-key',
-    category: 'provider-config',
-    description: 'Auth key alias (saved to profiles for auth persistence)',
-    type: 'string',
-    persistToProfile: true,
-  },
-  {
-    key: 'apiKeyfile',
-    aliases: ['api-keyfile'],
-    category: 'provider-config',
-    description: 'Path to file containing API key',
     type: 'string',
     persistToProfile: true,
   },
   {
     key: 'auth-keyfile',
+    aliases: ['apiKeyfile', 'api-keyfile'],
     category: 'provider-config',
-    description: 'Auth keyfile alias (saved to profiles for auth persistence)',
+    description: 'Path to file containing API key',
     type: 'string',
     persistToProfile: true,
   },
@@ -1264,7 +1250,17 @@ export function resolveAlias(key: string): string {
 }
 
 export function getSettingSpec(key: string): SettingSpec | undefined {
-  return SETTINGS_REGISTRY.find((s) => s.key === key);
+  // Direct canonical-key match first (fast path)
+  const direct = SETTINGS_REGISTRY.find((s) => s.key === key);
+  if (direct) {
+    return direct;
+  }
+  // Resolve alias to canonical key and look up the spec
+  const resolved = resolveAlias(key);
+  if (resolved !== key) {
+    return SETTINGS_REGISTRY.find((s) => s.key === resolved);
+  }
+  return undefined;
 }
 
 export function normalizeSetting(key: string, value: unknown): unknown {


### PR DESCRIPTION
## TLDR

Consolidates provider authentication settings so auth-key and auth-keyfile are the canonical settings, with apiKey and apiKeyfile retained only as compatibility aliases.

## Dive Deeper

This PR removes the standalone camelCase auth entries from the settings registry and makes the canonical kebab-case entries own persistence and alias resolution. Runtime/provider consumers now read and write provider auth storage through auth-key and auth-keyfile directly, while defensive redaction and reserved-key handling still strip legacy alias spellings so imported or malformed settings do not leak credentials.

The change also updates profile save/load behavior so auth-keyfile round-trips with auth-key, and adjusts subagent/profile/provider wiring and behavioral tests to match the base-url canonical setting pattern.

## Reviewer Test Plan

Reviewers can validate by loading or setting provider auth through auth-key and auth-keyfile, then confirming provider settings and profile persistence use those canonical keys. Legacy apiKey and apiKeyfile inputs should resolve through registry alias lookup, but runtime storage paths should no longer dual-write those names.

Local verification completed:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1560
