### PR TITLE
Fix dumpcontext request and response dumps (Fixes #1700)

### DIFF
--- a/packages/cli/src/ui/commands/dumpcontextCommand.test.ts
+++ b/packages/cli/src/ui/commands/dumpcontextCommand.test.ts
@@ -9,6 +9,21 @@ import { dumpcontextCommand } from './dumpcontextCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 
+vi.mock('@vybestack/llxprt-code-providers', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-providers')>();
+  return {
+    ...actual,
+    dumpRequestContext: vi.fn().mockResolvedValue({
+      baseId: '20260101-120000-anthropic-abc123',
+      requestFilename: '20260101-120000-anthropic-abc123-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    }),
+  };
+});
+
+import { dumpRequestContext } from '@vybestack/llxprt-code-providers';
+
 vi.mock('../contexts/RuntimeContext.js', () => ({
   getRuntimeApi: vi.fn(() => ({
     getEphemeralSetting: vi.fn((key: string) => {
@@ -23,11 +38,21 @@ vi.mock('../contexts/RuntimeContext.js', () => ({
 
 import { getRuntimeApi } from '../contexts/RuntimeContext.js';
 
+const dumpcontextAction = dumpcontextCommand.action;
+if (!dumpcontextAction) {
+  throw new Error('dumpcontextCommand must have an action');
+}
+
 describe('dumpcontextCommand', () => {
   let mockContext: CommandContext;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(dumpRequestContext).mockResolvedValue({
+      baseId: '20260101-120000-anthropic-abc123',
+      requestFilename: '20260101-120000-anthropic-abc123-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
     mockContext = createMockCommandContext();
   });
 
@@ -172,30 +197,613 @@ describe('dumpcontextCommand', () => {
   });
 
   describe('now subcommand', () => {
-    it('should return message indicating immediate dump', async () => {
+    it('should dump context immediately and not set ephemeral setting', async () => {
       const mockSetEphemeralSetting = vi.fn();
       vi.mocked(getRuntimeApi).mockReturnValue({
         getEphemeralSetting: vi.fn(() => 'off'),
         setEphemeralSetting: mockSetEphemeralSetting,
       } as never);
 
-      // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
-      if (!dumpcontextCommand.action) {
-        throw new Error('dumpcontextCommand must have an action');
-      }
+      const mockGetHistoryService = vi.fn().mockReturnValue({
+        getAll: vi.fn().mockReturnValue([
+          { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
+          { speaker: 'ai', blocks: [{ type: 'text', text: 'Hi there' }] },
+        ]),
+      });
+      const mockGetProviderManager = vi.fn().mockReturnValue({
+        getActiveProviderName: vi.fn().mockReturnValue('anthropic'),
+      });
 
-      const result = await dumpcontextCommand.action(mockContext, 'now');
+      const ctxWithHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: mockGetHistoryService,
+            }),
+            getProviderManager: mockGetProviderManager,
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
 
-      expect(mockSetEphemeralSetting).toHaveBeenCalledWith(
-        'dumpcontext',
-        'now',
+      const result = await dumpcontextAction(ctxWithHistory, 'now');
+
+      expect(mockSetEphemeralSetting).not.toHaveBeenCalled();
+      expect(dumpRequestContext).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ url: 'immediate-context-dump' }),
+        'anthropic',
       );
       expect(result).toStrictEqual({
         type: 'message',
         messageType: 'info',
         content: expect.stringContaining(
-          'Context will be dumped on next request',
+          'Immediate request context dumped to 20260101-120000-anthropic-abc123-request.json',
         ),
+      });
+      expect(result).toMatchObject({
+        content: expect.stringContaining(
+          'No model request was sent, so no model response dump was created.',
+        ),
+      });
+    });
+
+    it('should shape immediate dump body for OpenAI history', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: vi.fn().mockReturnValue({
+                getAll: vi.fn().mockReturnValue([
+                  {
+                    speaker: 'human',
+                    blocks: [
+                      { type: 'text', text: 'Hello' },
+                      {
+                        type: 'media',
+                        mimeType: 'image/png',
+                        encoding: 'base64',
+                        data: 'abc123',
+                      },
+                    ],
+                  },
+                  {
+                    speaker: 'ai',
+                    blocks: [
+                      { type: 'text', text: 'Hi' },
+                      {
+                        type: 'tool_call',
+                        id: 'call_1',
+                        name: 'read_file',
+                        parameters: { path: 'README.md' },
+                      },
+                    ],
+                  },
+                  {
+                    speaker: 'tool',
+                    blocks: [
+                      {
+                        type: 'tool_response',
+                        callId: 'call_1',
+                        toolName: 'read_file',
+                        result: 'contents',
+                      },
+                    ],
+                  },
+                ]),
+              }),
+            }),
+            getEphemeralSettings: vi.fn().mockReturnValue({}),
+            getProviderManager: vi.fn().mockReturnValue({
+              getActiveProviderName: vi.fn().mockReturnValue('openai'),
+              getActiveProvider: vi.fn().mockReturnValue({
+                getCurrentModel: vi.fn().mockReturnValue('gpt-4.1'),
+              }),
+            }),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      await dumpcontextAction(ctxWithHistory, 'now');
+
+      const requestArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(requestArg.body.model).toBe('gpt-4.1');
+
+      expect(requestArg.body.messages[0].content).toStrictEqual([
+        { type: 'text', text: 'Hello' },
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/png;base64,abc123' },
+        },
+      ]);
+      expect(requestArg.body.messages[1]).toMatchObject({
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: {
+              name: 'read_file',
+              arguments: '{"path":"README.md"}',
+            },
+          },
+        ],
+      });
+      expect(requestArg.body.messages[2]).toMatchObject({
+        role: 'tool',
+        tool_call_id: 'call_1',
+      });
+    });
+
+    it('should shape immediate dump body for OpenAI-compatible aliases', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const history = [
+        { speaker: 'human', blocks: [{ type: 'text', text: 'Hello alias' }] },
+      ];
+      const ctxWithHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: vi.fn().mockReturnValue({
+                getAll: vi.fn().mockReturnValue(history),
+              }),
+            }),
+            getEphemeralSettings: vi.fn().mockReturnValue({}),
+            getProviderManager: vi.fn().mockReturnValue({
+              getActiveProviderName: vi.fn().mockReturnValue('openaivercel'),
+            }),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      await dumpcontextAction(ctxWithHistory, 'now');
+
+      const requestArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(requestArg.body).toHaveProperty('messages');
+      expect(requestArg.body).not.toHaveProperty('history');
+      expect(requestArg.body.messages[0]).toMatchObject({
+        role: 'user',
+        content: 'Hello alias',
+      });
+    });
+
+    it('should shape immediate dump body for Anthropic history', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: vi.fn().mockReturnValue({
+                getAll: vi.fn().mockReturnValue([
+                  {
+                    speaker: 'human',
+                    blocks: [
+                      { type: 'text', text: 'Question' },
+                      {
+                        type: 'media',
+                        mimeType: 'image/png',
+                        encoding: 'base64',
+                        data: 'abc123',
+                      },
+                    ],
+                  },
+                  {
+                    speaker: 'ai',
+                    blocks: [
+                      { type: 'text', text: 'Answer' },
+                      {
+                        type: 'tool_call',
+                        id: 'toolu_1',
+                        name: 'search',
+                        parameters: { q: 'docs' },
+                      },
+                    ],
+                  },
+                  {
+                    speaker: 'tool',
+                    blocks: [
+                      {
+                        type: 'tool_response',
+                        callId: 'toolu_1',
+                        toolName: 'search',
+                        result: 'found',
+                      },
+                    ],
+                  },
+                ]),
+              }),
+            }),
+            getEphemeralSettings: vi.fn().mockReturnValue({}),
+            getProviderManager: vi.fn().mockReturnValue({
+              getActiveProviderName: vi.fn().mockReturnValue('anthropic'),
+            }),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      await dumpcontextAction(ctxWithHistory, 'now');
+
+      const requestArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(requestArg.body.messages[0]).toMatchObject({
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Question' },
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'abc123' },
+          },
+        ],
+      });
+      expect(requestArg.body.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Answer' },
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'search',
+            input: { q: 'docs' },
+          },
+        ],
+      });
+      expect(requestArg.body.messages[2]).toMatchObject({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_1',
+          },
+        ],
+      });
+    });
+
+    it('should shape immediate dump body for Gemini history', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: vi.fn().mockReturnValue({
+                getAll: vi.fn().mockReturnValue([
+                  {
+                    speaker: 'human',
+                    blocks: [
+                      { type: 'text', text: 'Ping' },
+                      {
+                        type: 'media',
+                        mimeType: 'image/png',
+                        encoding: 'base64',
+                        data: 'abc123',
+                      },
+                    ],
+                  },
+                  {
+                    speaker: 'ai',
+                    blocks: [
+                      { type: 'text', text: 'Pong' },
+                      {
+                        type: 'tool_call',
+                        id: 'call_1',
+                        name: 'lookup',
+                        parameters: { id: 7 },
+                      },
+                    ],
+                  },
+                  {
+                    speaker: 'tool',
+                    blocks: [
+                      {
+                        type: 'tool_response',
+                        callId: 'call_1',
+                        toolName: 'lookup',
+                        result: { ok: true },
+                      },
+                    ],
+                  },
+                ]),
+              }),
+            }),
+            getEphemeralSettings: vi.fn().mockReturnValue({}),
+            getProviderManager: vi.fn().mockReturnValue({
+              getActiveProviderName: vi.fn().mockReturnValue('gemini'),
+              getActiveProvider: vi.fn().mockReturnValue({
+                getCurrentModel: vi.fn().mockReturnValue('gemini-2.5-pro'),
+              }),
+            }),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      await dumpcontextAction(ctxWithHistory, 'now');
+
+      const requestArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(requestArg.body.model).toBe('gemini-2.5-pro');
+
+      expect(requestArg.body.contents).toStrictEqual([
+        {
+          role: 'user',
+          parts: [
+            { text: 'Ping' },
+            { inlineData: { mimeType: 'image/png', data: 'abc123' } },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [
+            { text: 'Pong' },
+            { functionCall: { id: 'call_1', name: 'lookup', args: { id: 7 } } },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'call_1',
+                name: 'lookup',
+                response: expect.objectContaining({ result: '{"ok":true}' }),
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should pass active config and model into Gemini immediate dump conversion', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const longResult = Array.from(
+        { length: 200 },
+        (_, i) => `line-${i}`,
+      ).join('\n');
+      const config = {
+        getAgentClient: vi.fn().mockReturnValue({
+          getHistoryService: vi.fn().mockReturnValue({
+            getAll: vi.fn().mockReturnValue([
+              {
+                speaker: 'tool',
+                blocks: [
+                  {
+                    type: 'tool_response',
+                    callId: 'call_1',
+                    toolName: 'search',
+                    result: longResult,
+                  },
+                  {
+                    type: 'media',
+                    mimeType: 'image/png',
+                    encoding: 'base64',
+                    data: 'image-data',
+                  },
+                ],
+              },
+            ]),
+          }),
+        }),
+        getProviderManager: vi.fn().mockReturnValue({
+          getActiveProviderName: vi.fn().mockReturnValue('gemini'),
+          getActiveProvider: vi.fn().mockReturnValue({
+            getCurrentModel: vi.fn().mockReturnValue('gemini-3-pro'),
+          }),
+        }),
+        getEphemeralSettings: vi.fn().mockReturnValue({
+          'tool-output-max-tokens': 5,
+          'tool-output-truncate-mode': 'warn',
+        }),
+      } as unknown as CommandContext['services']['config'];
+      const ctxWithHistory = createMockCommandContext({
+        services: { config },
+      });
+
+      await dumpcontextAction(ctxWithHistory, 'now');
+
+      const requestArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      const functionResponse =
+        requestArg.body.contents[0].parts[0].functionResponse;
+      expect(functionResponse.response).toMatchObject({
+        status: 'success',
+        truncated: true,
+        limitMessage: expect.stringContaining(
+          'search output exceeded token limit',
+        ),
+      });
+      expect(functionResponse.parts).toStrictEqual([
+        { inlineData: { mimeType: 'image/png', data: 'image-data' } },
+      ]);
+    });
+
+    it('should keep raw history for unknown providers', async () => {
+      const history = [
+        { speaker: 'human', blocks: [{ type: 'text', text: 'Hi' }] },
+      ];
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: vi.fn().mockReturnValue({
+                getAll: vi.fn().mockReturnValue(history),
+              }),
+            }),
+            getEphemeralSettings: vi.fn().mockReturnValue({}),
+            getProviderManager: vi.fn().mockReturnValue({
+              getActiveProviderName: vi.fn().mockReturnValue('custom'),
+            }),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      await dumpcontextAction(ctxWithHistory, 'now');
+
+      const requestArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(requestArg.body).toStrictEqual({ history });
+    });
+
+    it('should return friendly error when history is unavailable', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithoutHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue(null),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      const result = await dumpcontextAction(ctxWithoutHistory, 'now');
+
+      expect(dumpRequestContext).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('not available'),
+      });
+    });
+
+    it('should return friendly error when agent client is undefined', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithoutAgentClient = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue(undefined),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      const result = await dumpcontextAction(ctxWithoutAgentClient, 'now');
+
+      expect(dumpRequestContext).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('not available'),
+      });
+    });
+
+    it('should default provider name to backend when no provider manager', async () => {
+      const mockSetEphemeralSetting = vi.fn();
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: mockSetEphemeralSetting,
+      } as never);
+
+      const mockGetHistoryService = vi.fn().mockReturnValue({
+        getAll: vi
+          .fn()
+          .mockReturnValue([
+            { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
+          ]),
+      });
+
+      const ctxNoProviderManager = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: mockGetHistoryService,
+            }),
+            getProviderManager: vi.fn().mockReturnValue(undefined),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      await dumpcontextAction(ctxNoProviderManager, 'now');
+
+      expect(dumpRequestContext).toHaveBeenCalledOnce();
+      const requestArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(requestArg.method).toBe('DUMP');
+      expect(requestArg.url).toBe('immediate-context-dump');
+      // Provider should default to 'backend' when no provider manager
+      const providerArg = (dumpRequestContext as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(providerArg).toBe('backend');
+    });
+
+    it('should return friendly error when history service returns null', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithNullHistory = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: vi.fn().mockReturnValue({
+              getHistoryService: vi.fn().mockReturnValue(null),
+            }),
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      const result = await dumpcontextAction(ctxWithNullHistory, 'now');
+
+      expect(dumpRequestContext).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('not available'),
+      });
+    });
+
+    it('should return friendly error when getAgentClient is not callable', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const ctxWithoutCallableAgentClient = createMockCommandContext({
+        services: {
+          config: {
+            getAgentClient: undefined,
+          } as unknown as CommandContext['services']['config'],
+        },
+      });
+
+      const result = await dumpcontextAction(
+        ctxWithoutCallableAgentClient,
+        'now',
+      );
+
+      expect(dumpRequestContext).not.toHaveBeenCalled();
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('not available'),
       });
     });
   });

--- a/packages/cli/src/ui/commands/dumpcontextCommand.ts
+++ b/packages/cli/src/ui/commands/dumpcontextCommand.ts
@@ -19,13 +19,112 @@ import { CommandKind } from './types.js';
 import type { CommandArgumentSchema } from './schema/types.js';
 import { getRuntimeApi } from '../contexts/RuntimeContext.js';
 import type { DumpMode } from '@vybestack/llxprt-code-providers';
+import {
+  buildProviderDumpBody,
+  dumpRequestContext,
+} from '@vybestack/llxprt-code-providers';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
+
+type HistoryService = { getAll: () => unknown };
+
+type AgentClientWithHistory = {
+  getHistoryService?: () => HistoryService | null;
+};
+
+type ConfigWithMaybeAgentClient = NonNullable<
+  CommandContext['services']['config']
+> & {
+  getAgentClient: () => AgentClientWithHistory | null | undefined;
+};
+
+type ProviderManagerWithActive = {
+  getActiveProviderName?: () => string | undefined;
+  getActiveProvider?: () => { getCurrentModel?: () => string | undefined };
+};
+
+const historyUnavailableMessage =
+  'History is not available. Start a conversation first before dumping context.';
 
 const validModes: DumpMode[] = ['now', 'status', 'on', 'error', 'off'];
 
 function isValidMode(mode: string): mode is DumpMode {
   return validModes.includes(mode as DumpMode);
+}
+
+function hasCallableGetAgentClient(
+  config: CommandContext['services']['config'],
+): config is ConfigWithMaybeAgentClient {
+  return typeof config?.getAgentClient === 'function';
+}
+
+function getHistoryService(
+  config: CommandContext['services']['config'],
+): HistoryService | null {
+  if (!hasCallableGetAgentClient(config)) {
+    return null;
+  }
+  const getAgentClient: () => unknown = config.getAgentClient;
+  const agentClient = getAgentClient();
+  if (
+    typeof agentClient !== 'object' ||
+    agentClient === null ||
+    !('getHistoryService' in agentClient) ||
+    typeof agentClient.getHistoryService !== 'function'
+  ) {
+    return null;
+  }
+  return agentClient.getHistoryService() as HistoryService | null;
+}
+
+function getProviderDumpMetadata(
+  config: NonNullable<CommandContext['services']['config']>,
+): { providerName: string; activeModel: string | undefined } {
+  const providerManager = config.getProviderManager() as
+    | ProviderManagerWithActive
+    | undefined;
+  if (!providerManager) {
+    return { providerName: 'backend', activeModel: undefined };
+  }
+  const activeProvider = providerManager.getActiveProvider?.();
+  return {
+    providerName: providerManager.getActiveProviderName?.() ?? 'backend',
+    activeModel: activeProvider?.getCurrentModel?.(),
+  };
+}
+
+async function dumpImmediateContext(
+  context: CommandContext,
+): Promise<MessageActionReturn> {
+  const config = context.services.config;
+  const historyService = getHistoryService(config);
+  if (!config || !historyService) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: historyUnavailableMessage,
+    };
+  }
+  const history = historyService.getAll() as IContent[];
+  const { providerName, activeModel } = getProviderDumpMetadata(config);
+  const request = {
+    url: 'immediate-context-dump',
+    method: 'DUMP',
+    body: buildProviderDumpBody({
+      providerName,
+      history,
+      settings: context.services.settings,
+      config,
+      model: activeModel,
+    }),
+  };
+  const result = await dumpRequestContext(request, providerName);
+  return {
+    type: 'message',
+    messageType: 'info',
+    content: `Immediate request context dumped to ${result.requestFilename}\nNo model request was sent, so no model response dump was created.\nDump directory: ${result.dumpDir}`,
+  };
 }
 
 /**
@@ -35,7 +134,7 @@ const dumpcontextSchema: CommandArgumentSchema = [
   {
     kind: 'literal',
     value: 'now',
-    description: 'Dump context on next request only',
+    description: 'Dump context immediately',
   },
   {
     kind: 'literal',
@@ -90,15 +189,18 @@ export const dumpcontextCommand: SlashCommand = {
         return {
           type: 'message',
           messageType: 'info',
-          content: `Context dumping: ${currentMode}\n\nDump directory: ${dumpDir}\n\nAvailable modes:\n- now: Dump context on next request only\n- on: Dump context before every request\n- error: Dump context only on errors\n- off: Disable context dumping\n- status: Show current status (default)`,
+          content: `Context dumping: ${currentMode}\n\nDump directory: ${dumpDir}\n\nAvailable modes:\n- now: Dump context immediately\n- on: Dump context before every request\n- error: Dump context only on errors\n- off: Disable context dumping\n- status: Show current status (default)`,
         };
+      }
+
+      if (mode === 'now') {
+        return await dumpImmediateContext(context);
       }
 
       // Handle mode changes
       runtime.setEphemeralSetting('dumpcontext', mode);
 
-      const messages: Record<DumpMode, string> = {
-        now: `Context will be dumped on next request.\nDump directory: ${dumpDir}`,
+      const messages: Record<Exclude<DumpMode, 'now'>, string> = {
         on: `Context dumping enabled for all requests.\nDumps will be saved to: ${dumpDir}`,
         error: `Context dumping enabled for errors only.\nDumps will be saved to: ${dumpDir}`,
         off: 'Context dumping disabled.',

--- a/packages/providers/src/anthropic/AnthropicApiExecution.dumpContext.test.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.dumpContext.test.ts
@@ -1,0 +1,377 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { executeAnthropicApiCall } from './AnthropicApiExecution.js';
+import * as dumpSDKContextModule from '../utils/dumpSDKContext.js';
+import type Anthropic from '@anthropic-ai/sdk';
+
+describe('executeAnthropicApiCall dumpContext behavior', () => {
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKContextSpy: ReturnType<typeof vi.spyOn>;
+
+  const requestBody: Record<string, unknown> = {
+    model: 'claude-sonnet-4-5-20250929',
+    messages: [{ role: 'user', content: 'Hello' }],
+  };
+
+  const baseURL = 'https://api.anthropic.com';
+
+  const rateLimitLogger = { debug: vi.fn() };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-anthropic-test12',
+      requestFilename: '20260101-120000-anthropic-test12-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-anthropic-test12-response.json',
+    );
+
+    dumpSDKContextSpy = vi.spyOn(dumpSDKContextModule, 'dumpSDKContext');
+    dumpSDKContextSpy.mockResolvedValue('dump-file.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('on mode - pre-request dump before API call', () => {
+    it('should write request dump file BEFORE the API call is made', async () => {
+      const callOrder: string[] = [];
+
+      dumpSDKRequestContextSpy.mockImplementation(async () => {
+        callOrder.push('dumpSDKRequestContext');
+        return {
+          baseId: 'base-123',
+          requestFilename: 'base-123-request.json',
+          dumpDir: '/tmp/.llxprt/dumps',
+        };
+      });
+
+      const apiCallFn = vi.fn(async () => {
+        callOrder.push('apiCall');
+        return {
+          data: {
+            id: 'msg_test',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hi' }],
+            model: 'claude-sonnet-4-5-20250929',
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 10, output_tokens: 5 },
+          } as unknown as Anthropic.Message,
+          response: undefined,
+        };
+      });
+
+      await executeAnthropicApiCall({
+        apiCallFn,
+        dumpMode: 'on',
+        baseURL,
+        requestBody,
+        streamingEnabled: false,
+        rateLimitLogger,
+      });
+
+      expect(callOrder[0]).toBe('dumpSDKRequestContext');
+      expect(callOrder[1]).toBe('apiCall');
+    });
+
+    it('should write linked response dump file after successful non-streaming call', async () => {
+      const apiCallFn = vi.fn(async () => ({
+        data: {
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hi' }],
+          model: 'claude-sonnet-4-5-20250929',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        } as unknown as Anthropic.Message,
+        response: undefined,
+      }));
+
+      await executeAnthropicApiCall({
+        apiCallFn,
+        dumpMode: 'on',
+        baseURL,
+        requestBody,
+        streamingEnabled: false,
+        rateLimitLogger,
+      });
+
+      expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+      expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+
+      const [baseId] = dumpSDKResponseContextSpy.mock.calls[0];
+      expect(baseId).toBe('20260101-120000-anthropic-test12');
+    });
+  });
+
+  describe('on mode - streaming response accumulation', () => {
+    it('should wrap the stream, pass chunks through unchanged, and write linked response after stream completes', async () => {
+      const events: Anthropic.MessageStreamEvent[] = [
+        {
+          type: 'message_start',
+          message: {
+            id: 'msg_test',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-sonnet-4-5-20250929',
+            content: [],
+            stop_reason: null,
+            usage: {
+              input_tokens: 10,
+              output_tokens: 0,
+            },
+          },
+        } as unknown as Anthropic.MessageStreamEvent,
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Hello' },
+        } as unknown as Anthropic.MessageStreamEvent,
+        {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: ' world' },
+        } as unknown as Anthropic.MessageStreamEvent,
+        {
+          type: 'message_stop',
+        } as unknown as Anthropic.MessageStreamEvent,
+      ];
+
+      const originalStream: AsyncIterable<Anthropic.MessageStreamEvent> = {
+        async *[Symbol.asyncIterator]() {
+          for (const event of events) {
+            yield event;
+          }
+        },
+      };
+
+      const apiCallFn = vi.fn(async () => ({
+        data: originalStream as unknown as AsyncIterable<Anthropic.MessageStreamEvent>,
+        response: undefined,
+      }));
+
+      const result = await executeAnthropicApiCall({
+        apiCallFn,
+        dumpMode: 'on',
+        baseURL,
+        requestBody,
+        streamingEnabled: true,
+        rateLimitLogger,
+      });
+
+      const stream =
+        result.response as AsyncIterable<Anthropic.MessageStreamEvent>;
+
+      const received: Anthropic.MessageStreamEvent[] = [];
+      for await (const chunk of stream) {
+        received.push(chunk);
+      }
+
+      expect(received).toHaveLength(events.length);
+      expect(received).toStrictEqual(events);
+
+      expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+      const [baseId, , responseBody, isError] =
+        dumpSDKResponseContextSpy.mock.calls[0];
+      expect(baseId).toBe('20260101-120000-anthropic-test12');
+      expect(isError).toBe(false);
+      expect(responseBody).toStrictEqual({
+        streaming: true,
+        chunks: events,
+        completed: true,
+      });
+    });
+
+    it('should write response dump with accumulated chunks even if stream yields zero chunks', async () => {
+      const originalStream: AsyncIterable<Anthropic.MessageStreamEvent> = {
+        async *[Symbol.asyncIterator]() {
+          // Empty stream
+        },
+      };
+
+      const apiCallFn = vi.fn(async () => ({
+        data: originalStream as unknown as AsyncIterable<Anthropic.MessageStreamEvent>,
+        response: undefined,
+      }));
+
+      const result = await executeAnthropicApiCall({
+        apiCallFn,
+        dumpMode: 'on',
+        baseURL,
+        requestBody,
+        streamingEnabled: true,
+        rateLimitLogger,
+      });
+
+      const stream =
+        result.response as AsyncIterable<Anthropic.MessageStreamEvent>;
+      for await (const _chunk of stream) {
+        void _chunk;
+      }
+
+      expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+      const [, , responseBody] = dumpSDKResponseContextSpy.mock.calls[0];
+      expect(responseBody).toStrictEqual({
+        streaming: true,
+        chunks: [],
+        completed: true,
+      });
+    });
+
+    it('should write response dump after stream completes even if iteration errors', async () => {
+      const originalStream: AsyncIterable<Anthropic.MessageStreamEvent> = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'partial' },
+          } as unknown as Anthropic.MessageStreamEvent;
+          throw new Error('Stream interrupted');
+        },
+      };
+
+      const apiCallFn = vi.fn(async () => ({
+        data: originalStream as unknown as AsyncIterable<Anthropic.MessageStreamEvent>,
+        response: undefined,
+      }));
+
+      const result = await executeAnthropicApiCall({
+        apiCallFn,
+        dumpMode: 'on',
+        baseURL,
+        requestBody,
+        streamingEnabled: true,
+        rateLimitLogger,
+      });
+
+      const stream =
+        result.response as AsyncIterable<Anthropic.MessageStreamEvent>;
+
+      const received: Anthropic.MessageStreamEvent[] = [];
+      await expect(async () => {
+        for await (const chunk of stream) {
+          received.push(chunk);
+        }
+      }).rejects.toThrow('Stream interrupted');
+
+      expect(received).toHaveLength(1);
+      // Response dump should still be written with accumulated chunks
+      expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+      const [, , responseBody, isError] =
+        dumpSDKResponseContextSpy.mock.calls[0];
+      expect(responseBody).toMatchObject({
+        streaming: true,
+        chunks: expect.arrayContaining(received),
+        error: 'Error: Stream interrupted',
+      });
+      expect(isError).toBe(true);
+    });
+  });
+
+  describe('error mode - no pre-dump on success, dump after error', () => {
+    it('should NOT write request dump when error mode and API call succeeds', async () => {
+      const apiCallFn = vi.fn(async () => ({
+        data: {
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hi' }],
+          model: 'claude-sonnet-4-5-20250929',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        } as unknown as Anthropic.Message,
+        response: undefined,
+      }));
+
+      await executeAnthropicApiCall({
+        apiCallFn,
+        dumpMode: 'error',
+        baseURL,
+        requestBody,
+        streamingEnabled: false,
+        rateLimitLogger,
+      });
+
+      expect(dumpSDKRequestContextSpy).not.toHaveBeenCalled();
+      expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+      expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+    });
+
+    it('should dump after error with linked request/response when error mode', async () => {
+      const apiCallFn = vi.fn(async () => {
+        throw new Error('API Error: Rate limit exceeded');
+      });
+
+      await expect(
+        executeAnthropicApiCall({
+          apiCallFn,
+          dumpMode: 'error',
+          baseURL,
+          requestBody,
+          streamingEnabled: false,
+          rateLimitLogger,
+        }),
+      ).rejects.toThrow('API Error');
+
+      expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+      expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+        '20260101-120000-anthropic-test12',
+        'anthropic',
+        { error: 'API Error: Rate limit exceeded' },
+        true,
+      );
+      expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('off mode - no dumps', () => {
+    it('should not write any dump files when mode is off', async () => {
+      const apiCallFn = vi.fn(async () => ({
+        data: {
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hi' }],
+          model: 'claude-sonnet-4-5-20250929',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        } as unknown as Anthropic.Message,
+        response: undefined,
+      }));
+
+      await executeAnthropicApiCall({
+        apiCallFn,
+        dumpMode: 'off',
+        baseURL,
+        requestBody,
+        streamingEnabled: false,
+        rateLimitLogger,
+      });
+
+      expect(dumpSDKRequestContextSpy).not.toHaveBeenCalled();
+      expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+      expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicApiExecution.separateDump.test.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.separateDump.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as dumpSDKContextModule from '../utils/dumpSDKContext.js';
+import {
+  executeAnthropicApiCall,
+  type ApiExecutionParams,
+} from './AnthropicApiExecution.js';
+
+describe('AnthropicApiExecution separate request/response dump', () => {
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKContextSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-anthropic-test12',
+      requestFilename: '20260101-120000-anthropic-test12-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-anthropic-test12-response.json',
+    );
+
+    dumpSDKContextSpy = vi.spyOn(dumpSDKContextModule, 'dumpSDKContext');
+    dumpSDKContextSpy.mockResolvedValue('legacy-dump.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should dump request before API call and response after in on mode (non-streaming)', async () => {
+    const callOrder: string[] = [];
+
+    const apiCallFn = vi.fn().mockImplementation(async () => {
+      callOrder.push('apiCall');
+      return {
+        data: {
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hi' }],
+          model: 'claude-sonnet-4-5-20250929',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        response: undefined,
+      };
+    });
+
+    dumpSDKRequestContextSpy.mockImplementation(async () => {
+      callOrder.push('requestDump');
+      return {
+        baseId: '20260101-120000-anthropic-test12',
+        requestFilename: '20260101-120000-anthropic-test12-request.json',
+        dumpDir: '/tmp/.llxprt/dumps',
+      };
+    });
+
+    dumpSDKResponseContextSpy.mockImplementation(async () => {
+      callOrder.push('responseDump');
+      return '20260101-120000-anthropic-test12-response.json';
+    });
+
+    const params: ApiExecutionParams = {
+      apiCallFn,
+      dumpMode: 'on',
+      baseURL: 'https://api.anthropic.com',
+      requestBody: { model: 'claude-sonnet-4-5-20250929', messages: [] },
+      streamingEnabled: false,
+      rateLimitLogger: { debug: vi.fn() },
+    };
+
+    await executeAnthropicApiCall(params);
+
+    expect(callOrder).toStrictEqual(['requestDump', 'apiCall', 'responseDump']);
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    const [reqProvider, reqEndpoint, reqBody, reqBaseURL] =
+      dumpSDKRequestContextSpy.mock.calls[0];
+    expect(reqProvider).toBe('anthropic');
+    expect(reqEndpoint).toBe('/v1/messages');
+    expect(reqBody).toStrictEqual(params.requestBody);
+    expect(reqBaseURL).toBe('https://api.anthropic.com');
+
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+    const [respBaseId, respProvider, , respIsError] =
+      dumpSDKResponseContextSpy.mock.calls[0];
+    expect(respBaseId).toBe('20260101-120000-anthropic-test12');
+    expect(respProvider).toBe('anthropic');
+    expect(respIsError).toBe(false);
+
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write separate related request and error response dumps in error mode', async () => {
+    const callOrder: string[] = [];
+
+    const apiCallFn = vi.fn().mockImplementation(async () => {
+      callOrder.push('apiCall');
+      throw new Error('Rate limit exceeded');
+    });
+
+    dumpSDKRequestContextSpy.mockImplementation(async () => {
+      callOrder.push('errorRequestDump');
+      return {
+        baseId: '20260101-120000-anthropic-test12',
+        requestFilename: '20260101-120000-anthropic-test12-request.json',
+        dumpDir: '/tmp',
+      };
+    });
+    dumpSDKResponseContextSpy.mockImplementation(async () => {
+      callOrder.push('errorResponseDump');
+      return '20260101-120000-anthropic-test12-response.json';
+    });
+
+    const params: ApiExecutionParams = {
+      apiCallFn,
+      dumpMode: 'error',
+      baseURL: 'https://api.anthropic.com',
+      requestBody: { model: 'claude-sonnet-4-5-20250929', messages: [] },
+      streamingEnabled: false,
+      rateLimitLogger: { debug: vi.fn() },
+    };
+
+    await expect(executeAnthropicApiCall(params)).rejects.toThrow(
+      'Rate limit exceeded',
+    );
+
+    expect(callOrder).toStrictEqual([
+      'apiCall',
+      'errorRequestDump',
+      'errorResponseDump',
+    ]);
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
+      '20260101-120000-anthropic-test12',
+      'anthropic',
+      { error: 'Rate limit exceeded' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not dump request or response when mode is off', async () => {
+    const apiCallFn = vi.fn().mockResolvedValue({
+      data: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi' }],
+      },
+      response: undefined,
+    });
+
+    const params: ApiExecutionParams = {
+      apiCallFn,
+      dumpMode: 'off',
+      baseURL: 'https://api.anthropic.com',
+      requestBody: { model: 'claude-sonnet-4-5-20250929', messages: [] },
+      streamingEnabled: false,
+      rateLimitLogger: { debug: vi.fn() },
+    };
+
+    await executeAnthropicApiCall(params);
+
+    expect(dumpSDKRequestContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should send API request when request dump fails', async () => {
+    const apiCallFn = vi.fn().mockResolvedValue({
+      data: { id: 'msg_test', type: 'message', role: 'assistant', content: [] },
+      response: undefined,
+    });
+    const logger = { debug: vi.fn() };
+    dumpSDKRequestContextSpy.mockRejectedValueOnce(new Error('disk full'));
+
+    const params: ApiExecutionParams = {
+      apiCallFn,
+      dumpMode: 'on',
+      baseURL: 'https://api.anthropic.com',
+      requestBody: { model: 'claude-sonnet-4-5-20250929', messages: [] },
+      streamingEnabled: false,
+      rateLimitLogger: logger,
+    };
+
+    await executeAnthropicApiCall(params);
+
+    expect(apiCallFn).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('should dump streaming iteration errors in error mode after passing through chunks', async () => {
+    const chunks = [{ type: 'message_start', message: { id: 'msg_test' } }];
+    const stream = (async function* () {
+      yield chunks[0];
+      throw new Error('Anthropic stream failed');
+    })();
+    const apiCallFn = vi.fn().mockResolvedValue({
+      data: stream,
+      response: undefined,
+    });
+    const params: ApiExecutionParams = {
+      apiCallFn,
+      dumpMode: 'error',
+      baseURL: 'https://api.anthropic.com',
+      requestBody: { model: 'claude-sonnet-4-5-20250929', messages: [] },
+      streamingEnabled: true,
+      rateLimitLogger: { debug: vi.fn() },
+    };
+
+    const result = await executeAnthropicApiCall(params);
+    const received: unknown[] = [];
+    await expect(async () => {
+      for await (const chunk of result.response as AsyncIterable<unknown>) {
+        received.push(chunk);
+      }
+    }).rejects.toThrow('Anthropic stream failed');
+
+    expect(received).toStrictEqual(chunks);
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-anthropic-test12',
+      'anthropic',
+      {
+        streaming: true,
+        chunks,
+        error: 'Error: Anthropic stream failed',
+        completed: false,
+      },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not dump before success when mode is error and request succeeds', async () => {
+    const apiCallFn = vi.fn().mockResolvedValue({
+      data: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi' }],
+      },
+      response: undefined,
+    });
+
+    const params: ApiExecutionParams = {
+      apiCallFn,
+      dumpMode: 'error',
+      baseURL: 'https://api.anthropic.com',
+      requestBody: { model: 'claude-sonnet-4-5-20250929', messages: [] },
+      streamingEnabled: false,
+      rateLimitLogger: { debug: vi.fn() },
+    };
+
+    await executeAnthropicApiCall(params);
+
+    expect(dumpSDKRequestContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicApiExecution.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.ts
@@ -15,7 +15,12 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { DumpMode } from '../utils/dumpContext.js';
 import {
   shouldDumpSDKContext,
-  dumpSDKContext,
+  dumpSDKRequestContext,
+  dumpSDKResponseContext,
+  wrapStreamWithDump,
+  wrapStreamWithSDKErrorDump,
+  bestEffortDump,
+  dumpSDKErrorRequestResponse,
 } from '../utils/dumpSDKContext.js';
 import {
   type AnthropicRateLimitInfo,
@@ -162,78 +167,148 @@ export interface ApiExecutionResult {
   rateLimitInfo?: AnthropicRateLimitInfo;
 }
 
+async function dumpAnthropicRequest(
+  params: ApiExecutionParams,
+  shouldDumpSuccess: boolean,
+): Promise<string | undefined> {
+  if (!shouldDumpSuccess) {
+    return undefined;
+  }
+  const reqResult = await bestEffortDump(
+    'request',
+    'anthropic',
+    () =>
+      dumpSDKRequestContext(
+        'anthropic',
+        '/v1/messages',
+        params.requestBody,
+        params.baseURL,
+      ),
+    params.rateLimitLogger,
+  );
+  return reqResult?.baseId;
+}
+
+async function dumpAnthropicApiError(
+  params: ApiExecutionParams,
+  error: unknown,
+  requestBaseId: string | undefined,
+): Promise<void> {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  if (requestBaseId) {
+    await bestEffortDump(
+      'error-response',
+      'anthropic',
+      () =>
+        dumpSDKResponseContext(
+          requestBaseId,
+          'anthropic',
+          { error: errorMessage },
+          true,
+        ),
+      params.rateLimitLogger,
+    );
+    return;
+  }
+  await dumpSDKErrorRequestResponse(
+    'anthropic',
+    '/v1/messages',
+    params.requestBody,
+    { error: errorMessage },
+    params.baseURL,
+    dumpSDKRequestContext,
+    dumpSDKResponseContext,
+  );
+}
+
+async function handleAnthropicSuccessDump(
+  params: ApiExecutionParams,
+  response: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>,
+  shouldDumpSuccess: boolean,
+  shouldDumpError: boolean,
+  requestBaseId: string | undefined,
+): Promise<Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>> {
+  if (shouldDumpSuccess && requestBaseId) {
+    if (params.streamingEnabled) {
+      return wrapStreamWithDump(
+        response as AsyncIterable<Anthropic.MessageStreamEvent>,
+        requestBaseId,
+        'anthropic',
+        dumpSDKResponseContext,
+      );
+    }
+    await bestEffortDump(
+      'response',
+      'anthropic',
+      () => dumpSDKResponseContext(requestBaseId, 'anthropic', response, false),
+      params.rateLimitLogger,
+    );
+    return response;
+  }
+  if (params.streamingEnabled && shouldDumpError) {
+    return wrapStreamWithSDKErrorDump(
+      response as AsyncIterable<Anthropic.MessageStreamEvent>,
+      'anthropic',
+      '/v1/messages',
+      params.requestBody,
+      params.baseURL,
+      dumpSDKRequestContext,
+      dumpSDKResponseContext,
+    );
+  }
+  return response;
+}
+
+function extractAnthropicRateLimitInfo(
+  response: Response | undefined,
+  rateLimitLogger: ApiExecutionParams['rateLimitLogger'],
+): {
+  responseHeaders: Headers | undefined;
+  rateLimitInfo: AnthropicRateLimitInfo | undefined;
+} {
+  if (!response) {
+    return { responseHeaders: undefined, rateLimitInfo: undefined };
+  }
+  const responseHeaders = response.headers;
+  const rateLimitInfo = extractRateLimitHeaders(
+    responseHeaders,
+    rateLimitLogger,
+  );
+  rateLimitLogger.debug(() => formatRateLimitSummary(rateLimitInfo));
+  checkRateLimits(rateLimitInfo, rateLimitLogger);
+  return { responseHeaders, rateLimitInfo };
+}
+
 /**
  * Execute Anthropic API call with dump context handling and rate limit extraction
  */
 export async function executeAnthropicApiCall(
   params: ApiExecutionParams,
 ): Promise<ApiExecutionResult> {
-  const {
-    apiCallFn,
-    dumpMode,
-    baseURL,
-    requestBody,
-    streamingEnabled,
-    rateLimitLogger,
-  } = params;
-
-  const shouldDumpSuccess = shouldDumpSDKContext(dumpMode, false);
-  const shouldDumpError = shouldDumpSDKContext(dumpMode, true);
-
-  let responseHeaders: Headers | undefined;
-  let response: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>;
-  let rateLimitInfo: AnthropicRateLimitInfo | undefined;
+  const shouldDumpSuccess = shouldDumpSDKContext(params.dumpMode, false);
+  const shouldDumpError = shouldDumpSDKContext(params.dumpMode, true);
+  const requestBaseId = await dumpAnthropicRequest(params, shouldDumpSuccess);
 
   try {
-    // REQ-RETRY-001: Retry logic is now handled by RetryOrchestrator at a higher level
-    const result = await apiCallFn();
-
-    response = result.data as
+    const result = await params.apiCallFn();
+    const rawResponse = result.data as
       | Anthropic.Message
       | AsyncIterable<Anthropic.MessageStreamEvent>;
-
-    // Dump successful request if enabled
-    if (shouldDumpSuccess) {
-      await dumpSDKContext(
-        'anthropic',
-        '/v1/messages',
-        requestBody,
-        streamingEnabled ? { streaming: true } : response,
-        false,
-        baseURL,
-      );
-    }
-
-    if (result.response) {
-      responseHeaders = result.response.headers;
-
-      // Extract and process rate limit headers
-      rateLimitInfo = extractRateLimitHeaders(responseHeaders, rateLimitLogger);
-
-      const info = rateLimitInfo;
-      rateLimitLogger.debug(() => formatRateLimitSummary(info));
-
-      // Check and warn if approaching limits
-      checkRateLimits(info, rateLimitLogger);
-    }
+    const response = await handleAnthropicSuccessDump(
+      params,
+      rawResponse,
+      shouldDumpSuccess,
+      shouldDumpError,
+      requestBaseId,
+    );
+    return {
+      response,
+      ...extractAnthropicRateLimitInfo(result.response, params.rateLimitLogger),
+    };
   } catch (error) {
-    // Dump error if enabled
     if (shouldDumpError) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      await dumpSDKContext(
-        'anthropic',
-        '/v1/messages',
-        requestBody,
-        { error: errorMessage },
-        true,
-        baseURL,
-      );
+      await dumpAnthropicApiError(params, error, requestBaseId);
     }
-
-    // Re-throw the error
     throw error;
   }
-
-  return { response, responseHeaders, rateLimitInfo };
 }

--- a/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
@@ -161,6 +161,7 @@ describe('AnthropicProvider dumpContext integration', () => {
     expect(respProvider).toBe('anthropic');
     expect(respIsError).toBe(false);
     expect(respBody).toBeDefined();
+    expect(dumpContextSpy).not.toHaveBeenCalled();
   });
 
   it('should dump context only on error when mode is error', async () => {

--- a/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.dumpContext.test.ts
@@ -7,20 +7,39 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AnthropicProvider } from './AnthropicProvider.js';
 import * as dumpContextModule from '../utils/dumpContext.js';
+import * as dumpSDKContextModule from '../utils/dumpSDKContext.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 
 describe('AnthropicProvider dumpContext integration', () => {
   let provider: AnthropicProvider;
   let dumpContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    // Create provider with mock API key
     provider = new AnthropicProvider('sk-ant-test-key');
 
-    // Spy on dumpContext function
     dumpContextSpy = vi.spyOn(dumpContextModule, 'dumpContext');
     dumpContextSpy.mockResolvedValue('test-dump-file.json');
+
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-anthropic-test12',
+      requestFilename: '20260101-120000-anthropic-test12-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-anthropic-test12-response.json',
+    );
   });
 
   afterEach(() => {
@@ -129,16 +148,19 @@ describe('AnthropicProvider dumpContext integration', () => {
       results.push(chunk);
     }
 
-    // Should have called dumpContext with SDK-level data
-    expect(dumpContextSpy).toHaveBeenCalledOnce();
-    const [request, response, providerName] = dumpContextSpy.mock.calls[0];
-    expect(providerName).toBe('anthropic');
-    expect(request.url).toContain('anthropic.com');
-    expect(request.method).toBe('POST');
-    expect(request.body).toHaveProperty('model');
-    expect(request.body).toHaveProperty('messages');
-    expect(response).toHaveProperty('status');
-    expect(response).toHaveProperty('body');
+    // Should have called separate request and response dumps
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+
+    const [reqProvider, reqEndpoint] = dumpSDKRequestContextSpy.mock.calls[0];
+    expect(reqProvider).toBe('anthropic');
+    expect(reqEndpoint).toBe('/v1/messages');
+
+    const [, respProvider, respBody, respIsError] =
+      dumpSDKResponseContextSpy.mock.calls[0];
+    expect(respProvider).toBe('anthropic');
+    expect(respIsError).toBe(false);
+    expect(respBody).toBeDefined();
   });
 
   it('should dump context only on error when mode is error', async () => {
@@ -238,23 +260,24 @@ describe('AnthropicProvider dumpContext integration', () => {
       }
     }).rejects.toThrow(/API Error/);
 
-    // Should have called dumpContext on error
-    expect(dumpContextSpy).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({
-        url: expect.stringContaining('anthropic.com'),
-        method: 'POST',
-      }),
-      expect.objectContaining({
-        status: expect.any(Number),
-        body: expect.objectContaining({
-          error: expect.any(String),
-        }),
-      }),
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledExactlyOnceWith(
       'anthropic',
+      '/v1/messages',
+      expect.objectContaining({
+        model: 'claude-sonnet-4-5-20250929',
+      }),
+      'https://api.anthropic.com',
     );
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-anthropic-test12',
+      'anthropic',
+      { error: 'API Error: Rate limit exceeded' },
+      true,
+    );
+    expect(dumpContextSpy).not.toHaveBeenCalled();
   });
 
-  it('should dump context once and reset mode to off when mode is now', async () => {
+  it('should not dump context in provider when mode is now', async () => {
     const options: NormalizedGenerateChatOptions = {
       contents: [
         {
@@ -307,14 +330,8 @@ describe('AnthropicProvider dumpContext integration', () => {
       results.push(chunk);
     }
 
-    // Should have called dumpContext exactly once
-    expect(dumpContextSpy).toHaveBeenCalledExactlyOnceWith(
-      expect.any(Object),
-      expect.any(Object),
-      'anthropic',
-    );
-
-    // Note: The 'now' mode reset to 'off' is handled by the command layer,
-    // not by the provider, so we don't expect setEphemeralSettings to be called here
+    expect(dumpSDKRequestContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+    expect(dumpContextSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/providers/src/gemini/GeminiMessageConverter.test.ts
+++ b/packages/providers/src/gemini/GeminiMessageConverter.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { convertHistoryToGeminiFormat } from './GeminiMessageConverter.js';
+
+describe('GeminiMessageConverter', () => {
+  it('should normalize Gemini 3 tool-response media through shared media conversion', () => {
+    const contents: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-1',
+            toolName: 'screenshot',
+            result: { output: 'done' },
+          },
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            encoding: 'base64',
+            data: 'data:image/png;base64,iVBORw0KGgo=',
+          },
+          {
+            type: 'media',
+            mimeType: 'image/jpeg',
+            encoding: 'url',
+            data: 'https://example.com/photo.jpg',
+          },
+        ],
+      },
+    ];
+
+    const converted = convertHistoryToGeminiFormat(
+      contents,
+      'gemini-3-flash-preview',
+    );
+
+    const parts = converted[0].parts[0].functionResponse?.parts;
+    expect(parts).toStrictEqual([
+      { inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' } },
+      {
+        fileData: {
+          mimeType: 'image/jpeg',
+          fileUri: 'https://example.com/photo.jpg',
+        },
+      },
+    ]);
+  });
+
+  it('should normalize Gemini 2 tool-response media through shared media conversion', () => {
+    const contents: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-1',
+            toolName: 'screenshot',
+            result: { output: 'done' },
+          },
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            encoding: 'base64',
+            data: 'data:image/png;base64,iVBORw0KGgo=',
+          },
+          {
+            type: 'media',
+            mimeType: 'image/jpeg',
+            encoding: 'url',
+            data: 'https://example.com/photo.jpg',
+          },
+        ],
+      },
+    ];
+
+    const converted = convertHistoryToGeminiFormat(
+      contents,
+      'gemini-2.5-flash',
+    );
+
+    expect(converted[0].parts.slice(1)).toStrictEqual([
+      { inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' } },
+      {
+        fileData: {
+          mimeType: 'image/jpeg',
+          fileUri: 'https://example.com/photo.jpg',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/providers/src/gemini/GeminiMessageConverter.ts
+++ b/packages/providers/src/gemini/GeminiMessageConverter.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Part } from '@google/genai';
+import type {
+  IContent,
+  MediaBlock,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { isGemini3Model } from '@vybestack/llxprt-code-core/config/models.js';
+import { buildToolResponsePayload } from '../utils/toolResponsePayload.js';
+
+export function convertMediaBlockToGeminiParts(block: {
+  type: 'media';
+  encoding: string;
+  mimeType: string;
+  data: string;
+}): Part[] {
+  if (block.encoding === 'url') {
+    return [
+      { fileData: { mimeType: block.mimeType, fileUri: block.data } } as Part,
+    ];
+  }
+  let imageData = block.data;
+  if (imageData.startsWith('data:')) {
+    const base64Index = imageData.indexOf('base64,');
+    if (base64Index !== -1) {
+      imageData = imageData.substring(base64Index + 7);
+    }
+  }
+  return [
+    { inlineData: { mimeType: block.mimeType, data: imageData } } as Part,
+  ];
+}
+
+export function convertHumanBlocksToGeminiParts(
+  blocks: IContent['blocks'],
+): Part[] {
+  const parts: Part[] = [];
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      parts.push({ text: block.text });
+    } else if (block.type === 'media') {
+      parts.push(...convertMediaBlockToGeminiParts(block));
+    }
+  }
+  return parts;
+}
+
+export function convertAiBlocksToGeminiParts(
+  blocks: IContent['blocks'],
+): Part[] {
+  const parts: Part[] = [];
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      parts.push({ text: block.text });
+    } else if (block.type === 'tool_call') {
+      parts.push({
+        functionCall: {
+          id: block.id,
+          name: block.name,
+          args: block.parameters,
+        },
+      } as Part);
+    }
+  }
+  return parts;
+}
+
+export function convertToolContentToGeminiContents(
+  content: IContent,
+  currentModel: string,
+  configForMessages: unknown,
+  contents: Array<{ role: string; parts: Part[] }>,
+): void {
+  const toolResponseBlock = content.blocks.find(
+    (b) => b.type === 'tool_response',
+  );
+  if (!toolResponseBlock) {
+    throw new Error('Tool content must have a tool_response block');
+  }
+  const mediaBlocks = content.blocks.filter(
+    (b): b is MediaBlock => b.type === 'media',
+  );
+  const payload = buildToolResponsePayload(
+    toolResponseBlock,
+    configForMessages as Config | undefined,
+  );
+  const frPart: Part = {
+    functionResponse: {
+      id: toolResponseBlock.callId,
+      name: toolResponseBlock.toolName,
+      response: {
+        status: payload.status,
+        result: payload.result,
+        error: payload.error,
+        truncated: payload.truncated,
+        originalLength: payload.originalLength,
+        limitMessage: payload.limitMessage,
+      },
+    },
+  };
+  if (mediaBlocks.length > 0 && isGemini3Model(currentModel)) {
+    frPart.functionResponse!.parts = mediaBlocks.map((mb) => ({
+      inlineData: { mimeType: mb.mimeType, data: mb.data },
+    }));
+    contents.push({ role: 'user', parts: [frPart] });
+  } else if (mediaBlocks.length > 0) {
+    const parts: Part[] = [frPart];
+    for (const mb of mediaBlocks) {
+      parts.push({
+        inlineData: { mimeType: mb.mimeType, data: mb.data },
+      } as Part);
+    }
+    contents.push({ role: 'user', parts });
+  } else {
+    contents.push({ role: 'user', parts: [frPart] });
+  }
+}
+
+export function convertHistoryToGeminiFormat(
+  content: IContent[],
+  currentModel = 'gemini-2.5-pro',
+  configForMessages?: unknown,
+): Array<{ role: string; parts: Part[] }> {
+  const contents: Array<{ role: string; parts: Part[] }> = [];
+  for (const c of content) {
+    switch (c.speaker) {
+      case 'human': {
+        const parts = convertHumanBlocksToGeminiParts(c.blocks);
+        if (parts.length > 0) {
+          contents.push({ role: 'user', parts });
+        }
+        break;
+      }
+      case 'ai': {
+        const parts = convertAiBlocksToGeminiParts(c.blocks);
+        if (parts.length > 0) {
+          contents.push({ role: 'model', parts });
+        }
+        break;
+      }
+      case 'tool':
+        convertToolContentToGeminiContents(
+          c,
+          currentModel,
+          configForMessages,
+          contents,
+        );
+        break;
+      default:
+        break;
+    }
+  }
+  return contents;
+}

--- a/packages/providers/src/gemini/GeminiMessageConverter.ts
+++ b/packages/providers/src/gemini/GeminiMessageConverter.ts
@@ -104,17 +104,15 @@ export function convertToolContentToGeminiContents(
     },
   };
   if (mediaBlocks.length > 0 && isGemini3Model(currentModel)) {
-    frPart.functionResponse!.parts = mediaBlocks.map((mb) => ({
-      inlineData: { mimeType: mb.mimeType, data: mb.data },
-    }));
+    frPart.functionResponse!.parts = mediaBlocks.flatMap(
+      convertMediaBlockToGeminiParts,
+    );
     contents.push({ role: 'user', parts: [frPart] });
   } else if (mediaBlocks.length > 0) {
-    const parts: Part[] = [frPart];
-    for (const mb of mediaBlocks) {
-      parts.push({
-        inlineData: { mimeType: mb.mimeType, data: mb.data },
-      } as Part);
-    }
+    const parts: Part[] = [
+      frPart,
+      ...mediaBlocks.flatMap(convertMediaBlockToGeminiParts),
+    ];
     contents.push({ role: 'user', parts });
   } else {
     contents.push({ role: 'user', parts: [frPart] });

--- a/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.separateDump.test.ts
@@ -1,0 +1,652 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as dumpSDKContextModule from '../utils/dumpSDKContext.js';
+
+describe('Gemini non-OAuth non-streaming generate separate dump', () => {
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKContextSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-gemini-test12',
+      requestFilename: '20260101-120000-gemini-test12-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-gemini-test12-response.json',
+    );
+
+    dumpSDKContextSpy = vi.spyOn(dumpSDKContextModule, 'dumpSDKContext');
+    dumpSDKContextSpy.mockResolvedValue('legacy-dump.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should call dumpSDKRequestContext before SDK call and dumpSDKResponseContext after for on mode', async () => {
+    const callOrder: string[] = [];
+
+    dumpSDKRequestContextSpy.mockImplementation(async () => {
+      callOrder.push('requestDump');
+      return {
+        baseId: '20260101-120000-gemini-test12',
+        requestFilename: '20260101-120000-gemini-test12-request.json',
+        dumpDir: '/tmp/.llxprt/dumps',
+      };
+    });
+
+    const mockResponse = {
+      candidates: [{ content: { parts: [{ text: 'Hello' }] } }],
+    };
+
+    const mockContentGenerator = {
+      generateContent: vi.fn().mockImplementation(async () => {
+        callOrder.push('apiCall');
+        return mockResponse;
+      }),
+    };
+
+    const apiRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const mapResponseToChunks = vi
+      .fn()
+      .mockReturnValue([
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'Hello' }] },
+      ]);
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    const result = await provider['nonOAuthNonStreamingGenerate'](
+      mockContentGenerator,
+      apiRequest,
+      true,
+      false,
+      undefined,
+      mapResponseToChunks,
+      true,
+    );
+
+    expect(callOrder).toStrictEqual(['requestDump', 'apiCall']);
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+    expect(result.chunks).toBeDefined();
+    expect(result.chunks!.length).toBeGreaterThan(0);
+  });
+
+  it('should write separate related request and error response dumps in error mode', async () => {
+    const mockContentGenerator = {
+      generateContent: vi.fn().mockRejectedValue(new Error('API Error')),
+    };
+
+    const apiRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const mapResponseToChunks = vi.fn();
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    await expect(
+      provider['nonOAuthNonStreamingGenerate'](
+        mockContentGenerator,
+        apiRequest,
+        false,
+        true,
+        undefined,
+        mapResponseToChunks,
+        true,
+      ),
+    ).rejects.toThrow('API Error');
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
+      '20260101-120000-gemini-test12',
+      'gemini',
+      { error: 'API Error' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should send API request when request dump fails', async () => {
+    dumpSDKRequestContextSpy.mockRejectedValueOnce(new Error('disk full'));
+    const mockResponse = {
+      candidates: [{ content: { parts: [{ text: 'Hello' }] } }],
+    };
+    const mockContentGenerator = {
+      generateContent: vi.fn().mockResolvedValue(mockResponse),
+    };
+    const mapResponseToChunks = vi
+      .fn()
+      .mockReturnValue([
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'Hello' }] },
+      ]);
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    await provider['nonOAuthNonStreamingGenerate'](
+      mockContentGenerator,
+      { model: 'gemini-2.5-pro', contents: [], config: {} },
+      true,
+      false,
+      undefined,
+      mapResponseToChunks,
+      true,
+    );
+
+    expect(mockContentGenerator.generateContent).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should link on-mode API errors to the pre-request dump without legacy dumpSDKContext', async () => {
+    const callOrder: string[] = [];
+    dumpSDKRequestContextSpy.mockImplementation(async () => {
+      callOrder.push('requestDump');
+      return {
+        baseId: '20260101-120000-gemini-error',
+        requestFilename: '20260101-120000-gemini-error-request.json',
+        dumpDir: '/tmp/.llxprt/dumps',
+      };
+    });
+
+    const mockContentGenerator = {
+      generateContent: vi.fn().mockImplementation(async () => {
+        callOrder.push('apiCall');
+        throw new Error('API Error');
+      }),
+    };
+    const mapResponseToChunks = vi.fn();
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    await expect(
+      provider['nonOAuthNonStreamingGenerate'](
+        mockContentGenerator,
+        { model: 'gemini-2.5-pro', contents: [], config: {} },
+        true,
+        true,
+        undefined,
+        mapResponseToChunks,
+        true,
+      ),
+    ).rejects.toThrow('API Error');
+
+    expect(callOrder).toStrictEqual(['requestDump', 'apiCall']);
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
+      '20260101-120000-gemini-error',
+      'gemini',
+      { error: 'API Error' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('Gemini non-OAuth streaming generate separate dump', () => {
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKContextSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-gemini-test12',
+      requestFilename: '20260101-120000-gemini-test12-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-gemini-test12-response.json',
+    );
+
+    dumpSDKContextSpy = vi.spyOn(dumpSDKContextModule, 'dumpSDKContext');
+
+    dumpSDKContextSpy.mockResolvedValue('legacy-dump.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should wrap stream to capture chunks and write response dump after stream completes', async () => {
+    const chunks = [
+      { candidates: [{ content: { parts: [{ text: 'Hello' }] } }] },
+      { candidates: [{ content: { parts: [{ text: ' world' }] } }] },
+    ];
+
+    const mockStream = (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+
+    const mockContentGenerator = {
+      generateContentStream: vi.fn().mockResolvedValue(mockStream),
+    };
+
+    const apiRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    const result = await provider['nonOAuthStreamingGenerate'](
+      mockContentGenerator,
+      apiRequest,
+      true,
+      false,
+      undefined,
+    );
+
+    // Request dump should have been called before stream creation
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+
+    // Response dump should NOT have been called yet - stream hasn't been consumed
+    // (wrapStreamWithDump defers the response dump until after stream completes)
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+
+    // Consume the stream
+    const received: unknown[] = [];
+    for await (const chunk of result.stream as AsyncIterable<unknown>) {
+      received.push(chunk);
+    }
+
+    // All chunks should pass through unchanged
+    expect(received).toStrictEqual(chunks);
+
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-gemini-test12',
+      'gemini',
+      { streaming: true, chunks, completed: true },
+      false,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should pass through chunks even when stream errors mid-iteration', async () => {
+    const chunks = [
+      { candidates: [{ content: { parts: [{ text: 'partial' }] } }] },
+    ];
+
+    const mockStream = (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+      throw new Error('Stream interrupted');
+    })();
+
+    const mockContentGenerator = {
+      generateContentStream: vi.fn().mockResolvedValue(mockStream),
+    };
+
+    const apiRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    const result = await provider['nonOAuthStreamingGenerate'](
+      mockContentGenerator,
+      apiRequest,
+      true,
+      false,
+      undefined,
+    );
+
+    const received: unknown[] = [];
+    await expect(async () => {
+      for await (const chunk of result.stream as AsyncIterable<unknown>) {
+        received.push(chunk);
+      }
+    }).rejects.toThrow('Stream interrupted');
+
+    // All chunks yielded before the error should pass through
+    expect(received).toStrictEqual(chunks);
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-gemini-test12',
+      'gemini',
+      {
+        streaming: true,
+        chunks,
+        error: 'Error: Stream interrupted',
+        completed: false,
+      },
+      true,
+    );
+  });
+
+  it('should dump stream iteration errors in error mode after passing through chunks', async () => {
+    const chunks = [
+      { candidates: [{ content: { parts: [{ text: 'partial' }] } }] },
+    ];
+    const mockStream = (async function* () {
+      yield chunks[0];
+      throw new Error('Gemini stream failed');
+    })();
+    const mockContentGenerator = {
+      generateContentStream: vi.fn().mockResolvedValue(mockStream),
+    };
+    const apiRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    const result = await provider['nonOAuthStreamingGenerate'](
+      mockContentGenerator,
+      apiRequest,
+      false,
+      true,
+      undefined,
+    );
+
+    const received: unknown[] = [];
+    await expect(async () => {
+      for await (const chunk of result.stream as AsyncIterable<unknown>) {
+        received.push(chunk);
+      }
+    }).rejects.toThrow('Gemini stream failed');
+
+    expect(received).toStrictEqual(chunks);
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-gemini-test12',
+      'gemini',
+      {
+        streaming: true,
+        chunks,
+        error: 'Error: Gemini stream failed',
+        completed: false,
+      },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write separate related dumps for error during stream creation in error mode', async () => {
+    const mockContentGenerator = {
+      generateContentStream: vi
+        .fn()
+        .mockRejectedValue(new Error('Connection error')),
+    };
+
+    const apiRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    await expect(
+      provider['nonOAuthStreamingGenerate'](
+        mockContentGenerator,
+        apiRequest,
+        false,
+        true,
+        undefined,
+      ),
+    ).rejects.toThrow('Connection error');
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
+      '20260101-120000-gemini-test12',
+      'gemini',
+      { error: 'Connection error' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('Gemini OAuth streaming generate separate dump', () => {
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKContextSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-gemini-test12',
+      requestFilename: '20260101-120000-gemini-test12-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-gemini-test12-response.json',
+    );
+
+    dumpSDKContextSpy = vi.spyOn(dumpSDKContextModule, 'dumpSDKContext');
+    dumpSDKContextSpy.mockResolvedValue('legacy-dump.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should wrap stream to capture chunks and write response dump after stream completes', async () => {
+    const chunks = [
+      { candidates: [{ content: { parts: [{ text: 'OAuth Hello' }] } }] },
+      { candidates: [{ content: { parts: [{ text: ' world' }] } }] },
+    ];
+
+    const mockStream = (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+
+    const mockGeneratorWithStream = {
+      generateContentStream: vi.fn().mockResolvedValue(mockStream),
+    };
+
+    const oauthRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    const result = await provider['oauthStreamingGenerate'](
+      mockGeneratorWithStream,
+      oauthRequest,
+      'runtime-1',
+      'session-1',
+      true,
+      true,
+      false,
+      undefined,
+    );
+
+    // Request dump should have been called before stream creation
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+
+    // Response dump should NOT have been called yet - stream hasn't been consumed
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+
+    // Consume the stream
+    const received: unknown[] = [];
+    for await (const chunk of result.stream as AsyncIterable<unknown>) {
+      received.push(chunk);
+    }
+
+    // All chunks should pass through unchanged
+    expect(received).toStrictEqual(chunks);
+
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-gemini-test12',
+      'gemini',
+      { streaming: true, chunks, completed: true },
+      false,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write separate related dumps for OAuth error during stream creation in error mode', async () => {
+    const mockGeneratorWithStream = {
+      generateContentStream: vi
+        .fn()
+        .mockRejectedValue(new Error('OAuth error')),
+    };
+
+    const oauthRequest = {
+      model: 'gemini-2.5-pro',
+      contents: [],
+      config: {},
+    };
+
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    await expect(
+      provider['oauthStreamingGenerate'](
+        mockGeneratorWithStream,
+        oauthRequest,
+        'runtime-1',
+        'session-1',
+        true,
+        false,
+        true,
+        undefined,
+      ),
+    ).rejects.toThrow('OAuth error');
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
+      '20260101-120000-gemini-test12',
+      'gemini',
+      { error: 'OAuth error' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('Gemini OAuth non-streaming generate separate dump', () => {
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKContextSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-gemini-oauth',
+      requestFilename: '20260101-120000-gemini-oauth-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-gemini-oauth-response.json',
+    );
+
+    dumpSDKContextSpy = vi.spyOn(dumpSDKContextModule, 'dumpSDKContext');
+    dumpSDKContextSpy.mockResolvedValue('legacy-dump.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should link on-mode API errors to the pre-request dump without legacy dumpSDKContext', async () => {
+    const callOrder: string[] = [];
+    dumpSDKRequestContextSpy.mockImplementation(async () => {
+      callOrder.push('requestDump');
+      return {
+        baseId: '20260101-120000-gemini-oauth-error',
+        requestFilename: '20260101-120000-gemini-oauth-error-request.json',
+        dumpDir: '/tmp/.llxprt/dumps',
+      };
+    });
+
+    const mockGeneratorWithStream = {
+      generateContentStream: vi.fn(),
+      generateContent: vi.fn().mockImplementation(async () => {
+        callOrder.push('apiCall');
+        throw new Error('OAuth API Error');
+      }),
+    };
+    const mapResponseToChunks = vi.fn();
+    const { GeminiProvider } = await import('./GeminiProvider.js');
+    const provider = new GeminiProvider('test-api-key');
+
+    await expect(
+      provider['oauthNonStreamingGenerate'](
+        mockGeneratorWithStream,
+        { model: 'gemini-2.5-pro', contents: [], config: {} },
+        'session-1',
+        true,
+        true,
+        undefined,
+        mapResponseToChunks,
+        true,
+      ),
+    ).rejects.toThrow('OAuth API Error');
+
+    expect(callOrder).toStrictEqual(['requestDump', 'apiCall']);
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
+      '20260101-120000-gemini-oauth-error',
+      'gemini',
+      { error: 'OAuth API Error' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -16,11 +16,11 @@ import {
   type IContent,
   type ToolCallBlock,
   type ThinkingBlock,
-  type MediaBlock,
 } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { shouldIncludeSubagentDelegation } from '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js';
+import { convertHistoryToGeminiFormat } from './GeminiMessageConverter.js';
 import {
   Type,
   type Part,
@@ -38,14 +38,18 @@ import {
 // @plan:PLAN-20260608-ISSUE1586.P15 — auth types from auth package
 import { type OAuthManager } from '@vybestack/llxprt-code-auth';
 import { resolveUserMemory } from '../utils/userMemory.js';
-import { buildToolResponsePayload } from '../utils/toolResponsePayload.js';
 import {
   ensureActiveLoopHasThoughtSignatures,
   stripThoughtsFromHistory,
 } from './thoughtSignatures.js';
 import {
   shouldDumpSDKContext,
-  dumpSDKContext,
+  dumpSDKRequestContext,
+  dumpSDKResponseContext,
+  wrapStreamWithDump,
+  wrapStreamWithSDKErrorDump,
+  bestEffortDump,
+  dumpSDKErrorRequestResponse,
 } from '../utils/dumpSDKContext.js';
 import type { DumpMode } from '../utils/dumpContext.js';
 
@@ -1443,134 +1447,11 @@ export class GeminiProvider extends BaseProvider {
     currentModel: string,
     configForMessages: unknown,
   ): Array<{ role: string; parts: Part[] }> {
-    const contents: Array<{ role: string; parts: Part[] }> = [];
-    for (const c of content) {
-      if (c.speaker === 'human') {
-        const parts = this.convertHumanBlocks(c.blocks);
-        if (parts.length > 0) {
-          contents.push({ role: 'user', parts });
-        }
-      } else if (c.speaker === 'ai') {
-        const parts = this.convertAiBlocks(c.blocks);
-        if (parts.length > 0) {
-          contents.push({ role: 'model', parts });
-        }
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Defensive check for speaker type exhaustiveness
-      } else if (c.speaker === 'tool') {
-        this.convertToolBlocks(c, currentModel, configForMessages, contents);
-      }
-    }
-    return contents;
-  }
-
-  /** Convert human speaker blocks to Gemini Parts. */
-  private convertHumanBlocks(
-    blocks: NormalizedGenerateChatOptions['contents'][number]['blocks'],
-  ): Part[] {
-    const parts: Part[] = [];
-    for (const block of blocks) {
-      // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      if (block.type === 'text') {
-        parts.push({ text: block.text });
-      } else if (block.type === 'media') {
-        parts.push(...this.convertMediaBlock(block));
-      }
-    }
-    return parts;
-  }
-
-  /** Convert a media block to Gemini Part(s). */
-  private convertMediaBlock(block: {
-    type: 'media';
-    encoding: string;
-    mimeType: string;
-    data: string;
-  }): Part[] {
-    if (block.encoding === 'url') {
-      return [
-        { fileData: { mimeType: block.mimeType, fileUri: block.data } } as Part,
-      ];
-    }
-    let imageData = block.data;
-    if (imageData.startsWith('data:')) {
-      const base64Index = imageData.indexOf('base64,');
-      if (base64Index !== -1) {
-        imageData = imageData.substring(base64Index + 7);
-      }
-    }
-    return [
-      { inlineData: { mimeType: block.mimeType, data: imageData } } as Part,
-    ];
-  }
-
-  /** Convert AI speaker blocks to Gemini Parts. */
-  private convertAiBlocks(
-    blocks: NormalizedGenerateChatOptions['contents'][number]['blocks'],
-  ): Part[] {
-    const parts: Part[] = [];
-    for (const block of blocks) {
-      // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      if (block.type === 'text') {
-        parts.push({ text: block.text });
-      } else if (block.type === 'tool_call') {
-        const tc = block;
-        parts.push({
-          functionCall: { id: tc.id, name: tc.name, args: tc.parameters },
-        } as Part);
-      }
-    }
-    return parts;
-  }
-
-  /** Convert tool speaker content to Gemini format and push into contents. */
-  private convertToolBlocks(
-    c: NormalizedGenerateChatOptions['contents'][number],
-    currentModel: string,
-    configForMessages: unknown,
-    contents: Array<{ role: string; parts: Part[] }>,
-  ): void {
-    const toolResponseBlock = c.blocks.find((b) => b.type === 'tool_response');
-    if (!toolResponseBlock) {
-      throw new Error('Tool content must have a tool_response block');
-    }
-    const mediaBlocks = c.blocks.filter(
-      (b): b is MediaBlock => b.type === 'media',
+    return convertHistoryToGeminiFormat(
+      content,
+      currentModel,
+      configForMessages,
     );
-    const payload = buildToolResponsePayload(
-      toolResponseBlock,
-      configForMessages as Config | undefined,
-    );
-    const frPart: Part = {
-      functionResponse: {
-        id: toolResponseBlock.callId,
-        name: toolResponseBlock.toolName,
-        response: {
-          status: payload.status,
-          result: payload.result,
-          error: payload.error,
-          truncated: payload.truncated,
-          originalLength: payload.originalLength,
-          limitMessage: payload.limitMessage,
-        },
-      },
-    };
-    if (mediaBlocks.length > 0 && isGemini3Model(currentModel)) {
-      frPart.functionResponse!.parts = mediaBlocks.map((mb) => ({
-        inlineData: { mimeType: mb.mimeType, data: mb.data },
-      }));
-      contents.push({ role: 'user', parts: [frPart] });
-    } else if (mediaBlocks.length > 0) {
-      const parts: Part[] = [frPart];
-      // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      for (const mb of mediaBlocks) {
-        parts.push({
-          inlineData: { mimeType: mb.mimeType, data: mb.data },
-        } as Part);
-      }
-      contents.push({ role: 'user', parts });
-    } else {
-      contents.push({ role: 'user', parts: [frPart] });
-    }
   }
 
   /** Create the response-to-chunks mapper function. */
@@ -1898,20 +1779,29 @@ export class GeminiProvider extends BaseProvider {
     ) => IContent[],
     reasoningIncludeInResponse: boolean,
   ): Promise<GeminiGenerationResult> {
+    let requestBaseId: string | undefined;
+
+    if (shouldDumpSuccess) {
+      const reqResult = await bestEffortDump('request', 'gemini', () =>
+        dumpSDKRequestContext(
+          'gemini',
+          '/v1/models/generateContent',
+          oauthRequest,
+          baseURL ?? 'https://generativelanguage.googleapis.com',
+        ),
+      );
+      requestBaseId = reqResult?.baseId;
+    }
+
     // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
     try {
       const response = await generatorWithStream.generateContent!(
         oauthRequest,
         sessionId,
       );
-      if (shouldDumpSuccess) {
-        await dumpSDKContext(
-          'gemini',
-          '/v1/models/generateContent',
-          oauthRequest,
-          response,
-          false,
-          baseURL ?? 'https://generativelanguage.googleapis.com',
+      if (shouldDumpSuccess && requestBaseId) {
+        await bestEffortDump('response', 'gemini', () =>
+          dumpSDKResponseContext(requestBaseId, 'gemini', response, false),
         );
       }
       return {
@@ -1924,17 +1814,46 @@ export class GeminiProvider extends BaseProvider {
       if (shouldDumpError) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        await dumpSDKContext(
-          'gemini',
-          '/v1/models/generateContent',
-          oauthRequest,
-          { error: errorMessage },
-          true,
-          baseURL ?? 'https://generativelanguage.googleapis.com',
-        );
+        if (requestBaseId) {
+          await bestEffortDump('error-response', 'gemini', () =>
+            dumpSDKResponseContext(
+              requestBaseId,
+              'gemini',
+              { error: errorMessage },
+              true,
+            ),
+          );
+        } else {
+          await dumpSDKErrorRequestResponse(
+            'gemini',
+            '/v1/models/generateContent',
+            oauthRequest,
+            { error: errorMessage },
+            baseURL ?? 'https://generativelanguage.googleapis.com',
+            dumpSDKRequestContext,
+            dumpSDKResponseContext,
+          );
+        }
       }
       throw error;
     }
+  }
+
+  private buildOAuthStreamingPrelude(
+    runtimeId: string,
+    sessionId: string,
+  ): IContent[] {
+    return [
+      {
+        speaker: 'ai',
+        blocks: [],
+        metadata: {
+          session: sessionId,
+          runtime: runtimeId,
+          authMode: 'oauth',
+        },
+      } as IContent,
+    ];
   }
 
   /** Streaming OAuth generate with dump support. */
@@ -1955,50 +1874,64 @@ export class GeminiProvider extends BaseProvider {
     shouldDumpError: boolean,
     baseURL: string | undefined,
   ): Promise<GeminiGenerationResult> {
+    let requestBaseId: string | undefined;
+
+    if (shouldDumpSuccess) {
+      const reqResult = await bestEffortDump('request', 'gemini', () =>
+        dumpSDKRequestContext(
+          'gemini',
+          '/v1/models/streamGenerateContent',
+          oauthRequest,
+          baseURL ?? 'https://generativelanguage.googleapis.com',
+        ),
+      );
+      requestBaseId = reqResult?.baseId;
+    }
+
     try {
       const oauthStream = await Promise.resolve(
         generatorWithStream.generateContentStream(oauthRequest, sessionId),
       );
-      if (shouldDumpSuccess) {
-        await dumpSDKContext(
-          'gemini',
-          '/v1/models/streamGenerateContent',
-          oauthRequest,
-          { streaming: true },
-          false,
-          baseURL ?? 'https://generativelanguage.googleapis.com',
-        );
-      }
+      const streamForReturn = this.wrapGeminiStreamForDump(
+        oauthStream,
+        oauthRequest,
+        shouldDumpSuccess,
+        shouldDumpError,
+        requestBaseId,
+        baseURL,
+      );
       if (streamingEnabled) {
         return {
-          stream: oauthStream,
+          stream: streamForReturn,
           emitted: true,
-          preludeChunks: [
-            {
-              speaker: 'ai',
-              blocks: [],
-              metadata: {
-                session: sessionId,
-                runtime: runtimeId,
-                authMode: 'oauth',
-              },
-            } as IContent,
-          ],
+          preludeChunks: this.buildOAuthStreamingPrelude(runtimeId, sessionId),
         };
       }
-      return { stream: oauthStream, emitted: false };
+      return { stream: streamForReturn, emitted: false };
     } catch (error) {
       if (shouldDumpError) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        await dumpSDKContext(
-          'gemini',
-          '/v1/models/streamGenerateContent',
-          oauthRequest,
-          { error: errorMessage },
-          true,
-          baseURL ?? 'https://generativelanguage.googleapis.com',
-        );
+        if (requestBaseId) {
+          await bestEffortDump('error-response', 'gemini', () =>
+            dumpSDKResponseContext(
+              requestBaseId,
+              'gemini',
+              { error: errorMessage },
+              true,
+            ),
+          );
+        } else {
+          await dumpSDKErrorRequestResponse(
+            'gemini',
+            '/v1/models/streamGenerateContent',
+            oauthRequest,
+            { error: errorMessage },
+            baseURL ?? 'https://generativelanguage.googleapis.com',
+            dumpSDKRequestContext,
+            dumpSDKResponseContext,
+          );
+        }
       }
       throw error;
     }
@@ -2081,17 +2014,26 @@ export class GeminiProvider extends BaseProvider {
     ) => IContent[],
     reasoningIncludeInResponse: boolean,
   ): Promise<GeminiGenerationResult> {
-    try {
-      const response = await contentGenerator.generateContent(apiRequest);
-      // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      if (shouldDumpSuccess) {
-        await dumpSDKContext(
+    let requestBaseId: string | undefined;
+
+    if (shouldDumpSuccess) {
+      const reqResult = await bestEffortDump('request', 'gemini', () =>
+        dumpSDKRequestContext(
           'gemini',
           '/v1/models/generateContent',
           apiRequest,
-          response,
-          false,
           baseURL ?? 'https://generativelanguage.googleapis.com',
+        ),
+      );
+      requestBaseId = reqResult?.baseId;
+    }
+
+    try {
+      const response = await contentGenerator.generateContent(apiRequest);
+      // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
+      if (shouldDumpSuccess && requestBaseId) {
+        await bestEffortDump('response', 'gemini', () =>
+          dumpSDKResponseContext(requestBaseId, 'gemini', response, false),
         );
       }
       return {
@@ -2104,17 +2046,59 @@ export class GeminiProvider extends BaseProvider {
       if (shouldDumpError) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        await dumpSDKContext(
-          'gemini',
-          '/v1/models/generateContent',
-          apiRequest,
-          { error: errorMessage },
-          true,
-          baseURL ?? 'https://generativelanguage.googleapis.com',
-        );
+        if (requestBaseId) {
+          await bestEffortDump('error-response', 'gemini', () =>
+            dumpSDKResponseContext(
+              requestBaseId,
+              'gemini',
+              { error: errorMessage },
+              true,
+            ),
+          );
+        } else {
+          await dumpSDKErrorRequestResponse(
+            'gemini',
+            '/v1/models/generateContent',
+            apiRequest,
+            { error: errorMessage },
+            baseURL ?? 'https://generativelanguage.googleapis.com',
+            dumpSDKRequestContext,
+            dumpSDKResponseContext,
+          );
+        }
       }
       throw error;
     }
+  }
+
+  private wrapGeminiStreamForDump(
+    stream: AsyncIterable<GenerateContentResponse>,
+    request: GenerateContentParameters,
+    shouldDumpSuccess: boolean,
+    shouldDumpError: boolean,
+    requestBaseId: string | undefined,
+    baseURL: string | undefined,
+  ): AsyncIterable<GenerateContentResponse> {
+    if (shouldDumpSuccess && requestBaseId) {
+      return wrapStreamWithDump(
+        stream,
+        requestBaseId,
+        'gemini',
+        dumpSDKResponseContext,
+      );
+    }
+    if (shouldDumpError) {
+      return wrapStreamWithSDKErrorDump(
+        stream,
+        'gemini',
+        '/v1/models/streamGenerateContent',
+        request,
+        baseURL ?? 'https://generativelanguage.googleapis.com',
+        dumpSDKRequestContext,
+        dumpSDKResponseContext,
+      );
+    }
+    return stream;
   }
 
   private async nonOAuthStreamingGenerate(
@@ -2128,31 +2112,55 @@ export class GeminiProvider extends BaseProvider {
     shouldDumpError: boolean,
     baseURL: string | undefined,
   ): Promise<GeminiGenerationResult> {
-    try {
-      const stream = await contentGenerator.generateContentStream(apiRequest);
-      if (shouldDumpSuccess) {
-        await dumpSDKContext(
+    let requestBaseId: string | undefined;
+
+    if (shouldDumpSuccess) {
+      const reqResult = await bestEffortDump('request', 'gemini', () =>
+        dumpSDKRequestContext(
           'gemini',
           '/v1/models/streamGenerateContent',
           apiRequest,
-          { streaming: true },
-          false,
           baseURL ?? 'https://generativelanguage.googleapis.com',
-        );
-      }
-      return { stream, emitted: false };
+        ),
+      );
+      requestBaseId = reqResult?.baseId;
+    }
+
+    try {
+      const stream = await contentGenerator.generateContentStream(apiRequest);
+      const streamForReturn = this.wrapGeminiStreamForDump(
+        stream,
+        apiRequest,
+        shouldDumpSuccess,
+        shouldDumpError,
+        requestBaseId,
+        baseURL,
+      );
+      return { stream: streamForReturn, emitted: false };
     } catch (error) {
       if (shouldDumpError) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        await dumpSDKContext(
-          'gemini',
-          '/v1/models/streamGenerateContent',
-          apiRequest,
-          { error: errorMessage },
-          true,
-          baseURL ?? 'https://generativelanguage.googleapis.com',
-        );
+        if (requestBaseId) {
+          await bestEffortDump('error-response', 'gemini', () =>
+            dumpSDKResponseContext(
+              requestBaseId,
+              'gemini',
+              { error: errorMessage },
+              true,
+            ),
+          );
+        } else {
+          await dumpSDKErrorRequestResponse(
+            'gemini',
+            '/v1/models/streamGenerateContent',
+            apiRequest,
+            { error: errorMessage },
+            baseURL ?? 'https://generativelanguage.googleapis.com',
+            dumpSDKRequestContext,
+            dumpSDKResponseContext,
+          );
+        }
       }
       throw error;
     }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -123,3 +123,11 @@ export { getOpenAIProviderInfo } from './openai/getOpenAIProviderInfo.js';
 
 // --- Additional types needed for provider construction ---
 export type { DumpMode } from './utils/dumpContext.js';
+export { dumpRequestContext } from './utils/dumpContext.js';
+export {
+  buildAnthropicDumpMessages,
+  buildGeminiDumpContents,
+  buildOpenAIDumpMessages,
+  buildProviderDumpBody,
+} from './utils/providerRequestConversion.js';
+export { wrapStreamWithDump } from './utils/dumpSDKContext.js';

--- a/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
@@ -1,0 +1,466 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as dumpSDKContextModule from '../utils/dumpSDKContext.js';
+import {
+  executeApiRequest,
+  type ApiExecutionOptions,
+} from './OpenAIApiExecution.js';
+
+function createMockClient(response: unknown) {
+  return {
+    chat: {
+      completions: {
+        create: vi.fn().mockResolvedValue(response),
+      },
+    },
+  } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+}
+
+function createBaseOptions(
+  overrides: Partial<ApiExecutionOptions> = {},
+): ApiExecutionOptions {
+  return {
+    client: createMockClient({ id: 'chatcmpl-test', choices: [] }),
+    requestBody: {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello' }],
+    } as unknown as Parameters<typeof executeApiRequest>[0]['requestBody'],
+    abortSignal: undefined,
+    mergedHeaders: undefined,
+    dumpMode: 'on',
+    baseURL: 'https://api.openai.com/v1',
+    model: 'gpt-4o',
+    formattedTools: undefined,
+    streamingEnabled: false,
+    logger: { error: vi.fn(), debug: vi.fn() } as unknown as Parameters<
+      typeof executeApiRequest
+    >[0]['logger'],
+    getBaseURL: () => 'https://api.openai.com/v1',
+    ...overrides,
+  };
+}
+
+describe('OpenAI executeApiRequest separate request/response dump', () => {
+  let dumpSDKRequestContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+  let dumpSDKContextSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dumpSDKRequestContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKRequestContext',
+    );
+    dumpSDKRequestContextSpy.mockResolvedValue({
+      baseId: '20260101-120000-openai-test12',
+      requestFilename: '20260101-120000-openai-test12-request.json',
+      dumpDir: '/tmp/.llxprt/dumps',
+    });
+
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue(
+      '20260101-120000-openai-test12-response.json',
+    );
+
+    dumpSDKContextSpy = vi.spyOn(dumpSDKContextModule, 'dumpSDKContext');
+    dumpSDKContextSpy.mockResolvedValue('legacy-dump.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should dump request before API call and response after in on mode (non-streaming)', async () => {
+    const callOrder: string[] = [];
+
+    dumpSDKRequestContextSpy.mockImplementation(async () => {
+      callOrder.push('requestDump');
+      return {
+        baseId: '20260101-120000-openai-test12',
+        requestFilename: '20260101-120000-openai-test12-request.json',
+        dumpDir: '/tmp/.llxprt/dumps',
+      };
+    });
+
+    dumpSDKResponseContextSpy.mockImplementation(async () => {
+      callOrder.push('responseDump');
+      return '20260101-120000-openai-test12-response.json';
+    });
+
+    const mockResponse = { id: 'chatcmpl-test', choices: [] };
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockImplementation(async () => {
+            callOrder.push('apiCall');
+            return mockResponse;
+          }),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({ client, streamingEnabled: false });
+    await executeApiRequest(opts);
+
+    expect(callOrder).toStrictEqual(['requestDump', 'apiCall', 'responseDump']);
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    const [reqProvider, reqEndpoint, , reqBaseURL] =
+      dumpSDKRequestContextSpy.mock.calls[0];
+    expect(reqProvider).toBe('openai');
+    expect(reqEndpoint).toBe('/chat/completions');
+    expect(reqBaseURL).toBe('https://api.openai.com/v1');
+
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+    const [respBaseId, respProvider, , respIsError] =
+      dumpSDKResponseContextSpy.mock.calls[0];
+    expect(respBaseId).toBe('20260101-120000-openai-test12');
+    expect(respProvider).toBe('openai');
+    expect(respIsError).toBe(false);
+
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should wrap streaming response to capture chunks and dump after stream completes', async () => {
+    const chunks = [
+      { id: 'chatcmpl-test', choices: [{ delta: { content: 'Hello' } }] },
+      { id: 'chatcmpl-test', choices: [{ delta: { content: ' world' } }] },
+    ];
+
+    const mockStream = (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue(mockStream),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({ client, streamingEnabled: true });
+    const result = await executeApiRequest(opts);
+
+    // Request dump should have been called before stream creation
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+
+    // Response dump should NOT have been called yet - stream hasn't been consumed
+    // (wrapStreamWithDump defers the response dump until after stream completes)
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+
+    // Consume the stream
+    const received: unknown[] = [];
+    for await (const chunk of result as AsyncIterable<unknown>) {
+      received.push(chunk);
+    }
+
+    // All chunks should pass through unchanged
+    expect(received).toStrictEqual(chunks);
+
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-openai-test12',
+      'openai',
+      { streaming: true, chunks, completed: true },
+      false,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should pass through all chunks unchanged even when stream errors mid-iteration', async () => {
+    const chunks = [
+      { id: 'chatcmpl-test', choices: [{ delta: { content: 'partial' } }] },
+    ];
+
+    const mockStream = (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+      throw new Error('Stream interrupted');
+    })();
+
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue(mockStream),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({ client, streamingEnabled: true });
+    const result = await executeApiRequest(opts);
+
+    const received: unknown[] = [];
+    await expect(async () => {
+      for await (const chunk of result as AsyncIterable<unknown>) {
+        received.push(chunk);
+      }
+    }).rejects.toThrow('Stream interrupted');
+
+    // All chunks yielded before the error should pass through
+    expect(received).toStrictEqual(chunks);
+
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-openai-test12',
+      'openai',
+      {
+        streaming: true,
+        chunks,
+        error: 'Error: Stream interrupted',
+        completed: false,
+      },
+      true,
+    );
+  });
+
+  it('should not dump request or response when mode is off', async () => {
+    const opts = createBaseOptions({ dumpMode: 'off' });
+    await executeApiRequest(opts);
+
+    expect(dumpSDKRequestContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write separate related request and error response dumps in error mode', async () => {
+    const callOrder: string[] = [];
+
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockImplementation(async () => {
+            callOrder.push('apiCall');
+            throw new Error('Rate limit');
+          }),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    dumpSDKRequestContextSpy.mockImplementation(async () => {
+      callOrder.push('errorRequestDump');
+      return {
+        baseId: '20260101-120000-openai-test12',
+        requestFilename: '20260101-120000-openai-test12-request.json',
+        dumpDir: '/tmp',
+      };
+    });
+    dumpSDKResponseContextSpy.mockImplementation(async () => {
+      callOrder.push('errorResponseDump');
+      return '20260101-120000-openai-test12-response.json';
+    });
+
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'error',
+      streamingEnabled: false,
+    });
+
+    await expect(executeApiRequest(opts)).rejects.toThrow('Rate limit');
+
+    expect(callOrder).toStrictEqual([
+      'apiCall',
+      'errorRequestDump',
+      'errorResponseDump',
+    ]);
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledWith(
+      '20260101-120000-openai-test12',
+      'openai',
+      { error: 'Rate limit' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write linked error response dump instead of legacy dump in on mode (non-streaming)', async () => {
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockRejectedValue(new Error('Rate limit')),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'on',
+      streamingEnabled: false,
+    });
+
+    await expect(executeApiRequest(opts)).rejects.toThrow('Rate limit');
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+    const [baseId, provider, responseBody, isError] =
+      dumpSDKResponseContextSpy.mock.calls[0];
+    expect(baseId).toBe('20260101-120000-openai-test12');
+    expect(provider).toBe('openai');
+    expect(responseBody).toStrictEqual({ error: 'Rate limit' });
+    expect(isError).toBe(true);
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write linked error response dump instead of legacy dump in on mode when streaming request creation fails', async () => {
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockRejectedValue(new Error('Stream setup failed')),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'on',
+      streamingEnabled: true,
+    });
+
+    await expect(executeApiRequest(opts)).rejects.toThrow(
+      'Stream setup failed',
+    );
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+    const [baseId, provider, responseBody, isError] =
+      dumpSDKResponseContextSpy.mock.calls[0];
+    expect(baseId).toBe('20260101-120000-openai-test12');
+    expect(provider).toBe('openai');
+    expect(responseBody).toStrictEqual({ error: 'Stream setup failed' });
+    expect(isError).toBe(true);
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write separate error dumps before throwing enhanced Cerebras/Qwen tool errors', async () => {
+    const apiError = new Error(
+      '400 Tool is not present in the tools list: lookup_weather',
+    );
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockRejectedValue(apiError),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'error',
+      baseURL: 'https://api.cerebras.ai/v1',
+      getBaseURL: () => 'https://api.cerebras.ai/v1',
+      model: 'qwen-3-coder-480b',
+      formattedTools: [
+        {
+          type: 'function',
+          function: {
+            name: 'lookup_weather',
+            description: 'Look up the weather',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ],
+      streamingEnabled: false,
+    });
+
+    await expect(executeApiRequest(opts)).rejects.toThrow(
+      'Cerebras/Qwen API bug: Tool not found in list. We sent 1 tools. Known API issue.',
+    );
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'openai',
+      '/chat/completions',
+      opts.requestBody,
+      'https://api.cerebras.ai/v1',
+    );
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-openai-test12',
+      'openai',
+      { error: '400 Tool is not present in the tools list: lookup_weather' },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should send API request when request dump fails', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValue({ id: 'chatcmpl-test', choices: [] });
+    const client = {
+      chat: { completions: { create } },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+    dumpSDKRequestContextSpy.mockRejectedValueOnce(new Error('disk full'));
+
+    const opts = createBaseOptions({ client, dumpMode: 'on' });
+
+    await expect(executeApiRequest(opts)).resolves.toStrictEqual({
+      id: 'chatcmpl-test',
+      choices: [],
+    });
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+    expect(opts.logger.debug).toHaveBeenCalled();
+  });
+
+  it('should dump streaming iteration errors in error mode after passing through chunks', async () => {
+    const chunks = [
+      { id: 'chatcmpl-test', choices: [{ delta: { content: 'partial' } }] },
+    ];
+    const mockStream = (async function* () {
+      yield chunks[0];
+      throw new Error('Stream iteration failed');
+    })();
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue(mockStream),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'error',
+      streamingEnabled: true,
+    });
+
+    const result = await executeApiRequest(opts);
+    const received: unknown[] = [];
+    await expect(async () => {
+      for await (const chunk of result as AsyncIterable<unknown>) {
+        received.push(chunk);
+      }
+    }).rejects.toThrow('Stream iteration failed');
+
+    expect(received).toStrictEqual(chunks);
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      '20260101-120000-openai-test12',
+      'openai',
+      {
+        streaming: true,
+        chunks,
+        error: 'Error: Stream iteration failed',
+        completed: false,
+      },
+      true,
+    );
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not dump on success when mode is error', async () => {
+    const opts = createBaseOptions({ dumpMode: 'error' });
+    await executeApiRequest(opts);
+
+    expect(dumpSDKRequestContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKResponseContextSpy).not.toHaveBeenCalled();
+    expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.separateDump.test.ts
@@ -339,6 +339,50 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();
   });
 
+  it('should use request-scoped baseURL for streaming Cerebras/Qwen tool error handling', async () => {
+    const apiError = new Error(
+      '400 Tool is not present in the tools list: lookup_weather',
+    );
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockRejectedValue(apiError),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'error',
+      baseURL: 'https://api.cerebras.ai/v1',
+      getBaseURL: () => 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      formattedTools: [
+        {
+          type: 'function',
+          function: {
+            name: 'lookup_weather',
+            description: 'Look up the weather',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ],
+      streamingEnabled: true,
+    });
+
+    await expect(executeApiRequest(opts)).rejects.toThrow(
+      'Cerebras/Qwen API bug: Tool not found in list. We sent 1 tools. Known API issue.',
+    );
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'openai',
+      '/chat/completions',
+      opts.requestBody,
+      'https://api.cerebras.ai/v1',
+    );
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
+  });
+
   it('should write separate error dumps before throwing enhanced Cerebras/Qwen tool errors', async () => {
     const apiError = new Error(
       '400 Tool is not present in the tools list: lookup_weather',
@@ -387,6 +431,50 @@ describe('OpenAI executeApiRequest separate request/response dump', () => {
       true,
     );
     expect(dumpSDKContextSpy).not.toHaveBeenCalled();
+  });
+
+  it('should use request-scoped baseURL for non-streaming Cerebras/Qwen tool error handling', async () => {
+    const apiError = new Error(
+      '400 Tool is not present in the tools list: lookup_weather',
+    );
+    const client = {
+      chat: {
+        completions: {
+          create: vi.fn().mockRejectedValue(apiError),
+        },
+      },
+    } as unknown as Parameters<typeof executeApiRequest>[0]['client'];
+
+    const opts = createBaseOptions({
+      client,
+      dumpMode: 'error',
+      baseURL: 'https://api.cerebras.ai/v1',
+      getBaseURL: () => 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      formattedTools: [
+        {
+          type: 'function',
+          function: {
+            name: 'lookup_weather',
+            description: 'Look up the weather',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ],
+      streamingEnabled: false,
+    });
+
+    await expect(executeApiRequest(opts)).rejects.toThrow(
+      'Cerebras/Qwen API bug: Tool not found in list. We sent 1 tools. Known API issue.',
+    );
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'openai',
+      '/chat/completions',
+      opts.requestBody,
+      'https://api.cerebras.ai/v1',
+    );
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledOnce();
   });
 
   it('should send API request when request dump fails', async () => {

--- a/packages/providers/src/openai/OpenAIApiExecution.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.ts
@@ -20,7 +20,12 @@ import type OpenAI from 'openai';
 import { type DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import {
   shouldDumpSDKContext,
-  dumpSDKContext,
+  dumpSDKRequestContext,
+  dumpSDKResponseContext,
+  wrapStreamWithDump,
+  wrapStreamWithSDKErrorDump,
+  bestEffortDump,
+  dumpSDKErrorRequestResponse,
 } from '../utils/dumpSDKContext.js';
 import { type DumpMode } from '../utils/dumpContext.js';
 import { type OpenAITool } from './schemaConverter.js';
@@ -42,6 +47,7 @@ export interface ApiExecutionOptions {
 interface ErrorContext {
   requestBody: OpenAI.Chat.ChatCompletionCreateParams;
   shouldDumpError: boolean;
+  requestBaseId: string | undefined;
   baseURL: string | undefined;
   model: string;
   formattedTools: OpenAITool[] | undefined;
@@ -51,15 +57,51 @@ interface ErrorContext {
 }
 
 /**
+ * Write OpenAI request/response error dumps when error-mode dumping is enabled.
+ */
+async function dumpOpenAIErrorContext(
+  error: unknown,
+  resolvedBaseURL: string | undefined,
+  ctx: ErrorContext,
+): Promise<void> {
+  if (!ctx.shouldDumpError) {
+    return;
+  }
+
+  const dumpErrorMessage =
+    error instanceof Error ? error.message : String(error);
+  if (ctx.requestBaseId) {
+    await bestEffortDump('error-response', 'openai', () =>
+      dumpSDKResponseContext(
+        ctx.requestBaseId!,
+        'openai',
+        { error: dumpErrorMessage },
+        true,
+      ),
+    );
+  } else {
+    await dumpSDKErrorRequestResponse(
+      'openai',
+      '/chat/completions',
+      ctx.requestBody,
+      { error: dumpErrorMessage },
+      resolvedBaseURL ?? 'https://api.openai.com/v1',
+      dumpSDKRequestContext,
+      dumpSDKResponseContext,
+    );
+  }
+}
+
+/**
  * Check for Cerebras/Qwen "Tool not present" errors and throw enhanced error.
  * Returns true if the error was a Cerebras tool error (caller should not continue).
  */
-function handleCerebrasToolError(
+async function handleCerebrasToolError(
   error: unknown,
   errorMessage: string,
   resolvedBaseURL: string | undefined,
   ctx: ErrorContext,
-): boolean {
+): Promise<boolean> {
   if (
     !errorMessage.includes('Tool is not present in the tools list') ||
     (!ctx.model.toLowerCase().includes('qwen') &&
@@ -67,6 +109,9 @@ function handleCerebrasToolError(
   ) {
     return false;
   }
+
+  await dumpOpenAIErrorContext(error, resolvedBaseURL, ctx);
+
   ctx.logger.error(
     'Cerebras/Qwen API error: Tool not found despite being in request. This is a known API issue.',
     {
@@ -93,18 +138,7 @@ async function handleApiError(
 ): Promise<never> {
   const resolvedBaseURL = ctx.baseURL ?? ctx.getBaseURL();
 
-  if (ctx.shouldDumpError) {
-    const dumpErrorMessage =
-      error instanceof Error ? error.message : String(error);
-    await dumpSDKContext(
-      'openai',
-      '/chat/completions',
-      ctx.requestBody,
-      { error: dumpErrorMessage },
-      true,
-      resolvedBaseURL ?? 'https://api.openai.com/v1',
-    );
-  }
+  await dumpOpenAIErrorContext(error, resolvedBaseURL, ctx);
 
   const capturedErrorMessage =
     error instanceof Error ? error.message : String(error);
@@ -141,20 +175,48 @@ async function executeStreamingRequest(
 ): Promise<AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>> {
   const { client, requestBody, abortSignal, mergedHeaders, baseURL } = opts;
 
+  let requestBaseId: string | undefined;
+
+  if (shouldDumpSuccess) {
+    const reqResult = await bestEffortDump(
+      'request',
+      'openai',
+      () =>
+        dumpSDKRequestContext(
+          'openai',
+          '/chat/completions',
+          requestBody,
+          baseURL ?? 'https://api.openai.com/v1',
+        ),
+      opts.logger,
+    );
+    requestBaseId = reqResult?.baseId;
+  }
+
   try {
     const response = (await client.chat.completions.create(requestBody, {
       ...(abortSignal ? { signal: abortSignal } : {}),
       ...(mergedHeaders ? { headers: mergedHeaders } : {}),
     })) as AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>;
 
-    if (shouldDumpSuccess) {
-      await dumpSDKContext(
+    if (shouldDumpSuccess && requestBaseId) {
+      return wrapStreamWithDump(
+        response,
+        requestBaseId,
+        'openai',
+        dumpSDKResponseContext,
+      );
+    }
+
+    if (shouldDumpError) {
+      return wrapStreamWithSDKErrorDump(
+        response,
         'openai',
         '/chat/completions',
         requestBody,
-        { streaming: true },
-        false,
         baseURL ?? 'https://api.openai.com/v1',
+        dumpSDKRequestContext,
+        dumpSDKResponseContext,
       );
     }
 
@@ -166,6 +228,7 @@ async function executeStreamingRequest(
     const ctx: ErrorContext = {
       requestBody,
       shouldDumpError,
+      requestBaseId,
       baseURL,
       model: opts.model,
       formattedTools: opts.formattedTools,
@@ -174,7 +237,14 @@ async function executeStreamingRequest(
       getBaseURL: opts.getBaseURL,
     };
 
-    if (!handleCerebrasToolError(error, errorMessage, resolvedBaseURL, ctx)) {
+    if (
+      !(await handleCerebrasToolError(
+        error,
+        errorMessage,
+        resolvedBaseURL,
+        ctx,
+      ))
+    ) {
       await handleApiError(error, ctx);
     }
     // handleApiError always throws; handleCerebrasToolError throws on match
@@ -193,20 +263,36 @@ async function executeNonStreamingRequest(
 ): Promise<OpenAI.Chat.Completions.ChatCompletion> {
   const { client, requestBody, abortSignal, mergedHeaders, baseURL } = opts;
 
+  let requestBaseId: string | undefined;
+
+  if (shouldDumpSuccess) {
+    const reqResult = await bestEffortDump(
+      'request',
+      'openai',
+      () =>
+        dumpSDKRequestContext(
+          'openai',
+          '/chat/completions',
+          requestBody,
+          baseURL ?? 'https://api.openai.com/v1',
+        ),
+      opts.logger,
+    );
+    requestBaseId = reqResult?.baseId;
+  }
+
   try {
     const response = (await client.chat.completions.create(requestBody, {
       ...(abortSignal ? { signal: abortSignal } : {}),
       ...(mergedHeaders ? { headers: mergedHeaders } : {}),
     })) as OpenAI.Chat.Completions.ChatCompletion;
 
-    if (shouldDumpSuccess) {
-      await dumpSDKContext(
+    if (shouldDumpSuccess && requestBaseId) {
+      await bestEffortDump(
+        'response',
         'openai',
-        '/chat/completions',
-        requestBody,
-        response,
-        false,
-        baseURL ?? 'https://api.openai.com/v1',
+        () => dumpSDKResponseContext(requestBaseId, 'openai', response, false),
+        opts.logger,
       );
     }
 
@@ -228,6 +314,7 @@ async function executeNonStreamingRequest(
     const ctx: ErrorContext = {
       requestBody,
       shouldDumpError,
+      requestBaseId,
       baseURL,
       model: opts.model,
       formattedTools: opts.formattedTools,
@@ -236,7 +323,14 @@ async function executeNonStreamingRequest(
       getBaseURL: opts.getBaseURL,
     };
 
-    if (!handleCerebrasToolError(error, errorMessage, resolvedBaseURL, ctx)) {
+    if (
+      !(await handleCerebrasToolError(
+        error,
+        errorMessage,
+        resolvedBaseURL,
+        ctx,
+      ))
+    ) {
       await handleApiError(error, ctx);
     }
     // handleApiError always throws; handleCerebrasToolError throws on match

--- a/packages/providers/src/openai/OpenAIApiExecution.ts
+++ b/packages/providers/src/openai/OpenAIApiExecution.ts
@@ -73,7 +73,7 @@ async function dumpOpenAIErrorContext(
   if (ctx.requestBaseId) {
     await bestEffortDump('error-response', 'openai', () =>
       dumpSDKResponseContext(
-        ctx.requestBaseId!,
+        ctx.requestBaseId,
         'openai',
         { error: dumpErrorMessage },
         true,
@@ -223,7 +223,7 @@ async function executeStreamingRequest(
     return response;
   } catch (error) {
     const errorMessage = String(error);
-    const resolvedBaseURL = opts.getBaseURL();
+    const resolvedBaseURL = opts.baseURL ?? opts.getBaseURL();
 
     const ctx: ErrorContext = {
       requestBody,
@@ -299,7 +299,7 @@ async function executeNonStreamingRequest(
     return response;
   } catch (error) {
     const errorMessage = String(error);
-    const resolvedBaseURL = opts.getBaseURL();
+    const resolvedBaseURL = opts.baseURL ?? opts.getBaseURL();
 
     opts.logger.debug(() => `[OpenAIProvider] Chat request error`, {
       errorType: error?.constructor?.name,

--- a/packages/providers/src/utils/dumpContext.separateFiles.test.ts
+++ b/packages/providers/src/utils/dumpContext.separateFiles.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  dumpRequestContext,
+  dumpResponseContext,
+  generateDumpBaseId,
+} from './dumpContext.js';
+
+const DUMP_DIR = path.join(os.homedir(), '.llxprt', 'dumps');
+
+describe('dumpContext separate request/response files', () => {
+  const createdFiles: string[] = [];
+
+  afterEach(async () => {
+    for (const file of createdFiles) {
+      try {
+        await fs.unlink(file);
+      } catch {
+        // best effort cleanup
+      }
+    }
+    createdFiles.length = 0;
+  });
+
+  describe('generateDumpBaseId', () => {
+    it('should produce a deterministic date-prefixed string with random suffix', () => {
+      const id = generateDumpBaseId('anthropic');
+      const [date, time, provider, suffix] = id.split('-');
+      expect(date).toHaveLength(8);
+      expect(Number.isInteger(Number(date))).toBe(true);
+      expect(time).toHaveLength(6);
+      expect(Number.isInteger(Number(time))).toBe(true);
+      expect(provider).toBe('anthropic');
+      expect(suffix).toBeTruthy();
+    });
+
+    it('should produce unique ids on successive calls', () => {
+      const id1 = generateDumpBaseId('gemini');
+      const id2 = generateDumpBaseId('gemini');
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('dumpRequestContext', () => {
+    it('should write a request-only file with -request.json suffix', async () => {
+      const request = {
+        url: 'https://api.anthropic.com/v1/messages',
+        method: 'POST',
+        body: { model: 'claude-sonnet-4-5-20250929', messages: [] },
+      };
+      const result = await dumpRequestContext(request, 'anthropic');
+      expect(result.baseId).toBeTruthy();
+      expect(result.requestFilename).toMatch(/-request\.json$/);
+      expect(result.dumpDir).toBe(DUMP_DIR);
+
+      const filepath = path.join(DUMP_DIR, result.requestFilename);
+      createdFiles.push(filepath);
+
+      const content = JSON.parse(await fs.readFile(filepath, 'utf-8'));
+      expect(content.provider).toBe('anthropic');
+      expect(content.timestamp).toBeTruthy();
+      expect(content.request.url).toBe(request.url);
+      expect(content.request.method).toBe('POST');
+      expect(content.request.body).toStrictEqual(request.body);
+      expect(content).not.toHaveProperty('response');
+    });
+
+    it('should redact sensitive headers in request', async () => {
+      const request = {
+        url: 'https://api.openai.com/v1/chat/completions?key=secret',
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sk-secret',
+          'x-api-key': 'secret-key',
+        },
+        body: {},
+      };
+      const result = await dumpRequestContext(request, 'openai');
+      const filepath = path.join(DUMP_DIR, result.requestFilename);
+      createdFiles.push(filepath);
+
+      const content = JSON.parse(await fs.readFile(filepath, 'utf-8'));
+      expect(content.request.headers.Authorization).toBe('[REDACTED]');
+      expect(content.request.headers['x-api-key']).toBe('[REDACTED]');
+      expect(content.request.url).toContain('key=[REDACTED]');
+    });
+  });
+
+  describe('dumpResponseContext', () => {
+    it('should write a response file related to a given request base id', async () => {
+      const request = {
+        url: 'https://api.anthropic.com/v1/messages',
+        method: 'POST',
+        body: {},
+      };
+      const reqResult = await dumpRequestContext(request, 'anthropic');
+      const reqFilepath = path.join(DUMP_DIR, reqResult.requestFilename);
+      createdFiles.push(reqFilepath);
+
+      const response = {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: { id: 'msg_test', content: [{ type: 'text', text: 'Hi' }] },
+      };
+
+      const respResult = await dumpResponseContext(
+        reqResult.baseId,
+        response,
+        'anthropic',
+      );
+      expect(respResult.responseFilename).toMatch(/-response\.json$/);
+      expect(respResult.responseFilename).toContain(reqResult.baseId);
+
+      const respFilepath = path.join(DUMP_DIR, respResult.responseFilename);
+      createdFiles.push(respFilepath);
+
+      const content = JSON.parse(await fs.readFile(respFilepath, 'utf-8'));
+      expect(content.provider).toBe('anthropic');
+      expect(content.timestamp).toBeTruthy();
+      expect(content).not.toHaveProperty('request');
+      expect(content.response.status).toBe(200);
+      expect(content.response.body).toStrictEqual(response.body);
+      expect(content.relatedRequestFile).toBe(reqResult.requestFilename);
+    });
+
+    it('should write a response file for an error', async () => {
+      const baseId = generateDumpBaseId('gemini');
+      const response = {
+        status: 500,
+        body: { error: 'Rate limit exceeded' },
+      };
+
+      const respResult = await dumpResponseContext(baseId, response, 'gemini');
+      const respFilepath = path.join(DUMP_DIR, respResult.responseFilename);
+      createdFiles.push(respFilepath);
+
+      const content = JSON.parse(await fs.readFile(respFilepath, 'utf-8'));
+      expect(content.response.status).toBe(500);
+      expect(content.response.body.error).toBe('Rate limit exceeded');
+      expect(content.relatedRequestFile).toBe(`${baseId}-request.json`);
+    });
+  });
+
+  describe('request and response files are related by base id', () => {
+    it('should produce filenames sharing the same base id', async () => {
+      const request = {
+        url: 'https://generativelanguage.googleapis.com/v1/models/gemini-2.5-pro:generateContent',
+        method: 'POST',
+        body: { contents: [] },
+      };
+      const reqResult = await dumpRequestContext(request, 'gemini');
+      const reqFilepath = path.join(DUMP_DIR, reqResult.requestFilename);
+      createdFiles.push(reqFilepath);
+
+      const response = { status: 200, body: { candidates: [] } };
+      const respResult = await dumpResponseContext(
+        reqResult.baseId,
+        response,
+        'gemini',
+      );
+      const respFilepath = path.join(DUMP_DIR, respResult.responseFilename);
+      createdFiles.push(respFilepath);
+
+      expect(reqResult.requestFilename).toBe(
+        `${reqResult.baseId}-request.json`,
+      );
+      expect(respResult.responseFilename).toBe(
+        `${reqResult.baseId}-response.json`,
+      );
+      expect(respResult.responseFilename).toContain(reqResult.baseId);
+    });
+  });
+});

--- a/packages/providers/src/utils/dumpContext.test.ts
+++ b/packages/providers/src/utils/dumpContext.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { dumpContext, redactSensitiveData } from './dumpContext.js';
+import { dumpContext, redactSensitiveData, shouldDump } from './dumpContext.js';
 
 describe('dumpContext', () => {
   const testDumpDir = path.join(os.homedir(), '.llxprt', 'dumps');
@@ -34,6 +34,13 @@ describe('dumpContext', () => {
     } catch {
       // Ignore cleanup errors
     }
+  });
+
+  describe('shouldDump', () => {
+    it('should not let now mode trigger provider dumps', () => {
+      expect(shouldDump('now', false)).toBe(false);
+      expect(shouldDump('now', true)).toBe(false);
+    });
   });
 
   describe('redactSensitiveData', () => {
@@ -147,12 +154,16 @@ describe('dumpContext', () => {
         },
       };
 
-      const filename = await dumpContext(request, response, 'openai');
-      createdFiles.push(filename);
+      const baseId = await dumpContext(request, response, 'openai');
+      const requestFilename = `${baseId}-request.json`;
+      const responseFilename = `${baseId}-response.json`;
+      createdFiles.push(requestFilename, responseFilename);
+      // dumpContext returns a dump base id, not a generated filename.
+      expect(baseId).not.toMatch(/\.json$/);
       // eslint-disable-next-line sonarjs/regular-expr -- Static test regex reviewed for lint hardening; behavior preserved.
-      expect(filename).toMatch(/^\d{8}-\d{6}-openai-\w+\.json$/);
+      expect(baseId).toMatch(/^\d{8}-\d{6}-openai-\w+$/);
 
-      const filepath = path.join(testDumpDir, filename);
+      const filepath = path.join(testDumpDir, requestFilename);
       const content = await fs.readFile(filepath, 'utf-8');
       const dump = JSON.parse(content);
 
@@ -161,8 +172,16 @@ describe('dumpContext', () => {
       expect(dump.request.url).toBe(request.url);
       expect(dump.request.headers.Authorization).toBe('[REDACTED]');
       expect(dump.request.body.model).toBe('gpt-4');
-      expect(dump.response.status).toBe(200);
-      expect(dump.response.body.choices).toHaveLength(1);
+      expect(dump).not.toHaveProperty('response');
+
+      const responseFilepath = path.join(testDumpDir, responseFilename);
+      const responseContent = await fs.readFile(responseFilepath, 'utf-8');
+      const responseDump = JSON.parse(responseContent);
+      expect(responseDump.provider).toBe('openai');
+      expect(responseDump.relatedRequestFile).toBe(requestFilename);
+      expect(responseDump).not.toHaveProperty('request');
+      expect(responseDump.response.status).toBe(200);
+      expect(responseDump.response.body.choices).toHaveLength(1);
     });
   });
 
@@ -195,18 +214,23 @@ describe('dumpContext', () => {
         },
       };
 
-      const filename = await dumpContext(request, response, 'anthropic');
-      createdFiles.push(filename);
+      const baseId = await dumpContext(request, response, 'anthropic');
+      const requestFilename = `${baseId}-request.json`;
+      const responseFilename = `${baseId}-response.json`;
+      createdFiles.push(requestFilename, responseFilename);
       // eslint-disable-next-line sonarjs/regular-expr -- Static test regex reviewed for lint hardening; behavior preserved.
-      expect(filename).toMatch(/^\d{8}-\d{6}-anthropic-\w+\.json$/);
+      expect(baseId).toMatch(/^\d{8}-\d{6}-anthropic-\w+$/);
 
-      const filepath = path.join(testDumpDir, filename);
+      const filepath = path.join(testDumpDir, requestFilename);
       const content = await fs.readFile(filepath, 'utf-8');
       const dump = JSON.parse(content);
 
       expect(dump.provider).toBe('anthropic');
       expect(dump.request.headers['x-api-key']).toBe('[REDACTED]');
       expect(dump.request.body.model).toBe('claude-3-opus-20240229');
+      await expect(
+        fs.access(path.join(testDumpDir, responseFilename)),
+      ).resolves.toBeUndefined();
     });
   });
 
@@ -244,18 +268,52 @@ describe('dumpContext', () => {
         },
       };
 
-      const filename = await dumpContext(request, response, 'gemini');
-      createdFiles.push(filename);
+      const baseId = await dumpContext(request, response, 'gemini');
+      const requestFilename = `${baseId}-request.json`;
+      const responseFilename = `${baseId}-response.json`;
+      createdFiles.push(requestFilename, responseFilename);
       // eslint-disable-next-line sonarjs/regular-expr -- Static test regex reviewed for lint hardening; behavior preserved.
-      expect(filename).toMatch(/^\d{8}-\d{6}-gemini-\w+\.json$/);
+      expect(baseId).toMatch(/^\d{8}-\d{6}-gemini-\w+$/);
 
-      const filepath = path.join(testDumpDir, filename);
+      const filepath = path.join(testDumpDir, requestFilename);
       const content = await fs.readFile(filepath, 'utf-8');
       const dump = JSON.parse(content);
 
       expect(dump.provider).toBe('gemini');
       expect(dump.request.url).toMatch(/key=\[REDACTED\]/);
       expect(dump.request.body.contents).toHaveLength(1);
+      await expect(
+        fs.access(path.join(testDumpDir, responseFilename)),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('response handling', () => {
+    it('should create related response file when response body is falsy', async () => {
+      const request = {
+        url: 'https://api.example.com/v1/chat/completions',
+        method: 'POST',
+        headers: {},
+        body: { prompt: 'Return false' },
+      };
+      const response = {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: false,
+      };
+
+      const baseId = await dumpContext(request, response, 'openai');
+      const requestFilename = `${baseId}-request.json`;
+      const responseFilename = `${baseId}-response.json`;
+      createdFiles.push(requestFilename, responseFilename);
+
+      const responseContent = await fs.readFile(
+        path.join(testDumpDir, responseFilename),
+        'utf-8',
+      );
+      const responseDump = JSON.parse(responseContent);
+      expect(responseDump.relatedRequestFile).toBe(requestFilename);
+      expect(responseDump.response.body).toBe(false);
     });
   });
 
@@ -275,9 +333,9 @@ describe('dumpContext', () => {
       };
 
       // Should not throw even if there are issues
-      const filename = await dumpContext(request, response, 'openai');
-      createdFiles.push(filename);
-      expect(filename).toBeDefined();
+      const baseId = await dumpContext(request, response, 'openai');
+      createdFiles.push(`${baseId}-request.json`, `${baseId}-response.json`);
+      expect(baseId).toBeDefined();
     });
   });
 
@@ -302,9 +360,11 @@ describe('dumpContext', () => {
         body: { id: 'test' },
       };
 
-      const filename = await dumpContext(request, response, 'openai');
-      createdFiles.push(filename);
-      const filepath = path.join(testDumpDir, filename);
+      const baseId = await dumpContext(request, response, 'openai');
+      const requestFilename = `${baseId}-request.json`;
+      const responseFilename = `${baseId}-response.json`;
+      createdFiles.push(requestFilename, responseFilename);
+      const filepath = path.join(testDumpDir, requestFilename);
       const content = await fs.readFile(filepath, 'utf-8');
       const dump = JSON.parse(content);
 

--- a/packages/providers/src/utils/dumpContext.test.ts
+++ b/packages/providers/src/utils/dumpContext.test.ts
@@ -74,6 +74,27 @@ describe('dumpContext', () => {
       expect(redacted.headers['x-api-key']).toBe('[REDACTED]');
     });
 
+    it('should redact credential headers case-insensitively', () => {
+      const request = {
+        url: 'https://api.example.com',
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer sk-lowercase',
+          AUTHORIZATION: 'Bearer sk-uppercase',
+          'X-API-KEY': 'secret-key-uppercase',
+          'Content-Type': 'application/json',
+        },
+        body: { test: 'data' },
+      };
+
+      const redacted = redactSensitiveData(request);
+
+      expect(redacted.headers.authorization).toBe('[REDACTED]');
+      expect(redacted.headers.AUTHORIZATION).toBe('[REDACTED]');
+      expect(redacted.headers['X-API-KEY']).toBe('[REDACTED]');
+      expect(redacted.headers['Content-Type']).toBe('application/json');
+    });
+
     it('should redact key query parameter in URL', () => {
       const request = {
         url: 'https://api.example.com/v1/models?key=AIzaSyABC123',

--- a/packages/providers/src/utils/dumpContext.ts
+++ b/packages/providers/src/utils/dumpContext.ts
@@ -43,14 +43,16 @@ export function redactSensitiveData(request: DumpRequest): DumpRequest {
     headers: request.headers ? { ...request.headers } : undefined,
   };
 
-  // Redact Authorization header
-  if (redacted.headers?.Authorization) {
-    redacted.headers.Authorization = '[REDACTED]';
-  }
-
-  // Redact x-api-key header
-  if (redacted.headers?.['x-api-key']) {
-    redacted.headers['x-api-key'] = '[REDACTED]';
+  if (redacted.headers) {
+    for (const headerName of Object.keys(redacted.headers)) {
+      const normalizedHeaderName = headerName.toLowerCase();
+      if (
+        normalizedHeaderName === 'authorization' ||
+        normalizedHeaderName === 'x-api-key'
+      ) {
+        redacted.headers[headerName] = '[REDACTED]';
+      }
+    }
   }
 
   // Redact key query parameter in URL
@@ -146,21 +148,22 @@ export async function dumpRequestContext(
  * Includes relatedRequestFile metadata linking back to the request file.
  */
 export async function dumpResponseContext(
-  baseId: string,
+  baseId: string | undefined,
   response: DumpResponse,
   provider: string,
 ): Promise<DumpResponseResult> {
   const dumpDir = path.join(os.homedir(), '.llxprt', 'dumps');
   await fs.mkdir(dumpDir, { recursive: true });
 
-  const responseFilename = `${baseId}-response.json`;
+  const id = baseId ?? generateDumpBaseId(provider);
+  const responseFilename = `${id}-response.json`;
   const filepath = path.join(dumpDir, responseFilename);
 
   const data = {
     provider,
     timestamp: new Date().toISOString(),
     response,
-    relatedRequestFile: `${baseId}-request.json`,
+    ...(baseId ? { relatedRequestFile: `${baseId}-request.json` } : {}),
   };
 
   await fs.writeFile(filepath, JSON.stringify(data, null, 2), 'utf-8');

--- a/packages/providers/src/utils/dumpContext.ts
+++ b/packages/providers/src/utils/dumpContext.ts
@@ -29,8 +29,9 @@ export interface DumpResponse {
 export interface DumpData {
   provider: string;
   timestamp: string;
-  request: DumpRequest;
+  request?: DumpRequest;
   response?: DumpResponse;
+  relatedRequestFile?: string;
 }
 
 /**
@@ -67,52 +68,6 @@ export function redactSensitiveData(request: DumpRequest): DumpRequest {
 }
 
 /**
- * Generates a unique filename for the dump
- */
-function generateFilename(provider: string): string {
-  const now = new Date();
-  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
-  const timeStr = now.toISOString().slice(11, 19).replace(/:/g, '');
-  const randomStr = Math.random().toString(36).substring(2, 8);
-  return `${dateStr}-${timeStr}-${provider}-${randomStr}.json`;
-}
-
-/**
- * Dumps context (request and response) to a file in ~/.llxprt/dumps/
- * Returns the filename of the created dump file
- */
-export async function dumpContext(
-  request: DumpRequest,
-  response: DumpResponse | undefined,
-  provider: string,
-): Promise<string> {
-  try {
-    const dumpDir = path.join(os.homedir(), '.llxprt', 'dumps');
-    await fs.mkdir(dumpDir, { recursive: true });
-
-    const redactedRequest = redactSensitiveData(request);
-
-    const dumpData: DumpData = {
-      provider,
-      timestamp: new Date().toISOString(),
-      request: redactedRequest,
-      response,
-    };
-
-    const filename = generateFilename(provider);
-    const filepath = path.join(dumpDir, filename);
-
-    await fs.writeFile(filepath, JSON.stringify(dumpData, null, 2), 'utf-8');
-
-    logger.debug(() => `Context dumped to: ${filepath}`);
-    return filename;
-  } catch (error) {
-    logger.error(() => `Failed to dump context: ${error}`);
-    throw error;
-  }
-}
-
-/**
  * Checks if dumping should occur based on mode and error status
  */
 export function shouldDump(
@@ -124,7 +79,7 @@ export function shouldDump(
   }
 
   if (mode === 'now') {
-    return true; // Special case handled by command
+    return false;
   }
 
   if (mode === 'on') {
@@ -132,4 +87,108 @@ export function shouldDump(
   }
 
   return isError;
+}
+
+export interface DumpRequestResult {
+  baseId: string;
+  requestFilename: string;
+  dumpDir: string;
+}
+
+export interface DumpResponseResult {
+  responseFilename: string;
+  dumpDir: string;
+}
+
+/**
+ * Generates a shared base id used to relate request and response dump files.
+ */
+export function generateDumpBaseId(provider: string): string {
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+  const timeStr = now.toISOString().slice(11, 19).replace(/:/g, '');
+  const randomStr = Math.random().toString(36).substring(2, 8);
+  return `${dateStr}-${timeStr}-${provider}-${randomStr}`;
+}
+
+/**
+ * Writes a request-only dump file named {baseId}-request.json.
+ * Returns the base id and filename so the caller can later write a related response.
+ */
+export async function dumpRequestContext(
+  request: DumpRequest,
+  provider: string,
+  baseId?: string,
+): Promise<DumpRequestResult> {
+  const dumpDir = path.join(os.homedir(), '.llxprt', 'dumps');
+  await fs.mkdir(dumpDir, { recursive: true });
+
+  const id = baseId ?? generateDumpBaseId(provider);
+  const requestFilename = `${id}-request.json`;
+  const filepath = path.join(dumpDir, requestFilename);
+
+  const redactedRequest = redactSensitiveData(request);
+
+  const data = {
+    provider,
+    timestamp: new Date().toISOString(),
+    request: redactedRequest,
+  };
+
+  await fs.writeFile(filepath, JSON.stringify(data, null, 2), 'utf-8');
+  logger.debug(() => `Request context dumped to: ${filepath}`);
+
+  return { baseId: id, requestFilename, dumpDir };
+}
+
+/**
+ * Writes a response-only dump file named {baseId}-response.json.
+ * Includes relatedRequestFile metadata linking back to the request file.
+ */
+export async function dumpResponseContext(
+  baseId: string,
+  response: DumpResponse,
+  provider: string,
+): Promise<DumpResponseResult> {
+  const dumpDir = path.join(os.homedir(), '.llxprt', 'dumps');
+  await fs.mkdir(dumpDir, { recursive: true });
+
+  const responseFilename = `${baseId}-response.json`;
+  const filepath = path.join(dumpDir, responseFilename);
+
+  const data = {
+    provider,
+    timestamp: new Date().toISOString(),
+    response,
+    relatedRequestFile: `${baseId}-request.json`,
+  };
+
+  await fs.writeFile(filepath, JSON.stringify(data, null, 2), 'utf-8');
+  logger.debug(() => `Response context dumped to: ${filepath}`);
+
+  return { responseFilename, dumpDir };
+}
+
+/**
+ * Dumps context to separate related request and response files in ~/.llxprt/dumps/.
+ * Returns the shared base id used by the generated filenames.
+ */
+export async function dumpContext(
+  request: DumpRequest,
+  response: DumpResponse | undefined,
+  provider: string,
+): Promise<string> {
+  try {
+    const baseId = generateDumpBaseId(provider);
+    await dumpRequestContext(request, provider, baseId);
+    if (response !== undefined) {
+      await dumpResponseContext(baseId, response, provider);
+    }
+
+    logger.debug(() => `Context dumped with base id: ${baseId}`);
+    return baseId;
+  } catch (error) {
+    logger.error(() => `Failed to dump context: ${error}`);
+    throw error;
+  }
 }

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -12,6 +12,7 @@ import * as os from 'node:os';
 import * as dumpSDKContextModule from './dumpSDKContext.js';
 import {
   dumpSDKContext,
+  dumpSDKRequestContext,
   wrapStreamWithDump,
   wrapStreamWithSDKErrorDump,
 } from './dumpSDKContext.js';
@@ -43,6 +44,24 @@ describe('dumpSDKContext', () => {
     expect(parts[1]).toHaveLength(6);
     expect(parts[2]).toBe('openai');
     expect(parts[3]).toBeTruthy();
+  });
+
+  it('should build dump URLs like the OpenAI SDK when the base URL has a trailing slash', async () => {
+    const result = await dumpSDKRequestContext(
+      'openai',
+      '/chat/completions',
+      { model: 'test-model', messages: [] },
+      'https://ollama.com/v1/',
+    );
+    createdFiles.push(result.requestFilename);
+
+    const content = await fs.readFile(
+      path.join(result.dumpDir, result.requestFilename),
+      'utf-8',
+    );
+    const dump = JSON.parse(content) as { request: { url: string } };
+
+    expect(dump.request.url).toBe('https://ollama.com/v1/chat/completions');
   });
 });
 

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import * as dumpSDKContextModule from './dumpSDKContext.js';
+import {
+  dumpSDKContext,
+  wrapStreamWithDump,
+  wrapStreamWithSDKErrorDump,
+} from './dumpSDKContext.js';
+
+describe('dumpSDKContext', () => {
+  const dumpDir = path.join(os.homedir(), '.llxprt', 'dumps');
+  const createdFiles: string[] = [];
+
+  afterEach(async () => {
+    for (const file of createdFiles.splice(0)) {
+      await fs.rm(path.join(dumpDir, file), { force: true });
+    }
+  });
+
+  it('should return a dump base id rather than a dump filename', async () => {
+    const baseId = await dumpSDKContext(
+      'openai',
+      '/chat/completions',
+      { model: 'test-model', messages: [] },
+      { id: 'response-id' },
+      false,
+    );
+    createdFiles.push(`${baseId}-request.json`, `${baseId}-response.json`);
+
+    expect(baseId).not.toMatch(/\.json$/);
+    const parts = baseId.split('-');
+    expect(parts).toHaveLength(4);
+    expect(parts[0]).toHaveLength(8);
+    expect(parts[1]).toHaveLength(6);
+    expect(parts[2]).toBe('openai');
+    expect(parts[3]).toBeTruthy();
+  });
+});
+
+describe('wrapStreamWithDump', () => {
+  let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dumpSDKResponseContextSpy = vi.spyOn(
+      dumpSDKContextModule,
+      'dumpSDKResponseContext',
+    );
+    dumpSDKResponseContextSpy.mockResolvedValue('base-response.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should pass chunks through unchanged and dump accumulated chunks on success', async () => {
+    const chunks = [{ text: 'hello' }, { text: ' world' }];
+    const stream = (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+
+    const wrapped = wrapStreamWithDump(
+      stream,
+      'base-123',
+      'openai',
+      dumpSDKResponseContextSpy,
+    );
+    const received: unknown[] = [];
+
+    for await (const chunk of wrapped) {
+      received.push(chunk);
+    }
+
+    expect(received).toStrictEqual(chunks);
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'base-123',
+      'openai',
+      { streaming: true, chunks, completed: true },
+      false,
+    );
+  });
+
+  it('should dump accumulated chunks as an error response and rethrow stream errors exactly once', async () => {
+    const firstChunk = { text: 'partial' };
+    const stream = (async function* () {
+      yield firstChunk;
+      throw new Error('stream failed');
+    })();
+
+    const wrapped = wrapStreamWithDump(
+      stream,
+      'base-456',
+      'anthropic',
+      dumpSDKResponseContextSpy,
+    );
+    const received: unknown[] = [];
+
+    await expect(async () => {
+      for await (const chunk of wrapped) {
+        received.push(chunk);
+      }
+    }).rejects.toThrow('stream failed');
+
+    expect(received).toStrictEqual([firstChunk]);
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'base-456',
+      'anthropic',
+      {
+        streaming: true,
+        chunks: [firstChunk],
+        error: 'Error: stream failed',
+        completed: false,
+      },
+      true,
+    );
+  });
+
+  it('should dump accumulated chunks when the consumer stops iterating early', async () => {
+    const chunks = [{ text: 'first' }, { text: 'second' }];
+    const stream = (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+
+    const wrapped = wrapStreamWithDump(
+      stream,
+      'base-cancelled',
+      'gemini',
+      dumpSDKResponseContextSpy,
+    );
+    const received: unknown[] = [];
+
+    for await (const chunk of wrapped) {
+      received.push(chunk);
+      break;
+    }
+
+    expect(received).toStrictEqual([chunks[0]]);
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'base-cancelled',
+      'gemini',
+      { streaming: true, chunks: [chunks[0]], completed: false },
+      false,
+    );
+  });
+
+  it('should dump related request and error response and rethrow stream errors without a request base id', async () => {
+    const firstChunk = { text: 'partial' };
+    const requestBody = { model: 'test-model', messages: [] };
+    const stream = (async function* () {
+      yield firstChunk;
+      throw new Error('stream failed');
+    })();
+    const dumpSDKRequestContextSpy = vi
+      .spyOn(dumpSDKContextModule, 'dumpSDKRequestContext')
+      .mockResolvedValue({
+        baseId: 'base-789',
+        requestFilename: 'base-789-request.json',
+        dumpDir: '/tmp',
+      });
+
+    const wrapped = wrapStreamWithSDKErrorDump(
+      stream,
+      'openai',
+      '/chat/completions',
+      requestBody,
+      'https://api.openai.com/v1',
+      dumpSDKRequestContextSpy,
+      dumpSDKResponseContextSpy,
+    );
+    const received: unknown[] = [];
+
+    await expect(async () => {
+      for await (const chunk of wrapped) {
+        received.push(chunk);
+      }
+    }).rejects.toThrow('stream failed');
+
+    expect(received).toStrictEqual([firstChunk]);
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'openai',
+      '/chat/completions',
+      requestBody,
+      'https://api.openai.com/v1',
+    );
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      'base-789',
+      'openai',
+      {
+        streaming: true,
+        chunks: [firstChunk],
+        error: 'Error: stream failed',
+        completed: false,
+      },
+      true,
+    );
+  });
+});

--- a/packages/providers/src/utils/dumpSDKContext.test.ts
+++ b/packages/providers/src/utils/dumpSDKContext.test.ts
@@ -46,6 +46,40 @@ describe('dumpSDKContext', () => {
   });
 });
 
+describe('dumpSDKErrorRequestResponse', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should write an error response dump even when request dumping fails', async () => {
+    const dumpSDKRequestContextSpy = vi
+      .spyOn(dumpSDKContextModule, 'dumpSDKRequestContext')
+      .mockRejectedValue(new Error('disk full'));
+    const dumpSDKResponseContextSpy = vi
+      .spyOn(dumpSDKContextModule, 'dumpSDKResponseContext')
+      .mockResolvedValue('fallback-response.json');
+    const requestBody = { model: 'test-model', messages: [] };
+
+    await dumpSDKContextModule.dumpSDKErrorRequestResponse(
+      'openai',
+      '/chat/completions',
+      requestBody,
+      { error: 'Rate limit' },
+      'https://api.openai.com/v1',
+      dumpSDKRequestContextSpy,
+      dumpSDKResponseContextSpy,
+    );
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      undefined,
+      'openai',
+      { error: 'Rate limit' },
+      true,
+    );
+  });
+});
+
 describe('wrapStreamWithDump', () => {
   let dumpSDKResponseContextSpy: ReturnType<typeof vi.spyOn>;
 
@@ -200,6 +234,54 @@ describe('wrapStreamWithDump', () => {
       {
         streaming: true,
         chunks: [firstChunk],
+        error: 'Error: stream failed',
+        completed: false,
+      },
+      true,
+    );
+  });
+
+  it('should write an error response dump even when request dumping fails', async () => {
+    const dumpSDKRequestContextSpy = vi
+      .spyOn(dumpSDKContextModule, 'dumpSDKRequestContext')
+      .mockRejectedValue(new Error('disk full'));
+    const dumpSDKResponseContextSpy = vi
+      .spyOn(dumpSDKContextModule, 'dumpSDKResponseContext')
+      .mockResolvedValue('fallback-response.json');
+    const requestBody = { model: 'test-model', messages: [] };
+    const stream: AsyncIterable<unknown> = {
+      [Symbol.asyncIterator](): AsyncIterator<unknown> {
+        return {
+          async next(): Promise<IteratorResult<unknown>> {
+            throw new Error('stream failed');
+          },
+        };
+      },
+    };
+
+    const wrapped = wrapStreamWithSDKErrorDump(
+      stream,
+      'openai',
+      '/chat/completions',
+      requestBody,
+      'https://api.openai.com/v1',
+      dumpSDKRequestContextSpy,
+      dumpSDKResponseContextSpy,
+    );
+
+    await expect(async () => {
+      for await (const _chunk of wrapped) {
+        // Exhaust stream.
+      }
+    }).rejects.toThrow('stream failed');
+
+    expect(dumpSDKRequestContextSpy).toHaveBeenCalledOnce();
+    expect(dumpSDKResponseContextSpy).toHaveBeenCalledExactlyOnceWith(
+      undefined,
+      'openai',
+      {
+        streaming: true,
+        chunks: [],
         error: 'Error: stream failed',
         completed: false,
       },

--- a/packages/providers/src/utils/dumpSDKContext.ts
+++ b/packages/providers/src/utils/dumpSDKContext.ts
@@ -128,7 +128,7 @@ export async function dumpSDKRequestContext(
  * Writes a response-only SDK dump file related to the given request base id.
  */
 export async function dumpSDKResponseContext(
-  baseId: string,
+  baseId: string | undefined,
   providerName: string,
   response: unknown,
   isError: boolean,
@@ -244,11 +244,9 @@ export async function dumpSDKErrorRequestResponse(
     dumpRequest(providerName, endpoint, requestParams, baseURL),
   );
 
-  if (reqResult?.baseId) {
-    await bestEffortDump('error-response', providerName, () =>
-      dumpResponse(reqResult.baseId, providerName, errorResponse, true),
-    );
-  }
+  await bestEffortDump('error-response', providerName, () =>
+    dumpResponse(reqResult?.baseId, providerName, errorResponse, true),
+  );
 }
 
 /**

--- a/packages/providers/src/utils/dumpSDKContext.ts
+++ b/packages/providers/src/utils/dumpSDKContext.ts
@@ -4,15 +4,51 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { dumpContext, shouldDump } from './dumpContext.js';
+import {
+  dumpContext,
+  shouldDump,
+  dumpRequestContext,
+  dumpResponseContext,
+  type DumpRequestResult,
+} from './dumpContext.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 
 const logger = new DebugLogger('llxprt:core:dumpSDKContext');
+
+type DumpFailureLogger = Pick<DebugLogger, 'debug'>;
+
+function logDumpFailure(
+  operation: string,
+  providerName: string,
+  error: unknown,
+  log: DumpFailureLogger = logger,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  log.debug(
+    () =>
+      `Best-effort dump failed for ${providerName} ${operation}: ${message}`,
+  );
+}
+
+export async function bestEffortDump<T>(
+  operation: string,
+  providerName: string,
+  action: () => Promise<T>,
+  log?: DumpFailureLogger,
+): Promise<T | undefined> {
+  try {
+    return await action();
+  } catch (error) {
+    logDumpFailure(operation, providerName, error, log);
+    return undefined;
+  }
+}
 
 /**
  * Dumps SDK-level request/response data by synthesizing HTTP-like structure
  * This captures the actual SDK parameters and responses, which is more useful
  * for debugging than raw HTTP dumps.
+ * Returns the shared dump base id, not a dump filename.
  */
 export async function dumpSDKContext(
   providerName: string,
@@ -54,3 +90,211 @@ export async function dumpSDKContext(
 
 // Re-export shouldDump as shouldDumpSDKContext for backwards compatibility
 export { shouldDump as shouldDumpSDKContext };
+
+/**
+ * Writes a request-only SDK dump file. Returns the base id so the caller
+ * can later call dumpSDKResponseContext with the same base id to produce
+ * a related response file.
+ */
+export async function dumpSDKRequestContext(
+  providerName: string,
+  endpoint: string,
+  requestParams: unknown,
+  baseURL?: string,
+): Promise<DumpRequestResult> {
+  const url = baseURL
+    ? `${baseURL}${endpoint}`
+    : `https://api.${providerName}.com${endpoint}`;
+
+  const request = {
+    url,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'llxprt-code',
+    },
+    body: requestParams,
+  };
+
+  logger.debug(
+    () =>
+      `Dumping SDK request context for ${providerName}: endpoint=${endpoint}`,
+  );
+
+  return dumpRequestContext(request, providerName);
+}
+
+/**
+ * Writes a response-only SDK dump file related to the given request base id.
+ */
+export async function dumpSDKResponseContext(
+  baseId: string,
+  providerName: string,
+  response: unknown,
+  isError: boolean,
+): Promise<string> {
+  const dumpResponse = {
+    status: isError ? 500 : 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: response,
+  };
+
+  logger.debug(
+    () =>
+      `Dumping SDK response context for ${providerName}: isError=${isError}`,
+  );
+
+  const result = await dumpResponseContext(baseId, dumpResponse, providerName);
+  return result.responseFilename;
+}
+
+/**
+ * Wraps a streaming AsyncIterable so that chunks pass through unchanged while
+ * being accumulated. After the stream completes, errors, or is closed early,
+ * writes one linked response dump file containing the accumulated chunks.
+ *
+ * The response dump body is shaped as:
+ * - { streaming: true, chunks, completed: true } on normal completion
+ * - { streaming: true, chunks, error, completed: false } on stream error
+ * - { streaming: true, chunks, completed: false } when the consumer closes the
+ *   stream early
+ *
+ * Used by providers that support streaming to capture the full response for
+ * debugging without buffering the stream consumer.
+ */
+export function wrapStreamWithDump<T>(
+  stream: AsyncIterable<T>,
+  baseId: string,
+  providerName: string,
+  dumpResponse: typeof dumpSDKResponseContext = dumpSDKResponseContext,
+): AsyncIterable<T> {
+  const accumulated: T[] = [];
+  let dumped = false;
+
+  async function dumpOnce(
+    operation: string,
+    body: Record<string, unknown>,
+    isError: boolean,
+  ): Promise<void> {
+    if (dumped) {
+      return;
+    }
+    dumped = true;
+    await bestEffortDump(operation, providerName, () =>
+      dumpResponse(baseId, providerName, body, isError),
+    );
+  }
+
+  async function* iterate(): AsyncGenerator<T> {
+    let completed = false;
+    let failed = false;
+    try {
+      for await (const chunk of stream) {
+        accumulated.push(chunk);
+        yield chunk;
+      }
+      completed = true;
+    } catch (error) {
+      failed = true;
+      await dumpOnce(
+        'stream-error-response',
+        {
+          streaming: true,
+          chunks: [...accumulated],
+          error: String(error),
+          completed: false,
+        },
+        true,
+      );
+      throw error;
+    } finally {
+      if (!failed) {
+        await dumpOnce(
+          completed ? 'stream-response' : 'stream-cancelled-response',
+          {
+            streaming: true,
+            chunks: [...accumulated],
+            completed,
+          },
+          false,
+        );
+      }
+    }
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      return iterate()[Symbol.asyncIterator]();
+    },
+  };
+}
+
+export async function dumpSDKErrorRequestResponse(
+  providerName: string,
+  endpoint: string,
+  requestParams: unknown,
+  errorResponse: unknown,
+  baseURL?: string,
+  dumpRequest: typeof dumpSDKRequestContext = dumpSDKRequestContext,
+  dumpResponse: typeof dumpSDKResponseContext = dumpSDKResponseContext,
+): Promise<void> {
+  const reqResult = await bestEffortDump('error-request', providerName, () =>
+    dumpRequest(providerName, endpoint, requestParams, baseURL),
+  );
+
+  if (reqResult?.baseId) {
+    await bestEffortDump('error-response', providerName, () =>
+      dumpResponse(reqResult.baseId, providerName, errorResponse, true),
+    );
+  }
+}
+
+/**
+ * Wraps a streaming AsyncIterable when there is no pre-request dump base id.
+ * Chunks pass through unchanged; if iteration throws, writes best-effort
+ * separate related request and error response dumps.
+ */
+export function wrapStreamWithSDKErrorDump<T>(
+  stream: AsyncIterable<T>,
+  providerName: string,
+  endpoint: string,
+  requestParams: unknown,
+  baseURL: string | undefined,
+  dumpRequest: typeof dumpSDKRequestContext = dumpSDKRequestContext,
+  dumpResponse: typeof dumpSDKResponseContext = dumpSDKResponseContext,
+): AsyncIterable<T> {
+  const accumulated: T[] = [];
+
+  async function* iterate(): AsyncGenerator<T> {
+    try {
+      for await (const chunk of stream) {
+        accumulated.push(chunk);
+        yield chunk;
+      }
+    } catch (error) {
+      await dumpSDKErrorRequestResponse(
+        providerName,
+        endpoint,
+        requestParams,
+        {
+          streaming: true,
+          chunks: [...accumulated],
+          error: String(error),
+          completed: false,
+        },
+        baseURL,
+        dumpRequest,
+        dumpResponse,
+      );
+      throw error;
+    }
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      return iterate()[Symbol.asyncIterator]();
+    },
+  };
+}

--- a/packages/providers/src/utils/dumpSDKContext.ts
+++ b/packages/providers/src/utils/dumpSDKContext.ts
@@ -15,6 +15,22 @@ import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 
 const logger = new DebugLogger('llxprt:core:dumpSDKContext');
 
+function buildSDKDumpUrl(
+  providerName: string,
+  endpoint: string,
+  baseURL?: string,
+): string {
+  if (!baseURL) {
+    return `https://api.${providerName}.com${endpoint}`;
+  }
+
+  if (baseURL.endsWith('/') && endpoint.startsWith('/')) {
+    return `${baseURL}${endpoint.slice(1)}`;
+  }
+
+  return `${baseURL}${endpoint}`;
+}
+
 type DumpFailureLogger = Pick<DebugLogger, 'debug'>;
 
 function logDumpFailure(
@@ -58,9 +74,7 @@ export async function dumpSDKContext(
   isError: boolean,
   baseURL?: string,
 ): Promise<string> {
-  const url = baseURL
-    ? `${baseURL}${endpoint}`
-    : `https://api.${providerName}.com${endpoint}`;
+  const url = buildSDKDumpUrl(providerName, endpoint, baseURL);
 
   const request = {
     url,
@@ -102,9 +116,7 @@ export async function dumpSDKRequestContext(
   requestParams: unknown,
   baseURL?: string,
 ): Promise<DumpRequestResult> {
-  const url = baseURL
-    ? `${baseURL}${endpoint}`
-    : `https://api.${providerName}.com${endpoint}`;
+  const url = buildSDKDumpUrl(providerName, endpoint, baseURL);
 
   const request = {
     url,

--- a/packages/providers/src/utils/providerRequestConversion.ts
+++ b/packages/providers/src/utils/providerRequestConversion.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import { convertToAnthropicMessages } from '../anthropic/AnthropicMessageNormalizer.js';
+import { convertHistoryToGeminiFormat } from '../gemini/GeminiMessageConverter.js';
+import { buildMessagesWithReasoning } from '../openai/OpenAIRequestBuilder.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+
+interface MinimalSettings {
+  get?: (key: string) => unknown;
+}
+
+function asMinimalSettings(value: unknown): MinimalSettings | undefined {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'get' in value &&
+    typeof (value as { get?: unknown }).get === 'function'
+  ) {
+    return value as MinimalSettings;
+  }
+  return undefined;
+}
+
+function createSettings(overrides?: unknown): SettingsService {
+  const minimal = asMinimalSettings(overrides);
+  return {
+    get: (key: string) => minimal?.get?.(key),
+  } as SettingsService;
+}
+
+function createOptions(
+  history: IContent[],
+  settings?: unknown,
+): NormalizedGenerateChatOptions {
+  return {
+    contents: history,
+    settings: createSettings(settings),
+    invocation: { ephemerals: {} },
+    metadata: {},
+    resolved: {
+      model: '',
+      authToken: { token: '', source: 'none' },
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+}
+
+export function buildOpenAIDumpMessages(
+  history: IContent[],
+  settings?: unknown,
+  config?: Config,
+): unknown[] {
+  return buildMessagesWithReasoning(
+    history,
+    createOptions(history, settings),
+    'openai',
+    config,
+  );
+}
+
+export function buildAnthropicDumpMessages(
+  history: IContent[],
+  settings?: unknown,
+  config?: Config,
+): unknown[] {
+  return convertToAnthropicMessages(history, {
+    isOAuth: false,
+    stripFromContext:
+      (asMinimalSettings(settings)?.get?.('reasoning.stripFromContext') as
+        | 'all'
+        | 'allButLast'
+        | 'none'
+        | undefined) ?? 'none',
+    includeInContext:
+      (asMinimalSettings(settings)?.get?.('reasoning.includeInContext') as
+        | boolean
+        | undefined) ?? false,
+    reasoningEnabled: true,
+    config,
+    unprefixToolName: (name) => name,
+    logger: new DebugLogger('llxprt:providers:dumpConversion:anthropic'),
+  });
+}
+
+export function buildGeminiDumpContents(
+  history: IContent[],
+  model?: string,
+  config?: Config,
+): unknown[] {
+  return convertHistoryToGeminiFormat(history, model, config);
+}
+
+function normalizeProviderName(providerName: string): string {
+  return providerName.toLowerCase().trim();
+}
+
+function isOpenAICompatibleProvider(providerName: string): boolean {
+  const provider = normalizeProviderName(providerName);
+  return (
+    provider === 'openai' ||
+    provider === 'openaivercel' ||
+    provider.startsWith('openai-')
+  );
+}
+
+function isAnthropicCompatibleProvider(providerName: string): boolean {
+  const provider = normalizeProviderName(providerName);
+  return provider === 'anthropic' || provider.startsWith('anthropic-');
+}
+
+function isGeminiCompatibleProvider(providerName: string): boolean {
+  const provider = normalizeProviderName(providerName);
+  return provider === 'gemini' || provider.startsWith('gemini-');
+}
+
+function withModel(
+  body: Record<string, unknown>,
+  model: string | undefined,
+): Record<string, unknown> {
+  if (!model) {
+    return body;
+  }
+  return { model, ...body };
+}
+
+export function buildProviderDumpBody(params: {
+  providerName: string;
+  history: IContent[];
+  settings?: unknown;
+  config?: Config;
+  model?: string;
+}): Record<string, unknown> {
+  if (isOpenAICompatibleProvider(params.providerName)) {
+    return withModel(
+      {
+        messages: buildOpenAIDumpMessages(
+          params.history,
+          params.settings,
+          params.config,
+        ),
+      },
+      params.model,
+    );
+  }
+  if (isAnthropicCompatibleProvider(params.providerName)) {
+    return withModel(
+      {
+        messages: buildAnthropicDumpMessages(
+          params.history,
+          params.settings,
+          params.config,
+        ),
+      },
+      params.model,
+    );
+  }
+  if (isGeminiCompatibleProvider(params.providerName)) {
+    return withModel(
+      {
+        contents: buildGeminiDumpContents(
+          params.history,
+          params.model,
+          params.config,
+        ),
+      },
+      params.model,
+    );
+  }
+  return { history: params.history };
+}

--- a/packages/providers/src/utils/toolResponsePayload.test.ts
+++ b/packages/providers/src/utils/toolResponsePayload.test.ts
@@ -139,6 +139,27 @@ world
 stderr:
 warn`);
     });
+
+    it('should trim repeated trailing newlines from stdout and stderr', () => {
+      const repeatedNewlines = '\n'.repeat(10000);
+      const block: ToolResponseBlock = {
+        type: 'tool_response',
+        toolUseId: 'test-id',
+        toolName: 'test_tool',
+        result: {
+          stdout: `done${repeatedNewlines}`,
+          stderr: `warn${repeatedNewlines}`,
+        },
+      };
+
+      const payload = buildToolResponsePayload(block, undefined, true);
+
+      expect(payload.result).toBe(`stdout:
+done
+
+stderr:
+warn`);
+    });
   });
 
   describe('unicode sanitization', () => {

--- a/packages/providers/src/utils/toolResponsePayload.ts
+++ b/packages/providers/src/utils/toolResponsePayload.ts
@@ -90,23 +90,13 @@ export function humanizeJsonForDisplay(value: unknown): string | undefined {
 
     if (hasStdout === true) {
       out.push('stdout:');
-      out.push(
-        String(stdout)
-          // eslint-disable-next-line sonarjs/slow-regex -- Static regex reviewed for lint hardening; bounded inputs preserve behavior.
-          .replace(/[\r\n]+$/, '')
-          .trimEnd(),
-      );
+      out.push(String(stdout).trimEnd());
       out.push('');
     }
 
     if (hasStderr === true) {
       out.push('stderr:');
-      out.push(
-        String(stderr)
-          // eslint-disable-next-line sonarjs/slow-regex -- Static regex reviewed for lint hardening; bounded inputs preserve behavior.
-          .replace(/[\r\n]+$/, '')
-          .trimEnd(),
-      );
+      out.push(String(stderr).trimEnd());
       out.push('');
     }
 


### PR DESCRIPTION
## TLDR

Fixes dumpcontext reliability by making immediate dumps run from the command layer, writing request dumps before provider SDK calls, and writing response/error dumps as separate files linked back to their request dump.

## Dive Deeper

This change makes /dumpcontext now an immediate context dump instead of a deferred provider flag. It gathers the current session history, shapes it according to the active provider format, and writes a request-only dump without sending a model request.

Provider dumping now uses split files:

- Request dumps are written before Anthropic, Gemini, and OpenAI SDK calls when dumpcontext is on.
- Success responses are written as separate linked response dumps after the SDK call or after a stream completes.
- Error responses are written as separate linked response dumps after errors, including error-mode paths.
- Streaming responses are passed through unchanged while chunks are accumulated for the linked response dump.
- The old now-mode provider deferral is disabled so immediate dumps do not cause a later duplicate request dump.

The PR also adds shared provider request conversion for immediate command dumps and extracts Gemini history conversion so the command and provider share compatible behavior.

## Reviewer Test Plan

Suggested validation:

1. Run the automated verification commands listed below.
2. Start an interactive session and run /dumpcontext now after a message. Confirm a request-only dump appears under ~/.llxprt/dumps and no response dump is created.
3. Run /dumpcontext on, send a prompt with a streaming provider, and confirm a request dump is created before the provider call and a related response dump is created when streaming completes.
4. Run /dumpcontext error, trigger a provider error, and confirm the request and error response dumps are separate but linked by filename metadata.
5. Inspect dumps for OpenAI, Anthropic, and Gemini shaped request bodies where credentials are redacted.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS:

- npm run format
- npm run lint
- npm run test
- npm run typecheck
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

## Linked issues / bugs

Fixes #1700
