### PR TITLE
Fix #2133: apply_patch fails

### DIFF
--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -31,6 +31,37 @@ exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match
 "
 `;
 
+exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-render-collapsed-match 2`] = `
+"
+  ERROR  useMouseContext must be used within a MouseProvider
+
+ packages/cli/src/ui/contexts/MouseContext.tsx:40:11
+
+ 37: export function useMouseContext() {
+ 38:   const context = useContext(MouseContext);
+ 39:   if (!context) {
+ 40:     throw new Error('useMouseContext must be used within a MouseProvider');
+ 41:   }
+ 42:   return context;
+ 43: }
+
+ - useMouseContext (packages/cli/src/ui/contexts/MouseContext.tsx:40:11)
+ - useMouse (packages/cli/src/ui/hooks/useMouse.ts:24:38)
+ - useMousePaste (packages/cli/src/ui/components/InputPrompt.tsx:1753:3)
+ - InputPrompt (packages/cli/src/ui/components/InputPrompt.tsx:1794:3)
+ -Object.react-stack-bottom-fr
+  me                          (node_modules/react-reconciler/cjs/react-reconciler.development.js:15
+                              859:20)
+ - renderWithHooks (node_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionComponent
+                         (node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19
+                         )
+ - beginWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
+"
+`;
+
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-render-expanded-match 1`] = `
 "
   ERROR  useMouseContext must be used within a MouseProvider
@@ -59,6 +90,37 @@ exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match
  - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
  - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
  - workLoopSync (node_modules/react-reconciler/cjs/react-reconciler.development.js:12644:41)
+"
+`;
+
+exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-render-expanded-match 2`] = `
+"
+  ERROR  useMouseContext must be used within a MouseProvider
+
+ packages/cli/src/ui/contexts/MouseContext.tsx:40:11
+
+ 37: export function useMouseContext() {
+ 38:   const context = useContext(MouseContext);
+ 39:   if (!context) {
+ 40:     throw new Error('useMouseContext must be used within a MouseProvider');
+ 41:   }
+ 42:   return context;
+ 43: }
+
+ - useMouseContext (packages/cli/src/ui/contexts/MouseContext.tsx:40:11)
+ - useMouse (packages/cli/src/ui/hooks/useMouse.ts:24:38)
+ - useMousePaste (packages/cli/src/ui/components/InputPrompt.tsx:1753:3)
+ - InputPrompt (packages/cli/src/ui/components/InputPrompt.tsx:1794:3)
+ -Object.react-stack-bottom-fr
+  me                          (node_modules/react-reconciler/cjs/react-reconciler.development.js:15
+                              859:20)
+ - renderWithHooks (node_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionComponent
+                         (node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19
+                         )
+ - beginWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
 "
 `;
 
@@ -93,6 +155,37 @@ exports[`InputPrompt > snapshots > should not show inverted cursor when shell is
 "
 `;
 
+exports[`InputPrompt > snapshots > should not show inverted cursor when shell is focused 2`] = `
+"
+  ERROR  useMouseContext must be used within a MouseProvider
+
+ packages/cli/src/ui/contexts/MouseContext.tsx:40:11
+
+ 37: export function useMouseContext() {
+ 38:   const context = useContext(MouseContext);
+ 39:   if (!context) {
+ 40:     throw new Error('useMouseContext must be used within a MouseProvider');
+ 41:   }
+ 42:   return context;
+ 43: }
+
+ - useMouseContext (packages/cli/src/ui/contexts/MouseContext.tsx:40:11)
+ - useMouse (packages/cli/src/ui/hooks/useMouse.ts:24:38)
+ - useMousePaste (packages/cli/src/ui/components/InputPrompt.tsx:1753:3)
+ - InputPrompt (packages/cli/src/ui/components/InputPrompt.tsx:1794:3)
+ -Object.react-stack-bottom-fr
+  me                          (node_modules/react-reconciler/cjs/react-reconciler.development.js:15
+                              859:20)
+ - renderWithHooks (node_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionComponent
+                         (node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19
+                         )
+ - beginWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
+"
+`;
+
 exports[`InputPrompt > snapshots > should render correctly in shell mode 1`] = `
 "
   ERROR  useMouseContext must be used within a MouseProvider
@@ -121,6 +214,37 @@ exports[`InputPrompt > snapshots > should render correctly in shell mode 1`] = `
  - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
  - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
  - workLoopSync (node_modules/react-reconciler/cjs/react-reconciler.development.js:12644:41)
+"
+`;
+
+exports[`InputPrompt > snapshots > should render correctly in shell mode 2`] = `
+"
+  ERROR  useMouseContext must be used within a MouseProvider
+
+ packages/cli/src/ui/contexts/MouseContext.tsx:40:11
+
+ 37: export function useMouseContext() {
+ 38:   const context = useContext(MouseContext);
+ 39:   if (!context) {
+ 40:     throw new Error('useMouseContext must be used within a MouseProvider');
+ 41:   }
+ 42:   return context;
+ 43: }
+
+ - useMouseContext (packages/cli/src/ui/contexts/MouseContext.tsx:40:11)
+ - useMouse (packages/cli/src/ui/hooks/useMouse.ts:24:38)
+ - useMousePaste (packages/cli/src/ui/components/InputPrompt.tsx:1753:3)
+ - InputPrompt (packages/cli/src/ui/components/InputPrompt.tsx:1794:3)
+ -Object.react-stack-bottom-fr
+  me                          (node_modules/react-reconciler/cjs/react-reconciler.development.js:15
+                              859:20)
+ - renderWithHooks (node_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionComponent
+                         (node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19
+                         )
+ - beginWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
 "
 `;
 
@@ -155,6 +279,37 @@ exports[`InputPrompt > snapshots > should render correctly in yolo mode 1`] = `
 "
 `;
 
+exports[`InputPrompt > snapshots > should render correctly in yolo mode 2`] = `
+"
+  ERROR  useMouseContext must be used within a MouseProvider
+
+ packages/cli/src/ui/contexts/MouseContext.tsx:40:11
+
+ 37: export function useMouseContext() {
+ 38:   const context = useContext(MouseContext);
+ 39:   if (!context) {
+ 40:     throw new Error('useMouseContext must be used within a MouseProvider');
+ 41:   }
+ 42:   return context;
+ 43: }
+
+ - useMouseContext (packages/cli/src/ui/contexts/MouseContext.tsx:40:11)
+ - useMouse (packages/cli/src/ui/hooks/useMouse.ts:24:38)
+ - useMousePaste (packages/cli/src/ui/components/InputPrompt.tsx:1753:3)
+ - InputPrompt (packages/cli/src/ui/components/InputPrompt.tsx:1794:3)
+ -Object.react-stack-bottom-fr
+  me                          (node_modules/react-reconciler/cjs/react-reconciler.development.js:15
+                              859:20)
+ - renderWithHooks (node_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionComponent
+                         (node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19
+                         )
+ - beginWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
+"
+`;
+
 exports[`InputPrompt > snapshots > should render correctly when accepting edits 1`] = `
 "
   ERROR  useMouseContext must be used within a MouseProvider
@@ -183,5 +338,36 @@ exports[`InputPrompt > snapshots > should render correctly when accepting edits 
  - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
  - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
  - workLoopSync (node_modules/react-reconciler/cjs/react-reconciler.development.js:12644:41)
+"
+`;
+
+exports[`InputPrompt > snapshots > should render correctly when accepting edits 2`] = `
+"
+  ERROR  useMouseContext must be used within a MouseProvider
+
+ packages/cli/src/ui/contexts/MouseContext.tsx:40:11
+
+ 37: export function useMouseContext() {
+ 38:   const context = useContext(MouseContext);
+ 39:   if (!context) {
+ 40:     throw new Error('useMouseContext must be used within a MouseProvider');
+ 41:   }
+ 42:   return context;
+ 43: }
+
+ - useMouseContext (packages/cli/src/ui/contexts/MouseContext.tsx:40:11)
+ - useMouse (packages/cli/src/ui/hooks/useMouse.ts:24:38)
+ - useMousePaste (packages/cli/src/ui/components/InputPrompt.tsx:1753:3)
+ - InputPrompt (packages/cli/src/ui/components/InputPrompt.tsx:1794:3)
+ -Object.react-stack-bottom-fr
+  me                          (node_modules/react-reconciler/cjs/react-reconciler.development.js:15
+                              859:20)
+ - renderWithHooks (node_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionComponent
+                         (node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19
+                         )
+ - beginWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ - runWithFiberInDEV (node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ - performUnitOfWork (node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
 "
 `;

--- a/packages/tools/src/__tests__/apply-patch.test.ts
+++ b/packages/tools/src/__tests__/apply-patch.test.ts
@@ -86,16 +86,9 @@ describe('ApplyPatchTool issue #2133 regressions', () => {
       undefined,
       options?.lsp,
     );
-    try {
-      return await tool.build(params).execute(new AbortController().signal);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return {
-        llmContent: '',
-        returnDisplay: '',
-        error: { message },
-      };
-    }
+    // Use validateBuildAndExecute so validation and execution errors surface
+    // with their real ToolErrorType, matching the production call path.
+    return tool.validateBuildAndExecute(params, new AbortController().signal);
   }
 
   describe('single-file patch success', () => {
@@ -306,6 +299,7 @@ describe('ApplyPatchTool issue #2133 regressions', () => {
 
       expect(result.error).toBeDefined();
       // Empty patch_content is rejected by parameter validation before parsing.
+      expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
       expect(result.error?.message).toContain('patch_content');
       expect(readFileSync(target, 'utf-8')).toBe('unchanged\n');
     });
@@ -321,6 +315,7 @@ describe('ApplyPatchTool issue #2133 regressions', () => {
 
       expect(result.error).toBeDefined();
       expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+      expect(readFileSync(target, 'utf-8')).toBe('unchanged\n');
     });
   });
 

--- a/packages/tools/src/__tests__/apply-patch.test.ts
+++ b/packages/tools/src/__tests__/apply-patch.test.ts
@@ -240,6 +240,60 @@ describe('ApplyPatchTool issue #2133 regressions', () => {
     });
   });
 
+  describe('directory-qualified header mismatch rejection', () => {
+    it('rejects a directory-qualified header pointing at a same-named file in a different directory', async () => {
+      const srcDir = join(tempDir, 'src');
+      const testDir = join(tempDir, 'test');
+      mkdirSync(srcDir, { recursive: true });
+      mkdirSync(testDir, { recursive: true });
+
+      const target = join(testDir, 'foo.txt');
+      writeFileSync(target, 'keep-me\n', 'utf-8');
+
+      // Header targets src/foo.txt while absolute_path targets test/foo.txt.
+      // Basenames match, but the directory-qualified header must not validate.
+      const patch = `--- a/src/foo.txt
++++ b/src/foo.txt
+@@ -1,1 +1,1 @@
+-keep-me
++changed
+`;
+
+      const result = await executePatch({
+        absolute_path: target,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+      expect(result.llmContent).toContain('src/foo.txt');
+      expect(readFileSync(target, 'utf-8')).toBe('keep-me\n');
+    });
+
+    it('accepts a directory-qualified header matching the absolute_path relative path', async () => {
+      const srcDir = join(tempDir, 'src');
+      mkdirSync(srcDir, { recursive: true });
+
+      const target = join(srcDir, 'foo.txt');
+      writeFileSync(target, 'original\n', 'utf-8');
+
+      const patch = `--- a/src/foo.txt
++++ b/src/foo.txt
+@@ -1,1 +1,1 @@
+-original
++patched
+`;
+
+      const result = await executePatch({
+        absolute_path: target,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(readFileSync(target, 'utf-8')).toContain('patched');
+    });
+  });
+
   describe('empty or malformed patch rejection', () => {
     it('returns an error for an empty patch content and leaves the file unchanged', async () => {
       const target = join(tempDir, 'empty.txt');

--- a/packages/tools/src/__tests__/apply-patch.test.ts
+++ b/packages/tools/src/__tests__/apply-patch.test.ts
@@ -1,0 +1,328 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Focused behavioral tests for ApplyPatchTool regressions from issue #2133.
+ *
+ * Verifies observable behavior through infrastructure fakes: filesystem
+ * state, ToolResult content, and error types — NOT internal method calls.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IToolHost } from '../interfaces/index.js';
+import type { ILspService } from '../interfaces/index.js';
+
+import { ApplyPatchTool } from '../index.js';
+import { ToolErrorType } from '../index.js';
+import type { ToolResult } from '../index.js';
+
+function createTempDir(prefix = 'llxprt-apply-patch-test-'): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return {
+    dir,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+describe('ApplyPatchTool issue #2133 regressions', () => {
+  let tempDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmp = createTempDir();
+    tempDir = tmp.dir;
+    cleanup = tmp.cleanup;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function createFakeToolHost(targetDir: string): IToolHost {
+    return {
+      getTargetDir: () => targetDir,
+      getWorkspaceRoots: () => [targetDir],
+      getApprovalMode: () => 'auto',
+      setApprovalMode: () => {},
+      isInteractive: () => false,
+      hasFeatureFlag: () => false,
+    };
+  }
+
+  async function executePatch(
+    params: Record<string, unknown>,
+    options?: { lsp?: ILspService },
+  ): Promise<ToolResult> {
+    // Constructor signature: (host, messageBusOrIdeService, ideServiceOrLspService, lspService)
+    // When the second argument is not a message bus, the third argument is
+    // treated as the LSP service candidate.
+    const tool = new ApplyPatchTool(
+      createFakeToolHost(tempDir),
+      undefined,
+      options?.lsp,
+    );
+    try {
+      return await tool.build(params).execute(new AbortController().signal);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        llmContent: '',
+        returnDisplay: '',
+        error: { message },
+      };
+    }
+  }
+
+  describe('single-file patch success', () => {
+    it('modifies an existing file and writes expected content with no error', async () => {
+      const filePath = join(tempDir, 'target.txt');
+      writeFileSync(filePath, 'alpha\nbeta\ngamma', 'utf-8');
+
+      const patch = `--- a/target.txt
++++ b/target.txt
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++beta-modified
+ gamma`;
+
+      const result = await executePatch({
+        absolute_path: filePath,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Successfully applied patch');
+      expect(readFileSync(filePath, 'utf-8')).toContain('beta-modified');
+      // returnDisplay is a FileDiff object
+      expect(JSON.stringify(result.returnDisplay)).toContain('beta-modified');
+    });
+  });
+
+  describe('multi-hunk single-file patch success', () => {
+    it('applies multiple hunks in the same target file', async () => {
+      const filePath = join(tempDir, 'multi.txt');
+      writeFileSync(
+        filePath,
+        'line1\nline2\nline3\nline4\nline5\nline6',
+        'utf-8',
+      );
+
+      const patch = `--- a/multi.txt
++++ b/multi.txt
+@@ -1,2 +1,2 @@
+-line1
++line1-edited
+ line2
+@@ -5,2 +5,2 @@
+ line5
+-line6
++line6-edited`;
+
+      const result = await executePatch({
+        absolute_path: filePath,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeUndefined();
+      const content = readFileSync(filePath, 'utf-8');
+      expect(content).toContain('line1-edited');
+      expect(content).toContain('line6-edited');
+    });
+  });
+
+  describe('new-file patch success', () => {
+    it('creates a missing target file from a /dev/null to target-file patch', async () => {
+      const filePath = join(tempDir, 'new-file.txt');
+      expect(existsSync(filePath)).toBe(false);
+
+      const patch = `--- /dev/null
++++ b/new-file.txt
+@@ -0,0 +1,2 @@
++hello
++world`;
+
+      const result = await executePatch({
+        absolute_path: filePath,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain(
+        'Successfully created file from patch',
+      );
+      expect(readFileSync(filePath, 'utf-8')).toContain('hello');
+      expect(readFileSync(filePath, 'utf-8')).toContain('world');
+    });
+  });
+
+  describe('multi-file patch rejection', () => {
+    it('rejects a unified diff with two file sections and writes no partial changes', async () => {
+      const fileA = join(tempDir, 'a.txt');
+      const fileB = join(tempDir, 'b.txt');
+      writeFileSync(fileA, 'A-original\n', 'utf-8');
+      writeFileSync(fileB, 'B-original\n', 'utf-8');
+
+      const patch = `--- a/a.txt
++++ b/a.txt
+@@ -1,1 +1,1 @@
+-A-original
++A-patched
+--- a/b.txt
++++ b/b.txt
+@@ -1,1 +1,1 @@
+-B-original
++B-patched
+`;
+
+      const result = await executePatch({
+        absolute_path: fileA,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+      expect(result.llmContent).toContain('single target file patch');
+      expect(result.llmContent).toContain('2');
+      // No partial changes were applied to either file.
+      expect(readFileSync(fileA, 'utf-8')).toBe('A-original\n');
+      expect(readFileSync(fileB, 'utf-8')).toBe('B-original\n');
+    });
+  });
+
+  describe('patch target mismatch rejection', () => {
+    it('rejects a patch header for another file and leaves the target unchanged', async () => {
+      const target = join(tempDir, 'target.txt');
+      writeFileSync(target, 'keep-me\n', 'utf-8');
+
+      const patch = `--- a/other.txt
++++ b/other.txt
+@@ -1,1 +1,1 @@
+-keep-me
++changed
+`;
+
+      const result = await executePatch({
+        absolute_path: target,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+      expect(result.llmContent).toContain('other.txt');
+      expect(result.llmContent).toContain('target.txt');
+      expect(readFileSync(target, 'utf-8')).toBe('keep-me\n');
+    });
+  });
+
+  describe('empty or malformed patch rejection', () => {
+    it('returns an error for an empty patch content and leaves the file unchanged', async () => {
+      const target = join(tempDir, 'empty.txt');
+      writeFileSync(target, 'unchanged\n', 'utf-8');
+
+      const result = await executePatch({
+        absolute_path: target,
+        patch_content: '',
+      });
+
+      expect(result.error).toBeDefined();
+      // Empty patch_content is rejected by parameter validation before parsing.
+      expect(result.error?.message).toContain('patch_content');
+      expect(readFileSync(target, 'utf-8')).toBe('unchanged\n');
+    });
+
+    it('returns INVALID_TOOL_PARAMS for a patch with no parseable file sections', async () => {
+      const target = join(tempDir, 'malformed.txt');
+      writeFileSync(target, 'unchanged\n', 'utf-8');
+
+      const result = await executePatch({
+        absolute_path: target,
+        patch_content: 'this is not a patch at all',
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    });
+  });
+
+  describe('context mismatch apply failure', () => {
+    it('returns PATCH_APPLY_FAILURE and leaves the file unchanged', async () => {
+      const target = join(tempDir, 'mismatch.txt');
+      writeFileSync(target, 'actual content\n', 'utf-8');
+
+      const patch = `--- a/mismatch.txt
++++ b/mismatch.txt
+@@ -1,1 +1,1 @@
+-expected content
++patched content
+`;
+
+      const result = await executePatch({
+        absolute_path: target,
+        patch_content: patch,
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.PATCH_APPLY_FAILURE);
+      expect(readFileSync(target, 'utf-8')).toBe('actual content\n');
+    });
+  });
+
+  describe('LSP diagnostics path regression', () => {
+    it('waits for diagnostics on the actual absolute_path, not the patch header path', async () => {
+      const target = join(tempDir, 'lsp-target.txt');
+      writeFileSync(target, 'lsp-original\n', 'utf-8');
+
+      const patch = `--- a/lsp-target.txt
++++ b/lsp-target.txt
+@@ -1,1 +1,1 @@
+-lsp-original
++lsp-patched
+`;
+
+      let observedPath = '';
+      const fakeLsp: ILspService = {
+        waitForDiagnostics: (filePath: string) => {
+          observedPath = filePath;
+          return Promise.resolve([]);
+        },
+        getDiagnostics: () => [],
+        getLspConfig: () => undefined,
+      };
+
+      const result = await executePatch(
+        { absolute_path: target, patch_content: patch },
+        { lsp: fakeLsp },
+      );
+
+      expect(result.error).toBeUndefined();
+      // The diagnostics wait must use the actual absolute_path target.
+      expect(observedPath).toBe(target);
+    });
+  });
+});

--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -110,17 +110,14 @@ function isNonNullObject(value: unknown): value is object {
   return typeof value === 'object' && value !== null;
 }
 
-const MESSAGE_BUS_KEYS = [
-  'requestConfirmation',
-  'publishPolicyUpdate',
-  'publish',
-  'subscribe',
-] as const;
+// Required keys for duck-typing service shapes. Every key must be present
+// so partial objects are not misclassified as a given service.
+const MESSAGE_BUS_KEYS = ['requestConfirmation'] as const;
 
 const IDE_SERVICE_KEYS = [
   'applyDiff',
-  'openDiff',
   'getConnectionStatus',
+  'openDiff',
 ] as const;
 
 const LSP_SERVICE_KEYS = [
@@ -130,15 +127,15 @@ const LSP_SERVICE_KEYS = [
 ] as const;
 
 function hasMessageBusShape(value: unknown): value is IToolMessageBus {
-  return isNonNullObject(value) && MESSAGE_BUS_KEYS.some((k) => k in value);
+  return isNonNullObject(value) && MESSAGE_BUS_KEYS.every((k) => k in value);
 }
 
 function hasIdeServiceShape(value: unknown): value is IIdeService {
-  return isNonNullObject(value) && IDE_SERVICE_KEYS.some((k) => k in value);
+  return isNonNullObject(value) && IDE_SERVICE_KEYS.every((k) => k in value);
 }
 
 function hasLspServiceShape(value: unknown): value is ILspService {
-  return isNonNullObject(value) && LSP_SERVICE_KEYS.some((k) => k in value);
+  return isNonNullObject(value) && LSP_SERVICE_KEYS.every((k) => k in value);
 }
 
 function getLegacyIdeService(host: IToolHost): IIdeService | undefined {
@@ -364,8 +361,15 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       }
     }
 
-    // Parse and apply patch to get preview
+    // Parse and apply patch to get preview. Use the same validation path as
+    // execute so previews match execution behavior.
     const patches = Diff.parsePatch(this.params.patch_content);
+    if (patches.length === 0) {
+      return false;
+    }
+    if (patches.length > 1) {
+      return false;
+    }
     const newContentResult = Diff.applyPatch(currentContent, patches[0]);
 
     if (typeof newContentResult !== 'string') {
@@ -503,8 +507,9 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
   }
 
   private parsePatchContent(): Diff.StructuredPatch[] | ToolResult {
+    let patches: Diff.StructuredPatch[];
     try {
-      return Diff.parsePatch(this.params.patch_content);
+      patches = Diff.parsePatch(this.params.patch_content);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       return {
@@ -516,16 +521,50 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
         },
       };
     }
+
+    if (patches.length === 0) {
+      return {
+        llmContent:
+          'Patch content did not contain any parseable file sections. Provide a valid unified diff with at least one file section.',
+        returnDisplay: 'No parseable patch sections found.',
+        error: {
+          message: 'Patch content did not contain any parseable file sections.',
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+      };
+    }
+
+    if (patches.length > 1) {
+      const fileNames = patches
+        .map((p) => p.newFileName || p.oldFileName)
+        .join(', ');
+      return {
+        llmContent: `apply_patch accepts a single target file patch, but the provided patch_content contained ${patches.length} file sections (${fileNames}). Make a separate apply_patch call for each file.`,
+        returnDisplay: `Rejected multi-file patch: ${patches.length} file sections.`,
+        error: {
+          message: `apply_patch accepts a single target file patch, but the patch_content contained ${patches.length} file sections. Use a separate apply_patch call per file.`,
+          type: ToolErrorType.INVALID_TOOL_PARAMS,
+        },
+      };
+    }
+
+    return patches;
   }
 
   private applyPatch(
     currentContent: string,
     patches: Diff.StructuredPatch[],
   ): string | ToolResult {
+    const [patch] = patches;
+    const targetError = this.validatePatchTarget(patch);
+    if (targetError) {
+      return targetError;
+    }
+
     try {
-      const newContentResult = Diff.applyPatch(currentContent, patches[0]);
+      const newContentResult = Diff.applyPatch(currentContent, patch);
       if (typeof newContentResult !== 'string') {
-        throw new Error('Failed to apply patch: could not apply');
+        throw new Error('Failed to apply patch: context mismatch');
       }
       return newContentResult;
     } catch (error) {
@@ -535,10 +574,75 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
         returnDisplay: `Error applying patch: ${errorMsg}`,
         error: {
           message: `Failed to apply patch: ${errorMsg}`,
-          type: ToolErrorType.EDIT_NO_CHANGE,
+          type: ToolErrorType.PATCH_APPLY_FAILURE,
         },
       };
     }
+  }
+
+  /**
+   * Validates that the parsed patch header targets the same file as the
+   * absolute_path/file_path parameter. Prevents a patch for one file from
+   * being silently applied to a different target.
+   */
+  private validatePatchTarget(patch: Diff.StructuredPatch): ToolResult | null {
+    const filePath = this.getFilePath();
+    const targetName = path.basename(filePath);
+
+    const stripPrefix = (headerPath: string): string => {
+      // Remove a/ or b/ prefixes used in unified diffs.
+      if (headerPath.startsWith('a/') || headerPath.startsWith('b/')) {
+        return headerPath.slice(2);
+      }
+      return headerPath;
+    };
+
+    const newHeader = stripPrefix(patch.newFileName || '');
+    const oldHeader = stripPrefix(patch.oldFileName || '');
+
+    // /dev/null is valid for new-file or delete-style patches.
+    const isNewFileFromNull =
+      oldHeader === '/dev/null' &&
+      newHeader !== '' &&
+      newHeader !== '/dev/null';
+    const isDeleteToNull =
+      newHeader === '/dev/null' &&
+      oldHeader !== '' &&
+      oldHeader !== '/dev/null';
+
+    if (isNewFileFromNull || isDeleteToNull) {
+      // For new-file patches, the new header basename should match target.
+      if (isNewFileFromNull && path.basename(newHeader) === targetName) {
+        return null;
+      }
+      // For delete-style patches, the old header basename should match target.
+      if (isDeleteToNull && path.basename(oldHeader) === targetName) {
+        return null;
+      }
+    }
+
+    const newMatches =
+      newHeader !== '' &&
+      (path.basename(newHeader) === targetName ||
+        newHeader === path.relative(getTargetDirCompat(this.host), filePath));
+    const oldMatches =
+      oldHeader !== '' &&
+      (path.basename(oldHeader) === targetName ||
+        oldHeader === path.relative(getTargetDirCompat(this.host), filePath));
+
+    if (newMatches || oldMatches) {
+      return null;
+    }
+
+    const describedTarget = newHeader || oldHeader || '(unknown)';
+    return {
+      llmContent: `Patch header targets "${describedTarget}" but the absolute_path targets "${targetName}". Ensure the patch header matches the target file, or use a separate apply_patch call for "${describedTarget}".`,
+      returnDisplay: `Rejected patch: header target "${describedTarget}" does not match absolute_path "${targetName}".`,
+      error: {
+        message: `Patch header target "${describedTarget}" does not match absolute_path "${targetName}".`,
+        type: ToolErrorType.INVALID_TOOL_PARAMS,
+      },
+    };
   }
 
   private async writeAndFormatResult(
@@ -653,13 +757,9 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
   ): Promise<void> {
     try {
       if (this.lspService !== undefined) {
-        for (const contentFile of classification.contentWriteFiles) {
-          const absoluteFilePath = path.resolve(
-            getTargetDirCompat(this.host),
-            contentFile,
-          );
-          await this.lspService.waitForDiagnostics(absoluteFilePath, 5000);
-        }
+        // Wait for diagnostics on the actual file written by the tool
+        // (absolute_path), not the patch header path which may differ.
+        await this.lspService.waitForDiagnostics(filePath, 5000);
       }
 
       const diagBlock =

--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -621,14 +621,24 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       }
     }
 
-    const newMatches =
-      newHeader !== '' &&
-      (path.basename(newHeader) === targetName ||
-        newHeader === path.relative(getTargetDirCompat(this.host), filePath));
-    const oldMatches =
-      oldHeader !== '' &&
-      (path.basename(oldHeader) === targetName ||
-        oldHeader === path.relative(getTargetDirCompat(this.host), filePath));
+    const relativePath = path.relative(getTargetDirCompat(this.host), filePath);
+    const headerMatches = (header: string): boolean => {
+      if (header === '') {
+        return false;
+      }
+      // When the header contains a directory separator, the full relative path
+      // must match so that a directory-qualified header (e.g. 'a/src/foo.txt')
+      // cannot validate against an absolute_path ending in a different
+      // directory's same-named file. Only headers without a directory component
+      // fall back to basename comparison.
+      if (header.includes('/') || header.includes(path.sep)) {
+        return header === relativePath;
+      }
+      return path.basename(header) === targetName;
+    };
+
+    const newMatches = headerMatches(newHeader);
+    const oldMatches = headerMatches(oldHeader);
 
     if (newMatches || oldMatches) {
       return null;

--- a/packages/tools/src/tools/apply-patch.ts
+++ b/packages/tools/src/tools/apply-patch.ts
@@ -621,7 +621,13 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       }
     }
 
-    const relativePath = path.relative(getTargetDirCompat(this.host), filePath);
+    // Unified-diff headers always use forward slashes, but path.relative returns
+    // OS-native separators (backslashes on Windows). Normalize both sides to
+    // forward slashes so directory-qualified header matching works cross-platform.
+    const toPosix = (p: string): string => p.split(path.sep).join('/');
+    const relativePath = toPosix(
+      path.relative(getTargetDirCompat(this.host), filePath),
+    );
     const headerMatches = (header: string): boolean => {
       if (header === '') {
         return false;
@@ -632,7 +638,7 @@ class ApplyPatchToolInvocation extends BaseToolInvocation<
       // directory's same-named file. Only headers without a directory component
       // fall back to basename comparison.
       if (header.includes('/') || header.includes(path.sep)) {
-        return header === relativePath;
+        return toPosix(header) === relativePath;
       }
       return path.basename(header) === targetName;
     };

--- a/packages/tools/src/types/tool-error.ts
+++ b/packages/tools/src/types/tool-error.ts
@@ -49,6 +49,7 @@ export enum ToolErrorType {
   EDIT_NO_CHANGE = 'edit_no_change',
   EDIT_NO_CHANGE_LLM_JUDGEMENT = 'edit_no_change_llm_judgement',
   FILE_MODIFIED_CONFLICT = 'file_modified_conflict',
+  PATCH_APPLY_FAILURE = 'patch_apply_failure',
 
   // Glob-specific Errors
   GLOB_EXECUTION_ERROR = 'glob_execution_error',


### PR DESCRIPTION
## TLDR

Fixes #2133

This PR hardens apply_patch so it no longer reports success after silently applying only the first file section from a multi-file unified diff. It keeps the tool aligned with its single-target file schema by rejecting multi-file patches, validating patch headers against the requested target path, and returning a dedicated patch-apply failure error when diff context cannot be applied.

## Dive Deeper

Issue #2133 pointed to confusing apply_patch behavior where a successful result could be returned even though expected changes were missing. The underlying problem was that Diff.parsePatch can return multiple structured patches, but the implementation only used the first parsed patch. A patch containing multiple file sections could therefore partially apply and still look successful.

The implementation now:

- Rejects empty or unparseable patch content with INVALID_TOOL_PARAMS.
- Rejects multi-file unified diffs and instructs callers to use one apply_patch call per target file.
- Validates that the parsed patch header matches the provided absolute_path or file_path target before applying changes.
- Preserves valid single-file behavior, including multi-hunk patches and new-file patches from /dev/null.
- Adds PATCH_APPLY_FAILURE so context-mismatch failures are no longer reported as EDIT_NO_CHANGE.
- Tightens constructor duck-typing so partial service-shaped objects are not misclassified.
- Waits for LSP diagnostics using the actual file path written by the tool instead of resolving paths from patch headers.

Focused regression coverage was added for the issue scenarios and related edge cases in packages/tools/src/__tests__/apply-patch.test.ts.

## Reviewer Test Plan

Recommended validation:

- Run the focused apply_patch tests:

      npm run test --workspace @vybestack/llxprt-code-tools -- apply-patch

- Run the tools package verification commands:

      npm run test --workspace @vybestack/llxprt-code-tools
      npm run lint --workspace @vybestack/llxprt-code-tools
      npm run typecheck --workspace @vybestack/llxprt-code-tools

Manual review focus:

- Confirm multi-file patches are rejected before any partial write occurs.
- Confirm valid single-file and multi-hunk patches still apply successfully.
- Confirm patch header mismatches leave the target file unchanged.
- Confirm context mismatches return PATCH_APPLY_FAILURE.

## Testing Matrix

|          | APPLE | WIN | LINUX |
| -------- | ----- | --- | ----- |
| npm run  | ?     | ?   | ?     |
| npx      | ?     | ?   | ?     |
| Docker   | ?     | ?   | ?     |
| Podman   | ?     | -   | -     |
| Seatbelt | ?     | -   | -     |

## Linked issues / bugs

Fixes #2133
