### PR TITLE
Skip tests for doc-only workflow changes (Fixes #1565)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,36 @@ jobs:
             exit 0
           fi
 
+          gitignore_patch=''
+          if grep -Fxq '.gitignore' <<<"$files"; then
+            gitignore_patch="$(gh api \
+              --paginate \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[] | select(.filename == ".gitignore") | .patch' || true)"
+          fi
+
           docs_only=true
           while IFS= read -r file; do
             [[ -z "$file" ]] && continue
             case "$file" in
-              docs/*|README.md|README.*|*.md|*.mdx|*.rst|*.txt|*.adoc)
+              docs/*|README.md|README.*|CHANGELOG.md|CHANGELOG.*)
+                ;;
+              CONTRIBUTING.md|CONTRIBUTING.*|CODE_OF_CONDUCT.md|SECURITY.md)
+                ;;
+              *.md|*.mdx|*.rst|*.txt|*.adoc)
+                ;;
+              .gitignore)
+                if [[ -z "$gitignore_patch" ]]; then
+                  docs_only=false
+                  break
+                fi
+                if printf '%s\n' "$gitignore_patch" \
+                  | grep -E '^[+-][^+-]' \
+                  | grep -Ev '^[+-](!docs/reference/|#.*docs/reference)' >/dev/null; then
+                  docs_only=false
+                  break
+                fi
                 ;;
               *)
                 docs_only=false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,10 @@ jobs:
         env:
           GH_TOKEN: '${{ github.token }}'
           PR_NUMBER: >-
-            ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+            ${{
+              (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
+              github.event.pull_request.number || ''
+            }}
         run: |
           set -euo pipefail
 
@@ -76,11 +79,36 @@ jobs:
             exit 0
           fi
 
+          gitignore_patch=''
+          if grep -Fxq '.gitignore' <<<"$files"; then
+            gitignore_patch="$(gh api \
+              --paginate \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[] | select(.filename == ".gitignore") | .patch' || true)"
+          fi
+
           docs_only=true
           while IFS= read -r file; do
             [[ -z "$file" ]] && continue
             case "$file" in
-              docs/*|README.md|README.*|*.md|*.mdx|*.rst|*.txt|*.adoc)
+              docs/*|README.md|README.*|CHANGELOG.md|CHANGELOG.*)
+                ;;
+              CONTRIBUTING.md|CONTRIBUTING.*|CODE_OF_CONDUCT.md|SECURITY.md)
+                ;;
+              *.md|*.mdx|*.rst|*.txt|*.adoc)
+                ;;
+              .gitignore)
+                if [[ -z "$gitignore_patch" ]]; then
+                  docs_only=false
+                  break
+                fi
+                if printf '%s\n' "$gitignore_patch" \
+                  | grep -E '^[+-][^+-]' \
+                  | grep -Ev '^[+-](!docs/reference/|#.*docs/reference)' >/dev/null; then
+                  docs_only=false
+                  break
+                fi
                 ;;
               *)
                 docs_only=false


### PR DESCRIPTION
## TLDR

Fixes #1565 by making doc-only detection treat documentation-support workflow changes conservatively as docs-only, so unit CI and E2E jobs skip when PRs only change documentation content.

## Dive Deeper

- Updates the CI doc-only filter to allow common documentation file patterns and a narrowly scoped .gitignore change for unignoring docs/reference/.
- Mirrors the same classification in the E2E workflow so E2E jobs also skip for doc-only PRs.
- Fixes E2E PR number detection for pull_request_target events so fork-label E2E gating can inspect the PR file list.
- Keeps non-documentation .gitignore changes conservative: any changed .gitignore patch line outside the docs/reference exception still forces full tests.

## Reviewer Test Plan

- Inspect the workflow diff and verify the .gitignore exception is limited to docs/reference unignore/comment lines.
- Confirm a PR with docs files plus the docs/reference .gitignore unignore is classified as docs-only.
- Confirm a PR with source files or broader .gitignore changes is not classified as docs-only.
- Check GitHub Actions on this PR and verify workflow lint/format checks run while unit CI/E2E jobs are skipped where the doc-only filter applies.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | -   | -   | -   |
| npx      | -   | -   | ✅  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Validation performed:

- actionlint with the same ignores used by the CI workflow on .github/workflows/ci.yml and .github/workflows/e2e.yml: passed.
- npx prettier --check .github/workflows/ci.yml .github/workflows/e2e.yml: passed.
- yamllint 1.35.1 on both changed workflow files: passed with existing warning-level line-length/comment warnings only.
- git diff --check on both changed workflow files: passed.
- A local classifier harness against PR #1563 changed files and .gitignore patch: passed, classified docs_only=true.

Unit tests, TypeScript checks, build, and E2E were intentionally not run because only YAML workflow files changed.

## Linked issues / bugs

Fixes #1565
