### PR TITLE
Fix #1877: Subagent armTimeout fires against defunct instance if initScheduler rejects

### DIFF
--- a/packages/agents/src/core/subagent.ts
+++ b/packages/agents/src/core/subagent.ts
@@ -376,7 +376,7 @@ export class SubAgentScope {
     const setup = await this.prepareRun(context);
     if (!setup) return;
     const { chat, abortController } = setup;
-    const { scheduler, schedulerDispose } = await this.initScheduler(options);
+    let schedulerDispose: () => Promise<void> = async () => {};
 
     const execCtx = this.buildExecCtx();
     const startTime = Date.now();
@@ -384,6 +384,10 @@ export class SubAgentScope {
     let currentMessages = this.buildInitialMessages(context);
 
     try {
+      const { scheduler, schedulerDispose: disposeScheduler } =
+        await this.initScheduler(options);
+      schedulerDispose = disposeScheduler;
+
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/too-many-break-or-continue-in-loop -- Persisted subagent config and runtime tool payloads.
       while (true) {
         const check = checkTerminationConditions(


### PR DESCRIPTION
## TLDR

Fixes #1877

Moves interactive subagent scheduler initialization inside the cleanup boundary that is established after prepareRun arms the run timeout. If scheduler initialization fails, the finally block now still runs and clears the timeout handle instead of leaving a stale timer attached to a failed subagent run.

## Dive Deeper

The issue was that runInteractive prepared the run and armed the timeout before initializing the interactive scheduler, but scheduler initialization happened before entering the try/finally that performs cleanup. A scheduler factory failure could therefore skip cleanupInteractive, leaving the timeout active until max_time_minutes elapsed.

This change keeps the existing timeout semantics, including scheduler setup time in the timeout window, while ensuring cleanup always executes after prepareRun succeeds. The scheduler dispose callback is initialized to a no-op and replaced once initScheduler succeeds, so the existing cleanup path is safe whether initialization succeeds or throws.

## Reviewer Test Plan

Review packages/agents/src/core/subagent.ts and verify that:

- prepareRun still arms the timeout before interactive execution begins.
- initScheduler now runs inside the same try/finally boundary as cleanupInteractive.
- cleanupInteractive can safely run if initScheduler throws before a scheduler dispose callback exists.
- Normal interactive timeout and cleanup behavior remains unchanged after successful scheduler initialization.

Suggested validation:

- Run the agents subagent test coverage focused on subagent.test.ts.
- Exercise an interactive subagent configuration with max_time_minutes and a scheduler factory that fails during initialization; confirm the original scheduler error is reported and no later timeout mutation/log occurs.

## Testing Matrix

|          |   |   |   |
| -------- | --- | --- | --- |
| npm run  |   |   |   |
| npx      |   |   |   |
| Docker   |   | -   | -   |
| Podman   |   | -   | -   |
| Seatbelt |   | -   | -   |

## Linked issues / bugs

Fixes #1877
