### PR TITLE
Remove auth ESLint directive suppressions (Fixes #2121)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -152,13 +152,13 @@ const legacyDirectiveCleanupScopes = [
   'packages/cli/src/**/*.{ts,tsx}', // #2086/#2091 (#2087 files locked in completedDirectiveCleanupScopes)
   'packages/policy/src/**/*.{ts,tsx}', // #2089 not yet decomposed
   'packages/storage/src/**/*.{ts,tsx}', // #2092
-  // #2089 scope: the six target packages (auth/settings/telemetry/
+  // #2089 scope: the five target packages (settings/telemetry/
   // ide-integration/a2a-server) still contain other files with legacy
   // inline lint directives. Those packages are kept in legacy scope so
   // existing directives do not break lint. The target files and extracted
   // modules are locked in completedDirectiveCleanupScopes below, which
   // overrides this block for those specific files.
-  'packages/auth/src/**/*.{ts,tsx}', // #2089 (non-target files)
+  // packages/auth/src is locked in completedDirectiveCleanupScopes (#2121).
   'packages/settings/src/**/*.{ts,tsx}', // #2089 (non-target files)
   'packages/telemetry/src/**/*.{ts,tsx}', // #2089 (non-target files)
   'packages/ide-integration/src/**/*.{ts,tsx}', // #2089 (non-target files)
@@ -414,6 +414,9 @@ const completedDirectiveCleanupScopes = [
   // lint directives. The broad glob below supersedes the individual #2090
   // entries above. Locked to error so any new directive fails immediately.
   'packages/agents/src/**/*.{ts,tsx}', // #2117
+  // #2121 — all packages/auth/src files are now fully compliant: zero inline
+  // lint directives. Locked to error so any new directive fails immediately.
+  'packages/auth/src/**/*.{ts,tsx}', // #2121
   // #2091 packages/cli test cleanup — target files (and extracted helpers)
   // are fully compliant: zero inline lint directives. Locked to error so any
   // new directive fails immediately while the rest of packages/cli remains in

--- a/packages/auth/src/__tests__/auth-integration.spec.ts
+++ b/packages/auth/src/__tests__/auth-integration.spec.ts
@@ -51,7 +51,7 @@ interface MockProvider {
   name: string;
   isAuthenticated(): Promise<boolean>;
   resolveAuthentication(): Promise<string | null>;
-  makeApiCall?(): Promise<unknown>;
+  makeApiCall(): Promise<unknown>;
 }
 
 describe('Auth Integration: Complete Precedence Flow and Provider Coordination', () => {
@@ -290,9 +290,6 @@ describe('Auth Integration: Complete Precedence Flow and Provider Coordination',
       const oauthMetadata = integrationMetadata('qwen');
 
       // Mock provider API call that triggers lazy authentication
-      // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
-      if (!mockQwenProvider.makeApiCall)
-        throw new Error('unreachable: narrowing failed');
       vi.mocked(mockQwenProvider.makeApiCall).mockImplementation(async () => {
         const token = await mockOAuthManager.getToken('qwen', oauthMetadata);
         if (!token) {
@@ -334,9 +331,6 @@ describe('Auth Integration: Complete Precedence Flow and Provider Coordination',
       const oauthMetadata = integrationMetadata('qwen');
 
       // Mock provider API call that checks authentication
-      // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
-      if (!mockQwenProvider.makeApiCall)
-        throw new Error('unreachable: narrowing failed');
       vi.mocked(mockQwenProvider.makeApiCall).mockImplementation(async () => {
         const token = await mockOAuthManager.getToken('qwen', oauthMetadata);
         if (!token) {
@@ -481,9 +475,6 @@ describe('Auth Integration: Complete Precedence Flow and Provider Coordination',
       vi.mocked(mockOAuthManager.getToken).mockResolvedValue(
         'oauth-token-from-lazy-trigger',
       );
-      // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
-      if (!mockQwenProvider.makeApiCall)
-        throw new Error('unreachable: narrowing failed');
       vi.mocked(mockQwenProvider.makeApiCall).mockResolvedValue('api-success');
 
       const apiResult = await mockQwenProvider.makeApiCall();
@@ -535,8 +526,11 @@ describe('Auth Integration: Complete Precedence Flow and Provider Coordination',
         async () => mockOAuthManager.getToken('qwen', qwenMetadata), // OAuth only
       );
       vi.mocked(mockGeminiProvider.resolveAuthentication).mockImplementation(
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional falsy coalescing: empty string API key should be treated as missing
-        async () => process.env.OPENAI_API_KEY || null, // Env var only
+        async () =>
+          process.env.OPENAI_API_KEY !== '' &&
+          process.env.OPENAI_API_KEY !== undefined
+            ? process.env.OPENAI_API_KEY
+            : null, // Env var only (empty string treated as missing)
       );
 
       // When: Both providers resolve authentication

--- a/packages/auth/src/__tests__/oauth-logout-cache-invalidation.spec.ts
+++ b/packages/auth/src/__tests__/oauth-logout-cache-invalidation.spec.ts
@@ -142,10 +142,7 @@ describe('OAuth Logout Cache Invalidation (Issue #975)', () => {
     expect(cachedResult).toBe(staleToken);
 
     // Invalidate the cache (simulating logout)
-    // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
-    if (typeof resolver.invalidateCache === 'function') {
-      resolver.invalidateCache();
-    }
+    resolver.invalidateCache();
 
     // OAuth manager now returns fresh token
     vi.mocked(mockOAuthManager.getToken).mockResolvedValue(freshToken);

--- a/packages/auth/src/__tests__/qwen-device-flow.spec.ts
+++ b/packages/auth/src/__tests__/qwen-device-flow.spec.ts
@@ -288,6 +288,7 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
       testServer.removeAllListeners('request');
       let storedChallenge: string | undefined;
       let verifierVerified = false;
+      let computedChallenge: string | undefined;
 
       testServer.on('request', (req, res) => {
         if (req.url?.includes('device/code') === true) {
@@ -320,11 +321,9 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
             const verifier = params.get('code_verifier');
 
             if (verifier && storedChallenge) {
-              const expectedChallenge = createHash('sha256')
+              computedChallenge = createHash('sha256')
                 .update(verifier)
                 .digest('base64url');
-              // eslint-disable-next-line vitest/no-conditional-expect -- intentional: narrowing/filter/property-test context
-              expect(expectedChallenge).toBe(storedChallenge);
               verifierVerified = true;
             }
 
@@ -346,6 +345,7 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
       const tokenResult = await deviceFlow.pollForToken('test_device');
       expect(tokenResult.access_token).toBe('test_token');
       expect(verifierVerified).toBe(true);
+      expect(computedChallenge).toBe(storedChallenge);
     });
   });
 
@@ -506,16 +506,9 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
         expect(timestamps.length).toBeGreaterThanOrEqual(3);
 
         // Verify the intervals are at least close to 5 seconds (allowing some variance)
-        // eslint-disable-next-line vitest/no-conditional-in-test -- intentional: narrowing/filter/parameterized-test context
-        if (timestamps.length > 1) {
-          const intervals = timestamps
-            .slice(1)
-            .map((t, i) => t - timestamps[i]);
-          intervals.forEach((interval) =>
-            // eslint-disable-next-line vitest/no-conditional-expect -- intentional: narrowing/filter/property-test context
-            expect(interval).toBeGreaterThanOrEqual(4000),
-          ); // Allow some variance
-        }
+        const intervals = timestamps.slice(1).map((t, i) => t - timestamps[i]);
+        const minimumInterval = Math.min(...intervals);
+        expect(minimumInterval).toBeGreaterThanOrEqual(4000); // Allow some variance
       },
     );
 
@@ -851,6 +844,8 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
         'client_id',
         'code_verifier',
       ];
+      let capturedDeviceParams: URLSearchParams | null = null;
+      let capturedTokenParams: URLSearchParams | null = null;
 
       testServer.removeAllListeners('request');
       testServer.on('request', (req, res) => {
@@ -862,27 +857,28 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
           const params = new URLSearchParams(body);
 
           if (req.url?.includes('device/code') === true) {
-            requiredDeviceParams.forEach((param) => {
-              // eslint-disable-next-line vitest/no-conditional-expect -- intentional: narrowing/filter/property-test context
-              expect(params.has(param)).toBe(true);
-            });
-          } else if (req.url?.includes('token') === true) {
-            requiredTokenParams.forEach((param) => {
-              // eslint-disable-next-line vitest/no-conditional-expect -- intentional: narrowing/filter/property-test context
-              expect(params.has(param)).toBe(true);
-            });
+            capturedDeviceParams = params;
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(
+              JSON.stringify({
+                device_code: 'test',
+                user_code: 'TEST',
+                verification_uri: 'https://test',
+                expires_in: 900,
+                interval: 5,
+              }),
+            );
+          } else {
+            capturedTokenParams = params;
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(
+              JSON.stringify({
+                access_token: 'test_token',
+                token_type: 'Bearer',
+                expires_in: 3600,
+              }),
+            );
           }
-
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(
-            JSON.stringify({
-              device_code: 'test',
-              user_code: 'TEST',
-              verification_uri: 'https://test',
-              expires_in: 900,
-              interval: 5,
-            }),
-          );
         });
       });
 
@@ -894,6 +890,19 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
         expires_in: 900,
         interval: 5,
       });
+
+      const tokenResult = await deviceFlow.pollForToken('test');
+      expect(tokenResult.access_token).toBe('test_token');
+
+      const missingDeviceParams = requiredDeviceParams.filter(
+        (p) => capturedDeviceParams?.has(p) !== true,
+      );
+      expect(missingDeviceParams).toStrictEqual([]);
+
+      const missingTokenParams = requiredTokenParams.filter(
+        (p) => capturedTokenParams?.has(p) !== true,
+      );
+      expect(missingTokenParams).toStrictEqual([]);
     });
   });
 

--- a/packages/auth/src/__tests__/qwen-device-flow.spec.ts
+++ b/packages/auth/src/__tests__/qwen-device-flow.spec.ts
@@ -507,6 +507,7 @@ describe.skipIf(skipInCI)('QwenDeviceFlow - Behavioral Tests', () => {
 
         // Verify the intervals are at least close to 5 seconds (allowing some variance)
         const intervals = timestamps.slice(1).map((t, i) => t - timestamps[i]);
+        expect(intervals).not.toHaveLength(0);
         const minimumInterval = Math.min(...intervals);
         expect(minimumInterval).toBeGreaterThanOrEqual(4000); // Allow some variance
       },

--- a/scripts/tests/eslint-guard.test.js
+++ b/scripts/tests/eslint-guard.test.js
@@ -229,3 +229,35 @@ describe('packages/agents directive cleanup (#2117)', () => {
     ).toEqual([]);
   });
 });
+
+describe('packages/auth directive cleanup (#2121)', () => {
+  const authSrcDir = join(repoRoot, 'packages', 'auth', 'src');
+
+  it('has zero inline ESLint disable/enable directives', () => {
+    const directiveRe = /eslint-(?:disable|enable)(?:-next-line|-line)?\b/;
+    const offenders = [];
+    for (const file of listTsFiles(authSrcDir)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, idx) => {
+        if (directiveRe.test(line)) {
+          offenders.push(file.replace(repoRoot + '/', '') + ':' + (idx + 1));
+        }
+      });
+    }
+    expect(offenders, 'Found directives: ' + offenders.join(', ')).toEqual([]);
+  });
+
+  it('is locked in completedDirectiveCleanupScopes with a broad glob', () => {
+    const completed = extractScopeArray('completedDirectiveCleanupScopes');
+    expect(completed).toContain('packages/auth/src/**/*.{ts,tsx}');
+  });
+
+  it('is no longer in legacyDirectiveCleanupScopes', () => {
+    const legacy = extractScopeArray('legacyDirectiveCleanupScopes');
+    const authEntries = legacy.filter((e) => e.startsWith('packages/auth'));
+    expect(
+      authEntries,
+      'Legacy auth entries: ' + authEntries.join(', '),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## TLDR

Removes the remaining inline ESLint disable directives from packages/auth and locks the auth source tree into the completed directive cleanup guardrails.

## Dive Deeper

This PR resolves the auth cleanup inventory by refactoring tests instead of suppressing rules:

- makes the integration test mock provider API call required, removing conditional narrowing guards
- preserves the empty OPENAI_API_KEY means missing behavior with explicit checks instead of a lint suppression
- calls the auth resolver cache invalidation method directly now that it is part of the contract
- moves conditional Qwen device-flow assertions out of request callbacks and into post-action assertions
- moves packages/auth/src from the legacy directive cleanup scope to completed directive cleanup scope
- adds scripts guard coverage that fails if packages/auth/src contains any ESLint disable or enable directive

No central rule-off exceptions or replacement suppression comments were added.

## Reviewer Test Plan

Recommended validation:

- rg "eslint-(disable|enable)" packages/auth/src
- npm run test:scripts
- npm run lint --workspace @vybestack/llxprt-code-auth
- npm run typecheck --workspace @vybestack/llxprt-code-auth
- npm run test --workspace @vybestack/llxprt-code-auth
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

Notes from local validation:

- Targeted auth and guard validation passed.
- Full lint, typecheck, format, build, and smoke test passed.
- Full npm run test had unrelated package/agents property-test timeout failures locally. The same affected tests passed when rerun directly, and the auth workspace suite passed.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2121
