### PR TITLE
Remove a2a-server ESLint directive suppressions (Fixes #2123)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,17 +36,17 @@ const legacyDirectiveCleanupScopes = [
   'packages/cli/src/**/*.{ts,tsx}', // #2086/#2091 (#2087 files locked in completedDirectiveCleanupScopes)
   'packages/policy/src/**/*.{ts,tsx}', // #2089 not yet decomposed
   'packages/storage/src/**/*.{ts,tsx}', // #2092
-  // #2089 scope: the five target packages (settings/telemetry/
-  // ide-integration/a2a-server) still contain other files with legacy
-  // inline lint directives. Those packages are kept in legacy scope so
-  // existing directives do not break lint. The target files and extracted
-  // modules are locked in completedDirectiveCleanupScopes below, which
-  // overrides this block for those specific files.
+  // #2089 scope: the four remaining target packages (settings/telemetry/
+  // ide-integration) still contain other files with legacy inline lint
+  // directives. Those packages are kept in legacy scope so existing directives
+  // do not break lint. The target files and extracted modules are locked in
+  // completedDirectiveCleanupScopes below, which overrides this block for those
+  // specific files.
   // packages/auth/src is locked in completedDirectiveCleanupScopes (#2121).
+  // packages/a2a-server/src is locked in completedDirectiveCleanupScopes (#2123).
   'packages/settings/src/**/*.{ts,tsx}', // #2089 (non-target files)
   'packages/telemetry/src/**/*.{ts,tsx}', // #2089 (non-target files)
   'packages/ide-integration/src/**/*.{ts,tsx}', // #2089 (non-target files)
-  'packages/a2a-server/src/**/*.{ts,tsx}', // #2089 (non-target files)
 ];
 
 const completedDirectiveCleanupScopes = [
@@ -249,6 +249,11 @@ const completedDirectiveCleanupScopes = [
   // #2121 — all packages/auth/src files are now fully compliant: zero inline
   // lint directives. Locked to error so any new directive fails immediately.
   'packages/auth/src/**/*.{ts,tsx}', // #2121
+  // #2123 — all packages/a2a-server/src files are now fully compliant: zero
+  // inline lint directives. The broad glob below supersedes the individual
+  // #2089 a2a-server entries above. Locked to error so any new directive
+  // fails immediately.
+  'packages/a2a-server/src/**/*.{ts,tsx}', // #2123
   // #2091 packages/cli test cleanup — target files (and extracted helpers)
   // are fully compliant: zero inline lint directives. Locked to error so any
   // new directive fails immediately while the rest of packages/cli remains in

--- a/packages/a2a-server/src/persistence/gcs.test.ts
+++ b/packages/a2a-server/src/persistence/gcs.test.ts
@@ -266,10 +266,9 @@ describe('GCSTaskStore', () => {
     });
 
     it('should handle tar creation failure', async () => {
-      mockFse.pathExists.mockImplementation(
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Vitest mock handler, async is acceptable
-        async (path) =>
-          !path.toString().includes('task-task1-workspace-test-uuid.tar.gz'),
+      (fse.pathExists as Mock).mockImplementation(
+        (path: string) =>
+          !path.includes('task-task1-workspace-test-uuid.tar.gz'),
       );
       const store = new GCSTaskStore(bucketName);
       await expect(store.save(mockTask)).rejects.toThrow(

--- a/packages/a2a-server/src/utils/testing_utils.ts
+++ b/packages/a2a-server/src/utils/testing_utils.ts
@@ -95,11 +95,9 @@ function createConfirmationDetails(): ToolCallConfirmationDetails {
 }
 
 function createScheduledCalls(requests: ToolCallRequestInfo[]): MockToolCall[] {
-  return requests.map((requestItem, index) =>
+  return requests.map((requestItem) =>
     makeCall(
-      // Test utility mock contract: callId fallback for defensive testing
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Permissive mock contract for test utilities
-      requestItem.callId ?? `call-${index}`,
+      requestItem.callId,
       requestItem.name,
       'scheduled',
       requestItem.args,

--- a/scripts/check-eslint-guard.js
+++ b/scripts/check-eslint-guard.js
@@ -342,6 +342,92 @@ export function scanCoreDirectives(coreDir) {
 }
 
 /**
+ * Recursively lists all TypeScript source files under rootDir, excluding
+ * generated directories (node_modules, dist, coverage, .git).
+ */
+export function listTsFiles(rootDir) {
+  const results = [];
+  if (!existsSync(rootDir)) {
+    return results;
+  }
+  const entries = readdirSync(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory() && GENERATED_DIRECTORIES.has(entry.name)) {
+      continue;
+    }
+    const fullPath = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...listTsFiles(fullPath));
+    } else if (entry.isFile() && /\.(?:ts|tsx)$/.test(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Scans an arbitrary package source directory for inline ESLint disable/enable
+ * directives. Each violation references the supplied issueNumber so guard test
+ * failures point at the originating cleanup issue.
+ */
+export function scanPackageDirectives(packageDir, issueNumber) {
+  const target = packageDir;
+  if (!existsSync(target)) {
+    return [];
+  }
+  const files = listTsFiles(target);
+  const violations = [];
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split(String.fromCharCode(10));
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (DIRECTIVE_PATTERN.test(line)) {
+        violations.push({
+          file: relative(process.cwd(), file),
+          lineNumber: i + 1,
+          message: `Inline ESLint disable/enable directives are forbidden in this module (#${issueNumber}).`,
+          content: line,
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+const SCOPE_STRING_PATTERN = /'([^']+)'|"([^"]+)"|`([^`]+)`/;
+
+/**
+ * Extracts the string-literal entries of a named const scope array
+ * (legacyDirectiveCleanupScopes or completedDirectiveCleanupScopes) from
+ * eslint.config.js source text. Returns the raw string values.
+ */
+export function extractScopeArray(scopeName, configSource) {
+  const source =
+    configSource ??
+    readFileSync(join(process.cwd(), 'eslint.config.js'), 'utf8');
+  const startMatch = new RegExp('const\\s+' + scopeName + '\\s*=\\s*\\[').exec(
+    source,
+  );
+  if (startMatch === null) {
+    return [];
+  }
+  const startIdx = startMatch.index + startMatch[0].length;
+  const endIdx = source.indexOf(']', startIdx);
+  if (endIdx === -1) {
+    return [];
+  }
+  const body = source.slice(startIdx, endIdx);
+  const entries = [];
+  for (const rawLine of body.split(String.fromCharCode(10))) {
+    const match = SCOPE_STRING_PATTERN.exec(rawLine);
+    if (match !== null) {
+      entries.push(match[1] ?? match[2] ?? match[3]);
+    }
+  }
+  return entries;
+}
+
+/**
  * Inspects eslint.config.js source text and returns any directive cleanup scope
  * entries that reference packages/core. Issue #2115 requires packages/core to
  * be removed from both temporary and completed central directive lists.

--- a/scripts/tests/eslint-guard.test.js
+++ b/scripts/tests/eslint-guard.test.js
@@ -12,9 +12,13 @@ import {
   checkDiff,
   checkCoreCentralBypassesInConfig,
   checkCoreDirectiveScopesInConfig,
+  extractScopeArray,
   formatViolations,
   scanCoreDirectives,
+  scanPackageDirectives,
 } from '../check-eslint-guard.js';
+
+const repoRoot = process.cwd();
 
 function diffFor(file, addedLine) {
   return [
@@ -368,16 +372,9 @@ describe('packages/auth directive cleanup (#2121)', () => {
   const authSrcDir = join(repoRoot, 'packages', 'auth', 'src');
 
   it('has zero inline ESLint disable/enable directives', () => {
-    const directiveRe = /eslint-(?:disable|enable)(?:-next-line|-line)?\b/;
-    const offenders = [];
-    for (const file of listTsFiles(authSrcDir)) {
-      const lines = readFileSync(file, 'utf8').split('\n');
-      lines.forEach((line, idx) => {
-        if (directiveRe.test(line)) {
-          offenders.push(file.replace(repoRoot + '/', '') + ':' + (idx + 1));
-        }
-      });
-    }
+    const offenders = scanPackageDirectives(authSrcDir, '2121').map(
+      (v) => `${v.file}:${v.lineNumber}`,
+    );
     expect(offenders, 'Found directives: ' + offenders.join(', ')).toEqual([]);
   });
 
@@ -392,6 +389,33 @@ describe('packages/auth directive cleanup (#2121)', () => {
     expect(
       authEntries,
       'Legacy auth entries: ' + authEntries.join(', '),
+    ).toEqual([]);
+  });
+});
+
+describe('packages/a2a-server directive cleanup (#2123)', () => {
+  const a2aSrcDir = join(repoRoot, 'packages', 'a2a-server', 'src');
+
+  it('has zero inline ESLint disable/enable directives', () => {
+    const offenders = scanPackageDirectives(a2aSrcDir, '2123').map(
+      (v) => `${v.file}:${v.lineNumber}`,
+    );
+    expect(offenders, 'Found directives: ' + offenders.join(', ')).toEqual([]);
+  });
+
+  it('is locked in completedDirectiveCleanupScopes with a broad glob', () => {
+    const completed = extractScopeArray('completedDirectiveCleanupScopes');
+    expect(completed).toContain('packages/a2a-server/src/**/*.{ts,tsx}');
+  });
+
+  it('is no longer in legacyDirectiveCleanupScopes', () => {
+    const legacy = extractScopeArray('legacyDirectiveCleanupScopes');
+    const a2aEntries = legacy.filter((e) =>
+      e.startsWith('packages/a2a-server'),
+    );
+    expect(
+      a2aEntries,
+      'Legacy a2a-server entries: ' + a2aEntries.join(', '),
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## TLDR

Removes the remaining inline ESLint disable directives from packages/a2a-server and locks the module against future disable/enable directives. Fixes #2123.

## Dive Deeper

- Refactored the GCS persistence test mock to avoid the async mock handler suppression.
- Simplified the a2a-server testing utility scheduled-call construction so it no longer needs an unnecessary-condition suppression.
- Moved packages/a2a-server/src out of the legacy directive cleanup scope and into the completed cleanup scope.
- Added reusable ESLint guard helpers and a packages/a2a-server guard test that verifies:
  - zero inline ESLint disable/enable directives under packages/a2a-server/src
  - the broad a2a-server src glob is present in completedDirectiveCleanupScopes
  - no a2a-server entries remain in legacyDirectiveCleanupScopes

## Reviewer Test Plan

Reviewers can validate this by searching packages/a2a-server for ESLint disable/enable directives and running the focused guard and a2a-server checks.

Commands run locally:

    npm run lint:eslint-guard
    npm run test:scripts -- --run scripts/tests/eslint-guard.test.js
    npm run lint --workspace @vybestack/llxprt-code-a2a-server
    npm run typecheck --workspace @vybestack/llxprt-code-a2a-server
    npm run test --workspace @vybestack/llxprt-code-a2a-server
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

Full test verification note: direct npm run test was attempted, but local runs left orphaned/hung workspace test processes. To complete equivalent workspace coverage cleanly, I ran every workspace test script sequentially via npm run test --workspace <workspace>; all workspace test scripts passed. The specific agents tests that timed out in the interrupted aggregate run were also retried directly and passed.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2123
