### PR TITLE
Fix #1801: Sanitize ANSI escape codes in skill consent prompts

### DIFF
--- a/packages/cli/src/config/extensions/consent.test.ts
+++ b/packages/cli/src/config/extensions/consent.test.ts
@@ -530,8 +530,9 @@ describe('consent', () => {
       );
 
       const consentArg = requestConsent.mock.calls[0][0] as string;
-      // Raw ESC characters must never appear in the consent string
-      expect(consentArg).not.toContain('\u001b');
+      // Raw malicious name/description must not appear verbatim
+      expect(consentArg).not.toContain('evil\u001b[31mSkill');
+      expect(consentArg).not.toContain('bad\u001b[2Kdesc');
       // Escaped representations should be visible instead
       expect(consentArg).toContain('\\u001b[');
     });
@@ -552,8 +553,38 @@ describe('consent', () => {
 
       const result = await skillsConsentString([maliciousSkill], 'test-source');
 
-      expect(result).not.toContain('\u001b');
+      // Raw malicious name/description must not appear verbatim
+      expect(result).not.toContain('evil\u001b[31mSkill');
+      expect(result).not.toContain('bad\u001b[2Kdesc');
+      // Escaped representations should be visible instead
       expect(result).toContain('\\u001b[');
+    });
+
+    it('should escape ANSI control codes in skill location', async () => {
+      const ansiLocationDir = path.join(tempDir, 'ansi-location-skill');
+      await fs.mkdir(ansiLocationDir, { recursive: true });
+      await fs.writeFile(path.join(ansiLocationDir, 'SKILL.md'), 'body');
+
+      const maliciousSkill: SkillDefinition = {
+        name: 'loc-skill',
+        description: 'A skill with ANSI in location',
+        location: path.join(
+          ansiLocationDir,
+          '\u001b[31mfake\u001b[0m',
+          'SKILL.md',
+        ),
+        body: 'body',
+      };
+
+      const result = await skillsConsentString([maliciousSkill], 'test-source');
+
+      // Raw malicious location path must not appear verbatim
+      expect(result).not.toContain('\u001b[31mfake');
+      // Escaped representation should be visible
+      expect(result).toContain('\\u001b[');
+      // Sanitized name/description should be present
+      expect(result).toContain('loc-skill');
+      expect(result).toContain('A skill with ANSI in location');
     });
 
     it('should preserve normal skill metadata unchanged', async () => {

--- a/packages/cli/src/config/extensions/consent.test.ts
+++ b/packages/cli/src/config/extensions/consent.test.ts
@@ -15,6 +15,7 @@ import {
   requestConsentNonInteractive,
   requestConsentInteractive,
   maybeRequestConsentOrFail,
+  skillsConsentString,
   INSTALL_WARNING_MESSAGE,
   SKILLS_WARNING_MESSAGE,
 } from './consent.js';
@@ -504,6 +505,74 @@ describe('consent', () => {
           `    (Location: ${skill.location}) ${chalk.red('(Could not count items in directory)')}`,
         ),
       );
+    });
+
+    it('should escape ANSI control codes in skill metadata before rendering', async () => {
+      const maliciousSkill: SkillDefinition = {
+        name: 'evil\u001b[31mSkill\u001b[0m',
+        description: 'bad\u001b[2Kdesc',
+        location: path.join(tempDir, 'skill-ansi', 'SKILL.md'),
+        body: 'body',
+      };
+      await fs.mkdir(path.dirname(maliciousSkill.location), {
+        recursive: true,
+      });
+      await fs.writeFile(maliciousSkill.location, 'body');
+
+      const requestConsent = vi.fn().mockResolvedValue(true);
+      await maybeRequestConsentOrFail(
+        baseConfig,
+        requestConsent,
+        false,
+        undefined,
+        false,
+        [maliciousSkill],
+      );
+
+      const consentArg = requestConsent.mock.calls[0][0] as string;
+      // Raw ESC characters must never appear in the consent string
+      expect(consentArg).not.toContain('\u001b');
+      // Escaped representations should be visible instead
+      expect(consentArg).toContain('\\u001b[');
+    });
+  });
+
+  describe('skillsConsentString', () => {
+    it('should escape ANSI control codes in standalone skill metadata', async () => {
+      const skillDir = path.join(tempDir, 'ansi-skill');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), 'body');
+
+      const maliciousSkill: SkillDefinition = {
+        name: 'evil\u001b[31mSkill\u001b[0m',
+        description: 'bad\u001b[2Kdesc',
+        location: path.join(skillDir, 'SKILL.md'),
+        body: 'body',
+      };
+
+      const result = await skillsConsentString([maliciousSkill], 'test-source');
+
+      expect(result).not.toContain('\u001b');
+      expect(result).toContain('\\u001b[');
+    });
+
+    it('should preserve normal skill metadata unchanged', async () => {
+      const skillDir = path.join(tempDir, 'normal-skill');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), 'body');
+
+      const normalSkill: SkillDefinition = {
+        name: 'my-skill',
+        description: 'A normal description',
+        location: path.join(skillDir, 'SKILL.md'),
+        body: 'body',
+      };
+
+      const result = await skillsConsentString([normalSkill], 'test-source');
+
+      expect(result).toContain('my-skill');
+      expect(result).toContain('A normal description');
+      expect(result).toContain(normalSkill.location);
     });
   });
 });

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -254,8 +254,11 @@ async function promptForConsentInteractive(
 async function renderSkillsList(skills: SkillDefinition[]): Promise<string[]> {
   const output: string[] = [];
   for (const skill of skills) {
-    output.push(`  * ${chalk.bold(skill.name)}: ${skill.description}`);
-    const skillDir = path.dirname(skill.location);
+    const sanitizedSkill = escapeAnsiCtrlCodes(skill);
+    output.push(
+      `  * ${chalk.bold(sanitizedSkill.name)}: ${sanitizedSkill.description}`,
+    );
+    const skillDir = path.dirname(sanitizedSkill.location);
     let fileCountStr = '';
     try {
       const skillDirItems = await fs.readdir(skillDir);
@@ -263,7 +266,7 @@ async function renderSkillsList(skills: SkillDefinition[]): Promise<string[]> {
     } catch {
       fileCountStr = ` ${chalk.red('(Could not count items in directory)')}`;
     }
-    output.push(`    (Location: ${skill.location})${fileCountStr}`);
+    output.push(`    (Location: ${sanitizedSkill.location})${fileCountStr}`);
     output.push('');
   }
   return output;


### PR DESCRIPTION
## Summary

- Sanitizes skill manifest metadata before rendering it in extension and standalone skill consent prompts.
- Escapes ANSI/VT control sequences in skill name, description, and location fields so malicious manifests cannot hide, overwrite, or spoof consent dialog text.
- Adds regression coverage for both extension-provided and standalone skill consent rendering, while confirming normal skill metadata remains unchanged.

Fixes #1801

## Testing

- Not run in this PR-description generation step.
