### PR TITLE
Improve quality guards for compression and prompts (Fixes #1054)

### DIFF
--- a/packages/agents/src/core/__tests__/compression-boundary.test.ts
+++ b/packages/agents/src/core/__tests__/compression-boundary.test.ts
@@ -24,6 +24,9 @@ import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/Age
 import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
 import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import type { RuntimeProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import { adjustForToolCallBoundary } from '../../compression/utils.js';
 
 function createToolCallAiMessage(callIds: string[]): IContent {
@@ -104,23 +107,42 @@ function buildRuntimeContext(
     provider: mockProviderAdapter,
     telemetry: mockTelemetryAdapter,
     tools: mockToolsView,
-    providerRuntime: {
+    providerRuntime: createProviderRuntimeContext({
       runtimeId: 'test-runtime',
-      settingsService: { get: vi.fn(() => undefined) } as never,
-      config: {} as never,
-    },
+      settingsService: new SettingsService(),
+    }),
   });
 }
 
-function buildMockProvider(summaryText: string) {
+function buildMockProvider(summaryText: string): RuntimeProvider {
   return {
     name: 'test-provider',
+    isDefault: true,
     generateChatCompletion: vi.fn(async function* () {
       yield {
         speaker: 'ai',
         blocks: [{ type: 'text', text: summaryText }],
       };
     }),
+    getModels: vi.fn(async () => []),
+    getDefaultModel: vi.fn(() => 'test-model'),
+    getServerTools: vi.fn(() => []),
+    invokeServerTool: vi.fn(async () => undefined),
+  };
+}
+
+/**
+ * Builds a fully-typed ContentGenerator stub for tests.
+ * `countTokens` resolves to a token count that drives compression decisions.
+ */
+function createMockContentGenerator(tokenCount = 100): ContentGenerator {
+  return {
+    generateContent: vi.fn(),
+    generateContentStream: vi.fn(),
+    countTokens: vi.fn(async () => ({
+      totalTokens: tokenCount,
+    })),
+    embedContent: vi.fn(),
   };
 }
 
@@ -134,12 +156,7 @@ describe('Compression Boundary Logic (Issue #982)', () => {
     historyService = new HistoryService();
     runtimeContext = buildRuntimeContext(historyService);
 
-    mockContentGenerator = {
-      generateContent: vi.fn(),
-      generateContentStream: vi.fn(),
-      countTokens: vi.fn().mockReturnValue(100),
-      embedContent: vi.fn(),
-    } as unknown as ContentGenerator;
+    mockContentGenerator = createMockContentGenerator();
   });
 
   describe('adjustForToolCallBoundary (unit via compression/utils)', () => {
@@ -224,10 +241,8 @@ describe('Compression Boundary Logic (Issue #982)', () => {
       const summaryText =
         '<state_snapshot><overall_goal>Tool heavy</overall_goal></state_snapshot>';
       const mockProvider = buildMockProvider(summaryText);
-      vi.spyOn(chat as never, 'resolveProviderForRuntime').mockReturnValue(
-        mockProvider as never,
-      );
-      vi.spyOn(chat as never, 'providerSupportsIContent').mockReturnValue(true);
+      vi.spyOn(chat, 'resolveProviderForRuntime').mockReturnValue(mockProvider);
+      vi.spyOn(chat, 'providerSupportsIContent').mockReturnValue(true);
 
       const beforeCount = historyService.getCurated().length;
       await chat.performCompression('test-prompt-id');
@@ -262,10 +277,8 @@ describe('Compression Boundary Logic (Issue #982)', () => {
       const summaryText =
         '<state_snapshot><overall_goal>Boundary preserve</overall_goal></state_snapshot>';
       const mockProvider = buildMockProvider(summaryText);
-      vi.spyOn(chat as never, 'resolveProviderForRuntime').mockReturnValue(
-        mockProvider as never,
-      );
-      vi.spyOn(chat as never, 'providerSupportsIContent').mockReturnValue(true);
+      vi.spyOn(chat, 'resolveProviderForRuntime').mockReturnValue(mockProvider);
+      vi.spyOn(chat, 'providerSupportsIContent').mockReturnValue(true);
 
       await chat.performCompression('test-prompt-id');
 
@@ -328,10 +341,8 @@ describe('Compression Boundary Logic (Issue #982)', () => {
       const summaryText =
         '<state_snapshot><overall_goal>Continuous tools</overall_goal></state_snapshot>';
       const mockProvider = buildMockProvider(summaryText);
-      vi.spyOn(chat as never, 'resolveProviderForRuntime').mockReturnValue(
-        mockProvider as never,
-      );
-      vi.spyOn(chat as never, 'providerSupportsIContent').mockReturnValue(true);
+      vi.spyOn(chat, 'resolveProviderForRuntime').mockReturnValue(mockProvider);
+      vi.spyOn(chat, 'providerSupportsIContent').mockReturnValue(true);
 
       const beforeCount = historyService.getCurated().length;
       await chat.performCompression('test-prompt-id');
@@ -366,10 +377,8 @@ describe('Compression Boundary Logic (Issue #982)', () => {
       const summaryText =
         '<state_snapshot><overall_goal>Long tool seq</overall_goal></state_snapshot>';
       const mockProvider = buildMockProvider(summaryText);
-      vi.spyOn(chat as never, 'resolveProviderForRuntime').mockReturnValue(
-        mockProvider as never,
-      );
-      vi.spyOn(chat as never, 'providerSupportsIContent').mockReturnValue(true);
+      vi.spyOn(chat, 'resolveProviderForRuntime').mockReturnValue(mockProvider);
+      vi.spyOn(chat, 'providerSupportsIContent').mockReturnValue(true);
 
       await chat.performCompression('test-prompt-id');
 
@@ -405,10 +414,8 @@ describe('Compression Boundary Logic (Issue #982)', () => {
       const summaryText =
         '<state_snapshot><overall_goal>Issue 982</overall_goal></state_snapshot>';
       const mockProvider = buildMockProvider(summaryText);
-      vi.spyOn(chat as never, 'resolveProviderForRuntime').mockReturnValue(
-        mockProvider as never,
-      );
-      vi.spyOn(chat as never, 'providerSupportsIContent').mockReturnValue(true);
+      vi.spyOn(chat, 'resolveProviderForRuntime').mockReturnValue(mockProvider);
+      vi.spyOn(chat, 'providerSupportsIContent').mockReturnValue(true);
 
       await chat.performCompression('test-prompt-id');
 
@@ -437,10 +444,8 @@ describe('Compression Boundary Logic (Issue #982)', () => {
       const summaryText =
         '<state_snapshot><overall_goal>Edge case</overall_goal></state_snapshot>';
       const mockProvider = buildMockProvider(summaryText);
-      vi.spyOn(chat as never, 'resolveProviderForRuntime').mockReturnValue(
-        mockProvider as never,
-      );
-      vi.spyOn(chat as never, 'providerSupportsIContent').mockReturnValue(true);
+      vi.spyOn(chat, 'resolveProviderForRuntime').mockReturnValue(mockProvider);
+      vi.spyOn(chat, 'providerSupportsIContent').mockReturnValue(true);
 
       // Should not throw - small history may or may not compress
       await expect(

--- a/packages/agents/src/core/__tests__/compression-config.test.ts
+++ b/packages/agents/src/core/__tests__/compression-config.test.ts
@@ -57,9 +57,8 @@ describe('compression-config exported thresholds', () => {
 
   describe('preserve invariant', () => {
     it('keeps combined top + middle preserve below the token threshold', () => {
-      // The combined preserved fraction (top + middle) must not reach or exceed
-      // the compression trigger threshold, otherwise compression would never
-      // actually remove enough history to be worthwhile.
+      // This is a conservative sanity check: preserve thresholds apply to
+      // message ranges while the trigger threshold applies to token limits.
       const combined =
         COMPRESSION_TOP_PRESERVE_THRESHOLD + COMPRESSION_PRESERVE_THRESHOLD;
       expect(combined).toBeLessThan(COMPRESSION_TOKEN_THRESHOLD);

--- a/packages/agents/src/core/__tests__/compression-config.test.ts
+++ b/packages/agents/src/core/__tests__/compression-config.test.ts
@@ -172,7 +172,11 @@ describe('validateCompressionConfig', () => {
     } satisfies CompressionConfig);
     expect(result.valid).toBe(false);
     expect(result.errors).toHaveLength(2);
-    expect(result.errors[0]).toContain('maxMessageCharsInPreserved');
-    expect(result.errors[1]).toContain('combined preserve');
+    expect(result.errors).toStrictEqual(
+      expect.arrayContaining([
+        expect.stringContaining('maxMessageCharsInPreserved'),
+        expect.stringContaining('combined preserve'),
+      ]),
+    );
   });
 });

--- a/packages/agents/src/core/__tests__/compression-config.test.ts
+++ b/packages/agents/src/core/__tests__/compression-config.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for compression configuration invariants.
+ *
+ * These tests assert module-level invariants of the exported compression
+ * thresholds so that an invalid constant (e.g. NaN, out-of-range fraction,
+ * non-positive char limit) cannot silently ship. They do NOT mock anything;
+ * they validate the real exported values and the validation guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  COMPRESSION_TOKEN_THRESHOLD,
+  COMPRESSION_PRESERVE_THRESHOLD,
+  COMPRESSION_TOP_PRESERVE_THRESHOLD,
+  MAX_MESSAGE_CHARS_IN_PRESERVED,
+  validateCompressionConfig,
+  type CompressionConfig,
+} from '../compression-config.js';
+
+describe('compression-config exported thresholds', () => {
+  describe('COMPRESSION_TOKEN_THRESHOLD', () => {
+    it('is a finite number strictly between 0 and 1', () => {
+      expect(Number.isFinite(COMPRESSION_TOKEN_THRESHOLD)).toBe(true);
+      expect(COMPRESSION_TOKEN_THRESHOLD).toBeGreaterThan(0);
+      expect(COMPRESSION_TOKEN_THRESHOLD).toBeLessThan(1);
+    });
+  });
+
+  describe('COMPRESSION_PRESERVE_THRESHOLD', () => {
+    it('is a finite number strictly between 0 and 1', () => {
+      expect(Number.isFinite(COMPRESSION_PRESERVE_THRESHOLD)).toBe(true);
+      expect(COMPRESSION_PRESERVE_THRESHOLD).toBeGreaterThan(0);
+      expect(COMPRESSION_PRESERVE_THRESHOLD).toBeLessThan(1);
+    });
+
+    it('is derived from the token threshold via 2 * (1 - token)', () => {
+      expect(COMPRESSION_PRESERVE_THRESHOLD).toBeCloseTo(
+        2 * (1 - COMPRESSION_TOKEN_THRESHOLD),
+        10,
+      );
+    });
+  });
+
+  describe('COMPRESSION_TOP_PRESERVE_THRESHOLD', () => {
+    it('is a finite number strictly between 0 and 1', () => {
+      expect(Number.isFinite(COMPRESSION_TOP_PRESERVE_THRESHOLD)).toBe(true);
+      expect(COMPRESSION_TOP_PRESERVE_THRESHOLD).toBeGreaterThan(0);
+      expect(COMPRESSION_TOP_PRESERVE_THRESHOLD).toBeLessThan(1);
+    });
+  });
+
+  describe('preserve invariant', () => {
+    it('keeps combined top + middle preserve below the token threshold', () => {
+      // The combined preserved fraction (top + middle) must not reach or exceed
+      // the compression trigger threshold, otherwise compression would never
+      // actually remove enough history to be worthwhile.
+      const combined =
+        COMPRESSION_TOP_PRESERVE_THRESHOLD + COMPRESSION_PRESERVE_THRESHOLD;
+      expect(combined).toBeLessThan(COMPRESSION_TOKEN_THRESHOLD);
+    });
+  });
+
+  describe('MAX_MESSAGE_CHARS_IN_PRESERVED', () => {
+    it('is a positive integer', () => {
+      expect(Number.isInteger(MAX_MESSAGE_CHARS_IN_PRESERVED)).toBe(true);
+      expect(MAX_MESSAGE_CHARS_IN_PRESERVED).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('validateCompressionConfig', () => {
+  it('returns a valid result for the real exported configuration', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: COMPRESSION_TOKEN_THRESHOLD,
+      preserveThreshold: COMPRESSION_PRESERVE_THRESHOLD,
+      topPreserveThreshold: COMPRESSION_TOP_PRESERVE_THRESHOLD,
+      maxMessageCharsInPreserved: MAX_MESSAGE_CHARS_IN_PRESERVED,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it('rejects a token threshold at or beyond 1', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: 1,
+      preserveThreshold: 0.2,
+      topPreserveThreshold: 0.1,
+      maxMessageCharsInPreserved: 5000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a token threshold at or below 0', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: 0,
+      preserveThreshold: 0.2,
+      topPreserveThreshold: 0.1,
+      maxMessageCharsInPreserved: 5000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects NaN thresholds', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: Number.NaN,
+      preserveThreshold: 0.2,
+      topPreserveThreshold: 0.1,
+      maxMessageCharsInPreserved: 5000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a preserve threshold outside (0, 1)', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: 0.85,
+      preserveThreshold: 1.5,
+      topPreserveThreshold: 0.1,
+      maxMessageCharsInPreserved: 5000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a top preserve threshold outside (0, 1)', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: 0.85,
+      preserveThreshold: 0.2,
+      topPreserveThreshold: 0,
+      maxMessageCharsInPreserved: 5000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a non-positive or non-integer max message chars', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: 0.85,
+      preserveThreshold: 0.2,
+      topPreserveThreshold: 0.1,
+      maxMessageCharsInPreserved: 0,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects combined preserve that meets or exceeds the token threshold', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: 0.5,
+      preserveThreshold: 0.3,
+      topPreserveThreshold: 0.3,
+      maxMessageCharsInPreserved: 5000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('collects multiple errors rather than failing fast', () => {
+    const result = validateCompressionConfig({
+      tokenThreshold: Number.NaN,
+      preserveThreshold: 5,
+      topPreserveThreshold: -1,
+      maxMessageCharsInPreserved: -10,
+    } satisfies CompressionConfig);
+    expect(result.valid).toBe(false);
+    // At least one error per invalid field.
+    expect(result.errors.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/agents/src/core/__tests__/compression-config.test.ts
+++ b/packages/agents/src/core/__tests__/compression-config.test.ts
@@ -163,15 +163,16 @@ describe('validateCompressionConfig', () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 
-  it('collects multiple errors rather than failing fast', () => {
+  it('collects unrelated field errors with combined preserve errors', () => {
     const result = validateCompressionConfig({
-      tokenThreshold: Number.NaN,
-      preserveThreshold: 5,
-      topPreserveThreshold: -1,
+      tokenThreshold: 0.5,
+      preserveThreshold: 0.3,
+      topPreserveThreshold: 0.3,
       maxMessageCharsInPreserved: -10,
     } satisfies CompressionConfig);
     expect(result.valid).toBe(false);
-    // At least one error per invalid field.
-    expect(result.errors.length).toBeGreaterThanOrEqual(4);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toContain('maxMessageCharsInPreserved');
+    expect(result.errors[1]).toContain('combined preserve');
   });
 });

--- a/packages/agents/src/core/compression-config.ts
+++ b/packages/agents/src/core/compression-config.ts
@@ -5,7 +5,11 @@
  */
 
 /**
- * Compression configuration constants
+ * Compression configuration constants.
+ *
+ * Each constant is validated at module load time via {@link validateCompressionConfig}
+ * so that an invalid value (NaN, out-of-range fraction, non-positive char limit)
+ * cannot silently ship. The validation result is also exported for reuse/tests.
  */
 
 // Threshold for compression token count as a fraction of the model's token limit.
@@ -24,3 +28,111 @@ export const COMPRESSION_TOP_PRESERVE_THRESHOLD = 0.2;
 
 // Maximum characters to preserve in individual messages for saved sections
 export const MAX_MESSAGE_CHARS_IN_PRESERVED = 5000;
+
+/**
+ * The shape of the compression configuration values.
+ */
+export interface CompressionConfig {
+  tokenThreshold: number;
+  preserveThreshold: number;
+  topPreserveThreshold: number;
+  maxMessageCharsInPreserved: number;
+}
+
+/**
+ * Result of validating a {@link CompressionConfig}.
+ */
+export interface CompressionConfigValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Internal reference to the canonical configuration assembled from the
+ * exported constants. Used for the module-load self-check below.
+ */
+const CANONICAL_CONFIG: CompressionConfig = {
+  tokenThreshold: COMPRESSION_TOKEN_THRESHOLD,
+  preserveThreshold: COMPRESSION_PRESERVE_THRESHOLD,
+  topPreserveThreshold: COMPRESSION_TOP_PRESERVE_THRESHOLD,
+  maxMessageCharsInPreserved: MAX_MESSAGE_CHARS_IN_PRESERVED,
+};
+
+/**
+ * Validates that compression configuration values satisfy their invariants:
+ *
+ * - Each threshold must be finite and strictly within the open interval (0, 1).
+ * - `maxMessageCharsInPreserved` must be a positive integer.
+ * - The combined preserved fraction (`topPreserveThreshold + preserveThreshold`)
+ *   must remain strictly below `tokenThreshold`, otherwise compression would
+ *   never remove enough history to be effective.
+ *
+ * @returns A {@link CompressionConfigValidationResult} listing all violations
+ * (does not fail fast).
+ */
+export function validateCompressionConfig(
+  config: CompressionConfig,
+): CompressionConfigValidationResult {
+  const errors: string[] = [];
+
+  const {
+    tokenThreshold,
+    preserveThreshold,
+    topPreserveThreshold,
+    maxMessageCharsInPreserved,
+  } = config;
+
+  if (!isFiniteFraction(tokenThreshold)) {
+    errors.push(
+      `tokenThreshold must be finite and in (0, 1); got ${tokenThreshold}`,
+    );
+  }
+  if (!isFiniteFraction(preserveThreshold)) {
+    errors.push(
+      `preserveThreshold must be finite and in (0, 1); got ${preserveThreshold}`,
+    );
+  }
+  if (!isFiniteFraction(topPreserveThreshold)) {
+    errors.push(
+      `topPreserveThreshold must be finite and in (0, 1); got ${topPreserveThreshold}`,
+    );
+  }
+
+  if (
+    !Number.isInteger(maxMessageCharsInPreserved) ||
+    maxMessageCharsInPreserved <= 0
+  ) {
+    errors.push(
+      `maxMessageCharsInPreserved must be a positive integer; got ${maxMessageCharsInPreserved}`,
+    );
+  }
+
+  // Only enforce the combined invariant when individual thresholds are in range,
+  // otherwise the individual errors already explain the problem.
+  if (
+    errors.length === 0 &&
+    topPreserveThreshold + preserveThreshold >= tokenThreshold
+  ) {
+    errors.push(
+      `combined preserve (top ${topPreserveThreshold} + middle ${preserveThreshold} = ${topPreserveThreshold + preserveThreshold}) must be strictly less than tokenThreshold ${tokenThreshold}`,
+    );
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Returns true when `value` is a finite number strictly inside the open
+ * interval (0, 1).
+ */
+function isFiniteFraction(value: number): boolean {
+  return Number.isFinite(value) && value > 0 && value < 1;
+}
+
+// Module-load self-check: fail fast if the canonical constants are invalid.
+const SELF_CHECK = validateCompressionConfig(CANONICAL_CONFIG);
+if (!SELF_CHECK.valid) {
+  throw new Error(
+    `Invalid compression configuration: ${SELF_CHECK.errors.join('; ')}`,
+  );
+}

--- a/packages/agents/src/core/compression-config.ts
+++ b/packages/agents/src/core/compression-config.ts
@@ -82,17 +82,21 @@ export function validateCompressionConfig(
     maxMessageCharsInPreserved,
   } = config;
 
-  if (!isFiniteFraction(tokenThreshold)) {
+  const tokenThresholdIsValid = isFiniteFraction(tokenThreshold);
+  const preserveThresholdIsValid = isFiniteFraction(preserveThreshold);
+  const topPreserveThresholdIsValid = isFiniteFraction(topPreserveThreshold);
+
+  if (!tokenThresholdIsValid) {
     errors.push(
       `tokenThreshold must be finite and in (0, 1); got ${tokenThreshold}`,
     );
   }
-  if (!isFiniteFraction(preserveThreshold)) {
+  if (!preserveThresholdIsValid) {
     errors.push(
       `preserveThreshold must be finite and in (0, 1); got ${preserveThreshold}`,
     );
   }
-  if (!isFiniteFraction(topPreserveThreshold)) {
+  if (!topPreserveThresholdIsValid) {
     errors.push(
       `topPreserveThreshold must be finite and in (0, 1); got ${topPreserveThreshold}`,
     );
@@ -107,10 +111,10 @@ export function validateCompressionConfig(
     );
   }
 
-  // Only enforce the combined invariant when individual thresholds are in range,
-  // otherwise the individual errors already explain the problem.
   if (
-    errors.length === 0 &&
+    tokenThresholdIsValid &&
+    preserveThresholdIsValid &&
+    topPreserveThresholdIsValid &&
     topPreserveThreshold + preserveThreshold >= tokenThreshold
   ) {
     errors.push(

--- a/packages/agents/src/core/compression-config.ts
+++ b/packages/agents/src/core/compression-config.ts
@@ -63,9 +63,11 @@ const CANONICAL_CONFIG: CompressionConfig = {
  *
  * - Each threshold must be finite and strictly within the open interval (0, 1).
  * - `maxMessageCharsInPreserved` must be a positive integer.
- * - The combined preserved fraction (`topPreserveThreshold + preserveThreshold`)
- *   must remain strictly below `tokenThreshold`, otherwise compression would
- *   never remove enough history to be effective.
+ * - As a conservative sanity check, the combined preserved fraction
+ *   (`topPreserveThreshold + preserveThreshold`) must remain strictly below
+ *   `tokenThreshold`. The preservation thresholds are applied to message ranges
+ *   while `tokenThreshold` is a token-limit fraction, so this catches obviously
+ *   non-compressive settings rather than modeling exact token reduction.
  *
  * @returns A {@link CompressionConfigValidationResult} listing all violations
  * (does not fail fast).

--- a/packages/core/src/core/promptServiceManager.test.ts
+++ b/packages/core/src/core/promptServiceManager.test.ts
@@ -38,6 +38,7 @@ describe('PromptServiceManager', () => {
     } else {
       process.env.LLXPRT_PROMPTS_DIR = originalPromptsDir;
     }
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
   it('reports not initialized before initialize() is called', () => {

--- a/packages/core/src/core/promptServiceManager.test.ts
+++ b/packages/core/src/core/promptServiceManager.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for {@link PromptServiceManager}.
+ *
+ * These tests prove that the manager (which replaces the previous ad-hoc
+ * module-level singleton) provides idempotent and concurrent-safe
+ * initialization, and that its service accessor returns a usable instance.
+ *
+ * No mocks are used for the manager itself; it is exercised against a real
+ * temporary prompts directory so that observable behavior is asserted.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { PromptServiceManager } from './prompts.js';
+
+describe('PromptServiceManager', () => {
+  let tempDir: string;
+  let originalPromptsDir: string | undefined;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-psm-test-'));
+    originalPromptsDir = process.env.LLXPRT_PROMPTS_DIR;
+    process.env.LLXPRT_PROMPTS_DIR = tempDir;
+  });
+
+  afterAll(() => {
+    if (originalPromptsDir === undefined) {
+      delete process.env.LLXPRT_PROMPTS_DIR;
+    } else {
+      process.env.LLXPRT_PROMPTS_DIR = originalPromptsDir;
+    }
+  });
+
+  it('reports not initialized before initialize() is called', () => {
+    const manager = new PromptServiceManager();
+    expect(manager.isInitialized()).toBe(false);
+  });
+
+  it('initializes exactly once (idempotent)', async () => {
+    const manager = new PromptServiceManager();
+    expect(manager.isInitialized()).toBe(false);
+
+    await manager.initialize();
+    expect(manager.isInitialized()).toBe(true);
+
+    // A second initialize() must not throw and must remain initialized.
+    await expect(manager.initialize()).resolves.not.toThrow();
+    expect(manager.isInitialized()).toBe(true);
+  });
+
+  it('shares a single in-flight initialization promise across concurrent callers', async () => {
+    const manager = new PromptServiceManager();
+
+    // Fire many concurrent initializations; they must all resolve and share
+    // the same underlying promise (no duplicate PromptService construction).
+    const promise1 = manager.initialize();
+    const promise2 = manager.initialize();
+    const promise3 = manager.initialize();
+
+    expect(promise1).toBe(promise2);
+    expect(promise2).toBe(promise3);
+
+    await Promise.all([promise1, promise2, promise3]);
+    expect(manager.isInitialized()).toBe(true);
+  });
+
+  it('returns a usable PromptService from getService()', async () => {
+    const manager = new PromptServiceManager();
+    const service = await manager.getService();
+
+    expect(service).toBeDefined();
+    // consumeInstallerNotices is a real method on a fully initialized service.
+    expect(typeof service.consumeInstallerNotices).toBe('function');
+    // Calling it must not throw — proves the service is initialized.
+    expect(() => service.consumeInstallerNotices()).not.toThrow();
+  });
+
+  it('returns the same service instance across multiple getService() calls', async () => {
+    const manager = new PromptServiceManager();
+    const service1 = await manager.getService();
+    const service2 = await manager.getService();
+    expect(service1).toBe(service2);
+  });
+
+  it('can be reset and re-initialized with a different configuration', async () => {
+    const manager = new PromptServiceManager();
+    await manager.initialize();
+    expect(manager.isInitialized()).toBe(true);
+
+    manager.reset();
+    expect(manager.isInitialized()).toBe(false);
+
+    // Re-initialization must work after reset.
+    await manager.initialize();
+    expect(manager.isInitialized()).toBe(true);
+    const service = await manager.getService();
+    expect(service).toBeDefined();
+  });
+});

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -30,43 +30,78 @@ const SESSION_STARTED_AT = new Date();
 const SESSION_STARTED_AT_LABEL = SESSION_STARTED_AT.toLocaleString();
 const logger = new DebugLogger('llxprt:core:prompts');
 
-// Singleton instance of PromptService
-let promptService: PromptService | null = null;
-let promptServiceInitialized = false;
-let promptServiceInitPromise: Promise<void> | null = null;
-
 /**
- * Initialize the PromptService singleton
+ * Owns the lifecycle of a single {@link PromptService} instance.
+ *
+ * Replaces the previous ad-hoc module-level singleton variables
+ * (`promptService`, `promptServiceInitialized`, `promptServiceInitPromise`).
+ * Encapsulating the state in a class makes initialization idempotent and
+ * concurrent-safe, and allows the manager to be reset or replaced in tests.
  */
-async function initializePromptService(): Promise<void> {
-  promptServiceInitPromise ??= (async () => {
+export class PromptServiceManager {
+  private service: PromptService | null = null;
+  private initPromise: Promise<void> | null = null;
+
+  /**
+   * Returns true once initialization has fully completed.
+   */
+  isInitialized(): boolean {
+    return this.service !== null && this.initPromise !== null;
+  }
+
+  /**
+   * Initializes the underlying PromptService exactly once. Concurrent calls
+   * share the same in-flight promise, so initialization is idempotent and
+   * safe under concurrent access.
+   */
+  initialize(): Promise<void> {
+    this.initPromise ??= this.doInitialize();
+    return this.initPromise;
+  }
+
+  private async doInitialize(): Promise<void> {
     const envDir = process.env.LLXPRT_PROMPTS_DIR;
     const baseDir =
       envDir !== undefined && envDir !== ''
         ? envDir
         : path.join(os.homedir(), '.llxprt', 'prompts');
-    promptService = new PromptService({
+    const instance = new PromptService({
       baseDir,
       debugMode: process.env.DEBUG === 'true',
     });
-    await promptService.initialize();
-    promptServiceInitialized = true;
-  })();
-  return promptServiceInitPromise;
+    await instance.initialize();
+    this.service = instance;
+  }
+
+  /**
+   * Returns the initialized PromptService, initializing it if necessary.
+   * The returned instance is guaranteed to be fully initialized.
+   */
+  async getService(): Promise<PromptService> {
+    await this.initialize();
+    return this.service!;
+  }
+
+  /**
+   * Resets the manager to its pre-initialization state.
+   *
+   * Intended for tests that need to re-initialize with a different prompts
+   * directory. Not part of the stable public API surface consumed by the
+   * rest of the codebase.
+   */
+  reset(): void {
+    this.service = null;
+    this.initPromise = null;
+  }
 }
 
 /**
- * Get the singleton PromptService instance (async)
+ * The default module-level manager instance backing the public prompt API.
  */
-async function getPromptService(): Promise<PromptService> {
-  if (!promptServiceInitialized) {
-    await initializePromptService();
-  }
-  return promptService!;
-}
+const promptServiceManager = new PromptServiceManager();
 
 export async function drainPromptInstallerNotices(): Promise<string[]> {
-  const service = await getPromptService();
+  const service = await promptServiceManager.getService();
   return service.consumeInstallerNotices();
 }
 
@@ -537,7 +572,7 @@ export async function getCoreSystemPromptAsync(
   model?: string,
   tools?: string[],
 ): Promise<string> {
-  const service = await getPromptService();
+  const service = await promptServiceManager.getService();
 
   const {
     userMemory,
@@ -572,7 +607,7 @@ export async function getCoreSystemPromptAsync(
  * Initialize the prompt system - call this early in application startup
  */
 export async function initializePromptSystem(): Promise<void> {
-  await initializePromptService();
+  await promptServiceManager.initialize();
 }
 
 /**


### PR DESCRIPTION
## TLDR

Addresses the remaining issue #1054 quality items by adding compression config validation, removing unsafe casts from the compression boundary tests, and replacing the prompt-service ad-hoc singleton state with a small lifecycle manager.

## Dive Deeper

Changes included:

- Added compression config validation in packages/agents/src/core/compression-config.ts, including a module-load self-check so invalid threshold constants fail fast instead of silently shipping.
- Added behavioral coverage for compression threshold invariants and validation failures in packages/agents/src/core/__tests__/compression-config.test.ts.
- Reworked packages/agents/src/core/__tests__/compression-boundary.test.ts to use typed test doubles for ContentGenerator, RuntimeProvider, SettingsService, and provider runtime context instead of never/unknown casts.
- Introduced PromptServiceManager in packages/core/src/core/prompts.ts to encapsulate prompt service initialization state while preserving public APIs:
  - getCoreSystemPromptAsync
  - initializePromptSystem
  - drainPromptInstallerNotices
  - getCompressionPrompt
- Added behavioral tests for PromptServiceManager idempotent initialization, shared in-flight initialization, service reuse, and reset/reinitialize support.

## Reviewer Test Plan

Recommended validation:

    npm run test --workspace @vybestack/llxprt-code-agents -- compression-boundary.test.ts compression-config.test.ts
    npm run test --workspace @vybestack/llxprt-code-core -- promptServiceManager.test.ts prompts-async.test.ts prompts.coreMemory.test.ts prompts.test.ts
    npm run typecheck --workspace @vybestack/llxprt-code-agents && npm run typecheck --workspace @vybestack/llxprt-code-core
    npm run lint
    npm run build

Full local verification run:

    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load ollamaglm51 "write me a haiku and nothing else"

Notes:

- The prescribed synthetic smoke command reached the provider call path but failed locally with an OpenAI insufficient credits API error. The alternate ollamaglm51 smoke test completed successfully.
- A deepthinker review found no blocking issues.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1054
