### PR TITLE
Add presubmit npm script and streamline contributing guide (Fixes #2075)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,22 @@ This project values respectful and constructive collaboration. We expect all con
 
 ## Contribution Process
 
+### Before You Open a Pull Request
+
+Run the presubmit check from the repository root before opening a pull request:
+
+```bash
+npm run presubmit
+```
+
+This formats the repository and then runs linting, the build, type checking, and tests. (The build runs before type checking and tests because packages type-check and test against each other's built output.) If your PR is large or you run into problems that are hard to reproduce locally, you may also want to run the heavier CI-style preflight check:
+
+```bash
+npm run preflight
+```
+
+`preflight` performs a clean install and already includes formatting, CI linting, build, type checking, and CI tests, so you do not need to run those separately unless you are re-checking a specific failure after making fixes.
+
 ### Code Reviews
 
 All submissions, including submissions by project members, require review. We
@@ -54,7 +70,7 @@ If you'd like to get early feedback on your work, please use GitHub's **Draft Pu
 
 #### 4. Ensure All Checks Pass
 
-Before submitting your PR, ensure that all automated checks are passing by running `npm run preflight`. This command runs all tests, linting, and other style checks.
+Before submitting your PR, ensure that the contributor readiness checks pass by running `npm run presubmit`. This command formats the repository and then runs linting, the build, type checking, and tests.
 
 #### 5. Update Documentation
 
@@ -145,7 +161,7 @@ To execute the unit test suite for the project:
 npm run test
 ```
 
-This will run tests located in the `packages/core` and `packages/cli` directories. Ensure tests pass before submitting any changes. For a more comprehensive check, it is recommended to run `npm run preflight`.
+This will run tests located in the `packages/core` and `packages/cli` directories. Ensure tests pass before submitting any changes. For the standard pre-PR check, run `npm run presubmit`.
 
 #### Integration Tests
 
@@ -161,26 +177,34 @@ For more detailed information on the integration testing framework, please see t
 
 ### Linting and Preflight Checks
 
-To ensure code quality and formatting consistency, run the preflight check:
+To ensure code quality and formatting consistency before a PR, run the presubmit check:
+
+```bash
+npm run presubmit
+```
+
+This command runs formatting, linting, the build, type checking, and tests.
+
+For a larger PR or a difficult-to-reproduce failure, run the heavier preflight check:
 
 ```bash
 npm run preflight
 ```
 
-This command will run ESLint, Prettier, all tests, and other checks as defined in the project's `package.json`.
+This command runs a clean install and then formatting, CI linting, build, type checking, and CI tests as defined in the project's `package.json`.
 
 _ProTip_
 
-after cloning create a git precommit hook file to ensure your commits are always clean.
+After cloning, you can create a git pre-push hook to check your branch before pushing:
 
 ```bash
 echo "
-# Run npm build and check for errors
-if ! npm run preflight; then
-  echo "npm build failed. Commit aborted."
+# Run contributor readiness checks before pushing
+if ! npm run presubmit; then
+  echo "npm presubmit failed. Push aborted."
   exit 1
 fi
-" > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+" > .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 ```
 
 #### Formatting

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,4 +87,4 @@ LLxprt Code ships with built-in tools for file editing, shell commands, web sear
 
 ## Contributing
 
-LLxprt Code is open source and community-driven. See the **[Contributing Guide](./CONTRIBUTING.md)** to get started.
+LLxprt Code is open source and community-driven. See the **[Contributing Guide](../CONTRIBUTING.md)** to get started.

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "check": "npm run lint:all",
     "fix": "npm run format:all",
+    "presubmit": "npm run format && npm run lint && npm run build && npm run typecheck && npm run test",
     "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",


### PR DESCRIPTION
## TLDR

Adds a lightweight `npm run presubmit` script so contributors (and agents) have one obvious command to run before opening a PR, and streamlines the contributing guide around it. Closes #2075.

The new script runs, in order:

    format -> lint -> build -> typecheck -> test

Reviewers should note the ordering: `build` runs **before** `typecheck` and `test`. In this monorepo, packages type-check and test against each other's built `dist/` output, so running `build` last would intermittently fail whenever a sibling package's public API changed (I hit exactly this during verification after merging `main`). This matches the ordering already used by the existing `preflight` script.

## Dive Deeper

Issue #2075 asks for an obvious pre-PR command (the reporter listed test / typecheck / lint / format / build) and a refresh of the contributing docs.

Changes:

- **package.json**: add `presubmit` = `npm run format && npm run lint && npm run build && npm run typecheck && npm run test`. The existing `preflight` (clean + `npm ci` + CI variants) is intentionally left as the heavier release/CI-grade check.
- **CONTRIBUTING.md**:
  - New "Before You Open a Pull Request" section featuring `npm run presubmit`, and advising `npm run preflight` for large PRs or hard-to-reproduce failures. It notes that `preflight` already includes format/lint/build/typecheck/test, so those need not be re-run separately.
  - PR guideline #4, the unit-test section, and the "Linting and Preflight Checks" section now point at `presubmit`.
  - The ProTip git hook changed from a **pre-commit** hook running the heavy `preflight` (which did `clean` + `npm ci` on every commit) to a **pre-push** hook running `presubmit`.
- **docs/CONTRIBUTING.md**: this was a symlink to `../CONTRIBUTING.md`. Per the issue's request to keep a single standard guide, the symlink is removed so the root `CONTRIBUTING.md` (the conventional GitHub location) is the one source of truth.
- **docs/index.md**: the Contributing link now points to `../CONTRIBUTING.md`.

Note: CodeRabbit's study of the issue suggested ordering `... typecheck && test && build` and described the two CONTRIBUTING files as "byte-for-byte identical and will diverge." Both points were adjusted against the actual repo: the duplicate was a symlink (cannot diverge), and `build` must precede typecheck/test in this workspace setup.

## Reviewer Test Plan

1. Check out the branch and run `npm run presubmit` from the repo root. It should run format, lint, build, typecheck, and test in that order and exit 0.
2. Confirm `npm run preflight` still exists and is unchanged.
3. Read CONTRIBUTING.md and confirm the guidance is coherent and the pre-push hook snippet is correct.
4. Confirm `docs/CONTRIBUTING.md` no longer exists and the Contributing link in `docs/index.md` resolves to the root guide.

I verified `npm run presubmit` end-to-end locally: format, lint (0 errors), build, typecheck, and the full test suite all pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | -   | -   | -   |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

This is a tooling/documentation change (an npm script plus contributing docs); it does not affect runtime behavior of the CLI across platforms.

## Linked issues / bugs

Fixes #2075
