### PR TITLE
Retry Anthropic api_error (Internal Server Error) instead of breaking the loop (Fixes #2053)

### DIFF
--- a/packages/agents/src/compression/__tests__/compression-retry.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry.test.ts
@@ -77,13 +77,34 @@ function makeNetworkError(code: string): Error {
  * @requirement REQ-CR-001, REQ-CR-002
  */
 function makeAnthropicOverloadError(
-  type: 'overloaded_error' | 'rate_limit_error',
+  type: 'overloaded_error' | 'rate_limit_error' | 'api_error',
   message = 'Overloaded',
 ): Error {
   const err = new Error(message) as Error & {
     error?: { type?: string; message?: string };
   };
   err.error = { type, message };
+  return err;
+}
+
+/**
+ * Creates an Anthropic SDK-wrapped error. The Anthropic SDK throws stream error
+ * events as an APIError whose `error` property holds the entire response body,
+ * so the meaningful type is nested at `error.error.error.type` while the
+ * intermediate `error.error.type` is the generic envelope value "error". This
+ * is the shape that actually reaches retry classification in production
+ * (issue #2053).
+ */
+function makeAnthropicSdkWrappedError(
+  type: 'overloaded_error' | 'rate_limit_error' | 'api_error',
+  message = 'Internal server error',
+): Error {
+  const err = new Error(message) as Error & {
+    status?: number;
+    error?: { type?: string; error?: { type?: string; message?: string } };
+  };
+  err.status = undefined;
+  err.error = { type: 'error', error: { type, message } };
   return err;
 }
 
@@ -159,6 +180,34 @@ describe('isTransientCompressionError @plan PLAN-20260218-COMPRESSION-RETRY.P01'
     expect(
       isTransientCompressionError(
         makeAnthropicOverloadError('rate_limit_error', 'Rate limited'),
+      ),
+    ).toBe(true);
+  });
+
+  /**
+   * @requirement REQ-CR-001
+   * Anthropic api_error (Internal server error) carries no HTTP status but is
+   * transient and must be retried. Issue #2053: api_error broke the agent loop
+   * and failed compression because it was not classified as retryable.
+   */
+  it('returns true for Anthropic api_error internal server error (no HTTP status)', () => {
+    expect(
+      isTransientCompressionError(
+        makeAnthropicOverloadError('api_error', 'Internal server error'),
+      ),
+    ).toBe(true);
+  });
+
+  /**
+   * @requirement REQ-CR-001
+   * The Anthropic SDK wraps stream error events so the retryable type is nested
+   * at error.error.error.type. This is the shape that actually reaches
+   * compression retry classification in production (issue #2053).
+   */
+  it('returns true for SDK-wrapped Anthropic api_error (nested, no HTTP status)', () => {
+    expect(
+      isTransientCompressionError(
+        makeAnthropicSdkWrappedError('api_error', 'Internal server error'),
       ),
     ).toBe(true);
   });
@@ -547,6 +596,47 @@ describe('ChatSession compression retry behavior @plan PLAN-20260218-COMPRESSION
           callCount++;
           if (callCount < 3) {
             throw makeAnthropicOverloadError('overloaded_error');
+          }
+          return {
+            newHistory: [],
+            metadata: {
+              originalMessageCount: 10,
+              compressedMessageCount: 5,
+              strategyUsed: 'middle-out' as const,
+              llmCallMade: true,
+            },
+          };
+        }),
+      }),
+    );
+
+    await chat.performCompression('test-prompt');
+    expect(callCount).toBe(3);
+  });
+
+  /**
+   * @requirement REQ-CR-001
+   * Issue #2053: performCompression retries an Anthropic api_error
+   * (Internal server error) delivered in the real SDK-wrapped shape
+   * (HTTP status undefined, retryable type nested at error.error.error.type)
+   * and eventually succeeds instead of breaking compression.
+   */
+  it('retries an SDK-wrapped Anthropic api_error and eventually succeeds', async () => {
+    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
+
+    let callCount = 0;
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      () => ({
+        name: 'middle-out' as const,
+        requiresLLM: true,
+        trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+        compress: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount < 3) {
+            throw makeAnthropicSdkWrappedError(
+              'api_error',
+              'Internal server error',
+            );
           }
           return {
             newHistory: [],

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ApiError } from '@google/genai';
 import type { HttpError } from './retry.js';
-import { retryWithBackoff } from './retry.js';
+import { retryWithBackoff, isOverloadError } from './retry.js';
 import { setSimulate429 } from './testUtils.js';
 
 // Helper to create a mock function that fails a certain number of times
@@ -770,5 +770,178 @@ describe('retryWithBackoff', () => {
       expect.objectContaining({ name: 'AbortError' }),
     );
     expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * @requirement issue #2053 - Anthropic body-level api_error must be retried
+   * @scenario Default retry predicate retries SDK-wrapped api_error
+   * @given retryWithBackoff with no custom shouldRetryOnError and no
+   *   onPersistent429 failover callback
+   * @when the first call throws an Anthropic SDK-wrapped api_error (HTTP status
+   *   undefined, retryable type nested at error.error.error.type) and the
+   *   second call succeeds
+   * @then retryWithBackoff retries and resolves with the success value
+   */
+  it('should retry an Anthropic SDK-wrapped api_error with the default predicate (issue #2053)', async () => {
+    let attempt = 0;
+    const mockFn = vi.fn(async () => {
+      attempt++;
+      if (attempt <= 1) {
+        // Anthropic SDK throws `new APIError(undefined, body, ...)` for stream
+        // error events, storing the entire body on `error.error`. There is no
+        // HTTP status, so retryability must be derived from the body type.
+        const error = new Error('Internal server error') as HttpError & {
+          error?: unknown;
+        };
+        error.status = undefined;
+        error.error = {
+          type: 'error',
+          error: {
+            details: null,
+            type: 'api_error',
+            message: 'Internal server error',
+          },
+          request_id: 'req_011Cc7LnNajEpxrjW4iJ67q7',
+        };
+        throw error;
+      }
+      return 'success after api_error retry';
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 3,
+      initialDelayMs: 100,
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe('success after api_error retry');
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Behavioral tests for isOverloadError.
+ *
+ * isOverloadError detects Anthropic body-level error types that carry no HTTP
+ * status code and must be retried like an HTTP 429. Historically it only
+ * recognized overloaded_error and rate_limit_error; issue #2053 requires that
+ * api_error (Anthropic "Internal server error") is also treated as retryable.
+ */
+describe('isOverloadError', () => {
+  it('returns true for Anthropic api_error internal server error (issue #2053)', () => {
+    const error = {
+      type: 'error',
+      error: {
+        details: null,
+        type: 'api_error',
+        message: 'Internal server error',
+      },
+      request_id: 'req_011Cc7LnNajEpxrjW4iJ67q7',
+    };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns true for Anthropic overloaded_error', () => {
+    const error = {
+      type: 'error',
+      error: { type: 'overloaded_error', message: 'Overloaded' },
+    };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns true for Anthropic rate_limit_error', () => {
+    const error = {
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'Rate limited' },
+    };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns true when api_error is nested without a top-level type wrapper', () => {
+    const error = { error: { type: 'api_error' } };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns true when api_error appears as the top-level type', () => {
+    const error = { type: 'api_error', message: 'Internal server error' };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns true for an SDK-wrapped api_error (real Anthropic stream error, issue #2053)', () => {
+    // The Anthropic SDK throws `new APIError(undefined, body, ...)` for stream
+    // error events, storing the entire body on `error.error`. The retryable
+    // type is therefore nested at `error.error.error.type`, while the
+    // intermediate `error.error.type` is the generic envelope value "error".
+    const error = {
+      status: undefined,
+      error: {
+        type: 'error',
+        error: {
+          details: null,
+          type: 'api_error',
+          message: 'Internal server error',
+        },
+        request_id: 'req_011Cc7LnNajEpxrjW4iJ67q7',
+      },
+    };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns true for an SDK-wrapped overloaded_error', () => {
+    const error = {
+      status: undefined,
+      error: {
+        type: 'error',
+        error: { type: 'overloaded_error', message: 'Overloaded' },
+      },
+    };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns true for an SDK-wrapped rate_limit_error', () => {
+    const error = {
+      status: undefined,
+      error: {
+        type: 'error',
+        error: { type: 'rate_limit_error', message: 'Rate limited' },
+      },
+    };
+    expect(isOverloadError(error)).toBe(true);
+  });
+
+  it('returns false for a non-retryable Anthropic body error type', () => {
+    const error = {
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'bad' },
+    };
+    expect(isOverloadError(error)).toBe(false);
+  });
+
+  it('returns false for an SDK-wrapped non-retryable Anthropic body error type', () => {
+    const error = {
+      status: undefined,
+      error: {
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'bad' },
+      },
+    };
+    expect(isOverloadError(error)).toBe(false);
+  });
+
+  it('returns false for a bare error wrapper with no nested error type', () => {
+    const error = { type: 'error' };
+    expect(isOverloadError(error)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isOverloadError(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isOverloadError(undefined)).toBe(false);
+  });
+
+  it('returns false for a string error', () => {
+    expect(isOverloadError('some string')).toBe(false);
   });
 });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -237,10 +237,12 @@ export function isNetworkTransientError(error: unknown): boolean {
  *
  * Decision precedence (CRITICAL - do not reorder):
  * 1. Network error codes (ETIMEDOUT, ECONNRESET, etc.) → ALWAYS retry (regardless of retryFetchErrors)
- * 2. retryFetchErrors=true + generic "fetch failed" message → retry
- * 3. ApiError with status 400 → NEVER retry
- * 4. ApiError or generic status 429 or 5xx → retry
- * 5. All others → do not retry
+ * 2. RetryableQuotaError → retry
+ * 3. Anthropic body-level errors (overloaded_error, rate_limit_error, api_error, no HTTP status) → retry
+ * 4. retryFetchErrors=true + generic "fetch failed" message → retry
+ * 5. ApiError with status 400 → NEVER retry; ApiError 401/403/429/5xx → retry
+ * 6. Generic status 401/403/429 or 5xx → retry
+ * 7. All others → do not retry
  *
  * @param error The error object.
  * @param retryFetchErrors Whether to retry generic fetch failures (default: false).
@@ -261,7 +263,14 @@ export function isRetryableError(
     return true;
   }
 
-  // PRIORITY 3: Generic "fetch failed" messages only retry when explicitly enabled
+  // PRIORITY 3: Anthropic body-level errors (overloaded_error, rate_limit_error,
+  // api_error) carry no HTTP status, so they must be classified here. They are
+  // transient and retryable like an HTTP 429/5xx. (Issue #2053)
+  if (isOverloadError(error)) {
+    return true;
+  }
+
+  // PRIORITY 4: Generic "fetch failed" messages only retry when explicitly enabled
   if (retryFetchErrors === true) {
     const { messages } = collectErrorDetails(error);
     if (messages.some((msg) => msg.toLowerCase().includes('fetch failed'))) {
@@ -269,7 +278,7 @@ export function isRetryableError(
     }
   }
 
-  // PRIORITY 4: ApiError with deterministic 400 is NEVER retryable
+  // PRIORITY 5: ApiError with deterministic 400 is NEVER retryable
   if (error instanceof ApiError) {
     if (error.status === 400) return false;
     return (
@@ -281,7 +290,7 @@ export function isRetryableError(
     );
   }
 
-  // PRIORITY 5: Generic status-based retry (handles non-ApiError shapes)
+  // PRIORITY 6: Generic status-based retry (handles non-ApiError shapes)
   const status = getErrorStatus(error);
   if (status !== undefined) {
     return (
@@ -822,23 +831,46 @@ export async function retryWithBackoff<T>(
 }
 
 /**
- * Determines if an error is an Anthropic overloaded_error or rate_limit_error.
- * Anthropic returns overloaded_error and rate_limit_error as error types (not HTTP status):
+ * Determines if an error is a retryable Anthropic body-level error.
+ *
+ * The name `isOverloadError` is historical: this predicate now covers multiple
+ * Anthropic body-level error types that warrant a retry. Anthropic returns
+ * these as error types in the response body (not as an HTTP status code), so
+ * they must be classified here rather than via {@link getErrorStatus}:
  * {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
  * {"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}
+ * {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
+ *
+ * `api_error` is Anthropic's internal server error (equivalent to an HTTP 5xx)
+ * and is transient, so it is treated the same as overload and rate-limit
+ * errors. (Issue #2053)
+ *
+ * The Anthropic SDK wraps streaming error events in an `APIError` whose `error`
+ * property holds the entire parsed body. For these the retryable type lives one
+ * level deeper, at `error.error.error.type`, while the intermediate
+ * `error.error.type` is the generic envelope value `"error"`:
+ * {"error":{"type":"error","error":{"type":"api_error","message":"..."}}}
+ * Both the raw body shape and the SDK-wrapped shape are therefore inspected.
+ *
  * @param error The error object.
- * @returns True if the error is an overloaded_error or rate_limit_error, false otherwise.
+ * @returns True if the error is a retryable Anthropic body-level error
+ *   (overloaded_error, rate_limit_error, or api_error), false otherwise.
  */
 export function isOverloadError(error: unknown): boolean {
-  if (error !== null && error !== undefined && typeof error === 'object') {
-    const errorObj = error as {
-      error?: { type?: string; message?: string };
-      type?: string;
-    };
-    const errorType = errorObj.error?.type ?? errorObj.type;
-    return errorType === 'overloaded_error' || errorType === 'rate_limit_error';
+  if (error === null || error === undefined || typeof error !== 'object') {
+    return false;
   }
-  return false;
+  // Resolve the meaningful body-level type. The Anthropic SDK wraps stream
+  // errors so the type is nested at `error.error.error.type`; the intermediate
+  // `error.error.type` is the generic envelope value "error". Prefer the
+  // deepest available position, falling back to the raw body shapes.
+  const errorObj = error as {
+    error?: { type?: string; error?: { type?: string } };
+    type?: string;
+  };
+  const type =
+    errorObj.error?.error?.type ?? errorObj.error?.type ?? errorObj.type ?? '';
+  return ['overloaded_error', 'rate_limit_error', 'api_error'].includes(type);
 }
 
 /**

--- a/packages/providers/src/__tests__/RetryOrchestrator.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.test.ts
@@ -140,6 +140,34 @@ function createNetworkError(code = 'ECONNRESET'): Error {
 }
 
 /**
+ * Helper to create an Anthropic SDK-wrapped api_error (Internal Server Error).
+ *
+ * Mirrors how the Anthropic SDK throws stream error events: it constructs an
+ * APIError with `status: undefined` and stores the entire response body on the
+ * `error` property. The retryable type therefore lives at
+ * `error.error.error.type`, with the intermediate `error.error.type` being the
+ * generic envelope value "error". Carries no HTTP status, so retryability must
+ * be derived from the body-level type (issue #2053).
+ */
+function createAnthropicApiError(): Error {
+  const error = new Error('Internal server error') as Error & {
+    status?: number;
+    error?: unknown;
+  };
+  error.status = undefined;
+  error.error = {
+    type: 'error',
+    error: {
+      details: null,
+      type: 'api_error',
+      message: 'Internal server error',
+    },
+    request_id: 'req_011Cc7LnNajEpxrjW4iJ67q7',
+  };
+  return error;
+}
+
+/**
  * Helper to consume async iterator and return all chunks
  */
 async function consumeStream(
@@ -360,6 +388,36 @@ describe('RetryOrchestrator', () => {
 
       expect(throttleWaits.length).toBeGreaterThan(0);
       expect(throttleWaits[0]).toBeGreaterThan(0);
+    });
+
+    it('should retry on Anthropic SDK-wrapped api_error and then succeed (issue #2053)', async () => {
+      // Reproduces issue #2053: an Anthropic "Internal server error" (api_error)
+      // arrives with no HTTP status, wrapped by the SDK at
+      // error.error.error.type. Previously this broke the loop instead of
+      // retrying. The orchestrator must retry and yield the eventual success.
+      const apiError = createAnthropicApiError();
+      const provider = createTestProvider({
+        responses: [{ error: apiError }, 'success'],
+      });
+
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 3,
+        initialDelayMs: 10,
+      });
+
+      const options: GenerateChatOptions = {
+        contents: [{ role: 'user', blocks: [{ type: 'text', text: 'test' }] }],
+      };
+
+      const result = await consumeStream(
+        orchestrator.generateChatCompletion(options),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].blocks[0]).toMatchObject({
+        type: 'text',
+        text: 'test response',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #2053.

Anthropic occasionally returns a body-level `api_error` (HTTP-statusless):

    {"type":"error","error":{"details":null,"type":"api_error","message":"Internal server error"},"request_id":"req_..."}

Because this error carries no HTTP status code, the retry layer never classified it as transient. The result was that an Anthropic "Internal server error" **broke the agent loop** and also caused **context compression to fail permanently**, instead of being retried like a 429 / intermittent error.

## Root cause

`isOverloadError()` (in `packages/core/src/utils/retry.ts`) is the single chokepoint used by:

- the main request retry path (`RetryOrchestrator.shouldRetryError`),
- the generic `retryWithBackoff` classifier, and
- compression's `isTransientCompressionError()`.

It only recognized `overloaded_error` and `rate_limit_error`, so `api_error` fell through every retry path.

There is also a subtlety in the real error shape. The Anthropic SDK throws stream `error` events as `new APIError(undefined, body, ...)` and stores the **entire** body on the error's `.error` property. So the production error object looks like:

    { status: undefined, error: { type: 'error', error: { type: 'api_error', message: '...' }, request_id: '...' } }

The meaningful, retryable type is **nested** at `error.error.error.type`; the intermediate `error.error.type` is just the generic `"error"` envelope. The raw (un-wrapped) body shape instead exposes the type at `error.error.type`.

## Changes

- **`isOverloadError()`**: now resolves the body type from the deepest available position — `error.error.error.type ?? error.error.type ?? error.type` — and treats `api_error` as retryable alongside `overloaded_error` and `rate_limit_error`. This detects both the raw body shape and the real SDK-wrapped shape. Deterministic Anthropic types (`invalid_request_error`, `authentication_error`, etc.) and a bare `{type:"error"}` envelope remain **non-retryable**.
- **`isRetryableError()`**: the default `shouldRetryOnError` predicate for `retryWithBackoff` now consults `isOverloadError()`, so no-status Anthropic body errors retry on the default request path (used by `baseLlmClient` / `clientLlmUtilities` and `StreamProcessor`), not only via bucket failover.

Because all three retry consumers delegate to `isOverloadError()`, this single change closes both the loop-break path and the compression-failure path described in the issue.

## Tests (behavioral, RED-verified before the fix)

- **core `retry.test.ts`**: `isOverloadError` across raw and SDK-wrapped shapes for all three types, negative cases (deterministic types + bare envelope + null/undefined/string), and a behavioral `retryWithBackoff` default-predicate retry-then-succeed for an SDK-wrapped `api_error`.
- **providers `RetryOrchestrator.test.ts`**: behavioral retry-then-succeed on an SDK-wrapped `api_error`.
- **agents `compression-retry.test.ts`**: `isTransientCompressionError` for raw and SDK-wrapped `api_error`, plus a `performCompression` retry-then-succeed.

## Verification

- typecheck: 0 errors
- lint: 0 errors (1390 pre-existing baseline warnings)
- format: clean
- build: clean (no cycles)
- tests: core 4425, agents 1569, providers 3300 — all green
- smoke: profile haiku OK
