### PR TITLE
Inherit parent max turns for subagents (Fixes #2048)

### DIFF
--- a/packages/agents/src/core/subagentOrchestrator.test.ts
+++ b/packages/agents/src/core/subagentOrchestrator.test.ts
@@ -343,6 +343,344 @@ describe('SubagentOrchestrator - Config Resolution', () => {
     expect(runConfigArg.max_turns).toBe(200);
   });
 
+  it('defaults max_turns to the foreground config current maxTurnsPerPrompt when neither profile nor request specify limits', async () => {
+    const subagentConfig: SubagentConfig = {
+      name: 'parent-default-helper',
+      profile: 'default-profile',
+      systemPrompt: 'Assist without additional limits.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
+    const subagentManager = {
+      loadSubagent,
+    } as unknown as SubagentManager;
+
+    const loadProfile = vi.fn().mockResolvedValue(baseProfile);
+    const profileManager = {
+      loadProfile,
+    } as unknown as ProfileManager;
+
+    const configWithParentTurns = {
+      ...foregroundConfig,
+      getEphemeralSetting: (key: string) => {
+        if (key === 'maxTurnsPerPrompt') {
+          return 75;
+        }
+        return undefined;
+      },
+    } as unknown as Config;
+
+    const { factory } = createScopeFactory();
+    const runtimeBundle = createRuntimeBundle('parent-turns');
+    const runtimeLoader = vi.fn().mockResolvedValue(runtimeBundle);
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager,
+      profileManager,
+      foregroundConfig: configWithParentTurns,
+      scopeFactory: factory,
+      runtimeLoader,
+    });
+
+    await orchestrator.launch({ name: subagentConfig.name });
+
+    const [, , , , runConfigArg] = factory.mock.calls[0];
+    expect(runConfigArg.max_time_minutes).toBe(Number.POSITIVE_INFINITY);
+    expect(runConfigArg.max_turns).toBe(75);
+  });
+
+  it('reads the foreground config maxTurnsPerPrompt dynamically at launch time through a single orchestrator instance', async () => {
+    const subagentConfig: SubagentConfig = {
+      name: 'dynamic-parent-helper',
+      profile: 'default-profile',
+      systemPrompt: 'Assist.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    let parentMaxTurns = 50;
+    const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
+    const subagentManager = {
+      loadSubagent,
+    } as unknown as SubagentManager;
+
+    const loadProfile = vi.fn().mockResolvedValue(baseProfile);
+    const profileManager = {
+      loadProfile,
+    } as unknown as ProfileManager;
+
+    const configWithDynamicTurns = {
+      ...foregroundConfig,
+      getEphemeralSetting: (key: string) => {
+        if (key === 'maxTurnsPerPrompt') {
+          return parentMaxTurns;
+        }
+        return undefined;
+      },
+    } as unknown as Config;
+
+    const { factory } = createScopeFactory();
+    const runtimeLoader = vi.fn().mockResolvedValue(createRuntimeBundle());
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager,
+      profileManager,
+      foregroundConfig: configWithDynamicTurns,
+      scopeFactory: factory,
+      runtimeLoader,
+    });
+
+    await orchestrator.launch({ name: subagentConfig.name });
+
+    parentMaxTurns = 250;
+
+    await orchestrator.launch({ name: subagentConfig.name });
+
+    const [, , , , firstRunConfig] = factory.mock.calls[0];
+    expect(firstRunConfig.max_turns).toBe(50);
+
+    const [, , , , secondRunConfig] = factory.mock.calls[1];
+    expect(secondRunConfig.max_turns).toBe(250);
+  });
+
+  it('falls back to 200 when foreground config has no current maxTurnsPerPrompt', async () => {
+    const subagentConfig: SubagentConfig = {
+      name: 'no-parent-helper',
+      profile: 'default-profile',
+      systemPrompt: 'Assist.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
+    const subagentManager = {
+      loadSubagent,
+    } as unknown as SubagentManager;
+
+    const loadProfile = vi.fn().mockResolvedValue(baseProfile);
+    const profileManager = {
+      loadProfile,
+    } as unknown as ProfileManager;
+
+    const { factory } = createScopeFactory();
+    const runtimeBundle = createRuntimeBundle('no-parent-turns');
+    const runtimeLoader = vi.fn().mockResolvedValue(runtimeBundle);
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager,
+      profileManager,
+      foregroundConfig,
+      scopeFactory: factory,
+      runtimeLoader,
+    });
+
+    await orchestrator.launch({ name: subagentConfig.name });
+
+    const [, , , , runConfigArg] = factory.mock.calls[0];
+    expect(runConfigArg.max_turns).toBe(200);
+  });
+
+  it('respects explicit request max_turns over foreground config maxTurnsPerPrompt', async () => {
+    const subagentConfig: SubagentConfig = {
+      name: 'explicit-over-parent-helper',
+      profile: 'default-profile',
+      systemPrompt: 'Assist.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
+    const subagentManager = {
+      loadSubagent,
+    } as unknown as SubagentManager;
+
+    const loadProfile = vi.fn().mockResolvedValue(baseProfile);
+    const profileManager = {
+      loadProfile,
+    } as unknown as ProfileManager;
+
+    const configWithParentTurns = {
+      ...foregroundConfig,
+      getEphemeralSetting: (key: string) => {
+        if (key === 'maxTurnsPerPrompt') {
+          return 75;
+        }
+        return undefined;
+      },
+    } as unknown as Config;
+
+    const { factory } = createScopeFactory();
+    const runtimeBundle = createRuntimeBundle('explicit-over-parent');
+    const runtimeLoader = vi.fn().mockResolvedValue(runtimeBundle);
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager,
+      profileManager,
+      foregroundConfig: configWithParentTurns,
+      scopeFactory: factory,
+      runtimeLoader,
+    });
+
+    await orchestrator.launch({
+      name: subagentConfig.name,
+      runConfig: { max_turns: 10 },
+    });
+
+    const [, , , , runConfigArg] = factory.mock.calls[0];
+    expect(runConfigArg.max_turns).toBe(10);
+  });
+
+  it('respects profile maxTurnsPerPrompt over foreground config maxTurnsPerPrompt', async () => {
+    const subagentConfig: SubagentConfig = {
+      name: 'profile-over-parent-helper',
+      profile: 'profile-with-turns',
+      systemPrompt: 'Assist.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const profileWithTurns: Profile = {
+      ...baseProfile,
+      ephemeralSettings: {
+        ...baseProfile.ephemeralSettings,
+        maxTurnsPerPrompt: 500,
+      },
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
+    const subagentManager = {
+      loadSubagent,
+    } as unknown as SubagentManager;
+
+    const loadProfile = vi.fn().mockResolvedValue(profileWithTurns);
+    const profileManager = {
+      loadProfile,
+    } as unknown as ProfileManager;
+
+    const configWithParentTurns = {
+      ...foregroundConfig,
+      getEphemeralSetting: (key: string) => {
+        if (key === 'maxTurnsPerPrompt') {
+          return 75;
+        }
+        return undefined;
+      },
+    } as unknown as Config;
+
+    const { factory } = createScopeFactory();
+    const runtimeBundle = createRuntimeBundle('profile-over-parent');
+    const runtimeLoader = vi.fn().mockResolvedValue(runtimeBundle);
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager,
+      profileManager,
+      foregroundConfig: configWithParentTurns,
+      scopeFactory: factory,
+      runtimeLoader,
+    });
+
+    await orchestrator.launch({ name: subagentConfig.name });
+
+    const [, , , , runConfigArg] = factory.mock.calls[0];
+    expect(runConfigArg.max_turns).toBe(500);
+  });
+
+  it('omits max_turns when foreground config maxTurnsPerPrompt is unlimited (-1)', async () => {
+    const subagentConfig: SubagentConfig = {
+      name: 'unlimited-parent-helper',
+      profile: 'default-profile',
+      systemPrompt: 'Assist.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
+    const subagentManager = {
+      loadSubagent,
+    } as unknown as SubagentManager;
+
+    const loadProfile = vi.fn().mockResolvedValue(baseProfile);
+    const profileManager = {
+      loadProfile,
+    } as unknown as ProfileManager;
+
+    const configWithUnlimitedParentTurns = {
+      ...foregroundConfig,
+      getEphemeralSetting: (key: string) => {
+        if (key === 'maxTurnsPerPrompt') {
+          return -1;
+        }
+        return undefined;
+      },
+    } as unknown as Config;
+
+    const { factory } = createScopeFactory();
+    const runtimeBundle = createRuntimeBundle('unlimited-parent-turns');
+    const runtimeLoader = vi.fn().mockResolvedValue(runtimeBundle);
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager,
+      profileManager,
+      foregroundConfig: configWithUnlimitedParentTurns,
+      scopeFactory: factory,
+      runtimeLoader,
+    });
+
+    await orchestrator.launch({ name: subagentConfig.name });
+
+    const [, , , , runConfigArg] = factory.mock.calls[0];
+    expect(runConfigArg.max_turns).toBeUndefined();
+  });
+
+  it('falls back to 200 when foreground config maxTurnsPerPrompt is zero', async () => {
+    const subagentConfig: SubagentConfig = {
+      name: 'zero-parent-helper',
+      profile: 'default-profile',
+      systemPrompt: 'Assist.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const loadSubagent = vi.fn().mockResolvedValue(subagentConfig);
+    const subagentManager = {
+      loadSubagent,
+    } as unknown as SubagentManager;
+
+    const loadProfile = vi.fn().mockResolvedValue(baseProfile);
+    const profileManager = {
+      loadProfile,
+    } as unknown as ProfileManager;
+
+    const configWithZeroParentTurns = {
+      ...foregroundConfig,
+      getEphemeralSetting: (key: string) => {
+        if (key === 'maxTurnsPerPrompt') {
+          return 0;
+        }
+        return undefined;
+      },
+    } as unknown as Config;
+
+    const { factory } = createScopeFactory();
+    const runtimeBundle = createRuntimeBundle('zero-parent-turns');
+    const runtimeLoader = vi.fn().mockResolvedValue(runtimeBundle);
+
+    const orchestrator = new SubagentOrchestrator({
+      subagentManager,
+      profileManager,
+      foregroundConfig: configWithZeroParentTurns,
+      scopeFactory: factory,
+      runtimeLoader,
+    });
+
+    await orchestrator.launch({ name: subagentConfig.name });
+
+    const [, , , , runConfigArg] = factory.mock.calls[0];
+    expect(runConfigArg.max_turns).toBe(200);
+  });
+
   it('honors an already-aborted signal before beginning launch work', async () => {
     const subagentConfig: SubagentConfig = {
       name: 'cancel-helper',

--- a/packages/agents/src/core/subagentOrchestrator.ts
+++ b/packages/agents/src/core/subagentOrchestrator.ts
@@ -335,10 +335,13 @@ export class SubagentOrchestrator {
       'maxTurnsPerPrompt',
     ]);
 
-    const maxTurns = custom?.max_turns ?? profileMaxTurns ?? 200;
+    const parentMaxTurns = this.getParentMaxTurns();
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent settings cross persisted/runtime boundaries despite declared types.
-    if (maxTurns !== undefined && maxTurns > 0) {
+    const maxTurns = custom?.max_turns ?? profileMaxTurns ?? parentMaxTurns;
+
+    if (maxTurns === undefined) {
+      runConfig.max_turns = 200;
+    } else if (maxTurns > 0) {
       runConfig.max_turns = Math.floor(maxTurns);
     }
 
@@ -347,6 +350,25 @@ export class SubagentOrchestrator {
     }
 
     return runConfig;
+  }
+
+  private getParentMaxTurns(): number | undefined {
+    const config = this.options.foregroundConfig as Config & {
+      getEphemeralSetting?: (key: string) => unknown;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Foreground config may not implement getEphemeralSetting in all environments.
+    if (typeof config.getEphemeralSetting !== 'function') {
+      return undefined;
+    }
+    const value = config.getEphemeralSetting('maxTurnsPerPrompt');
+    if (
+      typeof value === 'number' &&
+      Number.isFinite(value) &&
+      (value === -1 || value > 0)
+    ) {
+      return value;
+    }
+    return undefined;
   }
 
   private async resolveRuntimeProfile(

--- a/packages/agents/src/core/subagentToolProcessing.test.ts
+++ b/packages/agents/src/core/subagentToolProcessing.test.ts
@@ -198,6 +198,15 @@ describe('subagentToolProcessing', () => {
       expect(output.final_message).toContain('maximum number of turns');
     });
 
+    it('should include actionable max_turns guidance in MAX_TURNS message', () => {
+      const output: OutputObject = {
+        emitted_vars: {},
+        terminate_reason: SubagentTerminateMode.MAX_TURNS,
+      };
+      finalizeOutput(output);
+      expect(output.final_message).toContain('max_turns');
+    });
+
     it('should set ERROR message', () => {
       const output: OutputObject = {
         emitted_vars: {},

--- a/packages/agents/src/core/subagentToolProcessing.ts
+++ b/packages/agents/src/core/subagentToolProcessing.ts
@@ -171,7 +171,9 @@ export function finalizeOutput(output: OutputObject): void {
       baseMessage = 'Stopped because the time limit was reached.';
       break;
     case SubagentTerminateMode.MAX_TURNS:
-      baseMessage = 'Stopped because the maximum number of turns was reached.';
+      baseMessage =
+        'Stopped because the maximum number of turns was reached. ' +
+        'Consider passing a higher max_turns value in the task tool invocation to allow more turns.';
       break;
     case SubagentTerminateMode.ERROR:
     default:

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -1226,6 +1226,139 @@ describe('TaskTool', () => {
     );
   });
 
+  describe('max_turns validation', () => {
+    const createTool = () =>
+      new TaskTool(config, {
+        orchestratorFactory: () => {
+          throw new Error('should not be called');
+        },
+      });
+
+    it('rejects max_turns of 0', () => {
+      const tool = createTool();
+
+      expect(() =>
+        tool.build({
+          subagent_name: 'helper',
+          goal_prompt: 'Do work',
+          max_turns: 0,
+        }),
+      ).toThrow('Task tool max_turns must be a positive integer or -1');
+    });
+
+    it('rejects fractional max_turns like 0.5', () => {
+      const tool = createTool();
+
+      expect(() =>
+        tool.build({
+          subagent_name: 'helper',
+          goal_prompt: 'Do work',
+          max_turns: 0.5,
+        }),
+      ).toThrow('Task tool max_turns must be a positive integer or -1');
+    });
+
+    it('rejects negative max_turns other than -1', () => {
+      const tool = createTool();
+
+      expect(() =>
+        tool.build({
+          subagent_name: 'helper',
+          goal_prompt: 'Do work',
+          max_turns: -2,
+        }),
+      ).toThrow('Task tool max_turns must be a positive integer or -1');
+    });
+
+    it('accepts max_turns of -1 for unlimited and wires it through', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-unlimited-turns',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'helper',
+        goal_prompt: 'Do work',
+        max_turns: -1,
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      expect(launch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runConfig: expect.objectContaining({
+            max_turns: -1,
+          }),
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('accepts positive integer max_turns and wires it through', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-fixed-turns',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'helper',
+        goal_prompt: 'Do work',
+        max_turns: 5,
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      expect(launch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runConfig: expect.objectContaining({
+            max_turns: 5,
+          }),
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+  });
+
   it('streams subagent messages on separate lines with normalized newlines', async () => {
     const dispose = vi.fn().mockResolvedValue(undefined);
     const updateOutput = vi.fn();

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -763,6 +763,150 @@ describe('TaskTool', () => {
     expect(result.returnDisplay).toMatch(/abort/i);
   });
 
+  describe('max_turns handling', () => {
+    it('passes max_turns from params into launch request runConfig', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-max-turns',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'helper',
+        goal_prompt: 'Ship it',
+        max_turns: 42,
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      expect(launch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runConfig: expect.objectContaining({
+            max_turns: 42,
+          }),
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('passes max_turns alongside timeout into runConfig without losing either', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-max-turns-timeout',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const configWithTimeout = {
+        ...config,
+        getEphemeralSettings: () => ({
+          'task-default-timeout-seconds': 60,
+          'task-max-timeout-seconds': 120,
+        }),
+      } as unknown as Config;
+      const tool = new TaskTool(configWithTimeout, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'helper',
+        goal_prompt: 'Ship it',
+        max_turns: 30,
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      expect(launch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runConfig: expect.objectContaining({
+            max_time_minutes: 1,
+            max_turns: 30,
+          }),
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('passes max_turns alongside grace_period_seconds into runConfig', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-max-turns-grace',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => true,
+      });
+
+      const invocation = tool.build({
+        subagent_name: 'helper',
+        goal_prompt: 'Ship it',
+        max_turns: 20,
+        grace_period_seconds: 15,
+      });
+
+      await invocation.execute(new AbortController().signal, undefined);
+
+      expect(launch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runConfig: expect.objectContaining({
+            max_turns: 20,
+            grace_period_seconds: 15,
+          }),
+        }),
+        expect.any(AbortSignal),
+      );
+    });
+  });
+
   describe('timeout_seconds handling', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -1474,6 +1474,17 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
       return 'Task tool requires a goal_prompt describing the assignment.';
     }
 
+    if (params.max_turns !== undefined) {
+      const maxTurns = params.max_turns;
+      if (
+        !Number.isFinite(maxTurns) ||
+        !Number.isInteger(maxTurns) ||
+        (maxTurns !== -1 && maxTurns < 1)
+      ) {
+        return 'Task tool max_turns must be a positive integer or -1 for unlimited.';
+      }
+    }
+
     return null;
   }
 

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -73,6 +73,7 @@ export interface TaskToolParams {
   contextVars?: Record<string, unknown>;
   timeout_seconds?: number;
   grace_period_seconds?: number;
+  max_turns?: number;
   async?: boolean;
 }
 
@@ -83,6 +84,7 @@ interface TaskToolInvocationParams {
   toolWhitelist?: string[];
   outputSpec?: Record<string, string>;
   context: Record<string, unknown>;
+  maxTurns?: number;
   async: boolean;
 }
 
@@ -296,6 +298,20 @@ class TaskToolInvocation extends BaseToolInvocation<
         max_time_minutes:
           launchRequest.runConfig?.max_time_minutes ?? Number.POSITIVE_INFINITY,
         grace_period_seconds: this.params.grace_period_seconds,
+      };
+    }
+
+    if (this.normalized.maxTurns !== undefined) {
+      launchRequest.runConfig = {
+        max_time_minutes:
+          launchRequest.runConfig?.max_time_minutes ?? Number.POSITIVE_INFINITY,
+        ...(launchRequest.runConfig?.grace_period_seconds !== undefined
+          ? {
+              grace_period_seconds:
+                launchRequest.runConfig.grace_period_seconds,
+            }
+          : {}),
+        max_turns: this.normalized.maxTurns,
       };
     }
 
@@ -1420,6 +1436,11 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
             description:
               'Optional grace period in seconds for recovery after a termination condition (TIMEOUT, MAX_TURNS, or protocol violation). Falls back to 60s if not specified or invalid.',
           },
+          max_turns: {
+            type: 'number',
+            description:
+              'Optional maximum number of turns for the subagent. Overrides the subagent profile and parent agent defaults when set.',
+          },
           async: {
             type: 'boolean',
             description:
@@ -1520,6 +1541,7 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
       toolWhitelist: toolWhitelist.length > 0 ? toolWhitelist : undefined,
       outputSpec,
       context,
+      maxTurns: params.max_turns,
       async: params.async ?? false,
     };
   }


### PR DESCRIPTION
## Summary

Fixes #2048.

Subagent max turns now defaults to the **parent agent's current** max turns
setting, read dynamically at launch time, instead of a hardcoded 200. This
keeps subagents aligned with the parent's loop-detection/turn budget even when
that budget is changed via an ephemeral setting mid-session.

## Motivation

Previously, when neither the task invocation nor the subagent profile specified
a turn limit, the orchestrator fell back to a hardcoded default of 200 turns.
This caused long-running subagents to hit MAX_TURNS unexpectedly, and the limit
ignored whatever the parent agent was actually configured to allow.

The requested behavior: a launched subagent should inherit whatever the parent's
max turns is **at the moment of launch** (so a runtime ephemeral change is
respected), unless explicitly overridden.

## Changes

- **`subagentOrchestrator.ts`** - `buildRunConfig()` now resolves max turns in
  this priority order:
  1. Explicit `max_turns` from the task/run config
  2. Subagent profile `maxTurnsPerPrompt`
  3. Parent foreground config's **current** `maxTurnsPerPrompt` (read at launch
     via `getEphemeralSetting`, not cached at construction)
  4. Hardcoded fallback of 200
  - A parent value of `-1` is treated as unlimited (omits `max_turns`),
    matching the existing profile/request unlimited convention. Zero or absent
    values fall through to the 200 fallback.
- **`task.ts`** - Added `max_turns` to `TaskToolParams` and the tool JSON
  schema, and wired it into `createLaunchRequest()` so a calling agent can set a
  per-launch limit without clobbering `max_time_minutes` or
  `grace_period_seconds`.
- **`subagentToolProcessing.ts`** - The MAX_TURNS termination message now
  includes actionable guidance suggesting the caller pass a higher `max_turns`
  in the task invocation next time.

## Tests (TDD, behavioral)

Added/updated behavioral tests in:
- `subagentOrchestrator.test.ts` - parent default inheritance, dynamic
  launch-time lookup through a single orchestrator instance (mutating the value
  between launches), explicit/profile precedence over parent, parent `-1`
  unlimited, parent `0` and absent both fall back to 200.
- `task.test.ts` - `max_turns` schema exposure and run-config composition with
  `timeout_seconds`/`grace_period_seconds`.
- `subagentToolProcessing.test.ts` - MAX_TURNS message contains the actionable
  `max_turns` hint.

## Verification

- npm run lint - 0 errors
- npm run typecheck - clean across all packages
- npm run format - applied
- npm run build - success
- npm run test - all package suites passing (agents, core, providers, settings,
  cli, tools, lsp, a2a-server)
- Smoke test - passing
