### PR TITLE
Add migration support for ui.disableLoadingPhrases (Fixes #1809)

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -62,6 +62,7 @@ import {
   SettingScope,
   type Settings,
   loadEnvironment,
+  migrateDeprecatedSettings,
 } from './settings';
 import { getV2NamespacedSettingPath } from './settingsMerge.js';
 
@@ -1798,6 +1799,149 @@ describe('Settings Loading and Merging', () => {
       const settings = loadSettings(MOCK_WORKSPACE_DIR);
 
       // Verify migrated value (inverted: disableLoadingPhrases=true → enableLoadingPhrases=false)
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+    });
+    it('should migrate ui.disableLoadingPhrases to ui.accessibility.enableLoadingPhrases', () => {
+      const userSettingsContent = {
+        ui: {
+          disableLoadingPhrases: true,
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Verify migrated value (inverted: disableLoadingPhrases=true → enableLoadingPhrases=false)
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+    });
+
+    it('should migrate ui.disableLoadingPhrases false to ui.accessibility.enableLoadingPhrases true', () => {
+      const userSettingsContent = {
+        ui: {
+          disableLoadingPhrases: false,
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Verify migrated value (inverted: disableLoadingPhrases=false → enableLoadingPhrases=true)
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(true);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(true);
+    });
+
+    it('should preserve existing ui.accessibility.enableLoadingPhrases when ui.disableLoadingPhrases is also present', () => {
+      const userSettingsContent = {
+        ui: {
+          disableLoadingPhrases: true,
+          accessibility: {
+            enableLoadingPhrases: true,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // The existing enableLoadingPhrases=true should NOT be overwritten by disableLoadingPhrases=true
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(true);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(true);
+    });
+
+    it('should remove ui.disableLoadingPhrases during cleanup while preserving other ui settings', () => {
+      const userSettingsContent = {
+        ui: {
+          disableLoadingPhrases: true,
+          theme: 'dark',
+          accessibility: {
+            enableLoadingPhrases: false,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // The existing enableLoadingPhrases should be preserved
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+      // Other ui settings should be preserved
+      expect(
+        (settings.user.settings.ui as Record<string, unknown>)['theme'],
+      ).toBe('dark');
+
+      // Now explicitly run cleanup to remove deprecated keys
+      migrateDeprecatedSettings(settings, true);
+
+      // The deprecated key should now be removed from ui
+      expect(
+        (settings.user.settings.ui as Record<string, unknown>)[
+          'disableLoadingPhrases'
+        ],
+      ).toBeUndefined();
+      // Other ui settings should still be preserved
+      expect(
+        (settings.user.settings.ui as Record<string, unknown>)['theme'],
+      ).toBe('dark');
+      // enableLoadingPhrases should still be preserved
       expect(
         (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
           'enableLoadingPhrases'

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1950,6 +1950,239 @@ describe('Settings Loading and Merging', () => {
       expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
     });
 
+    it('should migrate ui.accessibility.disableLoadingPhrases to ui.accessibility.enableLoadingPhrases', () => {
+      const userSettingsContent = {
+        ui: {
+          accessibility: {
+            disableLoadingPhrases: true,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Verify migrated value (inverted: disableLoadingPhrases=true → enableLoadingPhrases=false)
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+    });
+
+    it('should migrate ui.accessibility.disableLoadingPhrases false to ui.accessibility.enableLoadingPhrases true', () => {
+      const userSettingsContent = {
+        ui: {
+          accessibility: {
+            disableLoadingPhrases: false,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Verify migrated value (inverted: disableLoadingPhrases=false → enableLoadingPhrases=true)
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(true);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(true);
+    });
+
+    it('should prefer ui.accessibility.disableLoadingPhrases over ui.disableLoadingPhrases when both are present', () => {
+      const userSettingsContent = {
+        ui: {
+          disableLoadingPhrases: false,
+          accessibility: {
+            disableLoadingPhrases: true,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Nested ui.accessibility.disableLoadingPhrases=true should take priority over ui.disableLoadingPhrases=false
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+    });
+
+    it('should preserve existing ui.accessibility.enableLoadingPhrases when ui.accessibility.disableLoadingPhrases is also present', () => {
+      const userSettingsContent = {
+        ui: {
+          accessibility: {
+            disableLoadingPhrases: true,
+            enableLoadingPhrases: true,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Existing enableLoadingPhrases=true should NOT be overwritten
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(true);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(true);
+    });
+
+    it('should remove ui.accessibility.disableLoadingPhrases during cleanup while preserving other ui settings', () => {
+      const userSettingsContent = {
+        ui: {
+          theme: 'dark',
+          accessibility: {
+            disableLoadingPhrases: true,
+            enableLoadingPhrases: false,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // enableLoadingPhrases should be preserved
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+
+      // Run cleanup to remove deprecated keys
+      migrateDeprecatedSettings(settings, true);
+
+      // The deprecated nested key should now be removed from ui.accessibility
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'disableLoadingPhrases'
+        ],
+      ).toBeUndefined();
+      // Other ui settings should still be preserved
+      expect(
+        (settings.user.settings.ui as Record<string, unknown>)['theme'],
+      ).toBe('dark');
+      // enableLoadingPhrases should still be preserved
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+    });
+
+    it('should remove both ui.disableLoadingPhrases and ui.accessibility.disableLoadingPhrases during cleanup', () => {
+      const userSettingsContent = {
+        ui: {
+          disableLoadingPhrases: true,
+          theme: 'dark',
+          accessibility: {
+            disableLoadingPhrases: true,
+          },
+        },
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) {
+            return JSON.stringify(userSettingsContent);
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // Verify migrated value exists
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+
+      // Run cleanup to remove deprecated keys
+      migrateDeprecatedSettings(settings, true);
+
+      // Both deprecated keys should now be removed
+      expect(
+        (settings.user.settings.ui as Record<string, unknown>)[
+          'disableLoadingPhrases'
+        ],
+      ).toBeUndefined();
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'disableLoadingPhrases'
+        ],
+      ).toBeUndefined();
+      // Other ui settings should still be preserved
+      expect(
+        (settings.user.settings.ui as Record<string, unknown>)['theme'],
+      ).toBe('dark');
+      // enableLoadingPhrases should still be preserved
+      expect(
+        (settings.user.settings.ui?.accessibility as Record<string, unknown>)[
+          'enableLoadingPhrases'
+        ],
+      ).toBe(false);
+      expect(settings.merged.accessibility?.enableLoadingPhrases).toBe(false);
+    });
+
     it('should migrate fileFiltering.disableFuzzySearch to fileFiltering.enableFuzzySearch', () => {
       const userSettingsContent = {
         fileFiltering: {

--- a/packages/cli/src/config/settingsMigrations.ts
+++ b/packages/cli/src/config/settingsMigrations.ts
@@ -71,30 +71,45 @@ function migrateUiAccessibility(
   const uiAccessibility = uiSettings?.['accessibility'] as
     | Record<string, unknown>
     | undefined;
-  if (
-    uiSettings == null ||
-    uiAccessibility == null ||
-    typeof uiAccessibility['disableLoadingPhrases'] !== 'boolean'
-  ) {
+  const hasUiDeprecated =
+    uiSettings != null &&
+    typeof uiSettings['disableLoadingPhrases'] === 'boolean';
+  const hasNestedDeprecated =
+    uiAccessibility != null &&
+    typeof uiAccessibility['disableLoadingPhrases'] === 'boolean';
+  if (uiSettings == null || (!hasUiDeprecated && !hasNestedDeprecated)) {
     return false;
   }
   const hasNewValue =
-    typeof uiAccessibility['enableLoadingPhrases'] === 'boolean';
+    typeof uiAccessibility?.['enableLoadingPhrases'] === 'boolean';
   if (hasNewValue && !removeDeprecated) {
     return false;
   }
-  const newUiAccessibility: Record<string, unknown> = { ...uiAccessibility };
+  const newUiAccessibility: Record<string, unknown> = {
+    ...(uiAccessibility ?? {}),
+  };
   if (!hasNewValue) {
-    newUiAccessibility['enableLoadingPhrases'] =
-      !uiAccessibility['disableLoadingPhrases'];
+    const nestedVal =
+      uiAccessibility != null
+        ? uiAccessibility['disableLoadingPhrases']
+        : undefined;
+    const uiVal = uiSettings['disableLoadingPhrases'];
+    const deprecatedValue: boolean = hasNestedDeprecated
+      ? nestedVal === true
+      : uiVal === true;
+    newUiAccessibility['enableLoadingPhrases'] = !deprecatedValue;
   }
   if (removeDeprecated) {
     delete newUiAccessibility['disableLoadingPhrases'];
   }
-  loadedSettings.setValue(scope, 'ui', {
+  const newUiSettings: Record<string, unknown> = {
     ...uiSettings,
     accessibility: newUiAccessibility,
-  });
+  };
+  if (removeDeprecated) {
+    delete newUiSettings['disableLoadingPhrases'];
+  }
+  loadedSettings.setValue(scope, 'ui', newUiSettings);
   return true;
 }
 


### PR DESCRIPTION
## Summary

Settings migration currently handles  and , but legacy configs can also contain . This PR adds migration support for that third key path.

## Changes

- ****: Extended  to detect and migrate  in addition to the already-supported . When  is present:
  - It is migrated to  with inverted polarity (true→false, false→true).
  - If  already exists, the existing value is preserved (no overwrite).
  - When cleanup is enabled,  is removed while other  settings are preserved.

- ****: Added 4 new test cases:
  1. Migration of  → 
  2. Migration of  → 
  3. Compatibility: existing  is not overwritten when  is also present
  4. Cleanup:  is removed while unrelated  settings and  are preserved

## Acceptance Criteria (from issue #1809)

- [x] Add migration support for 
- [x] Keep compatibility behavior when both old and new keys exist
- [x] Add or update tests covering the ui-level key path

Fixes #1809