### PR TITLE
Remove ESLint suppressions from packages/agents source (Fixes #2085)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -414,6 +414,33 @@ const completedDirectiveCleanupScopes = [
   'packages/agents/src/tools/task.issues.test.ts', // #2090
   'packages/agents/src/tools/task.max-turns.test.ts', // #2090
   'packages/agents/src/tools/task.timeout.test.ts', // #2090
+  'packages/agents/src/agents/executor.ts', // #2085
+  'packages/agents/src/compression/HighDensityStrategy.ts', // #2085
+  'packages/agents/src/core/bucketFailoverIntegration.ts', // #2085
+  'packages/agents/src/core/chatSession.ts', // #2085
+  'packages/agents/src/core/clientHelpers.ts', // #2085
+  'packages/agents/src/core/DirectMessageProcessor.ts', // #2085
+  'packages/agents/src/core/MessageConverter.ts', // #2085
+  'packages/agents/src/core/StreamProcessor.ts', // #2085
+  'packages/agents/src/core/subagent.ts', // #2085
+  'packages/agents/src/core/subagentOrchestrator.ts', // #2085
+  'packages/agents/src/core/subagentToolProcessing.ts', // #2085
+  'packages/agents/src/core/TurnProcessor.ts', // #2085
+  'packages/agents/src/tools/task.ts', // #2085
+  // #2085 decomposition helpers extracted from the files above; keep locked so
+  // no inline disables can be reintroduced in the new modules.
+  'packages/agents/src/agents/executor-stream-processor.ts', // #2085
+  'packages/agents/src/agents/executor-tool-dispatch.ts', // #2085
+  'packages/agents/src/agents/recovery.ts', // #2085
+  'packages/agents/src/core/CompressionLoadBalancingProvider.ts', // #2085
+  'packages/agents/src/core/CompressionProfileResolver.ts', // #2085
+  'packages/agents/src/core/streamRequestHelpers.ts', // #2085
+  'packages/agents/src/core/streamResponseHelpers.ts', // #2085
+  'packages/agents/src/core/subagentNonInteractive.ts', // #2085
+  'packages/agents/src/tools/taskAbortHelpers.ts', // #2085
+  'packages/agents/src/tools/taskAsyncExecution.ts', // #2085
+  'packages/agents/src/tools/taskResultHelpers.ts', // #2085
+  'packages/agents/src/tools/taskToolGovernance.ts', // #2085
 ];
 
 export default tseslint.config(

--- a/packages/agents/src/agents/executor-stream-processor.ts
+++ b/packages/agents/src/agents/executor-stream-processor.ts
@@ -1,0 +1,228 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StreamEventType, type StreamEvent } from '../core/chatSession.js';
+import type {
+  Content,
+  Part,
+  FunctionCall,
+  FunctionDeclaration,
+  GenerateContentResponse,
+} from '@google/genai';
+import {
+  filterHookRestrictedFunctionCalls,
+  filterHookRestrictedParts,
+  getHookRestrictedAllowedTools,
+  getHookRestrictedFunctionCallsFromParts,
+  hasFilteredHookRestrictedToolCalls,
+  mergeHookRestrictedFunctionCalls,
+} from '../core/hookToolRestrictions.js';
+import { parseThought } from '@vybestack/llxprt-code-core/utils/thoughtUtils.js';
+import {
+  nextStreamEventWithIdleTimeout,
+  resolveStreamIdleTimeoutMs,
+} from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import type { ChatSession } from '../core/chatSession.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { SubagentActivityEventType } from './types.js';
+
+/** Result from the model call. */
+export type AgentModelResult = {
+  functionCalls: FunctionCall[];
+  textResponse: string;
+};
+
+/** Callback for emitting activity events. */
+export type StreamEmitActivityFn = (
+  type: SubagentActivityEventType,
+  data: Record<string, unknown>,
+) => void;
+
+/**
+ * Discriminated result for a single stream-event read.
+ */
+type StreamEventRead =
+  | { kind: 'done' }
+  | { kind: 'chunk'; value: GenerateContentResponse }
+  | { kind: 'skip' };
+
+/**
+ * Calls the generative model with the current context and tools, consuming
+ * the response stream and accumulating function calls and text.
+ *
+ * @returns The model's response, including any tool calls or text.
+ */
+export async function callModelAndConsumeStream(
+  chat: ChatSession,
+  message: Content,
+  tools: Array<{ functionDeclarations: FunctionDeclaration[] }> | undefined,
+  signal: AbortSignal,
+  promptId: string,
+  runtimeContext: Config,
+  emitActivity: StreamEmitActivityFn,
+): Promise<AgentModelResult> {
+  const timeoutController = new AbortController();
+  const timeoutSignal = timeoutController.signal;
+  const onAbort = () => timeoutController.abort();
+  signal.addEventListener('abort', onAbort, { once: true });
+
+  const messageParams = {
+    message: message.parts ?? [],
+    config: {
+      abortSignal: timeoutSignal,
+      tools,
+    },
+  };
+
+  let streamIterator: AsyncIterator<StreamEvent> | undefined;
+  const effectiveTimeoutMs = resolveStreamIdleTimeoutMs(runtimeContext);
+
+  try {
+    const responseStream = await chat.sendMessageStream(
+      messageParams,
+      promptId,
+    );
+
+    const functionCalls: FunctionCall[] = [];
+    let textResponse = '';
+    streamIterator = responseStream[Symbol.asyncIterator]();
+
+    await consumeStream(
+      streamIterator,
+      effectiveTimeoutMs,
+      signal,
+      timeoutSignal,
+      timeoutController,
+      functionCalls,
+      (text) => {
+        textResponse += text;
+      },
+      emitActivity,
+    );
+
+    return {
+      functionCalls,
+      textResponse,
+    };
+  } finally {
+    streamIterator?.return?.().catch(() => {});
+    timeoutController.abort();
+    signal.removeEventListener('abort', onAbort);
+  }
+}
+
+/** Consumes a response stream, accumulating function calls and text. */
+async function consumeStream(
+  streamIterator: AsyncIterator<StreamEvent>,
+  effectiveTimeoutMs: number,
+  signal: AbortSignal,
+  timeoutSignal: AbortSignal,
+  timeoutController: AbortController,
+  functionCalls: FunctionCall[],
+  onText: (text: string) => void,
+  emitActivity: StreamEmitActivityFn,
+): Promise<void> {
+  for (;;) {
+    const event = await readStreamEvent(
+      streamIterator,
+      effectiveTimeoutMs,
+      signal,
+      timeoutSignal,
+      timeoutController,
+    );
+    if (event.kind === 'done') {
+      break;
+    }
+    if (event.kind === 'chunk') {
+      processStreamChunk(event.value, functionCalls, onText, emitActivity);
+    }
+  }
+}
+
+/** Read and validate a single stream event. */
+async function readStreamEvent(
+  streamIterator: AsyncIterator<StreamEvent>,
+  effectiveTimeoutMs: number,
+  signal: AbortSignal,
+  timeoutSignal: AbortSignal,
+  timeoutController: AbortController,
+): Promise<StreamEventRead> {
+  let result: IteratorResult<StreamEvent>;
+  if (effectiveTimeoutMs > 0) {
+    result = await nextStreamEventWithIdleTimeout({
+      iterator: streamIterator,
+      timeoutMs: effectiveTimeoutMs,
+      signal: timeoutSignal,
+      onTimeout: () => {
+        if (signal.aborted) {
+          return;
+        }
+        timeoutController.abort();
+      },
+      createTimeoutError: () => createAbortError(),
+    });
+  } else {
+    result = await streamIterator.next();
+  }
+  if (result.done === true) {
+    return { kind: 'done' };
+  }
+  if (signal.aborted) {
+    return { kind: 'done' };
+  }
+  const resp = result.value;
+  if (resp.type === StreamEventType.CHUNK) {
+    return { kind: 'chunk', value: resp.value };
+  }
+  return { kind: 'skip' };
+}
+
+/** Processes a single stream chunk, extracting thoughts, function calls, and text. */
+function processStreamChunk(
+  chunk: GenerateContentResponse,
+  functionCalls: FunctionCall[],
+  onText: (text: string) => void,
+  emitActivity: StreamEmitActivityFn,
+): boolean {
+  const parts = chunk.candidates?.[0]?.content?.parts ?? [];
+  const allowedTools = getHookRestrictedAllowedTools(chunk);
+  const filteredParts = filterHookRestrictedParts(parts, allowedTools);
+  const { subject } = parseThought(
+    filteredParts.find((p: Part) => p.thought === true)?.text ?? '',
+  );
+
+  if (subject !== '') {
+    emitActivity('THOUGHT_CHUNK', { text: subject });
+  }
+
+  const partCalls = getHookRestrictedFunctionCallsFromParts(
+    filteredParts,
+    allowedTools,
+  );
+  const topLevelCalls = filterHookRestrictedFunctionCalls(
+    chunk.functionCalls ?? [],
+    allowedTools,
+  );
+  const allowedFunctionCalls = mergeHookRestrictedFunctionCalls(
+    partCalls,
+    topLevelCalls,
+  );
+  if (allowedFunctionCalls.length > 0) {
+    functionCalls.push(...allowedFunctionCalls);
+  }
+
+  const text = filteredParts
+    .filter((p: Part) => p.thought !== true && typeof p.text === 'string')
+    .map((p: Part) => p.text)
+    .join('');
+
+  if (text.length > 0) {
+    onText(text);
+  }
+
+  return hasFilteredHookRestrictedToolCalls(chunk);
+}

--- a/packages/agents/src/agents/executor-tool-dispatch.ts
+++ b/packages/agents/src/agents/executor-tool-dispatch.ts
@@ -1,0 +1,515 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Tool-dispatch helpers extracted from the agent executor.
+ *
+ * These pure functions handle the mechanics of processing model-requested
+ * function calls: dispatching each call, handling the special
+ * `complete_task` tool, validating output against the agent's output schema,
+ * and assembling the response parts for the next loop iteration.
+ *
+ * Extracted into a sibling module so the main executor file stays within the
+ * project line budget while preserving exact behavior.
+ */
+
+import { Type } from '@google/genai';
+import type { Content, Part, FunctionCall } from '@google/genai';
+import { type z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { Schema, FunctionDeclaration } from '@google/genai';
+import { executeToolCall } from '../core/nonInteractiveToolExecutor.js';
+import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { type ToolCallRequestInfo } from '@vybestack/llxprt-code-core/core/turn.js';
+import {
+  getHookRestrictedAllowedToolsForFunctionCall,
+  isHookRestrictedToolCall,
+} from '../core/hookToolRestrictions.js';
+import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
+import { TASK_COMPLETE_TOOL_NAME } from './recovery.js';
+import type { AgentDefinition, SubagentActivityEventType } from './types.js';
+
+/** Result of executing one or more tool calls. */
+export interface ToolExecutionResult {
+  responseParts: Part[];
+  partialResult: string | null;
+}
+
+/** Final result of processing all function calls in a turn. */
+export interface FunctionCallProcessingResult {
+  nextMessage: Content;
+  submittedOutput: string | null;
+  taskCompleted: boolean;
+  partialResult: string | null;
+}
+
+/** Callback for emitting activity events during tool execution. */
+export type EmitActivityFn = (
+  type: SubagentActivityEventType,
+  data: Record<string, unknown>,
+) => void;
+
+/** Output config type derived from an AgentDefinition. */
+type OutputConfig = NonNullable<AgentDefinition<z.ZodTypeAny>['outputConfig']>;
+
+/**
+ * Builds the `complete_task` tool function declaration, optionally configured
+ * with the agent's output schema.
+ */
+export function buildCompleteTaskDeclaration(
+  outputConfig: OutputConfig | undefined,
+): FunctionDeclaration {
+  const completeTool: FunctionDeclaration = {
+    name: TASK_COMPLETE_TOOL_NAME,
+    description: outputConfig
+      ? 'Call this tool to submit your final answer and complete the task. This is the ONLY way to finish.'
+      : 'Call this tool to signal that you have completed your task. This is the ONLY way to finish.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {},
+      required: [],
+    },
+  };
+
+  if (outputConfig) {
+    const jsonSchema = zodToJsonSchema(outputConfig.schema);
+    const {
+      $schema: _$schema,
+      definitions: _definitions,
+      ...schema
+    } = jsonSchema;
+    completeTool.parameters!.properties![outputConfig.outputName] =
+      schema as Schema;
+    completeTool.parameters!.required!.push(outputConfig.outputName);
+  }
+
+  return completeTool;
+}
+
+/**
+ * Processes all function calls requested by the model in a single turn.
+ *
+ * Dispatches each call (synchronously for `complete_task` and unauthorized
+ * calls, asynchronously for registered tools), then assembles the response
+ * parts.
+ */
+export async function processFunctionCalls(
+  functionCalls: FunctionCall[],
+  toolRegistry: ToolRegistry,
+  runtimeContext: Config,
+  messageBus: MessageBus,
+  definition: AgentDefinition<z.ZodTypeAny>,
+  emitActivity: EmitActivityFn,
+  signal: AbortSignal,
+  promptId: string,
+): Promise<FunctionCallProcessingResult> {
+  const allowedToolNames = new Set(toolRegistry.getAllToolNames());
+  allowedToolNames.add(TASK_COMPLETE_TOOL_NAME);
+
+  let submittedOutput: string | null = null;
+  let taskCompleted = false;
+
+  const toolExecutionPromises: Array<Promise<ToolExecutionResult | void>> = [];
+  const syncResponseParts: Part[] = [];
+  let executableFunctionCallCount = 0;
+
+  for (const [index, functionCall] of functionCalls.entries()) {
+    const dispatch = dispatchSingleFunctionCall(
+      functionCall,
+      index,
+      promptId,
+      allowedToolNames,
+      runtimeContext,
+      messageBus,
+      definition,
+      emitActivity,
+      signal,
+      taskCompleted,
+      submittedOutput,
+    );
+    if (dispatch.kind === 'skip') {
+      // Hook-restricted or otherwise filtered; do nothing.
+    } else if (dispatch.kind === 'complete-task') {
+      executableFunctionCallCount += 1;
+      taskCompleted = dispatch.taskCompleted;
+      submittedOutput = dispatch.submittedOutput;
+      syncResponseParts.push(...dispatch.syncParts);
+    } else if (dispatch.kind === 'unauthorized') {
+      executableFunctionCallCount += 1;
+      syncResponseParts.push(...dispatch.syncParts);
+    } else {
+      executableFunctionCallCount += 1;
+      toolExecutionPromises.push(dispatch.promise);
+    }
+  }
+
+  return assembleToolResponses(
+    executableFunctionCallCount,
+    syncResponseParts,
+    toolExecutionPromises,
+    submittedOutput,
+    taskCompleted,
+  );
+}
+
+/** Discriminated result for dispatching a single function call. */
+type FunctionCallDispatch =
+  | { kind: 'skip' }
+  | {
+      kind: 'complete-task';
+      taskCompleted: boolean;
+      submittedOutput: string | null;
+      syncParts: Part[];
+    }
+  | { kind: 'unauthorized'; syncParts: Part[] }
+  | { kind: 'execute'; promise: Promise<ToolExecutionResult | void> };
+
+/**
+ * Decide how to handle a single function call within a turn.
+ *
+ * Returns a discriminated result so the caller can process without multiple
+ * break/continue statements.
+ */
+function dispatchSingleFunctionCall(
+  functionCall: FunctionCall,
+  index: number,
+  promptId: string,
+  allowedToolNames: Set<string>,
+  runtimeContext: Config,
+  messageBus: MessageBus,
+  definition: AgentDefinition<z.ZodTypeAny>,
+  emitActivity: EmitActivityFn,
+  signal: AbortSignal,
+  currentTaskCompleted: boolean,
+  currentSubmittedOutput: string | null,
+): FunctionCallDispatch {
+  const callId = functionCall.id ?? `${promptId}-${index}`;
+  const args = functionCall.args ?? {};
+  const hookAllowedTools =
+    getHookRestrictedAllowedToolsForFunctionCall(functionCall);
+  if (isHookRestrictedToolCall(functionCall, hookAllowedTools)) {
+    return { kind: 'skip' };
+  }
+
+  emitActivity('TOOL_CALL_START', { name: functionCall.name, args });
+
+  if (functionCall.name === TASK_COMPLETE_TOOL_NAME) {
+    const result = handleCompleteTaskCall(
+      functionCall,
+      callId,
+      args,
+      currentTaskCompleted,
+      currentSubmittedOutput,
+      definition,
+      emitActivity,
+    );
+    return {
+      kind: 'complete-task',
+      taskCompleted: result.taskCompleted,
+      submittedOutput: result.submittedOutput,
+      syncParts: result.syncParts,
+    };
+  }
+
+  if (!allowedToolNames.has(functionCall.name as string)) {
+    const syncParts: Part[] = [];
+    handleUnauthorizedToolCall(functionCall, callId, syncParts, emitActivity);
+    return { kind: 'unauthorized', syncParts };
+  }
+
+  // ToolRegistry is not needed here; allowedToolNames already captures it.
+  return {
+    kind: 'execute',
+    promise: createToolExecutionPromise(
+      functionCall,
+      callId,
+      args,
+      signal,
+      promptId,
+      runtimeContext,
+      messageBus,
+      emitActivity,
+    ),
+  };
+}
+
+/** Handles a `complete_task` function call, returning updated state and response parts. */
+function handleCompleteTaskCall(
+  functionCall: FunctionCall,
+  callId: string,
+  args: Record<string, unknown>,
+  currentTaskCompleted: boolean,
+  currentSubmittedOutput: string | null,
+  definition: AgentDefinition<z.ZodTypeAny>,
+  emitActivity: EmitActivityFn,
+): {
+  taskCompleted: boolean;
+  submittedOutput: string | null;
+  syncParts: Part[];
+} {
+  const syncParts: Part[] = [];
+
+  if (currentTaskCompleted) {
+    const error =
+      'Task already marked complete in this turn. Ignoring duplicate call.';
+    syncParts.push({
+      functionResponse: {
+        name: TASK_COMPLETE_TOOL_NAME,
+        response: { error },
+        id: callId,
+      },
+    });
+    emitActivity('ERROR', {
+      context: 'tool_call',
+      name: functionCall.name,
+      error,
+    });
+    return {
+      taskCompleted: currentTaskCompleted,
+      submittedOutput: currentSubmittedOutput,
+      syncParts,
+    };
+  }
+
+  const { outputConfig } = definition;
+
+  if (outputConfig) {
+    const result = processCompleteTaskOutput(
+      functionCall,
+      callId,
+      args,
+      outputConfig,
+      definition,
+      emitActivity,
+    );
+    syncParts.push(...result.syncParts);
+    return {
+      taskCompleted: result.taskCompleted,
+      submittedOutput: result.submittedOutput,
+      syncParts,
+    };
+  }
+
+  syncParts.push({
+    functionResponse: {
+      name: TASK_COMPLETE_TOOL_NAME,
+      response: { status: 'Task marked complete.' },
+      id: callId,
+    },
+  });
+  emitActivity('TOOL_CALL_END', {
+    name: functionCall.name,
+    output: 'Task marked complete.',
+  });
+
+  return {
+    taskCompleted: true,
+    submittedOutput: 'Task completed successfully.',
+    syncParts,
+  };
+}
+
+/** Processes the output argument of a `complete_task` call when outputConfig is present. */
+function processCompleteTaskOutput(
+  functionCall: FunctionCall,
+  callId: string,
+  args: Record<string, unknown>,
+  outputConfig: OutputConfig,
+  definition: AgentDefinition<z.ZodTypeAny>,
+  emitActivity: EmitActivityFn,
+): {
+  taskCompleted: boolean;
+  submittedOutput: string | null;
+  syncParts: Part[];
+} {
+  const syncParts: Part[] = [];
+  const outputName = outputConfig.outputName;
+
+  if (args[outputName] !== undefined) {
+    const outputValue = args[outputName];
+    const validationResult = outputConfig.schema.safeParse(outputValue);
+
+    if (!validationResult.success) {
+      const error = `Output validation failed: ${JSON.stringify(validationResult.error.flatten())}`;
+      syncParts.push({
+        functionResponse: {
+          name: TASK_COMPLETE_TOOL_NAME,
+          response: { error },
+          id: callId,
+        },
+      });
+      emitActivity('ERROR', {
+        context: 'tool_call',
+        name: functionCall.name,
+        error,
+      });
+      return { taskCompleted: false, submittedOutput: null, syncParts };
+    }
+
+    const validatedOutput = validationResult.data;
+    let submittedOutput: string;
+    if (definition.processOutput) {
+      submittedOutput = definition.processOutput(validatedOutput);
+    } else if (typeof outputValue === 'string') {
+      submittedOutput = outputValue;
+    } else {
+      submittedOutput = JSON.stringify(outputValue, null, 2);
+    }
+
+    syncParts.push({
+      functionResponse: {
+        name: TASK_COMPLETE_TOOL_NAME,
+        response: { result: 'Output submitted and task completed.' },
+        id: callId,
+      },
+    });
+    emitActivity('TOOL_CALL_END', {
+      name: functionCall.name,
+      output: 'Output submitted and task completed.',
+    });
+    return { taskCompleted: true, submittedOutput, syncParts };
+  }
+
+  // Missing required output argument
+  const error = `Missing required argument '${outputName}' for completion.`;
+  syncParts.push({
+    functionResponse: {
+      name: TASK_COMPLETE_TOOL_NAME,
+      response: { error },
+      id: callId,
+    },
+  });
+  emitActivity('ERROR', {
+    context: 'tool_call',
+    name: functionCall.name,
+    error,
+  });
+  return { taskCompleted: false, submittedOutput: null, syncParts };
+}
+
+/** Handles an unauthorized tool call by pushing an error response. */
+function handleUnauthorizedToolCall(
+  functionCall: FunctionCall,
+  callId: string,
+  syncResponseParts: Part[],
+  emitActivity: EmitActivityFn,
+): void {
+  const error = `Unauthorized tool call: '${functionCall.name}' is not available to this agent.`;
+
+  debugLogger.warn(`[AgentExecutor] Blocked call: ${error}`);
+
+  syncResponseParts.push({
+    functionResponse: {
+      name: functionCall.name as string,
+      id: callId,
+      response: { error },
+    },
+  });
+
+  emitActivity('ERROR', {
+    context: 'tool_call_unauthorized',
+    name: functionCall.name,
+    callId,
+    error,
+  });
+}
+
+/** Creates an async promise that executes a standard tool call. */
+function createToolExecutionPromise(
+  functionCall: FunctionCall,
+  callId: string,
+  args: Record<string, unknown>,
+  signal: AbortSignal,
+  promptId: string,
+  runtimeContext: Config,
+  messageBus: MessageBus,
+  emitActivity: EmitActivityFn,
+): Promise<ToolExecutionResult | void> {
+  const hookAllowedTools =
+    getHookRestrictedAllowedToolsForFunctionCall(functionCall);
+  const requestInfo: ToolCallRequestInfo = {
+    callId,
+    name: functionCall.name as string,
+    args,
+    isClientInitiated: true,
+    prompt_id: promptId,
+    ...(hookAllowedTools !== undefined
+      ? { hookRestrictedAllowedTools: hookAllowedTools }
+      : {}),
+  };
+
+  return (async () => {
+    const completed = await executeToolCall(
+      runtimeContext,
+      requestInfo,
+      signal,
+      { messageBus },
+    );
+    const toolResponse = completed.response;
+
+    if (toolResponse.error) {
+      emitActivity('ERROR', {
+        context: 'tool_call',
+        name: functionCall.name,
+        error: toolResponse.error.message,
+      });
+    } else {
+      emitActivity('TOOL_CALL_END', {
+        name: functionCall.name,
+        output: toolResponse.resultDisplay,
+      });
+    }
+
+    return {
+      responseParts: toolResponse.responseParts,
+      partialResult:
+        typeof toolResponse.resultDisplay === 'string'
+          ? toolResponse.resultDisplay
+          : null,
+    };
+  })();
+}
+
+/** Assembles all tool response parts and returns the final result. */
+async function assembleToolResponses(
+  executableFunctionCallCount: number,
+  syncResponseParts: Part[],
+  toolExecutionPromises: Array<Promise<ToolExecutionResult | void>>,
+  submittedOutput: string | null,
+  taskCompleted: boolean,
+): Promise<FunctionCallProcessingResult> {
+  const asyncResults = await Promise.all(toolExecutionPromises);
+
+  const toolResponseParts: Part[] = [...syncResponseParts];
+  let partialResult: string | null = null;
+  for (const result of asyncResults) {
+    if (result) {
+      toolResponseParts.push(...result.responseParts);
+      if (result.partialResult !== null) {
+        partialResult = result.partialResult;
+      }
+    }
+  }
+
+  if (
+    executableFunctionCallCount > 0 &&
+    toolResponseParts.length === 0 &&
+    !taskCompleted
+  ) {
+    toolResponseParts.push({
+      text: 'All tool calls failed or were unauthorized. Please analyze the errors and try an alternative approach.',
+    });
+  }
+
+  return {
+    nextMessage: { role: 'user', parts: toolResponseParts },
+    submittedOutput,
+    taskCompleted,
+    partialResult,
+  };
+}

--- a/packages/agents/src/agents/executor.ts
+++ b/packages/agents/src/agents/executor.ts
@@ -4,46 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable max-lines -- Existing executor is above the project line budget; this change keeps recovery logic localized. */
-
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { reportError } from '@vybestack/llxprt-code-core/utils/errorReporting.js';
-import {
-  ChatSession,
-  StreamEventType,
-  type StreamEvent,
-} from '../core/chatSession.js';
-import { Type } from '@google/genai';
+import { ChatSession } from '../core/chatSession.js';
 import { loadAgentRuntime } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeLoader.js';
 import { type ReadonlySettingsSnapshot } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import { createSettingsProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/settingsRuntimeAdapter.js';
 import { createAgentRuntimeStateFromConfig } from '@vybestack/llxprt-code-core/runtime/runtimeStateFactory.js';
 import type {
   Content,
-  Part,
   FunctionCall,
   GenerateContentConfig,
-  GenerateContentResponse,
   FunctionDeclaration,
-  Schema,
 } from '@google/genai';
-import { executeToolCall } from '../core/nonInteractiveToolExecutor.js';
-import {
-  filterHookRestrictedFunctionCalls,
-  filterHookRestrictedParts,
-  getHookRestrictedAllowedTools,
-  getHookRestrictedAllowedToolsForFunctionCall,
-  getHookRestrictedFunctionCallsFromParts,
-  hasFilteredHookRestrictedToolCalls,
-  isHookRestrictedToolCall,
-  mergeHookRestrictedFunctionCalls,
-} from '../core/hookToolRestrictions.js';
 import { ToolRegistry } from '@vybestack/llxprt-code-tools';
+import type { AnyDeclarativeTool } from '@vybestack/llxprt-code-tools';
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
 import { CoreToolRegistryHostAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreToolRegistryHostAdapter.js';
 
-import { type ToolCallRequestInfo } from '@vybestack/llxprt-code-core/core/turn.js';
 import type {
   AgentDefinition,
   AgentInputs,
@@ -59,15 +38,21 @@ import {
 import { checkAgentTermination } from './executor-termination.js';
 import {
   type RecoveryState,
-  type RecoveryActive,
+  type EmitActivityFn,
   resolveGracePeriodSeconds,
-  isRecoverableTermination,
-  enterRecovery,
   recoveryFailureResult,
   markRecoveryResponseUsed,
+  checkRecoveryToolCalls,
+  handleTerminationReason,
+  handleProtocolViolation,
 } from './recovery.js';
 import { templateString } from './utils.js';
-import { parseThought } from '@vybestack/llxprt-code-core/utils/thoughtUtils.js';
+import { type z } from 'zod';
+import {
+  processFunctionCalls as processFunctionCallsDispatch,
+  buildCompleteTaskDeclaration,
+} from './executor-tool-dispatch.js';
+import { callModelAndConsumeStream } from './executor-stream-processor.js';
 
 /** Result type for a single agent loop iteration. */
 type AgentLoopIterationResult =
@@ -87,29 +72,40 @@ type AgentLoopIterationResult =
       };
     };
 
-type ToolExecutionResult = {
-  responseParts: Part[];
-  partialResult: string | null;
-};
-
-type AgentModelResult = {
-  functionCalls: FunctionCall[];
-  textResponse: string;
-};
-
-import { type z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
-import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
-import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
-import {
-  nextStreamEventWithIdleTimeout,
-  resolveStreamIdleTimeoutMs,
-} from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
-
 /** A callback function to report on agent activity. */
 export type ActivityCallback = (activity: SubagentActivityEvent) => void;
 
-const TASK_COMPLETE_TOOL_NAME = 'complete_task';
+/**
+ * Register tools from the agent's tool config into the isolated agent registry.
+ *
+ * String references are resolved from the parent registry; tool instances with
+ * a `build` method are registered directly; raw `FunctionDeclaration` objects
+ * are skipped (their schemas are passed to the model later).
+ */
+function registerToolsFromConfig(
+  tools: Array<string | FunctionDeclaration | AnyDeclarativeTool>,
+  parentToolRegistry: ToolRegistry,
+  agentToolRegistry: ToolRegistry,
+): void {
+  for (const toolRef of tools) {
+    if (typeof toolRef === 'string') {
+      // If the tool is referenced by name, retrieve it from the parent
+      // registry and register it with the agent's isolated registry.
+      const toolFromParent = parentToolRegistry.getTool(toolRef);
+      if (toolFromParent) {
+        agentToolRegistry.registerTool(toolFromParent);
+      }
+    } else if (
+      typeof toolRef === 'object' &&
+      'name' in toolRef &&
+      'build' in toolRef
+    ) {
+      agentToolRegistry.registerTool(toolRef);
+    }
+    // Note: Raw `FunctionDeclaration` objects in the config don't need to be
+    // registered; their schemas are passed directly to the model later.
+  }
+}
 
 /**
  * Executes an agent loop based on an {@link AgentDefinition}.
@@ -160,25 +156,11 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     const parentToolRegistry = runtimeContext.getToolRegistry();
 
     if (definition.toolConfig) {
-      for (const toolRef of definition.toolConfig.tools) {
-        if (typeof toolRef === 'string') {
-          // If the tool is referenced by name, retrieve it from the parent
-          // registry and register it with the agent's isolated registry.
-          const toolFromParent = parentToolRegistry.getTool(toolRef);
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (toolFromParent) {
-            agentToolRegistry.registerTool(toolFromParent);
-          }
-        } else if (
-          typeof toolRef === 'object' &&
-          'name' in toolRef &&
-          'build' in toolRef
-        ) {
-          agentToolRegistry.registerTool(toolRef);
-        }
-        // Note: Raw `FunctionDeclaration` objects in the config don't need to be
-        // registered; their schemas are passed directly to the model later.
-      }
+      registerToolsFromConfig(
+        definition.toolConfig.tools,
+        parentToolRegistry,
+        agentToolRegistry,
+      );
 
       agentToolRegistry.sortTools();
       // Validate that all registered tools are safe for non-interactive
@@ -287,8 +269,7 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     let recoveryState: RecoveryState = { phase: 'none' };
     let recoveryModelResponseUsed = false;
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Agent/model streams are external runtime boundaries.
-    while (true) {
+    for (;;) {
       const outcome = await this.runAgentLoopIteration(
         chat,
         tools,
@@ -367,7 +348,6 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
   }
 
   /** Body of the agent loop iteration (after termination checks). */
-  // eslint-disable-next-line max-lines-per-function -- Agent iteration orchestration coordinates model calls, recovery handling, and tool dispatch in one control-flow boundary.
   private async runAgentLoopIterationBody(
     chat: ChatSession,
     tools: FunctionDeclaration[],
@@ -386,58 +366,130 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
       };
     }
 
+    const promptId = `${this.runtimeContext.getSessionId()}#${this.agentId}#${turnCounter}`;
+    const nextTurnCounter = turnCounter + 1;
+
+    const modelOutcome = await this.executeModelCall(
+      chat,
+      tools,
+      signal,
+      currentMessage,
+      recoveryState,
+      recoveryModelResponseUsed,
+      finalResult,
+      promptId,
+    );
+    if (modelOutcome.kind === 'error') {
+      return modelOutcome.result;
+    }
+
+    return this.handleModelResponse(
+      modelOutcome.functionCalls,
+      signal,
+      promptId,
+      nextTurnCounter,
+      finalResult,
+      recoveryState,
+      recoveryModelResponseUsed,
+    );
+  }
+
+  /** Execute the model call, handling recovery-abort and error paths. */
+  private async executeModelCall(
+    chat: ChatSession,
+    tools: FunctionDeclaration[],
+    signal: AbortSignal,
+    currentMessage: Content,
+    recoveryState: RecoveryState,
+    recoveryModelResponseUsed: boolean,
+    finalResult: string | null,
+    promptId: string,
+  ): Promise<
+    | { kind: 'ok'; functionCalls: FunctionCall[] }
+    | { kind: 'error'; result: AgentLoopIterationResult }
+  > {
     const recoveryAbort =
       recoveryState.phase === 'active' && !recoveryModelResponseUsed
         ? this.createRecoveryAbortController(recoveryState.deadlineMs, signal)
         : undefined;
 
-    const promptId = `${this.runtimeContext.getSessionId()}#${this.agentId}#${turnCounter}`;
-    const nextTurnCounter = turnCounter + 1;
-
-    let modelResult: AgentModelResult;
-    let functionCalls: FunctionCall[];
     try {
-      modelResult = await this.callModel(
+      const toolsConfig =
+        tools.length > 0 ? [{ functionDeclarations: tools }] : undefined;
+      const modelResult = await callModelAndConsumeStream(
         chat,
         currentMessage,
-        tools,
+        toolsConfig,
         recoveryAbort?.signal ?? signal,
         promptId,
+        this.runtimeContext,
+        (type, data) => this.emitActivity(type, data),
       );
-      functionCalls = modelResult.functionCalls;
+      return { kind: 'ok', functionCalls: modelResult.functionCalls };
     } catch (error) {
-      if (recoveryState.phase === 'active') {
-        // If the parent signal was aborted, terminate as ABORTED rather than
-        // emitting a misleading recovery-timeout outcome.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- signal.aborted can be true even though the outer already-gated check passed; the catch path is reached from callModel which can throw on abort.
-        if (signal.aborted) {
-          return {
-            kind: 'done',
-            result: {
-              terminateReason: AgentTerminateMode.ABORTED,
-              finalResult,
-            },
-          };
-        }
-        this.emitRecoveryOutcome(
-          recoveryState.originalReason,
-          'failure',
-          recoveryState.originalReason,
-          recoveryState.gracePeriodSeconds,
-        );
-        return {
-          kind: 'done',
-          result: {
-            terminateReason: recoveryState.originalReason,
-            finalResult: finalResult ?? 'Recovery turn timed out.',
-          },
-        };
+      const errorResult = this.handleModelCallError(
+        error,
+        recoveryState,
+        signal,
+        finalResult,
+      );
+      if (errorResult !== null) {
+        return { kind: 'error', result: errorResult };
       }
       throw error;
     } finally {
       recoveryAbort?.abort();
     }
+  }
 
+  /** Handle an error from callModel during recovery or re-throw. */
+  private handleModelCallError(
+    error: unknown,
+    recoveryState: RecoveryState,
+    signal: AbortSignal,
+    finalResult: string | null,
+  ): AgentLoopIterationResult | null {
+    if (recoveryState.phase !== 'active') {
+      return null;
+    }
+    // If the parent signal was aborted, terminate as ABORTED rather than
+    // emitting a misleading recovery-timeout outcome. Using this.isAborted
+    // avoids TS narrowing the flag to false after the early return above,
+    // since signal.aborted can flip during the awaited callModel.
+    if (this.isAborted(signal)) {
+      return {
+        kind: 'done',
+        result: {
+          terminateReason: AgentTerminateMode.ABORTED,
+          finalResult,
+        },
+      };
+    }
+    this.emitRecoveryOutcome(
+      recoveryState.originalReason,
+      'failure',
+      recoveryState.originalReason,
+      recoveryState.gracePeriodSeconds,
+    );
+    return {
+      kind: 'done',
+      result: {
+        terminateReason: recoveryState.originalReason,
+        finalResult: finalResult ?? 'Recovery turn timed out.',
+      },
+    };
+  }
+
+  /** Handle the model's response: recovery checks, protocol violation, tool dispatch. */
+  private async handleModelResponse(
+    functionCalls: FunctionCall[],
+    signal: AbortSignal,
+    promptId: string,
+    nextTurnCounter: number,
+    finalResult: string | null,
+    recoveryState: RecoveryState,
+    recoveryModelResponseUsed: boolean,
+  ): Promise<AgentLoopIterationResult> {
     const newRecoveryModelResponseUsed = markRecoveryResponseUsed(
       recoveryState,
       recoveryModelResponseUsed,
@@ -450,45 +502,102 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
       };
     }
 
-    const checkResult = this.checkRecoveryToolCalls(
+    const gracePeriodSeconds = resolveGracePeriodSeconds(
+      this.definition.runConfig.grace_period_seconds,
+    );
+    const emitFn: EmitActivityFn = (type, data) =>
+      this.emitActivity(type, data);
+
+    const checkResult = checkRecoveryToolCalls(
       recoveryState,
       newRecoveryModelResponseUsed,
       functionCalls,
       finalResult,
+      emitFn,
     );
-
     if (checkResult) {
       return { kind: 'done', result: checkResult };
     }
 
     if (functionCalls.length === 0) {
-      const enterResult = this.handleProtocolViolation(
+      return this.handleEmptyFunctionCalls(
         recoveryState,
         finalResult,
+        nextTurnCounter,
+        gracePeriodSeconds,
+        emitFn,
       );
-      if (enterResult.entered) {
-        return {
-          kind: 'continue',
-          recoveryState: enterResult.state,
-          currentMessage: enterResult.warningMessage,
-          recoveryModelResponseUsed: false,
-          turnCounter: nextTurnCounter,
-          finalResult,
-        };
-      }
-      const activeGrace =
-        recoveryState.phase === 'active' ? recoveryState.gracePeriodSeconds : 0;
-      this.emitRecoveryOutcome(
-        enterResult.result.terminateReason,
-        'failure',
-        enterResult.result.terminateReason,
-        activeGrace,
-      );
-      return { kind: 'done', result: enterResult.result };
     }
 
+    return this.processToolCalls(
+      functionCalls,
+      signal,
+      promptId,
+      nextTurnCounter,
+      finalResult,
+      recoveryState,
+      newRecoveryModelResponseUsed,
+      emitFn,
+    );
+  }
+
+  /** Handle the protocol-violation path when the model returned no tool calls. */
+  private handleEmptyFunctionCalls(
+    recoveryState: RecoveryState,
+    finalResult: string | null,
+    nextTurnCounter: number,
+    gracePeriodSeconds: number,
+    emitFn: EmitActivityFn,
+  ): AgentLoopIterationResult {
+    const enterResult = handleProtocolViolation(
+      recoveryState,
+      finalResult,
+      gracePeriodSeconds,
+      emitFn,
+    );
+    if (enterResult.entered) {
+      return {
+        kind: 'continue',
+        recoveryState: enterResult.state,
+        currentMessage: enterResult.warningMessage,
+        recoveryModelResponseUsed: false,
+        turnCounter: nextTurnCounter,
+        finalResult,
+      };
+    }
+    const activeGrace =
+      recoveryState.phase === 'active' ? recoveryState.gracePeriodSeconds : 0;
+    this.emitRecoveryOutcome(
+      enterResult.result.terminateReason,
+      'failure',
+      enterResult.result.terminateReason,
+      activeGrace,
+    );
+    return { kind: 'done', result: enterResult.result };
+  }
+
+  /** Dispatch tool calls and handle task completion / recovery-failure paths. */
+  private async processToolCalls(
+    functionCalls: FunctionCall[],
+    signal: AbortSignal,
+    promptId: string,
+    nextTurnCounter: number,
+    finalResult: string | null,
+    recoveryState: RecoveryState,
+    newRecoveryModelResponseUsed: boolean,
+    emitFn: EmitActivityFn,
+  ): Promise<AgentLoopIterationResult> {
     const { nextMessage, submittedOutput, taskCompleted, partialResult } =
-      await this.processFunctionCalls(functionCalls, signal, promptId);
+      await processFunctionCallsDispatch(
+        functionCalls,
+        this.toolRegistry,
+        this.runtimeContext,
+        this.messageBus,
+        this.definition as unknown as AgentDefinition<z.ZodTypeAny>,
+        emitFn,
+        signal,
+        promptId,
+      );
 
     if (taskCompleted) {
       if (recoveryState.phase === 'active') {
@@ -499,10 +608,13 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
           recoveryState.gracePeriodSeconds,
         );
       }
-      finalResult = submittedOutput ?? 'Task completed successfully.';
+      const completedResult = submittedOutput ?? 'Task completed successfully.';
       return {
         kind: 'done',
-        result: { terminateReason: AgentTerminateMode.GOAL, finalResult },
+        result: {
+          terminateReason: AgentTerminateMode.GOAL,
+          finalResult: completedResult,
+        },
       };
     }
 
@@ -521,7 +633,6 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     }
 
     const nextFinalResult = partialResult ?? finalResult;
-
     return {
       kind: 'continue',
       recoveryState,
@@ -532,117 +643,22 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     };
   }
 
-  /** Check tool calls during recovery: non-complete_task = recovery failure. */
-  private checkRecoveryToolCalls(
-    recoveryState: RecoveryState,
-    recoveryModelResponseUsed: boolean,
-    functionCalls: FunctionCall[],
-    finalResult: string | null,
-  ): { terminateReason: AgentTerminateMode; finalResult: string } | null {
-    if (recoveryState.phase !== 'active' || !recoveryModelResponseUsed) {
-      return null;
-    }
-    const hasCompleteTask = functionCalls.some(
-      (fc) => fc.name === TASK_COMPLETE_TOOL_NAME,
-    );
-    if (!hasCompleteTask) {
-      this.emitRecoveryOutcome(
-        recoveryState.originalReason,
-        'failure',
-        recoveryState.originalReason,
-        recoveryState.gracePeriodSeconds,
-      );
-      return recoveryFailureResult(recoveryState.originalReason, finalResult);
-    }
-
-    // Recovery response must be exactly one complete_task call.
-    // If complete_task is accompanied by other tools, fail recovery immediately
-    // and do not execute any of the tool calls.
-    if (functionCalls.length > 1) {
-      this.emitRecoveryOutcome(
-        recoveryState.originalReason,
-        'failure',
-        recoveryState.originalReason,
-        recoveryState.gracePeriodSeconds,
-      );
-      return recoveryFailureResult(recoveryState.originalReason, finalResult);
-    }
-
-    return null;
-  }
-
   /** Handle termination-reason checks: enter recovery or return immediately. */
   private handleTerminationReason(
     reason: AgentTerminateMode,
     recoveryState: RecoveryState,
     finalResult: string | null,
-  ):
-    | { handled: true; newState: RecoveryActive; currentMessage: Content }
-    | {
-        handled: false;
-        result: {
-          terminateReason: AgentTerminateMode;
-          finalResult: string | null;
-        };
-      } {
-    if (isRecoverableTermination(reason) && recoveryState.phase === 'none') {
-      const gracePeriodSeconds = resolveGracePeriodSeconds(
-        this.definition.runConfig.grace_period_seconds,
-      );
-      const { state, warningMessage } = enterRecovery(
-        reason,
-        gracePeriodSeconds,
-        (type, data) => this.emitActivity(type, data),
-      );
-      return { handled: true, newState: state, currentMessage: warningMessage };
-    }
-
-    if (recoveryState.phase === 'active') {
-      const fail = recoveryFailureResult(
-        recoveryState.originalReason,
-        finalResult,
-      );
-      this.emitRecoveryOutcome(
-        recoveryState.originalReason,
-        'failure',
-        fail.terminateReason,
-        recoveryState.gracePeriodSeconds,
-      );
-      return { handled: false, result: fail };
-    }
-
-    return { handled: false, result: { terminateReason: reason, finalResult } };
-  }
-
-  /** Handle the protocol-violation path (model stopped calling tools). */
-  private handleProtocolViolation(
-    recoveryState: RecoveryState,
-    finalResult: string | null,
-  ):
-    | { entered: true; state: RecoveryActive; warningMessage: Content }
-    | {
-        entered: false;
-        result: { terminateReason: AgentTerminateMode; finalResult: string };
-      } {
-    if (recoveryState.phase === 'none') {
-      const gracePeriodSeconds = resolveGracePeriodSeconds(
-        this.definition.runConfig.grace_period_seconds,
-      );
-      const { state, warningMessage } = enterRecovery(
-        AgentTerminateMode.ERROR_NO_COMPLETE_TASK_CALL,
-        gracePeriodSeconds,
-        (type, data) => this.emitActivity(type, data),
-      );
-      return { entered: true, state, warningMessage };
-    }
-
-    // Already in recovery: the one recovery model response didn't call
-    // complete_task, so this empty response confirms recovery failure.
-    const fail = recoveryFailureResult(
-      recoveryState.originalReason,
-      finalResult,
+  ) {
+    const gracePeriodSeconds = resolveGracePeriodSeconds(
+      this.definition.runConfig.grace_period_seconds,
     );
-    return { entered: false, result: fail };
+    return handleTerminationReason(
+      reason,
+      recoveryState,
+      finalResult,
+      gracePeriodSeconds,
+      (type, data) => this.emitActivity(type, data),
+    );
   }
 
   private isAborted(signal: AbortSignal): boolean {
@@ -684,154 +700,6 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
       terminateReason,
       gracePeriodSeconds,
     });
-  }
-
-  /**
-   * Calls the generative model with the current context and tools.
-   *
-   * @returns The model's response, including any tool calls or text.
-   */
-  private async callModel(
-    chat: ChatSession,
-    message: Content,
-    tools: FunctionDeclaration[],
-    signal: AbortSignal,
-    promptId: string,
-  ): Promise<AgentModelResult> {
-    const timeoutController = new AbortController();
-    const timeoutSignal = timeoutController.signal;
-    const onAbort = () => timeoutController.abort();
-    signal.addEventListener('abort', onAbort, { once: true });
-
-    const messageParams = {
-      message: message.parts ?? [],
-      config: {
-        abortSignal: timeoutSignal,
-        tools: tools.length > 0 ? [{ functionDeclarations: tools }] : undefined,
-      },
-    };
-
-    let streamIterator: AsyncIterator<StreamEvent> | undefined;
-    const effectiveTimeoutMs = resolveStreamIdleTimeoutMs(this.runtimeContext);
-
-    try {
-      const responseStream = await chat.sendMessageStream(
-        messageParams,
-        promptId,
-      );
-
-      const functionCalls: FunctionCall[] = [];
-      let textResponse = '';
-      streamIterator = responseStream[Symbol.asyncIterator]();
-
-      await this.consumeStream(
-        streamIterator,
-        effectiveTimeoutMs,
-        signal,
-        timeoutSignal,
-        timeoutController,
-        functionCalls,
-        (text) => {
-          textResponse += text;
-        },
-      );
-
-      return {
-        functionCalls,
-        textResponse,
-      };
-    } finally {
-      streamIterator?.return?.().catch(() => {});
-      timeoutController.abort();
-      signal.removeEventListener('abort', onAbort);
-    }
-  }
-
-  /** Consumes a response stream, accumulating function calls and text. */
-  private async consumeStream(
-    streamIterator: AsyncIterator<StreamEvent>,
-    effectiveTimeoutMs: number,
-    signal: AbortSignal,
-    timeoutSignal: AbortSignal,
-    timeoutController: AbortController,
-    functionCalls: FunctionCall[],
-    onText: (text: string) => void,
-  ): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/too-many-break-or-continue-in-loop -- Agent/model streams are external runtime boundaries despite declared types.
-    while (true) {
-      let result: IteratorResult<StreamEvent>;
-      if (effectiveTimeoutMs > 0) {
-        result = await nextStreamEventWithIdleTimeout({
-          iterator: streamIterator,
-          timeoutMs: effectiveTimeoutMs,
-          signal: timeoutSignal,
-          onTimeout: () => {
-            if (signal.aborted) {
-              return;
-            }
-            timeoutController.abort();
-          },
-          createTimeoutError: () => createAbortError(),
-        });
-      } else {
-        result = await streamIterator.next();
-      }
-      if (result.done === true) {
-        break;
-      }
-
-      const resp = result.value;
-      if (signal.aborted) break;
-
-      if (resp.type === StreamEventType.CHUNK) {
-        this.processStreamChunk(resp.value, functionCalls, onText);
-      }
-    }
-  }
-
-  /** Processes a single stream chunk, extracting thoughts, function calls, and text. */
-  private processStreamChunk(
-    chunk: GenerateContentResponse,
-    functionCalls: FunctionCall[],
-    onText: (text: string) => void,
-  ): boolean {
-    const parts = chunk.candidates?.[0]?.content?.parts ?? [];
-    const allowedTools = getHookRestrictedAllowedTools(chunk);
-    const filteredParts = filterHookRestrictedParts(parts, allowedTools);
-    const { subject } = parseThought(
-      filteredParts.find((p: Part) => p.thought === true)?.text ?? '',
-    );
-
-    if (subject !== '') {
-      this.emitActivity('THOUGHT_CHUNK', { text: subject });
-    }
-
-    const partCalls = getHookRestrictedFunctionCallsFromParts(
-      filteredParts,
-      allowedTools,
-    );
-    const topLevelCalls = filterHookRestrictedFunctionCalls(
-      chunk.functionCalls ?? [],
-      allowedTools,
-    );
-    const allowedFunctionCalls = mergeHookRestrictedFunctionCalls(
-      partCalls,
-      topLevelCalls,
-    );
-    if (allowedFunctionCalls.length > 0) {
-      functionCalls.push(...allowedFunctionCalls);
-    }
-
-    const text = filteredParts
-      .filter((p: Part) => p.thought !== true && typeof p.text === 'string')
-      .map((p: Part) => p.text)
-      .join('');
-
-    if (text.length > 0) {
-      onText(text);
-    }
-
-    return hasFilteredHookRestrictedToolCalls(chunk);
   }
 
   /** Initializes a `ChatSession` instance for the agent run. */
@@ -918,8 +786,7 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
         providerRuntime,
         contentGeneratorConfig: this.runtimeContext.getContentGeneratorConfig(),
         toolRegistry: this.toolRegistry,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Agent/model streams are external runtime boundaries despite declared types.
-        providerManager: this.runtimeContext.getProviderManager?.(),
+        providerManager: this.runtimeContext.getProviderManager(),
       },
       overrides: {
         contentGenerator: this.tryGetContentGenerator(),
@@ -966,369 +833,10 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
   /** Attempts to get the content generator from the runtime context. */
   private tryGetContentGenerator() {
     try {
-      return (
-        this.runtimeContext
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Agent/model streams are external runtime boundaries despite declared types.
-          .getAgentClient?.()
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Agent/model streams are external runtime boundaries despite declared types.
-          ?.getContentGenerator()
-      );
+      return this.runtimeContext.getAgentClient().getContentGenerator();
     } catch {
       return undefined;
     }
-  }
-
-  /**
-   * Executes function calls requested by the model and returns the results.
-   *
-   * @returns A new `Content` object for history, any submitted output, and completion status.
-   */
-  private async processFunctionCalls(
-    functionCalls: FunctionCall[],
-    signal: AbortSignal,
-    promptId: string,
-  ): Promise<{
-    nextMessage: Content;
-    submittedOutput: string | null;
-    taskCompleted: boolean;
-    partialResult: string | null;
-  }> {
-    const allowedToolNames = new Set(this.toolRegistry.getAllToolNames());
-    allowedToolNames.add(TASK_COMPLETE_TOOL_NAME);
-
-    let submittedOutput: string | null = null;
-    let taskCompleted = false;
-
-    const toolExecutionPromises: Array<Promise<ToolExecutionResult | void>> =
-      [];
-    const syncResponseParts: Part[] = [];
-    let executableFunctionCallCount = 0;
-
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    for (const [index, functionCall] of functionCalls.entries()) {
-      const callId = functionCall.id ?? `${promptId}-${index}`;
-      const args = functionCall.args ?? {};
-      const hookAllowedTools =
-        getHookRestrictedAllowedToolsForFunctionCall(functionCall);
-      if (isHookRestrictedToolCall(functionCall, hookAllowedTools)) {
-        continue;
-      }
-
-      executableFunctionCallCount += 1;
-      this.emitActivity('TOOL_CALL_START', { name: functionCall.name, args });
-
-      if (functionCall.name === TASK_COMPLETE_TOOL_NAME) {
-        const result = this.handleCompleteTaskCall(
-          functionCall,
-          callId,
-          args,
-          taskCompleted,
-          submittedOutput,
-        );
-        taskCompleted = result.taskCompleted;
-        submittedOutput = result.submittedOutput;
-        syncResponseParts.push(...result.syncParts);
-        continue;
-      }
-
-      if (!allowedToolNames.has(functionCall.name as string)) {
-        this.handleUnauthorizedToolCall(
-          functionCall,
-          callId,
-          syncResponseParts,
-        );
-        continue;
-      }
-
-      toolExecutionPromises.push(
-        this.createToolExecutionPromise(
-          functionCall,
-          callId,
-          args,
-          signal,
-          promptId,
-        ),
-      );
-    }
-
-    return this.assembleToolResponses(
-      executableFunctionCallCount,
-      syncResponseParts,
-      toolExecutionPromises,
-      submittedOutput,
-      taskCompleted,
-    );
-  }
-
-  /** Handles a `complete_task` function call, returning updated state and response parts. */
-  private handleCompleteTaskCall(
-    functionCall: FunctionCall,
-    callId: string,
-    args: Record<string, unknown>,
-    currentTaskCompleted: boolean,
-    currentSubmittedOutput: string | null,
-  ): {
-    taskCompleted: boolean;
-    submittedOutput: string | null;
-    syncParts: Part[];
-  } {
-    const syncParts: Part[] = [];
-
-    if (currentTaskCompleted) {
-      const error =
-        'Task already marked complete in this turn. Ignoring duplicate call.';
-      syncParts.push({
-        functionResponse: {
-          name: TASK_COMPLETE_TOOL_NAME,
-          response: { error },
-          id: callId,
-        },
-      });
-      this.emitActivity('ERROR', {
-        context: 'tool_call',
-        name: functionCall.name,
-        error,
-      });
-      return {
-        taskCompleted: currentTaskCompleted,
-        submittedOutput: currentSubmittedOutput,
-        syncParts,
-      };
-    }
-
-    const { outputConfig } = this.definition;
-
-    if (outputConfig) {
-      const result = this.processCompleteTaskOutput(
-        functionCall,
-        callId,
-        args,
-        outputConfig,
-      );
-      syncParts.push(...result.syncParts);
-      return {
-        taskCompleted: result.taskCompleted,
-        submittedOutput: result.submittedOutput,
-        syncParts,
-      };
-    }
-
-    syncParts.push({
-      functionResponse: {
-        name: TASK_COMPLETE_TOOL_NAME,
-        response: { status: 'Task marked complete.' },
-        id: callId,
-      },
-    });
-    this.emitActivity('TOOL_CALL_END', {
-      name: functionCall.name,
-      output: 'Task marked complete.',
-    });
-
-    return {
-      taskCompleted: true,
-      submittedOutput: 'Task completed successfully.',
-      syncParts,
-    };
-  }
-
-  /** Processes the output argument of a `complete_task` call when outputConfig is present. */
-  private processCompleteTaskOutput(
-    functionCall: FunctionCall,
-    callId: string,
-    args: Record<string, unknown>,
-    outputConfig: NonNullable<AgentDefinition<z.ZodTypeAny>['outputConfig']>,
-  ): {
-    taskCompleted: boolean;
-    submittedOutput: string | null;
-    syncParts: Part[];
-  } {
-    const syncParts: Part[] = [];
-    const outputName = outputConfig.outputName;
-
-    if (args[outputName] !== undefined) {
-      const outputValue = args[outputName];
-      const validationResult = outputConfig.schema.safeParse(outputValue);
-
-      if (!validationResult.success) {
-        const error = `Output validation failed: ${JSON.stringify(validationResult.error.flatten())}`;
-        syncParts.push({
-          functionResponse: {
-            name: TASK_COMPLETE_TOOL_NAME,
-            response: { error },
-            id: callId,
-          },
-        });
-        this.emitActivity('ERROR', {
-          context: 'tool_call',
-          name: functionCall.name,
-          error,
-        });
-        return { taskCompleted: false, submittedOutput: null, syncParts };
-      }
-
-      const validatedOutput = validationResult.data;
-      let submittedOutput: string;
-      if (this.definition.processOutput) {
-        submittedOutput = this.definition.processOutput(validatedOutput);
-      } else if (typeof outputValue === 'string') {
-        submittedOutput = outputValue;
-      } else {
-        submittedOutput = JSON.stringify(outputValue, null, 2);
-      }
-
-      syncParts.push({
-        functionResponse: {
-          name: TASK_COMPLETE_TOOL_NAME,
-          response: { result: 'Output submitted and task completed.' },
-          id: callId,
-        },
-      });
-      this.emitActivity('TOOL_CALL_END', {
-        name: functionCall.name,
-        output: 'Output submitted and task completed.',
-      });
-      return { taskCompleted: true, submittedOutput, syncParts };
-    }
-
-    // Missing required output argument
-    const error = `Missing required argument '${outputName}' for completion.`;
-    syncParts.push({
-      functionResponse: {
-        name: TASK_COMPLETE_TOOL_NAME,
-        response: { error },
-        id: callId,
-      },
-    });
-    this.emitActivity('ERROR', {
-      context: 'tool_call',
-      name: functionCall.name,
-      error,
-    });
-    return { taskCompleted: false, submittedOutput: null, syncParts };
-  }
-
-  /** Handles an unauthorized tool call by pushing an error response. */
-  private handleUnauthorizedToolCall(
-    functionCall: FunctionCall,
-    callId: string,
-    syncResponseParts: Part[],
-  ): void {
-    const error = `Unauthorized tool call: '${functionCall.name}' is not available to this agent.`;
-
-    debugLogger.warn(`[AgentExecutor] Blocked call: ${error}`);
-
-    syncResponseParts.push({
-      functionResponse: {
-        name: functionCall.name as string,
-        id: callId,
-        response: { error },
-      },
-    });
-
-    this.emitActivity('ERROR', {
-      context: 'tool_call_unauthorized',
-      name: functionCall.name,
-      callId,
-      error,
-    });
-  }
-
-  /** Creates an async promise that executes a standard tool call. */
-  private createToolExecutionPromise(
-    functionCall: FunctionCall,
-    callId: string,
-    args: Record<string, unknown>,
-    signal: AbortSignal,
-    promptId: string,
-  ): Promise<ToolExecutionResult | void> {
-    const hookAllowedTools =
-      getHookRestrictedAllowedToolsForFunctionCall(functionCall);
-    const requestInfo: ToolCallRequestInfo = {
-      callId,
-      name: functionCall.name as string,
-      args,
-      isClientInitiated: true,
-      prompt_id: promptId,
-      ...(hookAllowedTools !== undefined
-        ? { hookRestrictedAllowedTools: hookAllowedTools }
-        : {}),
-    };
-
-    return (async () => {
-      const completed = await executeToolCall(
-        this.runtimeContext,
-        requestInfo,
-        signal,
-        { messageBus: this.messageBus },
-      );
-      const toolResponse = completed.response;
-
-      if (toolResponse.error) {
-        this.emitActivity('ERROR', {
-          context: 'tool_call',
-          name: functionCall.name,
-          error: toolResponse.error.message,
-        });
-      } else {
-        this.emitActivity('TOOL_CALL_END', {
-          name: functionCall.name,
-          output: toolResponse.resultDisplay,
-        });
-      }
-
-      return {
-        responseParts: toolResponse.responseParts,
-        partialResult:
-          typeof toolResponse.resultDisplay === 'string'
-            ? toolResponse.resultDisplay
-            : null,
-      };
-    })();
-  }
-
-  /** Assembles all tool response parts and returns the final result. */
-  private async assembleToolResponses(
-    executableFunctionCallCount: number,
-    syncResponseParts: Part[],
-    toolExecutionPromises: Array<Promise<ToolExecutionResult | void>>,
-    submittedOutput: string | null,
-    taskCompleted: boolean,
-  ): Promise<{
-    nextMessage: Content;
-    submittedOutput: string | null;
-    taskCompleted: boolean;
-    partialResult: string | null;
-  }> {
-    const asyncResults = await Promise.all(toolExecutionPromises);
-
-    const toolResponseParts: Part[] = [...syncResponseParts];
-    let partialResult: string | null = null;
-    for (const result of asyncResults) {
-      if (result) {
-        toolResponseParts.push(...result.responseParts);
-        if (result.partialResult !== null) {
-          partialResult = result.partialResult;
-        }
-      }
-    }
-
-    if (
-      executableFunctionCallCount > 0 &&
-      toolResponseParts.length === 0 &&
-      !taskCompleted
-    ) {
-      toolResponseParts.push({
-        text: 'All tool calls failed or were unauthorized. Please analyze the errors and try an alternative approach.',
-      });
-    }
-
-    return {
-      nextMessage: { role: 'user', parts: toolResponseParts },
-      submittedOutput,
-      taskCompleted,
-      partialResult,
-    };
   }
 
   /**
@@ -1358,32 +866,7 @@ export class AgentExecutor<TOutput extends z.ZodTypeAny> {
     }
 
     // Always inject complete_task.
-    // Configure its schema based on whether output is expected.
-    const completeTool: FunctionDeclaration = {
-      name: TASK_COMPLETE_TOOL_NAME,
-      description: outputConfig
-        ? 'Call this tool to submit your final answer and complete the task. This is the ONLY way to finish.'
-        : 'Call this tool to signal that you have completed your task. This is the ONLY way to finish.',
-      parameters: {
-        type: Type.OBJECT,
-        properties: {},
-        required: [],
-      },
-    };
-
-    if (outputConfig) {
-      const jsonSchema = zodToJsonSchema(outputConfig.schema);
-      const {
-        $schema: _$schema,
-        definitions: _definitions,
-        ...schema
-      } = jsonSchema;
-      completeTool.parameters!.properties![outputConfig.outputName] =
-        schema as Schema;
-      completeTool.parameters!.required!.push(outputConfig.outputName);
-    }
-
-    toolsList.push(completeTool);
+    toolsList.push(buildCompleteTaskDeclaration(outputConfig));
 
     return toolsList;
   }

--- a/packages/agents/src/agents/recovery.ts
+++ b/packages/agents/src/agents/recovery.ts
@@ -18,7 +18,7 @@
  * original termination reason is preserved and the loop ends immediately.
  */
 
-import type { Content } from '@google/genai';
+import type { Content, FunctionCall } from '@google/genai';
 import { AgentTerminateMode, type SubagentActivityEventType } from './types.js';
 
 /** Tool name used to signal task completion. */
@@ -187,4 +187,164 @@ export function recoveryFailureResult(
           '\n\nPartial result before recovery:\n' +
           partialResult,
   };
+}
+
+/**
+ * Callback for emitting activity events during recovery checks.
+ */
+export type EmitActivityFn = (
+  type: SubagentActivityEventType,
+  data: Record<string, unknown>,
+) => void;
+
+/** Emit a RECOVERY_OUTCOME telemetry event. */
+function emitRecoveryOutcome(
+  emitActivity: EmitActivityFn,
+  originalReason: AgentTerminateMode,
+  outcome: 'success' | 'failure',
+  terminateReason: AgentTerminateMode,
+  gracePeriodSeconds: number,
+): void {
+  emitActivity('RECOVERY_OUTCOME', {
+    originalReason,
+    outcome,
+    terminateReason,
+    gracePeriodSeconds,
+  });
+}
+
+/**
+ * Check tool calls during recovery: non-complete_task = recovery failure.
+ *
+ * Returns a failure result if the model (during its one recovery response)
+ * did not call `complete_task`, or called other tools alongside it.
+ * Returns `null` if recovery is not active, the response hasn't been used,
+ * or the calls are valid (exactly one `complete_task`).
+ */
+export function checkRecoveryToolCalls(
+  recoveryState: RecoveryState,
+  recoveryModelResponseUsed: boolean,
+  functionCalls: FunctionCall[],
+  finalResult: string | null,
+  emitActivity: EmitActivityFn,
+): { terminateReason: AgentTerminateMode; finalResult: string } | null {
+  if (recoveryState.phase !== 'active' || !recoveryModelResponseUsed) {
+    return null;
+  }
+  const hasCompleteTask = functionCalls.some(
+    (fc) => fc.name === TASK_COMPLETE_TOOL_NAME,
+  );
+  if (!hasCompleteTask) {
+    emitRecoveryOutcome(
+      emitActivity,
+      recoveryState.originalReason,
+      'failure',
+      recoveryState.originalReason,
+      recoveryState.gracePeriodSeconds,
+    );
+    return recoveryFailureResult(recoveryState.originalReason, finalResult);
+  }
+
+  // Recovery response must be exactly one complete_task call.
+  // If complete_task is accompanied by other tools, fail recovery immediately
+  // and do not execute any of the tool calls.
+  if (functionCalls.length > 1) {
+    emitRecoveryOutcome(
+      emitActivity,
+      recoveryState.originalReason,
+      'failure',
+      recoveryState.originalReason,
+      recoveryState.gracePeriodSeconds,
+    );
+    return recoveryFailureResult(recoveryState.originalReason, finalResult);
+  }
+
+  return null;
+}
+
+/** Result when a termination reason is handled (either enter recovery or finish). */
+export type TerminationHandlingResult =
+  | { handled: true; newState: RecoveryActive; currentMessage: Content }
+  | {
+      handled: false;
+      result: {
+        terminateReason: AgentTerminateMode;
+        finalResult: string | null;
+      };
+    };
+
+/**
+ * Handle termination-reason checks: enter recovery or return immediately.
+ *
+ * If the reason is recoverable and we're not already in recovery, enter
+ * recovery. If already in recovery, the second termination means recovery
+ * failed. Otherwise return the plain termination result.
+ */
+export function handleTerminationReason(
+  reason: AgentTerminateMode,
+  recoveryState: RecoveryState,
+  finalResult: string | null,
+  gracePeriodSeconds: number,
+  emitActivity: EmitActivityFn,
+): TerminationHandlingResult {
+  if (isRecoverableTermination(reason) && recoveryState.phase === 'none') {
+    const { state, warningMessage } = enterRecovery(
+      reason,
+      gracePeriodSeconds,
+      emitActivity,
+    );
+    return { handled: true, newState: state, currentMessage: warningMessage };
+  }
+
+  if (recoveryState.phase === 'active') {
+    const fail = recoveryFailureResult(
+      recoveryState.originalReason,
+      finalResult,
+    );
+    emitRecoveryOutcome(
+      emitActivity,
+      recoveryState.originalReason,
+      'failure',
+      fail.terminateReason,
+      recoveryState.gracePeriodSeconds,
+    );
+    return { handled: false, result: fail };
+  }
+
+  return { handled: false, result: { terminateReason: reason, finalResult } };
+}
+
+/** Result when a protocol violation is handled. */
+export type ProtocolViolationResult =
+  | { entered: true; state: RecoveryActive; warningMessage: Content }
+  | {
+      entered: false;
+      result: { terminateReason: AgentTerminateMode; finalResult: string };
+    };
+
+/**
+ * Handle the protocol-violation path (model stopped calling tools).
+ *
+ * If not already in recovery, enter recovery for a protocol violation.
+ * If already in recovery, the empty response confirms recovery failure.
+ */
+export function handleProtocolViolation(
+  recoveryState: RecoveryState,
+  finalResult: string | null,
+  gracePeriodSeconds: number,
+  emitActivity: EmitActivityFn,
+): ProtocolViolationResult {
+  if (recoveryState.phase === 'none') {
+    const { state, warningMessage } = enterRecovery(
+      AgentTerminateMode.ERROR_NO_COMPLETE_TASK_CALL,
+      gracePeriodSeconds,
+      emitActivity,
+    );
+    return { entered: true, state, warningMessage };
+  }
+
+  // Already in recovery: the one recovery model response didn't call
+  // complete_task, so this empty response confirms recovery failure.
+  const fail = recoveryFailureResult(recoveryState.originalReason, finalResult);
+  return { entered: false, result: fail };
 }

--- a/packages/agents/src/compression/HighDensityStrategy.ts
+++ b/packages/agents/src/compression/HighDensityStrategy.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 /**
  * @plan PLAN-20260211-HIGHDENSITY.P09
  * @plan PLAN-20260211-HIGHDENSITY.P11
@@ -148,6 +146,27 @@ function isEmptyTextBlock(block: ContentBlock): boolean {
 
 /**
  * @plan PLAN-20260211-HIGHDENSITY.P11
+ * Resolve write-tool target paths for a single AI entry's blocks.
+ * Returns resolved paths keyed to the given history index.
+ * @pseudocode high-density-optimize.md lines 70-90
+ */
+function collectLatestWriteIndexes(
+  blocks: readonly ContentBlock[],
+  workspaceRoot: string,
+): string[] {
+  return blocks
+    .filter(
+      (b): b is ToolCallBlock =>
+        b.type === 'tool_call' &&
+        (WRITE_TOOLS as readonly string[]).includes(b.name),
+    )
+    .map((b) => extractFilePath(b.parameters))
+    .filter((fp): fp is string => fp !== undefined)
+    .map((fp) => resolvePath(fp, workspaceRoot));
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P11
  * Build latest write map — latest write index per file path.
  * @pseudocode high-density-optimize.md lines 60-90
  */
@@ -163,25 +182,13 @@ function buildLatestWriteMap(
       continue;
     }
 
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    for (const block of entry.blocks) {
-      if (block.type !== 'tool_call') {
-        continue;
-      }
-      if (!(WRITE_TOOLS as readonly string[]).includes(block.name)) {
-        continue;
-      }
-
-      const filePath = extractFilePath(block.parameters);
-      if (filePath === undefined) {
-        continue;
-      }
-
-      const resolved = resolvePath(filePath, config.workspaceRoot);
-      if (!latestWrite.has(resolved)) {
-        latestWrite.set(resolved, index);
-      }
-    }
+    collectLatestWriteIndexes(entry.blocks, config.workspaceRoot).forEach(
+      (resolved) => {
+        if (!latestWrite.has(resolved)) {
+          latestWrite.set(resolved, index);
+        }
+      },
+    );
   }
 
   return latestWrite;
@@ -217,49 +224,71 @@ function identifyStaleReadCalls(
     );
     aiEntryTotalToolCalls.set(index, toolCallBlocks.length);
 
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    for (const block of toolCallBlocks) {
-      if (!(READ_TOOLS as readonly string[]).includes(block.name)) {
-        continue;
-      }
-
-      if (block.name === 'read_many_files') {
-        const canPrune = strategy.canPruneReadManyFiles(
-          block.parameters,
-          config.workspaceRoot,
-          latestWrite,
-          index,
-        );
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (!canPrune) {
-          continue;
-        }
-      } else {
-        const filePath = extractFilePath(block.parameters);
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (filePath === undefined) {
-          continue;
-        }
-
-        const resolved = resolvePath(filePath, config.workspaceRoot);
-        const writeIndex = latestWrite.get(resolved);
-
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (writeIndex === undefined || writeIndex <= index) {
-          continue;
-        }
-      }
-
-      // This read is stale
-      staleCallIds.add(block.id);
-      if (!aiEntryStaleBlocks.has(index)) {
-        aiEntryStaleBlocks.set(index, new Set());
-      }
-      aiEntryStaleBlocks.get(index)!.add(block.id);
+    const staleBlockIds = identifyStaleReadBlocksForEntry(
+      toolCallBlocks,
+      config.workspaceRoot,
+      latestWrite,
+      index,
+      strategy,
+    );
+    if (staleBlockIds.size > 0) {
+      staleBlockIds.forEach((id) => staleCallIds.add(id));
+      aiEntryStaleBlocks.set(index, staleBlockIds);
     }
   }
 
   return { staleCallIds, aiEntryStaleBlocks, aiEntryTotalToolCalls };
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P11
+ * Determine which read-tool-call blocks in a single AI entry are stale.
+ * @pseudocode high-density-optimize.md lines 100-160
+ */
+function identifyStaleReadBlocksForEntry(
+  toolCallBlocks: ToolCallBlock[],
+  workspaceRoot: string,
+  latestWrite: Map<string, number>,
+  index: number,
+  strategy: HighDensityStrategy,
+): Set<string> {
+  return new Set(
+    toolCallBlocks
+      .filter((b) => (READ_TOOLS as readonly string[]).includes(b.name))
+      .filter((b) =>
+        isStaleReadCall(b, workspaceRoot, latestWrite, index, strategy),
+      )
+      .map((b) => b.id),
+  );
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P11
+ * Check whether a single read-tool-call block is stale (superseded by a later write).
+ * @pseudocode high-density-optimize.md lines 110-155
+ */
+function isStaleReadCall(
+  block: ToolCallBlock,
+  workspaceRoot: string,
+  latestWrite: Map<string, number>,
+  index: number,
+  strategy: HighDensityStrategy,
+): boolean {
+  if (block.name === 'read_many_files') {
+    return strategy.canPruneReadManyFiles(
+      block.parameters,
+      workspaceRoot,
+      latestWrite,
+      index,
+    );
+  }
+  const filePath = extractFilePath(block.parameters);
+  if (filePath === undefined) {
+    return false;
+  }
+  const resolved = resolvePath(filePath, workspaceRoot);
+  const writeIndex = latestWrite.get(resolved);
+  return writeIndex !== undefined && writeIndex > index;
 }
 
 /**
@@ -311,50 +340,69 @@ function applyStaleToolEntries(
 ): number {
   let prunedCount = 0;
 
-  // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
   for (let index = 0; index < history.length; index++) {
     const entry = history[index];
-    if (entry.speaker !== 'tool') {
-      continue;
-    }
-    if (removals.has(index)) {
+    if (entry.speaker !== 'tool' || removals.has(index)) {
       continue;
     }
 
-    const responseBlocks = entry.blocks.filter(
-      (b): b is ToolResponseBlock => b.type === 'tool_response',
+    const pruned = applyStaleToolEntry(
+      index,
+      entry,
+      staleCallIds,
+      removals,
+      replacements,
     );
-    const staleResponses = responseBlocks.filter((b) =>
-      staleCallIds.has(b.callId),
-    );
-
-    if (staleResponses.length === 0) {
-      continue;
-    }
-
-    if (
-      staleResponses.length === responseBlocks.length &&
-      entry.blocks.every((b) => b.type === 'tool_response')
-    ) {
-      removals.add(index);
-      prunedCount = prunedCount + staleResponses.length;
-    } else {
-      const filteredBlocks = entry.blocks.filter(
-        (b) => b.type !== 'tool_response' || !staleCallIds.has(b.callId),
-      );
-      if (filteredBlocks.length === 0) {
-        removals.add(index);
-      } else {
-        replacements.set(index, {
-          ...entry,
-          blocks: filteredBlocks,
-        });
-      }
-      prunedCount = prunedCount + staleResponses.length;
-    }
+    prunedCount = prunedCount + pruned;
   }
 
   return prunedCount;
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P11
+ * Process a single tool entry — remove or replace stale tool_response blocks.
+ * Returns the number of pruned responses for this entry (0 if none stale).
+ * @pseudocode high-density-optimize.md lines 185-209
+ */
+function applyStaleToolEntry(
+  index: number,
+  entry: IContent,
+  staleCallIds: Set<string>,
+  removals: Set<number>,
+  replacements: Map<number, IContent>,
+): number {
+  const responseBlocks = entry.blocks.filter(
+    (b): b is ToolResponseBlock => b.type === 'tool_response',
+  );
+  const staleResponses = responseBlocks.filter((b) =>
+    staleCallIds.has(b.callId),
+  );
+
+  if (staleResponses.length === 0) {
+    return 0;
+  }
+
+  if (
+    staleResponses.length === responseBlocks.length &&
+    entry.blocks.every((b) => b.type === 'tool_response')
+  ) {
+    removals.add(index);
+    return staleResponses.length;
+  }
+
+  const filteredBlocks = entry.blocks.filter(
+    (b) => b.type !== 'tool_response' || !staleCallIds.has(b.callId),
+  );
+  if (filteredBlocks.length === 0) {
+    removals.add(index);
+  } else {
+    replacements.set(index, {
+      ...entry,
+      blocks: filteredBlocks,
+    });
+  }
+  return staleResponses.length;
 }
 
 /**
@@ -381,45 +429,55 @@ function scanFileInclusions(
 ): Map<string, InclusionEntry[]> {
   const inclusions = new Map<string, InclusionEntry[]>();
 
-  // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
   for (let index = 0; index < history.length; index++) {
     const entry = history[index];
-    if (entry.speaker !== 'human') {
-      continue;
-    }
-    if (existingRemovals.has(index)) {
+    if (entry.speaker !== 'human' || existingRemovals.has(index)) {
       continue;
     }
 
-    for (let blockIndex = 0; blockIndex < entry.blocks.length; blockIndex++) {
-      const block = entry.blocks[blockIndex];
-      if (block.type !== 'text') {
-        continue;
-      }
-
-      const text = block.text;
-      const matches = findAllInclusions(text);
-
-      for (const match of matches) {
-        const resolvedFilePath = resolvePath(
-          match.filePath,
-          config.workspaceRoot,
-        );
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (!inclusions.has(resolvedFilePath)) {
-          inclusions.set(resolvedFilePath, []);
-        }
-        inclusions.get(resolvedFilePath)!.push({
-          messageIndex: index,
-          blockIndex,
-          startOffset: match.startOffset,
-          endOffset: match.endOffset,
-        });
-      }
-    }
+    collectEntryInclusions(entry.blocks, index, config.workspaceRoot).forEach(
+      (inc) => {
+        const list = inclusions.get(inc.resolvedFilePath) ?? [];
+        list.push(inc.entry);
+        inclusions.set(inc.resolvedFilePath, list);
+      },
+    );
   }
 
   return inclusions;
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P11
+ * Collect file inclusions from a single human entry's text blocks.
+ * @pseudocode high-density-optimize.md lines 285-310
+ */
+function collectEntryInclusions(
+  blocks: readonly ContentBlock[],
+  messageIndex: number,
+  workspaceRoot: string,
+): Array<{ resolvedFilePath: string; entry: InclusionEntry }> {
+  const results: Array<{ resolvedFilePath: string; entry: InclusionEntry }> =
+    [];
+  for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
+    const block = blocks[blockIndex];
+    if (block.type !== 'text') {
+      continue;
+    }
+    const matches = findAllInclusions(block.text);
+    for (const match of matches) {
+      results.push({
+        resolvedFilePath: resolvePath(match.filePath, workspaceRoot),
+        entry: {
+          messageIndex,
+          blockIndex,
+          startOffset: match.startOffset,
+          endOffset: match.endOffset,
+        },
+      });
+    }
+  }
+  return results;
 }
 
 /**
@@ -503,6 +561,78 @@ function applyStaleInclusionRemovals(
   }
 
   return count;
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P14
+ * Find the file-path key parameter for a tool_call matching the given callId.
+ * @pseudocode high-density-compress.md lines 130-149
+ */
+function findKeyParamForCallId(
+  fullHistory: readonly IContent[],
+  callId: string,
+): string | undefined {
+  for (const entry of fullHistory) {
+    if (entry.speaker !== 'ai') {
+      continue;
+    }
+    const matchingBlock = entry.blocks.find(
+      (b): b is ToolCallBlock => b.type === 'tool_call' && b.id === callId,
+    );
+    if (matchingBlock) {
+      return extractFilePath(matchingBlock.parameters);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P11
+ * Classify a single read_many_files path for pruning eligibility.
+ * @pseudocode high-density-optimize.md lines 220-250
+ */
+function classifyReadManyFilesPath(
+  filePath: string,
+  workspaceRoot: string,
+  latestWrite: Map<string, number>,
+  readIndex: number,
+): 'glob' | 'concrete-with-write' | 'concrete-without-write' {
+  if (GLOB_CHARS.some((c) => filePath.includes(c))) {
+    return 'glob';
+  }
+  const resolved = resolvePath(filePath, workspaceRoot);
+  const writeIndex = latestWrite.get(resolved);
+  if (writeIndex === undefined || writeIndex <= readIndex) {
+    return 'concrete-without-write';
+  }
+  return 'concrete-with-write';
+}
+
+/**
+ * @plan PLAN-20260211-HIGHDENSITY.P11
+ * Walk a tool entry's blocks in reverse, counting per-tool responses and
+ * returning those exceeding the retention threshold. Mutates toolCounts.
+ * @pseudocode high-density-optimize.md lines 410-440
+ */
+function findPrunableToolResponses(
+  blocks: readonly ContentBlock[],
+  toolCounts: Map<string, number>,
+  retention: number,
+): number[] {
+  const prunable: number[] = [];
+  for (let blockIndex = blocks.length - 1; blockIndex >= 0; blockIndex--) {
+    const block = blocks[blockIndex];
+    if (block.type !== 'tool_response' || block.result === PRUNED_POINTER) {
+      continue;
+    }
+    const toolName = block.toolName;
+    const currentCount = (toolCounts.get(toolName) ?? 0) + 1;
+    toolCounts.set(toolName, currentCount);
+    if (currentCount > retention) {
+      prunable.push(blockIndex);
+    }
+  }
+  return prunable;
 }
 
 // ---------------------------------------------------------------------------
@@ -785,19 +915,7 @@ export class HighDensityStrategy implements CompressionStrategy {
     const outcome = hasError || looksLikeError ? 'error' : 'success';
 
     // Extract key param — look for matching tool_call by callId
-    let keyParam: string | undefined;
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    for (const entry of fullHistory) {
-      if (entry.speaker !== 'ai') continue;
-      for (const b of entry.blocks) {
-        if (b.type === 'tool_call' && b.id === block.callId) {
-          const params = b.parameters;
-          keyParam = extractFilePath(params);
-          break;
-        }
-      }
-      if (keyParam !== undefined) break;
-    }
+    const keyParam = findKeyParamForCallId(fullHistory, block.callId);
 
     if (keyParam) {
       return `[${toolName} ${keyParam}: ${outcome} ${RERUN_HINT_SUFFIX}]`;
@@ -919,23 +1037,27 @@ export class HighDensityStrategy implements CompressionStrategy {
     let allConcreteHaveWrite = true;
     let hasAnyConcrete = false;
 
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
     for (const filePath of paths) {
       if (typeof filePath !== 'string') {
         continue;
       }
-
-      if (GLOB_CHARS.some((c) => filePath.includes(c))) {
+      const classification = classifyReadManyFilesPath(
+        filePath,
+        workspaceRoot,
+        latestWrite,
+        readIndex,
+      );
+      if (classification === 'glob') {
         hasGlob = true;
-        continue;
       }
-
-      hasAnyConcrete = true;
-      const resolved = resolvePath(filePath, workspaceRoot);
-      const writeIndex = latestWrite.get(resolved);
-      if (writeIndex === undefined || writeIndex <= readIndex) {
+      if (
+        classification === 'concrete-with-write' ||
+        classification === 'concrete-without-write'
+      ) {
+        hasAnyConcrete = true;
+      }
+      if (classification === 'concrete-without-write') {
         allConcreteHaveWrite = false;
-        break;
       }
     }
 
@@ -992,40 +1114,18 @@ export class HighDensityStrategy implements CompressionStrategy {
     const toolCounts = new Map<string, number>();
     const entriesToPrune: Array<{ index: number; blockIndex: number }> = [];
 
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
     for (let index = history.length - 1; index >= 0; index--) {
       const entry = history[index];
-      if (entry.speaker !== 'tool') {
-        continue;
-      }
-      if (existingRemovals.has(index)) {
+      if (entry.speaker !== 'tool' || existingRemovals.has(index)) {
         continue;
       }
 
-      // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      for (
-        let blockIndex = entry.blocks.length - 1;
-        blockIndex >= 0;
-        blockIndex--
-      ) {
-        const block = entry.blocks[blockIndex];
-        if (block.type !== 'tool_response') {
-          continue;
-        }
-
-        // Skip already-pruned results to ensure idempotency
-        if (block.result === PRUNED_POINTER) {
-          continue;
-        }
-
-        const toolName = block.toolName;
-        let currentCount = toolCounts.get(toolName) ?? 0;
-        currentCount = currentCount + 1;
-        toolCounts.set(toolName, currentCount);
-
-        if (currentCount > retention) {
-          entriesToPrune.push({ index, blockIndex });
-        }
+      for (const blockIndex of findPrunableToolResponses(
+        entry.blocks,
+        toolCounts,
+        retention,
+      )) {
+        entriesToPrune.push({ index, blockIndex });
       }
     }
 

--- a/packages/agents/src/core/CompressionLoadBalancingProvider.ts
+++ b/packages/agents/src/core/CompressionLoadBalancingProvider.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+
+/**
+ * A single resolved candidate inside a load-balanced compression profile.
+ */
+export interface CompressionLoadBalancerCandidate {
+  profileName: string;
+  provider: IProvider;
+  runtime: ProviderRuntimeContext;
+  config: NonNullable<ProviderRuntimeContext['config']> | undefined;
+  resolved: RuntimeGenerateChatOptions['resolved'];
+  invocation: NonNullable<RuntimeGenerateChatOptions['invocation']>;
+}
+
+/**
+ * IProvider adapter that fans out across multiple resolved compression
+ * sub-profiles using either round-robin or failover strategy.
+ */
+export class CompressionLoadBalancingProvider implements IProvider {
+  readonly name = 'load-balancer';
+  private readonly selectedRoundRobinCandidate?: CompressionLoadBalancerCandidate;
+
+  constructor(
+    private readonly strategy: 'round-robin' | 'failover',
+    private readonly candidates: readonly CompressionLoadBalancerCandidate[],
+    initialIndex: number,
+  ) {
+    if (candidates.length === 0) {
+      throw new Error('Load-balanced compression profile requires subprofiles');
+    }
+    if (strategy === 'round-robin') {
+      this.selectedRoundRobinCandidate =
+        this.candidates[initialIndex % this.candidates.length];
+    }
+  }
+
+  async getModels() {
+    return [];
+  }
+
+  getDefaultModel(): string {
+    return this.candidates[0]?.resolved?.model ?? '';
+  }
+
+  getServerTools(): string[] {
+    return [];
+  }
+
+  async invokeServerTool(toolName: string): Promise<unknown> {
+    throw new Error(
+      `Server tool '${toolName}' not supported by compression load-balancer provider`,
+    );
+  }
+
+  generateChatCompletion(
+    options: RuntimeGenerateChatOptions,
+  ): AsyncIterableIterator<IContent>;
+  generateChatCompletion(content: IContent[]): AsyncIterableIterator<IContent>;
+  async *generateChatCompletion(
+    optionsOrContent: RuntimeGenerateChatOptions | IContent[],
+  ): AsyncIterableIterator<IContent> {
+    const options = Array.isArray(optionsOrContent)
+      ? { contents: optionsOrContent }
+      : optionsOrContent;
+
+    if (this.strategy === 'failover') {
+      yield* this.generateWithFailover(options);
+      return;
+    }
+
+    yield* this.generateWithCandidate(
+      this.selectedRoundRobinCandidate ?? this.candidates[0],
+      options,
+    );
+  }
+
+  private async *generateWithFailover(
+    options: RuntimeGenerateChatOptions,
+  ): AsyncIterableIterator<IContent> {
+    let lastError: unknown;
+    for (const candidate of this.candidates) {
+      try {
+        const bufferedChunks: IContent[] = [];
+        for await (const chunk of this.generateWithCandidate(
+          candidate,
+          options,
+        )) {
+          bufferedChunks.push(chunk);
+        }
+        yield* bufferedChunks;
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  private async *generateWithCandidate(
+    candidate: CompressionLoadBalancerCandidate,
+    options: RuntimeGenerateChatOptions,
+  ): AsyncIterableIterator<IContent> {
+    const candidateOptions: RuntimeGenerateChatOptions = {
+      ...options,
+      runtime: candidate.runtime,
+      settings: candidate.runtime
+        .settingsService as RuntimeGenerateChatOptions['settings'],
+      config: candidate.config,
+      resolved: {
+        ...options.resolved,
+        ...candidate.resolved,
+      },
+      invocation: candidate.invocation,
+      metadata: {
+        ...options.metadata,
+        ...(candidate.invocation.metadata as Record<string, unknown>),
+        selectedCompressionProfile: candidate.profileName,
+      },
+    };
+    yield* candidate.provider.generateChatCompletion(candidateOptions);
+  }
+}

--- a/packages/agents/src/core/CompressionProfileResolver.ts
+++ b/packages/agents/src/core/CompressionProfileResolver.ts
@@ -511,17 +511,19 @@ export async function resolveLoadBalancedCompressionProvider(
 
 /**
  * Resolve a compression profile by name into a provider + runtime + config.
- * When no profile name is given, the supplied default provider/runtime is used.
+ * When no profile name is given, the default provider is resolved lazily via
+ * `resolveDefaultProvider` so its throw/side-effect semantics only apply on the
+ * no-profile path (matching the pre-extraction control flow).
  */
 export async function resolveCompressionProvider(
   ctx: CompressionProfileResolverContext,
   profileName: string | undefined,
-  defaultProvider: IProvider,
+  resolveDefaultProvider: () => IProvider,
 ): Promise<CompressionProviderResult> {
   if (!profileName) {
     const runtime = ctx.providerRuntime;
     return {
-      provider: defaultProvider,
+      provider: resolveDefaultProvider(),
       runtime,
       config: runtime.config,
     };

--- a/packages/agents/src/core/CompressionProfileResolver.ts
+++ b/packages/agents/src/core/CompressionProfileResolver.ts
@@ -1,0 +1,566 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { isLoadBalancerProfile } from '@vybestack/llxprt-code-settings';
+import type {
+  LoadBalancerProfile,
+  StandardProfile,
+} from '@vybestack/llxprt-code-settings';
+import { getProviderKeyStorage } from '@vybestack/llxprt-code-core/storage/provider-key-storage.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { CompressionProviderResult } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import { CompressionProfileNotFoundError } from '@vybestack/llxprt-code-core/core/compression/types.js';
+
+import { CompressionLoadBalancingProvider } from './CompressionLoadBalancingProvider.js';
+import type { CompressionLoadBalancerCandidate } from './CompressionLoadBalancingProvider.js';
+
+/**
+ * Callbacks and runtime state required to resolve a compression profile
+ * into a concrete provider + runtime context. ChatSession supplies these.
+ */
+export interface CompressionProfileResolverContext {
+  /** The base provider-runtime snapshot (runtimeId, metadata, config). */
+  readonly providerRuntime: ProviderRuntimeContext;
+  /**
+   * Resolve an explicit provider by name for a compression sub-profile.
+   * Throws CompressionProfileNotFoundError when unavailable.
+   */
+  resolveExplicitCompressionProvider(
+    profileName: string,
+    providerName: string,
+  ): IProvider;
+  /** Map of round-robin indexes, mutated in place when strategy is round-robin. */
+  readonly roundRobinIndexes: Map<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure setting helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy aliased ephemeral keys into both global and provider-scoped settings.
+ */
+export function copyProfileSettingAliases(
+  profileSettings: SettingsService,
+  provider: string,
+  ephemerals: Record<string, unknown>,
+  aliases: ReadonlyArray<{
+    sourceKey: string;
+    globalKey?: string;
+    providerKey: string;
+  }>,
+): void {
+  for (const alias of aliases) {
+    const value = ephemerals[alias.sourceKey];
+    if (value === undefined) {
+      continue;
+    }
+    if (alias.globalKey) {
+      profileSettings.set(alias.globalKey, value);
+    }
+    profileSettings.setProviderSetting(provider, alias.providerKey, value);
+  }
+}
+
+/**
+ * Apply auth-related ephemeral settings (auth-key, keyfile, key-name, base-url,
+ * sandbox-base-url, api-version) to the profile settings.
+ */
+export function applyCompressionProfileAuthSettings(
+  profileSettings: SettingsService,
+  provider: string,
+  ephemerals: Record<string, unknown>,
+): void {
+  copyProfileSettingAliases(profileSettings, provider, ephemerals, [
+    { sourceKey: 'auth-key', globalKey: 'auth-key', providerKey: 'auth-key' },
+    {
+      sourceKey: 'auth-keyfile',
+      globalKey: 'auth-keyfile',
+      providerKey: 'auth-keyfile',
+    },
+    {
+      sourceKey: 'auth-key-name',
+      globalKey: 'auth-key-name',
+      providerKey: 'auth-key-name',
+    },
+  ]);
+
+  for (const key of ['base-url', 'sandbox-base-url', 'api-version']) {
+    const value = ephemerals[key];
+    if (value !== undefined) {
+      profileSettings.setProviderSetting(provider, key, value);
+    }
+  }
+}
+
+/**
+ * Apply model parameters (with camelCase aliases) to provider-scoped settings.
+ */
+export function applyCompressionProfileModelParams(
+  profileSettings: SettingsService,
+  provider: string,
+  modelParams: StandardProfile['modelParams'],
+): void {
+  for (const [key, value] of Object.entries(modelParams)) {
+    if (value !== undefined) {
+      profileSettings.setProviderSetting(provider, key, value);
+    }
+  }
+  const aliases: Record<string, unknown> = {
+    temperature: modelParams.temperature,
+    maxTokens: modelParams.max_tokens,
+    topP: modelParams.top_p,
+    topK: modelParams.top_k,
+    presencePenalty: modelParams.presence_penalty,
+    frequencyPenalty: modelParams.frequency_penalty,
+  };
+  for (const [key, value] of Object.entries(aliases)) {
+    if (value !== undefined) {
+      profileSettings.setProviderSetting(provider, key, value);
+    }
+  }
+}
+
+/**
+ * Apply all profile settings (provider, model, ephemerals, auth, modelParams)
+ * to a SettingsService instance.
+ */
+export function applyCompressionProfileSettings(
+  profileSettings: SettingsService,
+  profileName: string,
+  profile: StandardProfile,
+): void {
+  const provider = profile.provider;
+  const ephemerals = profile.ephemeralSettings as Record<string, unknown>;
+
+  profileSettings.setCurrentProfileName(profileName);
+  profileSettings.set('activeProvider', provider);
+  profileSettings.set('model', profile.model);
+  profileSettings.setProviderSetting(provider, 'enabled', true);
+  profileSettings.setProviderSetting(provider, 'model', profile.model);
+
+  for (const [key, value] of Object.entries(ephemerals)) {
+    if (value !== undefined) {
+      profileSettings.set(key, value);
+      profileSettings.setProviderSetting(provider, key, value);
+    }
+  }
+
+  applyCompressionProfileAuthSettings(profileSettings, provider, ephemerals);
+  applyCompressionProfileModelParams(
+    profileSettings,
+    provider,
+    profile.modelParams,
+  );
+
+  if (profile.auth) {
+    profileSettings.set('auth.type', profile.auth.type);
+    profileSettings.setProviderSetting(provider, 'auth', profile.auth);
+    if (profile.auth.buckets) {
+      profileSettings.set('auth.buckets', profile.auth.buckets);
+    }
+  }
+}
+
+/**
+ * Inherit parent ephemerals into the sub-profile settings, only when the key
+ * is not already set locally.
+ */
+export function applyCompressionProfileParentEphemerals(
+  profileSettings: SettingsService,
+  provider: string,
+  parentEphemerals: Record<string, unknown>,
+): void {
+  for (const [key, value] of Object.entries(parentEphemerals)) {
+    if (value !== undefined && profileSettings.get(key) === undefined) {
+      profileSettings.set(key, value);
+    }
+  }
+  for (const key of ['custom-headers', 'api-version', 'sandbox-base-url']) {
+    const value = parentEphemerals[key];
+    if (value !== undefined) {
+      profileSettings.setProviderSetting(provider, key, value);
+    }
+  }
+}
+
+/**
+ * Expand a `~/`-prefixed path to an absolute home-rooted path.
+ */
+export function expandProfilePath(value: string): string {
+  if (value.startsWith('~/')) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}
+
+/**
+ * Return the first non-empty trimmed string value from the list, or undefined.
+ */
+export function getStringSettingFromValues(
+  values: readonly unknown[],
+): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the ephemerals snapshot for a resolved profile (global + provider-scoped).
+ */
+export function buildCompressionProfileEphemeralsSnapshot(
+  profileSettings: SettingsService,
+  provider: string,
+): Record<string, unknown> {
+  return {
+    ...profileSettings.getAllGlobalSettings(),
+    [provider]: { ...profileSettings.getProviderSettings(provider) },
+  };
+}
+
+/**
+ * Resolve the auth token (direct key, key-name lookup, or keyfile read)
+ * for a compression profile. Returns an empty object when no auth is configured.
+ */
+export async function resolveCompressionProfileAuthToken(
+  profileSettings: SettingsService,
+  provider: string,
+): Promise<{ authToken: string } | Record<string, never>> {
+  const providerSettings = profileSettings.getProviderSettings(provider);
+  const directAuth = getStringSettingFromValues([
+    providerSettings['auth-key'],
+    profileSettings.get('auth-key'),
+  ]);
+  if (directAuth) {
+    return { authToken: directAuth };
+  }
+
+  const keyName = getStringSettingFromValues([
+    providerSettings['auth-key-name'],
+    profileSettings.get('auth-key-name'),
+  ]);
+  if (keyName) {
+    const token = await getProviderKeyStorage().getKey(keyName);
+    if (token) {
+      return { authToken: token };
+    }
+  }
+
+  const keyFile = getStringSettingFromValues([
+    providerSettings['auth-keyfile'],
+    profileSettings.get('auth-keyfile'),
+  ]);
+  if (keyFile) {
+    const token = (
+      await fs.readFile(expandProfilePath(keyFile), 'utf8')
+    ).trim();
+    if (token) {
+      return { authToken: token };
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Build the resolved options (model, baseURL, authToken, temperature, maxTokens)
+ * for a standard compression profile.
+ */
+export async function buildCompressionProfileResolvedOptions(
+  profileSettings: SettingsService,
+  profile: StandardProfile,
+): Promise<RuntimeGenerateChatOptions['resolved']> {
+  const providerSettings = profileSettings.getProviderSettings(
+    profile.provider,
+  );
+  const baseURL =
+    typeof providerSettings['base-url'] === 'string'
+      ? providerSettings['base-url']
+      : undefined;
+  const temperature =
+    typeof providerSettings.temperature === 'number'
+      ? providerSettings.temperature
+      : undefined;
+  const maxTokens =
+    typeof providerSettings.maxTokens === 'number'
+      ? providerSettings.maxTokens
+      : undefined;
+  return {
+    model: profile.model,
+    ...(baseURL ? { baseURL } : {}),
+    ...(await resolveCompressionProfileAuthToken(
+      profileSettings,
+      profile.provider,
+    )),
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrating resolvers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a single standard compression profile into a provider + runtime +
+ * resolved options + invocation context.
+ */
+export async function resolveStandardCompressionProvider(
+  ctx: CompressionProfileResolverContext,
+  profileName: string,
+  profile: StandardProfile,
+  profileManager: NonNullable<ReturnType<Config['getProfileManager']>>,
+  config: Config | undefined,
+  parentEphemerals: Record<string, unknown> = {},
+): Promise<CompressionProviderResult> {
+  const provider = ctx.resolveExplicitCompressionProvider(
+    profileName,
+    profile.provider,
+  );
+  const profileSettings = new SettingsService();
+  await profileManager.applyLoadedProfile(
+    profileName,
+    profile,
+    profileSettings,
+  );
+  applyCompressionProfileParentEphemerals(
+    profileSettings,
+    profile.provider,
+    parentEphemerals,
+  );
+
+  applyCompressionProfileSettings(profileSettings, profileName, profile);
+
+  const runtimeId = `${ctx.providerRuntime.runtimeId}::compression-profile:${profileName}`;
+  const metadata = {
+    ...(ctx.providerRuntime.metadata ?? {}),
+    source: 'ChatSession.resolveCompressionProvider',
+    compressionProfile: profileName,
+    compressionProvider: profile.provider,
+    runtimeId,
+    provider: profile.provider,
+    model: profile.model,
+  };
+  const runtime: ProviderRuntimeContext = {
+    settingsService: profileSettings,
+    config,
+    runtimeId,
+    metadata,
+  };
+  const resolved = await buildCompressionProfileResolvedOptions(
+    profileSettings,
+    profile,
+  );
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings: profileSettings,
+    providerName: profile.provider,
+    ephemeralsSnapshot: buildCompressionProfileEphemeralsSnapshot(
+      profileSettings,
+      profile.provider,
+    ),
+    metadata,
+    fallbackRuntimeId: runtimeId,
+  });
+
+  return {
+    provider,
+    runtime,
+    config,
+    resolved,
+    invocation,
+  };
+}
+
+/**
+ * Build the ordered candidate list for a load-balanced compression profile
+ * by resolving each sub-profile as a standard profile.
+ */
+export async function buildCompressionLoadBalancerCandidates(
+  ctx: CompressionProfileResolverContext,
+  profileName: string,
+  profile: LoadBalancerProfile,
+  config: Config | undefined,
+  profileManager: NonNullable<ReturnType<Config['getProfileManager']>>,
+): Promise<CompressionLoadBalancerCandidate[]> {
+  const candidates: CompressionLoadBalancerCandidate[] = [];
+  for (const subProfileName of profile.profiles) {
+    const subProfile = await profileManager.loadProfile(subProfileName);
+    if (isLoadBalancerProfile(subProfile)) {
+      throw new CompressionProfileNotFoundError(
+        profileName,
+        `load-balanced compression profile references nested load-balanced profile '${subProfileName}'`,
+      );
+    }
+    const candidate = await resolveStandardCompressionProvider(
+      ctx,
+      subProfileName,
+      subProfile,
+      profileManager,
+      config,
+      profile.ephemeralSettings as Record<string, unknown>,
+    );
+    if (!candidate.invocation) {
+      throw new CompressionProfileNotFoundError(
+        profileName,
+        `failed to build invocation context for subprofile '${subProfileName}'`,
+      );
+    }
+    candidates.push({
+      profileName: subProfileName,
+      provider: candidate.provider,
+      runtime: candidate.runtime,
+      config: candidate.config,
+      resolved: candidate.resolved,
+      invocation: candidate.invocation,
+    });
+  }
+  return candidates;
+}
+
+/**
+ * Resolve a load-balanced compression profile into a provider + runtime +
+ * invocation context, advancing the round-robin index when applicable.
+ */
+export async function resolveLoadBalancedCompressionProvider(
+  ctx: CompressionProfileResolverContext,
+  profileName: string,
+  profile: LoadBalancerProfile,
+  config: Config | undefined,
+  profileManager: NonNullable<ReturnType<Config['getProfileManager']>>,
+): Promise<CompressionProviderResult> {
+  const candidates = await buildCompressionLoadBalancerCandidates(
+    ctx,
+    profileName,
+    profile,
+    config,
+    profileManager,
+  );
+
+  const strategy = profile.policy === 'failover' ? 'failover' : 'round-robin';
+  const initialIndex = ctx.roundRobinIndexes.get(profileName) ?? 0;
+  if (strategy === 'round-robin') {
+    ctx.roundRobinIndexes.set(
+      profileName,
+      (initialIndex + 1) % candidates.length,
+    );
+  }
+  const provider = new CompressionLoadBalancingProvider(
+    strategy,
+    candidates,
+    initialIndex,
+  );
+  const runtimeId = `${ctx.providerRuntime.runtimeId}::compression-profile:${profileName}`;
+  const settings = new SettingsService();
+  settings.setCurrentProfileName(profileName);
+  settings.set('activeProvider', 'load-balancer');
+  settings.set('model', profile.model || provider.getDefaultModel());
+  for (const [key, value] of Object.entries(profile.ephemeralSettings)) {
+    if (value !== undefined) {
+      settings.set(key, value);
+    }
+  }
+  const metadata = {
+    ...(ctx.providerRuntime.metadata ?? {}),
+    source: 'ChatSession.resolveCompressionProvider',
+    compressionProfile: profileName,
+    compressionProvider: 'load-balancer',
+    runtimeId,
+    provider: 'load-balancer',
+    model: settings.get('model'),
+  };
+  const runtime: ProviderRuntimeContext = {
+    settingsService: settings,
+    config,
+    runtimeId,
+    metadata,
+  };
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'load-balancer',
+    ephemeralsSnapshot: buildCompressionProfileEphemeralsSnapshot(
+      settings,
+      'load-balancer',
+    ),
+    metadata,
+    fallbackRuntimeId: runtimeId,
+  });
+  return {
+    provider,
+    runtime,
+    config,
+    invocation,
+  };
+}
+
+/**
+ * Resolve a compression profile by name into a provider + runtime + config.
+ * When no profile name is given, the supplied default provider/runtime is used.
+ */
+export async function resolveCompressionProvider(
+  ctx: CompressionProfileResolverContext,
+  profileName: string | undefined,
+  defaultProvider: IProvider,
+): Promise<CompressionProviderResult> {
+  if (!profileName) {
+    const runtime = ctx.providerRuntime;
+    return {
+      provider: defaultProvider,
+      runtime,
+      config: runtime.config,
+    };
+  }
+
+  const config = ctx.providerRuntime.config;
+  const profileManager = config?.getProfileManager();
+  if (!profileManager) {
+    throw new CompressionProfileNotFoundError(
+      profileName,
+      'profile manager is unavailable',
+    );
+  }
+
+  let profile: Awaited<ReturnType<typeof profileManager.loadProfile>>;
+  try {
+    profile = await profileManager.loadProfile(profileName);
+  } catch (error) {
+    throw new CompressionProfileNotFoundError(
+      profileName,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  if (isLoadBalancerProfile(profile)) {
+    return resolveLoadBalancedCompressionProvider(
+      ctx,
+      profileName,
+      profile,
+      config,
+      profileManager,
+    );
+  }
+
+  return resolveStandardCompressionProvider(
+    ctx,
+    profileName,
+    profile,
+    profileManager,
+    config,
+  );
+}

--- a/packages/agents/src/core/DirectMessageProcessor.ts
+++ b/packages/agents/src/core/DirectMessageProcessor.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import type { GenerateContentResponse } from '@google/genai';
 import {
   type Content,
@@ -31,12 +29,14 @@ import {
   convertIContentToResponse,
   aggregateTextWithSpacing,
 } from './MessageConverter.js';
+import { resolveUserMemory } from './streamRequestHelpers.js';
 import { isSchemaDepthError } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
 import {
   nextStreamEventWithIdleTimeout,
   resolveStreamIdleTimeoutMs,
 } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import { getResponseTextFromParts } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
+import type { HookSystem } from '@vybestack/llxprt-code-core/hooks/hookSystem.js';
 
 type ToolGroupArray = Array<{
   functionDeclarations: Array<{
@@ -65,6 +65,33 @@ function isContentArray(value: unknown): value is Content[] {
   return Array.isArray(value);
 }
 
+/**
+ * Reads the next chunk from the stream iterator, applying idle-timeout
+ * watchdog when effectiveTimeoutMs > 0, or calling iterator.next() directly.
+ */
+async function readNextStreamChunk(
+  iterator: AsyncIterator<IContent>,
+  effectiveTimeoutMs: number,
+  timeoutSignal: AbortSignal,
+  upstreamAbortSignal: AbortSignal | undefined,
+  timeoutController: AbortController,
+): Promise<IteratorResult<IContent, unknown>> {
+  if (effectiveTimeoutMs <= 0) {
+    return iterator.next();
+  }
+  return nextStreamEventWithIdleTimeout({
+    iterator,
+    timeoutMs: effectiveTimeoutMs,
+    signal: timeoutSignal,
+    onTimeout: () => {
+      if (upstreamAbortSignal?.aborted !== true) {
+        timeoutController.abort();
+      }
+    },
+    createTimeoutError: () => createAbortError(),
+  });
+}
+
 function getIContentAutomaticFunctionCallingHistory(
   content: IContent,
 ): Content[] | undefined {
@@ -77,6 +104,32 @@ function getIContentAutomaticFunctionCallingHistory(
   const metadataValue =
     content.metadata?.providerMetadata?.['automaticFunctionCallingHistory'];
   return isContentArray(metadataValue) ? metadataValue : undefined;
+}
+
+/**
+ * Boundary-validation helper: resolves whether hooks are enabled.
+ * `Config.getEnableHooks()` is declared required, but test-doubles / partial
+ * Configs may omit it, so validate `typeof === 'function'` (mirrors main's
+ * optional-call `getEnableHooks?.()` short-circuit).
+ */
+function resolveHooksEnabled(config: Config | undefined): boolean {
+  if (config && typeof config.getEnableHooks === 'function') {
+    return config.getEnableHooks() === true;
+  }
+  return false;
+}
+
+/**
+ * Boundary-validation helper: resolves the HookSystem instance.
+ * `Config.getHookSystem()` is declared required, but test-doubles / partial
+ * Configs may omit it, so validate `typeof === 'function'` (mirrors main's
+ * optional-call `getHookSystem?.()` short-circuit).
+ */
+function resolveHookSystem(config: Config | undefined): HookSystem | undefined {
+  if (config && typeof config.getHookSystem === 'function') {
+    return config.getHookSystem();
+  }
+  return undefined;
 }
 
 /**
@@ -255,32 +308,14 @@ export class DirectMessageProcessor {
     let aggregatedText = '';
     try {
       const iterator = streamResponse[Symbol.asyncIterator]();
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      while (true) {
-        // Use watchdog if timeout > 0, otherwise call iterator.next() directly
-        let nextResponse: IteratorResult<IContent, unknown>;
-        if (effectiveTimeoutMs > 0) {
-          nextResponse = await nextStreamEventWithIdleTimeout({
-            iterator,
-            timeoutMs: effectiveTimeoutMs,
-            signal: timeoutSignal,
-            onTimeout: () => {
-              // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-              if (upstreamAbortSignal?.aborted === true) {
-                return;
-              }
-              timeoutController.abort();
-            },
-            createTimeoutError: () => createAbortError(),
-          });
-        } else {
-          // Watchdog disabled: call iterator.next() directly
-          nextResponse = await iterator.next();
-        }
-        if (nextResponse.done === true) {
-          break;
-        }
-
+      let nextResponse = await readNextStreamChunk(
+        iterator,
+        effectiveTimeoutMs,
+        timeoutSignal,
+        upstreamAbortSignal,
+        timeoutController,
+      );
+      while (nextResponse.done !== true) {
         const iContent = nextResponse.value;
         const { filteredIContent, response } = this._filterStreamedIContent(
           iContent,
@@ -289,13 +324,19 @@ export class DirectMessageProcessor {
         lastResponse = response;
 
         const result = aggregateTextWithSpacing(
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-          filteredIContent.blocks ?? [],
+          filteredIContent.blocks,
           aggregatedText,
           lastBlockWasNonText,
         );
         aggregatedText = result.text;
         lastBlockWasNonText = result.lastBlockWasNonText;
+        nextResponse = await readNextStreamChunk(
+          iterator,
+          effectiveTimeoutMs,
+          timeoutSignal,
+          upstreamAbortSignal,
+          timeoutController,
+        );
       }
     } finally {
       timeoutController.abort();
@@ -458,8 +499,7 @@ export class DirectMessageProcessor {
       settings:
         runtimeContext.settingsService as GenerateChatOptions['settings'],
       metadata: runtimeContext.metadata,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      userMemory: runtimeContext.config?.getUserMemory?.(),
+      userMemory: resolveUserMemory(runtimeContext.config),
     });
   }
 
@@ -526,12 +566,10 @@ export class DirectMessageProcessor {
     configForHooks: Config,
     toolsFromConfig: ToolGroupArray,
   ): Promise<ToolSelectionHookResult> {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    if (!configForHooks.getEnableHooks?.()) {
+    if (!resolveHooksEnabled(configForHooks)) {
       return { tools: toolsFromConfig, allowedFunctionNames: undefined };
     }
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    const hookSystem = configForHooks.getHookSystem?.();
+    const hookSystem = resolveHookSystem(configForHooks);
     if (!hookSystem) {
       return { tools: toolsFromConfig, allowedFunctionNames: undefined };
     }
@@ -592,10 +630,8 @@ export class DirectMessageProcessor {
     };
 
     let beforeModelResult = undefined;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    if (configForHooks.getEnableHooks?.()) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      const hookSystem = configForHooks.getHookSystem?.();
+    if (resolveHooksEnabled(configForHooks)) {
+      const hookSystem = resolveHookSystem(configForHooks);
       if (hookSystem) {
         await hookSystem.initialize();
         beforeModelResult =
@@ -682,10 +718,8 @@ export class DirectMessageProcessor {
     let afterModelModifiedText = false;
 
     // Trigger AfterModel hook
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    if (config?.getEnableHooks?.() === true) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      const hookSystem = config.getHookSystem?.();
+    if (resolveHooksEnabled(config)) {
+      const hookSystem = resolveHookSystem(config);
       if (hookSystem) {
         await hookSystem.initialize();
         const filteredContent = filterHookRestrictedContent(
@@ -700,23 +734,15 @@ export class DirectMessageProcessor {
           ContentConverters.toIContent(filteredContent),
         );
         if (afterModelResult) {
-          const modifiedResponse = afterModelResult.getModifiedResponse();
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (modifiedResponse) {
-            directResponse = this._applyHookRestrictedAllowedTools(
-              modifiedResponse,
-              allowedFunctionNames,
-            );
-            afterModelModifiedResponse = true;
-            // Re-derive aggregatedText from the hook-modified response so the
-            // text getter reflects the hook's intended text rather than the
-            // stale pre-hook provider output (issue #1749).
-            const modifiedText = this._extractResponseText(directResponse);
-            if (modifiedText !== '') {
-              aggregatedText = modifiedText;
-              afterModelModifiedText = true;
-            }
-          }
+          const outcome = this._applyAfterModelResult(
+            afterModelResult,
+            directResponse,
+            allowedFunctionNames,
+          );
+          directResponse = outcome.directResponse;
+          afterModelModifiedResponse = outcome.responseModified;
+          afterModelModifiedText = outcome.aggregatedText !== undefined;
+          aggregatedText = outcome.aggregatedText ?? aggregatedText;
         }
       }
     }
@@ -731,6 +757,41 @@ export class DirectMessageProcessor {
     }
 
     return directResponse;
+  }
+
+  /**
+   * Applies an AfterModel hook result, returning the (possibly modified)
+   * response along with flags indicating whether the response/text changed.
+   */
+  private _applyAfterModelResult(
+    afterModelResult: {
+      getModifiedResponse(): GenerateContentResponse | undefined;
+    },
+    currentResponse: GenerateContentResponse,
+    allowedFunctionNames: string[] | undefined,
+  ): {
+    directResponse: GenerateContentResponse;
+    responseModified: boolean;
+    aggregatedText: string | undefined;
+  } {
+    const modifiedResponse = afterModelResult.getModifiedResponse();
+    if (!modifiedResponse) {
+      return {
+        directResponse: currentResponse,
+        responseModified: false,
+        aggregatedText: undefined,
+      };
+    }
+    const directResponse = this._applyHookRestrictedAllowedTools(
+      modifiedResponse,
+      allowedFunctionNames,
+    );
+    // Re-derive aggregatedText from the hook-modified response so the
+    // text getter reflects the hook's intended text rather than the
+    // stale pre-hook provider output (issue #1749).
+    const modifiedText = this._extractResponseText(directResponse);
+    const aggregatedText = modifiedText !== '' ? modifiedText : undefined;
+    return { directResponse, responseModified: true, aggregatedText };
   }
 
   /**

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -572,7 +572,10 @@ function applyFinishReasonMapping(
       incomplete: FinishReason.MAX_TOKENS,
       failed: FinishReason.STOP,
     };
-    const hasMapping = terminationReason in finishReasonByTerminationReason;
+    const hasMapping = Object.prototype.hasOwnProperty.call(
+      finishReasonByTerminationReason,
+      terminationReason,
+    );
     if (hasMapping) {
       const mappedReason = finishReasonByTerminationReason[terminationReason];
       response.candidates[0].finishReason = mappedReason;

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 /**
  * MessageConverter - Pure functions for Gemini SDK ↔ IContent format translation.
  * Handles format conversion, speaker semantics, finish-reason mapping, and validation.
@@ -36,6 +34,56 @@ import { getResponseTextFromParts } from '@vybestack/llxprt-code-core/utils/gene
 
 const logger = new DebugLogger('llxprt:core:message-converter');
 
+// ---------------------------------------------------------------------------
+// Boundary-validation helpers (typed `unknown` so guards are necessary)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if `value` is a non-null object. Items in `PartListUnion`
+ * come from external/provider data where `typeof null === 'object'`.
+ */
+function isNonNullObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Type-guard for a Part carrying a `functionResponse`. Restores main's
+ * `item !== null && typeof item === 'object' && 'functionResponse' in item`
+ * check (`'functionResponse' in null` throws).
+ */
+function isFunctionResponsePart(item: unknown): boolean {
+  return (
+    typeof item === 'object' && item !== null && 'functionResponse' in item
+  );
+}
+
+/**
+ * Returns true if `part` is undefined, null, or an empty object. Restores
+ * main's `part === undefined || Object.keys(part).length === 0` guard
+ * (`Object.keys(undefined)` throws).
+ */
+function isEmptyOrMissingPart(part: unknown): boolean {
+  return (
+    part === undefined ||
+    part === null ||
+    Object.keys(part as Record<string, unknown>).length === 0
+  );
+}
+
+/**
+ * Reads a token count from provider usage metadata, defaulting to 0 when the
+ * field is absent. `UsageStats` declares these counts as required numbers, but
+ * `usage` is provider/runtime-boundary data that may omit them, so the default
+ * (main's `?? 0`) must be preserved via boundary validation. Mirrors `?? 0`
+ * exactly: only nullish values default; any present value passes through.
+ */
+function usageTokenCount(value: unknown): number {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  return value as number;
+}
+
 /**
  * Aggregates text from content blocks while preserving spacing around non-text blocks.
  */
@@ -63,6 +111,26 @@ export function aggregateTextWithSpacing(
 }
 
 /**
+ * Pushes mixed content items into a parts array, flattening nested arrays.
+ */
+function pushMixedContentParts(
+  message: Array<Part | string>,
+  parts: Part[],
+): void {
+  for (const item of message) {
+    if (typeof item === 'string') {
+      parts.push({ text: item });
+    } else if (Array.isArray(item)) {
+      for (const subItem of item) {
+        parts.push(subItem);
+      }
+    } else if (isNonNullObject(item)) {
+      parts.push(item);
+    }
+  }
+}
+
+/**
  * Custom createUserContent that properly handles function response arrays.
  * Each response must be a separate Part in the same Content, not nested arrays.
  */
@@ -80,10 +148,8 @@ export function createUserContentWithFunctionResponseFix(
   if (Array.isArray(message)) {
     // First check if this is an array of functionResponse Parts
     // This happens when multiple tool responses are sent together
-    const allFunctionResponses = message.every(
-      (item) =>
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        item !== null && typeof item === 'object' && 'functionResponse' in item,
+    const allFunctionResponses = message.every((item) =>
+      isFunctionResponsePart(item),
     );
 
     if (allFunctionResponses) {
@@ -93,21 +159,7 @@ export function createUserContentWithFunctionResponseFix(
       parts.push(...(message as Part[]));
     } else {
       // Process mixed content
-      for (const item of message) {
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (typeof item === 'string') {
-          parts.push({ text: item });
-        } else if (Array.isArray(item)) {
-          // Nested array case - flatten it
-          for (const subItem of item) {
-            parts.push(subItem);
-          }
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        } else if (item !== null && typeof item === 'object') {
-          // Individual part (function response, text, etc.)
-          parts.push(item);
-        }
-      }
+      pushMixedContentParts(message, parts);
     }
   } else {
     // Not an array, pass through to original createUserContent
@@ -141,10 +193,8 @@ export function normalizeToolInteractionInput(
   const parts = message as Part[];
 
   // Detect if this is a tool response sequence (functionResponse parts only)
-  const hasFunctionResponses = parts.some(
-    (part) =>
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      part !== null && typeof part === 'object' && 'functionResponse' in part,
+  const hasFunctionResponses = parts.some((part) =>
+    isFunctionResponsePart(part),
   );
 
   // If no function responses, fall back to original behavior
@@ -160,17 +210,15 @@ export function normalizeToolInteractionInput(
  * Checks if a part contains valid non-thought text content.
  */
 export function isValidNonThoughtTextPart(part: Part): boolean {
-  return (
-    // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    typeof part.text === 'string' &&
-    part.thought !== true &&
-    // Technically, the model should never generate parts that have text and
-    // any of these but we don't trust them so check anyways.
-    !part.functionCall &&
-    !part.functionResponse &&
-    !part.inlineData &&
-    !part.fileData
-  );
+  const hasText = typeof part.text === 'string' && part.thought !== true;
+  const hasNonTextPayload =
+    Boolean(part.functionCall) ||
+    Boolean(part.functionResponse) ||
+    Boolean(part.inlineData) ||
+    Boolean(part.fileData);
+  // Technically, the model should never generate parts that have text and
+  // any of these but we don't trust them so check anyways.
+  return hasText && !hasNonTextPayload;
 }
 
 /**
@@ -195,8 +243,7 @@ export function isValidContent(content: Content): boolean {
     return false;
   }
   for (const part of content.parts) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    if (part === undefined || Object.keys(part).length === 0) {
+    if (isEmptyOrMissingPart(part)) {
       return false;
     }
     if (part.thought !== true && part.text !== undefined && part.text === '') {
@@ -224,8 +271,7 @@ export function validateHistory(history: Content[]): void {
 export function extractCuratedHistory(
   comprehensiveHistory: Content[],
 ): Content[] {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-  if (comprehensiveHistory === undefined || comprehensiveHistory.length === 0) {
+  if (comprehensiveHistory.length === 0) {
     return [];
   }
   const curatedHistory: Content[] = [];
@@ -236,22 +282,35 @@ export function extractCuratedHistory(
       curatedHistory.push(comprehensiveHistory[i]);
       i++;
     } else {
-      const modelOutput: Content[] = [];
-      let isValid = true;
-      while (i < length && comprehensiveHistory[i].role === 'model') {
-        modelOutput.push(comprehensiveHistory[i]);
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (isValid && !isValidContent(comprehensiveHistory[i])) {
-          isValid = false;
-        }
-        i++;
-      }
-      if (isValid) {
-        curatedHistory.push(...modelOutput);
+      const result = collectModelRun(comprehensiveHistory, i, length);
+      i = result.nextIndex;
+      if (result.isValid) {
+        curatedHistory.push(...result.modelOutput);
       }
     }
   }
   return curatedHistory;
+}
+
+/**
+ * Collects a contiguous run of model-role content, tracking validity.
+ */
+function collectModelRun(
+  history: Content[],
+  startIndex: number,
+  length: number,
+): { modelOutput: Content[]; isValid: boolean; nextIndex: number } {
+  const modelOutput: Content[] = [];
+  let isValid = true;
+  let i = startIndex;
+  while (i < length && history[i].role === 'model') {
+    modelOutput.push(history[i]);
+    if (isValid && !isValidContent(history[i])) {
+      isValid = false;
+    }
+    i++;
+  }
+  return { modelOutput, isValid, nextIndex: i };
 }
 
 /**
@@ -260,15 +319,16 @@ export function extractCuratedHistory(
 export function hasTextContent(
   content: Content | undefined,
 ): content is Content & { parts: [{ text: string }, ...Part[]] } {
-  return Boolean(
-    // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    content &&
-      content.role === 'model' &&
-      content.parts &&
-      content.parts.length > 0 &&
-      typeof content.parts[0].text === 'string' &&
-      content.parts[0].text !== '',
-  );
+  if (
+    !content ||
+    content.role !== 'model' ||
+    !content.parts ||
+    content.parts.length === 0
+  ) {
+    return false;
+  }
+  const firstPartText = content.parts[0].text;
+  return typeof firstPartText === 'string' && firstPartText !== '';
 }
 
 /**
@@ -295,10 +355,8 @@ export function convertPartListUnionToIContent(input: PartListUnion): IContent {
  */
 export function convertMixedPartsToIContent(parts: Part[]): IContent {
   // Fast path: all function responses → tool message
-  const allFunctionResponses = parts.every(
-    (part) =>
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider/runtime parts can be malformed at this boundary despite static Part typing.
-      part !== null && typeof part === 'object' && 'functionResponse' in part,
+  const allFunctionResponses = parts.every((part) =>
+    isFunctionResponsePart(part),
   );
   if (allFunctionResponses) {
     return convertAllFunctionResponses(parts);
@@ -308,19 +366,29 @@ export function convertMixedPartsToIContent(parts: Part[]): IContent {
   const { blocks, hasAIContent, hasToolContent } = classifyMixedParts(parts);
 
   return {
-    // eslint-disable-next-line sonarjs/no-nested-conditional -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    speaker: hasToolContent ? 'tool' : hasAIContent ? 'ai' : 'human',
+    speaker: resolveSpeaker(hasToolContent, hasAIContent),
     blocks,
   };
+}
+
+function resolveSpeaker(
+  hasToolContent: boolean,
+  hasAIContent: boolean,
+): IContent['speaker'] {
+  if (hasToolContent) {
+    return 'tool';
+  }
+  if (hasAIContent) {
+    return 'ai';
+  }
+  return 'human';
 }
 
 function convertAllFunctionResponses(parts: Part[]): IContent {
   const blocks: ContentBlock[] = [];
   for (const part of parts) {
     if (
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider/runtime parts can be malformed at this boundary despite static Part typing.
-      part !== null &&
-      typeof part === 'object' &&
+      isNonNullObject(part) &&
       'functionResponse' in part &&
       part.functionResponse
     ) {
@@ -328,9 +396,7 @@ function convertAllFunctionResponses(parts: Part[]): IContent {
         type: 'tool_response',
         callId: part.functionResponse.id ?? '',
         toolName: part.functionResponse.name ?? '',
-        result:
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-          (part.functionResponse.response as Record<string, unknown>) ?? {},
+        result: part.functionResponse.response ?? {},
         error: undefined,
       } as ToolResponseBlock);
     }
@@ -370,8 +436,7 @@ function classifyMixedParts(parts: Part[]): {
         type: 'tool_call',
         id: part.functionCall.id ?? '',
         name: part.functionCall.name ?? '',
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        parameters: (part.functionCall.args as Record<string, unknown>) ?? {},
+        parameters: part.functionCall.args ?? {},
       } as ToolCallBlock);
     } else if ('functionResponse' in part && part.functionResponse) {
       hasToolContent = true;
@@ -379,9 +444,7 @@ function classifyMixedParts(parts: Part[]): {
         type: 'tool_response',
         callId: part.functionResponse.id ?? '',
         toolName: part.functionResponse.name ?? '',
-        result:
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-          (part.functionResponse.response as Record<string, unknown>) ?? {},
+        result: part.functionResponse.response ?? {},
         error: undefined,
       } as ToolResponseBlock);
     }
@@ -509,9 +572,9 @@ function applyFinishReasonMapping(
       incomplete: FinishReason.MAX_TOKENS,
       failed: FinishReason.STOP,
     };
-    const mappedReason = finishReasonByTerminationReason[terminationReason];
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    if (mappedReason !== undefined) {
+    const hasMapping = terminationReason in finishReasonByTerminationReason;
+    if (hasMapping) {
+      const mappedReason = finishReasonByTerminationReason[terminationReason];
       response.candidates[0].finishReason = mappedReason;
       logger.debug(
         () => `[stream:message-converter] applied terminal metadata`,
@@ -544,10 +607,8 @@ function applyFinishReasonMapping(
       {
         speaker: input.speaker,
         blockCount: input.blocks.length,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        stopReason: input.metadata?.stopReason,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        finishReason: input.metadata?.finishReason,
+        stopReason: input.metadata.stopReason,
+        finishReason: input.metadata.finishReason,
         hasCandidate: Boolean(response.candidates?.[0]),
       },
     );
@@ -575,12 +636,11 @@ export function applyResponseMetadata(
   // Add usage metadata if present
   if (input.metadata?.usage) {
     const usageMetadata: UsageMetadataWithCache = {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      promptTokenCount: input.metadata.usage.promptTokens ?? 0,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      candidatesTokenCount: input.metadata.usage.completionTokens ?? 0,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      totalTokenCount: input.metadata.usage.totalTokens ?? 0,
+      promptTokenCount: usageTokenCount(input.metadata.usage.promptTokens),
+      candidatesTokenCount: usageTokenCount(
+        input.metadata.usage.completionTokens,
+      ),
+      totalTokenCount: usageTokenCount(input.metadata.usage.totalTokens),
       cache_read_input_tokens:
         input.metadata.usage.cache_read_input_tokens ?? 0,
       cache_creation_input_tokens:

--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity, max-lines -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 /**
  * StreamProcessor - Handles API stream requests and response processing.
  * Extracted from chatSession.ts Phase 05.
@@ -18,7 +16,7 @@ import {
   type Content,
   type SendMessageParameters,
   type Part,
-  FinishReason,
+  type FinishReason,
   type GenerateContentConfig,
 } from '@google/genai';
 import {
@@ -28,13 +26,9 @@ import {
 import { prependAsyncGenerator } from '@vybestack/llxprt-code-core/utils/asyncIterator.js';
 // @plan:PLAN-20260608-ISSUE1586.P15 — auth types from auth package
 import { flushRuntimeAuthScope } from '@vybestack/llxprt-code-auth';
-import { isFunctionResponse } from '@vybestack/llxprt-code-core/utils/messageInspectors.js';
 import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
-import type {
-  IContent,
-  UsageStats,
-} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type {
   RuntimeGenerateChatOptions as GenerateChatOptions,
@@ -45,21 +39,13 @@ import type { ConversationManager } from './ConversationManager.js';
 import type { CompressionHandler } from '../compression/CompressionHandler.js';
 import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { ContentConverters } from '@vybestack/llxprt-code-core/services/history/ContentConverters.js';
+import { convertIContentToResponse } from './MessageConverter.js';
+import { logApiResponse, logApiError } from './turnLogging.js';
 import {
-  isValidResponse,
-  isValidNonThoughtTextPart,
-  convertIContentToResponse,
-} from './MessageConverter.js';
-import { logApiRequest, logApiResponse, logApiError } from './turnLogging.js';
-import {
-  InvalidStreamError,
   EmptyStreamError,
   isSchemaDepthError,
-  isThoughtPart,
-  type UsageMetadataWithCache,
 } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
 import type { ResponseOutcome } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
-import { analyzeResponseOutcome } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 import { hasCycleInSchema } from '@vybestack/llxprt-code-tools';
 import { isStructuredError } from '@vybestack/llxprt-code-core/utils/quotaErrorDetection.js';
 import {
@@ -69,36 +55,52 @@ import {
 import {
   attachHookRestrictedAllowedTools,
   filterHookRestrictedContent,
-  filterHookRestrictedFunctionCalls,
-  filterHookRestrictedParts,
   getHookRestrictedAllowedTools,
-  getHookRestrictedFunctionCallsFromParts,
-  mergeHookRestrictedFunctionCalls,
 } from './hookToolRestrictions.js';
 import { canonicalizeToolName } from './toolGovernance.js';
+import {
+  buildRequestContents,
+  selectRequestTools,
+  prepareRequestPayload,
+  buildRuntimeContext,
+  patchMissingFinishReason,
+  applyRequestModifications,
+  resolveUserMemory,
+  logOutgoingRequest,
+  type ToolGroupArray,
+  type ToolSelectionHookResult,
+} from './streamRequestHelpers.js';
+import {
+  createStreamAccumulator,
+  accumulateChunkMetadata,
+  consolidateTextParts,
+  extractResponseText,
+  validateStreamCompletion,
+  recordHistoryWithUsage,
+  trackPromptTokens,
+  isMissingFinishReason,
+  type StreamAccumulator,
+} from './streamResponseHelpers.js';
 
 /**
  * StreamProcessor handles making API calls and processing streaming responses.
  * Extracted from ChatSession to isolate streaming concerns.
  */
 
-type ToolGroupArray = Array<{
-  functionDeclarations?: Array<{
-    name: string;
-    description?: string;
-    parametersJsonSchema?: unknown;
-  }>;
-}>;
-
-interface ToolSelectionHookResult {
-  tools: GenerateContentConfig['tools'];
-  allowedFunctionNames: string[] | undefined;
-}
-
-function isMissingFinishReason(
-  finishReason: FinishReason | null | undefined | '',
-): boolean {
-  return finishReason == null || finishReason === '';
+/**
+ * Extract the allowedFunctionNames array from a tool-config object.
+ *
+ * Returns `undefined` when the config is absent or does not carry an
+ * `allowedFunctionNames` string array, otherwise returns the typed array.
+ */
+function extractAllowedFunctionNames(
+  toolConfig: unknown,
+): string[] | undefined {
+  if (toolConfig === null || toolConfig === undefined) return undefined;
+  if (typeof toolConfig !== 'object') return undefined;
+  if (!('allowedFunctionNames' in toolConfig)) return undefined;
+  if (!Array.isArray(toolConfig.allowedFunctionNames)) return undefined;
+  return toolConfig.allowedFunctionNames;
 }
 
 export class StreamProcessor {
@@ -136,7 +138,6 @@ export class StreamProcessor {
       () => '[StreamProcessor] Active provider snapshot before stream request',
       {
         providerName: provider.name,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Preserve defensive runtime boundary guard despite current static types.
         providerDefaultModel: provider.getDefaultModel?.(),
         configModel: this.runtimeContext.state.model,
         baseUrl: providerBaseUrl,
@@ -283,10 +284,9 @@ export class StreamProcessor {
     );
     requestPayload.contents = finalContents;
 
-    logApiRequest(
+    logOutgoingRequest(
       this.runtimeContext,
-      this.runtimeContext.state,
-      ContentConverters.toGeminiContents(requestPayload.contents),
+      requestPayload,
       this.runtimeContext.state.model,
       promptId,
     );
@@ -347,7 +347,6 @@ export class StreamProcessor {
 
     if (beforeModelResult?.isBlockingDecision() === true) {
       let syntheticResponse = beforeModelResult.getSyntheticResponse();
-      // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
       if (syntheticResponse) {
         const candidate = syntheticResponse.candidates?.[0];
         const candidateFinishReason = candidate?.finishReason as
@@ -386,29 +385,18 @@ export class StreamProcessor {
     syntheticResponse: GenerateContentResponse,
     candidate: NonNullable<GenerateContentResponse['candidates']>[0],
   ): GenerateContentResponse {
-    return {
-      ...syntheticResponse,
-      candidates: [{ ...candidate, finishReason: FinishReason.STOP }],
-    } as GenerateContentResponse;
+    return patchMissingFinishReason(syntheticResponse, candidate);
   }
 
   private _applyRequestModifications(
     beforeModelResult: BeforeModelHookOutput | undefined,
     requestContents: IContent[],
   ): IContent[] {
-    if (!beforeModelResult) return requestContents;
-
-    const modifiedRequest = beforeModelResult.applyLLMRequestModifications({
-      model: this.runtimeContext.state.model || '',
-      contents: ContentConverters.toGeminiContents(requestContents),
-    });
-    const modifiedContents = (
-      modifiedRequest as { contents?: Content[] | null }
-    ).contents;
-    if (modifiedContents !== undefined && modifiedContents !== null) {
-      return ContentConverters.toIContents(modifiedContents);
-    }
-    return requestContents;
+    return applyRequestModifications(
+      beforeModelResult,
+      requestContents,
+      this.runtimeContext.state.model,
+    );
   }
 
   private _prepareRequestPayload(
@@ -420,23 +408,15 @@ export class StreamProcessor {
     baseRuntimeContext: ProviderRuntimeContext;
     runtimeContext: ProviderRuntimeContext;
   } {
-    this.logger.debug(
-      () => '[StreamProcessor] Calling provider.generateChatCompletion',
-      {
-        providerName: this.providerResolver('stream').name,
-        model: this.runtimeContext.state.model,
-        historyLength: requestContents.length,
-        toolCount: tools?.length ?? 0,
-        baseUrl: this.runtimeContext.state.baseUrl,
-      },
-    );
-
-    const baseRuntimeContext = this.providerRuntimeBuilder(
-      'StreamProcessor.generateRequest',
-      { historyLength: requestContents.length },
-    );
-
-    const requestPayload = { contents: requestContents, tools };
+    const { requestPayload, baseRuntimeContext } = prepareRequestPayload({
+      requestContents,
+      tools,
+      logger: this.logger,
+      providerRuntimeBuilder: this.providerRuntimeBuilder,
+      providerName: this.providerResolver('stream').name,
+      modelName: this.runtimeContext.state.model,
+      baseUrl: this.runtimeContext.state.baseUrl,
+    });
 
     const runtimeContext = this._buildRuntimeContext(
       baseRuntimeContext,
@@ -450,14 +430,7 @@ export class StreamProcessor {
     baseRuntimeContext: ProviderRuntimeContext,
     params: SendMessageParameters,
   ): ProviderRuntimeContext {
-    if (!params.config?.abortSignal) return baseRuntimeContext;
-    return {
-      ...baseRuntimeContext,
-      metadata: {
-        ...(baseRuntimeContext.metadata ?? {}),
-        abortSignal: params.config.abortSignal,
-      },
-    };
+    return buildRuntimeContext(baseRuntimeContext, params);
   }
 
   private async _sendProviderRequest(
@@ -471,6 +444,7 @@ export class StreamProcessor {
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     const startTime = Date.now();
     try {
+      const userMemory = resolveUserMemory(baseRuntimeContext.config);
       const streamResponse = provider.generateChatCompletion({
         contents: requestPayload.contents,
         tools: requestPayload.tools as ProviderToolset | undefined,
@@ -482,8 +456,7 @@ export class StreamProcessor {
           ...runtimeContext.metadata,
           abortSignal: params.config?.abortSignal,
         },
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Preserve defensive runtime boundary guard despite current static types.
-        userMemory: baseRuntimeContext.config?.getUserMemory?.(),
+        userMemory,
       } as GenerateChatOptions);
 
       return await this._consumeFirstChunkAndReturn(
@@ -537,7 +510,7 @@ export class StreamProcessor {
   private _selectRequestTools(
     params: SendMessageParameters,
   ): GenerateContentConfig['tools'] {
-    return params.config?.tools ?? this.generationConfig.tools;
+    return selectRequestTools(params, this.generationConfig.tools);
   }
 
   private async _applyToolSelectionHook(
@@ -577,15 +550,8 @@ export class StreamProcessor {
     });
 
     const toolConfig = modifiedConfig?.toolConfig as unknown;
-    if (
-      // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      toolConfig !== undefined &&
-      toolConfig !== null &&
-      typeof toolConfig === 'object' &&
-      'allowedFunctionNames' in toolConfig &&
-      Array.isArray(toolConfig.allowedFunctionNames)
-    ) {
-      const allowedFunctions = toolConfig.allowedFunctionNames;
+    const allowedFunctions = extractAllowedFunctionNames(toolConfig);
+    if (allowedFunctions !== undefined) {
       const allowedNames = new Set(allowedFunctions.map(canonicalizeToolName));
       const filteredTools = toolsFromConfig
         .map((toolGroup) => ({
@@ -606,24 +572,11 @@ export class StreamProcessor {
   }
 
   private _buildRequestContents(userContent: Content | Content[]): IContent[] {
-    const matcher = this.conversationManager.makePositionMatcher();
-    if (Array.isArray(userContent)) {
-      const userIContents = userContent.map((content) => {
-        const turnKey = this.historyService.generateTurnKey();
-        const idGen = this.historyService.getIdGeneratorCallback(turnKey);
-        return ContentConverters.toIContent(content, idGen, matcher, turnKey);
-      });
-      return this.historyService.getCuratedForProvider(userIContents);
-    }
-    const turnKey = this.historyService.generateTurnKey();
-    const idGen = this.historyService.getIdGeneratorCallback(turnKey);
-    const userIContent = ContentConverters.toIContent(
+    return buildRequestContents(
       userContent,
-      idGen,
-      matcher,
-      turnKey,
+      this.conversationManager,
+      this.historyService,
     );
-    return this.historyService.getCuratedForProvider([userIContent]);
   }
 
   private async _handleBucketFailover(): Promise<boolean | null> {
@@ -698,18 +651,7 @@ export class StreamProcessor {
   }
 
   private _trackPromptTokens(iContent: IContent): void {
-    const promptTokens = iContent.metadata?.usage?.promptTokens;
-    if (promptTokens === undefined) return;
-
-    const cacheReads = iContent.metadata?.usage?.cache_read_input_tokens ?? 0;
-    const cacheWrites =
-      iContent.metadata?.usage?.cache_creation_input_tokens ?? 0;
-    const combinedPromptTokens = promptTokens + cacheReads + cacheWrites;
-    this.logger.debug(
-      () =>
-        `[StreamProcessor] Tracking promptTokens from IContent: ${combinedPromptTokens}`,
-    );
-    this.compressionHandler.lastPromptTokenCount = combinedPromptTokens;
+    trackPromptTokens(iContent, this.compressionHandler, this.logger);
   }
 
   private async _processAfterModelHook(
@@ -736,7 +678,6 @@ export class StreamProcessor {
         : undefined;
     if (hookSystem === undefined) return { type: 'passthrough' };
 
-    // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
     if (!hookSystem.isInitialized()) {
       await hookSystem.initialize();
     }
@@ -752,7 +693,6 @@ export class StreamProcessor {
       ContentConverters.toIContent(filteredContent),
     );
 
-    // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
     if (afterModelResult?.shouldStopExecution() === true) {
       const effectiveReason = afterModelResult.getEffectiveReason() as
         | string
@@ -763,7 +703,6 @@ export class StreamProcessor {
       );
     }
 
-    // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
     if (afterModelResult?.isBlockingDecision() === true) {
       const modifiedResponse = afterModelResult.getModifiedResponse();
       const syntheticResponse = attachHookRestrictedAllowedTools(
@@ -781,7 +720,6 @@ export class StreamProcessor {
     }
 
     const modifiedResponse = afterModelResult?.getModifiedResponse();
-    // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
     if (modifiedResponse) {
       return { type: 'modified', response: modifiedResponse };
     }
@@ -837,95 +775,22 @@ export class StreamProcessor {
     await this._finalizeStreamProcessing(acc, userInput);
   }
 
-  private _createStreamAccumulator(): {
-    modelResponseParts: Part[];
-    outcome: ResponseOutcome;
-    finishReason: FinishReason | undefined;
-    allChunks: GenerateContentResponse[];
-  } {
-    return {
-      modelResponseParts: [],
-      outcome: {
-        hasVisibleText: false,
-        hasThinking: false,
-        hasToolCalls: false,
-        isActionable: false,
-      },
-      finishReason: undefined,
-      allChunks: [],
-    };
+  private _createStreamAccumulator(): StreamAccumulator {
+    return createStreamAccumulator();
   }
 
   private _accumulateChunkMetadata(
     chunk: GenerateContentResponse,
-    acc: {
-      modelResponseParts: Part[];
-      outcome: ResponseOutcome;
-      finishReason: FinishReason | undefined;
-      allChunks: GenerateContentResponse[];
-    },
+    acc: StreamAccumulator,
     includeThoughts: boolean,
   ): void {
-    const candidateWithReason = chunk.candidates?.find(
-      (c) => c.finishReason !== undefined,
+    accumulateChunkMetadata(
+      chunk,
+      acc,
+      includeThoughts,
+      this.logger,
+      this.compressionHandler,
     );
-    if (candidateWithReason !== undefined)
-      acc.finishReason = candidateWithReason.finishReason as FinishReason;
-
-    const allowedTools = getHookRestrictedAllowedTools(chunk);
-    const parts = chunk.candidates?.[0]?.content?.parts ?? [];
-    const effectiveParts = isValidResponse(chunk)
-      ? filterHookRestrictedParts(parts, allowedTools)
-      : [];
-    const allowedPartCalls = getHookRestrictedFunctionCallsFromParts(
-      effectiveParts,
-      allowedTools,
-    );
-    const allowedMergedCalls = mergeHookRestrictedFunctionCalls(
-      allowedPartCalls,
-      filterHookRestrictedFunctionCalls(
-        chunk.functionCalls ?? [],
-        allowedTools,
-      ),
-    );
-    const allowedTopLevelCallParts = allowedMergedCalls
-      .slice(allowedPartCalls.length)
-      .map((functionCall) => ({ functionCall }));
-    const outcomeParts = [...effectiveParts, ...allowedTopLevelCallParts];
-
-    if (outcomeParts.length > 0) {
-      const chunkOutcome = analyzeResponseOutcome(outcomeParts);
-      acc.outcome = {
-        hasVisibleText:
-          acc.outcome.hasVisibleText || chunkOutcome.hasVisibleText,
-        hasThinking: acc.outcome.hasThinking || chunkOutcome.hasThinking,
-        hasToolCalls: acc.outcome.hasToolCalls || chunkOutcome.hasToolCalls,
-        isActionable: acc.outcome.isActionable || chunkOutcome.isActionable,
-      };
-      acc.modelResponseParts.push(
-        ...(includeThoughts
-          ? outcomeParts
-          : outcomeParts.filter((p) => !isThoughtPart(p))),
-      );
-    }
-
-    const chunkText = typeof chunk.text === 'string' ? chunk.text : '';
-    this.logger.debug(() => `[stream:terminal] observed converted chunk`, {
-      chunkFinishReason: candidateWithReason?.finishReason,
-      partCount: effectiveParts.length,
-      toolCallCount: allowedMergedCalls.length,
-      textLength: chunkText.length,
-      hasUsageMetadata: Boolean(chunk.usageMetadata),
-    });
-
-    if (chunk.usageMetadata?.promptTokenCount !== undefined) {
-      const chunkUsage = chunk.usageMetadata as UsageMetadataWithCache;
-      this.compressionHandler.lastPromptTokenCount =
-        chunk.usageMetadata.promptTokenCount +
-        (chunkUsage.cache_read_input_tokens ?? 0) +
-        (chunkUsage.cache_creation_input_tokens ?? 0);
-    }
-    acc.allChunks.push(chunk);
   }
 
   private async _finalizeStreamProcessing(
@@ -979,32 +844,14 @@ export class StreamProcessor {
    * Consolidate adjacent text parts.
    */
   private _consolidateTextParts(modelResponseParts: Part[]): Part[] {
-    const consolidatedParts: Part[] = [];
-    for (const part of modelResponseParts) {
-      const lastPart = consolidatedParts[consolidatedParts.length - 1];
-      if (
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Preserve defensive runtime boundary guard despite current static types.
-        lastPart?.text &&
-        isValidNonThoughtTextPart(lastPart) &&
-        isValidNonThoughtTextPart(part)
-      ) {
-        lastPart.text += part.text;
-      } else {
-        consolidatedParts.push(part);
-      }
-    }
-    return consolidatedParts;
+    return consolidateTextParts(modelResponseParts);
   }
 
   /**
    * Extract response text from consolidated parts.
    */
   private _extractResponseText(consolidatedParts: Part[]): string {
-    return consolidatedParts
-      .filter((part) => isValidNonThoughtTextPart(part))
-      .map((part) => part.text)
-      .join('')
-      .trim();
+    return extractResponseText(consolidatedParts);
   }
 
   /**
@@ -1016,76 +863,12 @@ export class StreamProcessor {
     finishReason: FinishReason | undefined,
     responseText: string,
   ): void {
-    const isToolContinuationInput = Array.isArray(userInput)
-      ? userInput.some(isFunctionResponse)
-      : isFunctionResponse(userInput);
-
-    const validationContext = {
-      hasToolCall: outcome.hasToolCalls,
-      hasTextResponse: outcome.hasVisibleText,
-      hasThinkingResponse: outcome.hasThinking,
+    validateStreamCompletion(
+      userInput,
+      outcome,
       finishReason,
-      responseTextLength: responseText.length,
-      isToolContinuationInput,
-    };
-
-    this.logger.debug(
-      () => `[stream:terminal] validating converted stream completion`,
-      validationContext,
-    );
-
-    const hasMissingFinishAndNoText =
-      isMissingFinishReason(finishReason) && !outcome.hasVisibleText;
-    const isEmptyResponse = responseText === '';
-    const noRelevantContent =
-      !outcome.hasToolCalls && !isToolContinuationInput && !outcome.hasThinking;
-    const isInvalidResponse =
-      noRelevantContent && (hasMissingFinishAndNoText || isEmptyResponse);
-
-    if (isInvalidResponse) {
-      this._throwMissingResponseError(
-        finishReason,
-        outcome.hasVisibleText,
-        validationContext,
-      );
-    }
-
-    if (finishReason === FinishReason.MALFORMED_FUNCTION_CALL) {
-      this.logger.warn(
-        () =>
-          `[stream:terminal] validation failed: malformed function call finishReason`,
-        validationContext,
-      );
-      throw new InvalidStreamError(
-        'Model stream ended with malformed function call.',
-        'MALFORMED_FUNCTION_CALL',
-      );
-    }
-  }
-
-  private _throwMissingResponseError(
-    finishReason: FinishReason | undefined,
-    hasTextResponse: boolean,
-    validationContext: Record<string, unknown>,
-  ): void {
-    if (isMissingFinishReason(finishReason) && !hasTextResponse) {
-      this.logger.warn(
-        () =>
-          `[stream:terminal] validation failed: missing finishReason and text`,
-        validationContext,
-      );
-      throw new InvalidStreamError(
-        'Model stream ended without a finish reason and no text response.',
-        'NO_FINISH_REASON_NO_TEXT',
-      );
-    }
-    this.logger.warn(
-      () => `[stream:terminal] validation failed: empty response text`,
-      validationContext,
-    );
-    throw new InvalidStreamError(
-      'Model stream ended with empty response text.',
-      'NO_RESPONSE_TEXT',
+      responseText,
+      this.logger,
     );
   }
 
@@ -1097,74 +880,15 @@ export class StreamProcessor {
     consolidatedParts: Part[],
     allChunks: GenerateContentResponse[],
   ): Promise<void> {
-    // Use recordHistory to correctly save the conversation turn.
-    const modelOutput: Content[] = [
-      { role: 'model', parts: consolidatedParts },
-    ];
-
-    // Capture usage metadata from the stream
-    let streamingUsageMetadata: UsageStats | null = null;
-    let actualPromptTokens: number | null = null;
-    // Find the last chunk that has usage metadata (similar to getLastChunkWithMetadata logic)
-    const lastChunkWithMetadata = allChunks
-      .slice()
-      .reverse()
-      .find((chunk) => chunk.usageMetadata);
-    if (lastChunkWithMetadata?.usageMetadata) {
-      streamingUsageMetadata = {
-        promptTokens: lastChunkWithMetadata.usageMetadata.promptTokenCount ?? 0,
-        completionTokens:
-          lastChunkWithMetadata.usageMetadata.candidatesTokenCount ?? 0,
-        totalTokens: lastChunkWithMetadata.usageMetadata.totalTokenCount ?? 0,
-      };
-      const usageMetadata =
-        lastChunkWithMetadata.usageMetadata as UsageMetadataWithCache;
-      const cacheReads = usageMetadata.cache_read_input_tokens ?? 0;
-      const cacheWrites = usageMetadata.cache_creation_input_tokens ?? 0;
-      actualPromptTokens =
-        streamingUsageMetadata.promptTokens + cacheReads + cacheWrites;
-    }
-
-    // Record history first (adds estimated tokens)
-    this.conversationManager.recordHistory(
+    await recordHistoryWithUsage({
       userInput,
-      modelOutput,
-      undefined,
-      streamingUsageMetadata,
-    );
-
-    // Ensure token estimation updates are complete before syncing to actual API prompt tokens.
-    await this.historyService.waitForTokenUpdates();
-
-    // Sync token counts AFTER recording history to replace estimated tokens with actual API prompt tokens
-    // Use explicit check for undefined to allow 0 values
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison -- preserve defensive runtime boundary guard despite current static types.
-    if (actualPromptTokens !== null && actualPromptTokens !== undefined) {
-      if (actualPromptTokens > 0) {
-        this.logger.debug(
-          () =>
-            `[StreamProcessor] Syncing prompt token count to HistoryService: ${actualPromptTokens}`,
-        );
-        this.historyService.syncTotalTokens(actualPromptTokens);
-        await this.historyService.waitForTokenUpdates();
-      }
-    } else if (this.compressionHandler.lastPromptTokenCount !== null) {
-      if (this.compressionHandler.lastPromptTokenCount > 0) {
-        this.logger.debug(
-          () =>
-            `[StreamProcessor] Syncing prompt token count to HistoryService: ${this.compressionHandler.lastPromptTokenCount}`,
-        );
-        this.historyService.syncTotalTokens(
-          this.compressionHandler.lastPromptTokenCount,
-        );
-        await this.historyService.waitForTokenUpdates();
-      }
-    } else {
-      this.logger.debug(
-        () =>
-          `[StreamProcessor] No token count to sync (lastPromptTokenCount: ${this.compressionHandler.lastPromptTokenCount})`,
-      );
-    }
+      consolidatedParts,
+      allChunks,
+      conversationManager: this.conversationManager,
+      historyService: this.historyService,
+      compressionHandler: this.compressionHandler,
+      logger: this.logger,
+    });
   }
 
   /**

--- a/packages/agents/src/core/TurnProcessor.ts
+++ b/packages/agents/src/core/TurnProcessor.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import type { GenerateContentResponse } from '@google/genai';
 import {
   type Content,
@@ -70,6 +68,19 @@ interface ToolSelectionHookResult {
 }
 
 import { hasCycleInSchema } from '@vybestack/llxprt-code-tools';
+
+/**
+ * Reads user memory from the runtime config. Config is typed with a required
+ * getUserMemory(), but runtime payloads (including test doubles) may omit it,
+ * so existence is validated at this boundary.
+ */
+function resolveUserMemory(config: Config | undefined): string {
+  if (!config) {
+    return '';
+  }
+  const getter = (config as unknown as Record<string, unknown>).getUserMemory;
+  return typeof getter === 'function' ? config.getUserMemory() : '';
+}
 
 /**
  * Handles turn-level operations: sendMessage, sendMessageStream, waitForIdle.
@@ -199,83 +210,94 @@ export class TurnProcessor {
   ): AsyncGenerator<StreamEvent> {
     try {
       let lastError: unknown = new Error('Request failed after all retries.');
-      // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      for (
-        let attempt = 0;
-        attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts;
-        attempt++
-      ) {
-        try {
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (attempt > 0) yield { type: StreamEventType.RETRY };
-
-          const currentParams = this._applyRetryTemperature(params, attempt);
-          const stream = await this.streamProcessor.makeApiCallAndProcessStream(
-            currentParams,
-            prompt_id,
-            pendingTokens,
-            userContent,
+      let attempt = 0;
+      let retrying = true;
+      while (retrying && attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts) {
+        const outcome = yield* this._runStreamAttempt(
+          params,
+          prompt_id,
+          pendingTokens,
+          userContent,
+          attempt,
+        );
+        lastError = outcome.error;
+        if (outcome.action !== 'retry') {
+          retrying = false;
+        } else {
+          await new Promise((res) =>
+            setTimeout(
+              res,
+              INVALID_CONTENT_RETRY_OPTIONS.initialDelayMs * (attempt + 1),
+            ),
           );
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          for await (const chunk of stream) {
-            yield { type: StreamEventType.CHUNK, value: chunk };
-          }
-          lastError = null;
-          break;
-        } catch (error) {
-          // Handle hook execution control errors before retry logic
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (error instanceof AgentExecutionStoppedError) {
-            yield {
-              type: StreamEventType.AGENT_EXECUTION_STOPPED,
-              reason: error.reason,
-              systemMessage: error.systemMessage,
-              contextCleared: error.contextCleared,
-            };
-            lastError = null;
-            break;
-          }
-
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (error instanceof AgentExecutionBlockedError) {
-            yield {
-              type: StreamEventType.AGENT_EXECUTION_BLOCKED,
-              reason: error.reason,
-              systemMessage: error.systemMessage,
-              contextCleared: error.contextCleared,
-            };
-            // If there's a synthetic response, yield it as a chunk
-            if (error.syntheticResponse) {
-              yield {
-                type: StreamEventType.CHUNK,
-                value: error.syntheticResponse,
-              };
-            }
-            lastError = null;
-            break;
-          }
-
-          lastError = error;
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (
-            (error instanceof InvalidStreamError ||
-              error instanceof EmptyStreamError) &&
-            attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1
-          ) {
-            await new Promise((res) =>
-              setTimeout(
-                res,
-                INVALID_CONTENT_RETRY_OPTIONS.initialDelayMs * (attempt + 1),
-              ),
-            );
-            continue;
-          }
-          break;
+          attempt++;
         }
       }
       if (lastError != null) throw lastError;
     } finally {
       onDone();
+    }
+  }
+
+  /**
+   * Runs a single stream attempt, yielding events incrementally. Returns the
+   * outcome (error + action) so the caller loop can decide retry vs stop with
+   * a single break/continue.
+   */
+  private async *_runStreamAttempt(
+    params: SendMessageParameters,
+    prompt_id: string,
+    pendingTokens: number,
+    userContent: Content | Content[],
+    attempt: number,
+  ): AsyncGenerator<StreamEvent, { error: unknown; action: 'retry' | 'stop' }> {
+    if (attempt > 0) {
+      yield { type: StreamEventType.RETRY };
+    }
+
+    try {
+      const currentParams = this._applyRetryTemperature(params, attempt);
+      const stream = await this.streamProcessor.makeApiCallAndProcessStream(
+        currentParams,
+        prompt_id,
+        pendingTokens,
+        userContent,
+      );
+      for await (const chunk of stream) {
+        yield { type: StreamEventType.CHUNK, value: chunk };
+      }
+      return { error: null, action: 'stop' };
+    } catch (error) {
+      // Hook execution control errors are yielded then stop the loop.
+      if (error instanceof AgentExecutionStoppedError) {
+        yield {
+          type: StreamEventType.AGENT_EXECUTION_STOPPED,
+          reason: error.reason,
+          systemMessage: error.systemMessage,
+          contextCleared: error.contextCleared,
+        };
+        return { error: null, action: 'stop' };
+      }
+      if (error instanceof AgentExecutionBlockedError) {
+        yield {
+          type: StreamEventType.AGENT_EXECUTION_BLOCKED,
+          reason: error.reason,
+          systemMessage: error.systemMessage,
+          contextCleared: error.contextCleared,
+        };
+        if (error.syntheticResponse) {
+          yield { type: StreamEventType.CHUNK, value: error.syntheticResponse };
+        }
+        return { error: null, action: 'stop' };
+      }
+      if (
+        (error instanceof InvalidStreamError ||
+          error instanceof EmptyStreamError) &&
+        attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1
+      ) {
+        return { error, action: 'retry' };
+      }
+      return { error, action: 'stop' };
     }
   }
 
@@ -437,7 +459,6 @@ export class TurnProcessor {
       () => '[TurnProcessor] Active provider snapshot before send',
       {
         providerName: provider.name,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Turn processor runtime payloads.
         providerDefaultModel: provider.getDefaultModel?.(),
         configModel: this.runtimeContext.state.model,
         baseUrl: this.resolveProviderBaseUrl(provider),
@@ -522,8 +543,7 @@ export class TurnProcessor {
       settings:
         runtimeContext.settingsService as GenerateChatOptions['settings'],
       metadata: runtimeContext.metadata,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Turn processor runtime payloads.
-      userMemory: runtimeContext.config?.getUserMemory?.(),
+      userMemory: resolveUserMemory(runtimeContext.config),
     });
   }
 
@@ -540,22 +560,23 @@ export class TurnProcessor {
       runtimeContext.config,
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Turn processor runtime payloads.
-    while (true) {
-      const nextResponse = await this._readProviderStreamResponse(
+    let nextResponse = await this._readProviderStreamResponse(
+      iterator,
+      timeoutController,
+      upstreamAbortSignal,
+      effectiveTimeoutMs,
+    );
+    while (nextResponse.done !== true) {
+      const iContent = nextResponse.value;
+      this._trackProviderPromptTokens(iContent);
+      blocks.push(...iContent.blocks);
+      lastResponse = iContent;
+      nextResponse = await this._readProviderStreamResponse(
         iterator,
         timeoutController,
         upstreamAbortSignal,
         effectiveTimeoutMs,
       );
-      if (nextResponse.done === true) {
-        break;
-      }
-
-      const iContent = nextResponse.value;
-      this._trackProviderPromptTokens(iContent);
-      blocks.push(...iContent.blocks);
-      lastResponse = iContent;
     }
 
     if (!lastResponse) throw new Error('No response from provider');
@@ -678,8 +699,7 @@ export class TurnProcessor {
       {
         providerName: provider.name,
         model: this.runtimeContext.state.model,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Turn processor runtime payloads.
-        toolCount: (tools as unknown[])?.length ?? 0,
+        toolCount: Array.isArray(tools) ? tools.length : 0,
         baseUrl,
       },
     );
@@ -721,8 +741,7 @@ export class TurnProcessor {
   ): void {
     const curatedHistory = this.historyService.getCurated();
     const index = ContentConverters.toGeminiContents(curatedHistory).length;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Turn processor runtime payloads.
-    const newEntries = afcHistory.slice(index) ?? [];
+    const newEntries = afcHistory.slice(index);
     const matcher = this.makePositionMatcher();
     for (const content of newEntries) {
       const turnKey = this.historyService.generateTurnKey();
@@ -849,27 +868,11 @@ export class TurnProcessor {
       const cyclicSchemaTools: string[] = [];
 
       for (const toolGroup of tools) {
-        if (
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Tool groups can be malformed at runtime.
-          toolGroup !== null &&
-          typeof toolGroup === 'object' &&
-          'functionDeclarations' in toolGroup &&
-          Array.isArray(toolGroup.functionDeclarations)
-        ) {
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          for (const funcDecl of toolGroup.functionDeclarations) {
-            const name = funcDecl.name ?? 'unknown';
-            toolNames.push(name);
-            const schema = funcDecl.parametersJsonSchema;
-            if (
-              schema != null &&
-              typeof schema === 'object' &&
-              hasCycleInSchema(schema as Record<string, unknown>)
-            ) {
-              cyclicSchemaTools.push(name);
-            }
-          }
-        }
+        this._collectCyclicSchemaToolNames(
+          toolGroup,
+          toolNames,
+          cyclicSchemaTools,
+        );
       }
 
       const metadata = {
@@ -889,6 +892,38 @@ export class TurnProcessor {
         () => `[TurnProcessor] Schema depth error encountered${extraDetails}`,
         metadata,
       );
+    }
+  }
+
+  /**
+   * Collects tool names and any with cyclic schemas from a single tool group.
+   * Tool groups can be malformed at runtime, so the shape is validated before use.
+   */
+  private _collectCyclicSchemaToolNames(
+    toolGroup: unknown,
+    toolNames: string[],
+    cyclicSchemaTools: string[],
+  ): void {
+    if (
+      typeof toolGroup !== 'object' ||
+      toolGroup === null ||
+      !('functionDeclarations' in toolGroup) ||
+      !Array.isArray(toolGroup.functionDeclarations)
+    ) {
+      return;
+    }
+
+    for (const funcDecl of toolGroup.functionDeclarations) {
+      const name = funcDecl.name ?? 'unknown';
+      toolNames.push(name);
+      const schema = funcDecl.parametersJsonSchema;
+      if (
+        schema != null &&
+        typeof schema === 'object' &&
+        hasCycleInSchema(schema as Record<string, unknown>)
+      ) {
+        cyclicSchemaTools.push(name);
+      }
     }
   }
 }

--- a/packages/agents/src/core/bucketFailoverIntegration.ts
+++ b/packages/agents/src/core/bucketFailoverIntegration.ts
@@ -9,8 +9,6 @@
  * Integrates bucket failover logic into ChatSession provider execution flow
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import type {
   IContent,
   ContentBlock,
@@ -50,22 +48,70 @@ function shouldFailover(error: Error): boolean {
     return true;
   }
 
-  return (
-    // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
+  const hasStatusCode =
     message.includes('429') ||
     message.includes('401') ||
     message.includes('403') ||
-    message.includes('rate limit') ||
-    message.includes('quota') ||
-    message.includes('402') ||
+    message.includes('402');
+  const hasRateLimitText =
+    message.includes('rate limit') || message.includes('quota');
+  const hasPaymentText =
     message.includes('payment') ||
     message.includes('revoked') ||
-    message.includes('permission_error') ||
-    (message.includes('token') && message.includes('expired'))
-  );
+    message.includes('permission_error');
+  const hasTokenExpiry =
+    message.includes('token') && message.includes('expired');
+
+  return hasStatusCode || hasRateLimitText || hasPaymentText || hasTokenExpiry;
 }
 
 const logger = new DebugLogger('llxprt:bucket:failover:integration');
+
+/**
+ * Returns true when there is at least one more bucket after currentIndex.
+ */
+function hasMoreBuckets(currentIndex: number, buckets: string[]): boolean {
+  return currentIndex < buckets.length - 1;
+}
+
+/**
+ * Notifies the caller that execution is failing over from the current bucket
+ * to the next one.
+ */
+function notifyFailover(
+  currentIndex: number,
+  buckets: string[],
+  notificationCallback?: (fromBucket: string, toBucket: string) => void,
+): void {
+  const currentBucket = buckets[currentIndex];
+  const nextBucket = buckets[currentIndex + 1];
+
+  if (notificationCallback) {
+    notificationCallback(currentBucket, nextBucket);
+  }
+
+  logger.debug(
+    () => `Failing over from bucket '${currentBucket}' to '${nextBucket}'`,
+  );
+}
+
+type FailoverAction = 'continue' | 'exhausted';
+
+/**
+ * Resolves the failover action for a failover-eligible error: continue to the
+ * next bucket if one remains (notifying the caller), otherwise signal exhaustion.
+ */
+function resolveFailoverAction(
+  currentIndex: number,
+  buckets: string[],
+  notificationCallback?: (fromBucket: string, toBucket: string) => void,
+): FailoverAction {
+  if (!hasMoreBuckets(currentIndex, buckets)) {
+    return 'exhausted';
+  }
+  notifyFailover(currentIndex, buckets, notificationCallback);
+  return 'continue';
+}
 
 /**
  * Configuration for bucket failover execution
@@ -162,32 +208,22 @@ export async function executeProviderWithBucketFailover(
       );
 
       // Check if this error should trigger failover
-      if (shouldFailover(err)) {
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if (i < buckets.length - 1) {
-          const nextBucket = buckets[i + 1];
-
-          // Notify about bucket switch
-          if (notificationCallback) {
-            notificationCallback(bucket, nextBucket);
-          }
-
-          logger.debug(
-            () => `Failing over from bucket '${bucket}' to '${nextBucket}'`,
-          );
-
-          // Continue to next bucket
-          continue;
-        } else {
-          // Last bucket also failed with failover error
-          const exhaustedMessage = formatAllBucketsExhaustedError(
-            provider.name,
-            buckets,
-            attemptedBuckets,
-            lastError,
-          );
-          throw new Error(exhaustedMessage);
-        }
+      const isFailover = shouldFailover(err);
+      if (
+        isFailover &&
+        resolveFailoverAction(i, buckets, notificationCallback) === 'continue'
+      ) {
+        continue;
+      }
+      if (isFailover) {
+        // Last bucket also failed with failover error
+        const exhaustedMessage = formatAllBucketsExhaustedError(
+          provider.name,
+          buckets,
+          attemptedBuckets,
+          lastError,
+        );
+        throw new Error(exhaustedMessage);
       }
 
       // Non-failover error - throw immediately

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -4,13 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable max-lines -- ChatSession coordinates legacy decomposed modules; further splitting is outside this change. */
-
 // ChatSession — thin coordinator that wires up the decomposed modules.
 
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
 import type {
   Content,
   GenerateContentConfig,
@@ -23,7 +18,6 @@ import type { CompletedToolCall } from './coreToolScheduler.js';
 import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
-import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import type {
@@ -35,15 +29,6 @@ import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime
 import { triggerPreCompressHook } from '@vybestack/llxprt-code-core/core/lifecycleHookTriggers.js';
 import { PreCompressTrigger } from '@vybestack/llxprt-code-core/hooks/types.js';
 import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
-import { SettingsService } from '@vybestack/llxprt-code-settings';
-import { getProviderKeyStorage } from '@vybestack/llxprt-code-core/storage/provider-key-storage.js';
-
-import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
-import { isLoadBalancerProfile } from '@vybestack/llxprt-code-settings';
-import type {
-  LoadBalancerProfile,
-  StandardProfile,
-} from '@vybestack/llxprt-code-settings';
 
 // Decomposed modules
 import { CompressionHandler } from '../compression/CompressionHandler.js';
@@ -56,6 +41,8 @@ import {
   convertIContentToResponse,
   validateHistory,
 } from './MessageConverter.js';
+import { resolveCompressionProvider } from './CompressionProfileResolver.js';
+import type { CompressionProfileResolverContext } from './CompressionProfileResolver.js';
 
 // Re-exports — consumers import from './chatSession.js'
 export {
@@ -94,8 +81,10 @@ export class AgentExecutionStoppedError extends Error {
     systemMessage?: string,
     contextCleared?: boolean,
   ) {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional falsy coalescing: empty systemMessage should fall through to reason
-    super(`Agent execution stopped: ${systemMessage || reason}`);
+    // Intentional falsy coalescing: empty systemMessage must fall through to reason.
+    const message =
+      systemMessage && systemMessage.length > 0 ? systemMessage : reason;
+    super(`Agent execution stopped: ${message}`);
     this.name = 'AgentExecutionStoppedError';
     this.reason = reason;
     this.systemMessage = systemMessage;
@@ -118,127 +107,15 @@ export class AgentExecutionBlockedError extends Error {
     systemMessage?: string,
     contextCleared?: boolean,
   ) {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional falsy coalescing: empty systemMessage should fall through to reason
-    super(`Agent execution blocked: ${systemMessage || reason}`);
+    // Intentional falsy coalescing: empty systemMessage must fall through to reason.
+    const message =
+      systemMessage && systemMessage.length > 0 ? systemMessage : reason;
+    super(`Agent execution blocked: ${message}`);
     this.name = 'AgentExecutionBlockedError';
     this.reason = reason;
     this.systemMessage = systemMessage;
     this.syntheticResponse = syntheticResponse;
     this.contextCleared = contextCleared;
-  }
-}
-
-interface CompressionLoadBalancerCandidate {
-  profileName: string;
-  provider: IProvider;
-  runtime: ProviderRuntimeContext;
-  config: Config | undefined;
-  resolved: RuntimeGenerateChatOptions['resolved'];
-  invocation: NonNullable<RuntimeGenerateChatOptions['invocation']>;
-}
-
-class CompressionLoadBalancingProvider implements IProvider {
-  readonly name = 'load-balancer';
-  private readonly selectedRoundRobinCandidate?: CompressionLoadBalancerCandidate;
-
-  constructor(
-    private readonly strategy: 'round-robin' | 'failover',
-    private readonly candidates: readonly CompressionLoadBalancerCandidate[],
-    initialIndex: number,
-  ) {
-    if (candidates.length === 0) {
-      throw new Error('Load-balanced compression profile requires subprofiles');
-    }
-    if (strategy === 'round-robin') {
-      this.selectedRoundRobinCandidate =
-        this.candidates[initialIndex % this.candidates.length];
-    }
-  }
-
-  async getModels() {
-    return [];
-  }
-
-  getDefaultModel(): string {
-    return this.candidates[0]?.resolved?.model ?? '';
-  }
-
-  getServerTools(): string[] {
-    return [];
-  }
-
-  async invokeServerTool(toolName: string): Promise<unknown> {
-    throw new Error(
-      `Server tool '${toolName}' not supported by compression load-balancer provider`,
-    );
-  }
-
-  generateChatCompletion(
-    options: RuntimeGenerateChatOptions,
-  ): AsyncIterableIterator<IContent>;
-  generateChatCompletion(content: IContent[]): AsyncIterableIterator<IContent>;
-  async *generateChatCompletion(
-    optionsOrContent: RuntimeGenerateChatOptions | IContent[],
-  ): AsyncIterableIterator<IContent> {
-    const options = Array.isArray(optionsOrContent)
-      ? { contents: optionsOrContent }
-      : optionsOrContent;
-
-    if (this.strategy === 'failover') {
-      yield* this.generateWithFailover(options);
-      return;
-    }
-
-    yield* this.generateWithCandidate(
-      this.selectedRoundRobinCandidate ?? this.candidates[0],
-      options,
-    );
-  }
-
-  private async *generateWithFailover(
-    options: RuntimeGenerateChatOptions,
-  ): AsyncIterableIterator<IContent> {
-    let lastError: unknown;
-    for (const candidate of this.candidates) {
-      try {
-        const bufferedChunks: IContent[] = [];
-        for await (const chunk of this.generateWithCandidate(
-          candidate,
-          options,
-        )) {
-          bufferedChunks.push(chunk);
-        }
-        yield* bufferedChunks;
-        return;
-      } catch (error) {
-        lastError = error;
-      }
-    }
-    throw lastError instanceof Error ? lastError : new Error(String(lastError));
-  }
-
-  private async *generateWithCandidate(
-    candidate: CompressionLoadBalancerCandidate,
-    options: RuntimeGenerateChatOptions,
-  ): AsyncIterableIterator<IContent> {
-    const candidateOptions: RuntimeGenerateChatOptions = {
-      ...options,
-      runtime: candidate.runtime,
-      settings: candidate.runtime
-        .settingsService as RuntimeGenerateChatOptions['settings'],
-      config: candidate.config,
-      resolved: {
-        ...options.resolved,
-        ...candidate.resolved,
-      },
-      invocation: candidate.invocation,
-      metadata: {
-        ...options.metadata,
-        ...(candidate.invocation.metadata as Record<string, unknown>),
-        selectedCompressionProfile: candidate.profileName,
-      },
-    };
-    yield* candidate.provider.generateChatCompletion(candidateOptions);
   }
 }
 
@@ -275,11 +152,6 @@ export class ChatSession {
     generationConfig: GenerateContentConfig = {},
     initialHistory: Content[] = [],
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Gemini chat runtime payloads.
-    if (view == null) {
-      throw new Error('AgentRuntimeContext is required for ChatSession');
-    }
-
     this.runtimeContext = view;
     this.runtimeState = view.state;
     this.historyService = view.history;
@@ -313,8 +185,7 @@ export class ChatSession {
       this.generationConfig,
       this.resolveCompressionProvider.bind(this),
       async (context: CompressionContext) => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Gemini chat runtime payloads.
-        const config = view.providerRuntime?.config;
+        const config = view.providerRuntime.config;
         if (config) {
           await triggerPreCompressHook(
             config,
@@ -407,8 +278,7 @@ export class ChatSession {
     const originalAdd = this.historyService.add.bind(this.historyService);
     this.historyService.add = (...args: Parameters<typeof originalAdd>) => {
       const result = originalAdd(...args);
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Gemini chat runtime payloads.
-      this.compressionHandler?.markDensityDirty();
+      this.compressionHandler.markDensityDirty();
       return result;
     };
     hs[ChatSession.DENSITY_WRAPPED] = true;
@@ -454,8 +324,7 @@ export class ChatSession {
   }
 
   resolveProviderForRuntime(compressionProfileName: string): IProvider {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Gemini chat runtime payloads.
-    const desiredProviderName = this.runtimeState.provider?.trim();
+    const desiredProviderName = this.runtimeState.provider.trim();
     const adapter = this.runtimeContext.provider;
 
     if (desiredProviderName) {
@@ -478,11 +347,7 @@ export class ChatSession {
       const previousProviderName = provider.name;
       try {
         adapter.setActiveProvider(desiredProviderName);
-        const updatedProvider = adapter.getActiveProvider();
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Gemini chat runtime payloads.
-        if (updatedProvider != null) {
-          provider = updatedProvider;
-        }
+        provider = adapter.getActiveProvider();
         this.logger.debug(
           () =>
             `[ChatSession] enforced provider switch to '${desiredProviderName}' (previous '${previousProviderName}') [${compressionProfileName}]`,
@@ -535,364 +400,28 @@ export class ChatSession {
     );
   }
 
+  // ── Compression profile resolution (delegated to CompressionProfileResolver) ──
+
+  private getCompressionProfileResolverContext(): CompressionProfileResolverContext {
+    return {
+      providerRuntime: this.runtimeContext.providerRuntime,
+      resolveExplicitCompressionProvider:
+        this.resolveExplicitCompressionProvider.bind(this),
+      roundRobinIndexes: this.compressionLoadBalancerRoundRobinIndexes,
+    };
+  }
+
   private async resolveCompressionProvider(
     profileName: string | undefined,
   ): Promise<CompressionProviderResult> {
-    if (!profileName) {
-      const provider = this.resolveProviderForRuntime(
-        'ChatSession.resolveCompressionProvider.default',
-      );
-      const runtime = this.runtimeContext.providerRuntime;
-      return {
-        provider,
-        runtime,
-        config: runtime.config,
-      };
-    }
-
-    const config = this.runtimeContext.providerRuntime.config;
-    const profileManager = config?.getProfileManager();
-    if (!profileManager) {
-      throw new CompressionProfileNotFoundError(
-        profileName,
-        'profile manager is unavailable',
-      );
-    }
-
-    let profile: Awaited<ReturnType<typeof profileManager.loadProfile>>;
-    try {
-      profile = await profileManager.loadProfile(profileName);
-    } catch (error) {
-      throw new CompressionProfileNotFoundError(
-        profileName,
-        error instanceof Error ? error.message : String(error),
-      );
-    }
-
-    if (isLoadBalancerProfile(profile)) {
-      return this.resolveLoadBalancedCompressionProvider(
-        profileName,
-        profile,
-        config,
-        profileManager,
-      );
-    }
-
-    return this.resolveStandardCompressionProvider(
+    const defaultProvider = this.resolveProviderForRuntime(
+      'ChatSession.resolveCompressionProvider.default',
+    );
+    return resolveCompressionProvider(
+      this.getCompressionProfileResolverContext(),
       profileName,
-      profile,
-      profileManager,
-      config,
+      defaultProvider,
     );
-  }
-  private async resolveLoadBalancedCompressionProvider(
-    profileName: string,
-    profile: LoadBalancerProfile,
-    config: Config | undefined,
-    profileManager: NonNullable<ReturnType<Config['getProfileManager']>>,
-  ): Promise<CompressionProviderResult> {
-    const candidates = await this.buildCompressionLoadBalancerCandidates(
-      profileName,
-      profile,
-      config,
-      profileManager,
-    );
-
-    const strategy = profile.policy === 'failover' ? 'failover' : 'round-robin';
-    const initialIndex =
-      this.compressionLoadBalancerRoundRobinIndexes.get(profileName) ?? 0;
-    if (strategy === 'round-robin') {
-      this.compressionLoadBalancerRoundRobinIndexes.set(
-        profileName,
-        (initialIndex + 1) % candidates.length,
-      );
-    }
-    const provider = new CompressionLoadBalancingProvider(
-      strategy,
-      candidates,
-      initialIndex,
-    );
-    const runtimeId = `${this.runtimeContext.providerRuntime.runtimeId}::compression-profile:${profileName}`;
-    const settings = new SettingsService();
-    settings.setCurrentProfileName(profileName);
-    settings.set('activeProvider', 'load-balancer');
-    settings.set('model', profile.model || provider.getDefaultModel());
-    for (const [key, value] of Object.entries(profile.ephemeralSettings)) {
-      if (value !== undefined) {
-        settings.set(key, value);
-      }
-    }
-    const metadata = {
-      ...(this.runtimeContext.providerRuntime.metadata ?? {}),
-      source: 'ChatSession.resolveCompressionProvider',
-      compressionProfile: profileName,
-      compressionProvider: 'load-balancer',
-      runtimeId,
-      provider: 'load-balancer',
-      model: settings.get('model'),
-    };
-    const runtime: ProviderRuntimeContext = {
-      settingsService: settings,
-      config,
-      runtimeId,
-      metadata,
-    };
-    const invocation = createRuntimeInvocationContext({
-      runtime,
-      settings,
-      providerName: 'load-balancer',
-      ephemeralsSnapshot: this.buildCompressionProfileEphemeralsSnapshot(
-        settings,
-        'load-balancer',
-      ),
-      metadata,
-      fallbackRuntimeId: runtimeId,
-    });
-    return {
-      provider,
-      runtime,
-      config,
-      invocation,
-    };
-  }
-
-  private async buildCompressionLoadBalancerCandidates(
-    profileName: string,
-    profile: LoadBalancerProfile,
-    config: Config | undefined,
-    profileManager: NonNullable<ReturnType<Config['getProfileManager']>>,
-  ): Promise<CompressionLoadBalancerCandidate[]> {
-    const candidates: CompressionLoadBalancerCandidate[] = [];
-    for (const subProfileName of profile.profiles) {
-      const subProfile = await profileManager.loadProfile(subProfileName);
-      if (isLoadBalancerProfile(subProfile)) {
-        throw new CompressionProfileNotFoundError(
-          profileName,
-          `load-balanced compression profile references nested load-balanced profile '${subProfileName}'`,
-        );
-      }
-      const candidate = await this.resolveStandardCompressionProvider(
-        subProfileName,
-        subProfile,
-        profileManager,
-        config,
-        profile.ephemeralSettings as Record<string, unknown>,
-      );
-      if (!candidate.invocation) {
-        throw new CompressionProfileNotFoundError(
-          profileName,
-          `failed to build invocation context for subprofile '${subProfileName}'`,
-        );
-      }
-      candidates.push({
-        profileName: subProfileName,
-        provider: candidate.provider,
-        runtime: candidate.runtime,
-        config: candidate.config,
-        resolved: candidate.resolved,
-        invocation: candidate.invocation,
-      });
-    }
-    return candidates;
-  }
-
-  private async resolveStandardCompressionProvider(
-    profileName: string,
-    profile: StandardProfile,
-    profileManager: NonNullable<ReturnType<Config['getProfileManager']>>,
-    config: Config | undefined,
-    parentEphemerals: Record<string, unknown> = {},
-  ): Promise<CompressionProviderResult> {
-    const provider = this.resolveExplicitCompressionProvider(
-      profileName,
-      profile.provider,
-    );
-    const profileSettings = new SettingsService();
-    await profileManager.applyLoadedProfile(
-      profileName,
-      profile,
-      profileSettings,
-    );
-    this.applyCompressionProfileParentEphemerals(
-      profileSettings,
-      profile.provider,
-      parentEphemerals,
-    );
-
-    this.applyCompressionProfileSettings(profileSettings, profileName, profile);
-
-    const runtimeId = `${this.runtimeContext.providerRuntime.runtimeId}::compression-profile:${profileName}`;
-    const metadata = {
-      ...(this.runtimeContext.providerRuntime.metadata ?? {}),
-      source: 'ChatSession.resolveCompressionProvider',
-      compressionProfile: profileName,
-      compressionProvider: profile.provider,
-      runtimeId,
-      provider: profile.provider,
-      model: profile.model,
-    };
-    const runtime: ProviderRuntimeContext = {
-      settingsService: profileSettings,
-      config,
-      runtimeId,
-      metadata,
-    };
-    const resolved = await this.buildCompressionProfileResolvedOptions(
-      profileSettings,
-      profile,
-    );
-    const invocation = createRuntimeInvocationContext({
-      runtime,
-      settings: profileSettings,
-      providerName: profile.provider,
-      ephemeralsSnapshot: this.buildCompressionProfileEphemeralsSnapshot(
-        profileSettings,
-        profile.provider,
-      ),
-      metadata,
-      fallbackRuntimeId: runtimeId,
-    });
-
-    return {
-      provider,
-      runtime,
-      config,
-      resolved,
-      invocation,
-    };
-  }
-
-  private applyCompressionProfileSettings(
-    profileSettings: SettingsService,
-    profileName: string,
-    profile: StandardProfile,
-  ): void {
-    const provider = profile.provider;
-    const ephemerals = profile.ephemeralSettings as Record<string, unknown>;
-
-    profileSettings.setCurrentProfileName(profileName);
-    profileSettings.set('activeProvider', provider);
-    profileSettings.set('model', profile.model);
-    profileSettings.setProviderSetting(provider, 'enabled', true);
-    profileSettings.setProviderSetting(provider, 'model', profile.model);
-
-    for (const [key, value] of Object.entries(ephemerals)) {
-      if (value !== undefined) {
-        profileSettings.set(key, value);
-        profileSettings.setProviderSetting(provider, key, value);
-      }
-    }
-
-    this.applyCompressionProfileAuthSettings(
-      profileSettings,
-      provider,
-      ephemerals,
-    );
-    this.applyCompressionProfileModelParams(
-      profileSettings,
-      provider,
-      profile.modelParams,
-    );
-
-    if (profile.auth) {
-      profileSettings.set('auth.type', profile.auth.type);
-      profileSettings.setProviderSetting(provider, 'auth', profile.auth);
-      if (profile.auth.buckets) {
-        profileSettings.set('auth.buckets', profile.auth.buckets);
-      }
-    }
-  }
-
-  private applyCompressionProfileAuthSettings(
-    profileSettings: SettingsService,
-    provider: string,
-    ephemerals: Record<string, unknown>,
-  ): void {
-    this.copyProfileSettingAliases(profileSettings, provider, ephemerals, [
-      { sourceKey: 'auth-key', globalKey: 'auth-key', providerKey: 'auth-key' },
-      {
-        sourceKey: 'auth-keyfile',
-        globalKey: 'auth-keyfile',
-        providerKey: 'auth-keyfile',
-      },
-      {
-        sourceKey: 'auth-key-name',
-        globalKey: 'auth-key-name',
-        providerKey: 'auth-key-name',
-      },
-    ]);
-
-    for (const key of ['base-url', 'sandbox-base-url', 'api-version']) {
-      const value = ephemerals[key];
-      if (value !== undefined) {
-        profileSettings.setProviderSetting(provider, key, value);
-      }
-    }
-  }
-
-  private copyProfileSettingAliases(
-    profileSettings: SettingsService,
-    provider: string,
-    ephemerals: Record<string, unknown>,
-    aliases: ReadonlyArray<{
-      sourceKey: string;
-      globalKey?: string;
-      providerKey: string;
-    }>,
-  ): void {
-    for (const alias of aliases) {
-      const value = ephemerals[alias.sourceKey];
-      if (value === undefined) {
-        continue;
-      }
-      if (alias.globalKey) {
-        profileSettings.set(alias.globalKey, value);
-      }
-      profileSettings.setProviderSetting(provider, alias.providerKey, value);
-    }
-  }
-
-  private applyCompressionProfileModelParams(
-    profileSettings: SettingsService,
-    provider: string,
-    modelParams: StandardProfile['modelParams'],
-  ): void {
-    for (const [key, value] of Object.entries(modelParams)) {
-      if (value !== undefined) {
-        profileSettings.setProviderSetting(provider, key, value);
-      }
-    }
-    const aliases: Record<string, unknown> = {
-      temperature: modelParams.temperature,
-      maxTokens: modelParams.max_tokens,
-      topP: modelParams.top_p,
-      topK: modelParams.top_k,
-      presencePenalty: modelParams.presence_penalty,
-      frequencyPenalty: modelParams.frequency_penalty,
-    };
-    for (const [key, value] of Object.entries(aliases)) {
-      if (value !== undefined) {
-        profileSettings.setProviderSetting(provider, key, value);
-      }
-    }
-  }
-
-  private applyCompressionProfileParentEphemerals(
-    profileSettings: SettingsService,
-    provider: string,
-    parentEphemerals: Record<string, unknown>,
-  ): void {
-    for (const [key, value] of Object.entries(parentEphemerals)) {
-      if (value !== undefined && profileSettings.get(key) === undefined) {
-        profileSettings.set(key, value);
-      }
-    }
-    for (const key of ['custom-headers', 'api-version', 'sandbox-base-url']) {
-      const value = parentEphemerals[key];
-      if (value !== undefined) {
-        profileSettings.setProviderSetting(provider, key, value);
-      }
-    }
   }
 
   private resolveProviderBaseUrl(_provider: IProvider): string | undefined {
@@ -904,9 +433,7 @@ export class ChatSession {
     metadata: Record<string, unknown> = {},
   ): ProviderRuntimeContext {
     const baseRuntime = this.runtimeContext.providerRuntime;
-    const runtimeId =
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Gemini chat runtime payloads.
-      baseRuntime.runtimeId ?? this.runtimeState.runtimeId ?? 'chatSession';
+    const runtimeId = baseRuntime.runtimeId ?? this.runtimeState.runtimeId;
 
     return {
       ...baseRuntime,
@@ -916,105 +443,6 @@ export class ChatSession {
         source,
         ...metadata,
       },
-    };
-  }
-
-  private async buildCompressionProfileResolvedOptions(
-    profileSettings: SettingsService,
-    profile: StandardProfile,
-  ): Promise<RuntimeGenerateChatOptions['resolved']> {
-    const providerSettings = profileSettings.getProviderSettings(
-      profile.provider,
-    );
-    const baseURL =
-      typeof providerSettings['base-url'] === 'string'
-        ? providerSettings['base-url']
-        : undefined;
-    const temperature =
-      typeof providerSettings.temperature === 'number'
-        ? providerSettings.temperature
-        : undefined;
-    const maxTokens =
-      typeof providerSettings.maxTokens === 'number'
-        ? providerSettings.maxTokens
-        : undefined;
-    return {
-      model: profile.model,
-      ...(baseURL ? { baseURL } : {}),
-      ...(await this.resolveCompressionProfileAuthToken(
-        profileSettings,
-        profile.provider,
-      )),
-      ...(temperature !== undefined ? { temperature } : {}),
-      ...(maxTokens !== undefined ? { maxTokens } : {}),
-    };
-  }
-
-  private async resolveCompressionProfileAuthToken(
-    profileSettings: SettingsService,
-    provider: string,
-  ): Promise<{ authToken: string } | Record<string, never>> {
-    const providerSettings = profileSettings.getProviderSettings(provider);
-    const directAuth = this.getStringSettingFromValues([
-      providerSettings['auth-key'],
-      profileSettings.get('auth-key'),
-    ]);
-    if (directAuth) {
-      return { authToken: directAuth };
-    }
-
-    const keyName = this.getStringSettingFromValues([
-      providerSettings['auth-key-name'],
-      profileSettings.get('auth-key-name'),
-    ]);
-    if (keyName) {
-      const token = await getProviderKeyStorage().getKey(keyName);
-      if (token) {
-        return { authToken: token };
-      }
-    }
-
-    const keyFile = this.getStringSettingFromValues([
-      providerSettings['auth-keyfile'],
-      profileSettings.get('auth-keyfile'),
-    ]);
-    if (keyFile) {
-      const token = (
-        await fs.readFile(this.expandProfilePath(keyFile), 'utf8')
-      ).trim();
-      if (token) {
-        return { authToken: token };
-      }
-    }
-
-    return {};
-  }
-
-  private getStringSettingFromValues(
-    values: readonly unknown[],
-  ): string | undefined {
-    for (const value of values) {
-      if (typeof value === 'string' && value.trim() !== '') {
-        return value.trim();
-      }
-    }
-    return undefined;
-  }
-
-  private expandProfilePath(value: string): string {
-    if (value.startsWith('~/')) {
-      return path.join(os.homedir(), value.slice(2));
-    }
-    return value;
-  }
-
-  private buildCompressionProfileEphemeralsSnapshot(
-    profileSettings: SettingsService,
-    provider: string,
-  ): Record<string, unknown> {
-    return {
-      ...profileSettings.getAllGlobalSettings(),
-      [provider]: { ...profileSettings.getProviderSettings(provider) },
     };
   }
 
@@ -1183,7 +611,6 @@ export class ChatSession {
    * Used by Turn and other consumers to access ephemeral settings.
    */
   getConfig(): Config | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Gemini chat runtime payloads.
-    return this.runtimeContext.providerRuntime?.config;
+    return this.runtimeContext.providerRuntime.config;
   }
 }

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -414,13 +414,13 @@ export class ChatSession {
   private async resolveCompressionProvider(
     profileName: string | undefined,
   ): Promise<CompressionProviderResult> {
-    const defaultProvider = this.resolveProviderForRuntime(
-      'ChatSession.resolveCompressionProvider.default',
-    );
     return resolveCompressionProvider(
       this.getCompressionProfileResolverContext(),
       profileName,
-      defaultProvider,
+      () =>
+        this.resolveProviderForRuntime(
+          'ChatSession.resolveCompressionProvider.default',
+        ),
     );
   }
 

--- a/packages/agents/src/core/clientHelpers.ts
+++ b/packages/agents/src/core/clientHelpers.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import { type PartListUnion, type Content } from '@google/genai';
 
 export function isThinkingSupported(model: string) {
   return !model.startsWith('gemini-2.0');
+}
+
+function getLastContent(contents: Content[]): Content | undefined {
+  return contents.length > 0 ? contents[contents.length - 1] : undefined;
 }
 
 /**
@@ -59,7 +61,7 @@ export function findCompressSplitPoint(
     cumulativeCharCount += charCounts[i];
   }
 
-  const lastContent = contents[contents.length - 1];
+  const lastContent = getLastContent(contents);
   const hasNoFunctionCall = (content: Content | undefined): boolean => {
     const parts = content?.parts;
 
@@ -67,7 +69,6 @@ export function findCompressSplitPoint(
   };
 
   if (lastSplitPoint > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider client runtime payloads.
     if (lastContent?.role === 'model' && hasNoFunctionCall(lastContent)) {
       return contents.length;
     }
@@ -83,12 +84,15 @@ export function findCompressSplitPoint(
     return lastToolCallSplitPoint;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider client runtime payloads.
   if (lastContent?.role === 'model' && hasNoFunctionCall(lastContent)) {
     return contents.length;
   }
 
   return lastSplitPoint;
+}
+
+function hasTextProperty(value: unknown): value is { text: string } {
+  return typeof value === 'object' && value !== null && 'text' in value;
 }
 
 export function extractPromptText(request: PartListUnion): string {
@@ -97,10 +101,8 @@ export function extractPromptText(request: PartListUnion): string {
     return request
       .map((part) => {
         if (typeof part === 'string') return part;
-        // Preserve defensive runtime check: part could be null at runtime despite types.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider client runtime payloads.
-        if (part !== null && typeof part === 'object' && 'text' in part) {
-          return (part as { text: string }).text;
+        if (hasTextProperty(part)) {
+          return part.text;
         }
         return '';
       })
@@ -108,9 +110,8 @@ export function extractPromptText(request: PartListUnion): string {
       .join(' ');
   }
   // Not an array, check for single object with text
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider client runtime payloads.
-  if (request !== null && typeof request === 'object' && 'text' in request) {
-    return (request as { text: string }).text;
+  if (hasTextProperty(request)) {
+    return request.text;
   }
   return '';
 }
@@ -121,14 +122,8 @@ export function estimateTextOnlyLength(request: PartListUnion): number {
   }
 
   if (!Array.isArray(request)) {
-    if (
-      typeof request === 'object' &&
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider client runtime payloads.
-      request !== null &&
-      'text' in request &&
-      request.text
-    ) {
-      return (request as { text: string }).text.length;
+    if (hasTextProperty(request) && request.text) {
+      return request.text.length;
     }
     return 0;
   }
@@ -137,13 +132,7 @@ export function estimateTextOnlyLength(request: PartListUnion): number {
   for (const part of request) {
     if (typeof part === 'string') {
       textLength += part.length;
-    } else if (
-      typeof part === 'object' &&
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Provider client runtime payloads.
-      part !== null &&
-      'text' in part &&
-      part.text
-    ) {
+    } else if (hasTextProperty(part) && part.text) {
       textLength += part.text.length;
     }
   }

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Pure request-preparation helpers extracted from StreamProcessor.
+ *
+ * These functions build the request payload, select tools, apply hook
+ * modifications, and resolve provider-runtime values. They take explicit
+ * params (no shared mutable state) so they can be unit-tested in isolation.
+ */
+
+import type {
+  Content,
+  GenerateContentResponse,
+  SendMessageParameters,
+} from '@google/genai';
+import { FinishReason, type GenerateContentConfig } from '@google/genai';
+import type { BeforeModelHookOutput } from '@vybestack/llxprt-code-core/hooks/types.js';
+import { ContentConverters } from '@vybestack/llxprt-code-core/services/history/ContentConverters.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { logApiRequest } from './turnLogging.js';
+import type { ConversationManager } from './ConversationManager.js';
+import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+
+export type ToolGroupArray = Array<{
+  functionDeclarations?: Array<{
+    name: string;
+    description?: string;
+    parametersJsonSchema?: unknown;
+  }>;
+}>;
+
+export interface ToolSelectionHookResult {
+  tools: GenerateContentConfig['tools'];
+  allowedFunctionNames: string[] | undefined;
+}
+
+/** Result of preparing a request payload with its runtime contexts. */
+export interface PreparedRequest {
+  requestPayload: { contents: IContent[]; tools: unknown };
+  baseRuntimeContext: ProviderRuntimeContext;
+}
+
+/**
+ * Build the request contents (curated IContent[]) from user input.
+ */
+export function buildRequestContents(
+  userContent: Content | Content[],
+  conversationManager: ConversationManager,
+  historyService: HistoryService,
+): IContent[] {
+  const matcher = conversationManager.makePositionMatcher();
+  if (Array.isArray(userContent)) {
+    const userIContents = userContent.map((content) => {
+      const turnKey = historyService.generateTurnKey();
+      const idGen = historyService.getIdGeneratorCallback(turnKey);
+      return ContentConverters.toIContent(content, idGen, matcher, turnKey);
+    });
+    return historyService.getCuratedForProvider(userIContents);
+  }
+  const turnKey = historyService.generateTurnKey();
+  const idGen = historyService.getIdGeneratorCallback(turnKey);
+  const userIContent = ContentConverters.toIContent(
+    userContent,
+    idGen,
+    matcher,
+    turnKey,
+  );
+  return historyService.getCuratedForProvider([userIContent]);
+}
+
+/**
+ * Select the tools for the request from params or the fallback generationConfig.
+ */
+export function selectRequestTools(
+  params: SendMessageParameters,
+  fallbackTools: GenerateContentConfig['tools'],
+): GenerateContentConfig['tools'] {
+  return params.config?.tools ?? fallbackTools;
+}
+
+/**
+ * Merge the base runtime context with request params. When the request config
+ * carries an abort signal, surface it via runtime metadata while preserving the
+ * original Config instance untouched.
+ */
+export function buildRuntimeContext(
+  baseRuntimeContext: ProviderRuntimeContext,
+  params: SendMessageParameters,
+): ProviderRuntimeContext {
+  if (!params.config?.abortSignal) return baseRuntimeContext;
+  return {
+    ...baseRuntimeContext,
+    metadata: {
+      ...(baseRuntimeContext.metadata ?? {}),
+      abortSignal: params.config.abortSignal,
+    },
+  };
+}
+
+interface PrepareRequestPayloadParams {
+  requestContents: IContent[];
+  tools: GenerateContentConfig['tools'];
+  logger: DebugLogger;
+  providerRuntimeBuilder: (
+    source: string,
+    extras?: Record<string, unknown>,
+  ) => ProviderRuntimeContext;
+  providerName: string;
+  modelName: string;
+  baseUrl: string | undefined;
+}
+
+/**
+ * Prepare the request payload (contents + tools) and the base provider runtime
+ * context. The request-specific runtime context (e.g. abort-signal metadata) is
+ * layered on by the caller via buildRuntimeContext.
+ */
+export function prepareRequestPayload(
+  args: PrepareRequestPayloadParams,
+): PreparedRequest {
+  args.logger.debug(
+    () => '[StreamProcessor] Calling provider.generateChatCompletion',
+    {
+      providerName: args.providerName,
+      model: args.modelName,
+      historyLength: args.requestContents.length,
+      toolCount: args.tools?.length ?? 0,
+      baseUrl: args.baseUrl,
+    },
+  );
+
+  const baseRuntimeContext = args.providerRuntimeBuilder(
+    'StreamProcessor.generateRequest',
+    { historyLength: args.requestContents.length },
+  );
+
+  const requestPayload = { contents: args.requestContents, tools: args.tools };
+
+  return { requestPayload, baseRuntimeContext };
+}
+
+/**
+ * Patch a synthetic response that is missing a finishReason.
+ */
+export function patchMissingFinishReason(
+  syntheticResponse: GenerateContentResponse,
+  candidate: NonNullable<GenerateContentResponse['candidates']>[0],
+): GenerateContentResponse {
+  return {
+    ...syntheticResponse,
+    candidates: [{ ...candidate, finishReason: FinishReason.STOP }],
+  } as GenerateContentResponse;
+}
+
+/**
+ * Apply LLM request modifications from a BeforeModel hook result.
+ */
+export function applyRequestModifications(
+  beforeModelResult: BeforeModelHookOutput | undefined,
+  requestContents: IContent[],
+  model: string,
+): IContent[] {
+  if (!beforeModelResult) return requestContents;
+
+  const modifiedRequest = beforeModelResult.applyLLMRequestModifications({
+    model: model || '',
+    contents: ContentConverters.toGeminiContents(requestContents),
+  });
+  const modifiedContents = (modifiedRequest as { contents?: Content[] | null })
+    .contents;
+  if (modifiedContents !== undefined && modifiedContents !== null) {
+    return ContentConverters.toIContents(modifiedContents);
+  }
+  return requestContents;
+}
+
+/**
+ * Resolve the user-memory string from the provider runtime config.
+ *
+ * `Config.getUserMemory()` is declared as a required method, but tests may
+ * mock Config without it, so boundary-validate `typeof === 'function'`.
+ */
+export function resolveUserMemory(
+  config: Config | undefined,
+): string | undefined {
+  if (config && typeof config.getUserMemory === 'function') {
+    return config.getUserMemory();
+  }
+  return undefined;
+}
+
+/**
+ * Log the outgoing API request via the telemetry runtime context.
+ */
+export function logOutgoingRequest(
+  runtimeContext: AgentRuntimeContext,
+  requestPayload: { contents: IContent[] },
+  modelName: string,
+  promptId: string,
+): void {
+  logApiRequest(
+    runtimeContext,
+    runtimeContext.state,
+    ContentConverters.toGeminiContents(requestPayload.contents),
+    modelName,
+    promptId,
+  );
+}

--- a/packages/agents/src/core/streamResponseHelpers.ts
+++ b/packages/agents/src/core/streamResponseHelpers.ts
@@ -1,0 +1,372 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Pure response-processing helpers extracted from StreamProcessor.
+ *
+ * These functions accumulate streamed chunk metadata, consolidate text parts,
+ * validate stream completion, and record history with usage metadata. They
+ * take explicit params (no shared mutable state) so they can be unit-tested
+ * in isolation.
+ */
+
+import type { Content, GenerateContentResponse, Part } from '@google/genai';
+import { FinishReason } from '@google/genai';
+import type {
+  IContent,
+  UsageStats,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { CompressionHandler } from '../compression/CompressionHandler.js';
+import type { ConversationManager } from './ConversationManager.js';
+import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import {
+  isValidResponse,
+  isValidNonThoughtTextPart,
+} from './MessageConverter.js';
+import {
+  filterHookRestrictedParts,
+  getHookRestrictedFunctionCallsFromParts,
+  filterHookRestrictedFunctionCalls,
+  mergeHookRestrictedFunctionCalls,
+  getHookRestrictedAllowedTools,
+} from './hookToolRestrictions.js';
+import { analyzeResponseOutcome } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
+import type { ResponseOutcome } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
+import { isFunctionResponse } from '@vybestack/llxprt-code-core/utils/messageInspectors.js';
+import {
+  InvalidStreamError,
+  isThoughtPart,
+  type UsageMetadataWithCache,
+} from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+
+/** Whether a finish reason is missing (null, undefined, or empty string). */
+export function isMissingFinishReason(
+  finishReason: FinishReason | null | undefined | '',
+): boolean {
+  return finishReason == null || finishReason === '';
+}
+
+/** Accumulator used while streaming chunks into a complete turn. */
+export interface StreamAccumulator {
+  modelResponseParts: Part[];
+  outcome: ResponseOutcome;
+  finishReason: FinishReason | undefined;
+  allChunks: GenerateContentResponse[];
+}
+
+/** Create a fresh stream accumulator. */
+export function createStreamAccumulator(): StreamAccumulator {
+  return {
+    modelResponseParts: [],
+    outcome: {
+      hasVisibleText: false,
+      hasThinking: false,
+      hasToolCalls: false,
+      isActionable: false,
+    },
+    finishReason: undefined,
+    allChunks: [],
+  };
+}
+
+/**
+ * Track prompt tokens from an IContent chunk's usage metadata.
+ */
+export function trackPromptTokens(
+  iContent: IContent,
+  compressionHandler: CompressionHandler,
+  logger: DebugLogger,
+): void {
+  const promptTokens = iContent.metadata?.usage?.promptTokens;
+  if (promptTokens === undefined) return;
+
+  const cacheReads = iContent.metadata?.usage?.cache_read_input_tokens ?? 0;
+  const cacheWrites =
+    iContent.metadata?.usage?.cache_creation_input_tokens ?? 0;
+  const combinedPromptTokens = promptTokens + cacheReads + cacheWrites;
+  logger.debug(
+    () =>
+      `[StreamProcessor] Tracking promptTokens from IContent: ${combinedPromptTokens}`,
+  );
+  compressionHandler.lastPromptTokenCount = combinedPromptTokens;
+}
+
+/**
+ * Accumulate metadata from a single streamed chunk into the accumulator.
+ */
+export function accumulateChunkMetadata(
+  chunk: GenerateContentResponse,
+  acc: StreamAccumulator,
+  includeThoughts: boolean,
+  logger: DebugLogger,
+  compressionHandler: CompressionHandler,
+): void {
+  const candidateWithReason = chunk.candidates?.find(
+    (c) => c.finishReason !== undefined,
+  );
+  if (candidateWithReason !== undefined)
+    acc.finishReason = candidateWithReason.finishReason as FinishReason;
+
+  const allowedTools = getHookRestrictedAllowedTools(chunk);
+  const parts = chunk.candidates?.[0]?.content?.parts ?? [];
+  const effectiveParts = isValidResponse(chunk)
+    ? filterHookRestrictedParts(parts, allowedTools)
+    : [];
+  const allowedPartCalls = getHookRestrictedFunctionCallsFromParts(
+    effectiveParts,
+    allowedTools,
+  );
+  const allowedMergedCalls = mergeHookRestrictedFunctionCalls(
+    allowedPartCalls,
+    filterHookRestrictedFunctionCalls(chunk.functionCalls ?? [], allowedTools),
+  );
+  const allowedTopLevelCallParts = allowedMergedCalls
+    .slice(allowedPartCalls.length)
+    .map((functionCall) => ({ functionCall }));
+  const outcomeParts = [...effectiveParts, ...allowedTopLevelCallParts];
+
+  if (outcomeParts.length > 0) {
+    const chunkOutcome = analyzeResponseOutcome(outcomeParts);
+    acc.outcome = {
+      hasVisibleText: acc.outcome.hasVisibleText || chunkOutcome.hasVisibleText,
+      hasThinking: acc.outcome.hasThinking || chunkOutcome.hasThinking,
+      hasToolCalls: acc.outcome.hasToolCalls || chunkOutcome.hasToolCalls,
+      isActionable: acc.outcome.isActionable || chunkOutcome.isActionable,
+    };
+    acc.modelResponseParts.push(
+      ...(includeThoughts
+        ? outcomeParts
+        : outcomeParts.filter((p) => !isThoughtPart(p))),
+    );
+  }
+
+  const chunkText = typeof chunk.text === 'string' ? chunk.text : '';
+  logger.debug(() => `[stream:terminal] observed converted chunk`, {
+    chunkFinishReason: candidateWithReason?.finishReason,
+    partCount: effectiveParts.length,
+    toolCallCount: allowedMergedCalls.length,
+    textLength: chunkText.length,
+    hasUsageMetadata: Boolean(chunk.usageMetadata),
+  });
+
+  if (chunk.usageMetadata?.promptTokenCount !== undefined) {
+    const chunkUsage = chunk.usageMetadata as UsageMetadataWithCache;
+    compressionHandler.lastPromptTokenCount =
+      chunk.usageMetadata.promptTokenCount +
+      (chunkUsage.cache_read_input_tokens ?? 0) +
+      (chunkUsage.cache_creation_input_tokens ?? 0);
+  }
+  acc.allChunks.push(chunk);
+}
+
+/**
+ * Consolidate adjacent text parts.
+ *
+ * The array index access can return `undefined` at runtime when the array
+ * is empty (length-1 == -1), so `lastPart` is annotated `Part | undefined`.
+ */
+export function consolidateTextParts(modelResponseParts: Part[]): Part[] {
+  const consolidatedParts: Part[] = [];
+  for (const part of modelResponseParts) {
+    const lastPart = consolidatedParts[consolidatedParts.length - 1] as
+      | Part
+      | undefined;
+    if (
+      lastPart?.text !== undefined &&
+      isValidNonThoughtTextPart(lastPart) &&
+      isValidNonThoughtTextPart(part)
+    ) {
+      lastPart.text += part.text;
+    } else {
+      consolidatedParts.push(part);
+    }
+  }
+  return consolidatedParts;
+}
+
+/**
+ * Extract response text from consolidated parts.
+ */
+export function extractResponseText(consolidatedParts: Part[]): string {
+  return consolidatedParts
+    .filter((part) => isValidNonThoughtTextPart(part))
+    .map((part) => part.text)
+    .join('')
+    .trim();
+}
+
+/**
+ * Throw the appropriate error for a missing/empty stream response.
+ */
+export function throwMissingResponseError(
+  finishReason: FinishReason | undefined,
+  hasTextResponse: boolean,
+  validationContext: Record<string, unknown>,
+  logger: DebugLogger,
+): void {
+  if (isMissingFinishReason(finishReason) && !hasTextResponse) {
+    logger.warn(
+      () =>
+        `[stream:terminal] validation failed: missing finishReason and text`,
+      validationContext,
+    );
+    throw new InvalidStreamError(
+      'Model stream ended without a finish reason and no text response.',
+      'NO_FINISH_REASON_NO_TEXT',
+    );
+  }
+  logger.warn(
+    () => `[stream:terminal] validation failed: empty response text`,
+    validationContext,
+  );
+  throw new InvalidStreamError(
+    'Model stream ended with empty response text.',
+    'NO_RESPONSE_TEXT',
+  );
+}
+
+/**
+ * Validate stream completion and throw appropriate errors.
+ */
+export function validateStreamCompletion(
+  userInput: Content | Content[],
+  outcome: ResponseOutcome,
+  finishReason: FinishReason | undefined,
+  responseText: string,
+  logger: DebugLogger,
+): void {
+  const isToolContinuationInput = Array.isArray(userInput)
+    ? userInput.some(isFunctionResponse)
+    : isFunctionResponse(userInput);
+
+  const validationContext = {
+    hasToolCall: outcome.hasToolCalls,
+    hasTextResponse: outcome.hasVisibleText,
+    hasThinkingResponse: outcome.hasThinking,
+    finishReason,
+    responseTextLength: responseText.length,
+    isToolContinuationInput,
+  };
+
+  logger.debug(
+    () => `[stream:terminal] validating converted stream completion`,
+    validationContext,
+  );
+
+  const hasMissingFinishAndNoText =
+    isMissingFinishReason(finishReason) && !outcome.hasVisibleText;
+  const isEmptyResponse = responseText === '';
+  const noRelevantContent =
+    !outcome.hasToolCalls && !isToolContinuationInput && !outcome.hasThinking;
+  const isInvalidResponse =
+    noRelevantContent && (hasMissingFinishAndNoText || isEmptyResponse);
+
+  if (isInvalidResponse) {
+    throwMissingResponseError(
+      finishReason,
+      outcome.hasVisibleText,
+      validationContext,
+      logger,
+    );
+  }
+
+  if (finishReason === FinishReason.MALFORMED_FUNCTION_CALL) {
+    logger.warn(
+      () =>
+        `[stream:terminal] validation failed: malformed function call finishReason`,
+      validationContext,
+    );
+    throw new InvalidStreamError(
+      'Model stream ended with malformed function call.',
+      'MALFORMED_FUNCTION_CALL',
+    );
+  }
+}
+
+interface RecordHistoryParams {
+  userInput: Content | Content[];
+  consolidatedParts: Part[];
+  allChunks: GenerateContentResponse[];
+  conversationManager: ConversationManager;
+  historyService: HistoryService;
+  compressionHandler: CompressionHandler;
+  logger: DebugLogger;
+}
+
+/**
+ * Record history with usage metadata and sync token counts.
+ *
+ * `actualPromptTokens` is typed `number | null` (never `undefined`), so only
+ * the null check is needed — the `!== undefined` comparison was a dead check.
+ */
+export async function recordHistoryWithUsage(
+  args: RecordHistoryParams,
+): Promise<void> {
+  const modelOutput: Content[] = [
+    { role: 'model', parts: args.consolidatedParts },
+  ];
+
+  let streamingUsageMetadata: UsageStats | null = null;
+  let actualPromptTokens: number | null = null;
+  const lastChunkWithMetadata = args.allChunks
+    .slice()
+    .reverse()
+    .find((chunk) => chunk.usageMetadata);
+  if (lastChunkWithMetadata?.usageMetadata) {
+    streamingUsageMetadata = {
+      promptTokens: lastChunkWithMetadata.usageMetadata.promptTokenCount ?? 0,
+      completionTokens:
+        lastChunkWithMetadata.usageMetadata.candidatesTokenCount ?? 0,
+      totalTokens: lastChunkWithMetadata.usageMetadata.totalTokenCount ?? 0,
+    };
+    const usageMetadata =
+      lastChunkWithMetadata.usageMetadata as UsageMetadataWithCache;
+    const cacheReads = usageMetadata.cache_read_input_tokens ?? 0;
+    const cacheWrites = usageMetadata.cache_creation_input_tokens ?? 0;
+    actualPromptTokens =
+      streamingUsageMetadata.promptTokens + cacheReads + cacheWrites;
+  }
+
+  args.conversationManager.recordHistory(
+    args.userInput,
+    modelOutput,
+    undefined,
+    streamingUsageMetadata,
+  );
+
+  await args.historyService.waitForTokenUpdates();
+
+  if (actualPromptTokens !== null) {
+    if (actualPromptTokens > 0) {
+      args.logger.debug(
+        () =>
+          `[StreamProcessor] Syncing prompt token count to HistoryService: ${actualPromptTokens}`,
+      );
+      args.historyService.syncTotalTokens(actualPromptTokens);
+      await args.historyService.waitForTokenUpdates();
+    }
+    return;
+  }
+
+  const fallbackTokens = args.compressionHandler.lastPromptTokenCount;
+  if (fallbackTokens !== null) {
+    if (fallbackTokens > 0) {
+      args.logger.debug(
+        () =>
+          `[StreamProcessor] Syncing prompt token count to HistoryService: ${fallbackTokens}`,
+      );
+      args.historyService.syncTotalTokens(fallbackTokens);
+      await args.historyService.waitForTokenUpdates();
+    }
+    return;
+  }
+
+  args.logger.debug(
+    () =>
+      `[StreamProcessor] No token count to sync (lastPromptTokenCount: ${fallbackTokens})`,
+  );
+}

--- a/packages/agents/src/core/subagent.ts
+++ b/packages/agents/src/core/subagent.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity, max-lines -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 /**
  * @plan PLAN-20251028-STATELESS6.P08
  * @requirement REQ-STAT6-001.1, REQ-STAT6-003.1
@@ -16,32 +14,13 @@ import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { type ToolCallRequestInfo, GeminiEventType, Turn } from './turn.js';
 import { type ToolExecutionConfig } from './nonInteractiveToolExecutor.js';
 import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
-import {
-  nextStreamEventWithIdleTimeout,
-  resolveStreamIdleTimeoutMs,
-} from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
-import {
-  type Content,
-  type Part,
-  type FunctionCall,
-  type FunctionDeclaration,
-} from '@google/genai';
+import { type Content, type Part } from '@google/genai';
 
-import {
-  StreamEventType,
-  type StreamEvent,
-  type ChatSession,
-} from './chatSession.js';
-import {
-  filterHookRestrictedParts,
-  filterHookRestrictedFunctionCalls,
-  getHookRestrictedAllowedTools,
-  getHookRestrictedFunctionCallsFromParts,
-  isHookRestrictedToolCall,
-  mergeHookRestrictedFunctionCalls,
-} from './hookToolRestrictions.js';
+import { type ChatSession } from './chatSession.js';
+import { isHookRestrictedToolCall } from './hookToolRestrictions.js';
 import type {
   AgentRuntimeContext,
+  ToolRegistryView,
   ReadonlySettingsSnapshot,
 } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import { GemmaToolCallParser } from '@vybestack/llxprt-code-core/parsers/TextToolCallParser.js';
@@ -61,23 +40,21 @@ import {
 import {
   isFatalToolError,
   buildToolUnavailableMessage,
-  resolveToolName,
   finalizeOutput,
   handleEmitValueCall,
   buildPartsFromCompletedCalls,
-  processFunctionCalls,
   buildTodoCompletionPrompt,
 } from './subagentToolProcessing.js';
 import {
   checkTerminationConditions,
   filterTextWithEmoji,
   checkGoalCompletion,
-  processNonInteractiveTextResponse,
   processInteractiveTextResponse,
   handleExecutionError,
   initInteractiveScheduler,
   type ExecutionLoopContext,
 } from './subagentExecution.js';
+import { executeNonInteractiveRun } from './subagentNonInteractive.js';
 
 // --- Internal imports from subagentTypes.ts (used within this file) ---
 import type { ContextState } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
@@ -97,6 +74,56 @@ import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentG
 
 // Types, interfaces, enums, and ContextState are now in subagentTypes.ts
 // Runtime setup helpers are now in subagentRuntimeSetup.ts
+
+/**
+ * Resolve the provider name, defaulting to 'backend' when the persisted
+ * runtime state carries a nullish provider (the declared type lies for
+ * deserialized configs). Mirrors the original `provider ?? 'backend'`
+ * nullish fallback exactly: a defined value (including '') passes through.
+ */
+function providerNameOrDefault(provider: string | null | undefined): string {
+  if (provider === null || provider === undefined) {
+    return 'backend';
+  }
+  return provider;
+}
+
+/**
+ * Process a single interactive stream event, accumulating text and
+ * dispatching emoji-filtered messages. Throws when content is blocked
+ * or when the provider signals an error.
+ *
+ * Extracted from runInteractiveTurn to keep nesting within limits.
+ */
+function processInteractiveStreamEvent(
+  event: { type: GeminiEventType; value?: unknown },
+  execCtx: ExecutionLoopContext,
+): string {
+  if (
+    event.type === GeminiEventType.Content &&
+    typeof event.value === 'string'
+  ) {
+    const value = event.value;
+    const filtered = filterTextWithEmoji(value, execCtx);
+    if (filtered.blocked) {
+      execCtx.output.terminate_reason = SubagentTerminateMode.ERROR;
+      throw new Error(filtered.error ?? 'Content blocked by emoji filter');
+    }
+    if (execCtx.onMessage && filtered.text) {
+      execCtx.onMessage(filtered.text);
+    }
+    return value;
+  }
+  if (event.type === GeminiEventType.Error) {
+    const eventError = (event.value as { error?: Error | null } | undefined)
+      ?.error;
+    if (eventError != null) {
+      execCtx.output.terminate_reason = SubagentTerminateMode.ERROR;
+      throw new Error(eventError.message);
+    }
+  }
+  return '';
+}
 
 /**
  * Represents the scope and execution environment for a subagent.
@@ -185,15 +212,22 @@ export class SubAgentScope {
       );
     }
 
-    const toolsView =
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Persisted subagent config and runtime tool payloads.
-      runtimeBundle.runtimeContext.tools ?? runtimeBundle.toolsView;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Persisted subagent config and runtime tool payloads.
-    if (toolsView == null) {
+    // Persisted subagent config may omit tools/toolsView despite the
+    // declared-required type; validate at the boundary.
+    const contextTools = runtimeBundle.runtimeContext.tools as
+      | ToolRegistryView
+      | undefined;
+    const bundleToolsView = runtimeBundle.toolsView as
+      | ToolRegistryView
+      | undefined;
+    const toolsCandidate: ToolRegistryView | undefined =
+      contextTools ?? bundleToolsView;
+    if (toolsCandidate == null) {
       throw new Error(
         'SubAgentScope.create requires a ToolRegistryView from the runtime bundle.',
       );
     }
+    const toolsView = toolsCandidate;
 
     const toolRegistry = overrides.toolRegistry ?? runtimeBundle.toolRegistry;
     if (!toolRegistry) {
@@ -390,46 +424,26 @@ export class SubAgentScope {
         await this.initScheduler(options);
       schedulerDispose = disposeScheduler;
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/too-many-break-or-continue-in-loop -- Persisted subagent config and runtime tool payloads.
-      while (true) {
-        const check = checkTerminationConditions(
-          turnCounter,
-          startTime,
-          execCtx,
-        );
-        if (check.shouldStop) break;
-
-        const { responseParts, textResponse, currentTurn } =
-          await this.runInteractiveTurn(
-            chat,
-            currentMessages,
-            abortController,
-            turnCounter++,
-            execCtx,
-          );
-        if (abortController.signal.aborted === true) return;
-
-        processInteractiveTextResponse(textResponse, execCtx);
-
-        const toolMessages = await this.handleInteractiveToolCalls(
-          responseParts,
-          scheduler,
+      let keepRunning = true;
+      while (keepRunning) {
+        const iteration = await this.runInteractiveLoopIteration(
+          chat,
+          currentMessages,
           abortController,
-          execCtx,
-        );
-        if (toolMessages) {
-          currentMessages = toolMessages;
-          continue;
-        }
-
-        const nextMessages = await this.runInteractiveGoalCheckLoop(
-          execCtx,
-          startTime,
           turnCounter,
-          currentTurn,
+          startTime,
+          execCtx,
+          scheduler,
         );
-        if (!nextMessages) break;
-        currentMessages = nextMessages;
+        if (iteration.action === 'abort') {
+          return;
+        }
+        if (iteration.action === 'stop') {
+          keepRunning = false;
+        } else {
+          currentMessages = iteration.messages;
+          turnCounter = iteration.turnCounter;
+        }
       }
       finalizeOutput(this.output);
     } catch (error) {
@@ -441,6 +455,76 @@ export class SubAgentScope {
     } finally {
       await this.cleanupInteractive(schedulerDispose, abortController);
     }
+  }
+
+  /**
+   * Discriminated result for a single interactive loop iteration.
+   * Extracting the loop body keeps the caller loop to a single control
+   * branch (no break/continue) and avoids the always-truthy while(true).
+   */
+  private async runInteractiveLoopIteration(
+    chat: ChatSession,
+    currentMessages: Content[],
+    abortController: AbortController,
+    turnCounter: number,
+    startTime: number,
+    execCtx: ExecutionLoopContext,
+    scheduler: {
+      schedule: (
+        req: ToolCallRequestInfo | ToolCallRequestInfo[],
+        signal: AbortSignal,
+      ) => Promise<void> | void;
+      awaitCompletedCalls: (
+        signal?: AbortSignal,
+      ) => Promise<CompletedToolCall[]>;
+    },
+  ): Promise<
+    | { action: 'stop' }
+    | { action: 'abort' }
+    | { action: 'continue'; messages: Content[]; turnCounter: number }
+  > {
+    const check = checkTerminationConditions(turnCounter, startTime, execCtx);
+    if (check.shouldStop) return { action: 'stop' };
+
+    const nextTurnCounter = turnCounter + 1;
+    const { responseParts, textResponse, currentTurn } =
+      await this.runInteractiveTurn(
+        chat,
+        currentMessages,
+        abortController,
+        turnCounter,
+        execCtx,
+      );
+    if (abortController.signal.aborted === true) return { action: 'abort' };
+
+    processInteractiveTextResponse(textResponse, execCtx);
+
+    const toolMessages = await this.handleInteractiveToolCalls(
+      responseParts,
+      scheduler,
+      abortController,
+      execCtx,
+    );
+    if (toolMessages) {
+      return {
+        action: 'continue',
+        messages: toolMessages,
+        turnCounter: nextTurnCounter,
+      };
+    }
+
+    const nextMessages = await this.runInteractiveGoalCheckLoop(
+      execCtx,
+      startTime,
+      nextTurnCounter,
+      currentTurn,
+    );
+    if (!nextMessages) return { action: 'stop' };
+    return {
+      action: 'continue',
+      messages: nextMessages,
+      turnCounter: nextTurnCounter,
+    };
   }
 
   private async initScheduler(
@@ -468,8 +552,13 @@ export class SubAgentScope {
   ) {
     const currentTurn = turnIndex;
     const promptId = `${this.runtimeContext.state.sessionId}#${this.subagentId}#${currentTurn}`;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Persisted subagent config and runtime tool payloads.
-    const providerName = this.runtimeContext.state.provider ?? 'backend';
+    // Persisted subagent runtime state may carry a nullish provider
+    // despite the declared-required type; validate at the boundary.
+    const providerRaw = this.runtimeContext.state.provider as
+      | string
+      | null
+      | undefined;
+    const providerName = providerNameOrDefault(providerRaw);
     const turn = new Turn(chat, promptId, this.subagentId, providerName);
     const parts = currentMessages[0]?.parts ?? [];
 
@@ -478,30 +567,8 @@ export class SubAgentScope {
       const stream = turn.run(parts, abortController.signal);
       for await (const event of stream) {
         if (abortController.signal.aborted === true) break;
-        if (event.type === GeminiEventType.Content && event.value) {
-          textResponse += event.value;
-          const filtered = filterTextWithEmoji(event.value, execCtx);
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (filtered.blocked) {
-            execCtx.output.terminate_reason = SubagentTerminateMode.ERROR;
-            throw new Error(
-              filtered.error ?? 'Content blocked by emoji filter',
-            );
-          }
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (execCtx.onMessage && filtered.text) {
-            execCtx.onMessage(filtered.text);
-          }
-        } else if (event.type === GeminiEventType.Error) {
-          const eventError = (
-            event.value as { error?: Error | null } | undefined
-          )?.error;
-          // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          if (eventError != null) {
-            execCtx.output.terminate_reason = SubagentTerminateMode.ERROR;
-            throw new Error(eventError.message);
-          }
-        }
+        const eventText = processInteractiveStreamEvent(event, execCtx);
+        textResponse += eventText;
       }
     } catch (error) {
       if (abortController.signal.aborted === true) {
@@ -657,291 +724,35 @@ export class SubAgentScope {
       return `Subagent ${this.subagentId} (${this.name}) starting run with toolCount=${toolsList.length} requestedOutputs=${outputs} runConfig=${JSON.stringify(this.runConfig)}`;
     });
     const execCtx = this.buildExecCtx();
-    let currentMessages: Content[] = this.buildInitialMessages(context);
+    const initialMessages = this.buildInitialMessages(context);
     const startTime = Date.now();
-    let turnCounter = 0;
 
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/too-many-break-or-continue-in-loop -- Persisted subagent config and runtime tool payloads.
-      while (true) {
-        const check = checkTerminationConditions(
-          turnCounter,
-          startTime,
-          execCtx,
-        );
-        if (check.shouldStop) break;
-
-        const currentTurn = turnCounter++;
-        const promptId = `${this.runtimeContext.state.sessionId}#${this.subagentId}#${currentTurn}`;
-        this.logger.debug(
-          () =>
-            `Subagent ${this.subagentId} turn=${currentTurn} promptId=${promptId}`,
-        );
-
-        const { functionCalls } = await this.runNonInteractiveTurn(
-          chat,
-          currentMessages,
-          toolsList,
-          abortController,
-          currentTurn,
-          execCtx,
-        );
-        if (abortController.signal.aborted === true) return;
-
-        // Post-send timeout recheck
-        const recheck = checkTerminationConditions(
-          turnCounter,
-          startTime,
-          execCtx,
-        );
-        if (recheck.shouldStop) break;
-
-        const nextMessages = await this.dispatchNonInteractiveTurnResult(
-          functionCalls,
-          abortController,
-          promptId,
-          currentTurn,
-          execCtx,
-        );
-        if (!nextMessages) break;
-        currentMessages = nextMessages;
-      }
-      finalizeOutput(this.output);
-    } catch (error) {
-      if (this.output.terminate_reason !== SubagentTerminateMode.TIMEOUT) {
-        handleExecutionError(error, execCtx);
-      }
-      finalizeOutput(this.output);
-      throw error;
-    } finally {
-      this.clearTimeoutHandle();
-      this.parentAbortCleanup?.();
-      this.parentAbortCleanup = undefined;
-      this.activeAbortController = null;
-    }
-  }
-
-  private async runNonInteractiveTurn(
-    chat: ChatSession,
-    currentMessages: Content[],
-    toolsList: FunctionDeclaration[],
-    abortController: AbortController,
-    currentTurn: number,
-    execCtx: ExecutionLoopContext,
-  ) {
-    const messageParams = {
-      message: currentMessages[0]?.parts ?? [],
-      config: {
-        abortSignal: abortController.signal,
-        tools: [{ functionDeclarations: toolsList }],
-      },
-    };
-
-    const responseStream = await chat.sendMessageStream(
-      messageParams,
-      `${this.runtimeContext.state.sessionId}#${this.subagentId}#${currentTurn}`,
-    );
-
-    const {
-      functionCalls: rawCalls,
-      textResponse,
-      parseableTextResponse,
-      hookRestrictedAllowedTools,
-    } = await this.consumeNonInteractiveStream(
-      responseStream,
+    await executeNonInteractiveRun(
+      chat,
+      toolsList,
       abortController,
-      currentTurn,
-    );
-    if (abortController.signal.aborted === true) {
-      return { functionCalls: [], textResponse: '' };
-    }
-
-    let functionCalls = rawCalls;
-    if (parseableTextResponse) {
-      const result = processNonInteractiveTextResponse(
-        parseableTextResponse,
-        functionCalls,
-        execCtx,
-        resolveToolName,
-        hookRestrictedAllowedTools,
-      );
-      functionCalls = result.functionCalls;
-    }
-
-    return { functionCalls, textResponse };
-  }
-
-  private async consumeNonInteractiveStream(
-    responseStream: AsyncIterable<StreamEvent>,
-    abortController: AbortController,
-    currentTurn: number,
-  ): Promise<{
-    functionCalls: FunctionCall[];
-    textResponse: string;
-    parseableTextResponse: string;
-    hookRestrictedAllowedTools: string[] | undefined;
-  }> {
-    const timeoutController = new AbortController();
-    const timeoutSignal = timeoutController.signal;
-    const onAbort = () => timeoutController.abort();
-    abortController.signal.addEventListener('abort', onAbort, { once: true });
-    if (abortController.signal.aborted === true) {
-      onAbort();
-      abortController.signal.removeEventListener('abort', onAbort);
-      return {
-        functionCalls: [],
-        textResponse: '',
-        parseableTextResponse: '',
-        hookRestrictedAllowedTools: undefined,
-      };
-    }
-
-    const functionCalls: FunctionCall[] = [];
-    let textResponse = '';
-    let parseableTextResponse = '';
-    let hookRestrictedAllowedTools: string[] | undefined;
-    const iterator = responseStream[Symbol.asyncIterator]();
-    const effectiveTimeoutMs = resolveStreamIdleTimeoutMs(this.config);
-
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Persisted subagent config and runtime tool payloads.
-      while (true) {
-        const result = await this.readNextNonInteractiveEvent(
-          iterator,
-          abortController,
-          timeoutController,
-          timeoutSignal,
-          effectiveTimeoutMs,
-        );
-        if (result.done === true) {
-          break;
-        }
-        const resp = result.value;
-        const isRuntimeAborted = Boolean(abortController.signal.aborted);
-        if (isRuntimeAborted) {
-          return {
-            functionCalls: [],
-            textResponse: '',
-            parseableTextResponse: '',
-            hookRestrictedAllowedTools,
-          };
-        }
-        if (resp.type === StreamEventType.CHUNK) {
-          const chunkResult = this.collectNonInteractiveChunk(
-            resp,
-            functionCalls,
-            currentTurn,
-          );
-          hookRestrictedAllowedTools =
-            chunkResult.hookRestrictedAllowedTools ??
-            hookRestrictedAllowedTools;
-          textResponse += chunkResult.text;
-          parseableTextResponse += chunkResult.text;
-        }
-      }
-    } finally {
-      iterator.return?.(undefined).catch(() => {});
-      timeoutController.abort();
-      abortController.signal.removeEventListener('abort', onAbort);
-    }
-
-    return {
-      functionCalls,
-      textResponse,
-      parseableTextResponse,
-      hookRestrictedAllowedTools,
-    };
-  }
-
-  private async readNextNonInteractiveEvent(
-    iterator: AsyncIterator<StreamEvent, unknown>,
-    abortController: AbortController,
-    timeoutController: AbortController,
-    timeoutSignal: AbortSignal,
-    effectiveTimeoutMs: number,
-  ): Promise<IteratorResult<StreamEvent, unknown>> {
-    if (effectiveTimeoutMs > 0) {
-      return nextStreamEventWithIdleTimeout({
-        iterator,
-        timeoutMs: effectiveTimeoutMs,
-        signal: timeoutSignal,
-        onTimeout: () => {
-          if (abortController.signal.aborted === true) {
-            return;
-          }
-          this.output.terminate_reason = SubagentTerminateMode.TIMEOUT;
-          timeoutController.abort();
-          abortController.abort(createAbortError());
-        },
-        createTimeoutError: () => createAbortError(),
-      });
-    }
-    return iterator.next();
-  }
-
-  private collectNonInteractiveChunk(
-    resp: StreamEvent & { type: StreamEventType.CHUNK },
-    functionCalls: FunctionCall[],
-    currentTurn: number,
-  ): { text: string; hookRestrictedAllowedTools: string[] | undefined } {
-    const allowedTools = getHookRestrictedAllowedTools(resp.value);
-    const parts = resp.value.candidates?.[0]?.content?.parts ?? [];
-    const partCalls = getHookRestrictedFunctionCallsFromParts(
-      parts,
-      allowedTools,
-    );
-    const topLevelCalls = filterHookRestrictedFunctionCalls(
-      resp.value.functionCalls ?? [],
-      allowedTools,
-    );
-    const chunkCalls = mergeHookRestrictedFunctionCalls(
-      partCalls,
-      topLevelCalls,
-    );
-    if (chunkCalls.length > 0) {
-      functionCalls.push(...chunkCalls);
-      this.logger.debug(
-        () =>
-          `Subagent ${this.subagentId} received ${chunkCalls.length} function calls on turn ${currentTurn}`,
-      );
-    }
-    if (allowedTools === undefined) {
-      return {
-        text: resp.value.text ?? '',
-        hookRestrictedAllowedTools: undefined,
-      };
-    }
-    const filteredParts = filterHookRestrictedParts(parts, allowedTools);
-    const filteredText = filteredParts
-      .map((part) => part.text)
-      .filter((text): text is string => typeof text === 'string')
-      .join('');
-    return { text: filteredText, hookRestrictedAllowedTools: allowedTools };
-  }
-
-  private async dispatchNonInteractiveTurnResult(
-    functionCalls: FunctionCall[],
-    abortController: AbortController,
-    promptId: string,
-    currentTurn: number,
-    execCtx: ExecutionLoopContext,
-  ): Promise<Content[] | null> {
-    if (functionCalls.length > 0) {
-      return processFunctionCalls(functionCalls, abortController, promptId, {
+      initialMessages,
+      startTime,
+      execCtx,
+      {
         output: this.output,
         subagentId: this.subagentId,
+        name: this.name,
+        runtimeContext: this.runtimeContext,
         logger: this.logger,
-        toolExecutorContext: this.toolExecutorContext,
         config: this.config,
+        runConfig: this.runConfig,
+        outputConfig: this.outputConfig,
+        toolExecutorContext: this.toolExecutorContext,
         messageBus: this.messageBus,
-      });
-    }
-    const todoReminder = await buildTodoCompletionPrompt(
-      this.runtimeContext,
-      this.subagentId,
-      this.logger,
+      },
+      () => {
+        this.clearTimeoutHandle();
+        this.parentAbortCleanup?.();
+        this.parentAbortCleanup = undefined;
+        this.activeAbortController = null;
+      },
     );
-    return checkGoalCompletion(execCtx, todoReminder, currentTurn);
   }
 
   private buildExecCtx(): ExecutionLoopContext {

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -1,0 +1,548 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Non-interactive subagent execution path.
+ *
+ * Pure helpers extracted from SubAgentScope to keep the coordinator file
+ * under the max-lines budget. These functions orchestrate the
+ * non-interactive turn loop: sending messages, consuming the provider
+ * stream, parsing function calls, and dispatching tool results.
+ *
+ * All dependencies are passed explicitly via the NonInteractiveRunContext.
+ *
+ * @see project-plans/issue1581/README.md
+ */
+
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  type FunctionCall,
+  type FunctionDeclaration,
+  type Content,
+} from '@google/genai';
+import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import {
+  nextStreamEventWithIdleTimeout,
+  resolveStreamIdleTimeoutMs,
+} from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import {
+  StreamEventType,
+  type StreamEvent,
+  type ChatSession,
+} from './chatSession.js';
+import {
+  filterHookRestrictedParts,
+  filterHookRestrictedFunctionCalls,
+  getHookRestrictedAllowedTools,
+  getHookRestrictedFunctionCallsFromParts,
+  mergeHookRestrictedFunctionCalls,
+} from './hookToolRestrictions.js';
+import type { ToolExecutionConfig } from './nonInteractiveToolExecutor.js';
+import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import {
+  SubagentTerminateMode,
+  type OutputObject,
+  type OutputConfig,
+  type RunConfig,
+} from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import type { ExecutionLoopContext } from './subagentExecution.js';
+import {
+  checkTerminationConditions,
+  processNonInteractiveTextResponse,
+  handleExecutionError,
+  checkGoalCompletion,
+} from './subagentExecution.js';
+import {
+  resolveToolName,
+  finalizeOutput,
+  processFunctionCalls,
+  buildTodoCompletionPrompt,
+} from './subagentToolProcessing.js';
+
+// ---------------------------------------------------------------------------
+// Run context — carries all collaborators the non-interactive path needs
+// ---------------------------------------------------------------------------
+
+/**
+ * Collaborator bag for the non-interactive execution path.
+ * Mirrors the SubAgentScope private fields consumed by runNonInteractive.
+ */
+export interface NonInteractiveRunContext {
+  readonly output: OutputObject;
+  readonly subagentId: string;
+  readonly name: string;
+  readonly runtimeContext: AgentRuntimeContext;
+  readonly logger: DebugLogger;
+  readonly config: Config;
+  readonly runConfig: RunConfig;
+  readonly outputConfig?: OutputConfig;
+  readonly toolExecutorContext: ToolExecutionConfig;
+  readonly messageBus?: MessageBus;
+}
+
+/** Result of a single non-interactive turn iteration. */
+type LoopIterationResult =
+  | { action: 'stop' }
+  | { action: 'abort' }
+  | { action: 'continue'; messages: Content[] };
+
+// ---------------------------------------------------------------------------
+// Stream consumption helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the next event from the non-interactive stream, applying the idle
+ * timeout watchdog when configured.
+ */
+export async function readNextNonInteractiveEvent(
+  iterator: AsyncIterator<StreamEvent, unknown>,
+  abortController: AbortController,
+  timeoutController: AbortController,
+  timeoutSignal: AbortSignal,
+  effectiveTimeoutMs: number,
+  output: OutputObject,
+): Promise<IteratorResult<StreamEvent, unknown>> {
+  if (effectiveTimeoutMs > 0) {
+    return nextStreamEventWithIdleTimeout({
+      iterator,
+      timeoutMs: effectiveTimeoutMs,
+      signal: timeoutSignal,
+      onTimeout: () => {
+        if (abortController.signal.aborted === true) {
+          return;
+        }
+        output.terminate_reason = SubagentTerminateMode.TIMEOUT;
+        timeoutController.abort();
+        abortController.abort(createAbortError());
+      },
+      createTimeoutError: () => createAbortError(),
+    });
+  }
+  return iterator.next();
+}
+
+/**
+ * Collect function calls and text from a single CHUNK stream event,
+ * respecting hook-restricted tool filtering.
+ */
+export function collectNonInteractiveChunk(
+  resp: StreamEvent & { type: StreamEventType.CHUNK },
+  functionCalls: FunctionCall[],
+  currentTurn: number,
+  logger: DebugLogger,
+  subagentId: string,
+): { text: string; hookRestrictedAllowedTools: string[] | undefined } {
+  const allowedTools = getHookRestrictedAllowedTools(resp.value);
+  const parts = resp.value.candidates?.[0]?.content?.parts ?? [];
+  const partCalls = getHookRestrictedFunctionCallsFromParts(
+    parts,
+    allowedTools,
+  );
+  const topLevelCalls = filterHookRestrictedFunctionCalls(
+    resp.value.functionCalls ?? [],
+    allowedTools,
+  );
+  const chunkCalls = mergeHookRestrictedFunctionCalls(partCalls, topLevelCalls);
+  if (chunkCalls.length > 0) {
+    functionCalls.push(...chunkCalls);
+    logger.debug(
+      () =>
+        `Subagent ${subagentId} received ${chunkCalls.length} function calls on turn ${currentTurn}`,
+    );
+  }
+  if (allowedTools === undefined) {
+    return {
+      text: resp.value.text ?? '',
+      hookRestrictedAllowedTools: undefined,
+    };
+  }
+  const filteredParts = filterHookRestrictedParts(parts, allowedTools);
+  const filteredText = filteredParts
+    .map((part) => part.text)
+    .filter((text): text is string => typeof text === 'string')
+    .join('');
+  return { text: filteredText, hookRestrictedAllowedTools: allowedTools };
+}
+
+/** Aggregated result of consuming the full non-interactive stream. */
+export interface NonInteractiveStreamResult {
+  functionCalls: FunctionCall[];
+  textResponse: string;
+  parseableTextResponse: string;
+  hookRestrictedAllowedTools: string[] | undefined;
+}
+
+/** Empty stream result returned when the stream is aborted before reading. */
+function emptyStreamResult(): NonInteractiveStreamResult {
+  return {
+    functionCalls: [],
+    textResponse: '',
+    parseableTextResponse: '',
+    hookRestrictedAllowedTools: undefined,
+  };
+}
+
+/**
+ * Consume the full non-interactive provider stream, applying the idle-timeout
+ * watchdog and aborting early when the runtime abort signal fires.
+ */
+export async function consumeNonInteractiveStream(
+  responseStream: AsyncIterable<StreamEvent>,
+  abortController: AbortController,
+  currentTurn: number,
+  config: Config,
+  logger: DebugLogger,
+  subagentId: string,
+  output: OutputObject,
+): Promise<NonInteractiveStreamResult> {
+  const timeoutController = new AbortController();
+  const timeoutSignal = timeoutController.signal;
+  const onAbort = () => timeoutController.abort();
+  abortController.signal.addEventListener('abort', onAbort, { once: true });
+  if (abortController.signal.aborted === true) {
+    onAbort();
+    abortController.signal.removeEventListener('abort', onAbort);
+    return emptyStreamResult();
+  }
+
+  const functionCalls: FunctionCall[] = [];
+  let textResponse = '';
+  let parseableTextResponse = '';
+  let hookRestrictedAllowedTools: string[] | undefined;
+  const iterator = responseStream[Symbol.asyncIterator]();
+  const effectiveTimeoutMs = resolveStreamIdleTimeoutMs(config);
+
+  try {
+    const readResult = await readStreamToCompletion(
+      iterator,
+      abortController,
+      timeoutController,
+      timeoutSignal,
+      effectiveTimeoutMs,
+      currentTurn,
+      functionCalls,
+      logger,
+      subagentId,
+      output,
+    );
+    textResponse = readResult.textResponse;
+    parseableTextResponse = readResult.parseableTextResponse;
+    if (readResult.aborted) {
+      return {
+        functionCalls: [],
+        textResponse,
+        parseableTextResponse,
+        hookRestrictedAllowedTools,
+      };
+    }
+    hookRestrictedAllowedTools = readResult.hookRestrictedAllowedTools;
+  } finally {
+    iterator.return?.(undefined).catch(() => {});
+    timeoutController.abort();
+    abortController.signal.removeEventListener('abort', onAbort);
+  }
+
+  return {
+    functionCalls,
+    textResponse,
+    parseableTextResponse,
+    hookRestrictedAllowedTools,
+  };
+}
+
+/**
+ * Internal: iterate the stream to completion, accumulating text and
+ * function calls. Returns whether the stream was aborted mid-read.
+ */
+async function readStreamToCompletion(
+  iterator: AsyncIterator<StreamEvent, unknown>,
+  abortController: AbortController,
+  timeoutController: AbortController,
+  timeoutSignal: AbortSignal,
+  effectiveTimeoutMs: number,
+  currentTurn: number,
+  functionCalls: FunctionCall[],
+  logger: DebugLogger,
+  subagentId: string,
+  output: OutputObject,
+): Promise<{
+  textResponse: string;
+  parseableTextResponse: string;
+  hookRestrictedAllowedTools: string[] | undefined;
+  aborted: boolean;
+}> {
+  let textResponse = '';
+  let parseableTextResponse = '';
+  let hookRestrictedAllowedTools: string[] | undefined;
+
+  let result = await readNextNonInteractiveEvent(
+    iterator,
+    abortController,
+    timeoutController,
+    timeoutSignal,
+    effectiveTimeoutMs,
+    output,
+  );
+  while (result.done !== true) {
+    const resp = result.value;
+    const isRuntimeAborted = Boolean(abortController.signal.aborted);
+    if (isRuntimeAborted) {
+      return {
+        textResponse,
+        parseableTextResponse,
+        hookRestrictedAllowedTools,
+        aborted: true,
+      };
+    }
+    if (resp.type === StreamEventType.CHUNK) {
+      const chunkResult = collectNonInteractiveChunk(
+        resp,
+        functionCalls,
+        currentTurn,
+        logger,
+        subagentId,
+      );
+      hookRestrictedAllowedTools =
+        chunkResult.hookRestrictedAllowedTools ?? hookRestrictedAllowedTools;
+      textResponse += chunkResult.text;
+      parseableTextResponse += chunkResult.text;
+    }
+    result = await readNextNonInteractiveEvent(
+      iterator,
+      abortController,
+      timeoutController,
+      timeoutSignal,
+      effectiveTimeoutMs,
+      output,
+    );
+  }
+
+  return {
+    textResponse,
+    parseableTextResponse,
+    hookRestrictedAllowedTools,
+    aborted: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Turn execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a single non-interactive turn: send the message, consume the
+ * stream, and parse any textual tool calls.
+ */
+export async function runNonInteractiveTurn(
+  chat: ChatSession,
+  currentMessages: Content[],
+  toolsList: FunctionDeclaration[],
+  abortController: AbortController,
+  currentTurn: number,
+  sessionId: string,
+  subagentId: string,
+  execCtx: ExecutionLoopContext,
+  config: Config,
+  logger: DebugLogger,
+  output: OutputObject,
+): Promise<{ functionCalls: FunctionCall[]; textResponse: string }> {
+  const messageParams = {
+    message: currentMessages[0]?.parts ?? [],
+    config: {
+      abortSignal: abortController.signal,
+      tools: [{ functionDeclarations: toolsList }],
+    },
+  };
+
+  const responseStream = await chat.sendMessageStream(
+    messageParams,
+    `${sessionId}#${subagentId}#${currentTurn}`,
+  );
+
+  const {
+    functionCalls: rawCalls,
+    textResponse,
+    parseableTextResponse,
+    hookRestrictedAllowedTools,
+  } = await consumeNonInteractiveStream(
+    responseStream,
+    abortController,
+    currentTurn,
+    config,
+    logger,
+    subagentId,
+    output,
+  );
+  if (abortController.signal.aborted === true) {
+    return { functionCalls: [], textResponse: '' };
+  }
+
+  let functionCalls = rawCalls;
+  if (parseableTextResponse) {
+    const result = processNonInteractiveTextResponse(
+      parseableTextResponse,
+      functionCalls,
+      execCtx,
+      resolveToolName,
+      hookRestrictedAllowedTools,
+    );
+    functionCalls = result.functionCalls;
+  }
+
+  return { functionCalls, textResponse };
+}
+
+/**
+ * Dispatch the result of a non-interactive turn: either execute function
+ * calls or run the goal-completion check.
+ */
+export async function dispatchNonInteractiveTurnResult(
+  functionCalls: FunctionCall[],
+  abortController: AbortController,
+  promptId: string,
+  currentTurn: number,
+  execCtx: ExecutionLoopContext,
+  ctx: NonInteractiveRunContext,
+): Promise<Content[] | null> {
+  if (functionCalls.length > 0) {
+    return processFunctionCalls(functionCalls, abortController, promptId, {
+      output: ctx.output,
+      subagentId: ctx.subagentId,
+      logger: ctx.logger,
+      toolExecutorContext: ctx.toolExecutorContext,
+      config: ctx.config,
+      messageBus: ctx.messageBus,
+    });
+  }
+  const todoReminder = await buildTodoCompletionPrompt(
+    ctx.runtimeContext,
+    ctx.subagentId,
+    ctx.logger,
+  );
+  return checkGoalCompletion(execCtx, todoReminder, currentTurn);
+}
+
+// ---------------------------------------------------------------------------
+// Main non-interactive loop (extracted to keep coordinator lean)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run one iteration of the non-interactive loop body. Returns a
+ * discriminated result so the caller loop has a single control branch.
+ */
+async function runNonInteractiveLoopIteration(
+  chat: ChatSession,
+  toolsList: FunctionDeclaration[],
+  abortController: AbortController,
+  currentMessages: Content[],
+  turnCounter: { value: number },
+  startTime: number,
+  execCtx: ExecutionLoopContext,
+  ctx: NonInteractiveRunContext,
+): Promise<LoopIterationResult> {
+  const check = checkTerminationConditions(
+    turnCounter.value,
+    startTime,
+    execCtx,
+  );
+  if (check.shouldStop) return { action: 'stop' };
+
+  const currentTurn = turnCounter.value++;
+  const sessionId = ctx.runtimeContext.state.sessionId;
+  const promptId = `${sessionId}#${ctx.subagentId}#${currentTurn}`;
+  ctx.logger.debug(
+    () => `Subagent ${ctx.subagentId} turn=${currentTurn} promptId=${promptId}`,
+  );
+
+  const { functionCalls } = await runNonInteractiveTurn(
+    chat,
+    currentMessages,
+    toolsList,
+    abortController,
+    currentTurn,
+    sessionId,
+    ctx.subagentId,
+    execCtx,
+    ctx.config,
+    ctx.logger,
+    ctx.output,
+  );
+  if (abortController.signal.aborted === true) return { action: 'abort' };
+
+  const recheck = checkTerminationConditions(
+    turnCounter.value,
+    startTime,
+    execCtx,
+  );
+  if (recheck.shouldStop) return { action: 'stop' };
+
+  const nextMessages = await dispatchNonInteractiveTurnResult(
+    functionCalls,
+    abortController,
+    promptId,
+    currentTurn,
+    execCtx,
+    ctx,
+  );
+  if (!nextMessages) return { action: 'stop' };
+  return { action: 'continue', messages: nextMessages };
+}
+
+/**
+ * Execute the full non-interactive subagent run loop.
+ *
+ * This is the top-level entry point called by SubAgentScope.runNonInteractive.
+ * It owns the try/catch/finally wrapping and the loop that delegates each
+ * iteration to {@link runNonInteractiveLoopIteration}.
+ */
+export async function executeNonInteractiveRun(
+  chat: ChatSession,
+  toolsList: FunctionDeclaration[],
+  abortController: AbortController,
+  initialMessages: Content[],
+  startTime: number,
+  execCtx: ExecutionLoopContext,
+  ctx: NonInteractiveRunContext,
+  cleanup: () => void,
+): Promise<void> {
+  let currentMessages = initialMessages;
+  const turnCounter = { value: 0 };
+
+  try {
+    let keepRunning = true;
+    while (keepRunning) {
+      const iteration = await runNonInteractiveLoopIteration(
+        chat,
+        toolsList,
+        abortController,
+        currentMessages,
+        turnCounter,
+        startTime,
+        execCtx,
+        ctx,
+      );
+      if (iteration.action === 'abort') {
+        return;
+      }
+      if (iteration.action === 'stop') {
+        keepRunning = false;
+      } else {
+        currentMessages = iteration.messages;
+      }
+    }
+    finalizeOutput(ctx.output);
+  } catch (error) {
+    if (ctx.output.terminate_reason !== SubagentTerminateMode.TIMEOUT) {
+      handleExecutionError(error, execCtx);
+    }
+    finalizeOutput(ctx.output);
+    throw error;
+  } finally {
+    cleanup();
+  }
+}

--- a/packages/agents/src/core/subagentOrchestrator.ts
+++ b/packages/agents/src/core/subagentOrchestrator.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import { randomUUID } from 'node:crypto';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { SubagentManager } from '@vybestack/llxprt-code-core/config/subagentManager.js';
@@ -130,20 +128,11 @@ export class SubagentOrchestrator {
         scope.dispose();
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent settings cross persisted/runtime boundaries despite declared types.
-      const history = runtimeResult.history ?? scope.runtimeContext.history;
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent settings cross persisted/runtime boundaries despite declared types.
-      if (history !== undefined) {
-        const disposable = (history as { dispose?: () => void }).dispose;
-        if (typeof disposable === 'function') {
-          disposable.call(history);
-        } else if (typeof history.clear === 'function') {
-          history.clear();
-          (
-            history as { removeAllListeners?: () => void }
-          ).removeAllListeners?.();
-        }
-      }
+      const history = firstDefinedHistory(
+        runtimeResult.history,
+        scope.runtimeContext.history,
+      );
+      disposeHistoryLike(history);
     };
   }
 
@@ -255,8 +244,7 @@ export class SubagentOrchestrator {
   }
 
   private async loadSubagentConfig(name: string): Promise<SubagentConfig> {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent settings cross persisted/runtime boundaries despite declared types.
-    if (!name?.trim()) {
+    if (!name.trim()) {
       throw new Error('Subagent name is required.');
     }
     try {
@@ -279,11 +267,9 @@ export class SubagentOrchestrator {
     basePrompt: string,
     additions?: string[],
   ): PromptConfig {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent settings cross persisted/runtime boundaries despite declared types.
-    const trimmedBase = basePrompt?.trim();
+    const trimmedBase = basePrompt.trim();
     const trimmedAdditions = (additions ?? [])
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent settings cross persisted/runtime boundaries despite declared types.
-      .map((part) => part?.trim())
+      .map((part) => part.trim())
       .filter((part): part is string => part.length > 0);
 
     const promptSections: string[] = [];
@@ -356,7 +342,6 @@ export class SubagentOrchestrator {
     const config = this.options.foregroundConfig as Config & {
       getEphemeralSetting?: (key: string) => unknown;
     };
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Foreground config may not implement getEphemeralSetting in all environments.
     if (typeof config.getEphemeralSetting !== 'function') {
       return undefined;
     }
@@ -516,14 +501,12 @@ export class SubagentOrchestrator {
       service.set('auth-keyfile', expandedKeyfile);
       service.set(`providers.${provider}.auth-keyfile`, expandedKeyfile);
       const authKey = service.get(`providers.${provider}.auth-key`);
+      const isNullOrUndefined = authKey === undefined || authKey === null;
+      const isEmptyPrimitive =
+        authKey === '' || authKey === false || authKey === 0;
+      const isNumericNaN = typeof authKey === 'number' && Number.isNaN(authKey);
       const shouldLoadApiKeyfile =
-        // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        authKey === undefined ||
-        authKey === null ||
-        authKey === '' ||
-        authKey === false ||
-        authKey === 0 ||
-        (typeof authKey === 'number' && Number.isNaN(authKey));
+        isNullOrUndefined || isEmptyPrimitive || isNumericNaN;
       if (shouldLoadApiKeyfile) {
         this.tryLoadApiKeyFromKeyfile(provider, expandedKeyfile, service);
       }
@@ -821,4 +804,38 @@ export class SubagentOrchestrator {
 
     return this.runtimeLoader(loaderOptions);
   }
+}
+
+/**
+ * Boundary-validation helper: disposes (or clears) a history-like object that
+ * may be `undefined`/`null` at runtime. Typed `unknown` so the guards are
+ * genuinely necessary (no lint suppression directive needed).
+ */
+function disposeHistoryLike(history: unknown): void {
+  if (history === undefined || history === null) {
+    return;
+  }
+  const disposable = (history as { dispose?: () => void }).dispose;
+  if (typeof disposable === 'function') {
+    disposable.call(history);
+    return;
+  }
+  const clearable = history as {
+    clear?: () => void;
+    removeAllListeners?: () => void;
+  };
+  if (typeof clearable.clear === 'function') {
+    clearable.clear();
+    if (typeof clearable.removeAllListeners === 'function') {
+      clearable.removeAllListeners();
+    }
+  }
+}
+
+/**
+ * Boundary-validation helper: picks the first defined history source without
+ * tripping `no-unnecessary-condition` (both args are statically required).
+ */
+function firstDefinedHistory(primary: unknown, fallback: unknown): unknown {
+  return primary ?? fallback;
 }

--- a/packages/agents/src/core/subagentToolProcessing.ts
+++ b/packages/agents/src/core/subagentToolProcessing.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, sonarjs/cognitive-complexity -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 /**
  * @fileoverview Tool call dispatch, emit handling, and response building
  * for subagents.
@@ -96,6 +94,44 @@ export function buildToolUnavailableMessage(
 }
 
 // ---------------------------------------------------------------------------
+// Boundary-validation helpers (typed `unknown` so guards are necessary)
+// ---------------------------------------------------------------------------
+
+/**
+ * Coerces a possibly-missing tool-call args / emitted-vars payload to a record,
+ * restoring the `?? {}` fallback stripped by issue #2085. Values are typed
+ * `unknown` so downstream null/undefined guards remain genuinely necessary.
+ */
+function asUnknownRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === 'object' && value !== null) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+/**
+ * Reads a `CompletedToolCall.response` through an `unknown` boundary so the
+ * optional-chaining access (`response?.responseParts` etc.) is genuinely
+ * necessary — restoring the defensive `call.response?.*` guards from main.
+ */
+function readResponse(call: CompletedToolCall):
+  | {
+      responseParts?: Part[];
+      resultDisplay?: ToolResultDisplay;
+      error?: { message?: string };
+    }
+  | undefined {
+  const response = (call as { response?: unknown }).response;
+  if (typeof response === 'object' && response !== null) {
+    return response as {
+      responseParts?: Part[];
+      resultDisplay?: ToolResultDisplay;
+      error?: { message?: string };
+    };
+  }
+  return undefined;
+}
+// ---------------------------------------------------------------------------
 // Fuzzy tool name resolution
 // ---------------------------------------------------------------------------
 
@@ -149,14 +185,11 @@ export function finalizeOutput(output: OutputObject): void {
     return;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
-  const emittedVars = output.emitted_vars ?? {};
+  const emittedVars = asUnknownRecord(output.emitted_vars);
   const emittedEntries = Object.entries(emittedVars)
     .filter(
       ([, value]) =>
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
         value !== undefined &&
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
         value !== null &&
         String(value).trim().length > 0,
     )
@@ -200,26 +233,41 @@ export interface EmitValueContext {
   logger: DebugLogger;
 }
 
+/**
+ * Resolves an emit-value argument by preferring the snake_case key and falling
+ * back to the camelCase key, returning '' when neither is a string.
+ */
+function resolveEmitArg(
+  args: Record<string, unknown>,
+  snakeKey: string,
+  camelKey: string,
+): string {
+  const snakeValue = args[snakeKey];
+  if (typeof snakeValue === 'string') {
+    return snakeValue;
+  }
+  const camelValue = args[camelKey];
+  if (typeof camelValue === 'string') {
+    return camelValue;
+  }
+  return '';
+}
+
 export function handleEmitValueCall(
   request: ToolCallRequestInfo,
   ctx: EmitValueContext,
 ): Part[] {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
-  const args = request.args ?? {};
-  const variableName =
-    typeof args.emit_variable_name === 'string'
-      ? args.emit_variable_name
-      : // eslint-disable-next-line sonarjs/no-nested-conditional -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        typeof args.emitVariableName === 'string'
-        ? args.emitVariableName
-        : '';
-  const variableValue =
-    typeof args.emit_variable_value === 'string'
-      ? args.emit_variable_value
-      : // eslint-disable-next-line sonarjs/no-nested-conditional -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        typeof args.emitVariableValue === 'string'
-        ? args.emitVariableValue
-        : '';
+  const args = asUnknownRecord(request.args);
+  const variableName = resolveEmitArg(
+    args,
+    'emit_variable_name',
+    'emitVariableName',
+  );
+  const variableValue = resolveEmitArg(
+    args,
+    'emit_variable_value',
+    'emitVariableValue',
+  );
 
   if (variableName && variableValue) {
     ctx.output.emitted_vars[variableName] = variableValue;
@@ -268,23 +316,30 @@ export interface BuildPartsContext {
   logger: DebugLogger;
 }
 
+/**
+ * Appends all non-functionCall parts from responseParts to aggregate.
+ */
+function appendNonFunctionCallParts(
+  aggregate: Part[],
+  responseParts: Part[],
+): void {
+  for (const part of responseParts) {
+    if (!('functionCall' in part)) {
+      aggregate.push(part);
+    }
+  }
+}
+
 export function buildPartsFromCompletedCalls(
   completedCalls: CompletedToolCall[],
   ctx: BuildPartsContext,
 ): Part[] {
   const aggregate: Part[] = [];
   for (const call of completedCalls) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads may be malformed at boundaries.
-    const responseParts = call.response?.responseParts;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads may omit response parts.
+    const response = readResponse(call);
+    const responseParts = response?.responseParts;
     if (responseParts !== undefined && responseParts.length > 0) {
-      for (const part of responseParts) {
-        // eslint-disable-next-line sonarjs/nested-control-flow -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        if ('functionCall' in part) {
-          continue;
-        }
-        aggregate.push(part);
-      }
+      appendNonFunctionCallParts(aggregate, responseParts);
     } else {
       aggregate.push({
         functionResponse: {
@@ -299,10 +354,8 @@ export function buildPartsFromCompletedCalls(
 
     if (call.status === 'error') {
       const errorMessage =
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
-        call.response?.error?.message ??
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
-        call.response?.resultDisplay ??
+        response?.error?.message ??
+        response?.resultDisplay ??
         'Tool execution failed.';
       ctx.logger.warn(
         () =>
@@ -315,12 +368,11 @@ export function buildPartsFromCompletedCalls(
       );
     }
 
+    const callTool = call.tool;
     const toolCanUpdateOutput =
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
-      call.status === 'success' && call.tool?.canUpdateOutput === true;
+      call.status === 'success' && callTool?.canUpdateOutput === true;
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Subagent tool-call runtime payloads.
-    const display = call.response?.resultDisplay;
+    const display = response?.resultDisplay;
     if (
       typeof display === 'string' &&
       ctx.onMessage &&

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* eslint-disable complexity, max-lines -- Phase 5: legacy core boundary retained while larger decomposition continues. */
-
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -18,41 +16,52 @@ import {
   type SubagentLaunchRequest,
 } from '../core/subagentOrchestrator.js';
 import type { SubAgentScope } from '../core/subagent.js';
-import {
-  ContextState,
-  SubagentTerminateMode,
-  type OutputObject,
-} from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { ContextState } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { SubagentSchedulerFactory } from '../core/subagentScheduler.js';
 import type { SubagentManager } from '@vybestack/llxprt-code-core/config/subagentManager.js';
 import type { ProfileManager } from '@vybestack/llxprt-code-settings';
-import { ToolErrorType } from '@vybestack/llxprt-code-tools';
-import { DEFAULT_AGENT_ID } from '@vybestack/llxprt-code-core/core/turn.js';
 import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import {
-  canonicalizeToolName,
-  buildToolGovernance,
-  isToolBlocked,
-} from '../core/toolGovernance.js';
+  createAbortState,
+  createTimeoutControllers,
+  isAbortError as isAbortErrorHelper,
+  isTimeoutError as isTimeoutErrorHelper,
+} from './taskAbortHelpers.js';
+import {
+  buildGovernedToolWhitelist,
+  filterExcludedFromWhitelist,
+  normalizeTaskParams,
+  type TaskToolInvocationParams,
+} from './taskToolGovernance.js';
+import {
+  createCancelledResult,
+  createErrorResult,
+  createTimeoutResult,
+  formatSuccessContent,
+  formatSuccessDisplay,
+} from './taskResultHelpers.js';
+import {
+  executeAsyncTask,
+  normalizeSubagentStreamingText,
+} from './taskAsyncExecution.js';
 
 const taskLogger = new DebugLogger('llxprt:task');
 
-// Tool timeout settings (Issue #1049)
-const DEFAULT_TASK_TIMEOUT_SECONDS = 900;
-const MAX_TASK_TIMEOUT_SECONDS = 1800;
-
-const normalizeToolNameForPolicy = (name: string): string =>
-  canonicalizeToolName(name);
-
-function normalizeSubagentStreamingText(text: string): string {
-  if (!text) {
-    return '';
-  }
-  const lf = text.replace(/\r\n?/g, '\n');
-  return lf.endsWith('\n') ? lf : lf + '\n';
+/**
+ * Boundary-validates a config accessor whose static type declares it required
+ * but whose runtime value may be absent (partial mocks / lightweight configs).
+ * Uses `typeof === 'function'` so the guard is real without tripping
+ * `@typescript-eslint/no-unnecessary-condition`.
+ */
+function resolveOptionalConfigMethod<T>(
+  config: Config,
+  methodName: 'getProfileManager' | 'getSubagentManager',
+): T | undefined {
+  const fn = (config as unknown as Record<string, unknown>)[methodName];
+  return typeof fn === 'function' ? (fn as () => T)() : undefined;
 }
 
 export interface TaskToolParams {
@@ -77,17 +86,6 @@ export interface TaskToolParams {
   async?: boolean;
 }
 
-interface TaskToolInvocationParams {
-  subagentName: string;
-  goalPrompt: string;
-  behaviourPrompts: string[];
-  toolWhitelist?: string[];
-  outputSpec?: Record<string, string>;
-  context: Record<string, unknown>;
-  maxTurns?: number;
-  async: boolean;
-}
-
 export interface TaskToolDependencies {
   orchestratorFactory?: () => SubagentOrchestrator;
   profileManager?: ProfileManager;
@@ -96,18 +94,6 @@ export interface TaskToolDependencies {
   isInteractiveEnvironment?: () => boolean;
   getAsyncTaskManager?: () => AsyncTaskManager | undefined;
 }
-interface AsyncSetupResult {
-  launchResult: Awaited<ReturnType<SubagentOrchestrator['launch']>>;
-  agentId: string;
-  scope: SubAgentScope;
-  contextState: ContextState;
-  dispose: () => Promise<void>;
-  asyncAbortController: AbortController;
-  timeoutId: NodeJS.Timeout | null;
-  timedOut: { value: boolean };
-  cleanupForegroundRelay: () => void;
-}
-
 function launchRequestName(
   launchResult: Awaited<ReturnType<SubagentOrchestrator['launch']>>,
 ): string {
@@ -120,51 +106,6 @@ interface TaskToolInvocationDeps {
   getSchedulerFactory?: () => SubagentSchedulerFactory | undefined;
   isInteractiveEnvironment?: () => boolean;
   getAsyncTaskManager?: () => AsyncTaskManager | undefined;
-}
-
-/**
- * Formats a human readable summary for successful subagent execution.
- */
-function formatSuccessDisplay(
-  subagentName: string,
-  agentId: string,
-  output: OutputObject,
-): string {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-  const emittedVars = Object.entries(output.emitted_vars ?? {});
-  const finalMessageSection = output.final_message
-    ? `Final message:\n${output.final_message}`
-    : 'Final message: _(none)_';
-  const emittedSection =
-    emittedVars.length === 0
-      ? 'Emitted variables: _(none)_'
-      : `Emitted variables:\n${emittedVars
-          .map(([key, value]) => `- **${key}**: ${value}`)
-          .join('\n')}`;
-
-  return [
-    `Subagent **${subagentName}** (\`${agentId}\`) completed with status \`${output.terminate_reason}\`.`,
-    finalMessageSection,
-    emittedSection,
-  ].join('\n\n');
-}
-
-/**
- * Summarizes the subagent output as JSON for inclusion in tool history.
- */
-function formatSuccessContent(agentId: string, output: OutputObject): string {
-  const payload: Record<string, unknown> = {
-    agent_id: agentId,
-    terminate_reason: output.terminate_reason,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    emitted_vars: output.emitted_vars ?? {},
-  };
-
-  if (output.final_message !== undefined) {
-    payload.final_message = output.final_message;
-  }
-
-  return JSON.stringify(payload, null, 2);
 }
 
 class TaskToolInvocation extends BaseToolInvocation<
@@ -185,100 +126,17 @@ class TaskToolInvocation extends BaseToolInvocation<
     return `Run subagent '${this.normalized.subagentName}' to accomplish: ${this.normalized.goalPrompt}`;
   }
 
-  private buildExcludedToolNames(): Set<string> {
-    return new Set(
-      ['task', 'list_subagents']
-        .map((name) => normalizeToolNameForPolicy(name))
-        .filter((name) => name.length > 0),
-    );
-  }
-
-  private isExcludedToolName(name: string, excluded: Set<string>): boolean {
-    const canonical = normalizeToolNameForPolicy(name);
-    return canonical.length > 0 && excluded.has(canonical);
-  }
-
   private buildGovernedToolWhitelist(
     candidateTools: string[] | undefined,
     registry: ToolRegistry,
   ): string[] | undefined {
-    if (!candidateTools || candidateTools.length === 0) {
-      return undefined;
-    }
-
-    const excluded = this.buildExcludedToolNames();
-    const governance = buildToolGovernance(this.config);
-    const allowedRegistryTools = registry
-      .getEnabledTools()
-      .map((tool) => tool.name)
-      .filter(
-        (name): name is string =>
-          !!name && !this.isExcludedToolName(name, excluded),
-      );
-
-    const allowedByCanonical = new Map<string, string>();
-    for (const toolName of allowedRegistryTools) {
-      const canonical = normalizeToolNameForPolicy(toolName);
-      if (canonical && !allowedByCanonical.has(canonical)) {
-        allowedByCanonical.set(canonical, toolName);
-      }
-    }
-
-    const filteredTools = candidateTools.map((name) => {
-      if (!name || this.isExcludedToolName(name, excluded)) {
-        return undefined;
-      }
-
-      const canonical = normalizeToolNameForPolicy(name);
-      if (!canonical || isToolBlocked(canonical, governance)) {
-        return undefined;
-      }
-
-      return allowedByCanonical.get(canonical);
-    });
-
-    const validTools = filteredTools.filter(
-      (name): name is string => typeof name === 'string' && name.length > 0,
-    );
-
-    if (validTools.length === 0) {
-      return undefined;
-    }
-
-    const uniqueByCanonical = new Set<string>();
-    const deduped: string[] = [];
-    for (const tool of validTools) {
-      const canonical = normalizeToolNameForPolicy(tool);
-      if (!canonical || uniqueByCanonical.has(canonical)) {
-        continue;
-      }
-      uniqueByCanonical.add(canonical);
-      deduped.push(tool);
-    }
-
-    return deduped.length > 0 ? deduped : undefined;
+    return buildGovernedToolWhitelist(candidateTools, registry, this.config);
   }
 
-  /**
-   * Filters excluded tools (task/list_subagents) from a whitelist when no
-   * registry is available to perform full governance validation. Non-excluded
-   * entries pass through unchanged. Returns undefined if the result is empty
-   * so the caller can apply fail-closed semantics for explicit whitelists.
-   */
   private filterExcludedFromWhitelist(
     candidateTools: string[] | undefined,
   ): string[] | undefined {
-    if (!candidateTools || candidateTools.length === 0) {
-      return undefined;
-    }
-
-    const excluded = this.buildExcludedToolNames();
-    const filtered = candidateTools.filter(
-      (name) =>
-        typeof name === 'string' && !this.isExcludedToolName(name, excluded),
-    );
-
-    return filtered.length > 0 ? filtered : undefined;
+    return filterExcludedFromWhitelist(candidateTools);
   }
 
   private createLaunchRequest(timeoutMs?: number): SubagentLaunchRequest {
@@ -391,7 +249,11 @@ class TaskToolInvocation extends BaseToolInvocation<
       timeoutController,
       timeoutId,
       onUserAbort,
-    } = this.createTimeoutControllers(signal);
+    } = createTimeoutControllers(
+      this.config,
+      signal,
+      this.params.timeout_seconds,
+    );
 
     if (signal.aborted) {
       onUserAbort();
@@ -399,9 +261,7 @@ class TaskToolInvocation extends BaseToolInvocation<
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
       }
-      return this.createCancelledResult(
-        'Task execution aborted before launch.',
-      );
+      return createCancelledResult('Task execution aborted before launch.');
     }
 
     let orchestrator: SubagentOrchestrator;
@@ -416,7 +276,7 @@ class TaskToolInvocation extends BaseToolInvocation<
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
       }
-      return this.createErrorResult(
+      return createErrorResult(
         error,
         'Task tool could not initialize subagent orchestrator.',
       );
@@ -460,9 +320,7 @@ class TaskToolInvocation extends BaseToolInvocation<
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
       }
-      return this.createCancelledResult(
-        'Task execution aborted before launch.',
-      );
+      return createCancelledResult('Task execution aborted before launch.');
     }
 
     const launchResult = await this.attemptLaunch(
@@ -480,15 +338,15 @@ class TaskToolInvocation extends BaseToolInvocation<
       if (this.lastLaunchError !== undefined) {
         const error = this.lastLaunchError;
         this.lastLaunchError = undefined;
-        return this.createErrorResult(
+        return createErrorResult(
           error,
           `Unable to launch subagent '${this.normalized.subagentName}'.`,
         );
       }
       if (abortState.aborted.timedOut) {
-        return this.createTimeoutResult(timeoutSeconds);
+        return createTimeoutResult(timeoutSeconds);
       }
-      return this.createCancelledResult('Task aborted during launch.');
+      return createCancelledResult('Task aborted during launch.');
     }
 
     return this.runSubagentExecution(
@@ -507,42 +365,7 @@ class TaskToolInvocation extends BaseToolInvocation<
     launchRequest: SubagentLaunchRequest,
     signal: AbortSignal,
   ) {
-    const state = { aborted: false, timedOut: false };
-    let liveScope:
-      | Awaited<ReturnType<SubagentOrchestrator['launch']>>
-      | undefined;
-    const abortHandler = () => {
-      if (state.aborted) return;
-      state.aborted = true;
-      taskLogger.warn(
-        () => `Cancellation requested for subagent '${launchRequest.name}'`,
-      );
-      try {
-        const candidate = liveScope?.scope as
-          | { cancel?: (reason?: string) => void }
-          | undefined;
-        candidate?.cancel?.('User aborted task execution.');
-      } catch (error) {
-        taskLogger.warn(
-          () =>
-            `Error while cancelling subagent '${launchRequest.name}': ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    };
-    const removeAbortHandler = () => {
-      signal.removeEventListener('abort', abortHandler);
-    };
-    const setLaunchResult = (
-      result: Awaited<ReturnType<SubagentOrchestrator['launch']>>,
-    ) => {
-      liveScope = result;
-    };
-    return {
-      aborted: state,
-      abortHandler,
-      removeAbortHandler,
-      setLaunchResult,
-    };
+    return createAbortState(launchRequest, signal);
   }
 
   private async attemptLaunch(
@@ -584,13 +407,20 @@ class TaskToolInvocation extends BaseToolInvocation<
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
       }
-      if (this.isTimeoutError(signal, timeoutController, error)) {
+      if (
+        isTimeoutErrorHelper(
+          signal,
+          timeoutController,
+          isAbortErrorHelper,
+          error,
+        )
+      ) {
         abortState.aborted.timedOut = true;
         return null;
       }
 
       if (
-        this.isAbortError(error) ||
+        isAbortErrorHelper(error) ||
         abortState.aborted.aborted ||
         signal.aborted
       ) {
@@ -641,7 +471,7 @@ class TaskToolInvocation extends BaseToolInvocation<
 
     if (signal.aborted || abortState.aborted.aborted) {
       await teardown();
-      return this.createCancelledResult(
+      return createCancelledResult(
         'Task aborted during launch.',
         agentId,
         scope.output,
@@ -766,20 +596,22 @@ class TaskToolInvocation extends BaseToolInvocation<
     teardown: () => Promise<void>,
     abortedState: { aborted: boolean; timedOut: boolean },
   ): Promise<ToolResult> {
-    if (this.isTimeoutError(signal, timeoutController, error)) {
+    if (
+      isTimeoutErrorHelper(signal, timeoutController, isAbortErrorHelper, error)
+    ) {
       await teardown();
-      return this.createTimeoutResult(timeoutSeconds, scope.output, agentId);
+      return createTimeoutResult(timeoutSeconds, scope.output, agentId);
     }
 
-    if (this.isAbortError(error) || abortedState.aborted || signal.aborted) {
+    if (isAbortErrorHelper(error) || abortedState.aborted || signal.aborted) {
       await teardown();
-      return this.createCancelledResult(
+      return createCancelledResult(
         'Task execution aborted before completion.',
         agentId,
         scope.output,
       );
     }
-    const result = this.createErrorResult(
+    const result = createErrorResult(
       error,
       `Subagent '${this.normalized.subagentName}' failed during execution.`,
       agentId,
@@ -803,25 +635,20 @@ class TaskToolInvocation extends BaseToolInvocation<
     if (abortedState.aborted) {
       await teardown();
       taskLogger.warn(() => `Subagent aborted before completion`);
-      return this.createCancelledResult(
+      return createCancelledResult(
         'Task execution aborted before completion.',
         agentId,
         scope.output,
       );
     }
-    if (this.isTimeoutError(signal, timeoutController)) {
+    if (isTimeoutErrorHelper(signal, timeoutController, isAbortErrorHelper)) {
       await teardown();
-      return this.createTimeoutResult(timeoutSeconds, scope.output);
+      return createTimeoutResult(timeoutSeconds, scope.output);
     }
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    const output = scope.output ?? {
-      terminate_reason: SubagentTerminateMode.ERROR,
-      emitted_vars: {},
-    };
+    const output = scope.output;
     taskLogger.debug(
       () =>
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        `Subagent finished with reason=${output.terminate_reason} emittedKeys=${Object.keys(output.emitted_vars ?? {}).join(', ')}`,
+        `Subagent finished with reason=${output.terminate_reason} emittedKeys=${Object.keys(output.emitted_vars).join(', ')}`,
     );
     const llmContent = formatSuccessContent(agentId, output);
     const returnDisplay = formatSuccessDisplay(
@@ -836,19 +663,10 @@ class TaskToolInvocation extends BaseToolInvocation<
       metadata: {
         agentId,
         terminateReason: output.terminate_reason,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        emittedVars: output.emitted_vars ?? {},
+        emittedVars: output.emitted_vars,
         ...(output.final_message ? { finalMessage: output.final_message } : {}),
       },
     };
-  }
-
-  private isAbortError(error: unknown): boolean {
-    if (error === null || error === undefined || typeof error !== 'object') {
-      return false;
-    }
-    const result = (error as { name?: string }).name === 'AbortError';
-    return result;
   }
 
   private buildContextState(): ContextState {
@@ -869,620 +687,25 @@ class TaskToolInvocation extends BaseToolInvocation<
     ]);
     return context;
   }
-
-  private createErrorResult(
-    error: unknown,
-    fallbackMessage: string,
-    agentId?: string,
-  ): ToolResult {
-    const detail =
-      error instanceof Error && error.message ? error.message : null;
-    const displayMessage = detail
-      ? `${fallbackMessage}\nDetails: ${detail}`
-      : fallbackMessage;
-    const message = detail ?? fallbackMessage;
-    taskLogger.warn(() => `Task tool error: ${displayMessage}`);
-    return {
-      llmContent: displayMessage,
-      returnDisplay: displayMessage,
-      metadata: agentId
-        ? {
-            agentId,
-            error: message,
-          }
-        : undefined,
-      error: {
-        message,
-        type: ToolErrorType.UNHANDLED_EXCEPTION,
-      },
-    };
-  }
-
-  private createCancelledResult(
-    message: string,
-    agentId?: string,
-    output?: OutputObject,
-  ): ToolResult {
-    taskLogger.warn(
-      () =>
-        `Task tool cancelled for agentId=${agentId ?? DEFAULT_AGENT_ID}: ${message}`,
-    );
-    return {
-      llmContent: message,
-      returnDisplay: message,
-      metadata: {
-        agentId: agentId ?? DEFAULT_AGENT_ID,
-        terminateReason: output?.terminate_reason,
-        emittedVars: output?.emitted_vars ?? {},
-        ...(output?.final_message
-          ? { finalMessage: output.final_message }
-          : {}),
-        cancelled: true,
-      },
-      error: {
-        message,
-        type: ToolErrorType.EXECUTION_FAILED,
-      },
-    };
-  }
-
-  private createTimeoutControllers(signal: AbortSignal): {
-    timeoutMs?: number;
-    timeoutSeconds?: number;
-    timeoutController: AbortController;
-    timeoutId: ReturnType<typeof setTimeout> | null;
-    onUserAbort: () => void;
-  } {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    const settings = this.config.getEphemeralSettings?.() ?? {};
-    const defaultTimeoutSeconds =
-      (settings['task-default-timeout-seconds'] as number | undefined) ??
-      DEFAULT_TASK_TIMEOUT_SECONDS;
-    const maxTimeoutSeconds =
-      (settings['task-max-timeout-seconds'] as number | undefined) ??
-      MAX_TASK_TIMEOUT_SECONDS;
-
-    const timeoutSeconds = this.resolveTimeoutSeconds(
-      this.params.timeout_seconds,
-      defaultTimeoutSeconds,
-      maxTimeoutSeconds,
-    );
-    // Convert seconds to milliseconds for setTimeout
-    const timeoutMs =
-      timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000;
-    const timeoutController = new AbortController();
-    const timeoutId =
-      timeoutMs === undefined
-        ? null
-        : setTimeout(() => timeoutController.abort(), timeoutMs);
-
-    const onUserAbort = () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-      timeoutController.abort();
-    };
-
-    signal.addEventListener('abort', onUserAbort, { once: true });
-
-    return {
-      timeoutMs,
-      timeoutSeconds,
-      timeoutController,
-      timeoutId,
-      onUserAbort,
-    };
-  }
-
-  private resolveTimeoutSeconds(
-    requestedTimeoutSeconds: number | undefined,
-    defaultTimeoutSeconds: number,
-    maxTimeoutSeconds: number,
-  ): number | undefined {
-    if (requestedTimeoutSeconds === -1 || defaultTimeoutSeconds === -1) {
-      return undefined;
-    }
-
-    const effectiveTimeout = requestedTimeoutSeconds ?? defaultTimeoutSeconds;
-    if (maxTimeoutSeconds === -1) {
-      return effectiveTimeout;
-    }
-
-    if (effectiveTimeout > maxTimeoutSeconds) {
-      return maxTimeoutSeconds;
-    }
-
-    return effectiveTimeout;
-  }
-
-  private isTimeoutError(
-    signal: AbortSignal,
-    timeoutController: AbortController,
-    error?: unknown,
-  ): boolean {
-    if (!timeoutController.signal.aborted || signal.aborted) {
-      return false;
-    }
-    if (error === undefined || error === null) {
-      return true;
-    }
-    return this.isAbortError(error);
-  }
-
-  private createTimeoutResult(
-    timeoutSeconds: number | undefined,
-    output?: OutputObject,
-    agentId?: string,
-  ): ToolResult {
-    const message = `Task timed out after ${timeoutSeconds ?? DEFAULT_TASK_TIMEOUT_SECONDS}s (timeout_seconds).`;
-    return {
-      llmContent: message,
-      returnDisplay: message,
-      metadata: {
-        agentId: agentId ?? DEFAULT_AGENT_ID,
-        terminateReason: output?.terminate_reason,
-        emittedVars: output?.emitted_vars ?? {},
-        ...(output?.final_message
-          ? { finalMessage: output.final_message }
-          : {}),
-        timedOut: true,
-      },
-      error: {
-        message,
-        type: ToolErrorType.TIMEOUT,
-      },
-    };
-  }
-
-  /**
-   * Wires the foreground turn's abort signal into the async abort controller so
-   * that ESC (which aborts the foreground turn) also cancels the detached
-   * subagent. Returns a cleanup function that removes the listener.
-   */
-  private setupForegroundRelay(
-    foregroundSignal: AbortSignal,
-    asyncAbortController: AbortController,
-  ): () => void {
-    const relayForegroundAbort = () => asyncAbortController.abort();
-    if (foregroundSignal.aborted) {
-      asyncAbortController.abort();
-    } else {
-      foregroundSignal.addEventListener('abort', relayForegroundAbort, {
-        once: true,
-      });
-    }
-    return () => {
-      foregroundSignal.removeEventListener('abort', relayForegroundAbort);
-    };
-  }
-
-  /**
-   * @plan PLAN-20260130-ASYNCTASK.P11
-   *
-   * Note: Async tasks run in the background — the foreground agent does not
-   * await their completion. They ARE, however, linked to the launching
-   * foreground turn's abort signal (issue #2074): the async abort controller
-   * registered with the AsyncTaskManager is passed to orchestrator.launch and
-   * relayed from the foreground signal, so pressing ESC (which aborts the
-   * foreground turn) also cancels the detached subagent. The AsyncTaskManager
-   * still owns timeout-driven cancellation independently of the foreground.
-   */
-  /**
-   * Validates async preconditions and reserves a booking slot. Returns either
-   * an error ToolResult (if async is unavailable or no slot is free) or the
-   * validated orchestrator + task manager + booking id.
-   */
-  private resolveAsyncContext():
-    | ToolResult
-    | {
-        asyncTaskManager: AsyncTaskManager;
-        orchestrator: SubagentOrchestrator;
-        bookingId: string;
-      } {
-    const settingsCheck = this.checkAsyncSettings();
-    if (settingsCheck) {
-      return settingsCheck;
-    }
-
-    const asyncTaskManager = this.deps.getAsyncTaskManager?.();
-    if (asyncTaskManager === undefined) {
-      return {
-        llmContent: 'Async mode requires AsyncTaskManager to be configured.',
-        returnDisplay: 'Error: Async mode not available.',
-        error: {
-          message: 'AsyncTaskManager not configured',
-          type: ToolErrorType.EXECUTION_FAILED,
-        },
-      };
-    }
-
-    let orchestrator: SubagentOrchestrator;
-    try {
-      orchestrator = this.deps.createOrchestrator();
-    } catch (error) {
-      return this.createErrorResult(
-        error,
-        'Failed to create orchestrator for async task.',
-      );
-    }
-
-    const bookingId = asyncTaskManager.tryReserveAsyncSlot();
-    if (!bookingId) {
-      return this.createAsyncSlotResult(asyncTaskManager);
-    }
-
-    return { asyncTaskManager, orchestrator, bookingId };
-  }
-
   private async executeAsync(
     signal: AbortSignal,
     updateOutput?: (output: string) => void,
   ): Promise<ToolResult> {
-    const ctx = this.resolveAsyncContext();
-    if (!('asyncTaskManager' in ctx)) {
-      return ctx;
-    }
-    const { asyncTaskManager, orchestrator, bookingId } = ctx;
-
-    const setupResult = await this.setupAsyncInfrastructure(
+    return executeAsyncTask(
+      {
+        config: this.config,
+        normalized: this.normalized,
+        params: this.params,
+        createOrchestrator: () => this.deps.createOrchestrator(),
+        getAsyncTaskManager: this.deps.getAsyncTaskManager,
+        isInteractiveEnvironment: this.deps.isInteractiveEnvironment,
+        getSchedulerFactory: this.deps.getSchedulerFactory,
+        buildLaunchRequest: () => this.createLaunchRequest(),
+        buildContextState: () => this.buildContextState(),
+      },
       signal,
-      orchestrator,
-      asyncTaskManager,
-      bookingId,
-    );
-    if ('error' in setupResult && setupResult.error) {
-      return setupResult;
-    }
-
-    const {
-      launchResult: _launchResult,
-      agentId,
-      scope,
-      contextState,
-      dispose,
-      asyncAbortController,
-      timeoutId,
-      timedOut,
-      cleanupForegroundRelay,
-    } = setupResult as AsyncSetupResult;
-
-    const asyncStreaming = this.setupAsyncStreaming(
-      scope,
-      agentId,
       updateOutput,
     );
-
-    this.executeInBackground(
-      scope,
-      contextState,
-      agentId,
-      asyncTaskManager,
-      dispose,
-      asyncAbortController.signal,
-      timeoutId,
-      asyncStreaming?.emitAsyncClosingSubagentTag,
-      cleanupForegroundRelay,
-      timedOut,
-    );
-
-    return {
-      llmContent:
-        `Async task launched: subagent '${this.normalized.subagentName}' (ID: ${agentId}). ` +
-        `Task is running in background. Use 'check_async_tasks' to monitor progress.`,
-      returnDisplay: `Async task started: **${this.normalized.subagentName}** (\`${agentId}\`)`,
-      metadata: {
-        agentId,
-        async: true,
-        status: 'running',
-      },
-    };
-  }
-
-  private checkAsyncSettings(): ToolResult | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    const settingsService = this.config.getSettingsService?.();
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    const globalSettings = settingsService?.getAllGlobalSettings?.() ?? {};
-    const subagentsSettings = globalSettings['subagents'] as
-      | { asyncEnabled?: boolean; maxAsync?: number }
-      | undefined;
-    const globalAsyncEnabled = subagentsSettings?.asyncEnabled !== false;
-    if (!globalAsyncEnabled) {
-      return {
-        llmContent:
-          'Async subagents are globally disabled via /settings. Enable "Async Subagents Enabled" in /settings to use async mode.',
-        returnDisplay: 'Error: Async subagents are globally disabled.',
-        error: {
-          message: 'Async subagents are globally disabled via /settings.',
-          type: ToolErrorType.EXECUTION_FAILED,
-        },
-      };
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    const ephemeralSettings = this.config.getEphemeralSettings?.() ?? {};
-    const profileAsyncEnabled =
-      ephemeralSettings['subagents.async.enabled'] !== false;
-    if (!profileAsyncEnabled) {
-      return {
-        llmContent:
-          'This profile disables async subagents. Re-enable with: /set subagents.async.enabled true',
-        returnDisplay: 'Error: Async subagents disabled in profile.',
-        error: {
-          message: 'Async subagents disabled in active profile.',
-          type: ToolErrorType.EXECUTION_FAILED,
-        },
-      };
-    }
-
-    return undefined;
-  }
-
-  private createAsyncSlotResult(
-    asyncTaskManager: AsyncTaskManager,
-  ): ToolResult {
-    const canLaunch = asyncTaskManager.canLaunchAsync();
-    const baseReason = canLaunch.reason ?? 'Async task limit reached';
-    const guidance =
-      'You can: (1) wait for running async tasks to complete using check_async_tasks, ' +
-      '(2) launch this subagent synchronously (without async: true), or ' +
-      '(3) try again later when a slot is available.';
-    const errorMessage = `${baseReason}. ${guidance}`;
-    return {
-      llmContent: errorMessage,
-      returnDisplay: baseReason,
-      error: {
-        message: baseReason,
-        type: ToolErrorType.EXECUTION_FAILED,
-      },
-    };
-  }
-
-  private async setupAsyncInfrastructure(
-    foregroundSignal: AbortSignal,
-    orchestrator: SubagentOrchestrator,
-    asyncTaskManager: AsyncTaskManager,
-    bookingId: string | undefined,
-  ): Promise<(AsyncSetupResult & { error?: undefined }) | ToolResult> {
-    let launchResult: Awaited<ReturnType<SubagentOrchestrator['launch']>>;
-    let agentId: string | undefined;
-    let scope: SubAgentScope;
-    let contextState: ContextState;
-    let dispose: (() => Promise<void>) | undefined;
-    const asyncAbortController = new AbortController();
-    let timeoutId: NodeJS.Timeout | null = null;
-    let taskRegistered = false;
-    const timedOut = { value: false };
-
-    // Relay the foreground signal BEFORE launch so an ESC pressed while the
-    // orchestrator is still loading config/profile (issue #2074) aborts the
-    // launch in-flight instead of being missed during that window.
-    const cleanupForegroundRelay = this.setupForegroundRelay(
-      foregroundSignal,
-      asyncAbortController,
-    );
-
-    try {
-      const launchRequest = this.createLaunchRequest();
-      launchResult = await orchestrator.launch(
-        launchRequest,
-        asyncAbortController.signal,
-      );
-      agentId = launchResult.agentId;
-      scope = launchResult.scope;
-      dispose = launchResult.dispose;
-      contextState = this.buildContextState();
-
-      const timeoutSetup = this.setupAsyncTimeout(
-        asyncAbortController,
-        timedOut,
-      );
-      timeoutId = timeoutSetup.timeoutId;
-
-      asyncTaskManager.registerTask(
-        {
-          id: agentId,
-          subagentName: this.normalized.subagentName,
-          goalPrompt: this.normalized.goalPrompt,
-          abortController: asyncAbortController,
-        },
-        bookingId,
-      );
-      taskRegistered = true;
-    } catch (error) {
-      cleanupForegroundRelay();
-      if (!taskRegistered && bookingId) {
-        asyncTaskManager.cancelReservation(bookingId);
-      }
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      if (dispose) {
-        // Defensively swallow disposal errors on the partial-launch path so a
-        // rejecting dispose() cannot surface as an unhandled rejection.
-        void dispose().catch(() => {});
-      }
-      return this.createErrorResult(
-        error,
-        `Failed to launch async subagent '${this.normalized.subagentName}'.`,
-      );
-    }
-
-    return {
-      launchResult,
-      agentId,
-      scope,
-      contextState,
-      dispose,
-      asyncAbortController,
-      timeoutId,
-      timedOut,
-      cleanupForegroundRelay,
-    };
-  }
-
-  private setupAsyncTimeout(
-    asyncAbortController: AbortController,
-    timedOut: { value: boolean },
-  ): {
-    timeoutId: NodeJS.Timeout | null;
-  } {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-    const settings = this.config.getEphemeralSettings?.() ?? {};
-    const defaultTimeoutSeconds =
-      (settings['task-default-timeout-seconds'] as number | undefined) ??
-      DEFAULT_TASK_TIMEOUT_SECONDS;
-    const maxTimeoutSeconds =
-      (settings['task-max-timeout-seconds'] as number | undefined) ??
-      MAX_TASK_TIMEOUT_SECONDS;
-
-    const timeoutSeconds = this.resolveTimeoutSeconds(
-      this.params.timeout_seconds,
-      defaultTimeoutSeconds,
-      maxTimeoutSeconds,
-    );
-    const timeoutMs =
-      timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000;
-    const timeoutId =
-      timeoutMs === undefined
-        ? null
-        : setTimeout(() => {
-            timedOut.value = true;
-            asyncAbortController.abort();
-          }, timeoutMs);
-
-    return { timeoutId };
-  }
-
-  private setupAsyncStreaming(
-    scope: SubAgentScope,
-    agentId: string,
-    updateOutput?: (output: string) => void,
-  ): { emitAsyncClosingSubagentTag: () => void } | undefined {
-    if (!updateOutput) return undefined;
-
-    let asyncXmlOutputOpen = false;
-    const emitAsyncClosingSubagentTag = () => {
-      if (!asyncXmlOutputOpen) {
-        return;
-      }
-      updateOutput(
-        `</subagent name="${this.normalized.subagentName}" id="${agentId}">\n`,
-      );
-      asyncXmlOutputOpen = false;
-    };
-
-    updateOutput(
-      `<subagent name="${this.normalized.subagentName}" id="${agentId}">\n`,
-    );
-    asyncXmlOutputOpen = true;
-
-    const existingHandler = scope.onMessage;
-    scope.onMessage = (message: string) => {
-      const cleaned = normalizeSubagentStreamingText(message);
-      if (cleaned.trim().length > 0) {
-        updateOutput(cleaned);
-      }
-      existingHandler?.(message);
-    };
-
-    return { emitAsyncClosingSubagentTag };
-  }
-
-  /**
-   * Handles the background task after the scope run completes with an aborted
-   * signal. Distinguishes timeout (failTask) from user-initiated cancellation
-   * (cancelTask, idempotent). Only acts if the task is still 'running' so a
-   * prior cancelTask is not overwritten.
-   */
-  private handleBackgroundAbort(
-    asyncTaskManager: AsyncTaskManager,
-    agentId: string,
-    timedOut: boolean,
-  ): void {
-    const task = asyncTaskManager.getTask(agentId);
-    if (task?.status !== 'running') return;
-    if (timedOut) {
-      asyncTaskManager.failTask(agentId, 'Async task timed out');
-    } else {
-      asyncTaskManager.cancelTask(agentId);
-    }
-  }
-
-  /**
-   * @plan PLAN-20260130-ASYNCTASK.P11
-   *
-   * Execute async task in background using the SAME execution path as sync tasks.
-   * The only difference is the foreground agent doesn't wait for completion.
-   * - Interactive environment → runInteractive() with shared scheduler (tool calls show in UI)
-   * - Non-interactive environment → runNonInteractive()
-   */
-  private executeInBackground(
-    scope: SubAgentScope,
-    contextState: ContextState,
-    agentId: string,
-    asyncTaskManager: AsyncTaskManager,
-    dispose: () => Promise<void>,
-    signal: AbortSignal,
-    timeoutId: ReturnType<typeof setTimeout> | null,
-    emitClosingSubagentTag?: () => void,
-    cleanupForegroundRelay?: () => void,
-    timedOut?: { value: boolean },
-  ): void {
-    void (async () => {
-      try {
-        const environmentInteractive =
-          this.deps.isInteractiveEnvironment?.() ?? true;
-
-        if (
-          environmentInteractive &&
-          typeof scope.runInteractive === 'function'
-        ) {
-          const schedulerFactory = this.deps.getSchedulerFactory?.();
-          const interactiveOptions = schedulerFactory
-            ? { schedulerFactory }
-            : undefined;
-          await scope.runInteractive(contextState, interactiveOptions);
-        } else {
-          await scope.runNonInteractive(contextState);
-        }
-
-        if (signal.aborted) {
-          this.handleBackgroundAbort(
-            asyncTaskManager,
-            agentId,
-            timedOut?.value === true,
-          );
-          return;
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-        const output = scope.output ?? {
-          terminate_reason: SubagentTerminateMode.ERROR,
-          emitted_vars: {},
-        };
-
-        asyncTaskManager.completeTask(agentId, output);
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        asyncTaskManager.failTask(agentId, errorMessage);
-      } finally {
-        emitClosingSubagentTag?.();
-
-        if (timeoutId !== null) {
-          clearTimeout(timeoutId);
-        }
-
-        cleanupForegroundRelay?.();
-
-        try {
-          await dispose();
-        } catch {
-          // Swallow dispose errors
-        }
-      }
-    })();
   }
 }
 
@@ -1625,47 +848,7 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
   }
 
   private normalizeParams(params: TaskToolParams): TaskToolInvocationParams {
-    const subagentName = (
-      params.subagent_name ??
-      params.subagentName ??
-      ''
-    ).trim();
-    const goalPrompt = (params.goal_prompt ?? params.goalPrompt ?? '').trim();
-
-    const behaviourPrompts = [
-      goalPrompt,
-      // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      ...(params.behaviour_prompts ??
-        params.behavior_prompts ??
-        params.behaviourPrompts ??
-        params.behaviorPrompts ??
-        []),
-    ]
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      .map((prompt) => prompt?.trim())
-      .filter((prompt): prompt is string => Boolean(prompt))
-      .filter((prompt, index, array) => array.indexOf(prompt) === index);
-
-    const toolWhitelist = (params.tool_whitelist ?? params.toolWhitelist ?? [])
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      .map((tool) => tool?.trim())
-      .filter((tool): tool is string => Boolean(tool));
-
-    const outputSpec = params.output_spec ?? params.outputSpec ?? undefined;
-
-    const context =
-      params.context ?? params.context_vars ?? params.contextVars ?? {};
-
-    return {
-      subagentName,
-      goalPrompt,
-      behaviourPrompts,
-      toolWhitelist: toolWhitelist.length > 0 ? toolWhitelist : undefined,
-      outputSpec,
-      context,
-      maxTurns: params.max_turns,
-      async: params.async ?? false,
-    };
+    return normalizeTaskParams(params);
   }
 
   private ensureOrchestrator(): SubagentOrchestrator {
@@ -1673,19 +856,12 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
       return this.dependencies.orchestratorFactory();
     }
 
-    const configWithManagers = this.config as Config & {
-      getProfileManager?: () => ProfileManager | undefined;
-      getSubagentManager?: () => SubagentManager | undefined;
-    };
-
     const profileManager =
       this.dependencies.profileManager ??
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      configWithManagers.getProfileManager?.();
+      resolveOptionalConfigMethod(this.config, 'getProfileManager');
     const subagentManager =
       this.dependencies.subagentManager ??
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- BN4-C-P01: preserve defensive runtime boundary guard despite current static types.
-      configWithManagers.getSubagentManager?.();
+      resolveOptionalConfigMethod(this.config, 'getSubagentManager');
 
     if (!profileManager || !subagentManager) {
       throw new Error(
@@ -1699,5 +875,4 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
       foregroundConfig: this.config,
     });
   }
-  /* eslint-enable complexity, max-lines -- Phase 5: legacy core boundary retained while larger decomposition continues. */
 }

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -61,7 +61,9 @@ function resolveOptionalConfigMethod<T>(
   methodName: 'getProfileManager' | 'getSubagentManager',
 ): T | undefined {
   const fn = (config as unknown as Record<string, unknown>)[methodName];
-  return typeof fn === 'function' ? (fn as () => T)() : undefined;
+  return typeof fn === 'function'
+    ? (fn as (this: Config) => T).call(config)
+    : undefined;
 }
 
 export interface TaskToolParams {

--- a/packages/agents/src/tools/taskAbortHelpers.ts
+++ b/packages/agents/src/tools/taskAbortHelpers.ts
@@ -1,0 +1,297 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
+import type { SubagentLaunchRequest } from '../core/subagentOrchestrator.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+
+const abortLogger = new DebugLogger('llxprt:task');
+
+// Tool timeout settings (Issue #1049)
+export const DEFAULT_TASK_TIMEOUT_SECONDS = 900;
+export const MAX_TASK_TIMEOUT_SECONDS = 1800;
+
+/**
+ * Reads ephemeral settings from the config using boundary-validation.
+ *
+ * The static `Config` type declares `getEphemeralSettings` as a required
+ * method, but callers (and tests) routinely pass partial objects where the
+ * method is absent. Validating with `typeof === 'function'` keeps the runtime
+ * guard without tripping `@typescript-eslint/no-unnecessary-condition`.
+ */
+export function readEphemeralSettings(config: {
+  getEphemeralSettings?: () => Record<string, unknown> | undefined;
+}): Record<string, unknown> {
+  return typeof config.getEphemeralSettings === 'function'
+    ? (config.getEphemeralSettings() ?? {})
+    : {};
+}
+
+/**
+ * Resolves the effective timeout (seconds) from the requested value, the
+ * configured default, and the configured maximum. Returns `undefined` when
+ * timeouts are disabled (-1).
+ */
+export function resolveTimeoutSeconds(
+  requestedTimeoutSeconds: number | undefined,
+  defaultTimeoutSeconds: number,
+  maxTimeoutSeconds: number,
+): number | undefined {
+  if (requestedTimeoutSeconds === -1 || defaultTimeoutSeconds === -1) {
+    return undefined;
+  }
+
+  const effectiveTimeout = requestedTimeoutSeconds ?? defaultTimeoutSeconds;
+  if (maxTimeoutSeconds === -1) {
+    return effectiveTimeout;
+  }
+
+  if (effectiveTimeout > maxTimeoutSeconds) {
+    return maxTimeoutSeconds;
+  }
+
+  return effectiveTimeout;
+}
+
+/**
+ * Resolves timeout seconds from the config's ephemeral settings, applying the
+ * default and maximum bounds configured there.
+ */
+export function resolveTimeoutFromConfig(
+  config: {
+    getEphemeralSettings?: () => Record<string, unknown> | undefined;
+  },
+  requestedTimeoutSeconds: number | undefined,
+): number | undefined {
+  const settings = readEphemeralSettings(config);
+  const defaultTimeoutSeconds =
+    (settings['task-default-timeout-seconds'] as number | undefined) ??
+    DEFAULT_TASK_TIMEOUT_SECONDS;
+  const maxTimeoutSeconds =
+    (settings['task-max-timeout-seconds'] as number | undefined) ??
+    MAX_TASK_TIMEOUT_SECONDS;
+
+  return resolveTimeoutSeconds(
+    requestedTimeoutSeconds,
+    defaultTimeoutSeconds,
+    maxTimeoutSeconds,
+  );
+}
+
+export interface TimeoutControllers {
+  timeoutMs?: number;
+  timeoutSeconds?: number;
+  timeoutController: AbortController;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+  onUserAbort: () => void;
+}
+
+/**
+ * Creates the foreground timeout controllers and wires the user-provided abort
+ * signal so that an external abort also fires the timeout controller (and
+ * clears any pending timeout).
+ */
+export function createTimeoutControllers(
+  config: {
+    getEphemeralSettings?: () => Record<string, unknown> | undefined;
+  },
+  signal: AbortSignal,
+  requestedTimeoutSeconds: number | undefined,
+): TimeoutControllers {
+  const timeoutSeconds = resolveTimeoutFromConfig(
+    config,
+    requestedTimeoutSeconds,
+  );
+  const timeoutMs =
+    timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000;
+  const timeoutController = new AbortController();
+  const timeoutId =
+    timeoutMs === undefined
+      ? null
+      : setTimeout(() => timeoutController.abort(), timeoutMs);
+
+  const onUserAbort = () => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+    timeoutController.abort();
+  };
+
+  signal.addEventListener('abort', onUserAbort, { once: true });
+
+  return {
+    timeoutMs,
+    timeoutSeconds,
+    timeoutController,
+    timeoutId,
+    onUserAbort,
+  };
+}
+
+/**
+ * Returns true when the error (if any) is a timeout: the timeout controller
+ * aborted while the foreground signal did not, and the error is either absent
+ * or an AbortError.
+ */
+export function isTimeoutError(
+  signal: AbortSignal,
+  timeoutController: AbortController,
+  isAbortError: (error: unknown) => boolean,
+  error?: unknown,
+): boolean {
+  if (!timeoutController.signal.aborted || signal.aborted) {
+    return false;
+  }
+  if (error === undefined || error === null) {
+    return true;
+  }
+  return isAbortError(error);
+}
+
+/**
+ * Returns true when the given error is an `AbortError` (by `name` property).
+ */
+export function isAbortError(error: unknown): boolean {
+  if (error === null || error === undefined || typeof error !== 'object') {
+    return false;
+  }
+  const result = (error as { name?: string }).name === 'AbortError';
+  return result;
+}
+
+export interface AbortState {
+  aborted: { aborted: boolean; timedOut: boolean };
+  abortHandler: () => void;
+  removeAbortHandler: () => void;
+  setLaunchResult: (
+    result: Awaited<ReturnType<SubagentOrchestrator['launch']>>,
+  ) => void;
+}
+
+/**
+ * Creates the abort-state closure used during synchronous launch. The abort
+ * handler cancels the live subagent scope (if one has been set) when the
+ * foreground signal fires.
+ */
+export function createAbortState(
+  launchRequest: SubagentLaunchRequest,
+  signal: AbortSignal,
+): AbortState {
+  const state = { aborted: false, timedOut: false };
+  let liveScope:
+    | Awaited<ReturnType<SubagentOrchestrator['launch']>>
+    | undefined;
+  const abortHandler = () => {
+    if (state.aborted) return;
+    state.aborted = true;
+    abortLogger.warn(
+      () => `Cancellation requested for subagent '${launchRequest.name}'`,
+    );
+    try {
+      const candidate = liveScope?.scope as
+        | { cancel?: (reason?: string) => void }
+        | undefined;
+      candidate?.cancel?.('User aborted task execution.');
+    } catch (error) {
+      abortLogger.warn(
+        () =>
+          `Error while cancelling subagent '${launchRequest.name}': ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+  const removeAbortHandler = () => {
+    signal.removeEventListener('abort', abortHandler);
+  };
+  const setLaunchResult = (
+    result: Awaited<ReturnType<SubagentOrchestrator['launch']>>,
+  ) => {
+    liveScope = result;
+  };
+  return {
+    aborted: state,
+    abortHandler,
+    removeAbortHandler,
+    setLaunchResult,
+  };
+}
+
+/**
+ * Handles the background task after the scope run completes with an aborted
+ * signal. Distinguishes timeout (failTask) from user-initiated cancellation
+ * (cancelTask, idempotent). Only acts if the task is still 'running' so a
+ * prior cancelTask is not overwritten.
+ */
+export function handleBackgroundAbort(
+  asyncTaskManager: {
+    getTask: (agentId: string) => { status: string } | undefined;
+    failTask: (agentId: string, reason: string) => void;
+    cancelTask: (agentId: string) => void;
+  },
+  agentId: string,
+  timedOut: boolean,
+): void {
+  const task = asyncTaskManager.getTask(agentId);
+  if (task?.status !== 'running') return;
+  if (timedOut) {
+    asyncTaskManager.failTask(agentId, 'Async task timed out');
+  } else {
+    asyncTaskManager.cancelTask(agentId);
+  }
+}
+
+/**
+ * Sets up an async timeout that aborts the provided controller and records the
+ * timeout in the shared `timedOut` flag. Returns the pending timeout id (or
+ * null when timeouts are disabled).
+ */
+export function setupAsyncTimeout(
+  config: {
+    getEphemeralSettings?: () => Record<string, unknown> | undefined;
+  },
+  requestedTimeoutSeconds: number | undefined,
+  asyncAbortController: AbortController,
+  timedOut: { value: boolean },
+): {
+  timeoutId: NodeJS.Timeout | null;
+} {
+  const timeoutSeconds = resolveTimeoutFromConfig(
+    config,
+    requestedTimeoutSeconds,
+  );
+  const timeoutMs =
+    timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000;
+  const timeoutId =
+    timeoutMs === undefined
+      ? null
+      : setTimeout(() => {
+          timedOut.value = true;
+          asyncAbortController.abort();
+        }, timeoutMs);
+
+  return { timeoutId };
+}
+
+/**
+ * Wires the foreground turn's abort signal into the async abort controller so
+ * that ESC (which aborts the foreground turn) also cancels the detached
+ * subagent. Returns a cleanup function that removes the listener.
+ */
+export function setupForegroundRelay(
+  foregroundSignal: AbortSignal,
+  asyncAbortController: AbortController,
+): () => void {
+  const relayForegroundAbort = () => asyncAbortController.abort();
+  if (foregroundSignal.aborted) {
+    asyncAbortController.abort();
+  } else {
+    foregroundSignal.addEventListener('abort', relayForegroundAbort, {
+      once: true,
+    });
+  }
+  return () => {
+    foregroundSignal.removeEventListener('abort', relayForegroundAbort);
+  };
+}

--- a/packages/agents/src/tools/taskAsyncExecution.ts
+++ b/packages/agents/src/tools/taskAsyncExecution.ts
@@ -1,0 +1,455 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type {
+  SubagentOrchestrator,
+  SubagentLaunchRequest,
+} from '../core/subagentOrchestrator.js';
+import type { SubAgentScope } from '../core/subagent.js';
+import { type ContextState } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
+import type { SubagentSchedulerFactory } from '../core/subagentScheduler.js';
+import { type ToolResult, ToolErrorType } from '@vybestack/llxprt-code-tools';
+import { type TaskToolInvocationParams } from './taskToolGovernance.js';
+import {
+  handleBackgroundAbort,
+  readEphemeralSettings,
+  setupAsyncTimeout,
+  setupForegroundRelay,
+} from './taskAbortHelpers.js';
+import { createErrorResult } from './taskResultHelpers.js';
+
+export interface AsyncSetupResult {
+  launchResult: Awaited<ReturnType<SubagentOrchestrator['launch']>>;
+  agentId: string;
+  scope: SubAgentScope;
+  contextState: ContextState;
+  dispose: () => Promise<void>;
+  asyncAbortController: AbortController;
+  timeoutId: NodeJS.Timeout | null;
+  timedOut: { value: boolean };
+  cleanupForegroundRelay: () => void;
+}
+
+/** Collaborators needed to run an async task. */
+export interface AsyncTaskCollaborators {
+  config: Config;
+  normalized: TaskToolInvocationParams;
+  params: { timeout_seconds?: number; grace_period_seconds?: number };
+  createOrchestrator: () => SubagentOrchestrator;
+  getAsyncTaskManager?: () => AsyncTaskManager | undefined;
+  isInteractiveEnvironment?: () => boolean;
+  getSchedulerFactory?: () => SubagentSchedulerFactory | undefined;
+  buildLaunchRequest: (params: {
+    timeout_seconds?: number;
+    grace_period_seconds?: number;
+  }) => SubagentLaunchRequest;
+  buildContextState: () => ContextState;
+}
+
+/** Normalizes a streaming text fragment to a single trailing newline. */
+export function normalizeSubagentStreamingText(text: string): string {
+  if (!text) {
+    return '';
+  }
+  const lf = text.replace(/\r\n?/g, '\n');
+  return lf.endsWith('\n') ? lf : lf + '\n';
+}
+
+/**
+ * Reads global + ephemeral settings to determine whether async subagents are
+ * enabled. Returns an error `ToolResult` when disabled, otherwise `undefined`.
+ *
+ * Uses boundary-validation for `getSettingsService` because partial config
+ * mocks omit the method even though the static `Config` type requires it.
+ */
+export function checkAsyncSettings(config: Config): ToolResult | undefined {
+  const settingsService =
+    typeof config.getSettingsService === 'function'
+      ? config.getSettingsService()
+      : undefined;
+  const globalSettings =
+    settingsService &&
+    typeof settingsService.getAllGlobalSettings === 'function'
+      ? settingsService.getAllGlobalSettings()
+      : {};
+  const subagentsSettings = globalSettings['subagents'] as
+    | { asyncEnabled?: boolean; maxAsync?: number }
+    | undefined;
+  const globalAsyncEnabled = subagentsSettings?.asyncEnabled !== false;
+  if (!globalAsyncEnabled) {
+    return {
+      llmContent:
+        'Async subagents are globally disabled via /settings. Enable "Async Subagents Enabled" in /settings to use async mode.',
+      returnDisplay: 'Error: Async subagents are globally disabled.',
+      error: {
+        message: 'Async subagents are globally disabled via /settings.',
+        type: ToolErrorType.EXECUTION_FAILED,
+      },
+    };
+  }
+
+  const ephemeralSettings = readEphemeralSettings(config);
+  const profileAsyncEnabled =
+    ephemeralSettings['subagents.async.enabled'] !== false;
+  if (!profileAsyncEnabled) {
+    return {
+      llmContent:
+        'This profile disables async subagents. Re-enable with: /set subagents.async.enabled true',
+      returnDisplay: 'Error: Async subagents disabled in profile.',
+      error: {
+        message: 'Async subagents disabled in active profile.',
+        type: ToolErrorType.EXECUTION_FAILED,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Builds the "no async slot available" `ToolResult`.
+ */
+export function createAsyncSlotResult(
+  asyncTaskManager: AsyncTaskManager,
+): ToolResult {
+  const canLaunch = asyncTaskManager.canLaunchAsync();
+  const baseReason = canLaunch.reason ?? 'Async task limit reached';
+  const guidance =
+    'You can: (1) wait for running async tasks to complete using check_async_tasks, ' +
+    '(2) launch this subagent synchronously (without async: true), or ' +
+    '(3) try again later when a slot is available.';
+  const errorMessage = `${baseReason}. ${guidance}`;
+  return {
+    llmContent: errorMessage,
+    returnDisplay: baseReason,
+    error: {
+      message: baseReason,
+      type: ToolErrorType.EXECUTION_FAILED,
+    },
+  };
+}
+
+/**
+ * Validates async preconditions and reserves a booking slot. Returns either
+ * an error ToolResult or the validated orchestrator + task manager + booking id.
+ */
+export function resolveAsyncContext(collaborators: AsyncTaskCollaborators):
+  | ToolResult
+  | {
+      asyncTaskManager: AsyncTaskManager;
+      orchestrator: SubagentOrchestrator;
+      bookingId: string;
+    } {
+  const settingsCheck = checkAsyncSettings(collaborators.config);
+  if (settingsCheck) {
+    return settingsCheck;
+  }
+
+  const asyncTaskManager = collaborators.getAsyncTaskManager?.();
+  if (asyncTaskManager === undefined) {
+    return {
+      llmContent: 'Async mode requires AsyncTaskManager to be configured.',
+      returnDisplay: 'Error: Async mode not available.',
+      error: {
+        message: 'AsyncTaskManager not configured',
+        type: ToolErrorType.EXECUTION_FAILED,
+      },
+    };
+  }
+
+  let orchestrator: SubagentOrchestrator;
+  try {
+    orchestrator = collaborators.createOrchestrator();
+  } catch (error) {
+    return createErrorResult(
+      error,
+      'Failed to create orchestrator for async task.',
+    );
+  }
+
+  const bookingId = asyncTaskManager.tryReserveAsyncSlot();
+  if (!bookingId) {
+    return createAsyncSlotResult(asyncTaskManager);
+  }
+
+  return { asyncTaskManager, orchestrator, bookingId };
+}
+
+/**
+ * Sets up the async infrastructure: relays the foreground signal, launches the
+ * subagent, registers the task, and arms the timeout. Returns either an error
+ * `ToolResult` (on launch failure) or the `AsyncSetupResult`.
+ */
+export async function setupAsyncInfrastructure(
+  collaborators: AsyncTaskCollaborators,
+  foregroundSignal: AbortSignal,
+  orchestrator: SubagentOrchestrator,
+  asyncTaskManager: AsyncTaskManager,
+  bookingId: string | undefined,
+): Promise<(AsyncSetupResult & { error?: undefined }) | ToolResult> {
+  let launchResult: Awaited<ReturnType<SubagentOrchestrator['launch']>>;
+  let agentId: string | undefined;
+  let scope: SubAgentScope;
+  let contextState: ContextState;
+  let dispose: (() => Promise<void>) | undefined;
+  const asyncAbortController = new AbortController();
+  let timeoutId: NodeJS.Timeout | null = null;
+  let taskRegistered = false;
+  const timedOut = { value: false };
+
+  // Relay the foreground signal BEFORE launch so an ESC pressed while the
+  // orchestrator is still loading config/profile (issue #2074) aborts the
+  // launch in-flight instead of being missed during that window.
+  const cleanupForegroundRelay = setupForegroundRelay(
+    foregroundSignal,
+    asyncAbortController,
+  );
+
+  try {
+    const launchRequest = collaborators.buildLaunchRequest(
+      collaborators.params,
+    );
+    launchResult = await orchestrator.launch(
+      launchRequest,
+      asyncAbortController.signal,
+    );
+    agentId = launchResult.agentId;
+    scope = launchResult.scope;
+    dispose = launchResult.dispose;
+    contextState = collaborators.buildContextState();
+
+    const timeoutSetup = setupAsyncTimeout(
+      collaborators.config,
+      collaborators.params.timeout_seconds,
+      asyncAbortController,
+      timedOut,
+    );
+    timeoutId = timeoutSetup.timeoutId;
+
+    asyncTaskManager.registerTask(
+      {
+        id: agentId,
+        subagentName: collaborators.normalized.subagentName,
+        goalPrompt: collaborators.normalized.goalPrompt,
+        abortController: asyncAbortController,
+      },
+      bookingId,
+    );
+    taskRegistered = true;
+  } catch (error) {
+    cleanupForegroundRelay();
+    if (!taskRegistered && bookingId) {
+      asyncTaskManager.cancelReservation(bookingId);
+    }
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    if (dispose) {
+      // Defensively swallow disposal errors on the partial-launch path so a
+      // rejecting dispose() cannot surface as an unhandled rejection.
+      void dispose().catch(() => {});
+    }
+    return createErrorResult(
+      error,
+      `Failed to launch async subagent '${collaborators.normalized.subagentName}'.`,
+    );
+  }
+
+  return {
+    launchResult,
+    agentId,
+    scope,
+    contextState,
+    dispose,
+    asyncAbortController,
+    timeoutId,
+    timedOut,
+    cleanupForegroundRelay,
+  };
+}
+
+/**
+ * Sets up async streaming XML tags and message relay. Returns `undefined` when
+ * no `updateOutput` callback was supplied.
+ */
+export function setupAsyncStreaming(
+  subagentName: string,
+  scope: SubAgentScope,
+  agentId: string,
+  updateOutput?: (output: string) => void,
+): { emitAsyncClosingSubagentTag: () => void } | undefined {
+  if (!updateOutput) return undefined;
+
+  let asyncXmlOutputOpen = false;
+  const emitAsyncClosingSubagentTag = () => {
+    if (!asyncXmlOutputOpen) {
+      return;
+    }
+    updateOutput(`</subagent name="${subagentName}" id="${agentId}">\n`);
+    asyncXmlOutputOpen = false;
+  };
+
+  updateOutput(`<subagent name="${subagentName}" id="${agentId}">\n`);
+  asyncXmlOutputOpen = true;
+
+  const existingHandler = scope.onMessage;
+  scope.onMessage = (message: string) => {
+    const cleaned = normalizeSubagentStreamingText(message);
+    if (cleaned.trim().length > 0) {
+      updateOutput(cleaned);
+    }
+    existingHandler?.(message);
+  };
+
+  return { emitAsyncClosingSubagentTag };
+}
+
+/**
+ * @plan PLAN-20260130-ASYNCTASK.P11
+ *
+ * Execute async task in background using the SAME execution path as sync tasks.
+ * The only difference is the foreground agent doesn't wait for completion.
+ * - Interactive environment → runInteractive() with shared scheduler
+ * - Non-interactive environment → runNonInteractive()
+ */
+export function executeInBackground(
+  collaborators: AsyncTaskCollaborators,
+  scope: SubAgentScope,
+  contextState: ContextState,
+  agentId: string,
+  asyncTaskManager: AsyncTaskManager,
+  dispose: () => Promise<void>,
+  signal: AbortSignal,
+  timeoutId: ReturnType<typeof setTimeout> | null,
+  emitClosingSubagentTag?: () => void,
+  cleanupForegroundRelay?: () => void,
+  timedOut?: { value: boolean },
+): void {
+  void (async () => {
+    try {
+      const environmentInteractive =
+        collaborators.isInteractiveEnvironment?.() ?? true;
+
+      if (
+        environmentInteractive &&
+        typeof scope.runInteractive === 'function'
+      ) {
+        const schedulerFactory = collaborators.getSchedulerFactory?.();
+        const interactiveOptions = schedulerFactory
+          ? { schedulerFactory }
+          : undefined;
+        await scope.runInteractive(contextState, interactiveOptions);
+      } else {
+        await scope.runNonInteractive(contextState);
+      }
+
+      if (signal.aborted) {
+        handleBackgroundAbort(
+          asyncTaskManager,
+          agentId,
+          timedOut?.value === true,
+        );
+        return;
+      }
+
+      const output = scope.output;
+
+      asyncTaskManager.completeTask(agentId, output);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      asyncTaskManager.failTask(agentId, errorMessage);
+    } finally {
+      emitClosingSubagentTag?.();
+
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+
+      cleanupForegroundRelay?.();
+
+      try {
+        await dispose();
+      } catch {
+        // Swallow dispose errors
+      }
+    }
+  })();
+}
+
+/**
+ * Orchestrates the full async execution path: validate preconditions, set up
+ * infrastructure, stream, and kick off background execution. Returns the
+ * "task launched" `ToolResult` immediately.
+ */
+export async function executeAsyncTask(
+  collaborators: AsyncTaskCollaborators,
+  signal: AbortSignal,
+  updateOutput?: (output: string) => void,
+): Promise<ToolResult> {
+  const ctx = resolveAsyncContext(collaborators);
+  if (!('asyncTaskManager' in ctx)) {
+    return ctx;
+  }
+  const { asyncTaskManager, orchestrator, bookingId } = ctx;
+
+  const setupResult = await setupAsyncInfrastructure(
+    collaborators,
+    signal,
+    orchestrator,
+    asyncTaskManager,
+    bookingId,
+  );
+  if ('error' in setupResult && setupResult.error) {
+    return setupResult;
+  }
+
+  const {
+    agentId,
+    scope,
+    contextState,
+    dispose,
+    asyncAbortController,
+    timeoutId,
+    timedOut,
+    cleanupForegroundRelay,
+  } = setupResult as AsyncSetupResult;
+
+  const asyncStreaming = setupAsyncStreaming(
+    collaborators.normalized.subagentName,
+    scope,
+    agentId,
+    updateOutput,
+  );
+
+  executeInBackground(
+    collaborators,
+    scope,
+    contextState,
+    agentId,
+    asyncTaskManager,
+    dispose,
+    asyncAbortController.signal,
+    timeoutId,
+    asyncStreaming?.emitAsyncClosingSubagentTag,
+    cleanupForegroundRelay,
+    timedOut,
+  );
+
+  return {
+    llmContent:
+      `Async task launched: subagent '${collaborators.normalized.subagentName}' (ID: ${agentId}). ` +
+      `Task is running in background. Use 'check_async_tasks' to monitor progress.`,
+    returnDisplay: `Async task started: **${collaborators.normalized.subagentName}** (\`${agentId}\`)`,
+    metadata: {
+      agentId,
+      async: true,
+      status: 'running',
+    },
+  };
+}

--- a/packages/agents/src/tools/taskResultHelpers.ts
+++ b/packages/agents/src/tools/taskResultHelpers.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type ToolResult, ToolErrorType } from '@vybestack/llxprt-code-tools';
+import { type OutputObject } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { DEFAULT_AGENT_ID } from '@vybestack/llxprt-code-core/core/turn.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { DEFAULT_TASK_TIMEOUT_SECONDS } from './taskAbortHelpers.js';
+
+const resultLogger = new DebugLogger('llxprt:task');
+
+/**
+ * Boundary-validation helper: coerces a possibly-missing `emitted_vars`
+ * payload (subagent runtime data) to a string record, restoring the `?? {}`
+ * fallback stripped by issue #2085.
+ */
+function asStringRecord(value: unknown): Record<string, string> {
+  if (typeof value === 'object' && value !== null) {
+    return value as Record<string, string>;
+  }
+  return {};
+}
+
+/**
+ * Formats a human readable summary for successful subagent execution.
+ */
+export function formatSuccessDisplay(
+  subagentName: string,
+  agentId: string,
+  output: OutputObject,
+): string {
+  const emittedVars = Object.entries(asStringRecord(output.emitted_vars));
+  const finalMessageSection = output.final_message
+    ? `Final message:\n${output.final_message}`
+    : 'Final message: _(none)_';
+  const emittedSection =
+    emittedVars.length === 0
+      ? 'Emitted variables: _(none)_'
+      : `Emitted variables:\n${emittedVars
+          .map(([key, value]) => `- **${key}**: ${value}`)
+          .join('\n')}`;
+
+  return [
+    `Subagent **${subagentName}** (\`${agentId}\`) completed with status \`${output.terminate_reason}\`.`,
+    finalMessageSection,
+    emittedSection,
+  ].join('\n\n');
+}
+
+/**
+ * Summarizes the subagent output as JSON for inclusion in tool history.
+ */
+export function formatSuccessContent(
+  agentId: string,
+  output: OutputObject,
+): string {
+  const payload: Record<string, unknown> = {
+    agent_id: agentId,
+    terminate_reason: output.terminate_reason,
+    emitted_vars: asStringRecord(output.emitted_vars),
+  };
+
+  if (output.final_message !== undefined) {
+    payload.final_message = output.final_message;
+  }
+
+  return JSON.stringify(payload, null, 2);
+}
+
+/**
+ * Builds an error `ToolResult` from a thrown error, preferring the error's
+ * message when present.
+ */
+export function createErrorResult(
+  error: unknown,
+  fallbackMessage: string,
+  agentId?: string,
+): ToolResult {
+  const detail = error instanceof Error && error.message ? error.message : null;
+  const displayMessage = detail
+    ? `${fallbackMessage}\nDetails: ${detail}`
+    : fallbackMessage;
+  const message = detail ?? fallbackMessage;
+  resultLogger.warn(() => `Task tool error: ${displayMessage}`);
+  return {
+    llmContent: displayMessage,
+    returnDisplay: displayMessage,
+    metadata: agentId
+      ? {
+          agentId,
+          error: message,
+        }
+      : undefined,
+    error: {
+      message,
+      type: ToolErrorType.UNHANDLED_EXCEPTION,
+    },
+  };
+}
+
+/**
+ * Builds a cancelled `ToolResult`.
+ */
+export function createCancelledResult(
+  message: string,
+  agentId?: string,
+  output?: OutputObject,
+): ToolResult {
+  resultLogger.warn(
+    () =>
+      `Task tool cancelled for agentId=${agentId ?? DEFAULT_AGENT_ID}: ${message}`,
+  );
+  return {
+    llmContent: message,
+    returnDisplay: message,
+    metadata: {
+      agentId: agentId ?? DEFAULT_AGENT_ID,
+      terminateReason: output?.terminate_reason,
+      emittedVars: output?.emitted_vars ?? {},
+      ...(output?.final_message ? { finalMessage: output.final_message } : {}),
+      cancelled: true,
+    },
+    error: {
+      message,
+      type: ToolErrorType.EXECUTION_FAILED,
+    },
+  };
+}
+
+/**
+ * Builds a timeout `ToolResult`.
+ */
+export function createTimeoutResult(
+  timeoutSeconds: number | undefined,
+  output?: OutputObject,
+  agentId?: string,
+): ToolResult {
+  const message = `Task timed out after ${timeoutSeconds ?? DEFAULT_TASK_TIMEOUT_SECONDS}s (timeout_seconds).`;
+  return {
+    llmContent: message,
+    returnDisplay: message,
+    metadata: {
+      agentId: agentId ?? DEFAULT_AGENT_ID,
+      terminateReason: output?.terminate_reason,
+      emittedVars: output?.emitted_vars ?? {},
+      ...(output?.final_message ? { finalMessage: output.final_message } : {}),
+      timedOut: true,
+    },
+    error: {
+      message,
+      type: ToolErrorType.TIMEOUT,
+    },
+  };
+}

--- a/packages/agents/src/tools/taskToolGovernance.ts
+++ b/packages/agents/src/tools/taskToolGovernance.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
+import {
+  canonicalizeToolName,
+  buildToolGovernance,
+  isToolBlocked,
+} from '../core/toolGovernance.js';
+import type { TaskToolParams } from './task.js';
+
+const normalizeToolNameForPolicy = (name: string): string =>
+  canonicalizeToolName(name);
+
+/**
+ * Internal normalized parameters derived from the public `TaskToolParams`.
+ */
+export interface TaskToolInvocationParams {
+  subagentName: string;
+  goalPrompt: string;
+  behaviourPrompts: string[];
+  toolWhitelist?: string[];
+  outputSpec?: Record<string, string>;
+  context: Record<string, unknown>;
+  maxTurns?: number;
+  async: boolean;
+}
+
+/**
+ * The set of tool names always excluded from subagent tool whitelists
+ * (canonicalized).
+ */
+export function buildExcludedToolNames(): Set<string> {
+  return new Set(
+    ['task', 'list_subagents']
+      .map((name) => normalizeToolNameForPolicy(name))
+      .filter((name) => name.length > 0),
+  );
+}
+
+/**
+ * Returns true when the canonical form of `name` is in the excluded set.
+ */
+export function isExcludedToolName(
+  name: string,
+  excluded: Set<string>,
+): boolean {
+  const canonical = normalizeToolNameForPolicy(name);
+  return canonical.length > 0 && excluded.has(canonical);
+}
+
+/**
+ * Builds the governed tool whitelist from candidate tools and the registry,
+ * filtering excluded tools, blocked tools, and tools not present in the
+ * registry. Returns `undefined` when the result is empty so callers can apply
+ * fail-closed semantics for explicit whitelists.
+ */
+export function buildGovernedToolWhitelist(
+  candidateTools: string[] | undefined,
+  registry: ToolRegistry,
+  config: Config,
+): string[] | undefined {
+  if (!candidateTools || candidateTools.length === 0) {
+    return undefined;
+  }
+
+  const excluded = buildExcludedToolNames();
+  const governance = buildToolGovernance(config);
+  const allowedRegistryTools = registry
+    .getEnabledTools()
+    .map((tool) => tool.name)
+    .filter(
+      (name): name is string =>
+        typeof name === 'string' &&
+        name.length > 0 &&
+        !isExcludedToolName(name, excluded),
+    );
+
+  const allowedByCanonical = new Map<string, string>();
+  for (const toolName of allowedRegistryTools) {
+    const canonical = normalizeToolNameForPolicy(toolName);
+    if (canonical && !allowedByCanonical.has(canonical)) {
+      allowedByCanonical.set(canonical, toolName);
+    }
+  }
+
+  const filteredTools = candidateTools.map((name) => {
+    if (typeof name !== 'string' || isExcludedToolName(name, excluded)) {
+      return undefined;
+    }
+
+    const canonical = normalizeToolNameForPolicy(name);
+    if (!canonical || isToolBlocked(canonical, governance)) {
+      return undefined;
+    }
+
+    return allowedByCanonical.get(canonical);
+  });
+
+  const validTools = filteredTools.filter(
+    (name): name is string => typeof name === 'string' && name.length > 0,
+  );
+
+  if (validTools.length === 0) {
+    return undefined;
+  }
+
+  const uniqueByCanonical = new Set<string>();
+  const deduped: string[] = [];
+  for (const tool of validTools) {
+    const canonical = normalizeToolNameForPolicy(tool);
+    if (!canonical || uniqueByCanonical.has(canonical)) {
+      continue;
+    }
+    uniqueByCanonical.add(canonical);
+    deduped.push(tool);
+  }
+
+  return deduped.length > 0 ? deduped : undefined;
+}
+
+/**
+ * Filters excluded tools (task/list_subagents) from a whitelist when no
+ * registry is available to perform full governance validation. Non-excluded
+ * entries pass through unchanged. Returns undefined if the result is empty
+ * so the caller can apply fail-closed semantics for explicit whitelists.
+ */
+export function filterExcludedFromWhitelist(
+  candidateTools: string[] | undefined,
+): string[] | undefined {
+  if (!candidateTools || candidateTools.length === 0) {
+    return undefined;
+  }
+
+  const excluded = buildExcludedToolNames();
+  const filtered = candidateTools.filter(
+    (name) => typeof name === 'string' && !isExcludedToolName(name, excluded),
+  );
+
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+/**
+ * Normalizes the public `TaskToolParams` (which accepts multiple alias keys)
+ * into the canonical `TaskToolInvocationParams`. Trims prompts/tools, dedupes
+ * behaviour prompts, and resolves the async flag.
+ */
+export function normalizeTaskParams(
+  params: TaskToolParams,
+): TaskToolInvocationParams {
+  const subagentName = (
+    params.subagent_name ??
+    params.subagentName ??
+    ''
+  ).trim();
+  const goalPrompt = (params.goal_prompt ?? params.goalPrompt ?? '').trim();
+
+  const behaviourPrompts = [goalPrompt, ...resolveBehaviourPrompts(params)]
+    .map((prompt) => prompt.trim())
+    .filter((prompt): prompt is string => Boolean(prompt))
+    .filter((prompt, index, array) => array.indexOf(prompt) === index);
+
+  const toolWhitelist = resolveToolWhitelist(params)
+    .map((tool) => tool.trim())
+    .filter((tool): tool is string => Boolean(tool));
+
+  const outputSpec = params.output_spec ?? params.outputSpec ?? undefined;
+
+  const context =
+    params.context ?? params.context_vars ?? params.contextVars ?? {};
+
+  return {
+    subagentName,
+    goalPrompt,
+    behaviourPrompts,
+    toolWhitelist: toolWhitelist.length > 0 ? toolWhitelist : undefined,
+    outputSpec,
+    context,
+    maxTurns: params.max_turns,
+    async: params.async ?? false,
+  };
+}
+
+function resolveBehaviourPrompts(params: TaskToolParams): string[] {
+  return (
+    firstDefined(
+      params.behaviour_prompts,
+      params.behavior_prompts,
+      params.behaviourPrompts,
+    ) ??
+    params.behaviorPrompts ??
+    []
+  );
+}
+
+function firstDefined<T>(...values: Array<T | undefined>): T | undefined {
+  for (const value of values) {
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveToolWhitelist(params: TaskToolParams): string[] {
+  return params.tool_whitelist ?? params.toolWhitelist ?? [];
+}


### PR DESCRIPTION
## Summary

Removes every file-level and inline `eslint-disable` directive from the 13 in-scope `packages/agents` source files and makes them pass the project lint budget by **decomposition and real boundary-validation, not re-suppression**.

This is a **structure-only refactor**: no runtime behavior changes, all existing tests pass unchanged.

Fixes #2085.

## Background

The in-scope files carried blanket "Phase 5" `complexity` / `cognitive-complexity` / `max-lines` file-level disables plus ~130 inline `no-unnecessary-condition`, control-flow, and `prefer-nullish-coalescing` suppressions. Stripping them exposed **144 real violations** — and notably **zero** genuine complexity/cognitive-complexity violations once the over-broad file-level disables were removed (those blanket disables were hiding nothing in that category). Every exposed violation was fixed at the source.

### Violation inventory (baseline after stripping suppressions)

| Rule | Count |
|------|-------|
| `@typescript-eslint/no-unnecessary-condition` | 94 |
| `sonarjs/nested-control-flow` | 20 |
| `sonarjs/too-many-break-or-continue-in-loop` | 13 |
| `sonarjs/expression-complexity` | 6 |
| `max-lines` | 5 |
| `sonarjs/no-nested-conditional` | 3 |
| `@typescript-eslint/prefer-nullish-coalescing` | 2 |
| `max-lines-per-function` | 1 |

## Decomposition

Oversized files were split into cohesive pure-function helper modules, mirroring the existing `executor-prompt-builder` / `recovery.ts` extraction pattern. **All exported classes and public signatures are unchanged** — imports elsewhere are unaffected.

| Original file | Extracted modules |
|---------------|-------------------|
| `executor.ts` | `executor-tool-dispatch.ts`, `executor-stream-processor.ts`, expanded `recovery.ts` |
| `task.ts` | `taskAbortHelpers.ts`, `taskToolGovernance.ts`, `taskResultHelpers.ts`, `taskAsyncExecution.ts` |
| `chatSession.ts` | `CompressionProfileResolver.ts`, `CompressionLoadBalancingProvider.ts` |
| `StreamProcessor.ts` | `streamRequestHelpers.ts`, `streamResponseHelpers.ts` |
| `subagent.ts` | `subagentNonInteractive.ts` |

The 147-line `runAgentLoopIterationBody` in `executor.ts` was split into focused methods, each under the 80-line budget.

## Violation fixes (behavior-preserving)

- **`no-unnecessary-condition`**: removed dead defensive checks that contradicted the static type (the issue explicitly mandates this). Where the value is a genuine external/runtime boundary — provider usage metadata, persisted tool-call payloads, optional `Config` methods absent in partial test mocks — the value is routed through an `unknown`-typed helper or a `typeof x === 'function'` guard so the check is genuinely necessary and the runtime defense is preserved.
- **`prefer-nullish-coalescing`**: where an empty string must fall through to a fallback, used explicit truthiness rather than `??` to preserve the original falsy semantics (e.g. system-message-vs-reason selection).
- **`nested-control-flow` / `too-many-break-or-continue` / `expression-complexity` / `no-nested-conditional`**: flattened with guard clauses, named sub-booleans, and extracted helper functions.

A small number of genuine external-boundary regressions discovered during review (token-count default coalescing, `emitted_vars` filtering, provider-name nullish passthrough) were caught and fixed with nullish-only mirrors that exactly reproduce the original `?? default` semantics.

## Enforcement

Added all 13 in-scope files **plus the 12 newly-extracted helper modules** to `completedDirectiveCleanupScopes` in `eslint.config.js`. This re-enables the strict `eslint-comments/no-use` rule and `reportUnusedDisableDirectives` for the whole scope, so **CI now fails if any inline disable is reintroduced** in these files going forward.

## Verification

All green:

- `npm run typecheck`
- `npm run lint:ci` (`--max-warnings 0`)
- `npm run build`
- `npm run format` (check)
- `node scripts/check-eslint-guard.js` (ESLint policy guard)
- All per-package test suites (agents 1664, core, providers, cli, a2a-server, vscode-ide-companion)
- Agent smoke test (end-to-end haiku generation)

## Acceptance criteria

- [x] No file-level complexity/cognitive-complexity/max-lines disables in the 13 files
- [x] No inline eslint-disable directives remain in scope
- [x] `npm run lint` passes with budgets enforced
- [x] No behavioral regressions; existing tests green
- [x] Scope locked so new inline disables fail CI
