### PR TITLE
Preserve subagent tool defaults (Fixes #2069)

### DIFF
--- a/packages/agents/src/core/subagent.test.ts
+++ b/packages/agents/src/core/subagent.test.ts
@@ -943,6 +943,103 @@ describe('subagent.ts', () => {
       });
     });
 
+    // Issue #2069: explicit empty/fail-closed toolConfig must be preserved through
+    // SubAgentScope.create so buildRuntimeFunctionDeclarations produces no normal
+    // declarations. Omitted toolConfig must yield runtime default declarations.
+    describe('create (toolConfig preservation — Issue #2069)', () => {
+      it('explicit empty toolConfig + outputConfig yields only self_emitvalue', async () => {
+        const { config } = await createMockConfig();
+        const runtimeToolsView: ToolRegistryView = {
+          listToolNames: vi.fn(() => ['read_file', 'write_file']),
+          getToolMetadata: vi.fn(() => ({
+            name: 'read_file',
+            description: 'Reads a file',
+            parameterSchema: { type: 'object', properties: {} },
+          })),
+        };
+        const runtimeBundle = createStatelessRuntimeBundle({
+          toolsView: runtimeToolsView,
+        });
+        const { overrides } = createRuntimeOverrides({ runtimeBundle });
+
+        vi.mocked(ChatSession).mockClear();
+        mockSendMessageStream.mockImplementation(createMockStream(['stop']));
+
+        const outputConfig: OutputConfig = {
+          outputs: { result: 'The answer' },
+        };
+
+        const scope = await SubAgentScope.create(
+          'fail-closed-agent',
+          config,
+          { systemPrompt: 'Fail closed' },
+          defaultModelConfig,
+          defaultRunConfig,
+          { tools: [] },
+          outputConfig,
+          overrides,
+        );
+        await scope.runNonInteractive(new ContextState());
+
+        const generationConfig = getGenerationConfigFromMock();
+        const toolGroups = generationConfig.tools ?? [];
+        expect(toolGroups).toHaveLength(1);
+        const functionDeclarations = toolGroups[0]?.functionDeclarations ?? [];
+        // Only self_emitvalue should be present; no normal runtime tools.
+        expect(functionDeclarations).toHaveLength(1);
+        expect(functionDeclarations[0]?.name).toBe('self_emitvalue');
+        // Runtime tool metadata must NOT have been read for declarations.
+        expect(runtimeToolsView.getToolMetadata).not.toHaveBeenCalled();
+      });
+
+      it('omitted toolConfig + outputConfig yields runtime default tools plus self_emitvalue', async () => {
+        const { config } = await createMockConfig();
+        const runtimeToolsView: ToolRegistryView = {
+          listToolNames: vi.fn(() => ['read_file', 'write_file', 'task']),
+          getToolMetadata: vi.fn((name: string) => ({
+            name,
+            description: `Tool ${name}`,
+            parameterSchema: { type: 'object', properties: {} },
+          })),
+        };
+        const runtimeBundle = createStatelessRuntimeBundle({
+          toolsView: runtimeToolsView,
+        });
+        const { overrides } = createRuntimeOverrides({ runtimeBundle });
+
+        vi.mocked(ChatSession).mockClear();
+        mockSendMessageStream.mockImplementation(createMockStream(['stop']));
+
+        const outputConfig: OutputConfig = {
+          outputs: { result: 'The answer' },
+        };
+
+        const scope = await SubAgentScope.create(
+          'default-tools-agent',
+          config,
+          { systemPrompt: 'Default tools' },
+          defaultModelConfig,
+          defaultRunConfig,
+          undefined,
+          outputConfig,
+          overrides,
+        );
+        await scope.runNonInteractive(new ContextState());
+
+        const generationConfig = getGenerationConfigFromMock();
+        const toolGroups = generationConfig.tools ?? [];
+        expect(toolGroups).toHaveLength(1);
+        const functionDeclarations = toolGroups[0]?.functionDeclarations ?? [];
+        const names = functionDeclarations.map((d) => d?.name);
+        // Runtime default tools (minus excluded) plus self_emitvalue.
+        expect(names).toContain('read_file');
+        expect(names).toContain('write_file');
+        expect(names).toContain('self_emitvalue');
+        // task must be excluded from runtime defaults.
+        expect(names).not.toContain('task');
+      });
+    });
+
     describe('runNonInteractive - Initialization and Prompting', () => {
       it('should correctly template the system prompt and initialize ChatSession', async () => {
         const { config } = await createMockConfig();

--- a/packages/agents/src/core/subagent.ts
+++ b/packages/agents/src/core/subagent.ts
@@ -207,9 +207,11 @@ export class SubAgentScope {
         toolConfig,
         toolsView,
       });
-      // Use undefined if all tools were filtered out
-      toolConfig =
-        filteredToolConfig.tools.length > 0 ? filteredToolConfig : undefined;
+      // Preserve explicit empty/fail-closed semantics: an explicit toolConfig
+      // that filters to zero tools must remain { tools: [] } so the runtime
+      // produces no normal declarations. Only undefined toolConfig means
+      // runtime/profile defaults.
+      toolConfig = filteredToolConfig;
     }
 
     const settingsSnapshot =

--- a/packages/agents/src/core/subagentRuntimeSetup.test.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.test.ts
@@ -704,6 +704,19 @@ describe('subagentRuntimeSetup', () => {
       expect(config.getEphemeralSettings()['tools.allowed']).toStrictEqual([]);
     });
 
+    it('preserves parent explicit empty tools.allowed when intersecting with a non-empty whitelist', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+        undefined,
+        { tools: { allowed: [] } },
+        { tools: ['read_file'] },
+      );
+      expect(config.getEphemeralSetting('tools.allowed')).toStrictEqual([]);
+      expect(config.getEphemeralSettings()['tools.allowed']).toStrictEqual([]);
+    });
     it('does not set tools.allowed when toolConfig is undefined', () => {
       const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
       const config = createToolExecutionConfig(

--- a/packages/agents/src/core/subagentRuntimeSetup.test.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable max-lines, eslint-comments/disable-enable-pair -- Phase 5: large behavioral coverage file retained together to avoid fragmenting related scenarios. */
+
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { CreateChatObjectParams } from './subagentRuntimeSetup.js';
 
@@ -327,6 +329,154 @@ describe('subagentRuntimeSetup', () => {
       const decls = buildRuntimeFunctionDeclarations(toolsView, toolConfig);
       expect(decls).toStrictEqual([]);
     });
+
+    // Issue #2069: omitted toolConfig must use runtime default tools, not no tools
+    it('uses all runtime tools when toolConfig is undefined (omitted)', () => {
+      const toolsView = {
+        listToolNames: () => ['read_file', 'write_file', 'edit_file'],
+        getToolMetadata: (name: string) => ({
+          name,
+          description: `Description of ${name}`,
+          parameterSchema: { type: 'OBJECT', properties: {} },
+        }),
+      };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, undefined);
+      expect(decls.length).toBe(3);
+      expect(decls.map((d: { name: string }) => d.name)).toStrictEqual([
+        'read_file',
+        'write_file',
+        'edit_file',
+      ]);
+    });
+
+    // Issue #2069: explicit empty toolConfig must remain no tools (fail-closed)
+    it('returns no tools when toolConfig has explicit empty tools array', () => {
+      const toolsView = {
+        listToolNames: () => ['read_file', 'write_file'],
+        getToolMetadata: (name: string) => ({
+          name,
+          description: '',
+          parameterSchema: { type: 'OBJECT', properties: {} },
+        }),
+      };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, {
+        tools: [],
+      });
+      expect(decls).toStrictEqual([]);
+    });
+
+    // Issue #2069: canonicalization must match task.ts canonical (full snake_case)
+    it('matches CamelCase tool names in whitelist against snake_case registry via canonicalization', () => {
+      const toolsView = {
+        listToolNames: () => ['read_file', 'write_file'],
+        getToolMetadata: (name: string) => ({
+          name,
+          description: '',
+          parameterSchema: { type: 'OBJECT', properties: {} },
+        }),
+      };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, {
+        tools: ['ReadFile'],
+      });
+      expect(decls.map((d: { name: string }) => d.name)).toStrictEqual([
+        'read_file',
+      ]);
+    });
+
+    // Issue #2069: excluded task/list_subagents must be excluded from default
+    it('excludes task and list_subagents from runtime default tools', () => {
+      const toolsView = {
+        listToolNames: () => [
+          'read_file',
+          'write_file',
+          'task',
+          'list_subagents',
+        ],
+        getToolMetadata: (name: string) => ({
+          name,
+          description: '',
+          parameterSchema: { type: 'OBJECT', properties: {} },
+        }),
+      };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, undefined);
+      const names = decls.map((d: { name: string }) => d.name);
+      expect(names).toContain('read_file');
+      expect(names).toContain('write_file');
+      expect(names).not.toContain('task');
+      expect(names).not.toContain('list_subagents');
+    });
+
+    // Issue #2069: non-string FunctionDeclaration entries named task must be
+    // excluded even when injected via an explicit ToolConfig.
+    it('excludes non-string FunctionDeclaration named task from explicit toolConfig', () => {
+      const toolsView = {
+        listToolNames: () => ['read_file'],
+        getToolMetadata: (name: string) => ({
+          name,
+          description: '',
+          parameterSchema: { type: 'OBJECT', properties: {} },
+        }),
+      };
+      const taskDecl = { name: 'task', description: 'nested task' };
+      const toolConfig = { tools: [taskDecl] };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, toolConfig);
+      expect(decls).toStrictEqual([]);
+    });
+
+    // Issue #2069: non-string FunctionDeclaration entries named list_subagents
+    // must be excluded even when injected via an explicit ToolConfig.
+    it('excludes non-string FunctionDeclaration named list_subagents from explicit toolConfig', () => {
+      const toolsView = {
+        listToolNames: () => ['read_file'],
+        getToolMetadata: (name: string) => ({
+          name,
+          description: '',
+          parameterSchema: { type: 'OBJECT', properties: {} },
+        }),
+      };
+      const listSubagentsDecl = {
+        name: 'list_subagents',
+        description: 'enumerate subagents',
+      };
+      const toolConfig = { tools: [listSubagentsDecl] };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, toolConfig);
+      expect(decls).toStrictEqual([]);
+    });
+
+    // Issue #2069: canonical variants of excluded tool names in non-string
+    // declarations must also be excluded.
+    it('excludes non-string FunctionDeclaration with CamelCase name matching excluded tool', () => {
+      const toolsView = {
+        listToolNames: () => ['read_file'],
+        getToolMetadata: (name: string) => ({
+          name,
+          description: '',
+          parameterSchema: { type: 'OBJECT', properties: {} },
+        }),
+      };
+      const taskDecl = { name: 'Task', description: 'nested task' };
+      const goodDecl = { name: 'read_file', description: 'read' };
+      const toolConfig = { tools: [taskDecl, goodDecl] };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, toolConfig);
+      const names = decls.map((d: { name: string }) => d.name);
+      expect(names).not.toContain('Task');
+      expect(names).not.toContain('task');
+      expect(names).toContain('read_file');
+    });
+
+    // Issue #2069: non-string FunctionDeclaration with no name is preserved
+    // (cannot match excluded tools).
+    it('preserves non-string FunctionDeclaration with no name', () => {
+      const toolsView = {
+        listToolNames: () => [],
+        getToolMetadata: () => undefined,
+      };
+      const anonDecl = { description: 'anonymous' };
+      const toolConfig = { tools: [anonDecl] };
+      const decls = buildRuntimeFunctionDeclarations(toolsView, toolConfig);
+      expect(decls).toHaveLength(1);
+      expect(decls[0]).toBe(anonDecl);
+    });
   });
 
   describe('getScopeLocalFuncDefs', () => {
@@ -522,6 +672,129 @@ describe('subagentRuntimeSetup', () => {
       await expect(createChatObject(params)).rejects.toThrow(
         'PromptConfig.systemPrompt must be a non-empty string.',
       );
+    });
+  });
+
+  describe('createToolExecutionConfig — fail-closed empty whitelist (#2069)', () => {
+    const makeFixture = () => ({
+      runtimeBundle: {
+        runtimeContext: { state: { sessionId: 'sess-fc' } },
+      },
+      toolRegistry: {
+        getTool: () => undefined,
+        getFunctionDeclarationsFiltered: () => [],
+      },
+      foregroundConfig: {
+        getOrCreateScheduler: () => {},
+        disposeScheduler: () => {},
+      },
+    });
+
+    it('preserves explicit empty tools array as tools.allowed=[]', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+        undefined,
+        undefined,
+        { tools: [] },
+      );
+      expect(config.getEphemeralSetting('tools.allowed')).toStrictEqual([]);
+      expect(config.getEphemeralSettings()['tools.allowed']).toStrictEqual([]);
+    });
+
+    it('does not set tools.allowed when toolConfig is undefined', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(config.getEphemeralSetting('tools.allowed')).toBeUndefined();
+      expect(config.getEphemeralSettings()['tools.allowed']).toBeUndefined();
+    });
+
+    it('does not set tools.allowed when toolConfig is omitted', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+      );
+      expect(config.getEphemeralSetting('tools.allowed')).toBeUndefined();
+    });
+  });
+
+  describe('createSchedulerConfig — fail-closed empty whitelist (#2069)', () => {
+    it('getAllowedTools() returns [] for explicit empty even when foreground returns defaults', () => {
+      const toolExecCtxWithEmpty = {
+        getToolRegistry: () => ({}),
+        getSessionId: () => 'sess-fc',
+        getEphemeralSettings: () => ({ 'tools.allowed': [] }),
+        getEphemeralSetting: (key: string) =>
+          key === 'tools.allowed' ? [] : undefined,
+        getExcludeTools: () => [],
+        getTelemetryLogPromptsEnabled: () => false,
+        getOrCreateScheduler: () => Promise.resolve({}),
+        disposeScheduler: () => {},
+      };
+      const foregroundWithDefaults = {
+        getApprovalMode: () => 'DEFAULT',
+        getPolicyEngine: () => undefined,
+        getOrCreateScheduler: () => Promise.resolve({}),
+        disposeScheduler: () => {},
+        getEphemeralSettings: () => ({}),
+        getExcludeTools: () => [],
+        getTelemetryLogPromptsEnabled: () => false,
+        getAllowedTools: () => ['read_file', 'write_file'],
+        getEnableHooks: () => false,
+        getHooks: () => undefined,
+        getHookSystem: () => undefined,
+        getWorkingDir: () => '/tmp',
+        getTargetDir: () => '/tmp',
+      };
+      const config = createSchedulerConfig(
+        toolExecCtxWithEmpty,
+        foregroundWithDefaults,
+      );
+      expect(config.getAllowedTools()).toStrictEqual([]);
+    });
+
+    it('getAllowedTools() falls back to foreground when ephemerals omit tools.allowed', () => {
+      const toolExecCtxNoOverride = {
+        getToolRegistry: () => ({}),
+        getSessionId: () => 'sess-default',
+        getEphemeralSettings: () => ({}),
+        getEphemeralSetting: () => undefined,
+        getExcludeTools: () => [],
+        getTelemetryLogPromptsEnabled: () => false,
+        getOrCreateScheduler: () => Promise.resolve({}),
+        disposeScheduler: () => {},
+      };
+      const foregroundWithDefaults = {
+        getApprovalMode: () => 'DEFAULT',
+        getPolicyEngine: () => undefined,
+        getOrCreateScheduler: () => Promise.resolve({}),
+        disposeScheduler: () => {},
+        getEphemeralSettings: () => ({}),
+        getExcludeTools: () => [],
+        getTelemetryLogPromptsEnabled: () => false,
+        getAllowedTools: () => ['read_file'],
+        getEnableHooks: () => false,
+        getHooks: () => undefined,
+        getHookSystem: () => undefined,
+        getWorkingDir: () => '/tmp',
+        getTargetDir: () => '/tmp',
+      };
+      const config = createSchedulerConfig(
+        toolExecCtxNoOverride,
+        foregroundWithDefaults,
+      );
+      expect(config.getAllowedTools()).toStrictEqual(['read_file']);
     });
   });
 
@@ -745,6 +1018,126 @@ describe('subagentRuntimeSetup', () => {
 
       expect(toolExecDisposeCalled).toBe(true);
       expect(foregroundDisposeCalled).toBe(false);
+    });
+  });
+
+  describe('Issue #2069: scheduler governance excludes task/list_subagents', () => {
+    const makeFixture = () => ({
+      runtimeBundle: {
+        runtimeContext: { state: { sessionId: 'sess-2069' } },
+      },
+      toolRegistry: {
+        getTool: () => undefined,
+        getFunctionDeclarationsFiltered: () => [],
+      },
+      foregroundConfig: {
+        getOrCreateScheduler: () => {},
+        disposeScheduler: () => {},
+      },
+    });
+
+    it('createToolExecutionConfig().getExcludeTools() returns task and list_subagents', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+      );
+      const excluded = config.getExcludeTools();
+      expect(excluded).toContain('task');
+      expect(excluded).toContain('list_subagents');
+    });
+
+    it('createSchedulerConfig().getExcludeTools() surfaces task/list_subagents from toolExecutorContext', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const toolExecConfig = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+      );
+      const schedulerConfig = createSchedulerConfig(
+        toolExecConfig,
+        foregroundConfig,
+      );
+      const excluded = schedulerConfig.getExcludeTools();
+      expect(excluded).toContain('task');
+      expect(excluded).toContain('list_subagents');
+    });
+
+    it('buildToolGovernance from schedulerConfig marks task/list_subagents as blocked (fail-closed)', async () => {
+      const { buildToolGovernance, isToolBlocked } = await import(
+        './toolGovernance.js'
+      );
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const toolExecConfig = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+      );
+      const schedulerConfig = createSchedulerConfig(
+        toolExecConfig,
+        foregroundConfig,
+      );
+
+      const governance = buildToolGovernance(schedulerConfig);
+      expect(isToolBlocked('task', governance)).toBe(true);
+      expect(isToolBlocked('list_subagents', governance)).toBe(true);
+      // Non-excluded tool should not be blocked by excluded set alone
+      expect(isToolBlocked('read_file', governance)).toBe(false);
+    });
+
+    it('applyToolWhitelistToEphemerals removes task/list_subagents from tools.allowed', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const toolConfig = { tools: ['read_file', 'task', 'list_subagents'] };
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+        undefined,
+        undefined,
+        toolConfig,
+      );
+      const allowed = config.getEphemeralSetting('tools.allowed') as string[];
+      expect(Array.isArray(allowed)).toBe(true);
+      expect(allowed).toContain('read_file');
+      expect(allowed).not.toContain('task');
+      expect(allowed).not.toContain('list_subagents');
+    });
+
+    it('applyToolWhitelistToEphemerals sets tools.allowed to [] when only excluded tools remain', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const toolConfig = { tools: ['task', 'list_subagents'] };
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+        undefined,
+        undefined,
+        toolConfig,
+      );
+      const allowed = config.getEphemeralSetting('tools.allowed') as string[];
+      expect(Array.isArray(allowed)).toBe(true);
+      expect(allowed).toStrictEqual([]);
+    });
+
+    it('applyToolWhitelistToEphemerals removes canonical variants (TaskTool, listSubagents)', () => {
+      const { runtimeBundle, toolRegistry, foregroundConfig } = makeFixture();
+      const toolConfig = {
+        tools: ['ReadFileTool', 'TaskTool', 'listSubagents'],
+      };
+      const config = createToolExecutionConfig(
+        runtimeBundle,
+        toolRegistry,
+        foregroundConfig,
+        undefined,
+        undefined,
+        toolConfig,
+      );
+      const allowed = config.getEphemeralSetting('tools.allowed') as string[];
+      expect(Array.isArray(allowed)).toBe(true);
+      expect(allowed).toContain('read_file');
+      expect(allowed).not.toContain('task');
+      expect(allowed).not.toContain('list_subagents');
     });
   });
 });

--- a/packages/agents/src/core/subagentRuntimeSetup.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.ts
@@ -36,6 +36,10 @@ import type {
 } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import type { AgentRuntimeLoaderResult } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeLoader.js';
 import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
+import {
+  canonicalizeToolName,
+  INVALID_TOOL_NAME,
+} from '@vybestack/llxprt-code-tools';
 import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
@@ -58,9 +62,37 @@ import {
 // Simple utilities
 // ---------------------------------------------------------------------------
 
-/** Canonicalizes a tool name for whitelist matching (trim + lowercase). */
-export const canonicalizeToolName = (name: string): string =>
-  name.trim().toLowerCase();
+/**
+ * Tools that must never be exposed to a subagent because they would allow
+ * nested subagent spawning (recursive task delegation) or enumeration of the
+ * parent's subagent registry from within a sandboxed runtime.
+ */
+const SUBAGENT_EXCLUDED_TOOLS: ReadonlySet<string> = new Set(
+  ['task', 'list_subagents'].map(canonicalizeToolName),
+);
+
+/**
+ * Returns true when a canonical (or raw) tool name is excluded from subagent
+ * runtimes (task/list_subagents).
+ */
+function isSubagentExcludedToolName(name: string): boolean {
+  const canonical = canonicalizeToolName(name);
+  return Boolean(canonical) && SUBAGENT_EXCLUDED_TOOLS.has(canonical);
+}
+
+/**
+ * Returns true when a non-string FunctionDeclaration entry is excluded from
+ * subagent runtimes (task/list_subagents). Declarations without a usable
+ * string name are never excluded.
+ */
+function isSubagentExcludedDeclaration(decl: unknown): boolean {
+  if (typeof decl !== 'object' || decl === null || !('name' in decl)) {
+    return false;
+  }
+
+  const declName = decl.name;
+  return typeof declName === 'string' && isSubagentExcludedToolName(declName);
+}
 
 /**
  * Converts a ToolMetadata object into a FunctionDeclaration for the Gemini API.
@@ -203,7 +235,10 @@ export function createToolExecutionConfig(
     getToolRegistry: () => toolRegistry,
     getEphemeralSettings: () => ({ ...ephemerals }),
     getEphemeralSetting: (key: string) => ephemerals[key],
-    getExcludeTools: () => [],
+    // Issue #2069: scheduler governance must fail-closed for subagent-excluded
+    // tools (task/list_subagents) so they can never be executed by a subagent
+    // runtime, regardless of registry resolution or ephemeral whitelist state.
+    getExcludeTools: () => Array.from(SUBAGENT_EXCLUDED_TOOLS),
     getSessionId: () => runtimeBundle.runtimeContext.state.sessionId,
     getTelemetryLogPromptsEnabled: () =>
       Boolean(settingsSnapshot?.telemetry?.enabled),
@@ -224,17 +259,31 @@ function applyToolWhitelistToEphemerals(
 ): void {
   const normalizedWhitelist = toolConfig.tools
     .filter((entry): entry is string => typeof entry === 'string')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
-    .map((entry) => entry.toLowerCase());
+    .map(canonicalizeToolName)
+    .filter(
+      (entry) =>
+        entry !== INVALID_TOOL_NAME &&
+        entry.length > 0 &&
+        !SUBAGENT_EXCLUDED_TOOLS.has(entry),
+    );
 
-  if (normalizedWhitelist.length === 0) return;
+  // Explicit empty/fail-closed: preserve tools.allowed=[] so the scheduler
+  // does not fall back to parent/default allowed tools.
+  if (normalizedWhitelist.length === 0) {
+    ephemerals['tools.allowed'] = [];
+    return;
+  }
 
   const existingAllowed = Array.isArray(ephemerals['tools.allowed'])
     ? (ephemerals['tools.allowed'] as string[])
-        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-        .filter((entry) => entry.length > 0)
-        .map((entry) => entry.toLowerCase())
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map(canonicalizeToolName)
+        .filter(
+          (entry) =>
+            entry !== INVALID_TOOL_NAME &&
+            entry.length > 0 &&
+            !SUBAGENT_EXCLUDED_TOOLS.has(entry),
+        )
     : [];
 
   const allowedSet =
@@ -272,36 +321,70 @@ export function buildRuntimeFunctionDeclarations(
   toolsView: ToolRegistryView,
   toolConfig: ToolConfig | undefined,
 ): FunctionDeclaration[] {
-  if (!toolConfig || toolConfig.tools.length === 0) {
-    const noFunctionDeclarations: FunctionDeclaration[] = [];
-    return noFunctionDeclarations;
-  }
-
   const listedNames =
     typeof toolsView.listToolNames === 'function'
       ? toolsView.listToolNames()
       : [];
-  const allowedNames = new Set(listedNames.map(canonicalizeToolName));
+  const registryNameByCanonical = new Map<string, string>();
+  for (const name of listedNames) {
+    const canonical = canonicalizeToolName(name);
+    if (canonical && !registryNameByCanonical.has(canonical)) {
+      registryNameByCanonical.set(canonical, name);
+    }
+  }
+  const allowedNames = new Set(registryNameByCanonical.keys());
 
   const declarations: FunctionDeclaration[] = [];
+
+  if (toolConfig === undefined) {
+    for (const name of listedNames) {
+      if (isSubagentExcludedToolName(name)) {
+        continue;
+      }
+      const metadata = toolsView.getToolMetadata(name);
+      if (metadata) {
+        declarations.push(convertMetadataToFunctionDeclaration(name, metadata));
+      } else {
+        debugLogger.warn(
+          `Tool "${name}" is not available in the runtime view and is skipped.`,
+        );
+      }
+    }
+    return declarations;
+  }
+
+  if (toolConfig.tools.length === 0) {
+    const noFunctionDeclarations: FunctionDeclaration[] = [];
+    return noFunctionDeclarations;
+  }
+
   // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
   for (const entry of toolConfig.tools) {
     if (typeof entry !== 'string') {
+      // Non-string FunctionDeclaration entries must still be filtered for
+      // subagent-excluded tools (task/list_subagents) to prevent a caller
+      // from injecting them via an explicit ToolConfig.
+      if (isSubagentExcludedDeclaration(entry)) {
+        continue;
+      }
       declarations.push(entry);
       continue;
     }
 
-    if (
-      allowedNames.size > 0 &&
-      !allowedNames.has(canonicalizeToolName(entry))
-    ) {
+    const canonical = canonicalizeToolName(entry);
+    if (SUBAGENT_EXCLUDED_TOOLS.has(canonical)) {
+      continue;
+    }
+
+    if (allowedNames.size > 0 && !allowedNames.has(canonical)) {
       debugLogger.warn(
         `Tool "${entry}" is not permitted by the runtime view and is skipped.`,
       );
       continue;
     }
 
-    const metadata = toolsView.getToolMetadata(entry);
+    const resolvedName = registryNameByCanonical.get(canonical) ?? entry;
+    const metadata = toolsView.getToolMetadata(resolvedName);
     if (!metadata) {
       debugLogger.warn(
         `Tool "${entry}" is not available in the runtime view and is skipped.`,
@@ -309,7 +392,9 @@ export function buildRuntimeFunctionDeclarations(
       continue;
     }
 
-    declarations.push(convertMetadataToFunctionDeclaration(entry, metadata));
+    declarations.push(
+      convertMetadataToFunctionDeclaration(resolvedName, metadata),
+    );
   }
   return declarations;
 }

--- a/packages/agents/src/core/subagentRuntimeSetup.ts
+++ b/packages/agents/src/core/subagentRuntimeSetup.ts
@@ -274,8 +274,10 @@ function applyToolWhitelistToEphemerals(
     return;
   }
 
-  const existingAllowed = Array.isArray(ephemerals['tools.allowed'])
-    ? (ephemerals['tools.allowed'] as string[])
+  const existingAllowedValue = ephemerals['tools.allowed'];
+  const hasExistingAllowed = Array.isArray(existingAllowedValue);
+  const existingAllowed = hasExistingAllowed
+    ? existingAllowedValue
         .filter((entry): entry is string => typeof entry === 'string')
         .map(canonicalizeToolName)
         .filter(
@@ -286,10 +288,9 @@ function applyToolWhitelistToEphemerals(
         )
     : [];
 
-  const allowedSet =
-    existingAllowed.length > 0
-      ? normalizedWhitelist.filter((entry) => existingAllowed.includes(entry))
-      : normalizedWhitelist;
+  const allowedSet = hasExistingAllowed
+    ? normalizedWhitelist.filter((entry) => existingAllowed.includes(entry))
+    : normalizedWhitelist;
 
   ephemerals['tools.allowed'] = Array.from(new Set(allowedSet));
 }

--- a/packages/agents/src/core/toolGovernance.test.ts
+++ b/packages/agents/src/core/toolGovernance.test.ts
@@ -42,6 +42,7 @@ describe('buildToolGovernance', () => {
       const governance = buildToolGovernance(config);
 
       expect(governance.allowed).toStrictEqual(new Set());
+      expect(governance.allowedExplicit).toBe(false);
     });
 
     it('should return empty allowed set when tools.allowed is not an array', () => {
@@ -52,6 +53,32 @@ describe('buildToolGovernance', () => {
       const governance = buildToolGovernance(config);
 
       expect(governance.allowed).toStrictEqual(new Set());
+      // Non-array values are not treated as an explicit allowlist; default
+      // (unrestricted) behavior applies.
+      expect(governance.allowedExplicit).toBe(false);
+    });
+
+    // Issue #2069: explicit empty tools.allowed must be distinguished from
+    // absent tools.allowed.
+    it('should set allowedExplicit=true for explicit empty tools.allowed', () => {
+      const config = createMockConfig({
+        ephemerals: { 'tools.allowed': [] },
+      });
+
+      const governance = buildToolGovernance(config);
+
+      expect(governance.allowed).toStrictEqual(new Set());
+      expect(governance.allowedExplicit).toBe(true);
+    });
+
+    it('should set allowedExplicit=true for non-empty tools.allowed', () => {
+      const config = createMockConfig({
+        ephemerals: { 'tools.allowed': ['read_file'] },
+      });
+
+      const governance = buildToolGovernance(config);
+
+      expect(governance.allowedExplicit).toBe(true);
     });
   });
 
@@ -225,6 +252,7 @@ describe('isToolBlocked', () => {
     it('should block excluded tools', () => {
       const governance: ToolGovernance = {
         allowed: new Set<string>(),
+        allowedExplicit: false,
         disabled: new Set<string>(),
         excluded: new Set(['shell']),
       };
@@ -235,6 +263,7 @@ describe('isToolBlocked', () => {
     it('should block excluded tools even if in allowed set', () => {
       const governance: ToolGovernance = {
         allowed: new Set(['shell']),
+        allowedExplicit: true,
         disabled: new Set<string>(),
         excluded: new Set(['shell']),
       };
@@ -247,6 +276,7 @@ describe('isToolBlocked', () => {
     it('should block disabled tools', () => {
       const governance: ToolGovernance = {
         allowed: new Set<string>(),
+        allowedExplicit: false,
         disabled: new Set(['write_file']),
         excluded: new Set<string>(),
       };
@@ -257,6 +287,7 @@ describe('isToolBlocked', () => {
     it('should block disabled tools even if in allowed set', () => {
       const governance: ToolGovernance = {
         allowed: new Set(['write_file']),
+        allowedExplicit: true,
         disabled: new Set(['write_file']),
         excluded: new Set<string>(),
       };
@@ -269,6 +300,7 @@ describe('isToolBlocked', () => {
     it('should block tools not in allowed set when allowed is non-empty', () => {
       const governance: ToolGovernance = {
         allowed: new Set(['read_file', 'glob']),
+        allowedExplicit: true,
         disabled: new Set<string>(),
         excluded: new Set<string>(),
       };
@@ -277,9 +309,10 @@ describe('isToolBlocked', () => {
       expect(isToolBlocked('read_file', governance)).toBe(false);
     });
 
-    it('should allow all tools when allowed set is empty', () => {
+    it('should allow all tools when allowed set is absent (unrestricted)', () => {
       const governance: ToolGovernance = {
         allowed: new Set<string>(),
+        allowedExplicit: false,
         disabled: new Set<string>(),
         excluded: new Set<string>(),
       };
@@ -290,10 +323,50 @@ describe('isToolBlocked', () => {
     });
   });
 
+  // Issue #2069: explicit empty allowlist must block all normal tools
+  describe('explicit empty allowlist (fail-closed)', () => {
+    it('should block all normal tools when allowed is explicit empty', () => {
+      const governance: ToolGovernance = {
+        allowed: new Set<string>(),
+        allowedExplicit: true,
+        disabled: new Set<string>(),
+        excluded: new Set<string>(),
+      };
+
+      expect(isToolBlocked('any_tool', governance)).toBe(true);
+      expect(isToolBlocked('write_file', governance)).toBe(true);
+      expect(isToolBlocked('shell', governance)).toBe(true);
+      expect(isToolBlocked('read_file', governance)).toBe(true);
+    });
+
+    it('should block all tools from buildToolGovernance with tools.allowed=[]', () => {
+      const config = createMockConfig({
+        ephemerals: { 'tools.allowed': [] },
+      });
+      const governance = buildToolGovernance(config);
+
+      expect(governance.allowedExplicit).toBe(true);
+      expect(isToolBlocked('read_file', governance)).toBe(true);
+      expect(isToolBlocked('shell', governance)).toBe(true);
+      expect(isToolBlocked('write_file', governance)).toBe(true);
+    });
+
+    it('should remain unrestricted when tools.allowed is absent', () => {
+      const config = createMockConfig({ ephemerals: {} });
+      const governance = buildToolGovernance(config);
+
+      expect(governance.allowedExplicit).toBe(false);
+      expect(isToolBlocked('read_file', governance)).toBe(false);
+      expect(isToolBlocked('shell', governance)).toBe(false);
+      expect(isToolBlocked('write_file', governance)).toBe(false);
+    });
+  });
+
   describe('priority order: excluded > disabled > allowed whitelist', () => {
     it('should prioritize excluded over disabled', () => {
       const governance: ToolGovernance = {
         allowed: new Set<string>(),
+        allowedExplicit: false,
         disabled: new Set(['shell']),
         excluded: new Set(['shell']),
       };
@@ -304,6 +377,7 @@ describe('isToolBlocked', () => {
     it('should prioritize disabled over allowed whitelist', () => {
       const governance: ToolGovernance = {
         allowed: new Set(['shell', 'read_file']),
+        allowedExplicit: true,
         disabled: new Set(['shell']),
         excluded: new Set<string>(),
       };
@@ -317,6 +391,7 @@ describe('isToolBlocked', () => {
     it('should normalize tool names when checking blocked status', () => {
       const governance: ToolGovernance = {
         allowed: new Set<string>(),
+        allowedExplicit: false,
         disabled: new Set(['write_file']),
         excluded: new Set<string>(),
       };
@@ -328,6 +403,7 @@ describe('isToolBlocked', () => {
     it('should handle camelCase tool names in blocking decisions', () => {
       const governance: ToolGovernance = {
         allowed: new Set<string>(),
+        allowedExplicit: false,
         disabled: new Set(['write_file']),
         excluded: new Set<string>(),
       };

--- a/packages/agents/src/core/toolGovernance.ts
+++ b/packages/agents/src/core/toolGovernance.ts
@@ -21,6 +21,15 @@ export interface ToolGovernanceConfig {
 
 export interface ToolGovernance {
   allowed: Set<string>;
+  /**
+   * Whether an explicit allowlist was provided (even if empty).
+   *
+   * - `false`: no explicit allowlist → unrestricted (runtime/profile defaults
+   *   apply). Disabled/excluded still block.
+   * - `true`: an explicit allowlist was provided. When `allowed` is empty,
+   *   this means "block all normal tools" (fail-closed).
+   */
+  allowedExplicit: boolean;
   disabled: Set<string>;
   excluded: Set<string>;
 }
@@ -33,9 +42,9 @@ export function buildToolGovernance(
       ? (config.getEphemeralSettings() ?? {})
       : {};
 
-  const allowedRaw = isStringArray(ephemerals['tools.allowed'])
-    ? ephemerals['tools.allowed']
-    : [];
+  const allowedValue = ephemerals['tools.allowed'];
+  const allowedExplicit = isStringArray(allowedValue);
+  const allowedRaw: string[] = allowedExplicit ? allowedValue : [];
 
   let disabledRaw: string[];
   if (isStringArray(ephemerals['tools.disabled'])) {
@@ -53,6 +62,7 @@ export function buildToolGovernance(
 
   return {
     allowed: new Set(allowedRaw.map(canonicalizeToolName)),
+    allowedExplicit,
     disabled: new Set(disabledRaw.map(canonicalizeToolName)),
     excluded: new Set(excludedRaw.map(canonicalizeToolName)),
   };
@@ -72,7 +82,7 @@ export function isToolBlocked(
     return true;
   }
 
-  if (governance.allowed.size > 0 && !governance.allowed.has(canonical)) {
+  if (governance.allowedExplicit && !governance.allowed.has(canonical)) {
     return true;
   }
 

--- a/packages/agents/src/scheduler/tool-dispatcher.test.ts
+++ b/packages/agents/src/scheduler/tool-dispatcher.test.ts
@@ -17,7 +17,7 @@ import {
   type ToolResult,
 } from '@vybestack/llxprt-code-tools';
 import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
-import { PolicyEngine } from '@vybestack/llxprt-code-core/policy/policy-engine.js';
+import { PolicyEngine } from '@vybestack/llxprt-code-policy';
 import { PolicyDecision } from '@vybestack/llxprt-code-core/policy/types.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools';
 import type { ContextAwareTool } from '@vybestack/llxprt-code-tools';
@@ -139,6 +139,7 @@ function makeGovernance(
 ): ToolGovernance {
   return {
     allowed: new Set<string>(),
+    allowedExplicit: false,
     disabled: new Set<string>(),
     excluded: new Set<string>(),
     ...overrides,
@@ -224,6 +225,55 @@ describe('ToolDispatcher', () => {
       if (results[0].status !== 'error')
         throw new Error('unreachable: narrowing failed');
       expect(results[0].response.errorType).toBe(ToolErrorType.TOOL_DISABLED);
+    });
+
+    // Issue #2069: explicit empty allowlist (tools.allowed=[]) must block all
+    // normal tools at the dispatcher level, returning TOOL_DISABLED and never
+    // resolving the registry tool.
+    it('returns ErroredToolCall with TOOL_DISABLED for explicit empty allowlist and never resolves registry tool', () => {
+      const tool = new MockTool('my_tool');
+      const registry = makeMockRegistry(tool);
+      const dispatcher = new ToolDispatcher(registry as never, config);
+      const governance = makeGovernance({
+        allowed: new Set<string>(),
+        allowedExplicit: true,
+      });
+
+      const results = dispatcher.resolveAndValidate(
+        [makeRequest('my_tool')],
+        governance,
+        false,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('error');
+      // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
+      if (results[0].status !== 'error')
+        throw new Error('unreachable: narrowing failed');
+      expect(results[0].response.errorType).toBe(ToolErrorType.TOOL_DISABLED);
+      // The tool must never have been resolved from the registry.
+      expect(registry.getTool).not.toHaveBeenCalled();
+    });
+
+    // Issue #2069: absent allowlist must remain unrestricted.
+    it('resolves registry tool normally when allowlist is absent (unrestricted)', () => {
+      const tool = new MockTool('my_tool');
+      const registry = makeMockRegistry(tool);
+      const dispatcher = new ToolDispatcher(registry as never, config);
+      const governance = makeGovernance({
+        allowed: new Set<string>(),
+        allowedExplicit: false,
+      });
+
+      const results = dispatcher.resolveAndValidate(
+        [makeRequest('my_tool')],
+        governance,
+        false,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('validating');
+      expect(registry.getTool).toHaveBeenCalledWith('my_tool');
     });
 
     it('drops requests blocked by hookRestrictedAllowed before validation', () => {

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -239,7 +239,10 @@ describe('TaskTool', () => {
       | { toolConfig?: unknown }
       | undefined;
     expect(launchRequest).toBeDefined();
-    expect(launchRequest).not.toHaveProperty('toolConfig');
+    // Explicit whitelist fully filtered to zero must preserve fail-closed
+    // toolConfig: { tools: [] }, NOT omit toolConfig (which means runtime defaults).
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig).toStrictEqual({ tools: [] });
   });
 
   it('filters excluded task tools from explicit whitelist using canonical tool names', async () => {
@@ -353,7 +356,10 @@ describe('TaskTool', () => {
       | { toolConfig?: unknown }
       | undefined;
     expect(launchRequest).toBeDefined();
-    expect(launchRequest).not.toHaveProperty('toolConfig');
+    // Explicit empty whitelist must preserve fail-closed toolConfig: { tools: [] },
+    // NOT omit toolConfig (which means runtime defaults).
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig).toStrictEqual({ tools: [] });
   });
 
   it('backfills sessionId from config when context does not provide one', async () => {
@@ -2014,6 +2020,213 @@ describe('TaskTool', () => {
       expect(updateOutput).toHaveBeenLastCalledWith(
         '</subagent name="async-helper" id="async-xml-agent">\n',
       );
+    });
+  });
+
+  describe('Issue #2069: toolConfig omission with output_spec', () => {
+    it('omits toolConfig (not empty) when no explicit whitelist and registry unavailable, so runtime uses profile defaults', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-2069-no-registry',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      // Config WITHOUT getToolRegistry — simulates registry unavailable
+      const configNoRegistry = {
+        getSessionId: () => 'session-2069',
+      } as unknown as Config;
+
+      const tool = new TaskTool(configNoRegistry, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'rustcoder',
+        goal_prompt: 'Write a function',
+        output_spec: { result: 'The implementation' },
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      const launchRequest = launch.mock.calls[0]?.[0] as
+        | { toolConfig?: unknown; outputConfig?: unknown }
+        | undefined;
+      expect(launchRequest).toBeDefined();
+      // toolConfig must be absent (undefined) so runtime uses profile defaults
+      expect(launchRequest).not.toHaveProperty('toolConfig');
+      // outputConfig must still be present
+      expect(launchRequest).toHaveProperty('outputConfig');
+    });
+
+    it('omits toolConfig (not parent registry-derived) when no explicit whitelist and registry available, so runtime uses profile defaults', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-2069-with-registry',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const configWithRegistry = {
+        getSessionId: () => 'session-2069',
+        getEphemeralSettings: () => ({}),
+        getExcludeTools: () => [],
+        getToolRegistry: () => ({
+          getEnabledTools: () => [
+            { name: 'read_file' },
+            { name: 'write_file' },
+            { name: 'task' },
+            { name: 'list_subagents' },
+          ],
+        }),
+      } as unknown as Config;
+
+      const tool = new TaskTool(configWithRegistry, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'rustcoder',
+        goal_prompt: 'Write a function',
+        output_spec: { result: 'The implementation' },
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      const launchRequest = launch.mock.calls[0]?.[0] as
+        | { toolConfig?: unknown; outputConfig?: unknown }
+        | undefined;
+      expect(launchRequest).toBeDefined();
+      // Issue #2069: no explicit whitelist must NOT synthesize toolConfig from
+      // the parent registry. toolConfig omitted → runtime/profile defaults apply.
+      expect(launchRequest).not.toHaveProperty('toolConfig');
+      // outputConfig must still be present
+      expect(launchRequest).toHaveProperty('outputConfig');
+    });
+  });
+
+  describe('Issue #2069: no-registry explicit whitelist must strip task/list_subagents', () => {
+    it('filters task/list_subagents from explicit whitelist when registry is unavailable', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-2069-no-reg-filter',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      // Config WITHOUT getToolRegistry — simulates registry unavailable
+      const configNoRegistry = {
+        getSessionId: () => 'session-2069',
+      } as unknown as Config;
+
+      const tool = new TaskTool(configNoRegistry, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'helper',
+        goal_prompt: 'Do work',
+        tool_whitelist: ['read_file', 'task', 'list_subagents'],
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      const launchRequest = launch.mock.calls[0]?.[0] as
+        | { toolConfig?: { tools?: string[] } }
+        | undefined;
+      expect(launchRequest).toBeDefined();
+      expect(launchRequest).toHaveProperty('toolConfig');
+      // task/list_subagents must be removed even without a registry;
+      // read_file is preserved (no-registry explicit whitelist semantics).
+      expect(launchRequest?.toolConfig?.tools).toStrictEqual(['read_file']);
+    });
+
+    it('preserves fail-closed toolConfig { tools: [] } when explicit whitelist only contains task/list_subagents and registry unavailable', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-2069-no-reg-failclosed',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const configNoRegistry = {
+        getSessionId: () => 'session-2069',
+      } as unknown as Config;
+
+      const tool = new TaskTool(configNoRegistry, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'helper',
+        goal_prompt: 'Do work',
+        tool_whitelist: ['task', 'list_subagents'],
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      const launchRequest = launch.mock.calls[0]?.[0] as
+        | { toolConfig?: { tools?: string[] } }
+        | undefined;
+      expect(launchRequest).toBeDefined();
+      expect(launchRequest).toHaveProperty('toolConfig');
+      expect(launchRequest?.toolConfig?.tools).toStrictEqual([]);
     });
   });
 });

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -255,6 +255,28 @@ class TaskToolInvocation extends BaseToolInvocation<
     return deduped.length > 0 ? deduped : undefined;
   }
 
+  /**
+   * Filters excluded tools (task/list_subagents) from a whitelist when no
+   * registry is available to perform full governance validation. Non-excluded
+   * entries pass through unchanged. Returns undefined if the result is empty
+   * so the caller can apply fail-closed semantics for explicit whitelists.
+   */
+  private filterExcludedFromWhitelist(
+    candidateTools: string[] | undefined,
+  ): string[] | undefined {
+    if (!candidateTools || candidateTools.length === 0) {
+      return undefined;
+    }
+
+    const excluded = this.buildExcludedToolNames();
+    const filtered = candidateTools.filter(
+      (name) =>
+        typeof name === 'string' && !this.isExcludedToolName(name, excluded),
+    );
+
+    return filtered.length > 0 ? filtered : undefined;
+  }
+
   private createLaunchRequest(timeoutMs?: number): SubagentLaunchRequest {
     const { subagentName, behaviourPrompts, toolWhitelist, outputSpec } =
       this.normalized;
@@ -287,22 +309,21 @@ class TaskToolInvocation extends BaseToolInvocation<
       Array.isArray(this.params.tool_whitelist) ||
       Array.isArray(this.params.toolWhitelist);
 
-    if (registry) {
-      if (effectiveWhitelist && effectiveWhitelist.length > 0) {
+    // Issue #2069: no explicit whitelist must preserve omitted toolConfig so
+    // the subagent runtime/profile default tools apply. Do NOT synthesize a
+    // whitelist from the parent registry regardless of registry availability.
+    if (hasExplicitWhitelist) {
+      if (registry && effectiveWhitelist && effectiveWhitelist.length > 0) {
         effectiveWhitelist = this.buildGovernedToolWhitelist(
           effectiveWhitelist,
           registry,
         );
-      }
-
-      if (
-        !hasExplicitWhitelist &&
-        (!effectiveWhitelist || effectiveWhitelist.length === 0)
-      ) {
-        effectiveWhitelist = this.buildGovernedToolWhitelist(
-          registry.getEnabledTools().map((tool) => tool.name),
-          registry,
-        );
+      } else {
+        // No registry available: still filter excluded tools (task/list_subagents)
+        // so they can never be exposed to a subagent runtime. Non-excluded entries
+        // pass through unchanged (no registry validation possible).
+        effectiveWhitelist =
+          this.filterExcludedFromWhitelist(effectiveWhitelist);
       }
     }
 
@@ -313,6 +334,11 @@ class TaskToolInvocation extends BaseToolInvocation<
       launchRequest.toolConfig = {
         tools: Array.from(whitelistSet),
       };
+    } else if (hasExplicitWhitelist) {
+      // Explicit empty or fully-filtered-to-zero whitelist must remain fail-closed.
+      // toolConfig: { tools: [] } tells the runtime to expose no normal tools.
+      // Omitting toolConfig entirely (the else case) means runtime/profile defaults.
+      launchRequest.toolConfig = { tools: [] };
     }
 
     taskLogger.debug(() => {

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.test.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.test.ts
@@ -64,6 +64,196 @@ function createAdapter(
   });
 }
 
+interface AdapterWithLaunch {
+  adapter: CoreSubagentServiceAdapter;
+  launch: ReturnType<typeof vi.fn>;
+}
+
+function createAdapterWithLaunch(
+  configOverrides: Partial<Config> = {},
+): AdapterWithLaunch {
+  const spies: ScopeSpies = {
+    runInteractive: vi.fn().mockResolvedValue(undefined),
+    runNonInteractive: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+  };
+  const launchResult = createLaunchResult(spies);
+  const launch = vi.fn().mockResolvedValue(launchResult);
+
+  const fakeOrchestrator = {
+    launch,
+  } as unknown as CoreSubagentLauncher;
+
+  const config = {
+    getEphemeralSettings: () => ({}),
+    getSessionId: () => 'session-test',
+    isInteractive: () => false,
+    ...configOverrides,
+  } as unknown as Config;
+
+  const adapter = new CoreSubagentServiceAdapter({
+    managerProvider: () => ({}) as unknown as SubagentManager,
+    profileManagerProvider: () => ({}) as unknown as ProfileManager,
+    config,
+    isInteractiveEnvironment: () => false,
+    orchestratorFactory: () => fakeOrchestrator,
+  });
+  return { adapter, launch };
+}
+
+describe('CoreSubagentServiceAdapter toolConfig preservation (Issue #2069)', () => {
+  it('preserves explicit empty toolWhitelist as toolConfig: { tools: [] }', async () => {
+    const { adapter, launch } = createAdapterWithLaunch();
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      toolWhitelist: [],
+      hasExplicitToolWhitelist: true,
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: unknown }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig).toStrictEqual({ tools: [] });
+  });
+
+  it('preserves explicit whitelist fully filtered to zero as toolConfig: { tools: [] }', async () => {
+    const { adapter, launch } = createAdapterWithLaunch({
+      getEphemeralSettings: () => ({ 'tools.disabled': ['read_file'] }),
+      getToolRegistry: () => ({
+        getEnabledTools: () => [{ name: 'read_file' }, { name: 'write_file' }],
+      }),
+    } as Partial<Config>);
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      toolWhitelist: ['read_file'],
+      hasExplicitToolWhitelist: true,
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: unknown }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig).toStrictEqual({ tools: [] });
+  });
+
+  it('filters explicit whitelist to zero when config ephemerals have tools.allowed=[] (Issue #2069)', async () => {
+    const { adapter, launch } = createAdapterWithLaunch({
+      getEphemeralSettings: () => ({ 'tools.allowed': [] }),
+      getExcludeTools: () => [],
+      getToolRegistry: () => ({
+        getEnabledTools: () => [{ name: 'read_file' }, { name: 'write_file' }],
+      }),
+    } as Partial<Config>);
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      toolWhitelist: ['read_file', 'write_file'],
+      hasExplicitToolWhitelist: true,
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: unknown }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    // Explicit empty tools.allowed in config means "block all normal tools"
+    // (fail-closed), so even an explicit non-empty request whitelist filters to
+    // zero → toolConfig { tools: [] }.
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig).toStrictEqual({ tools: [] });
+  });
+
+  it('omits toolConfig when no explicit whitelist and registry unavailable', async () => {
+    const { adapter, launch } = createAdapterWithLaunch();
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: unknown }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).not.toHaveProperty('toolConfig');
+  });
+
+  it('omits toolConfig when no explicit whitelist but registry available (Issue #2069)', async () => {
+    const { adapter, launch } = createAdapterWithLaunch({
+      getEphemeralSettings: () => ({}),
+      getExcludeTools: () => [],
+      getToolRegistry: () => ({
+        getEnabledTools: () => [
+          { name: 'read_file' },
+          { name: 'write_file' },
+          { name: 'task' },
+          { name: 'list_subagents' },
+        ],
+      }),
+    } as Partial<Config>);
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      // No toolWhitelist and no hasExplicitToolWhitelist → runtime defaults.
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: unknown }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    // No explicit whitelist must NOT synthesize toolConfig from the parent
+    // registry. toolConfig omitted → runtime/profile defaults apply.
+    expect(launchRequest).not.toHaveProperty('toolConfig');
+  });
+
+  it('filters task/list_subagents from explicit whitelist when registry is unavailable (Issue #2069)', async () => {
+    // No getToolRegistry on config — simulates registry unavailable
+    const { adapter, launch } = createAdapterWithLaunch({});
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      toolWhitelist: ['read_file', 'task', 'list_subagents'],
+      hasExplicitToolWhitelist: true,
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: { tools?: string[] } }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).toHaveProperty('toolConfig');
+    // task/list_subagents must be removed even without a registry;
+    // read_file is preserved (no-registry explicit whitelist semantics).
+    expect(launchRequest?.toolConfig?.tools).toStrictEqual(['read_file']);
+  });
+
+  it('preserves fail-closed toolConfig { tools: [] } when explicit whitelist only contains task/list_subagents and registry unavailable (Issue #2069)', async () => {
+    const { adapter, launch } = createAdapterWithLaunch({});
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      toolWhitelist: ['task', 'list_subagents'],
+      hasExplicitToolWhitelist: true,
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: { tools?: string[] } }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig?.tools).toStrictEqual([]);
+  });
+});
+
 describe('CoreSubagentServiceAdapter runScope interactivity', () => {
   it('runs the subagent non-interactively when the environment is non-interactive', async () => {
     const spies: ScopeSpies = {
@@ -103,5 +293,59 @@ describe('CoreSubagentServiceAdapter runScope interactivity', () => {
     expect(spies.runInteractive).toHaveBeenCalledTimes(1);
     expect(spies.runNonInteractive).not.toHaveBeenCalled();
     expect(spies.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CoreSubagentServiceAdapter inferred explicit whitelist (Issue #2069 direct callers)', () => {
+  it('treats toolWhitelist: [] without hasExplicitToolWhitelist as explicit and fail-closed', async () => {
+    const { adapter, launch } = createAdapterWithLaunch();
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      // Direct ISubagentService caller: toolWhitelist present but flag omitted.
+      toolWhitelist: [],
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: unknown }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig).toStrictEqual({ tools: [] });
+  });
+
+  it('treats toolWhitelist with only excluded tools and no flag as explicit and fail-closed', async () => {
+    const { adapter, launch } = createAdapterWithLaunch({});
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      toolWhitelist: ['task', 'list_subagents'],
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: { tools?: string[] } }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig?.tools).toStrictEqual([]);
+  });
+
+  it('treats toolWhitelist: ["read_file"] without flag as explicit and preserves it after excluded filtering (no registry)', async () => {
+    const { adapter, launch } = createAdapterWithLaunch({});
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      toolWhitelist: ['read_file'],
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { toolConfig?: { tools?: string[] } }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).toHaveProperty('toolConfig');
+    expect(launchRequest?.toolConfig?.tools).toStrictEqual(['read_file']);
   });
 });

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
@@ -294,6 +294,11 @@ export class CoreSubagentServiceAdapter implements ISubagentService {
     const effectiveWhitelist = this.buildEffectiveToolWhitelist(request);
     if (effectiveWhitelist !== undefined && effectiveWhitelist.length > 0) {
       launchRequest.toolConfig = { tools: effectiveWhitelist };
+    } else if (this.hasExplicitWhitelist(request)) {
+      // Explicit empty or fully-filtered-to-zero whitelist must remain fail-closed.
+      // toolConfig: { tools: [] } tells the runtime to expose no normal tools.
+      // Omitting toolConfig entirely (the else case) means runtime/profile defaults.
+      launchRequest.toolConfig = { tools: [] };
     }
 
     if (request.outputSpec && Object.keys(request.outputSpec).length > 0) {
@@ -310,35 +315,74 @@ export class CoreSubagentServiceAdapter implements ISubagentService {
     return launchRequest;
   }
 
+  /**
+   * Centralized explicit-whitelist detection (Issue #2069).
+   *
+   * The Task tool always sets hasExplicitToolWhitelist based on whether an
+   * array was passed, but ISubagentService.executeSubagent is a public
+   * interface and direct callers may pass toolWhitelist without the flag.
+   * Treat an Array toolWhitelist as explicit regardless of the flag so that
+   * empty/fully-filtered whitelists fail closed to { tools: [] }.
+   */
+  private hasExplicitWhitelist(request: SubagentRequest): boolean {
+    return (
+      request.hasExplicitToolWhitelist === true ||
+      Array.isArray(request.toolWhitelist)
+    );
+  }
+
   private buildEffectiveToolWhitelist(
     request: SubagentRequest,
   ): string[] | undefined {
+    // Issue #2069: no explicit whitelist must preserve omitted toolConfig so
+    // the subagent runtime/profile default tools apply. Do NOT synthesize a
+    // whitelist from the parent registry regardless of registry availability.
+    // Explicitness is inferred from Array.isArray(request.toolWhitelist) so
+    // direct ISubagentService callers (which may omit hasExplicitToolWhitelist)
+    // are treated consistently with the Task tool.
+    if (!this.hasExplicitWhitelist(request)) {
+      return undefined;
+    }
+
     const registry = this.config?.getToolRegistry?.() as
       | ToolRegistry
       | undefined;
-    if (registry === undefined) {
-      return request.toolWhitelist;
-    }
 
     let effectiveWhitelist = request.toolWhitelist;
-    if (effectiveWhitelist && effectiveWhitelist.length > 0) {
+    if (registry && effectiveWhitelist && effectiveWhitelist.length > 0) {
       effectiveWhitelist = this.buildGovernedToolWhitelist(
         effectiveWhitelist,
         registry,
       );
-    }
-
-    if (
-      !request.hasExplicitToolWhitelist &&
-      (!effectiveWhitelist || effectiveWhitelist.length === 0)
-    ) {
-      effectiveWhitelist = this.buildGovernedToolWhitelist(
-        registry.getEnabledTools().map((tool) => tool.name),
-        registry,
-      );
+    } else {
+      // No registry available: still filter excluded tools (task/list_subagents)
+      // so they can never be exposed to a subagent runtime. Non-excluded entries
+      // pass through unchanged (no registry validation possible).
+      effectiveWhitelist = this.filterExcludedFromWhitelist(effectiveWhitelist);
     }
 
     return effectiveWhitelist;
+  }
+
+  /**
+   * Filters excluded tools (task/list_subagents) from a whitelist when no
+   * registry is available to perform full governance validation. Non-excluded
+   * entries pass through unchanged. Returns undefined if the result is empty
+   * so the caller can apply fail-closed semantics for explicit whitelists.
+   */
+  private filterExcludedFromWhitelist(
+    candidateTools: string[] | undefined,
+  ): string[] | undefined {
+    if (!candidateTools || candidateTools.length === 0) {
+      return undefined;
+    }
+
+    const excluded = buildExcludedToolNames();
+    const filtered = candidateTools.filter(
+      (name) => typeof name === 'string' && !isExcludedToolName(name, excluded),
+    );
+
+    return filtered.length > 0 ? filtered : undefined;
   }
 
   private buildGovernedToolWhitelist(

--- a/packages/core/src/tools-adapters/coreSubagentServiceHelpers.test.ts
+++ b/packages/core/src/tools-adapters/coreSubagentServiceHelpers.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildToolGovernance,
+  isToolBlocked,
+  type ToolGovernance,
+} from './coreSubagentServiceHelpers.js';
+
+function createMockConfig(options: {
+  ephemerals?: Record<string, unknown>;
+  excludeTools?: string[];
+}) {
+  const ephemerals = options.ephemerals ?? {};
+  return {
+    getEphemeralSettings: () => ephemerals,
+    getExcludeTools: () => options.excludeTools ?? [],
+  };
+}
+
+describe('coreSubagentServiceHelpers buildToolGovernance', () => {
+  describe('allowedExplicit semantics (Issue #2069)', () => {
+    it('treats absent tools.allowed as unrestricted (allowedExplicit=false)', () => {
+      const governance = buildToolGovernance(createMockConfig({}));
+
+      expect(governance.allowed).toStrictEqual(new Set());
+      expect(governance.allowedExplicit).toBe(false);
+    });
+
+    it('treats non-array tools.allowed as unrestricted (allowedExplicit=false)', () => {
+      const governance = buildToolGovernance(
+        createMockConfig({ ephemerals: { 'tools.allowed': 'nope' } }),
+      );
+
+      expect(governance.allowed).toStrictEqual(new Set());
+      expect(governance.allowedExplicit).toBe(false);
+    });
+
+    it('treats explicit empty tools.allowed as fail-closed (allowedExplicit=true)', () => {
+      const governance = buildToolGovernance(
+        createMockConfig({ ephemerals: { 'tools.allowed': [] } }),
+      );
+
+      expect(governance.allowed).toStrictEqual(new Set());
+      expect(governance.allowedExplicit).toBe(true);
+    });
+
+    it('treats explicit non-empty tools.allowed as explicit allowlist', () => {
+      const governance = buildToolGovernance(
+        createMockConfig({
+          ephemerals: { 'tools.allowed': ['read_file'] },
+        }),
+      );
+
+      expect(governance.allowed).toStrictEqual(new Set(['read_file']));
+      expect(governance.allowedExplicit).toBe(true);
+    });
+  });
+
+  describe('disabled and excluded extraction', () => {
+    it('extracts tools.disabled', () => {
+      const governance = buildToolGovernance(
+        createMockConfig({
+          ephemerals: { 'tools.disabled': ['shell'] },
+        }),
+      );
+
+      expect(governance.disabled).toStrictEqual(new Set(['shell']));
+    });
+
+    it('extracts excluded tools from getExcludeTools()', () => {
+      const governance = buildToolGovernance(
+        createMockConfig({ excludeTools: ['dangerous_tool'] }),
+      );
+
+      expect(governance.excluded).toStrictEqual(new Set(['dangerous_tool']));
+    });
+  });
+});
+
+describe('coreSubagentServiceHelpers isToolBlocked', () => {
+  it('allows all normal tools when no explicit allowlist (unrestricted)', () => {
+    const governance: ToolGovernance = {
+      allowed: new Set(),
+      allowedExplicit: false,
+      disabled: new Set(),
+      excluded: new Set(),
+    };
+
+    expect(isToolBlocked('read_file', governance)).toBe(false);
+    expect(isToolBlocked('write_file', governance)).toBe(false);
+  });
+
+  it('blocks all normal tools when explicit empty allowlist (fail-closed)', () => {
+    const governance: ToolGovernance = {
+      allowed: new Set(),
+      allowedExplicit: true,
+      disabled: new Set(),
+      excluded: new Set(),
+    };
+
+    expect(isToolBlocked('read_file', governance)).toBe(true);
+    expect(isToolBlocked('write_file', governance)).toBe(true);
+    expect(isToolBlocked('shell', governance)).toBe(true);
+  });
+
+  it('blocks tools not in explicit non-empty allowlist', () => {
+    const governance: ToolGovernance = {
+      allowed: new Set(['read_file']),
+      allowedExplicit: true,
+      disabled: new Set(),
+      excluded: new Set(),
+    };
+
+    expect(isToolBlocked('read_file', governance)).toBe(false);
+    expect(isToolBlocked('write_file', governance)).toBe(true);
+  });
+
+  it('blocks excluded and disabled tools regardless of allowlist', () => {
+    const governance: ToolGovernance = {
+      allowed: new Set(['shell']),
+      allowedExplicit: true,
+      disabled: new Set(['shell']),
+      excluded: new Set(),
+    };
+
+    expect(isToolBlocked('shell', governance)).toBe(true);
+  });
+});
+
+describe('coreSubagentServiceHelpers buildToolGovernance + isToolBlocked integration', () => {
+  it('blocks all tools when config ephemerals have tools.allowed=[]', () => {
+    const governance = buildToolGovernance(
+      createMockConfig({ ephemerals: { 'tools.allowed': [] } }),
+    );
+
+    expect(governance.allowedExplicit).toBe(true);
+    expect(isToolBlocked('read_file', governance)).toBe(true);
+    expect(isToolBlocked('shell', governance)).toBe(true);
+    expect(isToolBlocked('write_file', governance)).toBe(true);
+  });
+
+  it('remains unrestricted when tools.allowed is absent', () => {
+    const governance = buildToolGovernance(createMockConfig({}));
+
+    expect(governance.allowedExplicit).toBe(false);
+    expect(isToolBlocked('read_file', governance)).toBe(false);
+    expect(isToolBlocked('shell', governance)).toBe(false);
+    expect(isToolBlocked('write_file', governance)).toBe(false);
+  });
+});

--- a/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
+++ b/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
@@ -25,8 +25,17 @@ interface ToolGovernanceConfig {
   getExcludeTools?: () => string[] | undefined;
 }
 
-interface ToolGovernance {
+export interface ToolGovernance {
   allowed: Set<string>;
+  /**
+   * Whether an explicit allowlist was provided (even if empty).
+   *
+   * - `false`: no explicit allowlist → unrestricted (runtime/profile defaults
+   *   apply). Disabled/excluded still block.
+   * - `true`: an explicit allowlist was provided. When `allowed` is empty,
+   *   this means "block all normal tools" (fail-closed).
+   */
+  allowedExplicit: boolean;
   disabled: Set<string>;
   excluded: Set<string>;
 }
@@ -67,9 +76,9 @@ export function buildToolGovernance(
       ? (config.getEphemeralSettings() ?? {})
       : {};
 
-  const allowedRaw = isStringArray(ephemerals['tools.allowed'])
-    ? ephemerals['tools.allowed']
-    : [];
+  const allowedValue = ephemerals['tools.allowed'];
+  const allowedExplicit = isStringArray(allowedValue);
+  const allowedRaw: string[] = allowedExplicit ? allowedValue : [];
 
   let disabledRaw: string[];
   if (isStringArray(ephemerals['tools.disabled'])) {
@@ -87,6 +96,7 @@ export function buildToolGovernance(
 
   return {
     allowed: new Set(allowedRaw.map(canonicalizeToolName)),
+    allowedExplicit,
     disabled: new Set(disabledRaw.map(canonicalizeToolName)),
     excluded: new Set(excludedRaw.map(canonicalizeToolName)),
   };
@@ -106,7 +116,7 @@ export function isToolBlocked(
     return true;
   }
 
-  if (governance.allowed.size > 0 && !governance.allowed.has(canonical)) {
+  if (governance.allowedExplicit && !governance.allowed.has(canonical)) {
     return true;
   }
 


### PR DESCRIPTION
## TLDR

Fixes subagent tool provisioning so omitted tool whitelists use runtime/profile defaults instead of leaving output-producing subagents with only self_emitvalue, while explicit empty or fully filtered whitelists still fail closed.

## Dive Deeper

This change separates three previously-collapsed states across the task tool, core adapter, subagent scope creation, runtime function declaration generation, and scheduler governance:

- No explicit whitelist: omit toolConfig and allow the subagent runtime/profile tool view to supply normal tools.
- Explicit empty whitelist: preserve toolConfig with an empty tools array and expose no normal tools.
- Explicit whitelist filtered to zero tools: preserve the same fail-closed empty toolConfig rather than falling back to defaults.

It also hardens task/list_subagents exclusion so subagents cannot receive or execute nested delegation tools via default runtime declarations, explicit whitelists, no-registry paths, or scheduler allowed-tool ephemerals. Runtime declaration matching now uses the canonical tool-name normalization so CamelCase and Tool-suffixed names resolve consistently to registry names.

The tests cover TaskTool launch requests, CoreSubagentServiceAdapter launch requests, runtime declaration generation, SubAgentScope real-flow declaration behavior with outputConfig, tool-governance fail-closed behavior, and scheduler enforcement.

## Reviewer Test Plan

Reviewers can validate the fix by running:

    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else"

Behavioral cases to inspect:

- Launch a subagent with output_spec and no tool_whitelist: it should receive normal runtime/profile tools plus self_emitvalue.
- Launch a subagent with tool_whitelist: [] and output_spec: it should receive only self_emitvalue.
- Launch a subagent whose explicit whitelist filters down to no allowed tools: it should remain fail-closed.
- Verify task and list_subagents are not exposed to or executable by subagents.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS:

- npm run test: passed across workspaces. The aggregate workspace runner was signal-terminated during later workspaces by the local shell, so the remaining later workspaces were run explicitly and passed: providers, agents, cli, and a2a-server.
- npm run lint: passed with existing warnings only.
- npm run typecheck: passed.
- npm run format: passed.
- npm run build: passed.
- node scripts/start.js --profile-load synthetic "write me a haiku and nothing else": build was up-to-date, but provider call failed with HTTP 402 insufficient Synthetic credits.
- node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else": passed.

## Linked issues / bugs

Fixes #2069
