### PR TITLE
Re-derive aggregatedText after AfterModel hook modification (Fixes #1749)

### DIFF
--- a/packages/agents/src/core/DirectMessageProcessor.ts
+++ b/packages/agents/src/core/DirectMessageProcessor.ts
@@ -36,6 +36,7 @@ import {
   nextStreamEventWithIdleTimeout,
   resolveStreamIdleTimeoutMs,
 } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import { getResponseTextFromParts } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 
 type ToolGroupArray = Array<{
   functionDeclarations: Array<{
@@ -773,13 +774,16 @@ export class DirectMessageProcessor {
   }
 
   /**
-   * Concatenates the text from the first candidate's parts.
+   * Concatenates the visible (non-thought) text from the first candidate's
+   * parts. Delegates to the canonical helper so thinking content is excluded
+   * (see #721, #1730).
    */
   private _extractResponseText(response: GenerateContentResponse): string {
-    return (response.candidates?.[0]?.content?.parts ?? [])
-      .filter((part) => typeof part.text === 'string')
-      .map((part) => part.text)
-      .join('');
+    return (
+      getResponseTextFromParts(
+        response.candidates?.[0]?.content?.parts ?? [],
+      ) ?? ''
+    );
   }
 
   /**

--- a/packages/agents/src/core/DirectMessageProcessor.ts
+++ b/packages/agents/src/core/DirectMessageProcessor.ts
@@ -678,6 +678,7 @@ export class DirectMessageProcessor {
     }
 
     let afterModelModifiedResponse = false;
+    let afterModelModifiedText = false;
 
     // Trigger AfterModel hook
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
@@ -706,42 +707,62 @@ export class DirectMessageProcessor {
               allowedFunctionNames,
             );
             afterModelModifiedResponse = true;
+            // Re-derive aggregatedText from the hook-modified response so the
+            // text getter reflects the hook's intended text rather than the
+            // stale pre-hook provider output (issue #1749).
+            const modifiedText = this._extractResponseText(directResponse);
+            if (modifiedText !== '') {
+              aggregatedText = modifiedText;
+              afterModelModifiedText = true;
+            }
           }
         }
       }
     }
 
     const canAppendAggregatedText =
-      aggregatedText.trim() !== '' && !afterModelModifiedResponse;
+      aggregatedText.trim() !== '' &&
+      (!afterModelModifiedResponse || afterModelModifiedText);
 
     // Ensure text content is included
     if (canAppendAggregatedText) {
-      const candidate = directResponse.candidates?.[0];
-      if (candidate) {
-        const parts = candidate.content?.parts ?? [];
-        const hasText = parts.some(
-          (part) => typeof part.text === 'string' && part.text.trim() !== '',
-        );
-        if (!hasText) {
-          candidate.content = candidate.content ?? {
-            role: 'model',
-            parts: [],
-          };
-          candidate.content.parts = [
-            ...(candidate.content.parts ?? []),
-            { text: aggregatedText },
-          ];
-        }
-      }
-      Object.defineProperty(directResponse, 'text', {
-        configurable: true,
-        get() {
-          return aggregatedText;
-        },
-      });
+      this._ensureResponseText(directResponse, aggregatedText);
     }
 
     return directResponse;
+  }
+
+  /**
+   * Ensures the response exposes the provided text via a candidate part and a
+   * stable `text` getter. Existing non-empty text parts are left untouched.
+   */
+  private _ensureResponseText(
+    response: GenerateContentResponse,
+    text: string,
+  ): void {
+    const candidate = response.candidates?.[0];
+    if (candidate) {
+      const parts = candidate.content?.parts ?? [];
+      const hasText = parts.some(
+        (part) => typeof part.text === 'string' && part.text.trim() !== '',
+      );
+      if (!hasText) {
+        candidate.content = candidate.content ?? {
+          role: 'model',
+          parts: [],
+        };
+        candidate.content.parts = [
+          ...(candidate.content.parts ?? []),
+          { text },
+        ];
+      }
+    }
+    Object.defineProperty(response, 'text', {
+      configurable: true,
+      get() {
+        return text;
+      },
+    });
   }
 
   private _applyHookRestrictedAllowedTools(
@@ -749,6 +770,16 @@ export class DirectMessageProcessor {
     allowedFunctionNames: string[] | undefined,
   ): GenerateContentResponse {
     return attachHookRestrictedAllowedTools(response, allowedFunctionNames);
+  }
+
+  /**
+   * Concatenates the text from the first candidate's parts.
+   */
+  private _extractResponseText(response: GenerateContentResponse): string {
+    return (response.candidates?.[0]?.content?.parts ?? [])
+      .filter((part) => typeof part.text === 'string')
+      .map((part) => part.text)
+      .join('');
   }
 
   /**

--- a/packages/agents/src/core/chatSession.issue1749.test.ts
+++ b/packages/agents/src/core/chatSession.issue1749.test.ts
@@ -199,4 +199,47 @@ describe('Issue 1749: AfterModel hook modified-response text', () => {
 
     expect(response.text).toBe('plain provider text');
   });
+
+  it('excludes thought parts from hook-modified response text', async () => {
+    registerStubProvider('original provider text');
+
+    const afterModelResult = new AfterModelHookOutput({});
+    vi.spyOn(afterModelResult, 'getModifiedResponse').mockReturnValue({
+      candidates: [
+        {
+          content: {
+            role: 'model' as const,
+            parts: [
+              { thought: true, text: 'internal reasoning' },
+              { text: 'visible answer' },
+            ],
+          },
+          finishReason: 'STOP' as const,
+        },
+      ],
+    } as unknown as ReturnType<AfterModelHookOutput['getModifiedResponse']>);
+
+    const hookConfig = Object.create(config) as Config;
+    Object.defineProperties(hookConfig, {
+      getEnableHooks: { value: () => true },
+      getHookSystem: {
+        value: () => ({
+          initialize: async () => undefined,
+          fireBeforeToolSelectionEvent: async () => undefined,
+          fireBeforeModelEvent: async () => undefined,
+          fireAfterModelEvent: async () => afterModelResult,
+        }),
+      },
+    });
+
+    const chat = buildChatSession(hookConfig);
+
+    const response = await chat.generateDirectMessage(
+      { message: 'Trigger thought filtering' },
+      'prompt-issue-1749-thought',
+    );
+
+    expect(response.text).toBe('visible answer');
+    expect(response.text).not.toContain('internal reasoning');
+  });
 });

--- a/packages/agents/src/core/chatSession.issue1749.test.ts
+++ b/packages/agents/src/core/chatSession.issue1749.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ChatSession } from './chatSession.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { ConfigParameters } from '@vybestack/llxprt-code-core/config/config.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { TestRuntimeProviderManager } from '../test-utils/runtimeProviderManager.js';
+import {
+  createProviderRuntimeContext,
+  type ProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import {
+  createProviderAdapterFromManager,
+  createTelemetryAdapterFromConfig,
+  createToolRegistryViewFromRegistry,
+} from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
+import { AfterModelHookOutput } from '@vybestack/llxprt-code-core/hooks/types.js';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+
+vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  retryWithBackoff: vi.fn((fn: () => unknown) => fn()),
+}));
+
+function createConfigParams(
+  settingsService: SettingsService,
+): ConfigParameters {
+  return {
+    cwd: '/tmp',
+    targetDir: '/tmp/project',
+    debugMode: false,
+    question: undefined,
+    userMemory: '',
+    embeddingModel: 'gemini-embedding',
+    sandbox: undefined,
+    sessionId: 'test-session',
+    model: 'gemini-1.5-pro',
+    settingsService,
+  };
+}
+
+/**
+ * Issue #1749: AfterModel hook modified-response text must not be overwritten
+ * (or left stale) by the pre-hook aggregatedText in
+ * DirectMessageProcessor._processDirectResponse().
+ *
+ * When the AfterModel hook returns a modified response via getModifiedResponse(),
+ * the resulting response.text must reflect the hook's intended text, not the
+ * original provider text aggregated before the hook fired.
+ */
+describe('Issue 1749: AfterModel hook modified-response text', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let manager: TestRuntimeProviderManager;
+  let providerRuntime: ProviderRuntimeContext;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = new Config(createConfigParams(settingsService));
+
+    settingsService.set('providers.stub.base-url', 'https://stub.example.com');
+    settingsService.set('providers.stub.auth-key', 'stub-api-key');
+    settingsService.set('providers.stub.model', 'stub-model');
+
+    providerRuntime = createProviderRuntimeContext({
+      settingsService,
+      config,
+      runtimeId: 'test.runtime',
+      metadata: { source: 'chatSession.issue1749.test' },
+    });
+
+    manager = new TestRuntimeProviderManager(providerRuntime);
+    manager.setConfig(config);
+    config.setProviderManager(manager);
+  });
+
+  function buildChatSession(hookConfig: Config): ChatSession {
+    const runtimeState = createAgentRuntimeState({
+      runtimeId: 'runtime-test',
+      provider: 'stub',
+      model: config.getModel(),
+      sessionId: config.getSessionId(),
+    });
+    const view = createAgentRuntimeContext({
+      state: runtimeState,
+      history: new HistoryService(),
+      settings: {
+        compressionThreshold: 0.8,
+        contextLimit: 128000,
+        preserveThreshold: 0.2,
+        telemetry: {
+          enabled: true,
+          target: null,
+        },
+        'reasoning.includeInContext': true,
+      },
+      provider: createProviderAdapterFromManager(config.getProviderManager()),
+      telemetry: createTelemetryAdapterFromConfig(config),
+      tools: createToolRegistryViewFromRegistry(config.getToolRegistry()),
+      providerRuntime: { ...providerRuntime, config: hookConfig },
+    });
+
+    return new ChatSession(view, {} as unknown as ContentGenerator, {}, []);
+  }
+
+  function registerStubProvider(text: string): void {
+    const generateChatCompletionMock = vi.fn(async function* () {
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text }],
+      };
+    });
+    const provider: IProvider = {
+      name: 'stub',
+      isDefault: true,
+      getModels: vi.fn(async () => []),
+      getDefaultModel: () => 'stub-model',
+      generateChatCompletion: generateChatCompletionMock,
+      getServerTools: () => [],
+      invokeServerTool: vi.fn(),
+      getAuthToken: vi.fn(async () => 'stub-auth-token'),
+    } as unknown as IProvider;
+    manager.registerProvider(provider);
+  }
+
+  it('reflects hook-modified text in response.text instead of stale provider text', async () => {
+    registerStubProvider('original provider text');
+
+    const hookConfig = Object.create(config) as Config;
+    Object.defineProperties(hookConfig, {
+      getEnableHooks: { value: () => true },
+      getHookSystem: {
+        value: () => ({
+          initialize: async () => undefined,
+          fireBeforeToolSelectionEvent: async () => undefined,
+          fireBeforeModelEvent: async () => undefined,
+          fireAfterModelEvent: async () =>
+            new AfterModelHookOutput({
+              hookSpecificOutput: {
+                llm_response: {
+                  candidates: [
+                    {
+                      content: {
+                        role: 'model' as const,
+                        parts: ['hook modified text'],
+                      },
+                      finishReason: 'STOP' as const,
+                    },
+                  ],
+                },
+              },
+            }),
+        }),
+      },
+    });
+
+    const chat = buildChatSession(hookConfig);
+
+    const response = await chat.generateDirectMessage(
+      { message: 'Trigger AfterModel modification' },
+      'prompt-issue-1749',
+    );
+
+    expect(response.text).toBe('hook modified text');
+    expect(response.text).not.toContain('original provider text');
+    expect(JSON.stringify(response)).not.toContain('original provider text');
+  });
+
+  it('preserves provider text when AfterModel hook does not modify the response', async () => {
+    registerStubProvider('plain provider text');
+
+    const hookConfig = Object.create(config) as Config;
+    Object.defineProperties(hookConfig, {
+      getEnableHooks: { value: () => true },
+      getHookSystem: {
+        value: () => ({
+          initialize: async () => undefined,
+          fireBeforeToolSelectionEvent: async () => undefined,
+          fireBeforeModelEvent: async () => undefined,
+          fireAfterModelEvent: async () => new AfterModelHookOutput({}),
+        }),
+      },
+    });
+
+    const chat = buildChatSession(hookConfig);
+
+    const response = await chat.generateDirectMessage(
+      { message: 'No modification' },
+      'prompt-issue-1749-noop',
+    );
+
+    expect(response.text).toBe('plain provider text');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1749.

In DirectMessageProcessor._processDirectResponse(), when the AfterModel hook
returns a modified response via getModifiedResponse(), the hook's intended text
was not reliably surfaced on response.text. The pre-existing guard skipped text
injection entirely for any modified response, which left response.text as
undefined whenever the hook-modified response carried text only in its candidate
parts and omitted the top-level text field.

## Root cause

aggregatedText is accumulated from the provider stream before the AfterModel
hook fires. When a hook rewrites the response, the code adopted the modified
response object but continued to gate the text getter on the stale pre-hook
aggregatedText, then skipped injection on modification. As a result the hook's
rewritten text never reached response.text in the parts-only case.

## Fix

- After applying the hook modification, re-derive aggregatedText from the
  modified response's candidate parts (filter parts with a string text, map,
  join). Only adopt the derived value when it is non-empty, preserving the
  original fallback behavior for text-less modifications.
- Surface the re-derived text through the existing text getter so response.text
  reflects the hook's intent rather than the stale provider output.
- Extracted _ensureResponseText and _extractResponseText helpers to keep
  _processDirectResponse within the function-length budget and remove
  duplication.

## Tests

Added packages/agents/src/core/chatSession.issue1749.test.ts:

1. A modifying AfterModel hook (text only in candidate parts, no top-level text)
   results in response.text equal to the hook text and the original provider
   text absent from the serialized response. This test fails on the prior code
   (response.text is undefined) and passes with the fix.
2. A no-op AfterModel hook preserves the original provider text on response.text.

## Verification

- npm run typecheck: pass
- eslint on changed files: no new errors (only 3 pre-existing warnings on the
  file header that exist on main)
- npm run format: applied
- npm run build: pass
- Targeted vitest (runtime, hook-control, issue1749): pass
- Full agents core suite: 790 tests pass (the 11 file-collection errors are a
  pre-existing vitest module-resolution quirk reproducible on main, unrelated to
  this change)
- Smoke test (haiku) via local profile: pass
