### PR TITLE
Add configurable max heap setting (Fixes #1624)

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -382,6 +382,11 @@ In addition to a project settings file, a project's `.llxprt` directory can cont
   - **Default:** `true`
   - **Requires restart:** Yes
 
+- **`ui.maxHeapSizeMB`** (number):
+  - **Description:** Caps the auto-configured Node.js max old space heap size. Overrides the default 8GB cap when auto-configure is enabled. Must be an integer.
+  - **Default:** `8192`
+  - **Requires restart:** Yes
+
 - **`ui.historyMaxItems`** (number):
   - **Description:** Maximum number of history items to keep.
   - **Default:** `100`

--- a/packages/cli/src/cli-sandbox.test.tsx
+++ b/packages/cli/src/cli-sandbox.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { main } from './cli.js';
+import type { LoadedSettings } from './config/settings.js';
+import { loadSettings } from './config/settings.js';
+import { loadCliConfig } from './config/config.js';
+import { parseArguments } from './config/cliArgParser.js';
+import type { Config } from '@vybestack/llxprt-code-core';
+import { OutputFormat } from '@vybestack/llxprt-code-core';
+import { dynamicSettingsRegistry } from './utils/dynamicSettings.js';
+import {
+  shouldRelaunchForMemory,
+  computeSandboxMemoryArgs,
+} from './utils/bootstrap.js';
+import { start_sandbox } from './utils/sandbox.js';
+
+vi.mock('./config/settings.js', () => ({
+  loadSettings: vi.fn().mockReturnValue({
+    merged: {
+      advanced: {},
+      security: { auth: {} },
+      ui: { useAlternateBuffer: true },
+    },
+    setValue: vi.fn(),
+    forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+    errors: [],
+  }),
+  migrateDeprecatedSettings: vi.fn(),
+  SettingScope: {
+    User: 'user',
+    Workspace: 'workspace',
+    System: 'system',
+    SystemDefaults: 'system-defaults',
+  },
+}));
+
+vi.mock('./ui/utils/terminalCapabilityManager.js', () => ({
+  terminalCapabilityManager: {
+    detectCapabilities: vi.fn(),
+    getTerminalBackgroundColor: vi.fn(),
+  },
+}));
+
+vi.mock('./config/config.js', () => ({
+  loadCliConfig: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('./config/cliArgParser.js', () => ({
+  parseArguments: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('read-package-up', () => ({
+  readPackageUp: vi.fn().mockResolvedValue({
+    packageJson: { name: 'test-pkg', version: 'test-version' },
+    path: '/fake/path/package.json',
+  }),
+}));
+
+vi.mock('update-notifier', () => ({
+  default: vi.fn(() => ({ notify: vi.fn() })),
+}));
+
+vi.mock('./utils/events.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils/events.js')>();
+  return { ...actual, appEvents: { emit: vi.fn() } };
+});
+
+vi.mock('./utils/sandbox.js', () => ({
+  sandbox_command: vi.fn(() => ''),
+  start_sandbox: vi.fn(() => Promise.resolve(0)),
+}));
+
+vi.mock('./utils/bootstrap.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils/bootstrap.js')>();
+  return {
+    ...actual,
+    shouldRelaunchForMemory: vi.fn(() => []),
+    isDebugMode: vi.fn(() => false),
+    computeSandboxMemoryArgs: vi.fn(
+      (...args: Parameters<typeof actual.computeSandboxMemoryArgs>) =>
+        actual.computeSandboxMemoryArgs(...args),
+    ),
+  };
+});
+
+vi.mock('./utils/relaunch.js', () => ({
+  relaunchAppInChildProcess: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('./utils/version.js', () => ({
+  getCliVersion: vi.fn(() => Promise.resolve('1.0.0')),
+}));
+
+vi.mock('./utils/terminalTheme.js', () => ({
+  setupTerminalAndTheme: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+vi.mock('./ui/utils/updateCheck.js', () => ({
+  checkForUpdates: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock('./utils/cleanup.js', () => ({
+  cleanupCheckpoints: vi.fn(() => Promise.resolve()),
+  registerCleanup: vi.fn(),
+  registerSyncCleanup: vi.fn(),
+  runExitCleanup: vi.fn(),
+}));
+
+vi.mock('ink', () => ({
+  render: vi.fn().mockReturnValue({ unmount: vi.fn() }),
+}));
+
+vi.mock('./ui/utils/mouse.js', () => ({
+  enableMouseEvents: vi.fn(),
+  disableMouseEvents: vi.fn(),
+  parseMouseEvent: vi.fn(),
+  isIncompleteMouseSequence: vi.fn(),
+  isMouseEventsActive: vi.fn(() => false),
+  setMouseEventsActive: vi.fn(() => false),
+  ENABLE_MOUSE_EVENTS: '',
+  DISABLE_MOUSE_EVENTS: '',
+}));
+
+const { mockWriteToStdout } = vi.hoisted(() => ({
+  mockWriteToStdout: vi.fn().mockReturnValue(true),
+}));
+vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
+  return {
+    ...actual,
+    writeToStdout: mockWriteToStdout,
+    writeToStderr: vi.fn().mockReturnValue(true),
+    patchStdio: vi.fn(() => vi.fn()),
+  };
+});
+
+describe('cli sandbox maxHeapSizeMB integration', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dynamicSettingsRegistry.reset();
+    process.env = { ...originalEnv };
+    delete process.env.SANDBOX;
+    delete process.env.LLXPRT_CODE_NO_RELAUNCH;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('passes settings maxHeapSizeMB to computeSandboxMemoryArgs and start_sandbox', async () => {
+    const shouldRelaunchMock = vi.mocked(shouldRelaunchForMemory);
+    const loadSettingsMock = vi.mocked(loadSettings);
+    const loadCliConfigMock = vi.mocked(loadCliConfig);
+    const startSandboxMock = vi.mocked(start_sandbox);
+    const computeMock = vi.mocked(computeSandboxMemoryArgs);
+
+    shouldRelaunchMock.mockReturnValue([]);
+    const customMaxHeap = 4096;
+    loadSettingsMock.mockReturnValue({
+      merged: {
+        ui: {
+          autoConfigureMaxOldSpaceSize: true,
+          maxHeapSizeMB: customMaxHeap,
+        },
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      errors: [],
+    } as unknown as LoadedSettings);
+
+    const mockConfig = buildSandboxConfig();
+    loadCliConfigMock.mockResolvedValue(mockConfig);
+    vi.mocked(parseArguments).mockResolvedValueOnce(buildArgv('test prompt'));
+
+    const originalIsTTY = process.stdin.isTTY;
+    const originalSetRawMode = process.stdin.setRawMode;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, 'setRawMode', {
+      value: vi.fn(),
+      configurable: true,
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('PROCESS_EXIT');
+    });
+
+    try {
+      await main();
+    } catch {
+      // Expected from process.exit mock
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdin, 'setRawMode', {
+        value: originalSetRawMode,
+        configurable: true,
+      });
+    }
+
+    // Prove settings.merged.ui.maxHeapSizeMB flows to computeSandboxMemoryArgs
+    expect(computeMock).toHaveBeenCalledWith(false, undefined, customMaxHeap);
+    // Prove the resulting args flow to start_sandbox
+    expect(startSandboxMock).toHaveBeenCalledWith(
+      expect.anything(),
+      computeSandboxMemoryArgs(false, undefined, customMaxHeap),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    exitSpy.mockRestore();
+  });
+});
+
+function buildSandboxConfig(): Config {
+  const fn = vi.fn;
+  return {
+    initialize: fn().mockResolvedValue(undefined),
+    refreshAuth: fn().mockResolvedValue(undefined),
+    getProvider: fn(() => undefined),
+    getProviderManager: fn(() => ({
+      getActiveProvider: fn().mockReturnValue(null),
+      getActiveProviderName: fn().mockReturnValue(undefined),
+      getServerToolsProvider: fn().mockReturnValue(null),
+    })),
+    getConversationLoggingEnabled: fn(() => false),
+    getMcpServers: fn(() => ({})),
+    getDebugMode: fn(() => false),
+    getIdeMode: fn(() => false),
+    getIdeClient: fn(() => null),
+    getListExtensions: fn(() => false),
+    getOutputFormat: fn(() => OutputFormat.TEXT),
+    getToolRegistryInfo: fn(() => ({ registered: [], unregistered: [] })),
+    getSandbox: fn(() => ({ command: 'docker', image: 'test-image' })),
+    getModel: fn(() => 'test-model'),
+    getProjectRoot: fn(() => '/tmp/project'),
+    isInteractive: fn(() => false),
+    getSessionId: fn(() => 'session-sandbox-test'),
+    getQuestion: fn(() => ''),
+    isContinueSession: fn(() => false),
+    getExperimentalZedIntegration: fn(() => false),
+    getZedIntegrationEnabled: fn(() => false),
+    getTrustedFolder: fn(() => true),
+    getScreenReader: fn(() => false),
+    storage: {},
+    getProjectTempDir: fn(() => '/tmp/project-temp'),
+    getContinueSessionRef: fn(() => null),
+    getWorkspaceContext: fn(() => ({ getDirectories: () => ['/tmp/project'] })),
+    setTerminalBackground: fn(),
+    getTerminalBackground: fn(() => undefined),
+    getPolicyEngine: fn(() => null),
+  } as unknown as Config;
+}
+
+function buildArgv(prompt?: string) {
+  return {
+    model: undefined,
+    sandbox: undefined,
+    sandboxImage: undefined,
+    sandboxEngine: undefined,
+    sandboxProfileLoad: undefined,
+    debug: undefined,
+    prompt: prompt ?? undefined,
+    promptInteractive: undefined,
+    outputFormat: undefined,
+    showMemoryUsage: undefined,
+    yolo: undefined,
+    approvalMode: undefined,
+    telemetry: undefined,
+    checkpointing: undefined,
+    telemetryTarget: undefined,
+    telemetryOtlpEndpoint: undefined,
+    telemetryLogPrompts: undefined,
+    telemetryOutfile: undefined,
+    allowedMcpServerNames: undefined,
+    allowedTools: undefined,
+    experimentalAcp: false,
+    experimentalUi: undefined,
+    extensions: undefined,
+    listExtensions: undefined,
+    provider: undefined,
+    key: undefined,
+    keyfile: undefined,
+    baseurl: undefined,
+    proxy: undefined,
+    includeDirectories: undefined,
+    profileLoad: undefined,
+    loadMemoryFromIncludeDirectories: undefined,
+    ideMode: undefined,
+    screenReader: undefined,
+    sessionSummary: undefined,
+    dumponerror: undefined,
+    promptWords: [] as string[],
+    query: undefined,
+    set: undefined,
+    continue: undefined,
+    nobrowser: undefined,
+    listSessions: undefined,
+    deleteSession: undefined,
+  };
+}

--- a/packages/cli/src/cli.test.tsx
+++ b/packages/cli/src/cli.test.tsx
@@ -682,7 +682,7 @@ describe('cli.tsx deferred initialization', () => {
     relaunchMock.mockResolvedValue(0);
     loadSettingsMock.mockReturnValue({
       merged: {
-        ui: { autoConfigureMaxOldSpaceSize: true },
+        ui: { autoConfigureMaxOldSpaceSize: true, maxHeapSizeMB: 8192 },
       },
       setValue: vi.fn(),
       forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
@@ -703,8 +703,8 @@ describe('cli.tsx deferred initialization', () => {
     // Expected to throw from process.exit mock
     expect(caughtError?.message).toBe('PROCESS_EXIT');
 
-    // Verify relaunch check happened
-    expect(shouldRelaunchMock).toHaveBeenCalled();
+    // Verify relaunch check happened with both debug mode and maxHeapSizeMB
+    expect(shouldRelaunchMock).toHaveBeenCalledWith(false, 8192);
     expect(relaunchMock).toHaveBeenCalledWith(['--max-old-space-size=4096']);
 
     // Verify loadCliConfig was NOT called
@@ -772,7 +772,7 @@ describe('cli.tsx deferred initialization', () => {
     expect(loadSettingsMock).toHaveBeenCalled();
   });
 
-  it('should use isDebugMode for early debug detection', async () => {
+  it('should use isDebugMode for early debug detection and pass maxHeapSizeMB', async () => {
     const isDebugModeMock = vi.mocked(isDebugMode);
     const shouldRelaunchMock = vi.mocked(shouldRelaunchForMemory);
     const loadSettingsMock = vi.mocked(loadSettings);
@@ -782,7 +782,7 @@ describe('cli.tsx deferred initialization', () => {
 
     loadSettingsMock.mockReturnValue({
       merged: {
-        ui: { autoConfigureMaxOldSpaceSize: true },
+        ui: { autoConfigureMaxOldSpaceSize: true, maxHeapSizeMB: 8192 },
       },
       setValue: vi.fn(),
       forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
@@ -797,7 +797,33 @@ describe('cli.tsx deferred initialization', () => {
 
     // Debug mode should be detected
     expect(isDebugModeMock).toHaveBeenCalled();
-    // And passed to shouldRelaunchForMemory
-    expect(shouldRelaunchMock).toHaveBeenCalledWith(true);
+    // And passed to shouldRelaunchForMemory with the maxHeapSizeMB from settings
+    expect(shouldRelaunchMock).toHaveBeenCalledWith(true, 8192);
+  });
+
+  it('should pass non-default maxHeapSizeMB to shouldRelaunchForMemory', async () => {
+    const isDebugModeMock = vi.mocked(isDebugMode);
+    const shouldRelaunchMock = vi.mocked(shouldRelaunchForMemory);
+    const loadSettingsMock = vi.mocked(loadSettings);
+
+    isDebugModeMock.mockReturnValue(false);
+    shouldRelaunchMock.mockReturnValue([]);
+
+    loadSettingsMock.mockReturnValue({
+      merged: {
+        ui: { autoConfigureMaxOldSpaceSize: true, maxHeapSizeMB: 4096 },
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      errors: [],
+    } as unknown as LoadedSettings);
+
+    try {
+      await main();
+    } catch {
+      // Expected
+    }
+
+    expect(shouldRelaunchMock).toHaveBeenCalledWith(false, 4096);
   });
 });

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -411,7 +411,8 @@ export async function main() {
   ) {
     // Only relaunch with a larger heap when the autosizing setting is enabled.
     const debugMode = isDebugMode();
-    const memoryArgs = shouldRelaunchForMemory(debugMode);
+    const maxHeapSizeMB = settings.merged.ui.maxHeapSizeMB;
+    const memoryArgs = shouldRelaunchForMemory(debugMode, maxHeapSizeMB);
     if (memoryArgs.length > 0) {
       const exitCode = await relaunchAppInChildProcess(memoryArgs);
       process.exit(exitCode);
@@ -826,6 +827,7 @@ export async function main() {
       sandboxMemoryArgs = computeSandboxMemoryArgs(
         config.getDebugMode(),
         containerMemoryMB,
+        settings.merged.ui.maxHeapSizeMB,
       );
     }
     const sandboxConfig = config.getSandbox();

--- a/packages/cli/src/config/settings-schema/schema-ui.ts
+++ b/packages/cli/src/config/settings-schema/schema-ui.ts
@@ -273,6 +273,18 @@ export const UI_SETTINGS_SCHEMA = {
           'Automatically configure Node.js max old space size based on system memory.',
         showInDialog: true,
       },
+      maxHeapSizeMB: {
+        type: 'number',
+        label: 'Max Heap Size (MB)',
+        category: 'UI',
+        requiresRestart: true,
+        default: 8192,
+        minimum: 512,
+        multipleOf: 1,
+        description:
+          'Caps the auto-configured Node.js max old space heap size. Overrides the default 8GB cap when auto-configure is enabled. Must be an integer.',
+        showInDialog: true,
+      },
       historyMaxItems: {
         type: 'number',
         label: 'History Max Items',

--- a/packages/cli/src/config/settings-schema/types.ts
+++ b/packages/cli/src/config/settings-schema/types.ts
@@ -106,6 +106,11 @@ export interface SettingDefinition {
    * For number types, the maximum allowed value.
    */
   maximum?: number;
+  /**
+   * For number types, requires values to be multiples of this number
+   * (e.g. multipleOf 1 restricts to integers).
+   */
+  multipleOf?: number;
 }
 
 export interface SettingsSchema {

--- a/packages/cli/src/config/settings-validation.ts
+++ b/packages/cli/src/config/settings-validation.ts
@@ -51,7 +51,7 @@ function buildStringJsonSchema(def: JsonSchemaLike): z.ZodTypeAny {
 
 function applyNumberBounds(
   schema: z.ZodNumber,
-  def: { minimum?: unknown; maximum?: unknown },
+  def: { minimum?: unknown; maximum?: unknown; multipleOf?: unknown },
 ): z.ZodNumber {
   let boundedSchema = schema;
   if (typeof def.minimum === 'number') {
@@ -59,6 +59,9 @@ function applyNumberBounds(
   }
   if (typeof def.maximum === 'number') {
     boundedSchema = boundedSchema.max(def.maximum);
+  }
+  if (typeof def.multipleOf === 'number') {
+    boundedSchema = boundedSchema.multipleOf(def.multipleOf);
   }
   return boundedSchema;
 }
@@ -192,13 +195,21 @@ function buildObjectShapeFromProperties(
 }
 
 /**
- * Builds a Zod schema for primitive types (string, number, boolean).
+ * Shape accepted by buildPrimitiveSchema — captures numeric constraints.
  */
-function buildPrimitiveSchema(definition: {
+interface PrimitiveSchemaDefinition {
   type: 'string' | 'number' | 'boolean';
   minimum?: number;
   maximum?: number;
-}): z.ZodTypeAny {
+  multipleOf?: number;
+}
+
+/**
+ * Builds a Zod schema for primitive types (string, number, boolean).
+ */
+function buildPrimitiveSchema(
+  definition: PrimitiveSchemaDefinition,
+): z.ZodTypeAny {
   switch (definition.type) {
     case 'string':
       return z.string();
@@ -241,11 +252,7 @@ function buildZodSchemaFromDefinition(
     case 'number':
     case 'boolean':
       baseSchema = buildPrimitiveSchema(
-        definition as {
-          type: 'string' | 'number' | 'boolean';
-          minimum?: number;
-          maximum?: number;
-        },
+        definition as PrimitiveSchemaDefinition,
       );
       break;
 
@@ -312,13 +319,7 @@ function buildZodSchemaFromCollection(
     case 'string':
     case 'number':
     case 'boolean':
-      return buildPrimitiveSchema(
-        collection as {
-          type: 'string' | 'number' | 'boolean';
-          minimum?: number;
-          maximum?: number;
-        },
-      );
+      return buildPrimitiveSchema(collection as PrimitiveSchemaDefinition);
 
     case 'enum': {
       return buildEnumSchema(collection.options);

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -15,6 +15,7 @@ import {
   getEnableHooks,
   getEnableHooksUI,
 } from './settingsSchema.js';
+import { validateSettings } from './settings-validation.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -220,6 +221,121 @@ describe('SettingsSchema', () => {
       expect(
         SETTINGS_SCHEMA.ui.properties.autoConfigureMaxOldSpaceSize.showInDialog,
       ).toBe(true);
+    });
+
+    describe('ui.maxHeapSizeMB', () => {
+      it('should be defined in the UI settings schema', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB).toBeDefined();
+      });
+
+      it('should be a number type', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.type).toBe('number');
+      });
+
+      it('should have label Max Heap Size (MB)', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.label).toBe(
+          'Max Heap Size (MB)',
+        );
+      });
+
+      it('should be in the UI category', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.category).toBe('UI');
+      });
+
+      it('should require restart', () => {
+        expect(
+          SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.requiresRestart,
+        ).toBe(true);
+      });
+
+      it('should default to 8192', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.default).toBe(8192);
+      });
+
+      it('should have minimum of 512', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.minimum).toBe(512);
+      });
+
+      it('should show in dialog', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.showInDialog).toBe(
+          true,
+        );
+      });
+
+      it('should have a description', () => {
+        const description =
+          SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.description;
+        expect(typeof description).toBe('string');
+        expect(typeof description === 'string' && description.length > 0).toBe(
+          true,
+        );
+      });
+
+      it('should have multipleOf 1 (integer constraint)', () => {
+        expect(SETTINGS_SCHEMA.ui.properties.maxHeapSizeMB.multipleOf).toBe(1);
+      });
+
+      it('should accept integer value 512 via validation', () => {
+        const result = validateSettings({
+          ui: { maxHeapSizeMB: 512 },
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should accept integer value 8192 via validation', () => {
+        const result = validateSettings({
+          ui: { maxHeapSizeMB: 8192 },
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should reject fractional value 1536.75 via validation', () => {
+        const result = validateSettings({
+          ui: { maxHeapSizeMB: 1536.75 },
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('should reject value below minimum 512 (e.g. 511) via validation', () => {
+        const result = validateSettings({
+          ui: { maxHeapSizeMB: 511 },
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('should accept value exactly at minimum 512 via validation', () => {
+        const result = validateSettings({
+          ui: { maxHeapSizeMB: 512 },
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should reject fractional value below minimum via validation', () => {
+        const result = validateSettings({
+          ui: { maxHeapSizeMB: 511.5 },
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('should infer Settings[ui][maxHeapSizeMB] as number (accepts 4096 without casts)', () => {
+        // Compile-time proof: maxHeapSizeMB is `number`, not the literal 8192.
+        // If InferSettings incorrectly produced the literal type 8192, assigning
+        // 4096 (or any other number) would fail to compile.
+        const settings: Settings = {
+          ui: {
+            maxHeapSizeMB: 4096,
+          },
+        };
+        expect(settings.ui?.maxHeapSizeMB).toBe(4096);
+
+        // Also prove it accepts the default value
+        const defaultSettings: Settings = {
+          ui: {
+            maxHeapSizeMB: 8192,
+          },
+        };
+        expect(defaultSettings.ui?.maxHeapSizeMB).toBe(8192);
+      });
     });
 
     it('should infer Settings type correctly', () => {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -427,9 +427,11 @@ type InferSettings<T extends SettingsSchema> = {
       ? T[K]['options'] extends readonly SettingEnumOption[]
         ? T[K]['options'][number]['value']
         : T[K]['default']
-      : T[K]['default'] extends boolean
-        ? boolean
-        : T[K]['default'];
+      : T[K]['type'] extends 'number'
+        ? number
+        : T[K]['default'] extends boolean
+          ? boolean
+          : T[K]['default'];
 };
 
 export type Settings = InferSettings<SettingsSchemaType>;

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -555,6 +555,52 @@ function commitEditRestartRequired(
   });
 }
 
+type ParseEditResult = { ok: true; value: string | number } | { ok: false };
+
+function isValidNumericEdit(
+  value: number,
+  definition: ReturnType<typeof getSettingDefinition>,
+): boolean {
+  if (definition === undefined) {
+    return true;
+  }
+  if (typeof definition.minimum === 'number' && value < definition.minimum) {
+    return false;
+  }
+  if (typeof definition.maximum === 'number' && value > definition.maximum) {
+    return false;
+  }
+  if (
+    typeof definition.multipleOf === 'number' &&
+    definition.multipleOf > 0 &&
+    !Number.isInteger(value / definition.multipleOf)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function parseEditValue(
+  editBuffer: string,
+  definition: ReturnType<typeof getSettingDefinition>,
+): ParseEditResult {
+  if (definition?.type !== 'number') {
+    return { ok: true, value: editBuffer };
+  }
+
+  const trimmed = editBuffer.trim();
+  if (trimmed === '') {
+    return { ok: false };
+  }
+
+  const parsed = Number(trimmed);
+  if (Number.isNaN(parsed) || !isValidNumericEdit(parsed, definition)) {
+    return { ok: false };
+  }
+
+  return { ok: true, value: parsed };
+}
+
 function commitEdit(
   key: string,
   editBuffer: string,
@@ -572,36 +618,25 @@ function commitEdit(
   >,
 ): void {
   const definition = getSettingDefinition(key);
-  const type = definition?.type;
   const clearEditState = () => {
     setEditingKey(null);
     setEditBuffer('');
     setEditCursorPos(0);
   };
-
-  if (editBuffer.trim() === '' && type === 'number') {
+  const parsed = parseEditValue(editBuffer, definition);
+  if (!parsed.ok) {
     clearEditState();
     return;
   }
 
-  let parsed: string | number;
-  if (type === 'number') {
-    const numParsed = Number(editBuffer.trim());
-    if (Number.isNaN(numParsed)) {
-      clearEditState();
-      return;
-    }
-    parsed = numParsed;
-  } else {
-    parsed = editBuffer;
-  }
-
-  setPendingSettings((prev) => setPendingSettingValueAny(key, parsed, prev));
+  setPendingSettings((prev) =>
+    setPendingSettingValueAny(key, parsed.value, prev),
+  );
 
   if (!requiresRestart(key)) {
     commitEditImmediate(
       key,
-      parsed,
+      parsed.value,
       settings,
       selectedScope,
       setModifiedSettings,
@@ -611,7 +646,7 @@ function commitEdit(
   } else {
     commitEditRestartRequired(
       key,
-      parsed,
+      parsed.value,
       setShowRestartPrompt,
       setModifiedSettings,
       setRestartRequiredSettings,

--- a/packages/cli/src/utils/bootstrap.test.ts
+++ b/packages/cli/src/utils/bootstrap.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
 import os from 'node:os';
+import v8 from 'node:v8';
 import {
   shouldRelaunchForMemory,
   isDebugMode,
@@ -116,6 +117,113 @@ describe('bootstrap utilities', () => {
       expect(consoleSpy).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+
+    describe('custom maxHeapCapMB parameter', () => {
+      let totalmemSpy: ReturnType<typeof vi.spyOn>;
+      let heapStatsSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        delete process.env.LLXPRT_CODE_NO_RELAUNCH;
+        // Mock a 16 GB machine: 16 * 1024 * 1024 * 1024 = 17179869184 bytes
+        totalmemSpy = vi.spyOn(os, 'totalmem').mockReturnValue(17179869184);
+        // Mock current heap at 1024 MB: 1024 * 1024 * 1024 = 1073741824 bytes
+        heapStatsSpy = vi.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+          total_heap_size: 0,
+          total_heap_size_executable: 0,
+          total_physical_size: 0,
+          total_available_size: 0,
+          used_heap_size: 0,
+          heap_size_limit: 1073741824,
+          malloced_memory: 0,
+          peak_malloced_memory: 0,
+          does_zap_garbage: 0,
+          number_of_native_contexts: 0,
+          number_of_detached_contexts: 0,
+          total_global_handles_size: 0,
+          used_global_handles_size: 0,
+          external_memory: 0,
+        });
+      });
+
+      afterEach(() => {
+        totalmemSpy.mockRestore();
+        heapStatsSpy.mockRestore();
+      });
+
+      it('should use custom cap when provided instead of default', () => {
+        // 16 GB total -> 50% = 8192, cap=768 -> target = min(8192, 768) = 768
+        // current heap = 1024 -> 768 < 1024 so no relaunch needed
+        const result = shouldRelaunchForMemory(false, 768);
+        expect(result).toStrictEqual([]);
+      });
+
+      it('should relaunch when custom cap produces target above current heap', () => {
+        // 16 GB total -> 50% = 8192, cap=4096 -> target = min(8192, 4096) = 4096
+        // current heap = 1024 -> 4096 > 1024 so relaunch needed
+        const result = shouldRelaunchForMemory(false, 4096);
+        expect(result).toStrictEqual(['--max-old-space-size=4096']);
+      });
+
+      it('should prove it uses the provided cap, not the default', () => {
+        // 16 GB total -> 50% = 8192
+        // With cap=2048: target = min(8192, 2048) = 2048, current=1024 -> relaunch
+        // With default cap (8192): target = min(8192, 8192) = 8192, current=1024 -> relaunch
+        // These produce different results, proving the cap is used
+        const resultWithCustom = shouldRelaunchForMemory(false, 2048);
+        const resultWithDefault = shouldRelaunchForMemory(false, 8192);
+
+        expect(resultWithCustom).toStrictEqual(['--max-old-space-size=2048']);
+        expect(resultWithDefault).toStrictEqual(['--max-old-space-size=8192']);
+        expect(resultWithCustom).not.toStrictEqual(resultWithDefault);
+      });
+
+      it('should fall back to MAX_HEAP_CAP_MB when cap is undefined', () => {
+        // Both calls use the same mocked system, so results must be identical
+        const resultWithUndefined = shouldRelaunchForMemory(false);
+        const resultWithExplicitDefault = shouldRelaunchForMemory(
+          false,
+          MAX_HEAP_CAP_MB,
+        );
+        expect(resultWithUndefined).toStrictEqual(resultWithExplicitDefault);
+      });
+
+      it('should honor minimum value 512 as cap', () => {
+        // 16 GB total -> 50% = 8192, cap=512 -> target = min(8192, 512) = 512
+        // current heap = 1024 -> 512 < 1024 so no relaunch
+        const result = shouldRelaunchForMemory(false, 512);
+        expect(result).toStrictEqual([]);
+      });
+
+      it('should use larger custom cap exceeding default', () => {
+        // 16 GB total -> 50% = 8192, cap=32768 -> target = min(8192, 32768) = 8192
+        // current heap = 1024 -> 8192 > 1024 so relaunch
+        const result = shouldRelaunchForMemory(false, 32768);
+        expect(result).toStrictEqual(['--max-old-space-size=8192']);
+      });
+
+      it('should floor fractional cap to integer', () => {
+        // 16 GB total -> 50% = 8192, cap=1536.75 -> floored to 1536 -> target = min(8192, 1536) = 1536
+        // current heap = 1024 -> 1536 > 1024 so relaunch
+        const result = shouldRelaunchForMemory(false, 1536.75);
+        expect(result).toStrictEqual(['--max-old-space-size=1536']);
+      });
+
+      it('should never emit fractional --max-old-space-size even with fractional cap', () => {
+        const result = shouldRelaunchForMemory(false, 4096.9);
+        // 16 GB total -> 50% = 8192, floored cap=4096 -> target = min(8192, 4096) = 4096
+        expect(result).toStrictEqual(['--max-old-space-size=4096']);
+        const value = result[0].split('=')[1];
+        expect(value).not.toContain('.');
+        expect(Number.isInteger(Number(value))).toBe(true);
+      });
+
+      it('should floor fractional cap below current heap so no relaunch occurs', () => {
+        // 16 GB total -> 50% = 8192, cap=1023.9 -> floored to 1023 -> target = min(8192, 1023) = 1023
+        // current heap = 1024 -> 1023 < 1024 so no relaunch
+        const result = shouldRelaunchForMemory(false, 1023.9);
+        expect(result).toStrictEqual([]);
+      });
+    });
   });
 
   describe('RELAUNCH_EXIT_CODE', () => {
@@ -220,6 +328,73 @@ describe('bootstrap utilities', () => {
     it('should not cap when 50% of container memory is below the cap', () => {
       const result = computeSandboxMemoryArgs(false, 8192);
       expect(result).toStrictEqual(['--max-old-space-size=4096']);
+    });
+
+    describe('custom maxHeapCapMB parameter', () => {
+      it('should use custom cap when provided', () => {
+        const result = computeSandboxMemoryArgs(false, 6144, 2048);
+        // 50% of 6144 = 3072, but capped at 2048
+        expect(result).toStrictEqual(['--max-old-space-size=2048']);
+      });
+
+      it('should fall back to MAX_HEAP_CAP_MB when cap is undefined', () => {
+        const result = computeSandboxMemoryArgs(false, 6144);
+        // 50% of 6144 = 3072, capped at default 8192 -> 3072
+        expect(result).toStrictEqual(['--max-old-space-size=3072']);
+      });
+
+      it('should honor minimum value 512 as cap with large container', () => {
+        const result = computeSandboxMemoryArgs(false, 131072, 512);
+        expect(result).toStrictEqual(['--max-old-space-size=512']);
+      });
+
+      it('should use 50% of container when below custom cap', () => {
+        const result = computeSandboxMemoryArgs(false, 2048, 8192);
+        // 50% of 2048 = 1024, well below cap of 8192
+        expect(result).toStrictEqual(['--max-old-space-size=1024']);
+      });
+
+      it('should use custom cap larger than default', () => {
+        const result = computeSandboxMemoryArgs(false, 131072, 32768);
+        // 50% of 131072 = 65536, capped at 32768
+        expect(result).toStrictEqual(['--max-old-space-size=32768']);
+      });
+
+      it('should still clamp to minimum 128 when both container and cap are tiny', () => {
+        // Container 64MB -> 50% = 32, but min floor is 128
+        const result = computeSandboxMemoryArgs(false, 64, 512);
+        expect(result).toStrictEqual(['--max-old-space-size=128']);
+      });
+
+      it('should produce same result as default when cap matches MAX_HEAP_CAP_MB', () => {
+        const resultExplicit = computeSandboxMemoryArgs(
+          false,
+          6144,
+          MAX_HEAP_CAP_MB,
+        );
+        const resultDefault = computeSandboxMemoryArgs(false, 6144);
+        expect(resultExplicit).toStrictEqual(resultDefault);
+      });
+
+      it('should floor fractional cap to integer', () => {
+        // 50% of 6144 = 3072, cap=2048.75 -> floored to 2048 -> min(3072, 2048) = 2048
+        const result = computeSandboxMemoryArgs(false, 6144, 2048.75);
+        expect(result).toStrictEqual(['--max-old-space-size=2048']);
+      });
+
+      it('should never emit fractional --max-old-space-size even with fractional cap', () => {
+        const result = computeSandboxMemoryArgs(false, 8192, 4096.5);
+        const arg = result[0];
+        const value = arg.split('=')[1];
+        expect(value).not.toContain('.');
+        expect(Number.isInteger(Number(value))).toBe(true);
+      });
+
+      it('should floor fractional cap that dominates container memory', () => {
+        // 50% of 4096 = 2048, cap=1023.1 -> floored to 1023 -> min(2048, 1023) = 1023
+        const result = computeSandboxMemoryArgs(false, 4096, 1023.1);
+        expect(result).toStrictEqual(['--max-old-space-size=1023']);
+      });
     });
   });
 

--- a/packages/cli/src/utils/bootstrap.ts
+++ b/packages/cli/src/utils/bootstrap.ts
@@ -41,7 +41,11 @@ export function isDebugMode(): boolean {
  * @param debugMode - Whether to log debug information
  * @returns Array of Node.js arguments for relaunch, or empty array if no relaunch needed
  */
-export function shouldRelaunchForMemory(debugMode: boolean): string[] {
+export function shouldRelaunchForMemory(
+  debugMode: boolean,
+  maxHeapCapMB: number = MAX_HEAP_CAP_MB,
+): string[] {
+  const cap = Math.floor(maxHeapCapMB);
   const totalMemoryMB = os.totalmem() / (1024 * 1024);
   const heapStats = v8.getHeapStatistics();
   const currentMaxOldSpaceSizeMb = Math.floor(
@@ -50,7 +54,7 @@ export function shouldRelaunchForMemory(debugMode: boolean): string[] {
 
   const targetMaxOldSpaceSizeInMB = Math.min(
     Math.floor(totalMemoryMB * 0.5),
-    MAX_HEAP_CAP_MB,
+    cap,
   );
 
   if (debugMode) {
@@ -128,11 +132,13 @@ export function parseDockerMemoryToMB(memoryStr: string): number | undefined {
 export function computeSandboxMemoryArgs(
   debugMode: boolean,
   containerMemoryMB?: number,
+  maxHeapCapMB: number = MAX_HEAP_CAP_MB,
 ): string[] {
+  const cap = Math.floor(maxHeapCapMB);
   const totalMemoryMB = containerMemoryMB ?? os.totalmem() / (1024 * 1024);
   const targetMaxOldSpaceSizeInMB = Math.max(
     128,
-    Math.min(Math.floor(totalMemoryMB * 0.5), MAX_HEAP_CAP_MB),
+    Math.min(Math.floor(totalMemoryMB * 0.5), cap),
   );
 
   if (debugMode) {

--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -81,34 +81,6 @@ describe('SettingsUtils', () => {
       });
     });
 
-    describe('numeric setting client-side validation', () => {
-      it('should accept value within bounds for maxHeapSizeMB', () => {
-        const definition = getSettingDefinition('ui.maxHeapSizeMB');
-        const value = 4096;
-        expect(value).toBeGreaterThanOrEqual(definition!.minimum!);
-        expect(Number.isInteger(value / definition!.multipleOf!)).toBe(true);
-      });
-
-      it('should reject value below minimum for maxHeapSizeMB', () => {
-        const definition = getSettingDefinition('ui.maxHeapSizeMB');
-        const value = 256;
-        expect(value < definition!.minimum!).toBe(true);
-      });
-
-      it('should reject fractional value when multipleOf is 1', () => {
-        const definition = getSettingDefinition('ui.maxHeapSizeMB');
-        const value = 1536.75;
-        expect(Number.isInteger(value / definition!.multipleOf!)).toBe(false);
-      });
-
-      it('should accept value exactly at minimum', () => {
-        const definition = getSettingDefinition('ui.maxHeapSizeMB');
-        const value = 512;
-        expect(value).toBeGreaterThanOrEqual(definition!.minimum!);
-        expect(Number.isInteger(value / definition!.multipleOf!)).toBe(true);
-      });
-    });
-
     describe('requiresRestart', () => {
       it('should return true for settings that require restart', () => {
         expect(requiresRestart('ui.autoConfigureMaxOldSpaceSize')).toBe(true);

--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -71,12 +71,49 @@ describe('SettingsUtils', () => {
         const definition = getSettingDefinition('invalidSetting');
         expect(definition).toBeUndefined();
       });
+
+      it('should expose numeric constraints for maxHeapSizeMB', () => {
+        const definition = getSettingDefinition('ui.maxHeapSizeMB');
+        expect(definition).toBeDefined();
+        expect(definition?.type).toBe('number');
+        expect(definition?.minimum).toBe(512);
+        expect(definition?.multipleOf).toBe(1);
+      });
+    });
+
+    describe('numeric setting client-side validation', () => {
+      it('should accept value within bounds for maxHeapSizeMB', () => {
+        const definition = getSettingDefinition('ui.maxHeapSizeMB');
+        const value = 4096;
+        expect(value).toBeGreaterThanOrEqual(definition!.minimum!);
+        expect(Number.isInteger(value / definition!.multipleOf!)).toBe(true);
+      });
+
+      it('should reject value below minimum for maxHeapSizeMB', () => {
+        const definition = getSettingDefinition('ui.maxHeapSizeMB');
+        const value = 256;
+        expect(value < definition!.minimum!).toBe(true);
+      });
+
+      it('should reject fractional value when multipleOf is 1', () => {
+        const definition = getSettingDefinition('ui.maxHeapSizeMB');
+        const value = 1536.75;
+        expect(Number.isInteger(value / definition!.multipleOf!)).toBe(false);
+      });
+
+      it('should accept value exactly at minimum', () => {
+        const definition = getSettingDefinition('ui.maxHeapSizeMB');
+        const value = 512;
+        expect(value).toBeGreaterThanOrEqual(definition!.minimum!);
+        expect(Number.isInteger(value / definition!.multipleOf!)).toBe(true);
+      });
     });
 
     describe('requiresRestart', () => {
       it('should return true for settings that require restart', () => {
         expect(requiresRestart('ui.autoConfigureMaxOldSpaceSize')).toBe(true);
         expect(requiresRestart('checkpointing.enabled')).toBe(true);
+        expect(requiresRestart('ui.maxHeapSizeMB')).toBe(true);
       });
 
       it('should return false for settings that do not require restart', () => {
@@ -95,10 +132,58 @@ describe('SettingsUtils', () => {
         expect(getDefaultValue('fileFiltering.enableRecursiveFileSearch')).toBe(
           true,
         );
+        expect(getDefaultValue('ui.maxHeapSizeMB')).toBe(8192);
       });
 
       it('should return undefined for invalid settings', () => {
         expect(getDefaultValue('invalidSetting')).toBeUndefined();
+      });
+    });
+
+    describe('ui.maxHeapSizeMB merge/default behavior', () => {
+      it('should default to 8192 when omitted from settings', () => {
+        // When no ui.maxHeapSizeMB is set, getEffectiveValue should fall back to default
+        const emptySettings = {};
+        const emptyMerged = {};
+        const value = getEffectiveValue(
+          'ui.maxHeapSizeMB',
+          emptySettings as never,
+          emptyMerged as never,
+        );
+        expect(value).toBe(8192);
+      });
+
+      it('should return configured value when set in merged settings', () => {
+        const emptyScope = {};
+        const merged = { ui: { maxHeapSizeMB: 4096 } };
+        const value = getEffectiveValue(
+          'ui.maxHeapSizeMB',
+          emptyScope as never,
+          merged as never,
+        );
+        expect(value).toBe(4096);
+      });
+
+      it('should return configured value when set in scope settings', () => {
+        const scopeSettings = { ui: { maxHeapSizeMB: 4096 } };
+        const emptyMerged = {};
+        const value = getEffectiveValue(
+          'ui.maxHeapSizeMB',
+          scopeSettings as never,
+          emptyMerged as never,
+        );
+        expect(value).toBe(4096);
+      });
+
+      it('should prefer scope value over merged value', () => {
+        const scopeSettings = { ui: { maxHeapSizeMB: 2048 } };
+        const merged = { ui: { maxHeapSizeMB: 4096 } };
+        const value = getEffectiveValue(
+          'ui.maxHeapSizeMB',
+          scopeSettings as never,
+          merged as never,
+        );
+        expect(value).toBe(2048);
       });
     });
 
@@ -107,6 +192,7 @@ describe('SettingsUtils', () => {
         const restartSettings = getRestartRequiredSettings();
         expect(restartSettings).toContain('ui.autoConfigureMaxOldSpaceSize');
         expect(restartSettings).toContain('checkpointing.enabled');
+        expect(restartSettings).toContain('ui.maxHeapSizeMB');
         expect(restartSettings).not.toContain('ui.showMemoryUsage');
       });
     });
@@ -255,6 +341,7 @@ describe('SettingsUtils', () => {
         expect(shouldShowInDialog('ui.vimMode')).toBe(true);
         expect(shouldShowInDialog('ui.hideWindowTitle')).toBe(true);
         expect(shouldShowInDialog('ui.usageStatisticsEnabled')).toBe(false);
+        expect(shouldShowInDialog('ui.maxHeapSizeMB')).toBe(true);
       });
 
       it('should return false for settings marked to hide from dialog', () => {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -537,6 +537,15 @@
           "default": true,
           "type": "boolean"
         },
+        "maxHeapSizeMB": {
+          "title": "Max Heap Size (MB)",
+          "description": "Caps the auto-configured Node.js max old space heap size. Overrides the default 8GB cap when auto-configure is enabled. Must be an integer.",
+          "markdownDescription": "Caps the auto-configured Node.js max old space heap size. Overrides the default 8GB cap when auto-configure is enabled. Must be an integer.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `8192`",
+          "default": 8192,
+          "type": "number",
+          "minimum": 512,
+          "multipleOf": 1
+        },
         "historyMaxItems": {
           "title": "History Max Items",
           "description": "Maximum number of history items to keep.",

--- a/scripts/generate-settings-schema.ts
+++ b/scripts/generate-settings-schema.ts
@@ -191,6 +191,9 @@ function buildSchemaForType(
       if ('maximum' in source && source.maximum !== undefined) {
         numberSchema.maximum = source.maximum;
       }
+      if ('multipleOf' in source && source.multipleOf !== undefined) {
+        numberSchema.multipleOf = source.multipleOf;
+      }
       return numberSchema;
     }
     case 'enum':


### PR DESCRIPTION
## TLDR

Adds a UI/settings.json setting, ui.maxHeapSizeMB, so users can configure the cap used by automatic Node.js max old space sizing instead of being limited to the previous hardcoded 8192 MB cap.

## Dive Deeper

This change:

- Adds ui.maxHeapSizeMB to the UI settings schema with default 8192, minimum 512, integer-only validation, restart requirement, and dialog visibility.
- Passes the configured value into both non-sandbox relaunch memory sizing and sandbox process memory argument computation.
- Keeps MAX_HEAP_CAP_MB as the fallback/default cap for direct utility callers.
- Extends schema validation and generated settings schema support for numeric multipleOf constraints.
- Adds defensive runtime flooring so fractional direct utility inputs cannot emit fractional max old space arguments.
- Validates numeric edits in the settings dialog against schema minimum, maximum, and multipleOf constraints before accepting pending values.
- Adds tests for schema behavior, settings utility behavior, CLI wiring, sandbox wiring, bootstrap cap calculation, type inference, and validation edge cases.

## Reviewer Test Plan

Reviewers can validate by:

1. Running the verification commands listed below.
2. Opening the settings UI and confirming Max Heap Size (MB) appears under UI settings.
3. Setting ui.maxHeapSizeMB to a valid integer such as 4096 and restarting; automatic max old space sizing should use that cap.
4. Trying invalid values such as 511 or 1536.75; validation should reject them.
5. Using sandbox mode with auto memory configuration enabled and confirming the sandbox process receives memory args computed with the configured cap.

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  | [OK]  |   |   |
| npx      |   |   |   |
| Docker   |   |   |   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

Verified on macOS:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

## Linked issues / bugs

Fixes #1624
