### PR TITLE
Fix error-on-cancel and ESC not cancelling subagents (Fixes #2076, Fixes #2074)

### DIFF
--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -1730,6 +1730,83 @@ describe('TaskTool', () => {
       expect(launchSignal!.aborted).toBe(true);
     });
 
+    it('aborts the launch signal when the foreground aborts DURING launch (before registration)', async () => {
+      // Regression for the relay-installed-after-launch gap: if the foreground
+      // turn is cancelled (ESC) while orchestrator.launch is still pending —
+      // e.g. loading config/profile — the launch signal must already observe
+      // the abort, because the relay is wired BEFORE launch is awaited.
+      const realAsyncTaskManager = new AsyncTaskManager();
+      let capturedLaunchSignal: AbortSignal | undefined;
+      let resolveLaunch: (() => void) | undefined;
+      const launchGate = new Promise<void>((resolve) => {
+        resolveLaunch = resolve;
+      });
+      const launchMock = vi
+        .fn()
+        .mockImplementation(
+          async (_request: unknown, launchSignal: AbortSignal) => {
+            capturedLaunchSignal = launchSignal;
+            // Simulate slow launch (config/profile loading) that has not yet
+            // returned a scope when the user presses ESC.
+            await launchGate;
+            return {
+              agentId: 'async-launch-abort-agent',
+              scope: {
+                runNonInteractive: vi.fn().mockImplementation(
+                  () =>
+                    new Promise<void>(() => {
+                      // never resolves
+                    }),
+                ),
+                output: {
+                  terminate_reason: SubagentTerminateMode.GOAL,
+                  emitted_vars: {},
+                },
+              },
+              dispose: vi.fn().mockResolvedValue(undefined),
+            };
+          },
+        );
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () =>
+          ({ launch: launchMock }) as unknown as SubagentOrchestrator,
+        getAsyncTaskManager: () => realAsyncTaskManager,
+        isInteractiveEnvironment: () => false,
+      });
+      const params: TaskToolParams = {
+        subagent_name: 'helper',
+        goal_prompt: 'Slow launch work',
+        async: true,
+      };
+
+      const foregroundController = new AbortController();
+      const invocation = tool.build(params);
+      const executePromise = invocation.execute(foregroundController.signal);
+
+      // Wait until launch has been entered (signal captured) but is still gated.
+      while (capturedLaunchSignal === undefined) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+      expect(capturedLaunchSignal.aborted).toBe(false);
+
+      // Press ESC while launch is still pending.
+      foregroundController.abort();
+      expect(capturedLaunchSignal.aborted).toBe(true);
+
+      // Let launch resolve so the invocation can settle cleanly.
+      resolveLaunch?.();
+      await executePromise;
+
+      // The task that registered after the gated launch carries the SAME
+      // (already-aborted) controller the relay aborted, so it is registered in
+      // an aborted state rather than as a live, unstoppable background task.
+      const registered = realAsyncTaskManager.getTask(
+        'async-launch-abort-agent',
+      );
+      expect(registered).toBeDefined();
+      expect(registered!.abortController?.signal.aborted).toBe(true);
+    });
+
     it('returns immediately with launch status when async=true (does not block)', async () => {
       const mockAsyncTaskManager = {
         canLaunchAsync: () => ({ allowed: true }),

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -15,7 +15,7 @@ import {
   SubagentTerminateMode,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools';
-import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
+import { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
 
 describe('TaskTool', () => {
   let config: Config;
@@ -1584,7 +1584,7 @@ describe('TaskTool', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
     });
 
-    it('passes undefined (not foreground signal) to orchestrator.launch for async tasks', async () => {
+    it('passes the async abort controller signal to orchestrator.launch so cancelTask can stop the subagent', async () => {
       const mockAsyncTaskManager = {
         canLaunchAsync: () => ({ allowed: true }),
         tryReserveAsyncSlot: () => 'booking-1',
@@ -1619,11 +1619,115 @@ describe('TaskTool', () => {
       const invocation = tool.build(params);
       await invocation.execute(new AbortController().signal);
 
-      // Async tasks must NOT pass the foreground signal to launch
-      // so the scope has no parent abort signal dependency
-      expect(launchMock).toHaveBeenCalledWith(expect.anything(), undefined);
+      // Async tasks MUST pass an AbortSignal (the async abort controller) to
+      // launch so AsyncTaskManager.cancelTask can abort the running subagent.
+      expect(launchMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(AbortSignal),
+      );
 
       await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    it('wires the async abort controller so cancelTask aborts the launch signal', async () => {
+      // End-to-end wiring at the task-tool boundary: the signal passed to
+      // launch is the SAME AbortController registered with the AsyncTaskManager.
+      // Aborting it via cancelTask flips that signal's .aborted to true,
+      // proving the subagent CAN be stopped by cancellation.
+      const realAsyncTaskManager = new AsyncTaskManager();
+      const launchMock = vi.fn().mockResolvedValue({
+        agentId: 'async-cancel-agent',
+        scope: {
+          runNonInteractive: vi.fn().mockImplementation(
+            () =>
+              new Promise<void>(() => {
+                // never resolves; we cancel via cancelTask
+              }),
+          ),
+          output: {
+            terminate_reason: SubagentTerminateMode.GOAL,
+            emitted_vars: {},
+          },
+        },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () =>
+          ({ launch: launchMock }) as unknown as SubagentOrchestrator,
+        getAsyncTaskManager: () => realAsyncTaskManager,
+        isInteractiveEnvironment: () => false,
+      });
+      const params: TaskToolParams = {
+        subagent_name: 'helper',
+        goal_prompt: 'Cancellable work',
+        async: true,
+      };
+
+      const invocation = tool.build(params);
+      await invocation.execute(new AbortController().signal);
+
+      // The signal passed to launch is the async abort controller's signal.
+      const launchSignal = launchMock.mock.calls[0]?.[1] as
+        | AbortSignal
+        | undefined;
+      expect(launchSignal).toBeInstanceOf(AbortSignal);
+      expect(launchSignal!.aborted).toBe(false);
+
+      // Cancel via the real AsyncTaskManager → the launch signal aborts.
+      realAsyncTaskManager.cancelTask('async-cancel-agent');
+
+      expect(launchSignal!.aborted).toBe(true);
+    });
+
+    it('relays the foreground signal abort into the async abort controller', async () => {
+      // Fix (b): when the foreground signal passed to executeAsync aborts,
+      // the async abort controller's signal must also abort so the subagent
+      // stops.
+      const realAsyncTaskManager = new AsyncTaskManager();
+      const launchMock = vi.fn().mockResolvedValue({
+        agentId: 'async-relay-agent',
+        scope: {
+          runNonInteractive: vi.fn().mockImplementation(
+            () =>
+              new Promise<void>(() => {
+                // never resolves
+              }),
+          ),
+          output: {
+            terminate_reason: SubagentTerminateMode.GOAL,
+            emitted_vars: {},
+          },
+        },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () =>
+          ({ launch: launchMock }) as unknown as SubagentOrchestrator,
+        getAsyncTaskManager: () => realAsyncTaskManager,
+        isInteractiveEnvironment: () => false,
+      });
+      const params: TaskToolParams = {
+        subagent_name: 'helper',
+        goal_prompt: 'Relay work',
+        async: true,
+      };
+
+      const foregroundController = new AbortController();
+      const invocation = tool.build(params);
+      await invocation.execute(foregroundController.signal);
+
+      const launchSignal = launchMock.mock.calls[0]?.[1] as
+        | AbortSignal
+        | undefined;
+      expect(launchSignal).toBeInstanceOf(AbortSignal);
+      expect(launchSignal!.aborted).toBe(false);
+
+      // Abort the FOREGROUND signal (ESC) → the launch signal must also abort.
+      foregroundController.abort();
+
+      // Give the once-listener a tick to fire.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(launchSignal!.aborted).toBe(true);
     });
 
     it('returns immediately with launch status when async=true (does not block)', async () => {
@@ -1862,6 +1966,60 @@ describe('TaskTool', () => {
       expect(completeTaskMock).not.toHaveBeenCalled();
 
       vi.useRealTimers();
+    });
+
+    it('does NOT label a user-cancelled task as timeout (cancelTask sets status to cancelled)', async () => {
+      // Fix (d): when the signal aborts because the user cancelled (via
+      // AsyncTaskManager.cancelTask, which sets status='cancelled'), the
+      // background path must NOT call failTask with 'Async task timed out'.
+      // Only a true timeout should be labelled as such.
+      const realAsyncTaskManager = new AsyncTaskManager();
+      let resolveRun: (() => void) | undefined;
+      const failTaskSpy = vi.spyOn(realAsyncTaskManager, 'failTask');
+      const launchMock = vi.fn().mockResolvedValue({
+        agentId: 'async-cancel-status',
+        scope: {
+          output: {
+            terminate_reason: SubagentTerminateMode.GOAL,
+            emitted_vars: {},
+          },
+          runNonInteractive: vi.fn(
+            () =>
+              new Promise<void>((resolve) => {
+                resolveRun = resolve;
+              }),
+          ),
+        },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () =>
+          ({ launch: launchMock }) as unknown as SubagentOrchestrator,
+        getAsyncTaskManager: () => realAsyncTaskManager,
+        isInteractiveEnvironment: () => false,
+      });
+      const params: TaskToolParams = {
+        subagent_name: 'helper',
+        goal_prompt: 'User-cancelled task',
+        async: true,
+      };
+
+      const invocation = tool.build(params);
+      await invocation.execute(new AbortController().signal);
+
+      // Cancel via cancelTask (sets status to 'cancelled').
+      realAsyncTaskManager.cancelTask('async-cancel-status');
+
+      // Let the scope return (simulating scope completing after cancellation).
+      resolveRun?.();
+      // Wait for the background execution to finish.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // The task must NOT be labelled as a timeout.
+      expect(failTaskSpy).not.toHaveBeenCalledWith(
+        'async-cancel-status',
+        'Async task timed out',
+      );
     });
 
     it('returns error when async=true but global subagents.asyncEnabled is false', async () => {

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -104,6 +104,7 @@ interface AsyncSetupResult {
   dispose: () => Promise<void>;
   asyncAbortController: AbortController;
   timeoutId: NodeJS.Timeout | null;
+  timedOut: { value: boolean };
 }
 
 function launchRequestName(
@@ -569,6 +570,12 @@ class TaskToolInvocation extends BaseToolInvocation<
         timeoutController.signal,
       );
       abortState.setLaunchResult(launchResult);
+      if (signal.aborted) {
+        const scopeCandidate = launchResult.scope as
+          | { cancel?: (reason?: string) => void }
+          | undefined;
+        scopeCandidate?.cancel?.('User aborted task execution.');
+      }
       return launchResult;
     } catch (error) {
       abortState.removeAbortHandler();
@@ -1027,6 +1034,28 @@ class TaskToolInvocation extends BaseToolInvocation<
   }
 
   /**
+   * Wires the foreground turn's abort signal into the async abort controller so
+   * that ESC (which aborts the foreground turn) also cancels the detached
+   * subagent. Returns a cleanup function that removes the listener.
+   */
+  private setupForegroundRelay(
+    foregroundSignal: AbortSignal,
+    asyncAbortController: AbortController,
+  ): () => void {
+    const relayForegroundAbort = () => asyncAbortController.abort();
+    if (foregroundSignal.aborted) {
+      asyncAbortController.abort();
+    } else {
+      foregroundSignal.addEventListener('abort', relayForegroundAbort, {
+        once: true,
+      });
+    }
+    return () => {
+      foregroundSignal.removeEventListener('abort', relayForegroundAbort);
+    };
+  }
+
+  /**
    * @plan PLAN-20260130-ASYNCTASK.P11
    *
    * Note: Async tasks are designed to run independently in the background.
@@ -1034,10 +1063,18 @@ class TaskToolInvocation extends BaseToolInvocation<
    * to the parent agent's signal. This is an intentional design choice to allow
    * async tasks to continue running even if the foreground agent is interrupted.
    */
-  private async executeAsync(
-    signal: AbortSignal,
-    updateOutput?: (output: string) => void,
-  ): Promise<ToolResult> {
+  /**
+   * Validates async preconditions and reserves a booking slot. Returns either
+   * an error ToolResult (if async is unavailable or no slot is free) or the
+   * validated orchestrator + task manager + booking id.
+   */
+  private resolveAsyncContext():
+    | ToolResult
+    | {
+        asyncTaskManager: AsyncTaskManager;
+        orchestrator: SubagentOrchestrator;
+        bookingId: string;
+      } {
     const settingsCheck = this.checkAsyncSettings();
     if (settingsCheck) {
       return settingsCheck;
@@ -1070,6 +1107,19 @@ class TaskToolInvocation extends BaseToolInvocation<
       return this.createAsyncSlotResult(asyncTaskManager);
     }
 
+    return { asyncTaskManager, orchestrator, bookingId };
+  }
+
+  private async executeAsync(
+    signal: AbortSignal,
+    updateOutput?: (output: string) => void,
+  ): Promise<ToolResult> {
+    const ctx = this.resolveAsyncContext();
+    if (!('asyncTaskManager' in ctx)) {
+      return ctx;
+    }
+    const { asyncTaskManager, orchestrator, bookingId } = ctx;
+
     const setupResult = await this.setupAsyncInfrastructure(
       orchestrator,
       asyncTaskManager,
@@ -1087,12 +1137,18 @@ class TaskToolInvocation extends BaseToolInvocation<
       dispose,
       asyncAbortController,
       timeoutId,
+      timedOut,
     } = setupResult as AsyncSetupResult;
 
     const asyncStreaming = this.setupAsyncStreaming(
       scope,
       agentId,
       updateOutput,
+    );
+
+    const cleanupForegroundRelay = this.setupForegroundRelay(
+      signal,
+      asyncAbortController,
     );
 
     this.executeInBackground(
@@ -1104,6 +1160,8 @@ class TaskToolInvocation extends BaseToolInvocation<
       asyncAbortController.signal,
       timeoutId,
       asyncStreaming?.emitAsyncClosingSubagentTag,
+      cleanupForegroundRelay,
+      timedOut,
     );
 
     return {
@@ -1192,16 +1250,23 @@ class TaskToolInvocation extends BaseToolInvocation<
     const asyncAbortController = new AbortController();
     let timeoutId: NodeJS.Timeout | null = null;
     let taskRegistered = false;
+    const timedOut = { value: false };
 
     try {
       const launchRequest = this.createLaunchRequest();
-      launchResult = await orchestrator.launch(launchRequest, undefined);
+      launchResult = await orchestrator.launch(
+        launchRequest,
+        asyncAbortController.signal,
+      );
       agentId = launchResult.agentId;
       scope = launchResult.scope;
       dispose = launchResult.dispose;
       contextState = this.buildContextState();
 
-      const timeoutSetup = this.setupAsyncTimeout(asyncAbortController);
+      const timeoutSetup = this.setupAsyncTimeout(
+        asyncAbortController,
+        timedOut,
+      );
       timeoutId = timeoutSetup.timeoutId;
 
       asyncTaskManager.registerTask(
@@ -1238,10 +1303,14 @@ class TaskToolInvocation extends BaseToolInvocation<
       dispose,
       asyncAbortController,
       timeoutId,
+      timedOut,
     };
   }
 
-  private setupAsyncTimeout(asyncAbortController: AbortController): {
+  private setupAsyncTimeout(
+    asyncAbortController: AbortController,
+    timedOut: { value: boolean },
+  ): {
     timeoutId: NodeJS.Timeout | null;
   } {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
@@ -1263,7 +1332,10 @@ class TaskToolInvocation extends BaseToolInvocation<
     const timeoutId =
       timeoutMs === undefined
         ? null
-        : setTimeout(() => asyncAbortController.abort(), timeoutMs);
+        : setTimeout(() => {
+            timedOut.value = true;
+            asyncAbortController.abort();
+          }, timeoutMs);
 
     return { timeoutId };
   }
@@ -1304,6 +1376,26 @@ class TaskToolInvocation extends BaseToolInvocation<
   }
 
   /**
+   * Handles the background task after the scope run completes with an aborted
+   * signal. Distinguishes timeout (failTask) from user-initiated cancellation
+   * (cancelTask, idempotent). Only acts if the task is still 'running' so a
+   * prior cancelTask is not overwritten.
+   */
+  private handleBackgroundAbort(
+    asyncTaskManager: AsyncTaskManager,
+    agentId: string,
+    timedOut: boolean,
+  ): void {
+    const task = asyncTaskManager.getTask(agentId);
+    if (task?.status !== 'running') return;
+    if (timedOut) {
+      asyncTaskManager.failTask(agentId, 'Async task timed out');
+    } else {
+      asyncTaskManager.cancelTask(agentId);
+    }
+  }
+
+  /**
    * @plan PLAN-20260130-ASYNCTASK.P11
    *
    * Execute async task in background using the SAME execution path as sync tasks.
@@ -1320,6 +1412,8 @@ class TaskToolInvocation extends BaseToolInvocation<
     signal: AbortSignal,
     timeoutId: ReturnType<typeof setTimeout> | null,
     emitClosingSubagentTag?: () => void,
+    cleanupForegroundRelay?: () => void,
+    timedOut?: { value: boolean },
   ): void {
     void (async () => {
       try {
@@ -1340,10 +1434,11 @@ class TaskToolInvocation extends BaseToolInvocation<
         }
 
         if (signal.aborted) {
-          const task = asyncTaskManager.getTask(agentId);
-          if (task?.status === 'running') {
-            asyncTaskManager.failTask(agentId, 'Async task timed out');
-          }
+          this.handleBackgroundAbort(
+            asyncTaskManager,
+            agentId,
+            timedOut?.value === true,
+          );
           return;
         }
 
@@ -1364,6 +1459,8 @@ class TaskToolInvocation extends BaseToolInvocation<
         if (timeoutId !== null) {
           clearTimeout(timeoutId);
         }
+
+        cleanupForegroundRelay?.();
 
         try {
           await dispose();

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -105,6 +105,7 @@ interface AsyncSetupResult {
   asyncAbortController: AbortController;
   timeoutId: NodeJS.Timeout | null;
   timedOut: { value: boolean };
+  cleanupForegroundRelay: () => void;
 }
 
 function launchRequestName(
@@ -1058,10 +1059,13 @@ class TaskToolInvocation extends BaseToolInvocation<
   /**
    * @plan PLAN-20260130-ASYNCTASK.P11
    *
-   * Note: Async tasks are designed to run independently in the background.
-   * Unlike foreground task execution, they do NOT wire cancellation or timeout
-   * to the parent agent's signal. This is an intentional design choice to allow
-   * async tasks to continue running even if the foreground agent is interrupted.
+   * Note: Async tasks run in the background — the foreground agent does not
+   * await their completion. They ARE, however, linked to the launching
+   * foreground turn's abort signal (issue #2074): the async abort controller
+   * registered with the AsyncTaskManager is passed to orchestrator.launch and
+   * relayed from the foreground signal, so pressing ESC (which aborts the
+   * foreground turn) also cancels the detached subagent. The AsyncTaskManager
+   * still owns timeout-driven cancellation independently of the foreground.
    */
   /**
    * Validates async preconditions and reserves a booking slot. Returns either
@@ -1121,6 +1125,7 @@ class TaskToolInvocation extends BaseToolInvocation<
     const { asyncTaskManager, orchestrator, bookingId } = ctx;
 
     const setupResult = await this.setupAsyncInfrastructure(
+      signal,
       orchestrator,
       asyncTaskManager,
       bookingId,
@@ -1138,17 +1143,13 @@ class TaskToolInvocation extends BaseToolInvocation<
       asyncAbortController,
       timeoutId,
       timedOut,
+      cleanupForegroundRelay,
     } = setupResult as AsyncSetupResult;
 
     const asyncStreaming = this.setupAsyncStreaming(
       scope,
       agentId,
       updateOutput,
-    );
-
-    const cleanupForegroundRelay = this.setupForegroundRelay(
-      signal,
-      asyncAbortController,
     );
 
     this.executeInBackground(
@@ -1238,6 +1239,7 @@ class TaskToolInvocation extends BaseToolInvocation<
   }
 
   private async setupAsyncInfrastructure(
+    foregroundSignal: AbortSignal,
     orchestrator: SubagentOrchestrator,
     asyncTaskManager: AsyncTaskManager,
     bookingId: string | undefined,
@@ -1251,6 +1253,14 @@ class TaskToolInvocation extends BaseToolInvocation<
     let timeoutId: NodeJS.Timeout | null = null;
     let taskRegistered = false;
     const timedOut = { value: false };
+
+    // Relay the foreground signal BEFORE launch so an ESC pressed while the
+    // orchestrator is still loading config/profile (issue #2074) aborts the
+    // launch in-flight instead of being missed during that window.
+    const cleanupForegroundRelay = this.setupForegroundRelay(
+      foregroundSignal,
+      asyncAbortController,
+    );
 
     try {
       const launchRequest = this.createLaunchRequest();
@@ -1280,6 +1290,7 @@ class TaskToolInvocation extends BaseToolInvocation<
       );
       taskRegistered = true;
     } catch (error) {
+      cleanupForegroundRelay();
       if (!taskRegistered && bookingId) {
         asyncTaskManager.cancelReservation(bookingId);
       }
@@ -1287,7 +1298,9 @@ class TaskToolInvocation extends BaseToolInvocation<
         clearTimeout(timeoutId);
       }
       if (dispose) {
-        void dispose();
+        // Defensively swallow disposal errors on the partial-launch path so a
+        // rejecting dispose() cannot surface as an unhandled rejection.
+        void dispose().catch(() => {});
       }
       return this.createErrorResult(
         error,
@@ -1304,6 +1317,7 @@ class TaskToolInvocation extends BaseToolInvocation<
       asyncAbortController,
       timeoutId,
       timedOut,
+      cleanupForegroundRelay,
     };
   }
 

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
@@ -530,14 +530,15 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
     const controllerA = new AbortController();
     const controllerB = new AbortController();
 
-    const errors: unknown[] = [];
+    let firstError: unknown;
+    let secondError: unknown;
 
     // Start the first run WITHOUT awaiting it.
     const firstPromise = act(async () => {
       try {
         await result.current.runLoop('go', controllerA.signal, 'p1');
       } catch (e) {
-        errors.push(e);
+        firstError = e;
       }
     });
 
@@ -552,17 +553,20 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
       try {
         await result.current.runLoop('go2', controllerB.signal, 'p2');
       } catch (e) {
-        errors.push(e);
+        secondError = e;
       }
     });
 
     await Promise.all([firstPromise, secondPromise]);
 
-    // Neither run must have thrown the concurrent-execution error.
-    for (const e of errors) {
-      const msg = e instanceof Error ? e.message : String(e);
-      expect(msg).not.toContain('concurrent');
-    }
+    // The second (re-submit) run must succeed without error — proving the
+    // serialization allowed it to run after the cancelled first run.
+    expect(secondError).toBeUndefined();
+    // The first run was cancelled, so it may throw, but must NOT be the
+    // concurrent-execution error.
+    const firstMsg =
+      firstError instanceof Error ? firstError.message : String(firstError);
+    expect(firstMsg).not.toContain('concurrent');
   });
 
   it('clears external (subagent) tools from the display via markToolsAsDisplayCleared', async () => {

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
@@ -500,12 +500,21 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
 
     // First turn: a tool call that blocks until its signal aborts.
     // Second turn (for the re-submit 'go2'): completes normally.
-    const { client } = createScriptedAgentClient([
+    const { client, turnMessages } = createScriptedAgentClient([
       [toolCallRequestEvent('record_tool', 'call-concurrent'), finishedEvent()],
       [contentEvent('second-turn'), finishedEvent()],
     ]);
 
     const addItem = vi.fn();
+
+    // Capture streamed content so we can prove the second run actually
+    // executed its model turn (not merely that it failed to throw).
+    let streamedContent = '';
+    const processStreamEventFn = (event: ServerGeminiStreamEvent) => {
+      if (event.type === GeminiEventType.Content) {
+        streamedContent += event.value;
+      }
+    };
 
     const { result } = renderHook(() =>
       useAgenticLoop({
@@ -520,7 +529,7 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
         onEditorOpen: () => {},
         onEditorClose: () => {},
         onTodoPause: () => {},
-        processStreamEventRef: { current: () => {} },
+        processStreamEventRef: { current: processStreamEventFn },
         flushPendingHistoryItem: () => {},
         clearPendingHistoryItem: () => {},
         performMemoryRefresh: async () => {},
@@ -567,6 +576,11 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
     const firstMsg =
       firstError instanceof Error ? firstError.message : String(firstError);
     expect(firstMsg).not.toContain('concurrent');
+
+    // Stronger proof the second run ACTUALLY RAN (not just didn't throw): its
+    // 'go2' message reached the model and its second-turn content streamed in.
+    expect(turnMessages).toContain('go2');
+    expect(streamedContent).toContain('second-turn');
   });
 
   it('clears external (subagent) tools from the display via markToolsAsDisplayCleared', async () => {

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
@@ -479,6 +479,92 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
     expect(settled).toBe(true);
   });
 
+  it('serializes overlapping runLoop calls so a fast re-submit after cancel does not throw concurrent-execution', async () => {
+    // Reproduces issue #2076: after cancelling (ESC), a new message submitted
+    // before the previous generator's async teardown finishes must NOT throw
+    // "AgenticLoop.run does not support concurrent executions". runLoop must
+    // await the previous in-flight run's settlement before starting a new one.
+    const tool = toolRegistry.getTool('record_tool') as MockTool;
+    tool.executeFn.mockImplementation(
+      (_p: Record<string, unknown>, signal: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          if (signal.aborted) {
+            reject(new Error('aborted'));
+            return;
+          }
+          signal.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true,
+          });
+        }),
+    );
+
+    // First turn: a tool call that blocks until its signal aborts.
+    // Second turn (for the re-submit 'go2'): completes normally.
+    const { client } = createScriptedAgentClient([
+      [toolCallRequestEvent('record_tool', 'call-concurrent'), finishedEvent()],
+      [contentEvent('second-turn'), finishedEvent()],
+    ]);
+
+    const addItem = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAgenticLoop({
+        config,
+        agentClient: client,
+        messageBus,
+        interactiveMode: true,
+        addItem,
+        onToolCallsUpdate: () => {},
+        outputUpdateHandler: () => {},
+        getPreferredEditor: () => undefined,
+        onEditorOpen: () => {},
+        onEditorClose: () => {},
+        onTodoPause: () => {},
+        processStreamEventRef: { current: () => {} },
+        flushPendingHistoryItem: () => {},
+        clearPendingHistoryItem: () => {},
+        performMemoryRefresh: async () => {},
+      }),
+    );
+
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+
+    const errors: unknown[] = [];
+
+    // Start the first run WITHOUT awaiting it.
+    const firstPromise = act(async () => {
+      try {
+        await result.current.runLoop('go', controllerA.signal, 'p1');
+      } catch (e) {
+        errors.push(e);
+      }
+    });
+
+    // Wait until the tool is in-flight.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Cancel the first run (ESC).
+    controllerA.abort();
+
+    // Immediately submit a second run BEFORE the first settles.
+    const secondPromise = act(async () => {
+      try {
+        await result.current.runLoop('go2', controllerB.signal, 'p2');
+      } catch (e) {
+        errors.push(e);
+      }
+    });
+
+    await Promise.all([firstPromise, secondPromise]);
+
+    // Neither run must have thrown the concurrent-execution error.
+    for (const e of errors) {
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(msg).not.toContain('concurrent');
+    }
+  });
+
   it('clears external (subagent) tools from the display via markToolsAsDisplayCleared', async () => {
     // An external tool carries a non-default agentId. The subagent flow owns
     // its results, so the loop's display handling must mark it display-cleared

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useCancellation.asyncTasks.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useCancellation.asyncTasks.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable eslint-comments/disable-enable-pair -- behavioral coverage of async-task cancellation wiring. */
+
+/**
+ * Behavioral tests proving that cancelOngoingRequest (ESC) cancels running
+ * async subagent tasks via AsyncTaskManager. Uses a REAL AsyncTaskManager so
+ * cancelTask actually aborts the registered AbortController.
+ */
+
+import { describe, it, expect } from 'vitest';
+import React, { act } from 'react';
+import { renderHook } from '../../../../test-utils/render.js';
+import { useCancellation } from '../useGeminiStreamLifecycle.js';
+import { StreamingState, MessageType } from '../../../types.js';
+import { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
+import { KeypressProvider } from '../../../contexts/KeypressContext.js';
+import type { HistoryItemWithoutId } from '../../../types.js';
+
+describe('useCancellation — cancels running async tasks on ESC', () => {
+  it('calls cancelTask on all running async tasks when cancelOngoingRequest fires', async () => {
+    const asyncTaskManager = new AsyncTaskManager();
+    const seededController = new AbortController();
+    asyncTaskManager.registerTask({
+      id: 'running-async-agent',
+      subagentName: 'helper',
+      goalPrompt: 'do work',
+      abortController: seededController,
+    });
+
+    expect(seededController.signal.aborted).toBe(false);
+    expect(asyncTaskManager.getTask('running-async-agent')?.status).toBe(
+      'running',
+    );
+
+    const cancelRunningAsyncTasks = () => {
+      const mgr = asyncTaskManager;
+      mgr.getRunningTasks().forEach((t) => mgr.cancelTask(t.id));
+    };
+
+    const abortControllerRef = { current: new AbortController() };
+    const turnCancelledRef = { current: false };
+    const pendingHistoryItemRef = { current: null };
+    const queuedSubmissionsRef = { current: [] };
+    const addedItems: HistoryItemWithoutId[] = [];
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <KeypressProvider>{children}</KeypressProvider>
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCancellation(
+          StreamingState.Responding,
+          turnCancelledRef,
+          abortControllerRef,
+          () => {},
+          pendingHistoryItemRef,
+          () => {},
+          (item: HistoryItemWithoutId) => {
+            addedItems.push(item);
+            return addedItems.length;
+          },
+          () => {},
+          () => {},
+          () => {},
+          queuedSubmissionsRef,
+          cancelRunningAsyncTasks,
+        ),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.cancelOngoingRequest();
+    });
+
+    expect(seededController.signal.aborted).toBe(true);
+    expect(asyncTaskManager.getTask('running-async-agent')?.status).toBe(
+      'cancelled',
+    );
+
+    // The standard cancellation side effects still fire.
+    expect(addedItems.some((i) => i.type === MessageType.INFO)).toBe(true);
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useCancellation.asyncTasks.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useCancellation.asyncTasks.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable eslint-comments/disable-enable-pair -- behavioral coverage of async-task cancellation wiring. */
-
 /**
  * Behavioral tests proving that cancelOngoingRequest (ESC) cancels running
  * async subagent tasks via AsyncTaskManager. Uses a REAL AsyncTaskManager so

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useCancellation.asyncTasks.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useCancellation.asyncTasks.test.tsx
@@ -86,4 +86,79 @@ describe('useCancellation — cancels running async tasks on ESC', () => {
     // The standard cancellation side effects still fire.
     expect(addedItems.some((i) => i.type === MessageType.INFO)).toBe(true);
   });
+
+  it('cancels a task launched by a PRIOR (already-settled) turn (issue #2074)', async () => {
+    // Locks in the intentional session-wide cancellation: an async task whose
+    // own foreground-signal relay was bound to an EARLIER turn (now settled and
+    // unable to abort) must still be cancelled by ESC on a LATER turn. This is
+    // why cancellation goes through the session-wide AsyncTaskManager rather
+    // than relying solely on the per-launch foreground relay.
+    const asyncTaskManager = new AsyncTaskManager();
+
+    // Simulate the prior turn's foreground signal: it already aborted/settled
+    // and is wired to the task via a relay, but that relay can no longer fire.
+    const priorTurnController = new AbortController();
+    const taskController = new AbortController();
+    const relay = () => taskController.abort();
+    priorTurnController.signal.addEventListener('abort', relay, { once: true });
+    asyncTaskManager.registerTask({
+      id: 'cross-turn-async-agent',
+      subagentName: 'helper',
+      goalPrompt: 'long-running work from a previous turn',
+      abortController: taskController,
+    });
+
+    // The prior turn has ended; its relay is detached and will never fire.
+    priorTurnController.signal.removeEventListener('abort', relay);
+    expect(taskController.signal.aborted).toBe(false);
+
+    const cancelRunningAsyncTasks = () => {
+      const mgr = asyncTaskManager;
+      mgr.getRunningTasks().forEach((t) => mgr.cancelTask(t.id));
+    };
+
+    // A NEW foreground turn with its own (different) abort controller.
+    const newTurnAbortRef = { current: new AbortController() };
+    const turnCancelledRef = { current: false };
+    const pendingHistoryItemRef = { current: null };
+    const queuedSubmissionsRef = { current: [] };
+    const addedItems: HistoryItemWithoutId[] = [];
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <KeypressProvider>{children}</KeypressProvider>
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCancellation(
+          StreamingState.Responding,
+          turnCancelledRef,
+          newTurnAbortRef,
+          () => {},
+          pendingHistoryItemRef,
+          () => {},
+          (item: HistoryItemWithoutId) => {
+            addedItems.push(item);
+            return addedItems.length;
+          },
+          () => {},
+          () => {},
+          () => {},
+          queuedSubmissionsRef,
+          cancelRunningAsyncTasks,
+        ),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.cancelOngoingRequest();
+    });
+
+    // Even though the task's own relay (prior turn) can never fire, the
+    // session-wide cancellation aborts it.
+    expect(taskController.signal.aborted).toBe(true);
+    expect(asyncTaskManager.getTask('cross-turn-async-agent')?.status).toBe(
+      'cancelled',
+    );
+  });
 });

--- a/packages/cli/src/ui/hooks/geminiStream/useAgenticLoop.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useAgenticLoop.ts
@@ -283,24 +283,26 @@ export function useAgenticLoop(args: UseAgenticLoopArgs): UseAgenticLoopReturn {
       signal: AbortSignal,
       promptId: string,
     ): Promise<void> => {
-      const previous = inflightRunRef.current;
-      if (previous) {
-        await previous.catch(() => {
-          // Swallow the previous run's error; only the current run's error
-          // propagates.
-        });
-      }
-
       const userMessageTimestamp = Date.now();
-      const currentRun = iterateLoop(
-        loop,
-        message,
-        signal,
-        promptId,
-        latestArgs.current,
-        userMessageTimestamp,
-        processedMemoryTools,
-      );
+      // Chain on the current in-flight promise BEFORE assigning the new one so
+      // that multiple overlapping callers serialize correctly: if B and C both
+      // enter while A runs, C chains onto B's promise (which chains onto A).
+      // The previous run's error is swallowed; only the current run's error
+      // propagates to the caller.
+      const previous = inflightRunRef.current ?? Promise.resolve();
+      const currentRun = previous
+        .catch(() => {})
+        .then(() =>
+          iterateLoop(
+            loop,
+            message,
+            signal,
+            promptId,
+            latestArgs.current,
+            userMessageTimestamp,
+            processedMemoryTools,
+          ),
+        );
       inflightRunRef.current = currentRun;
       try {
         await currentRun;

--- a/packages/cli/src/ui/hooks/geminiStream/useAgenticLoop.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useAgenticLoop.ts
@@ -189,6 +189,28 @@ function handleToolsComplete(
   }
 }
 
+/**
+ * Iterates the AgenticLoop generator, routing each event until the loop ends or
+ * the signal aborts. Returns a promise that settles when iteration completes.
+ */
+function iterateLoop(
+  loop: AgenticLoop,
+  message: PartListUnion,
+  signal: AbortSignal,
+  promptId: string,
+  args: UseAgenticLoopArgs,
+  userMessageTimestamp: number,
+  processedMemoryTools: Set<string>,
+): Promise<void> {
+  return (async () => {
+    const iterator = loop.run(message, signal, promptId);
+    for await (const event of iterator) {
+      if (signal.aborted) break;
+      routeLoopEvent(event, args, userMessageTimestamp, processedMemoryTools);
+    }
+  })();
+}
+
 export function useAgenticLoop(args: UseAgenticLoopArgs): UseAgenticLoopReturn {
   const processedMemoryTools = useMemo(() => new Set<string>(), []);
   const latestArgs = useRef(args);
@@ -247,22 +269,45 @@ export function useAgenticLoop(args: UseAgenticLoopArgs): UseAgenticLoopReturn {
     ],
   );
 
+  // Serializes overlapping runLoop calls so a fast re-submit after a cancel
+  // does not collide with the previous run's async teardown. The loop instance
+  // is stable (memoized), and its `run()` rejects concurrent executions. We
+  // therefore await any in-flight previous run — swallowing its (expected)
+  // cancellation error — before starting the new run. The new run's own error
+  // still propagates to the caller.
+  const inflightRunRef = useRef<Promise<void> | null>(null);
+
   const runLoop = useCallback(
     async (
       message: PartListUnion,
       signal: AbortSignal,
       promptId: string,
     ): Promise<void> => {
+      const previous = inflightRunRef.current;
+      if (previous) {
+        await previous.catch(() => {
+          // Swallow the previous run's error; only the current run's error
+          // propagates.
+        });
+      }
+
       const userMessageTimestamp = Date.now();
-      const iterator = loop.run(message, signal, promptId);
-      for await (const event of iterator) {
-        if (signal.aborted) break;
-        routeLoopEvent(
-          event,
-          latestArgs.current,
-          userMessageTimestamp,
-          processedMemoryTools,
-        );
+      const currentRun = iterateLoop(
+        loop,
+        message,
+        signal,
+        promptId,
+        latestArgs.current,
+        userMessageTimestamp,
+        processedMemoryTools,
+      );
+      inflightRunRef.current = currentRun;
+      try {
+        await currentRun;
+      } finally {
+        if (inflightRunRef.current === currentRun) {
+          inflightRunRef.current = null;
+        }
       }
     },
     [loop, processedMemoryTools],

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamLifecycle.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamLifecycle.ts
@@ -220,6 +220,7 @@ export function useCancellation(
   onCancelSubmit: (shouldRestorePrompt?: boolean) => void,
   setIsResponding: React.Dispatch<React.SetStateAction<boolean>>,
   queuedSubmissionsRef: React.MutableRefObject<QueuedSubmission[]>,
+  cancelRunningAsyncTasks: () => void = () => {},
 ) {
   const cancelOngoingRequest = useCallback(() => {
     if (
@@ -232,6 +233,7 @@ export function useCancellation(
     turnCancelledRef.current = true;
     abortControllerRef.current?.abort();
     if (abortControllerRef.current) cancelAllToolCalls();
+    cancelRunningAsyncTasks();
     if (pendingHistoryItemRef.current) flushPendingHistoryItem(Date.now());
     addItem({ type: MessageType.INFO, text: 'Request cancelled.' }, Date.now());
     setPendingHistoryItem(null);
@@ -243,6 +245,7 @@ export function useCancellation(
     turnCancelledRef,
     abortControllerRef,
     cancelAllToolCalls,
+    cancelRunningAsyncTasks,
     pendingHistoryItemRef,
     flushPendingHistoryItem,
     addItem,

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
@@ -98,6 +98,14 @@ export function useGeminiStreamOrchestration(
     st.isResponding,
     scheduler.toolCalls,
   );
+  // Cancels EVERY running async subagent on ESC, not only those launched by the
+  // current foreground turn. This is intentional (issue #2074): an async task
+  // launched in a prior turn has its foreground-signal relay bound to that
+  // earlier turn's signal, which already settled and can never abort. Relaying
+  // alone would therefore leave such cross-turn tasks running, which is the
+  // exact bug #2074 reports. The AsyncTaskManager is the single session-wide
+  // owner of running tasks, so cancelling all of them is the only mechanism
+  // that reliably stops detached subagents regardless of launch turn.
   const cancelRunningAsyncTasks = useCallback(() => {
     const mgr = args.config.getAsyncTaskManager();
     mgr?.getRunningTasks().forEach((t) => mgr.cancelTask(t.id));

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStreamOrchestration.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import {
   type Config,
   type EditorType,
@@ -98,6 +98,10 @@ export function useGeminiStreamOrchestration(
     st.isResponding,
     scheduler.toolCalls,
   );
+  const cancelRunningAsyncTasks = useCallback(() => {
+    const mgr = args.config.getAsyncTaskManager();
+    mgr?.getRunningTasks().forEach((t) => mgr.cancelTask(t.id));
+  }, [args.config]);
   const { cancelOngoingRequest } = useCancellation(
     streamingState,
     st.turnCancelledRef,
@@ -110,6 +114,7 @@ export function useGeminiStreamOrchestration(
     args.onCancelSubmit,
     st.setIsResponding,
     st.queuedSubmissionsRef,
+    cancelRunningAsyncTasks,
   );
   // Refs to break the circular dependency between useSubmitQuery (which
   // creates useStreamEventHandlers → processStreamEvent) and useAgenticLoop


### PR DESCRIPTION
## Summary

Fixes two related cancellation bugs: the "error on cancel" race (#2076) and ESC not cancelling async subagent calls (#2074).

## Issue #2076 — "error on cancel"

After cancelling a request (ESC) and quickly submitting a new message, users got: `✕ [API Error: AgenticLoop.run does not support concurrent executions]`. The previous request was cancelled but its async teardown (scheduler cancel + dispose) hadn't finished, so `isRunning` was still true when the new `loop.run()` was attempted.

**Fix:** Serialize overlapping `runLoop` calls in `useAgenticLoop.ts` via an `inflightRunRef`. Before starting a new run, await the previous in-flight run's settlement (swallowing its expected cancellation error). The identity check in `finally` prevents a slow previous teardown from clearing a newer run's ref.

## Issue #2074 — "ESC isn't cancelling subagent calls"

ESC cancelled the foreground turn but async (`async=true`) subagents kept running. Five coordinated changes:

- **(a)** Pass `asyncAbortController.signal` (not `undefined`) to `orchestrator.launch` so `AsyncTaskManager.cancelTask` can relay abort to the SubAgentScope via `bindParentSignal`.
- **(b)** Relay the foreground signal into the async abort controller so ESC cancels the async subagent launched in the current turn.
- **(c)** CLI `cancelOngoingRequest` now calls `cancelTask` on all running AsyncTaskManager tasks.
- **(d)** Distinguish timeout from user-cancel: only `failTask` with the timeout message when the timeout flag is set; otherwise `cancelTask` (idempotent, does not overwrite an already-cancelled status).
- **(e)** Harden sync launch race: cancel the scope immediately if the signal is already aborted when launch resolves.

## Test plan

All changes follow strict TDD (RED → GREEN):

### #2076 tests
- `useAgenticLoop.test.tsx`: "serializes overlapping runLoop calls so a fast re-submit after cancel does not throw concurrent-execution" — calls runLoop twice in quick succession (second before first settles), asserts no concurrent-execution error.

### #2074 tests
- `task.test.ts`: Inverted the async-launch contract test — now asserts `launch` receives `expect.any(AbortSignal)` instead of `undefined`.
- `task.test.ts`: "wires the async abort controller so cancelTask aborts the launch signal" — uses a real AsyncTaskManager, captures the launch signal, calls cancelTask, asserts the signal is aborted.
- `task.test.ts`: "relays the foreground signal abort into the async abort controller" — aborts the foreground controller, asserts the launch signal aborts.
- `task.test.ts`: "does NOT label a user-cancelled task as timeout" — aborts without timeout, asserts failTask is NOT called with the timeout message.
- `useCancellation.asyncTasks.test.tsx` (new): Uses a real AsyncTaskManager seeded with a running task, calls `cancelOngoingRequest`, asserts the task's signal is aborted and status is cancelled.

## Verification

All 6 verification commands pass:
- `npm run test` — CLI: 4685 passed (3 skipped), Agents: 1663 passed
- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run format` — clean
- `npm run build` — success
- Smoke test — success