### PR TITLE
Avoid profile switch stalls after failed turns (Fixes #2049)

### DIFF
--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { PartListUnion } from '@google/genai';
+import type { Content, PartListUnion } from '@google/genai';
 import type { ServerGeminiStreamEvent, ModelInfo } from './turn.js';
 import { GeminiEventType } from './turn.js';
 import type { ChatSession } from './chatSession.js';
@@ -334,6 +334,23 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
     // The ModelInfo should reflect provider manager active model,
     // not the config model
     expect(infos[0]?.model).toBe('provider-active-model');
+  });
+
+  it('restores all committed previous history when initializing the next chat', async () => {
+    const previousHistory: Content[] = [
+      { role: 'user', parts: [{ text: 'first user turn' }] },
+      { role: 'model', parts: [{ text: 'first model response' }] },
+      { role: 'user', parts: [{ text: 'second user turn' }] },
+      { role: 'model', parts: [{ text: 'second model response' }] },
+    ];
+    const { orchestrator } = buildOrchestrator();
+    const deps = orchestrator['deps'];
+    vi.mocked(deps.hasChat).mockReturnValue(false);
+    vi.mocked(deps.getPreviousHistory).mockReturnValue(previousHistory);
+
+    await collectModelInfos(orchestrator, 'prompt-restore-history');
+
+    expect(deps.startChat).toHaveBeenCalledWith(previousHistory);
   });
 
   it('uses the configured context-limit for preflight overflow checks', async () => {

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -156,8 +156,7 @@ export class MessageStreamOrchestrator {
       logger.debug('Restoring previous history during prompt generation', {
         historyLength: previousHistory.length,
       });
-      const conversationHistory = previousHistory.slice(2);
-      setChat(await startChat(conversationHistory));
+      setChat(await startChat(previousHistory));
     } else {
       setChat(await startChat());
     }

--- a/packages/agents/src/core/client.test.ts
+++ b/packages/agents/src/core/client.test.ts
@@ -3481,6 +3481,40 @@ sub memory
       expect(client['_previousHistory']).toBe(liveHistory);
     });
 
+    it('preserves stored conversation history when refreshing tools before the next turn', async () => {
+      const committedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'We are fixing issue 2049.' }] },
+        {
+          role: 'model',
+          parts: [{ text: 'Profile switches must preserve context.' }],
+        },
+      ];
+      client.storeHistoryForLaterUse(committedHistory);
+      client['chat'] = undefined;
+      const startChatSpy = vi
+        .spyOn(client, 'startChat')
+        .mockImplementation(async (extraHistory?: Content[]) => {
+          const restoredHistory = extraHistory ?? [];
+          return {
+            getHistory: vi.fn().mockReturnValue(restoredHistory),
+            getHistoryService: vi.fn().mockReturnValue({
+              clear: vi.fn(),
+              findUnmatchedToolCalls: vi.fn().mockReturnValue([]),
+              getCurated: vi.fn().mockReturnValue([]),
+              getTotalTokens: vi.fn().mockReturnValue(0),
+            }),
+            getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+            setTools: vi.fn(),
+          } as unknown as ChatSession;
+        });
+
+      await client.setTools();
+
+      expect(startChatSpy).toHaveBeenCalledWith(committedHistory);
+      const restoredHistory =
+        await AgentClient.prototype.getHistory.call(client);
+      expect(restoredHistory).toStrictEqual(committedHistory);
+    });
     it('also resets currentSequenceModel on ModelChanged', () => {
       client['currentSequenceModel'] = 'sticky-model';
       coreEvents.emitModelChanged('other-model');

--- a/packages/agents/src/core/client.test.ts
+++ b/packages/agents/src/core/client.test.ts
@@ -83,6 +83,8 @@ import { TodoReminderService } from '@vybestack/llxprt-code-core/services/todo-r
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import { uiTelemetryService } from '@vybestack/llxprt-code-core/telemetry/uiTelemetry.js';
 import { coreEvents } from '@vybestack/llxprt-code-core/utils/events.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import { ContentConverters } from '@vybestack/llxprt-code-core/services/history/ContentConverters.js';
 
 // --- Mocks ---
 const mockChatCreateFn = vi.fn();
@@ -3056,6 +3058,23 @@ sub memory
       expect(client['ideContextTracker']['forceFullIdeContext']).toBe(true);
     });
 
+    it('returns history from a stored history service after profile invalidation', async () => {
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'remember issue 2049' }] },
+        { role: 'model', parts: [{ text: 'we are preserving history' }] },
+      ];
+      const historyService = new HistoryService();
+      for (const content of history) {
+        historyService.add(ContentConverters.toIContent(content), 'test-model');
+      }
+      client['_storedHistoryService'] = historyService;
+      client['_previousHistory'] = undefined;
+      client['chat'] = undefined;
+      client.getHistory = AgentClient.prototype.getHistory.bind(client);
+
+      await expect(client.getHistory()).resolves.toStrictEqual(history);
+    });
+
     it('should update chat immediately when chat is initialized', async () => {
       // Arrange
       const mockChat = {
@@ -3396,6 +3415,7 @@ sub memory
         vertexai: false,
       });
       expect(client['_storedHistoryService']).toBe(historyService);
+      expect(client.getHistoryService()).toBe(historyService);
       expect(client['_previousHistory']).toBeUndefined();
     });
 
@@ -3436,6 +3456,29 @@ sub memory
       expect(executeSpy).toHaveBeenCalledOnce();
       expect(client.hasChatInitialized()).toBe(false);
       expect(client['_storedHistoryService']).toBe(historyService);
+    });
+
+    it('uses live chat history instead of a stale stored snapshot when reinitializing', async () => {
+      const storedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'old turn' }] },
+      ];
+      const liveHistory: Content[] = [
+        ...storedHistory,
+        { role: 'model', parts: [{ text: 'new committed turn' }] },
+      ];
+      const mockChat: Partial<ChatSession> = {
+        getHistory: vi.fn().mockReturnValue(liveHistory),
+      };
+      client['chat'] = mockChat as ChatSession;
+      client['_previousHistory'] = storedHistory;
+
+      await client.initialize({
+        model: 'new-model',
+        apiKey: 'test-key',
+        vertexai: false,
+      });
+
+      expect(client['_previousHistory']).toBe(liveHistory);
     });
 
     it('also resets currentSequenceModel on ModelChanged', () => {

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -44,6 +44,7 @@ import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/Agen
 import { subscribeToAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import { BaseLLMClient } from './baseLlmClient.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { ContentConverters } from '@vybestack/llxprt-code-core/services/history/ContentConverters.js';
 
 import {
   coreEvents,
@@ -267,10 +268,7 @@ export class AgentClient implements AgentClientContract {
   }
 
   async initialize(contentGeneratorConfig: ContentGeneratorConfig) {
-    // Preserve chat history before resetting, but only if we don't already have stored history
-    // (e.g., from storeHistoryForLaterUse called before initialize)
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional falsy coalescing: empty array means "no stored history"
-    const previousHistory = this._previousHistory || this.chat?.getHistory();
+    const previousHistory = this.chat?.getHistory() ?? this._previousHistory;
 
     // Reset the client to force reinitialization with new auth
     this.contentGenerator = undefined;
@@ -385,7 +383,7 @@ export class AgentClient implements AgentClientContract {
   getHistoryService(): HistoryService | null {
     // Removed verbose debug logging
     if (!this.hasChatInitialized()) {
-      return null;
+      return this._storedHistoryService ?? null;
     }
     const historyService = this.getChat().getHistoryService();
     // Removed verbose debug logging
@@ -403,11 +401,6 @@ export class AgentClient implements AgentClientContract {
   }
 
   async getHistory(): Promise<Content[]> {
-    // If we have stored history but no chat, return the stored history
-    if (!this.hasChatInitialized() && this._previousHistory) {
-      return this._previousHistory;
-    }
-
     // If chat is initialized, get its current history
     if (this.hasChatInitialized()) {
       const chat = this.getChat() as unknown as {
@@ -418,6 +411,16 @@ export class AgentClient implements AgentClientContract {
         await chat.waitForIdle();
       }
       return chat.getHistory();
+    }
+
+    if (this._previousHistory) {
+      return this._previousHistory;
+    }
+
+    if (this._storedHistoryService) {
+      return ContentConverters.toGeminiContents(
+        this._storedHistoryService.getAll(),
+      );
     }
 
     // No history available

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -524,9 +524,8 @@ export class AgentClient implements AgentClientContract {
     }
 
     const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
-    // Ensure chat is initialized before setting tools
     if (!this.hasChatInitialized()) {
-      await this.resetChat();
+      this.chat = await this.startChat(this._previousHistory ?? []);
     }
     this.getChat().setTools(tools);
   }

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
+import type { Content } from '@google/genai';
 import type { ConfigParameters, SandboxConfig } from './config.js';
 import {
   Config,
@@ -435,6 +436,69 @@ describe('Server Config (config.ts)', () => {
       expect(mockNewClient.initialize).toHaveBeenCalledWith(mockContentConfig);
     });
 
+    it('preserves committed chat history without waiting for an active turn to become idle', async () => {
+      const config = new Config(baseParams);
+      const mockContentConfig = {
+        model: 'gemini-pro',
+        apiKey: 'test-key',
+      };
+      const committedHistory: Content[] = [
+        {
+          role: 'user',
+          parts: [{ text: 'Remember we are fixing issue 2049' }],
+        },
+        { role: 'model', parts: [{ text: 'We are preserving history.' }] },
+      ];
+      const partialInFlightHistory: Content[] = [
+        ...committedHistory,
+        { role: 'user', parts: [{ text: 'This turn is still retrying' }] },
+      ];
+
+      (createContentGeneratorConfig as Mock).mockReturnValue(mockContentConfig);
+
+      const chatGetHistory = vi.fn().mockReturnValue(committedHistory);
+      const mockHistoryService = { setTokenizerFactory: vi.fn() };
+      const mockExistingClient = {
+        isInitialized: vi.fn().mockReturnValue(true),
+        hasChatInitialized: vi.fn().mockReturnValue(true),
+        getChat: vi.fn().mockReturnValue({
+          getHistory: chatGetHistory,
+        }),
+        getHistory: vi.fn(async () => {
+          throw new Error('refreshAuth should not wait for idle history');
+        }),
+        getHistoryService: vi.fn().mockReturnValue(mockHistoryService),
+      };
+
+      const mockNewClient = {
+        isInitialized: vi.fn().mockReturnValue(true),
+        getHistory: vi.fn().mockReturnValue(committedHistory),
+        getHistoryService: vi.fn().mockReturnValue(null),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        storeHistoryForLaterUse: vi.fn(),
+        storeHistoryServiceForReuse: vi.fn(),
+      };
+
+      (
+        config as unknown as { agentClient: typeof mockExistingClient }
+      ).agentClient = mockExistingClient;
+      AgentClient.mockImplementation(() => mockNewClient);
+
+      await config.refreshAuth();
+
+      expect(mockExistingClient.getHistory).not.toHaveBeenCalled();
+      expect(mockExistingClient.getChat).toHaveBeenCalled();
+      expect(chatGetHistory).toHaveBeenCalled();
+      expect(mockExistingClient.getHistoryService).not.toHaveBeenCalled();
+      expect(mockNewClient.storeHistoryServiceForReuse).not.toHaveBeenCalled();
+      expect(mockNewClient.storeHistoryForLaterUse).toHaveBeenCalledWith(
+        committedHistory,
+      );
+      expect(mockNewClient.storeHistoryForLaterUse).not.toHaveBeenCalledWith(
+        partialInFlightHistory,
+      );
+    });
+
     it('should handle case when no existing client is initialized', async () => {
       const config = new Config(baseParams);
       const mockContentConfig = {
@@ -472,7 +536,7 @@ describe('Server Config (config.ts)', () => {
       expect(mockNewClient.setHistory).not.toHaveBeenCalled();
     });
 
-    it('should strip thoughts when switching from GenAI to Vertex', async () => {
+    it('should strip thought signatures when switching from GenAI to Vertex', async () => {
       const config = new Config(baseParams);
       const mockContentConfig = {
         model: 'gemini-pro',
@@ -488,13 +552,24 @@ describe('Server Config (config.ts)', () => {
         vertexai: true,
       });
 
-      const mockExistingHistory = [
-        { role: 'user', parts: [{ text: 'Hello' }] },
+      const mockExistingHistory: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              text: 'Hidden reasoning',
+              thought: true,
+              thoughtSignature: 'genai-signature',
+            },
+            { text: 'Visible response' },
+          ],
+        },
       ];
+      const mockHistoryService = { setTokenizerFactory: vi.fn() };
       const mockExistingClient = {
         isInitialized: vi.fn().mockReturnValue(true),
         getHistory: vi.fn().mockReturnValue(mockExistingHistory),
-        getHistoryService: vi.fn().mockReturnValue(null),
+        getHistoryService: vi.fn().mockReturnValue(mockHistoryService),
       };
       const mockNewClient = {
         isInitialized: vi.fn().mockReturnValue(true),
@@ -503,6 +578,7 @@ describe('Server Config (config.ts)', () => {
         setHistory: vi.fn(),
         initialize: vi.fn().mockResolvedValue(undefined),
         storeHistoryForLaterUse: vi.fn(),
+        storeHistoryServiceForReuse: vi.fn(),
       };
 
       (
@@ -512,14 +588,23 @@ describe('Server Config (config.ts)', () => {
 
       await config.refreshAuth();
 
-      // When switching from GenAI to Vertex, thoughts should be stripped
-      // The history is stored with thoughts stripped before initialize
+      expect(mockNewClient.storeHistoryServiceForReuse).not.toHaveBeenCalled();
       expect(mockNewClient.storeHistoryForLaterUse).toHaveBeenCalled();
 
-      // Get the actual call arguments to verify thoughts stripping
       const storedHistory =
         mockNewClient.storeHistoryForLaterUse.mock.calls[0][0];
-      expect(storedHistory).toStrictEqual(mockExistingHistory);
+      expect(storedHistory).toStrictEqual([
+        {
+          role: 'model',
+          parts: [
+            {
+              text: 'Hidden reasoning',
+              thought: true,
+            },
+            { text: 'Visible response' },
+          ],
+        },
+      ]);
     });
 
     it('should not strip thoughts when switching from Vertex to GenAI', async () => {
@@ -680,9 +765,7 @@ describe('Server Config (config.ts)', () => {
       expect(mockNewClient.storeHistoryForLaterUse).toHaveBeenCalledWith(
         mockExistingHistory,
       );
-      expect(mockNewClient.storeHistoryServiceForReuse).toHaveBeenCalledWith(
-        mockHistoryService,
-      );
+      expect(mockNewClient.storeHistoryServiceForReuse).not.toHaveBeenCalled();
 
       // CRITICAL: Verify OAuth was NOT triggered during refresh
       expect(mockOAuthManager.authenticate).not.toHaveBeenCalled();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -260,8 +260,16 @@ export class Config extends ConfigBase {
     if (!previousAgentClient?.isInitialized()) {
       return { history: [], historyService: null };
     }
-    const existingHistory = await previousAgentClient.getHistory();
-    const existingHistoryService = previousAgentClient.getHistoryService();
+    const hasInitializedChat =
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- preserve defensive runtime boundary guard for legacy AgentClient-compatible implementations.
+      typeof previousAgentClient.hasChatInitialized === 'function' &&
+      previousAgentClient.hasChatInitialized();
+    const existingHistory = hasInitializedChat
+      ? previousAgentClient.getChat().getHistory()
+      : await previousAgentClient.getHistory();
+    const existingHistoryService = hasInitializedChat
+      ? null
+      : previousAgentClient.getHistoryService();
     logger.debug('Retrieved existing state', {
       historyLength: existingHistory.length,
       hasHistoryService: !!existingHistoryService,
@@ -299,19 +307,19 @@ export class Config extends ConfigBase {
     existingHistoryService: HistoryService | null,
     newContentGeneratorConfig: ReturnType<typeof createContentGeneratorConfig>,
   ): void {
-    if (existingHistoryService) {
-      logger.debug('Storing existing HistoryService for reuse', {
-        historyLength: existingHistory.length,
-      });
-      newAgentClient.storeHistoryServiceForReuse(existingHistoryService);
-    }
-    if (existingHistory.length === 0) {
-      return;
-    }
     const fromGenaiToVertex =
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
       this.contentGeneratorConfig?.vertexai === false &&
       newContentGeneratorConfig.vertexai === true;
+    if (existingHistoryService) {
+      logger.debug('Skipping existing HistoryService reuse', {
+        historyLength: existingHistory.length,
+        fromGenaiToVertex,
+      });
+    }
+    if (existingHistory.length === 0) {
+      return;
+    }
     logger.debug('Storing history for later use', {
       historyLength: existingHistory.length,
       fromGenaiToVertex,


### PR DESCRIPTION
## TLDR

Fixes profile/provider switching stalls after a failed or still-active turn by snapshotting already committed chat history without waiting for the previous turn to become idle. This keeps the next model call grounded in the conversation so it continues where the user left off, while avoiding promotion of partial failed in-flight content into history.

## Dive Deeper

The previous refresh path asked the existing AgentClient for history while rebuilding content generator state. For initialized chats, that history API waits for the current turn to become idle. If the prior provider call was stuck in quota retry/backoff, profile loading was blocked behind the request the user was trying to escape.

This change makes the refresh path use the initialized chat's committed history snapshot directly, skips live HistoryService reuse across the switch, and stores the committed Content array for the new client. That avoids unbounded waits and prevents late mutable state from the old chat from contaminating the new one.

Additional history-preservation fixes:

- Invalidated clients can recover committed history from a stored HistoryService when no chat is active.
- Reinitialization prefers live chat history over stale stored snapshots.
- The next chat initialization restores all committed previous history instead of dropping the first two turns.
- GenAI to Vertex transitions still strip thought signatures while preserving visible history and thought text.

## Reviewer Test Plan

Recommended validation:

1. Start a long or failing provider turn, then switch profiles with /profile load gpt55high. The switch should not wait for the failed turn to become idle.
2. Continue the conversation after switching. The model should still see the committed prior turns and continue from the current topic instead of acting like the session restarted.
3. Confirm partial output from the failed in-flight turn is not treated as a completed history turn.
4. Run the focused tests:
   npm run test --workspace @vybestack/llxprt-code-core -- src/config/config.test.ts
   npm run test --workspace @vybestack/llxprt-code-agents -- src/core/MessageStreamOrchestrator.modelinfo.test.ts src/core/client.test.ts

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else"

## Linked issues / bugs

Fixes #2049
