### PR TITLE
Remove policy ESLint directive suppressions (Fixes #2122)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,7 +34,7 @@ const legacyDirectiveCleanupScopes = [
   // #2116: provider module entries removed after directive cleanup.
   // packages/agents/src is locked in completedDirectiveCleanupScopes (#2117).
   'packages/cli/src/**/*.{ts,tsx}', // #2086/#2091 (#2087 files locked in completedDirectiveCleanupScopes)
-  'packages/policy/src/**/*.{ts,tsx}', // #2089 not yet decomposed
+  // packages/policy/src is locked in completedDirectiveCleanupScopes (#2122).
   'packages/storage/src/**/*.{ts,tsx}', // #2092
   // #2089 scope: the five target packages (settings/telemetry/
   // ide-integration/a2a-server) still contain other files with legacy
@@ -249,6 +249,9 @@ const completedDirectiveCleanupScopes = [
   // #2121 — all packages/auth/src files are now fully compliant: zero inline
   // lint directives. Locked to error so any new directive fails immediately.
   'packages/auth/src/**/*.{ts,tsx}', // #2121
+  // #2122 — all packages/policy/src files are now fully compliant: zero inline
+  // lint directives. Locked to error so any new directive fails immediately.
+  'packages/policy/src/**/*.{ts,tsx}', // #2122
   // #2091 packages/cli test cleanup — target files (and extracted helpers)
   // are fully compliant: zero inline lint directives. Locked to error so any
   // new directive fails immediately while the rest of packages/cli remains in

--- a/packages/policy/src/policy-engine.ts
+++ b/packages/policy/src/policy-engine.ts
@@ -151,14 +151,13 @@ export class PolicyEngine {
     command: string,
     subCommands: string[],
   ): PolicyDecision {
+    // Filter out the original command to prevent infinite recursion
+    const subCommandsToEvaluate = subCommands
+      .map((rawSubCmd) => rawSubCmd.trim())
+      .filter((subCmd) => subCmd !== command);
+
     let aggregateDecision = PolicyDecision.ALLOW;
-
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    for (const rawSubCmd of subCommands) {
-      const subCmd = rawSubCmd.trim();
-      // Prevent infinite recursion
-      if (subCmd === command) continue;
-
+    for (const subCmd of subCommandsToEvaluate) {
       // Preserve dir_path from original args
       const subResult = this.evaluate(
         toolName,
@@ -167,8 +166,8 @@ export class PolicyEngine {
       );
 
       if (subResult === PolicyDecision.DENY) {
-        aggregateDecision = PolicyDecision.DENY;
-        break; // Fail fast: DENY overrides everything
+        // Fail fast: DENY overrides everything
+        return PolicyDecision.DENY;
       } else if (subResult === PolicyDecision.ASK_USER) {
         aggregateDecision = PolicyDecision.ASK_USER;
         // Continue checking for DENY (don't short-circuit)
@@ -260,25 +259,16 @@ export class PolicyEngine {
   ): PolicyRule | undefined {
     const argsString = stableStringify(args);
 
-    // eslint-disable-next-line sonarjs/too-many-break-or-continue-in-loop -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-    for (const rule of this.rules) {
+    return this.rules.find((rule) => {
       // Check tool name match
       const toolMatches = !rule.toolName || rule.toolName === toolName;
       if (!toolMatches) {
-        continue;
+        return false;
       }
 
       // Check args pattern match
-      const argsMatch = !rule.argsPattern || rule.argsPattern.test(argsString);
-      if (!argsMatch) {
-        continue;
-      }
-
-      // Both match - return this rule
-      return rule;
-    }
-
-    return undefined;
+      return !rule.argsPattern || rule.argsPattern.test(argsString);
+    });
   }
 
   /**

--- a/packages/policy/src/toml-loader.ts
+++ b/packages/policy/src/toml-loader.ts
@@ -305,20 +305,52 @@ function resolveRulePatterns(
     );
   } catch (e) {
     const error = e as Error;
-    const patternStr =
-      // eslint-disable-next-line sonarjs/expression-complexity -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-      (typeof rule.commandRegex === 'string' && rule.commandRegex !== ''
-        ? rule.commandRegex
-        : '') ||
-      (typeof rule.commandPrefix === 'string' && rule.commandPrefix !== ''
-        ? rule.commandPrefix
-        : '') ||
-      'unknown';
+    const patternStr = resolvePatternDescription(rule);
     errors.push(
       buildRegexError(filePath, file, tierName, patternStr, error.message),
     );
     return null;
   }
+}
+
+/**
+ * Resolves a human-readable description of the pattern that failed to compile.
+ * Prefers commandRegex, then commandPrefix, falling back to 'unknown'.
+ */
+function resolvePatternDescription(rule: PolicyRuleToml): string {
+  if (typeof rule.commandRegex === 'string' && rule.commandRegex !== '') {
+    return rule.commandRegex;
+  }
+  if (typeof rule.commandPrefix === 'string' && rule.commandPrefix !== '') {
+    return rule.commandPrefix;
+  }
+  return 'unknown';
+}
+
+/**
+ * Normalizes an optional string or string[] into an array. When the value is
+ * undefined, returns [undefined] so call sites iterate exactly once.
+ */
+function normalizeToOptionalArray(
+  value: string | string[] | undefined,
+): Array<string | undefined> {
+  if (value === undefined) {
+    return [undefined];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Normalizes an optional string or string[] into a string[]. When the value is
+ * undefined, returns [].
+ */
+function normalizeToStringArray(
+  value: string | string[] | undefined,
+): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
 }
 
 /** Expands a single validated rule into PolicyRule objects, handling toolName/mcpName arrays. */
@@ -333,13 +365,9 @@ function expandRuleToPolicyRules(
     patterns.length > 0 ? patterns : [undefined];
 
   return argsPatterns.flatMap((argsPattern) => {
-    const toolNames: Array<string | undefined> =
-      rule.toolName !== undefined
-        ? // eslint-disable-next-line sonarjs/no-nested-conditional -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          Array.isArray(rule.toolName)
-          ? rule.toolName
-          : [rule.toolName]
-        : [undefined];
+    const toolNames: Array<string | undefined> = normalizeToOptionalArray(
+      rule.toolName,
+    );
 
     return toolNames.map((toolName) => {
       const hasMcpName = rule.mcpName !== undefined && rule.mcpName !== '';
@@ -524,12 +552,7 @@ function expandTomlRule(
   const hasCommandRegex =
     rule.commandRegex !== undefined && rule.commandRegex !== '';
   if (hasCommandPrefix) {
-    const prefixes = Array.isArray(rule.commandPrefix)
-      ? rule.commandPrefix
-      : // eslint-disable-next-line sonarjs/no-nested-conditional -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-        rule.commandPrefix !== undefined
-        ? [rule.commandPrefix]
-        : [];
+    const prefixes = normalizeToStringArray(rule.commandPrefix);
     commandPrefixes.push(...prefixes);
   } else if (hasCommandRegex) {
     effectiveArgsPattern = `"command":"${rule.commandRegex}`;
@@ -546,13 +569,9 @@ function expandTomlRule(
 
   // For each argsPattern, expand toolName arrays
   return argsPatterns.flatMap((argsPattern) => {
-    const toolNames: Array<string | undefined> =
-      rule.toolName !== undefined
-        ? // eslint-disable-next-line sonarjs/no-nested-conditional -- Existing structure is intentionally preserved; refactoring this boundary is outside the lint slice.
-          Array.isArray(rule.toolName)
-          ? rule.toolName
-          : [rule.toolName]
-        : [undefined];
+    const toolNames: Array<string | undefined> = normalizeToOptionalArray(
+      rule.toolName,
+    );
 
     // Create a policy rule for each tool name
     return toolNames.map((toolName) => {

--- a/scripts/check-eslint-guard.js
+++ b/scripts/check-eslint-guard.js
@@ -559,7 +559,8 @@ function extractArrayStart(line) {
 }
 
 function isModulePathLine(line, modulePath) {
-  return !isCommentOnlyLine(line) && line.includes(modulePath);
+  const code = stripInlineComment(line);
+  return !isCommentOnlyLine(code) && code.includes(modulePath);
 }
 
 const SCOPE_DECLARATION_ARRAYS = new Set([

--- a/scripts/check-eslint-guard.js
+++ b/scripts/check-eslint-guard.js
@@ -292,7 +292,7 @@ function isScannableTextFile(fileName) {
   return !BINARY_EXTENSIONS.has(extname(fileName).toLowerCase());
 }
 
-function scanDirectoryForDirectives(rootDir) {
+function scanDirectoryForDirectives(rootDir, modulePath, issueNumber) {
   const violations = [];
   const entries = readdirSync(rootDir, { withFileTypes: true });
   for (const entry of entries) {
@@ -301,15 +301,19 @@ function scanDirectoryForDirectives(rootDir) {
     }
     const fullPath = join(rootDir, entry.name);
     if (entry.isDirectory()) {
-      violations.push(...scanDirectoryForDirectives(fullPath));
+      violations.push(
+        ...scanDirectoryForDirectives(fullPath, modulePath, issueNumber),
+      );
     } else if (entry.isFile() && isScannableTextFile(entry.name)) {
-      violations.push(...scanFileForDirectives(fullPath));
+      violations.push(
+        ...scanFileForDirectives(fullPath, modulePath, issueNumber),
+      );
     }
   }
   return violations;
 }
 
-function scanFileForDirectives(filePath) {
+function scanFileForDirectives(filePath, modulePath, issueNumber) {
   const violations = [];
   const contents = readFileSync(filePath, 'utf8');
   const lines = contents.split('\n');
@@ -319,8 +323,7 @@ function scanFileForDirectives(filePath) {
       violations.push({
         file: relative(process.cwd(), filePath),
         lineNumber: i + 1,
-        message:
-          'Inline ESLint disable/enable directives are forbidden in packages/core by #2115.',
+        message: `Inline ESLint disable/enable directives are forbidden in ${modulePath} by #${issueNumber}.`,
         content: line,
       });
     }
@@ -329,28 +332,50 @@ function scanFileForDirectives(filePath) {
 }
 
 /**
+ * Scans a named package directory for any inline ESLint disable/enable
+ * directives. Returns a list of violations; an empty array means the policy is
+ * satisfied. The modulePath (e.g. "packages/core") and issueNumber are used to
+ * build descriptive violation messages.
+ */
+export function scanModuleDirectives(modulePath, issueNumber, baseDir) {
+  const target = baseDir || join(process.cwd(), ...modulePath.split('/'));
+  if (!existsSync(target)) {
+    return [];
+  }
+  return scanDirectoryForDirectives(target, modulePath, issueNumber);
+}
+
+/**
  * Scans the packages/core directory for any inline ESLint disable/enable
  * directives. Returns a list of violations; an empty array means the policy is
  * satisfied. Issue #2115 requires zero such directives in packages/core.
  */
 export function scanCoreDirectives(coreDir) {
-  const target = coreDir || join(process.cwd(), 'packages', 'core');
-  if (!existsSync(target)) {
-    return [];
+  if (coreDir) {
+    return scanDirectoryForDirectives(coreDir, 'packages/core', '2115');
   }
-  return scanDirectoryForDirectives(target);
+  return scanModuleDirectives('packages/core', '2115');
 }
 
 /**
  * Inspects eslint.config.js source text and returns any directive cleanup scope
- * entries that reference packages/core. Issue #2115 requires packages/core to
- * be removed from both temporary and completed central directive lists.
+ * entries that reference the given module path. By default both
+ * legacyDirectiveCleanupScopes and completedDirectiveCleanupScopes are checked.
+ * When checkCompletedScopes is false, only legacyDirectiveCleanupScopes is
+ * checked — this is used when a module is intentionally locked in
+ * completedDirectiveCleanupScopes as its durable enforcement.
  */
-export function checkCoreDirectiveScopesInConfig(configSource) {
+export function checkModuleDirectiveScopesInConfig(
+  configSource,
+  modulePath,
+  issueNumber,
+  checkCompletedScopes = true,
+) {
   const violations = [];
   const lines = configSource.split('\n');
   let currentScope = null;
   let currentStatement = '';
+  let currentCode = '';
   let currentStartLine = 0;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -361,29 +386,81 @@ export function checkCoreDirectiveScopesInConfig(configSource) {
     if (scopeMatch) {
       currentScope = scopeMatch[1];
       currentStatement = line;
+      currentCode = stripInlineComment(line);
       currentStartLine = i + 1;
     } else if (currentScope !== null) {
       currentStatement += '\n' + line;
+      currentCode += '\n' + stripInlineComment(line);
     }
 
     if (currentScope !== null && /;\s*(?:\/\/.*)?$/.test(line)) {
-      if (currentStatement.includes('packages/core')) {
+      const shouldFlag =
+        currentScope === 'legacyDirectiveCleanupScopes' ||
+        (checkCompletedScopes &&
+          currentScope === 'completedDirectiveCleanupScopes');
+      if (shouldFlag && currentCode.includes(modulePath)) {
         violations.push({
           file: 'eslint.config.js',
           lineNumber: currentStartLine,
-          message: `packages/core must not remain in ${currentScope} (#2115).`,
+          message: `${modulePath} must not remain in ${currentScope} (#${issueNumber}).`,
           content: currentStatement,
         });
       }
       currentScope = null;
       currentStatement = '';
+      currentCode = '';
     }
   }
   return violations;
 }
 
+/**
+ * Inspects eslint.config.js source text and returns any directive cleanup scope
+ * entries that reference packages/core. Issue #2115 requires packages/core to
+ * be removed from both temporary and completed central directive lists.
+ */
+export function checkCoreDirectiveScopesInConfig(configSource) {
+  return checkModuleDirectiveScopesInConfig(
+    configSource,
+    'packages/core',
+    '2115',
+  );
+}
+
 function isCommentOnlyLine(line) {
   return line.trim().startsWith('//');
+}
+
+/**
+ * Strips trailing // comments from a line, respecting string literals so that
+ * // inside quotes is not mistaken for a comment start.
+ */
+function stripInlineComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    const next = line[i + 1];
+    if (quote === null && char === '/' && next === '/') {
+      return line.slice(0, i);
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote !== null) {
+      if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+    }
+  }
+  return line;
 }
 
 function extractArrayStart(line) {
@@ -395,12 +472,51 @@ function extractArrayStart(line) {
   return allowMatch === null ? null : 'allow';
 }
 
-function isCorePathLine(line) {
-  return !isCommentOnlyLine(line) && line.includes('packages/core');
+function isModulePathLine(line, modulePath) {
+  return !isCommentOnlyLine(line) && line.includes(modulePath);
 }
 
-function hasCoreCentralBypassOnSingleLine(line) {
-  if (!isCorePathLine(line)) {
+const SCOPE_DECLARATION_ARRAYS = new Set([
+  'legacyDirectiveCleanupScopes',
+  'completedDirectiveCleanupScopes',
+]);
+
+/**
+ * Returns true if the line is a bare quoted string literal entry (e.g.
+ * a glob like 'packages/policy/src/...'). These appear as individual entries
+ * inside arrays.
+ */
+function isBareStringEntry(line) {
+  return /^\s*['"`]/.test(line);
+}
+
+/**
+ * Returns true if the line is a file-pattern reference inside an ESLint config
+ * block (i.e. mentions the module path) that should set the object-depth
+ * tracker for central-bypass analysis.
+ *
+ * Bare quoted string literals are excluded only when they appear inside a
+ * top-level scope-declaration array (legacyDirectiveCleanupScopes /
+ * completedDirectiveCleanupScopes), so those entries are not mistaken for
+ * config-block file patterns. Inside config objects, bare quoted strings in a
+ * files array are legitimate module references and must be tracked.
+ */
+function isModuleFilesLine(line, modulePath, currentArray) {
+  if (!isModulePathLine(line, modulePath)) {
+    return false;
+  }
+  if (
+    isBareStringEntry(line) &&
+    currentArray !== null &&
+    SCOPE_DECLARATION_ARRAYS.has(currentArray)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function hasModuleCentralBypassOnSingleLine(line, modulePath) {
+  if (!isModulePathLine(line, modulePath)) {
     return null;
   }
   if (/\bignores\s*:/.test(line)) {
@@ -415,8 +531,8 @@ function hasCoreCentralBypassOnSingleLine(line) {
   return null;
 }
 
-function coreCentralBypassMessage(kind) {
-  return `packages/core must not be covered by central ESLint ${kind} entries (#2115).`;
+function moduleCentralBypassMessage(modulePath, kind, issueNumber) {
+  return `${modulePath} must not be covered by central ESLint ${kind} entries (#${issueNumber}).`;
 }
 
 function countBraceDelta(line) {
@@ -487,25 +603,29 @@ function countOpeningBraces(line) {
   return count;
 }
 
-function enclosingObjectDepth(line, braceDepth) {
-  const coreIndex = line.indexOf('packages/core');
+function enclosingObjectDepth(line, braceDepth, modulePath) {
+  const moduleIndex = line.indexOf(modulePath);
   const openIndex = line.indexOf('{');
-  if (openIndex !== -1 && openIndex < coreIndex) {
+  if (openIndex !== -1 && openIndex < moduleIndex) {
     return braceDepth + 1;
   }
   return braceDepth;
 }
 
 /**
- * Inspects eslint.config.js source text for packages/core central bypasses that
+ * Inspects eslint.config.js source text for module-path central bypasses that
  * would reintroduce the old suppression pattern outside source files.
  */
-export function checkCoreCentralBypassesInConfig(configSource) {
+export function checkModuleCentralBypassesInConfig(
+  configSource,
+  modulePath,
+  issueNumber,
+) {
   const violations = [];
   const lines = configSource.split('\n');
   let currentArray = null;
   let braceDepth = 0;
-  let coreObjectDepth = null;
+  let moduleObjectDepth = null;
   let rulesObjectDepth = null;
 
   for (let i = 0; i < lines.length; i++) {
@@ -520,43 +640,66 @@ export function checkCoreCentralBypassesInConfig(configSource) {
       currentArray = null;
     }
 
-    const singleLineBypass = hasCoreCentralBypassOnSingleLine(line);
+    const singleLineBypass = hasModuleCentralBypassOnSingleLine(
+      line,
+      modulePath,
+    );
     if (singleLineBypass !== null) {
       violations.push({
         file: 'eslint.config.js',
         lineNumber,
-        message: coreCentralBypassMessage(singleLineBypass),
+        message: moduleCentralBypassMessage(
+          modulePath,
+          singleLineBypass,
+          issueNumber,
+        ),
         content: line,
       });
     }
 
-    if (isCorePathLine(line)) {
+    if (isModulePathLine(line, modulePath)) {
       if (currentArray === 'ignores') {
         violations.push({
           file: 'eslint.config.js',
           lineNumber,
-          message: coreCentralBypassMessage('ignore'),
+          message: moduleCentralBypassMessage(
+            modulePath,
+            'ignore',
+            issueNumber,
+          ),
           content: line,
         });
       } else if (currentArray === 'allow') {
         violations.push({
           file: 'eslint.config.js',
           lineNumber,
-          message: coreCentralBypassMessage('allow-list'),
+          message: moduleCentralBypassMessage(
+            modulePath,
+            'allow-list',
+            issueNumber,
+          ),
           content: line,
         });
       }
-      coreObjectDepth = enclosingObjectDepth(line, braceDepth);
+      // Only set the object-depth tracker for file-pattern lines inside config
+      // blocks, not bare scope-declaration-array string literals.
+      if (isModuleFilesLine(line, modulePath, currentArray)) {
+        moduleObjectDepth = enclosingObjectDepth(line, braceDepth, modulePath);
+      }
     }
 
-    const inCoreObject =
-      coreObjectDepth !== null && braceDepth >= coreObjectDepth;
-    if (inCoreObject) {
+    const inModuleObject =
+      moduleObjectDepth !== null && braceDepth >= moduleObjectDepth;
+    if (inModuleObject) {
       if (/^\s*ignores\s*:/.test(line)) {
         violations.push({
           file: 'eslint.config.js',
           lineNumber,
-          message: coreCentralBypassMessage('scoped ignore'),
+          message: moduleCentralBypassMessage(
+            modulePath,
+            'scoped ignore',
+            issueNumber,
+          ),
           content: line,
         });
       }
@@ -570,7 +713,11 @@ export function checkCoreCentralBypassesInConfig(configSource) {
         violations.push({
           file: 'eslint.config.js',
           lineNumber,
-          message: coreCentralBypassMessage('rule-off'),
+          message: moduleCentralBypassMessage(
+            modulePath,
+            'rule-off',
+            issueNumber,
+          ),
           content: line,
         });
       }
@@ -580,13 +727,25 @@ export function checkCoreCentralBypassesInConfig(configSource) {
     if (rulesObjectDepth !== null && braceDepth < rulesObjectDepth) {
       rulesObjectDepth = null;
     }
-    if (coreObjectDepth !== null && braceDepth < coreObjectDepth) {
-      coreObjectDepth = null;
+    if (moduleObjectDepth !== null && braceDepth < moduleObjectDepth) {
+      moduleObjectDepth = null;
       rulesObjectDepth = null;
     }
   }
 
   return violations;
+}
+
+/**
+ * Inspects eslint.config.js source text for packages/core central bypasses that
+ * would reintroduce the old suppression pattern outside source files.
+ */
+export function checkCoreCentralBypassesInConfig(configSource) {
+  return checkModuleCentralBypassesInConfig(
+    configSource,
+    'packages/core',
+    '2115',
+  );
 }
 
 export function formatViolations(violations) {
@@ -608,14 +767,33 @@ function main() {
   // Issue #2115 durable guard: packages/core must contain zero inline ESLint
   // disable/enable directives and must not be present in central directive
   // cleanup scope lists.
-  const coreDirectiveViolations = scanCoreDirectives();
-  violations.push(...coreDirectiveViolations);
+  violations.push(...scanCoreDirectives());
+
+  // Issue #2122 durable guard: packages/policy must contain zero inline ESLint
+  // disable/enable directives and must not be present in central directive
+  // cleanup scope lists.
+  violations.push(...scanModuleDirectives('packages/policy', '2122'));
 
   const configPath = join(process.cwd(), 'eslint.config.js');
   if (existsSync(configPath)) {
     const configSource = readFileSync(configPath, 'utf8');
     violations.push(...checkCoreDirectiveScopesInConfig(configSource));
     violations.push(...checkCoreCentralBypassesInConfig(configSource));
+    violations.push(
+      ...checkModuleDirectiveScopesInConfig(
+        configSource,
+        'packages/policy',
+        '2122',
+        false,
+      ),
+    );
+    violations.push(
+      ...checkModuleCentralBypassesInConfig(
+        configSource,
+        'packages/policy',
+        '2122',
+      ),
+    );
   }
 
   if (violations.length === 0) {

--- a/scripts/tests/eslint-guard.test.js
+++ b/scripts/tests/eslint-guard.test.js
@@ -5,16 +5,65 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import {
   checkDiff,
   checkCoreCentralBypassesInConfig,
   checkCoreDirectiveScopesInConfig,
+  checkModuleCentralBypassesInConfig,
+  checkModuleDirectiveScopesInConfig,
   formatViolations,
   scanCoreDirectives,
+  scanModuleDirectives,
 } from '../check-eslint-guard.js';
+
+const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+function listTsFiles(dir) {
+  const results = [];
+  if (!existsSync(dir)) {
+    return results;
+  }
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      results.push(...listTsFiles(fullPath));
+    } else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function extractScopeArray(scopeName) {
+  const configPath = join(repoRoot, 'eslint.config.js');
+  const source = readFileSync(configPath, 'utf8');
+  const match = new RegExp(scopeName + String.raw`\s*=\s*\[([\s\S]*?)\];`).exec(
+    source,
+  );
+  if (!match) {
+    return [];
+  }
+  const body = match[1];
+  const entries = [];
+  const lineRegex = /'([^']+)'/g;
+  let lineMatch;
+  while ((lineMatch = lineRegex.exec(body)) !== null) {
+    entries.push(lineMatch[1]);
+  }
+  return entries;
+}
 
 function diffFor(file, addedLine) {
   return [
@@ -392,6 +441,261 @@ describe('packages/auth directive cleanup (#2121)', () => {
     expect(
       authEntries,
       'Legacy auth entries: ' + authEntries.join(', '),
+    ).toEqual([]);
+  });
+});
+
+describe('packages/policy directive cleanup (#2122)', () => {
+  const policySrcDir = join(repoRoot, 'packages', 'policy', 'src');
+
+  describe('scanModuleDirectives', () => {
+    it('reports violations when packages/policy files contain directives', () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-policy-'));
+      const subDir = join(tmpDir, 'src');
+      mkdirSync(subDir, { recursive: true });
+      writeFileSync(
+        join(subDir, 'example.ts'),
+        [
+          'export const x = 1;',
+          '// eslint-disable-next-line sonarjs/expression-complexity',
+          'export const y = (a && b) || (c && d) ? e : f;',
+        ].join('\n'),
+      );
+
+      const violations = scanModuleDirectives(
+        'packages/policy',
+        '2122',
+        tmpDir,
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('#2122');
+      expect(violations[0].message).toContain('packages/policy');
+      expect(violations[0].lineNumber).toBe(2);
+    });
+
+    it('passes when packages/policy files contain no directives', () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-policy-clean-'));
+      writeFileSync(
+        join(tmpDir, 'clean.ts'),
+        ['export const x = 1;', 'export const y = 2;'].join('\n'),
+      );
+
+      expect(scanModuleDirectives('packages/policy', '2122', tmpDir)).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe('checkModuleDirectiveScopesInConfig', () => {
+    it('flags packages/policy entries left in legacyDirectiveCleanupScopes', () => {
+      const config = [
+        'const legacyDirectiveCleanupScopes = [',
+        "  'packages/policy/src/**/*.{ts,tsx}', // remaining policy cleanup",
+        "  'packages/cli/src/foo.ts',",
+        '];',
+      ].join('\n');
+
+      const violations = checkModuleDirectiveScopesInConfig(
+        config,
+        'packages/policy',
+        '2122',
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].file).toBe('eslint.config.js');
+      expect(violations[0].message).toContain('#2122');
+      expect(violations[0].message).toContain('legacyDirectiveCleanupScopes');
+    });
+
+    it('passes when directive cleanup scopes have no packages/policy entries', () => {
+      const config = [
+        'const legacyDirectiveCleanupScopes = [',
+        "  'packages/cli/src/foo.ts',",
+        '];',
+        'const completedDirectiveCleanupScopes = [',
+        "  'packages/core/src/**/*.{ts,tsx}',",
+        '];',
+      ].join('\n');
+
+      expect(
+        checkModuleDirectiveScopesInConfig(config, 'packages/policy', '2122'),
+      ).toEqual([]);
+    });
+
+    it('allows packages/policy in completedDirectiveCleanupScopes (lock)', () => {
+      const config = [
+        'const legacyDirectiveCleanupScopes = [',
+        "  'packages/cli/src/foo.ts',",
+        '];',
+        'const completedDirectiveCleanupScopes = [',
+        "  'packages/policy/src/**/*.{ts,tsx}', // #2122",
+        '];',
+      ].join('\n');
+
+      // With checkCompletedScopes=false (default for policy), the completed
+      // scope entry is allowed as the durable lock.
+      expect(
+        checkModuleDirectiveScopesInConfig(
+          config,
+          'packages/policy',
+          '2122',
+          false,
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe('checkModuleCentralBypassesInConfig', () => {
+    it('flags packages/policy central rule-off blocks', () => {
+      const config = [
+        '{',
+        "  files: ['packages/policy/src/example.ts'],",
+        '  rules: {',
+        "    'sonarjs/expression-complexity': 'off',",
+        '  },',
+        '}',
+      ].join('\n');
+
+      const violations = checkModuleCentralBypassesInConfig(
+        config,
+        'packages/policy',
+        '2122',
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('rule-off');
+      expect(violations[0].message).toContain('#2122');
+    });
+
+    it('flags packages/policy scoped ignores', () => {
+      const config = [
+        '{',
+        "  files: ['packages/policy/src/**/*.ts'],",
+        "  ignores: ['**/*.test.ts'],",
+        '  rules: {},',
+        '}',
+      ].join('\n');
+
+      const violations = checkModuleCentralBypassesInConfig(
+        config,
+        'packages/policy',
+        '2122',
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('scoped ignore');
+    });
+
+    it('allows packages/policy positive enforcement blocks', () => {
+      const config = [
+        '{',
+        "  files: ['packages/policy/src/example.ts'],",
+        '  rules: {',
+        "    'max-lines': ['error', { max: 800 }],",
+        '  },',
+        '}',
+      ].join('\n');
+
+      expect(
+        checkModuleCentralBypassesInConfig(config, 'packages/policy', '2122'),
+      ).toEqual([]);
+    });
+
+    it('flags packages/policy multi-line files arrays with rule-off', () => {
+      const config = [
+        '{',
+        '  files: [',
+        "    'packages/policy/src/**/*.ts',",
+        '  ],',
+        '  rules: {',
+        "    'sonarjs/expression-complexity': 'off',",
+        '  },',
+        '}',
+      ].join('\n');
+
+      const violations = checkModuleCentralBypassesInConfig(
+        config,
+        'packages/policy',
+        '2122',
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('rule-off');
+      expect(violations[0].message).toContain('#2122');
+    });
+
+    it('flags packages/policy multi-line files arrays with scoped ignores', () => {
+      const config = [
+        '{',
+        '  files: [',
+        "    'packages/policy/src/**/*.ts',",
+        '  ],',
+        "  ignores: ['**/*.test.ts'],",
+        '  rules: {},',
+        '}',
+      ].join('\n');
+
+      const violations = checkModuleCentralBypassesInConfig(
+        config,
+        'packages/policy',
+        '2122',
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('scoped ignore');
+    });
+
+    it('does not flag completedDirectiveCleanupScopes entries as central bypasses', () => {
+      const config = [
+        'const completedDirectiveCleanupScopes = [',
+        "  'packages/policy/src/**/*.{ts,tsx}', // #2122",
+        '];',
+      ].join('\n');
+
+      expect(
+        checkModuleCentralBypassesInConfig(config, 'packages/policy', '2122'),
+      ).toEqual([]);
+    });
+
+    it('does not flag legacyDirectiveCleanupScopes entries as central bypasses', () => {
+      const config = [
+        'const legacyDirectiveCleanupScopes = [',
+        "  'packages/policy/src/**/*.ts',",
+        '];',
+      ].join('\n');
+
+      expect(
+        checkModuleCentralBypassesInConfig(config, 'packages/policy', '2122'),
+      ).toEqual([]);
+    });
+  });
+
+  it('has zero inline ESLint disable/enable directives in source', () => {
+    const directiveRe = /eslint-(?:disable|enable)(?:-next-line|-line)?\b/;
+    const offenders = [];
+    for (const file of listTsFiles(policySrcDir)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, idx) => {
+        if (directiveRe.test(line)) {
+          offenders.push(file.replace(repoRoot + '/', '') + ':' + (idx + 1));
+        }
+      });
+    }
+    expect(offenders, 'Found directives: ' + offenders.join(', ')).toEqual([]);
+  });
+
+  it('is locked in completedDirectiveCleanupScopes with a broad glob', () => {
+    const completed = extractScopeArray('completedDirectiveCleanupScopes');
+    expect(completed).toContain('packages/policy/src/**/*.{ts,tsx}');
+  });
+
+  it('is no longer in legacyDirectiveCleanupScopes', () => {
+    const legacy = extractScopeArray('legacyDirectiveCleanupScopes');
+    const policyEntries = legacy.filter((e) => e.startsWith('packages/policy'));
+    expect(
+      policyEntries,
+      'Legacy policy entries: ' + policyEntries.join(', '),
     ).toEqual([]);
   });
 });

--- a/scripts/tests/eslint-guard.test.js
+++ b/scripts/tests/eslint-guard.test.js
@@ -607,6 +607,20 @@ describe('packages/policy directive cleanup (#2122)', () => {
       expect(violations[0].message).toContain('scoped ignore');
     });
 
+    it('ignores packages/policy references in trailing comments', () => {
+      const config = [
+        '{',
+        "  files: ['packages/cli/src/example.ts'], // not packages/policy",
+        '  rules: {',
+        "    'sonarjs/expression-complexity': 'off',",
+        '  },',
+        '}',
+      ].join('\n');
+
+      expect(
+        checkModuleCentralBypassesInConfig(config, 'packages/policy', '2122'),
+      ).toEqual([]);
+    });
     it('does not flag completedDirectiveCleanupScopes entries as central bypasses', () => {
       const config = [
         'const completedDirectiveCleanupScopes = [',


### PR DESCRIPTION
## TLDR

Removes all inline ESLint disable and enable directives from packages/policy and locks the module with durable guard coverage.

## Dive Deeper

This PR fixes the remaining policy-module directive cleanup by:

- Refactoring policy-engine loop control so sonarjs/too-many-break-or-continue-in-loop passes without suppressions.
- Extracting toml-loader helper functions for pattern descriptions and optional array normalization so expression-complexity and nested-conditional suppressions are no longer needed.
- Moving packages/policy/src from the temporary legacy directive cleanup scope to the completed cleanup scope.
- Generalizing the ESLint guard helpers so packages/policy is scanned for directive comments and central bypasses, including multi-line files arrays.
- Adding guard tests for policy directive scanning, cleanup scope placement, central bypass rejection, and completed-scope locking.

## Reviewer Test Plan

Review the policy-engine and toml-loader refactors for behavior preservation, then verify the guard rejects policy directive regressions and central bypasses.

Suggested commands:

    rg -n "eslint-(disable|enable)(-next-line|-line)?" packages/policy/src
    node scripts/check-eslint-guard.js
    npx vitest run scripts/tests/eslint-guard.test.js
    npx eslint packages/policy/src --ext .ts,.tsx

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS:

    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

Also ran targeted checks:

    node scripts/check-eslint-guard.js
    npx vitest run scripts/tests/eslint-guard.test.js
    npm run test --workspace @vybestack/llxprt-code-agents -- src/api/__tests__/cli-turn-parity.early.spec.ts src/api/__tests__/cli-turn-parity.spec.ts

## Linked issues / bugs

Fixes #2122
