### PR TITLE
Clarify tool display-state flag after engine-owned continuation (Fixes #2054)

### DIFF
--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/toolCompletionHandler.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/toolCompletionHandler.test.ts
@@ -57,7 +57,7 @@ function makeCompletedTool(overrides: {
       agentId: overrides.agentId ?? DEFAULT_AGENT_ID,
     },
     status: overrides.status ?? 'success',
-    responseSubmittedToGemini: false,
+    displayCleared: false,
     response: {
       callId: overrides.callId,
       responseParts: overrides.responseParts ?? [functionResponsePart],

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
@@ -479,11 +479,11 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
     expect(settled).toBe(true);
   });
 
-  it('clears external (subagent) tools from the display via markToolsAsSubmitted', async () => {
+  it('clears external (subagent) tools from the display via markToolsAsDisplayCleared', async () => {
     // An external tool carries a non-default agentId. The subagent flow owns
-    // its results, so the loop's display handling must mark it submitted to
-    // remove it from the pending React display state. Primary tools must NOT
-    // be marked submitted (continuation owns them).
+    // its results, so the loop's display handling must mark it display-cleared
+    // to remove it from the pending React display state. Primary tools must NOT
+    // be marked cleared (continuation owns them).
     const tool = toolRegistry.getTool('record_tool') as MockTool;
 
     const externalRequest: ToolCallRequestInfo = {
@@ -503,7 +503,7 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
       [contentEvent('after-subagent'), finishedEvent()],
     ]);
 
-    const markedSubmitted: string[][] = [];
+    const markedDisplayCleared: string[][] = [];
 
     const { result } = renderHook(() =>
       useAgenticLoop({
@@ -512,8 +512,8 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
         messageBus,
         interactiveMode: true,
         addItem: vi.fn(),
-        markToolsAsSubmitted: (callIds) => {
-          markedSubmitted.push(callIds);
+        markToolsAsDisplayCleared: (callIds) => {
+          markedDisplayCleared.push(callIds);
         },
         onToolCallsUpdate: () => {},
         outputUpdateHandler: () => {},
@@ -532,10 +532,10 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
       await result.current.runLoop('go', new AbortController().signal, 'p1');
     });
 
-    // The external tool's callId was marked submitted exactly once so the
-    // display clears it. The tool itself still executed once (the loop ran it).
+    // The external tool's callId was marked display-cleared exactly once so
+    // the display clears it. The tool itself still executed once (the loop ran it).
     await waitFor(() => {
-      expect(markedSubmitted.flat()).toContain('subagent-call');
+      expect(markedDisplayCleared.flat()).toContain('subagent-call');
     });
     expect(tool.executeFn).toHaveBeenCalledTimes(1);
   });
@@ -580,5 +580,54 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
 
     expect(oldRouter).not.toHaveBeenCalled();
     expect(newRouter).toHaveBeenCalled();
+  });
+
+  it('drives primary continuation without ever display-clearing the primary tool', async () => {
+    // The display-clearing path is for external (subagent) tools only. A
+    // primary tool drives the loop's continuation turn (turn 2 carries the
+    // functionResponse the loop built) and is NEVER routed through
+    // markToolsAsDisplayCleared — proving continuation is decoupled from the
+    // display-state marker.
+    const { client, turnMessages } = createScriptedAgentClient([
+      [toolCallRequestEvent('record_tool', 'primary-call'), finishedEvent()],
+      [contentEvent('continuation-content'), finishedEvent()],
+    ]);
+
+    const markedDisplayCleared: string[][] = [];
+
+    const { result } = renderHook(() =>
+      useAgenticLoop({
+        config,
+        agentClient: client,
+        messageBus,
+        interactiveMode: true,
+        addItem: vi.fn(),
+        markToolsAsDisplayCleared: (callIds) => {
+          markedDisplayCleared.push(callIds);
+        },
+        onToolCallsUpdate: () => {},
+        outputUpdateHandler: () => {},
+        getPreferredEditor: () => undefined,
+        onEditorOpen: () => {},
+        onEditorClose: () => {},
+        onTodoPause: () => {},
+        processStreamEventRef: { current: () => {} },
+        flushPendingHistoryItem: () => {},
+        clearPendingHistoryItem: () => {},
+        performMemoryRefresh: async () => {},
+      }),
+    );
+
+    await act(async () => {
+      await result.current.runLoop('go', new AbortController().signal, 'p1');
+    });
+
+    // Two turns => the loop drove continuation for the primary tool.
+    expect(turnMessages).toHaveLength(2);
+    const turn2Parts = toParts(turnMessages[1]);
+    expect(turn2Parts.some((p) => 'functionResponse' in p)).toBe(true);
+    // The primary tool's callId was never passed to the display-clearing
+    // callback: continuation does not depend on (or trigger) display clearing.
+    expect(markedDisplayCleared.flat()).not.toContain('primary-call');
   });
 });

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
@@ -535,8 +535,9 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
     // The external tool's callId was marked display-cleared exactly once so
     // the display clears it. The tool itself still executed once (the loop ran it).
     await waitFor(() => {
-      expect(markedDisplayCleared.flat()).toContain('subagent-call');
+      expect(markedDisplayCleared).toHaveLength(1);
     });
+    expect(markedDisplayCleared[0]).toStrictEqual(['subagent-call']);
     expect(tool.executeFn).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/cli/src/ui/hooks/geminiStream/useAgenticLoop.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useAgenticLoop.ts
@@ -107,11 +107,11 @@ export interface UseAgenticLoopArgs {
   /** Invoked when the pause tool succeeds. */
   onTodoPause?: () => void;
   /**
-   * Marks the given tool callIds as submitted so the React display state clears
-   * them. Used for external (subagent) tools whose results are owned by the
+   * Marks the given tool callIds as cleared from the React display state.
+   * Used for external (subagent) tools whose results are owned by the
    * subagent flow, not the primary loop continuation. Display-only.
    */
-  markToolsAsSubmitted?: (callIds: string[]) => void;
+  markToolsAsDisplayCleared?: (callIds: string[]) => void;
   /** Display callbacks forwarded into the loop's scheduler. */
   onToolCallsUpdate?: (toolCalls: ToolCall[]) => void;
   outputUpdateHandler?: (callId: string, chunk: string | AnsiOutput) => void;
@@ -181,9 +181,11 @@ function handleToolsComplete(
 
   // Clear external (subagent) tools from the React display state. Their results
   // are owned by the subagent flow, not the primary loop continuation, so the
-  // display must mark them submitted to remove them from the pending view.
+  // display must mark them cleared to remove them from the pending view.
   if (externalTools.length > 0) {
-    args.markToolsAsSubmitted?.(externalTools.map((tc) => tc.request.callId));
+    args.markToolsAsDisplayCleared?.(
+      externalTools.map((tc) => tc.request.callId),
+    );
   }
 }
 

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamLifecycle.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamLifecycle.ts
@@ -53,7 +53,7 @@ function isOutstandingToolCall(tc: TrackedToolCall): boolean {
   if (!isTerminalToolCall(status)) return false;
   return (
     (tc as TrackedCompletedToolCall | TrackedCancelledToolCall)
-      .responseSubmittedToGemini !== true
+      .displayCleared !== true
   );
 }
 
@@ -114,7 +114,7 @@ function processPrimaryCompletion(
   addItem: UseHistoryManagerReturn['addItem'],
   agentClient: AgentClientContract,
   config: Config,
-  markToolsAsSubmitted: (callIds: string[]) => void,
+  markToolsAsDisplayCleared: (callIds: string[]) => void,
 ): void {
   addItem(
     mapTrackedToolCallsToDisplay(completedToolCallsFromScheduler),
@@ -134,25 +134,25 @@ function processPrimaryCompletion(
       `Error recording completed tool call information: ${error}`,
     );
   }
-  // Mark external (subagent) tools as submitted so the display state clears
-  // them. Continuation is owned by the AgenticLoop; this is display-only.
+  // Mark external (subagent) tools as cleared from display. Continuation is
+  // owned by the AgenticLoop; this is display-only.
   const { externalTools } = classifyCompletedTools(
     completedToolCallsFromScheduler,
   );
   if (externalTools.length > 0) {
-    markToolsAsSubmitted(externalTools.map((tc) => tc.request.callId));
+    markToolsAsDisplayCleared(externalTools.map((tc) => tc.request.callId));
   }
 }
 
 function processSecondaryCompletion(
   completedToolCallsFromScheduler: TrackedToolCall[],
-  markToolsAsSubmitted: (callIds: string[]) => void,
+  markToolsAsDisplayCleared: (callIds: string[]) => void,
   addItem: UseHistoryManagerReturn['addItem'],
 ): void {
   const callIdsToMark = completedToolCallsFromScheduler.map(
     (toolCall) => toolCall.request.callId,
   );
-  if (callIdsToMark.length > 0) markToolsAsSubmitted(callIdsToMark);
+  if (callIdsToMark.length > 0) markToolsAsDisplayCleared(callIdsToMark);
   addItem(
     mapTrackedToolCallsToDisplay(completedToolCallsFromScheduler),
     Date.now(),

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
@@ -75,7 +75,7 @@ interface ToolSchedulerState {
   scheduler: ReturnType<typeof useToolSchedulerSetup>;
   toolCalls: TrackedToolCall[];
   scheduleToolCalls: UseSubmitQueryDeps['scheduleToolCalls'];
-  markToolsAsSubmitted: (callIds: string[]) => void;
+  markToolsAsDisplayCleared: (callIds: string[]) => void;
   cancelAllToolCalls: () => void;
   lastToolOutputTime: number;
   interactiveRuntimeReady: boolean;
@@ -177,7 +177,7 @@ function useToolSchedulerState(
   const [
     toolCalls,
     scheduleToolCalls,
-    markToolsAsSubmitted,
+    markToolsAsDisplayCleared,
     cancelAllToolCalls,
     lastToolOutputTime,
     interactiveRuntimeReady,
@@ -188,7 +188,7 @@ function useToolSchedulerState(
     scheduler,
     toolCalls,
     scheduleToolCalls,
-    markToolsAsSubmitted,
+    markToolsAsDisplayCleared,
     cancelAllToolCalls,
     lastToolOutputTime,
     interactiveRuntimeReady,
@@ -260,7 +260,7 @@ function useLoopForStream(
     clearPendingHistoryItem: () => st.setPendingHistoryItem(null),
     performMemoryRefresh: args.performMemoryRefresh,
     onTodoPause: args.onTodoPause,
-    markToolsAsSubmitted: scheduler.markToolsAsSubmitted,
+    markToolsAsDisplayCleared: scheduler.markToolsAsDisplayCleared,
     onToolCallsUpdate: scheduler.replaceToolCalls,
     outputUpdateHandler: scheduler.updateToolOutput,
     getPreferredEditor: args.getPreferredEditor,

--- a/packages/cli/src/ui/hooks/useGeminiStream.dedup.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.dedup.test.tsx
@@ -82,7 +82,7 @@ vi.mock('./useReactToolScheduler.js', () => ({
     return [
       [], // toolCalls
       scheduleFn,
-      vi.fn(), // markToolsAsSubmitted
+      vi.fn(), // markToolsAsDisplayCleared
       vi.fn(), // cancelAllToolCalls
       0,
       true,

--- a/packages/cli/src/ui/hooks/useGeminiStream.subagent.spec.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.subagent.spec.tsx
@@ -22,10 +22,12 @@ import type {
   EditorType,
   AnyToolInvocation,
 } from '@vybestack/llxprt-code-core';
+import { DEFAULT_AGENT_ID } from '@vybestack/llxprt-code-core';
 import type { Part, PartListUnion } from '@google/genai';
 import type { LoadedSettings } from '../../config/settings.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import type { SlashCommandProcessorResult } from '../types.js';
+import { StreamingState } from '../types.js';
 
 const inkMock = vi.hoisted(() => {
   const noop = vi.fn(() => null);
@@ -154,7 +156,7 @@ describe('useGeminiStream subagent isolation', () => {
   let mockOnDebugMessage: Mock;
   let mockHandleSlashCommand: Mock;
   let mockScheduleToolCalls: Mock;
-  let mockMarkToolsAsSubmitted: Mock;
+  let mockMarkToolsAsDisplayCleared: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -220,14 +222,14 @@ describe('useGeminiStream subagent isolation', () => {
     } as unknown as LoadedSettings;
 
     mockScheduleToolCalls = vi.fn();
-    mockMarkToolsAsSubmitted = vi.fn();
+    mockMarkToolsAsDisplayCleared = vi.fn();
 
     const mockCancelAllToolCalls = vi.fn();
 
     mockUseReactToolScheduler.mockReturnValue([
       [],
       mockScheduleToolCalls,
-      mockMarkToolsAsSubmitted,
+      mockMarkToolsAsDisplayCleared,
       mockCancelAllToolCalls,
       0,
       true,
@@ -259,7 +261,7 @@ describe('useGeminiStream subagent isolation', () => {
       return [
         [],
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         vi.fn(),
         0,
         true,
@@ -299,7 +301,7 @@ describe('useGeminiStream subagent isolation', () => {
         agentId: 'agent-sub',
       },
       status: 'success',
-      responseSubmittedToGemini: false,
+      displayCleared: false,
       response: {
         callId: 'subagent-call',
         responseParts: [{ text: 'subagent output' } as Part],
@@ -327,9 +329,248 @@ describe('useGeminiStream subagent isolation', () => {
     });
 
     await waitFor(() => {
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['subagent-call']);
+      expect(mockMarkToolsAsDisplayCleared).toHaveBeenCalledWith([
+        'subagent-call',
+      ]);
       expect(mockSendMessageStream).not.toHaveBeenCalled();
       expect(client.addHistory).not.toHaveBeenCalled();
     });
+  });
+
+  it('marks a terminal subagent tool as outstanding until displayCleared transitions it out of Responding', () => {
+    const client = new MockedAgentClientClass(mockConfig);
+
+    const unclearedSubagentTool: TrackedCompletedToolCall = {
+      request: {
+        callId: 'subagent-pending',
+        name: 'task',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-pending',
+        agentId: 'agent-sub',
+      },
+      status: 'success',
+      displayCleared: false,
+      response: {
+        callId: 'subagent-pending',
+        responseParts: [{ text: 'pending output' } as Part],
+        resultDisplay: undefined,
+        error: undefined,
+        errorType: undefined,
+      },
+      invocation: {
+        getDescription: () => `Mock description`,
+      } as unknown as AnyToolInvocation,
+      tool: {
+        name: 'task',
+        displayName: 'Task',
+        description: 'Launch subagent',
+        build: vi.fn(),
+      } as any,
+    };
+
+    mockUseReactToolScheduler.mockReturnValue([
+      [unclearedSubagentTool],
+      mockScheduleToolCalls,
+      mockMarkToolsAsDisplayCleared,
+      vi.fn(),
+      0,
+      true,
+      vi.fn(),
+      vi.fn(),
+    ] as const);
+
+    const { result } = renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+        mockConfig,
+        mockSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand as unknown as (
+          cmd: PartListUnion,
+        ) => Promise<SlashCommandProcessorResult | false>,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        () => {},
+        () => {},
+        () => {},
+      ),
+    );
+
+    // A terminal-but-not-yet-display-cleared subagent tool keeps the stream in
+    // Responding because isOutstandingToolCall treats it as outstanding.
+    expect(result.current.streamingState).toBe(StreamingState.Responding);
+  });
+
+  it('transitions a terminal subagent tool out of Responding once displayCleared is true', () => {
+    const client = new MockedAgentClientClass(mockConfig);
+
+    const clearedSubagentTool: TrackedCompletedToolCall = {
+      request: {
+        callId: 'subagent-cleared',
+        name: 'task',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-cleared',
+        agentId: 'agent-sub',
+      },
+      status: 'success',
+      displayCleared: true,
+      response: {
+        callId: 'subagent-cleared',
+        responseParts: [{ text: 'cleared output' } as Part],
+        resultDisplay: undefined,
+        error: undefined,
+        errorType: undefined,
+      },
+      invocation: {
+        getDescription: () => `Mock description`,
+      } as unknown as AnyToolInvocation,
+      tool: {
+        name: 'task',
+        displayName: 'Task',
+        description: 'Launch subagent',
+        build: vi.fn(),
+      } as any,
+    };
+
+    mockUseReactToolScheduler.mockReturnValue([
+      [clearedSubagentTool],
+      mockScheduleToolCalls,
+      mockMarkToolsAsDisplayCleared,
+      vi.fn(),
+      0,
+      true,
+      vi.fn(),
+      vi.fn(),
+    ] as const);
+
+    const { result } = renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+        mockConfig,
+        mockSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand as unknown as (
+          cmd: PartListUnion,
+        ) => Promise<SlashCommandProcessorResult | false>,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        () => {},
+        () => {},
+        () => {},
+      ),
+    );
+
+    // Once displayCleared is true, the terminal tool is no longer outstanding,
+    // so the streaming state settles to Idle without any model resubmission.
+    expect(result.current.streamingState).toBe(StreamingState.Idle);
+    expect(mockSendMessageStream).not.toHaveBeenCalled();
+  });
+
+  it('renders a completed client-initiated tool to display without resubmitting to the model or marking it display-cleared', async () => {
+    const client = new MockedAgentClientClass(mockConfig);
+
+    let capturedOnComplete:
+      | ((
+          schedulerId: symbol,
+          completedTools: TrackedToolCall[],
+          options: { isPrimary: boolean },
+        ) => Promise<void>)
+      | null = null;
+
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete as typeof capturedOnComplete;
+      return [
+        [],
+        mockScheduleToolCalls,
+        mockMarkToolsAsDisplayCleared,
+        vi.fn(),
+        0,
+        true,
+        vi.fn(),
+        vi.fn(),
+      ] as const;
+    });
+
+    renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+        mockConfig,
+        mockSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand as unknown as (
+          cmd: PartListUnion,
+        ) => Promise<SlashCommandProcessorResult | false>,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        () => {},
+        () => {},
+        () => {},
+      ),
+    );
+
+    // A client-initiated tool completes through the MAIN scheduler: it has
+    // isClientInitiated: true and agentId: DEFAULT_AGENT_ID, and its completion
+    // callback is invoked with { isPrimary: true }.
+    const clientInitiatedTool: TrackedCompletedToolCall = {
+      request: {
+        callId: 'client-callId',
+        name: 'list_directory',
+        args: {},
+        isClientInitiated: true,
+        prompt_id: 'prompt-client',
+        agentId: DEFAULT_AGENT_ID,
+      },
+      status: 'success',
+      displayCleared: false,
+      response: {
+        callId: 'client-callId',
+        responseParts: [{ text: 'dir listing' } as Part],
+        resultDisplay: undefined,
+        error: undefined,
+        errorType: undefined,
+      },
+      invocation: {
+        getDescription: () => `Mock description`,
+      } as unknown as AnyToolInvocation,
+      tool: {
+        name: 'list_directory',
+        displayName: 'List Directory',
+        description: 'List files',
+        build: vi.fn(),
+      } as any,
+    };
+
+    await act(async () => {
+      if (capturedOnComplete) {
+        await capturedOnComplete(Symbol('scheduler'), [clientInitiatedTool], {
+          isPrimary: true,
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(mockAddItem).toHaveBeenCalled();
+    });
+
+    // Completing a client-initiated tool does NOT resubmit to the model.
+    expect(mockSendMessageStream).not.toHaveBeenCalled();
+    // A client-initiated PRIMARY tool is cleared by the scheduler emptying its
+    // list, NOT via the displayCleared flag, so markToolsAsDisplayCleared is
+    // never called for it.
+    expect(mockMarkToolsAsDisplayCleared).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -153,7 +153,7 @@ describe('useGeminiStream', () => {
   let mockHandleSlashCommand: Mock;
   let mockScheduleToolCalls: Mock;
   let mockCancelAllToolCalls: Mock;
-  let mockMarkToolsAsSubmitted: Mock;
+  let mockMarkToolsAsDisplayCleared: Mock;
   let handleAtCommandSpy: MockInstance;
 
   beforeEach(() => {
@@ -221,13 +221,13 @@ describe('useGeminiStream', () => {
     // Mock return value for useReactToolScheduler
     mockScheduleToolCalls = vi.fn();
     mockCancelAllToolCalls = vi.fn();
-    mockMarkToolsAsSubmitted = vi.fn();
+    mockMarkToolsAsDisplayCleared = vi.fn();
 
     // Default mock for useReactToolScheduler to prevent toolCalls being undefined initially
     mockUseReactToolScheduler.mockReturnValue([
       [], // Default to empty array for toolCalls
       mockScheduleToolCalls,
-      mockMarkToolsAsSubmitted,
+      mockMarkToolsAsDisplayCleared,
       mockCancelAllToolCalls,
       0,
       true,
@@ -298,7 +298,7 @@ describe('useGeminiStream', () => {
                   responseParts: [],
                   resultDisplay: 'Request cancelled.',
                 },
-                responseSubmittedToGemini: true, // Mark as "processed"
+                displayCleared: true, // Cleared from display
               } as any as TrackedCancelledToolCall;
             }
             return tc;
@@ -309,7 +309,7 @@ describe('useGeminiStream', () => {
         mockUseReactToolScheduler.mockImplementation(() => [
           props.toolCalls,
           mockScheduleToolCalls,
-          mockMarkToolsAsSubmitted,
+          mockMarkToolsAsDisplayCleared,
           statefulCancelAllToolCalls, // Use the stateful mock
           0,
           true,
@@ -342,7 +342,7 @@ describe('useGeminiStream', () => {
     return {
       result,
       rerender,
-      mockMarkToolsAsSubmitted,
+      mockMarkToolsAsDisplayCleared,
       mockSendMessageStream,
       client,
     };
@@ -364,7 +364,7 @@ describe('useGeminiStream', () => {
       prompt_id: 'prompt-id-1',
     },
     status: status as 'awaiting_approval',
-    responseSubmittedToGemini: false,
+    displayCleared: false,
     confirmationDetails:
       confirmationType === 'edit'
         ? {
@@ -450,7 +450,7 @@ describe('useGeminiStream', () => {
           prompt_id: 'prompt-id-1',
         },
         status: 'success',
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         response: {
           callId: 'call1',
           responseParts: [{ text: 'tool 1 response' }],
@@ -478,7 +478,7 @@ describe('useGeminiStream', () => {
           prompt_id: 'prompt-id-1',
         },
         status: 'executing',
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         tool: {
           name: 'tool2',
           displayName: 'tool2',
@@ -493,13 +493,13 @@ describe('useGeminiStream', () => {
       } as TrackedExecutingToolCall,
     ];
 
-    const { mockMarkToolsAsSubmitted, mockSendMessageStream } =
+    const { mockMarkToolsAsDisplayCleared, mockSendMessageStream } =
       renderTestHook(toolCalls);
 
     // Effect for submitting tool responses depends on toolCalls and isResponding
     // isResponding is initially false, so the effect should run.
 
-    expect(mockMarkToolsAsSubmitted).not.toHaveBeenCalled();
+    expect(mockMarkToolsAsDisplayCleared).not.toHaveBeenCalled();
     expect(mockSendMessageStream).not.toHaveBeenCalled(); // submitQuery uses this
   });
 
@@ -516,7 +516,7 @@ describe('useGeminiStream', () => {
           prompt_id: 'prompt-id-2',
         },
         status: 'success',
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         response: {
           callId: 'call1',
           responseParts: toolCall1ResponseParts,
@@ -538,7 +538,7 @@ describe('useGeminiStream', () => {
           prompt_id: 'prompt-id-2',
         },
         status: 'error',
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         response: {
           callId: 'call2',
           responseParts: toolCall2ResponseParts,
@@ -561,7 +561,7 @@ describe('useGeminiStream', () => {
       return [
         [],
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -600,7 +600,7 @@ describe('useGeminiStream', () => {
     });
 
     await waitFor(() => {
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledTimes(1);
+      expect(mockMarkToolsAsDisplayCleared).toHaveBeenCalledTimes(1);
       expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
     });
 
@@ -643,7 +643,7 @@ describe('useGeminiStream', () => {
           prompt_id: 'prompt-id-filter',
         },
         status: 'success',
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         response: {
           callId: 'call-filter',
           responseParts: toolCallResponseParts,
@@ -671,7 +671,7 @@ describe('useGeminiStream', () => {
       return [
         [],
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -708,7 +708,7 @@ describe('useGeminiStream', () => {
     });
 
     await waitFor(() => {
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledTimes(1);
+      expect(mockMarkToolsAsDisplayCleared).toHaveBeenCalledTimes(1);
       expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
     });
 
@@ -746,7 +746,7 @@ describe('useGeminiStream', () => {
           responseParts: [{ text: 'cancelled' }],
           errorType: undefined, // FIX: Added missing property
         },
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         tool: {
           displayName: 'mock tool',
         },
@@ -771,7 +771,7 @@ describe('useGeminiStream', () => {
       return [
         [],
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -810,7 +810,7 @@ describe('useGeminiStream', () => {
     });
 
     await waitFor(() => {
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['1']);
+      expect(mockMarkToolsAsDisplayCleared).toHaveBeenCalledWith(['1']);
       expect(client.addHistory).toHaveBeenCalledWith({
         role: 'user',
         parts: [{ text: 'cancelled' }],
@@ -848,7 +848,7 @@ describe('useGeminiStream', () => {
         error: undefined,
         errorType: undefined, // FIX: Added missing property
       },
-      responseSubmittedToGemini: false,
+      displayCleared: false,
     };
     const cancelledToolCall2: TrackedCancelledToolCall = {
       request: {
@@ -877,7 +877,7 @@ describe('useGeminiStream', () => {
         error: undefined,
         errorType: undefined, // FIX: Added missing property
       },
-      responseSubmittedToGemini: false,
+      displayCleared: false,
     };
     const allCancelledTools = [cancelledToolCall1, cancelledToolCall2];
     const client = new MockedAgentClientClass(mockConfig);
@@ -895,7 +895,7 @@ describe('useGeminiStream', () => {
       return [
         [],
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -934,8 +934,8 @@ describe('useGeminiStream', () => {
     });
 
     await waitFor(() => {
-      // The tools should be marked as submitted locally
-      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith([
+      // The tools should be marked as display-cleared locally
+      expect(mockMarkToolsAsDisplayCleared).toHaveBeenCalledWith([
         'cancel-1',
         'cancel-2',
       ]);
@@ -972,7 +972,7 @@ describe('useGeminiStream', () => {
           prompt_id: 'prompt-id-4',
         },
         status: 'executing',
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         tool: {
           name: 'tool1',
           displayName: 'tool1',
@@ -1016,7 +1016,7 @@ describe('useGeminiStream', () => {
       return [
         currentToolCalls,
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -1055,7 +1055,7 @@ describe('useGeminiStream', () => {
       return [
         completedToolCalls,
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -1067,7 +1067,8 @@ describe('useGeminiStream', () => {
     });
 
     // 3. The state should *still* be Responding, not Idle.
-    // This is because the completed tool's response has not been submitted yet.
+    // This is because the completed tool has not yet been cleared from the
+    // display (displayCleared is still false), so it remains outstanding.
     expect(result.current.streamingState).toBe(StreamingState.Responding);
 
     // 4. Trigger the onComplete callback to simulate tool completion
@@ -1299,7 +1300,7 @@ describe('useGeminiStream', () => {
         {
           request: { callId: 'call1', name: 'tool1', args: {} },
           status: 'executing',
-          responseSubmittedToGemini: false,
+          displayCleared: false,
           tool: {
             name: 'tool1',
             description: 'desc1',
@@ -1339,7 +1340,7 @@ describe('useGeminiStream', () => {
             prompt_id: 'prompt-id-1',
           },
           status: 'awaiting_approval',
-          responseSubmittedToGemini: false,
+          displayCleared: false,
           tool: {
             name: 'some_tool',
             description: 'a tool',
@@ -1580,7 +1581,7 @@ describe('useGeminiStream', () => {
           prompt_id: 'prompt-id-6',
         },
         status: 'success',
-        responseSubmittedToGemini: false,
+        displayCleared: false,
         response: {
           callId: 'save-mem-call-1',
           responseParts: [{ text: 'Memory saved' }],
@@ -1613,7 +1614,7 @@ describe('useGeminiStream', () => {
         return [
           [],
           mockScheduleToolCalls,
-          mockMarkToolsAsSubmitted,
+          mockMarkToolsAsDisplayCleared,
           mockCancelAllToolCalls,
           0,
           true,
@@ -1829,7 +1830,7 @@ describe('useGeminiStream', () => {
             prompt_id: 'prompt-id-1',
           },
           status: 'awaiting_approval',
-          responseSubmittedToGemini: false,
+          displayCleared: false,
           // No confirmationDetails
           tool: {
             name: 'replace',
@@ -1870,7 +1871,7 @@ describe('useGeminiStream', () => {
             prompt_id: 'prompt-id-1',
           },
           status: 'awaiting_approval',
-          responseSubmittedToGemini: false,
+          displayCleared: false,
           confirmationDetails: {
             type: 'edit',
             title: 'Confirm Edit',
@@ -1928,7 +1929,7 @@ describe('useGeminiStream', () => {
             prompt_id: 'prompt-id-1',
           },
           status: 'awaiting_approval',
-          responseSubmittedToGemini: false,
+          displayCleared: false,
           confirmationDetails: {
             type: 'edit',
             title: 'Confirm Edit',
@@ -1958,7 +1959,7 @@ describe('useGeminiStream', () => {
             prompt_id: 'prompt-id-1',
           },
           status: 'executing',
-          responseSubmittedToGemini: false,
+          displayCleared: false,
           tool: {
             name: 'write_file',
             displayName: 'write_file',
@@ -2274,7 +2275,7 @@ describe('useGeminiStream', () => {
       return [
         [], // toolCalls
         mockScheduleToolCalls,
-        vi.fn(), // markToolsAsSubmitted
+        vi.fn(), // markToolsAsDisplayCleared
         vi.fn(), // cancelAllToolCalls
         0, // lastToolOutputTime
         true, // interactiveRuntimeReady
@@ -2493,7 +2494,7 @@ describe('useGeminiStream', () => {
       mockUseReactToolScheduler.mockReturnValue([
         [],
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -2546,7 +2547,7 @@ describe('useGeminiStream', () => {
       mockUseReactToolScheduler.mockReturnValue([
         newToolCalls,
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -2579,7 +2580,7 @@ describe('useGeminiStream', () => {
       mockUseReactToolScheduler.mockReturnValue([
         [pendingToolCall],
         mockScheduleToolCalls,
-        mockMarkToolsAsSubmitted,
+        mockMarkToolsAsDisplayCleared,
         mockCancelAllToolCalls,
         0,
         true,
@@ -3209,7 +3210,7 @@ describe('useGeminiStream', () => {
           mockUseReactToolScheduler.mockReturnValue([
             props.toolCalls,
             mockScheduleToolCalls,
-            mockMarkToolsAsSubmitted,
+            mockMarkToolsAsDisplayCleared,
             mockCancelAllToolCalls,
             0,
             true,
@@ -3345,7 +3346,7 @@ describe('useGeminiStream', () => {
           mockUseReactToolScheduler.mockReturnValue([
             props.toolCalls,
             mockScheduleToolCalls,
-            mockMarkToolsAsSubmitted,
+            mockMarkToolsAsDisplayCleared,
             mockCancelAllToolCalls,
             0,
             true,

--- a/packages/cli/src/ui/hooks/useGeminiStream.thinking.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.thinking.test.tsx
@@ -214,7 +214,7 @@ describe('useGeminiStream - ThinkingBlock Integration', () => {
   let mockHandleSlashCommand: Mock;
   let mockScheduleToolCalls: Mock;
   let mockCancelAllToolCalls: Mock;
-  let mockMarkToolsAsSubmitted: Mock;
+  let mockMarkToolsAsDisplayCleared: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -287,12 +287,12 @@ describe('useGeminiStream - ThinkingBlock Integration', () => {
 
     mockScheduleToolCalls = vi.fn();
     mockCancelAllToolCalls = vi.fn();
-    mockMarkToolsAsSubmitted = vi.fn();
+    mockMarkToolsAsDisplayCleared = vi.fn();
 
     mockUseReactToolScheduler.mockReturnValue([
       [],
       mockScheduleToolCalls,
-      mockMarkToolsAsSubmitted,
+      mockMarkToolsAsDisplayCleared,
       mockCancelAllToolCalls,
       0,
       true,
@@ -329,7 +329,7 @@ describe('useGeminiStream - ThinkingBlock Integration', () => {
     mockUseReactToolScheduler.mockImplementation(() => [
       currentToolCalls,
       mockScheduleToolCalls,
-      mockMarkToolsAsSubmitted,
+      mockMarkToolsAsDisplayCleared,
       mockCancelAllToolCalls,
       0,
       true,
@@ -391,7 +391,7 @@ describe('useGeminiStream - ThinkingBlock Integration', () => {
     return {
       result,
       rerender,
-      mockMarkToolsAsSubmitted,
+      mockMarkToolsAsDisplayCleared,
       mockSendMessageStream,
       client,
     };

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -66,25 +66,25 @@ export type ScheduleFn = (
   request: ToolCallRequestInfo | ToolCallRequestInfo[],
   signal: AbortSignal,
 ) => Promise<void>;
-export type MarkToolsAsSubmittedFn = (callIds: string[]) => void;
+export type MarkToolsAsDisplayClearedFn = (callIds: string[]) => void;
 
 export type TrackedScheduledToolCall = ScheduledToolCall & {
-  responseSubmittedToGemini?: boolean;
+  displayCleared?: boolean;
 };
 export type TrackedValidatingToolCall = ValidatingToolCall & {
-  responseSubmittedToGemini?: boolean;
+  displayCleared?: boolean;
 };
 export type TrackedWaitingToolCall = WaitingToolCall & {
-  responseSubmittedToGemini?: boolean;
+  displayCleared?: boolean;
 };
 export type TrackedExecutingToolCall = ExecutingToolCall & {
-  responseSubmittedToGemini?: boolean;
+  displayCleared?: boolean;
 };
 export type TrackedCompletedToolCall = CompletedToolCall & {
-  responseSubmittedToGemini?: boolean;
+  displayCleared?: boolean;
 };
 export type TrackedCancelledToolCall = CancelledToolCall & {
-  responseSubmittedToGemini?: boolean;
+  displayCleared?: boolean;
 };
 
 export type TrackedToolCall =
@@ -109,7 +109,7 @@ export type UpdateToolOutputFn = (
 export type ReactToolSchedulerResult = readonly [
   TrackedToolCall[],
   ScheduleFn,
-  MarkToolsAsSubmittedFn,
+  MarkToolsAsDisplayClearedFn,
   CancelAllFn,
   number,
   boolean,
@@ -160,9 +160,9 @@ function updatePendingItemWithOutput(
 }
 
 /**
- * Maps updated calls preserving the responseSubmittedToGemini flag.
+ * Maps updated calls preserving the displayCleared flag.
  */
-function mapCallsWithSubmittedFlag(
+function mapCallsWithDisplayClearedFlag(
   prevCalls: TrackedToolCall[],
   updatedCalls: ToolCall[],
 ): TrackedToolCall[] {
@@ -172,9 +172,8 @@ function mapCallsWithSubmittedFlag(
   );
   return updatedCalls.map((call) => ({
     ...call,
-    responseSubmittedToGemini:
-      previousCallMap.get(call.request.callId)?.responseSubmittedToGemini ??
-      false,
+    displayCleared:
+      previousCallMap.get(call.request.callId)?.displayCleared ?? false,
   })) as TrackedToolCall[];
 }
 
@@ -215,15 +214,15 @@ function updateSchedulerState(
 }
 
 /**
- * Marks tool calls as submitted to Gemini.
+ * Marks tool calls as cleared from display.
  */
-function markCallsAsSubmitted(
+function markCallsAsDisplayCleared(
   calls: TrackedToolCall[],
   callIdsToMark: string[],
 ): TrackedToolCall[] {
   return calls.map((call) =>
     callIdsToMark.includes(call.request.callId)
-      ? { ...call, responseSubmittedToGemini: true }
+      ? { ...call, displayCleared: true }
       : call,
   );
 }
@@ -408,7 +407,7 @@ function useToolCallUpdaters(
   const replaceToolCallsForScheduler = useCallback(
     (schedulerId: symbol, updatedCalls: ToolCall[]) => {
       updateToolCallsForScheduler(schedulerId, (prevCalls) =>
-        mapCallsWithSubmittedFlag(prevCalls, updatedCalls),
+        mapCallsWithDisplayClearedFlag(prevCalls, updatedCalls),
       );
     },
     [updateToolCallsForScheduler],
@@ -587,6 +586,26 @@ function useExternalSchedulerSetup(
 }
 
 /**
+ * Composes external scheduler factory creation with its registration effect.
+ */
+function useExternalSchedulerRegistration(
+  config: Config,
+  refs: SchedulerRefs,
+  runtimeMessageBus: MessageBus | undefined,
+  setExternalSchedulerRegistered: (registered: boolean) => void,
+): void {
+  const createExternalScheduler = useExternalSchedulerFactoryCreator(
+    refs,
+    runtimeMessageBus,
+  );
+  useExternalSchedulerSetup(
+    config,
+    createExternalScheduler,
+    setExternalSchedulerRegistered,
+  );
+}
+
+/**
  * Hook that manages schedule function.
  */
 function useScheduleFn(
@@ -610,13 +629,13 @@ function useScheduleFn(
 }
 
 /**
- * Hook that manages markToolsAsSubmitted function.
+ * Hook that manages markToolsAsDisplayCleared function.
  */
-function useMarkToolsAsSubmitted(
+function useMarkToolsAsDisplayCleared(
   setToolCallsByScheduler: React.Dispatch<
     React.SetStateAction<Map<symbol, TrackedToolCall[]>>
   >,
-): MarkToolsAsSubmittedFn {
+): MarkToolsAsDisplayClearedFn {
   return useCallback(
     (callIdsToMark: string[]) => {
       if (callIdsToMark.length === 0) return;
@@ -624,7 +643,7 @@ function useMarkToolsAsSubmitted(
         let changed = false;
         const next = new Map(prev);
         for (const [schedulerId, calls] of prev) {
-          const updatedCalls = markCallsAsSubmitted(calls, callIdsToMark);
+          const updatedCalls = markCallsAsDisplayCleared(calls, callIdsToMark);
           const hasChange = updatedCalls.some(
             (call, index) => call !== calls[index],
           );
@@ -753,7 +772,7 @@ function useDerivedToolCallState(
 function buildReactToolSchedulerResult(
   toolCalls: TrackedToolCall[],
   schedule: ScheduleFn,
-  markToolsAsSubmitted: MarkToolsAsSubmittedFn,
+  markToolsAsDisplayCleared: MarkToolsAsDisplayClearedFn,
   cancelAllToolCalls: CancelAllFn,
   lastToolOutputTime: number,
   interactiveRuntimeReady: boolean,
@@ -763,7 +782,7 @@ function buildReactToolSchedulerResult(
   return [
     toolCalls,
     schedule,
-    markToolsAsSubmitted,
+    markToolsAsDisplayCleared,
     cancelAllToolCalls,
     lastToolOutputTime,
     interactiveRuntimeReady,
@@ -849,18 +868,17 @@ export function useReactToolScheduler(
     pendingScheduleRequests,
   );
 
-  const createExternalScheduler = useExternalSchedulerFactoryCreator(
+  useExternalSchedulerRegistration(
+    config,
     refs,
     runtimeMessageBus,
-  );
-  useExternalSchedulerSetup(
-    config,
-    createExternalScheduler,
     setExternalSchedulerRegistered,
   );
 
   const schedule = useScheduleFn(scheduler, pendingScheduleRequests);
-  const markToolsAsSubmitted = useMarkToolsAsSubmitted(setToolCallsByScheduler);
+  const markToolsAsDisplayCleared = useMarkToolsAsDisplayCleared(
+    setToolCallsByScheduler,
+  );
   const { toolCalls, cancelAllToolCalls } = useDerivedToolCallState(
     toolCallsByScheduler,
     scheduler,
@@ -879,7 +897,7 @@ export function useReactToolScheduler(
   return buildReactToolSchedulerResult(
     toolCalls,
     schedule,
-    markToolsAsSubmitted,
+    markToolsAsDisplayCleared,
     cancelAllToolCalls,
     lastToolOutputTime,
     interactiveRuntimeReady,

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -1247,6 +1247,186 @@ describe('useReactToolScheduler', () => {
   });
 });
 
+/**
+ * Helper that builds a ScheduledToolCall fixture bound to a real MockTool
+ * and its invocation, for seeding display state via the real hook's public
+ * replaceToolCallsForScheduler surface (tuple index 6).
+ */
+const buildScheduledToolCall = (
+  callId: string,
+  tool: MockTool,
+  status: 'scheduled' | 'success' | 'executing' = 'scheduled',
+): ToolCall =>
+  ({
+    status,
+    request: buildRequest({ callId }),
+    tool,
+    invocation: tool.build(buildRequest({ callId }).args),
+  }) as unknown as ToolCall;
+
+/**
+ * Behavioral coverage for the displayCleared display-state flag exercised
+ * end-to-end through the REAL useReactToolScheduler hook's public writer
+ * surfaces (markToolsAsDisplayCleared tuple index 2 and
+ * replaceToolCallsForScheduler tuple index 6), asserting on the observable
+ * toolCalls tuple element (index 0). Only the infra CoreToolScheduler is
+ * mocked (via buildMockScheduler); the hook under test is real.
+ *
+ * The completed primary tool call is cleared from display state by the
+ * harness's onAllToolCallsComplete -> replaceToolCallsForScheduler(main, []),
+ * so these tests seed tracked calls directly via the public
+ * replaceToolCallsForScheduler surface, which routes through the real
+ * mapCallsWithDisplayClearedFlag preservation logic.
+ */
+describe('useReactToolScheduler displayCleared display-state', () => {
+  let onComplete: Mock;
+  let setPendingHistoryItem: Mock;
+  let displayClearedTool: MockTool;
+
+  beforeEach(() => {
+    onComplete = vi.fn();
+    setPendingHistoryItem = vi.fn();
+    (mockConfig.getApprovalMode as Mock).mockReturnValue(ApprovalMode.DEFAULT);
+    mockToolRegistry.getTool.mockClear();
+    displayClearedTool = new MockTool({
+      name: 'displayClearedTool',
+      displayName: 'Display Cleared Tool',
+      shouldConfirmExecute: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    for (const [sessionId, scheduler] of createdSchedulers.entries()) {
+      scheduler.dispose();
+      createdSchedulers.delete(sessionId);
+    }
+    DebugLogger.disposeAll();
+  });
+
+  it('marks a completed tool as displayCleared when markToolsAsDisplayCleared is called for its callId', async () => {
+    const { result } = renderScheduler(
+      onComplete,
+      mockConfig,
+      setPendingHistoryItem,
+    );
+
+    const replaceToolCalls = result.current[6];
+    const markToolsAsDisplayCleared = result.current[2];
+
+    // Seed two tracked calls into display state via the real hook. The tool to
+    // be cleared is seeded as a completed ('success') call to mirror the real
+    // scenario of clearing a finished tool from display.
+    await act(async () => {
+      replaceToolCalls([
+        buildScheduledToolCall('to-clear', displayClearedTool, 'success'),
+        buildScheduledToolCall('leave-alone', displayClearedTool),
+      ]);
+    });
+
+    const beforeCalls = result.current[0];
+    expect(
+      beforeCalls.find((c) => c.request.callId === 'to-clear')?.displayCleared,
+    ).toBeFalsy();
+    expect(
+      beforeCalls.find((c) => c.request.callId === 'leave-alone')
+        ?.displayCleared,
+    ).toBeFalsy();
+
+    // Mark only one callId via the real hook writer surface.
+    await act(async () => {
+      markToolsAsDisplayCleared(['to-clear']);
+    });
+
+    const afterCalls = result.current[0];
+    expect(
+      afterCalls.find((c) => c.request.callId === 'to-clear')?.displayCleared,
+    ).toBe(true);
+    expect(
+      afterCalls.find((c) => c.request.callId === 'leave-alone')
+        ?.displayCleared,
+    ).toBeFalsy();
+  });
+
+  it('preserves displayCleared across a subsequent scheduler tool-calls update (mapCallsWithDisplayClearedFlag)', async () => {
+    const { result } = renderScheduler(
+      onComplete,
+      mockConfig,
+      setPendingHistoryItem,
+    );
+
+    const replaceToolCalls = result.current[6];
+    const markToolsAsDisplayCleared = result.current[2];
+
+    // Seed a tracked call, then mark it displayCleared via the real hook.
+    await act(async () => {
+      replaceToolCalls([
+        buildScheduledToolCall('persist-1', displayClearedTool),
+      ]);
+    });
+    await act(async () => {
+      markToolsAsDisplayCleared(['persist-1']);
+    });
+    expect(
+      result.current[0].find((c) => c.request.callId === 'persist-1')
+        ?.displayCleared,
+    ).toBe(true);
+
+    // Replace tool calls again with an update to the SAME callId plus a
+    // brand-new callId; the prior displayCleared value must be preserved.
+    await act(async () => {
+      replaceToolCalls([
+        buildScheduledToolCall('persist-1', displayClearedTool, 'success'),
+        buildScheduledToolCall('fresh-2', displayClearedTool),
+      ]);
+    });
+
+    const updatedCalls = result.current[0];
+    expect(
+      updatedCalls.find((c) => c.request.callId === 'persist-1')
+        ?.displayCleared,
+    ).toBe(true);
+    expect(
+      updatedCalls.find((c) => c.request.callId === 'fresh-2')?.displayCleared,
+    ).toBeFalsy();
+  });
+
+  it('is a no-op when markToolsAsDisplayCleared is called with an empty array', async () => {
+    const { result } = renderScheduler(
+      onComplete,
+      mockConfig,
+      setPendingHistoryItem,
+    );
+
+    const replaceToolCalls = result.current[6];
+    const markToolsAsDisplayCleared = result.current[2];
+
+    // Seed tracked calls with known (falsey) displayCleared values.
+    await act(async () => {
+      replaceToolCalls([
+        buildScheduledToolCall('noop-1', displayClearedTool),
+        buildScheduledToolCall('noop-2', displayClearedTool),
+      ]);
+    });
+
+    const beforeCalls = result.current[0];
+
+    // Empty-array mark must early-return without state churn.
+    await act(async () => {
+      markToolsAsDisplayCleared([]);
+    });
+
+    const afterCalls = result.current[0];
+    expect(afterCalls).toBe(beforeCalls);
+    expect(
+      afterCalls.map((c) => [c.request.callId, c.displayCleared]),
+    ).toStrictEqual([
+      ['noop-1', false],
+      ['noop-2', false],
+    ]);
+  });
+});
+
 describe('mapToDisplay', () => {
   const baseRequest: ToolCallRequestInfo = buildRequest();
 


### PR DESCRIPTION
## Summary

Closes #2054.

After primary tool continuation moved into the engine-owned `AgenticLoop`, the CLI field `responseSubmittedToGemini` on `TrackedToolCall` no longer participates in primary continuation control flow. It is now purely a **CLI display-state marker** used to clear pending tool display in the external/subagent and client-initiated paths. The old name implied the CLI still owned model resubmission, which is misleading.

This PR renames the field and its associated types/helpers/hooks to display-oriented names, keeps behavior unchanged, and adds behavioral tests that prove the flag is a display-state marker — not a continuation gate.

## Rename (packages/cli)

| Old | New |
| --- | --- |
| `responseSubmittedToGemini` | `displayCleared` |
| `MarkToolsAsSubmittedFn` | `MarkToolsAsDisplayClearedFn` |
| `markCallsAsSubmitted` | `markCallsAsDisplayCleared` |
| `mapCallsWithSubmittedFlag` | `mapCallsWithDisplayClearedFlag` |
| `useMarkToolsAsSubmitted` | `useMarkToolsAsDisplayCleared` |
| `markToolsAsSubmitted` | `markToolsAsDisplayCleared` |

`isOutstandingToolCall` (the sole production reader) now reads `displayCleared`; it only derives `StreamingState` (Responding vs Idle) and never gates continuation.

Files:
- `useReactToolScheduler.ts` — field on all `TrackedToolCall` variants, type, helpers, hook, and result-tuple element.
- `geminiStream/useGeminiStreamLifecycle.ts` — `isOutstandingToolCall` + primary/secondary completion wiring (primary marks only external tools).
- `geminiStream/useGeminiStreamOrchestration.ts` — wiring.
- `geminiStream/useAgenticLoop.ts` — arg + JSDoc.

## Architecture notes (verified against source)

- `displayCleared` is CLI-only state on `TrackedToolCall`; it is **read** in exactly one production site (`isOutstandingToolCall`) and only affects display/`StreamingState`.
- Primary continuation is engine-owned: `AgenticLoop.run` continues from `result.nextMessage`, and `buildNextMessage` builds `functionResponse` parts from primary, non-client-initiated completed tools — entirely from engine state, with no CLI display field involved.
- A primary tool's display is cleared by the main scheduler emptying its tracked list (`replaceToolCallsForScheduler(mainSchedulerId, [])`), **not** by `markToolsAsDisplayCleared`. Only external (non-primary `agentId`) tools are marked via the flag in `processPrimaryCompletion`; `processSecondaryCompletion` marks all of its tools.

## Tests

Real-hook writer-side coverage — `useToolScheduler.test.ts` (new `displayCleared display-state` block, exercises the real `useReactToolScheduler`, mocking only the infra scheduler):
- Selective marking via the real `markToolsAsDisplayCleared` (only the targeted callId flips to `true`).
- Preservation across a subsequent scheduler update via the real `mapCallsWithDisplayClearedFlag` (a new callId defaults to `false`).
- Empty-array call is a no-op (referential identity preserved — locks the early return).

Primary continuation independence — `useAgenticLoop.test.tsx`:
- A real `AgenticLoop` (scripted provider boundary) drives a continuation turn while the primary tool is **never** display-cleared, proving continuation does not depend on the flag.

Display-clearing semantics — `useGeminiStream.subagent.spec.tsx`:
- External/subagent tools transition outstanding -> idle `StreamingState` once display-cleared.
- A client-initiated tool (`agentId === DEFAULT_AGENT_ID`, completing as `isPrimary: true`) renders to display without resubmitting to the model.

Remaining touched test files are mechanical renames.

## Verification

- `npm run test` (packages/cli): 350 files, 4683 passed, 3 skipped, 0 failed.
- `npm run typecheck`: pass.
- `npm run lint`: 0 errors (warnings at baseline).
- `npm run format`: clean.
- `npm run build`: pass.
- Smoke (`scripts/start.js --profile-load synthetic ...`): reaches the provider and fails only on an environmental 402 (insufficient credits / $0.00 balance) — not a code issue.

## Scope

CLI-only rename plus tests. The flag is in-memory React state (not persisted), so no migration is required.
