### PR TITLE
Harden Codex Responses request validation (Fixes #2135, Fixes #2137)

### DIFF
--- a/packages/providers/src/openai-responses/OpenAIResponsesInputBuilder.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesInputBuilder.ts
@@ -78,7 +78,7 @@ function appendInputForContent(
   }
 
   if (item.speaker === 'ai') {
-    appendAssistantInput(input, item, context, nextReasoningId);
+    appendAssistantInput(input, item, patchedContent, context, nextReasoningId);
     return;
   }
 
@@ -106,6 +106,7 @@ function appendHumanInput(
 function appendAssistantInput(
   input: ResponsesInputItem[],
   content: IContent,
+  patchedContent: IContent[],
   context: ResponsesInputBuildContext,
   nextReasoningId: () => string,
 ): void {
@@ -138,9 +139,18 @@ function appendAssistantInput(
   if (contentText) input.push({ role: 'assistant', content: contentText });
 
   for (const toolCall of toolCallBlocks) {
+    const normalizedCallId = normalizeToOpenAIToolId(toolCall.id);
+    if (!hasMatchingToolResponse(patchedContent, normalizedCallId)) {
+      context.debug(
+        () =>
+          `Dropping dangling function_call with call_id=${normalizedCallId} (no matching tool_response in history)`,
+      );
+      continue;
+    }
+
     input.push({
       type: 'function_call',
-      call_id: normalizeToOpenAIToolId(toolCall.id),
+      call_id: normalizedCallId,
       name: toolCall.name,
       arguments: JSON.stringify(toolCall.parameters),
     });
@@ -227,6 +237,21 @@ function hasMatchingToolCall(
         (block) =>
           block.type === 'tool_call' &&
           normalizeToOpenAIToolId(block.id) === outputCallId,
+      ),
+  );
+}
+
+function hasMatchingToolResponse(
+  patchedContent: IContent[],
+  callId: string,
+): boolean {
+  return patchedContent.some(
+    (msg) =>
+      msg.speaker === 'tool' &&
+      msg.blocks.some(
+        (block) =>
+          block.type === 'tool_response' &&
+          normalizeToOpenAIToolId(block.callId) === callId,
       ),
   );
 }

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -32,6 +32,7 @@ import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { OpenAIResponsesProviderBase } from './OpenAIResponsesProviderBase.js';
 import { buildOpenAIResponsesInput } from './OpenAIResponsesInputBuilder.js';
+import { sanitizePromptCacheKey } from './sanitizePromptCacheKey.js';
 import type {
   OpenAIResponsesRequest,
   ResponsesInputItem,
@@ -505,7 +506,7 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
       options.runtime?.runtimeId;
     if (typeof cacheKey !== 'string' || cacheKey.trim() === '') return;
 
-    request.prompt_cache_key = cacheKey;
+    request.prompt_cache_key = sanitizePromptCacheKey(cacheKey);
     if (!isCodex) request.prompt_cache_retention = '24h';
   }
 

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.toolPairing.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesInputBuilder.toolPairing.test.ts
@@ -1,0 +1,372 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for OpenAIResponsesInputBuilder tool-call / tool-response
+ * pairing logic (issues #2137, #855).
+ *
+ * These tests call buildOpenAIResponsesInput directly with realistic
+ * IContent[] histories and assert the emitted ResponsesInputItem[] shape.
+ * No mocks of the builder itself are used — only a minimal
+ * ToolOutputSettingsProvider stub.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { ToolOutputSettingsProvider } from '@vybestack/llxprt-code-core/utils/toolOutputLimiter.js';
+import {
+  buildOpenAIResponsesInput,
+  type ResponsesInputBuildContext,
+} from '../OpenAIResponsesInputBuilder.js';
+
+function buildContext(
+  overrides: Partial<ResponsesInputBuildContext> = {},
+): ResponsesInputBuildContext {
+  const stubConfig: ToolOutputSettingsProvider = {
+    getEphemeralSettings: () => ({}),
+  };
+  return {
+    includeReasoningInContext: true,
+    outputLimiterConfig: stubConfig,
+    debug: () => {},
+    ...overrides,
+  };
+}
+
+function functionCalls(input: unknown[]): unknown[] {
+  return input.filter(
+    (i) =>
+      typeof i === 'object' &&
+      i !== null &&
+      (i as { type?: string }).type === 'function_call',
+  );
+}
+
+function functionCallOutputs(input: unknown[]): unknown[] {
+  return input.filter(
+    (i) =>
+      typeof i === 'object' &&
+      i !== null &&
+      (i as { type?: string }).type === 'function_call_output',
+  );
+}
+
+function callId(item: unknown): string {
+  return (item as { call_id?: string }).call_id ?? '';
+}
+
+function build(...contents: IContent[]): unknown[] {
+  return buildOpenAIResponsesInput(contents, buildContext()) as unknown[];
+}
+
+describe('OpenAIResponsesInputBuilder tool pairing @issue:2137', () => {
+  it('emits paired function_call and function_call_output', () => {
+    const input = build(
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_abc123',
+            name: 'run_shell_command',
+            parameters: { command: 'echo hi' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_abc123',
+            toolName: 'run_shell_command',
+            result: 'hi',
+          },
+        ],
+      },
+    );
+
+    const calls = functionCalls(input);
+    const outputs = functionCallOutputs(input);
+    expect(calls).toHaveLength(1);
+    expect(outputs).toHaveLength(1);
+    expect(callId(calls[0])).toBe('call_abc123');
+    expect(callId(outputs[0])).toBe('call_abc123');
+  });
+
+  it('drops orphan function_call_output with no matching tool_call', () => {
+    const debugFn = vi.fn();
+    const ctx = buildContext({ debug: debugFn });
+    const input = buildOpenAIResponsesInput(
+      [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hello' }],
+        },
+        {
+          speaker: 'tool',
+          blocks: [
+            {
+              type: 'tool_response',
+              callId: 'call_orphan',
+              toolName: 'run_shell_command',
+              result: 'no matching call',
+            },
+          ],
+        },
+      ],
+      ctx,
+    ) as unknown[];
+
+    expect(functionCallOutputs(input)).toHaveLength(0);
+    expect(functionCalls(input)).toHaveLength(0);
+    expect(debugFn).toHaveBeenCalled();
+  });
+
+  it('omits dangling historical function_call with no matching tool_response', () => {
+    const debugFn = vi.fn();
+    const ctx = buildContext({ debug: debugFn });
+    const input = buildOpenAIResponsesInput(
+      [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'do something' }],
+        },
+        {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'call_dangling',
+              name: 'run_shell_command',
+              parameters: { command: 'ls' },
+            },
+          ],
+        },
+        // No tool_response for call_dangling
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'never mind' }],
+        },
+      ],
+      ctx,
+    ) as unknown[];
+
+    expect(functionCalls(input)).toHaveLength(0);
+    expect(debugFn).toHaveBeenCalled();
+  });
+
+  it('preserves assistant text but omits dangling tool_call when both present', () => {
+    const input = buildOpenAIResponsesInput(
+      [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hi' }],
+        },
+        {
+          speaker: 'ai',
+          blocks: [
+            { type: 'text', text: 'Let me check that.' },
+            {
+              type: 'tool_call',
+              id: 'call_text_and_dangling',
+              name: 'read_file',
+              parameters: { path: '/tmp/x' },
+            },
+          ],
+        },
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'wait' }],
+        },
+      ],
+      buildContext(),
+    ) as unknown[];
+
+    // Assistant text is preserved
+    const assistantMessages = input.filter(
+      (i) =>
+        typeof i === 'object' &&
+        i !== null &&
+        (i as { role?: string }).role === 'assistant' &&
+        typeof (i as { content?: unknown }).content === 'string',
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect((assistantMessages[0] as { content: string }).content).toBe(
+      'Let me check that.',
+    );
+
+    // Dangling tool call is omitted
+    expect(functionCalls(input)).toHaveLength(0);
+  });
+
+  it('omits only the missing call in a parallel pair (one output missing)', () => {
+    const input = build(
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_first',
+            name: 'run_shell_command',
+            parameters: { command: 'echo one' },
+          },
+          {
+            type: 'tool_call',
+            id: 'call_second',
+            name: 'run_shell_command',
+            parameters: { command: 'echo two' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_first',
+            toolName: 'run_shell_command',
+            result: 'one',
+          },
+          // No response for call_second
+        ],
+      },
+    );
+
+    const calls = functionCalls(input);
+    const outputs = functionCallOutputs(input);
+    // Only call_first is paired; call_second has no response so it's dropped.
+    expect(calls).toHaveLength(1);
+    expect(outputs).toHaveLength(1);
+    expect(callId(calls[0])).toBe('call_first');
+    expect(callId(outputs[0])).toBe('call_first');
+  });
+
+  it('emits both parallel calls when both have matching outputs', () => {
+    const input = build(
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_a',
+            name: 'run_shell_command',
+            parameters: { command: 'echo a' },
+          },
+          {
+            type: 'tool_call',
+            id: 'call_b',
+            name: 'run_shell_command',
+            parameters: { command: 'echo b' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_a',
+            toolName: 'run_shell_command',
+            result: 'a',
+          },
+          {
+            type: 'tool_response',
+            callId: 'call_b',
+            toolName: 'run_shell_command',
+            result: 'b',
+          },
+        ],
+      },
+    );
+
+    const calls = functionCalls(input);
+    const outputs = functionCallOutputs(input);
+    expect(calls).toHaveLength(2);
+    expect(outputs).toHaveLength(2);
+  });
+
+  it('uses normalized call_ids consistently between call and output', () => {
+    // A tool_call stored with a hist_tool_ prefix id and a tool_response
+    // with a call_ prefix id — both normalize to the same call_xxx.
+    const input = build(
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'hist_tool_abc123',
+            name: 'read_file',
+            parameters: { path: '/tmp/f' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_abc123',
+            toolName: 'read_file',
+            result: 'contents',
+          },
+        ],
+      },
+    );
+
+    const calls = functionCalls(input);
+    const outputs = functionCallOutputs(input);
+    expect(calls).toHaveLength(1);
+    expect(outputs).toHaveLength(1);
+    expect(callId(calls[0])).toBe(callId(outputs[0]));
+    expect(callId(calls[0])).toBe('call_abc123');
+  });
+
+  it('does not emit thinking blocks without encryptedContent as reasoning', () => {
+    const input = buildOpenAIResponsesInput(
+      [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'think about it' }],
+        },
+        {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'thinking',
+              thought: 'I should reason carefully',
+              sourceField: 'reasoning_content',
+            },
+            { type: 'text', text: 'Here is my answer.' },
+          ],
+        },
+      ],
+      buildContext(),
+    ) as unknown[];
+
+    // No reasoning item emitted because there's no encryptedContent.
+    const reasoning = input.filter(
+      (i) =>
+        typeof i === 'object' &&
+        i !== null &&
+        (i as { type?: string }).type === 'reasoning',
+    );
+    expect(reasoning).toHaveLength(0);
+
+    // Text is preserved.
+    const assistantMessages = input.filter(
+      (i) =>
+        typeof i === 'object' &&
+        i !== null &&
+        (i as { role?: string }).role === 'assistant' &&
+        typeof (i as { content?: unknown }).content === 'string',
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect((assistantMessages[0] as { content: string }).content).toBe(
+      'Here is my answer.',
+    );
+  });
+});

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
@@ -483,4 +483,79 @@ describe('OpenAIResponsesProvider prompt-caching @issue:1145', () => {
     expect(requestBody.prompt_cache_key).toBe('test-runtime-id-123');
     expect(requestBody.prompt_cache_retention).toBe('24h');
   });
+
+  it('should sanitize a long compression-style runtimeId to <=64 chars (issue #2135)', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+
+    let capturedBody: string | undefined;
+    mockFetch.mockImplementation(
+      async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        if (init?.body != null) {
+          capturedBody =
+            typeof init.body === 'string'
+              ? init.body
+              : await new Response(init.body).text();
+        }
+        return createMockStreamingResponse();
+      },
+    );
+
+    // 69-char compression-profile runtime ID as reported in issue #2135.
+    const longRuntimeId =
+      'cli-isolated-abcdefghij0::compression-profile:compression-profile';
+    expect(longRuntimeId.length).toBeGreaterThan(64);
+
+    const settings = new SettingsService();
+    settings.set('activeProvider', provider.name);
+    settings.setProviderSetting(provider.name, 'model', 'o3-mini');
+
+    const config = createRuntimeConfigStub(settings);
+    const runtime = createProviderRuntimeContext({
+      settingsService: settings,
+      runtimeId: longRuntimeId,
+      config,
+    });
+
+    const invocation = createRuntimeInvocationContext({
+      runtime,
+      settings,
+      providerName: provider.name,
+      ephemeralsSnapshot: { 'prompt-caching': '1h' },
+    });
+
+    const options = createProviderCallOptions({
+      settings,
+      config,
+      runtime,
+      invocation,
+      providerName: provider.name,
+      contents: [
+        { speaker: 'human', blocks: [{ type: 'text', text: 'test message' }] },
+      ],
+      ephemeralSettings: { 'prompt-caching': '1h' },
+    });
+
+    const generator = provider.generateChatCompletion(options);
+    for await (const _content of generator) {
+      // drain
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(capturedBody).toBeDefined();
+    const requestBody = JSON.parse(capturedBody!);
+
+    const cacheKey = requestBody.prompt_cache_key as string;
+    expect(typeof cacheKey).toBe('string');
+    expect(cacheKey.length).toBeLessThanOrEqual(64);
+    // Must not be the raw over-long id
+    expect(cacheKey).not.toBe(longRuntimeId);
+    // non-Codex still gets retention
+    expect(requestBody.prompt_cache_retention).toBe('24h');
+  });
 });

--- a/packages/providers/src/openai-responses/__tests__/sanitizePromptCacheKey.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/sanitizePromptCacheKey.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for sanitizePromptCacheKey (issue #2135).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizePromptCacheKey,
+  MAX_PROMPT_CACHE_KEY_LENGTH,
+} from '../sanitizePromptCacheKey.js';
+
+describe('sanitizePromptCacheKey @issue:2135', () => {
+  it('returns a runtimeId at exactly 64 chars unchanged', () => {
+    const id64 = 'a'.repeat(64);
+    expect(sanitizePromptCacheKey(id64)).toBe(id64);
+    expect(sanitizePromptCacheKey(id64).length).toBe(64);
+  });
+
+  it('returns a short runtimeId unchanged (trimmed)', () => {
+    expect(sanitizePromptCacheKey('test-runtime-id-123')).toBe(
+      'test-runtime-id-123',
+    );
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(sanitizePromptCacheKey('  test-id  ')).toBe('test-id');
+  });
+
+  it('maps a long compression-style runtimeId to <=64 chars deterministically', () => {
+    // This is the exact shape from issue #2135 (69 chars).
+    const longId =
+      'cli-isolated-abcdefghij0::compression-profile:compression-profile';
+    expect(longId.length).toBeGreaterThan(MAX_PROMPT_CACHE_KEY_LENGTH);
+
+    const sanitized = sanitizePromptCacheKey(longId);
+    expect(sanitized.length).toBeLessThanOrEqual(MAX_PROMPT_CACHE_KEY_LENGTH);
+    expect(sanitized.startsWith('rk:')).toBe(true);
+
+    // Deterministic: same input -> same output
+    expect(sanitizePromptCacheKey(longId)).toBe(sanitized);
+  });
+
+  it('produces distinct keys for distinct long runtimeIds (no naive truncation collision)', () => {
+    const base =
+      'cli-isolated-session-0000000000000000000000000000000000000000';
+    const longA = `${base}::compression-profile:profileA`;
+    const longB = `${base}::compression-profile:profileB`;
+
+    // Naive truncation to 64 chars would yield the same key for both.
+    expect(longA.slice(0, 64)).toBe(longB.slice(0, 64));
+
+    const sanitizedA = sanitizePromptCacheKey(longA);
+    const sanitizedB = sanitizePromptCacheKey(longB);
+    expect(sanitizedA).not.toBe(sanitizedB);
+    expect(sanitizedA.length).toBeLessThanOrEqual(MAX_PROMPT_CACHE_KEY_LENGTH);
+    expect(sanitizedB.length).toBeLessThanOrEqual(MAX_PROMPT_CACHE_KEY_LENGTH);
+  });
+});

--- a/packages/providers/src/openai-responses/sanitizePromptCacheKey.ts
+++ b/packages/providers/src/openai-responses/sanitizePromptCacheKey.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createHash } from 'node:crypto';
+
+/**
+ * Maximum length for OpenAI prompt_cache_key (API enforces 64 chars).
+ */
+export const MAX_PROMPT_CACHE_KEY_LENGTH = 64;
+
+/**
+ * Short prefix used when a runtimeId exceeds the max length and must be
+ * deterministically compressed.  Keeping it compact leaves room for a
+ * meaningful hash suffix.
+ */
+const COMPRESSED_PREFIX = 'rk:';
+
+/**
+ * Sanitizes a runtimeId for use as an OpenAI `prompt_cache_key`.
+ *
+ * - If the trimmed id already fits within the 64-character limit it is
+ *   returned unchanged (trimmed).
+ * - If the id exceeds the limit it is deterministically mapped to
+ *   `rk:` + a SHA-256 hex digest prefix, producing a stable key that
+ *   stays within the limit and remains collision-resistant across
+ *   distinct runtime IDs.
+ *
+ * This avoids the "string too long" 400 error (issue #2135) that occurs
+ * when compression-profile runtime IDs such as
+ * `cli-isolated-...::compression-profile:compression-profile` reach 69+
+ * characters.
+ */
+export function sanitizePromptCacheKey(runtimeId: string): string {
+  const trimmed = runtimeId.trim();
+  if (trimmed.length <= MAX_PROMPT_CACHE_KEY_LENGTH) {
+    return trimmed;
+  }
+
+  const hash = createHash('sha256').update(trimmed).digest('hex');
+  return `${COMPRESSED_PREFIX}${hash.slice(0, MAX_PROMPT_CACHE_KEY_LENGTH - COMPRESSED_PREFIX.length)}`;
+}

--- a/packages/providers/src/openai/parseResponsesStream.test.ts
+++ b/packages/providers/src/openai/parseResponsesStream.test.ts
@@ -190,7 +190,9 @@ describe('parseErrorResponse', () => {
 
   it('should handle invalid JSON in error response', () => {
     const error = parseErrorResponse(500, 'Not JSON', 'Responses');
-    expect(error.message).toBe('Server error: Responses API error: 500');
+    expect(error.message).toContain('Server error');
+    expect(error.message).toContain('Status: 500');
+    expect(error.message).toContain('Not JSON');
   });
 
   it('should handle unknown status codes', () => {
@@ -200,6 +202,42 @@ describe('parseErrorResponse', () => {
       'Responses',
     );
     expect(error.message).toBe('I am a teapot');
+  });
+
+  it('should include status and empty-body indication for empty 400 body @issue:2137', () => {
+    const error = parseErrorResponse(400, '', 'Responses');
+    expect(error.message).toContain('Status: 400');
+    expect(error.message).toContain('empty response body');
+    expect(error.message).not.toBe('Client error: Unknown error');
+  });
+
+  it('should include status and body snippet for empty JSON object 400 @issue:2137', () => {
+    const error = parseErrorResponse(400, '{}', 'Responses');
+    expect(error.message).toContain('Status: 400');
+    expect(error.message).toContain('body:');
+    expect(error.message).not.toBe('Client error: Unknown error');
+  });
+
+  it('should include status and body snippet for JSON with empty error object @issue:2137', () => {
+    const error = parseErrorResponse(400, '{"error":{}}', 'Responses');
+    expect(error.message).toContain('Status: 400');
+    expect(error.message).toContain('body:');
+    expect(error.message).not.toBe('Client error: Unknown error');
+  });
+
+  it('should include status and body snippet for plain-text 400 body @issue:2137', () => {
+    const error = parseErrorResponse(400, 'Bad Request', 'Responses');
+    expect(error.message).toContain('Status: 400');
+    expect(error.message).toContain('Bad Request');
+  });
+
+  it('should still extract standard error messages for structured 400s @issue:2137', () => {
+    const error = parseErrorResponse(
+      400,
+      '{"error":{"message":"Invalid prompt"}}',
+      'Responses',
+    );
+    expect(error.message).toBe('Client error: Invalid prompt');
   });
 
   it('should parse cached_tokens from response.completed usage data', async () => {

--- a/packages/providers/src/openai/responsesErrorParsing.ts
+++ b/packages/providers/src/openai/responsesErrorParsing.ts
@@ -59,6 +59,28 @@ function resolveErrorPrefix(status: number): string {
   }
 }
 
+/**
+ * Maximum number of characters from the raw response body included in
+ * diagnostic error messages for unstructured / unknown errors.
+ */
+const MAX_BODY_SNIPPET_LENGTH = 200;
+
+/**
+ * Builds a diagnostic message for cases where structured error extraction
+ * failed (empty body, empty JSON object, or a body with no recognizable
+ * error fields).  This ensures the caller gets a message that includes the
+ * HTTP status and a safe body snippet instead of a bare "Unknown error".
+ */
+function buildDiagnosticMessage(status: number, body: string): string {
+  const trimmed = body.trim();
+  if (trimmed === '') {
+    return `Unknown error (Status: ${status}, empty response body)`;
+  }
+  const snippet = trimmed.slice(0, MAX_BODY_SNIPPET_LENGTH);
+  const ellipsis = trimmed.length > MAX_BODY_SNIPPET_LENGTH ? '...' : '';
+  return `Unknown error (Status: ${status}, body: ${snippet}${ellipsis})`;
+}
+
 export function parseErrorResponse(
   status: number,
   body: string,
@@ -68,7 +90,14 @@ export function parseErrorResponse(
   try {
     const errorData = JSON.parse(body);
 
-    const message = resolveErrorMessage(errorData);
+    const resolvedMessage = resolveErrorMessage(errorData);
+    // When structured extraction fails, enrich the "Unknown error" with
+    // status and a safe body snippet so diagnostics are actionable
+    // (e.g. issue #2137's bare "Client error: Unknown error").
+    const message =
+      resolvedMessage === 'Unknown error'
+        ? buildDiagnosticMessage(status, body)
+        : resolvedMessage;
 
     // 418 I'm a teapot: return message without prefix
     if (status === 418) {
@@ -85,12 +114,11 @@ export function parseErrorResponse(
     (error as { code?: string }).code = errorData.error?.code ?? errorData.code;
     return error;
   } catch {
-    // For invalid JSON, use a consistent format
+    // For invalid JSON / empty body, include diagnostic body snippet.
     const errorPrefix =
       status >= 500 && status < 600 ? 'Server error' : 'API Error';
-    const error = new Error(
-      `${errorPrefix}: ${providerName} API error: ${status}`,
-    );
+    const detail = buildDiagnosticMessage(status, body);
+    const error = new Error(`${errorPrefix}: ${providerName} - ${detail}`);
     (error as { status?: number }).status = status;
     return error;
   }

--- a/packages/providers/src/openai/responsesErrorParsing.ts
+++ b/packages/providers/src/openai/responsesErrorParsing.ts
@@ -115,8 +115,7 @@ export function parseErrorResponse(
     return error;
   } catch {
     // For invalid JSON / empty body, include diagnostic body snippet.
-    const errorPrefix =
-      status >= 500 && status < 600 ? 'Server error' : 'API Error';
+    const errorPrefix = resolveErrorPrefix(status);
     const detail = buildDiagnosticMessage(status, body);
     const error = new Error(`${errorPrefix}: ${providerName} - ${detail}`);
     (error as { status?: number }).status = status;


### PR DESCRIPTION
## TLDR

Fixes Codex/OpenAI Responses 400s by bounding prompt_cache_key to OpenAI's 64-character limit and by preventing malformed function-call history from being sent to the Responses API.

## Dive Deeper

This PR addresses two related failure modes in the Codex/OpenAI Responses provider:

- Long compression-profile runtime IDs were being used directly as prompt_cache_key. The OpenAI Responses API rejects keys longer than 64 characters, and the reported 69-character key matches the compression-profile runtime ID shape. This PR maps over-long runtime IDs to deterministic SHA-256-based keys while preserving existing keys that already fit.
- Responses input construction already dropped orphan function_call_output items, but still emitted dangling function_call items with no matching tool_response. The #2137 dump had exactly that shape at the end of history. This PR drops those dangling calls before request construction while preserving assistant text and valid paired tool calls/outputs.

It also improves unstructured 400 diagnostics so empty, unknown JSON, or plain-text error bodies include status/body context instead of collapsing to Client error: Unknown error.

## Reviewer Test Plan

Review the new behavioral tests around prompt cache key sanitization and Responses tool-call pairing. Good cases to validate manually are:

- Codex/OpenAI Responses with prompt caching enabled and a long compression-profile runtime ID.
- A conversation history containing a completed tool call and tool output pair.
- A conversation history ending with an assistant tool call that has no tool response yet.
- A 400 response with an empty or unstructured body.

Local verification completed:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run lint
- npm run typecheck
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2135
Fixes #2137
