### PR TITLE
Fix event-driven profile-aware model display (Fixes #1770)

### DIFF
--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -1,0 +1,321 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for MessageStreamOrchestrator ModelInfo emission.
+ *
+ * Issue #1770 requirements:
+ * 1. ModelInfo must be emitted when composite provider/profile/model identity
+ *    changes during same-prompt retries/continuations — not only inside
+ *    isNewPrompt.
+ * 2. Duplicate ModelInfo must be suppressed for the same identity.
+ * 3. Model resolution should prefer the provider manager's active model where
+ *    available, not just config.getModel.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PartListUnion } from '@google/genai';
+import type { ServerGeminiStreamEvent, ModelInfo } from './turn.js';
+import { GeminiEventType } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
+import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
+
+const mockTurnRun = vi.fn();
+
+vi.mock('./turn.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./turn.js')>();
+  class MockTurn {
+    pendingToolCalls: unknown[] = [];
+    run = mockTurnRun;
+  }
+  return {
+    ...actual,
+    Turn: MockTurn as unknown as typeof actual.Turn,
+  };
+});
+
+import {
+  MessageStreamOrchestrator,
+  type MessageStreamDeps,
+} from './MessageStreamOrchestrator.js';
+
+interface HarnessState {
+  model: string;
+  providerName?: string;
+  profileName?: string | null;
+  providerManagerActiveModel?: string;
+  lastPromptId?: string;
+  currentSequenceModel: string | null;
+}
+
+interface BuildOptions extends Partial<HarnessState> {
+  /** Override the stream produced by Turn.run */
+  turnStream?: AsyncGenerator<ServerGeminiStreamEvent>;
+}
+
+function buildOrchestrator(options: BuildOptions = {}): {
+  orchestrator: InstanceType<typeof MessageStreamOrchestrator>;
+  state: HarnessState;
+} {
+  const state: HarnessState = {
+    model: options.model ?? 'gpt-4',
+    providerName: options.providerName,
+    profileName: options.profileName ?? null,
+    providerManagerActiveModel: options.providerManagerActiveModel,
+    lastPromptId: options.lastPromptId,
+    currentSequenceModel: options.currentSequenceModel ?? null,
+  };
+
+  const mockChat = {
+    getLastPromptTokenCount: vi.fn().mockReturnValue(100),
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+  };
+
+  const providerManager = {
+    getActiveProviderName: vi.fn(() => state.providerName ?? ''),
+    getActiveProvider: vi.fn(() => ({
+      name: state.providerName ?? 'openai',
+      getDefaultModel: vi.fn(() => state.providerManagerActiveModel ?? ''),
+    })),
+  };
+
+  const config = {
+    getContentGeneratorConfig: vi.fn(() => ({
+      providerManager,
+      model: state.model,
+    })),
+    getMaxSessionTurns: vi.fn(() => 0),
+    getIdeMode: vi.fn(() => false),
+    getModel: vi.fn(() => state.model),
+    getSettingsService: vi.fn(() => ({
+      getCurrentProfileName: vi.fn(() => state.profileName ?? null),
+      get: vi.fn((key: string) =>
+        key === 'currentProfile' ? state.profileName : undefined,
+      ),
+    })),
+  } as unknown as Config;
+
+  const stream =
+    options.turnStream ??
+    (async function* (): AsyncGenerator<ServerGeminiStreamEvent> {
+      yield { type: GeminiEventType.Content, value: 'hello' };
+      yield {
+        type: GeminiEventType.Finished,
+        value: { outcome: { hadVisibleOutput: true } },
+      };
+    })();
+
+  mockTurnRun.mockReturnValue(stream);
+
+  const deps: MessageStreamDeps = {
+    config,
+    getChat: () => mockChat as unknown as ChatSession,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    } as unknown as DebugLogger,
+    loopDetector: {
+      reset: vi.fn(),
+      turnStarted: vi.fn().mockResolvedValue(false),
+      addAndCheck: vi.fn().mockReturnValue(false),
+    } as unknown as LoopDetectionService,
+    todoContinuationService: {
+      clearPausedState: vi.fn().mockResolvedValue(undefined),
+      toolActivityCount: 0,
+      toolCallReminderLevel: 'none',
+      consecutiveComplexTurns: 0,
+      lastTodoSnapshot: [],
+      recordModelActivity: vi.fn(),
+      isTodoPauseResponse: vi.fn().mockReturnValue(false),
+      isTodoToolCall: vi.fn().mockReturnValue(false),
+      applyPendingReminder: vi.fn((r: PartListUnion) => Promise.resolve(r)),
+      getTodoReminderForCurrentState: vi.fn().mockResolvedValue({
+        todos: [],
+        activeTodos: [],
+        reminder: undefined,
+      }),
+      areTodoSnapshotsEqual: vi.fn().mockReturnValue(true),
+      processComplexityAnalysis: vi.fn().mockReturnValue(undefined),
+      appendTodoSuffixToRequest: vi.fn(),
+      appendSystemReminderToRequest: vi.fn(),
+      updateTodoToolAvailabilityFromDeclarations: vi.fn(),
+      setLastTodoToolTurn: vi.fn(),
+      shouldDeferStreamEvent: vi.fn().mockReturnValue(false),
+    } as unknown as MessageStreamDeps['todoContinuationService'],
+    ideContextTracker: {
+      getContextParts: vi.fn().mockReturnValue({
+        contextParts: [],
+        newIdeContext: undefined,
+      }),
+      recordSentContext: vi.fn(),
+    } as unknown as MessageStreamDeps['ideContextTracker'],
+    agentHookManager: {
+      cleanupOldHookState: vi.fn(),
+      fireBeforeAgentHookSafe: vi.fn().mockResolvedValue(undefined),
+      fireAfterAgentHookSafe: vi.fn().mockResolvedValue(undefined),
+    } as unknown as MessageStreamDeps['agentHookManager'],
+    getEffectiveModel: () => {
+      if (state.currentSequenceModel) return state.currentSequenceModel;
+      return state.model;
+    },
+    getHistory: vi.fn().mockResolvedValue([]),
+    getSessionTurnCount: vi.fn().mockReturnValue(1),
+    incrementSessionTurnCount: vi.fn(),
+    lazyInitialize: vi.fn().mockResolvedValue(undefined),
+    startChat: vi.fn().mockResolvedValue(mockChat),
+    getPreviousHistory: vi.fn().mockReturnValue(undefined),
+    setChat: vi.fn(),
+    hasChat: vi.fn().mockReturnValue(true),
+    complexityAnalyzer: {
+      analyzeComplexity: vi.fn().mockReturnValue({
+        complexityScore: 0.2,
+        isComplex: false,
+        detectedTasks: [],
+        sequentialIndicators: [],
+        questionCount: 0,
+        shouldSuggestTodos: false,
+      }),
+    } as unknown as ComplexityAnalyzer,
+    getLastPromptId: () => state.lastPromptId,
+    setLastPromptId: (id: string) => {
+      state.lastPromptId = id;
+    },
+    resetCurrentSequenceModel: () => {
+      state.currentSequenceModel = null;
+    },
+    updateTelemetryTokenCount: vi.fn(),
+    sendMessageStream: vi.fn(),
+  };
+
+  return {
+    orchestrator: new MessageStreamOrchestrator(deps),
+    state,
+  };
+}
+
+/** Run execute and collect all ModelInfo events. */
+async function collectModelInfos(
+  orchestrator: InstanceType<typeof MessageStreamOrchestrator>,
+  promptId: string,
+): Promise<ModelInfo[]> {
+  const events: ServerGeminiStreamEvent[] = [];
+  for await (const event of orchestrator.execute(
+    [{ text: 'test' }] as PartListUnion,
+    new AbortController().signal,
+    promptId,
+    1,
+    false,
+  )) {
+    events.push(event);
+  }
+  return events
+    .filter(
+      (e): e is { type: typeof GeminiEventType.ModelInfo; value: ModelInfo } =>
+        e.type === GeminiEventType.ModelInfo,
+    )
+    .map((e) => e.value);
+}
+
+describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits ModelInfo for a new prompt', async () => {
+    const { orchestrator } = buildOrchestrator({
+      model: 'gpt-4',
+      providerName: 'openai',
+      profileName: null,
+    });
+
+    const infos = await collectModelInfos(orchestrator, 'prompt-1');
+
+    expect(infos).toHaveLength(1);
+    expect(infos[0]?.model).toBe('gpt-4');
+  });
+
+  it('emits exactly one ModelInfo on a continuation when model identity changes', async () => {
+    const { orchestrator, state } = buildOrchestrator({
+      model: 'gpt-4',
+      providerName: 'openai',
+    });
+
+    // Simulate the first prompt already completed (lastPromptId is set)
+    state.lastPromptId = 'prompt-1';
+
+    // Now simulate a model change during a continuation (same prompt id)
+    state.model = 'claude-3';
+    state.providerName = 'anthropic';
+    state.currentSequenceModel = 'claude-3';
+
+    // Re-enter execute with the SAME prompt id (continuation/retry)
+    const infos = await collectModelInfos(orchestrator, 'prompt-1');
+
+    // Should emit exactly one ModelInfo for the changed identity
+    expect(infos).toHaveLength(1);
+    expect(infos[0]?.model).toBe('claude-3');
+    expect(infos[0]?.providerName).toBe('anthropic');
+  });
+
+  it('does not emit duplicate ModelInfo for same identity on continuation', async () => {
+    const { orchestrator, state } = buildOrchestrator({
+      model: 'gpt-4',
+      providerName: 'openai',
+    });
+
+    // First: run the initial prompt to set the last-emitted identity
+    const infos1 = await collectModelInfos(orchestrator, 'prompt-1');
+    expect(infos1).toHaveLength(1);
+
+    // Now re-enter with the SAME prompt id — same model/provider/profile
+    state.lastPromptId = 'prompt-1';
+
+    const infos2 = await collectModelInfos(orchestrator, 'prompt-1');
+
+    // No new prompt, no identity change → zero ModelInfo events
+    expect(infos2).toHaveLength(0);
+  });
+
+  it('emits ModelInfo when only profile changes on continuation', async () => {
+    const { orchestrator, state } = buildOrchestrator({
+      model: 'gpt-4',
+      providerName: 'openai',
+      profileName: 'profile-a',
+    });
+
+    state.lastPromptId = 'prompt-1';
+
+    // Change profile only
+    state.profileName = 'profile-b';
+
+    const infos = await collectModelInfos(orchestrator, 'prompt-1');
+
+    expect(infos).toHaveLength(1);
+    expect(infos[0]?.profileName).toBe('profile-b');
+    expect(infos[0]?.displayLabel).toBe('profile-b');
+  });
+
+  it('prefers provider manager active model over config.getModel', async () => {
+    const { orchestrator } = buildOrchestrator({
+      model: 'config-model',
+      providerName: 'openai',
+      providerManagerActiveModel: 'provider-active-model',
+    });
+
+    const infos = await collectModelInfos(orchestrator, 'prompt-new');
+
+    expect(infos).toHaveLength(1);
+    // The ModelInfo should reflect provider manager active model,
+    // not the config model
+    expect(infos[0]?.model).toBe('provider-active-model');
+  });
+});

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -11,6 +11,7 @@ import {
   GeminiEventType,
   DEFAULT_AGENT_ID,
   type ServerGeminiFinishedOutcome,
+  type ModelInfo,
 } from './turn.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { ChatSession } from './chatSession.js';
@@ -88,6 +89,8 @@ export const MAX_TURNS = 100;
 const MAX_RETRIES = 3;
 
 export class MessageStreamOrchestrator {
+  #lastModelIdentity: string | null = null;
+
   constructor(private readonly deps: MessageStreamDeps) {}
 
   async *execute(
@@ -169,6 +172,8 @@ export class MessageStreamOrchestrator {
       resetCurrentSequenceModel();
       await todoContinuationService.clearPausedState();
 
+      yield* this._emitModelInfoForNewSequence();
+
       const hookOutput = await agentHookManager.fireBeforeAgentHookSafe(
         ctx.prompt_id,
         ctx.promptText,
@@ -199,6 +204,11 @@ export class MessageStreamOrchestrator {
         const requestArray = Array.isArray(request) ? request : [request];
         request = [...requestArray, { text: additionalContext }];
       }
+    } else {
+      // Continuation / retry of the same prompt — emit ModelInfo only when
+      // the composite provider/profile/model identity has changed since the
+      // last emission. Duplicates for the same identity are suppressed.
+      yield* this._emitModelInfoIfChanged();
     }
 
     incrementSessionTurnCount();
@@ -744,6 +754,93 @@ export class MessageStreamOrchestrator {
     const providerManager = contentGenConfig?.providerManager;
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional falsy coalescing: empty provider name should fall back to 'backend'
     return providerManager?.getActiveProviderName() || 'backend';
+  }
+
+  /**
+   * Resolves the effective model for ModelInfo, preferring the provider
+   * manager's active provider default model where available.
+   */
+  private _resolveModelForInfo(): string {
+    const contentGenConfig = this.deps.config.getContentGeneratorConfig();
+    const providerManager = contentGenConfig?.providerManager;
+    const providerDefault = providerManager
+      ?.getActiveProvider()
+      ?.getDefaultModel?.();
+    if (providerDefault && providerDefault.trim() !== '') {
+      return providerDefault;
+    }
+    return this.deps.getEffectiveModel();
+  }
+
+  private _buildModelInfo(): ModelInfo {
+    const model = this._resolveModelForInfo();
+    const providerName = this._getProviderName();
+    const profileName = this._getProfileName();
+    const hasProfile = typeof profileName === 'string' && profileName !== '';
+    const displayLabel = hasProfile ? profileName : model;
+    return { model, providerName, profileName, displayLabel };
+  }
+
+  /**
+   * Computes a collision-safe composite identity key from provider, profile,
+   * and model. Uses JSON.stringify to guarantee unambiguous delimiting — a
+   * null-byte-joined approach can still collide when a field value itself
+   * contains a null byte.
+   */
+  private _modelIdentityKey(info: ModelInfo): string {
+    return JSON.stringify([
+      info.providerName ?? '',
+      info.profileName ?? '',
+      info.model,
+    ]);
+  }
+
+  private async *_emitModelInfoForNewSequence(): AsyncGenerator<
+    ServerGeminiStreamEvent,
+    void
+  > {
+    const info = this._buildModelInfo();
+    this.#lastModelIdentity = this._modelIdentityKey(info);
+    yield { type: GeminiEventType.ModelInfo, value: info };
+  }
+
+  /**
+   * Emits a ModelInfo event only when the current composite identity
+   * (model/provider/profile) differs from the last emission.
+   * Suppresses duplicates for the same identity.
+   */
+  private async *_emitModelInfoIfChanged(): AsyncGenerator<
+    ServerGeminiStreamEvent,
+    void
+  > {
+    const info = this._buildModelInfo();
+    const key = this._modelIdentityKey(info);
+    if (key === this.#lastModelIdentity) return;
+    this.#lastModelIdentity = key;
+    yield { type: GeminiEventType.ModelInfo, value: info };
+  }
+
+  private _getProfileName(): string | null {
+    try {
+      const settingsService = (
+        this.deps.config as unknown as {
+          getSettingsService?: () => {
+            getCurrentProfileName?: () => string | null;
+            get?: (key: string) => unknown;
+          };
+        }
+      ).getSettingsService?.();
+      if (settingsService?.getCurrentProfileName) {
+        return settingsService.getCurrentProfileName();
+      }
+      if (settingsService?.get) {
+        const profile = settingsService.get('currentProfile');
+        return typeof profile === 'string' ? profile : null;
+      }
+    } catch {
+      // Settings service unavailable — no profile info
+    }
+    return null;
   }
 
   private _resetTodoState(

--- a/packages/agents/src/core/__tests__/agentClient.dispose.test.ts
+++ b/packages/agents/src/core/__tests__/agentClient.dispose.test.ts
@@ -12,11 +12,14 @@ describe('AgentClient.dispose', () => {
     const client = Object.create(AgentClient.prototype) as AgentClient & {
       _unsubscribe?: () => void;
       handleModelChanged?: () => void;
+      handleModelProfileChanged?: () => void;
     };
     const unsubscribe = vi.fn();
     const handleModelChanged = vi.fn();
+    const handleModelProfileChanged = vi.fn();
     client['_unsubscribe'] = unsubscribe;
     client['handleModelChanged'] = handleModelChanged;
+    client['handleModelProfileChanged'] = handleModelProfileChanged;
 
     client.dispose();
     expect(unsubscribe).toHaveBeenCalledTimes(1);

--- a/packages/agents/src/core/client.test.ts
+++ b/packages/agents/src/core/client.test.ts
@@ -63,7 +63,12 @@ import type { ConfigParameters } from '@vybestack/llxprt-code-core/config/config
 import type { ChatSession } from './chatSession.js';
 import { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
-import { GeminiEventType, Turn } from './turn.js';
+import {
+  GeminiEventType,
+  Turn,
+  type ServerGeminiStreamEvent,
+  type ModelInfo,
+} from './turn.js';
 import { FileDiscoveryService } from '@vybestack/llxprt-code-core/services/fileDiscoveryService.js';
 import { setSimulate429 } from '@vybestack/llxprt-code-core/utils/testUtils.js';
 import { retryWithBackoff } from '@vybestack/llxprt-code-core/utils/retry.js';
@@ -76,6 +81,7 @@ import { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complex
 import { TodoReminderService } from '@vybestack/llxprt-code-core/services/todo-reminder-service.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import { uiTelemetryService } from '@vybestack/llxprt-code-core/telemetry/uiTelemetry.js';
+import { coreEvents } from '@vybestack/llxprt-code-core/utils/events.js';
 
 // --- Mocks ---
 const mockChatCreateFn = vi.fn();
@@ -1532,7 +1538,18 @@ sub memory
       }
 
       // Verify that the max session turns limit was respected
-      expect(events).toStrictEqual([{ type: GeminiEventType.MaxSessionTurns }]);
+      expect(events).toStrictEqual([
+        {
+          type: GeminiEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'backend',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
+        { type: GeminiEventType.MaxSessionTurns },
+      ]);
     });
 
     it('should yield ContextWindowWillOverflow when the context window is about to overflow', async () => {
@@ -1739,6 +1756,15 @@ sub memory
 
       // Assert
       expect(events).toStrictEqual([
+        {
+          type: GeminiEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'backend',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
         { type: GeminiEventType.InvalidStream },
         { type: GeminiEventType.Content, value: 'Continued content' },
       ]);
@@ -1788,7 +1814,18 @@ sub memory
       const events = await fromAsync(stream);
 
       // Assert
-      expect(events).toStrictEqual([{ type: GeminiEventType.InvalidStream }]);
+      expect(events).toStrictEqual([
+        {
+          type: GeminiEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'backend',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
+        { type: GeminiEventType.InvalidStream },
+      ]);
 
       // Verify that turn.run was called only once
       expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
@@ -1852,6 +1889,15 @@ sub memory
       ).toBe(false);
       expect(events).toStrictEqual([
         {
+          type: GeminiEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'backend',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
+        {
           type: GeminiEventType.Thought,
           value: {
             subject: 'Planning',
@@ -1890,10 +1936,11 @@ sub memory
       const events = await fromAsync(stream);
 
       // Assert
-      // We expect 2 InvalidStream events (original + 1 retry)
-      expect(events.length).toBe(2);
+      // We expect 1 ModelInfo + 2 InvalidStream events (original + 1 retry)
+      expect(events.length).toBe(3);
+      expect(events[0]?.type).toBe(GeminiEventType.ModelInfo);
       expect(
-        events.every((e) => e.type === GeminiEventType.InvalidStream),
+        events.slice(1).every((e) => e.type === GeminiEventType.InvalidStream),
       ).toBe(true);
 
       // Verify that turn.run was called twice
@@ -1951,8 +1998,17 @@ sub memory
       const stream = client.sendMessageStream(initialRequest, signal, promptId);
       const events = await fromAsync(stream);
 
-      // Assert: both the error event and the retried content should appear
+      // Assert: model_info, then error event and retried content
       expect(events).toStrictEqual([
+        {
+          type: GeminiEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'backend',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
         {
           type: GeminiEventType.Error,
           value: {
@@ -2008,8 +2064,17 @@ sub memory
       const stream = client.sendMessageStream(initialRequest, signal, promptId);
       const events = await fromAsync(stream);
 
-      // Assert: only the error event, no retry
+      // Assert: model_info, then only the error event, no retry
       expect(events).toStrictEqual([
+        {
+          type: GeminiEventType.ModelInfo,
+          value: {
+            model: 'test-model',
+            providerName: 'backend',
+            profileName: null,
+            displayLabel: 'test-model',
+          },
+        },
         {
           type: GeminiEventType.Error,
           value: {
@@ -2053,14 +2118,17 @@ sub memory
       const stream = client.sendMessageStream(initialRequest, signal, promptId);
       const events = await fromAsync(stream);
 
-      // Assert: exactly 2 Error events (original + 1 retry), no infinite loop
-      expect(events.length).toBe(2);
+      // Assert: 1 ModelInfo + exactly 2 Error events (original + 1 retry), no infinite loop
+      expect(events.length).toBe(3);
+      expect(events[0]?.type).toBe(GeminiEventType.ModelInfo);
       expect(
-        events.every(
-          (e) =>
-            e.type === GeminiEventType.Error &&
-            (e.value as { error: { status?: number } }).error.status === 413,
-        ),
+        events
+          .slice(1)
+          .every(
+            (e) =>
+              e.type === GeminiEventType.Error &&
+              (e.value as { error: { status?: number } }).error.status === 413,
+          ),
       ).toBe(true);
 
       // turn.run should be called exactly twice
@@ -3268,6 +3336,223 @@ sub memory
           part.text === 'Additional context from hook',
       );
       expect(hasAdditionalContext).toBe(true);
+    });
+  });
+
+  describe('ModelProfileChanged resets sequence model (issue #1770)', () => {
+    it('resets currentSequenceModel when ModelProfileChanged fires', () => {
+      // Set a sticky model
+      client['currentSequenceModel'] = 'sticky-model';
+      expect(client.getCurrentSequenceModel()).toBe('sticky-model');
+
+      // Emit ModelProfileChanged — should reset the sticky model
+      coreEvents.emitModelProfileChanged({
+        model: 'new-model',
+        providerName: 'anthropic',
+        profileName: null,
+        displayLabel: 'new-model',
+      });
+
+      // currentSequenceModel should now be null
+      expect(client.getCurrentSequenceModel()).toBeNull();
+    });
+
+    it('also resets currentSequenceModel on ModelChanged', () => {
+      client['currentSequenceModel'] = 'sticky-model';
+      coreEvents.emitModelChanged('other-model');
+      expect(client.getCurrentSequenceModel()).toBeNull();
+    });
+  });
+
+  describe('ModelInfo during InvalidStream continuation when model changes mid-sequence (issue #1770)', () => {
+    let getModelSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      };
+      client['chat'] = mockChat as ChatSession;
+      getModelSpy = vi.spyOn(client['config'], 'getModel');
+    });
+
+    afterEach(() => {
+      getModelSpy.mockRestore();
+    });
+
+    /**
+     * Helper: collect only ModelInfo events from a stream.
+     */
+    async function collectModelInfos(
+      stream: AsyncIterable<ServerGeminiStreamEvent>,
+    ): Promise<ModelInfo[]> {
+      const events = await fromAsync(stream);
+      return events
+        .filter(
+          (
+            e,
+          ): e is ServerGeminiStreamEvent & {
+            type: typeof GeminiEventType.ModelInfo;
+            value: ModelInfo;
+          } => e.type === GeminiEventType.ModelInfo,
+        )
+        .map((e) => e.value);
+    }
+
+    it('emits exactly one additional ModelInfo when model changes during InvalidStream continuation', async () => {
+      // Stream 2: continuation succeeds
+      const mockStream2 = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'Continued' };
+        yield { type: GeminiEventType.Finished, value: { reason: 'STOP' } };
+      })();
+
+      getModelSpy.mockReturnValue('test-model');
+
+      // Intercept between stream1 and stream2 to simulate a model change.
+      // After the first Turn.run returns InvalidStream, change config.getModel
+      // so the continuation's _buildModelInfo reads a different effective model.
+      mockTurnRunFn.mockReset();
+      let callCount = 0;
+      mockTurnRunFn.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          const stream = (async function* () {
+            yield { type: GeminiEventType.InvalidStream };
+          })();
+          // Simulate model change before continuation
+          getModelSpy.mockReturnValue('changed-model');
+          // Reset sequence model so orchestrator re-reads from config
+          coreEvents.emitModelProfileChanged({
+            model: 'changed-model',
+            providerName: 'anthropic',
+            profileName: null,
+            displayLabel: 'changed-model',
+          });
+          return stream;
+        }
+        return mockStream2;
+      });
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'prompt-change-mid-seq',
+      );
+
+      const infos = await collectModelInfos(stream);
+
+      // First emission for the initial model, then exactly one additional
+      // ModelInfo for the changed identity — no duplicates.
+      expect(infos).toHaveLength(2);
+      expect(infos[0]?.model).toBe('test-model');
+      expect(infos[1]?.model).toBe('changed-model');
+    });
+
+    it('does not emit additional ModelInfo when identity is unchanged during continuation', async () => {
+      const mockStream1 = (async function* () {
+        yield { type: GeminiEventType.InvalidStream };
+      })();
+      const mockStream2 = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'Continued' };
+        yield { type: GeminiEventType.Finished, value: { reason: 'STOP' } };
+      })();
+
+      getModelSpy.mockReturnValue('test-model');
+      mockTurnRunFn.mockReset();
+      mockTurnRunFn
+        .mockReturnValueOnce(mockStream1)
+        .mockReturnValue(mockStream2);
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'prompt-same-identity',
+      );
+
+      const infos = await collectModelInfos(stream);
+
+      // Same model/provider/profile across continuation → only one ModelInfo
+      expect(infos).toHaveLength(1);
+      expect(infos[0]?.model).toBe('test-model');
+    });
+
+    it('emits exactly one additional ModelInfo when provider changes during continuation', async () => {
+      const mockStream2 = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'ok' };
+        yield { type: GeminiEventType.Finished, value: { reason: 'STOP' } };
+      })();
+
+      getModelSpy.mockReturnValue('test-model');
+
+      // The orchestrator's _getProviderName reads from
+      // getContentGeneratorConfig().providerManager?.getActiveProviderName().
+      // We spy on getContentGeneratorConfig to return different provider info
+      // after the first stream.
+      const getContentGenSpy = vi.spyOn(
+        client['config'],
+        'getContentGeneratorConfig',
+      );
+      getContentGenSpy.mockReturnValue({
+        model: 'test-model',
+        apiKey: 'test-key',
+        vertexai: false,
+      });
+
+      mockTurnRunFn.mockReset();
+      let callCount = 0;
+      mockTurnRunFn.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          const stream = (async function* () {
+            yield { type: GeminiEventType.InvalidStream };
+          })();
+          // Simulate provider change before continuation: now the config
+          // returns a providerManager with a different active provider.
+          getContentGenSpy.mockReturnValue({
+            model: 'test-model',
+            apiKey: 'test-key',
+            vertexai: false,
+            providerManager: {
+              getActiveProviderName: () => 'anthropic',
+              getActiveProvider: () => ({
+                name: 'anthropic',
+                getDefaultModel: () => 'test-model',
+              }),
+            },
+          } as unknown as ContentGeneratorConfig);
+          // Reset sequence model so orchestrator re-reads
+          coreEvents.emitModelProfileChanged({
+            model: 'test-model',
+            providerName: 'anthropic',
+            profileName: null,
+            displayLabel: 'test-model',
+          });
+          return stream;
+        }
+        return mockStream2;
+      });
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'prompt-provider-change',
+      );
+
+      const infos = await collectModelInfos(stream);
+
+      getContentGenSpy.mockRestore();
+
+      // First emission (provider 'backend' — no providerManager), then one
+      // additional for provider change to 'anthropic' — exactly one, not
+      // duplicates.
+      expect(infos).toHaveLength(2);
+      expect(infos[0]?.providerName).toBe('backend');
+      expect(infos[1]?.providerName).toBe('anthropic');
     });
   });
 });

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -186,6 +186,10 @@ export class AgentClient implements AgentClientContract {
     );
 
     coreEvents.on(CoreEvent.ModelChanged, this.handleModelChanged);
+    coreEvents.on(
+      CoreEvent.ModelProfileChanged,
+      this.handleModelProfileChanged,
+    );
   }
 
   private _buildOrchestratorDeps(): MessageStreamDeps {
@@ -228,8 +232,16 @@ export class AgentClient implements AgentClientContract {
     this.currentSequenceModel = null;
   };
 
+  private handleModelProfileChanged = () => {
+    this.currentSequenceModel = null;
+  };
+
   dispose(): void {
     coreEvents.off(CoreEvent.ModelChanged, this.handleModelChanged);
+    coreEvents.off(
+      CoreEvent.ModelProfileChanged,
+      this.handleModelProfileChanged,
+    );
     if (this._unsubscribe) {
       this._unsubscribe();
       this._unsubscribe = undefined;

--- a/packages/cli/src/runtime/profileSnapshot.test.ts
+++ b/packages/cli/src/runtime/profileSnapshot.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { coreEvents, CoreEvent } from '@vybestack/llxprt-code-core';
+import type { Profile } from '@vybestack/llxprt-code-settings';
+
+// Mock external dependencies of applyProfileSnapshot so we can verify
+// emission without bootstrapping the entire CLI runtime.
+vi.mock('./runtimeAccessors.js', () => ({
+  getCliRuntimeServices: vi.fn(() => ({
+    config: {},
+    settingsService: { setCurrentProfileName: vi.fn() },
+    providerManager: {},
+  })),
+  getCliOAuthManager: vi.fn(() => null),
+  getActiveModelName: vi.fn(() => 'test-model'),
+  getActiveModelParams: vi.fn(() => ({})),
+  _internal: {
+    resolveActiveProviderName: vi.fn(() => 'test-provider'),
+    getProviderSettingsSnapshot: vi.fn(() => ({})),
+    getActiveProviderOrThrow: vi.fn(),
+    extractModelParams: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('./profileApplication.js', () => ({
+  applyProfileWithGuards: vi.fn(
+    async (profile: { provider: string; model: string }) => ({
+      providerName: profile.provider,
+      modelName: profile.model,
+      infoMessages: [],
+      warnings: [],
+      providerChanged: true,
+      baseUrl: undefined,
+      didFallback: false,
+      requestedProvider: profile.provider,
+    }),
+  ),
+}));
+
+import {
+  applyProfileSnapshot,
+  buildModelProfileInfoPayload,
+} from './profileSnapshot.js';
+
+describe('buildModelProfileInfoPayload', () => {
+  it('builds payload with profile name as displayLabel when profile is active', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'gpt-4o',
+      providerName: 'openai',
+      profileName: 'production',
+    });
+
+    expect(payload).toStrictEqual({
+      model: 'gpt-4o',
+      providerName: 'openai',
+      profileName: 'production',
+      displayLabel: 'production',
+    });
+  });
+
+  it('uses model name as displayLabel when no profile is active', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'llama3',
+      providerName: 'ollama',
+      profileName: null,
+    });
+
+    expect(payload).toStrictEqual({
+      model: 'llama3',
+      providerName: 'ollama',
+      profileName: null,
+      displayLabel: 'llama3',
+    });
+  });
+
+  it('uses model name as displayLabel when profile name is empty string', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'gemini-2.0-flash',
+      providerName: 'gemini',
+      profileName: '',
+    });
+
+    expect(payload.displayLabel).toBe('gemini-2.0-flash');
+  });
+
+  it('falls back to model name when providerName is absent', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'test-model',
+      profileName: 'my-profile',
+    });
+
+    expect(payload).toStrictEqual({
+      model: 'test-model',
+      providerName: undefined,
+      profileName: 'my-profile',
+      displayLabel: 'my-profile',
+    });
+  });
+
+  it('prefers displayName over profileName and model when supplied', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'gpt-4o',
+      providerName: 'openai',
+      profileName: 'production',
+      displayName: 'Production Environment',
+    });
+
+    expect(payload).toStrictEqual({
+      model: 'gpt-4o',
+      providerName: 'openai',
+      profileName: 'production',
+      displayName: 'Production Environment',
+      displayLabel: 'Production Environment',
+    });
+  });
+
+  it('prefers displayName even when no profile is active', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'llama3',
+      providerName: 'ollama',
+      profileName: null,
+      displayName: 'My Ollama Setup',
+    });
+
+    expect(payload.displayLabel).toBe('My Ollama Setup');
+    expect(payload.displayName).toBe('My Ollama Setup');
+  });
+
+  it('ignores empty displayName and falls back to profileName', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'gpt-4o',
+      providerName: 'openai',
+      profileName: 'work',
+      displayName: '',
+    });
+
+    expect(payload.displayLabel).toBe('work');
+  });
+
+  it('ignores whitespace-only displayName and falls back to profileName', () => {
+    const payload = buildModelProfileInfoPayload({
+      model: 'gpt-4o',
+      providerName: 'openai',
+      profileName: 'work',
+      displayName: '   ',
+    });
+
+    expect(payload.displayLabel).toBe('work');
+  });
+
+  /**
+   * Rationale (issue #1770 fix #5): The Profile schema (StandardProfile |
+   * LoadBalancerProfile) does NOT define a displayName or name field.
+   * The profile key name (options.profileName) IS the display label.
+   * No schema expansion is necessary — buildModelProfileInfoPayload already
+   * accepts an optional displayName for forward compatibility if a future
+   * schema change adds one.
+   */
+  it('uses profileName as displayLabel because Profile schema has no displayName field', () => {
+    // Simulate what applyProfileSnapshot does: pass profileName as the display
+    // label source, with no explicit displayName.
+    const payload = buildModelProfileInfoPayload({
+      model: 'claude-sonnet',
+      providerName: 'anthropic',
+      profileName: 'my-custom-profile',
+      // No displayName — simulating the current Profile schema
+    });
+
+    expect(payload.displayLabel).toBe('my-custom-profile');
+    expect(payload.displayName).toBeUndefined();
+  });
+
+  it('would use displayName if Profile schema adds one in the future', () => {
+    // Forward-compatibility test: if a displayName field is added to the
+    // Profile schema, applyProfileSnapshot can pass it and it takes precedence.
+    const payload = buildModelProfileInfoPayload({
+      model: 'claude-sonnet',
+      providerName: 'anthropic',
+      profileName: 'raw-key',
+      displayName: 'My Friendly Profile Name',
+    });
+
+    expect(payload.displayLabel).toBe('My Friendly Profile Name');
+    expect(payload.displayName).toBe('My Friendly Profile Name');
+  });
+});
+
+describe('ModelProfileChanged emission from applyProfileSnapshot', () => {
+  beforeEach(() => {
+    coreEvents.removeAllListeners();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    coreEvents.removeAllListeners();
+    vi.restoreAllMocks();
+  });
+
+  it('emits ModelProfileChanged event with model, provider, and profile from application result', async () => {
+    const listener = vi.fn();
+    coreEvents.on(CoreEvent.ModelProfileChanged, listener);
+
+    const profile: Profile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'claude-sonnet',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileSnapshot(profile, { profileName: 'work' });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-sonnet',
+        providerName: 'anthropic',
+        profileName: 'work',
+        displayLabel: 'work',
+      }),
+    );
+  });
+
+  it('uses model as displayLabel when profileName is null', async () => {
+    const listener = vi.fn();
+    coreEvents.on(CoreEvent.ModelProfileChanged, listener);
+
+    const profile: Profile = {
+      version: 1,
+      provider: 'ollama',
+      model: 'llama3',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileSnapshot(profile, { profileName: undefined });
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'llama3',
+        profileName: null,
+        displayLabel: 'llama3',
+      }),
+    );
+  });
+
+  it('does not emit before applyProfileSnapshot is called', async () => {
+    const listener = vi.fn();
+    coreEvents.on(CoreEvent.ModelProfileChanged, listener);
+
+    // Just attaching the listener should not produce any emission
+    expect(listener).not.toHaveBeenCalled();
+
+    const profile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileSnapshot(profile, { profileName: 'prod' });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/runtime/profileSnapshot.ts
+++ b/packages/cli/src/runtime/profileSnapshot.ts
@@ -6,7 +6,11 @@
 
 /* eslint-disable complexity, eslint-comments/disable-enable-pair -- Phase 5: legacy CLI boundary retained while larger decomposition continues. */
 
-import { DebugLogger } from '@vybestack/llxprt-code-core';
+import {
+  DebugLogger,
+  coreEvents,
+  type ModelProfileInfoPayload,
+} from '@vybestack/llxprt-code-core';
 import {
   ProfileManager,
   getProfilePersistableKeys,
@@ -461,6 +465,38 @@ function buildProfileLoadResult(
   };
 }
 
+export interface ModelProfileInfoInput {
+  model: string;
+  providerName?: string;
+  profileName?: string | null;
+  /**
+   * Explicit human-readable display name. When supplied and non-empty, takes
+   * precedence over profileName and model for the computed displayLabel.
+   */
+  displayName?: string;
+}
+
+export function buildModelProfileInfoPayload(
+  input: ModelProfileInfoInput,
+): ModelProfileInfoPayload {
+  const profileName = input.profileName ?? null;
+  const hasProfile = typeof profileName === 'string' && profileName !== '';
+  const trimmedDisplayName = input.displayName?.trim();
+  const hasDisplayName =
+    typeof trimmedDisplayName === 'string' && trimmedDisplayName !== '';
+  const profileLabel = hasProfile ? profileName : undefined;
+  const displayLabel = hasDisplayName
+    ? trimmedDisplayName
+    : (profileLabel ?? input.model);
+  return {
+    model: input.model,
+    providerName: input.providerName,
+    profileName,
+    ...(hasDisplayName ? { displayName: trimmedDisplayName } : {}),
+    displayLabel,
+  };
+}
+
 export async function applyProfileSnapshot(
   profile: Profile,
   options: ProfileLoadOptions = {},
@@ -480,7 +516,17 @@ export async function applyProfileSnapshot(
     }
   }
 
-  return buildProfileLoadResult(options.profileName, applicationResult);
+  const result = buildProfileLoadResult(options.profileName, applicationResult);
+
+  coreEvents.emitModelProfileChanged(
+    buildModelProfileInfoPayload({
+      model: result.modelName,
+      providerName: result.providerName,
+      profileName: result.profileName,
+    }),
+  );
+
+  return result;
 }
 
 export async function saveProfileSnapshot(

--- a/packages/cli/src/runtime/providerSwitch.spec.ts
+++ b/packages/cli/src/runtime/providerSwitch.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { coreEvents } from '@vybestack/llxprt-code-core';
 import { DEFAULT_PRESERVE_EPHEMERALS } from './providerSwitch.js';
 
 vi.mock('./runtimeAccessors.js', () => {
@@ -24,7 +25,7 @@ vi.mock('./runtimeAccessors.js', () => {
   };
   const mockSettingsService = {
     set: vi.fn(),
-    get: vi.fn(() => 'openai'),
+    get: vi.fn((key: string) => (key === 'currentProfile' ? null : 'openai')),
     getProviderSetting: vi.fn(),
     setProviderSetting: vi.fn(),
     switchProvider: vi.fn(),
@@ -37,6 +38,10 @@ vi.mock('./runtimeAccessors.js', () => {
       name: 'openai',
       getDefaultModel: vi.fn(() => 'gpt-4'),
       getModels: vi.fn(() => []),
+    })),
+    getProviderByName: vi.fn(() => ({
+      name: 'gemini',
+      getDefaultModel: vi.fn(() => 'gemini-2.0-flash'),
     })),
   };
   return {
@@ -127,6 +132,284 @@ describe('providerSwitch', () => {
       await expect(switchActiveProvider('   ', {})).rejects.toThrow(
         'Provider name is required.',
       );
+    });
+
+    it('emits ModelProfileChanged with resolved model when modelToApply is empty', async () => {
+      const { switchActiveProvider } = await import('./providerSwitch.js');
+      const emitSpy = vi.spyOn(coreEvents, 'emitModelProfileChanged');
+
+      // computeModelDefaults mock returns {} so modelToApply stays empty.
+      // getActiveModelName mock returns 'gpt-4' as fallback.
+      await switchActiveProvider('gemini', {});
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      const emitted = emitSpy.mock.calls[0][0];
+      // Must NOT be empty string — should fall back to the active model
+      expect(emitted.model).not.toBe('');
+      expect(emitted.model).toBe('gpt-4');
+      expect(emitted.displayLabel).not.toBe('');
+    });
+
+    it('does not emit empty model/displayLabel even when no default model exists', async () => {
+      const { switchActiveProvider } = await import('./providerSwitch.js');
+      const emitSpy = vi.spyOn(coreEvents, 'emitModelProfileChanged');
+
+      // Make the provider return no default model so modelToApply resolves to ''
+      const { getCliRuntimeServices } = await import('./runtimeAccessors.js');
+      const mockFn = getCliRuntimeServices as unknown as ReturnType<
+        typeof vi.fn
+      >;
+      mockFn.mockReturnValue({
+        config: {
+          setEphemeralSetting: vi.fn(),
+          getEphemeralSetting: vi.fn(),
+          getEphemeralSettings: vi.fn(() => ({})),
+          setProviderManager: vi.fn(),
+          setProvider: vi.fn(),
+          setModel: vi.fn(),
+          getModel: vi.fn(() => ''),
+          setBucketFailoverHandler: vi.fn(),
+          setContentGeneratorConfig: vi.fn(),
+          getContentGeneratorConfig: vi.fn(),
+          get: vi.fn(),
+          set: vi.fn(),
+        },
+        settingsService: {
+          set: vi.fn(),
+          get: vi.fn(() => null),
+          getProviderSetting: vi.fn(),
+          setProviderSetting: vi.fn(),
+          switchProvider: vi.fn(),
+          providerSettings: vi.fn(() => ({})),
+        },
+        providerManager: {
+          getActiveProviderName: vi.fn(() => 'openai'),
+          setActiveProvider: vi.fn(),
+          getActiveProvider: vi.fn(() => ({
+            name: 'openai',
+            getDefaultModel: vi.fn(() => undefined),
+            getModels: vi.fn(() => []),
+          })),
+          getProviderByName: vi.fn(() => ({
+            name: 'gemini',
+            getDefaultModel: vi.fn(() => undefined),
+          })),
+        },
+      });
+
+      await switchActiveProvider('gemini', {});
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      const emitted = emitSpy.mock.calls[0][0];
+      // Even with no default model, must not emit empty string
+      expect(emitted.model).not.toBe('');
+      expect(emitted.displayLabel).not.toBe('');
+    });
+
+    it('does not emit empty displayLabel when no profile and no modelToApply', async () => {
+      const { switchActiveProvider } = await import('./providerSwitch.js');
+      const emitSpy = vi.spyOn(coreEvents, 'emitModelProfileChanged');
+
+      await switchActiveProvider('gemini', {});
+
+      const emitted = emitSpy.mock.calls[0][0];
+      expect(emitted.displayLabel).not.toBe('');
+      // Falls back to active model name when no profile
+      expect(emitted.displayLabel).toBe('gpt-4');
+    });
+
+    it('falls back to provider name when active model, config model, and provider default are all empty', async () => {
+      const { switchActiveProvider } = await import('./providerSwitch.js');
+      const emitSpy = vi.spyOn(coreEvents, 'emitModelProfileChanged');
+
+      // Override mocks so ALL model sources return empty.
+      // Provider manager active name must differ from the target ('gemini')
+      // so that switchActiveProvider actually performs a switch.
+      const { getCliRuntimeServices, getActiveModelName } = await import(
+        './runtimeAccessors.js'
+      );
+      (
+        getCliRuntimeServices as unknown as ReturnType<typeof vi.fn>
+      ).mockReturnValue({
+        config: {
+          setEphemeralSetting: vi.fn(),
+          getEphemeralSetting: vi.fn(),
+          getEphemeralSettings: vi.fn(() => ({})),
+          setProviderManager: vi.fn(),
+          setProvider: vi.fn(),
+          setModel: vi.fn(),
+          getModel: vi.fn(() => ''),
+          setBucketFailoverHandler: vi.fn(),
+          setContentGeneratorConfig: vi.fn(),
+          getContentGeneratorConfig: vi.fn(),
+          get: vi.fn(),
+          set: vi.fn(),
+        },
+        settingsService: {
+          set: vi.fn(),
+          get: vi.fn(() => null),
+          getProviderSetting: vi.fn(),
+          setProviderSetting: vi.fn(),
+          switchProvider: vi.fn(),
+          providerSettings: vi.fn(() => ({})),
+          getCurrentProfileName: vi.fn(() => null),
+        },
+        providerManager: {
+          getActiveProviderName: vi.fn(() => 'openai'),
+          setActiveProvider: vi.fn(),
+          getActiveProvider: vi.fn(() => ({
+            name: 'openai',
+            getDefaultModel: vi.fn(() => ''),
+            getModels: vi.fn(() => []),
+          })),
+          getProviderByName: vi.fn(() => ({
+            name: 'gemini',
+            getDefaultModel: vi.fn(() => ''),
+          })),
+        },
+      });
+      (
+        getActiveModelName as unknown as ReturnType<typeof vi.fn>
+      ).mockReturnValue('');
+
+      await switchActiveProvider('gemini', {});
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      const emitted = emitSpy.mock.calls[0][0];
+      // model must NEVER be empty — fallback chain ends with provider name
+      expect(emitted.model).not.toBe('');
+      expect(emitted.model).toBe('gemini');
+      // displayLabel must NEVER be empty either
+      expect(emitted.displayLabel).not.toBe('');
+      expect(emitted.displayLabel).toBe('gemini');
+    });
+
+    it('does not use stale getActiveModelName when modelToApply is empty; prefers context-scoped config model', async () => {
+      const { switchActiveProvider } = await import('./providerSwitch.js');
+      const { getCliRuntimeServices, getActiveModelName } = await import(
+        './runtimeAccessors.js'
+      );
+
+      // modelToApply will be empty because provider has no default model.
+      // config.getModel reflects the post-switch model.
+      // getActiveModelName is STALE — returns the old provider's model.
+      (
+        getCliRuntimeServices as unknown as ReturnType<typeof vi.fn>
+      ).mockReturnValue({
+        config: {
+          setEphemeralSetting: vi.fn(),
+          getEphemeralSetting: vi.fn(),
+          getEphemeralSettings: vi.fn(() => ({})),
+          setProviderManager: vi.fn(),
+          setProvider: vi.fn(),
+          setModel: vi.fn(),
+          getModel: vi.fn(() => 'gemini-2.0-flash'),
+          setBucketFailoverHandler: vi.fn(),
+          setContentGeneratorConfig: vi.fn(),
+          getContentGeneratorConfig: vi.fn(),
+          get: vi.fn(),
+          set: vi.fn(),
+        },
+        settingsService: {
+          set: vi.fn(),
+          get: vi.fn(() => null),
+          getProviderSetting: vi.fn(),
+          setProviderSetting: vi.fn(),
+          switchProvider: vi.fn(),
+          providerSettings: vi.fn(() => ({})),
+          getCurrentProfileName: vi.fn(() => null),
+        },
+        providerManager: {
+          getActiveProviderName: vi.fn(() => 'openai'),
+          setActiveProvider: vi.fn(),
+          // No default model → modelToApply resolves to ''
+          getActiveProvider: vi.fn(() => ({
+            name: 'gemini',
+            getDefaultModel: vi.fn(() => ''),
+            getModels: vi.fn(() => []),
+          })),
+          getProviderByName: vi.fn(() => ({
+            name: 'gemini',
+            getDefaultModel: vi.fn(() => ''),
+          })),
+        },
+      });
+      // Stale global: still returns old provider's model
+      (
+        getActiveModelName as unknown as ReturnType<typeof vi.fn>
+      ).mockReturnValue('gpt-4-stale');
+
+      const emitSpy = vi.spyOn(coreEvents, 'emitModelProfileChanged');
+      await switchActiveProvider('gemini', {});
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      const emitted = emitSpy.mock.calls[0][0];
+      // Must NOT use stale 'gpt-4-stale' from the global accessor.
+      // Should use context-scoped config model 'gemini-2.0-flash'.
+      expect(emitted.model).not.toBe('gpt-4-stale');
+      expect(emitted.model).toBe('gemini-2.0-flash');
+    });
+
+    it('multi-provider: emitting context-scoped model, not stale global, when switching from openai to anthropic', async () => {
+      const { switchActiveProvider } = await import('./providerSwitch.js');
+      const { getCliRuntimeServices, getActiveModelName } = await import(
+        './runtimeAccessors.js'
+      );
+
+      (
+        getCliRuntimeServices as unknown as ReturnType<typeof vi.fn>
+      ).mockReturnValue({
+        config: {
+          setEphemeralSetting: vi.fn(),
+          getEphemeralSetting: vi.fn(),
+          getEphemeralSettings: vi.fn(() => ({})),
+          setProviderManager: vi.fn(),
+          setProvider: vi.fn(),
+          setModel: vi.fn(),
+          // Post-switch config model is the anthropic model
+          getModel: vi.fn(() => 'claude-sonnet'),
+          setBucketFailoverHandler: vi.fn(),
+          setContentGeneratorConfig: vi.fn(),
+          getContentGeneratorConfig: vi.fn(),
+          get: vi.fn(),
+          set: vi.fn(),
+        },
+        settingsService: {
+          set: vi.fn(),
+          get: vi.fn(() => null),
+          getProviderSetting: vi.fn(),
+          setProviderSetting: vi.fn(),
+          switchProvider: vi.fn(),
+          providerSettings: vi.fn(() => ({})),
+          getCurrentProfileName: vi.fn(() => null),
+        },
+        providerManager: {
+          getActiveProviderName: vi.fn(() => 'openai'),
+          setActiveProvider: vi.fn(),
+          // No default model → modelToApply resolves to ''
+          getActiveProvider: vi.fn(() => ({
+            name: 'anthropic',
+            getDefaultModel: vi.fn(() => ''),
+            getModels: vi.fn(() => []),
+          })),
+          getProviderByName: vi.fn(() => ({
+            name: 'anthropic',
+            getDefaultModel: vi.fn(() => ''),
+          })),
+        },
+      });
+      // Stale global: still returns old openai model
+      (
+        getActiveModelName as unknown as ReturnType<typeof vi.fn>
+      ).mockReturnValue('gpt-4o-stale');
+
+      const emitSpy = vi.spyOn(coreEvents, 'emitModelProfileChanged');
+      await switchActiveProvider('anthropic', {});
+
+      const emitted = emitSpy.mock.calls[0][0];
+      // Must use context-scoped model, not stale global
+      expect(emitted.model).toBe('claude-sonnet');
+      expect(emitted.providerName).toBe('anthropic');
     });
   });
 });

--- a/packages/cli/src/runtime/providerSwitch.ts
+++ b/packages/cli/src/runtime/providerSwitch.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Config } from '@vybestack/llxprt-code-core';
-import { DebugLogger } from '@vybestack/llxprt-code-core';
+import { DebugLogger, coreEvents } from '@vybestack/llxprt-code-core';
 import type { IProvider } from '@vybestack/llxprt-code-providers';
 import type { HistoryItemWithoutId } from '../ui/types.js';
 import {
@@ -29,6 +29,7 @@ import {
 } from '../providers/providerAliases.js';
 import { ensureOAuthProviderRegistered } from '../providers/oauth-provider-registration.js';
 import { configureProviderRuntimeFactories } from '../providers/providerManagerInstance.js';
+import { getActiveProfileName } from './profileSnapshot.js';
 
 const logger = new DebugLogger('llxprt:runtime:settings');
 
@@ -836,6 +837,30 @@ export async function switchActiveProvider(
   applyModelDefaults(context);
   addProviderInfoMessages(context);
   await initializeContentGeneratorConfigIfSupported(context.config);
+
+  const profileName = getActiveProfileName();
+
+  // Context-scoped model resolution (issue #1770): prefer the context-local
+  // model sources over the stale global getActiveModelName().
+  // Fallback chain: modelToApply → provider-scoped default → config model
+  // → provider name. Must NEVER emit empty string for model.
+  const providerDefaultModel =
+    context.providerManager.getActiveProvider()?.getDefaultModel?.() ?? '';
+  const effectiveModel =
+    context.modelToApply ||
+    providerDefaultModel ||
+    context.config.getModel() ||
+    context.name;
+
+  // displayLabel: profile → model → provider name. Must NEVER be empty.
+  const displayLabel = profileName ?? effectiveModel;
+
+  coreEvents.emitModelProfileChanged({
+    model: effectiveModel,
+    providerName: context.name,
+    profileName,
+    displayLabel,
+  });
 
   return {
     changed: true,

--- a/packages/cli/src/ui/AppContainerRuntime.tsx
+++ b/packages/cli/src/ui/AppContainerRuntime.tsx
@@ -236,6 +236,7 @@ function buildUIStateParamsCore(r: HookResults) {
       : d.providerOptions,
     selectedProvider: d.selectedProvider,
     currentModel: d.currentModel,
+    currentModelLabel: d.currentModelLabel,
     contextLimit: d.contextLimit,
     profiles: d.profiles,
     toolsDialogAction: d.toolsDialogAction,

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -347,7 +347,7 @@ describe('<HistoryItemDisplay />', () => {
       <HistoryItemDisplay {...baseItem} item={item} />,
     );
     const output = lastFrame();
-    expect(output).toContain('Switched to profile: production');
+    expect(output).toContain('Responding with: production');
     // Should not use warning icon semantics
     expect(output).not.toContain('ℹ');
   });

--- a/packages/cli/src/ui/components/messages/ProfileChangeMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ProfileChangeMessage.test.tsx
@@ -20,15 +20,25 @@ function getRenderedOutput(stdout: RenderStdout): string {
 }
 
 describe('ProfileChangeMessage', () => {
-  it('renders profile name in message text', async () => {
+  it('renders display label in "Responding with" message', async () => {
     const { stdout } = renderWithProviders(
       <ProfileChangeMessage profileName="production" />,
     );
 
     await waitFor(() => {
       expect(getRenderedOutput(stdout)).toContain(
-        'Switched to profile: production',
+        'Responding with: production',
       );
+    });
+  });
+
+  it('renders model name as display label when no profile is active', async () => {
+    const { stdout } = renderWithProviders(
+      <ProfileChangeMessage profileName="llama3" />,
+    );
+
+    await waitFor(() => {
+      expect(getRenderedOutput(stdout)).toContain('Responding with: llama3');
     });
   });
 
@@ -40,7 +50,7 @@ describe('ProfileChangeMessage', () => {
     await waitFor(() => {
       const output = getRenderedOutput(stdout);
       expect(output).toBeTruthy();
-      expect(output).toContain('Switched to profile:');
+      expect(output).toContain('Responding with');
     });
   });
 
@@ -51,23 +61,8 @@ describe('ProfileChangeMessage', () => {
 
     await waitFor(() => {
       const output = getRenderedOutput(stdout);
-      expect(output).toContain('Switched to profile: dev');
-      // Should not contain the info icon 'ℹ' or warning icon '!'
-      expect(output).not.toContain('ℹ');
+      expect(output).toContain('Responding with: dev');
       expect(output).not.toContain('!');
-    });
-  });
-
-  it('uses sentence-case capitalization', async () => {
-    const { stdout } = renderWithProviders(
-      <ProfileChangeMessage profileName="staging" />,
-    );
-
-    await waitFor(() => {
-      // Message should start with capital 'S' in 'Switched'
-      expect(getRenderedOutput(stdout)).toContain(
-        'Switched to profile: staging',
-      );
     });
   });
 });

--- a/packages/cli/src/ui/components/messages/ProfileChangeMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ProfileChangeMessage.tsx
@@ -16,8 +16,6 @@ export const ProfileChangeMessage: React.FC<ProfileChangeMessageProps> = ({
   profileName,
 }) => (
   <Box marginLeft={2} marginTop={1}>
-    <Text color={theme.ui.comment}>
-      {`Switched to profile: ${profileName}`}
-    </Text>
+    <Text color={theme.ui.comment}>{`Responding with: ${profileName}`}</Text>
   </Box>
 );

--- a/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.test.ts
@@ -58,6 +58,7 @@ const makeParams = (): UIStateParams => ({
   providerOptions: [],
   selectedProvider: '',
   currentModel: '',
+  currentModelLabel: undefined,
   contextLimit: undefined,
   profiles: [],
   toolsDialogAction: 'enable',

--- a/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts
+++ b/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts
@@ -85,6 +85,7 @@ export interface UIStateParams {
   providerOptions: string[];
   selectedProvider: string;
   currentModel: string;
+  currentModelLabel?: string;
   contextLimit: number | undefined;
   profiles: string[];
   toolsDialogAction: 'enable' | 'disable';
@@ -286,6 +287,7 @@ function buildDialogData(p: UIStateParams) {
     providerOptions: p.providerOptions,
     selectedProvider: p.selectedProvider,
     currentModel: p.currentModel,
+    currentModelLabel: p.currentModelLabel,
     contextLimit: p.contextLimit,
     profiles: p.profiles,
     toolsDialogAction: p.toolsDialogAction,

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppDialogs.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppDialogs.ts
@@ -134,7 +134,12 @@ function useDialogsCore(
   st: ReturnType<typeof useDialogsState>,
 ) {
   const { config, settings, addItem, consoleMessages } = p;
-  const { currentModel, setCurrentModel } = useModelTracking({ config });
+  const {
+    currentModel,
+    setCurrentModel,
+    currentModelLabel,
+    setCurrentModelLabel,
+  } = useModelTracking({ config });
   const [contextLimit, setContextLimit] = useState<number | undefined>(
     () => config.getEphemeralSetting('context-limit') as number | undefined,
   );
@@ -161,6 +166,8 @@ function useDialogsCore(
   return {
     currentModel,
     setCurrentModel,
+    currentModelLabel,
+    setCurrentModelLabel,
     contextLimit,
     setContextLimit,
     ...displayPrefs,
@@ -193,6 +200,8 @@ function useDialogsAuthProviders(
   st: ReturnType<typeof useDialogsState>,
   currentModel: string,
   setCurrentModel: (model: string) => void,
+  currentModelLabel: string,
+  setCurrentModelLabel: (label: string) => void,
   contextLimit: number | undefined,
   setContextLimit: (limit: number | undefined) => void,
   setShowErrorDetails: (value: boolean) => void,
@@ -227,7 +236,10 @@ function useDialogsAuthProviders(
     config,
     currentModel,
     setCurrentModel,
+    currentModelLabel,
+    setCurrentModelLabel,
     getActiveModelName: runtime.getActiveModelName,
+    getActiveProviderName: runtime.getActiveProviderName,
     contextLimit,
     setContextLimit,
   });
@@ -259,6 +271,8 @@ function useDialogsAuth(
   st: ReturnType<typeof useDialogsState>,
   currentModel: string,
   setCurrentModel: (model: string) => void,
+  currentModelLabel: string,
+  setCurrentModelLabel: (label: string) => void,
   contextLimit: number | undefined,
   setContextLimit: (limit: number | undefined) => void,
   setShowErrorDetails: (value: boolean) => void,
@@ -278,6 +292,8 @@ function useDialogsAuth(
     st,
     currentModel,
     setCurrentModel,
+    currentModelLabel,
+    setCurrentModelLabel,
     contextLimit,
     setContextLimit,
     setShowErrorDetails,
@@ -389,6 +405,8 @@ export function useAppDialogs(params: AppDialogsParams) {
     st,
     core.currentModel,
     core.setCurrentModel,
+    core.currentModelLabel,
+    core.setCurrentModelLabel,
     core.contextLimit,
     core.setContextLimit,
     core.setShowErrorDetails,

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.test.ts
@@ -7,28 +7,45 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '../../../../test-utils/render.js';
 import { useModelRuntimeSync } from './useModelRuntimeSync.js';
+import {
+  coreEvents,
+  CoreEvent,
+  type ModelProfileInfoPayload,
+} from '@vybestack/llxprt-code-core';
+
+function createConfig(
+  model = 'config-model',
+  contextLimit?: number,
+): {
+  getModel: () => string;
+  getEphemeralSetting: (key: string) => number | undefined;
+} {
+  return {
+    getModel: vi.fn().mockReturnValue(model),
+    getEphemeralSetting: vi.fn().mockReturnValue(contextLimit),
+  } as unknown as {
+    getModel: () => string;
+    getEphemeralSetting: (key: string) => number | undefined;
+  };
+}
 
 describe('useModelRuntimeSync', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    coreEvents.removeAllListeners();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    coreEvents.removeAllListeners();
     vi.clearAllMocks();
   });
 
-  it('uses provider model when runtime model is non-empty and updates current model', () => {
+  it('uses provider model on initial sync when runtime model is non-empty', () => {
     const setCurrentModel = vi.fn();
     const setContextLimit = vi.fn();
     const getActiveModelName = vi.fn().mockReturnValue('provider-model');
-    const config = {
-      getModel: vi.fn().mockReturnValue('config-model'),
-      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
-    } as unknown as {
-      getModel: () => string;
-      getEphemeralSetting: (key: string) => number | undefined;
-    };
+    const config = createConfig();
 
     renderHook(() =>
       useModelRuntimeSync({
@@ -48,13 +65,7 @@ describe('useModelRuntimeSync', () => {
     const setCurrentModel = vi.fn();
     const setContextLimit = vi.fn();
     const getActiveModelName = vi.fn().mockReturnValue('   ');
-    const config = {
-      getModel: vi.fn().mockReturnValue('config-model'),
-      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
-    } as unknown as {
-      getModel: () => string;
-      getEphemeralSetting: (key: string) => number | undefined;
-    };
+    const config = createConfig('config-model');
 
     renderHook(() =>
       useModelRuntimeSync({
@@ -74,13 +85,7 @@ describe('useModelRuntimeSync', () => {
     const setCurrentModel = vi.fn();
     const setContextLimit = vi.fn();
     const getActiveModelName = vi.fn().mockReturnValue('provider-model');
-    const config = {
-      getModel: vi.fn().mockReturnValue('config-model'),
-      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
-    } as unknown as {
-      getModel: () => string;
-      getEphemeralSetting: (key: string) => number | undefined;
-    };
+    const config = createConfig();
 
     renderHook(() =>
       useModelRuntimeSync({
@@ -96,26 +101,16 @@ describe('useModelRuntimeSync', () => {
     expect(setCurrentModel).not.toHaveBeenCalled();
   });
 
-  it('polls every 500ms and clears interval on unmount', () => {
+  it('updates model when ModelProfileChanged event is emitted', () => {
     const setCurrentModel = vi.fn();
     const setContextLimit = vi.fn();
-    const getActiveModelName = vi
-      .fn()
-      .mockReturnValueOnce('provider-a')
-      .mockReturnValueOnce('provider-b')
-      .mockReturnValueOnce('provider-c');
-    const config = {
-      getModel: vi.fn().mockReturnValue('config-model'),
-      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
-    } as unknown as {
-      getModel: () => string;
-      getEphemeralSetting: (key: string) => number | undefined;
-    };
+    const getActiveModelName = vi.fn().mockReturnValue('provider-a');
+    const config = createConfig();
 
-    const { unmount } = renderHook(() =>
+    renderHook(() =>
       useModelRuntimeSync({
         config: config as never,
-        currentModel: 'none',
+        currentModel: 'provider-a',
         setCurrentModel,
         getActiveModelName,
         contextLimit: undefined,
@@ -123,34 +118,128 @@ describe('useModelRuntimeSync', () => {
       }),
     );
 
-    expect(setCurrentModel).toHaveBeenCalledWith('provider-a');
+    expect(setCurrentModel).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(500);
+    getActiveModelName.mockReturnValue('provider-b');
+    const payload: ModelProfileInfoPayload = {
+      model: 'provider-b',
+      providerName: 'openai',
+      profileName: 'work',
+      displayLabel: 'work',
+    };
+    coreEvents.emitModelProfileChanged(payload);
+
     expect(setCurrentModel).toHaveBeenCalledWith('provider-b');
+  });
+
+  it('updates model when ModelChanged event is emitted', () => {
+    const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
+    const getActiveModelName = vi.fn().mockReturnValue('model-a');
+    const config = createConfig('model-a');
+
+    renderHook(() =>
+      useModelRuntimeSync({
+        config: config as never,
+        currentModel: 'model-a',
+        setCurrentModel,
+        getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
+      }),
+    );
+
+    expect(setCurrentModel).not.toHaveBeenCalled();
+
+    getActiveModelName.mockReturnValue('model-b');
+    coreEvents.emitModelChanged('model-b');
+
+    expect(setCurrentModel).toHaveBeenCalledWith('model-b');
+  });
+
+  it('updates model when SettingsChanged event is emitted', () => {
+    const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
+    const getActiveModelName = vi.fn().mockReturnValue('same-model');
+    const config = createConfig('same-model');
+
+    renderHook(() =>
+      useModelRuntimeSync({
+        config: config as never,
+        currentModel: 'same-model',
+        setCurrentModel,
+        getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
+      }),
+    );
+
+    expect(setCurrentModel).not.toHaveBeenCalled();
+
+    getActiveModelName.mockReturnValue('new-model');
+    coreEvents.emitSettingsChanged();
+
+    expect(setCurrentModel).toHaveBeenCalledWith('new-model');
+  });
+
+  it('does not use setInterval polling', () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
+    const getActiveModelName = vi.fn().mockReturnValue('provider-model');
+    const config = createConfig();
+
+    renderHook(() =>
+      useModelRuntimeSync({
+        config: config as never,
+        currentModel: 'provider-model',
+        setCurrentModel,
+        getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
+      }),
+    );
+
+    const pollingIntervals = setIntervalSpy.mock.calls.filter(
+      ([, delay]) => delay === 500,
+    );
+    expect(pollingIntervals).toHaveLength(0);
+    setIntervalSpy.mockRestore();
+  });
+
+  it('cleans up event subscriptions on unmount', () => {
+    const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
+    const getActiveModelName = vi.fn().mockReturnValue('same-model');
+    const config = createConfig('same-model');
+
+    const { unmount } = renderHook(() =>
+      useModelRuntimeSync({
+        config: config as never,
+        currentModel: 'same-model',
+        setCurrentModel,
+        getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
+      }),
+    );
+
+    expect(coreEvents.listenerCount(CoreEvent.ModelChanged)).toBeGreaterThan(0);
 
     unmount();
 
-    const callsAfterUnmount = setCurrentModel.mock.calls.length;
-    vi.advanceTimersByTime(2000);
-
-    expect(setCurrentModel).toHaveBeenCalledTimes(callsAfterUnmount);
+    expect(coreEvents.listenerCount(CoreEvent.ModelChanged)).toBe(0);
+    expect(coreEvents.listenerCount(CoreEvent.ModelProfileChanged)).toBe(0);
+    expect(coreEvents.listenerCount(CoreEvent.SettingsChanged)).toBe(0);
   });
 
   describe('contextLimit tracking', () => {
-    it('detects contextLimit changes and calls setContextLimit', () => {
+    it('detects contextLimit changes via event and calls setContextLimit', () => {
       const setCurrentModel = vi.fn();
       const setContextLimit = vi.fn();
       const getActiveModelName = vi.fn().mockReturnValue('same-model');
-      const config = {
-        getModel: vi.fn().mockReturnValue('same-model'),
-        getEphemeralSetting: vi
-          .fn()
-          .mockReturnValueOnce(undefined)
-          .mockReturnValueOnce(200000),
-      } as unknown as {
-        getModel: () => string;
-        getEphemeralSetting: (key: string) => number | undefined;
-      };
+      const config = createConfig('same-model', undefined);
 
       renderHook(() =>
         useModelRuntimeSync({
@@ -165,7 +254,8 @@ describe('useModelRuntimeSync', () => {
 
       expect(setContextLimit).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(500);
+      config.getEphemeralSetting = vi.fn().mockReturnValue(200000);
+      coreEvents.emitSettingsChanged();
 
       expect(setContextLimit).toHaveBeenCalledWith(200000);
     });
@@ -174,13 +264,7 @@ describe('useModelRuntimeSync', () => {
       const setCurrentModel = vi.fn();
       const setContextLimit = vi.fn();
       const getActiveModelName = vi.fn().mockReturnValue('same-model');
-      const config = {
-        getModel: vi.fn().mockReturnValue('same-model'),
-        getEphemeralSetting: vi.fn().mockReturnValue(200000),
-      } as unknown as {
-        getModel: () => string;
-        getEphemeralSetting: (key: string) => number | undefined;
-      };
+      const config = createConfig('same-model', 200000);
 
       renderHook(() =>
         useModelRuntimeSync({
@@ -195,29 +279,17 @@ describe('useModelRuntimeSync', () => {
 
       expect(setContextLimit).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(500);
-      vi.advanceTimersByTime(500);
+      coreEvents.emitSettingsChanged();
+      coreEvents.emitSettingsChanged();
 
       expect(setContextLimit).not.toHaveBeenCalled();
     });
 
-    it('detects both model and contextLimit changes simultaneously', () => {
+    it('detects both model and contextLimit changes simultaneously via event', () => {
       const setCurrentModel = vi.fn();
       const setContextLimit = vi.fn();
-      const getActiveModelName = vi
-        .fn()
-        .mockReturnValueOnce('old-model')
-        .mockReturnValueOnce('new-model');
-      const config = {
-        getModel: vi.fn().mockReturnValue('old-model'),
-        getEphemeralSetting: vi
-          .fn()
-          .mockReturnValueOnce(undefined)
-          .mockReturnValueOnce(200000),
-      } as unknown as {
-        getModel: () => string;
-        getEphemeralSetting: (key: string) => number | undefined;
-      };
+      const getActiveModelName = vi.fn().mockReturnValue('old-model');
+      const config = createConfig('old-model', undefined);
 
       renderHook(() =>
         useModelRuntimeSync({
@@ -233,10 +305,206 @@ describe('useModelRuntimeSync', () => {
       expect(setCurrentModel).not.toHaveBeenCalled();
       expect(setContextLimit).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(500);
+      getActiveModelName.mockReturnValue('new-model');
+      config.getEphemeralSetting = vi.fn().mockReturnValue(200000);
+      coreEvents.emitSettingsChanged();
 
       expect(setCurrentModel).toHaveBeenCalledWith('new-model');
       expect(setContextLimit).toHaveBeenCalledWith(200000);
+    });
+  });
+
+  describe('profile-aware display label tracking', () => {
+    it('updates modelLabel when ModelProfileChanged fires with same model but different profile', () => {
+      const setCurrentModel = vi.fn();
+      const setCurrentModelLabel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('gpt-4o');
+      const config = createConfig('gpt-4o');
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'gpt-4o',
+          setCurrentModel,
+          currentModelLabel: 'work',
+          setCurrentModelLabel,
+          getActiveModelName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      // Footer label starts as 'work', model unchanged
+      expect(setCurrentModel).not.toHaveBeenCalled();
+
+      // Profile changes from 'work' to 'personal' but model string stays 'gpt-4o'
+      coreEvents.emitModelProfileChanged({
+        model: 'gpt-4o',
+        providerName: 'openai',
+        profileName: 'personal',
+        displayLabel: 'personal',
+      });
+
+      // Model string unchanged so setCurrentModel not called
+      expect(setCurrentModel).not.toHaveBeenCalled();
+      // But the footer-visible label DID change
+      expect(setCurrentModelLabel).toHaveBeenCalledWith('personal');
+    });
+
+    it('updates modelLabel when provider changes but model string is unchanged', () => {
+      const setCurrentModel = vi.fn();
+      const setCurrentModelLabel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('llama3');
+      const config = createConfig('llama3');
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'llama3',
+          setCurrentModel,
+          currentModelLabel: 'ollama:llama3',
+          setCurrentModelLabel,
+          getActiveModelName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      // Provider changes from ollama to groq but model string stays 'llama3'
+      coreEvents.emitModelProfileChanged({
+        model: 'llama3',
+        providerName: 'groq',
+        profileName: null,
+        displayLabel: 'groq:llama3',
+      });
+
+      // Model string unchanged
+      expect(setCurrentModel).not.toHaveBeenCalled();
+      // Label identity includes provider so it changed
+      expect(setCurrentModelLabel).toHaveBeenCalledWith('groq:llama3');
+    });
+
+    it('does not call setCurrentModelLabel when identity is unchanged', () => {
+      const setCurrentModel = vi.fn();
+      const setCurrentModelLabel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('gpt-4o');
+      const config = createConfig('gpt-4o');
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'gpt-4o',
+          setCurrentModel,
+          currentModelLabel: 'work',
+          setCurrentModelLabel,
+          getActiveModelName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      coreEvents.emitModelProfileChanged({
+        model: 'gpt-4o',
+        providerName: 'openai',
+        profileName: 'work',
+        displayLabel: 'work',
+      });
+
+      expect(setCurrentModelLabel).not.toHaveBeenCalled();
+    });
+
+    it('updates modelLabel on initial sync using computed display label', () => {
+      const setCurrentModel = vi.fn();
+      const setCurrentModelLabel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('gpt-4o');
+      const config = createConfig('gpt-4o');
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'gpt-4o',
+          setCurrentModel,
+          currentModelLabel: '',
+          setCurrentModelLabel,
+          getActiveModelName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      expect(setCurrentModelLabel).toHaveBeenCalledWith('gpt-4o');
+    });
+
+    it('updates stale profile label when ModelChanged fires and provider/model differ', () => {
+      const setCurrentModel = vi.fn();
+      const setCurrentModelLabel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('gpt-4o');
+      const getActiveProviderName = vi.fn().mockReturnValue('openai');
+      const config = createConfig('gpt-4o');
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'gpt-4o',
+          setCurrentModel,
+          // Profile label set by a previous ModelProfileChanged event
+          currentModelLabel: 'work-profile',
+          setCurrentModelLabel,
+          getActiveModelName,
+          getActiveProviderName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      // No initial update — label already set
+      expect(setCurrentModelLabel).not.toHaveBeenCalled();
+
+      // Model changes via ModelChanged event (e.g. user switched model in-session)
+      getActiveModelName.mockReturnValue('claude-sonnet');
+      getActiveProviderName.mockReturnValue('anthropic');
+      coreEvents.emitModelChanged('claude-sonnet');
+
+      // Label should update from stale 'work-profile' to reflect new model
+      expect(setCurrentModelLabel).toHaveBeenCalledWith(
+        'anthropic:claude-sonnet',
+      );
+    });
+
+    it('updates stale profile label when SettingsChanged fires and model changes', () => {
+      const setCurrentModel = vi.fn();
+      const setCurrentModelLabel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('gpt-4o');
+      const getActiveProviderName = vi.fn().mockReturnValue('openai');
+      const config = createConfig('gpt-4o');
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'gpt-4o',
+          setCurrentModel,
+          currentModelLabel: 'old-profile',
+          setCurrentModelLabel,
+          getActiveModelName,
+          getActiveProviderName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      expect(setCurrentModelLabel).not.toHaveBeenCalled();
+
+      getActiveModelName.mockReturnValue('llama3');
+      getActiveProviderName.mockReturnValue('ollama');
+      coreEvents.emitSettingsChanged();
+
+      expect(setCurrentModelLabel).toHaveBeenCalledWith('ollama:llama3');
     });
   });
 });

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.ts
@@ -5,13 +5,27 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { debugLogger, type Config } from '@vybestack/llxprt-code-core';
+import {
+  coreEvents,
+  CoreEvent,
+  debugLogger,
+  type Config,
+  type ModelProfileInfoPayload,
+} from '@vybestack/llxprt-code-core';
 
 interface UseModelRuntimeSyncParams {
   config: Config;
   currentModel: string;
   setCurrentModel: (model: string) => void;
+  /**
+   * Profile-aware display label shown in the footer (e.g. profile name or
+   * provider:model composite). Tracked separately from the raw model string
+   * so provider/profile-only changes still update the footer.
+   */
+  currentModelLabel?: string;
+  setCurrentModelLabel?: (label: string) => void;
   getActiveModelName: () => string | undefined;
+  getActiveProviderName?: () => string | undefined;
   contextLimit?: number;
   setContextLimit: (limit: number | undefined) => void;
 }
@@ -20,25 +34,62 @@ export function useModelRuntimeSync({
   config,
   currentModel,
   setCurrentModel,
+  currentModelLabel,
+  setCurrentModelLabel,
   getActiveModelName,
+  getActiveProviderName,
   contextLimit,
   setContextLimit,
 }: UseModelRuntimeSyncParams): void {
   const contextLimitRef = useRef(contextLimit);
   contextLimitRef.current = contextLimit;
 
-  useEffect(() => {
-    const checkModelChange = () => {
-      const configModel = config.getModel();
-      const providerModel = getActiveModelName();
-      const trimmed = providerModel?.trim();
-      const effectiveModel = trimmed && trimmed !== '' ? trimmed : configModel;
+  const currentModelRef = useRef(currentModel);
+  currentModelRef.current = currentModel;
 
-      if (effectiveModel !== currentModel) {
+  const currentModelLabelRef = useRef(currentModelLabel);
+  currentModelLabelRef.current = currentModelLabel;
+
+  useEffect(() => {
+    const syncModelAndContextLimit = (
+      payload?: ModelProfileInfoPayload,
+      isInitial = false,
+    ): void => {
+      const effectiveModel =
+        payload?.model ?? computeEffectiveModel(config, getActiveModelName);
+
+      if (effectiveModel !== currentModelRef.current) {
         debugLogger.debug(
-          `[Model Update] Updating footer from ${currentModel} to ${effectiveModel}`,
+          `[Model Update] Updating footer from ${currentModelRef.current} to ${effectiveModel}`,
         );
         setCurrentModel(effectiveModel);
+      }
+
+      if (setCurrentModelLabel) {
+        const effectiveLabel = computeEffectiveModelLabel(
+          payload,
+          config,
+          getActiveModelName,
+          getActiveProviderName,
+        );
+        // On the initial sync (no event), only seed the label when the consumer
+        // has not provided one yet, preserving a prior profile-aware label.
+        // On event-triggered syncs (ModelChanged/SettingsChanged/ModelProfileChanged),
+        // always update when the computed label differs so stale profile labels
+        // are refreshed when the underlying model/provider changes.
+        const shouldUpdateLabel =
+          !isInitial ||
+          !currentModelLabelRef.current ||
+          currentModelLabelRef.current === '';
+        if (
+          shouldUpdateLabel &&
+          effectiveLabel !== currentModelLabelRef.current
+        ) {
+          debugLogger.debug(
+            `[Model Update] Updating footer label from ${currentModelLabelRef.current} to ${effectiveLabel}`,
+          );
+          setCurrentModelLabel(effectiveLabel);
+        }
       }
 
       const currentContextLimit = config.getEphemeralSetting(
@@ -49,15 +100,64 @@ export function useModelRuntimeSync({
       }
     };
 
-    checkModelChange();
-    const interval = setInterval(checkModelChange, 500);
+    syncModelAndContextLimit(undefined, true);
 
-    return () => clearInterval(interval);
+    const handleModelChanged = () => syncModelAndContextLimit();
+    const handleModelProfileChanged = (payload: ModelProfileInfoPayload) =>
+      syncModelAndContextLimit(payload);
+    const handleSettingsChanged = () => syncModelAndContextLimit();
+
+    coreEvents.on(CoreEvent.ModelChanged, handleModelChanged);
+    coreEvents.on(CoreEvent.ModelProfileChanged, handleModelProfileChanged);
+    coreEvents.on(CoreEvent.SettingsChanged, handleSettingsChanged);
+
+    return () => {
+      coreEvents.off(CoreEvent.ModelChanged, handleModelChanged);
+      coreEvents.off(CoreEvent.ModelProfileChanged, handleModelProfileChanged);
+      coreEvents.off(CoreEvent.SettingsChanged, handleSettingsChanged);
+    };
   }, [
     config,
-    currentModel,
     getActiveModelName,
+    getActiveProviderName,
     setCurrentModel,
+    setCurrentModelLabel,
     setContextLimit,
   ]);
+}
+
+function computeEffectiveModel(
+  config: Config,
+  getActiveModelName: () => string | undefined,
+): string {
+  const configModel = config.getModel();
+  const providerModel = getActiveModelName();
+  const trimmed = providerModel?.trim();
+  return trimmed && trimmed !== '' ? trimmed : configModel;
+}
+
+/**
+ * Computes the profile-aware display label shown in the footer.
+ *
+ * Prefers an explicit `displayLabel` from a profile/provider/model change
+ * payload. When no payload is available (e.g. ModelChanged/SettingsChanged),
+ * derives a composite label from the active provider and model so that
+ * provider-only or profile-only changes still produce a distinct label.
+ */
+function computeEffectiveModelLabel(
+  payload: ModelProfileInfoPayload | undefined,
+  config: Config,
+  getActiveModelName: () => string | undefined,
+  getActiveProviderName?: () => string | undefined,
+): string {
+  if (payload) {
+    const trimmedLabel = payload.displayLabel.trim();
+    if (trimmedLabel !== '') {
+      return trimmedLabel;
+    }
+  }
+
+  const model = computeEffectiveModel(config, getActiveModelName);
+  const provider = getActiveProviderName?.()?.trim();
+  return provider && provider !== '' ? `${provider}:${model}` : model;
 }

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useModelTracking.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useModelTracking.ts
@@ -41,12 +41,19 @@ export interface UseModelTrackingParams {
 export interface UseModelTrackingResult {
   currentModel: string;
   setCurrentModel: (model: string) => void;
+  /**
+   * Profile-aware display label for the footer. Reflects profile/provider/model
+   * identity so the footer updates even when the raw model string is unchanged.
+   */
+  currentModelLabel: string;
+  setCurrentModelLabel: (label: string) => void;
 }
 
 export function useModelTracking({
   config,
 }: UseModelTrackingParams): UseModelTrackingResult {
   const [currentModel, setCurrentModel] = useState(config.getModel());
+  const [currentModelLabel, setCurrentModelLabel] = useState(config.getModel());
 
   // Update currentModel when settings change - get it from the SAME place as diagnostics
   useEffect(() => {
@@ -109,5 +116,7 @@ export function useModelTracking({
   return {
     currentModel,
     setCurrentModel,
+    currentModelLabel,
+    setCurrentModelLabel,
   };
 }

--- a/packages/cli/src/ui/containers/SessionController.test.tsx
+++ b/packages/cli/src/ui/containers/SessionController.test.tsx
@@ -448,11 +448,12 @@ describe('SessionController', () => {
     unmount();
   });
 
-  it('should handle model changes via polling', async () => {
+  it('should handle model changes via events (not polling)', async () => {
     const providerModule = await import(
       '../../providers/providerManagerInstance.js'
     );
     const mockGetProviderManager = vi.mocked(providerModule.getProviderManager);
+    const { coreEvents } = await import('@vybestack/llxprt-code-core');
 
     let contextValue: SessionContextType | undefined;
 
@@ -485,8 +486,8 @@ describe('SessionController', () => {
         }) as Partial<IProvider>,
     } as ReturnType<typeof providerModule.getProviderManager>);
 
-    // Advance timer to trigger the interval
-    vi.advanceTimersByTime(1100);
+    // Emit event instead of advancing timer
+    coreEvents.emitModelChanged('new-model');
 
     // Re-render to get updated state
     rerender(
@@ -495,11 +496,34 @@ describe('SessionController', () => {
       </SessionController>,
     );
 
-    // The polling should have updated the state
+    // The event should have updated the state
     expect(contextValue!.sessionState.currentModel).toBe(
       'new-provider:new-model',
     );
 
+    unmount();
+  });
+
+  it('does not use setInterval polling', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    const TestComponent = () => {
+      React.useContext(SessionContext);
+      return null;
+    };
+
+    const { unmount } = render(
+      <SessionController config={mockConfig as Config}>
+        <TestComponent />
+      </SessionController>,
+    );
+
+    // No 1-second polling intervals should be created
+    const pollingIntervals = setIntervalSpy.mock.calls.filter(
+      ([, delay]) => delay === 1000,
+    );
+    expect(pollingIntervals).toHaveLength(0);
+    setIntervalSpy.mockRestore();
     unmount();
   });
 

--- a/packages/cli/src/ui/containers/SessionController.tsx
+++ b/packages/cli/src/ui/containers/SessionController.tsx
@@ -22,6 +22,8 @@ import {
   getErrorMessage,
   loadCoreMemoryContent,
   debugLogger,
+  coreEvents,
+  CoreEvent,
 } from '@vybestack/llxprt-code-core';
 import { loadHierarchicalLlxprtMemory } from '../../config/environmentLoader.js';
 import { loadSettings } from '../../config/settings.js';
@@ -267,9 +269,18 @@ function useModelChangeWatcher(
       scheduleWarningClear(currentTimerRef, dispatch);
     };
     checkModelChange();
-    const interval = setInterval(checkModelChange, 1000);
+
+    // Event-driven updates replace the former 1-second setInterval polling.
+    // These coreEvents fire on model/profile/provider/settings changes.
+    const handleChange = () => checkModelChange();
+    coreEvents.on(CoreEvent.ModelChanged, handleChange);
+    coreEvents.on(CoreEvent.ModelProfileChanged, handleChange);
+    coreEvents.on(CoreEvent.SettingsChanged, handleChange);
+
     return () => {
-      clearInterval(interval);
+      coreEvents.off(CoreEvent.ModelChanged, handleChange);
+      coreEvents.off(CoreEvent.ModelProfileChanged, handleChange);
+      coreEvents.off(CoreEvent.SettingsChanged, handleChange);
       if (currentTimerRef.current) clearTimeout(currentTimerRef.current);
     };
   }, [

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -88,6 +88,7 @@ export interface UIState {
   providerOptions: string[];
   selectedProvider: string;
   currentModel: string;
+  currentModelLabel?: string;
   contextLimit: number | undefined;
   profiles: string[];
   toolsDialogAction: 'enable' | 'disable';

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useDisplayUserMessage.profileChange.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useDisplayUserMessage.profileChange.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the consolidated inline notification path (issue #1770).
+ *
+ * The old useDisplayUserMessage path emitted profile_change history items
+ * when the active profile differed from lastProfileNameRef. This created
+ * duplicate notifications alongside the ModelInfo event path.
+ *
+ * ModelInfo (streamEventDispatcher.handleModelInfoEvent) is now the single
+ * inline notification owner. useDisplayUserMessage must only add the USER
+ * message and track lastProfileNameRef — it must NOT add profile_change items.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type React from 'react';
+import type { Config } from '@vybestack/llxprt-code-core';
+import { renderHook } from '../../../../test-utils/render.js';
+import { useStreamEventHandlers } from '../useStreamEventHandlers.js';
+import type { LoadedSettings } from '../../../../config/settings.js';
+import type { HistoryItemWithoutId } from '../../../types.js';
+import type { QueuedSubmission } from '../types.js';
+
+describe('useDisplayUserMessage — consolidated profile_change path (issue #1770)', () => {
+  const mockConfig = {
+    getModel: vi.fn(() => 'gpt-4o'),
+    getMaxSessionTurns: vi.fn(() => 42),
+    getEphemeralSetting: vi.fn(() => undefined),
+    getSettingsService: vi.fn(() => ({
+      get: vi.fn(() => null),
+      getCurrentProfileName: vi.fn(() => 'work'),
+    })),
+  } as unknown as Config;
+
+  const mockSettings = {
+    merged: { showProfileChangeInChat: true },
+  } as unknown as LoadedSettings;
+
+  let mockAddItem: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockAddItem = vi.fn();
+  });
+
+  function renderHandlerWithRefs(overrides?: {
+    lastProfileNameRef?: React.MutableRefObject<string | undefined>;
+  }) {
+    const lastProfileNameRef = overrides?.lastProfileNameRef ?? {
+      current: 'old-profile' as string | undefined,
+    };
+    const { result } = renderHook(() =>
+      useStreamEventHandlers({
+        config: mockConfig,
+        settings: mockSettings,
+        addItem: mockAddItem,
+        onDebugMessage: vi.fn(),
+        onCancelSubmit: vi.fn(),
+        sanitizeContent: (text: string) => ({ text, blocked: false }),
+        flushPendingHistoryItem: vi.fn(),
+        pendingHistoryItemRef: {
+          current: null,
+        } as React.MutableRefObject<HistoryItemWithoutId | null>,
+        thinkingBlocksRef: { current: [] },
+        turnCancelledRef: { current: false },
+        queuedSubmissionsRef: { current: [] as QueuedSubmission[] },
+        setPendingHistoryItem: vi.fn(),
+        setIsResponding: vi.fn(),
+        setThought: vi.fn(),
+        setLastGeminiActivityTime: vi.fn(),
+        scheduleToolCalls: vi.fn().mockResolvedValue(undefined),
+        abortActiveStream: vi.fn(),
+        handleShellCommand: vi.fn(() => false),
+        handleSlashCommand: vi.fn().mockResolvedValue(false),
+        logger: null,
+        shellModeActive: false,
+        loopDetectedRef: { current: false },
+        lastProfileNameRef,
+        lastModelInfoRef: { current: null },
+        lastModelIdentityRef: { current: null },
+      }),
+    );
+    return { result, lastProfileNameRef };
+  }
+
+  it('does not emit profile_change from useDisplayUserMessage even when profile differs', () => {
+    // lastProfileNameRef starts as 'old-profile', live profile is 'work'
+    const { result } = renderHandlerWithRefs({
+      lastProfileNameRef: { current: 'old-profile' },
+    });
+
+    result.current.displayUserMessage('Hello', 1000);
+
+    // Only the USER message should be added — no profile_change item
+    expect(mockAddItem).toHaveBeenCalledTimes(1);
+    expect(mockAddItem.mock.calls[0][0]).toStrictEqual({
+      type: 'user',
+      text: 'Hello',
+    });
+  });
+
+  it('adds only the user message even when showProfileChangeInChat is true', () => {
+    const { result } = renderHandlerWithRefs({
+      lastProfileNameRef: { current: 'previous' },
+    });
+
+    result.current.displayUserMessage('Test query', 2000);
+
+    // Exactly one call — the user message only
+    expect(mockAddItem).toHaveBeenCalledTimes(1);
+    const addedItem = mockAddItem.mock.calls[0][0];
+    expect(addedItem.type).toBe('user');
+    expect(addedItem.type).not.toBe('profile_change');
+  });
+
+  it('still tracks lastProfileNameRef for backward compatibility', () => {
+    const lastProfileNameRef = { current: 'before' as string | undefined };
+    const { result } = renderHandlerWithRefsWithRef(lastProfileNameRef);
+
+    result.current.displayUserMessage('query', 3000);
+
+    // Ref should be updated to the current profile name
+    expect(lastProfileNameRef.current).toBe('work');
+  });
+
+  function renderHandlerWithRefsWithRef(
+    lastProfileNameRef: React.MutableRefObject<string | undefined>,
+  ) {
+    const { result } = renderHook(() =>
+      useStreamEventHandlers({
+        config: mockConfig,
+        settings: mockSettings,
+        addItem: mockAddItem,
+        onDebugMessage: vi.fn(),
+        onCancelSubmit: vi.fn(),
+        sanitizeContent: (text: string) => ({ text, blocked: false }),
+        flushPendingHistoryItem: vi.fn(),
+        pendingHistoryItemRef: {
+          current: null,
+        } as React.MutableRefObject<HistoryItemWithoutId | null>,
+        thinkingBlocksRef: { current: [] },
+        turnCancelledRef: { current: false },
+        queuedSubmissionsRef: { current: [] as QueuedSubmission[] },
+        setPendingHistoryItem: vi.fn(),
+        setIsResponding: vi.fn(),
+        setThought: vi.fn(),
+        setLastGeminiActivityTime: vi.fn(),
+        scheduleToolCalls: vi.fn().mockResolvedValue(undefined),
+        abortActiveStream: vi.fn(),
+        handleShellCommand: vi.fn(() => false),
+        handleSlashCommand: vi.fn().mockResolvedValue(false),
+        logger: null,
+        shellModeActive: false,
+        loopDetectedRef: { current: false },
+        lastProfileNameRef,
+        lastModelInfoRef: { current: null },
+        lastModelIdentityRef: { current: null },
+      }),
+    );
+    return { result };
+  }
+});

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useStreamEventHandlers.watchdog.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useStreamEventHandlers.watchdog.test.ts
@@ -104,6 +104,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
         shellModeActive: false,
         loopDetectedRef: { current: false },
         lastProfileNameRef: { current: undefined as string | undefined },
+        lastModelInfoRef: { current: null as string | null },
+        lastModelIdentityRef: { current: null as string | null },
       }),
     );
 
@@ -147,6 +149,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
     const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
     const loopDetectedRef = { current: false };
     const lastProfileNameRef = { current: undefined as string | undefined };
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
 
     const { result } = renderHook(() =>
       useStreamEventHandlers({
@@ -173,6 +177,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
         shellModeActive: false,
         loopDetectedRef,
         lastProfileNameRef,
+        lastModelInfoRef,
+        lastModelIdentityRef,
       }),
     );
 
@@ -238,6 +244,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
     const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
     const loopDetectedRef = { current: false };
     const lastProfileNameRef = { current: undefined as string | undefined };
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
 
     const { result } = renderHook(() =>
       useStreamEventHandlers({
@@ -264,6 +272,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
         shellModeActive: false,
         loopDetectedRef,
         lastProfileNameRef,
+        lastModelInfoRef,
+        lastModelIdentityRef,
       }),
     );
 
@@ -320,6 +330,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
     const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
     const loopDetectedRef = { current: false };
     const lastProfileNameRef = { current: undefined as string | undefined };
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
 
     const { result } = renderHook(() =>
       useStreamEventHandlers({
@@ -346,6 +358,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
         shellModeActive: false,
         loopDetectedRef,
         lastProfileNameRef,
+        lastModelInfoRef,
+        lastModelIdentityRef,
       }),
     );
 
@@ -417,6 +431,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
     const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
     const loopDetectedRef = { current: false };
     const lastProfileNameRef = { current: undefined as string | undefined };
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
 
     const { result } = renderHook(() =>
       useStreamEventHandlers({
@@ -443,6 +459,8 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
         shellModeActive: false,
         loopDetectedRef,
         lastProfileNameRef,
+        lastModelInfoRef,
+        lastModelIdentityRef,
       }),
     );
 
@@ -548,6 +566,8 @@ describe('useStreamEventHandlers stream idle timeout behavioral tests', () => {
     const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
     const loopDetectedRef = { current: false };
     const lastProfileNameRef = { current: undefined as string | undefined };
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
 
     const { result } = renderHook(() =>
       useStreamEventHandlers({
@@ -574,6 +594,8 @@ describe('useStreamEventHandlers stream idle timeout behavioral tests', () => {
         shellModeActive: false,
         loopDetectedRef,
         lastProfileNameRef,
+        lastModelInfoRef,
+        lastModelIdentityRef,
       }),
     );
 
@@ -651,6 +673,8 @@ describe('useStreamEventHandlers stream idle timeout behavioral tests', () => {
     const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
     const loopDetectedRef = { current: false };
     const lastProfileNameRef = { current: undefined as string | undefined };
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
 
     let resolveIterator: () => void;
     const iteratorPromise = new Promise<void>((resolve) => {
@@ -682,6 +706,8 @@ describe('useStreamEventHandlers stream idle timeout behavioral tests', () => {
         shellModeActive: false,
         loopDetectedRef,
         lastProfileNameRef,
+        lastModelInfoRef,
+        lastModelIdentityRef,
       }),
     );
 
@@ -759,6 +785,8 @@ describe('useStreamEventHandlers stream idle timeout behavioral tests', () => {
     const queuedSubmissionsRef = { current: [] as QueuedSubmission[] };
     const loopDetectedRef = { current: false };
     const lastProfileNameRef = { current: undefined as string | undefined };
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
 
     const { result } = renderHook(() =>
       useStreamEventHandlers({
@@ -785,6 +813,8 @@ describe('useStreamEventHandlers stream idle timeout behavioral tests', () => {
         shellModeActive: false,
         loopDetectedRef,
         lastProfileNameRef,
+        lastModelInfoRef,
+        lastModelIdentityRef,
       }),
     );
 

--- a/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.test.ts
@@ -1,0 +1,388 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type React from 'react';
+import {
+  GeminiEventType,
+  type ServerGeminiStreamEvent,
+} from '@vybestack/llxprt-code-core';
+import type { StreamEventDeps } from './streamEventDispatcher.js';
+import { dispatchStreamEvent } from './streamEventDispatcher.js';
+import type { HistoryItemWithoutId } from '../../types.js';
+
+type GeminiEvent = ServerGeminiStreamEvent;
+
+function createDeps(overrides: Partial<StreamEventDeps> = {}): StreamEventDeps {
+  return {
+    config: { getModel: () => 'test-model' } as never,
+    addItem: vi.fn(),
+    sanitizeContent: (text: string) => ({ text, blocked: false }),
+    flushPendingHistoryItem: vi.fn(),
+    pendingHistoryItemRef: {
+      current: null,
+    } as React.MutableRefObject<HistoryItemWithoutId | null>,
+    thinkingBlocksRef: { current: [] } as React.MutableRefObject<
+      Array<import('@vybestack/llxprt-code-core').ThinkingBlock>
+    >,
+    turnCancelledRef: { current: false } as React.MutableRefObject<boolean>,
+    loopDetectedRef: { current: false } as React.MutableRefObject<boolean>,
+    lastModelInfoRef: { current: null } as React.MutableRefObject<
+      string | null
+    >,
+    lastModelIdentityRef: { current: null } as React.MutableRefObject<
+      string | null
+    >,
+    setPendingHistoryItem: vi.fn(),
+    setLastGeminiActivityTime: vi.fn(),
+    setThought: vi.fn(),
+    handleContentEvent: vi.fn((_value, buffer) => buffer),
+    handleUserCancelledEvent: vi.fn(),
+    handleErrorEvent: vi.fn(),
+    handleChatCompressionEvent: vi.fn(),
+    handleFinishedEvent: vi.fn(),
+    handleMaxSessionTurnsEvent: vi.fn(),
+    handleContextWindowWillOverflowEvent: vi.fn(),
+    handleCitationEvent: vi.fn(),
+    scheduleToolCalls: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createModelInfoEvent(
+  model: string,
+  extras: {
+    providerName?: string;
+    profileName?: string | null;
+    displayLabel?: string;
+  } = {},
+): GeminiEvent {
+  return {
+    type: GeminiEventType.ModelInfo,
+    value: {
+      model,
+      providerName: extras.providerName,
+      profileName: extras.profileName,
+      displayLabel: extras.displayLabel ?? model,
+    },
+  } as GeminiEvent;
+}
+
+describe('dispatchStreamEvent - ModelInfo inline notification', () => {
+  it('adds a profile_change history item when model differs from previous sequence', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'old-profile' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['openai', 'old-profile', 'old-model']) as
+        | string
+        | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('gpt-4o', {
+      providerName: 'openai',
+      profileName: 'production',
+      displayLabel: 'production',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).toHaveBeenCalledTimes(1);
+    const [item, timestamp] = addItem.mock.calls[0];
+    expect(item.type).toBe('profile_change');
+    expect(item.profileName).toBe('production');
+    expect(timestamp).toBe(1000);
+  });
+
+  it('does not add notification when model/profile same as previous sequence', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'production' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['openai', 'production', 'gpt-4o']) as
+        | string
+        | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('gpt-4o', {
+      providerName: 'openai',
+      profileName: 'production',
+      displayLabel: 'production',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).not.toHaveBeenCalled();
+  });
+
+  it('updates lastModelInfoRef after first emission', () => {
+    const lastModelInfoRef = { current: 'old-label' as string | null };
+    const deps = createDeps({ lastModelInfoRef });
+
+    const event = createModelInfoEvent('claude-sonnet', {
+      profileName: 'work',
+      displayLabel: 'work',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(lastModelInfoRef.current).toBe('work');
+  });
+
+  it('adds a Responding-with notification on first assistant response so users always see model context', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('llama3', {
+      profileName: null,
+      displayLabel: 'llama3',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    // Baseline: first response always shows a notification so the user sees
+    // which model/profile is handling their prompt.
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem.mock.calls[0][0].type).toBe('profile_change');
+    expect(addItem.mock.calls[0][0].profileName).toBe('llama3');
+    expect(lastModelInfoRef.current).toBe('llama3');
+  });
+
+  it('adds a Responding-with notification on first response with profile name when available', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('gpt-4o', {
+      providerName: 'openai',
+      profileName: 'work',
+      displayLabel: 'work',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem.mock.calls[0][0].profileName).toBe('work');
+  });
+
+  it('does not add a duplicate notification on second response with same identity', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: null as string | null };
+    const lastModelIdentityRef = { current: null as string | null };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('gpt-4o', {
+      providerName: 'openai',
+      profileName: 'work',
+      displayLabel: 'work',
+    });
+
+    // First response: notification shown
+    dispatchStreamEvent(event, deps, '', [], 1000);
+    expect(addItem).toHaveBeenCalledTimes(1);
+
+    // Second response, same identity: no duplicate
+    dispatchStreamEvent(event, deps, '', [], 2000);
+    expect(addItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses displayLabel for the profile_change item name', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'old-profile' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['openai', 'old-profile', 'old-model']) as
+        | string
+        | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('gpt-4o', {
+      profileName: 'my-profile',
+      displayLabel: 'My Custom Label',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem.mock.calls[0][0].profileName).toBe('My Custom Label');
+  });
+
+  it('handles events without profileName by using displayLabel', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'old-model' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['ollama', '', 'old-model']) as string | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('new-model', {
+      profileName: null,
+      displayLabel: 'new-model',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem.mock.calls[0][0].profileName).toBe('new-model');
+  });
+
+  it('produces notification when displayLabel is same but provider differs', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'My Label' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['openai', 'work', 'gpt-4o']) as string | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    // Same displayLabel 'My Label' but different provider
+    const event = createModelInfoEvent('gpt-4o', {
+      providerName: 'azure',
+      profileName: 'work',
+      displayLabel: 'My Label',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem.mock.calls[0][0].profileName).toBe('My Label');
+  });
+
+  it('produces notification when displayLabel is same but model differs', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'work' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['openai', 'work', 'gpt-4o']) as string | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    // Same displayLabel 'work' but different model
+    const event = createModelInfoEvent('gpt-4o-mini', {
+      providerName: 'openai',
+      profileName: 'work',
+      displayLabel: 'work',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem.mock.calls[0][0].profileName).toBe('work');
+  });
+
+  it('produces notification when displayLabel is same but profile differs', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'gpt-4o' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['openai', 'work', 'gpt-4o']) as string | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    // Same displayLabel (falls back to model 'gpt-4o') but different profile
+    const event = createModelInfoEvent('gpt-4o', {
+      providerName: 'openai',
+      profileName: 'personal',
+      displayLabel: 'gpt-4o',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem.mock.calls[0][0].profileName).toBe('gpt-4o');
+  });
+
+  it('does not produce notification when full identity matches even if displayLabel computed identically', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'work' as string | null };
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['openai', 'work', 'gpt-4o']) as string | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    const event = createModelInfoEvent('gpt-4o', {
+      providerName: 'openai',
+      profileName: 'work',
+      displayLabel: 'work',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    expect(addItem).not.toHaveBeenCalled();
+  });
+
+  it('uses collision-safe identity: values containing pipe characters do not collide', () => {
+    const addItem = vi.fn();
+    const lastModelInfoRef = { current: 'model-label' as string | null };
+    // Previous identity: provider 'a|b', profile '', model 'model'
+    const lastModelIdentityRef = {
+      current: JSON.stringify(['a|b', '', 'model']) as string | null,
+    };
+    const deps = createDeps({
+      addItem,
+      lastModelInfoRef,
+      lastModelIdentityRef,
+    });
+
+    // New event: provider 'a', profile 'b', model 'model'
+    // With a naive pipe-join, both would produce 'a|b||model' and incorrectly
+    // suppress the notification. JSON.stringify avoids this collision.
+    const event = createModelInfoEvent('model', {
+      providerName: 'a',
+      profileName: 'b',
+      displayLabel: 'model-label',
+    });
+
+    dispatchStreamEvent(event, deps, '', [], 1000);
+
+    // Identity is different: ['a','b','model'] !== ['a|b','','model']
+    expect(addItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.ts
@@ -23,6 +23,7 @@ import {
   type Config,
   type ThoughtSummary,
   type ThinkingBlock,
+  type ModelInfo,
   uiTelemetryService,
 } from '@vybestack/llxprt-code-core';
 import type React from 'react';
@@ -44,6 +45,13 @@ export interface StreamEventDeps {
   thinkingBlocksRef: React.MutableRefObject<ThinkingBlock[]>;
   turnCancelledRef: React.MutableRefObject<boolean>;
   loopDetectedRef: React.MutableRefObject<boolean>;
+  lastModelInfoRef: React.MutableRefObject<string | null>;
+  /**
+   * Composite identity (provider|profile|model) tracked across ModelInfo
+   * events so that same-displayLabel but different provider/model/profile
+   * changes still produce an inline notification.
+   */
+  lastModelIdentityRef: React.MutableRefObject<string | null>;
   setPendingHistoryItem: React.Dispatch<
     React.SetStateAction<HistoryItemWithoutId | null>
   >;
@@ -294,9 +302,60 @@ function handleNotificationStreamEvent(
           event.value.promptTokenCount,
         );
       return true;
+    case ServerGeminiEventType.ModelInfo:
+      handleModelInfoEvent(deps, event.value, userMessageTimestamp);
+      return true;
     default:
       return false;
   }
+}
+
+function handleModelInfoEvent(
+  deps: StreamEventDeps,
+  info: ModelInfo,
+  userMessageTimestamp: number,
+): void {
+  const displayLabel = info.displayLabel ?? info.model;
+  const identity = computeModelIdentity(info);
+  const previousLabel = deps.lastModelInfoRef.current;
+  const previousIdentity = deps.lastModelIdentityRef.current;
+  deps.lastModelInfoRef.current = displayLabel;
+  deps.lastModelIdentityRef.current = identity;
+
+  // Baseline behavior: always show a "Responding with: {label}" notification
+  // on the first assistant response (previousIdentity === null) so users see
+  // model/profile context for every prompt. Suppress duplicates when the
+  // composite identity is unchanged across retries/continuations.
+  if (previousIdentity !== null && previousIdentity === identity) {
+    return;
+  }
+
+  void previousLabel; // tracked for diagnostics; identity is the dedup key
+
+  deps.addItem(
+    {
+      type: 'profile_change',
+      profileName: displayLabel,
+    },
+    userMessageTimestamp,
+  );
+}
+
+/**
+ * Computes a collision-safe composite identity string from provider, profile,
+ * and model so that deduplication distinguishes changes even when the
+ * displayLabel is the same (e.g. two profiles named identically on different
+ * providers).
+ *
+ * Uses JSON.stringify to guarantee unambiguous delimiting — a pipe-joined
+ * approach can collide when a field value itself contains the delimiter.
+ */
+function computeModelIdentity(info: ModelInfo): string {
+  return JSON.stringify([
+    info.providerName ?? '',
+    info.profileName ?? '',
+    info.model,
+  ]);
 }
 
 function handleContentLikeStreamEvent(

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
@@ -284,6 +284,8 @@ function buildSubmitQueryDeps({
     shellModeActive: args.shellModeActive,
     loopDetectedRef,
     lastProfileNameRef: st.lastProfileNameRef,
+    lastModelInfoRef: st.lastModelInfoRef,
+    lastModelIdentityRef: st.lastModelIdentityRef,
     abortControllerRef: st.abortControllerRef,
     submitQueryRef: st.submitQueryRef,
     isResponding: st.isResponding,

--- a/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
@@ -35,7 +35,6 @@ import {
 import { type PartListUnion } from '@google/genai';
 import { type LoadedSettings } from '../../../config/settings.js';
 import {
-  type HistoryItem,
   type HistoryItemWithoutId,
   type HistoryItemToolGroup,
   MessageType,
@@ -157,6 +156,8 @@ interface StreamEventHandlerDeps {
   shellModeActive: boolean;
   loopDetectedRef: React.MutableRefObject<boolean>;
   lastProfileNameRef: React.MutableRefObject<string | undefined>;
+  lastModelInfoRef: React.MutableRefObject<string | null>;
+  lastModelIdentityRef: React.MutableRefObject<string | null>;
 }
 
 export function useStreamEventHandlers(
@@ -514,38 +515,20 @@ function usePrepareQueryDeps(deps: StreamEventHandlerDeps): PrepareQueryDeps {
 }
 
 function useDisplayUserMessage(deps: StreamEventHandlerDeps) {
-  const { addItem, config, lastProfileNameRef, settings } = deps;
+  const { addItem, config, lastProfileNameRef } = deps;
   return useCallback(
     (trimmedQuery: string, userMessageTimestamp: number) => {
       addItem(
         { type: MessageType.USER, text: trimmedQuery },
         userMessageTimestamp,
       );
-      const showProfileChangeInChat =
-        settings.merged.showProfileChangeInChat ?? true;
+      // Inline profile_change notifications are now owned exclusively by the
+      // ModelInfo event path (streamEventDispatcher.handleModelInfoEvent).
+      // We still track lastProfileNameRef for backward-compatible diagnostics.
       const liveProfileName = getCurrentProfileName(config);
-      if (
-        showProfileChangeInChat &&
-        liveProfileName !== null &&
-        lastProfileNameRef.current !== undefined &&
-        liveProfileName !== lastProfileNameRef.current
-      ) {
-        addItem(
-          { type: 'profile_change', profileName: liveProfileName } as Omit<
-            HistoryItem,
-            'id'
-          >,
-          userMessageTimestamp,
-        );
-      }
       lastProfileNameRef.current = liveProfileName ?? undefined;
     },
-    [
-      addItem,
-      config,
-      settings.merged.showProfileChangeInChat,
-      lastProfileNameRef,
-    ],
+    [addItem, config, lastProfileNameRef],
   );
 }
 
@@ -662,6 +645,8 @@ async function consumeStreamEvents(
         thinkingBlocksRef: deps.thinkingBlocksRef,
         turnCancelledRef: deps.turnCancelledRef,
         loopDetectedRef: deps.loopDetectedRef,
+        lastModelInfoRef: deps.lastModelInfoRef,
+        lastModelIdentityRef: deps.lastModelIdentityRef,
         setPendingHistoryItem: deps.setPendingHistoryItem,
         setLastGeminiActivityTime: deps.setLastGeminiActivityTime,
         setThought: deps.setThought,

--- a/packages/cli/src/ui/hooks/geminiStream/useStreamState.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useStreamState.ts
@@ -37,6 +37,8 @@ export interface UseStreamStateReturn {
   isResponding: boolean;
   setIsResponding: React.Dispatch<React.SetStateAction<boolean>>;
   lastProfileNameRef: React.MutableRefObject<string | undefined>;
+  lastModelInfoRef: React.MutableRefObject<string | null>;
+  lastModelIdentityRef: React.MutableRefObject<string | null>;
   thought: ThoughtSummary | null;
   setThought: React.Dispatch<React.SetStateAction<ThoughtSummary | null>>;
   pendingHistoryItem: HistoryItemWithoutId | null;
@@ -200,6 +202,8 @@ export function useStreamState(
   const turnCancelledRef = useRef(false);
   const [isResponding, setIsResponding] = useState<boolean>(false);
   const lastProfileNameRef = useRef<string | undefined>(undefined);
+  const lastModelInfoRef = useRef<string | null>(null);
+  const lastModelIdentityRef = useRef<string | null>(null);
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   const [pendingHistoryItem, pendingHistoryItemRef, setPendingHistoryItem] =
     useStateAndRef<HistoryItemWithoutId | null>(null);
@@ -244,6 +248,8 @@ export function useStreamState(
     isResponding,
     setIsResponding,
     lastProfileNameRef,
+    lastModelInfoRef,
+    lastModelIdentityRef,
     thought,
     setThought,
     pendingHistoryItem,

--- a/packages/cli/src/ui/hooks/geminiStream/useSubmitQuery.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useSubmitQuery.ts
@@ -83,6 +83,8 @@ export interface UseSubmitQueryDeps {
   shellModeActive: boolean;
   loopDetectedRef: React.MutableRefObject<boolean>;
   lastProfileNameRef: React.MutableRefObject<string | undefined>;
+  lastModelInfoRef: React.MutableRefObject<string | null>;
+  lastModelIdentityRef: React.MutableRefObject<string | null>;
   abortControllerRef: React.MutableRefObject<AbortController | null>;
   submitQueryRef: React.MutableRefObject<
     | ((
@@ -124,6 +126,7 @@ export interface UseSubmitQueryReturn {
   handleLoopDetectedEvent: () => void;
 }
 
+/* eslint-disable max-lines-per-function */
 export function useSubmitQuery(deps: UseSubmitQueryDeps): UseSubmitQueryReturn {
   const { startNewPrompt, getPromptCount } = useSessionStats();
 
@@ -156,6 +159,8 @@ export function useSubmitQuery(deps: UseSubmitQueryDeps): UseSubmitQueryReturn {
     shellModeActive: deps.shellModeActive,
     loopDetectedRef: deps.loopDetectedRef,
     lastProfileNameRef: deps.lastProfileNameRef,
+    lastModelInfoRef: deps.lastModelInfoRef,
+    lastModelIdentityRef: deps.lastModelIdentityRef,
   });
 
   const scheduleNextQueuedSubmission = useScheduleNext(deps);

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -253,6 +253,7 @@ function buildMainControlsProps(
     vimModeEnabled: uiState.vimModeEnabled,
     vimMode: uiState.vimMode,
     currentModel: uiState.currentModel,
+    currentModelLabel: uiState.currentModelLabel,
     contextLimit: uiState.contextLimit,
     branchName: uiState.branchName,
     debugMessage: uiState.debugMessage,

--- a/packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.tsx
@@ -464,6 +464,7 @@ export interface FooterProps {
   vimModeEnabled: boolean;
   vimMode: string | undefined;
   currentModel: string;
+  currentModelLabel?: string;
   contextLimit: number | undefined;
   branchName: string | undefined;
   debugMessage: string;
@@ -488,6 +489,7 @@ export function FooterSection(props: FooterProps) {
     vimModeEnabled,
     vimMode,
     currentModel,
+    currentModelLabel,
     contextLimit,
     branchName,
     debugMessage,
@@ -503,7 +505,7 @@ export function FooterSection(props: FooterProps) {
 
   return (
     <Footer
-      model={currentModel}
+      model={currentModelLabel ?? currentModel}
       targetDir={config.getTargetDir()}
       debugMode={config.getDebugMode()}
       branchName={branchName}
@@ -567,6 +569,7 @@ export interface MainControlsProps {
   vimModeEnabled: boolean;
   vimMode: string | undefined;
   currentModel: string;
+  currentModelLabel?: string;
   contextLimit: number | undefined;
   branchName: string | undefined;
   debugMessage: string;
@@ -614,6 +617,7 @@ export function MainControls(props: MainControlsProps) {
         vimModeEnabled={props.vimModeEnabled}
         vimMode={props.vimMode}
         currentModel={props.currentModel}
+        currentModelLabel={props.currentModelLabel}
         contextLimit={props.contextLimit}
         branchName={props.branchName}
         debugMessage={props.debugMessage}

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -261,6 +261,9 @@ export type ServerGeminiCitationEvent = {
 
 export interface ModelInfo {
   model: string;
+  providerName?: string;
+  profileName?: string | null;
+  displayLabel?: string;
 }
 
 export type ServerGeminiModelInfoEvent = {

--- a/packages/core/src/utils/events.test.ts
+++ b/packages/core/src/utils/events.test.ts
@@ -9,6 +9,7 @@ import {
   CoreEventEmitter,
   CoreEvent,
   type UserFeedbackPayload,
+  type ModelProfileInfoPayload,
 } from './events.js';
 
 describe('CoreEventEmitter', () => {
@@ -155,5 +156,95 @@ describe('CoreEventEmitter', () => {
       message: 'Re-entrant message',
     });
     expect(listener.mock.calls[2][0]).toMatchObject({ message: 'Buffered 2' });
+  });
+
+  describe('ModelProfileChanged event', () => {
+    it('emits ModelProfileChanged with model, provider, profile, and display label', () => {
+      const listener = vi.fn();
+      events.on(CoreEvent.ModelProfileChanged, listener);
+
+      const payload: ModelProfileInfoPayload = {
+        model: 'gpt-4o',
+        providerName: 'openai',
+        profileName: 'production',
+        displayLabel: 'production',
+      };
+
+      events.emitModelProfileChanged(payload);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(payload);
+    });
+
+    it('emits ModelProfileChanged with only model when profile/provider unknown', () => {
+      const listener = vi.fn();
+      events.on(CoreEvent.ModelProfileChanged, listener);
+
+      const payload: ModelProfileInfoPayload = {
+        model: 'gemini-2.0-flash',
+        displayLabel: 'gemini-2.0-flash',
+      };
+
+      events.emitModelProfileChanged(payload);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(payload);
+    });
+
+    it('carries optional displayName for profile-aware UI', () => {
+      const listener = vi.fn();
+      events.on(CoreEvent.ModelProfileChanged, listener);
+
+      const payload: ModelProfileInfoPayload = {
+        model: 'claude-sonnet',
+        providerName: 'anthropic',
+        profileName: 'work',
+        displayName: 'Work Profile',
+        displayLabel: 'Work Profile',
+      };
+
+      events.emitModelProfileChanged(payload);
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          displayName: 'Work Profile',
+          displayLabel: 'Work Profile',
+        }),
+      );
+    });
+
+    it('allows null profileName for no-profile state', () => {
+      const listener = vi.fn();
+      events.on(CoreEvent.ModelProfileChanged, listener);
+
+      events.emitModelProfileChanged({
+        model: 'llama3',
+        providerName: 'ollama',
+        profileName: null,
+        displayLabel: 'llama3',
+      });
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ profileName: null }),
+      );
+    });
+
+    it('stop receiving ModelProfileChanged after off()', () => {
+      const listener = vi.fn();
+      events.on(CoreEvent.ModelProfileChanged, listener);
+
+      events.emitModelProfileChanged({
+        model: 'm1',
+        displayLabel: 'm1',
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      events.off(CoreEvent.ModelProfileChanged, listener);
+      events.emitModelProfileChanged({
+        model: 'm2',
+        displayLabel: 'm2',
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -60,10 +60,28 @@ export interface McpClientUpdatePayload {
   readonly clients: ReadonlyMap<string, McpClient>;
 }
 
+/**
+ * Payload for the 'model-profile-changed' event.
+ * Carries enough data for UI footer updates and inline chat notifications.
+ */
+export interface ModelProfileInfoPayload {
+  /** The active model name. */
+  model: string;
+  /** The active provider name, when available. */
+  providerName?: string;
+  /** The active profile name, when available; null when no profile is active. */
+  profileName?: string | null;
+  /** Human-readable display name for the profile, when available. */
+  displayName?: string;
+  /** Computed label for UI display (profile name, display name, or model). */
+  displayLabel: string;
+}
+
 export enum CoreEvent {
   UserFeedback = 'user-feedback',
   MemoryChanged = 'memory-changed',
   ModelChanged = 'model-changed',
+  ModelProfileChanged = 'model-profile-changed',
   ConsoleLog = 'console-log',
   Output = 'output',
   ExternalEditorClosed = 'external-editor-closed',
@@ -134,6 +152,10 @@ export class CoreEventEmitter extends EventEmitter {
     listener: (model: string) => void,
   ): this;
   override on(
+    event: CoreEvent.ModelProfileChanged,
+    listener: (payload: ModelProfileInfoPayload) => void,
+  ): this;
+  override on(
     event: CoreEvent.ConsoleLog,
     listener: (payload: ConsoleLogPayload) => void,
   ): this;
@@ -167,6 +189,10 @@ export class CoreEventEmitter extends EventEmitter {
     listener: (model: string) => void,
   ): this;
   override off(
+    event: CoreEvent.ModelProfileChanged,
+    listener: (payload: ModelProfileInfoPayload) => void,
+  ): this;
+  override off(
     event: CoreEvent.ConsoleLog,
     listener: (payload: ConsoleLogPayload) => void,
   ): this;
@@ -197,6 +223,10 @@ export class CoreEventEmitter extends EventEmitter {
   ): boolean;
   override emit(event: CoreEvent.ModelChanged, model: string): boolean;
   override emit(
+    event: CoreEvent.ModelProfileChanged,
+    payload: ModelProfileInfoPayload,
+  ): boolean;
+  override emit(
     event: CoreEvent.ConsoleLog,
     payload: ConsoleLogPayload,
   ): boolean;
@@ -217,6 +247,14 @@ export class CoreEventEmitter extends EventEmitter {
    */
   emitModelChanged(model: string): void {
     this.emit(CoreEvent.ModelChanged, model);
+  }
+
+  /**
+   * Emits a model-profile-changed event carrying model, provider, profile,
+   * and display label data for event-driven UI/footer updates.
+   */
+  emitModelProfileChanged(payload: ModelProfileInfoPayload): void {
+    this.emit(CoreEvent.ModelProfileChanged, payload);
   }
 
   /**


### PR DESCRIPTION
## TLDR

Replaces polling-based model/profile display with event-driven model, provider, and profile notifications. The footer now tracks a profile-aware display label and chat history shows Responding with notifications from stream ModelInfo events.

## Dive Deeper

This adds a core ModelProfileChanged event carrying model, provider, profile, display name, and display label information. Profile loading and provider switching emit the event, and UI runtime state subscribes to model, profile, and settings events instead of checking on an interval.

Agent streaming now emits ModelInfo for the initial response sequence and for retry or continuation identity changes. The UI consumes those stream events into profile_change history items with composite provider/profile/model deduplication, so unchanged retries do not duplicate notifications while model/profile/provider changes are visible.

The change also consolidates the older user-message profile-change path so ModelInfo owns inline response notifications, and adds behavioral coverage for footer updates, profile event payloads, provider switching, stream dispatch, agent retry/continuation behavior, and cleanup.

## Reviewer Test Plan

Recommended validation:

- Load a profile and confirm the footer shows the profile-aware label immediately.
- Switch profiles or providers mid-session and confirm the footer updates without waiting for polling.
- Send prompts before and after switching model/profile/provider and confirm chat history includes Responding with entries for the active identity and suppresses duplicate unchanged identities.
- Exercise retry or continuation paths and confirm changed identities produce one additional ModelInfo notification.

Local verification run:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1770
