### PR TITLE
Disable google_web_search by default (Fixes #2036)

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -182,7 +182,7 @@ In addition to a project settings file, a project's `.llxprt` directory can cont
   - **Default:**
 
     ```json
-    ["google_web_fetch"]
+    ["google_web_fetch", "google_web_search"]
     ```
 
   - **Requires restart:** Yes

--- a/packages/agents/src/core/subagentOrchestrator.test.ts
+++ b/packages/agents/src/core/subagentOrchestrator.test.ts
@@ -543,6 +543,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
     const loaderArgs = runtimeLoader.mock.calls[0][0];
     expect(loaderArgs.profile.settings.tools?.disabled).toStrictEqual([
       'google_web_fetch',
+      'google_web_search',
     ]);
   });
 
@@ -588,6 +589,7 @@ describe('SubagentOrchestrator - Runtime Assembly', () => {
     const loaderArgs = runtimeLoader.mock.calls[0][0];
     expect(loaderArgs.profile.settings.tools?.disabled).toStrictEqual([
       'write_file',
+      'google_web_search',
     ]);
   });
 

--- a/packages/agents/src/core/subagentOrchestrator.ts
+++ b/packages/agents/src/core/subagentOrchestrator.ts
@@ -64,7 +64,10 @@ const createAbortError = (message: string): Error => {
   return error;
 };
 
-const DEFAULT_DISABLED_TOOLS = ['google_web_fetch'] as const;
+const DEFAULT_DISABLED_TOOLS = [
+  'google_web_fetch',
+  'google_web_search',
+] as const;
 
 const normalizeDefaultToolSet = (tools: readonly string[]): Set<string> =>
   new Set(tools.map((tool) => canonicalizeToolName(tool)).filter(Boolean));

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1798,6 +1798,28 @@ describe('defaultDisabledTools', () => {
     );
   });
 
+  it('should seed tools.disabled with both default-disabled tools', async () => {
+    const settings: Settings = {
+      defaultDisabledTools: ['google_web_fetch', 'google_web_search'],
+    };
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments({} as Settings);
+    const config = await loadCliConfig(
+      settings,
+      [],
+      new ExtensionEnablementManager(
+        ExtensionStorage.getUserExtensionsDir(),
+        argv.extensions,
+      ),
+      'test-session',
+      argv,
+    );
+    const disabled = config.getEphemeralSetting('tools.disabled');
+    expect(disabled).toStrictEqual(
+      expect.arrayContaining(['google_web_fetch', 'google_web_search']),
+    );
+  });
+
   it('should merge defaultDisabledTools with existing tools.disabled', async () => {
     const settings: Settings = {
       defaultDisabledTools: ['google_web_fetch'],

--- a/packages/cli/src/config/settings-schema/schema-core.ts
+++ b/packages/cli/src/config/settings-schema/schema-core.ts
@@ -235,7 +235,7 @@ export const CORE_SETTINGS_SCHEMA = {
     label: 'Default Disabled Tools',
     category: 'Advanced',
     requiresRestart: true,
-    default: ['google_web_fetch'] as string[] | undefined,
+    default: ['google_web_fetch', 'google_web_search'] as string[] | undefined,
     description:
       'Tool names disabled by default. Users can re-enable them with /tools enable.',
     showInDialog: false,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -388,6 +388,7 @@ describe('SettingsSchema', () => {
       expect(SETTINGS_SCHEMA.defaultDisabledTools.category).toBe('Advanced');
       expect(SETTINGS_SCHEMA.defaultDisabledTools.default).toStrictEqual([
         'google_web_fetch',
+        'google_web_search',
       ]);
       expect(SETTINGS_SCHEMA.defaultDisabledTools.showInDialog).toBe(false);
       expect(SETTINGS_SCHEMA.defaultDisabledTools.requiresRestart).toBe(true);

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -183,8 +183,8 @@
     "defaultDisabledTools": {
       "title": "Default Disabled Tools",
       "description": "Tool names disabled by default. Users can re-enable them with /tools enable.",
-      "markdownDescription": "Tool names disabled by default. Users can re-enable them with /tools enable.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `[\n  \"google_web_fetch\"\n]`",
-      "default": ["google_web_fetch"],
+      "markdownDescription": "Tool names disabled by default. Users can re-enable them with /tools enable.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `[\n  \"google_web_fetch\",\n  \"google_web_search\"\n]`",
+      "default": ["google_web_fetch", "google_web_search"],
       "type": "array",
       "items": {}
     },


### PR DESCRIPTION
## Summary

Disables the `google_web_search` tool by default, fixing #2036.

Google web search has been unreliable, and Google may disable auth for it. Per the issue and the maintainer's note ("we already did this for google webfetch so this should be the same"), this change mirrors the existing `google_web_fetch` precedent exactly.

This uses the `tools.disabled` ephemeral soft-block mechanism (NOT `excludeTools`), so the tool remains registered and discoverable. Users can re-enable it at runtime via `/tools enable`, and that preference persists to their profile.

## Changes

Adds `google_web_search` alongside the existing `google_web_fetch` in every place that defines the default-disabled tool set:

- `packages/cli/src/config/settings-schema/schema-core.ts` — `defaultDisabledTools` default is now `['google_web_fetch', 'google_web_search']`.
- `packages/agents/src/core/subagentOrchestrator.ts` — `DEFAULT_DISABLED_TOOLS` now includes `google_web_search` so subagents inherit the same default.
- `schemas/settings.schema.json` and `docs/cli/configuration.md` — regenerated from the schema via `npm run schema:settings` and `npm run docs:settings`.

## Tests

- `packages/cli/src/config/settingsSchema.test.ts` — updated the schema default assertion.
- `packages/cli/src/config/config.test.ts` — added a behavioral test verifying both default-disabled tools are seeded into the `tools.disabled` ephemeral setting via `loadCliConfig`.
- `packages/agents/src/core/subagentOrchestrator.test.ts` — updated the default-seed assertions. The "preserves profile disabled tools even when present in tools.allowed" test correctly gains `google_web_search` because it is default-disabled and not present in that test's `tools.allowed` fixture.

## Verification

- `npm run test` — pass
- `npm run lint` — pass (0 errors)
- `npm run typecheck` — pass
- `npm run format` — pass
- `npm run build` — pass
- Smoke test (`node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else"`) — pass

## Notes

- `toolRegistryFactory.ts` was intentionally NOT modified — the tool stays registered.
- `docs/reference/profiles.md` was left unchanged; its `tools.disabled` snippet is an illustrative user example, not documentation of the default set.

Fixes #2036
