### PR TITLE
Fix subagent wizard invocation crash (Fixes #2068)

### DIFF
--- a/packages/core/src/runtime/RuntimeInvocationContext.ts
+++ b/packages/core/src/runtime/RuntimeInvocationContext.ts
@@ -56,6 +56,8 @@ export interface RuntimeInvocationContext {
   readonly userMemory?: string;
   /** Optional redaction configuration for logging/telemetry surfaces */
   readonly redaction?: Readonly<RedactionConfig>;
+  /** Optional AbortSignal propagated through retry orchestration and providers */
+  readonly signal?: AbortSignal;
   /** Helper to read a strongly-typed ephemeral override */
   getEphemeral<T = unknown>(key: string): T | undefined;
   /** Helper to read a CLI setting value */
@@ -81,6 +83,8 @@ export interface RuntimeInvocationContextInit {
   userMemory?: string;
   /** Optional redaction configuration override */
   redaction?: RedactionConfig;
+  /** Optional AbortSignal propagated to retry orchestration and providers */
+  signal?: AbortSignal;
   /** Optional fallback runtime id when runtime.runtimeId is missing */
   fallbackRuntimeId?: string;
 }
@@ -147,6 +151,7 @@ export function createRuntimeInvocationContext(
     telemetry: init.telemetry,
     userMemory,
     redaction,
+    signal: init.signal,
     getEphemeral<T = unknown>(key: string): T | undefined {
       return ephemerals[key] as T | undefined;
     },

--- a/packages/providers/src/BaseProviderNormalization.ts
+++ b/packages/providers/src/BaseProviderNormalization.ts
@@ -7,7 +7,10 @@
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { SettingsService } from '@vybestack/llxprt-code-settings';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
-import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import {
+  createRuntimeInvocationContext,
+  type RuntimeInvocationContext,
+} from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
 import { MissingProviderRuntimeError } from './errors.js';
 import type { GenerateChatOptions, ProviderToolset } from './IProvider.js';
 import type {
@@ -196,6 +199,51 @@ function mergeInvocationMetadata(
   };
 }
 
+/**
+ * Determines whether a value conforms to the RuntimeInvocationContext contract.
+ * A malformed stub (e.g. { signal } or { ephemerals: {} }) created by retry
+ * orchestration or legacy callers lacks the helper methods and must not be
+ * trusted as a real invocation context.
+ */
+const INVOCATION_METHODS = [
+  'getModelBehavior',
+  'getCliSetting',
+  'getEphemeral',
+  'getModelParam',
+  'getProviderOverrides',
+] as const;
+
+function isRuntimeInvocationContext(
+  value: unknown,
+): value is GenerateChatOptions['invocation'] & RuntimeInvocationContext {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return INVOCATION_METHODS.every(
+    (method) => typeof candidate[method] === 'function',
+  );
+}
+
+/**
+ * Extracts a legacy AbortSignal smuggled onto a malformed invocation stub so
+ * it can be preserved when a fresh RuntimeInvocationContext is created.
+ */
+function extractLegacySignal(invocation: unknown): AbortSignal | undefined {
+  if (invocation === null || typeof invocation !== 'object') {
+    return undefined;
+  }
+  const signal = (invocation as { signal?: unknown }).signal;
+  if (
+    typeof signal === 'object' &&
+    signal !== null &&
+    typeof (signal as { aborted?: unknown }).aborted === 'boolean'
+  ) {
+    return signal as AbortSignal;
+  }
+  return undefined;
+}
+
 export function normalizeProviderGenerateChatOptions(
   provider: BaseProvider,
   providedOptions: GenerateChatOptions,
@@ -222,21 +270,23 @@ export function normalizeProviderGenerateChatOptions(
     metadata: guard.metadata,
     config: finalConfig,
   };
-  const invocation =
-    providedOptions.invocation ??
-    createRuntimeInvocationContext({
-      runtime: normalizedRuntime,
-      settings,
-      providerName: deps.providerName,
-      ephemeralsSnapshot: deps.buildEphemeralsSnapshot(settings),
-      telemetry: resolved.telemetry,
-      metadata: guard.metadata,
-      userMemory:
-        typeof providedOptions.userMemory === 'string'
-          ? providedOptions.userMemory
-          : undefined,
-      fallbackRuntimeId: `${deps.providerName}:normalizeGenerateChatOptions`,
-    });
+  const legacySignal = extractLegacySignal(providedOptions.invocation);
+  const invocation = isRuntimeInvocationContext(providedOptions.invocation)
+    ? providedOptions.invocation
+    : createRuntimeInvocationContext({
+        runtime: normalizedRuntime,
+        settings,
+        providerName: deps.providerName,
+        ephemeralsSnapshot: deps.buildEphemeralsSnapshot(settings),
+        telemetry: resolved.telemetry,
+        metadata: guard.metadata,
+        userMemory:
+          typeof providedOptions.userMemory === 'string'
+            ? providedOptions.userMemory
+            : undefined,
+        signal: legacySignal,
+        fallbackRuntimeId: `${deps.providerName}:normalizeGenerateChatOptions`,
+      });
 
   return {
     ...providedOptions,

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -49,6 +49,34 @@ import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { AllBucketsExhaustedError } from './errors.js';
 import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/configTypes.js';
 
+/**
+ * Internal shape used to carry an AbortSignal through retry orchestration when
+ * no full RuntimeInvocationContext is available (e.g. legacy signal signature).
+ * BaseProvider normalization detects this shape and replaces it with a real
+ * RuntimeInvocationContext while preserving the signal via extractLegacySignal.
+ */
+interface SignalOnlyInvocation {
+  readonly signal?: AbortSignal;
+}
+
+function withLegacySignal(
+  signal: AbortSignal | undefined,
+): GenerateChatOptions['invocation'] | undefined {
+  if (!signal) {
+    return undefined;
+  }
+  return { signal } as unknown as GenerateChatOptions['invocation'];
+}
+
+function extractSignal(
+  invocation: GenerateChatOptions['invocation'],
+): AbortSignal | undefined {
+  if (!invocation) {
+    return undefined;
+  }
+  return (invocation as unknown as SignalOnlyInvocation).signal;
+}
+
 function isSignalAborted(signal: AbortSignal | undefined): boolean {
   return signal?.aborted === true;
 }
@@ -195,24 +223,24 @@ export class RetryOrchestrator implements IProvider {
 
     if (Array.isArray(optionsOrContents)) {
       // Legacy signature: (contents, tools?, signal?)
+      // The signal is carried on invocation so retry logic and the wrapped
+      // provider can read it; BaseProvider normalization replaces this stub
+      // with a real RuntimeInvocationContext (preserving the signal).
       options = {
         contents: optionsOrContents,
         tools,
-        invocation: signal
-          ? ({ signal } as unknown as GenerateChatOptions['invocation'])
-          : undefined,
+        invocation: withLegacySignal(signal),
       } as GenerateChatOptions;
     } else {
       // Modern signature: (options)
       options = optionsOrContents;
 
-      // Ensure invocation.signal is propagated to options
+      // Ensure invocation.signal is propagated to options when only a signal
+      // was supplied and no invocation exists yet.
       if (!options.invocation && signal) {
         options = {
           ...options,
-          invocation: {
-            signal,
-          } as unknown as GenerateChatOptions['invocation'],
+          invocation: withLegacySignal(signal),
         };
       }
     }
@@ -240,7 +268,7 @@ export class RetryOrchestrator implements IProvider {
 
     // Extract signal - it may be on invocation or in options directly
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider retry runtime state.
-    const signal = (options.invocation as { signal?: AbortSignal })?.signal;
+    const signal = extractSignal(options.invocation);
 
     // Check for abort before starting
     if (isSignalAborted(signal)) {

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -68,6 +68,22 @@ function withLegacySignal(
   return { signal } as unknown as GenerateChatOptions['invocation'];
 }
 
+function withSignal(
+  invocation: GenerateChatOptions['invocation'],
+  signal: AbortSignal | undefined,
+): GenerateChatOptions['invocation'] | undefined {
+  if (!signal) {
+    return invocation;
+  }
+  if (!invocation) {
+    return withLegacySignal(signal);
+  }
+  return {
+    ...invocation,
+    signal,
+  } as GenerateChatOptions['invocation'];
+}
+
 function extractSignal(
   invocation: GenerateChatOptions['invocation'],
 ): AbortSignal | undefined {
@@ -233,16 +249,10 @@ export class RetryOrchestrator implements IProvider {
       } as GenerateChatOptions;
     } else {
       // Modern signature: (options)
-      options = optionsOrContents;
-
-      // Ensure invocation.signal is propagated to options when only a signal
-      // was supplied and no invocation exists yet.
-      if (!options.invocation && signal) {
-        options = {
-          ...options,
-          invocation: withLegacySignal(signal),
-        };
-      }
+      options = {
+        ...optionsOrContents,
+        invocation: withSignal(optionsOrContents.invocation, signal),
+      };
     }
 
     return this.generateChatCompletionWithRetry(options);

--- a/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
+++ b/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @plan PLAN-20260616-ISSUE2068
+ * Behavioral tests: BaseProvider normalization must never pass a malformed
+ * invocation stub through to providers. A stub like { signal } or
+ * { ephemerals: {} } lacks the RuntimeInvocationContext methods
+ * (getModelBehavior, getCliSetting, ...) and crashes providers with
+ * "options.invocation.getModelBehavior is not a function".
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BaseProvider,
+  type NormalizedGenerateChatOptions,
+} from '../BaseProvider.js';
+import type { GenerateChatOptions } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { RuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  clearActiveProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+
+const PROVIDER_NAME = 'invocation-safety';
+
+class InvocationSafetyProvider extends BaseProvider {
+  lastNormalizedOptions: NormalizedGenerateChatOptions | undefined;
+
+  constructor() {
+    super({ name: PROVIDER_NAME });
+  }
+
+  async getModels(): Promise<never[]> {
+    return [];
+  }
+
+  getDefaultModel(): string {
+    return 'invocation-safety-model';
+  }
+
+  protected supportsOAuth(): boolean {
+    return false;
+  }
+
+  protected generateChatCompletionWithOptions(
+    options: NormalizedGenerateChatOptions,
+  ): AsyncIterableIterator<IContent> {
+    this.lastNormalizedOptions = options;
+    return (async function* () {})();
+  }
+}
+
+function wireProviderWithAuth(provider: InvocationSafetyProvider): void {
+  (
+    provider as unknown as {
+      authResolver: {
+        resolveAuthentication: (input: unknown) => Promise<string>;
+        setSettingsService: (settings: SettingsService | undefined) => void;
+      };
+    }
+  ).authResolver = {
+    resolveAuthentication: vi.fn().mockResolvedValue('token'),
+    setSettingsService: vi.fn(),
+  };
+}
+
+function createSettings(provider: InvocationSafetyProvider): SettingsService {
+  const settings = new SettingsService();
+  settings.set('model', `${PROVIDER_NAME}-model`);
+  settings.setProviderSetting(PROVIDER_NAME, 'model', `${PROVIDER_NAME}-model`);
+  const config = createRuntimeConfigStub(settings);
+  setActiveProviderRuntimeContext({
+    settingsService: settings,
+    config,
+  });
+  (provider as unknown as { defaultConfig?: unknown }).defaultConfig = config;
+  return settings;
+}
+
+describe('BaseProvider normalization invocation safety', () => {
+  const prompt: IContent = {
+    speaker: 'human',
+    blocks: [{ type: 'text', text: 'hi' }],
+  };
+
+  beforeEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  it('replaces a malformed invocation stub carrying only signal with a real RuntimeInvocationContext', async () => {
+    const provider = new InvocationSafetyProvider();
+    wireProviderWithAuth(provider);
+    const settings = createSettings(provider);
+
+    const abortController = new AbortController();
+    const malformedInvocation = {
+      signal: abortController.signal,
+    } as unknown as RuntimeInvocationContext;
+
+    const options = {
+      contents: [prompt],
+      settings,
+      invocation: malformedInvocation,
+    } as GenerateChatOptions;
+
+    await provider.generateChatCompletion(options).next();
+
+    const normalized = provider.lastNormalizedOptions;
+    expect(normalized).toBeDefined();
+    expect(normalized!.invocation).not.toBe(malformedInvocation);
+    expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
+  });
+
+  it('preserves AbortSignal from a malformed stub on the normalized invocation', async () => {
+    const provider = new InvocationSafetyProvider();
+    wireProviderWithAuth(provider);
+    const settings = createSettings(provider);
+
+    const abortController = new AbortController();
+    const malformedInvocation = {
+      signal: abortController.signal,
+    } as unknown as RuntimeInvocationContext;
+
+    const options = {
+      contents: [prompt],
+      settings,
+      invocation: malformedInvocation,
+    } as GenerateChatOptions;
+
+    await provider.generateChatCompletion(options).next();
+
+    const normalized = provider.lastNormalizedOptions;
+    expect(normalized).toBeDefined();
+    expect(normalized!.invocation.signal).toBe(abortController.signal);
+  });
+
+  it('uses settings-derived model behavior when replacing a malformed stub', async () => {
+    const provider = new InvocationSafetyProvider();
+    wireProviderWithAuth(provider);
+    const settings = createSettings(provider);
+    settings.set('reasoning.enabled', true);
+
+    const malformedInvocation = {
+      ephemerals: {},
+    } as unknown as RuntimeInvocationContext;
+
+    const options = {
+      contents: [prompt],
+      settings,
+      invocation: malformedInvocation,
+    } as GenerateChatOptions;
+
+    await provider.generateChatCompletion(options).next();
+
+    const normalized = provider.lastNormalizedOptions;
+    expect(normalized).toBeDefined();
+    expect(
+      normalized!.invocation.getModelBehavior<boolean>('reasoning.enabled'),
+    ).toBe(true);
+  });
+
+  it('reuses a valid RuntimeInvocationContext unchanged', async () => {
+    const { createProviderCallOptions } = await import(
+      '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js'
+    );
+
+    const provider = new InvocationSafetyProvider();
+    wireProviderWithAuth(provider);
+    const settings = createSettings(provider);
+
+    const validOptions = createProviderCallOptions({
+      providerName: PROVIDER_NAME,
+      settings,
+    });
+
+    const options = {
+      ...validOptions,
+      contents: [prompt],
+    } as GenerateChatOptions;
+
+    await provider.generateChatCompletion(options).next();
+
+    const normalized = provider.lastNormalizedOptions;
+    expect(normalized).toBeDefined();
+    expect(normalized!.invocation).toBe(validOptions.invocation);
+  });
+});

--- a/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @plan PLAN-20260616-ISSUE2068
+ * Behavioral tests: RetryOrchestrator must not fabricate invocation stubs
+ * that lack the RuntimeInvocationContext contract. When the legacy
+ * (contents, tools, signal) signature is used, the signal must propagate
+ * without producing a malformed invocation that crashes providers calling
+ * options.invocation.getModelBehavior.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import {
+  BaseProvider,
+  type NormalizedGenerateChatOptions,
+} from '../BaseProvider.js';
+import type { IProvider, GenerateChatOptions } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IModel } from '../IModel.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  clearActiveProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+
+async function consumeStream(
+  stream: AsyncIterableIterator<IContent>,
+): Promise<void> {
+  for await (const _chunk of stream) {
+    void _chunk;
+  }
+}
+
+const PROVIDER_NAME = 'retry-invocation-safety';
+
+/**
+ * A real BaseProvider subclass so the full normalization path (which is the
+ * production crash site) is exercised. RetryOrchestrator wraps this provider.
+ */
+class SafetyBaseProvider extends BaseProvider {
+  lastNormalized: NormalizedGenerateChatOptions | undefined;
+
+  constructor() {
+    super({ name: PROVIDER_NAME });
+  }
+
+  async getModels(): Promise<never[]> {
+    return [];
+  }
+
+  getDefaultModel(): string {
+    return 'safety-model';
+  }
+
+  protected supportsOAuth(): boolean {
+    return false;
+  }
+
+  protected generateChatCompletionWithOptions(
+    options: NormalizedGenerateChatOptions,
+  ): AsyncIterableIterator<IContent> {
+    this.lastNormalized = options;
+    return (async function* () {
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'ok' }],
+      } as IContent;
+    })();
+  }
+}
+
+function wireProvider(provider: SafetyBaseProvider): SettingsService {
+  (
+    provider as unknown as {
+      authResolver: {
+        resolveAuthentication: (input: unknown) => Promise<string>;
+        setSettingsService: (settings: SettingsService | undefined) => void;
+      };
+    }
+  ).authResolver = {
+    resolveAuthentication: vi.fn().mockResolvedValue('token'),
+    setSettingsService: vi.fn(),
+  };
+  const settings = new SettingsService();
+  settings.set('model', `${PROVIDER_NAME}-model`);
+  settings.setProviderSetting(PROVIDER_NAME, 'model', `${PROVIDER_NAME}-model`);
+  const config = createRuntimeConfigStub(settings);
+  setActiveProviderRuntimeContext({ settingsService: settings, config });
+  (provider as unknown as { defaultConfig?: unknown }).defaultConfig = config;
+  return settings;
+}
+
+describe('RetryOrchestrator invocation safety', () => {
+  const prompt: IContent = {
+    speaker: 'human',
+    blocks: [{ type: 'text', text: 'hi' }],
+  } as IContent;
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  it('does not crash a wrapped BaseProvider when the legacy signal signature is used', async () => {
+    const baseProvider = new SafetyBaseProvider();
+    wireProvider(baseProvider);
+    const orchestrator = new RetryOrchestrator(baseProvider);
+
+    const abortController = new AbortController();
+
+    // Legacy signature: (contents, tools, signal)
+    await consumeStream(
+      orchestrator.generateChatCompletion(
+        [prompt],
+        undefined,
+        abortController.signal,
+      ),
+    );
+
+    const normalized = baseProvider.lastNormalized;
+    expect(normalized).toBeDefined();
+    expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
+    expect(normalized!.invocation.signal).toBe(abortController.signal);
+  });
+
+  it('does not crash a wrapped BaseProvider when only options + signal are provided', async () => {
+    const baseProvider = new SafetyBaseProvider();
+    const settings = wireProvider(baseProvider);
+    const orchestrator = new RetryOrchestrator(baseProvider);
+
+    const abortController = new AbortController();
+
+    const options: GenerateChatOptions = {
+      contents: [prompt],
+      settings,
+    };
+
+    await consumeStream(
+      orchestrator.generateChatCompletion(
+        options,
+        undefined,
+        abortController.signal,
+      ),
+    );
+
+    const normalized = baseProvider.lastNormalized;
+    expect(normalized).toBeDefined();
+    expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
+    expect(normalized!.invocation.signal).toBe(abortController.signal);
+  });
+
+  it('preserves abort propagation through the legacy signal signature', async () => {
+    let providerCalls = 0;
+
+    const provider: IProvider = {
+      name: 'abort-legacy-provider',
+      // eslint-disable-next-line require-yield -- intentionally throw-only generator to trigger retry/abort path
+      async *generateChatCompletion(_options: GenerateChatOptions) {
+        providerCalls++;
+        throw new Error('Aborted');
+      },
+      async getModels(): Promise<IModel[]> {
+        return [];
+      },
+      getDefaultModel(): string {
+        return 'test-model';
+      },
+      getServerTools(): string[] {
+        return [];
+      },
+      async invokeServerTool(): Promise<unknown> {
+        return null;
+      },
+    };
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 3,
+      initialDelayMs: 1000,
+    });
+
+    const abortController = new AbortController();
+    setTimeout(() => abortController.abort(), 50);
+
+    await expect(
+      consumeStream(
+        orchestrator.generateChatCompletion(
+          [prompt],
+          undefined,
+          abortController.signal,
+        ),
+      ),
+    ).rejects.toThrow(/abort/i);
+
+    expect(providerCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it('propagates signal to the wrapped provider via invocation', async () => {
+    let receivedSignal: AbortSignal | undefined;
+
+    const provider: IProvider = {
+      name: 'signal-receiver-provider',
+      async *generateChatCompletion(options: GenerateChatOptions) {
+        receivedSignal = options.invocation?.signal;
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'ok' }],
+        } as IContent;
+      },
+      async getModels(): Promise<IModel[]> {
+        return [];
+      },
+      getDefaultModel(): string {
+        return 'test-model';
+      },
+      getServerTools(): string[] {
+        return [];
+      },
+      async invokeServerTool(): Promise<unknown> {
+        return null;
+      },
+    };
+
+    const orchestrator = new RetryOrchestrator(provider);
+
+    const abortController = new AbortController();
+
+    await consumeStream(
+      orchestrator.generateChatCompletion(
+        [prompt],
+        undefined,
+        abortController.signal,
+      ),
+    );
+
+    expect(receivedSignal).toBe(abortController.signal);
+  });
+});

--- a/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
@@ -152,6 +152,34 @@ describe('RetryOrchestrator invocation safety', () => {
     expect(normalized!.invocation.signal).toBe(abortController.signal);
   });
 
+  it('adds an explicit signal to an existing invocation object', async () => {
+    const baseProvider = new SafetyBaseProvider();
+    const settings = wireProvider(baseProvider);
+    const orchestrator = new RetryOrchestrator(baseProvider);
+
+    const existingInvocation = {
+      ephemerals: {},
+    } as GenerateChatOptions['invocation'];
+    const abortController = new AbortController();
+
+    await consumeStream(
+      orchestrator.generateChatCompletion(
+        {
+          contents: [prompt],
+          settings,
+          invocation: existingInvocation,
+        },
+        undefined,
+        abortController.signal,
+      ),
+    );
+
+    const normalized = baseProvider.lastNormalized;
+    expect(normalized).toBeDefined();
+    expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
+    expect(normalized!.invocation.signal).toBe(abortController.signal);
+  });
+
   it('preserves abort propagation through the legacy signal signature', async () => {
     let providerCalls = 0;
 
@@ -160,7 +188,7 @@ describe('RetryOrchestrator invocation safety', () => {
       // eslint-disable-next-line require-yield -- intentionally throw-only generator to trigger retry/abort path
       async *generateChatCompletion(_options: GenerateChatOptions) {
         providerCalls++;
-        throw new Error('Aborted');
+        throw Object.assign(new Error('Transient failure'), { status: 500 });
       },
       async getModels(): Promise<IModel[]> {
         return [];

--- a/packages/providers/src/utils/providerRequestConversion.ts
+++ b/packages/providers/src/utils/providerRequestConversion.ts
@@ -43,7 +43,14 @@ function createOptions(
   return {
     contents: history,
     settings: createSettings(settings),
-    invocation: { ephemerals: {} },
+    invocation: {
+      ephemerals: {},
+      getModelBehavior: () => undefined,
+      getCliSetting: () => undefined,
+      getEphemeral: () => undefined,
+      getModelParam: () => undefined,
+      getProviderOverrides: () => undefined,
+    },
     metadata: {},
     resolved: {
       model: '',


### PR DESCRIPTION
## TLDR

Fixes the subagent creation wizard crash caused by malformed provider invocation objects reaching providers without RuntimeInvocationContext helper methods.

The fix makes provider normalization reject malformed invocation stubs, rebuild a real runtime invocation context, and preserve AbortSignal propagation for retry orchestration.

## Dive Deeper

The crash happened because some call paths passed plain invocation-shaped objects, such as signal-only or ephemerals-only stubs, into provider normalization. Since normalization only checked whether invocation was truthy, those malformed stubs bypassed createRuntimeInvocationContext and then providers crashed when calling getModelBehavior.

This change:

- Adds optional signal support to RuntimeInvocationContext so abort signals can be carried by real contexts.
- Adds a RuntimeInvocationContext contract guard in BaseProvider normalization.
- Replaces malformed invocation stubs with real contexts while preserving legacy AbortSignal values.
- Keeps RetryOrchestrator signal propagation compatible with legacy and modern signatures.
- Makes dump conversion use an invocation object that has the expected helper methods.
- Adds behavioral regression tests covering malformed stub replacement, model behavior access, valid context reuse, and retry signal propagation.

## Reviewer Test Plan

Suggested validation:

1. Start the subagent creation wizard with a profile/provider that previously hit the invocation error.
2. Save a new subagent and confirm the wizard completes without the getModelBehavior crash.
3. Exercise a normal prompt send and cancellation path to confirm AbortSignal propagation still works.
4. Run the focused provider tests:
   npm test --workspace @vybestack/llxprt-code-providers -- BaseProviderNormalization.invocation.test.ts RetryOrchestrator.invocation.test.ts

Verification already run:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load synthetic "write me a haiku and nothing else" attempted and reached provider API, failing only with synthetic.new 402 insufficient credits rather than the invocation crash
- node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else" passed
- deepthinker review passed with no required remediation

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2068
