### PR TITLE
Fix #1802: Deep merge hooksConfig/hooks settings across scopes

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -3257,5 +3257,126 @@ describe('Settings Loading and Merging', () => {
         userHooks.BeforeTool,
       );
     });
+
+    it('hooksConfig preserves all nested keys when workspace overrides only disabled (issue #1802)', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettingsContent = {
+        hooksConfig: {
+          enabled: true,
+          disabled: ['hookA'],
+          notifications: false,
+        },
+      };
+      const workspaceSettingsContent = {
+        hooksConfig: {
+          disabled: [],
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // User enabled and notifications are preserved; workspace disabled wins
+      expect(settings.merged.hooksConfig.enabled).toBe(true);
+      expect(settings.merged.hooksConfig.notifications).toBe(false);
+      expect(settings.merged.hooksConfig.disabled).toStrictEqual([]);
+    });
+
+    it('system override for hooksConfig wins over workspace and user while preserving unrelated keys (issue #1802)', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const systemSettingsContent = {
+        hooksConfig: {
+          enabled: true,
+        },
+      };
+      const userSettingsContent = {
+        hooksConfig: {
+          enabled: true,
+          notifications: false,
+        },
+      };
+      const workspaceSettingsContent = {
+        hooksConfig: {
+          enabled: false,
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === getSystemSettingsPath())
+            return JSON.stringify(systemSettingsContent);
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // System enabled=true wins over workspace enabled=false; user notifications=false is preserved
+      expect(settings.merged.hooksConfig.enabled).toBe(true);
+      expect(settings.merged.hooksConfig.notifications).toBe(false);
+    });
+
+    it('workspace trust disabled preserves user hooksConfig and hooks, ignoring workspace (issue #1802)', () => {
+      vi.mocked(isWorkspaceTrusted).mockReturnValue(false);
+      vi.mocked(isFolderTrustEnabled).mockReturnValue(true);
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettingsContent = {
+        hooksConfig: { enabled: true },
+        hooks: {
+          BeforeTool: [
+            {
+              matcher: 'ReadFile',
+              hooks: [{ type: 'command', command: 'user-before.sh' }],
+            },
+          ],
+        },
+        folderTrustFeature: true,
+        folderTrust: true,
+      };
+      const workspaceSettingsContent = {
+        hooksConfig: { enabled: false, notifications: false },
+        hooks: {
+          AfterTool: [
+            {
+              matcher: 'WriteFile',
+              hooks: [{ type: 'command', command: 'workspace-after.sh' }],
+            },
+          ],
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      // User settings are preserved; workspace is ignored
+      expect(settings.merged.hooksConfig.enabled).toBe(true);
+      expect(settings.merged.hooksConfig.notifications).toBe(true); // schema default
+      expect(settings.merged.hooks.BeforeTool).toStrictEqual(
+        userSettingsContent.hooks.BeforeTool,
+      );
+      expect(settings.merged.hooks.AfterTool).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## TLDR

Adds regression coverage for issue #1802 to ensure hook settings are merged key-by-key across settings scopes instead of losing unrelated nested fields when a higher-precedence scope provides only a partial hook configuration.

## Dive Deeper

Issue #1802 reported that partial workspace hook settings could overwrite the entire lower-precedence hook object. The existing merge implementation in packages/cli/src/config/settingsMerge.ts already uses object-section merging for both hooksConfig and hooks, so this PR locks that intended behavior in with focused behavioral tests in packages/cli/src/config/settings.test.ts.

The new tests cover:

- hooksConfig preserving user-level enabled and notifications values while allowing workspace disabled to override only that nested key.
- system override precedence for hooksConfig while preserving unrelated lower-precedence keys.
- disabled workspace trust ignoring workspace hooksConfig and hooks while preserving trusted user settings and schema defaults.

These tests protect the split hooksConfig/hooks representation from regressing back to whole-object replacement semantics.

## Reviewer Test Plan

Recommended validation:

1. Run the focused settings test file:
   npm test -- packages/cli/src/config/settings.test.ts
2. Confirm the new issue #1802 cases fail if hooksConfig or hooks are merged only by top-level spread and pass with object-section merging.
3. Run the standard project verification before merge:
   npm run test
   npm run lint
   npm run typecheck
   npm run format
   npm run build
   node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | -   | -   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1802
