### PR TITLE
Eagerly authenticate remaining buckets after Pass 3 reauth (Fixes #1658)

### DIFF
--- a/packages/cli/src/auth/BucketFailoverHandlerImpl.case-49.spec.ts
+++ b/packages/cli/src/auth/BucketFailoverHandlerImpl.case-49.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { BucketFailoverHandlerImpl } from './BucketFailoverHandlerImpl.js';
+import { OAuthManager } from './oauth-manager.js';
+import {
+  makeToken,
+  MemoryTokenStore,
+} from './BucketFailoverHandlerImpl.test-helpers.js';
+
+describe('BucketFailoverHandlerImpl #49', () => {
+  it('eagerly authenticates remaining buckets after successful pass-3 foreground reauth', async () => {
+    // Arrange
+    const tokenStore = new MemoryTokenStore();
+
+    const oauthManager = {
+      getOAuthToken: vi.fn((_provider: string, bucket?: string) =>
+        tokenStore.getToken('anthropic', bucket),
+      ),
+      getTokenStore: vi.fn(() => tokenStore),
+      setSessionBucket: vi.fn(),
+      getSessionBucket: vi.fn(() => 'bucket-a'),
+      authenticate: vi.fn(async (_p: string, bucket?: string) => {
+        if (bucket === 'bucket-b') {
+          await tokenStore.saveToken(
+            'anthropic',
+            makeToken('reauth-b'),
+            bucket,
+          );
+        }
+      }),
+      authenticateMultipleBuckets: vi.fn(async () => {}),
+    };
+
+    const handler = new BucketFailoverHandlerImpl(
+      ['bucket-a', 'bucket-b'],
+      'anthropic',
+      oauthManager as unknown as OAuthManager,
+    );
+
+    // Act
+    const result = await handler.tryFailover({ triggeringStatus: 401 });
+
+    // Assert
+    expect(result).toBe(true);
+    expect(handler.getCurrentBucket()).toBe('bucket-b');
+    expect(oauthManager.authenticateMultipleBuckets).toHaveBeenCalledTimes(1);
+    expect(oauthManager.authenticateMultipleBuckets).toHaveBeenCalledWith(
+      'anthropic',
+      ['bucket-a', 'bucket-b'],
+      undefined,
+    );
+  });
+
+  it('swallows eager auth failure after successful pass-3 reauth (best-effort)', async () => {
+    // Arrange
+    const tokenStore = new MemoryTokenStore();
+
+    const oauthManager = {
+      getOAuthToken: vi.fn((_provider: string, bucket?: string) =>
+        tokenStore.getToken('anthropic', bucket),
+      ),
+      getTokenStore: vi.fn(() => tokenStore),
+      setSessionBucket: vi.fn(),
+      getSessionBucket: vi.fn(() => 'bucket-a'),
+      authenticate: vi.fn(async (_p: string, bucket?: string) => {
+        if (bucket === 'bucket-b') {
+          await tokenStore.saveToken(
+            'anthropic',
+            makeToken('reauth-b'),
+            bucket,
+          );
+        }
+      }),
+      authenticateMultipleBuckets: vi.fn(async () => {
+        throw new Error('eager auth failed');
+      }),
+    };
+
+    const handler = new BucketFailoverHandlerImpl(
+      ['bucket-a', 'bucket-b'],
+      'anthropic',
+      oauthManager as unknown as OAuthManager,
+    );
+
+    // Act
+    const result = await handler.tryFailover({ triggeringStatus: 401 });
+
+    // Assert
+    expect(result).toBe(true);
+    expect(handler.getCurrentBucket()).toBe('bucket-b');
+    expect(oauthManager.authenticateMultipleBuckets).toHaveBeenCalledTimes(1);
+  });
+
+  it('consolidates prompts so a later failover needs no second foreground reauth', async () => {
+    // Arrange: three expired/unauthenticated buckets
+    const tokenStore = new MemoryTokenStore();
+    let sessionBucket: string | undefined = 'bucket-a';
+
+    const oauthManager = {
+      getOAuthToken: vi.fn((_provider: string, bucket?: string) =>
+        tokenStore.getToken('anthropic', bucket),
+      ),
+      getTokenStore: vi.fn(() => tokenStore),
+      setSessionBucket: vi.fn((_provider: string, bucket: string) => {
+        sessionBucket = bucket;
+      }),
+      getSessionBucket: vi.fn(() => sessionBucket),
+      authenticate: vi.fn(async (_p: string, bucket?: string) => {
+        if (bucket === 'bucket-b') {
+          await tokenStore.saveToken(
+            'anthropic',
+            makeToken('reauth-b'),
+            bucket,
+          );
+        }
+      }),
+      // Eager auth authenticates the remaining unauthenticated buckets.
+      authenticateMultipleBuckets: vi.fn(async () => {
+        await tokenStore.saveToken(
+          'anthropic',
+          makeToken('eager-c'),
+          'bucket-c',
+        );
+      }),
+    };
+
+    const handler = new BucketFailoverHandlerImpl(
+      ['bucket-a', 'bucket-b', 'bucket-c'],
+      'anthropic',
+      oauthManager as unknown as OAuthManager,
+    );
+
+    // Act: first failover triggers a single foreground reauth (bucket-b)
+    // plus eager auth of the rest (bucket-c).
+    const firstResult = await handler.tryFailover({ triggeringStatus: 401 });
+
+    // Act: bucket-b later hits quota, triggering a second failover.
+    const secondResult = await handler.tryFailover({ triggeringStatus: 429 });
+
+    // Assert: both failovers succeed and the second switches to the
+    // already-authenticated bucket-c without any additional browser prompt.
+    expect(firstResult).toBe(true);
+    expect(secondResult).toBe(true);
+    expect(handler.getCurrentBucket()).toBe('bucket-c');
+    expect(oauthManager.authenticate).toHaveBeenCalledTimes(1);
+    expect(oauthManager.authenticate).toHaveBeenCalledWith(
+      'anthropic',
+      'bucket-b',
+      {
+        signalAuthCompletion: false,
+      },
+    );
+  });
+});

--- a/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
+++ b/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
@@ -575,6 +575,21 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
         () =>
           `Bucket failover: switched from ${currentBucket} to ${candidateBucket} after reauth`,
       );
+
+      // @fix issue1658
+      // After a successful foreground reauth, eagerly authenticate any
+      // remaining unauthenticated buckets so subsequent failovers do not
+      // trigger additional mid-turn browser prompts. Best-effort: a failure
+      // here must not block the already-successful primary reauth.
+      try {
+        await this.ensureBucketsAuthenticated();
+      } catch (eagerAuthError) {
+        logger.warn(
+          `Eager bucket authentication after pass-3 reauth failed (continuing with successful reauth):`,
+          eagerAuthError,
+        );
+      }
+
       return true;
     } catch (reauthError) {
       logger.warn(


### PR DESCRIPTION
## Summary

Fixes #1658.

When bucket failover **Pass 3** performs a foreground browser reauth for one bucket, it previously authenticated **only that one bucket** and returned. If that bucket later hit quota (429), another `tryFailover()` was triggered and Pass 3 had to authenticate yet another bucket — causing a **second mid-turn browser popup**.

This change makes Pass 3, on a **successful** foreground reauth, eagerly authenticate any remaining unauthenticated buckets in the same batch by reusing the existing `ensureBucketsAuthenticated()` method. The user authenticates everything once, and subsequent failovers are seamless with no additional popups.

## Implementation

In `packages/cli/src/auth/BucketFailoverHandlerImpl.ts`, inside `performForegroundReauth()`, after the candidate bucket is successfully reauthenticated, its token is verified, and the session switches to it (and before `return true`):

- Await `this.ensureBucketsAuthenticated()` to authenticate the remaining unauthenticated buckets.
- Wrap the call in try/catch — the eager auth is **best-effort**: a partial failure is logged as a warning but never blocks the already-successful primary reauth from returning `true`.

No changes were needed to `ensureBucketsAuthenticated()` or any supporting infrastructure. The existing behavior is reused:

- It is a no-op for single-bucket profiles.
- `ensureBucketsAuthInFlight` deduplication prevents concurrent eager-auth calls.
- The orchestrator's `filterUnauthenticatedBuckets()` excludes the just-authenticated bucket (token expiry > now + 30s), so it is not re-prompted.
- `auth-bucket-delay` / `auth-bucket-prompt` ephemerals are already honored by `authenticateMultipleBuckets()`.

The change runs **only** on the Pass 3 success path; timeout and failure paths are unaffected.

### Prerequisite

Depends on the refresh-before-reauth fix from #1652 (PR #1656), which has already landed on `main` (commits `67c5db235` / merge `766915a80`). This ensures `authenticate()` tries token refresh before opening a browser, so eager auth does not open unnecessary browsers for expired-but-refreshable tokens.

## Tests

New behavioral spec `packages/cli/src/auth/BucketFailoverHandlerImpl.case-49.spec.ts` (3 tests, following the existing `case-*` patterns):

1. Eager auth (`authenticateMultipleBuckets`) is invoked after a successful Pass 3 foreground reauth, with the correct provider/buckets/metadata; failover still returns `true` and switches to the reauthed bucket.
2. An eager-auth failure is swallowed (best-effort) — failover still returns `true` and switches to the reauthed bucket.
3. End-to-end consolidation: with three expired buckets, the first failover does a single foreground reauth (bucket-b) plus eager auth of the rest (bucket-c); a later 429 on bucket-b triggers a second failover that switches to the already-authenticated bucket-c with **no additional** `authenticate()` (browser) call.

## Verification

All run from repo root and passing:

- `npm run test` — CLI (514 files / 5879 tests), core (228 / 4405), providers, agents, tools all green; auth suite 130 files / 888 tests.
- `npm run typecheck` — clean across all workspaces.
- `npm run lint` — 0 errors.
- `npm run format` — clean.
- `npm run build` — success.
- Smoke test: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — produced a haiku.

## Review

Reviewed by an independent deep-review pass for correctness, re-entrancy/deadlock safety, double-prompt avoidance, best-effort guarantee, ephemeral handling, and test quality. Verdict: approve; intent and constraints faithfully satisfied. The suggested 3-bucket consolidation test was added.
