### PR TITLE
Fix profile auth isolation for load balancers (Fixes #2132)

### DIFF
--- a/packages/providers/src/__tests__/LoadBalancingProvider.delegation.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.delegation.test.ts
@@ -261,9 +261,9 @@ describe('LoadBalancingProvider', () => {
       }
     });
 
-    it('should preserve existing resolved options if sub-profile does not override them', async () => {
+    it('should NOT inherit parent resolved authToken when sub-profile omits it (issue #2132)', async () => {
       const lbConfig: LoadBalancingProviderConfig = {
-        profileName: 'preserve-resolved-test',
+        profileName: 'isolate-authtoken-test',
         strategy: 'round-robin',
         subProfiles: [
           {
@@ -296,27 +296,84 @@ describe('LoadBalancingProvider', () => {
       providerManager.getProviderByName = () => mockProvider as IProvider;
 
       try {
-        // Pass existing resolved options
+        // Pass existing resolved options with an authToken from a previous profile
         const iterator = provider.generateChatCompletion({
           contents: [{ role: 'user', parts: [{ text: 'test' }] }],
           resolved: {
             model: 'original-model',
             baseURL: 'https://original.api.com',
-            authToken: 'original-token',
+            authToken: 'leaked-token-from-opus',
           },
         });
         for await (const _chunk of iterator) {
           // Consume
         }
 
-        // Verify original resolved options were preserved
+        // authToken must NOT leak through; baseURL still inherited by design
         expect(capturedOptions).toBeDefined();
         expect(capturedOptions!.resolved).toBeDefined();
         expect(capturedOptions!.resolved!.model).toBe('original-model');
         expect(capturedOptions!.resolved!.baseURL).toBe(
           'https://original.api.com',
         );
-        expect(capturedOptions!.resolved!.authToken).toBe('original-token');
+        expect(capturedOptions!.resolved!.authToken).toBeUndefined();
+      } finally {
+        providerManager.getProviderByName = originalGetProvider;
+      }
+    });
+
+    it('should pass sub-profile authToken through when explicitly set (issue #2132)', async () => {
+      const lbConfig: LoadBalancingProviderConfig = {
+        profileName: 'pass-authtoken-test',
+        strategy: 'round-robin',
+        subProfiles: [
+          {
+            name: 'authed-sub',
+            providerName: 'gemini',
+            modelId: 'custom-model',
+            authToken: 'sub-profile-secret',
+          },
+        ],
+      };
+
+      const provider = new LoadBalancingProvider(lbConfig, providerManager);
+
+      let capturedOptions: GenerateChatOptions | undefined;
+      const mockProvider = {
+        name: 'gemini',
+        async *generateChatCompletion(
+          options: GenerateChatOptions,
+        ): AsyncIterableIterator<IContent> {
+          capturedOptions = options;
+          yield { role: 'model', parts: [{ text: 'response' }] };
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'gemini-flash',
+        getServerTools: () => [],
+        invokeServerTool: async () => ({}),
+      };
+
+      const originalGetProvider =
+        providerManager.getProviderByName.bind(providerManager);
+      providerManager.getProviderByName = () => mockProvider as IProvider;
+
+      try {
+        const iterator = provider.generateChatCompletion({
+          contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+          resolved: {
+            model: 'original-model',
+            baseURL: 'https://original.api.com',
+            authToken: 'parent-token-that-should-be-overridden',
+          },
+        });
+        for await (const _chunk of iterator) {
+          // Consume
+        }
+
+        // Sub-profile authToken must take precedence over parent
+        expect(capturedOptions).toBeDefined();
+        expect(capturedOptions!.resolved).toBeDefined();
+        expect(capturedOptions!.resolved!.authToken).toBe('sub-profile-secret');
       } finally {
         providerManager.getProviderByName = originalGetProvider;
       }

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
@@ -319,6 +319,13 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       expect(error.message).toContain('test-profile');
       expect(error.message).toContain('sole');
     });
+
+    it('uses diagnostic fallback when no backend attempts were recorded', () => {
+      const error = new LoadBalancerFailoverError('test-profile', []);
+
+      expect(error.message).toContain('no backend attempts were recorded');
+      expect(error.message).toContain('(tried: none)');
+    });
   });
   describe('ResolvedSubProfile settings propagation', () => {
     it('applies sub-profile ephemerals and modelParams on the failover path', async () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
@@ -13,6 +13,7 @@ import {
   LoadBalancingProvider,
   type LoadBalancingProviderConfig,
 } from '../LoadBalancingProvider.js';
+import { LoadBalancerFailoverError } from '../errors.js';
 import type { IProvider } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { GenerateChatOptions } from '../GenerateChatOptions.js';
@@ -177,6 +178,146 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
           results.push(chunk);
         }
       }).rejects.toThrow(/(backend-one|backend-two)/i);
+    });
+
+    it('includes per-backend failure messages when multiple backends fail', async () => {
+      let callCount = 0;
+      const mockProvider: IProvider = {
+        name: 'test-provider',
+        async *generateChatCompletion(): AsyncGenerator<IContent> {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error('rate limited by vendor');
+          }
+          if (callCount === 2) {
+            throw new Error('authentication failed');
+          }
+          yield undefined as unknown as IContent; // unreachable
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'test-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => ({ content: [] }),
+      };
+
+      providerManager.registerProvider(mockProvider);
+
+      const lbConfig: LoadBalancingProviderConfig = {
+        profileName: 'test-per-backend-msg',
+        strategy: 'failover',
+        subProfiles: [
+          {
+            name: 'zai',
+            providerName: 'test-provider',
+            modelId: 'model1',
+            baseURL: 'https://api.test.com',
+            authToken: 'test-token-1',
+          },
+          {
+            name: 'glm51',
+            providerName: 'test-provider',
+            modelId: 'model2',
+            baseURL: 'https://api.test.com',
+            authToken: 'test-token-2',
+          },
+        ],
+      };
+
+      const provider = new LoadBalancingProvider(lbConfig, providerManager);
+      const options: GenerateChatOptions = {
+        prompt: 'test prompt',
+        messages: [{ role: 'user' as const, content: 'test' }],
+      };
+
+      await expect(async () => {
+        const results: IContent[] = [];
+        for await (const chunk of provider.generateChatCompletion(options)) {
+          results.push(chunk);
+        }
+      }).rejects.toThrow(
+        'zai: rate limited by vendor; glm51: authentication failed',
+      );
+    });
+
+    it('includes HTTP status codes in per-backend summary when available', async () => {
+      let callCount = 0;
+      const mockProvider: IProvider = {
+        name: 'test-provider',
+        async *generateChatCompletion(): AsyncGenerator<IContent> {
+          callCount++;
+          if (callCount === 1) {
+            const error = new Error('Unauthorized') as Error & {
+              status: number;
+            };
+            error.status = 401;
+            throw error;
+          }
+          if (callCount === 2) {
+            const error = new Error('Rate limit') as Error & {
+              status: number;
+            };
+            error.status = 429;
+            throw error;
+          }
+          yield undefined as unknown as IContent; // unreachable
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'test-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => ({ content: [] }),
+      };
+
+      providerManager.registerProvider(mockProvider);
+
+      const lbConfig: LoadBalancingProviderConfig = {
+        profileName: 'test-per-backend-status',
+        strategy: 'failover',
+        subProfiles: [
+          {
+            name: 'zai',
+            providerName: 'test-provider',
+            modelId: 'model1',
+            baseURL: 'https://api.test.com',
+            authToken: 'test-token-1',
+          },
+          {
+            name: 'glm51',
+            providerName: 'test-provider',
+            modelId: 'model2',
+            baseURL: 'https://api.test.com',
+            authToken: 'test-token-2',
+          },
+        ],
+      };
+
+      const provider = new LoadBalancingProvider(lbConfig, providerManager);
+      const options: GenerateChatOptions = {
+        prompt: 'test prompt',
+        messages: [{ role: 'user' as const, content: 'test' }],
+      };
+
+      await expect(async () => {
+        const results: IContent[] = [];
+        for await (const chunk of provider.generateChatCompletion(options)) {
+          results.push(chunk);
+        }
+      }).rejects.toThrow(
+        'zai: Unauthorized (status: 401); glm51: Rate limit (status: 429)',
+      );
+    });
+
+    it('preserves single-failure message format for backward compatibility', () => {
+      // Test the error class directly since failover requires 2+ backends.
+      // When only one failure is recorded, the error message should be the
+      // raw error message (not the per-backend summary format).
+      const error = new LoadBalancerFailoverError('test-profile', [
+        { profile: 'sole', error: new Error('only backend failed') },
+      ]);
+
+      expect(error.message).toContain('only backend failed');
+      expect(error.message).not.toContain('sole:');
+      expect(error.message).toContain('test-profile');
+      expect(error.message).toContain('sole');
     });
   });
   describe('ResolvedSubProfile settings propagation', () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.selection.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.selection.test.ts
@@ -469,10 +469,10 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       });
     });
 
-    it('should preserve resolved baseURL and authToken when sub-profile omits them', async () => {
+    it('should NOT inherit parent resolved authToken when sub-profile omits it (issue #2132)', async () => {
       const captured: Array<{ baseURL?: string; authToken?: string }> = [];
 
-      const mockProvider: IProvider = {
+      const mockProvider = {
         name: 'test-provider',
         async *generateChatCompletion(
           options: GenerateChatOptions,
@@ -489,10 +489,12 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
         invokeServerTool: async () => ({ content: [] }),
       };
 
-      providerManager.registerProvider(mockProvider);
+      const originalGetProvider =
+        providerManager.getProviderByName.bind(providerManager);
+      providerManager.getProviderByName = () => mockProvider as IProvider;
 
       const lbConfig: LoadBalancingProviderConfig = {
-        profileName: 'test-preserve-resolved',
+        profileName: 'test-no-authtoken-leak',
         strategy: 'failover',
         subProfiles: [
           {
@@ -510,29 +512,34 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
         ],
       };
 
-      const provider = new LoadBalancingProvider(lbConfig, providerManager);
-      const options: GenerateChatOptions = {
-        prompt: 'test prompt',
-        messages: [{ role: 'user' as const, content: 'test' }],
-        resolved: {
-          model: 'original-model',
-          baseURL: 'https://original.api.com',
-          authToken: 'original-token',
-        },
-      };
+      try {
+        const provider = new LoadBalancingProvider(lbConfig, providerManager);
+        const options: GenerateChatOptions = {
+          prompt: 'test prompt',
+          messages: [{ role: 'user' as const, content: 'test' }],
+          resolved: {
+            model: 'original-model',
+            baseURL: 'https://original.api.com',
+            authToken: 'original-token',
+          },
+        };
 
-      const results: IContent[] = [];
-      for await (const chunk of provider.generateChatCompletion(options)) {
-        results.push(chunk);
+        const results: IContent[] = [];
+        for await (const chunk of provider.generateChatCompletion(options)) {
+          results.push(chunk);
+        }
+
+        expect(results).toHaveLength(1);
+        // baseURL is still inherited (per design), but authToken must NOT leak
+        expect(captured).toStrictEqual([
+          {
+            baseURL: 'https://original.api.com',
+            authToken: undefined,
+          },
+        ]);
+      } finally {
+        providerManager.getProviderByName = originalGetProvider;
       }
-
-      expect(results).toHaveLength(1);
-      expect(captured).toStrictEqual([
-        {
-          baseURL: 'https://original.api.com',
-          authToken: 'original-token',
-        },
-      ]);
     });
 
     it('should override resolved baseURL when sub-profile provides one', async () => {
@@ -563,12 +570,14 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
             providerName: 'test-provider',
             modelId: 'model1',
             baseURL: 'https://subprofile.api.com',
+            authToken: 'sub-token',
           },
           {
             name: 'second',
             providerName: 'test-provider',
             modelId: 'model2',
             baseURL: 'https://subprofile.api.com',
+            authToken: 'sub-token',
           },
         ],
       };
@@ -651,6 +660,77 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
 
       expect(results).toHaveLength(1);
       expect(captured).toStrictEqual([{ authToken: 'subprofile-token' }]);
+    });
+  });
+
+  describe('AuthToken isolation on failover path (issue #2132)', () => {
+    it('should NOT leak parent authToken to failover delegate when sub-profile omits it', async () => {
+      let callCount = 0;
+      const capturedAuthTokens: Array<string | undefined> = [];
+
+      const mockProvider = {
+        name: 'test-provider',
+        async *generateChatCompletion(
+          options: GenerateChatOptions,
+        ): AsyncGenerator<IContent> {
+          callCount++;
+          capturedAuthTokens.push(options.resolved?.authToken);
+          if (callCount === 1) {
+            throw new Error('first backend error');
+          }
+          yield { type: 'text' as const, content: 'success from second' };
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'test-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => ({ content: [] }),
+      };
+
+      const originalGetProvider =
+        providerManager.getProviderByName.bind(providerManager);
+      providerManager.getProviderByName = () => mockProvider as IProvider;
+
+      const lbConfig: LoadBalancingProviderConfig = {
+        profileName: 'test-failover-auth-isolation',
+        strategy: 'failover',
+        subProfiles: [
+          {
+            name: 'first',
+            providerName: 'test-provider',
+            modelId: 'model1',
+            // authToken intentionally omitted
+          },
+          {
+            name: 'second',
+            providerName: 'test-provider',
+            modelId: 'model2',
+            // authToken intentionally omitted
+          },
+        ],
+      };
+
+      try {
+        const provider = new LoadBalancingProvider(lbConfig, providerManager);
+        const options: GenerateChatOptions = {
+          prompt: 'test prompt',
+          messages: [{ role: 'user' as const, content: 'test' }],
+          resolved: {
+            model: 'parent-model',
+            authToken: 'leaked-opus-token',
+          },
+        };
+
+        const results: IContent[] = [];
+        for await (const chunk of provider.generateChatCompletion(options)) {
+          results.push(chunk);
+        }
+
+        expect(results).toHaveLength(1);
+        // Both delegates must have authToken = undefined, not the leaked parent token
+        expect(capturedAuthTokens).toStrictEqual([undefined, undefined]);
+      } finally {
+        providerManager.getProviderByName = originalGetProvider;
+      }
     });
   });
 });

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.selection.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.selection.test.ts
@@ -13,9 +13,8 @@ import {
   LoadBalancingProvider,
   type LoadBalancingProviderConfig,
 } from '../LoadBalancingProvider.js';
-import type { IProvider } from '../IProvider.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
-import type { GenerateChatOptions } from '../GenerateChatOptions.js';
 
 describe('LoadBalancingProvider - Failover Strategy', () => {
   let settingsService: SettingsService;
@@ -515,8 +514,9 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       try {
         const provider = new LoadBalancingProvider(lbConfig, providerManager);
         const options: GenerateChatOptions = {
-          prompt: 'test prompt',
-          messages: [{ role: 'user' as const, content: 'test' }],
+          contents: [
+            { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+          ],
           resolved: {
             model: 'original-model',
             baseURL: 'https://original.api.com',
@@ -712,8 +712,9 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       try {
         const provider = new LoadBalancingProvider(lbConfig, providerManager);
         const options: GenerateChatOptions = {
-          prompt: 'test prompt',
-          messages: [{ role: 'user' as const, content: 'test' }],
+          contents: [
+            { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+          ],
           resolved: {
             model: 'parent-model',
             authToken: 'leaked-opus-token',

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -193,7 +193,7 @@ export class LoadBalancerFailoverError extends Error {
     profileName: string,
     failures: Array<{ profile: string; error: Error }>,
   ) {
-    const profileNames = failures.map((f) => f.profile).join(', ');
+    const profileNames = failures.map((f) => f.profile).join(', ') || 'none';
     const errorSummary = summarizeFailures(failures);
     super(
       `Load balancer "${profileName}" failover exhausted: ${errorSummary} (tried: ${profileNames})`,
@@ -213,6 +213,10 @@ export class LoadBalancerFailoverError extends Error {
 function summarizeFailures(
   failures: Array<{ profile: string; error: Error }>,
 ): string {
+  if (failures.length === 0) {
+    return 'no backend attempts were recorded';
+  }
+
   if (failures.length === 1) {
     return failures[0].error.message;
   }

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -10,6 +10,8 @@
  * @pseudocode consumer-migration.md lines 10-15
  */
 
+import { getErrorStatus } from '@vybestack/llxprt-code-core/utils/retry.js';
+
 /**
  * Error thrown when authentication is required but not available
  */
@@ -192,10 +194,7 @@ export class LoadBalancerFailoverError extends Error {
     failures: Array<{ profile: string; error: Error }>,
   ) {
     const profileNames = failures.map((f) => f.profile).join(', ');
-    const errorSummary =
-      failures.length === 1
-        ? failures[0].error.message
-        : `${failures.length} backends failed`;
+    const errorSummary = summarizeFailures(failures);
     super(
       `Load balancer "${profileName}" failover exhausted: ${errorSummary} (tried: ${profileNames})`,
     );
@@ -203,6 +202,28 @@ export class LoadBalancerFailoverError extends Error {
     this.profileName = profileName;
     this.failures = failures;
   }
+}
+
+/**
+ * Build a human-readable summary of per-backend failures. For a single failure
+ * the underlying message is used; for multiple failures each backend name,
+ * message, and HTTP status (when available) are included so callers can diagnose
+ * auth, rate-limit, and server issues without inspecting structured fields.
+ */
+function summarizeFailures(
+  failures: Array<{ profile: string; error: Error }>,
+): string {
+  if (failures.length === 1) {
+    return failures[0].error.message;
+  }
+
+  return failures
+    .map((failure) => {
+      const status = getErrorStatus(failure.error);
+      const statusSuffix = status !== undefined ? ` (status: ${status})` : '';
+      return `${failure.profile}: ${failure.error.message}${statusSuffix}`;
+    })
+    .join('; ');
 }
 
 /**

--- a/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
+++ b/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
@@ -49,10 +49,15 @@ function buildDelegateResolvedOptions(
   }
 
   // LoadBalancerSubProfile (legacy path)
+  // authToken is intentionally isolated: when the sub-profile omits authToken,
+  // the parent resolved.authToken must NOT leak through, otherwise credentials
+  // from a previously loaded profile contaminate delegates with different auth.
+  const { authToken: _parentAuthToken, ...resolvedWithoutAuth } =
+    options.resolved ?? {};
   const resolvedOptions: GenerateChatOptions = {
     ...options,
     resolved: {
-      ...options.resolved,
+      ...resolvedWithoutAuth,
       ...(typeof subProfile.modelId === 'string' &&
         subProfile.modelId !== '' && { model: subProfile.modelId }),
       ...(typeof subProfile.baseURL === 'string' &&
@@ -114,10 +119,15 @@ function buildResolvedSubProfileOptions(
     'stream',
   );
 
+  // authToken isolation: strip parent resolved.authToken so a sub-profile that
+  // omits authToken does not inherit credentials from the upstream invocation.
+  const { authToken: _parentAuthToken, ...resolvedWithoutAuth } =
+    options.resolved ?? {};
+
   const resolvedOptions: GenerateChatOptions = {
     ...options,
     resolved: {
-      ...options.resolved,
+      ...resolvedWithoutAuth,
       model: subProfile.model,
       ...(typeof subProfile.baseURL === 'string' &&
         subProfile.baseURL !== '' && { baseURL: subProfile.baseURL }),

--- a/packages/providers/src/runtime/__tests__/profileApplication.authclear.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.authclear.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for profile application clearing stale auth state on profile switch.
+ * Ensures that switching profiles (e.g. from opusthinking to glm) cannot
+ * reuse the previous profile's auth-key, auth-keyfile, auth-key-name, or
+ * base-url when the new profile omits those directives.
+ *
+ * @plan PLAN-20260623-ISSUE2132
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Profile } from '@vybestack/llxprt-code-settings';
+import {
+  switchActiveProviderMock,
+  setActiveModelMock,
+  updateActiveProviderBaseUrlMock,
+  updateActiveProviderApiKeyMock,
+  setActiveModelParamMock,
+  clearActiveModelParamMock,
+  getActiveModelParamsMock,
+  setEphemeralSettingMock,
+  getCliRuntimeServicesMock,
+  getActiveProviderOrThrowMock,
+  isCliStatelessProviderModeEnabledMock,
+  isCliRuntimeStatelessReadyMock,
+  createProviderKeyStorageMock,
+  configStub,
+  providerManagerStub,
+  resetProfileApplicationStubs,
+  restoreGcpEnvVars,
+} from './profileApplicationTestSetup.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    readFile: vi.fn(),
+  };
+});
+
+vi.mock('../runtimeSettings.js', () => ({
+  switchActiveProvider: switchActiveProviderMock,
+  setActiveModel: setActiveModelMock,
+  updateActiveProviderBaseUrl: updateActiveProviderBaseUrlMock,
+  updateActiveProviderApiKey: updateActiveProviderApiKeyMock,
+  setActiveModelParam: setActiveModelParamMock,
+  clearActiveModelParam: clearActiveModelParamMock,
+  getActiveModelParams: getActiveModelParamsMock,
+  setEphemeralSetting: setEphemeralSettingMock,
+  createProviderKeyStorage: createProviderKeyStorageMock,
+  getCliRuntimeServices: getCliRuntimeServicesMock,
+  getActiveProviderOrThrow: getActiveProviderOrThrowMock,
+  isCliStatelessProviderModeEnabled: isCliStatelessProviderModeEnabledMock,
+  isCliRuntimeStatelessReady: isCliRuntimeStatelessReadyMock,
+}));
+
+const { applyProfileWithGuards } = await import('../profileApplication.js');
+
+describe('Profile application clears stale auth state (issue #2132)', () => {
+  let savedGcpProject: string | undefined;
+  let savedGcpLocation: string | undefined;
+
+  beforeEach(() => {
+    const saved = resetProfileApplicationStubs();
+    savedGcpProject = saved.savedGcpProject;
+    savedGcpLocation = saved.savedGcpLocation;
+  });
+
+  afterEach(() => {
+    restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
+    vi.clearAllMocks();
+  });
+
+  it('clears stale auth-key when switching to a profile without auth-key directive', async () => {
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    // Simulate previous profile (e.g. opusthinking) having set an auth-key
+    configStub.setEphemeralSetting('auth-key', 'stale-opus-token');
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    expect(configStub.getEphemeralSetting('auth-key')).toBeUndefined();
+    expect(updateActiveProviderApiKeyMock).toHaveBeenCalledWith(null);
+  });
+
+  it('clears stale auth-key-name when switching to a profile without auth-key-name', async () => {
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    // Simulate previous profile having resolved a named key
+    configStub.setEphemeralSetting('auth-key-name', 'anthropic-oauth-bucket');
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBeUndefined();
+  });
+
+  it('clears stale auth-keyfile when switching to a profile without auth-keyfile', async () => {
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    configStub.setEphemeralSetting('auth-keyfile', '/home/user/.old_key');
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    expect(configStub.getEphemeralSetting('auth-keyfile')).toBeUndefined();
+  });
+
+  it('clears stale base-url when switching to a profile without base-url', async () => {
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    configStub.setEphemeralSetting(
+      'base-url',
+      'https://old-anthropic-proxy.com',
+    );
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    expect(configStub.getEphemeralSetting('base-url')).toBeUndefined();
+    expect(updateActiveProviderBaseUrlMock).toHaveBeenCalledWith(null);
+  });
+
+  it('clears all stale auth state simultaneously when switching profiles', async () => {
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    // Simulate all auth-related ephemerals being set by previous profile
+    configStub.setEphemeralSetting('auth-key', 'stale-key');
+    configStub.setEphemeralSetting('auth-key-name', 'stale-named-key');
+    configStub.setEphemeralSetting('auth-keyfile', '/home/user/.stale_keyfile');
+    configStub.setEphemeralSetting('base-url', 'https://stale-proxy.com');
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    expect(configStub.getEphemeralSetting('auth-key')).toBeUndefined();
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBeUndefined();
+    expect(configStub.getEphemeralSetting('auth-keyfile')).toBeUndefined();
+    expect(configStub.getEphemeralSetting('base-url')).toBeUndefined();
+    expect(updateActiveProviderApiKeyMock).toHaveBeenCalledWith(null);
+    expect(updateActiveProviderBaseUrlMock).toHaveBeenCalledWith(null);
+  });
+
+  it('preserves explicit auth-key on the newly loaded profile', async () => {
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    // Previous profile set a different auth-key
+    configStub.setEphemeralSetting('auth-key', 'old-opus-key');
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {
+        'auth-key': 'new-glm-key',
+      },
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    expect(configStub.getEphemeralSetting('auth-key')).toBe('new-glm-key');
+    expect(updateActiveProviderApiKeyMock).toHaveBeenCalledWith('new-glm-key');
+  });
+
+  it('preserves explicit auth-keyfile on the newly loaded profile', async () => {
+    const mockFs = await import('node:fs/promises');
+    vi.mocked(mockFs.readFile).mockResolvedValue('keyfile-content');
+
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    // Previous profile set auth-key-name (higher precedence)
+    configStub.setEphemeralSetting('auth-key-name', 'old-named-key');
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {
+        'auth-keyfile': '/home/user/.glm_key',
+      },
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    // The stale auth-key-name should be cleared and not interfere
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBeUndefined();
+    // auth-keyfile should be set from the new profile
+    expect(configStub.getEphemeralSetting('auth-keyfile')).toBe(
+      '/home/user/.glm_key',
+    );
+  });
+
+  it('preserves explicit auth-key-name on the newly loaded profile', async () => {
+    providerManagerStub.available = ['openai'];
+    providerManagerStub.providerLookup = new Map([
+      ['openai', { name: 'openai' }],
+    ]);
+
+    // Previous profile set a direct auth-key
+    configStub.setEphemeralSetting('auth-key', 'old-direct-key');
+
+    const keyStorage = createProviderKeyStorageMock();
+    keyStorage.getKey.mockResolvedValue('resolved-named-key-value');
+
+    const newProfile: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'glm-4.6',
+      modelParams: {},
+      ephemeralSettings: {
+        'auth-key-name': 'glm-named-key',
+      },
+    };
+
+    await applyProfileWithGuards(newProfile, { profileName: 'glm' });
+
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBe(
+      'glm-named-key',
+    );
+    // The resolved key from the named key should be applied
+    expect(updateActiveProviderApiKeyMock).toHaveBeenCalledWith(
+      'resolved-named-key-value',
+    );
+  });
+});

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -537,6 +537,7 @@ function clearProfileEphemerals(
     ...previousEphemeralKeys.filter((key) => key !== 'activeProvider'),
     ...Object.keys(sanitizedEphemeralSettings),
     'auth-key',
+    'auth-key-name',
     'auth-keyfile',
     'base-url',
   ]);


### PR DESCRIPTION
## TLDR

Fixes stale profile auth state leaking from a previously active profile into a newly loaded profile and into load-balancer delegate calls. This isolates delegate auth tokens, clears named auth references during profile loads, and makes load-balancer exhaustion errors show per-backend causes.

## Dive Deeper

Changes included:

- Load-balancer delegate option building now strips parent resolved authToken before merging sub-profile settings, so stale credentials from the upstream invocation cannot contaminate delegates.
- Explicit non-empty sub-profile authToken still wins and is passed through.
- Profile loading now clears auth-key-name along with auth-key, auth-keyfile, and base-url, preventing stale named auth references from surviving a profile switch.
- LoadBalancerFailoverError now includes per-backend profile names, failure messages, and HTTP status where available when multiple backends fail, while preserving the structured failures field and single-failure message compatibility.
- Added behavioral coverage for profile auth clearing, load-balancer auth isolation on round-robin and failover paths, explicit sub-profile token precedence, and detailed failover diagnostics.

## Reviewer Test Plan

Recommended validation:

1. Load a profile with auth, then load a different load-balancer profile whose members rely on their own auth settings. Verify delegate requests do not use the previous profile auth token.
2. Exercise a load-balancer profile with two failing members and verify the final error names each failed backend and includes the individual failure reason.
3. Confirm a sub-profile with an explicit authToken still passes that token to the delegate provider.
4. Confirm baseURL inheritance remains unchanged when a sub-profile omits baseURL.

Verification already run on macOS:

- npm test --workspace @vybestack/llxprt-code-providers -- LoadBalancingProvider.failover.errors.test.ts LoadBalancingProvider.failover.selection.test.ts LoadBalancingProvider.delegation.test.ts profileApplication.authclear.test.ts
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
- tmux harness regression: load opusthinking, prompt, load glm, prompt, and assert no API Error or glm failover exhaustion output

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2132
