### PR TITLE
Fix dumpcontext invocation propagation (Fixes #2066)

### DIFF
--- a/packages/cli/src/ui/commands/dumpcontextCommand.test.ts
+++ b/packages/cli/src/ui/commands/dumpcontextCommand.test.ts
@@ -246,6 +246,51 @@ describe('dumpcontextCommand', () => {
       });
     });
 
+    it('should dump context immediately when getAgentClient relies on its receiver (this binding)', async () => {
+      vi.mocked(getRuntimeApi).mockReturnValue({
+        getEphemeralSetting: vi.fn(() => 'off'),
+        setEphemeralSetting: vi.fn(),
+      } as never);
+
+      const historyService = {
+        getAll: vi
+          .fn()
+          .mockReturnValue([
+            { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
+          ]),
+      };
+
+      const configWithReceiverDependentMethod = {
+        agentClient: {
+          getHistoryService: () => historyService,
+        },
+        getAgentClient() {
+          return this.agentClient;
+        },
+        getProviderManager() {
+          return {
+            getActiveProviderName: () => 'anthropic',
+          };
+        },
+      };
+
+      const ctxWithHistory = createMockCommandContext();
+      ctxWithHistory.services.config =
+        configWithReceiverDependentMethod as unknown as CommandContext['services']['config'];
+
+      const result = await dumpcontextAction(ctxWithHistory, 'now');
+
+      expect(dumpRequestContext).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ url: 'immediate-context-dump' }),
+        'anthropic',
+      );
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('Immediate request context dumped to'),
+      });
+    });
+
     it('should shape immediate dump body for OpenAI history', async () => {
       vi.mocked(getRuntimeApi).mockReturnValue({
         getEphemeralSetting: vi.fn(() => 'off'),

--- a/packages/cli/src/ui/commands/dumpcontextCommand.ts
+++ b/packages/cli/src/ui/commands/dumpcontextCommand.ts
@@ -65,16 +65,16 @@ function getHistoryService(
   if (!hasCallableGetAgentClient(config)) {
     return null;
   }
-  const getAgentClient: () => unknown = config.getAgentClient;
-  const agentClient = getAgentClient();
+  const agentClient = config.getAgentClient();
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison -- callers may return null/undefined at runtime */
   if (
-    typeof agentClient !== 'object' ||
     agentClient === null ||
-    !('getHistoryService' in agentClient) ||
+    agentClient === undefined ||
     typeof agentClient.getHistoryService !== 'function'
   ) {
     return null;
   }
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison */
   return agentClient.getHistoryService() as HistoryService | null;
 }
 

--- a/packages/providers/src/BaseProviderNormalization.ts
+++ b/packages/providers/src/BaseProviderNormalization.ts
@@ -222,21 +222,40 @@ export function normalizeProviderGenerateChatOptions(
     metadata: guard.metadata,
     config: finalConfig,
   };
-  const invocation =
-    providedOptions.invocation ??
-    createRuntimeInvocationContext({
-      runtime: normalizedRuntime,
-      settings,
-      providerName: deps.providerName,
-      ephemeralsSnapshot: deps.buildEphemeralsSnapshot(settings),
-      telemetry: resolved.telemetry,
-      metadata: guard.metadata,
-      userMemory:
-        typeof providedOptions.userMemory === 'string'
-          ? providedOptions.userMemory
-          : undefined,
-      fallbackRuntimeId: `${deps.providerName}:normalizeGenerateChatOptions`,
-    });
+  const snapshot = deps.buildEphemeralsSnapshot(settings);
+  const fallbackInvocation = createRuntimeInvocationContext({
+    runtime: normalizedRuntime,
+    settings,
+    providerName: deps.providerName,
+    ephemeralsSnapshot: snapshot,
+    telemetry: resolved.telemetry,
+    metadata: guard.metadata,
+    userMemory:
+      typeof providedOptions.userMemory === 'string'
+        ? providedOptions.userMemory
+        : undefined,
+    fallbackRuntimeId: `${deps.providerName}:normalizeGenerateChatOptions`,
+  });
+
+  const invocation = providedOptions.invocation
+    ? createRuntimeInvocationContext({
+        runtime: {
+          ...normalizedRuntime,
+          runtimeId: providedOptions.invocation.runtimeId,
+        },
+        settings,
+        providerName: deps.providerName,
+        ephemeralsSnapshot: {
+          ...snapshot,
+          ...providedOptions.invocation.ephemerals,
+        },
+        telemetry: providedOptions.invocation.telemetry ?? resolved.telemetry,
+        metadata: providedOptions.invocation.metadata,
+        userMemory: providedOptions.invocation.userMemory,
+        redaction: providedOptions.invocation.redaction,
+        fallbackRuntimeId: providedOptions.invocation.runtimeId,
+      })
+    : fallbackInvocation;
 
   return {
     ...providedOptions,

--- a/packages/providers/src/__tests__/BaseProviderNormalization.ephemeralPropagation.test.ts
+++ b/packages/providers/src/__tests__/BaseProviderNormalization.ephemeralPropagation.test.ts
@@ -1,0 +1,291 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { BaseProvider } from '../BaseProvider.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import {
+  clearActiveProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+  createProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+
+class HarnessProvider extends BaseProvider {
+  lastNormalizedOptions?: NormalizedGenerateChatOptions;
+
+  constructor(config: Config, settingsService: SettingsService) {
+    super({ name: 'stub-provider' }, undefined, config, settingsService);
+  }
+
+  async getModels(): Promise<never[]> {
+    return [];
+  }
+
+  getDefaultModel(): string {
+    return 'stub-default-model';
+  }
+
+  protected supportsOAuth(): boolean {
+    return false;
+  }
+
+  protected generateChatCompletionWithOptions(
+    options: NormalizedGenerateChatOptions,
+  ): AsyncIterableIterator<never> {
+    this.lastNormalizedOptions = options;
+    return (async function* () {})();
+  }
+}
+
+const prompt = {
+  speaker: 'human' as const,
+  blocks: [] as unknown[],
+};
+
+async function collect(
+  iterator: AsyncIterableIterator<unknown>,
+): Promise<void> {
+  for await (const _chunk of iterator) {
+    // consume iterator
+  }
+}
+
+interface Harness {
+  provider: HarnessProvider;
+  manager: ProviderManager;
+  settingsService: SettingsService;
+  runtimeContext: ReturnType<typeof createHarnessRuntimeContext>;
+}
+
+function createHarnessRuntimeContext(settingsService: SettingsService) {
+  const config = createRuntimeConfigStub(settingsService);
+  const runtimeContext = {
+    settingsService,
+    config,
+    runtimeId: 'ephemeral-harness',
+  };
+  return { config, runtimeContext };
+}
+
+function createHarnessWithDumpContext(): Harness {
+  const settingsService = new SettingsService();
+  settingsService.set('dumpcontext', 'on');
+  const { config, runtimeContext } =
+    createHarnessRuntimeContext(settingsService);
+  const manager = new ProviderManager({
+    settingsService,
+    config,
+    runtime: runtimeContext,
+  });
+  setActiveProviderRuntimeContext(runtimeContext);
+  const provider = new HarnessProvider(config, settingsService);
+  manager.registerProvider(provider);
+  settingsService.set('activeProvider', provider.name);
+  settingsService.setProviderSetting(provider.name, 'model', 'stub-model');
+  settingsService.setProviderSetting(provider.name, 'auth-key', 'stub-key');
+  settingsService.setProviderSetting(
+    provider.name,
+    'base-url',
+    'https://stub.example.com',
+  );
+  manager.setActiveProvider(provider.name);
+  return { provider, manager, settingsService, runtimeContext };
+}
+
+describe('BaseProvider ephemeral snapshot propagation into invocation', () => {
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  it('includes current settings ephemerals in the invocation when no invocation is provided', async () => {
+    const { provider, manager, settingsService, runtimeContext } =
+      createHarnessWithDumpContext();
+
+    await collect(
+      manager.getActiveProvider().generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [prompt],
+          settings: settingsService,
+          config: runtimeContext.config,
+          runtime: runtimeContext,
+        }),
+      ),
+    );
+
+    expect(provider.lastNormalizedOptions?.invocation).toBeDefined();
+    expect(
+      provider.lastNormalizedOptions?.invocation.ephemerals.dumpcontext,
+    ).toBe('on');
+  });
+
+  it('merges current settings ephemerals into a provided invocation', async () => {
+    const { provider, manager, settingsService, runtimeContext } =
+      createHarnessWithDumpContext();
+
+    const staleInvocation = createRuntimeInvocationContext({
+      runtime: createProviderRuntimeContext({
+        runtimeId: 'ephemeral-provided-invocation',
+        settingsService,
+        config: runtimeContext.config,
+      }),
+      settings: settingsService,
+      providerName: provider.name,
+      ephemeralsSnapshot: {},
+      fallbackRuntimeId: 'ephemeral-provided-invocation',
+    });
+
+    await collect(
+      manager.getActiveProvider().generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [prompt],
+          settings: settingsService,
+          config: runtimeContext.config,
+          runtime: runtimeContext,
+          invocation: staleInvocation,
+        }),
+      ),
+    );
+
+    const invocation = provider.lastNormalizedOptions?.invocation;
+    expect(invocation).toBeDefined();
+    expect(invocation?.ephemerals.dumpcontext).toBe('on');
+    expect(invocation?.getEphemeral('dumpcontext')).toBe('on');
+    expect(invocation?.getCliSetting('dumpcontext')).toBe('on');
+  });
+
+  it('preserves explicit ephemerals on the provided invocation over snapshot values', async () => {
+    const { provider, manager, settingsService, runtimeContext } =
+      createHarnessWithDumpContext();
+
+    const explicitInvocation = createRuntimeInvocationContext({
+      runtime: createProviderRuntimeContext({
+        runtimeId: 'ephemeral-precedence',
+        settingsService,
+        config: runtimeContext.config,
+      }),
+      settings: settingsService,
+      providerName: provider.name,
+      ephemeralsSnapshot: { dumpcontext: 'error' },
+      fallbackRuntimeId: 'ephemeral-precedence',
+    });
+
+    await collect(
+      manager.getActiveProvider().generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [prompt],
+          settings: settingsService,
+          config: runtimeContext.config,
+          runtime: runtimeContext,
+          invocation: explicitInvocation,
+        }),
+      ),
+    );
+
+    const invocation = provider.lastNormalizedOptions?.invocation;
+    expect(invocation).toBeDefined();
+    expect(invocation?.ephemerals.dumpcontext).toBe('error');
+    expect(invocation?.getEphemeral('dumpcontext')).toBe('error');
+  });
+
+  it('preserves the provided invocation runtimeId over the normalized runtime id', async () => {
+    const { provider, manager, settingsService, runtimeContext } =
+      createHarnessWithDumpContext();
+
+    expect(runtimeContext.runtimeId).toBe('ephemeral-harness');
+
+    const providedInvocation = createRuntimeInvocationContext({
+      runtime: createProviderRuntimeContext({
+        runtimeId: 'ephemeral-provided-runtimeId',
+        settingsService,
+        config: runtimeContext.config,
+      }),
+      settings: settingsService,
+      providerName: provider.name,
+      ephemeralsSnapshot: {},
+      fallbackRuntimeId: 'ephemeral-provided-runtimeId',
+    });
+
+    await collect(
+      manager.getActiveProvider().generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [prompt],
+          settings: settingsService,
+          config: runtimeContext.config,
+          runtime: runtimeContext,
+          invocation: providedInvocation,
+        }),
+      ),
+    );
+
+    const invocation = provider.lastNormalizedOptions?.invocation;
+    expect(invocation).toBeDefined();
+    // The provided invocation's runtimeId must win, not the normalized
+    // runtime's runtimeId ('ephemeral-harness').
+    expect(invocation?.runtimeId).toBe('ephemeral-provided-runtimeId');
+    expect(invocation?.runtimeId).not.toBe(runtimeContext.runtimeId);
+  });
+
+  it('preserves provided invocation metadata, userMemory, redaction, and telemetry', async () => {
+    const { provider, manager, settingsService, runtimeContext } =
+      createHarnessWithDumpContext();
+
+    const providedMetadata = { correlationId: 'corr-123', source: 'unit-test' };
+    const providedUserMemory = 'remember: user prefers concise answers';
+    const providedRedaction = {
+      redactApiKeys: true,
+      redactCredentials: true,
+      redactFilePaths: false,
+      redactUrls: false,
+      redactEmails: true,
+      redactPersonalInfo: true,
+    };
+
+    const providedInvocation = createRuntimeInvocationContext({
+      runtime: createProviderRuntimeContext({
+        runtimeId: 'ephemeral-preserve-all',
+        settingsService,
+        config: runtimeContext.config,
+      }),
+      settings: settingsService,
+      providerName: provider.name,
+      ephemeralsSnapshot: {},
+      metadata: providedMetadata,
+      userMemory: providedUserMemory,
+      redaction: providedRedaction,
+      fallbackRuntimeId: 'ephemeral-preserve-all',
+    });
+
+    await collect(
+      manager.getActiveProvider().generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [prompt],
+          settings: settingsService,
+          config: runtimeContext.config,
+          runtime: runtimeContext,
+          invocation: providedInvocation,
+        }),
+      ),
+    );
+
+    const invocation = provider.lastNormalizedOptions?.invocation;
+    expect(invocation).toBeDefined();
+    expect(invocation?.runtimeId).toBe('ephemeral-preserve-all');
+    expect(invocation?.metadata).toMatchObject(providedMetadata);
+    expect(invocation?.userMemory).toBe(providedUserMemory);
+    expect(invocation?.redaction).toMatchObject(providedRedaction);
+  });
+});

--- a/packages/providers/src/__tests__/BaseProviderNormalization.ephemeralPropagation.test.ts
+++ b/packages/providers/src/__tests__/BaseProviderNormalization.ephemeralPropagation.test.ts
@@ -252,6 +252,11 @@ describe('BaseProvider ephemeral snapshot propagation into invocation', () => {
       redactEmails: true,
       redactPersonalInfo: true,
     };
+    const providedTelemetry = {
+      providerName: provider.name,
+      modelId: 'stub-model',
+      tokenUsage: { input: 10, output: 20, total: 30 },
+    };
 
     const providedInvocation = createRuntimeInvocationContext({
       runtime: createProviderRuntimeContext({
@@ -265,6 +270,7 @@ describe('BaseProvider ephemeral snapshot propagation into invocation', () => {
       metadata: providedMetadata,
       userMemory: providedUserMemory,
       redaction: providedRedaction,
+      telemetry: providedTelemetry,
       fallbackRuntimeId: 'ephemeral-preserve-all',
     });
 
@@ -287,5 +293,6 @@ describe('BaseProvider ephemeral snapshot propagation into invocation', () => {
     expect(invocation?.metadata).toMatchObject(providedMetadata);
     expect(invocation?.userMemory).toBe(providedUserMemory);
     expect(invocation?.redaction).toMatchObject(providedRedaction);
+    expect(invocation?.telemetry).toBe(providedTelemetry);
   });
 });

--- a/packages/providers/src/gemini/GeminiProvider.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.test.ts
@@ -136,18 +136,15 @@ describe('GeminiProvider', () => {
           blocks: [{ type: 'text', text: 'hello ephemerals' }],
         },
       ] as IContent[],
+      settingsOverrides: {
+        global: { maxOutputTokens: 42 },
+      },
     });
-    // @plan PLAN-20260126-SETTINGS-SEPARATION.P09
-    // Provider-scoped settings now go through invocation.modelParams after separation
     options.invocation = {
       ...options.invocation,
       ephemerals: {
         ...options.invocation.ephemerals,
         tools: { allowed: ['read_file'], disabled: ['web_search'] },
-        gemini: { maxOutputTokens: 42 },
-      },
-      modelParams: {
-        maxOutputTokens: 42,
       },
     };
 


### PR DESCRIPTION
## TLDR

Fixes /dumpcontext now by preserving the Config getAgentClient receiver binding, and fixes /dumpcontext on by ensuring fresh ephemeral settings are merged into every provider invocation, including caller-provided invocation contexts.

## Dive Deeper

This fixes two dumpcontext paths:

- /dumpcontext now no longer detaches config.getAgentClient before calling it, so Config methods that depend on this continue to work.
- Provider normalization now always snapshots current ephemerals and rebuilds provided invocation contexts with the merged snapshot. Explicit ephemerals from a provided invocation still win, while helpers and derived views such as getEphemeral and getCliSetting remain coherent.

The provider tests cover propagation with and without a provided invocation, explicit precedence, runtimeId preservation, and preservation of invocation metadata/userMemory/redaction. The CLI test covers the receiver-binding regression for immediate dumps.

## Reviewer Test Plan

Recommended validation:

1. Run /dumpcontext now after starting a conversation and confirm it reports an immediate request context dump without sending a model request.
2. Run /dumpcontext on and then send a prompt; confirm the provider receives dumpcontext in invocation ephemerals and creates request dumps.
3. Run the focused regression tests:
   npm test -- --run src/ui/commands/dumpcontextCommand.test.ts from packages/cli
   npm test -- --run src/__tests__/BaseProviderNormalization.ephemeralPropagation.test.ts from packages/providers

Full verification run locally on macOS:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load synthetic "write me a haiku and nothing else" was attempted and failed due external synthetic provider credits: 402 insufficient credits / no active subscription.
- node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else" passed.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2066
