### PR TITLE
Allow 0.5% context-limit fudge factor before hard-limit truncation (Fixes #2067)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -57,6 +57,12 @@ import {
  */
 export class CompressionHandler {
   static readonly TOKEN_SAFETY_MARGIN = 1000;
+  /**
+   * Estimation cushion (0.5%) applied on top of TOKEN_SAFETY_MARGIN so that
+   * marginally-over requests (e.g. a few tokens) are allowed through instead of
+   * blocking the turn. Interim solution for #2067; a targeted truncation
+   * strategy is planned for a future release.
+   */
   static readonly CONTEXT_LIMIT_FUDGE_FACTOR = 0.005;
   static readonly DEFAULT_COMPLETION_BUDGET = 65_536;
   static readonly COMPRESSION_COOLDOWN_MS = 60_000;

--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -57,6 +57,7 @@ import {
  */
 export class CompressionHandler {
   static readonly TOKEN_SAFETY_MARGIN = 1000;
+  static readonly CONTEXT_LIMIT_FUDGE_FACTOR = 0.005;
   static readonly DEFAULT_COMPLETION_BUDGET = 65_536;
   static readonly COMPRESSION_COOLDOWN_MS = 60_000;
   static readonly COMPRESSION_FAILURE_THRESHOLD = 3;
@@ -375,9 +376,16 @@ export class CompressionHandler {
     );
     const userContextLimit = this.runtimeContext.ephemerals.contextLimit();
     const limit = tokenLimit(this.runtimeContext.state.model, userContextLimit);
-    const marginAdjustedLimit = Math.max(
+    const safetyAdjustedLimit = Math.max(
       0,
       limit - CompressionHandler.TOKEN_SAFETY_MARGIN,
+    );
+    const marginAdjustedLimit = Math.min(
+      limit,
+      Math.floor(
+        safetyAdjustedLimit +
+          safetyAdjustedLimit * CompressionHandler.CONTEXT_LIMIT_FUDGE_FACTOR,
+      ),
     );
     return { completionBudget, limit, marginAdjustedLimit };
   }

--- a/packages/agents/src/compression/__tests__/compression-retry.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry.test.ts
@@ -1022,6 +1022,68 @@ describe('Hard-limit compression behavior (Issue #1791)', () => {
   }
 
   /**
+   * @requirement REQ-2067.1
+   * Hard-limit gate allows a small estimation cushion before mutating history.
+   */
+  it('allows projected tokens within the 0.5% context-limit fudge factor', async () => {
+    const chat = makeChatForEnforceContextWindow({
+      totalTokens: 149_002,
+      contextLimit: 200_000,
+      maxOutputTokens: 40_000,
+    });
+
+    const getStrategy = vi.spyOn(compressionFactory, 'getCompressionStrategy');
+
+    await expect(
+      chat['enforceContextWindow'](10_000, 'test-prompt'),
+    ).resolves.toBeUndefined();
+
+    expect(getStrategy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * @requirement REQ-2067.2
+   * Hard-limit gate still enforces requests beyond the estimation cushion.
+   */
+  it('still enforces projected tokens beyond the 0.5% context-limit fudge factor', async () => {
+    const chat = makeChatForEnforceContextWindow({
+      totalTokens: 150_000,
+      contextLimit: 200_000,
+      maxOutputTokens: 40_000,
+    });
+
+    let compressionAttempts = 0;
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      () => ({
+        name: 'middle-out' as const,
+        requiresLLM: true,
+        trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+        compress: vi.fn().mockImplementation(async () => {
+          compressionAttempts++;
+          return {
+            newHistory: [
+              { role: 'user', parts: [{ text: 'hello' }] },
+              { role: 'model', parts: [{ text: 'hi' }] },
+            ],
+            metadata: {
+              originalMessageCount: 10,
+              compressedMessageCount: 9,
+              strategyUsed: 'middle-out' as const,
+              llmCallMade: true,
+            },
+          };
+        }),
+      }),
+    );
+    vi.spyOn(chat['historyService'], 'getTotalTokens').mockReturnValue(150_000);
+
+    await expect(
+      chat['enforceContextWindow'](10_000, 'test-prompt'),
+    ).rejects.toThrow('tokensStillNeeded=5');
+
+    expect(compressionAttempts).toBeGreaterThan(0);
+  });
+  /**
    * @requirement REQ-1791.1
    * enforceContextWindow bypasses cooldown and still attempts compression.
    */
@@ -1376,13 +1438,13 @@ describe('Hard-limit compression behavior (Issue #1791)', () => {
     }
 
     expect(errorMessage).toContain(
-      'Request still exceeds the safety-adjusted context limit (99000 tokens).',
+      'Request still exceeds the safety-adjusted context limit (99495 tokens).',
     );
     expect(errorMessage).toContain(
       'density optimization and compression reduced 0 tokens',
     );
     expect(errorMessage).toContain('completionBudget=90000');
-    expect(errorMessage).toContain('tokensStillNeeded=81000');
+    expect(errorMessage).toContain('tokensStillNeeded=80505');
     expect(errorMessage).toContain(
       'consumes more than 80% of the context window (100000)',
     );


### PR DESCRIPTION
## TLDR

Adds a 0.5% context-limit fudge factor to the hard-limit enforcement gate in `CompressionHandler`. When projected token usage is barely over the safety-adjusted limit (e.g. 2 tokens over, as reported in #2067), the request is now allowed to proceed instead of failing. This is an interim fix — larger truncation improvements are deferred to the next release.

## Dive Deeper

### The problem

When compression reduces token usage significantly but leaves the request just barely over the safety-adjusted limit, `enforceContextWindow` throws a hard `buildContextOverflowError`. In the reported case, compression reduced 15,935 tokens (from 214,937 to 199,002) but the request was still 2 tokens over the 199,000 safety-adjusted limit, so the turn was blocked entirely.

### The fix

- Added `CONTEXT_LIMIT_FUDGE_FACTOR = 0.005` (0.5%) to `CompressionHandler`.
- `computeContextLimits` now computes the effective enforcement limit as:

  `min(limit, floor(safetyAdjustedLimit + safetyAdjustedLimit * 0.005))`

  This grants a small estimation cushion without exceeding the actual model/context limit.
- The fudge is applied on top of the existing 1000-token `TOKEN_SAFETY_MARGIN` and is capped at the real provider limit via `Math.min`, so we never allow a request that the provider would reject.

### Why a fudge factor instead of truncation

Truncation removes whole oldest messages via `TopDownTruncationStrategy`. For a 2-token overage this would remove far more context than needed, which confuses the model mid-conversation. Per discussion with the maintainer, a temporary estimation cushion is the preferred interim approach. A more targeted, limit-aware truncation strategy is planned for the next release.

### What this does NOT change

- Does not alter the truncation fallback behavior for genuinely ineffective compression.
- Does not address the separate manual `/compress` empty-summary failure mode (that is a related but distinct issue).
- The 5% effectiveness threshold in `forceTruncationIfIneffective` is intentionally left in place for this release.

## Reviewer Test Plan

1. Pull branch `issue2067`.
2. Run the compression retry test suite:
   `npm test --workspace @vybestack/llxprt-code-agents -- src/compression/__tests__/compression-retry.test.ts`
3. Verify the two new tests pass:
   - "allows projected tokens within the 0.5% context-limit fudge factor"
   - "still enforces projected tokens beyond the 0.5% context-limit fudge factor"
4. Optionally, run the full agents workspace test suite to confirm no regressions.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2067
