### PR TITLE
Retry compression on provider overload/rate-limit errors (Fixes #2045)

### DIFF
--- a/packages/agents/src/compression/__tests__/compression-retry.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry.test.ts
@@ -66,6 +66,27 @@ function makeNetworkError(code: string): Error {
   return err;
 }
 
+/**
+ * Creates an Anthropic-style overload/rate-limit error. The real provider
+ * attaches a structured `error` object to the thrown Error, e.g.
+ * `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`.
+ * These errors carry no HTTP status code, so they must be classified via
+ * {@link isOverloadError} rather than via status.
+ *
+ * @plan PLAN-20260218-COMPRESSION-RETRY.P01
+ * @requirement REQ-CR-001, REQ-CR-002
+ */
+function makeAnthropicOverloadError(
+  type: 'overloaded_error' | 'rate_limit_error',
+  message = 'Overloaded',
+): Error {
+  const err = new Error(message) as Error & {
+    error?: { type?: string; message?: string };
+  };
+  err.error = { type, message };
+  return err;
+}
+
 // ---------------------------------------------------------------------------
 // Phase 1: isTransientCompressionError
 // ---------------------------------------------------------------------------
@@ -119,6 +140,27 @@ describe('isTransientCompressionError @plan PLAN-20260218-COMPRESSION-RETRY.P01'
   it('returns true for error with "network timeout" message', () => {
     const err = new Error('network timeout');
     expect(isTransientCompressionError(err)).toBe(true);
+  });
+
+  /**
+   * @requirement REQ-CR-001
+   * Anthropic overload errors (no HTTP status) are transient.
+   * Issue #2045: compression failed with overloaded_error and was not retried.
+   */
+  it('returns true for Anthropic overloaded_error (no HTTP status)', () => {
+    expect(
+      isTransientCompressionError(
+        makeAnthropicOverloadError('overloaded_error'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for Anthropic rate_limit_error (no HTTP status)', () => {
+    expect(
+      isTransientCompressionError(
+        makeAnthropicOverloadError('rate_limit_error', 'Rate limited'),
+      ),
+    ).toBe(true);
   });
 
   /**
@@ -191,6 +233,26 @@ describe('shouldRetryCompressionError @plan PLAN-20260218-COMPRESSION-RETRY.P01'
     expect(shouldRetryCompressionError(makeNetworkError('ECONNRESET'))).toBe(
       true,
     );
+  });
+
+  /**
+   * @requirement REQ-CR-002
+   * Issue #2045: overload/rate-limit errors should trigger a retry.
+   */
+  it('returns true for Anthropic overloaded_error', () => {
+    expect(
+      shouldRetryCompressionError(
+        makeAnthropicOverloadError('overloaded_error'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for Anthropic rate_limit_error', () => {
+    expect(
+      shouldRetryCompressionError(
+        makeAnthropicOverloadError('rate_limit_error', 'Rate limited'),
+      ),
+    ).toBe(true);
   });
 
   /**
@@ -449,6 +511,42 @@ describe('ChatSession compression retry behavior @plan PLAN-20260218-COMPRESSION
           callCount++;
           if (callCount < 3) {
             throw makeHttpError(503);
+          }
+          return {
+            newHistory: [],
+            metadata: {
+              originalMessageCount: 10,
+              compressedMessageCount: 5,
+              strategyUsed: 'middle-out' as const,
+              llmCallMade: true,
+            },
+          };
+        }),
+      }),
+    );
+
+    await chat.performCompression('test-prompt');
+    expect(callCount).toBe(3);
+  });
+
+  /**
+   * @requirement REQ-CR-003
+   * Issue #2045: performCompression retries an Anthropic overload error
+   * (which carries no HTTP status) and eventually succeeds.
+   */
+  it('retries an Anthropic overloaded_error and eventually succeeds', async () => {
+    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
+
+    let callCount = 0;
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      () => ({
+        name: 'middle-out' as const,
+        requiresLLM: true,
+        trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+        compress: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount < 3) {
+            throw makeAnthropicOverloadError('overloaded_error');
           }
           return {
             newHistory: [],

--- a/packages/core/src/core/compression/types.ts
+++ b/packages/core/src/core/compression/types.ts
@@ -17,7 +17,11 @@
  */
 
 import type { IContent, UsageStats } from '../../services/history/IContent.js';
-import { getErrorStatus, isNetworkTransientError } from '../../utils/retry.js';
+import {
+  getErrorStatus,
+  isNetworkTransientError,
+  isOverloadError,
+} from '../../utils/retry.js';
 import type { AgentRuntimeContext } from '../../runtime/AgentRuntimeContext.js';
 import type { AgentRuntimeState } from '../../runtime/AgentRuntimeState.js';
 import type { DebugLogger } from '../../debug/DebugLogger.js';
@@ -321,6 +325,9 @@ export class CompressionProfileNotFoundError extends CompressionStrategyError {
  * Transient errors include:
  * - HTTP 429 (rate limit)
  * - HTTP 5xx (server errors)
+ * - Provider-specific overload / rate-limit errors (e.g. Anthropic's
+ *   `overloaded_error` and `rate_limit_error`), which carry no HTTP status
+ *   code but are transient — treated equivalently to HTTP 429. (Issue #2045)
  * - Network connectivity errors (ECONNRESET, ETIMEDOUT, etc.)
  *
  * Permanent errors include:
@@ -352,6 +359,13 @@ export function isTransientCompressionError(error: unknown): boolean {
     if (status >= 500 && status < 600) return true;
     // All other HTTP errors (4xx etc.) are permanent
     return false;
+  }
+
+  // Provider-specific overload / rate-limit errors (e.g. Anthropic's
+  // overloaded_error and rate_limit_error) carry no HTTP status code but
+  // are transient — treat them equivalently to HTTP 429. (Issue #2045)
+  if (isOverloadError(error)) {
+    return true;
   }
 
   // Network transient errors (ECONNRESET, ETIMEDOUT, etc.)


### PR DESCRIPTION
## Summary

Fixes #2045.

Context compression failed **permanently** (and broke the loop, returning the user to the prompt) when the Anthropic provider returned an `overloaded_error`:

    [API Error: Compression strategy "middle-out" failed: LLM provider call failed:
     {"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"}}]

The user expected this to be retried, just like the normal request path retries overloaded/429/etc.

## Root Cause

The compression retry/fallback mechanism gates on `isTransientCompressionError()` in `packages/core/src/core/compression/types.ts`. That classifier checked:

- HTTP 429 (transient)
- HTTP 5xx (transient)
- Network errors via `isNetworkTransientError` (transient)

…but it never checked for Anthropic's provider-specific `overloaded_error` / `rate_limit_error`. Those errors carry **no HTTP status code** — they arrive as an `Error` with a structured `.error = { type: 'overloaded_error', message: ... }` payload. With no status and no overload check, they fell through to `return false` (permanent), so compression skipped its existing retry-with-backoff and `TopDownTruncation` fallback.

The repository already has `isOverloadError()` in `packages/core/src/utils/retry.ts`, and it is **already used by the normal request retry path** (`RetryOrchestrator`, `retryWithBackoff`). The compression classifier simply never used it.

## The Fix

In `packages/core/src/core/compression/types.ts`:

- Import `isOverloadError` from `../../utils/retry.js`.
- In `isTransientCompressionError()`, add an `isOverloadError(error)` check **after** the HTTP-status block and **before** the network-error check. Overload errors have no status, so they correctly fall through to this new check and are treated equivalently to HTTP 429.
- Update the JSDoc to document the new transient category.

`shouldRetryCompressionError()` is an alias that delegates to `isTransientCompressionError()`, so it inherits the behavior automatically.

This makes compression retry on the same transient conditions as normal processing (429, 5xx, network, and now provider overload/rate-limit), satisfying the issue intent.

## Tests (TDD)

Added to `packages/agents/src/compression/__tests__/compression-retry.test.ts` (failing first, then green):

- A `makeAnthropicOverloadError(type, message)` helper that builds the real error shape (`new Error(message)` with `.error = { type, message }`), faithful to the existing simulation in `packages/core/src/utils/retry.test.ts`.
- Unit assertions that `isTransientCompressionError` and `shouldRetryCompressionError` return `true` for both `overloaded_error` and `rate_limit_error`.
- An integration test that drives `ChatSession.performCompression` through the real `retryWithBackoff` path (only `delay` mocked) and verifies an `overloaded_error` is retried and eventually succeeds.

## Verification

- Targeted compression-retry suite: all green (previously-failing overload tests now pass).
- `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`: all pass.
- Smoke test (`node scripts/start.js --profile-load synthetic "write me a haiku and nothing else"`): exit 0.

## Risk

Low. `isOverloadError` matches only `error.error?.type ?? error.type` equal to `overloaded_error` or `rate_limit_error` — a narrow, well-established predicate already trusted by the normal retry path. No currently-permanent error is reclassified other than these intended transient cases. Single-file production change.
