### PR TITLE
Validate ast_edit preview replacements (Fixes #1755)

### DIFF
--- a/packages/tools/src/tools/ast-edit/__tests__/ast-edit-preview.test.ts
+++ b/packages/tools/src/tools/ast-edit/__tests__/ast-edit-preview.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../../../interfaces/index.js';
+import { ASTEditTool } from '../../ast-edit.js';
+import type { ToolResult } from '../../tools.js';
+
+function createTempDir(prefix = 'llxprt-ast-preview-test-'): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return {
+    dir,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup after each test.
+      }
+    },
+  };
+}
+
+function createFakeToolHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'auto',
+    setApprovalMode: () => {},
+    isInteractive: () => false,
+    hasFeatureFlag: () => false,
+  };
+}
+
+async function executePreview(
+  tool: ASTEditTool,
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  return tool.build(params).execute(new AbortController().signal);
+}
+
+describe('ASTEditTool preview phase validation (issue #1755)', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('returns EDIT_NO_OCCURRENCE_FOUND error when old_string is absent in preview mode', async () => {
+    const filePath = join(tempDir, 'absent-old-string.ts');
+    const originalContent = 'const greeting = "hello";\n';
+    writeFileSync(filePath, originalContent, 'utf-8');
+
+    const tool = new ASTEditTool(createFakeToolHost(tempDir));
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'THIS STRING DOES NOT EXIST',
+      new_string: 'const greeting = "world";',
+      force: false,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('edit_no_occurrence_found');
+    expect(String(result.llmContent)).toContain('0 occurrences');
+    expect(String(result.llmContent)).not.toContain('LLXPRT EDIT PREVIEW');
+    expect(String(result.llmContent)).not.toContain(
+      'NEXT STEP: Call again with force: true',
+    );
+    expect(readFileSync(filePath, 'utf-8')).toBe(originalContent);
+  });
+
+  it('returns LLXPRT EDIT PREVIEW green-light when old_string matches in preview mode', async () => {
+    const filePath = join(tempDir, 'valid-old-string.ts');
+    writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+
+    const tool = new ASTEditTool(createFakeToolHost(tempDir));
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'const greeting = "hello";',
+      new_string: 'const greeting = "world";',
+      force: false,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('LLXPRT EDIT PREVIEW');
+    expect(String(result.llmContent)).toContain(
+      'NEXT STEP: Call again with force: true',
+    );
+  });
+
+  it('preserves new-file preview semantics when old_string is empty and file does not exist', async () => {
+    const filePath = join(tempDir, 'brand-new-file.ts');
+
+    const tool = new ASTEditTool(createFakeToolHost(tempDir));
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: '',
+      new_string: 'const brandNew = 42;\n',
+      force: false,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain('LLXPRT EDIT PREVIEW');
+    expect(String(result.llmContent)).toContain(
+      'NEXT STEP: Call again with force: true',
+    );
+  });
+
+  it('does not modify file content when old_string is absent in preview mode', async () => {
+    const filePath = join(tempDir, 'unchanged-file.ts');
+    const originalContent =
+      'export function add(a: number, b: number): number {\n  return a + b;\n}\n';
+    writeFileSync(filePath, originalContent, 'utf-8');
+
+    const tool = new ASTEditTool(createFakeToolHost(tempDir));
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: 'export function subtract(',
+      new_string: 'export function subtract(a: number, b: number): number {',
+      force: false,
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.type).toBe('edit_no_occurrence_found');
+    expect(readFileSync(filePath, 'utf-8')).toBe(originalContent);
+  });
+
+  it('builds enhanced context from current content in preview mode', async () => {
+    const filePath = join(tempDir, 'current-context.ts');
+    const originalContent =
+      'export function greet(name: string): string {\n  return `hello ${name}`;\n}\n';
+    writeFileSync(filePath, originalContent, 'utf-8');
+
+    const tool = new ASTEditTool(createFakeToolHost(tempDir));
+    const result = await executePreview(tool, {
+      file_path: filePath,
+      old_string: originalContent,
+      new_string: '',
+      force: false,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(String(result.llmContent)).toContain(
+      '- Context: typescript file with 1 declarations',
+    );
+  });
+});

--- a/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
@@ -6,8 +6,6 @@
  * AST Edit Tool Invocation - Handles execution of edit operations
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import * as path from 'path';
 import { promises as fsPromises } from 'fs';
 import * as Diff from 'diff';
@@ -24,7 +22,6 @@ import {
 } from '../tools.js';
 import { ToolErrorType } from '../../types/tool-error.js';
 import { makeRelative, shortenPath } from '../../utils/paths.js';
-import { isNodeError } from '../../utils/errors.js';
 import type {
   Diagnostic,
   IToolHost,
@@ -38,7 +35,6 @@ import { ensureParentDirectoriesExist } from '../../utils/ensure-dirs.js';
 import type { ASTEditToolParams } from './types.js';
 import { ASTConfig } from './ast-config.js';
 import type { ASTContextCollector } from './context-collector.js';
-import { applyReplacement } from './edit-helpers.js';
 import {
   calculateEdit,
   validateASTSyntax,
@@ -163,16 +159,20 @@ export class ASTEditToolInvocation
 
   private async executePreview(_signal: AbortSignal): Promise<ToolResult> {
     try {
-      const rawCurrentContent = await this.readFileContent();
-      const currentContent = rawCurrentContent.replace(/\r\n/g, '\n');
-      const currentMtime = await this.getFileLastModified(
-        this.params.file_path,
-      );
+      const editData = await this.calculateEdit(this.params, _signal);
+      if (editData.error) {
+        return {
+          llmContent: editData.error.raw,
+          returnDisplay: `Error: ${editData.error.display}`,
+          error: {
+            message: editData.error.raw,
+            type: editData.error.type,
+          },
+        };
+      }
 
-      const isNewFile = this.detectNewFile(rawCurrentContent, currentMtime);
-
-      const freshnessError = this.checkFreshness(currentMtime);
-      if (freshnessError) return freshnessError;
+      const currentContent = editData.currentContent ?? '';
+      const currentMtime = editData.fileFreshness ?? null;
 
       const workspaceRoot = this.host.getTargetDir();
       const enhancedContext =
@@ -182,22 +182,15 @@ export class ASTEditToolInvocation
           workspaceRoot,
         );
 
-      const newContent = applyReplacement(
-        currentContent,
-        this.params.old_string,
-        this.params.new_string,
-        isNewFile,
-      );
-      const astValidation = this.validateASTSyntax(
-        this.params.file_path,
-        newContent,
-      );
+      const astValidation =
+        editData.astValidation ??
+        this.validateASTSyntax(this.params.file_path, editData.newContent);
 
       const fileName = path.basename(this.params.file_path);
       const fileDiff = Diff.createPatch(
         fileName,
         currentContent,
-        newContent,
+        editData.newContent,
         'Current',
         'Proposed',
         DEFAULT_CREATE_PATCH_OPTIONS,
@@ -214,7 +207,7 @@ export class ASTEditToolInvocation
         fileDiff,
         fileName,
         originalContent: currentContent,
-        newContent,
+        newContent: editData.newContent,
         metadata: { astValidation, currentMtime },
       };
 
@@ -233,41 +226,6 @@ export class ASTEditToolInvocation
         },
       };
     }
-  }
-
-  private detectNewFile(
-    rawCurrentContent: string,
-    mtime: number | null,
-  ): boolean {
-    if (this.params.old_string === '' && rawCurrentContent === '') {
-      return mtime === null;
-    }
-    return false;
-  }
-
-  private checkFreshness(currentMtime: number | null): ToolResult | null {
-    if (
-      this.params.last_modified !== undefined &&
-      currentMtime !== null &&
-      currentMtime > this.params.last_modified
-    ) {
-      const errorMessage = `File ${this.params.file_path} mismatch. Expected mtime <= ${this.params.last_modified}, but found ${currentMtime}.`;
-      const displayMessage = `File has been modified since it was last read. Please read the file again to get the latest content.`;
-      const rawErrorMessage = JSON.stringify({
-        message: errorMessage,
-        current_mtime: currentMtime,
-        your_mtime: this.params.last_modified,
-      });
-      return {
-        llmContent: rawErrorMessage,
-        returnDisplay: `Error: ${displayMessage}`,
-        error: {
-          message: rawErrorMessage,
-          type: ToolErrorType.FILE_MODIFIED_CONFLICT,
-        },
-      };
-    }
-    return null;
   }
 
   private buildPreviewLlmContent(
@@ -578,22 +536,6 @@ export class ASTEditToolInvocation
     abortSignal: AbortSignal,
   ): Promise<CalculatedEdit> {
     return calculateEdit(params, this.host, abortSignal);
-  }
-
-  private async readFileContent(): Promise<string> {
-    try {
-      const fileSystemService = this.host.getFileSystemService?.() as
-        | { readTextFile?: (filePath: string) => Promise<string> }
-        | undefined;
-      return fileSystemService?.readTextFile
-        ? await fileSystemService.readTextFile(this.params.file_path)
-        : await fsPromises.readFile(this.params.file_path, 'utf-8');
-    } catch (error) {
-      if (isNodeError(error) && error.code === 'ENOENT') {
-        return '';
-      }
-      throw error;
-    }
   }
 
   private validateASTSyntax(


### PR DESCRIPTION
## TLDR

Fixes ast_edit preview mode so it validates replacement inputs before returning a green-light preview. When old_string is absent, preview now returns the same no-occurrence error as apply mode instead of telling the caller to retry with force true.

## Dive Deeper

Preview now delegates to the shared edit calculation path before building the enhanced preview. This keeps preview and apply behavior aligned for occurrence validation, file freshness, no-change detection, new-file semantics, CRLF normalization, and AST validation.

Added behavioral coverage for:

- absent old_string returning edit_no_occurrence_found in preview
- successful preview when old_string matches
- empty old_string preserving new-file preview behavior
- preview errors leaving file content unchanged
- enhanced context continuing to use current file content

## Reviewer Test Plan

Pull this branch and run:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

Manual validation option:

1. Use ast_edit in preview mode on an existing file with an old_string that does not appear in the file.
2. Confirm the result is an edit_no_occurrence_found error and does not include LLXPRT EDIT PREVIEW or the instruction to call again with force true.
3. Use ast_edit in preview mode with a matching old_string and confirm preview behavior still succeeds.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1755
