### PR TITLE
Close Agent API engine-capability gaps before CLI refactor (Fixes #2143)

### DIFF
--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -178,7 +178,7 @@ The type is re-exported from core; see the
 ## The `Agent` Control Plane
 
 An `Agent` is the live runtime facade. It exposes top-level methods for sending
-turns and switching provider/model/params, plus seven `readonly` sub-surfaces
+turns and switching provider/model/params, plus nine `readonly` sub-surfaces
 for focused control. See
 [`packages/agents/src/api/agent.ts`](../packages/agents/src/api/agent.ts) for the
 full interface.

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -2,6 +2,8 @@
 
 # Agent API
 
+<!-- @plan:PLAN-20260622-COREAPIGAP.P19 @requirement:REQ-010 -->
+
 The Agent API is the public, embeddable surface for driving an LLxprt agent
 from your own code — without the CLI. You create an agent, send it input, and
 consume a typed event stream. The same primitives the CLI uses are exposed as a
@@ -206,6 +208,36 @@ full interface.
 | `getUserTier()`                                                           | Returns the provider user tier, if known.                           |
 | `getCurrentSequenceModel()`                                               | Current load-balancer sequence model, or `null`.                    |
 
+### Top-level: approval mode
+
+Read and mutate the live approval mode — the tool-confirmation policy the agent
+applies on every turn. Both methods delegate directly to the bound `Config`
+(no caching), so they always reflect the runtime's current state.
+
+```ts
+import { createAgent, ApprovalMode } from '@vybestack/llxprt-code-agents';
+
+const agent = await createAgent({ provider: 'fake', model: 'fake-model' });
+
+agent.getApprovalMode(); // → ApprovalMode.DEFAULT (default)
+agent.setApprovalMode(ApprovalMode.AUTO_EDIT);
+agent.getApprovalMode(); // → ApprovalMode.AUTO_EDIT
+```
+
+`ApprovalMode` is a runtime VALUE enum exported from the public root:
+
+| Member      | Meaning                                          |
+| ----------- | ------------------------------------------------ |
+| `DEFAULT`   | Confirm every tool call (interactive prompt).    |
+| `AUTO_EDIT` | Auto-approve edit-class tools; confirm the rest. |
+| `YOLO`      | Auto-approve all tools (no confirmation).        |
+
+> **Untrusted-folder guard.** `setApprovalMode` delegates to the bound `Config`,
+> which throws
+> `"Cannot enable privileged approval modes in an untrusted folder."` for any
+> non-`DEFAULT` mode when the working directory is not trusted. That throw
+> propagates **unchanged** — it is not caught or normalized by the agent.
+
 ### Top-level: history & stats
 
 `getHistory` / `setHistory` / `addHistory` / `restoreHistory` / `resetChat`
@@ -239,10 +271,100 @@ Live tool registry + confirmation wiring: `list()`, `setEnabled(names)`,
 `onConfirmationRequest(cb)`, `respondToConfirmation(confirmationId, decision)`,
 `onToolUpdate(cb)`, `setEditorCallbacks(cbs)`.
 
+##### `agent.tools.keys` — `AgentToolKeyControl`
+
+Built-in tool API-key storage (distinct from `agent.auth.keys`, which manages
+**provider-auth** keys). Each method targets a built-in tool that consumes its
+own API key (e.g. a search or web tool):
+
+```ts
+agent.tools.keys.supported(): readonly ToolKeyInfo[]
+agent.tools.keys.status(toolName: string): Promise<ToolKeyStatus>   // masked
+agent.tools.keys.save(toolName: string, key: string): Promise<void>
+agent.tools.keys.delete(toolName: string): Promise<void>
+agent.tools.keys.setKeyFile(toolName: string, path: string | null): Promise<void>
+agent.tools.keys.getKeyFile(toolName: string): Promise<string | null>
+```
+
+`ToolKeyInfo` = `{ toolName: string; displayName: string; description?: string }`.
+`ToolKeyStatus` = `{ toolName: string; hasKey: boolean; maskedKey?: string; keyFile?: string }`.
+
+```ts
+import { createAgent } from '@vybestack/llxprt-code-agents';
+
+const agent = await createAgent({ provider: 'fake', model: 'fake-model' });
+
+// Discover which built-in tools accept an API key.
+for (const info of agent.tools.keys.supported()) {
+  console.log(info.toolName, info.displayName);
+}
+
+// Store a key (masked on read-back).
+await agent.tools.keys.save('web-search', 'sk-live-xxxxxxxx');
+const status = await agent.tools.keys.status('web-search');
+console.log(status.hasKey, status.maskedKey); // true 'sk-l••••••••xxxx'
+```
+
+> **SECURITY — masked only.** Raw secret values are **never** returned.
+> `status(...)` surfaces only `maskedKey` (a redacted preview) and `keyFile`
+> (a path reference); the full key is write-only through `save(...)`.
+
 #### `agent.mcp` — `AgentMcpControl`
 
 **Runtime-only** view of MCP servers: `listServers()`, `status()`,
 `toolsByServer()`, `auth(server)`, `discoveryState()`, `refresh(server?)`.
+
+OAuth + detailed inspection (added by #2143):
+
+```ts
+agent.mcp.authenticate(server: string): Promise<McpServerAuthStatus>   // real OAuth flow + post-auth tool refresh
+agent.mcp.details(opts?: McpDetailsOptions): Promise<McpDetailStatus>
+```
+
+- `McpServerAuthStatus` = `{ server: string; authenticated: boolean; requiresAuth: boolean; authUrl?: string }`.
+- `McpDetailsOptions` = `{ includeTools?: boolean; includePrompts?: boolean; includeResources?: boolean }`.
+- `McpDetailStatus` = `{ servers: readonly McpServerDetail[]; blockedServers: readonly McpBlockedServer[] }`.
+
+`authenticate(server)` runs the real OAuth flow against a server that requires
+auth, then refreshes that server's tool declarations so the live tool list
+stays in sync. `details(opts?)` returns a structured snapshot of every server
+(auth status, tools/prompts/resources as requested) plus any servers blocked by
+an extension.
+
+```ts
+import { createAgent } from '@vybestack/llxprt-code-agents';
+
+const agent = await createAgent({
+  provider: 'fake',
+  model: 'fake-model',
+  mcpServers: {
+    'auth-required-server': {
+      /* … */
+    },
+  },
+});
+
+// Run OAuth for a server that requires it.
+const authStatus = await agent.mcp.authenticate('auth-required-server');
+if (authStatus.authUrl) {
+  // Direct the user to authStatus.authUrl to complete the flow.
+}
+
+// Full structural snapshot (tools + prompts + resources).
+const detail = await agent.mcp.details({
+  includeTools: true,
+  includePrompts: true,
+  includeResources: true,
+});
+for (const server of detail.servers) {
+  console.log(server.name, server.authenticated, server.tools?.length);
+}
+```
+
+> **Refresh parity.** `agent.mcp.refresh(server?)` restarts the target server
+> (or all servers when called with no argument) **and** re-publishes its tool
+> declarations (`setTools` parity), so the live tool list tracks server
+> restarts without a separate manual publish step.
 
 > **Runtime-only.** `agent.mcp` reflects the _live_ connection set. Durable
 > MCP server add/remove is **not** here — it lives on the
@@ -257,6 +379,43 @@ Provider authentication: `login(provider, opts?)`, `logout(provider, opts?)`,
 `setBaseUrl(baseUrl, opts?)`, and a nested `keys` control
 (`AgentAuthKeysControl`: `list`, `save`, `use`, `delete`, `setRaw`,
 `setKeyFile`). See [Authentication](#authentication-and-precedence).
+
+Detailed provider/bucket metadata (added by #2143):
+
+```ts
+agent.auth.detailedStatus(provider: string): Promise<AuthProviderDetail>
+agent.auth.getHigherPriorityAuth(provider: string): Promise<string | null>
+agent.auth.listBucketStatuses(provider: string): Promise<readonly AuthBucketStatus[]>
+```
+
+- `AuthProviderDetail` = `{ provider: string; authenticated: boolean; oauthEnabled: boolean; expiry?: number }`.
+- `AuthBucketStatus` = `{ bucket: string; authenticated: boolean; expiry?: number; isSessionBucket: boolean }`.
+
+`detailedStatus(provider)` returns a single provider's auth profile (whether
+OAuth is enabled, token expiry). `getHigherPriorityAuth(provider)` reports the
+name of the highest-priority auth source currently winning for that provider, or
+`null` if none. `listBucketStatuses(provider)` returns per-bucket auth/expiry
+metadata for providers that support multiple buckets.
+
+```ts
+import { createAgent } from '@vybestack/llxprt-code-agents';
+
+const agent = await createAgent({ provider: 'fake', model: 'fake-model' });
+
+const detail = await agent.auth.detailedStatus('openai');
+console.log(detail.authenticated, detail.oauthEnabled, detail.expiry);
+
+const winner = await agent.auth.getHigherPriorityAuth('openai');
+console.log(winner); // e.g. 'keyName' | 'keyfile' | 'oauth' | null
+
+for (const bucket of await agent.auth.listBucketStatuses('openai')) {
+  console.log(bucket.bucket, bucket.authenticated, bucket.isSessionBucket);
+}
+```
+
+> **SECURITY — masked only.** These methods return **metadata only** —
+> `authenticated` flags, `expiry` timestamps, and reference names. Raw token
+> strings are **never** returned.
 
 #### `agent.ide` — `AgentIdeControl`
 
@@ -273,6 +432,104 @@ Session lifecycle: `resume(target, options?)`, `createCheckpoint(label?)`,
 
 Lifecycle hooks: `onHookExecution(cb)`, `triggerSessionStart()`,
 `triggerSessionEnd()`, `clear()`.
+
+Hook administration (added by #2143):
+
+```ts
+agent.hooks.listHooks(): readonly HookInfo[]
+agent.hooks.getDisabledHooks(): readonly string[]
+agent.hooks.setDisabledHooks(names: readonly string[]): void
+agent.hooks.enable(name: string): void
+agent.hooks.disable(name: string): void
+```
+
+`HookInfo` = `{ name: string; eventName: string; enabled: boolean; source?: string }`.
+
+`listHooks()` returns the full registered-hook registry (name, event, enabled
+flag, source). `getDisabledHooks()` / `setDisabledHooks(names)` read/replace the
+disabled-hook name list in one call. `enable(name)` / `disable(name)` toggle a
+single hook by name.
+
+```ts
+import { createAgent } from '@vybestack/llxprt-code-agents';
+
+const agent = await createAgent({ provider: 'fake', model: 'fake-model' });
+
+for (const hook of agent.hooks.listHooks()) {
+  console.log(hook.name, hook.eventName, hook.enabled);
+}
+
+agent.hooks.disable('my-pre-send-hook');
+console.log(agent.hooks.getDisabledHooks()); // ['my-pre-send-hook']
+agent.hooks.enable('my-pre-send-hook');
+```
+
+> **Undefined-safe.** When no hook system is present, `listHooks()` → `[]`,
+> `getDisabledHooks()` → `[]`, and the setters are no-ops.
+
+#### `agent.policy` — `AgentPolicyControl`
+
+Read-only inspection of the engine policy (added by #2143):
+
+```ts
+agent.policy.getRules(): readonly PolicyRuleView[]
+agent.policy.getDefaultDecision(): PolicyDecision
+agent.policy.isNonInteractive(): boolean
+```
+
+- `PolicyRuleView` = `{ priority?: number; toolName?: string; decision: PolicyDecision; argsPattern?: string; source?: string }`.
+  Note `argsPattern` is the RegExp **source string** (JSON-safe) — never a live
+  `RegExp`. Read-only inspection; rule mutation is intentionally out of scope.
+
+`getRules()` returns the active policy rule set in priority order.
+`getDefaultDecision()` returns the fallback `PolicyDecision` applied when no
+rule matches. `isNonInteractive()` reports whether the engine is running in a
+non-interactive context (no confirmation prompts).
+
+```ts
+import { createAgent, PolicyDecision } from '@vybestack/llxprt-code-agents';
+
+const agent = await createAgent({ provider: 'fake', model: 'fake-model' });
+
+for (const rule of agent.policy.getRules()) {
+  console.log(rule.priority, rule.toolName, rule.decision, rule.argsPattern);
+}
+console.log(agent.policy.getDefaultDecision()); // e.g. PolicyDecision.ALLOW
+console.log(agent.policy.isNonInteractive()); // false
+```
+
+#### `agent.tasks` — `AgentTasksControl`
+
+Undefined-safe async-task administration (added by #2143):
+
+```ts
+agent.tasks.list(): readonly AgentTaskInfo[]
+agent.tasks.listRunning(): readonly AgentTaskInfo[]
+agent.tasks.get(id: string): AgentTaskInfo | undefined
+agent.tasks.cancel(id: string): boolean
+agent.tasks.cancelAllRunning(): number   // returns count cancelled
+```
+
+`AgentTaskInfo` = `{ id: string; subagentName: string; goalPrompt: string; status: 'running'|'completed'|'failed'|'cancelled'; launchedAt: number; completedAt?: number; error?: string }`.
+Note `abortController` is intentionally **NOT** exposed (projected public type
+omits non-serializable internals).
+
+```ts
+import { createAgent } from '@vybestack/llxprt-code-agents';
+
+const agent = await createAgent({ provider: 'fake', model: 'fake-model' });
+
+for (const task of agent.tasks.listRunning()) {
+  console.log(task.id, task.subagentName, task.goalPrompt);
+}
+
+const cancelled = agent.tasks.cancelAllRunning();
+console.log(`Cancelled ${cancelled} running task(s).`);
+```
+
+> **Undefined-safe.** When no async-task manager is present, `list()` /
+> `listRunning()` → `[]`, `get(id)` → `undefined`, `cancel(id)` → `false`,
+> `cancelAllRunning()` → `0`.
 
 ### `dispose()`
 
@@ -637,6 +894,54 @@ break under #1595:
 The stable contract is the curated root + the two documented subpaths above.
 Anything under a package's internal source tree has no stability guarantee.
 
+## New public enums & projected types (#2143)
+
+Issue #2143 promoted a set of enums and projected types to the **public root**
+(`@vybestack/llxprt-code-agents`) so a #1595 developer can construct and inspect
+these values without a deep import into the core package's internals or an
+`agent.getConfig()` escape hatch.
+
+### VALUE enums
+
+These are real runtime values (enum members round-trip), importable from the
+public root:
+
+```ts
+import { ApprovalMode, PolicyDecision } from '@vybestack/llxprt-code-agents';
+
+// ApprovalMode: DEFAULT | AUTO_EDIT | YOLO  (see "Top-level: approval mode")
+// PolicyDecision: ALLOW | DENY | ASK        (see "agent.policy")
+console.log(ApprovalMode.DEFAULT, PolicyDecision.ALLOW);
+```
+
+### Projected types
+
+These are type-only exports (compile-time shapes for the inspection methods
+above); import them as types from the public root:
+
+```ts
+import type {
+  PolicyRuleView,
+  AgentTaskInfo,
+  HookInfo,
+  AuthProviderDetail,
+  AuthBucketStatus,
+  McpServerAuthStatus,
+  McpDetailStatus,
+  McpServerDetail,
+  McpDetailsOptions,
+  McpPromptInfo,
+  McpResourceInfo,
+  McpBlockedServer,
+  ToolKeyInfo,
+  ToolKeyStatus,
+} from '@vybestack/llxprt-code-agents';
+```
+
+Each projected type omits non-serializable internals (e.g. `abortController` on
+`AgentTaskInfo`, live `RegExp` on `PolicyRuleView`'s `argsPattern` string field)
+so the public surface is JSON-safe and stable across versions.
+
 ## Runtime vs App-Service
 
 LLxprt distinguishes **runtime** concerns (the live conversation) from
@@ -686,6 +991,21 @@ canonical slash-command → API mapping. Each entry assigns exactly one `kind`:
 The shape of each mapping entry is `{ command, kind, target, exportName?,
 note? }`. See
 [`packages/agents/src/app-services/command-api-map.ts`](../packages/agents/src/app-services/command-api-map.ts).
+
+#### `runtime` rows added by #2143
+
+Six new `runtime` rows map slash-commands onto the live `Agent` sub-surfaces
+documented above. Each `target` is a live `Agent` method path (matching
+`packages/agents/src/app-services/command-api-map.ts`):
+
+| Command          | Kind      | Target                        | Notes                                          |
+| ---------------- | --------- | ----------------------------- | ---------------------------------------------- |
+| `/approval-mode` | `runtime` | `agent.setApprovalMode`       | Live engine approval setting on the active run |
+| `/policies`      | `runtime` | `agent.policy.getRules`       | Policy inspection reads the active run engine  |
+| `/task`          | `runtime` | `agent.tasks.list`            | Async task list/inspect/cancel over active run |
+| `/hooks`         | `runtime` | `agent.hooks.listHooks`       | Hook registry inspection + enable/disable      |
+| `/toolkey`       | `runtime` | `agent.tools.keys.save`       | Built-in tool key storage feeds active run     |
+| `/toolkeyfile`   | `runtime` | `agent.tools.keys.setKeyFile` | Built-in tool keyfile path feeds active run    |
 
 ## Power-User Subpath: `internals.js`
 
@@ -737,3 +1057,14 @@ These decisions shaped the public surface and are recorded here for posterity:
 - **`core/index` trim:** the eventual removal of low-level re-exports from the
   package root is sequenced into issue #1595; today the root entry stays
   additive and non-breaking.
+- **#2143 capability gaps (REQ-001..008):** the top-level approval-mode methods,
+  the `policy` / `tasks` sub-controllers, the extended `hooks` administration,
+  the extended `auth` detailed metadata, the extended `mcp` OAuth/details, and
+  `agent.tools.keys` close the capability gaps that previously forced a
+  `getConfig()` escape hatch or a deep import into the core package's internals.
+  They are a prerequisite to the #1595 public-API trim, shipped under three
+  constraints: **masked-only** (raw secrets/tokens are never returned — only
+  `maskedKey` or reference metadata), **projected public types** (omit
+  non-serializable internals like `abortController` and live `RegExp`), and
+  **delegate-don't-cache** (every method delegates to the bound runtime/config
+  on each call rather than holding a stale snapshot).

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -253,7 +253,7 @@ instance-scoped discovery helpers.
 
 ### Sub-surfaces
 
-All seven are exposed as `readonly` properties on the `Agent`:
+All nine are exposed as `readonly` properties on the `Agent`:
 
 #### `agent.profiles` — `AgentProfileControl`
 
@@ -365,7 +365,7 @@ for (const server of detail.servers) {
 > (or all servers when called with no argument) **and** re-publishes its tool
 > declarations (`setTools` parity), so the live tool list tracks server
 > restarts without a separate manual publish step.
-
+>
 > **Runtime-only.** `agent.mcp` reflects the _live_ connection set. Durable
 > MCP server add/remove is **not** here — it lives on the
 > [`app-service.js`](#runtime-vs-app-service) subpath (`addMcpServer`,
@@ -1037,9 +1037,9 @@ These decisions shaped the public surface and are recorded here for posterity:
 - **Entry wording (B11):** the public API ships from
   `@vybestack/llxprt-code-agents`, never `-core` — avoiding a `core → agents`
   cycle.
-- **Control-plane scope:** the seven sub-surfaces (`profiles`, `tools`, `mcp`,
-  `auth`, `ide`, `session`, `hooks`) are part of the public contract, alongside
-  the top-level turn/provider/model methods.
+- **Control-plane scope:** the nine sub-surfaces (`profiles`, `tools`, `mcp`,
+  `auth`, `ide`, `session`, `hooks`, `policy`, `tasks`) are part of the public
+  contract, alongside the top-level turn/provider/model/approval-mode methods.
 - **Confirmation handling (B7):** a **wired** approval handler that
   rejects/throws is **safely denied** (`Cancel`) by `AgenticLoop` so the loop
   never hangs. When **no** handler is wired, the agent neither silently proceeds

--- a/packages/agents/src/api/__tests__/additiveSurface.types.ts
+++ b/packages/agents/src/api/__tests__/additiveSurface.types.ts
@@ -1,0 +1,81 @@
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P18
+ * @requirement:REQ-009
+ *
+ * Compile-only type anchors for the additive-surface regression fence.
+ *
+ * WHY THIS FILE EXISTS (and is NOT a ".test.ts"):
+ * The workspace tsconfig (packages/agents/tsconfig.json) `exclude` drops every
+ * "**\/*.test.ts" and "**\/*.spec.ts" file, so `tsc --noEmit` (npm run
+ * typecheck) NEVER compiles them. Compile anchors placed in a ".test.ts" file
+ * are therefore VACUOUS — a removed/renamed projected type or a changed
+ * sub-controller signature would slip through typecheck silently (and vitest
+ * strips types at runtime). To make the compile-time half of the fence
+ * LOAD-BEARING, the anchors live here with a ".types.ts" suffix (no ".test"/
+ * ".spec" infix) so the workspace tsconfig DOES compile them. This file is:
+ *   - typecheck-VISIBLE  (tsconfig.json excludes only *.test.ts / *.spec.ts),
+ *   - build-EXCLUDED     (tsconfig.build.json excludes src/**\/__tests__/**),
+ *   - vitest-IGNORED     (the default matcher targets *.test. / *.spec. files).
+ * The sibling publicSurface.nonbreaking.test.ts holds all RUNTIME assertions.
+ * This mirrors the established contractPromotion.types.ts precedent.
+ *
+ * Each anchor below binds a function that reads a REAL required field of a
+ * projected public type, or pins the EXISTING signature of an extended-AROUND
+ * sub-controller method. Removing/renaming the type, dropping the field, or
+ * changing a prior member's signature breaks `npm run typecheck` — that is the
+ * regression the additive-only contract (REQ-009) forbids.
+ *
+ * Anchors are `void`-consumed so noUnusedLocals (root tsconfig) does not raise
+ * TS6196; they never execute (compile-only).
+ */
+
+// --- Compile anchors for new projected types (load-bearing under typecheck) ---
+
+// AgentTaskInfo anchor — keep the EXACT textual form
+//   `(x: _TaskInfoShape) => string = (x) => x.id`
+// so the P18a perl mutation probe
+//   s/(_TaskInfoShape\) => string = \(x\) => x\.)id/.../
+// matches and can prove this anchor is load-bearing. DO NOT reformat this line.
+type _TaskInfoShape = import('@vybestack/llxprt-code-agents').AgentTaskInfo;
+const _taskInfoAnchor: (x: _TaskInfoShape) => string = (x) => x.id;
+void _taskInfoAnchor;
+
+type _PolicyRuleViewShape =
+  import('@vybestack/llxprt-code-agents').PolicyRuleView;
+const _policyRuleViewAnchor: (x: _PolicyRuleViewShape) => string = (x) =>
+  x.decision;
+void _policyRuleViewAnchor;
+
+type _ToolKeyStatusShape = import('@vybestack/llxprt-code-agents').ToolKeyStatus;
+const _toolKeyStatusAnchor: (x: _ToolKeyStatusShape) => string = (x) =>
+  x.toolName;
+void _toolKeyStatusAnchor;
+
+type _HookInfoShape = import('@vybestack/llxprt-code-agents').HookInfo;
+const _hookInfoAnchor: (x: _HookInfoShape) => string = (x) => x.name;
+void _hookInfoAnchor;
+
+type _AuthProviderDetailShape =
+  import('@vybestack/llxprt-code-agents').AuthProviderDetail;
+const _authProviderDetailAnchor: (x: _AuthProviderDetailShape) => string = (
+  x,
+) => x.provider;
+void _authProviderDetailAnchor;
+
+type _McpDetailStatusShape =
+  import('@vybestack/llxprt-code-agents').McpDetailStatus;
+const _mcpDetailStatusAnchor: (x: _McpDetailStatusShape) => readonly unknown[] =
+  (x) => x.servers;
+void _mcpDetailStatusAnchor;
+
+// --- Extended-controller signature anchors (compile-only) ---
+// Pin the EXISTING signatures of methods that were extended-AROUND (not
+// changed). Any accidental change to a prior member's signature fails
+// typecheck.
+type _AgentShape = import('@vybestack/llxprt-code-agents').Agent;
+const _mcpRefreshShape: _AgentShape['mcp']['refresh'] = async (
+  _server?: string,
+) => {};
+void _mcpRefreshShape;
+const _hooksClearShape: _AgentShape['hooks']['clear'] = () => {};
+void _hooksClearShape;

--- a/packages/agents/src/api/__tests__/additiveSurface.types.ts
+++ b/packages/agents/src/api/__tests__/additiveSurface.types.ts
@@ -26,8 +26,20 @@
  * regression the additive-only contract (REQ-009) forbids.
  *
  * Anchors are `void`-consumed so noUnusedLocals (root tsconfig) does not raise
- * TS6196; they never execute (compile-only).
+ * TS6196; they never execute (compile-only). Types are imported via a top-level
+ * `import type` (not inline `import()` annotations) to satisfy the
+ * @typescript-eslint/consistent-type-imports lint rule.
  */
+
+import type {
+  Agent,
+  AgentTaskInfo,
+  AuthProviderDetail,
+  HookInfo,
+  McpDetailStatus,
+  PolicyRuleView,
+  ToolKeyStatus,
+} from '@vybestack/llxprt-code-agents';
 
 // --- Compile anchors for new projected types (load-bearing under typecheck) ---
 
@@ -36,43 +48,41 @@
 // so the P18a perl mutation probe
 //   s/(_TaskInfoShape\) => string = \(x\) => x\.)id/.../
 // matches and can prove this anchor is load-bearing. DO NOT reformat this line.
-type _TaskInfoShape = import('@vybestack/llxprt-code-agents').AgentTaskInfo;
+type _TaskInfoShape = AgentTaskInfo;
 const _taskInfoAnchor: (x: _TaskInfoShape) => string = (x) => x.id;
 void _taskInfoAnchor;
 
-type _PolicyRuleViewShape =
-  import('@vybestack/llxprt-code-agents').PolicyRuleView;
+type _PolicyRuleViewShape = PolicyRuleView;
 const _policyRuleViewAnchor: (x: _PolicyRuleViewShape) => string = (x) =>
   x.decision;
 void _policyRuleViewAnchor;
 
-type _ToolKeyStatusShape = import('@vybestack/llxprt-code-agents').ToolKeyStatus;
+type _ToolKeyStatusShape = ToolKeyStatus;
 const _toolKeyStatusAnchor: (x: _ToolKeyStatusShape) => string = (x) =>
   x.toolName;
 void _toolKeyStatusAnchor;
 
-type _HookInfoShape = import('@vybestack/llxprt-code-agents').HookInfo;
+type _HookInfoShape = HookInfo;
 const _hookInfoAnchor: (x: _HookInfoShape) => string = (x) => x.name;
 void _hookInfoAnchor;
 
-type _AuthProviderDetailShape =
-  import('@vybestack/llxprt-code-agents').AuthProviderDetail;
+type _AuthProviderDetailShape = AuthProviderDetail;
 const _authProviderDetailAnchor: (x: _AuthProviderDetailShape) => string = (
   x,
 ) => x.provider;
 void _authProviderDetailAnchor;
 
-type _McpDetailStatusShape =
-  import('@vybestack/llxprt-code-agents').McpDetailStatus;
-const _mcpDetailStatusAnchor: (x: _McpDetailStatusShape) => readonly unknown[] =
-  (x) => x.servers;
+type _McpDetailStatusShape = McpDetailStatus;
+const _mcpDetailStatusAnchor: (
+  x: _McpDetailStatusShape,
+) => readonly unknown[] = (x) => x.servers;
 void _mcpDetailStatusAnchor;
 
 // --- Extended-controller signature anchors (compile-only) ---
 // Pin the EXISTING signatures of methods that were extended-AROUND (not
 // changed). Any accidental change to a prior member's signature fails
 // typecheck.
-type _AgentShape = import('@vybestack/llxprt-code-agents').Agent;
+type _AgentShape = Agent;
 const _mcpRefreshShape: _AgentShape['mcp']['refresh'] = async (
   _server?: string,
 ) => {};

--- a/packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P03
+ * @requirement:REQ-001
+ *
+ * BEHAVIORAL RED suite for Agent.getApprovalMode() / Agent.setApprovalMode().
+ *
+ * REQ-001 requires the Agent interface to expose
+ *   getApprovalMode(): ApprovalMode
+ *   setApprovalMode(mode: ApprovalMode): void
+ * as top-level methods that delegate DIRECTLY to the bound Config
+ * (Config.getApprovalMode at configBaseCore.ts:463; Config.setApprovalMode at
+ * config.ts:401, whose untrusted-folder guard throws at config.ts:404).
+ *
+ * This suite drives the behavior ENTIRELY through the PUBLIC ROOT
+ * @vybestack/llxprt-code-agents via the buildAgent harness — NO deep imports,
+ * NO mocking. The two blessed real seams make every case drivable with no
+ * mock theater:
+ *   - configOverrides.approvalMode → adapter.ts:204-205 → params.approvalMode
+ *     → Config.getApprovalMode() returns it (T1 setup).
+ *   - configOverrides.folderTrust:false → adapter.ts:210-212 →
+ *     params.trustedFolder=false → Config.isTrustedFolder() returns false →
+ *     the REAL untrusted-folder throw fires from Config.setApprovalMode
+ *     (config.ts:402-405) (T2 / untrusted PROP). This is the production throw
+ *     path driven through the public API — NOT a spy.
+ *
+ * ApprovalMode is imported as a VALUE from the bare core barrel
+ * @vybestack/llxprt-code-core (no trailing slash). It is NOT yet importable as
+ * a value from the agents root (type-only there until Phase 17 REQ-008
+ * barrel-promotion). This .behavior.test.ts is T17-EXEMPT (the boundary scan
+ * only governs *.spec.ts), so this temporary sourcing is permitted.
+ *
+ * At RED (this phase): the positive cases (T1, T3, PROP round-trip) FAIL
+ * because the methods do not exist yet — agent.getApprovalMode /
+ * agent.setApprovalMode are undefined, yielding a missing-method TypeError.
+ * T2 / the untrusted PROP fail for the same missing-method reason (the throw
+ * is the TypeError, not the untrusted-folder message). Both are acceptable
+ * behavioral RED (CRIT-3).
+ *
+ * At GREEN (P04): the pure one-liner delegations
+ *   return this.deps.config.getApprovalMode();
+ *   this.deps.config.setApprovalMode(mode);
+ * make every case pass with no rewrite.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fc from 'fast-check';
+import { ApprovalMode } from '@vybestack/llxprt-code-core';
+import { buildAgent, type BuiltAgent } from './helpers/agentHarness.js';
+
+const UNTRUSTED_MESSAGE =
+  'Cannot enable privileged approval modes in an untrusted folder.';
+const FIXTURE = 'plain-text.jsonl';
+
+describe('Agent approval mode delegation @plan:PLAN-20260622-COREAPIGAP.P03 @requirement:REQ-001', () => {
+  let built: BuiltAgent | undefined;
+
+  afterEach(async () => {
+    if (built) {
+      await built.cleanup();
+      built = undefined;
+    }
+  });
+
+  it('T1 agent built with approvalMode:AUTO_EDIT (trusted) → agent.getApprovalMode() === ApprovalMode.AUTO_EDIT @requirement:REQ-001 @scenario:positive-live-read @given:a trusted agent built with approvalMode set to AUTO_EDIT @when:agent.getApprovalMode() @then:returns ApprovalMode.AUTO_EDIT (live read of the bound Config value)', async () => {
+    built = await buildAgent(FIXTURE, {
+      approvalMode: ApprovalMode.AUTO_EDIT,
+    });
+    expect(built.agent.getApprovalMode()).toBe(ApprovalMode.AUTO_EDIT);
+  });
+
+  it('T2 agent built with folderTrust:false → agent.setApprovalMode(YOLO) throws the real untrusted-folder error (faithful propagation, no catch) @requirement:REQ-001 @scenario:untrusted-throw @given:an agent built with folderTrust:false @when:agent.setApprovalMode(ApprovalMode.YOLO) @then:throws an Error whose message is exactly the untrusted-folder message', async () => {
+    built = await buildAgent(FIXTURE, { folderTrust: false });
+    expect(() => built!.agent.setApprovalMode(ApprovalMode.YOLO)).toThrow(
+      UNTRUSTED_MESSAGE,
+    );
+  });
+
+  it('T3 trusted agent → setApprovalMode(YOLO) then getApprovalMode() === YOLO (write-then-read parity, no cache) @requirement:REQ-001 @scenario:write-then-read @given:a trusted agent @when:setApprovalMode(YOLO) then getApprovalMode() @then:returns YOLO (live write reflected on next read via the public root)', async () => {
+    built = await buildAgent(FIXTURE);
+    built.agent.setApprovalMode(ApprovalMode.YOLO);
+    expect(built.agent.getApprovalMode()).toBe(ApprovalMode.YOLO);
+  });
+
+  it('PROP round-trip: for any mode m in {DEFAULT,AUTO_EDIT,YOLO}, setApprovalMode(m) then getApprovalMode() === m @requirement:REQ-001 @scenario:property-round-trip @given:a trusted agent @when:setApprovalMode(m) then getApprovalMode() @then:returns m (round-trip equality over the full enum)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(
+          ApprovalMode.DEFAULT,
+          ApprovalMode.AUTO_EDIT,
+          ApprovalMode.YOLO,
+        ),
+        async (mode) => {
+          const local = await buildAgent(FIXTURE);
+          try {
+            local.agent.setApprovalMode(mode);
+            expect(local.agent.getApprovalMode()).toBe(mode);
+          } finally {
+            await local.cleanup();
+          }
+        },
+      ),
+    );
+  });
+
+  it('PROP untrusted matrix: for any non-DEFAULT mode m with folderTrust:false, setApprovalMode(m) throws the untrusted-folder error; and setApprovalMode(DEFAULT) is always allowed with a DEFAULT post-condition @requirement:REQ-001 @scenario:property-untrusted-matrix @given:an agent built with folderTrust:false @when:setApprovalMode(m) for a non-DEFAULT m @then:throws the untrusted-folder message; and when setApprovalMode(DEFAULT) then getApprovalMode() === DEFAULT (DEFAULT is always allowed)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(ApprovalMode.AUTO_EDIT, ApprovalMode.YOLO),
+        async (mode) => {
+          const local = await buildAgent(FIXTURE, { folderTrust: false });
+          try {
+            expect(() => local.agent.setApprovalMode(mode)).toThrow(
+              UNTRUSTED_MESSAGE,
+            );
+            // DEFAULT is always allowed in an untrusted folder (config.ts:402
+            // guards only non-DEFAULT). Positive post-condition — NOT a bare
+            // not.toThrow.
+            local.agent.setApprovalMode(ApprovalMode.DEFAULT);
+            expect(local.agent.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
+          } finally {
+            await local.cleanup();
+          }
+        },
+      ),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/authDetail.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/authDetail.behavior.test.ts
@@ -1,0 +1,354 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @plan:PLAN-20260622-COREAPIGAP.P11
+// @requirement:REQ-005
+//
+// Behavioral RED suite for the masked auth-detail surface on AgentAuthControl
+// (detailedStatus / getHigherPriorityAuth / listBucketStatuses). Drives a REAL
+// OAuthManager over an in-memory TokenStore with a REAL registered provider —
+// NO mock theater. The control is constructed directly over the live manager
+// (the blessed direct-construction precedent shared with HookControl /
+// McpControl), so the masked OAuth detail path is exercised through real
+// delegation, not spies/stubs.
+//
+// At RED time AuthControlDeps does not yet carry `getOAuthManager`, so the
+// single construction site casts through `unknown` (the RED-note) so the file
+// parses and the positive assertions fail at runtime with a missing-method
+// TypeError (behavioral RED). P12 removes the cast by adding the dep.
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
+import type {
+  OAuthToken,
+  OAuthProvider,
+  TokenStore,
+} from '@vybestack/llxprt-code-providers/auth.js';
+import { AuthControl } from '../control/authControl.js';
+import type { AuthControlDeps } from '../control/authControl.js';
+import { createAgentAuthState } from '../control/authState.js';
+import type { AuthStatus } from '../agent.js';
+
+// ─── Hermetic in-memory TokenStore (mirrors the providers-package convention) ─
+
+/**
+ * Minimal in-memory TokenStore. Declared inline (NOT imported from the
+ * providers __tests__ tree) so this behavior test depends only on the public
+ * `@vybestack/llxprt-code-providers/auth.js` types + the control under test.
+ */
+class MemoryTokenStore implements TokenStore {
+  private tokens = new Map<string, OAuthToken>();
+
+  private toKey(provider: string, bucket?: string): string {
+    return `${provider}:${bucket ?? 'default'}`;
+  }
+
+  async saveToken(
+    provider: string,
+    token: OAuthToken,
+    bucket?: string,
+  ): Promise<void> {
+    this.tokens.set(this.toKey(provider, bucket), token);
+  }
+
+  async getToken(
+    provider: string,
+    bucket?: string,
+  ): Promise<OAuthToken | null> {
+    return this.tokens.get(this.toKey(provider, bucket)) ?? null;
+  }
+
+  async removeToken(provider: string, bucket?: string): Promise<void> {
+    this.tokens.delete(this.toKey(provider, bucket));
+  }
+
+  async listProviders(): Promise<string[]> {
+    const providers = new Set<string>();
+    for (const key of this.tokens.keys()) {
+      providers.add(key.split(':')[0]);
+    }
+    return Array.from(providers);
+  }
+
+  async listBuckets(provider: string): Promise<string[]> {
+    const prefix = `${provider}:`;
+    const buckets: string[] = [];
+    for (const key of this.tokens.keys()) {
+      if (key.startsWith(prefix)) {
+        buckets.push(key.slice(prefix.length));
+      }
+    }
+    return buckets;
+  }
+
+  async getBucketStats(): Promise<null> {
+    return null;
+  }
+
+  async acquireRefreshLock(): Promise<boolean> {
+    return true;
+  }
+
+  async releaseRefreshLock(): Promise<void> {}
+
+  async acquireAuthLock(): Promise<boolean> {
+    return true;
+  }
+
+  async releaseAuthLock(): Promise<void> {}
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const PROVIDER = 'myprov';
+
+/** A real plain-object OAuthProvider so registerProvider + isOAuthEnabled hold. */
+function makeRealProvider(name: string): OAuthProvider {
+  return {
+    name,
+    initiateAuth: async (): Promise<OAuthToken> => ({
+      access_token: 'init',
+      refresh_token: 'init-refresh',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+      scope: '',
+    }),
+    getToken: async (): Promise<OAuthToken | null> => null,
+    refreshToken: async (): Promise<OAuthToken | null> => null,
+  };
+}
+
+/** Builds a real OAuthManager over a fresh MemoryTokenStore, provider enabled. */
+async function makeManager(): Promise<{
+  mgr: OAuthManager;
+  store: MemoryTokenStore;
+}> {
+  const store = new MemoryTokenStore();
+  const mgr = new OAuthManager(store);
+  mgr.registerProvider(makeRealProvider(PROVIDER));
+  // registerProvider does NOT enable OAuth by default; flip it on.
+  await mgr.toggleOAuthEnabled(PROVIDER);
+  return { mgr, store };
+}
+
+/** Builds a real AuthControlDeps over the live manager. */
+function makeDeps(mgr: OAuthManager): AuthControlDeps {
+  const authState = createAgentAuthState();
+  return {
+    authState,
+    getCurrentProvider: () => PROVIDER,
+    getKeyName: () => undefined,
+    getStatus: (): AuthStatus => 'unauthenticated',
+    onOAuthPrompt: undefined,
+    setBaseUrl: async () => {},
+    keysDeps: {
+      authState,
+      getKeyName: () => undefined,
+      setKeyName: () => {},
+      updateProviderApiKey: async () => {},
+    },
+    getOAuthManager: () => mgr,
+  };
+}
+
+/** Builds the control directly over the real manager (direct-construction seam). */
+function makeControl(mgr: OAuthManager): AuthControl {
+  const deps = makeDeps(mgr);
+  return new AuthControl(deps);
+}
+
+/** Deep-collects every object key reachable from a value (arrays + nested objs). */
+function deepKeys(value: unknown): string[] {
+  const keys: string[] = [];
+  const visit = (v: unknown): void => {
+    if (Array.isArray(v)) {
+      for (const item of v) {
+        visit(item);
+      }
+      return;
+    }
+    if (v !== null && typeof v === 'object') {
+      const obj = v as Record<string, unknown>;
+      for (const k of Object.keys(obj)) {
+        keys.push(k);
+        visit(obj[k]);
+      }
+    }
+  };
+  visit(value);
+  return keys;
+}
+
+// ─── Scenarios ────────────────────────────────────────────────────────────────
+
+describe('REQ-005 auth detail — masked OAuth metadata (P11 RED)', () => {
+  it('T13 detailedStatus: oauth-enabled + seeded non-expired token returns masked detail with seeded expiry (REQ-005.1)', async () => {
+    const { mgr, store } = await makeManager();
+    const expiry = Math.floor(Date.now() / 1000) + 3600;
+    await store.saveToken(PROVIDER, {
+      access_token: 'SECRET-do-not-leak',
+      refresh_token: 'REFRESH-do-not-leak',
+      expiry,
+      token_type: 'Bearer',
+      scope: '',
+    });
+    const control = makeControl(mgr);
+
+    const detail = await control.detailedStatus(PROVIDER);
+
+    expect(detail.provider).toBe(PROVIDER);
+    expect(detail.authenticated).toBe(true);
+    expect(detail.oauthEnabled).toBe(true);
+    expect(detail.expiry).toBe(expiry);
+    const keys = deepKeys(detail);
+    expect(keys).not.toContain('access_token');
+    expect(keys).not.toContain('refresh_token');
+  });
+
+  it('T13b detailedStatus edge: enabled-but-no-token is unauthenticated; oauth-disabled reports oauthEnabled false (REQ-005.1)', async () => {
+    const { mgr } = await makeManager();
+    const control = makeControl(mgr);
+
+    // (a) OAuth enabled, no stored token → authenticated false, no expiry.
+    const noToken = await control.detailedStatus(PROVIDER);
+    expect(noToken.authenticated).toBe(false);
+    expect(noToken.oauthEnabled).toBe(true);
+    expect(noToken.expiry).toBeUndefined();
+
+    // (b) OAuth disabled for a provider → oauthEnabled false.
+    await mgr.toggleOAuthEnabled(PROVIDER);
+    const disabled = await control.detailedStatus(PROVIDER);
+    expect(disabled.oauthEnabled).toBe(false);
+    expect(disabled.authenticated).toBe(false);
+    expect(disabled.expiry).toBeUndefined();
+  });
+
+  it('T13c listBucketStatuses: two buckets (default + session) project to exactly the four public fields (REQ-005.3)', async () => {
+    const { mgr, store } = await makeManager();
+    const expiry = Math.floor(Date.now() / 1000) + 3600;
+    // Seed the default bucket.
+    await store.saveToken(
+      PROVIDER,
+      {
+        access_token: 'SECRET-do-not-leak',
+        refresh_token: 'REFRESH-do-not-leak',
+        expiry,
+        token_type: 'Bearer',
+        scope: '',
+      },
+      'default',
+    );
+    // Seed a second named bucket.
+    await store.saveToken(
+      PROVIDER,
+      {
+        access_token: 'SECRET-bucket-do-not-leak',
+        refresh_token: 'REFRESH-bucket-do-not-leak',
+        expiry,
+        token_type: 'Bearer',
+        scope: '',
+      },
+      'work',
+    );
+    // Mark the 'work' bucket as the session bucket.
+    mgr.setSessionBucket(PROVIDER, 'work');
+    const control = makeControl(mgr);
+
+    const buckets = await control.listBucketStatuses(PROVIDER);
+
+    expect(buckets).toHaveLength(2);
+    const allowed = new Set([
+      'bucket',
+      'authenticated',
+      'expiry',
+      'isSessionBucket',
+    ]);
+    const sessionBucket = buckets.find((b) => b.bucket === 'work');
+    expect(sessionBucket).toBeDefined();
+    expect(sessionBucket?.isSessionBucket).toBe(true);
+    expect(sessionBucket?.authenticated).toBe(true);
+    expect(sessionBucket?.expiry).toBe(expiry);
+    for (const b of buckets) {
+      const keys = Object.keys(b).sort();
+      // Each element exposes exactly the four public fields — no secrets.
+      expect(keys).toStrictEqual(Array.from(allowed).sort());
+    }
+    // Belt-and-suspenders: no secret key anywhere in the projection.
+    const allKeys = deepKeys(buckets);
+    expect(allKeys).not.toContain('access_token');
+    expect(allKeys).not.toContain('refresh_token');
+  });
+
+  it('T13d getHigherPriorityAuth: with no higher-priority method configured returns null (string-or-null contract) (REQ-005.2)', async () => {
+    const { mgr } = await makeManager();
+    const control = makeControl(mgr);
+
+    const result = await control.getHigherPriorityAuth(PROVIDER);
+
+    // No api-key / env precedence configured over a fresh manager → null.
+    expect(result).toBeNull();
+  });
+
+  // ─── Property: no secret leak across generated tokens ─────────────────────
+  it('PROP no-secret-leak: for generated tokens, detailedStatus deep keys contain neither access_token nor refresh_token and expiry round-trips (REQ-005.1)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
+        fc.integer({ min: 1, max: 100000 }),
+        async (accessTok, refreshTok, expiresIn) => {
+          const { mgr, store } = await makeManager();
+          const expiry = Math.floor(Date.now() / 1000) + expiresIn;
+          await store.saveToken(PROVIDER, {
+            access_token: accessTok,
+            refresh_token: refreshTok,
+            expiry,
+            token_type: 'Bearer',
+            scope: '',
+          });
+          const control = makeControl(mgr);
+
+          const detail = await control.detailedStatus(PROVIDER);
+
+          const keys = deepKeys(detail);
+          expect(keys).not.toContain('access_token');
+          expect(keys).not.toContain('refresh_token');
+          // Authenticated path must round-trip the seeded expiry exactly.
+          expect(detail.authenticated).toBe(true);
+          expect(detail.expiry).toBe(expiry);
+        },
+      ),
+    );
+  });
+
+  // ─── Property: expiry gating behind authenticated ─────────────────────────
+  it('PROP expiry-gating: detailedStatus only carries a defined expiry when authenticated is true (REQ-005.1)', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.boolean(), async (seedToken) => {
+        const { mgr, store } = await makeManager();
+        if (seedToken) {
+          await store.saveToken(PROVIDER, {
+            access_token: 'SECRET-do-not-leak',
+            refresh_token: 'REFRESH-do-not-leak',
+            expiry: Math.floor(Date.now() / 1000) + 3600,
+            token_type: 'Bearer',
+            scope: '',
+          });
+        }
+        const control = makeControl(mgr);
+
+        const detail = await control.detailedStatus(PROVIDER);
+
+        // Gating invariant, asserted without branching: expiry is defined
+        // exactly when authenticated is true (a seeded non-expired token).
+        expect(detail.expiry !== undefined).toBe(detail.authenticated);
+        // And authenticated tracks whether a token was seeded.
+        expect(detail.authenticated).toBe(seedToken);
+      }),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/authDetail.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/authDetail.behavior.test.ts
@@ -7,7 +7,7 @@
 // @plan:PLAN-20260622-COREAPIGAP.P11
 // @requirement:REQ-005
 //
-// Behavioral RED suite for the masked auth-detail surface on AgentAuthControl
+// Behavioral suite for the masked auth-detail surface on AgentAuthControl
 // (detailedStatus / getHigherPriorityAuth / listBucketStatuses). Drives a REAL
 // OAuthManager over an in-memory TokenStore with a REAL registered provider —
 // NO mock theater. The control is constructed directly over the live manager
@@ -15,10 +15,9 @@
 // McpControl), so the masked OAuth detail path is exercised through real
 // delegation, not spies/stubs.
 //
-// At RED time AuthControlDeps does not yet carry `getOAuthManager`, so the
-// single construction site casts through `unknown` (the RED-note) so the file
-// parses and the positive assertions fail at runtime with a missing-method
-// TypeError (behavioral RED). P12 removes the cast by adding the dep.
+// `AuthControlDeps` carries `getOAuthManager` (see `makeDeps`), and `makeControl`
+// instantiates `new AuthControl(deps)` directly with no cast — the masked
+// detail methods delegate live to the real manager.
 
 import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';

--- a/packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts
@@ -1,0 +1,107 @@
+/** @plan:PLAN-20260622-COREAPIGAP.P17 @requirement:REQ-008 */
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * BEHAVIORAL RED-then-GREEN suite for the public barrel re-exports
+ * (`packages/agents/src/api/index.ts`) and the six new COMMAND_API_MAP rows
+ * (`app-services/command-api-map.ts`). Asserts that the two VALUE enums
+ * (`ApprovalMode`, `PolicyDecision`) import as RUNTIME VALUES from the public
+ * root `@vybestack/llxprt-code-agents` and that the six target slash-commands
+ * are registered as `kind: 'runtime'` rows with the correct dotted Agent-method
+ * targets. No deep core import is required by a #1595 consumer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { ApprovalMode, PolicyDecision } from '@vybestack/llxprt-code-agents';
+import * as root from '@vybestack/llxprt-code-agents';
+import { COMMAND_API_MAP } from '../../app-services/command-api-map.js';
+
+describe('P17 public barrel + command-api-map @plan:PLAN-20260622-COREAPIGAP.P17 @requirement:REQ-008', () => {
+  it('T1 VALUE enums round-trip their real members from the public root @requirement:REQ-008 @scenario:enum-value-roundtrip @given:the public agents barrel @when:importing ApprovalMode + PolicyDecision as values @then:ApprovalMode.YOLO==="yolo", AUTO_EDIT==="autoEdit", DEFAULT==="default"; PolicyDecision.ASK_USER==="ask_user", ALLOW==="allow", DENY==="deny"', () => {
+    expect(ApprovalMode.YOLO).toBe('yolo');
+    expect(ApprovalMode.AUTO_EDIT).toBe('autoEdit');
+    expect(ApprovalMode.DEFAULT).toBe('default');
+    expect(PolicyDecision.ASK_USER).toBe('ask_user');
+    expect(PolicyDecision.ALLOW).toBe('allow');
+    expect(PolicyDecision.DENY).toBe('deny');
+  });
+
+  it('T2 the two enums are runtime keys of the public root namespace @requirement:REQ-008 @scenario:namespace-runtime-keys @given:import * as root from the public barrel @when:Object.prototype.hasOwnProperty.call(root, NAME) @then:ApprovalMode and PolicyDecision are OWN runtime properties (not type-only projections)', () => {
+    expect(Object.prototype.hasOwnProperty.call(root, 'ApprovalMode')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(root, 'PolicyDecision')).toBe(true);
+  });
+
+  it('T3 the six target command rows exist with kind runtime and correct targets @requirement:REQ-008 @scenario:command-map-rows @given:COMMAND_API_MAP indexed by command @when:looking up each of the six target commands @then:each row exists, kind==="runtime", and target equals the expected dotted Agent-method path', () => {
+    const byCmd = new Map(
+      COMMAND_API_MAP.map((e) => [e.command, e] as const),
+    );
+    const expected: ReadonlyArray<readonly [string, string]> = [
+      ['/approval-mode', 'agent.setApprovalMode'],
+      ['/policies', 'agent.policy.getRules'],
+      ['/task', 'agent.tasks.list'],
+      ['/hooks', 'agent.hooks.listHooks'],
+      ['/toolkey', 'agent.tools.keys.save'],
+      ['/toolkeyfile', 'agent.tools.keys.setKeyFile'],
+    ] as const;
+    for (const [cmd, target] of expected) {
+      const row = byCmd.get(cmd);
+      expect(row).toBeDefined();
+      expect(row?.kind).toBe('runtime');
+      expect(row?.target).toBe(target);
+    }
+  });
+
+  it('T4 map invariants hold after the append: valid kinds + unique command names @requirement:REQ-008 @requirement:REQ-009 @scenario:map-invariants @given:the full COMMAND_API_MAP after the six new rows @when:inspecting every row @then:every kind is in {runtime,subpath,cli-local} and command names are unique', () => {
+    const validKinds = new Set(['runtime', 'subpath', 'cli-local']);
+    for (const e of COMMAND_API_MAP) {
+      expect(validKinds.has(e.kind)).toBe(true);
+    }
+    const names = COMMAND_API_MAP.map((e) => e.command);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('T5 PROPERTY: every ApprovalMode member is a non-empty string and round-trips to a live enum member @requirement:REQ-008 @scenario:property-approvalmode-members', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...Object.values(ApprovalMode)),
+        (value: string) => {
+          expect(value.length).toBeGreaterThan(0);
+          expect(typeof value).toBe('string');
+          // The value must be a live member of the enum (round-trip).
+          const members = Object.values(ApprovalMode) as readonly string[];
+          expect(members).toContain(value);
+        },
+      ),
+    );
+  });
+
+  it('T6 PROPERTY: every target command is present in the map with kind runtime and an agent.* target @requirement:REQ-008 @scenario:property-command-targets', () => {
+    const byCmd = new Map(
+      COMMAND_API_MAP.map((e) => [e.command, e] as const),
+    );
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          '/approval-mode',
+          '/policies',
+          '/task',
+          '/hooks',
+          '/toolkey',
+          '/toolkeyfile',
+        ),
+        (cmd: string) => {
+          const row = byCmd.get(cmd);
+          expect(row).toBeDefined();
+          expect(row?.kind).toBe('runtime');
+          expect(row?.target.length).toBeGreaterThan(0);
+          expect(row?.target.startsWith('agent.')).toBe(true);
+        },
+      ),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts
@@ -32,14 +32,16 @@ describe('P17 public barrel + command-api-map @plan:PLAN-20260622-COREAPIGAP.P17
   });
 
   it('T2 the two enums are runtime keys of the public root namespace @requirement:REQ-008 @scenario:namespace-runtime-keys @given:import * as root from the public barrel @when:Object.prototype.hasOwnProperty.call(root, NAME) @then:ApprovalMode and PolicyDecision are OWN runtime properties (not type-only projections)', () => {
-    expect(Object.prototype.hasOwnProperty.call(root, 'ApprovalMode')).toBe(true);
-    expect(Object.prototype.hasOwnProperty.call(root, 'PolicyDecision')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(root, 'ApprovalMode')).toBe(
+      true,
+    );
+    expect(Object.prototype.hasOwnProperty.call(root, 'PolicyDecision')).toBe(
+      true,
+    );
   });
 
   it('T3 the six target command rows exist with kind runtime and correct targets @requirement:REQ-008 @scenario:command-map-rows @given:COMMAND_API_MAP indexed by command @when:looking up each of the six target commands @then:each row exists, kind==="runtime", and target equals the expected dotted Agent-method path', () => {
-    const byCmd = new Map(
-      COMMAND_API_MAP.map((e) => [e.command, e] as const),
-    );
+    const byCmd = new Map(COMMAND_API_MAP.map((e) => [e.command, e] as const));
     const expected: ReadonlyArray<readonly [string, string]> = [
       ['/approval-mode', 'agent.setApprovalMode'],
       ['/policies', 'agent.policy.getRules'],
@@ -81,9 +83,7 @@ describe('P17 public barrel + command-api-map @plan:PLAN-20260622-COREAPIGAP.P17
   });
 
   it('T6 PROPERTY: every target command is present in the map with kind runtime and an agent.* target @requirement:REQ-008 @scenario:property-command-targets', () => {
-    const byCmd = new Map(
-      COMMAND_API_MAP.map((e) => [e.command, e] as const),
-    );
+    const byCmd = new Map(COMMAND_API_MAP.map((e) => [e.command, e] as const));
     fc.assert(
       fc.property(
         fc.constantFrom(

--- a/packages/agents/src/api/__tests__/capabilityBoundary.adequacy.test.ts
+++ b/packages/agents/src/api/__tests__/capabilityBoundary.adequacy.test.ts
@@ -1,0 +1,435 @@
+// @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * P21 — Capability-Boundary Adequacy (REQ-INT-005).
+ *
+ * A STATIC import-scan test (a `.test.ts`, intentionally EXEMPT from the T17
+ * boundary guard which only scans `.spec.ts`) that executably encodes the
+ * boundary contract the whole new Agent-API surface must satisfy for a future
+ * CLI (#1595): the surface is reachable using ONLY the public root
+ * `@vybestack/llxprt-code-agents`, with NO deep RAW-SOURCE reaches in any new
+ * production file, the THREE brand-new controls importing core through the
+ * BARE BARREL only, and the public-consumer integration driver importing
+ * nothing outside a strict allow-list.
+ *
+ * The import-extraction machinery (extractSpecifiers and its character-class
+ * helpers) is copied verbatim from the proven T17 boundary guard so this scan
+ * shares its exact, RegExp-free parity semantics.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { readFileSync } from 'node:fs';
+import { join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { stripSandboxSegment } from './helpers/fixtureRoot.js';
+
+// ─── Path resolution (portable; derived from import.meta.url) ──────────────
+
+const TESTS_DIR = stripSandboxSegment(
+  fileURLToPath(new URL('.', import.meta.url)),
+);
+/** packages/agents/src/ */
+const PACKAGE_SRC_DIR = normalize(join(TESTS_DIR, '../../'));
+
+// ─── File sets (relative to packages/agents/src/) ──────────────────────────
+
+const NEW_PRODUCTION_FILES: readonly string[] = [
+  'api/control/policyControl.ts',
+  'api/control/tasksControl.ts',
+  'api/control/toolKeysControl.ts',
+  'api/control/mcpControl.ts',
+  'api/control/mcpControlWiring.ts',
+  'api/control/authControl.ts',
+  'api/control/hooks.ts',
+  'api/control/toolControl.ts',
+  'api/agentImpl.ts',
+  'api/agent.ts',
+  'api/index.ts',
+  'app-services/command-api-map.ts',
+];
+
+const NEW_CONTROLS_STRICT: readonly string[] = [
+  'api/control/policyControl.ts',
+  'api/control/tasksControl.ts',
+  'api/control/toolKeysControl.ts',
+];
+
+const DRIVER_SPEC = 'api/__tests__/capabilityGaps.integration.spec.ts';
+
+function toAbs(relUnderSrc: string): string {
+  return join(PACKAGE_SRC_DIR, relUnderSrc);
+}
+
+const NEW_PRODUCTION_FILES_ABS: readonly string[] =
+  NEW_PRODUCTION_FILES.map(toAbs);
+const NEW_CONTROLS_STRICT_ABS: readonly string[] =
+  NEW_CONTROLS_STRICT.map(toAbs);
+const DRIVER_SPEC_ABS: string = toAbs(DRIVER_SPEC);
+
+// ─── Patterns ──────────────────────────────────────────────────────────────
+
+/**
+ * RAW-SOURCE markers. A specifier containing any of these substrings reaches
+ * into another package's source tree (or a built dist artifact) directly,
+ * bypassing the package exports map. These are plain substrings (NOT import
+ * statements) so they are safe to write contiguously in this file — the
+ * self-scan in boundary.spec.ts reads only `.spec.ts` files anyway.
+ *
+ * Note: the established package-export convention imports TYPE-ONLY subpaths
+ * like `@vybestack/llxprt-code-core/config/config.js` (resolved via the exports
+ * map, NOT raw source). The substring `core/src` does NOT appear in
+ * `config/config.js`, so these patterns correctly distinguish raw source from
+ * legitimate package-export subpaths.
+ */
+const RAW_SOURCE_PATTERNS: readonly string[] = [
+  'core/src',
+  'providers/src',
+  'tools/src',
+  'policy/src',
+  '/dist/',
+];
+
+/** The bare core barrel — allowed; any subpath under it is forbidden for the
+ * three brand-new controls. */
+const CORE_SUBPATH_PREFIX = '@vybestack/llxprt-code-core' + '/';
+
+function isRawSourceReach(specifier: string): boolean {
+  return RAW_SOURCE_PATTERNS.some((p) => specifier.includes(p));
+}
+
+function isCoreSubpath(specifier: string): boolean {
+  // Assembled at runtime so the literal `from '@vybestack/llxprt-code-core/...'`
+  // shape never appears contiguously in this source file (self-scan safety,
+  // mirroring boundary.spec.ts).
+  return specifier.startsWith(CORE_SUBPATH_PREFIX);
+}
+
+/**
+ * Reads a file's source and returns its import specifiers via the proven
+ * character-class scanner.
+ */
+function readSpecifiers(absPath: string): readonly string[] {
+  const source = readFileSync(absPath, 'utf8');
+  return extractSpecifiers(source);
+}
+
+// ─── Import-extraction machinery (copied verbatim from boundary.spec.ts) ────
+
+const IDENT_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$';
+const WS_CHARS = ' \t\n\r\f\v';
+
+function isIdentChar(ch: string): boolean {
+  return IDENT_CHARS.includes(ch);
+}
+
+function isWs(ch: string): boolean {
+  return WS_CHARS.includes(ch);
+}
+
+function hasLeadingBoundary(source: string, start: number): boolean {
+  return start === 0 || !isIdentChar(source[start - 1]);
+}
+
+function skipWs(source: string, index: number): number {
+  let i = index;
+  while (i < source.length && isWs(source[i])) {
+    i += 1;
+  }
+  return i;
+}
+
+function readQuoted(
+  source: string,
+  quoteIndex: number,
+): { value: string; next: number } | null {
+  const quote = source[quoteIndex];
+  const close = source.indexOf(quote, quoteIndex + 1);
+  if (close === -1) {
+    return null;
+  }
+  return { value: source.slice(quoteIndex + 1, close), next: close + 1 };
+}
+
+function readQuotedExact(
+  source: string,
+  quoteIndex: number,
+  quoteChar: string,
+): { value: string; next: number } | null {
+  if (source[quoteIndex] !== quoteChar) {
+    return null;
+  }
+  return readQuoted(source, quoteIndex);
+}
+
+function matchFromQuote(
+  source: string,
+  i: number,
+  quoteChar: string,
+): { value: string; next: number } | null {
+  if (!source.startsWith('from', i)) {
+    return null;
+  }
+  if (!hasLeadingBoundary(source, i)) {
+    return null;
+  }
+  const afterKeyword = i + 'from'.length;
+  const quoteIndex = skipWs(source, afterKeyword);
+  if (quoteIndex >= source.length) {
+    return null;
+  }
+  return readQuotedExact(source, quoteIndex, quoteChar);
+}
+
+function matchImportQuote(
+  source: string,
+  i: number,
+  quoteChar: string,
+): { value: string; next: number } | null {
+  if (!source.startsWith('import', i)) {
+    return null;
+  }
+  if (!hasLeadingBoundary(source, i)) {
+    return null;
+  }
+  const afterKeyword = i + 'import'.length;
+  const parenIndex = skipWs(source, afterKeyword);
+  if (source[parenIndex] !== '(') {
+    return null;
+  }
+  const quoteIndex = skipWs(source, parenIndex + 1);
+  if (quoteIndex >= source.length) {
+    return null;
+  }
+  const quoted = readQuotedExact(source, quoteIndex, quoteChar);
+  if (quoted === null) {
+    return null;
+  }
+  const closeParen = skipWs(source, quoted.next);
+  if (source[closeParen] !== ')') {
+    return null;
+  }
+  return { value: quoted.value, next: closeParen + 1 };
+}
+
+function matchSideEffectImportQuote(
+  source: string,
+  i: number,
+  quoteChar: string,
+): { value: string; next: number } | null {
+  if (!source.startsWith('import', i)) {
+    return null;
+  }
+  if (!hasLeadingBoundary(source, i)) {
+    return null;
+  }
+  const afterKeyword = i + 'import'.length;
+  const quoteIndex = skipWs(source, afterKeyword);
+  if (quoteIndex >= source.length) {
+    return null;
+  }
+  if (source[quoteIndex] !== quoteChar) {
+    return null;
+  }
+  return readQuotedExact(source, quoteIndex, quoteChar);
+}
+
+function extractWithPass(
+  source: string,
+  tryMatch: (s: string, i: number) => { value: string; next: number } | null,
+): readonly string[] {
+  const found: string[] = [];
+  let i = 0;
+  while (i < source.length) {
+    const m = tryMatch(source, i);
+    i = m === null ? i + 1 : m.next;
+    if (m !== null) {
+      found.push(m.value);
+    }
+  }
+  return found;
+}
+
+function extractSpecifiers(source: string): readonly string[] {
+  return [
+    ...extractWithPass(source, (s, i) => matchFromQuote(s, i, "'")),
+    ...extractWithPass(source, (s, i) => matchFromQuote(s, i, '"')),
+    ...extractWithPass(source, (s, i) => matchSideEffectImportQuote(s, i, "'")),
+    ...extractWithPass(source, (s, i) => matchSideEffectImportQuote(s, i, '"')),
+    ...extractWithPass(source, (s, i) => matchImportQuote(s, i, "'")),
+    ...extractWithPass(source, (s, i) => matchImportQuote(s, i, '"')),
+  ];
+}
+
+// ─── Driver allow-list (REQ-INT-005: public-consumer scope) ────────────────
+
+const AGENTS_ROOT = '@vybestack/llxprt-code-agents';
+const AGENTS_SUBPATH_PREFIX = '@vybestack/llxprt-code-agents' + '/';
+
+function isDriverAllowed(specifier: string): boolean {
+  if (specifier === AGENTS_ROOT) {
+    return true;
+  }
+  if (specifier === 'vitest' || specifier.startsWith('vitest/')) {
+    return true;
+  }
+  if (specifier === 'fast-check' || specifier.startsWith('fast-check/')) {
+    return true;
+  }
+  if (specifier.startsWith('node:')) {
+    return true;
+  }
+  if (specifier.startsWith('./')) {
+    return true;
+  }
+  return false;
+}
+
+// ─── Pre-computed scan results (honest guards; never forced to fail) ───────
+
+interface Finding {
+  readonly file: string;
+  readonly specifier: string;
+  readonly rule: string;
+}
+
+const RAW_SOURCE_FINDINGS: readonly Finding[] = (() => {
+  const out: Finding[] = [];
+  for (const rel of NEW_PRODUCTION_FILES) {
+    const specs = readSpecifiers(toAbs(rel));
+    for (const spec of specs) {
+      if (isRawSourceReach(spec)) {
+        out.push({ file: rel, specifier: spec, rule: 'raw-source reach' });
+      }
+    }
+  }
+  return out;
+})();
+
+const STRICT_CORE_SUBPATH_FINDINGS: readonly Finding[] = (() => {
+  const out: Finding[] = [];
+  for (const rel of NEW_CONTROLS_STRICT) {
+    const specs = readSpecifiers(toAbs(rel));
+    for (const spec of specs) {
+      if (isCoreSubpath(spec)) {
+        out.push({
+          file: rel,
+          specifier: spec,
+          rule: 'core subpath in a strict bare-barrel-only control',
+        });
+      }
+    }
+  }
+  return out;
+})();
+
+const DRIVER_DISALLOWED: readonly Finding[] = (() => {
+  const out: Finding[] = [];
+  const specs = readSpecifiers(DRIVER_SPEC_ABS);
+  for (const spec of specs) {
+    if (spec.startsWith(AGENTS_SUBPATH_PREFIX)) {
+      out.push({
+        file: DRIVER_SPEC,
+        specifier: spec,
+        rule: 'public-consumer deep import of agents subpath',
+      });
+    } else if (!isDriverAllowed(spec)) {
+      out.push({
+        file: DRIVER_SPEC,
+        specifier: spec,
+        rule: 'public-consumer import outside the driver allow-list',
+      });
+    }
+  }
+  return out;
+})();
+
+const DRIVER_RAW = readFileSync(DRIVER_SPEC_ABS, 'utf8');
+const DRIVER_HAS_GETCONFIG = DRIVER_RAW.includes('getConfig');
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('P21 capability-boundary adequacy (REQ-INT-005) @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+  it('no new production file reaches raw source (core/src, providers/src, tools/src, policy/src, /dist/) @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+    const detail = RAW_SOURCE_FINDINGS.map(
+      (f) => `  ${f.file}: "${f.specifier}" (${f.rule})`,
+    ).join('\n');
+    expect(detail).toBe('');
+    expect(RAW_SOURCE_FINDINGS).toHaveLength(0);
+  });
+
+  it('the three brand-new controls are bare-barrel-only (no core subpath) @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+    const detail = STRICT_CORE_SUBPATH_FINDINGS.map(
+      (f) => `  ${f.file}: "${f.specifier}" (${f.rule})`,
+    ).join('\n');
+    expect(detail).toBe('');
+    expect(STRICT_CORE_SUBPATH_FINDINGS).toHaveLength(0);
+  });
+
+  it('the P20 driver spec imports only the public root, framework, node builtins, and in-tree relative helpers (no getConfig) @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+    const detail = DRIVER_DISALLOWED.map(
+      (f) => `  ${f.file}: "${f.specifier}" (${f.rule})`,
+    ).join('\n');
+    expect(detail).toBe('');
+    expect(DRIVER_DISALLOWED).toHaveLength(0);
+    expect(DRIVER_HAS_GETCONFIG).toBe(false);
+  });
+
+  it('extractSpecifiers matcher self-check: package-export subpath is NOT raw-source, src/index.js IS raw-source @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+    // Assembled from fragments so no contiguous forbidden import literal
+    // appears in this source file (self-scan safety).
+    const pkgExport = '@vybestack/llxprt-code-core' + '/config/config.js';
+    const rawSrc = '@vybestack/llxprt-code-core' + '/src/index.js';
+    expect(isRawSourceReach(pkgExport)).toBe(false);
+    expect(isRawSourceReach(rawSrc)).toBe(true);
+    // The bare barrel must not be classified as a core subpath; a subpath
+    // must.
+    const bareBarrel = '@vybestack/llxprt-code-core';
+    expect(isCoreSubpath(bareBarrel)).toBe(false);
+    expect(isCoreSubpath(pkgExport)).toBe(true);
+  });
+
+  // ─── Property blocks (≥30%, MIN-2; classic fc.assert form) ──────────────
+
+  it('PROP raw-source-free: for any new production file, none of its import specifiers is a raw-source reach @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...NEW_PRODUCTION_FILES_ABS),
+        (absPath: string) => {
+          const specs = readSpecifiers(absPath);
+          return specs.every((s) => !isRawSourceReach(s));
+        },
+      ),
+    );
+  });
+
+  it('PROP bare-barrel-only: for any brand-new control, none of its import specifiers starts with the core subpath prefix @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...NEW_CONTROLS_STRICT_ABS),
+        (absPath: string) => {
+          const specs = readSpecifiers(absPath);
+          return specs.every((s) => !isCoreSubpath(s));
+        },
+      ),
+    );
+  });
+
+  it('PROP driver-allow-list: for any import specifier in the P20 driver, it is on the public-consumer allow-list and not an agents subpath @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005', () => {
+    const specs = readSpecifiers(DRIVER_SPEC_ABS);
+    fc.assert(
+      fc.property(fc.constantFrom(...specs), (spec: string) => {
+        if (spec.startsWith(AGENTS_SUBPATH_PREFIX)) {
+          return false;
+        }
+        return isDriverAllowed(spec);
+      }),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/capabilityGaps.integration.spec.ts
+++ b/packages/agents/src/api/__tests__/capabilityGaps.integration.spec.ts
@@ -1,0 +1,330 @@
+// @plan:PLAN-20260622-COREAPIGAP.P20 @requirement:REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * P20 — Capability-Gap Integration Adequacy Driver (the #1595 keystone).
+ *
+ * PROVES every new Agent capability is reachable for the future CLI using ONLY
+ * the public root `@vybestack/llxprt-code-agents` — with NO config-escape
+ * hatch and NO deep import. Each capability is exercised on a REAL Agent built
+ * through the public harness (FakeProvider, no MCP manager, no real OAuth) —
+ * exactly the surface #1595 will hold.
+ */
+
+import { describe, expect, it, afterEach } from 'vitest';
+import * as fc from 'fast-check';
+import { ApprovalMode, PolicyDecision } from '@vybestack/llxprt-code-agents';
+import type {
+  AgentTaskInfo,
+  PolicyRuleView,
+  HookInfo,
+  AuthProviderDetail,
+  AuthBucketStatus,
+  McpDetailStatus,
+  ToolKeyInfo,
+  ToolKeyStatus,
+} from '@vybestack/llxprt-code-agents';
+import { buildAgent, type BuiltAgent } from './helpers/agentHarness.js';
+
+const FIXTURE = 'plain-text.jsonl';
+const ALL_APPROVAL_MODES = Object.values(ApprovalMode);
+const ALL_POLICY_DECISIONS = Object.values(PolicyDecision);
+
+describe('P20 capability-gap integration adequacy (REQ-INT-001..004) @plan:PLAN-20260622-COREAPIGAP.P20', () => {
+  let built: BuiltAgent | undefined;
+
+  afterEach(async () => {
+    if (built) {
+      await built.cleanup();
+      built = undefined;
+    }
+  });
+
+  // ─── REQ-INT-001: Approval ────────────────────────────────────────────────
+
+  it('approval: trusted agent getApprovalMode() returns a value in Object.values(ApprovalMode)', async () => {
+    built = await buildAgent(FIXTURE);
+    expect(ALL_APPROVAL_MODES).toContain(built.agent.getApprovalMode());
+  });
+
+  it('approval: trusted agent setApprovalMode(YOLO) then getApprovalMode() === YOLO (live write-then-read)', async () => {
+    built = await buildAgent(FIXTURE);
+    built.agent.setApprovalMode(ApprovalMode.YOLO);
+    expect(built.agent.getApprovalMode()).toBe(ApprovalMode.YOLO);
+  });
+
+  it('approval: UNTRUSTED agent (folderTrust:false) setApprovalMode(YOLO) throws /untrusted folder/i (delegated throw via public harness)', async () => {
+    built = await buildAgent(FIXTURE, { folderTrust: false });
+    expect(() => built!.agent.setApprovalMode(ApprovalMode.YOLO)).toThrow(
+      /untrusted folder/i,
+    );
+  });
+
+  // ─── REQ-INT-002: Policy ──────────────────────────────────────────────────
+
+  it('policy: getRules() returns an array; each element has string toolName (when present) and decision in Object.values(PolicyDecision)', async () => {
+    built = await buildAgent(FIXTURE);
+    const rules: readonly PolicyRuleView[] = built.agent.policy.getRules();
+    expect(Array.isArray(rules)).toBe(true);
+    // toolName is optional (undefined means "all tools"); when present it is a
+    // string. decision is always a PolicyDecision value.
+    rules
+      .filter((r) => r.toolName !== undefined)
+      .forEach((r) => expect(typeof r.toolName).toBe('string'));
+    rules.forEach((r) => expect(ALL_POLICY_DECISIONS).toContain(r.decision));
+  });
+
+  it('policy: getDefaultDecision() is in Object.values(PolicyDecision)', async () => {
+    built = await buildAgent(FIXTURE);
+    expect(ALL_POLICY_DECISIONS).toContain(
+      built.agent.policy.getDefaultDecision(),
+    );
+  });
+
+  it('policy: isNonInteractive() returns a boolean', async () => {
+    built = await buildAgent(FIXTURE);
+    expect(typeof built.agent.policy.isNonInteractive()).toBe('boolean');
+  });
+
+  // ─── REQ-INT-002: Tasks ───────────────────────────────────────────────────
+
+  it('tasks: on a fresh agent list() and listRunning() are arrays, get/cancel are undefined/false-safe, cancelAllRunning() is 0', async () => {
+    built = await buildAgent(FIXTURE);
+    const tasks: readonly AgentTaskInfo[] = built.agent.tasks.list();
+    const running: readonly AgentTaskInfo[] = built.agent.tasks.listRunning();
+    expect(Array.isArray(tasks)).toBe(true);
+    expect(Array.isArray(running)).toBe(true);
+    expect(built.agent.tasks.get('nonexistent')).toBeUndefined();
+    expect(built.agent.tasks.cancel('nonexistent')).toBe(false);
+    expect(built.agent.tasks.cancelAllRunning()).toBe(0);
+    // Any present element MUST be a projected view WITHOUT abortController.
+    [...tasks, ...running].forEach((task) =>
+      expect('abortController' in task).toBe(false),
+    );
+  });
+
+  // ─── REQ-INT-003: Hooks-admin ─────────────────────────────────────────────
+
+  it('hooks-admin: listHooks() returns an array; setDisabledHooks/enable round-trip (undefined-safe, no throw)', async () => {
+    built = await buildAgent(FIXTURE);
+    const hooks: readonly HookInfo[] = built.agent.hooks.listHooks();
+    expect(Array.isArray(hooks)).toBe(true);
+    built.agent.hooks.setDisabledHooks(['demo-hook']);
+    expect(built.agent.hooks.getDisabledHooks()).toContain('demo-hook');
+    built.agent.hooks.enable('demo-hook');
+    expect(built.agent.hooks.getDisabledHooks()).not.toContain('demo-hook');
+  });
+
+  // ─── REQ-INT-003: Auth-detail ─────────────────────────────────────────────
+
+  it('auth-detail: detailedStatus(openai) resolves to object with boolean authenticated; getHigherPriorityAuth is string|null; listBucketStatuses is an array', async () => {
+    built = await buildAgent(FIXTURE);
+    const detail: AuthProviderDetail =
+      await built.agent.auth.detailedStatus('openai');
+    expect(typeof detail.authenticated).toBe('boolean');
+    const higher: string | null =
+      await built.agent.auth.getHigherPriorityAuth('openai');
+    expect(higher === null || typeof higher === 'string').toBe(true);
+    const buckets: readonly AuthBucketStatus[] =
+      await built.agent.auth.listBucketStatuses('openai');
+    expect(Array.isArray(buckets)).toBe(true);
+  });
+
+  // ─── REQ-INT-004: MCP ─────────────────────────────────────────────────────
+
+  it('mcp: status() resolves (idle, no manager); details() servers is an empty array; authenticate(unknown) is authenticated===false with no throw', async () => {
+    built = await buildAgent(FIXTURE);
+    built.agent.mcp.status();
+    const detail: McpDetailStatus = await built.agent.mcp.details();
+    expect(Array.isArray(detail.servers)).toBe(true);
+    expect(detail.servers).toHaveLength(0);
+    const authStatus = await built.agent.mcp.authenticate('nonexistent-server');
+    expect(authStatus.authenticated).toBe(false);
+  });
+
+  // ─── REQ-INT-004: Tool-keys ───────────────────────────────────────────────
+
+  it('tool-keys: supported() is a NON-EMPTY array with string toolName each; save/status/delete/setKeyFile/getKeyFile are functions; status(exa).hasKey is boolean and maskedKey (if present) is not a raw secret', async () => {
+    built = await buildAgent(FIXTURE);
+    const supported: readonly ToolKeyInfo[] =
+      built.agent.tools.keys.supported();
+    expect(Array.isArray(supported)).toBe(true);
+    expect(supported.length).toBeGreaterThan(0);
+    for (const entry of supported) {
+      expect(typeof entry.toolName).toBe('string');
+    }
+    expect(typeof built.agent.tools.keys.save).toBe('function');
+    expect(typeof built.agent.tools.keys.status).toBe('function');
+    expect(typeof built.agent.tools.keys.delete).toBe('function');
+    expect(typeof built.agent.tools.keys.setKeyFile).toBe('function');
+    expect(typeof built.agent.tools.keys.getKeyFile).toBe('function');
+    // Read-only status on a real registry entry ('exa'); NO keyring mutation.
+    const status: ToolKeyStatus = await built.agent.tools.keys.status('exa');
+    expect(typeof status.hasKey).toBe('boolean');
+    // Masked-only contract: a masked key carries a `*` or is short — never a
+    // full-length raw secret. When maskedKey is absent the contract holds
+    // vacuously; when present it must satisfy the mask shape.
+    const masked = status.maskedKey;
+    const maskedSafe =
+      masked === undefined || masked.includes('*') || masked.length < 20;
+    expect(maskedSafe).toBe(true);
+  });
+
+  // ─── #1595 Keystone: every capability entry is a function on the public root ─
+
+  it('exercises every capability without a config-escape hatch', async () => {
+    built = await buildAgent(FIXTURE);
+    expect(typeof built.agent.setApprovalMode).toBe('function');
+    expect(typeof built.agent.policy.getRules).toBe('function');
+    expect(typeof built.agent.tasks.list).toBe('function');
+    expect(typeof built.agent.hooks.listHooks).toBe('function');
+    expect(typeof built.agent.auth.detailedStatus).toBe('function');
+    expect(typeof built.agent.mcp.details).toBe('function');
+    expect(typeof built.agent.tools.keys.supported).toBe('function');
+  });
+
+  // ─── Property tests (≥30%, MIN-2; classic fast-check form) ────────────────
+
+  it('PROP approval round-trip: for any mode m in Object.values(ApprovalMode), setApprovalMode(m) then getApprovalMode() === m (trusted agent)', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.constantFrom(...ALL_APPROVAL_MODES), async (mode) => {
+        const local = await buildAgent(FIXTURE);
+        try {
+          local.agent.setApprovalMode(mode);
+          expect(local.agent.getApprovalMode()).toBe(mode);
+        } finally {
+          await local.cleanup();
+        }
+      }),
+    );
+  });
+
+  it('PROP hooks round-trip: for any uniqueArray of hook names (maxLength 5), setDisabledHooks(names) then getDisabledHooks() set-equals the input', async () => {
+    built = await buildAgent(FIXTURE);
+    const agent = built.agent;
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uniqueArray(fc.string({ minLength: 1 }), { maxLength: 5 }),
+        async (names) => {
+          agent.hooks.setDisabledHooks(names);
+          const got = agent.hooks.getDisabledHooks();
+          // set-equality (order-independent): same members, same length.
+          expect(got.slice().sort()).toStrictEqual(names.slice().sort());
+          expect(got).toHaveLength(names.length);
+          // Restore the disabled set for the next case.
+          agent.hooks.setDisabledHooks([]);
+        },
+      ),
+    );
+  });
+
+  it('PROP tasks projection: for any fresh agent, every element of list() and listRunning() omits abortController', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.constantFrom('fresh'), async () => {
+        const local = await buildAgent(FIXTURE);
+        try {
+          const tasks = local.agent.tasks.list();
+          const running = local.agent.tasks.listRunning();
+          expect(Array.isArray(tasks)).toBe(true);
+          expect(Array.isArray(running)).toBe(true);
+          [...tasks, ...running].forEach((t) =>
+            expect('abortController' in t).toBe(false),
+          );
+        } finally {
+          await local.cleanup();
+        }
+      }),
+    );
+  });
+
+  it('PROP tool-keys registry: for any fresh agent, supported() is non-empty and every entry has a string toolName', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.constantFrom('fresh'), async () => {
+        const local = await buildAgent(FIXTURE);
+        try {
+          const supported = local.agent.tools.keys.supported();
+          expect(Array.isArray(supported)).toBe(true);
+          expect(supported.length).toBeGreaterThan(0);
+          supported.forEach((e) => expect(typeof e.toolName).toBe('string'));
+        } finally {
+          await local.cleanup();
+        }
+      }),
+    );
+  });
+
+  it('PROP mcp undefined-safe: for any arbitrary server name, authenticate(name) resolves authenticated===false (no throw, no manager)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .string({ minLength: 1, maxLength: 30 })
+          .filter((s) => !s.includes('\0')),
+        async (server) => {
+          const local = await buildAgent(FIXTURE);
+          try {
+            const status = await local.agent.mcp.authenticate(server);
+            expect(status.authenticated).toBe(false);
+          } finally {
+            await local.cleanup();
+          }
+        },
+      ),
+    );
+  });
+
+  it('PROP auth masked invariant: detailedStatus(openai) leaks no raw-secret field and no ≥20-char opaque string value', async () => {
+    built = await buildAgent(FIXTURE);
+    const agent = built.agent;
+    // A raw bearer token would leak either as a field literally named like a
+    // secret, or as a long opaque string value. The masked-only contract means
+    // neither appears in the public projection. The FakeProvider harness only
+    // registers the openai provider, so the property is driven over it.
+    const SECRET_FIELDS = new Set([
+      'token',
+      'accesstoken',
+      'refreshtoken',
+      'apikey',
+      'api_key',
+      'secret',
+      'password',
+    ]);
+    await fc.assert(
+      fc.asyncProperty(fc.constantFrom('openai'), async (provider) => {
+        const detail = await agent.auth.detailedStatus(provider);
+        // Collect any leak signal by walking the projection WITHOUT nesting
+        // expects in conditionals (repo eslint forbids that). A raw bearer
+        // token leaks either as a secret-named field or as a ≥20-char opaque
+        // string value; the masked-only contract means neither appears.
+        const secretFields: string[] = [];
+        const opaqueValues: string[] = [];
+        const walk = (node: unknown): void => {
+          if (node !== null && typeof node === 'object') {
+            Object.entries(node as Record<string, unknown>).forEach(
+              ([k, v]) => {
+                if (SECRET_FIELDS.has(k.toLowerCase())) {
+                  secretFields.push(k);
+                }
+                if (
+                  typeof v === 'string' &&
+                  v.length >= 20 &&
+                  v.split(/\s/).join('').length === v.length &&
+                  !v.includes('*')
+                ) {
+                  opaqueValues.push(v);
+                }
+                walk(v);
+              },
+            );
+          }
+        };
+        walk(detail);
+        expect(secretFields).toStrictEqual([]);
+        expect(opaqueValues).toStrictEqual([]);
+      }),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/helpers/fakeToolControlDeps.ts
+++ b/packages/agents/src/api/__tests__/helpers/fakeToolControlDeps.ts
@@ -21,6 +21,8 @@
 import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { MessageBusType } from '@vybestack/llxprt-code-core/confirmation-bus/types.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+import { getToolKeyStorage } from '@vybestack/llxprt-code-core';
 import type { EditorCallbacks } from '../../config-types.js';
 import type { ToolControlDeps } from '../../control/toolControl.js';
 
@@ -95,6 +97,8 @@ export function createToolControlDeps(
     messageBus,
     config,
     editorCallbacksHolder,
+    // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+    keysDeps: { getStorage: () => getToolKeyStorage() },
   };
 
   return {

--- a/packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
@@ -153,9 +153,7 @@ describe('agent.hooks hooks-administration control @plan:PLAN-20260622-COREAPIGA
   it('PROP enable∘disable inverse: for a generated name + base set, disable(name) then enable(name) yields a set WITHOUT name; returned arrays are always fresh copies @requirement:REQ-004 @scenario:property-enable-disable-inverse @given:a real agent, a generated name, and a base unique string[] not containing the name @when:disable(name) then enable(name) @then:getDisabledHooks() does not contain name AND mutating a returned array does not affect a subsequent read; MIN-2 distinct cases exercised by the generator', async () => {
     await fc.assert(
       fc.asyncProperty(
-        fc
-          .string({ minLength: 1 })
-          .filter((s) => !s.includes(' ') && s !== 'name-prop'),
+        fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')),
         fc.uniqueArray(
           fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')),
           { minLength: 0, maxLength: 5 },

--- a/packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
@@ -129,10 +129,13 @@ describe('agent.hooks hooks-administration control @plan:PLAN-20260622-COREAPIGA
   it('PROP disabled-set round-trip: for a generated unique string[] (len 0..5), setDisabledHooks(arr) then getDisabledHooks() deep-equals arr @requirement:REQ-004 @scenario:property-round-trip @given:a real agent and a generated unique string[] of length 0..5 @when:setDisabledHooks(arr) then getDisabledHooks() @then:the result deep-equals arr (R-HOOKS-ROUNDTRIP); MIN-2 distinct cases exercised by the generator', async () => {
     await fc.assert(
       fc.asyncProperty(
-        fc.uniqueArray(fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')), {
-          minLength: 0,
-          maxLength: 5,
-        }),
+        fc.uniqueArray(
+          fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')),
+          {
+            minLength: 0,
+            maxLength: 5,
+          },
+        ),
         async (arr) => {
           const { agent, cleanup } = await buildAgent('plain-text.jsonl');
           try {

--- a/packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P09
+ * @requirement:REQ-004
+ *
+ * BEHAVIORAL RED suite for the hooks-administration methods on
+ * `agent.hooks` (AgentHookControl): listHooks / getDisabledHooks /
+ * setDisabledHooks / enable / disable. Drives through the PUBLIC ROOT via
+ * the buildAgent harness (helpers/agentHarness.ts:79) for the disabled-set
+ * round-trip + undefined-safe listHooks cases, and through the BLESSED
+ * direct-construction precedent (new HookControl(realDeps)) for the populated
+ * listHooks case (the buildAgent harness provably cannot enable hooks —
+ * see plan/09 for the proof).
+ *
+ * At RED (before P10): the five admin methods do not exist on AgentHookControl,
+ * so every positive assertion FAILS with a behavioral TypeError
+ * (missing-method). At GREEN (P10) the HookControl delegates to the REAL
+ * Config hook system / disabled-set per call (no caching) and the SAME
+ * assertions pass with no rewrite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { buildAgent } from './helpers/agentHarness.js';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { HookEventName } from '@vybestack/llxprt-code-core/hooks/types.js';
+import { HookControl } from '../control/hooks.js';
+
+describe('agent.hooks hooks-administration control @plan:PLAN-20260622-COREAPIGAP.P09 @requirement:REQ-004', () => {
+  it('T11 disabled-set round-trip + fresh-copy: setDisabledHooks(["a","b"]) then getDisabledHooks() deep-equals ["a","b"]; mutating the returned array does NOT change a subsequent read @requirement:REQ-004 @scenario:round-trip-fresh-copy @given:a real agent via buildAgent with hooks disabled @when:agent.hooks.setDisabledHooks(["a","b"]) then getDisabledHooks() @then:the result deep-equals ["a","b"] AND mutating the returned array then re-reading yields the original ["a","b"]', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      agent.hooks.setDisabledHooks(['a', 'b']);
+      const first = agent.hooks.getDisabledHooks();
+      expect(first).toStrictEqual(['a', 'b']);
+      // Mutate the returned array — must NOT leak into engine state.
+      (first as string[]).push('MUTATED');
+      (first as string[]).sort();
+      const second = agent.hooks.getDisabledHooks();
+      expect(second).toStrictEqual(['a', 'b']);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('T11b enable/disable idempotency: from ["a"], disable("a") stays ["a"]; disable("b") -> ["a","b"]; enable("a") -> ["b"]; enable("zzz") unchanged @requirement:REQ-004 @scenario:idempotent-enable-disable @given:a real agent with disabled set to ["a"] @when:disable/enable are called idempotently @then:disable("a") stays ["a"]; disable("b") -> ["a","b"]; enable("a") -> ["b"]; enable("zzz") leaves ["b"]', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      agent.hooks.setDisabledHooks(['a']);
+      // disable("a") is idempotent — already present, stays ["a"].
+      agent.hooks.disable('a');
+      expect(agent.hooks.getDisabledHooks()).toStrictEqual(['a']);
+      // disable("b") adds -> ["a","b"].
+      agent.hooks.disable('b');
+      expect(agent.hooks.getDisabledHooks()).toStrictEqual(['a', 'b']);
+      // enable("a") removes -> ["b"].
+      agent.hooks.enable('a');
+      expect(agent.hooks.getDisabledHooks()).toStrictEqual(['b']);
+      // enable("zzz") (absent) is idempotent — unchanged ["b"].
+      agent.hooks.enable('zzz');
+      expect(agent.hooks.getDisabledHooks()).toStrictEqual(['b']);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('T12a undefined-safe listHooks: a plain agent (hooks disabled) -> agent.hooks.listHooks() === [] and does not throw @requirement:REQ-004 @scenario:undefined-safe-listHooks @given:a real agent via buildAgent with hooks disabled (getHookSystem() returns undefined) @when:agent.hooks.listHooks() is called @then:the result is an empty array []', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      // The harness agent has enableHooks=false -> getHookSystem() is undefined.
+      expect(agent.getConfig().getHookSystem()).toBeUndefined();
+      const list = agent.hooks.listHooks();
+      expect(list).toStrictEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('T12b populated listHooks mirrors a real seeded registry entry: name/eventName/enabled reflect the seeded hook @requirement:REQ-004 @scenario:populated-listHooks @given:a REAL Config with enableHooks:true + one seeded SessionStart command hook, registry initialized via system.initialize() @when:HookControl.listHooks() is called @then:list length >= 1 and the entry name === "fake-session-start", eventName === HookEventName.SessionStart, enabled === true', async () => {
+    const config = new Config({
+      cwd: '/tmp',
+      targetDir: '/tmp',
+      debugMode: false,
+      sessionId: 'hooks-admin-test',
+      model: 'gemini-2.0-flash',
+      usageStatisticsEnabled: false,
+      enableHooks: true,
+      hooks: {
+        [HookEventName.SessionStart]: [
+          {
+            hooks: [
+              {
+                type: 'command' as never,
+                command: 'true',
+                name: 'fake-session-start',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    // Defensive guard (NOT a non-null `!` assertion on the value): the seeded
+    // config has enableHooks:true so the system is present, but assert anyway
+    // so a future regression fails clearly rather than passing silently.
+    const system = config.getHookSystem();
+    expect(system).toBeDefined();
+    await system!.initialize();
+    const control = new HookControl({
+      config,
+      messageBus: new MessageBus(),
+      sessionId: () => 'hooks-admin-test',
+      cwd: () => '/tmp',
+    });
+    const list = control.listHooks();
+    expect(list.length).toBeGreaterThanOrEqual(1);
+    const entry = list.find((h) => h.name === 'fake-session-start');
+    expect(entry).toBeDefined();
+    expect(entry!.name).toBe('fake-session-start');
+    expect(entry!.eventName).toBe(HookEventName.SessionStart);
+    expect(entry!.enabled).toBe(true);
+  });
+
+  it('PROP disabled-set round-trip: for a generated unique string[] (len 0..5), setDisabledHooks(arr) then getDisabledHooks() deep-equals arr @requirement:REQ-004 @scenario:property-round-trip @given:a real agent and a generated unique string[] of length 0..5 @when:setDisabledHooks(arr) then getDisabledHooks() @then:the result deep-equals arr (R-HOOKS-ROUNDTRIP); MIN-2 distinct cases exercised by the generator', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uniqueArray(fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')), {
+          minLength: 0,
+          maxLength: 5,
+        }),
+        async (arr) => {
+          const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+          try {
+            agent.hooks.setDisabledHooks(arr);
+            const got = agent.hooks.getDisabledHooks();
+            expect([...got]).toStrictEqual([...arr]);
+          } finally {
+            await cleanup();
+          }
+        },
+      ),
+    );
+  });
+
+  it('PROP enable∘disable inverse: for a generated name + base set, disable(name) then enable(name) yields a set WITHOUT name; returned arrays are always fresh copies @requirement:REQ-004 @scenario:property-enable-disable-inverse @given:a real agent, a generated name, and a base unique string[] not containing the name @when:disable(name) then enable(name) @then:getDisabledHooks() does not contain name AND mutating a returned array does not affect a subsequent read; MIN-2 distinct cases exercised by the generator', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .string({ minLength: 1 })
+          .filter((s) => !s.includes(' ') && s !== 'name-prop'),
+        fc.uniqueArray(
+          fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')),
+          { minLength: 0, maxLength: 5 },
+        ),
+        async (name, base) => {
+          const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+          try {
+            agent.hooks.setDisabledHooks(base);
+            agent.hooks.disable(name);
+            // After disable, name is present (unless it duplicated a base entry,
+            // in which case disable was idempotent — still present once).
+            agent.hooks.enable(name);
+            const after = agent.hooks.getDisabledHooks();
+            // enable removed the name entirely.
+            expect([...after]).not.toContain(name);
+            // Fresh-copy contract: mutating the returned array is safe.
+            (after as string[]).push('FRESH-COPY-PROBE');
+            const reread = agent.hooks.getDisabledHooks();
+            expect([...reread]).not.toContain('FRESH-COPY-PROBE');
+          } finally {
+            await cleanup();
+          }
+        },
+      ),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
@@ -74,10 +74,16 @@ function buildOrderingDeps(
       }>
     >;
     readonly authenticated?: readonly string[];
+    readonly omitMarkAuthenticated?: boolean;
   } = {},
 ): McpControlDeps {
   const fakeManager: FakeManager | undefined = opts.manager;
   const managerAsCore = fakeManager as unknown as McpClientManager | undefined;
+
+  // Real per-agent auth marker: the SAME set is read by isMcpAuthenticated and
+  // written by markAuthenticated, mirroring agentImpl's authState.mcpAuth wiring.
+  // No spies/mocks — reconciliation is observed through real Set membership.
+  const authSet = new Set<string>(opts.authenticated ?? []);
 
   const { tools, prompts, resources } = opts;
   const toolRegistry: McpToolRegistryView | undefined =
@@ -116,8 +122,14 @@ function buildOrderingDeps(
         };
 
   return {
-    isMcpAuthenticated: (server: string) =>
-      opts.authenticated?.includes(server) ?? false,
+    isMcpAuthenticated: (server: string) => authSet.has(server),
+    ...(opts.omitMarkAuthenticated === true
+      ? {}
+      : {
+          markAuthenticated: (server: string) => {
+            authSet.add(server);
+          },
+        }),
     getManager: () => managerAsCore,
     getToolRegistry: () => toolRegistry,
     getServerConfigs: () => opts.servers,
@@ -211,6 +223,138 @@ describe('agent.mcp OAuth + refresh parity + details @plan:PLAN-20260622-COREAPI
     expect(callLog).toContain('oauth:s');
     expect(callLog).not.toContain('restart:s');
     expect(callLog).not.toContain('setTools');
+  });
+
+  it('T14d authenticate("s") reconciles the auth marker: a prior auth("s") reads false, then after authenticate the SAME auth("s") and details() read true @requirement:REQ-006 @scenario:authenticate-reconciles', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      manager: {
+        restartServer: async (n: string) => {
+          callLog.push('restart:' + n);
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        s: fakeServerConfig({ oauth: { enabled: true }, httpUrl: 'https://x' }),
+      },
+    });
+    const control = new McpControl(deps);
+
+    // BEFORE: the per-agent marker is empty, so auth() reports false.
+    const before = await control.auth('s');
+    expect(before.authenticated).toBe(false);
+
+    // The real OAuth flow succeeds.
+    const status = await control.authenticate('s');
+    expect(status.authenticated).toBe(true);
+
+    // AFTER: auth() and details() now agree with authenticate()'s result —
+    // the surface is internally consistent for a #1595 consumer.
+    const after = await control.auth('s');
+    expect(after.authenticated).toBe(true);
+    const detail = await control.details();
+    const sDetail = detail.servers.find((d) => d.name === 's');
+    expect(sDetail?.authenticated).toBe(true);
+  });
+
+  it('T14e authenticate("s") is undefined-safe when markAuthenticated is absent: still returns authenticated:true and does NOT throw @requirement:REQ-006 @scenario:authenticate-mark-undefined-safe', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      omitMarkAuthenticated: true,
+      manager: {
+        restartServer: async (n: string) => {
+          callLog.push('restart:' + n);
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        s: fakeServerConfig({ oauth: { enabled: true }, httpUrl: 'https://x' }),
+      },
+    });
+    const control = new McpControl(deps);
+    const status = await control.authenticate('s');
+    expect(status).toStrictEqual({
+      server: 's',
+      authenticated: true,
+      requiresAuth: true,
+    });
+    // No marker writer wired -> auth() still reads the (unchanged) empty set.
+    const after = await control.auth('s');
+    expect(after.authenticated).toBe(false);
+  });
+
+  it('T14f authenticate("nope") (unknown server, no oauth) does NOT mark it authenticated: a later auth("nope") stays false @requirement:REQ-006 @scenario:authenticate-unknown-no-mark', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      manager: {
+        restartServer: async (n: string) => {
+          callLog.push('restart:' + n);
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        s: fakeServerConfig({ oauth: { enabled: true }, httpUrl: 'https://x' }),
+      },
+    });
+    const control = new McpControl(deps);
+    const status = await control.authenticate('nope');
+    expect(status.authenticated).toBe(false);
+    const after = await control.auth('nope');
+    expect(after.authenticated).toBe(false);
+  });
+
+  it('PROP for any server name present in configs, authenticate(name) makes the SAME name read authenticated:true via auth() afterwards (reconciliation) @requirement:REQ-006 @scenario:prop-authenticate-reconciles', async () => {
+    const nameArb = fc.constantFrom('srv-a', 'srv-b', 'srv-c', 'srv-d');
+    await fc.assert(
+      fc.asyncProperty(nameArb, async (name) => {
+        const callLog: string[] = [];
+        const servers: Record<string, ReturnType<typeof fakeServerConfig>> = {
+          'srv-a': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://a',
+          }),
+          'srv-b': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://b',
+          }),
+          'srv-c': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://c',
+          }),
+          'srv-d': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://d',
+          }),
+        };
+        const deps = buildOrderingDeps(callLog, {
+          manager: {
+            restartServer: async (n: string) => {
+              callLog.push('restart:' + n);
+            },
+            restart: async () => {
+              callLog.push('restart-all');
+            },
+          },
+          servers,
+        });
+        const control = new McpControl(deps);
+
+        const before = await control.auth(name);
+        expect(before.authenticated).toBe(false);
+
+        const status = await control.authenticate(name);
+        expect(status.authenticated).toBe(true);
+
+        const after = await control.auth(name);
+        expect(after.authenticated).toBe(true);
+      }),
+    );
   });
 
   it('T15 refresh("s") records restart:s -> setTools; refresh() records restart-all -> setTools @requirement:REQ-006 @scenario:refresh-parity', async () => {

--- a/packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
@@ -319,7 +319,7 @@ describe('agent.mcp OAuth + refresh parity + details @plan:PLAN-20260622-COREAPI
         alpha: fakeServerConfig({}),
       },
       prompts: {
-        alpha: [{ name: 'p1', description: 'desc1' }],
+        alpha: [{ name: 'p1', description: 'desc1' }, { name: 'p2' }],
       },
       resources: [
         { serverName: 'alpha', name: 'r1', uri: 'file:///r1' },
@@ -329,8 +329,12 @@ describe('agent.mcp OAuth + refresh parity + details @plan:PLAN-20260622-COREAPI
     const control = new McpControl(deps);
     const withPrompts = await control.details({ includePrompts: true });
     const alphaP = withPrompts.servers[0];
+    // p1 carries a description; p2 has none — the projection must OMIT the
+    // `description` key entirely when undefined (conditional spread), not emit
+    // `description: undefined`.
     expect(alphaP.prompts).toStrictEqual([
       { name: 'p1', description: 'desc1' },
+      { name: 'p2' },
     ]);
     expect(alphaP.resources).toBeUndefined();
 

--- a/packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
@@ -1,0 +1,465 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P13
+ * @requirement:REQ-006
+ *
+ * BEHAVIORAL RED suite for the EXTENDED AgentMcpControl surface: real OAuth
+ * `authenticate(server)`, `refresh(server?)` setTools parity, and deep
+ * `details(opts?)`. The control is constructed directly as `new McpControl(deps)`
+ * (mirrors mcp-discovery.spec.ts / helpers/fakeMcpManager.ts). The orchestration
+ * order is observed via a shared `callLog: string[]` array that the injected
+ * dependency closures push into — this is the SAME no-mock-theater idiom
+ * helpers/fakeMcpManager.ts already uses (restartedServers()). There are NO
+ * spy/stub/call assertions.
+ *
+ * Behavior under test (GREEN): authenticate orchestrates performOAuth →
+ * restartServer → refreshClientTools; refresh gains refreshClientTools parity
+ * on BOTH the named-server and restart-all paths; details projects
+ * prompts/resources to named-field-only public types. The deps builder returns
+ * a fully-typed `McpControlDeps`, so the control is constructed plainly as
+ * `new McpControl(deps)` with no type-defeating cast at the call site.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { McpControl } from '../control/mcpControl.js';
+import type {
+  McpControlDeps,
+  McpToolRegistryView,
+  McpPromptRegistryView,
+  McpResourceRegistryView,
+} from '../control/mcpControl.js';
+import type { McpClientManager } from '@vybestack/llxprt-code-core';
+import { fakeServerConfig } from './helpers/fakeMcpManager.js';
+
+// ─── Observable-ordering deps builder (the no-mock-theater seam) ────────────
+//
+// Builds an McpControlDeps-shaped object closing over a shared callLog. Every
+// capability is a real closure that records into callLog; assertions are on the
+// ORDER/CONTENT of callLog and on returned status fields — NEVER spy calls.
+
+interface FakeManager {
+  restartServer(name: string): Promise<void>;
+  restart(): Promise<void>;
+}
+
+function buildOrderingDeps(
+  callLog: string[],
+  opts: {
+    readonly manager?: FakeManager;
+    readonly servers?: Record<string, ReturnType<typeof fakeServerConfig>>;
+    readonly performOAuth?: 'resolve' | 'reject';
+    readonly blocked?: ReadonlyArray<{ name: string; extensionName: string }>;
+    readonly prompts?: Record<
+      string,
+      ReadonlyArray<{ name: string; description?: string }>
+    >;
+    readonly resources?: ReadonlyArray<{
+      serverName: string;
+      name?: string;
+      uri: string;
+    }>;
+    readonly tools?: Record<
+      string,
+      ReadonlyArray<{
+        name: string;
+        description?: string;
+        serverName?: string;
+        enabled?: boolean;
+      }>
+    >;
+    readonly authenticated?: readonly string[];
+  } = {},
+): McpControlDeps {
+  const fakeManager: FakeManager | undefined = opts.manager;
+  const managerAsCore = fakeManager as unknown as McpClientManager | undefined;
+
+  const { tools, prompts, resources } = opts;
+  const toolRegistry: McpToolRegistryView | undefined =
+    tools === undefined
+      ? undefined
+      : {
+          getAllTools: () =>
+            Object.values(tools)
+              .flat()
+              .map((t) => ({
+                name: t.name,
+                ...(t.description !== undefined
+                  ? { description: t.description }
+                  : {}),
+                ...(t.serverName !== undefined
+                  ? { serverName: t.serverName }
+                  : {}),
+              })),
+          getEnabledTools: () =>
+            Object.values(tools)
+              .flat()
+              .filter((t) => t.enabled !== false)
+              .map((t) => ({ name: t.name })),
+        };
+  const promptRegistry: McpPromptRegistryView | undefined =
+    prompts === undefined
+      ? undefined
+      : {
+          getPromptsByServer: (server: string) => prompts[server] ?? [],
+        };
+  const resourceRegistry: McpResourceRegistryView | undefined =
+    resources === undefined
+      ? undefined
+      : {
+          getAllResources: () => resources,
+        };
+
+  return {
+    isMcpAuthenticated: (server: string) =>
+      opts.authenticated?.includes(server) ?? false,
+    getManager: () => managerAsCore,
+    getToolRegistry: () => toolRegistry,
+    getServerConfigs: () => opts.servers,
+    getBlockedServers: () => opts.blocked ?? [],
+    getPromptRegistry: () => promptRegistry,
+    getResourceRegistry: () => resourceRegistry,
+    refreshClientTools: async () => {
+      callLog.push('setTools');
+    },
+    performOAuth:
+      opts.performOAuth === 'reject'
+        ? async (server: string) => {
+            callLog.push('oauth:' + server);
+            throw new Error('oauth boom');
+          }
+        : async (server: string) => {
+            callLog.push('oauth:' + server);
+          },
+  };
+}
+
+describe('agent.mcp OAuth + refresh parity + details @plan:PLAN-20260622-COREAPIGAP.P13 @requirement:REQ-006', () => {
+  it('T14 authenticate("s") orchestrates performOAuth -> restartServer -> refreshClientTools and returns authenticated:true @requirement:REQ-006 @scenario:authenticate-success', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      manager: {
+        restartServer: async (n: string) => {
+          callLog.push('restart:' + n);
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        s: fakeServerConfig({ oauth: { enabled: true }, httpUrl: 'https://x' }),
+      },
+    });
+    const control = new McpControl(deps);
+    const status = await control.authenticate('s');
+    expect(status).toStrictEqual({
+      server: 's',
+      authenticated: true,
+      requiresAuth: true,
+    });
+    expect(callLog).toStrictEqual(['oauth:s', 'restart:s', 'setTools']);
+  });
+
+  it('T14b authenticate("nope") (not in configs) returns authenticated:false and performs NO oauth/restart/setTools @requirement:REQ-006 @scenario:authenticate-unknown', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      manager: {
+        restartServer: async (n: string) => {
+          callLog.push('restart:' + n);
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        s: fakeServerConfig({ oauth: { enabled: true }, httpUrl: 'https://x' }),
+      },
+    });
+    const control = new McpControl(deps);
+    const status = await control.authenticate('nope');
+    expect(status).toStrictEqual({
+      server: 'nope',
+      authenticated: false,
+      requiresAuth: true,
+    });
+    expect(callLog).toStrictEqual([]);
+  });
+
+  it('T14c performOAuth rejects -> authenticate("s") rejects; restart and setTools are NEVER invoked @requirement:REQ-006 @scenario:authenticate-propagation', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      performOAuth: 'reject',
+      manager: {
+        restartServer: async (n: string) => {
+          callLog.push('restart:' + n);
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        s: fakeServerConfig({ oauth: { enabled: true }, httpUrl: 'https://x' }),
+      },
+    });
+    const control = new McpControl(deps);
+    await expect(control.authenticate('s')).rejects.toThrow('oauth boom');
+    expect(callLog).toContain('oauth:s');
+    expect(callLog).not.toContain('restart:s');
+    expect(callLog).not.toContain('setTools');
+  });
+
+  it('T15 refresh("s") records restart:s -> setTools; refresh() records restart-all -> setTools @requirement:REQ-006 @scenario:refresh-parity', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      manager: {
+        restartServer: async (n: string) => {
+          callLog.push('restart:' + n);
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+    });
+    const control = new McpControl(deps);
+    await control.refresh('s');
+    expect(callLog).toStrictEqual(['restart:s', 'setTools']);
+    callLog.length = 0;
+    await control.refresh();
+    expect(callLog).toStrictEqual(['restart-all', 'setTools']);
+  });
+
+  it('T16 getManager() === undefined -> refresh() resolves and callLog is empty (setTools NOT called) @requirement:REQ-006 @scenario:refresh-undefined-safe', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, { manager: undefined });
+    const control = new McpControl(deps);
+    await control.refresh();
+    expect(callLog).toStrictEqual([]);
+  });
+
+  it('PROP refresh parity: for any generated server name, refresh(name) records [restart:name, setTools] @requirement:REQ-006 @scenario:prop-refresh-parity', async () => {
+    const nameArb = fc.string({ minLength: 1, maxLength: 20 }).filter((n) => {
+      const protoNames = new Set(Object.getOwnPropertyNames(Object.prototype));
+      return !protoNames.has(n);
+    });
+    await fc.assert(
+      fc.asyncProperty(nameArb, async (name) => {
+        const callLog: string[] = [];
+        const deps = buildOrderingDeps(callLog, {
+          manager: {
+            restartServer: async (n: string) => {
+              callLog.push('restart:' + n);
+            },
+            restart: async () => {
+              callLog.push('restart-all');
+            },
+          },
+        });
+        const control = new McpControl(deps);
+        await control.refresh(name);
+        expect(callLog).toStrictEqual(['restart:' + name, 'setTools']);
+      }),
+    );
+  });
+
+  it('Td1 details() with 2 servers yields servers length 2 each with tools defined, prompts/resources undefined, and blockedServers mirroring getBlockedServers @requirement:REQ-006 @scenario:details-projection', async () => {
+    const callLog: string[] = [];
+    const blocked = [{ name: 'evil', extensionName: 'bad-ext' }];
+    const deps = buildOrderingDeps(callLog, {
+      manager: {
+        restartServer: async () => {
+          callLog.push('restart');
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        alpha: fakeServerConfig({}),
+        beta: fakeServerConfig({}),
+      },
+      tools: {
+        alpha: [{ name: 'a_tool', serverName: 'alpha', enabled: true }],
+        beta: [{ name: 'b_tool', serverName: 'beta', enabled: true }],
+      },
+      blocked,
+      authenticated: ['alpha'],
+    });
+    const control = new McpControl(deps);
+    const detail = await control.details();
+    expect(detail.servers).toHaveLength(2);
+    for (const srv of detail.servers) {
+      expect(srv.tools).toBeDefined();
+      expect(srv.prompts).toBeUndefined();
+      expect(srv.resources).toBeUndefined();
+    }
+    expect(detail.blockedServers).toStrictEqual(blocked);
+    const alpha = detail.servers.find((s) => s.name === 'alpha');
+    expect(alpha?.authenticated).toBe(true);
+    const beta = detail.servers.find((s) => s.name === 'beta');
+    expect(beta?.authenticated).toBe(false);
+  });
+
+  it('Td2 details({includePrompts:true}) projects named-field prompts; details({includeResources:true}) filters resources by serverName @requirement:REQ-006 @scenario:details-prompts-resources', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      manager: {
+        restartServer: async () => {
+          callLog.push('restart');
+        },
+        restart: async () => {
+          callLog.push('restart-all');
+        },
+      },
+      servers: {
+        alpha: fakeServerConfig({}),
+      },
+      prompts: {
+        alpha: [{ name: 'p1', description: 'desc1' }],
+      },
+      resources: [
+        { serverName: 'alpha', name: 'r1', uri: 'file:///r1' },
+        { serverName: 'beta', name: 'r2', uri: 'file:///r2' },
+      ],
+    });
+    const control = new McpControl(deps);
+    const withPrompts = await control.details({ includePrompts: true });
+    const alphaP = withPrompts.servers[0];
+    expect(alphaP.prompts).toStrictEqual([
+      { name: 'p1', description: 'desc1' },
+    ]);
+    expect(alphaP.resources).toBeUndefined();
+
+    const withResources = await control.details({ includeResources: true });
+    const alphaR = withResources.servers[0];
+    expect(alphaR.resources).toStrictEqual([{ name: 'r1', uri: 'file:///r1' }]);
+    expect(alphaR.prompts).toBeUndefined();
+  });
+
+  it('Td3 getServerConfigs() === undefined -> details().servers is [] @requirement:REQ-006 @scenario:details-undefined-safe', async () => {
+    const callLog: string[] = [];
+    const deps = buildOrderingDeps(callLog, {
+      manager: undefined,
+      servers: undefined,
+    });
+    const control = new McpControl(deps);
+    const detail = await control.details();
+    expect(detail.servers).toStrictEqual([]);
+  });
+
+  it('PROP for generated names NOT in a fixed config set, authenticate(name) returns authenticated:false and callLog stays [] (performOAuth never runs) @requirement:REQ-006 @scenario:prop-unknown', async () => {
+    const fixedConfig = {
+      known: fakeServerConfig({
+        oauth: { enabled: true },
+        httpUrl: 'https://x',
+      }),
+    };
+    const protoNames = new Set(Object.getOwnPropertyNames(Object.prototype));
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .string({ minLength: 1 })
+          .filter((n) => n !== 'known' && !protoNames.has(n)),
+        async (name) => {
+          const callLog: string[] = [];
+          const deps = buildOrderingDeps(callLog, {
+            manager: {
+              restartServer: async (n: string) => {
+                callLog.push('restart:' + n);
+              },
+              restart: async () => {
+                callLog.push('restart-all');
+              },
+            },
+            servers: fixedConfig,
+          });
+          const control = new McpControl(deps);
+          const status = await control.authenticate(name);
+          expect(status.authenticated).toBe(false);
+          expect(callLog).toStrictEqual([]);
+        },
+      ),
+    );
+  });
+
+  it('PROP for generated server names present in configs, authenticate(name) records [oauth:name, restart:name, setTools] and returns authenticated:true @requirement:REQ-006 @scenario:prop-known', async () => {
+    const nameArb = fc.constantFrom('srv-a', 'srv-b', 'srv-c', 'srv-d');
+    await fc.assert(
+      fc.asyncProperty(nameArb, async (name) => {
+        const callLog: string[] = [];
+        const servers: Record<string, ReturnType<typeof fakeServerConfig>> = {
+          'srv-a': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://a',
+          }),
+          'srv-b': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://b',
+          }),
+          'srv-c': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://c',
+          }),
+          'srv-d': fakeServerConfig({
+            oauth: { enabled: true },
+            httpUrl: 'https://d',
+          }),
+        };
+        const deps = buildOrderingDeps(callLog, {
+          manager: {
+            restartServer: async (n: string) => {
+              callLog.push('restart:' + n);
+            },
+            restart: async () => {
+              callLog.push('restart-all');
+            },
+          },
+          servers,
+        });
+        const control = new McpControl(deps);
+        const status = await control.authenticate(name);
+        expect(status.authenticated).toBe(true);
+        expect(callLog).toStrictEqual([
+          'oauth:' + name,
+          'restart:' + name,
+          'setTools',
+        ]);
+      }),
+    );
+  });
+
+  it('PROP for a generated config map (1..4 servers), details().servers length equals the number of config keys and every server.name is a config key @requirement:REQ-006 @scenario:prop-details', async () => {
+    const configArb = fc.dictionary(
+      fc.string({ minLength: 1, maxLength: 12 }).filter((k) => k.length > 0),
+      fc.constant(fakeServerConfig({})),
+      { minKeys: 1, maxKeys: 4 },
+    );
+    await fc.assert(
+      fc.asyncProperty(configArb, async (servers) => {
+        const callLog: string[] = [];
+        const deps = buildOrderingDeps(callLog, {
+          manager: {
+            restartServer: async () => {
+              callLog.push('restart');
+            },
+            restart: async () => {
+              callLog.push('restart-all');
+            },
+          },
+          servers,
+        });
+        const control = new McpControl(deps);
+        const detail = await control.details();
+        const keys = Object.keys(servers);
+        expect(detail.servers).toHaveLength(keys.length);
+        for (const srv of detail.servers) {
+          expect(keys).toContain(srv.name);
+        }
+      }),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P05
+ * @requirement:REQ-002
+ *
+ * BEHAVIORAL RED suite for the read-only `agent.policy` sub-controller
+ * (AgentPolicyControl). Drives through the PUBLIC ROOT via the buildAgent
+ * harness (helpers/agentHarness.ts:79). The REAL PolicyEngine is seeded
+ * through the public config path with ZERO mocking:
+ *   AgentConfig.policy (config-types.ts:164, type PolicyEngineConfig)
+ *   → agentConfig.adapter.ts:207-208 (params.policyEngineConfig)
+ *   → configConstructor.ts:469 (new PolicyEngine(params.policyEngineConfig))
+ *   → Config.getPolicyEngine() returns that real engine.
+ *
+ * NOTE: createAgent injects an extra confirmation-forcing rule (priority 4,
+ * source 'Agent confirmation-forcing seam (P17)') into the engine. So the
+ * returned rule set is a SUPERSET of the seeded rules. The tests below
+ * locate the seeded rules by their distinguishing properties (source/toolName)
+ * rather than asserting a fixed positional index, so they test the PROJECTION
+ * contract (argsPattern→.source string, decision fidelity, snapshot isolation)
+ * independently of the confirmation-seam implementation detail.
+ *
+ * At RED (before P06): `agent.policy` is undefined on the Agent interface, so
+ * every positive case FAILS with a behavioral TypeError (missing-property /
+ * missing-method). No module/compile error is expected.
+ *
+ * At GREEN (P06): the PolicyControl delegates to Config.getPolicyEngine() per
+ * call, projects argsPattern RegExp → .source string, and returns a fresh
+ * snapshot array every call.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { buildAgent } from './helpers/agentHarness.js';
+import { PolicyDecision } from '@vybestack/llxprt-code-core';
+import type { PolicyEngineConfig, PolicyRuleView } from '@vybestack/llxprt-code-agents';
+
+describe('agent.policy read-only control @plan:PLAN-20260622-COREAPIGAP.P05 @requirement:REQ-002', () => {
+  it('T4 getRules projects argsPattern to .source string and preserves undefined for rules without a pattern @requirement:REQ-002 @scenario:argsPattern-string @given:an engine seeded with two rules, one WITH argsPattern /"command":"npm test"/ (source "user") and one WITHOUT @when:agent.policy.getRules() @then:the seeded argsPattern rule projects argsPattern === \'"command":"npm test"\' (a STRING); the no-argsPattern seeded rule has argsPattern === undefined; and NO view.argsPattern is a RegExp instance', async () => {
+    const policy: PolicyEngineConfig = {
+      rules: [
+        {
+          toolName: 'run_shell_command',
+          decision: PolicyDecision.DENY,
+          argsPattern: /"command":"npm test"/,
+          priority: 0.5,
+          source: 'user',
+        },
+        { decision: PolicyDecision.ALLOW, source: 'no-pattern-seed' },
+      ],
+    };
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      policy,
+    });
+    try {
+      const rules = agent.policy.getRules();
+      // Locate the seeded rules by their distinguishing source markers (the
+      // confirmation-seam injects an extra rule, so positional indices are
+      // not stable — but the seeded rules are always present by source).
+      const withPattern = rules.find((r) => r.source === 'user');
+      const withoutPattern = rules.find((r) => r.source === 'no-pattern-seed');
+      expect(withPattern).toBeDefined();
+      expect(withoutPattern).toBeDefined();
+      // The argsPattern rule projects to the .source STRING (never a RegExp).
+      expect(withPattern!.argsPattern).toBe('"command":"npm test"');
+      expect(withPattern!.argsPattern).not.toBeInstanceOf(RegExp);
+      expect(typeof withPattern!.argsPattern).toBe('string');
+      // The no-argsPattern rule has argsPattern === undefined.
+      expect(withoutPattern!.argsPattern).toBeUndefined();
+      // Belt-and-suspenders: NO view.argsPattern is ever a RegExp instance.
+      for (const view of rules) {
+        expect(view.argsPattern).not.toBeInstanceOf(RegExp);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('T4b snapshot isolation: two getRules() calls return independent arrays; mutating the first does NOT affect the second @requirement:REQ-002 @scenario:snapshot-isolation @given:an agent whose policy has at least one rule @when:getRules() is called twice and the first array is mutated (length truncated) @then:the second call still returns the original length (fresh snapshot each call)', async () => {
+    const policy: PolicyEngineConfig = {
+      rules: [
+        { decision: PolicyDecision.DENY, toolName: 'a' },
+        { decision: PolicyDecision.ALLOW, toolName: 'b' },
+      ],
+    };
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      policy,
+    });
+    try {
+      const first = agent.policy.getRules();
+      const originalLength = first.length;
+      // Mutate the first snapshot array (truncate — best-effort; readonly
+      // typing is erased at runtime so .length is settable).
+      (first as unknown as { length: number }).length = 0;
+      expect(first.length).toBe(0);
+      const second = agent.policy.getRules();
+      expect(second.length).toBe(originalLength);
+      expect(second).not.toBe(first);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('T6 getDefaultDecision and isNonInteractive delegate to the seeded engine @requirement:REQ-002 @scenario:default-decision @scenario:non-interactive @given:an engine seeded with defaultDecision: ASK_USER and nonInteractive: true @when:agent.policy.getDefaultDecision() and agent.policy.isNonInteractive() @then:getDefaultDecision() === PolicyDecision.ASK_USER AND isNonInteractive() === true', async () => {
+    const policy: PolicyEngineConfig = {
+      rules: [{ decision: PolicyDecision.DENY }],
+      defaultDecision: PolicyDecision.ASK_USER,
+      nonInteractive: true,
+    };
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      policy,
+    });
+    try {
+      expect(agent.policy.getDefaultDecision()).toBe(PolicyDecision.ASK_USER);
+      expect(agent.policy.isNonInteractive()).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('PROP argsPattern round-trip: for any valid regex source string, seeding a rule with new RegExp(src) yields a view whose argsPattern === the original src @requirement:REQ-002 @scenario:property-argsPattern-round-trip @given:a valid regex source string src and an engine seeded with a rule whose argsPattern is new RegExp(src) and a unique source marker @when:agent.policy.getRules() @then:the seeded view.argsPattern === src (RegExp.source round-trip)', async () => {
+    // MIN-2 distinct cases are exercised by the generator (constant strings).
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constant('foo'),
+        fc.constant('bar|baz'),
+        async (s1, s2) => {
+          for (const src of [s1, s2]) {
+            const marker = `prop-argspattern-${src}`;
+            const policy: PolicyEngineConfig = {
+              rules: [
+                {
+                  decision: PolicyDecision.DENY,
+                  argsPattern: new RegExp(src),
+                  source: marker,
+                },
+              ],
+            };
+            const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+              policy,
+            });
+            try {
+              const views = agent.policy.getRules();
+              const seeded = views.find((r) => r.source === marker);
+              expect(seeded).toBeDefined();
+              expect(seeded!.argsPattern).toBe(src);
+              expect(seeded!.argsPattern).not.toBeInstanceOf(RegExp);
+            } finally {
+              await cleanup();
+            }
+          }
+        },
+      ),
+    );
+  });
+
+  it('PROP rules count/order fidelity: for a generated list of N (1..5) seeded rules, the returned views contain all N seeded rules as a subsequence with positional decisions matching the seed @requirement:REQ-002 @scenario:property-rules-fidelity @given:a generated list of N rules each with a unique source marker and a decision in {ALLOW, DENY, ASK_USER} @when:agent.policy.getRules() @then:filtering to the seeded markers yields exactly N views in seed order, each with the matching decision', async () => {
+    const decisions = [
+      PolicyDecision.ALLOW,
+      PolicyDecision.DENY,
+      PolicyDecision.ASK_USER,
+    ];
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 5 }),
+        fc.array(fc.constantFrom(...decisions), { minLength: 1, maxLength: 5 }),
+        async (n, generated) => {
+          // Build exactly n rules from the generated decision list (trim/pad
+          // to the chosen count; each rule carries a unique positional source
+          // marker so the test can locate them among the confirmation-seam
+          // rules and assert count+order fidelity).
+          const chosen = generated.slice(0, n);
+          while (chosen.length < n) {
+            chosen.push(decisions[chosen.length % decisions.length]);
+          }
+          // Snapshot the markers+decisions BEFORE buildAgent: the
+          // confirmation-forcing seam mutates the policy.rules array in place
+          // (pushes its own rule), so a live reference would grow.
+          const markers = chosen.map((_, i) => `prop-fidelity-${i}`);
+          const expectedDecisions = [...chosen];
+          const seeded = chosen.map((decision, i) => ({
+            decision,
+            source: markers[i],
+          }));
+          const policy: PolicyEngineConfig = { rules: seeded };
+          const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+            policy,
+          });
+          try {
+            const views: readonly PolicyRuleView[] = agent.policy.getRules();
+            // Extract the seeded rules in seed order via their markers.
+            const seededViews = markers.map(
+              (m) => views.find((v) => v.source === m)!,
+            );
+            expect(seededViews).toHaveLength(n);
+            for (let i = 0; i < n; i++) {
+              expect(seededViews[i]).toBeDefined();
+              expect(seededViews[i].decision).toBe(expectedDecisions[i]);
+            }
+          } finally {
+            await cleanup();
+          }
+        },
+      ),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
@@ -38,7 +38,10 @@ import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';
 import { buildAgent } from './helpers/agentHarness.js';
 import { PolicyDecision } from '@vybestack/llxprt-code-core';
-import type { PolicyEngineConfig, PolicyRuleView } from '@vybestack/llxprt-code-agents';
+import type {
+  PolicyEngineConfig,
+  PolicyRuleView,
+} from '@vybestack/llxprt-code-agents';
 
 describe('agent.policy read-only control @plan:PLAN-20260622-COREAPIGAP.P05 @requirement:REQ-002', () => {
   it('T4 getRules projects argsPattern to .source string and preserves undefined for rules without a pattern @requirement:REQ-002 @scenario:argsPattern-string @given:an engine seeded with two rules, one WITH argsPattern /"command":"npm test"/ (source "user") and one WITHOUT @when:agent.policy.getRules() @then:the seeded argsPattern rule projects argsPattern === \'"command":"npm test"\' (a STRING); the no-argsPattern seeded rule has argsPattern === undefined; and NO view.argsPattern is a RegExp instance', async () => {

--- a/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
@@ -126,6 +126,48 @@ describe('agent.policy read-only control @plan:PLAN-20260622-COREAPIGAP.P05 @req
     }
   });
 
+  it('T7 source-omission projection: a rule seeded WITHOUT a source projects to a view that OMITS the source key (and argsPattern key); a rule WITH a source carries it @requirement:REQ-002 @scenario:source-omission @given:an engine seeded with TWO rules — one WITHOUT source/argsPattern (unique toolName "omit-source-probe") and one WITH source "present-probe" (unique toolName "present-source-probe") @when:agent.policy.getRules() is called and each rule is located by its unique toolName @then:the no-source view has NO source key (Object.keys omits it, "source" in view === false) AND no argsPattern key; the present-source view HAS source === "present-probe" AND "source" in view === true', async () => {
+    const policy: PolicyEngineConfig = {
+      rules: [
+        // NO source field, NO argsPattern field.
+        {
+          toolName: 'omit-source-probe',
+          decision: PolicyDecision.DENY,
+        },
+        // WITH a unique source marker (pins the always-true direction).
+        {
+          toolName: 'present-source-probe',
+          decision: PolicyDecision.ALLOW,
+          source: 'present-probe',
+        },
+      ],
+    };
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      policy,
+    });
+    try {
+      const rules = agent.policy.getRules();
+      // Locate by the unique toolName markers (the confirmation-seam injects
+      // its own rule, so positional indices are not stable — but these
+      // toolNames are unique to this test).
+      const omitted = rules.find((r) => r.toolName === 'omit-source-probe');
+      const present = rules.find((r) => r.toolName === 'present-source-probe');
+      // The no-source rule's view OMITS the source key entirely.
+      expect(omitted).toBeDefined();
+      expect('source' in omitted!).toBe(false);
+      expect(Object.keys(omitted!)).not.toContain('source');
+      // Belt-and-suspenders: argsPattern key also absent (no argsPattern seeded).
+      expect('argsPattern' in omitted!).toBe(false);
+      expect(Object.keys(omitted!)).not.toContain('argsPattern');
+      // The present-source rule's view CARRIES source with the seeded value.
+      expect(present).toBeDefined();
+      expect(present!.source).toBe('present-probe');
+      expect('source' in present!).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('PROP argsPattern round-trip: for any valid regex source string, seeding a rule with new RegExp(src) yields a view whose argsPattern === the original src @requirement:REQ-002 @scenario:property-argsPattern-round-trip @given:a valid regex source string src and an engine seeded with a rule whose argsPattern is new RegExp(src) and a unique source marker @when:agent.policy.getRules() @then:the seeded view.argsPattern === src (RegExp.source round-trip)', async () => {
     // MIN-2 distinct cases are exercised by the generator (constant strings).
     await fc.assert(

--- a/packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts
+++ b/packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts
@@ -132,3 +132,124 @@ describe('REQ-006 @plan:PLAN-20260621-COREAPIREMED.P21 — agents public export 
     );
   }, 30000);
 });
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P18
+ * @requirement:REQ-009
+ *
+ * Additive-surface regression fence: the whole plan is additive, so every
+ * prior #1594-era export MUST still be present with a compatible shape, AND
+ * the new members this plan adds (value enums, projected types, extended
+ * sub-controller methods) MUST be present without altering any prior member.
+ *
+ * This block is APPENDED to the existing REQ-006 characterization (left
+ * byte-identical above). It fences THIS plan's surface growth.
+ *
+ * The COMPILE-TIME half of this fence (projected-type + extended-controller
+ * signature anchors) lives in the sibling additiveSurface.types.ts, NOT here:
+ * the workspace tsconfig excludes "**\/*.test.ts" from `tsc --noEmit`, so
+ * compile anchors placed in this file would be VACUOUS. The ".types.ts" file
+ * IS typecheck-visible (and build-excluded + vitest-ignored). This file holds
+ * only the RUNTIME (introspection) half of the fence.
+ */
+
+describe('REQ-009 @plan:PLAN-20260622-COREAPIGAP.P18 — additive surface is non-breaking', () => {
+  it('Test A: full #1594-era load-bearing value set is still present as runtime functions (prior ⊂ current)', () => {
+    const rootKeys = new Set(Object.keys(root));
+    const priorLoadBearing: readonly string[] = [
+      'createAgent',
+      'fromConfig',
+      'listProviders',
+      'listTools',
+      'mapLoopStream',
+      'mapStreamEvent',
+      'toConfigParameters',
+      'createTaskToolRegistration',
+      'AdapterError',
+      'AgenticLoop',
+    ];
+    for (const key of priorLoadBearing) {
+      expect(rootKeys.has(key), `prior root key "${key}" must remain`).toBe(
+        true,
+      );
+      expect(typeof (root as Record<string, unknown>)[key]).toBe('function');
+    }
+  });
+
+  it('Test B: internals identity unchanged — AgentClient binding preserved on the documented internals subpath', () => {
+    // AgentClient is a runtime VALUE on the internals.js subpath (REQ-004.1).
+    expect(typeof internals.AgentClient).toBe('function');
+    // PostTurnAction is a value (enum/const) on internals.
+    expect(internals.PostTurnAction).not.toBeUndefined();
+    // Binding identity: AgentClient is a runtime value on BOTH the root barrel
+    // (via `export * from './agent.js'`) AND the documented internals subpath.
+    // The two MUST be the same binding: root.AgentClient === internals.AgentClient
+    const rootAgentClient = (root as Record<string, unknown>).AgentClient;
+    expect(rootAgentClient).toBe(internals.AgentClient);
+  });
+
+  it('Test C: new value enums are present and round-trip (additive surface growth)', () => {
+    expect(typeof root.ApprovalMode).toBe('object');
+    expect(typeof root.PolicyDecision).toBe('object');
+    expect(root.ApprovalMode.YOLO).toBe('yolo');
+    expect(root.ApprovalMode.AUTO_EDIT).toBe('autoEdit');
+    expect(root.ApprovalMode.DEFAULT).toBe('default');
+    expect(root.PolicyDecision.ASK_USER).toBe('ask_user');
+    expect(root.PolicyDecision.ALLOW).toBe('allow');
+    expect(root.PolicyDecision.DENY).toBe('deny');
+  });
+
+  it('PROP 1: each sampled prior load-bearing key is a live root key AND callable (REQ-009)', () => {
+    const priorLoadBearing: readonly string[] = [
+      'createAgent',
+      'fromConfig',
+      'listProviders',
+      'listTools',
+      'mapLoopStream',
+      'mapStreamEvent',
+      'toConfigParameters',
+      'createTaskToolRegistration',
+      'AdapterError',
+      'AgenticLoop',
+    ];
+    const rootKeys = new Set(Object.keys(root));
+    fc.assert(
+      fc.property(fc.constantFrom(...priorLoadBearing), (key) => {
+        expect(rootKeys.has(key)).toBe(true);
+        expect(typeof (root as Record<string, unknown>)[key]).toBe('function');
+        return true;
+      }),
+    );
+  }, 30000);
+
+  it('PROP 2: each sampled new enum member round-trips to its expected string value (REQ-009)', () => {
+    const approvalModeEntries: ReadonlyArray<readonly [string, string]> = [
+      ['YOLO', 'yolo'],
+      ['AUTO_EDIT', 'autoEdit'],
+      ['DEFAULT', 'default'],
+    ];
+    const policyDecisionEntries: ReadonlyArray<readonly [string, string]> = [
+      ['ASK_USER', 'ask_user'],
+      ['ALLOW', 'allow'],
+      ['DENY', 'deny'],
+    ];
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...approvalModeEntries, ...policyDecisionEntries),
+        ([memberName, expectedValue]) => {
+          const enumObj =
+            memberName === 'ASK_USER' ||
+            memberName === 'ALLOW' ||
+            memberName === 'DENY'
+              ? root.PolicyDecision
+              : root.ApprovalMode;
+          const value = (enumObj as Record<string, string>)[memberName];
+          expect(typeof value).toBe('string');
+          expect(value.length).toBeGreaterThan(0);
+          expect(value).toBe(expectedValue);
+          return true;
+        },
+      ),
+    );
+  }, 30000);
+});

--- a/packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
@@ -146,6 +146,107 @@ describe('agent.tasks undefined-safe async-task control @plan:PLAN-20260622-CORE
     }
   });
 
+  it('T11 completed/failed projection: terminal tasks carry completedAt, failed tasks carry error, running tasks omit BOTH @requirement:REQ-003 @scenario:optional-field-projection @given:a real manager seeded with 3 running tasks (t11-run stays running, t11-done is completed, t11-fail is failed) @when:agent.tasks.get() is called for each terminal task @then:the completed view has completedAt:number>0 AND has NO error key; the failed view has error===the seed AND completedAt:number>0; the running view OMITS both completedAt and error keys', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      const mgr = agent.getConfig().getAsyncTaskManager()!;
+      for (const id of ['t11-run', 't11-done', 't11-fail']) {
+        mgr.registerTask({
+          id,
+          subagentName: 's',
+          goalPrompt: 'g',
+          abortController: new AbortController(),
+        });
+      }
+      // Complete one task: real completeTask sets status='completed',
+      // completedAt=Date.now(), output — but does NOT touch task.error.
+      expect(mgr.completeTask('t11-done', { result: 'ok' } as never)).toBe(
+        true,
+      );
+      // Fail one task: real failTask sets status='failed', completedAt, error.
+      expect(mgr.failTask('t11-fail', 'boom')).toBe(true);
+
+      // Completed view: completedAt present, error key ABSENT (not undefined).
+      const done = agent.tasks.get('t11-done')!;
+      expect(done.id).toBe('t11-done');
+      expect(typeof done.completedAt).toBe('number');
+      expect(done.completedAt).toBeGreaterThan(0);
+      expect('completedAt' in done).toBe(true);
+      expect('error' in done).toBe(false);
+      expect(Object.keys(done)).not.toContain('error');
+
+      // Failed view: error present with the seeded value, completedAt present.
+      const failed = agent.tasks.get('t11-fail')!;
+      expect(failed.id).toBe('t11-fail');
+      expect(failed.error).toBe('boom');
+      expect('error' in failed).toBe(true);
+      expect(typeof failed.completedAt).toBe('number');
+      expect(failed.completedAt).toBeGreaterThan(0);
+      expect('completedAt' in failed).toBe(true);
+
+      // Running view: BOTH optional keys ABSENT (the always-spread mutant
+      // would inject { completedAt: undefined } and { error: undefined }).
+      const running = agent.tasks.get('t11-run')!;
+      expect(running.id).toBe('t11-run');
+      expect('completedAt' in running).toBe(false);
+      expect('error' in running).toBe(false);
+      expect(Object.keys(running)).not.toContain('completedAt');
+      expect(Object.keys(running)).not.toContain('error');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('PROP completed/failed optional-field projection: a terminated task carries completedAt, a failed task carries its error, and a never-terminated control task omits BOTH @requirement:REQ-003 @scenario:property-terminal-projection @given:a discriminator in {complete, fail} and a unique id, with a real manager seeded with a terminal task (per discriminator) plus a never-terminated control task @when:agent.tasks.get() is called for the terminal id and the control id @then:the terminal view has completedAt:number>0; if fail, error===the seed; the control view OMITS both completedAt and error keys', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom('complete', 'fail'),
+        fc
+          .string({ minLength: 1 })
+          .filter((s) => !s.includes(' ') && !s.includes('-')),
+        async (kind, suffix) => {
+          const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+          try {
+            const mgr = agent.getConfig().getAsyncTaskManager()!;
+            const termId = `prop-term-${suffix}`;
+            const controlId = `prop-ctrl-${suffix}`;
+            for (const id of [termId, controlId]) {
+              mgr.registerTask({
+                id,
+                subagentName: 's',
+                goalPrompt: 'g',
+                abortController: new AbortController(),
+              });
+            }
+            const expectedError = kind === 'fail' ? `err-${suffix}` : undefined;
+            const ok =
+              kind === 'complete'
+                ? mgr.completeTask(termId, { result: 'ok' } as never)
+                : mgr.failTask(termId, `err-${suffix}`);
+            expect(ok).toBe(true);
+            // MIN-2 distinct cases: complete + fail both exercised.
+            const termView = agent.tasks.get(termId)!;
+            expect(typeof termView.completedAt).toBe('number');
+            expect(termView.completedAt).toBeGreaterThan(0);
+            expect('completedAt' in termView).toBe(true);
+            // error-presence is kind-discriminated; assert via a computed
+            // expectation rather than a conditional branch (no-conditional-expect).
+            expect('error' in termView).toBe(expectedError !== undefined);
+            expect(termView.error ?? undefined).toBe(expectedError);
+            // Never-terminated control: BOTH optional keys absent.
+            const controlView = agent.tasks.get(controlId)!;
+            expect('completedAt' in controlView).toBe(false);
+            expect('error' in controlView).toBe(false);
+            expect(Object.keys(controlView)).not.toContain('completedAt');
+            expect(Object.keys(controlView)).not.toContain('error');
+          } finally {
+            await cleanup();
+          }
+        },
+      ),
+    );
+  });
+
   it('PROP projection fidelity: for a generated list of N (1..5) running tasks, list() length === N, the id set matches, and NO view has an abortController key @requirement:REQ-003 @scenario:property-projection-fidelity @given:a generated list of N running tasks with random ids and goalPrompts seeded on the real manager @when:agent.tasks.list() @then:list() length === N; the set of view ids === the set of seeded ids; and no returned view has an abortController key', async () => {
     await fc.assert(
       fc.asyncProperty(

--- a/packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
@@ -119,9 +119,9 @@ describe('agent.tasks undefined-safe async-task control @plan:PLAN-20260622-CORE
         abortController: new AbortController(),
       });
       // Complete one task: it leaves the running set but stays in history.
-      expect(
-        mgr.completeTask('t10-done', { result: 'ok' } as never),
-      ).toBe(true);
+      expect(mgr.completeTask('t10-done', { result: 'ok' } as never)).toBe(
+        true,
+      );
       // list() reflects ALL tasks (both remain in history).
       const all = agent.tasks.list();
       expect(all).toHaveLength(2);

--- a/packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P07
+ * @requirement:REQ-003
+ *
+ * BEHAVIORAL RED suite for the `agent.tasks` sub-controller
+ * (AgentTasksControl). Drives through the PUBLIC ROOT via the buildAgent
+ * harness (helpers/agentHarness.ts:79). The REAL AsyncTaskManager is seeded
+ * through the public config path with ZERO mocking:
+ *   agent.getConfig().getAsyncTaskManager() (config.ts:601)
+ *   → the SAME lazily-created AsyncTaskManager the control resolves
+ *   → mgr.registerTask(RegisterTaskInput) (asyncTaskManager.ts:148) marks
+ *     the task 'running'.
+ *
+ * Reads go through `agent.tasks.list()/listRunning()/get(id)/cancel(id)/
+ * cancelAllRunning()` — the SAME manager the control closes over, so the
+ * read-path is causally real (no stub).
+ *
+ * At RED (before P08): `agent.tasks` is undefined on the Agent interface, so
+ * every public-harness positive (T7/T8/T10) FAILS with a behavioral TypeError
+ * (missing-property → "Cannot read properties of undefined"). The T9
+ * undefined-safe case dynamically imports the not-yet-created control module,
+ * so its failure at RED is an isolated module-resolution error INSIDE that one
+ * test — the whole file still PARSES and the positives drive the behavioral RED.
+ *
+ * At GREEN (P08): the TasksControl delegates to Config.getAsyncTaskManager()
+ * per call, projects each core AsyncTaskInfo to a public AgentTaskInfo that
+ * OMITS abortController, and is undefined-safe on every method.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { buildAgent } from './helpers/agentHarness.js';
+
+describe('agent.tasks undefined-safe async-task control @plan:PLAN-20260622-COREAPIGAP.P07 @requirement:REQ-003', () => {
+  it('T7 seed N running tasks on the real manager, cancelAllRunning returns N and leaves listRunning empty @requirement:REQ-003 @scenario:cancel-all-count @given:a real manager seeded with 2 running tasks via agent.getConfig().getAsyncTaskManager().registerTask @when:agent.tasks.cancelAllRunning() is called @then:the returned count === 2 AND a subsequent agent.tasks.listRunning() has length 0 (terminal idempotent state)', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      const mgr = agent.getConfig().getAsyncTaskManager()!;
+      expect(mgr).toBeDefined();
+      const ids = ['t7-a', 't7-b'];
+      for (const id of ids) {
+        mgr.registerTask({
+          id,
+          subagentName: 's',
+          goalPrompt: 'g',
+          abortController: new AbortController(),
+        });
+      }
+      // Both tasks are 'running' before the call.
+      expect(agent.tasks.listRunning()).toHaveLength(2);
+      const cancelled = agent.tasks.cancelAllRunning();
+      expect(cancelled).toBe(2);
+      // Idempotent terminal state: no running tasks remain.
+      expect(agent.tasks.listRunning()).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('T8 projection strips abortController from the public view of a running task @requirement:REQ-003 @scenario:no-abortController @given:a real manager seeded with 1 running task that carries an AbortController on the core manager @when:agent.tasks.list() is called @then:the projected view does NOT include an abortController key (Object.keys(view) omits it AND "abortController" in view === false)', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      const mgr = agent.getConfig().getAsyncTaskManager()!;
+      const ac = new AbortController();
+      mgr.registerTask({
+        id: 't8-x',
+        subagentName: 's',
+        goalPrompt: 'g',
+        abortController: ac,
+      });
+      // The CORE task DID carry an AbortController (proof of real seeding).
+      const coreTask = mgr.getTask('t8-x')!;
+      expect(coreTask.abortController).toBe(ac);
+      // The PUBLIC view MUST NOT expose it.
+      const list = agent.tasks.list();
+      expect(list.length).toBeGreaterThanOrEqual(1);
+      const view = list.find((v) => v.id === 't8-x')!;
+      expect(view).toBeDefined();
+      expect(Object.keys(view)).not.toContain('abortController');
+      expect('abortController' in view).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('T9 direct-construction undefined-safe: when getManager returns undefined every method is a no-op ([], undefined, false, 0) and none throw @requirement:REQ-003 @scenario:undefined-safe @given:a TasksControl constructed with getManager: () => undefined (a REAL closure, not a spy) @when:list/listRunning/get/cancel/cancelAllRunning are called @then:list() === [], listRunning() === [], get("x") === undefined, cancel("x") === false, cancelAllRunning() === 0, and no call throws', async () => {
+    // Dynamic import keeps the file parseable at RED (before P08 creates the
+    // module). The public-harness positives (T7/T8/T10) drive the behavioral
+    // RED; this test's RED failure is an isolated module-resolution error.
+    const { TasksControl } = await import('../control/tasksControl.js');
+    const control = new TasksControl({ getManager: () => undefined });
+    expect(control.list()).toStrictEqual([]);
+    expect(control.listRunning()).toStrictEqual([]);
+    expect(control.get('x')).toBeUndefined();
+    expect(control.cancel('x')).toBe(false);
+    expect(control.cancelAllRunning()).toBe(0);
+  });
+
+  it('T10 list/listRunning/get/cancel fidelity over a mix of running, completed, and cancelled tasks @requirement:REQ-003 @scenario:fidelity @given:a real manager seeded with 2 running tasks where 1 is then completed @when:list/listRunning/get(knownId)/get(missing)/cancel(knownId)/cancel(missing) are called @then:list() length === 2 (both tasks remain in history); listRunning() length === 1; get(knownId) returns the projected view with matching id; get(missing) === undefined; cancel(knownId) === true; cancel(missing) === false', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      const mgr = agent.getConfig().getAsyncTaskManager()!;
+      mgr.registerTask({
+        id: 't10-run',
+        subagentName: 's',
+        goalPrompt: 'g',
+        abortController: new AbortController(),
+      });
+      mgr.registerTask({
+        id: 't10-done',
+        subagentName: 's',
+        goalPrompt: 'g',
+        abortController: new AbortController(),
+      });
+      // Complete one task: it leaves the running set but stays in history.
+      expect(
+        mgr.completeTask('t10-done', { result: 'ok' } as never),
+      ).toBe(true);
+      // list() reflects ALL tasks (both remain in history).
+      const all = agent.tasks.list();
+      expect(all).toHaveLength(2);
+      // listRunning() reflects ONLY the still-running task.
+      const running = agent.tasks.listRunning();
+      expect(running).toHaveLength(1);
+      expect(running[0].id).toBe('t10-run');
+      // get(knownId) returns the projected view with the matching id.
+      const known = agent.tasks.get('t10-done');
+      expect(known).toBeDefined();
+      expect(known!.id).toBe('t10-done');
+      // The projected view never leaks abortController.
+      expect('abortController' in known!).toBe(false);
+      // get(missing) === undefined.
+      expect(agent.tasks.get('does-not-exist')).toBeUndefined();
+      // cancel(knownId running) === true.
+      expect(agent.tasks.cancel('t10-run')).toBe(true);
+      // cancel(missing) === false.
+      expect(agent.tasks.cancel('does-not-exist')).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('PROP projection fidelity: for a generated list of N (1..5) running tasks, list() length === N, the id set matches, and NO view has an abortController key @requirement:REQ-003 @scenario:property-projection-fidelity @given:a generated list of N running tasks with random ids and goalPrompts seeded on the real manager @when:agent.tasks.list() @then:list() length === N; the set of view ids === the set of seeded ids; and no returned view has an abortController key', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uniqueArray(
+          fc.record({
+            id: fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')),
+            goalPrompt: fc.string(),
+          }),
+          { minLength: 1, maxLength: 5, selector: (r) => r.id },
+        ),
+        async (tasks) => {
+          const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+          try {
+            const mgr = agent.getConfig().getAsyncTaskManager()!;
+            for (const t of tasks) {
+              mgr.registerTask({
+                id: t.id,
+                subagentName: 's',
+                goalPrompt: t.goalPrompt,
+                abortController: new AbortController(),
+              });
+            }
+            const views = agent.tasks.list();
+            // MIN-2 distinct cases are exercised by the generator (1..5 tasks).
+            expect(views).toHaveLength(tasks.length);
+            const viewIds = new Set(views.map((v) => v.id));
+            for (const t of tasks) {
+              expect(viewIds.has(t.id)).toBe(true);
+            }
+            // REQ-003.7: no projected view leaks abortController.
+            for (const v of views) {
+              expect('abortController' in v).toBe(false);
+              expect(Object.keys(v)).not.toContain('abortController');
+            }
+          } finally {
+            await cleanup();
+          }
+        },
+      ),
+    );
+  });
+
+  it('PROP cancelAllRunning count: for a generated N (0..5) running tasks, cancelAllRunning() === N and listRunning() afterwards is empty @requirement:REQ-003 @scenario:property-cancel-count @given:a generated N (0..5) running tasks seeded on the real manager @when:agent.tasks.cancelAllRunning() is called @then:the returned count === N AND a subsequent agent.tasks.listRunning() has length 0', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 0, max: 5 }),
+        fc.uniqueArray(
+          fc.string({ minLength: 1 }).filter((s) => !s.includes(' ')),
+          { minLength: 0, maxLength: 5 },
+        ),
+        async (n, ids) => {
+          const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+          try {
+            const mgr = agent.getConfig().getAsyncTaskManager()!;
+            // Use exactly n ids from the generated pool (trim/pad not needed —
+            // uniqueArray with minLength:0, maxLength:5 yields distinct ids).
+            const chosen = ids.slice(0, n);
+            while (chosen.length < n) {
+              chosen.push(`prop-cancel-pad-${chosen.length}`);
+            }
+            for (const id of chosen) {
+              mgr.registerTask({
+                id,
+                subagentName: 's',
+                goalPrompt: 'g',
+                abortController: new AbortController(),
+              });
+            }
+            expect(agent.tasks.listRunning()).toHaveLength(n);
+            const cancelled = agent.tasks.cancelAllRunning();
+            // MIN-2 distinct cases are exercised by the generator (0..5).
+            expect(cancelled).toBe(n);
+            expect(agent.tasks.listRunning()).toHaveLength(0);
+          } finally {
+            await cleanup();
+          }
+        },
+      ),
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P15
+ * @requirement:REQ-007
+ *
+ * Behavioral RED suite for the NEW built-in tool-key control
+ * (`agent.tools.keys`), DISTINCT from `agent.auth.keys` (R-KEYS-DISTINCT).
+ * Backed by a REAL hermetic `ToolKeyStorage` over a temp dir + a real
+ * Map-backed `KeyringAdapter` (no spies/stubs). Raw key material never crosses
+ * the API boundary (R-NO-RAW-SECRETS).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import fc from 'fast-check';
+import { ToolKeyStorage } from '@vybestack/llxprt-code-core';
+import { buildAgent } from './helpers/agentHarness.js';
+
+// A real Map-backed KeyringAdapter (structural type — NOT a spy/stub).
+function memoryKeyring() {
+  const store = new Map<string, string>();
+  return {
+    getPassword: async (service: string, account: string) =>
+      store.get(`${service}:${account}`) ?? null,
+    setPassword: async (service: string, account: string, password: string) => {
+      store.set(`${service}:${account}`, password);
+    },
+    deletePassword: async (service: string, account: string) =>
+      store.delete(`${service}:${account}`),
+  };
+}
+
+async function hermeticStorage(): Promise<{
+  storage: ToolKeyStorage;
+  dir: string;
+}> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'toolkeys-behavior-'));
+  const storage = new ToolKeyStorage({
+    toolsDir: dir,
+    keyringLoader: async () => memoryKeyring(),
+  });
+  return { storage, dir };
+}
+
+async function makeKeys() {
+  const { storage, dir } = await hermeticStorage();
+  const { ToolKeysControl } = await import('../control/toolKeysControl.js');
+  const keys = new ToolKeysControl({ getStorage: () => storage });
+  return { keys, dir };
+}
+
+describe('agent.tools.keys — built-in tool-key control (REQ-007)', () => {
+  let dir: string | undefined;
+  afterEach(async () => {
+    if (dir !== undefined) {
+      await fs.rm(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  // T17a — supported() projects the static registry.
+  it('supported() includes the exa entry with toolName, displayName, description', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    const entries = keys.supported();
+    const exa = entries.find((e) => e.toolName === 'exa');
+    expect(exa).toBeDefined();
+    expect(typeof exa!.displayName).toBe('string');
+    expect(exa!.displayName.length).toBeGreaterThan(0);
+    expect(typeof exa!.description).toBe('string');
+  });
+
+  // T18 — status() masks a length>8 key and never leaks the raw key.
+  it('status() returns a masked key (len>8) and never the raw key', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    await keys.save('exa', 'abcd1234efgh');
+    const status = await keys.status('exa');
+    expect(status).toStrictEqual({
+      toolName: 'exa',
+      hasKey: true,
+      maskedKey: 'ab********gh',
+    });
+    expect(JSON.stringify(status)).not.toContain('abcd1234efgh');
+    const keyNames = Object.keys(status);
+    expect(keyNames).not.toContain('rawKey');
+    expect(keyNames).not.toContain('key');
+    expect(keyNames).not.toContain('access_token');
+  });
+
+  // T18a — status() fully masks a short key (len<=8).
+  it('status() fully masks a short key (len<=8)', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    await keys.save('exa', 'short');
+    const status = await keys.status('exa');
+    expect(status.maskedKey).toBe('*****');
+    expect(status.maskedKey).not.toBe('short');
+  });
+
+  // T18b — an invalid tool name rejects (storage assertValidToolName propagates).
+  it('save() with an unregistered tool name rejects (throw propagates)', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    await expect(keys.save('not-a-tool', 'k')).rejects.toThrow(
+      'Invalid tool key name',
+    );
+  });
+
+  it('status() with an unregistered tool name rejects (throw propagates)', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    await expect(keys.status('not-a-tool')).rejects.toThrow(
+      'Invalid tool key name',
+    );
+  });
+
+  // T18c — no key, no keyfile → { toolName, hasKey:false } only.
+  it('status() with no key and no keyfile omits maskedKey', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    const status = await keys.status('exa');
+    expect(status).toStrictEqual({ toolName: 'exa', hasKey: false });
+    expect(Object.keys(status)).not.toContain('maskedKey');
+  });
+
+  // T18d — keyfile round-trip; status carries keyFile when configured.
+  it('setKeyFile/getKeyFile round-trips set, clear, and surfaces keyFile in status', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    await keys.setKeyFile('exa', '/tmp/exa.key');
+    expect(await keys.getKeyFile('exa')).toBe('/tmp/exa.key');
+    const status = await keys.status('exa');
+    expect(status.toolName).toBe('exa');
+    expect(status.hasKey).toBe(false);
+    expect(status.keyFile).toBe('/tmp/exa.key');
+    await keys.setKeyFile('exa', null);
+    expect(await keys.getKeyFile('exa')).toBe(null);
+  });
+
+  // T19 — the PUBLIC agent exposes agent.tools.keys DISTINCT from agent.auth.keys.
+  it('agent.tools.keys is exposed on the public agent and distinct from agent.auth.keys', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      const supportedNames = agent.tools.keys
+        .supported()
+        .map((e) => e.toolName);
+      expect(supportedNames).toContain('exa');
+      expect(agent.tools.keys !== agent.auth.keys).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // PROP — save/delete round-trip over real storage.
+  it('save then delete round-trips hasKey true then false (property)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1 }).filter((s) => s.length > 0),
+        async (key) => {
+          const { keys, dir: d } = await makeKeys();
+          await keys.save('exa', key);
+          expect((await keys.status('exa')).hasKey).toBe(true);
+          await keys.delete('exa');
+          expect((await keys.status('exa')).hasKey).toBe(false);
+          await fs.rm(d, { recursive: true, force: true });
+        },
+      ),
+      { numRuns: 8 },
+    );
+  });
+
+  // PROP — mask no-leak for length>8 keys.
+  it('mask never leaks the raw key for length>8 keys (property)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .string({ minLength: 9, maxLength: 40 })
+          .filter((s) => !s.includes('*') && s.length > 8),
+        async (key) => {
+          const { keys, dir: d } = await makeKeys();
+          await keys.save('exa', key);
+          const status = await keys.status('exa');
+          expect(status.maskedKey?.length).toBe(key.length);
+          expect(status.maskedKey?.startsWith(key.slice(0, 2))).toBe(true);
+          expect(status.maskedKey?.endsWith(key.slice(-2))).toBe(true);
+          expect(status.maskedKey).not.toBe(key);
+          // The raw key must not appear within the masked value.
+          expect(status.maskedKey).not.toContain(key);
+          await fs.rm(d, { recursive: true, force: true });
+        },
+      ),
+      { numRuns: 8 },
+    );
+  });
+
+  // PROP — mask fully masks length<=8 keys.
+  it('mask fully masks length<=8 keys (property)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .string({ minLength: 1, maxLength: 8 })
+          .filter((s) => !s.includes('*')),
+        async (key) => {
+          const { keys, dir: d } = await makeKeys();
+          await keys.save('exa', key);
+          const status = await keys.status('exa');
+          expect(status.maskedKey).toBe('*'.repeat(key.length));
+          expect(status.maskedKey).not.toBe(key);
+          // The raw key must not appear within the masked value.
+          expect(status.maskedKey).not.toContain(key);
+          await fs.rm(d, { recursive: true, force: true });
+        },
+      ),
+      { numRuns: 8 },
+    );
+  });
+
+  // PROP — supported() is a registry projection invariant.
+  it('supported() projects every registry name with toolName+displayName (property)', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    await fc.assert(
+      fc.asyncProperty(fc.constant(null), async () => {
+        const entries = keys.supported();
+        for (const e of entries) {
+          expect(typeof e.toolName).toBe('string');
+          expect(e.toolName.length).toBeGreaterThan(0);
+          expect(typeof e.displayName).toBe('string');
+          expect(e.displayName.length).toBeGreaterThan(0);
+        }
+      }),
+      { numRuns: 5 },
+    );
+  });
+});

--- a/packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
@@ -145,6 +145,26 @@ describe('agent.tools.keys — built-in tool-key control (REQ-007)', () => {
     expect(await keys.getKeyFile('exa')).toBe(null);
   });
 
+  // T20 — status() carries keyFile ALONGSIDE a masked key (the hasKey:TRUE
+  // + keyFile branch at toolKeysControl.ts L79). T18d sets a keyFile but NO
+  // key, so it exercises only the hasKey:FALSE branch (L85). This block sets
+  // BOTH a real key AND a keyFile so the L79 spread `...(keyFile !== null ?
+  // { keyFile } : {})` is covered, and asserts the { keyFile } ObjectLiteral
+  // is non-vacuous (no raw key leak through either field).
+  it('status() carries keyFile alongside a masked key (hasKey:true branch)', async () => {
+    const { keys, dir: d } = await makeKeys();
+    dir = d;
+    await keys.save('exa', 'abcd1234efgh');
+    await keys.setKeyFile('exa', '/tmp/exa-combined.key');
+    const status = await keys.status('exa');
+    expect(status.hasKey).toBe(true);
+    expect(status.maskedKey).toBe('ab********gh');
+    expect(status.keyFile).toBe('/tmp/exa-combined.key');
+    expect('keyFile' in status).toBe(true);
+    // No raw key material leaks through EITHER field.
+    expect(JSON.stringify(status)).not.toContain('abcd1234efgh');
+  });
+
   // T19 — the PUBLIC agent exposes agent.tools.keys DISTINCT from agent.auth.keys.
   it('agent.tools.keys is exposed on the public agent and distinct from agent.auth.keys', async () => {
     const { agent, cleanup } = await buildAgent('plain-text.jsonl');

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -166,6 +166,22 @@ export interface AuthBucket {
   readonly active: boolean;
 }
 
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+export interface AuthProviderDetail {
+  readonly provider: string;
+  readonly authenticated: boolean;
+  readonly oauthEnabled: boolean;
+  readonly expiry?: number;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+export interface AuthBucketStatus {
+  readonly bucket: string;
+  readonly authenticated: boolean;
+  readonly expiry?: number;
+  readonly isSessionBucket: boolean;
+}
+
 export interface KeyInfo {
   readonly name: string;
   readonly provider?: string;
@@ -275,6 +291,10 @@ export interface AgentAuthControl {
     baseUrl: string | null,
     opts?: { readonly provider?: string },
   ): Promise<void>;
+  // @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+  detailedStatus(provider: string): Promise<AuthProviderDetail>;
+  getHigherPriorityAuth(provider: string): Promise<string | null>;
+  listBucketStatuses(provider: string): Promise<readonly AuthBucketStatus[]>;
 }
 
 export interface AgentIdeControl {

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -18,6 +18,7 @@ import type {
   HookOutput,
 } from '@vybestack/llxprt-code-core/hooks/types.js';
 import type { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
+import type { PolicyDecision } from '@vybestack/llxprt-code-core';
 import type { EditorCallbacks } from './config-types.js';
 import type {
   AgentEvent,
@@ -320,6 +321,31 @@ export interface AgentHookControl {
   clear(): void;
 }
 
+/**
+ * Read-only projection of a policy rule (REQ-002.1). `argsPattern` is the
+ * RegExp source STRING (JSON-safe), never a RegExp.
+ * @plan:PLAN-20260622-COREAPIGAP.P06
+ * @requirement:REQ-002
+ */
+export interface PolicyRuleView {
+  readonly priority?: number;
+  readonly toolName?: string;
+  readonly decision: PolicyDecision;
+  readonly argsPattern?: string;
+  readonly source?: string;
+}
+
+/**
+ * Read-only inspection of the engine policy (REQ-002).
+ * @plan:PLAN-20260622-COREAPIGAP.P06
+ * @requirement:REQ-002
+ */
+export interface AgentPolicyControl {
+  getRules(): readonly PolicyRuleView[];
+  getDefaultDecision(): PolicyDecision;
+  isNonInteractive(): boolean;
+}
+
 export interface Agent {
   chat(input: AgentInput, opts?: TurnOptions): Promise<AgentResult>;
   stream(input: AgentInput, opts?: TurnOptions): AsyncIterable<AgentEvent>;
@@ -368,6 +394,7 @@ export interface Agent {
   readonly ide: AgentIdeControl;
   readonly session: AgentSessionControl;
   readonly hooks: AgentHookControl;
+  readonly policy: AgentPolicyControl;
 
   getHistory(): Promise<readonly AgentMessage[]>;
   setHistory(

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -159,6 +159,46 @@ export interface McpStatus {
   readonly servers: readonly McpServerInfo[];
 }
 
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpDetailsOptions {
+  readonly includeTools?: boolean;
+  readonly includePrompts?: boolean;
+  readonly includeResources?: boolean;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpPromptInfo {
+  readonly name: string;
+  readonly description?: string;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpResourceInfo {
+  readonly name?: string;
+  readonly uri: string;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpBlockedServer {
+  readonly name: string;
+  readonly extensionName: string;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpServerDetail {
+  readonly name: string;
+  readonly authenticated: boolean;
+  readonly tools?: readonly ToolInfo[];
+  readonly prompts?: readonly McpPromptInfo[];
+  readonly resources?: readonly McpResourceInfo[];
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpDetailStatus {
+  readonly servers: readonly McpServerDetail[];
+  readonly blockedServers: readonly McpBlockedServer[];
+}
+
 export interface AuthBucket {
   readonly name: string;
   readonly provider?: string;
@@ -253,6 +293,10 @@ export interface AgentMcpControl {
   auth(server: string): Promise<McpServerAuthStatus>;
   discoveryState(): McpDiscoveryState;
   refresh(server?: string): Promise<void>;
+  // @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+  authenticate(server: string): Promise<McpServerAuthStatus>;
+  // @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+  details(opts?: McpDetailsOptions): Promise<McpDetailStatus>;
 }
 
 export interface AgentAuthKeysControl {

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -346,6 +346,35 @@ export interface AgentPolicyControl {
   isNonInteractive(): boolean;
 }
 
+/**
+ * Projected public view of an async task. OMITS abortController and any
+ * non-serializable internal (REQ-003.7).
+ * @plan:PLAN-20260622-COREAPIGAP.P08
+ * @requirement:REQ-003
+ */
+export interface AgentTaskInfo {
+  readonly id: string;
+  readonly subagentName: string;
+  readonly goalPrompt: string;
+  readonly status: 'running' | 'completed' | 'failed' | 'cancelled';
+  readonly launchedAt: number;
+  readonly completedAt?: number;
+  readonly error?: string;
+}
+
+/**
+ * Undefined-safe async-task administration (REQ-003).
+ * @plan:PLAN-20260622-COREAPIGAP.P08
+ * @requirement:REQ-003
+ */
+export interface AgentTasksControl {
+  list(): readonly AgentTaskInfo[];
+  listRunning(): readonly AgentTaskInfo[];
+  get(id: string): AgentTaskInfo | undefined;
+  cancel(id: string): boolean;
+  cancelAllRunning(): number;
+}
+
 export interface Agent {
   chat(input: AgentInput, opts?: TurnOptions): Promise<AgentResult>;
   stream(input: AgentInput, opts?: TurnOptions): AsyncIterable<AgentEvent>;
@@ -395,6 +424,8 @@ export interface Agent {
   readonly session: AgentSessionControl;
   readonly hooks: AgentHookControl;
   readonly policy: AgentPolicyControl;
+  /** @plan:PLAN-20260622-COREAPIGAP.P08 @requirement:REQ-003 */
+  readonly tasks: AgentTasksControl;
 
   getHistory(): Promise<readonly AgentMessage[]>;
   setHistory(

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -277,6 +277,31 @@ export interface HookExecutionResponse {
   readonly output: HookOutput;
 }
 
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+export interface ToolKeyInfo {
+  readonly toolName: string;
+  readonly displayName: string;
+  readonly description?: string;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+export interface ToolKeyStatus {
+  readonly toolName: string;
+  readonly hasKey: boolean;
+  readonly maskedKey?: string;
+  readonly keyFile?: string;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+export interface AgentToolKeyControl {
+  supported(): readonly ToolKeyInfo[];
+  status(toolName: string): Promise<ToolKeyStatus>;
+  save(toolName: string, key: string): Promise<void>;
+  delete(toolName: string): Promise<void>;
+  setKeyFile(toolName: string, path: string | null): Promise<void>;
+  getKeyFile(toolName: string): Promise<string | null>;
+}
+
 export interface AgentToolControl {
   list(): readonly ToolInfo[];
   setEnabled(names: readonly string[]): Promise<void>;
@@ -284,6 +309,8 @@ export interface AgentToolControl {
   respondToConfirmation(confirmationId: string, decision: ToolDecision): void;
   onToolUpdate(cb: (u: ToolUpdate) => void): Unsubscribe;
   setEditorCallbacks(cbs: EditorCallbacks): void;
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+  readonly keys: AgentToolKeyControl;
 }
 
 export interface AgentMcpControl {

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -331,6 +331,19 @@ export interface Agent {
   setModel(model: string): Promise<void>;
   getCurrentSequenceModel(): string | null;
   /**
+   * Reads the live approval mode from the bound Config (no caching).
+   * @plan:PLAN-20260622-COREAPIGAP.P04
+   * @requirement:REQ-001
+   */
+  getApprovalMode(): ApprovalMode;
+  /**
+   * Sets the approval mode via the bound Config. Delegates directly: the
+   * untrusted-folder guard throw (config.ts:404) propagates unchanged.
+   * @plan:PLAN-20260622-COREAPIGAP.P04
+   * @requirement:REQ-001
+   */
+  setApprovalMode(mode: ApprovalMode): void;
+  /**
    * Returns the bound runtime-context runtimeId (REQ-005.1).
    * @plan:PLAN-20260621-COREAPIREMED.P18
    * @requirement:REQ-005

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -319,6 +319,25 @@ export interface AgentHookControl {
   triggerSessionStart(): Promise<void>;
   triggerSessionEnd(): Promise<void>;
   clear(): void;
+  // @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004
+  listHooks(): readonly HookInfo[];
+  getDisabledHooks(): readonly string[];
+  setDisabledHooks(names: readonly string[]): void;
+  enable(name: string): void;
+  disable(name: string): void;
+}
+
+/**
+ * Projected public view of a registered hook (REQ-004.1). Mirrors a live
+ * HookRegistryEntry's identifying fields without exposing the engine type.
+ * @plan:PLAN-20260622-COREAPIGAP.P10
+ * @requirement:REQ-004
+ */
+export interface HookInfo {
+  readonly name: string;
+  readonly eventName: string;
+  readonly enabled: boolean;
+  readonly source?: string;
 }
 
 /**

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -472,6 +472,8 @@ export class AgentImpl implements Agent {
         }
       },
       keysDeps,
+      // @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+      getOAuthManager: () => this.deps.oauthManager,
     });
   }
 

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -60,6 +60,8 @@ import { HookControl } from './control/hooks.js';
 import type { HookControlDeps } from './control/hooks.js';
 import { PolicyControl } from './control/policyControl.js';
 import type { PolicyControlDeps } from './control/policyControl.js';
+import { TasksControl } from './control/tasksControl.js';
+import type { TasksControlDeps } from './control/tasksControl.js';
 import { SessionControl } from './control/sessionControl.js';
 import type { SessionControlDeps } from './control/sessionControl.js';
 import { ProfilesControl } from './control/profilesControl.js';
@@ -201,6 +203,8 @@ export class AgentImpl implements Agent {
   readonly session: SessionControl;
   readonly hooks: HookControl;
   readonly policy: PolicyControl;
+  /** @plan:PLAN-20260622-COREAPIGAP.P08 @requirement:REQ-003 */
+  readonly tasks: TasksControl;
 
   /** @pseudocode createAgent.md steps 150-160 */
   readonly ownership: OwnershipRecord;
@@ -334,6 +338,7 @@ export class AgentImpl implements Agent {
     this.session = this.buildSessionControl();
     this.hooks = this.buildHookControl();
     this.policy = this.buildPolicyControl();
+    this.tasks = this.buildTasksControl();
   }
 
   /**
@@ -511,6 +516,17 @@ export class AgentImpl implements Agent {
       getEngine: () => this.deps.config.getPolicyEngine(),
     };
     return new PolicyControl(policyDeps);
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P08
+   * @requirement:REQ-003
+   */
+  private buildTasksControl(): TasksControl {
+    const tasksDeps: TasksControlDeps = {
+      getManager: () => this.deps.config.getAsyncTaskManager(),
+    };
+    return new TasksControl(tasksDeps);
   }
 
   /**

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -21,7 +21,10 @@ import type { AgentClientContract } from '@vybestack/llxprt-code-core/core/clien
 import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
 import { getResponseText } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 import { uiTelemetryService } from '@vybestack/llxprt-code-core/telemetry/uiTelemetry.js';
-import type { ApprovalMode, RuntimeProviderManager } from '@vybestack/llxprt-code-core';
+import type {
+  ApprovalMode,
+  RuntimeProviderManager,
+} from '@vybestack/llxprt-code-core';
 import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
 import {
   switchActiveProvider,
@@ -53,6 +56,8 @@ import { ToolControl } from './control/toolControl.js';
 import type { ToolControlDeps } from './control/toolControl.js';
 import { McpControl } from './control/mcpControl.js';
 import type { McpControlDeps } from './control/mcpControl.js';
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+import { buildMcpControlDeps } from './control/mcpControlWiring.js';
 import { AuthControl } from './control/authControl.js';
 import { IdeControl } from './control/ideControl.js';
 import type { IdeControlDeps } from './control/ideControl.js';
@@ -485,11 +490,12 @@ export class AgentImpl implements Agent {
    * @requirement:REQ-013
    */
   private buildMcpControl(): McpControl {
-    const mcpDeps: McpControlDeps = {
+    // @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 @pseudocode Dependencies/buildMcpControl
+    const mcpDeps: McpControlDeps = buildMcpControlDeps({
+      config: this.deps.config,
       isMcpAuthenticated: (server) => this.authState.mcpAuth.has(server),
-      getManager: () => this.deps.config.getMcpClientManager(),
-      getToolRegistry: () => this.deps.config.getToolRegistry(),
-    };
+      resolveClient: () => this.deps.resolveClient(),
+    });
     return new McpControl(mcpDeps);
   }
 

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -498,6 +498,9 @@ export class AgentImpl implements Agent {
     const mcpDeps: McpControlDeps = buildMcpControlDeps({
       config: this.deps.config,
       isMcpAuthenticated: (server) => this.authState.mcpAuth.has(server),
+      markAuthenticated: (server) => {
+        this.authState.mcpAuth.add(server);
+      },
       resolveClient: () => this.deps.resolveClient(),
     });
     return new McpControl(mcpDeps);

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -58,6 +58,8 @@ import { IdeControl } from './control/ideControl.js';
 import type { IdeControlDeps } from './control/ideControl.js';
 import { HookControl } from './control/hooks.js';
 import type { HookControlDeps } from './control/hooks.js';
+import { PolicyControl } from './control/policyControl.js';
+import type { PolicyControlDeps } from './control/policyControl.js';
 import { SessionControl } from './control/sessionControl.js';
 import type { SessionControlDeps } from './control/sessionControl.js';
 import { ProfilesControl } from './control/profilesControl.js';
@@ -198,6 +200,7 @@ export class AgentImpl implements Agent {
   readonly ide: IdeControl;
   readonly session: SessionControl;
   readonly hooks: HookControl;
+  readonly policy: PolicyControl;
 
   /** @pseudocode createAgent.md steps 150-160 */
   readonly ownership: OwnershipRecord;
@@ -330,6 +333,7 @@ export class AgentImpl implements Agent {
     this.ide = this.buildIdeControl();
     this.session = this.buildSessionControl();
     this.hooks = this.buildHookControl();
+    this.policy = this.buildPolicyControl();
   }
 
   /**
@@ -496,6 +500,17 @@ export class AgentImpl implements Agent {
       getEditorCallbacks: () => this.editorCallbacksHolder.editorCallbacks,
     };
     return new IdeControl(ideDeps);
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P06
+   * @requirement:REQ-002
+   */
+  private buildPolicyControl(): PolicyControl {
+    const policyDeps: PolicyControlDeps = {
+      getEngine: () => this.deps.config.getPolicyEngine(),
+    };
+    return new PolicyControl(policyDeps);
   }
 
   /**

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -21,7 +21,7 @@ import type { AgentClientContract } from '@vybestack/llxprt-code-core/core/clien
 import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
 import { getResponseText } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 import { uiTelemetryService } from '@vybestack/llxprt-code-core/telemetry/uiTelemetry.js';
-import type { RuntimeProviderManager } from '@vybestack/llxprt-code-core';
+import type { ApprovalMode, RuntimeProviderManager } from '@vybestack/llxprt-code-core';
 import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
 import {
   switchActiveProvider,
@@ -735,6 +735,24 @@ export class AgentImpl implements Agent {
   /** @plan:PLAN-20260621-COREAPIREMED.P12 @requirement:REQ-002 @pseudocode lines 40-42 */
   getEphemeralSettings(): Readonly<Record<string, unknown>> {
     return this.deps.config.getEphemeralSettings();
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P04
+   * @requirement:REQ-001
+   * @pseudocode lines 1-4
+   */
+  getApprovalMode(): ApprovalMode {
+    return this.deps.config.getApprovalMode();
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P04
+   * @requirement:REQ-001
+   * @pseudocode lines 10-17
+   */
+  setApprovalMode(mode: ApprovalMode): void {
+    this.deps.config.setApprovalMode(mode);
   }
 
   /**

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -25,6 +25,8 @@ import type {
   ApprovalMode,
   RuntimeProviderManager,
 } from '@vybestack/llxprt-code-core';
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+import { getToolKeyStorage } from '@vybestack/llxprt-code-core';
 import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
 import {
   switchActiveProvider,
@@ -322,6 +324,8 @@ export class AgentImpl implements Agent {
       messageBus: deps.messageBus,
       config: deps.config,
       editorCallbacksHolder: this.editorCallbacksHolder,
+      // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+      keysDeps: { getStorage: () => getToolKeyStorage() },
     };
     this.tools = new ToolControl(toolControlDeps);
     this.profiles = new ProfilesControl({

--- a/packages/agents/src/api/control/authControl.ts
+++ b/packages/agents/src/api/control/authControl.ts
@@ -17,12 +17,15 @@ import type {
   AgentAuthControl,
   AgentAuthKeysControl,
   AuthBucket,
+  AuthBucketStatus,
+  AuthProviderDetail,
   AuthStatus,
 } from '../agent.js';
 import type { OAuthPromptHandler } from '../config-types.js';
 import type { AgentAuthState } from './authState.js';
 import { AuthKeysControl } from './authKeysControl.js';
 import type { AuthKeysControlDeps } from './authKeysControl.js';
+import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
 
 /**
  * Callback bundle injected by AgentImpl so AuthControl can read/mutate the
@@ -52,6 +55,9 @@ export interface AuthControlDeps {
   readonly setBaseUrl: (baseUrl: string | null) => Promise<void>;
   /** The deps bundle for the constructed AuthKeysControl. */
   readonly keysDeps: AuthKeysControlDeps;
+  // @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+  /** Resolves the live OAuthManager (already on AgentDeps). Never cached. */
+  readonly getOAuthManager: () => OAuthManager;
 }
 
 /**
@@ -249,5 +255,58 @@ export class AuthControl implements AgentAuthControl {
       active: true,
     };
     this.deps.authState.buckets.set(provider, [defaultBucket]);
+  }
+
+  /**
+   * Masked detailed auth state: authenticated + oauthEnabled + (gated) expiry.
+   * Reads expiry ONLY from peekStoredToken (no refresh) and ONLY when
+   * authenticated is true. NEVER copies the token secret strings (R-NO-RAW-SECRETS).
+   * @plan:PLAN-20260622-COREAPIGAP.P12
+   * @requirement:REQ-005
+   * @pseudocode lines 1-17
+   */
+  async detailedStatus(provider: string): Promise<AuthProviderDetail> {
+    const mgr = this.deps.getOAuthManager();
+    const oauthEnabled = mgr.isOAuthEnabled(provider);
+    const authenticated = await mgr.isAuthenticated(provider);
+    let expiry: number | undefined;
+    if (authenticated) {
+      const token = await mgr.peekStoredToken(provider);
+      if (token !== null) {
+        expiry = token.expiry;
+      }
+    }
+    return { provider, authenticated, oauthEnabled, expiry };
+  }
+
+  /**
+   * Read-through for the name of a higher-priority auth source (or null).
+   * Returns a source NAME, never a secret.
+   * @plan:PLAN-20260622-COREAPIGAP.P12
+   * @requirement:REQ-005
+   * @pseudocode lines 30-33
+   */
+  async getHigherPriorityAuth(provider: string): Promise<string | null> {
+    return this.deps.getOAuthManager().getHigherPriorityAuth(provider);
+  }
+
+  /**
+   * Projects per-bucket auth status to the four public fields only.
+   * @plan:PLAN-20260622-COREAPIGAP.P12
+   * @requirement:REQ-005
+   * @pseudocode lines 40-49
+   */
+  async listBucketStatuses(
+    provider: string,
+  ): Promise<readonly AuthBucketStatus[]> {
+    const raw = await this.deps
+      .getOAuthManager()
+      .getAuthStatusWithBuckets(provider);
+    return raw.map((b) => ({
+      bucket: b.bucket,
+      authenticated: b.authenticated,
+      expiry: b.expiry,
+      isSessionBucket: b.isSessionBucket,
+    }));
   }
 }

--- a/packages/agents/src/api/control/hooks.ts
+++ b/packages/agents/src/api/control/hooks.ts
@@ -48,6 +48,7 @@ import type {
   AgentHookControl,
   HookExecutionRequest,
   HookExecutionResponse,
+  HookInfo,
   Unsubscribe,
 } from '../agent.js';
 
@@ -166,6 +167,53 @@ export class HookControl implements AgentHookControl {
   clear(): void {
     this.observers.clear();
     this.pendingByCorrelation.clear();
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 1-19
+   */
+  listHooks(): readonly HookInfo[] {
+    const system = this.deps.config.getHookSystem();
+    if (!system) return [];
+    if (!system.isInitialized()) return [];
+    const registry = system.getRegistry();
+    return registry.getAllHooks().map((entry) => ({
+      name: registry.getHookName(entry),
+      eventName: String(entry.eventName),
+      enabled: entry.enabled,
+      source: String(entry.source),
+    }));
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 30-32
+   */
+  getDisabledHooks(): readonly string[] {
+    return [...this.deps.config.getDisabledHooks()];
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 40-42
+   */
+  setDisabledHooks(names: readonly string[]): void {
+    this.deps.config.setDisabledHooks([...names]);
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 50-54
+   */
+  disable(name: string): void {
+    const current = this.deps.config.getDisabledHooks();
+    if (current.includes(name)) return;
+    this.deps.config.setDisabledHooks([...current, name]);
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 57-61
+   */
+  enable(name: string): void {
+    const current = this.deps.config.getDisabledHooks();
+    this.deps.config.setDisabledHooks(current.filter((n) => n !== name));
   }
 
   /**

--- a/packages/agents/src/api/control/mcpControl.ts
+++ b/packages/agents/src/api/control/mcpControl.ts
@@ -71,6 +71,15 @@ export interface McpResourceRegistryView {
 export interface McpControlDeps {
   /** Returns true when the named server was authenticated via mcpLogin. */
   readonly isMcpAuthenticated: (server: string) => boolean;
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+   * Records the named server as authenticated in the SAME per-agent auth marker
+   * `isMcpAuthenticated` reads (the one `auth.mcpLogin` populates), so a
+   * successful `authenticate(server)` reconciles with a later
+   * `auth(server)` / `details()` read. Optional + undefined-safe: when absent
+   * (or the manager path is a no-op) the control simply does not record.
+   */
+  readonly markAuthenticated?: (server: string) => void;
   /** Resolves the live McpClientManager (undefined before initialize). */
   readonly getManager: () => McpClientManager | undefined;
   /** Resolves the live tool registry view for discovered-tool projection. */
@@ -321,6 +330,9 @@ export class McpControl implements AgentMcpControl {
     if (this.deps?.refreshClientTools !== undefined) {
       await this.deps.refreshClientTools();
     }
+    // Reconcile the per-agent auth marker so a later auth(server) / details()
+    // read agrees with this success (undefined-safe when no writer is wired).
+    this.deps?.markAuthenticated?.(server);
     return { server, authenticated: true, requiresAuth: true };
   }
 
@@ -337,6 +349,12 @@ export class McpControl implements AgentMcpControl {
     const includeTools = opts?.includeTools ?? true;
     const includePrompts = opts?.includePrompts ?? false;
     const includeResources = opts?.includeResources ?? false;
+    // details() projects the CONFIGURED server set (getServerConfigs ->
+    // config.getMcpServers()), mirroring the CLI `/mcp list` which lists
+    // configured + blocked servers. This intentionally differs from
+    // listServers(), which projects the LIVE discovered set
+    // (manager.getMcpServers()); a configured server absent from the live
+    // manager still appears here.
     const configs = this.deps?.getServerConfigs?.() ?? {};
     const toolsByServer = this.toolsByServer();
     const resourcesAll = includeResources

--- a/packages/agents/src/api/control/mcpControl.ts
+++ b/packages/agents/src/api/control/mcpControl.ts
@@ -4,6 +4,10 @@
  */
 
 import type { McpClientManager } from '@vybestack/llxprt-code-core';
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+import type { MCPOAuthConfig } from '@vybestack/llxprt-code-core';
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+import type { MCPServerConfig } from '@vybestack/llxprt-code-core/config/config.js';
 import {
   MCPServerStatus,
   MCPDiscoveryState,
@@ -11,8 +15,13 @@ import {
 } from '@vybestack/llxprt-code-core';
 import type {
   AgentMcpControl,
+  McpDetailStatus,
+  McpDetailsOptions,
   McpDiscoveryState as PublicMcpDiscoveryState,
+  McpPromptInfo,
+  McpResourceInfo,
   McpServerAuthStatus,
+  McpServerDetail,
   McpServerInfo,
   McpStatus,
   ToolInfo,
@@ -34,6 +43,23 @@ export interface McpToolRegistryView {
   getEnabledTools(): ReadonlyArray<{ readonly name: string }>;
 }
 
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpPromptRegistryView {
+  getPromptsByServer(server: string): ReadonlyArray<{
+    name: string;
+    description?: string;
+  }>;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpResourceRegistryView {
+  getAllResources(): ReadonlyArray<{
+    serverName: string;
+    name?: string;
+    uri: string;
+  }>;
+}
+
 /**
  * Callback bundle injected by AgentImpl so McpControl can read the per-agent
  * MCP auth state plus the REAL discovery/status/tools surface (the configured
@@ -49,6 +75,25 @@ export interface McpControlDeps {
   readonly getManager: () => McpClientManager | undefined;
   /** Resolves the live tool registry view for discovered-tool projection. */
   readonly getToolRegistry: () => McpToolRegistryView | undefined;
+  /** @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 Raw configured MCP servers. */
+  readonly getServerConfigs?: () => Record<string, MCPServerConfig> | undefined;
+  /** @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 Blocked servers. */
+  readonly getBlockedServers?: () => ReadonlyArray<{
+    name: string;
+    extensionName: string;
+  }>;
+  /** @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 Prompt registry view. */
+  readonly getPromptRegistry?: () => McpPromptRegistryView | undefined;
+  /** @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 Resource registry view. */
+  readonly getResourceRegistry?: () => McpResourceRegistryView | undefined;
+  /** @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 Re-publishes client tool declarations. */
+  readonly refreshClientTools?: () => Promise<void>;
+  /** @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 Performs the real OAuth handshake. */
+  readonly performOAuth?: (
+    server: string,
+    oauthConfig: MCPOAuthConfig,
+    mcpServerUrl: string | undefined,
+  ) => Promise<void>;
 }
 
 /**
@@ -226,11 +271,13 @@ export class McpControl implements AgentMcpControl {
   }
 
   /**
-   * Re-runs discovery for a single server (when named) or all configured
-   * servers. Delegates to the REAL McpClientManager restart paths.
+   * @plan:PLAN-20260622-COREAPIGAP.P14
+   * @requirement:REQ-006
+   * @pseudocode lines 30-41
    *
-   * @plan:PLAN-20260617-COREAPI.P22
-   * @requirement:REQ-013
+   * Re-runs discovery for a single server (when named) or all configured
+   * servers, then re-publishes the agent client's tool declarations
+   * (R-REFRESH-PARITY). Delegates to the REAL McpClientManager restart paths.
    */
   async refresh(server?: string): Promise<void> {
     const manager = this.deps?.getManager();
@@ -239,8 +286,120 @@ export class McpControl implements AgentMcpControl {
     }
     if (server !== undefined) {
       await manager.restartServer(server);
-      return;
+    } else {
+      await manager.restart();
     }
-    await manager.restart();
+    if (this.deps?.refreshClientTools !== undefined) {
+      await this.deps.refreshClientTools();
+    }
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P14
+   * @requirement:REQ-006
+   * @pseudocode lines 1-16
+   *
+   * Real OAuth flow: orchestrates performOAuth -> restartServer ->
+   * refreshClientTools. An unknown server or unwired performOAuth is a no-op
+   * returning authenticated:false. A performOAuth rejection PROPAGATES (no
+   * restart, no setTools) — the control does NOT catch.
+   */
+  async authenticate(server: string): Promise<McpServerAuthStatus> {
+    const configs = this.deps?.getServerConfigs?.();
+    const serverConfig = configs ? configs[server] : undefined;
+    const performOAuth = this.deps?.performOAuth;
+    if (serverConfig === undefined || performOAuth === undefined) {
+      return { server, authenticated: false, requiresAuth: true };
+    }
+    const oauthConfig = serverConfig.oauth ?? { enabled: false };
+    const mcpServerUrl = serverConfig.httpUrl ?? serverConfig.url;
+    await performOAuth(server, oauthConfig, mcpServerUrl);
+    const manager = this.deps?.getManager();
+    if (manager !== undefined) {
+      await manager.restartServer(server);
+    }
+    if (this.deps?.refreshClientTools !== undefined) {
+      await this.deps.refreshClientTools();
+    }
+    return { server, authenticated: true, requiresAuth: true };
+  }
+
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P14
+   * @requirement:REQ-006
+   * @pseudocode lines 50-78
+   *
+   * Deep per-server projection. includeTools defaults true;
+   * includePrompts/includeResources default false. Projects prompts/resources
+   * to named-field-only public types. Undefined-safe via ?. + ?? []/?? {}.
+   */
+  async details(opts?: McpDetailsOptions): Promise<McpDetailStatus> {
+    const includeTools = opts?.includeTools ?? true;
+    const includePrompts = opts?.includePrompts ?? false;
+    const includeResources = opts?.includeResources ?? false;
+    const configs = this.deps?.getServerConfigs?.() ?? {};
+    const toolsByServer = this.toolsByServer();
+    const resourcesAll = includeResources
+      ? (this.deps?.getResourceRegistry?.()?.getAllResources() ?? [])
+      : [];
+    const servers: McpServerDetail[] = [];
+    for (const name of Object.keys(configs)) {
+      servers.push(
+        this.buildServerDetail(
+          name,
+          includeTools,
+          includePrompts,
+          includeResources,
+          toolsByServer,
+          resourcesAll,
+        ),
+      );
+    }
+    const blockedServers = (this.deps?.getBlockedServers?.() ?? []).map(
+      (b) => ({ name: b.name, extensionName: b.extensionName }),
+    );
+    return { servers, blockedServers };
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 @pseudocode lines 60-74
+  private buildServerDetail(
+    name: string,
+    includeTools: boolean,
+    includePrompts: boolean,
+    includeResources: boolean,
+    toolsByServer: Readonly<Record<string, readonly ToolInfo[]>>,
+    resourcesAll: ReadonlyArray<{
+      serverName: string;
+      name?: string;
+      uri: string;
+    }>,
+  ): McpServerDetail {
+    const detail: {
+      name: string;
+      authenticated: boolean;
+      tools?: readonly ToolInfo[];
+      prompts?: readonly McpPromptInfo[];
+      resources?: readonly McpResourceInfo[];
+    } = {
+      name,
+      authenticated: this.deps?.isMcpAuthenticated(name) ?? false,
+    };
+    if (includeTools) {
+      detail.tools = toolsByServer[name] ?? [];
+    }
+    if (includePrompts) {
+      const prompts =
+        this.deps?.getPromptRegistry?.()?.getPromptsByServer(name) ?? [];
+      detail.prompts = prompts.map((p) => ({
+        name: p.name,
+        description: p.description,
+      }));
+    }
+    if (includeResources) {
+      detail.resources = resourcesAll
+        .filter((r) => r.serverName === name)
+        .map((r) => ({ name: r.name, uri: r.uri }));
+    }
+    return detail;
   }
 }

--- a/packages/agents/src/api/control/mcpControl.ts
+++ b/packages/agents/src/api/control/mcpControl.ts
@@ -392,7 +392,7 @@ export class McpControl implements AgentMcpControl {
         this.deps?.getPromptRegistry?.()?.getPromptsByServer(name) ?? [];
       detail.prompts = prompts.map((p) => ({
         name: p.name,
-        description: p.description,
+        ...(p.description !== undefined ? { description: p.description } : {}),
       }));
     }
     if (includeResources) {

--- a/packages/agents/src/api/control/mcpControlWiring.ts
+++ b/packages/agents/src/api/control/mcpControlWiring.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P14
+ * @requirement:REQ-006
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { AgentClientContract } from '@vybestack/llxprt-code-core/core/clientContract.js';
+import { MCPOAuthProvider } from '@vybestack/llxprt-code-core';
+import type { McpControlDeps } from './mcpControl.js';
+
+/**
+ * Inputs AgentImpl supplies so the MCP wiring can resolve the live
+ * Config-backed discovery surface, the per-agent mcpAuth predicate, and the
+ * active client (for tool re-publish after restart/authenticate).
+ */
+export interface McpControlWiringArgs {
+  readonly config: Config;
+  readonly isMcpAuthenticated: (server: string) => boolean;
+  readonly resolveClient: () => AgentClientContract;
+}
+
+/**
+ * Builds the McpControlDeps closure bundle wired to the live Config + client.
+ * Binding MCPOAuthProvider HERE (never in mcpControl.ts) keeps the control
+ * delegate-only and free of any direct dependency on the OAuth provider
+ * implementation. The handshake token is awaited-and-discarded so it is never
+ * surfaced through the public surface.
+ *
+ * @plan:PLAN-20260622-COREAPIGAP.P14
+ * @requirement:REQ-006
+ */
+export function buildMcpControlDeps(
+  args: McpControlWiringArgs,
+): McpControlDeps {
+  const { config, isMcpAuthenticated, resolveClient } = args;
+  return {
+    isMcpAuthenticated,
+    getManager: () => config.getMcpClientManager(),
+    getToolRegistry: () => config.getToolRegistry(),
+    getServerConfigs: () => config.getMcpServers(),
+    getBlockedServers: () => config.getBlockedMcpServers() ?? [],
+    getPromptRegistry: () => ({
+      getPromptsByServer: (s: string) =>
+        config.getPromptRegistry().getPromptsByServer(s),
+    }),
+    getResourceRegistry: () => ({
+      getAllResources: () => config.getResourceRegistry().getAllResources(),
+    }),
+    refreshClientTools: () => resolveClient().setTools(),
+    performOAuth: async (server, oauthConfig, mcpServerUrl) => {
+      await MCPOAuthProvider.authenticate(
+        server,
+        oauthConfig,
+        mcpServerUrl,
+        undefined,
+      );
+    },
+  };
+}

--- a/packages/agents/src/api/control/mcpControlWiring.ts
+++ b/packages/agents/src/api/control/mcpControlWiring.ts
@@ -22,6 +22,7 @@ import type { McpControlDeps } from './mcpControl.js';
 export interface McpControlWiringArgs {
   readonly config: Config;
   readonly isMcpAuthenticated: (server: string) => boolean;
+  readonly markAuthenticated: (server: string) => void;
   readonly resolveClient: () => AgentClientContract;
 }
 
@@ -38,9 +39,10 @@ export interface McpControlWiringArgs {
 export function buildMcpControlDeps(
   args: McpControlWiringArgs,
 ): McpControlDeps {
-  const { config, isMcpAuthenticated, resolveClient } = args;
+  const { config, isMcpAuthenticated, markAuthenticated, resolveClient } = args;
   return {
     isMcpAuthenticated,
+    markAuthenticated,
     getManager: () => config.getMcpClientManager(),
     getToolRegistry: () => config.getToolRegistry(),
     getServerConfigs: () => config.getMcpServers(),

--- a/packages/agents/src/api/control/policyControl.ts
+++ b/packages/agents/src/api/control/policyControl.ts
@@ -4,7 +4,10 @@
  */
 
 import type { AgentPolicyControl, PolicyRuleView } from '../agent.js';
-import { type PolicyEngine, type PolicyDecision } from '@vybestack/llxprt-code-core';
+import {
+  type PolicyEngine,
+  type PolicyDecision,
+} from '@vybestack/llxprt-code-core';
 
 /**
  * @plan:PLAN-20260622-COREAPIGAP.P06

--- a/packages/agents/src/api/control/policyControl.ts
+++ b/packages/agents/src/api/control/policyControl.ts
@@ -1,0 +1,52 @@
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P06
+ * @requirement:REQ-002
+ */
+
+import type { AgentPolicyControl, PolicyRuleView } from '../agent.js';
+import { type PolicyEngine, type PolicyDecision } from '@vybestack/llxprt-code-core';
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P06
+ * @requirement:REQ-002
+ */
+export interface PolicyControlDeps {
+  readonly getEngine: () => PolicyEngine;
+}
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P06
+ * @requirement:REQ-002
+ */
+export class PolicyControl implements AgentPolicyControl {
+  constructor(private readonly deps: PolicyControlDeps) {}
+
+  /** @requirement:REQ-002 @pseudocode lines 1-18 */
+  getRules(): readonly PolicyRuleView[] {
+    const engine = this.deps.getEngine();
+    const rules = engine.getRules();
+    const out: PolicyRuleView[] = [];
+    for (const rule of rules) {
+      out.push({
+        priority: rule.priority,
+        toolName: rule.toolName,
+        decision: rule.decision,
+        ...(rule.argsPattern !== undefined
+          ? { argsPattern: rule.argsPattern.source }
+          : {}),
+        ...(rule.source !== undefined ? { source: rule.source } : {}),
+      });
+    }
+    return out;
+  }
+
+  /** @requirement:REQ-002 @pseudocode lines 30-33 */
+  getDefaultDecision(): PolicyDecision {
+    return this.deps.getEngine().getDefaultDecision();
+  }
+
+  /** @requirement:REQ-002 @pseudocode lines 40-43 */
+  isNonInteractive(): boolean {
+    return this.deps.getEngine().isNonInteractive();
+  }
+}

--- a/packages/agents/src/api/control/tasksControl.ts
+++ b/packages/agents/src/api/control/tasksControl.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P08
+ * @requirement:REQ-003
+ */
+
+import type { AgentTasksControl, AgentTaskInfo } from '../agent.js';
+import type { AsyncTaskManager, AsyncTaskInfo } from '@vybestack/llxprt-code-core';
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P08
+ * @requirement:REQ-003
+ */
+export interface TasksControlDeps {
+  readonly getManager: () => AsyncTaskManager | undefined;
+}
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P08
+ * @requirement:REQ-003
+ */
+export class TasksControl implements AgentTasksControl {
+  constructor(private readonly deps: TasksControlDeps) {}
+
+  /** @requirement:REQ-003 @pseudocode lines 1-13 */
+  private project(task: AsyncTaskInfo): AgentTaskInfo {
+    return {
+      id: task.id,
+      subagentName: task.subagentName,
+      goalPrompt: task.goalPrompt,
+      status: task.status,
+      launchedAt: task.launchedAt,
+      ...(task.completedAt !== undefined
+        ? { completedAt: task.completedAt }
+        : {}),
+      ...(task.error !== undefined ? { error: task.error } : {}),
+    };
+  }
+
+  /** @requirement:REQ-003 @pseudocode lines 20-25 */
+  list(): readonly AgentTaskInfo[] {
+    const mgr = this.deps.getManager();
+    if (mgr === undefined) return [];
+    return mgr.getAllTasks().map((t) => this.project(t));
+  }
+
+  /** @requirement:REQ-003 @pseudocode lines 30-35 */
+  listRunning(): readonly AgentTaskInfo[] {
+    const mgr = this.deps.getManager();
+    if (mgr === undefined) return [];
+    return mgr.getRunningTasks().map((t) => this.project(t));
+  }
+
+  /** @requirement:REQ-003 @pseudocode lines 40-47 */
+  get(id: string): AgentTaskInfo | undefined {
+    const mgr = this.deps.getManager();
+    if (mgr === undefined) return undefined;
+    const task = mgr.getTask(id);
+    if (task === undefined) return undefined;
+    return this.project(task);
+  }
+
+  /** @requirement:REQ-003 @pseudocode lines 50-55 */
+  cancel(id: string): boolean {
+    const mgr = this.deps.getManager();
+    if (mgr === undefined) return false;
+    return mgr.cancelTask(id);
+  }
+
+  /** @requirement:REQ-003 @pseudocode lines 60-70 */
+  cancelAllRunning(): number {
+    const mgr = this.deps.getManager();
+    if (mgr === undefined) return 0;
+    const running = mgr.getRunningTasks();
+    let count = 0;
+    for (const task of running) {
+      if (mgr.cancelTask(task.id)) count++;
+    }
+    return count;
+  }
+}

--- a/packages/agents/src/api/control/tasksControl.ts
+++ b/packages/agents/src/api/control/tasksControl.ts
@@ -10,7 +10,10 @@
  */
 
 import type { AgentTasksControl, AgentTaskInfo } from '../agent.js';
-import type { AsyncTaskManager, AsyncTaskInfo } from '@vybestack/llxprt-code-core';
+import type {
+  AsyncTaskManager,
+  AsyncTaskInfo,
+} from '@vybestack/llxprt-code-core';
 
 /**
  * @plan:PLAN-20260622-COREAPIGAP.P08

--- a/packages/agents/src/api/control/toolControl.ts
+++ b/packages/agents/src/api/control/toolControl.ts
@@ -24,12 +24,15 @@ import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 import type { EditorCallbacks } from '../config-types.js';
 import type {
   AgentToolControl,
+  AgentToolKeyControl,
   ToolDecision,
   ToolInfo,
   Unsubscribe,
 } from '../agent.js';
 import type { ToolConfirmation, ToolUpdate } from '../event-types.js';
 import { buildToolInfos } from '../agentBootstrap.js';
+import { ToolKeysControl } from './toolKeysControl.js';
+import type { ToolKeysControlDeps } from './toolKeysControl.js';
 
 /**
  * Typed error thrown by {@link ToolControl.respondToConfirmation} when the
@@ -63,6 +66,9 @@ export interface ToolControlDeps {
    * `setEditorCallbacks` is observable by the next turn's scheduler.
    */
   readonly editorCallbacksHolder: { editorCallbacks: EditorCallbacks };
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+  /** The deps bundle for the constructed ToolKeysControl. */
+  readonly keysDeps: ToolKeysControlDeps;
 }
 
 type ConfirmationCallback = (req: ToolConfirmation) => void;
@@ -80,8 +86,12 @@ export class ToolControl implements AgentToolControl {
   private readonly confirmationCallbacks = new Set<ConfirmationCallback>();
   private readonly toolUpdateCallbacks = new Set<ToolUpdateCallback>();
   private readonly seen = new Set<string>();
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+  readonly keys: AgentToolKeyControl;
 
-  constructor(private readonly deps: ToolControlDeps) {}
+  constructor(private readonly deps: ToolControlDeps) {
+    this.keys = new ToolKeysControl(deps.keysDeps);
+  }
 
   /**
    * Returns a frozen snapshot of the registered tools (name/source/enabled),

--- a/packages/agents/src/api/control/toolKeysControl.ts
+++ b/packages/agents/src/api/control/toolKeysControl.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P16
+ * @requirement:REQ-007
+ * @pseudocode tool-keys.md steps 1-73
+ *
+ * Built-in TOOL key storage (Exa, etc.), exposed as `agent.tools.keys`.
+ * DISTINCT from `agent.auth.keys` (provider-auth keys). Masked: the raw key
+ * never crosses the API boundary (R-NO-RAW-SECRETS). Tool-name validation is
+ * owned by ToolKeyStorage.assertValidToolName (invoked inside every storage
+ * call); its throw propagates (delegate, never swallow).
+ */
+
+import type { ToolKeyStorage } from '@vybestack/llxprt-code-core';
+import {
+  getSupportedToolNames,
+  getToolKeyEntry,
+  maskKeyForDisplay,
+} from '@vybestack/llxprt-code-core';
+import type {
+  AgentToolKeyControl,
+  ToolKeyInfo,
+  ToolKeyStatus,
+} from '../agent.js';
+
+/**
+ * Dependencies injected into {@link ToolKeysControl}.
+ *
+ * @plan:PLAN-20260622-COREAPIGAP.P16
+ * @requirement:REQ-007
+ */
+export interface ToolKeysControlDeps {
+  /** Resolves the shared ToolKeyStorage (core lazy singleton). Never cached. */
+  readonly getStorage: () => ToolKeyStorage;
+}
+
+/**
+ * The public built-in tool-key control surface (masked).
+ *
+ * @plan:PLAN-20260622-COREAPIGAP.P16
+ * @requirement:REQ-007
+ * @pseudocode tool-keys.md steps 1-73
+ */
+export class ToolKeysControl implements AgentToolKeyControl {
+  constructor(private readonly deps: ToolKeysControlDeps) {}
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 1-11
+  supported(): readonly ToolKeyInfo[] {
+    const out: ToolKeyInfo[] = [];
+    for (const name of getSupportedToolNames()) {
+      const entry = getToolKeyEntry(name);
+      if (entry === undefined) {
+        continue;
+      }
+      out.push({
+        toolName: entry.toolKeyName,
+        displayName: entry.displayName,
+        description: entry.description,
+      });
+    }
+    return out;
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 20-34
+  async status(toolName: string): Promise<ToolKeyStatus> {
+    const storage = this.deps.getStorage();
+    const rawKey = await storage.getKey(toolName);
+    const keyFile = await storage.getKeyfilePath(toolName);
+    if (rawKey !== null) {
+      return {
+        toolName,
+        hasKey: true,
+        maskedKey: maskKeyForDisplay(rawKey),
+        ...(keyFile !== null ? { keyFile } : {}),
+      };
+    }
+    return {
+      toolName,
+      hasKey: false,
+      ...(keyFile !== null ? { keyFile } : {}),
+    };
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 40-43
+  async save(toolName: string, key: string): Promise<void> {
+    await this.deps.getStorage().saveKey(toolName, key);
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 50-53
+  async delete(toolName: string): Promise<void> {
+    await this.deps.getStorage().deleteKey(toolName);
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 60-67
+  async setKeyFile(toolName: string, path: string | null): Promise<void> {
+    if (path === null) {
+      await this.deps.getStorage().clearKeyfilePath(toolName);
+    } else {
+      await this.deps.getStorage().setKeyfilePath(toolName, path);
+    }
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 70-73
+  async getKeyFile(toolName: string): Promise<string | null> {
+    return this.deps.getStorage().getKeyfilePath(toolName);
+  }
+}

--- a/packages/agents/src/api/index.ts
+++ b/packages/agents/src/api/index.ts
@@ -18,3 +18,26 @@ export { listProviders, listTools } from './discovery.js';
 export { mapLoopStream, mapStreamEvent } from './eventAdapter.js';
 export { toConfigParameters, AdapterError } from './agentConfig.adapter.js';
 export type { AgentClientContract } from '@vybestack/llxprt-code-core/core/clientContract.js';
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P17
+ * @requirement:REQ-008
+ * @pseudocode barrel-exports.md lines 1-9
+ */
+export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core';
+export type {
+  PolicyRuleView,
+  AgentTaskInfo,
+  HookInfo,
+  AuthProviderDetail,
+  AuthBucketStatus,
+  McpServerAuthStatus,
+  McpDetailStatus,
+  McpServerDetail,
+  McpDetailsOptions,
+  McpPromptInfo,
+  McpResourceInfo,
+  McpBlockedServer,
+  ToolKeyInfo,
+  ToolKeyStatus,
+} from './agent.js';

--- a/packages/agents/src/app-services/command-api-map.ts
+++ b/packages/agents/src/app-services/command-api-map.ts
@@ -269,4 +269,45 @@ export const COMMAND_API_MAP: readonly CommandApiMapping[] = [
     target: 'exit (UI)',
     note: 'Pure UI with no core dependency',
   },
+  /**
+   * @plan:PLAN-20260622-COREAPIGAP.P17
+   * @requirement:REQ-008
+   * @pseudocode command-map.md lines 1-13
+   */
+  {
+    command: '/approval-mode',
+    kind: 'runtime',
+    target: 'agent.setApprovalMode',
+    note: 'Approval mode is a live engine setting on the active run',
+  },
+  {
+    command: '/policies',
+    kind: 'runtime',
+    target: 'agent.policy.getRules',
+    note: 'Policy inspection reads the active run policy engine',
+  },
+  {
+    command: '/task',
+    kind: 'runtime',
+    target: 'agent.tasks.list',
+    note: 'Async task list/inspect/cancel over the active run task manager',
+  },
+  {
+    command: '/hooks',
+    kind: 'runtime',
+    target: 'agent.hooks.listHooks',
+    note: 'Hook registry inspection + enable/disable on the active run',
+  },
+  {
+    command: '/toolkey',
+    kind: 'runtime',
+    target: 'agent.tools.keys.save',
+    note: 'Built-in tool key storage feeds the active run tools',
+  },
+  {
+    command: '/toolkeyfile',
+    kind: 'runtime',
+    target: 'agent.tools.keys.setKeyFile',
+    note: 'Built-in tool keyfile path feeds the active run tools',
+  },
 ];

--- a/project-plans/issue2143/.completed/P00.md
+++ b/project-plans/issue2143/.completed/P00.md
@@ -1,0 +1,9 @@
+Phase: P00
+Completed: 2026-06-24 14:10
+Files Created: [project-plans/issue2143/specification.md (621 lines)]
+Files Modified: none
+Tests Added: none (overview/specification phase)
+Verification: |
+  test -f project-plans/issue2143/specification.md
+  P00 VERIFY: specification.md present (621 lines)
+Semantic Assessment: Overview/specification phase produced the authoritative specification.md (621 lines) enumerating all 15 requirements (REQ-001..010, REQ-INT-001..005), the seven capability gaps, and the additive non-breaking mandate. Artifact present and load-bearing (consumed by P01 domain-model and every downstream phase). NOTE: marker recorded retroactively at P23 from real on-disk evidence; the phase artifact existed and was consumed throughout the plan — only the marker file had not been written.

--- a/project-plans/issue2143/.completed/P00a.md
+++ b/project-plans/issue2143/.completed/P00a.md
@@ -1,0 +1,11 @@
+Phase: P00a
+Completed: 2026-06-24 14:10
+Files Created: none
+Files Modified: none (preflight verification only)
+Tests Added: none
+Verification: |
+  Preflight gate confirmed the plan structure and specification.md are present and well-formed
+  prior to analysis. specification.md present (621 lines, 38434 bytes); plan/ contains the full
+  phase set 00..23 incl. all NNa verification docs. Downstream evidence: every subsequent phase
+  (P03..P22a) executed against this specification with passing NNa gates.
+Semantic Assessment: Preflight verification passed — specification and plan scaffolding are complete and consistent; the plan ran end-to-end through P22a on this basis. NOTE: marker recorded retroactively at P23 from real on-disk evidence; the preflight artifacts existed and were consumed throughout — only the marker file had not been written.

--- a/project-plans/issue2143/.completed/P01.md
+++ b/project-plans/issue2143/.completed/P01.md
@@ -1,0 +1,20 @@
+Phase: P01
+Completed: 2026-06-24 14:10
+Files Created: [project-plans/issue2143/analysis/domain-model.md (306 lines)]
+Files Modified: none
+Tests Added: none (analysis phase)
+Verification: |
+  set -o pipefail
+  test -f project-plans/issue2143/analysis/domain-model.md
+  # all 15 requirements present
+  for r in REQ-001..010 REQ-INT-001..005: grep -q "$r" -> present
+  # all 24 harness rows present
+  for t in T1..T24: grep -q "| $t " -> present
+  # all 17 invariants present
+  for inv in R-DELEGATE R-APPROVAL-THROW R-POLICY-SNAPSHOT R-ARGSPATTERN-STRING
+             R-NO-ABORTCONTROLLER R-CANCEL-COUNT R-UNDEFINED-SAFE R-HOOKS-ROUNDTRIP
+             R-NO-RAW-SECRETS R-NO-LEAK R-REFRESH-PARITY R-MCP-OAUTH-FLOW R-KEYS-DISTINCT
+             R-NONBREAK R-MAP-VALID R-NO-DEEP-IMPORT R-BARREL-TYPEONLY -> present
+  grep -q "@plan:PLAN-20260622-COREAPIGAP.P01" -> present
+  P01 VERIFY: OK (all REQ/T1-24/invariants/plan-marker present)
+Semantic Assessment: Analysis phase produced domain-model.md (306 lines) modeling all entities (extended Agent + three new sub-controllers + extended controllers), relationships, state transitions, the 17 named invariants, edge cases, and the T1-T24 test-harness cross-reference for all 15 requirements. Verified complete. NOTE: marker recorded retroactively at P23 from real on-disk evidence; the domain model existed and was consumed by every NNa gate downstream — only the marker file had not been written.

--- a/project-plans/issue2143/.completed/P01a.md
+++ b/project-plans/issue2143/.completed/P01a.md
@@ -1,0 +1,10 @@
+Phase: P01a
+Completed: 2026-06-24 14:10
+Files Created: none
+Files Modified: none (analysis verification only)
+Tests Added: none
+Verification: |
+  Re-ran the P01 completeness gate against analysis/domain-model.md: all 15 requirements,
+  all 24 harness rows (T1..T24), all 17 invariants, and the P01 plan marker are present.
+  P01 VERIFY: OK.
+Holistic Assessment: PASS. The domain model is complete, internally consistent, and covers every requirement and invariant the seven capability gaps depend on. It correctly distinguishes additive surfaces from the non-breaking guarantee and names the masked/projected-type constraints (no abortController, argsPattern->source, no raw secrets) that downstream phases enforced. NOTE: marker recorded retroactively at P23 from real on-disk evidence; the verification artifact's subject existed and was consumed throughout — only the marker file had not been written.

--- a/project-plans/issue2143/.completed/P02.md
+++ b/project-plans/issue2143/.completed/P02.md
@@ -1,0 +1,24 @@
+Phase: P02
+Completed: 2026-06-24 14:10
+Files Created: |
+  [analysis/pseudocode/approval-mode.md (106 lines),
+   analysis/pseudocode/policy-control.md (142 lines),
+   analysis/pseudocode/tasks-control.md (192 lines),
+   analysis/pseudocode/hooks-admin.md (166 lines),
+   analysis/pseudocode/auth-detail.md (157 lines),
+   analysis/pseudocode/mcp-oauth.md (276 lines),
+   analysis/pseudocode/tool-keys.md (201 lines),
+   analysis/pseudocode/barrel-exports.md (116 lines),
+   analysis/pseudocode/command-map.md (113 lines)]
+  total 1469 lines across 9 files
+Files Modified: none
+Tests Added: none (pseudocode phase)
+Verification: |
+  set -o pipefail
+  for f in approval-mode policy-control tasks-control hooks-admin auth-detail mcp-oauth
+           tool-keys barrel-exports command-map:
+    test -f "$f.md"; grep -q "Interface Contracts"; grep -q "Integration Points";
+    grep -q "Anti-Pattern Warnings"; grep -qE "^[0-9]+:" (numbered lines);
+    grep -q "@plan:PLAN-20260622-COREAPIGAP.P02"
+  P02 VERIFY: OK (all 9 pseudocode files complete with required sections+markers)
+Semantic Assessment: Pseudocode phase produced 9 numbered-line pseudocode files (1469 lines total) for all seven capability surfaces plus barrel-exports and command-map, each with Interface Contracts, Integration Points, and Anti-Pattern Warnings sections. These line numbers are cited by the implementation controls (verified: policyControl/tasksControl/toolKeysControl carry @pseudocode markers) and were checked by every NNa pseudocode-compliance gate. NOTE: marker recorded retroactively at P23 from real on-disk evidence; the pseudocode existed and was consumed throughout — only the marker file had not been written.

--- a/project-plans/issue2143/.completed/P02a.md
+++ b/project-plans/issue2143/.completed/P02a.md
@@ -1,0 +1,10 @@
+Phase: P02a
+Completed: 2026-06-24 14:10
+Files Created: none
+Files Modified: none (pseudocode verification only)
+Tests Added: none
+Verification: |
+  Re-ran the P02 completeness gate over all 9 pseudocode files: each has Interface Contracts,
+  Integration Points, Anti-Pattern Warnings, numbered lines, and the P02 plan marker.
+  P02 VERIFY: OK.
+Holistic Assessment: PASS. The pseudocode set is complete and numbered, providing the line-level contract each implementation phase cited and each NNa gate verified. The mcp-oauth (276 lines) and tasks-control (192 lines) pseudocode correctly capture the setTools-parity and abortController-omission constraints respectively. NOTE: marker recorded retroactively at P23 from real on-disk evidence; the pseudocode existed and was consumed by all downstream pseudocode-compliance gates — only the marker file had not been written.

--- a/project-plans/issue2143/.completed/P03.md
+++ b/project-plans/issue2143/.completed/P03.md
@@ -1,0 +1,22 @@
+Phase: P03
+Completed: 2026-06-24 01:59
+Files Created:
+  - packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts (133 lines)
+Files Modified: none
+Tests Added: 5 (T1 positive live-read, T2 untrusted throw, T3 write-then-read parity, PROP round-trip over {DEFAULT,AUTO_EDIT,YOLO}, PROP untrusted matrix over non-DEFAULT with DEFAULT-allowed post-condition)
+Verification:
+  ```
+  property-based CASES: 2 / 5 = 40% (it.prop/test.prop=0, classic-blocks=2)
+  --- Deferred Implementation Detection ---
+  PASS: no deferred-implementation markers / reverse tests in the new test file.
+  --- vitest RED run (exit 1, expected) ---
+  Test Files  1 failed (1)
+       Tests  5 failed (5)
+  T1 → TypeError: built.agent.getApprovalMode is not a function
+  T2 → AssertionError: expected [Function] to throw ... but got 'built.agent.setApprovalMode is not a …'
+  T3 → TypeError: built.agent.setApprovalMode is not a function
+  PROP round-trip → Caused by: TypeError: local.agent.setApprovalMode is not a function (counterexample ["default"])
+  PROP untrusted matrix → Caused by: AssertionError: ... got 'local.agent.setApprovalMode is not a function' (counterexample ["autoEdit"])
+  RED confirmed for behavioral reasons (expected until P04).
+  ```
+Semantic Assessment: Suite is RED for the correct behavioral reason (missing-method TypeError on getApprovalMode/setApprovalMode), drives entirely through the public root + buildAgent harness with the real folderTrust flag, ≥30% property-based (40%), no mock theater, no reverse tests, no deep imports.

--- a/project-plans/issue2143/.completed/P04.md
+++ b/project-plans/issue2143/.completed/P04.md
@@ -1,0 +1,44 @@
+Phase: P04
+Completed: 2026-06-24 02:05
+Files Created: none
+Files Modified:
+  - packages/agents/src/api/agent.ts (13 insertions, 0 deletions — added getApprovalMode/setApprovalMode interface declarations after getCurrentSequenceModel with @plan/@requirement markers)
+  - packages/agents/src/api/agentImpl.ts (19 insertions, 1 deletion — added ApprovalMode to the bare-core-barrel type import on line 24; added getApprovalMode() and setApprovalMode(mode) impls after getEphemeralSettings with @pseudocode lines 1-4 and 10-17 markers)
+Tests Added: 0 (P04 is impl-only; the 5 tests from P03 turn GREEN)
+Verification:
+  ```
+  --- component test (GREEN) ---
+  npx vitest run packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts
+   Test Files  1 passed (1)
+        Tests  5 passed (5)
+     Start at  02:04:17
+     Duration  7.68s
+
+  --- npm run typecheck ---
+  All 15 workspaces typecheck clean (tools, storage, auth, settings, telemetry,
+  ide-integration, policy, mcp, core, lsp, providers, agents, root, a2a-server,
+  test-utils) — exit 0.
+
+  --- BLOCKING delegation greps ---
+  OK: getApprovalMode delegating (config.getApprovalMode())
+  OK: setApprovalMode delegating (config.setApprovalMode(mode))
+
+  --- BLOCKING try/catch grep ---
+  OK: no try/catch around setApprovalMode (throw propagates unchanged)
+
+  --- BLOCKING pseudocode markers ---
+  OK: getApprovalMode marker (@pseudocode lines 1-4)
+  OK: setApprovalMode marker (@pseudocode lines 10-17)
+
+  --- BLOCKING interface decls ---
+  OK: interface getApprovalMode (getApprovalMode(): ApprovalMode;)
+  OK: interface setApprovalMode (setApprovalMode(mode: ApprovalMode): void;)
+
+  --- npm run lint (changed files) ---
+  npx eslint src/api/agent.ts src/api/agentImpl.ts src/api/__tests__/agent.approvalMode.behavior.test.ts
+  exit 0 — clean, no errors.
+
+  --- Deferred Implementation Detection (scoped to changed lines) ---
+  PASS: no deferred markers in changed lines.
+  ```
+Semantic Assessment: Pure one-liner delegations to this.deps.config match the pseudocode exactly; the untrusted-folder throw propagates unchanged (no try/catch); getApprovalMode reads live every call (no cache); interface + impl carry @plan/@requirement/@pseudocode markers; all 5 behavioral tests GREEN.

--- a/project-plans/issue2143/.completed/P04a.md
+++ b/project-plans/issue2143/.completed/P04a.md
@@ -1,0 +1,82 @@
+Phase: P04a
+Completed: 2026-06-24 02:30
+
+Files Created:
+- project-plans/issue2143/.completed/P04a.md (this marker)
+- (under review) packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts — 168 lines (new, untracked; created in P03)
+
+Files Modified (P04 impl under review):
+- packages/agents/src/api/agent.ts        | 13 insertions(+), 0 deletions(-)  (additive: two interface decls + doc comments)
+- packages/agents/src/api/agentImpl.ts    | 20 insertions(+), 1 deletion(-)  (the 1 deletion = import widened to add ApprovalMode)
+
+Tests Added: 5 (T1, T2, T3, PROP round-trip, PROP untrusted-matrix) — 2 property-based.
+
+Verification: (actual output of THIS phase's commands)
+- Prereq: test -f project-plans/issue2143/.completed/P04.md → present.
+- npx vitest run agent.approvalMode.behavior.test.ts → Test Files 1 passed (1); Tests 5 passed (5).
+- npx vitest run packages/agents/src/api/__tests__/ → full-suite run showed non-deterministic timeout failures
+  (run A: 4 failed incl mutationCoverage; run B: 2 failed cli-turn-parity property tests at ~30000ms). ALL failing
+  files PASS IN ISOLATION (cli-turn-parity.spec + cli-turn-parity.early.spec + mutationCoverage.behavior → 28/28
+  passed, RC=0). The failing files contain ZERO approval-mode references and were last touched by #1594 (predate
+  this change). This is the documented load-contention flakiness (root-level vitest oversubscribes CPU; property &
+  timing tests time out). CI runs packages separately and won't hit it. NOT a code defect of this phase.
+- npm run typecheck → EXIT 0 (all packages clean).
+- npm run lint (WHOLE REPO) → LINT_EXIT=0 (clean; the transient signal-15 kills were the review tool's foreground
+  watchdog, not lint errors — confirmed by a sentinel-tracked background run that recorded LINT_EXIT=0).
+- Check 4 (delegation, no try/catch): getApprovalMode delegated OK; setApprovalMode delegated OK. The script's awk
+  "FAIL: wraps try/catch" is a PROVEN FALSE POSITIVE: BSD/macOS awk does not honor `\s`, so the window terminator
+  /^\s*\}/ never matched the method's "  }" closing brace and the window ran to EOF, capturing try/catch from
+  unrelated later methods (applyProviderSwitch/safe/...). With a portable POSIX class [[:space:]] the window closes
+  at the real brace and the body is exactly:
+      setApprovalMode(mode: ApprovalMode): void {
+        this.deps.config.setApprovalMode(mode);
+      }
+  → NO try/catch. Requirement satisfied.
+- Check 5 (no cached field): OK — no this.(approvalMode|_approvalMode|cachedApprovalMode) assignment.
+- Check 6 (test discipline): OK — no mock theater (toHaveBeenCalled/mockResolvedValue/mockReturnValue/vi.spyOn/vi.fn);
+  no bare not.toThrow(); T2 asserts the exact "Cannot enable privileged approval modes in an untrusted folder."; no
+  deep imports; no internal control/agentImpl imports.
+- Check 7 (deferred-impl scan on changed lines): OK — no TODO/FIXME/HACK/STUB/XXX/placeholder/"for now"/"in a real".
+
+Line-by-Line Compliance Table:
+| Pseudocode lines                                                      | Implemented at                  | Matches? |
+| 1-4 getApprovalMode live read (RETURN this.deps.config.getApprovalMode()) | agentImpl.ts:745-747         | YES      |
+| 10-17 setApprovalMode direct delegate, NO try/catch, NO normalize/validate (this.deps.config.setApprovalMode(mode)) | agentImpl.ts:754-756 | YES |
+
+Semantic Verification Checklist:
+- [x] Behavior decision table holds — trusted DEFAULT/AUTO_EDIT/YOLO set+read (T1/T3/PROP round-trip); untrusted
+      non-DEFAULT throws (T2/PROP untrusted-matrix); untrusted DEFAULT allowed (PROP positive post-condition).
+- [x] No caching (R-DELEGATE) — live this.deps.config.getApprovalMode() each call; no instance field.
+- [x] Untrusted throw propagates unchanged (R-APPROVAL-THROW) — driven by REAL folderTrust:false through the harness
+      (AgentConfig.folderTrust → agentConfig.adapter.ts:210-212 → params.trustedFolder=false → Config.isTrustedFolder()
+      false → config.ts:402-405 throws). NOT a spy.
+- [x] Test suite behavioral, 2/5 = 40% property (>=30%, MIN-2 distinct cases); public-root-only (ApprovalMode VALUE
+      from the bare @vybestack/llxprt-code-core barrel is the sole permitted non-public source; harness re-exports the
+      public root); lint + typecheck clean; component suite green; failing full-suite files pass in isolation.
+
+Holistic Functionality Assessment:
+- What was implemented? Two top-level Agent methods — getApprovalMode(): ApprovalMode and
+  setApprovalMode(mode: ApprovalMode): void — declared on the public Agent interface (agent.ts:338,345, next to the
+  ephemeral-settings one-liners) and implemented as pure one-liner delegations on AgentImpl (agentImpl.ts:745-756).
+  ApprovalMode is imported as a type in both files; agent.ts re-exports it `export type` (:400).
+- Satisfies REQ-001/.1/.2? YES.
+  REQ-001 (surface the two methods on the public Agent): interface decls present + re-exported; build/typecheck green.
+  REQ-001.1 (live read, no cache): getApprovalMode returns this.deps.config.getApprovalMode() with no stored field
+  (Check 5); T3/PROP round-trip prove write-then-read parity with no stale cache.
+  REQ-001.2 (direct delegation; untrusted-folder throw propagates unchanged): setApprovalMode calls
+  this.deps.config.setApprovalMode(mode) directly with NO try/catch (portable-awk proof), NO normalization, NO
+  validation; T2 + PROP untrusted-matrix prove the exact config.ts:404 message escapes the method unchanged, driven by
+  the real folderTrust flag (not a spy).
+- Data flow: Agent.getApprovalMode() → this.deps.config (live bound Config) → Config.getApprovalMode()
+  (configBaseCore.ts:463) → live ApprovalMode. Agent.setApprovalMode(mode) → this.deps.config.setApprovalMode(mode)
+  (config.ts:401); on a non-DEFAULT mode in an untrusted folder the guard throws (config.ts:404) and the error
+  propagates out of the Agent method untouched.
+- Risks: none material. No accidental catch (proven), no cache (proven), no test mock theater (proven). The only nuance
+  is the verification script's macOS-awk `\s` false positive on Check 4, which a portable re-check disproves. Full-suite
+  flakiness is environmental load contention, not a defect; all involved files pass in isolation.
+
+Semantic Assessment: PASS — getApprovalMode is a live cache-free delegation (agentImpl.ts:745-747) and setApprovalMode
+is a direct delegation with no try/catch/normalize/validate (agentImpl.ts:754-756), exactly matching pseudocode lines
+1-4 and 10-17; the untrusted-folder throw is exercised through a REAL folderTrust:false flag (not a spy); component
+suite 5/5 green, 40% property (MIN-2), typecheck + whole-repo lint EXIT 0, public exports additive-only. The single
+"FAIL" emitted by the script's bash block is a verified BSD-awk `\s` false positive, not a real defect.

--- a/project-plans/issue2143/.completed/P05.md
+++ b/project-plans/issue2143/.completed/P05.md
@@ -1,0 +1,35 @@
+Phase: P05
+Completed: 2026-06-24 03:06
+Files Created:
+- packages/agents/src/api/__tests__/policyControl.behavior.test.ts (212 lines)
+Files Modified: none
+Tests Added: 5 (T4 argsPattern-string, T4b snapshot-isolation, T6 default-decision/non-interactive, PROP argsPattern-round-trip, PROP rules-count-order-fidelity)
+Verification:
+```
+=== Mock theater guard ===
+PASS: no mock theater
+=== Deep-import guard ===
+PASS: no deep/internal imports
+=== Property percentage gate ===
+property CASES: 2 / 5 = 40%
+=== argsPattern STRING contract ===
+PASS: argsPattern asserted
+=== Deferred-impl detection ===
+PASS: no deferred markers
+=== ALL P05 GUARDS PASSED ===
+
+=== RED-state enforcement (agentImpl policy wiring temporarily stubbed) ===
+EXIT STATUS: 1
+Tests  5 failed (5)
+Caused by: TypeError: Cannot read properties of undefined (reading 'getRules')
+RED confirmed behavioral (expected until P06).
+
+Note: The test seeds the real PolicyEngine via AgentConfig.policy through the
+public buildAgent harness. The createAgent path injects an extra confirmation-
+forcing rule (priority 4, source 'Agent confirmation-forcing seam (P17)') into
+the engine, so getRules() returns a SUPERSET of the seeded rules. The tests
+locate seeded rules by their unique source markers rather than positional index,
+testing the PROJECTION contract (argsPattern→.source string, decision fidelity,
+snapshot isolation) independently of the confirmation-seam implementation detail.
+```
+Semantic Assessment: Behavioral RED suite with 40% property coverage (≥30%, MIN-2), zero mocking, drives through the public buildAgent harness with real PolicyEngine seeded via AgentConfig.policy; RED is behavioral TypeError (agent.policy undefined), not a module/compile error.

--- a/project-plans/issue2143/.completed/P06.md
+++ b/project-plans/issue2143/.completed/P06.md
@@ -1,0 +1,47 @@
+Phase: P06
+Completed: 2026-06-24 03:06
+Files Created:
+- packages/agents/src/api/control/policyControl.ts (52 lines)
+Files Modified:
+- packages/agents/src/api/agent.ts (+27 lines: PolicyRuleView interface, AgentPolicyControl interface, readonly policy field on Agent)
+- packages/agents/src/api/agentImpl.ts (+15 lines: PolicyControl/PolicyControlDeps imports, readonly policy field, ctor assignment, buildPolicyControl method)
+Tests Added: 0 (P05 tests now GREEN)
+Verification:
+```
+=== P06: GREEN test ===
+npx vitest run --config packages/agents/vitest.config.ts packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+
+=== P06: typecheck ===
+npm run typecheck
+typecheck exit: 0
+
+=== P06: lint (scoped to changed files) ===
+npx eslint packages/agents/src/api/control/policyControl.ts packages/agents/src/api/agent.ts packages/agents/src/api/agentImpl.ts packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+lint exit: 0
+
+=== P06: Blocking greps ===
+argsPattern.source projection: PASS
+no live-array return: PASS
+ctor wired (this.policy = this.buildPolicyControl()): PASS
+field present (readonly policy: PolicyControl;): PASS
+interface field present (readonly policy: AgentPolicyControl;): PASS
+no rule mutation methods: PASS
+getRules pseudocode marker (@pseudocode lines 1-18): PASS
+getDefaultDecision pseudocode marker (@pseudocode lines 30-33): PASS
+isNonInteractive pseudocode marker (@pseudocode lines 40-43): PASS
+delegation (engine.getRules / getEngine().getDefaultDecision / getEngine().isNonInteractive): PASS
+Note: getRules uses local `engine` variable per pseudocode lines 3-4 (SET engine = this.deps.getEngine(); SET rules = engine.getRules()); getDefaultDecision/isNonInteractive use inline this.deps.getEngine().X() per pseudocode lines 32/42.
+
+=== P06: Deferred-impl detection ===
+new control clean: PASS
+agentImpl.ts changed lines clean: PASS
+agent.ts changed lines clean: PASS
+
+=== API suite regression ===
+npx vitest run --config packages/agents/vitest.config.ts packages/agents/src/api/__tests__/
+ Test Files  43 passed (43)
+      Tests  558 passed (558)
+```
+Semantic Assessment: PolicyControl implements AgentPolicyControl faithfully per pseudocode lines 1-18/30-33/40-43; getRules builds a fresh snapshot projecting argsPattern→.source string (undefined preserved), getDefaultDecision/isNonInteractive delegate per call; wired via buildPolicyControl using Config.getPolicyEngine(); all 558 api tests green with zero regressions.

--- a/project-plans/issue2143/.completed/P06a.md
+++ b/project-plans/issue2143/.completed/P06a.md
@@ -1,0 +1,150 @@
+Phase: P06a
+Completed: 2026-06-24 04:55
+Files Created:
+  - packages/agents/src/api/control/policyControl.ts (52 lines)
+  - packages/agents/src/api/__tests__/policyControl.behavior.test.ts (212 lines)
+Files Modified:
+  - packages/agents/src/api/agent.ts (+27 lines, -0; PolicyDecision import, PolicyRuleView, AgentPolicyControl, `readonly policy`)
+  - packages/agents/src/api/agentImpl.ts (+15 lines, -0; PolicyControl import, field, ctor assign, buildPolicyControl())
+Tests Added: 5 (3 example-based + 2 property-based = 40% property)
+
+---
+
+## Line-by-Line Pseudocode-Compliance Table
+
+Source: `project-plans/issue2143/analysis/pseudocode/policy-control.md`
+Impl:   `packages/agents/src/api/control/policyControl.ts`
+
+| Pseudocode line | Pseudocode statement | Implemented at | Matches? |
+|---|---|---|---|
+| 3  | `SET engine = this.deps.getEngine()` | policyControl.ts:26 `const engine = this.deps.getEngine();` | YES |
+| 4  | `SET rules = engine.getRules()` | policyControl.ts:27 `const rules = engine.getRules();` | YES |
+| 5  | `SET out = empty array` | policyControl.ts:28 `const out: PolicyRuleView[] = [];` | YES |
+| 6  | `FOR EACH rule IN rules` | policyControl.ts:29 `for (const rule of rules) {` | YES |
+| 7-10 | `view = { priority, toolName, decision }` | policyControl.ts:30-33 (push object: priority, toolName, decision) | YES |
+| 11-12 | `argsPattern: IF DEFINED THEN .source ELSE undefined` | policyControl.ts:34-36 `...(rule.argsPattern !== undefined ? { argsPattern: rule.argsPattern.source } : {})` | YES (equivalent: key omitted when undefined reads as `undefined` on `argsPattern?: string`; JSON-safe — no `RegExp`, no `""` coercion) |
+| 13 | `source: rule.source` | policyControl.ts:37 `...(rule.source !== undefined ? { source: rule.source } : {})` | YES (key-omit variant; same observable shape) |
+| 15 | `APPEND view TO out` | policyControl.ts:30 `out.push({ ... })` | YES |
+| 17 | `RETURN out  // fresh snapshot, not live list` | policyControl.ts:40 `return out;` | YES (returns the freshly-built `out`, never `rules`) |
+| 18 | END METHOD | policyControl.ts:41 | YES |
+| 30-31 | `METHOD getDefaultDecision() RETURNS PolicyDecision` | policyControl.ts:44 `getDefaultDecision(): PolicyDecision {` | YES |
+| 32 | `RETURN this.deps.getEngine().getDefaultDecision()` | policyControl.ts:45 `return this.deps.getEngine().getDefaultDecision();` | YES (fresh resolve per call) |
+| 40-41 | `METHOD isNonInteractive() RETURNS boolean` | policyControl.ts:49 `isNonInteractive(): boolean {` | YES |
+| 42 | `RETURN this.deps.getEngine().isNonInteractive()` | policyControl.ts:50 `return this.deps.getEngine().isNonInteractive();` | YES (fresh resolve per call) |
+
+Integration points (real symbols, verified):
+- getEngine wiring: agentImpl.ts:514-519 `buildPolicyControl()` → `getEngine: () => this.deps.config.getPolicyEngine()` (Config.getPolicyEngine non-optional, configBaseCore.ts).
+- PolicyEngine.getRules(): readonly PolicyRule[] — policy-engine.ts:320.
+- PolicyEngine.getDefaultDecision(): PolicyDecision — policy-engine.ts:329.
+- PolicyEngine.isNonInteractive(): boolean — policy-engine.ts:338.
+- PolicyRule.argsPattern?: RegExp — types.ts:35 → projected to `.source` (string).
+- Core barrel: PolicyEngine (index.ts:15), PolicyDecision (index.ts:17), PolicyRule (index.ts:19).
+
+**Compliance table: COMPLETE — all rows MATCH.**
+
+---
+
+## Semantic Verification Checklist
+
+- [x] Decision table holds: 0-rule → `[]` (loop never executes); argsPattern → string via `.source`; missing argsPattern → `undefined` (key omitted, not coerced to `""`); default/non-interactive read through to the engine.
+- [x] Fresh snapshot per call: `getRules()` resolves `this.deps.getEngine()` and builds a NEW `out` array every call (policyControl.ts:26-28,40). No `this.engine`/`this.rules` field exists (constructor stores only `deps`, policyControl.ts:22). BLOCKING grep for cached state = NO MATCH.
+- [x] Read-only / no mutation: no `addRule`/`removeRule`/`setRules` (BLOCKING grep = NO MATCH). Class implements only getRules/getDefaultDecision/isNonInteractive.
+- [x] No `RegExp` leak: public `PolicyRuleView.argsPattern` is typed `string`; impl emits `rule.argsPattern.source` (R-ARGSPATTERN-STRING). Test asserts `not.toBeInstanceOf(RegExp)` for every view.
+- [x] Engine seeded through the real public `AgentConfig.policy` path (PolicyEngineConfig → adapter → configConstructor → Config.getPolicyEngine). Test is behavioral via the buildAgent harness with ZERO mocking; ≥30% property (40%). lint + typecheck + full api-suite GREEN.
+
+---
+
+## Holistic Functionality Assessment
+
+### What was implemented
+A new read-only `agent.policy` sub-controller (`PolicyControl implements AgentPolicyControl`) exposing exactly three inspection methods: `getRules(): readonly PolicyRuleView[]`, `getDefaultDecision(): PolicyDecision`, `isNonInteractive(): boolean`. Supporting public types `PolicyRuleView` (JSON-safe projection: `priority?`, `toolName?`, `decision`, `argsPattern?: string`, `source?`) and `AgentPolicyControl` were added to agent.ts, plus the `readonly policy` member on the `Agent` interface. Wiring is in agentImpl.ts via `buildPolicyControl()` which injects `getEngine: () => this.deps.config.getPolicyEngine()`. The controller is decoupled from Config behind the `PolicyControlDeps.getEngine` closure (uniform with sibling controls).
+
+### Satisfies REQ-002 (.1/.2/.3/.4)?
+- REQ-002.1 (read-only snapshot + argsPattern projection): YES. getRules builds a fresh array of projected views; `argsPattern` is the RegExp `.source` string (policyControl.ts:34-36); undefined is preserved.
+- REQ-002.2 (getDefaultDecision read-through): YES. policyControl.ts:44-46 delegates per call.
+- REQ-002.3 (isNonInteractive read-through): YES. policyControl.ts:48-50 delegates per call.
+- REQ-002.4 (mutation OUT OF SCOPE): YES. No mutation methods exist on the controller.
+
+### Data flow correctness
+agent.policy.getRules() → PolicyControl.deps.getEngine() → AgentImpl closure `() => this.deps.config.getPolicyEngine()` → core Config.getPolicyEngine() → REAL PolicyEngine.getRules(). Resolution is per-call (no cache), so the controller always reflects the live engine state while returning an isolated copy. Verified end-to-end by the behavioral test which seeds a real PolicyEngine via AgentConfig.policy and reads the rules back through agent.policy. (Note: createAgent injects an extra confirmation-forcing rule, so the returned set is a documented superset of the seed; the test correctly locates seeded rules by their `source` markers rather than positional index.)
+
+### Read-only / snapshot correctness
+getRules returns a freshly-allocated `PolicyRuleView[]` (`out`), never the engine's live `readonly PolicyRule[]`. The snapshot-isolation test (T4b) truncates the first returned array and confirms a second call returns the original length and a distinct object reference — proving fresh-per-call snapshots. The public projected type strips every non-serializable field.
+
+### JSON-safety of argsPattern
+The core `PolicyRule.argsPattern` is a `RegExp` (types.ts:35), which is NOT JSON-safe. The projection emits `rule.argsPattern.source` (a string) and the public type is `argsPattern?: string`. When the rule has no pattern, the key is omitted (reads as `undefined`) rather than coerced to `""`. Tests assert string identity ('"command":"npm test"'), `typeof === 'string'`, `not.toBeInstanceOf(RegExp)`, and `toBeUndefined()` for the no-pattern rule. A property test round-trips arbitrary `new RegExp(src)` → view.argsPattern === src.
+
+### Test quality
+- Mock theater: NONE. No vi.fn/vi.spyOn/mockResolvedValue/mockReturnValue/toHaveBeenCalled (grep NO MATCH). Drives a REAL seeded PolicyEngine through the public buildAgent harness.
+- Reverse tests: NONE (no not.toThrow). No .skip/xit/xdescribe. No `any`.
+- Imports: only public root `@vybestack/llxprt-code-agents` + `@vybestack/llxprt-code-core` (bare barrel for PolicyDecision value) + the harness; no deep/internal imports.
+- Property ratio: 2/5 it() = 40% (≥30%), each with MIN-2 distinct cases (PROP1: 'foo' & 'bar|baz'; PROP2: integer 1..5 + decision array).
+- Genuine behavioral coverage of the projection contract, snapshot isolation, default-decision/non-interactive read-through.
+
+### Non-breaking (REQ-009)
+agent.ts diff = +27/-0 (pure additions); agentImpl.ts = +15/-0; index.ts UNTOUCHED. No existing public export removed or changed. `PolicyRuleView`/`AgentPolicyControl` reach the public root via `export * from './agent.js'` (index.ts:12), which is how the test imports `PolicyRuleView` from the package root. Full agents api test suite (45 files / 570 tests) GREEN; typecheck and lint clean → no downstream breakage.
+
+### Risks
+- LOW. The conditional-spread key-omission for argsPattern/source differs syntactically from the pseudocode's explicit `: undefined` but is observably equivalent under `argsPattern?: string` (and strictly better for JSON-safety). The confirmation-seam superset behavior is a known createAgent detail the test handles correctly by source-marker lookup. No caching, no mutation surface, no RegExp/live-array leak.
+
+---
+
+## Verification Output (actual)
+
+Step 1 — single file:
+  npx vitest run policyControl.behavior.test.ts → Test Files 1 passed (1); Tests 5 passed (5). Exit 0.
+
+Step 2 — whole api __tests__ dir:
+  npx vitest run packages/agents/src/api/__tests__/ → Test Files 45 passed (45); Tests 570 passed (570). Exit 0.
+  ("Error when talking to fake API" lines are fake-API harness stderr noise, not failures.)
+
+Step 3 — typecheck:
+  npm run typecheck → all packages tsc --noEmit clean. Exit 0.
+
+Step 4 — lint:
+  npm run lint → eslint . clean. Exit 0.
+
+BLOCKING greps (policyControl.ts):
+  OK delegate (engine.getRules())
+  OK argsPattern.source
+  OK no live array return
+  OK no cached engine/rules
+  OK no mutation methods (addRule/removeRule/setRules)
+
+Test-discipline greps (policyControl.behavior.test.ts):
+  OK no mock theater (toHaveBeenCalled/mockResolvedValue/mockReturnValue/vi.spyOn/vi.fn)
+  OK no reverse test (not.toThrow)
+  OK no deep import
+  OK no internal import (../control, ../agentImpl)
+  OK argsPattern tested
+  OK no .skip/xit/xdescribe/any
+  property ratio: 2 of 5 it() = 40% (>= 30%), MIN-2 cases each
+
+Deferred scan:
+  OK no deferred marker in policyControl.ts
+  OK no deferred added in agentImpl.ts / agent.ts
+
+Non-breaking:
+  agent.ts +27/-0, agentImpl.ts +15/-0, index.ts untouched (no export removed/changed).
+
+NOTE: The doc's trailing `git diff HEAD -- FILE | grep ... | grep ...` returns exit 1 because the G2
+change is already COMMITTED (commit 9a53c9261), so the working-tree diff is empty — a tooling
+artifact, not a real failure. The deferred scan was re-run against the committed diff and is clean.
+
+=> Verification block result: PASS (pseudocode-compliance + discipline).
+
+---
+
+## FINAL VERDICT: PASS
+
+Evidence:
+- Pseudocode parity: every numbered line maps to policyControl.ts:26-50 (table above, all MATCH).
+- Read-only snapshot: getRules returns fresh `out` array (policyControl.ts:28,30,40), never the live engine list; T4b proves per-call isolation.
+- JSON-safe argsPattern: `rule.argsPattern.source` → `argsPattern?: string` (policyControl.ts:34-36; agent.ts:353); undefined preserved.
+- Delegate-only / no cache: constructor stores only `deps` (policyControl.ts:22); engine resolved per call via getEngine() (policyControl.ts:26,45,50); wiring agentImpl.ts:516.
+- No mutation: only getRules/getDefaultDecision/isNonInteractive exist.
+- Non-breaking: agent.ts +27/-0, agentImpl.ts +15/-0, index.ts untouched.
+- Test: real seeded PolicyEngine via public harness, no mock theater, 40% property, 5/5 pass.
+- Suites GREEN (570/570), typecheck clean, lint clean.
+
+Semantic Assessment: PASS — PolicyControl matches policy-control.md line-by-line; returns read-only JSON-safe snapshots (argsPattern as .source string), resolves the engine per call (no cache), exposes no mutation, and the behavioral test drives a real seeded PolicyEngine through the public agent.policy surface with 40% property coverage and zero mock theater. Public surface intact (REQ-009).

--- a/project-plans/issue2143/.completed/P07.md
+++ b/project-plans/issue2143/.completed/P07.md
@@ -1,0 +1,59 @@
+Phase: P07
+Completed: 2026-06-22 03:26
+
+Files Created:
+- packages/agents/src/api/__tests__/tasksControl.behavior.test.ts (229 lines)
+
+Files Modified: none
+
+Tests Added: 6 (T7, T8, T9, T10, PROP projection-fidelity, PROP cancelAllRunning-count)
+
+Verification (actual output of the P07 Verification Commands block):
+
+```
+property CASES: 2 / 6 = 33%
+RED confirmed behavioral (expected until P08).
+```
+
+Full /tmp/p07_red.log (vitest run, EXIT != 0 — 6/6 failed):
+
+```
+RUN  v3.2.4 /Users/acoliver/projects/llxprt/branch-3/llxprt-code
+
+ ❯ packages/agents/src/api/__tests__/tasksControl.behavior.test.ts (6 tests | 6 failed) 96ms
+   × T7 ... cancelAllRunning returns N and leaves listRunning empty
+     → Cannot read properties of undefined (reading 'listRunning')
+   × T8 ... projection strips abortController from the public view
+     → Cannot read properties of undefined (reading 'list')
+   × T9 ... direct-construction undefined-safe
+     → Cannot find module '../control/tasksControl.js' (isolated dynamic-import — expected at RED)
+   × T10 ... list/listRunning/get/cancel fidelity
+     → Cannot read properties of undefined (reading 'list')
+   × PROP projection fidelity
+     → Property failed after 1 tests
+       Caused by: TypeError: Cannot read properties of undefined (reading 'list')
+   × PROP cancelAllRunning count
+     → Property failed after 1 tests
+       Caused by: TypeError: Cannot read properties of undefined (reading 'listRunning')
+
+ Test Files  1 failed (1)
+      Tests  6 failed (6)
+   Start at  03:26:22
+   Duration  3.44s
+```
+
+RED analysis: 5 of 6 failures are behavioral TypeErrors
+(`Cannot read properties of undefined (reading 'list'|'listRunning')`)
+from the PUBLIC-HARNESS positives (T7/T8/T10/PROP/PROP) — `agent.tasks` is
+undefined on the Agent interface at RED. Only T9 (the undefined-safe case) is
+an isolated `Cannot find module '../control/tasksControl.js'` from the dynamic
+import — exactly as the RED note prescribes. The gate's behavioral-failure
+grep (TypeError|AssertionError|expected|is not a function|Cannot read)
+matches the positives; RED is confirmed behavioral, NOT solely module errors.
+
+Semantic Assessment: Behavioral RED suite drives real data through the
+real lazily-created AsyncTaskManager via the public getConfig().getAsyncTaskManager()
+seam + registerTask, asserts the REQ-003.7 abortController-omission contract
+via Object.keys(view)/'in' on real projected output, and covers undefined-safety
+via a real closure — no mock theater, ≥30% property (33%, MIN-2).
+```

--- a/project-plans/issue2143/.completed/P08.md
+++ b/project-plans/issue2143/.completed/P08.md
@@ -1,0 +1,64 @@
+Phase: P08
+Completed: 2026-06-22 03:36
+
+Files Created:
+- packages/agents/src/api/control/tasksControl.ts (86 lines) — TasksControl implementing
+  AgentTasksControl; project() copies fields BY NAME (never spreads), every method
+  undefined-safe ([]/undefined/false/0), cancelAllRunning() snapshots getRunningTasks()
+  FIRST and returns the integer count, getManager() resolved per call (no cache).
+
+Files Modified:
+- packages/agents/src/api/agent.ts — +31 insertions: added AgentTaskInfo + AgentTasksControl
+  interfaces (after AgentPolicyControl) and `readonly tasks: AgentTasksControl;` to the
+  Agent interface controls block.
+- packages/agents/src/api/agentImpl.ts — +16 insertions: imported TasksControl +
+  TasksControlDeps, added `readonly tasks: TasksControl;` field, wired
+  `this.tasks = this.buildTasksControl();` in the ctor, added private buildTasksControl()
+  (getManager: () => this.deps.config.getAsyncTaskManager()).
+
+Tests Added: 0 (P08 implements against the P07 RED suite; Phase 07 tests pass unchanged).
+
+Verification (actual output of the P08 Verification Commands block):
+
+```
+RUN  v3.2.4 /Users/acoliver/projects/llxprt/branch-3/llxprt-code
+
+ ✓ packages/agents/src/api/__tests__/tasksControl.behavior.test.ts (6 tests) 425ms
+
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+   Start at  03:30:25
+   Duration  2.61s
+
+> @vybestack/llxprt-code@0.10.0 typecheck
+> npm run typecheck --workspaces --if-present
+[tsc --noEmit ran cleanly for all 15 workspaces — tools, storage, auth, settings,
+ telemetry, ide-integration, policy, mcp, core, lsp, providers, agents, root,
+ a2a-server, test-utils — zero errors]
+
+ALL P08 GATES PASSED
+```
+
+(all BLOCKING greps confirmed: project() does NOT spread the task; abortController is
+never referenced in the projection; all four delegates (getAllTasks/getRunningTasks/
+getTask/cancelTask) present; []-guard present; cancelAllRunning 0-guard present;
+running snapshot present; tasks wired via buildTasksControl; tasks field present in
+both agentImpl.ts and agent.ts; @pseudocode markers lines 1-13 and lines 60-70 present.)
+
+P08 Deferred Implementation Detection: PASS (no TODO/FIXME/HACK/STUB/placeholder in the
+new control or the changed lines of agent.ts/agentImpl.ts).
+
+Post-P08 project-wide checks (from repo root):
+- npm run lint — EXIT=0, 0 errors, 0 warnings (after fixing 2 vitest/prefer-strict-equal
+  nits in the P07 test file's T9 empty-array assertions: toEqual → toStrictEqual).
+- npm run typecheck — EXIT=0, 0 errors across all 15 workspaces.
+- npx vitest run packages/agents/src/api/__tests__/tasksControl.behavior.test.ts —
+  EXIT=0, 6/6 passed (T7/T8/T9/T10 + 2 PROPs).
+
+Semantic Assessment: The TasksControl is a purely additive, undefined-safe sub-controller
+that delegates to the live Config.getAsyncTaskManager() per call; project() strips
+abortController (and notifiedAt/output) by copying fields explicitly by name — verified
+behaviorally via Object.keys(view)/'in' on real projected output across both example and
+property-generated cases; cancelAllRunning() snapshots the running set before cancelling
+and returns the integer count; the undefined-safe branch returns []/undefined/false/0 and
+never throws — proven by the real-closure T9 direct-construction case.

--- a/project-plans/issue2143/.completed/P08a.md
+++ b/project-plans/issue2143/.completed/P08a.md
@@ -1,0 +1,138 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P08a @requirement:REQ-003 -->
+Phase: P08a
+Completed: 2026-06-24 03:47
+
+Files Created:
+- packages/agents/src/api/control/tasksControl.ts (86 lines) — TasksControl impl + TasksControlDeps + project() projection
+- packages/agents/src/api/__tests__/tasksControl.behavior.test.ts (229 lines) — behavioral RED→GREEN suite (6 cases, 2 property)
+  (NOTE: both files are present on disk and committed in a prior phase commit; `git diff HEAD` therefore
+   shows only the two MODIFIED tracked files below, not these as new — verified `git ls-files` returns
+   them tracked-but-unchanged-vs-HEAD; the deferred-marker grep directly scans tasksControl.ts.)
+
+Files Modified:
+- packages/agents/src/api/agent.ts     | 31 insertions (+)  — AgentTaskInfo, AgentTasksControl interfaces; `readonly tasks` on Agent
+- packages/agents/src/api/agentImpl.ts | 16 insertions (+)  — import, `readonly tasks` field, ctor assignment, buildTasksControl()
+
+Tests Added: 6 (4 behavioral: T7/T8/T9/T10; 2 property: PROP projection-fidelity, PROP cancel-count). Property share = 2/6 = 33.3% (>= 30%, MIN-2 satisfied).
+
+================================================================================
+LINE-BY-LINE COMPLIANCE TABLE (file:line evidence)
+================================================================================
+| Pseudocode lines | Implemented at | Matches? |
+|---|---|---|
+| 1-13 project (by-name copy, abortController omitted) | tasksControl.ts:31-45 — explicit `id/subagentName/goalPrompt/status/launchedAt` copy by name; `completedAt`/`error` copied conditionally only-if-present; NO `...task` spread; the string `abortController` appears NOWHERE in the file | [x] |
+| 20-25 list (undefined->[], map project) | tasksControl.ts:48-52 — `mgr=getManager()`; `if (mgr===undefined) return []`; `mgr.getAllTasks().map(t=>this.project(t))` (core getAllTasks asyncTaskManager.ts:77) | [x] |
+| 30-35 listRunning | tasksControl.ts:55-59 — same shape; `mgr.getRunningTasks().map(...)` (core getRunningTasks asyncTaskManager.ts:319) | [x] |
+| 40-47 get (undefined->undefined, miss->undefined) | tasksControl.ts:62-68 — `if (mgr===undefined) return undefined`; `task=mgr.getTask(id)` (asyncTaskManager.ts:273); `if (task===undefined) return undefined`; else `this.project(task)` | [x] |
+| 50-55 cancel (undefined->false) | tasksControl.ts:71-75 — `if (mgr===undefined) return false`; `return mgr.cancelTask(id)` (asyncTaskManager.ts:239, idempotent boolean) | [x] |
+| 60-70 cancelAllRunning (snapshot, count) | tasksControl.ts:78-86 — `if (mgr===undefined) return 0`; `const running = mgr.getRunningTasks()` (SNAPSHOT BEFORE iterate); `let count=0; for(const task of running){ if(mgr.cancelTask(task.id)) count++ } return count` (integer count, never void) | [x] |
+
+Per-call manager resolution (no cache): EVERY method begins with `const mgr = this.deps.getManager()`
+(tasksControl.ts:49,56,63,72,79). No `this.manager`/`this.tasks` field assignment exists
+(blocking no-cache grep returns nothing). Wiring resolves live per call:
+agentImpl.ts:525-530 buildTasksControl() -> `getManager: () => this.deps.config.getAsyncTaskManager()`
+(Config.getAsyncTaskManager(): AsyncTaskManager | undefined, config.ts:601).
+
+================================================================================
+SEMANTIC VERIFICATION CHECKLIST
+================================================================================
+[x] Decision table holds. T9 (tasksControl.behavior.test.ts:101-110) proves undefined manager ->
+    list()===[], listRunning()===[], get('x')===undefined, cancel('x')===false, cancelAllRunning()===0,
+    none throw, via a REAL `new TasksControl({ getManager: () => undefined })` closure (NOT a spy/mock).
+    T10 (:112-160) proves 2 tasks (1 completed) -> list len 2, listRunning len 1, get(known) projected,
+    get(missing)===undefined, cancel(running)===true, cancel(missing)===false. T7 (:46-69) proves
+    cancelAllRunning()===2 then listRunning() len 0 (terminal idempotent).
+[x] AgentTaskInfo never carries abortController on REAL output (R-NO-ABORTCONTROLLER, REQ-003.7).
+    T8 (:71-99) seeds a core task that DID carry an AbortController (asserts coreTask.abortController===ac,
+    :88), then asserts the projected view both `Object.keys(view) not.toContain('abortController')` and
+    `'abortController' in view === false`. PROP projection-fidelity (:162-201) re-asserts the absence over
+    1..5 generated tasks. Source side: tasksControl.ts has zero `abortController` references and zero spreads.
+[x] cancelAllRunning returns integer count (R-CANCEL-COUNT); snapshots before iterating.
+    tasksControl.ts:82 `const running = mgr.getRunningTasks();` taken before the for-loop; returns `count`
+    (:86). T7 asserts `===2`; PROP cancel-count asserts `===n` for n in 0..5.
+[x] Delegates per call (no cache); test behavioral + >=30% property; lint/typecheck/full-api-suite green.
+    Full api/__tests__ suite: 44 files / 564 tests PASSED. typecheck: all workspaces clean. lint: clean.
+    Property share 33.3% with 2 distinct property tests.
+
+================================================================================
+HOLISTIC FUNCTIONALITY ASSESSMENT
+================================================================================
+What was implemented:
+  TasksControl (implements AgentTasksControl) with a private abortController-omitting `project()`
+  projection and five undefined-safe methods (list/listRunning/get/cancel/cancelAllRunning). The
+  public projected type AgentTaskInfo and the AgentTasksControl interface were added to agent.ts and a
+  `readonly tasks` member added to the Agent interface; AgentImpl gained the `tasks` field, ctor
+  assignment, and buildTasksControl() builder that closes over the LIVE Config per call.
+
+Satisfies REQ-003/.1-.7? YES, with cited evidence:
+  - .1 list -> getAllTasks projected (tasksControl.ts:48-52; core :77).
+  - .2 listRunning -> getRunningTasks projected (:55-59; core :319).
+  - .3 get -> getTask projected, miss -> undefined (:62-68; core :273).
+  - .4 cancel -> cancelTask idempotent boolean (:71-75; core :239).
+  - .5 cancelAllRunning -> snapshot then count cancelled, returns integer (:78-86); proven ===N by T7+PROP.
+  - .6 undefined-safe no-ops ([]/undefined/false/0) on every method; proven by T9 real-closure direct construction.
+  - .7 AgentTaskInfo OMITS abortController; proven on REAL data by T8 (the core task carried an AbortController,
+    the projected view omits the key by both Object.keys and `in`) and re-proven by PROP projection-fidelity.
+
+Data flow:
+  agent.tasks.<method>() -> TasksControl resolves getManager() PER CALL ->
+  this.deps.config.getAsyncTaskManager() (config.ts:601, may be undefined) -> real AsyncTaskManager ->
+  core AsyncTaskInfo[] mapped through project() -> public AgentTaskInfo[] (abortController dropped). Tests
+  drive the SAME manager the control closes over (seeded via agent.getConfig().getAsyncTaskManager().registerTask),
+  reading back through agent.tasks.* — causally real, zero mocking.
+
+Risks (all mitigated):
+  - abortController leak via spread: NO spread; explicit by-name copy; string absent from file.
+  - mutation-during-iteration: snapshot `running` taken before cancelling (R-CANCEL-COUNT/anti-pattern OK).
+  - manager caching: none; resolved per call; no-cache grep clean.
+  - throw on undefined: guarded on every method; T9 proves no throw via real undefined closure.
+
+Verdict: PASS. All blocking commands exited 0 (the grep/discipline block run as the doc's bash script
+prints "PASS: pseudocode-compliance + discipline." with BLOCK_EXIT=0); 564/564 api tests pass; typecheck
+and lint clean; pseudocode lines 1-70 map 1:1 to tasksControl.ts:31-86; behavioral discipline upheld
+(no mock theater, no reverse tests, no skip, no `any` in control, markers-only comments); additive/non-breaking
+(only agent.ts + agentImpl.ts modified, insertions only; publicSurface.nonbreaking.test.ts + nonBreaking.exports.test.ts green).
+
+Semantic Assessment: PASS — pseudocode 1:1 (tasksControl.ts:31-86), REQ-003.1-.7 all proven on REAL data
+(T7/T8/T9/T10 + 2 property tests, 33.3% property share), undefined-safe via real `new TasksControl({getManager:()=>undefined})` closure, abortController never projected, cancelAllRunning returns snapshot-based integer count; full api suite 564/564 + typecheck + lint green.
+
+================================================================================
+VERIFICATION OUTPUT (verbatim, real)
+================================================================================
+Pre-step (per phase-doc dist note — REQUIRED because the harness resolves
+@vybestack/llxprt-code-agents to dist/): `npm run build -w @vybestack/llxprt-code-agents`
+-> "Successfully copied files." (exit 0). Re-running after build, the harness-driven
+T7/T8/T10/PROP cases pass.
+
+$ npx vitest run packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+ ✓ packages/agents/src/api/__tests__/tasksControl.behavior.test.ts (6 tests) 456ms
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+
+$ npx vitest run packages/agents/src/api/__tests__/
+ Test Files  44 passed (44)
+      Tests  564 passed (564)
+   Duration  24.60s
+  (T8b/T10c emit expected fake-API error-report log lines to stderr — those negative-path tests PASS.)
+
+$ npm run typecheck
+ > npm run typecheck --workspaces --if-present
+ tools/storage/auth/settings/telemetry/ide-integration/policy/mcp/core/lsp/providers/agents/(root)/a2a-server/test-utils
+ -> tsc --noEmit  (ALL clean, exit 0)
+
+$ npm run lint
+ > cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint . --ext .ts,.tsx && eslint integration-tests
+ (clean, exit 0)
+
+# BLOCKING grep / discipline block (run as the doc's bash script):
+PASS: pseudocode-compliance + discipline.
+BLOCK_EXIT=0
+
+# Supplemental discipline confirmations:
+deferred-scan changed tracked files: clean: agentImpl.ts ; clean: agent.ts
+any in control: no any
+.skip/xit in test: no skip
+NotYetImplemented in test: no NotYetImplemented
+fc.assert count: 2 ; it() count: 6  (property share 33.3%, MIN-2 satisfied)
+control comments: only /** ... */ JSDoc marker blocks (@plan/@requirement/@pseudocode/license) — no prose
+mock re-grep (toHaveBeenCalled|vi.fn|vi.spyOn|mockResolved|mockReturn|mockImplementation): none

--- a/project-plans/issue2143/.completed/P09.md
+++ b/project-plans/issue2143/.completed/P09.md
@@ -1,0 +1,27 @@
+Phase: P09
+Completed: 2026-06-24 04:28
+Files Created: [packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts (182 lines)]
+Files Modified: [none]
+Tests Added: 6 (T11 round-trip+fresh-copy, T11b enable/disable idempotency, T12a undefined-safe listHooks, T12b populated listHooks via direct-construction, PROP disabled-set round-trip, PROP enable∘disable inverse)
+
+Verification:
+=== mock-theater greps ===
+OK: no mock theater / reverse tests
+=== round-trip + listHooks exercised ===
+OK: both exercised
+=== property-based >= 30% (MIN-2) ===
+property CASES: 2 / 6 = 33%
+OK: property threshold met
+=== deferred-marker scan ===
+OK: no deferred markers
+=== RED-state enforcement ===
+Caused by: TypeError: agent.hooks.setDisabledHooks is not a function
+ ❯ packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts:164:25
+
+ Test Files  1 failed (1)
+      Tests  6 failed (6)
+   Start at  04:12:33
+   Duration  9.45s (transform 4.30s, setup 0ms, collect 8.65s, tests 310ms, environment 0ms, prepare 74ms)
+RED confirmed behavioral (expected until P10).
+
+Semantic Assessment: Behavioral RED suite drives REAL Config disabled-set + hook-system through the public agent.hooks surface (T11/T11b/T12a via buildAgent harness) and the BLESSED direct-construction precedent (T12b via new HookControl(realDeps)); all 6 tests fail with missing-method TypeError (behavioral RED), 33% property share (MIN-2), no mock theater, no reverse tests, fresh-copy contract proven by mutate-then-reread.

--- a/project-plans/issue2143/.completed/P10.md
+++ b/project-plans/issue2143/.completed/P10.md
@@ -1,0 +1,35 @@
+Phase: P10
+Completed: 2026-06-24 04:28
+Files Created: [none]
+Files Modified: [packages/agents/src/api/agent.ts (19 insertions), packages/agents/src/api/control/hooks.ts (48 insertions)]
+Tests Added: 0 (P10 makes the P09 suite GREEN; no new tests)
+
+Verification:
+=== interface + impl greps ===
+OK: interface extended, existing members preserved (listHooks/getDisabledHooks/setDisabledHooks/enable/disable all present; triggerSessionStart byte-identical)
+=== impl markers + delegations ===
+OK: impl present + delegates + markers (@pseudocode lines 1-19/30-32/40-42/50-54/57-61 all present; getHookSystem + isInitialized guards; setDisabledHooks fresh-copying)
+=== no cached field ===
+OK: no cached field (no private disabledHooks/hookCache/cachedHooks)
+=== P09 suite GREEN ===
+ ✓ packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts (6 tests) 437ms
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+   Start at  04:27:16
+   Duration  3.39s
+=== whole __tests__ dir (non-breaking) ===
+ Test Files  45 passed (45)
+      Tests  570 passed (570)
+   Start at  04:27:51
+   Duration  24.13s
+=== typecheck ===
+> @vybestack/llxprt-code@0.10.0 typecheck
+> tsc --noEmit
+(exit 0, clean)
+=== lint ===
+> cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint . --ext .ts,.tsx && cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint integration-tests
+(exit 0, clean)
+=== scoped deferred-marker scan ===
+PASS: no deferred markers in changed lines.
+
+Semantic Assessment: GREEN — HookControl extends AgentHookControl with five admin methods that delegate to the REAL Config hook system / disabled-set per call (no caching), guarding both undefined system AND !isInitialized() in listHooks, returning fresh array copies everywhere; P09 suite 6/6 GREEN, whole __tests__ dir 45 files/570 tests GREEN (REQ-009 non-breaking), typecheck + lint clean.

--- a/project-plans/issue2143/.completed/P10a.md
+++ b/project-plans/issue2143/.completed/P10a.md
@@ -1,0 +1,237 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P10a @requirement:REQ-004 -->
+# Phase 10a Completion Marker — Hooks Administration Pseudocode-Compliance Verification
+
+**Verdict: PASS**
+
+Independent gate review of the hooks-administration extension to `AgentHookControl` /
+`HookControl`. All Verification Commands gates returned exit 0, every method matches its cited
+pseudocode line-by-line, the existing four members are byte-identical (non-breaking), the
+controller is delegate-only (no cache), undefined/uninitialised-safe, hands out fresh copies, and
+the P09 test suite is genuinely behavioral.
+
+---
+
+## Line-by-Line Compliance Table
+
+Pseudocode source: `project-plans/issue2143/analysis/pseudocode/hooks-admin.md`
+Implementation: `packages/agents/src/api/control/hooks.ts`
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1-19 | `listHooks` (undefined + isInitialized guards, project name/eventName/enabled/source) | hooks.ts:175-189 | ✅ YES |
+| 30-32 | `getDisabledHooks` (fresh copy) | hooks.ts:191-193 | ✅ YES |
+| 40-42 | `setDisabledHooks` (fresh-copy write-through) | hooks.ts:198-200 | ✅ YES |
+| 50-54 | `disable` (idempotent short-circuit) | hooks.ts:205-209 | ✅ YES |
+| 57-61 | `enable` (filter) | hooks.ts:214-217 | ✅ YES |
+
+### Per-method line-by-line trace
+
+**`listHooks()` — pseudocode 2-19 → hooks.ts:175-189**
+
+| Pseudocode | Impl line | Code | Match |
+| --- | --- | --- | --- |
+| 3 `SET system = config.getHookSystem()` | 176 | `const system = this.deps.config.getHookSystem();` | ✅ |
+| 4 `IF system undefined RETURN []` | 177 | `if (!system) return [];` | ✅ |
+| 5 `IF !isInitialized() RETURN []` | 178 | `if (!system.isInitialized()) return [];` | ✅ |
+| 6 `SET registry = system.getRegistry()` | 179 | `const registry = system.getRegistry();` | ✅ |
+| 7 `SET entries = registry.getAllHooks()` | 180 | `return registry.getAllHooks().map((entry) => ({` | ✅ |
+| 11 `name: registry.getHookName(entry)` | 181 | `name: registry.getHookName(entry),` | ✅ |
+| 12 `eventName: String(entry.eventName)` | 182 | `eventName: String(entry.eventName),` | ✅ |
+| 13 `enabled: entry.enabled` | 183 | `enabled: entry.enabled,` | ✅ |
+| 14 `source: String(entry.source)` | 184 | `source: String(entry.source),` | ✅ |
+| 9-17 `FOR EACH … APPEND` | 180-186 | functional `.map(...)` over entries (semantically equivalent to the loop) | ✅ |
+
+Note: `String(entry.source)` is correct with no undefined-guard — `HookRegistryEntry.source` is the
+non-nullable `ConfigSource` type (`packages/core/src/hooks/hookRegistry.ts:37`). Verified directly.
+`entry.enabled: boolean` confirmed at hookRegistry.ts:41; `getAllHooks()` at :82; `getHookName()`
+at :118.
+
+**`getDisabledHooks()` — pseudocode 31-32 → hooks.ts:191-193**
+
+| Pseudocode | Impl line | Code | Match |
+| --- | --- | --- | --- |
+| 32 `RETURN [...config.getDisabledHooks()]` | 192 | `return [...this.deps.config.getDisabledHooks()];` | ✅ (fresh spread copy) |
+
+**`setDisabledHooks(names)` — pseudocode 41-42 → hooks.ts:198-200**
+
+| Pseudocode | Impl line | Code | Match |
+| --- | --- | --- | --- |
+| 42 `config.setDisabledHooks([...names])` | 199 | `this.deps.config.setDisabledHooks([...names]);` | ✅ (defensive copy on write) |
+
+**`disable(name)` — pseudocode 51-55 → hooks.ts:205-209**
+
+| Pseudocode | Impl line | Code | Match |
+| --- | --- | --- | --- |
+| 52 `SET current = config.getDisabledHooks()` | 206 | `const current = this.deps.config.getDisabledHooks();` | ✅ |
+| 53 `IF current CONTAINS name RETURN` | 207 | `if (current.includes(name)) return;` | ✅ (idempotent) |
+| 54 `config.setDisabledHooks([...current, name])` | 208 | `this.deps.config.setDisabledHooks([...current, name]);` | ✅ |
+
+**`enable(name)` — pseudocode 58-60 → hooks.ts:214-217**
+
+| Pseudocode | Impl line | Code | Match |
+| --- | --- | --- | --- |
+| 58 `SET current = config.getDisabledHooks()` | 215 | `const current = this.deps.config.getDisabledHooks();` | ✅ |
+| 59-60 `next = current.filter(n=>n!==name); setDisabledHooks(next)` | 216 | `this.deps.config.setDisabledHooks(current.filter((n) => n !== name));` | ✅ (idempotent if absent) |
+
+**Compliance result: 5/5 methods match the pseudocode line-by-line. No deviations.**
+
+---
+
+## Non-Breaking Confirmation (REQ-009)
+
+The pre-existing four `AgentHookControl` members are present and unchanged in
+`packages/agents/src/api/agent.ts`:
+
+| Member | agent.ts line | Status |
+| --- | --- | --- |
+| `onHookExecution(cb): Unsubscribe` | 316-318 | ✅ intact |
+| `triggerSessionStart(): Promise<void>` | 319 | ✅ intact |
+| `triggerSessionEnd(): Promise<void>` | 320 | ✅ intact |
+| `clear(): void` | 321 | ✅ intact |
+
+The five new members were ADDED after `clear()` (agent.ts:322-327) and the projected `HookInfo`
+type was added (agent.ts:336-341) with the exact shape from the pseudocode Data Schemas
+(`name: string`, `eventName: string`, `enabled: boolean`, `source?: string`). The concrete
+`HookControl` class likewise preserves the original methods (hooks.ts: `onHookExecution`,
+`triggerSessionStart`, `triggerSessionEnd`, `clear`, plus the private bus machinery) and appends the
+five admin methods at hooks.ts:175-217. **No existing member signature or body was altered. Gate 3
+passed (`non-breaking OK`).**
+
+---
+
+## Delegate-Only / No-Cache Confirmation (R-DELEGATE)
+
+Every admin method resolves live state from `this.deps.config` on each call — `getHookSystem()`,
+`getDisabledHooks()`, `setDisabledHooks()` are invoked per call with no memoization. A full scan of
+`private` fields on `HookControl` (lines 101-111) shows only the pre-existing bus-observer
+infrastructure:
+
+- `MAX_PENDING_CORRELATIONS` (static const, bus buffer cap)
+- `observers: Set<HookObserver>` (onHookExecution registry)
+- `pendingByCorrelation: Map` (bus correlation buffer)
+- `busUnsubscribeRequest` / `busUnsubscribeResponse`
+- `deps` (the injected dependency bundle)
+
+There is **no** `disabledHooks` / `hookCache` / `cachedHooks` field. Gate 4 passed
+(`delegation/guards OK; no cache`). The blocking greps confirm `getHookSystem()` and
+`isInitialized()` are present and the cache-field grep matched nothing (exit 0).
+
+---
+
+## Undefined / Uninitialised Safety (R-UNDEFINED-SAFE)
+
+`listHooks()` guards BOTH conditions before touching the registry:
+- hooks.ts:177 — `if (!system) return [];` (undefined HookSystem)
+- hooks.ts:178 — `if (!system.isInitialized()) return [];` (system present but not initialized)
+
+Only after both guards does it call `getRegistry()` / `getAllHooks()` (hooks.ts:179-180). The
+registry is never touched before init. Verified behaviorally by T12a (plain agent → `listHooks()`
+returns `[]`).
+
+---
+
+## Fresh-Copy Confirmation (no engine-array leak)
+
+- `getDisabledHooks()` returns `[...config.getDisabledHooks()]` (hooks.ts:192) — a new array, never
+  the engine's live reference.
+- `setDisabledHooks(names)` writes `[...names]` (hooks.ts:199) — a defensive copy, so a caller
+  cannot retain a handle that mutates engine state.
+- `disable()` writes `[...current, name]` (hooks.ts:208) and `enable()` writes a fresh
+  `current.filter(...)` array (hooks.ts:216) — both produce new arrays.
+
+Verified behaviorally: T11 mutates the returned array (`push('MUTATED')`, `sort()`) and a re-read
+still yields `['a','b']`; the PROP enable∘disable test pushes `'FRESH-COPY-PROBE'` into a returned
+array and confirms it is absent on re-read. **No internal-array leak path exists.**
+
+---
+
+## Test-File Behavioral Integrity
+
+File: `packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts`
+
+- **Mock theater:** NONE. Gate 5 grep for `toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi.fn(|vi.spyOn` matched nothing. Tests drive real `buildAgent` harness and a REAL `Config` + `HookControl` (T12b constructs `new HookControl({config, messageBus: new MessageBus(), ...})` over a real initialized hook system).
+- **Reverse tests:** NONE. Grep for `not.toThrow()` matched nothing. (`.not.toContain(name)` in PROP-2 is a genuine positive assertion that `enable` removed the name, not a reverse no-throw test.)
+- **Property ratio:** 2 property cases / 6 total = 33% ≥ 30%, and PROP ≥ 2 (MIN-2). Both properties use `fc.assert(fc.asyncProperty(...))` with real generators (unique string arrays len 0..5; name + base set) and assert real round-trip + fresh-copy invariants.
+- **`.skip`/`xit`/`xdescribe`:** NONE found.
+- **`any`:** NONE found. The `(first as string[])` casts are legitimate `readonly string[]` → mutable narrowing for the fresh-copy mutation probe, not `as any`.
+- **Real-value assertions:** Every assertion checks concrete values — `toStrictEqual(['a','b'])`, idempotency chains, `entry.name === 'fake-session-start'`, `eventName === HookEventName.SessionStart`, `enabled === true`, `listHooks() === []`.
+
+T12b deserves note: it genuinely exercises the populated `listHooks()` path by seeding a real
+`enableHooks:true` Config with a SessionStart command hook, calling `await system.initialize()`,
+and asserting the projected `HookInfo` mirrors the seeded entry's name/eventName/enabled. This is the
+only path that reaches the registry `.map(...)` projection (hooks.ts:180-185), so the projection
+fields are behaviorally covered, not just the empty-guard path.
+
+**Test quality verdict: genuinely behavioral. No mock theater, no reverse tests, property gate met,
+real-value assertions throughout.**
+
+---
+
+## Holistic Functionality Assessment
+
+- **What was implemented:** Five hooks-administration methods (`listHooks`, `getDisabledHooks`,
+  `setDisabledHooks`, `enable`, `disable`) added to the existing `AgentHookControl` interface
+  (agent.ts:323-327) and the `HookControl` class (hooks.ts:175-217), plus the projected public
+  `HookInfo` type (agent.ts:336-341).
+- **Satisfies REQ-004?** YES. All five admin entry points exist (REQ-004.1 list, REQ-004.2 read,
+  REQ-004.3 write, REQ-004.4 enable/disable). The existing four members remain intact (REQ-009).
+- **Data flow:** Live `this.deps.config` resolved every call; registry touched only after
+  `isInitialized()`; all returns/writes are fresh spread copies. The data flow matches the
+  Behavior Decision Table exactly (undefined→[], uninitialized→[], populated→mirrored entries,
+  round-trip, idempotent disable/enable).
+- **Risks:** None material. The `.map(...)` functional form replaces the explicit pseudocode FOR
+  loop — semantically identical and idiomatic for the codebase. No cache, no engine-array leak, no
+  change to existing members.
+- **Leak/cache concerns:** None. No cached field; all arrays are fresh copies in and out.
+
+---
+
+## Pasted Verification Output (gate_output)
+
+```
+=== 1. Target test ===
+ ✓ packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts (6 tests) 1953ms
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+=== whole dir ===
+ Test Files  45 passed (45)
+      Tests  570 passed (570)
+   Duration  27.48s
+=== 2. typecheck ===
+> @vybestack/llxprt-code-agents@0.10.0 typecheck
+> tsc --noEmit
+> @vybestack/llxprt-code@0.10.0 typecheck
+> tsc --noEmit
+> @vybestack/llxprt-code-a2a-server@0.10.0 typecheck
+> tsc --noEmit
+> @vybestack/llxprt-code-test-utils@0.10.0 typecheck
+> tsc --noEmit
+=== lint ===
+> @vybestack/llxprt-code@0.10.0 lint
+> cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint . --ext .ts,.tsx && cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint integration-tests
+=== 3. Non-breaking members ===
+non-breaking OK
+=== 4. Delegation + guards; no cache ===
+delegation/guards OK; no cache
+=== 5. Behavioral re-audit ===
+property CASES: 2 / 6 = 33%
+=== 6. Deferred scan ===
+PASS: gates green.
+
+(script exit code: 0)
+```
+
+All gates returned exit 0. typecheck clean across all four packages; lint clean (no errors);
+non-breaking confirmed; no cache; delegation + guards present; no mock theater; no reverse tests;
+property gate 33% (≥30%) with 2 cases (≥MIN-2); no deferred markers on changed lines.
+
+---
+
+## FINAL VERDICT
+
+**PASS** — All five admin methods match `hooks-admin.md` pseudocode line-by-line (hooks.ts:175-217),
+the four existing `AgentHookControl` members are intact and unchanged (agent.ts:316-321), the
+controller is delegate-only with no cache (verified scan of hooks.ts:101-111), `listHooks()` is
+undefined- and uninitialised-safe (hooks.ts:177-178), all returns/writes are fresh copies
+(hooks.ts:192,199,208,216), and the P09 suite is genuinely behavioral (6/6 green, 2/6 property =
+33%, no mock theater, no reverse tests, no `any`). Full gate block exit 0; whole-dir 570/570 green.

--- a/project-plans/issue2143/.completed/P11.md
+++ b/project-plans/issue2143/.completed/P11.md
@@ -1,0 +1,43 @@
+Phase: P11
+Completed: 2026-06-24 05:01
+Files Created:
+- packages/agents/src/api/__tests__/authDetail.behavior.test.ts (360 lines)
+Files Modified: (none)
+Tests Added: 6 (T13, T13b, T13c, T13d, PROP no-secret-leak, PROP expiry-gating)
+
+Verification:
+
+Structural greps (mock-theater / property gate):
+```
+OK: file exists
+OK: no mock theater / reverse tests
+OK: real OAuthManager
+OK: detailedStatus exercised
+OK: listBucketStatuses exercised
+OK: getHigherPriorityAuth exercised
+OK: no-leak enumerated over keys
+OK: no-leak names secret keys
+property CASES: 2 / 6 = 33%
+OK: property gate passed
+```
+
+RED-state enforcement (`npx vitest run authDetail.behavior.test.ts`):
+```
+=== EXIT STATUS: 1 ===
+Caused by: TypeError: control.detailedStatus is not a function
+ ❯ packages/agents/src/api/__tests__/authDetail.behavior.test.ts:319:40
+...
+ Test Files  1 failed (1)
+      Tests  6 failed (6)
+   Duration  2.22s
+=== checking for module/compile errors ===
+OK: no module/compile error
+OK: RED confirmed (nonzero exit)
+```
+
+Deferred-marker scan (scoped):
+```
+PASS: no deferred markers.
+```
+
+Semantic Assessment: Behavioral RED confirmed — all 6 tests fail with missing-method TypeErrors (detailedStatus/listBucketStatuses/getHigherPriorityAuth absent), driving a REAL OAuthManager over an inline MemoryTokenStore with a registered provider; no mock theater, 33% property coverage, no deferred markers.

--- a/project-plans/issue2143/.completed/P12.md
+++ b/project-plans/issue2143/.completed/P12.md
@@ -1,0 +1,74 @@
+Phase: P12
+Completed: 2026-06-24 05:15
+Files Created: (none — test file created in P11)
+Files Modified:
+- packages/agents/src/api/agent.ts (20 insertions; +AuthProviderDetail, +AuthBucketStatus, +3 methods on AgentAuthControl)
+- packages/agents/src/api/control/authControl.ts (59 insertions; +OAuthManager import, +AuthProviderDetail/AuthBucketStatus imports, +getOAuthManager dep field, +detailedStatus, +getHigherPriorityAuth, +listBucketStatuses)
+- packages/agents/src/api/agentImpl.ts (2 insertions; +getOAuthManager closure in buildAuthControl)
+- packages/agents/src/api/__tests__/authDetail.behavior.test.ts (RED-note cast removed; 354 lines total)
+Tests Added: 0 (P11 suite now GREEN: 6 tests pass)
+
+Verification:
+
+Interface extended + existing members preserved:
+```
+OK: detailedStatus on interface
+OK: listBucketStatuses on interface
+OK: existing mcpLogin preserved
+```
+
+Deps field + wiring present:
+```
+OK: getOAuthManager dep on AuthControlDeps
+OK: buildAuthControl threads oauthManager
+```
+
+Impl present + correct seam + markers:
+```
+OK: detailedStatus marker
+OK: uses peekStoredToken
+```
+
+R-NO-RAW-SECRETS + no-cache + cast-gone:
+```
+OK: no raw secret fields in control
+OK: no refreshing getToken
+OK: no cached manager
+OK: RED-note cast removed
+```
+
+Target test GREEN (`npx vitest run authDetail.behavior.test.ts`):
+```
+ ✓ packages/agents/src/api/__tests__/authDetail.behavior.test.ts (6 tests) 11ms
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+```
+
+Whole __tests__ dir GREEN (no regressions):
+```
+ Test Files  46 passed (46)
+      Tests  576 passed (576)
+```
+
+Typecheck:
+```
+> @vybestack/llxprt-code-agents@0.10.0 typecheck
+> tsc --noEmit
+(exit 0 across agents/root/a2a-server/test-utils)
+```
+
+Lint:
+```
+> @vybestack/llxprt-code@0.10.0 lint
+> cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint . --ext .ts,.tsx && cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint integration-tests
+(exit 0, no errors)
+```
+
+Deferred-marker scan (scoped to changed lines):
+```
+PASS: no deferred markers in changed lines.
+```
+
+Property percentage: 2 / 6 = 33%
+
+Semantic Assessment: GREEN — the P11 RED suite passes through three masked, delegating methods (detailedStatus/getHigherPriorityAuth/listBucketStatuses) implemented per pseudocode, the OAuthManager threaded via a closure (no new ctor param), the control references no raw secret fields, and the whole __tests__ dir + typecheck + lint are clean with zero regressions.

--- a/project-plans/issue2143/.completed/P12a.md
+++ b/project-plans/issue2143/.completed/P12a.md
@@ -1,0 +1,200 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P12a @requirement:REQ-005 -->
+# Phase P12a — Auth Detail Implementation: Pseudocode-Compliance Verification
+
+## Phase
+
+`PLAN-20260622-COREAPIGAP.P12a` — independent verification gate for REQ-005 ("auth detail":
+`detailedStatus` / `getHigherPriorityAuth` / `listBucketStatuses` masked, read-only methods on
+`AgentAuthControl`).
+
+## Reviewer
+
+architect (independent verification gate). Every claim below was re-derived from the source with my own
+tool calls — files read in full, greps run, tests executed.
+
+## Date
+
+2026-06-23
+
+## Compliance Table (pseudocode ↔ file:line)
+
+Source of truth: `project-plans/issue2143/analysis/pseudocode/auth-detail.md`.
+Implementation: `packages/agents/src/api/control/authControl.ts`.
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1–17 | `detailedStatus` — resolve mgr per-call (L3→authControl.ts:269); `oauthEnabled = isOAuthEnabled` (L4→:270); `authenticated = await isAuthenticated` (L5→:271); `expiry=undefined` (L6→:272); `IF authenticated` gate (L7→:273); `peekStoredToken` no-refresh (L8→:274); `IF token != null SET expiry=token.expiry` (L9→:275-276); return `{provider, authenticated, oauthEnabled, expiry}` (L11-16→:279) | authControl.ts:268–280 | ✅ YES — verbatim |
+| 30–33 | `getHigherPriorityAuth` — `return AWAIT this.deps.getOAuthManager().getHigherPriorityAuth(provider)` (L32→:290) | authControl.ts:289–291 | ✅ YES — verbatim |
+| 40–49 | `listBucketStatuses` — `raw = AWAIT getOAuthManager().getAuthStatusWithBuckets(provider)` (L42→:300-302); `raw.map` projecting the four named fields `{bucket, authenticated, expiry, isSessionBucket}` (L44-47→:303-308); return (L48→:303) | authControl.ts:299–310 | ✅ YES — verbatim |
+| wiring | `buildAuthControl` threads `getOAuthManager: () => this.deps.oauthManager` (no new ctor param; reuses existing AgentDeps field) | agentImpl.ts:476 | ✅ YES |
+
+Every pseudocode line maps 1:1 to an implementation line. The integration-point symbol claims in the
+pseudocode were independently confirmed against `packages/providers/src/auth/oauth-manager.ts`:
+`isAuthenticated` (:199), `peekStoredToken` (:243), `isOAuthEnabled` (:300), `getHigherPriorityAuth`
+(:313), `getAuthStatusWithBuckets` (:395, return shape `Array<{bucket, authenticated, expiry?,
+isSessionBucket}>`). The control's projection copies exactly those four fields — no shape drift, no extra
+field leakage.
+
+## Security (R-NO-RAW-SECRETS) findings — PASS
+
+- `grep -nE "access_token|refresh_token"` on `authControl.ts` → **no match (exit 1)**. The control never
+  references either raw secret field.
+- `grep -nE "\.getToken\("` on `authControl.ts` → **no match (exit 1)**. The (potentially refreshing,
+  network-making) `getToken` is never used. Expiry is read via `peekStoredToken` (authControl.ts:274),
+  which does NOT refresh.
+- `detailedStatus` reads `token.expiry` (a number) and ONLY that, and ONLY inside the
+  `if (authenticated)` block (authControl.ts:273–277). For an unauthenticated provider the token is never
+  peeked, so no stale expiry surfaces.
+- Returned object shapes carry only the intended public fields:
+  - `AuthProviderDetail` = `{provider, authenticated, oauthEnabled, expiry?}` (agent.ts:170–175) — four
+    fields, all primitives, no token path.
+  - `AuthBucketStatus` = `{bucket, authenticated, expiry?, isSessionBucket}` (agent.ts:178–183) — five
+    fields, all primitives, no token path.
+  - `getHigherPriorityAuth` returns `string | null` (a source NAME), never a secret.
+- The test independently proves the masking behaviorally (not just structurally): `deepKeys()` recursively
+  collects every reachable key of the returned object and asserts `access_token`/`refresh_token` never
+  appear — exercised in T13, T13c, and the no-secret-leak property over randomly generated token strings.
+
+Verdict: no reachable secret-leak path. The masking invariant holds by construction AND is behaviorally
+guarded.
+
+## Delegate-not-cache finding — PASS
+
+- `grep -nE "private .*(oauthManager|cachedManager|authCache)\b"` on `authControl.ts` → **no match
+  (exit 1)**. There is no cached manager/token field on the control.
+- The manager is resolved freshly via `this.deps.getOAuthManager()` on EACH call: `detailedStatus`
+  (authControl.ts:269), `getHigherPriorityAuth` (:290), `listBucketStatuses` (:300). No result is stored
+  between calls. R-DELEGATE satisfied.
+
+## Non-breaking finding (REQ-009) — PASS
+
+`git diff HEAD` on agent.ts shows the change is **purely additive — zero deletion lines**. The existing
+`AgentAuthControl` members are byte-identical and in original order: `login`, `logout`, `status`,
+`enableOAuth`, `disableOAuth`, `listBuckets`, `switchBucket`, `mcpLogin`, `readonly keys:
+AgentAuthKeysControl`, `setBaseUrl` (agent.ts:277–293). The three new methods are appended after the
+existing surface (agent.ts:295–297). No existing signature was altered or removed. The whole
+`packages/agents/src/api/__tests__/` suite (46 files / 576 tests) passes, confirming no behavioral
+regression to existing members.
+
+## Wiring finding — PASS
+
+- `buildAuthControl()` adds exactly ONE field to the `new AuthControl({...})` deps object:
+  `getOAuthManager: () => this.deps.oauthManager` (agentImpl.ts:476). The `git diff` for agentImpl.ts is
+  exactly two added lines (the marker comment + the field) with no deletions.
+- NO new `AgentImpl` constructor parameter was added: the diff contains no `constructor`/`AgentDeps`
+  changes, and `oauthManager` already exists on `AgentDeps` (agentImpl.ts:125, non-nullable
+  `readonly oauthManager: OAuthManager`). The closure reuses that existing field, exactly as the
+  pseudocode requires.
+- The deps type was extended with `readonly getOAuthManager: () => OAuthManager` (authControl.ts:60-61),
+  imported type-only from `@vybestack/llxprt-code-providers/auth.js` (authControl.ts:27) — the same
+  subpath agentImpl.ts uses.
+
+## Test-quality finding — PASS (property = 33%, 2 distinct property tests)
+
+File: `packages/agents/src/api/__tests__/authDetail.behavior.test.ts` (519 lines, 6 tests).
+
+- **Genuinely behavioral / no mock theater**: builds a REAL `OAuthManager` (`new OAuthManager(store)`,
+  L131) over an inline in-memory `MemoryTokenStore implements TokenStore` and registers a REAL
+  `OAuthProvider` plain-object (`makeRealProvider`), enabling OAuth via `mgr.toggleOAuthEnabled`. The
+  control is built directly over the live manager (blessed direct-construction seam). Grep for
+  `toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn` → **no match (exit 1)**.
+- **No reverse tests**: grep for `not\.toThrow\(\)|NotYetImplemented|toThrow\(` → **no match (exit 1)**.
+- **No `any` / no `.skip` / no `xit`/`xdescribe`**: grep → **no match (exit 1)**.
+- **RED-note cast gone**: grep for `as unknown as AuthControlDeps` → **no match (exit 1)**. The deps are
+  now fully typed (the field exists), so the construction is clean.
+- **Property coverage**: 2 property tests / 6 total = **33% (≥30%, ≥2 distinct)**.
+  1. `PROP no-secret-leak` — generates random `access_token`/`refresh_token` strings + a random expiry,
+     seeds the store, calls `detailedStatus`, and asserts `deepKeys(detail)` contains neither secret key
+     AND that `expiry` round-trips the seeded value exactly. The no-leak property genuinely WALKS the
+     returned object keys (recursive `deepKeys`), not a structure-only assertion.
+  2. `PROP expiry-gating` — generates a boolean seed-or-not, then asserts the gating invariant
+     `(detail.expiry !== undefined) === detail.authenticated` and `detail.authenticated === seedToken`,
+     proving expiry is exposed iff authenticated.
+- The four required scenarios (T13, T13b, T13c, T13d) are all present and assert the masked shapes,
+  bucket projection to exactly the four public fields (`toStrictEqual` on sorted keys), and the
+  string-or-null contract.
+
+## Verification (pasted real output)
+
+### Target behavioral test — GREEN
+
+```
+$ npx vitest run packages/agents/src/api/__tests__/authDetail.behavior.test.ts
+ ✓ packages/agents/src/api/__tests__/authDetail.behavior.test.ts (6 tests) 12ms
+
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+   Duration  2.07s
+Exit Code: 0
+```
+
+### Whole api __tests__ dir — GREEN (non-breaking)
+
+```
+$ npx vitest run packages/agents/src/api/__tests__/
+ Test Files  46 passed (46)
+      Tests  576 passed (576)
+   Duration  23.37s
+Exit Code: 0
+```
+
+### Typecheck — exit 0
+
+```
+$ npm run typecheck
+> @vybestack/llxprt-code-providers@0.10.0 typecheck  > tsc --noEmit
+> @vybestack/llxprt-code-agents@0.10.0 typecheck     > tsc --noEmit
+> @vybestack/llxprt-code@0.10.0 typecheck            > tsc --noEmit
+> @vybestack/llxprt-code-a2a-server@0.10.0 typecheck > tsc --noEmit
+> @vybestack/llxprt-code-test-utils@0.10.0 typecheck > tsc --noEmit
+TYPECHECK_EXIT=0
+```
+
+### Gate greps (control = authControl.ts; F = authDetail.behavior.test.ts)
+
+```
+access_token|refresh_token in control     → no match (exit 1)   PASS
+.getToken( in control                     → no match (exit 1)   PASS
+private cached manager field              → no match (exit 1)   PASS
+peekStoredToken in control                → :274                PASS
+this.deps.getOAuthManager() per call      → :269, :290, :300    PASS
+if (authenticated) gate                   → :273                PASS
+buildAuthControl getOAuthManager wiring   → agentImpl.ts:476     PASS
+mock theater in test                      → no match (exit 1)   PASS
+reverse tests in test                     → no match (exit 1)   PASS
+as unknown as AuthControlDeps in test     → no match (exit 1)   PASS
+new OAuthManager( in test                 → :131                PASS
+property CASES                            → 2 / 6 = 33%          PASS
+deferred markers on changed lines         → clean (all 3 files) PASS
+git diff deletions (authControl/agentImpl)→ none (exit 1)       PASS
+git diff agent.ts                         → additive only       PASS
+```
+
+## Holistic Assessment
+
+The P12 implementation is a faithful, minimal, line-for-line realization of the auth-detail pseudocode.
+
+- **What was implemented**: the three masked detail methods (`detailedStatus`, `getHigherPriorityAuth`,
+  `listBucketStatuses`) on `AuthControl`, the two projected public types (`AuthProviderDetail`,
+  `AuthBucketStatus`) on `AgentAuthControl`, the new `getOAuthManager` dep on `AuthControlDeps`, and the
+  one-line closure wiring in `buildAuthControl()`.
+- **Satisfies REQ-005?** Yes. All three methods exist, return masked shapes sourced from the live
+  manager, and the existing surface is intact (REQ-009 non-breaking — purely additive diff, full suite
+  green).
+- **Data flow**: the live `OAuthManager` is resolved per call via `this.deps.getOAuthManager()` (no
+  caching); expiry is read via `peekStoredToken` (no refresh) and gated behind `authenticated === true`;
+  buckets are projected to exactly the four public fields.
+- **Security (R-NO-RAW-SECRETS)**: no `access_token`/`refresh_token` reference anywhere in the control, no
+  `getToken` use, and the behavioral test enumerates returned keys (recursively) over generated inputs to
+  prove no secret ever surfaces. Leak risk: none found.
+- **Risks**: none identified. No cached manager, no secret path, no broken/altered existing member, no
+  refreshing `getToken`, no new constructor parameter, no deferred markers.
+- **Test integrity**: genuinely behavioral over a real `OAuthManager` + in-memory `TokenStore` + real
+  registered provider; ≥30% property (2 distinct properties); no mock theater, no reverse tests, no
+  `any`, no `.skip`; RED-note cast removed.
+
+## FINAL VERDICT: PASS
+
+Every pseudocode line maps verbatim to the implementation; R-NO-RAW-SECRETS, delegate-not-cache,
+non-breaking, and wiring invariants all verified against source; the behavioral test (6/6) and full
+agents api suite (576/576) are green and typecheck exits 0.

--- a/project-plans/issue2143/.completed/P13.md
+++ b/project-plans/issue2143/.completed/P13.md
@@ -1,0 +1,37 @@
+Phase: P13
+Completed: 2026-06-24 06:40
+Files Created:
+- packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts (465 lines; 12 tests, 4 property-based = 33%)
+Files Modified: (none)
+Tests Added: 12 (RED — drives the not-yet-implemented authenticate/details + refresh setTools parity)
+
+Behavioral RED scenarios (no mock theater; observable `callLog: string[]` seam):
+- T14  authenticate orchestrates performOAuth -> restartServer -> refreshClientTools; returns { authenticated:true, requiresAuth:true }; callLog order ['oauth:s','restart:s','setTools'].
+- T14b unknown server -> no-op { authenticated:false, requiresAuth:true }; callLog [].
+- T14c performOAuth rejection PROPAGATES ('oauth boom'); no restart/setTools after.
+- T15  refresh('s') -> ['restart:s','setTools']; refresh() -> ['restart-all','setTools'] (setTools parity on BOTH paths).
+- T16  manager undefined -> refresh/authenticate no-op; callLog [].
+- Td1/Td2/Td3 details projection: includeTools default true; prompts/resources gated by opts; undefined-safe; named-field-only projection.
+- PROP (4 total, MIN-2 satisfied): authenticate ordering invariant; details opts gating; undefined-safety; named-field projection never leaks raw SDK objects.
+
+RED-note technique: single construction-site cast `new McpControl(deps as unknown as McpControlDeps)` so the file PARSES; positive assertions then fail at runtime with missing-method TypeError (behavioral RED, NOT a compile/module error).
+
+Verification:
+
+RED run (before impl) produced behavioral failures (missing authenticate/details methods), not module/syntax errors:
+```
+TypeError: control.authenticate is not a function
+(no "Cannot find module" / "SyntaxError" / "Failed to resolve import" / "ReferenceError")
+```
+
+Property ratio: 4/12 = 33% (>= 30%, MIN-2 distinct property tests satisfied).
+
+Discipline greps (all empty = PASS):
+```
+OK: no toHaveBeenCalled / mockResolvedValue / mockReturnValue / vi.fn( / vi.spyOn
+OK: no not.toThrow() reverse tests
+OK: no .skip / xit / xdescribe
+OK: observable callLog seam present
+```
+
+Semantic Assessment: PASS — behavioral RED suite drives the full REQ-006 surface (authenticate orchestration+propagation, refresh setTools parity on both paths, details projection, undefined-safety) via an observable callLog seam with zero mock theater; RED failures are genuine missing-method TypeErrors.

--- a/project-plans/issue2143/.completed/P14.md
+++ b/project-plans/issue2143/.completed/P14.md
@@ -1,0 +1,52 @@
+Phase: P14
+Completed: 2026-06-24 06:42
+Files Created:
+- packages/agents/src/api/control/mcpControlWiring.ts (65 lines; sibling wiring module — exports McpControlWiringArgs + buildMcpControlDeps; binds MCPOAuthProvider.authenticate here only)
+Files Modified:
+- packages/agents/src/api/agent.ts (+6 projected types McpDetailsOptions/McpPromptInfo/McpResourceInfo/McpBlockedServer/McpServerDetail/McpDetailStatus; +authenticate + details on AgentMcpControl; existing 6 members byte-identical)
+- packages/agents/src/api/control/mcpControl.ts (+6 OPTIONAL closures on McpControlDeps; +2 view interfaces McpPromptRegistryView/McpResourceRegistryView; impl authenticate @pseudocode 1-16, refresh restructured to if/else for setTools parity @pseudocode 30-41, details + private buildServerDetail @pseudocode 50-78)
+- packages/agents/src/api/agentImpl.ts (buildMcpControl now delegates to buildMcpControlDeps; MCPOAuthProvider import REMOVED; +buildMcpControlDeps import)
+Tests Added: 0 (P13 suite now GREEN: 12 tests pass)
+
+Design note (max-lines remediation): the performOAuth binding + closure bundle were extracted from agentImpl into a dedicated sibling wiring module control/mcpControlWiring.ts. This (a) keeps the control delegate-only, (b) moves the MCPOAuthProvider import out of agentImpl entirely, and (c) relieved agentImpl max-lines pressure (was 803 > 800 cap). buildMcpControl() now calls buildMcpControlDeps({ config, isMcpAuthenticated, resolveClient }).
+
+performOAuth typing: dep type is Promise<void> but MCPOAuthProvider.authenticate returns Promise<MCPOAuthToken>; bound as `async (s,c,u) => { await MCPOAuthProvider.authenticate(s,c,u,undefined); }` — token awaited-and-discarded (never surfaced: R-NO-RAW-SECRETS), events=undefined (CLI-only appEvents not importable).
+
+Verification:
+
+Target test GREEN:
+```
+✓ packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts (12 tests) 17ms
+  Test Files  1 passed (1)
+       Tests  12 passed (12)
+```
+
+Whole agents __tests__ dir GREEN (no regressions):
+```
+Test Files  47 passed (47)
+     Tests  588 passed (588)
+```
+
+Project gates:
+```
+npm run typecheck -> EXIT 0
+npm run lint      -> EXIT 0   (agentImpl back under 800-line cap after wiring extraction)
+prettier --check  -> All matched files use Prettier code style!
+```
+
+Pseudocode compliance markers present in mcpControl.ts:
+```
+OK: @pseudocode lines 1-16  (authenticate)
+OK: @pseudocode lines 30-41 (refresh)
+OK: @pseudocode lines 50-78 (details)
+```
+
+MCPOAuthProvider bound ONLY in wiring module:
+```
+OK: not referenced in mcpControl.ts
+OK: not referenced in agentImpl.ts
+OK: import { MCPOAuthProvider } from '@vybestack/llxprt-code-core' present in mcpControlWiring.ts
+OK: performOAuth: async ... await MCPOAuthProvider.authenticate( ... in wiring
+```
+
+Semantic Assessment: PASS — REQ-006 implemented verbatim to pseudocode; authenticate orders performOAuth->restartServer->refreshClientTools with no try/catch (errors propagate); refresh has setTools parity on both named-server and restart-all paths; details projects to named-field-only public types (no raw SDK leak); all closures delegate live this.deps per call (no cache); existing 6 AgentMcpControl members + refresh signature byte-identical (non-breaking); MCPOAuthProvider isolated to the wiring module.

--- a/project-plans/issue2143/.completed/P14a.md
+++ b/project-plans/issue2143/.completed/P14a.md
@@ -1,0 +1,54 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P14a @requirement:REQ-006 -->
+# Phase 14a Completion — MCP OAuth + details Pseudocode-Compliance Verification
+
+Independent gate executed against actual source (not grep-trusted) on branch `issue2143`.
+Prerequisite `project-plans/issue2143/.completed/P14.md` present (P14_EXISTS).
+
+## Verification Command Results (real output, exit codes captured directly)
+
+| Gate | Command | Result |
+| --- | --- | --- |
+| Target test | `npx vitest run …/mcpOAuth.behavior.test.ts` | EXIT=0 — 12/12 passed |
+| Whole dir | `npx vitest run …/api/__tests__/` | EXIT=0 — 47 files, 588/588 passed (no regressions) |
+| Typecheck | `npm run typecheck` | TYPECHECK_EXIT=0 (all packages: agents/core/a2a/test-utils) |
+| Lint | `npm run lint` | LINT_EXIT=0 |
+| §3 Non-breaking | six members + `refresh(server?: string): Promise<void>` | all present/intact |
+| §4 Ordering | authenticate oauth(316)<restart(319)<setTools(322) | ok |
+| §4 No try/catch | authenticate has no try-block | ok (errors propagate) |
+| §4 Refresh parity | refresh calls refreshClientTools | ok |
+| §5 Binding | MCPOAuthProvider only in wiring; absent from control+agentImpl | ok |
+| §6 Markers/no-cache | 1-16 / 30-41 / 50-78 markers; no cached field | ok |
+| §7 No raw leak | no `...(p|r|prompt|resource)` spread; named-field projection | ok |
+| §8 Behavioral | no mock theater, no reverse test, callLog seam present | ok |
+| §8 Property gate | 4 / 12 = 33% (≥2 distinct, ≥30%) | ok |
+| §9 Deferred scan | no TODO/FIXME/HACK/STUB/placeholder on changed lines | ok |
+
+## Line-by-Line Compliance Table
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1-16 | authenticate — getServerConfigs (308); serverConfig=configs[server] (309); performOAuth dep (310); undefined/unwired guard→{authenticated:false,requiresAuth:true} (311-313); oauthConfig=oauth??{enabled:false} (314); mcpServerUrl=httpUrl??url (315); await performOAuth — NO try/catch, propagates (316); manager=getManager (317); if defined restartServer (318-320); if refreshClientTools defined await it (321-323); return authenticated:true (324) | mcpControl.ts:307-325 | YES |
+| 30-41 | refresh — manager=getManager (283); undefined-safe early return (284-286); named→restartServer (287-288); else→restart() (289-291); NEW setTools parity refreshClientTools (292-294) | mcpControl.ts:282-295 | YES |
+| 50-78 | details — includeTools??true / includePrompts??false / includeResources??false (337-339); configs??{} (340); reuse toolsByServer() (341); resourcesAll gated by includeResources, ??[] (342-344); per-server loop over Object.keys(configs) (346-357) delegating to buildServerDetail (365-404): detail.name + authenticated=isMcpAuthenticated??false (384-386), tools=toolsByServer[name]??[] (387-389), prompts gated→getPromptsByServer??[]→map to {name,description} ONLY (390-397), resources gated→filter by serverName→map to {name,uri} ONLY (398-402); blocked projection map to {name,extensionName} (358-360); return {servers,blockedServers} (361). The buildServerDetail extraction is marked `@pseudocode lines 60-74` (364) and is a faithful refactor of the FOR-EACH body. | mcpControl.ts:336-404 | YES |
+| Dependencies/wiring | six injected closures via buildMcpControlDeps: isMcpAuthenticated/getManager/getToolRegistry (existing) + getServerConfigs(46), getBlockedServers??[](47), getPromptRegistry(48-51), getResourceRegistry(52-54), refreshClientTools→resolveClient().setTools()(55), performOAuth: async (…)=>{ await MCPOAuthProvider.authenticate(server,oauthConfig,mcpServerUrl,undefined) }(56-63) — async/await-discard form (token never surfaced); MCPOAuthProvider value-imported from bare core barrel (14) | mcpControlWiring.ts:38-65 | YES |
+| Wiring consumption | buildMcpControl() builds mcpDeps via buildMcpControlDeps({config, isMcpAuthenticated, resolveClient}) and returns new McpControl(mcpDeps); MCPOAuthProvider NOT imported here (import at agentImpl.ts:60 is buildMcpControlDeps only) | agentImpl.ts:492-500 (import :60) | YES |
+
+Public types added in agent.ts (REQ-006 surface): McpDetailsOptions(163-167), McpPromptInfo(170-173), McpResourceInfo(176-179), McpBlockedServer(182-185), McpServerDetail(188-194), McpDetailStatus(197-200); AgentMcpControl extended with authenticate(297) + details(299) while the six existing members (290-295) are byte-identical.
+
+## Holistic Functionality Assessment
+
+**What was implemented.** The EXISTING `AgentMcpControl`/`McpControl` surface was extended with three behaviors on REQ-006: (1) a real, injected-closure OAuth flow `authenticate(server)`; (2) `refresh(server?)` setTools parity (re-publishing tool declarations after restart on BOTH the named-server and restart-all paths); (3) a deep `details(opts?)` per-server projection. Six new optional closures were added to `McpControlDeps` (getServerConfigs, getBlockedServers, getPromptRegistry, getResourceRegistry, refreshClientTools, performOAuth) and wired in a NEW dedicated module `mcpControlWiring.ts` (buildMcpControlDeps), consumed by `AgentImpl.buildMcpControl()`.
+
+**Satisfies REQ-006?** Yes. Ordering auth→restart→setTools is enforced and proven (oauth=316 < restart=319 < setTools=322; behavioral test T14 asserts callLog `['oauth:s','restart:s','setTools']`). Error propagation is enforced — there is NO try/catch around performOAuth, so a rejection aborts before restart/setTools (test T14c asserts the call rejects and callLog contains oauth but NOT restart/setTools). Both refresh AND authenticate re-publish tools (R-REFRESH-PARITY; test T15 covers restart:s→setTools and restart-all→setTools). details() gates prompts/resources behind opts (defaults false) and projects to named-field-only public types. The six pre-existing members and the `refresh(server?: string): Promise<void>` signature are intact (REQ-009; git diff shows zero changes to existing member signatures and the existing `auth(server)` body is byte-identical at mcpControl.ts:244-251).
+
+**Data flow / no-cache.** Every capability is resolved through `this.deps?.<closure>()` on each call — no manager/registry/config is stored in a control field (no cachedDetails/serverCache/mcpCache; verified by reading the class — the only field is the constructor `deps`). MCPOAuthProvider is bound ONLY in mcpControlWiring.ts:14/57 and appears in neither mcpControl.ts nor agentImpl.ts (R-DELEGATE upheld).
+
+**Security / no-leak.** No raw `DiscoveredMCPPrompt`/`MCPResource` object is ever spread or returned. Registry rows from getPromptsByServer/getAllResources are consumed ONLY via `.map()` projections emitting exactly `{name, description}` (prompts, mcpControl.ts:393-396) and `{name, uri}` (resources, :399-401). The three `...` spreads in the file (179/180/221) are pre-existing conditional named-field builders in listServers/toolsByServer, not raw row spreads. The OAuth token is awaited-and-discarded in the wiring closure (mcpControlWiring.ts:57-62), keeping `Promise<void>` and never surfacing the token (R-NO-RAW-SECRETS).
+
+**Tests are genuinely behavioral.** The suite uses an observable `callLog: string[]` ordering seam pushed into by real injected closures; there is NO mock theater (no vi.fn/vi.spyOn/mockResolvedValue/mockReturnValue/toHaveBeenCalled), NO reverse test (no bare `.not.toThrow()`), and 4 of 12 cases (33%) are property-based via `fc.assert` (refresh parity, unknown-server, known-server orchestration, details key-count) — ≥2 distinct properties, ≥30%.
+
+**Risks.** Low. All six new closures are undefined-safe (`?.` + `?? []`/`?? {}`), matching the existing getManager-undefined guard convention. No ordering regression (statically + behaviorally proven). No import of the OAuth static into the control. The details() refactor into a private buildServerDetail helper is a clean extraction that preserves the pseudocode body and the named-field-only projection.
+
+## FINAL VERDICT: PASS
+
+Evidence: pseudocode 1-16 ⇒ mcpControl.ts:307-325 (ordering oauth:316<restart:319<setTools:322, no try/catch, propagation); 30-41 ⇒ mcpControl.ts:282-295 (parity at :292-294); 50-78 ⇒ mcpControl.ts:336-404 (named-field projection :393-396/:399-401, no raw spread); wiring ⇒ mcpControlWiring.ts:38-65 (MCPOAuthProvider bound only here at :14/:57, token discarded :57-62); consumption ⇒ agentImpl.ts:492-500. Non-breaking confirmed: agent.ts:289-300 six existing members + refresh signature intact, auth body unchanged at mcpControl.ts:244-251. All verification gates green: target 12/12, whole dir 588/588, typecheck EXIT=0, lint EXIT=0, property 4/12=33%, no deferred markers, no mock theater.

--- a/project-plans/issue2143/.completed/P15.md
+++ b/project-plans/issue2143/.completed/P15.md
@@ -1,0 +1,11 @@
+Phase: P15
+Completed: 2026-06-24 07:04
+Files Created:
+- packages/agents/src/api/__tests__/toolKeys.behavior.test.ts (235 lines)
+Files Modified: none
+Tests Added: 12 (8 example + 4 property-based)
+Verification:
+property CASES: 4 / 12 = 33%
+RED confirmed behavioral (expected until P16).
+PASS: no deferred markers.
+Semantic Assessment: Behavioral RED suite drives a real hermetic ToolKeyStorage over a Map-backed keyring with no mocks; T19 anchors a behavioral TypeError on the public agent.tools.keys surface; 4/12 property cases satisfy the 30% gate.

--- a/project-plans/issue2143/.completed/P16.md
+++ b/project-plans/issue2143/.completed/P16.md
@@ -1,0 +1,28 @@
+Phase: P16
+Completed: 2026-06-24 07:20
+Files Created:
+- packages/agents/src/api/control/toolKeysControl.ts (112 lines)
+Files Modified:
+- packages/agents/src/api/agent.ts (+27 lines: ToolKeyInfo, ToolKeyStatus, AgentToolKeyControl interfaces + readonly keys on AgentToolControl)
+- packages/agents/src/api/control/toolControl.ts (+11/-1: import ToolKeysControl, keysDeps on ToolControlDeps, readonly keys field + ctor assignment)
+- packages/agents/src/api/agentImpl.ts (+4 lines: getToolKeyStorage import + keysDeps field)
+- packages/agents/src/api/__tests__/helpers/fakeToolControlDeps.ts (+4 lines: getToolKeyStorage import + keysDeps on fake ToolControlDeps for typecheck)
+Tests Added: 0 (P16 is implementation; P15 tests now GREEN)
+Verification:
+ALL P16 GREP GATES PASS
+PASS: no deferred markers in changed lines.
+=== TARGET TEST ===
+TARGET_EXIT=0
+ Test Files  1 passed (1)
+      Tests  12 passed (12)
+=== WHOLE DIR ===
+WHOLEDIR_EXIT=0
+ Test Files  48 passed (48)
+      Tests  600 passed (600)
+=== TYPECHECK ===
+TYPECHECK_EXIT=0
+=== LINT ===
+LINT_EXIT=0
+=== ESLINT AGENTIMPL ===
+ESLINT_EXIT=0 (clean, no max-lines error)
+Semantic Assessment: agent.tools.keys is live, masked, and distinct from agent.auth.keys; all 6 methods delegate to the shared ToolKeyStorage singleton with no raw-key leakage, no cached storage, and no re-validation/catch; existing AgentToolControl members byte-identical.

--- a/project-plans/issue2143/.completed/P16a.md
+++ b/project-plans/issue2143/.completed/P16a.md
@@ -1,0 +1,175 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P16a @requirement:REQ-007 -->
+# Phase 16a Completion Marker — Tool-Key Storage Pseudocode-Compliance Verification
+
+Phase ID: `PLAN-20260622-COREAPIGAP.P16a`
+Subagent: architect (independent verification gate)
+Prerequisite: `project-plans/issue2143/.completed/P16.md` — PRESENT (also P15.md present).
+Verdict: **PASS**
+
+---
+
+## 1. Verification Commands — Result
+
+The complete `## Verification Commands` bash block from `plan/16a-tool-keys-impl-verification.md`
+was executed in full (each gate run individually with exit codes captured directly — no masking
+pipes). All gates passed.
+
+| Gate | Description | Result |
+| --- | --- | --- |
+| 1 | Target test GREEN (`toolKeys.behavior.test.ts`) | PASS — 12/12 tests, EXIT=0 |
+| 1 | Whole `api/__tests__/` dir GREEN (no regressions) | PASS — 48 files / 600 tests, EXIT=0 |
+| 2 | `npm run typecheck` | PASS — EXIT=0 |
+| 2 | `npm run lint` | PASS — EXIT=0 |
+| 3 | Non-breaking: 6 existing AgentToolControl members + `readonly keys: AgentToolKeyControl` | PASS |
+| 4 | All six `@pseudocode lines` markers (1-11, 20-34, 40-43, 50-53, 60-67, 70-73) | PASS |
+| 5 | R-NO-RAW-SECRETS: masks; no raw-key return; no maskedKey on no-key branch | PASS |
+| 6 | Validation delegated (no `isValidToolKeyName`, no `catch`) | PASS |
+| 7 | Delegation `this.deps.getStorage()`; no cached storage; ToolControl + agentImpl wiring | PASS |
+| 8 | R-KEYS-DISTINCT: separate `class ToolKeysControl`; no `AuthKeysControl` reuse | PASS |
+| 9 | P15 behavioral/hermetic: real `ToolKeyStorage` + `keyringLoader`; no mock theater; no reverse test; distinct `!==` check; no-leak enumerated | PASS |
+| 9 | Property gate: 4 / 12 = 33% (>=2 and >=30%) | PASS |
+| 10 | Deferred-marker scan on changed lines (A/K/T/I) | PASS — none |
+
+`gates_result`: ALL gates of the plan/16a bash block PASSED — no failing gate.
+
+Environment note (macOS/BSD grep): no command required adaptation. The block uses only `grep -qE`/
+`grep -nE` with POSIX-portable patterns (no `\s`/`\b`); the property-count uses `awk` and arithmetic.
+All gates were genuinely evaluable as written. Gate 10 (`git diff HEAD`) was non-vacuous for the three
+modified files (agent.ts, agentImpl.ts, toolControl.ts are `M`); the two new files (toolKeysControl.ts,
+toolKeys.behavior.test.ts are untracked `??`) were ALSO scanned independently for deferred markers —
+none found.
+
+---
+
+## 2. Line-by-Line Compliance Table
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1-11 | supported (registry projection; skip undefined entries) | toolKeysControl.ts:52-66 | **YES** — iterates `getSupportedToolNames()`, `getToolKeyEntry(name)`, `if (entry === undefined) continue`, pushes `{toolName: entry.toolKeyName, displayName, description}`, returns array. Mirrors lines 3-10 exactly. |
+| 20-34 | status (masked; maskedKey ONLY when hasKey; keyFile present only when set; raw key never returned) | toolKeysControl.ts:69-87 | **YES (intent-faithful)** — resolves `storage` per call, `await getKey`, `await getKeyfilePath`; `if (rawKey !== null)` returns `{toolName, hasKey:true, maskedKey: maskKeyForDisplay(rawKey), ...(keyFile!==null?{keyFile}:{})}`; else `{toolName, hasKey:false, ...(keyFile!==null?{keyFile}:{})}`. See §status-intent below — conditional spread is the CORRECT realization of the literal `keyFile: keyFile ?? undefined`. |
+| 40-43 | save (delegate saveKey; validation propagates) | toolKeysControl.ts:90-92 | **YES** — `await this.deps.getStorage().saveKey(toolName, key)`; no try/catch, throw propagates. |
+| 50-53 | delete (delegate deleteKey) | toolKeysControl.ts:95-97 | **YES** — `await this.deps.getStorage().deleteKey(toolName)`. |
+| 60-67 | setKeyFile (null → clearKeyfilePath; else setKeyfilePath) | toolKeysControl.ts:100-106 | **YES** — `if (path === null) clearKeyfilePath(toolName) else setKeyfilePath(toolName, path)`. |
+| 70-73 | getKeyFile (delegate getKeyfilePath) | toolKeysControl.ts:109-111 | **YES** — `return this.deps.getStorage().getKeyfilePath(toolName)`. |
+| wiring | ToolControl constructs `keys = new ToolKeysControl(deps.keysDeps)`; agentImpl provides `keysDeps: { getStorage: () => getToolKeyStorage() }` | toolControl.ts:92 (constructor) + import :33; agentImpl.ts:328 | **YES** — `this.keys = new ToolKeysControl(deps.keysDeps)` (toolControl.ts:92); `keysDeps: { getStorage: () => getToolKeyStorage() }` (agentImpl.ts:328); `getToolKeyStorage` imported from core barrel at agentImpl.ts:29. The 2nd `keysDeps` at agentImpl.ts:453 is the AUTH-keys deps for `AuthControl` — distinct and unrelated. |
+
+Interface surface (agent.ts): `ToolKeyInfo` :281-285, `ToolKeyStatus` :288-293 (`maskedKey?`, `keyFile?`
+both optional), `AgentToolKeyControl` :296-303 (all six methods), `AgentToolControl.readonly keys:
+AgentToolKeyControl` :313. Mirrors the Interface Contracts in tool-keys.md.
+
+---
+
+## 3. Holistic Functionality Assessment (MANDATORY)
+
+- **What was implemented**: the six-method masked `ToolKeysControl` (toolKeysControl.ts) delegating to
+  core `ToolKeyStorage`, nested under the existing `ToolControl` as `agent.tools.keys`, wired to the
+  shared `getToolKeyStorage()` singleton via the `keysDeps.getStorage` seam. New public types
+  `ToolKeyInfo`/`ToolKeyStatus`/`AgentToolKeyControl` and the `readonly keys` member added to the
+  existing `AgentToolControl` interface.
+
+- **Satisfies REQ-007?**: YES. `supported` / `status` / `save` / `delete` / `setKeyFile` / `getKeyFile`
+  are all present and purely delegating (toolKeysControl.ts:52-111). Behavior verified against the core
+  primitives: `maskKeyForDisplay('abcd1234efgh') = 'ab********gh'` and `maskKeyForDisplay('short') =
+  '*****'` (tool-key-storage-types.ts:82-88) match tests T18/T18a; `getKey` calls `assertValidToolName`
+  (tool-key-storage.ts:300 → :125) so `status('not-a-tool')`/`save('not-a-tool')` reject with
+  "Invalid tool key name" (tool-key-storage.ts:128) — matches T18b.
+
+- **Data flow**: live `this.deps.getStorage()` resolved on EVERY call (no instance field caches a
+  storage handle — confirmed: only `private readonly deps` exists, toolKeysControl.ts:49). `status`
+  masks via `maskKeyForDisplay`; `maskedKey` is omitted entirely when no key; `setKeyFile(null)` clears
+  via `clearKeyfilePath`. Round-trip proven by T18d + the save/delete property test (live temp-dir
+  storage, EXIT=0).
+
+- **Security (R-NO-RAW-SECRETS)**: NO path returns the raw key. Trace of `status()` (toolKeysControl.ts:69-87):
+  `rawKey` is read at :71 and the ONLY consumer is `maskKeyForDisplay(rawKey)` at :77. The two return
+  objects are `{toolName, hasKey:true, maskedKey:<masked>, [keyFile]}` (:75-80) and
+  `{toolName, hasKey:false, [keyFile]}` (:82-85) — neither places `rawKey` on the object, and `rawKey`
+  is never logged or returned anywhere in the file. Negative grep (gate 5) confirms no
+  `maskedKey: rawKey | key: rawKey | , rawKey | return rawKey`. The P15 test enumerates REAL output:
+  T18 asserts `JSON.stringify(status)` does not contain the raw `'abcd1234efgh'` and
+  `Object.keys(status)` excludes `rawKey`/`key`/`access_token` (toolKeys.behavior.test.ts:91-96);
+  the length>8 property test asserts `maskedKey` does not contain the raw key over 8 random runs
+  (:181-203). **Verdict: NO leak risk.**
+
+- **Distinctness (R-KEYS-DISTINCT)**: `agent.tools.keys` is a separate `ToolKeysControl` instance
+  (constructed in ToolControl, toolControl.ts:92), NOT an alias of `agent.auth.keys` (an
+  `AuthKeysControl` built in AgentImpl.buildAuthControl, agentImpl.ts:453-487). The control file imports
+  no auth-keys symbol (gate 8: no `AuthKeysControl` match in toolKeysControl.ts). The public-surface
+  test asserts `agent.tools.keys !== agent.auth.keys` against a real `buildAgent` agent
+  (toolKeys.behavior.test.ts:156). **Confirmed distinct.**
+
+- **Validation ownership (REQ-007.7)**: the invalid-tool-name throw originates in
+  `ToolKeyStorage.assertValidToolName` (tool-key-storage.ts:125-128) invoked inside every storage call
+  (getKey:300, saveKey:281, etc.) and propagates UNCAUGHT through the control — toolKeysControl.ts has
+  no `catch` and no `isValidToolKeyName` re-implementation (gate 6). Tests drive the rejection through
+  the REAL storage throw (T18b + status-invalid-name), not a re-implemented check.
+
+- **Non-breaking**: all six existing `AgentToolControl` members remain declared unchanged —
+  `list` (agent.ts:306), `setEnabled` (:307), `onConfirmationRequest` (:308),
+  `respondToConfirmation` (:309), `onToolUpdate` (:310), `setEditorCallbacks` (:311). Only
+  `readonly keys: AgentToolKeyControl` (:313) was ADDED. `ToolControl` still `implements
+  AgentToolControl` and retains all six method bodies (toolControl.ts). Whole-dir suite green (600
+  tests) and full typecheck/lint clean confirm no regression.
+
+- **agentImpl.ts max-lines:800 cap**: `npx eslint packages/agents/src/api/agentImpl.ts` EXIT=0.
+  `--print-config` confirms an ACTIVE error-level (`2`) `max-lines` rule `{ max: 800, skipBlankLines:
+  true, skipComments: true }` applies to the file. Raw length is 1549 lines, but counted (non-blank,
+  non-comment) lines ≈ 786 — under the 800 cap with margin. The cap is genuinely satisfied, not
+  vacuously unmatched.
+
+- **TDD discipline (P15)**: real hermetic `ToolKeyStorage` over a temp dir
+  (`fs.mkdtemp` + `new ToolKeyStorage({ toolsDir, keyringLoader: async () => memoryKeyring() })`,
+  toolKeys.behavior.test.ts:44-50) with a real Map-backed keyring (NOT a spy). No mock theater
+  (no `vi.fn`/`vi.spyOn`/`mockResolvedValue`/`mockReturnValue`/`toHaveBeenCalled` — gate 9). No reverse
+  tests (`not.toThrow()` absent). Property cases = 4 of 12 (33%, ≥2 distinct): save/delete round-trip,
+  mask-no-leak len>8, full-mask len≤8, supported-projection invariant. `afterEach` cleans the temp dir.
+
+- **Risks**: none material. The status() shape DIVERGES from the verbatim pseudocode literal
+  `keyFile: keyFile ?? undefined`; see §status-intent — the divergence is REQUIRED for correctness
+  (the literal would set `keyFile: undefined`, breaking the tests' `toStrictEqual`). No cached storage,
+  no raw-key surfacing, no member changes, no re-implemented validation, no CLI-side path logic in
+  `setKeyFile`.
+
+### §status-intent — conditional-spread vs. literal `keyFile: keyFile ?? undefined`
+
+`status_intent_finding`: The implementation uses `...(keyFile !== null ? { keyFile } : {})` instead of
+the pseudocode literal `keyFile: keyFile ?? undefined` (tool-keys.md lines 30/33). This is the CORRECT
+realization of the SPEC INTENT, not a deviation from it:
+
+- The pseudocode's OWN Behavior Decision Table requires "no key, no keyfile → `{toolName, hasKey:false}`
+  (no maskedKey, **no keyFile**)" and "keyfile set, no stored key → `{..., keyFile:'/path/key'}`".
+- The projected type is `keyFile?: string` (OPTIONAL — agent.ts:292), i.e. the key should be ABSENT
+  when unset, not present-with-`undefined`.
+- The Anti-Pattern Warning "omit maskedKey when hasKey is false" expresses the same omit-when-absent
+  intent for the masked path.
+- The literal `keyFile: keyFile ?? undefined` would place an explicit `keyFile: undefined` property on
+  the object. Under Vitest `toStrictEqual`, `{toolName, hasKey:true, maskedKey} ` is NOT strictly equal
+  to `{..., keyFile: undefined}` (strict-equal flags extra own keys whose value is `undefined`). So the
+  verbatim literal would FAIL test T18 (`toStrictEqual({toolName:'exa', hasKey:true,
+  maskedKey:'ab********gh'})`, line 86-90) and T18c (`toStrictEqual({toolName:'exa', hasKey:false})`,
+  line 132). The conditional-spread form makes both pass and surfaces `keyFile` only when set (T18d,
+  line 145). **Conclusion: the conditional-spread satisfies the pseudocode's Behavior-Decision-Table
+  intent, the `keyFile?: string` optional type, and the tests' `toStrictEqual` shape. Matches = YES.**
+
+---
+
+## 4. Variable Evidence Summary
+
+- `security_finding`: NO leak. `rawKey` (toolKeysControl.ts:71) feeds ONLY `maskKeyForDisplay(rawKey)`
+  (:77); never placed on a returned object (:75-80, :82-85) nor logged. P15 enumerates real output —
+  `JSON.stringify`/`Object.keys` no-leak asserts at toolKeys.behavior.test.ts:91-96 + property at :181-203.
+- `distinct_finding`: DISTINCT. Separate `ToolKeysControl` instance (toolControl.ts:92) vs `AuthKeysControl`
+  (agentImpl.ts:453-487); no auth-keys import in the control; public test asserts
+  `agent.tools.keys !== agent.auth.keys` (toolKeys.behavior.test.ts:156).
+- `nonbreaking_finding`: 6 existing members intact (agent.ts:306-311); only `readonly keys` added (:313);
+  600-test dir suite + full typecheck/lint green.
+
+---
+
+## 5. Final Verdict
+
+**PASS.** Every plan/16a gate passed with directly-captured exit codes; the implementation mirrors the
+tool-keys.md pseudocode method-by-method (status() being an intent-faithful conditional-spread
+realization of the literal); R-NO-RAW-SECRETS, R-KEYS-DISTINCT, validation-ownership, non-breaking, and
+the agentImpl.ts max-lines:800 cap are all confirmed with file:line evidence; the P15 suite is genuinely
+behavioral/hermetic with 33% property coverage and no mock theater or reverse tests.

--- a/project-plans/issue2143/.completed/P17.md
+++ b/project-plans/issue2143/.completed/P17.md
@@ -1,0 +1,78 @@
+Phase: P17
+Completed: 2026-06-22 19:54
+
+Files Created:
+- packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts (107 lines)
+
+Files Modified:
+- packages/agents/src/api/index.ts (+23/-0)
+- packages/agents/src/app-services/command-api-map.ts (+41/-0)
+
+Tests Added: 6 (T1 enum value round-trip, T2 namespace runtime keys, T3 six command/target rows, T4 map invariants, T5 PROPERTY ApprovalMode members, T6 PROPERTY command targets)
+
+RED evidence:
+RED captured BEFORE Step 2 via `npx vitest run packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts > /tmp/p17_red.log 2>&1` → EXIT=1.
+No module/syntax errors (verified: grep for `Cannot find module|SyntaxError|Failed to resolve import` in /tmp/p17_red.log = no matches). The public-root NAMES resolve via the star re-export; the enums are type-only pre-GREEN so they surface as `undefined` at runtime → behavioral AssertionErrors. The six command-map rows are absent → `expected undefined to be defined`. Tail of /tmp/p17_red.log:
+
+```
+ FAIL  ... > T3 the six target command rows exist with kind runtime and correct targets ...
+AssertionError: expected undefined to be defined
+ ❯ packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts:53:19
+
+ FAIL  ... > T5 PROPERTY: every ApprovalMode member ...
+TypeError: Cannot convert undefined or null to object
+ ❯ packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts:71:35
+     71|         fc.constantFrom(...Object.values(ApprovalMode)),
+                                   ^
+
+ FAIL  ... > T6 PROPERTY: every target command is present ...
+Error: Property failed after 1 tests
+Counterexample: ["/approval-mode"]
+Caused by: AssertionError: expected undefined to be defined
+
+ Test Files  1 failed (1)
+      Tests  5 failed | 1 passed (6)
+```
+(T4 map-invariants passed at RED — the existing map is internally consistent pre-append; the 5 failures are the enum-value + missing-row behavioral failures.)
+
+ApprovalMode collision outcome: SHADOWED CLEANLY. The explicit VALUE `export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core'` was added to api/index.ts AFTER the existing `export * from './agent.js'` (which carries `export type { ApprovalMode }` at agent.ts:568) and `export * from './config-types.js'` (which carries `export type { ApprovalMode, ... }`). The explicit named VALUE re-export shadows the star-propagated type-only forms cleanly — NO TS2308 ("already exported a member named 'ApprovalMode'") was emitted. Evidence: `npm run typecheck` EXIT=0 (all packages); `npm run build` EXIT=0. The 14 projected type names are NET-NEW (PolicyRuleView, AgentTaskInfo, HookInfo, AuthProviderDetail, AuthBucketStatus, McpServerAuthStatus, McpDetailStatus, McpServerDetail, McpDetailsOptions, McpPromptInfo, McpResourceInfo, McpBlockedServer, ToolKeyInfo, ToolKeyStatus) so they cannot collide.
+
+NOTE on resolution path: the public-root import `@vybestack/llxprt-code-agents` resolves to the package's `package.json` exports `.` → `./dist/index.js` (the BUILT artifact), NOT the src alias, when vitest runs from the monorepo root without a root vitest.config. A `npm run build` was therefore required for the runtime-namespace assertions (T2 hasOwnProperty + the T1/T5/T6 VALUE assertions) to go GREEN — the stale dist (pre-P17) had no `ApprovalMode`/`PolicyDecision` value export. After rebuild the dist's `src/api/index.js` carries `export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core'` and the root namespace exposes both as runtime `object` values (127 keys, up from 125). This is a dist-freshness requirement, not a code defect.
+
+Verification (actual output of the plan/17 Verification Commands block — /tmp/p17_verify.log, VERIFY_EXIT=0):
+```
+[1] test file exists OK
+[2a] value enums present OK
+[2b] no type-only enum re-export OK
+[2c] all 14 projected types present OK
+[3] existing barrel lines intact OK
+[4] six command/target rows present OK
+map invariants OK
+[5] node dist map invariant check OK
+=== [6] target test ===
+ ✓ packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts (6 tests) 7ms
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+=== [7] boundary spec ===
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+=== [8] whole dir ===
+whole dir EXIT=0 (0=pass)
+ Test Files  49 passed (49)
+      Tests  606 passed (606)
+=== [9] typecheck ===
+> @vybestack/llxprt-code-test-utils@0.10.0 typecheck
+> tsc --noEmit
+(typecheck EXIT=0 across all packages)
+=== [10] build ===
+[watch] build started
+[watch] build finished
+(build EXIT=0)
+[11] property CASES: 2 / 6 = 33%
+[12] no mock theater / reverse tests OK
+[13] no deferred markers OK
+PASS: P17 barrel + command-map green.
+```
+Additionally: `npm run lint` EXIT=0 (whole-repo, stricter-than-main branch eslint config).
+
+Semantic Assessment: The public agents barrel now surfaces both VALUE enums (ApprovalMode, PolicyDecision) and all 14 projected public types by name, and COMMAND_API_MAP documents all six target slash-commands as kind:'runtime' — so a #1595 consumer can name every new symbol and discover every command→method mapping from `@vybestack/llxprt-code-agents` with no deep core import.

--- a/project-plans/issue2143/.completed/P17a.md
+++ b/project-plans/issue2143/.completed/P17a.md
@@ -1,0 +1,36 @@
+# P17a — Verification Gate: Phase 17 (PLAN-20260622-COREAPIGAP.P17)
+
+- **Phase:** P17 — public barrel value/type re-exports (REQ-008) + six command→API-map runtime rows (REQ-008/REQ-009 non-breaking)
+- **Reviewed-at:** 2026-06-24T11:08:25Z
+- **Reviewer:** independent verification gate (source-grounded, self-run commands)
+- **Branch:** issue2143
+
+## Compliance table
+
+| Requirement | Verdict | Evidence (file:line / command-exit personally observed) |
+|---|---|---|
+| VALUE export present & plain (not `export type`) | PASS | `packages/agents/src/api/index.ts:27` → `export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core';`. grep shows enums NOT in either `export type` block (lines 20, 28). |
+| 14 type-only names in an `export type` block from `./agent.js` | PASS | `index.ts:28-43` `export type { PolicyRuleView, AgentTaskInfo, HookInfo, AuthProviderDetail, AuthBucketStatus, McpServerAuthStatus, McpDetailStatus, McpServerDetail, McpDetailsOptions, McpPromptInfo, McpResourceInfo, McpBlockedServer, ToolKeyInfo, ToolKeyStatus } from './agent.js';` — all 14 present, count verified. |
+| 14 names are REAL exported declarations | PASS | Loop over `agent.ts`: each name returns exactly `1` matching `export (interface|type|enum) NAME`. |
+| value-not-type correctness (verbatimModuleSyntax) | PASS | grep: `ApprovalMode`/`PolicyDecision` appear ONLY on line 27 (plain `export {`), never inside `export type {` (lines 20/28). |
+| Six command rows present, kind 'runtime', correct dotted targets | PASS | `command-api-map.ts` rows for `/approval-mode`→`agent.setApprovalMode`, `/policies`→`agent.policy.getRules`, `/task`→`agent.tasks.list`, `/hooks`→`agent.hooks.listHooks`, `/toolkey`→`agent.tools.keys.save`, `/toolkeyfile`→`agent.tools.keys.setKeyFile` (lines ~278-313); also confirmed in built dist (node check PASS for all six). |
+| Append-only (index.ts) | PASS | `git diff HEAD -- packages/agents/src/api/index.ts` EXIT=0: only `+` additions after pre-existing line 20; zero removed/changed pre-existing lines. |
+| Append-only (command-api-map.ts) | PASS | `git diff HEAD -- packages/agents/src/app-services/command-api-map.ts` EXIT=0: only `+` additions appended after the last pre-existing `/quit` cli-local row; zero removed/reordered/retyped rows. Total rows now 43 (37 prior + 6). |
+| Targets backed by REAL Agent methods | PASS | `agent.ts`: `setApprovalMode`:510; `AgentPolicyControl.getRules`:454 via `policy`:536; `AgentTasksControl.list`:481 via `tasks`:538; `AgentHookControl.listHooks`:414 via `hooks`:535; `AgentToolControl.keys`:313→`AgentToolKeyControl.save`:299/`setKeyFile`:301 via `tools`:530. |
+| Build green | PASS | `npm run build` BUILD_EXIT=0. dist artifacts present: `packages/agents/dist/index.js`, `packages/agents/dist/src/app-services/command-api-map.js`. |
+| Built dist runtime-value assertions | PASS | node import of dist: `typeof ApprovalMode==='object'`; YOLO=`yolo`, AUTO_EDIT=`autoEdit`, DEFAULT=`default`; `typeof PolicyDecision==='object'`; ASK_USER=`ask_user`, ALLOW=`allow`, DENY=`deny`; `hasOwnProperty(root,'ApprovalMode')`=true, `(...,'PolicyDecision')`=true. ALL_DIST_CHECKS=PASS, EXIT=0. |
+| Built command-map invariants (kinds valid, unique names) | PASS | node check on dist command-map: all six rows runtime+correct target; every kind ∈ {runtime,subpath,cli-local}; command names unique. |
+| Behavioral test: public-root import, real members, six rows | PASS | `barrelAndCommandMap.behavior.test.ts:20-21` imports `{ ApprovalMode, PolicyDecision }` and `* as root` from `@vybestack/llxprt-code-agents` (NOT deep). T1 real members, T2 hasOwnProperty runtime keys, T3 six-row assertions, T4 invariants. |
+| Property gate (≥30%, MIN-2) | PASS | T5 + T6 are fast-check `fc.assert(fc.property(...))` blocks = 2 of 6 tests = 33.3% ≥ 30%; 2 distinct property blocks (MIN-2). |
+| Test discipline (no mock theater/reverse/skip/any) | PASS | grep for `vi.fn|vi.spyOn|mockResolvedValue|mockReturnValue|toHaveBeenCalled|not.toThrow|NotYetImplemented|.skip|xit(|: any|<any>| as any` → EXIT=1 (zero matches). |
+| Test runs GREEN | PASS | `npx vitest run .../barrelAndCommandMap.behavior.test.ts` EXIT=0, 6/6 passed. |
+| API test dir no regressions | PASS | `npx vitest run packages/agents/src/api/__tests__/` EXIT=0 → 49 files / 606 tests passed. |
+| app-service-boundary.spec.ts invariants hold | PASS | `npx vitest run .../app-service-boundary.spec.ts` EXIT=0, 5/5 passed (no-orphan/kind-validity/durable-required). |
+| Typecheck green | PASS | `npm run typecheck` TYPECHECK_EXIT=0. |
+| No TS2308 "already exported a member named 'ApprovalMode'" | PASS | grep `TS2308|already exported a member named` over typecheck log → grepexit=1 (zero matches); value export shadows pre-existing type-only re-exports cleanly. |
+| Lint green | PASS | `npm run lint` LINT_EXIT=0. |
+
+## Blockers
+none
+
+## VERDICT: PASS

--- a/project-plans/issue2143/.completed/P18.md
+++ b/project-plans/issue2143/.completed/P18.md
@@ -1,0 +1,80 @@
+Phase: P18
+Completed: 2026-06-22 20:40
+Files Created:
+  - packages/agents/src/api/__tests__/additiveSurface.types.ts (81 lines) —
+    compile-only type anchors for the additive-surface fence. Lives as `.types.ts`
+    (NOT `.test.ts`) because packages/agents/tsconfig.json excludes **/*.test.ts and
+    **/*.spec.ts from `tsc --noEmit`; anchors in a .test.ts would be VACUOUS (never
+    typechecked, types stripped by vitest). This file is typecheck-VISIBLE,
+    build-EXCLUDED (tsconfig.build.json excludes src/**/__tests__/**), vitest-IGNORED.
+    Mirrors the contractPromotion.types.ts precedent. Holds 8 void-consumed anchors:
+    6 projected-type field anchors (AgentTaskInfo→x.id, PolicyRuleView→x.decision,
+    ToolKeyStatus→x.toolName, HookInfo→x.name, AuthProviderDetail→x.provider,
+    McpDetailStatus→x.servers) + 2 extended-controller signature anchors
+    (Agent['mcp']['refresh'], Agent['hooks']['clear']).
+Files Modified:
+  - packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts +121/-0
+    (NEW REQ-009 describe block, RUNTIME assertions only; compile anchors relocated to
+    additiveSurface.types.ts). Pre-existing REQ-006 block left byte-identical.
+
+Tests Added: 5 in the new REQ-009 describe block (3 regular it() + 2 property it()):
+  - Test A: full #1594-era load-bearing value set is still present as runtime functions
+    (prior ⊂ current): createAgent, fromConfig, listProviders, listTools, mapLoopStream,
+    mapStreamEvent, toConfigParameters, createTaskToolRegistration, AdapterError, AgenticLoop
+  - Test B: internals identity unchanged — root.AgentClient === internals.AgentClient,
+    PostTurnAction defined
+  - Test C: new value enums present + round-trip (ApprovalMode YOLO/AUTO_EDIT/DEFAULT,
+    PolicyDecision ASK_USER/ALLOW/DENY)
+  - PROP 1: each sampled prior load-bearing key is a live root key AND callable
+  - PROP 2: each sampled new enum member round-trips to its expected string value
+Plus 8 compile-time anchors in additiveSurface.types.ts (proven load-bearing under typecheck).
+
+Self-Verification (actual output):
+
+## Anchor file is typecheck-visible (the CCF-6 fix)
+```
+( cd packages/agents && npx tsc --noEmit --listFilesOnly | grep additiveSurface.types.ts )
+=> src/api/__tests__/additiveSurface.types.ts   (IN the typecheck file set)
+```
+
+## Compile anchors are LOAD-BEARING (mutation probe)
+```
+# mutate AgentTaskInfo anchor x.id -> x.__nope_field__ in additiveSurface.types.ts
+npm run typecheck  =>  EXIT != 0
+src/api/__tests__/additiveSurface.types.ts(40,65): error TS2339:
+  Property '__nope_field__' does not exist on type 'AgentTaskInfo'.
+# restore
+npm run typecheck  =>  EXIT=0 (green again)
+```
+
+## Built-artifact subset + identity (no shrink)
+```
+root = require('./packages/agents/dist/index.js')              # package "." export
+internals = require('./packages/agents/dist/src/internals.js') # "./internals.js" export
+=> SUBSET+IDENTITY OK (root keys=127); all 10 prior keys typeof 'function';
+   root.AgentClient === internals.AgentClient
+```
+
+## Tests
+```
+publicSurface.nonbreaking.test.ts  EXIT=0   10 passed (10)
+nonBreaking.exports.test.ts        EXIT=0    3 passed (3)
+whole __tests__/ dir               EXIT=0   49 files / 611 passed (611)
+```
+
+## Discipline + property + no-production-change
+```
+mock theater / reverse tests: NONE
+production source under packages/agents/src (excl __tests__): NONE changed
+property CASES: 3 / 10 = 30%  (>= MIN-2, >= 30%)  PASS
+typecheck EXIT=0, build EXIT=0
+```
+
+Semantic Assessment: PASS — REQ-009 additive-only fence is now genuinely load-bearing.
+The compile-time half (projected types + extended-controller signatures) lives in a
+typecheck-visible additiveSurface.types.ts (proven via tsc --listFilesOnly + a real
+TS2339 mutation probe that fires precisely on that file and clears on restore); the
+runtime half (prior-key subset, internals identity, enum round-trips) lives in the
+.test.ts. Built-artifact check proves the #1594-era public surface did not shrink
+(127 root keys, all prior keys present as functions, AgentClient identity preserved).
+No production source changed.

--- a/project-plans/issue2143/.completed/P18a.md
+++ b/project-plans/issue2143/.completed/P18a.md
@@ -1,0 +1,116 @@
+Phase: P18a
+Completed: 2026-06-22 08:55
+Files Created: none
+Files Modified: none (verification only; mutation probe applied to additiveSurface.types.ts then fully restored — git diff clean, byte-identical to backup)
+
+Verification: [actual observed output]
+
+--- Section 1: existing characterization preserved + new REQ-009 block present ---
+OK: REQ-006 block present  (grep "REQ-006 @plan:PLAN-20260621-COREAPIREMED.P21")
+OK: REQ-009 block present  (grep "REQ-009 @plan:PLAN-20260622-COREAPIGAP.P18")
+
+--- Section 2: compile anchors live in a typecheck-VISIBLE non-.test.ts file ---
+OK: packages/agents/src/api/__tests__/additiveSurface.types.ts exists
+OK: not a .test.ts/.spec.ts
+
+tsc --listFilesOnly grep evidence (run from packages/agents):
+  $ npx tsc --noEmit --listFilesOnly 2>/dev/null | grep "additiveSurface.types.ts"
+  /Users/acoliver/projects/llxprt/branch-3/llxprt-code/packages/agents/src/api/__tests__/additiveSurface.types.ts
+  => The anchor file IS in the typecheck file set (a .test.ts would NOT be).
+
+--- Section 2b: mutation probe proves the fence is LOAD-BEARING ---
+Backup made; AgentTaskInfo anchor present; perl mutation applied (exact anchor form matched):
+  40:const _taskInfoAnchor: (x: _TaskInfoShape) => string = (x) => x.__nope_field__;
+
+  $ npm run typecheck   (with bogus field)
+  typecheck exit code: 2   (FAILED as expected)
+  probe log line:
+    src/api/__tests__/additiveSurface.types.ts(40,65): error TS2339: Property '__nope_field__' does not exist on type 'AgentTaskInfo'.
+  => TS2339 fired on additiveSurface.types.ts line 40 — fence is NON-VACUOUS.
+
+Restore:
+  OK: bogus field removed, file restored
+  OK: identical to backup (diff -q clean)
+  git diff --stat additiveSurface.types.ts => empty (no residual mutation)
+
+  $ npm run typecheck   (after restore)
+  typecheck exit code after restore: 0   (GREEN)
+
+--- Section 3: built-artifact subset proof (no shrink) ---
+Verified real export paths from packages/agents/package.json:
+  main: dist/index.js   ("." -> ./dist/index.js)
+  exports["./internals.js"].import -> ./dist/src/internals.js
+  (matches the spec's EXACT paths)
+
+  $ npm run build  => exit code 0 (green)
+
+  $ node (ESM dynamic import; dist is ESM):
+    const root = await import('./packages/agents/dist/index.js');
+    const internals = await import('./packages/agents/dist/src/internals.js');
+  Output:
+    built-artifact subset + identity preserved (root keys=127)
+    all 10 prior keys present & typeof function: createAgent, fromConfig, listProviders,
+      listTools, mapLoopStream, mapStreamEvent, toConfigParameters, createTaskToolRegistration,
+      AdapterError, AgenticLoop
+  => Prior 10 #1594-era keys ⊂ current built barrel (root keys=127), each typeof 'function';
+     internals.AgentClient is a function; root.AgentClient === internals.AgentClient (identity preserved).
+
+--- Section 4: both non-breaking tests + whole dir GREEN ---
+  publicSurface.nonbreaking.test.ts:  Test Files 1 passed (1), Tests 10 passed (10)
+  nonBreaking.exports.test.ts:        Test Files 1 passed (1), Tests 3 passed (3)
+  whole packages/agents/src/api/__tests__/ dir: exit 0; Test Files 49 passed (49), Tests 611 passed (611)
+
+--- Section 5: discipline + no-production-change ---
+  Mock-theater/reverse scan on publicSurface.nonbreaking.test.ts: OK (no toHaveBeenCalled / mock* /
+    vi.fn / vi.spyOn / not.toThrow()).
+  git diff HEAD --name-only (full):
+    .llxprt/LLXPRT.md                                              (auto-managed memory — ignored per spec)
+    packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts  (+121, REQ-009 block — TEST artifact)
+    project-plans/issue2143/plan/18-non-breaking.md                (plan doc)
+    project-plans/issue2143/plan/18a-non-breaking-verification.md   (plan doc)
+   untracked: additiveSurface.types.ts (new anchor), .completed/P18.md, .completed/P18a.md
+  Filtered (production src under packages/agents/src/ excluding __tests__/): EMPTY
+  => OK: NO production source changed by this phase (test-only regression fence).
+
+--- Section 6: property gate ---
+  property CASES: 3 / 10 = 30%
+  => PASS: PROP=3 (>=2 MIN-2) AND PCT=30% (>=30%).
+
+--- Independent inspection ---
+  additiveSurface.types.ts: 8 const anchors, 8 void-consumes; NO any/as any/<any>;
+    exact perl-targeted line present: `const _taskInfoAnchor: (x: _TaskInfoShape) => string = (x) => x.id;`
+    All 6 projected-type anchors present (AgentTaskInfo, PolicyRuleView, ToolKeyStatus, HookInfo,
+    AuthProviderDetail, McpDetailStatus) + 2 extended-controller signature anchors
+    (_mcpRefreshShape: Agent['mcp']['refresh'], _hooksClearShape: Agent['hooks']['clear']).
+  publicSurface.nonbreaking.test.ts REQ-009 block asserts (not theater):
+    - prior subset: rootKeys.has(key) === true AND typeof === 'function' for all 10 keys;
+    - internals identity: expect(root.AgentClient).toBe(internals.AgentClient);
+    - enum round-trips: ApprovalMode.YOLO==='yolo'/AUTO_EDIT==='autoEdit'/DEFAULT==='default',
+      PolicyDecision.ASK_USER==='ask_user'/ALLOW==='allow'/DENY==='deny';
+    - 2 property cases (prior-key liveness+callable; enum-member string round-trip).
+
+Holistic Assessment: PASS
+
+- Anchors typecheck-visible: PASS. `additiveSurface.types.ts` appears in the
+  `tsc --noEmit --listFilesOnly` set (full absolute path printed). A `.test.ts` would be excluded by
+  packages/agents/tsconfig.json — this file is not, so its compile anchors are genuinely compiled.
+- Fence is non-vacuous: PASS. The mutation probe (x.id -> x.__nope_field__ in the .types.ts) caused
+  `npm run typecheck` to FAIL with exactly `additiveSurface.types.ts(40,65): error TS2339: Property
+  '__nope_field__' does not exist on type 'AgentTaskInfo'`, and typecheck returned to exit 0 after a
+  byte-identical restore. The compile half of the fence really guards the projected-type shapes.
+- No shrink: PASS. Against the REAL package root (dist/index.js, 127 runtime keys) and internals
+  (dist/src/internals.js), all 10 prior #1594-era keys are present as functions and the AgentClient
+  binding identity (root === internals) is preserved.
+- Existing characterization intact: PASS. Both the REQ-006 (PLAN-20260621-COREAPIREMED.P21) and the
+  new REQ-009 (PLAN-20260622-COREAPIGAP.P18) blocks are present; both non-breaking tests are green
+  (10 + 3) and the whole api/__tests__ dir is green (49 files / 611 tests).
+- Additive proven: PASS. New value enums ApprovalMode/PolicyDecision round-trip; prior member runtime
+  kinds unchanged (functions); extended-controller prior signatures (mcp.refresh, hooks.clear) pinned
+  by compile anchors; no prior member shape changed.
+- Discipline: PASS. No mock theater / reverse tests in the .test.ts; property gate 3/10=30% (PROP>=2);
+  no production source under packages/agents/src/ (excluding __tests__/) changed.
+
+Verdict: PASS — additiveSurface.types.ts anchors proven typecheck-visible AND load-bearing (TS2339
+probe), prior #1594-era surface did not shrink (10 keys ⊂ 127-key built barrel + AgentClient identity
+preserved), existing REQ-006 characterization intact, all non-breaking tests + whole api/__tests__ dir
+green, property gate satisfied, and no production source changed. Mutation probe fully restored.

--- a/project-plans/issue2143/.completed/P19.md
+++ b/project-plans/issue2143/.completed/P19.md
@@ -1,0 +1,68 @@
+Phase: P19
+Completed: 2026-06-22 20:45
+Files Created: none
+Files Modified: docs/agent-api.md +331/-0
+Verification:
+
+```
+=== CHECK 1: symbols present ===
+OK (all symbols present)
+=== CHECK 2: six command rows ===
+OK (all six command rows present)
+=== CHECK 3 (intent): no NEW deep-core import string added by P19 ===
+OK (P19 added zero deep-core strings; 3 pre-existing prose mentions unchanged)
+OK (public-root import present)
+=== CHECK 4: existing sections preserved + append-only ===
+OK (all existing sections preserved)
+OK (append-only: no removed heading/fence/row)
+=== CHECK 5: plan marker ===
+OK (plan marker present)
+=== CHECK 6: format ===
+
+> @vybestack/llxprt-code@0.10.0 format
+> prettier --experimental-cli --write .
+
+=== DIFFSTAT ===
+ docs/agent-api.md | 331 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 331 insertions(+)
+PASS: P19 docs green.
+
+[format idempotency re-run: EXIT=0, no files listed — clean]
+```
+
+Append-only proof:
+```
+$ git diff HEAD -- docs/agent-api.md | grep -E "^-" | grep -vE "^---"
+(none — purely additive)
+```
+Total removed content lines = 0 (the single "^-" count is the `--- a/` diff header).
+331 insertions, 0 deletions.
+
+Discrepancies followed:
+- (a) `PolicyRuleView.argsPattern` documented as `argsPattern?: string` (RegExp
+  source string, JSON-safe) — the WRONG `argsPatternSource` appears NOWHERE.
+- (b) `AgentHookControl` documents `enable(name)` and `disable(name)` ONLY —
+  `enableAll()`/`disableAll()` are NOT invented (confirmed: grep for
+  enableAll|disableAll returns nothing).
+
+Spec-defect note (check #3): the spec's blunt
+`if grep -nE "@vybestack/llxprt-code-core/" "$D"` fails on the UNMODIFIED HEAD
+file (3 pre-existing prose mentions: telemetry source path at L251/L1053 and a
+deep-import warning at L889 — none are code examples). The check's STATED intent
+(comment in the spec) is "no example reaches around the public API". P19
+satisfies that intent: it adds ZERO new deep-core strings (verified via
+`git diff HEAD | grep "^+" | grep "@vybestack/llxprt-code-core/"` = empty) and
+every new code example imports only from `@vybestack/llxprt-code-agents`. The
+3 pre-existing prose lines were left untouched (append-only constraint forbids
+removal).
+
+Lint note: `npm run lint` surfaces 7 pre-existing errors in
+`packages/agents/src/api/__tests__/additiveSurface.types.ts` (a P18 artifact);
+confirmed present on HEAD via `git stash` probe. P19 is docs-only; eslint does
+not target `.md`, so lint is a no-op for this phase's changes.
+
+Semantic Assessment: A #1595 developer reading only docs/agent-api.md can now
+discover and call every new public capability (approval mode, policy, tasks,
+hooks admin, auth detail, mcp OAuth/details, tools.keys, enums + projected
+types, six command-map rows) via public-root-only imports matching the shipped
+signatures — no getConfig() escape hatch or deep-core import required.

--- a/project-plans/issue2143/.completed/P19a.md
+++ b/project-plans/issue2143/.completed/P19a.md
@@ -1,0 +1,73 @@
+Phase: P19a
+Completed: 2026-06-24 09:24
+Files Created: none
+Files Modified: none (verification only)
+Verification:
+# Check 1 — every documented method exists in agent.ts (no drift)
+CHECK1_FAILS=0
+# Check 2 — enums/types documented AND on the public surface + barrel export
+CHECK2_FAILS=0
+# Check 3 — NO new deep-core reference added by this phase; public-root example present
+=== CHECK3: NEW deep-core in added lines ===
+EXIT=1                 # grep found ZERO added '@vybestack/llxprt-code-core/' lines (empty = pass)
+--- added deep-core lines (should be empty) ---
+                       # (empty)
+--- public-root example present? ---
+PUBLIC_ROOT_EXIT=0     # at least one "from '@vybestack/llxprt-code-agents'" example present
+# Check 4 — six command rows documented AND present in production command-api-map.ts
+CHECK4_FAILS=0
+# Check 5 — append-only: no removed heading/code-fence/table-row
+=== CHECK5: append-only (removed headings/fences/rows) ===
+removed-content-lines:
+C5_REMOVED_COUNT=0
+# Check 6 — masked-only / never-raw security statement present
+CHECK6_EXIT=0
+# Check 7 — format gate
+FORMAT_EXIT=0
+
+# Independent diff-scope confirmation (post-format re-check)
+git diff HEAD --stat -- docs/agent-api.md
+ docs/agent-api.md | 331 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 331 insertions(+)
+removed-content-lines (^-#|^-```|^-| ): 0
+new deep-core in added lines: 0
+
+# agent.ts shipped signatures (grep -nE) matched docs verbatim:
+301:  setKeyFile(toolName: string, path: string | null): Promise<void>;
+302:  getKeyFile(toolName: string): Promise<string | null>;
+366:  detailedStatus(provider: string): Promise<AuthProviderDetail>;
+367:  getHigherPriorityAuth(provider: string): Promise<string | null>;
+368:  listBucketStatuses(provider: string): Promise<readonly AuthBucketStatus[]>;
+414:  listHooks(): readonly HookInfo[];
+415:  getDisabledHooks(): readonly string[];
+416:  setDisabledHooks(names: readonly string[]): void;
+454:  getRules(): readonly PolicyRuleView[];
+455:  getDefaultDecision(): PolicyDecision;
+456:  isNonInteractive(): boolean;
+482:  listRunning(): readonly AgentTaskInfo[];
+485:  cancelAllRunning(): number;
+503:  getApprovalMode(): ApprovalMode;
+510:  setApprovalMode(mode: ApprovalMode): void;
+
+# barrel: packages/agents/src/api/index.ts:27
+27:export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core';
+
+# command-api-map.ts rows:
+278: command: '/approval-mode',   284: command: '/policies',   290: command: '/task',
+296: command: '/hooks',           302: command: '/toolkey',    308: command: '/toolkeyfile',
+
+# security-masked statements: docs/agent-api.md:308-309 (tool-keys), :416-418 (auth)
+
+Holistic Assessment: PASS — All seven scripted gates (1-7) returned clean (CHECK1_FAILS=0, CHECK2_FAILS=0, CHECK3 grep EXIT=1 i.e. no added deep-core lines + PUBLIC_ROOT_EXIT=0, CHECK4_FAILS=0, CHECK5 C5_REMOVED_COUNT=0, CHECK6_EXIT=0, FORMAT_EXIT=0), and independent inspection confirms every claim.
+
+ACCURACY / NO-DRIFT: All 15 documented methods exist in packages/agents/src/api/agent.ts with signatures matching the doc verbatim — tool-keys setKeyFile/getKeyFile (agent.ts:301-302), auth detailedStatus/getHigherPriorityAuth/listBucketStatuses (agent.ts:366-368), hooks listHooks/getDisabledHooks/setDisabledHooks (agent.ts:414-416), policy getRules/getDefaultDecision/isNonInteractive (agent.ts:454-456), tasks listRunning/cancelAllRunning (agent.ts:482,485), approval getApprovalMode/setApprovalMode (agent.ts:503,510). Spot-checked 3 examples by eye: (a) agent.tools.keys.* block (docs:283-289) matches AgentToolKeyControl interface (agent.ts:296-303) exactly; (b) agent.auth.detailedStatus/getHigherPriorityAuth/listBucketStatuses (docs ~376-378) matches agent.ts:366-368; (c) agent.policy.getRules/getDefaultDecision/isNonInteractive (docs ~456-458) matches AgentPolicyControl (agent.ts:453-457). All 11 projected types/enums exist on the surface — AuthProviderDetail{provider,authenticated,oauthEnabled,expiry?} (agent.ts:210-215), AuthBucketStatus{bucket,authenticated,expiry?,isSessionBucket} (agent.ts:218-223), McpServerAuthStatus{server,authenticated,requiresAuth,authUrl?} (agent.ts:150-155), McpDetailStatus{servers,blockedServers} (agent.ts:197-200), ToolKeyInfo (agent.ts:281), ToolKeyStatus{toolName,hasKey,maskedKey?,keyFile?} (agent.ts:288-292) — all shapes match the doc tables. Barrel exports the VALUE enums: packages/agents/src/api/index.ts:27 `export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core'`.
+
+NO NEW ESCAPE: git diff HEAD added-lines grep for '@vybestack/llxprt-code-core/' = 0 matches (no new deep-core import added by this phase). Pre-existing intentional prose mentions (telemetry uiTelemetry.js path, Import-Boundary section) are preserved, not removed. At least one example imports the public root '@vybestack/llxprt-code-agents' (PUBLIC_ROOT_EXIT=0).
+
+COMPLETENESS: All six command rows documented (docs §"runtime rows added by #2143" table) AND present as `command: '<CMD>'` in command-api-map.ts:278/284/290/296/302/308 — full map parity.
+
+SECURITY: masked-only / never-raw stated for both secret-bearing surfaces — tool-keys (docs:308-309 "Raw secret values are **never** returned ... only maskedKey ... write-only") and auth (docs:416-418 "metadata only ... Raw token strings are **never** returned").
+
+APPEND-ONLY: git diff HEAD -- docs/agent-api.md = 331 insertions(+), 0 deletions; zero removed headings/code-fences/table-rows (C5_REMOVED_COUNT=0). Verdict holds after running the format gate (re-checked: still 331 insertions/0 deletions, 0 removed content, 0 new deep-core).
+
+VERDICT: PASS.

--- a/project-plans/issue2143/.completed/P20.md
+++ b/project-plans/issue2143/.completed/P20.md
@@ -1,0 +1,15 @@
+Phase: P20
+Completed: 2026-06-24 09:49
+Files Created: capabilityGaps.integration.spec.ts (330 lines)
+Files Modified: none
+Tests Added: 18 it() blocks; 6 are property tests (6/18 = 33%)
+Verification:
+BUILD_EXIT=0
+DRV_EXIT=0 (18 passed)
+BOUNDARY_EXIT=0 (5 passed)
+TC_EXIT=0
+FMT_EXIT=0
+LINT_EXIT=0
+property CASES: 6 / 18 = 33%
+PASS: P20 adequacy driver green.
+Semantic Assessment: all 7 caps reachable via public root only, no getConfig escape, T17 boundary green

--- a/project-plans/issue2143/.completed/P20a.md
+++ b/project-plans/issue2143/.completed/P20a.md
@@ -1,0 +1,87 @@
+Phase: P20a
+Completed: 2026-06-22 10:05
+Files Created: none
+Files Modified: none (verification only)
+Verification:
+  --- Prerequisite ---
+  test -f project-plans/issue2143/.completed/P20.md -> EXIT=0 (branch issue2143)
+
+  --- BLOCK 1: escape/deep-import gates ---
+  OK: no getConfig
+  OK: no internals/dist
+  OK: no deep import
+  OK: import set clean (exactly {@vybestack/llxprt-code-agents, node:*, vitest, fast-check, ./helpers/agentHarness.js})
+
+  --- BLOCK 2: behavioral real-call gates ---
+  OK: auth.detailedStatus called
+  OK: mcp.details called
+  OK: tasks called
+  OK: policy.getRules called
+  OK: hooks driven
+  OK: approval set
+  OK: tool-keys called
+  OK: untrusted throw driven (folderTrust:false + /untrusted folder/i)
+
+  --- BLOCK 3: driver + boundary + .spec.ts scope ---
+  npx vitest run capabilityGaps.integration.spec.ts -> DRIVER_EXIT=0
+    ✓ capabilityGaps.integration.spec.ts (18 tests) 874ms ; Test Files 1 passed (1) ; Tests 18 passed (18)
+  npx vitest run boundary.spec.ts -> BOUNDARY_EXIT=0
+    ✓ boundary.spec.ts (5 tests) 2ms ; Test Files 1 passed (1) ; Tests 5 passed (5)
+  in T17 scope (.spec.ts) — file is *.spec.ts so the T17 boundary guard collects & polices it (collectFromEntries: name.endsWith('.spec.ts'); not a helper)
+
+  --- BLOCK 4: whole dir + typecheck ---
+  npx vitest run packages/agents/src/api/__tests__/ -> ALLDIR_EXIT=0
+    Test Files 50 passed (50) ; Tests 629 passed (629) ; Duration 23.57s  (no regressions)
+  npm run typecheck -> TYPECHECK_EXIT=0 (agents + core + a2a-server + test-utils all tsc --noEmit clean)
+
+  --- BLOCK 5: discipline + property gate ---
+  OK: discipline clean (no toHaveBeenCalled/mockResolvedValue/mockReturnValue/vi.fn/vi.spyOn/not.toThrow()/.skip)
+  property CASES: TOTAL=18 PROP_CASE_FORMS=0 CLASSIC_PROP_BLOCKS=6 PROP=6 PCT=33% -> OK (PROP>=2 && PCT>=30)
+
+  --- Edge-fidelity provenance ---
+  folderTrust maps to a REAL engine throw (not a test-only throw):
+    agentConfig.adapter.ts:210-212  config.folderTrust -> params.folderTrust + params.trustedFolder
+    core/config/config.ts:404       'Cannot enable privileged approval modes in an untrusted folder.'
+  config-types.ts:178               readonly folderTrust?: boolean   (real public AgentConfig field)
+
+Holistic Assessment: PASS
+
+#1595 REACHABILITY VERDICT: PASS. A CLI restricted to ONLY the public root
+`@vybestack/llxprt-code-agents` can now drive all seven engine capabilities on a
+REAL Agent (harness uses real createAgent over the LLXPRT_FAKE_RESPONSES
+FakeProvider production seam — NO vi.fn/mock/spy anywhere). The import set is
+exactly {public root, node:*, vitest, fast-check, ./helpers/agentHarness.js} —
+zero getConfig escape, zero deep import, zero internals/dist. The file is a
+*.spec.ts so the T17 boundary guard (boundary.spec.ts, 5/5 GREEN) statically
+polices it, which is the strongest possible proof the #1595 boundary holds.
+
+Each capability is genuinely CALLED with await/expect on real results (NOT a
+typeof-only sham — the lone typeof block at 181-188 is a supplementary
+function-presence assertion, in addition to the real-call tests below):
+
+  1. APPROVAL (REQ-INT-001): live write-then-read at 56-57
+     (setApprovalMode(YOLO) -> getApprovalMode()===YOLO); value-in-enum read at
+     51; property round-trip over all modes at 197-198; UNTRUSTED engine throw
+     /untrusted folder/i driven through the public harness at 61-63
+     (folderTrust:false -> adapter trustedFolder=false -> core config.ts:404).
+  2. POLICY (REQ-INT-002): getRules() at 71 (array + decision-in-enum +
+     string toolName), getDefaultDecision() at 84, isNonInteractive() at 90.
+  3. TASKS (REQ-INT-002): list() 97, listRunning() 98, get('nonexistent')
+     undefined 101, cancel false 102, cancelAllRunning()===0 103; abortController
+     PROJECTED OUT asserted at 106 and in the property at 235.
+  4. HOOKS-ADMIN (REQ-INT-003): listHooks() 114, setDisabledHooks/getDisabledHooks
+     /enable round-trip 116-119; property set-equality round-trip 213-219.
+  5. AUTH-DETAIL (REQ-INT-003): detailedStatus('openai') 127, getHigherPriorityAuth
+     130, listBucketStatuses 133; masked invariant property (no secret-named
+     field, no >=20-char opaque value) at 297/325-326.
+  6. MCP (REQ-INT-004): status() 141, details() 142 (servers empty array),
+     authenticate('nonexistent-server')===false 145; property authenticate over
+     arbitrary names 269.
+  7. TOOL-KEYS (REQ-INT-004): supported() non-empty 154, status('exa') 166
+     (hasKey boolean; maskedKey masked/short — never a raw secret, asserted
+     172-174); property supported() non-empty registry 249.
+
+Edge fidelity confirmed: untrusted-folder throw is engine-driven through the
+public harness (61-63); abortController is projected out of task views (106, 235);
+auth/tool-keys output is masked (no raw secrets — 172-174, 325-326). No
+weakening or rationalization was required; every mandated gate is genuinely GREEN.

--- a/project-plans/issue2143/.completed/P21.md
+++ b/project-plans/issue2143/.completed/P21.md
@@ -1,0 +1,32 @@
+Phase: P21
+Completed: 2026-06-24 10:23
+Files Created: capabilityBoundary.adequacy.test.ts (440 lines)
+Files Modified: none
+Tests Added: 7
+Verification:
+```
+build EXIT=0
+boundary EXIT=0
+
+ ✓ packages/agents/src/api/__tests__/boundary.spec.ts (5 tests) 2ms
+
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+
+scan EXIT=0
+
+ ✓ packages/agents/src/api/__tests__/capabilityBoundary.adequacy.test.ts (7 tests) 45ms
+
+ Test Files  1 passed (1)
+      Tests  7 passed (7)
+
+dir EXIT=0
+
+ Test Files  51 passed (51)
+      Tests  636 passed (636)
+
+typecheck EXIT=0
+property CASES: 4 / 7 = 57%
+PASS: P21 boundary green.
+```
+Semantic Assessment: whole new surface is deep-import-free (raw-source); the 3 new controls are bare-barrel-only; T17 guard polices the new spec surface.

--- a/project-plans/issue2143/.completed/P21a.md
+++ b/project-plans/issue2143/.completed/P21a.md
@@ -1,0 +1,75 @@
+Phase: P21a
+Completed: 2026-06-22 10:50
+Files Created: none
+Files Modified: none (verification only; probe file restored)
+Verification:
+=== Step 1: standing T17 guard, scan test, whole dir, typecheck ===
+boundary EXIT=0   (boundary.spec.ts: 5 passed)
+scan EXIT=0       (capabilityBoundary.adequacy.test.ts: 7 passed)
+dir EXIT=0        (51 files, 636 tests passed)
+typecheck EXIT=0  (tsc --noEmit clean across packages)
+
+=== Step 2: NON-VACUITY PROBE (inject raw-source deep import into policyControl.ts) ===
+PROBE RESULT: scan correctly FAILED on injected deep import (has teeth)
+  417|       fc.assert(
+       |          ^
+  418|         fc.property(
+  419|           fc.constantFrom(...NEW_CONTROLS_STRICT_ABS),
+Caused by: Error: Property failed by returning false
+ ❯ packages/agents/src/api/__tests__/capabilityBoundary.adequacy.test.ts:417:10
+ Test Files  1 failed (1)
+      Tests  4 failed | 3 passed (7)
+(Injected `import '@vybestack/llxprt-code-core/src/index.js';` — the "core/src"
+raw-source pattern tripped BOTH the deterministic RAW_SOURCE_FINDINGS guard,
+the STRICT_CORE_SUBPATH_FINDINGS guard, AND the two property blocks → 4 of 7
+it() blocks turned RED. This is genuine teeth, not a forced failure.)
+
+restore-recheck EXIT=0  (after restore: 7 passed)
+policyControl.ts restored byte-identical
+shell scan: no deep import in .spec.ts
+shell scan: no .spec.ts imports internals
+policyControl: bare-barrel-only OK
+tasksControl: bare-barrel-only OK
+toolKeysControl: bare-barrel-only OK
+GATE COMPLETE
+
+=== Whole-set coverage cross-check (git diff --stat main...HEAD) ===
+12 changed agents production files, ALL 12 present in NEW_PRODUCTION_FILES:
+  agent.ts, agentImpl.ts, control/{authControl,hooks,mcpControl,mcpControlWiring,
+  policyControl,tasksControl,toolControl,toolKeysControl}.ts, index.ts,
+  app-services/command-api-map.ts. No material omission.
+
+=== Asymmetric-rule reality ===
+agentImpl.ts uses 10 package-export subpaths (code_assist/types.js, config/config.js,
+utils/extensionLoader.js, confirmation-bus/message-bus.js, runtime/AgentRuntimeState.js,
+services/history/HistoryService.js, core/clientContract.js, core/turn.js,
+utils/generateContentResponseUtilities.js, telemetry/uiTelemetry.js) — none contain
+"core/src" → NOT raw-source → correctly ALLOWED. mcpControl.ts + mcpControlWiring.ts
+use config/config.js + core/clientContract.js — also allowed. The 3 new controls
+(policyControl/tasksControl/toolKeysControl) have core-subpath count = 0 each → the
+STRICTER bare-barrel-only rule holds. Matcher self-check test proves
+isRawSourceReach('@vybestack/llxprt-code-core/config/config.js')===false while
+isRawSourceReach('.../src/index.js')===true, and isCoreSubpath discriminates bare
+barrel (false) from subpath (true).
+
+=== Discipline ===
+No mock theater (zero toHaveBeenCalled/mockResolvedValue/mockReturnValue/vi.fn/
+vi.spyOn/not.toThrow()). The grep "any" hits are English prose in comments and PROP
+test names ("for any new production file"), NOT the TS `any` type. No .skip/.only/todo.
+Property blocks = 3 of 7 it() = 42% (≥30%, MIN-2 satisfied); each uses
+fc.assert + fc.property + fc.constantFrom(...realAbsPaths) operating on REAL file
+contents read via readFileSync/extractSpecifiers.
+
+Holistic Assessment: PASS. #1595 BOUNDARY VERDICT — A future CLI can reach the WHOLE
+new Agent-API capability surface via the public root `@vybestack/llxprt-code-agents`
+alone with NO deep import: every public-consumer .spec.ts is free of /src/, core/src,
+providers/src, tools/src, policy/src, and internals.js (shell scan + T17 guard agree),
+and the static scan executably encodes this. NON-VACUITY PROVEN: injecting a real
+raw-source import (`@vybestack/llxprt-code-core/src/index.js`) into policyControl.ts
+turned the scan RED (4 failed | 3 passed), and removal restored it byte-identical to
+7/7 — the test has genuine teeth, not a vacuous always-pass. The ASYMMETRIC RULE is
+implemented CORRECTLY: it forbids only RAW-SOURCE reaches across the whole 12-file set
+(so it does NOT false-fail the ~established package-export subpath convention used by
+agentImpl.ts/mcpControl*/etc.), while applying the bare-barrel-only constraint ONLY to
+the 3 brand-new controls — confirmed both by the discriminating matcher self-check and
+by direct subpath counts (0/0/0). All exit codes are zero; gate is green.

--- a/project-plans/issue2143/.completed/P22.md
+++ b/project-plans/issue2143/.completed/P22.md
@@ -1,0 +1,55 @@
+Phase: P22
+Completed: 2026-06-24 13:56
+
+Files Created: none
+Files Modified (test-only, +163 insertions, no production source changed):
+- packages/agents/src/api/__tests__/tasksControl.behavior.test.ts (+101; T11 example + property block — assert projected AgentTaskInfo carries completedAt/error after completeTask/failTask and OMITS them while running)
+- packages/agents/src/api/__tests__/policyControl.behavior.test.ts (+42; T7 — seed a sourceless PolicyEngine rule, assert projected PolicyRuleView OMITS the source key)
+- packages/agents/src/api/__tests__/toolKeys.behavior.test.ts (+20; T20 — save key AND set keyFile, assert masked status carries keyFile in the hasKey:true branch)
+- project-plans/issue2143/plan/22-quality-gates.md (CCF-7 mutation-score jq fix — compute from raw mutants[].status)
+- project-plans/issue2143/plan/22a-quality-gates-verification.md (same jq fix)
+
+Tests Added: 4 (tasks: T11 + 1 property; policy: T7; toolKeys: T20)
+
+Verification:
+
+== Deterministic suite (CLEAN source, before mutation overwrite) ==
+- npm run typecheck   -> EXIT=0
+- npm run lint        -> EXIT=0 (whole-repo eslint)
+- npm run build       -> EXIT=0
+- npm run format / prettier --check (3 strengthened tests) -> EXIT=0 ("All matched files use Prettier code style!")
+- smoke: node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else" -> EXIT=0 (haiku printed)
+
+== Full npm run test (root orchestrator) ==
+- Aggregate: all packages green EXCEPT 2 fast-check property tests timed out at 30000ms under
+  root-orchestrator CPU oversubscription (documented load-contention behavior):
+    FAIL src/api/__tests__/cli-turn-parity.early.spec.ts > EP3 property (PLAN-20260621-COREAPIREMED.P07)
+    FAIL src/api/__tests__/cli-turn-parity.spec.ts > PROP parity (PLAN-20260621-COREAPIREMED.P19)
+  Both are PRIOR-PLAN files, untouched by P22.
+- ISOLATION re-run (gate-mandated flake confirmation):
+    npx vitest run cli-turn-parity.early.spec.ts cli-turn-parity.spec.ts -> EXIT=0
+    Test Files 2 passed (2) | Tests 6 passed (6)
+  => confirmed load-contention flake, NOT a code defect. CI runs packages separately.
+- agents API suite in isolation: 640/640 pass (51 files; +4 new tests over the prior 636).
+
+== Mutation gate (npm run test:mutation:api — full src/api/** scope, 30 files / 2651 mutants) ==
+- Stryker run EXIT=0; "Final mutation score of 89.25 is greater than or equal to break threshold 80"
+- Done in 53 minutes 9 seconds; original files restored from .stryker-tmp backup (src/api git-clean after).
+- OVERALL (gate jq): detected=2366 valid=2651 score=89.25% (>= 80%)  [up from 88.83% baseline]
+- PER NEW CONTROL (each >= 80%):
+    src/api/control/policyControl.ts   : 100.00%  (14/14, 0 survived, 0 nocov)   [was 92.86%]
+    src/api/control/tasksControl.ts    : 100.00%  (42/42, 0 survived, 0 nocov)   [was 80.95%]
+    src/api/control/toolKeysControl.ts :  91.18%  (31/34, 2 survived, 1 nocov)   [was 85.29%]
+  The toolKeysControl residual (L57 unreachable `continue` over a fully-populated registry; L101
+  setKeyFile(null) === clearKeyfilePath) are EQUIVALENT mutants — not behaviorally killable via the
+  public surface; file remains well above the 80% gate.
+
+== Static gates (BLOCKING) ==
+- Deferred-implementation markers (TODO/FIXME/HACK/STUB/XXX/TEMPORARY/WIP) in src/api production: NONE
+- Deferred-implementation prose (in a real/in production/ideally/for now/placeholder/...): NONE
+- N5 comment discipline on the 3 new controls: clean (only @plan/@requirement/@pseudocode markers)
+
+Semantic Assessment: Full suite green (sole failures are confirmed isolated-green load-contention
+flakes in prior-plan parity property tests); mutation 89.25% overall with all three new control files
+>= 80% (two at 100%); smoke haiku printed. Additive API surface is production-quality and ready for
+the final adequacy evaluation.

--- a/project-plans/issue2143/.completed/P22a.md
+++ b/project-plans/issue2143/.completed/P22a.md
@@ -1,0 +1,49 @@
+Phase: P22a
+Completed: 2026-06-24 14:05
+Files Created: none
+Files Modified: none (verification only)
+Verification: |
+  # 1. Deterministic core gates
+  npm run typecheck -> TYPECHECK_EXIT=0 (0 errors)
+    NOTE: An initial typecheck run reported TS2307 (cannot find module
+    @vybestack/llxprt-code-policy / -mcp) and TS6305 ("Output file ... has not
+    been built from source file") — these were a concurrency race because
+    `npm run build` was launched as a background job at the same time and was
+    actively rewriting the workspace dist/ that typecheck reads. After build
+    finished (EXIT=0), typecheck was re-run inline and reported EXIT=0 with
+    grep -cE "error TS" == 0. No genuine type defect.
+  npm run lint  -> EXIT=0 (sentinel /tmp/v_lint.done = EXIT=0; 0 errors/warnings)
+  npm run build -> EXIT=0 (sentinel /tmp/v_build.done = EXIT=0; [watch] build finished)
+
+  # 2. Agents API test surface in isolation
+  npx vitest run packages/agents/src/api/__tests__/ -> API_SUITE_EXIT=0
+    Test Files  51 passed (51)
+         Tests  640 passed (640)
+    (the "Error when talking to fake API" stderr lines are intentional
+    fake-API behavioral test fixtures, not failures — suite exit 0.)
+
+  # 3. Mutation evidence (read from packages/agents/reports/mutation/mutation.json;
+  #    computed via spec jq: detected/(detected+survived+nocoverage)*100)
+  overall api mutation: 89.24933987174651   -> OVERALL OK >=80
+  policyControl:   score=100                mutants=14  -> OK >=80, non-vacuous
+  tasksControl:    score=100                mutants=42  -> OK >=80, non-vacuous
+  toolKeysControl: score=91.17647058823529  mutants=34  -> OK >=80, non-vacuous
+  per-file mutation non-vacuous and >=80%
+
+  # 4. Hygiene
+  deferred-marker scan (packages/agents/src/api, excl __tests__) -> CLEAN: no deferred markers in production
+  prose-comment scan policyControl   -> CLEAN: no prose comments
+  prose-comment scan tasksControl    -> CLEAN: no prose comments
+  prose-comment scan toolKeysControl -> CLEAN: no prose comments
+
+  # 5. Smoke (cited from P22 marker)
+  node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else" -> EXIT=0 (haiku printed)
+
+  PASS: P22a quality gates verified.
+Holistic Assessment: PASS. Deterministic gates green (typecheck EXIT=0 after the
+  build-race was resolved, lint EXIT=0, build EXIT=0); agents API suite green in
+  isolation (51 files / 640 tests, exit 0); mutation report shows overall 89.25%
+  with all three new controls non-vacuous and >=80% (policyControl 100%/14 mutants,
+  tasksControl 100%/42 mutants, toolKeysControl 91.18%/34 mutants); hygiene clean
+  (no deferred markers in api production, no prose comments in the 3 controls); P22
+  smoke haiku printed EXIT=0. Every spec check passed.

--- a/project-plans/issue2143/.completed/P23.md
+++ b/project-plans/issue2143/.completed/P23.md
@@ -1,0 +1,132 @@
+Phase: P23
+Completed: 2026-06-24 14:20
+Files Created: [project-plans/issue2143/plan-evaluation.json]
+Files Modified: none
+Tests Added: none (evaluation phase)
+
+Evaluation Artifact (project-plans/issue2143/plan-evaluation.json):
+
+```json
+{
+  "compliant": true,
+  "has_integration_plan": true,
+  "builds_in_isolation": false,
+  "gaps_closed": { "G1": true, "G2": true, "G3": true, "G4": true, "G5": true, "G6": true, "G7": true },
+  "additive_only_non_breaking": true,
+  "enables_1595": true,
+  "public_root_only_reachable": true,
+  "reverse_testing_found": false,
+  "mock_theater_found": false,
+  "property_ge_30": true,
+  "mutation_ge_80": true,
+  "docs_updated": true,
+  "violations": []
+}
+```
+
+Verification (actual output of this phase's verification commands):
+
+```
+plan-evaluation.json asserts full closure + #1595 adequacy
+PASS: P23 final evaluation green.
+OVERALL_EXIT=0
+```
+
+Independent grounding evidence (verified against source, not markers):
+
+INTEGRATION-FIRST (all PASS):
+- git diff --stat main...HEAD shows the plan UPDATED specific existing files
+  (agent.ts, agentImpl.ts, control/authControl.ts, control/hooks.ts,
+  control/mcpControl.ts, control/toolControl.ts, api/index.ts,
+  app-services/command-api-map.ts, docs/agent-api.md) and ADDED three controls
+  under the existing control/ convention (policyControl.ts, tasksControl.ts,
+  toolKeysControl.ts) + one wiring helper (mcpControlWiring.ts). No parallel
+  V2/New surface. 26 files, +4321/-12.
+- capabilityGaps.integration.spec.ts imports ONLY from
+  '@vybestack/llxprt-code-agents' (public root) and drives all seven
+  capabilities on a real buildAgent harness — it cannot be written without the
+  new public methods. No getConfig (grep EXIT=1), no deep import, no /internals.js.
+- Every capability reachable on a real harness-built Agent via the public root
+  only (P20/P20a Holistic PASS; #1595 REACHABILITY VERDICT: PASS).
+
+GAP CLOSURE (each G has (a) surface + (b) behavior + (c) reachability + (d) constraint):
+- G1 approval: Agent.getApprovalMode()/setApprovalMode() top-level (agent.ts:495-509);
+  agentImpl delegates directly to config (agentImpl.ts:788-799) so the untrusted
+  throw propagates UNCAUGHT; integration spec drives folderTrust:false ->
+  toThrow(/untrusted folder/i) through the public harness.
+- G2 policy: AgentPolicyControl read-only (getRules/getDefaultDecision/
+  isNonInteractive); PolicyRuleView.argsPattern projected to .source STRING
+  (policyControl.ts:35), never RegExp; barrel-only core import.
+- G3 tasks: AgentTasksControl undefined-safe; AgentTaskInfo OMITS abortController
+  (agent.ts type has only 7 serializable fields; tasksControl.project() copies
+  no abortController); cancelAllRunning() returns count; integration asserts
+  'abortController' in task === false.
+- G4 hooks-admin: AgentHookControl extended with listHooks/getDisabledHooks/
+  setDisabledHooks/enable/disable; undefined-safe (if (!system) return []);
+  set round-trip proven.
+- G5 auth-detail: AuthControl.detailedStatus/getHigherPriorityAuth/
+  listBucketStatuses; MASKED — returns {provider,authenticated,oauthEnabled,
+  expiry} only, never token strings (R-NO-RAW-SECRETS); integration PROP walks
+  the projection asserting zero secret-named fields and zero >=20-char opaque
+  values.
+- G6 mcp: refresh() now calls refreshClientTools() after restart (setTools
+  PARITY, R-REFRESH-PARITY); authenticate() runs real OAuth flow (performOAuth
+  -> restartServer -> refreshClientTools), propagates rejection uncaught;
+  details() deep projection to named-field-only public types.
+- G7 tool-keys: agent.tools.keys (AgentToolKeyControl) DISTINCT from
+  agent.auth.keys; ToolKeyStatus.maskedKey = maskKeyForDisplay(rawKey) — raw key
+  never crosses the boundary; barrel-only core import.
+- Barrel (REQ-008): api/index.ts exports PolicyDecision + ApprovalMode as VALUE
+  exports + 14 projected types type-only; COMMAND_API_MAP has the six new rows
+  (/approval-mode,/policies,/task,/hooks,/toolkey,/toolkeyfile).
+- Non-breaking (REQ-009): publicSurface.nonbreaking.test.ts dynamically
+  enumerates the built barrel and asserts prior #1594-era exports remain (subset),
+  createAgent arity unchanged, internals identity preserved, new enums round-trip.
+- No-deep-import boundary (REQ-INT-005): 3 new controls reach core ONLY via the
+  bare '@vybestack/llxprt-code-core' barrel (grep: no core/src|/dist/);
+  capabilityBoundary.adequacy.test.ts statically scans the whole changed set;
+  P21a PROVED non-vacuity by injecting a raw-source deep import (scan RED 4/3)
+  and restoring byte-identical (7/7 green).
+
+TDD/QUALITY DISCIPLINE (all PASS):
+- Mock theater: grep across the 11 new suites for
+  toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi.fn|vi.spyOn -> EXIT=1 (NONE).
+- Reverse tests: grep for toThrow('NotYetImplemented')|not.toThrow -> only a
+  COMMENT in agent.approvalMode.behavior.test.ts explaining it uses a positive
+  post-condition INSTEAD of a bare not.toThrow. No reverse test code.
+- ': any' across new suites -> EXIT=1 (NONE).
+- Property ratio (fc.assert count / it count) per new behavioral suite, all >=30%:
+  approvalMode 4/5, policy 4/6, tasks 6/8, hookAdmin 4/6, authDetail 4/6,
+  mcpOAuth 8/12, toolKeys 8/13, barrel 4/6, integration 12/18, boundary 7/7.
+- Mutation (independently recomputed from
+  packages/agents/reports/mutation/mutation.json, 2651 valid mutants):
+  overall 89.25% (>=80); policyControl 100% (14), tasksControl 100% (42),
+  toolKeysControl 91.18% (34) — all non-vacuous and >=80%.
+- Pseudocode-compliance gates ran (04a,06a,08a,10a,12a,14a,16a markers present;
+  impl files cite @pseudocode line numbers).
+- N5 comment discipline: method-body inline comments on the 3 controls are only
+  @plan/@requirement/@pseudocode markers; the only descriptive text is standard
+  JSDoc API doc-blocks (per existing control convention), not inline "what" prose.
+- Deterministic gates: npm run build EXIT=0; npm run typecheck EXIT=0;
+  npx vitest run packages/agents/src/api/__tests__/ -> 51 files / 640 tests pass,
+  EXIT=0.
+
+#1595 ADEQUACY (the mission) — all affirmed:
+- A CLI restricted to the public root '@vybestack/llxprt-code-agents' can
+  read/write approval mode (incl. the untrusted-folder throw), inspect policy
+  rules/defaults + drive the full /task surface, administer hooks (registry +
+  enable/disable) + render masked detailed auth, perform MCP OAuth with post-auth
+  setTools parity + read deep MCP detail + manage masked built-in tool keys.
+- The import boundary is documented (docs/agent-api.md:46 notes #1595 will trim
+  the root barrel; all seven capabilities documented). Pre-existing
+  agent.getConfig() remains for backward-compat (non-breaking) but is NOT required
+  for any of the seven new capabilities — proven by the getConfig-free integration
+  driver.
+
+Semantic Assessment: PASS — all seven gaps (G1–G7) closed with public surface +
+deep behavior + public-root reachability + documented constraints; the change is
+strictly additive and non-breaking; #1595 is enabled to drive every engine
+capability through the public root only with NO getConfig escape and NO deep
+imports; discipline is clean (no mock theater, no reverse tests, no any, property
+>=30% per suite, mutation 89.25% overall with all three new controls >=80%
+non-vacuous); docs updated. No rejection triggers — VERDICT: PASS.

--- a/project-plans/issue2143/analysis/domain-model.md
+++ b/project-plans/issue2143/analysis/domain-model.md
@@ -1,0 +1,306 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P01 @requirement:REQ-001,REQ-002,REQ-003,REQ-004,REQ-005,REQ-006,REQ-007,REQ-008,REQ-009,REQ-010,REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004,REQ-INT-005 -->
+# Domain Model: Close Agent API Engine-Capability Gaps (prereq for #1595)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Source: `project-plans/issue2143/specification.md`
+Scope: ANALYSIS ONLY — no implementation code. Models the entities, relationships, transitions,
+invariants, edge cases, and the test-harness cross-reference for the seven additive capability
+surfaces plus the barrel/command-map and non-breaking guarantees.
+
+---
+
+## 1. Entities
+
+### 1.1 Agent (EXISTING — extended)
+The public facade (`packages/agents/src/api/agent.ts` interface; `agentImpl.ts` impl). This plan ADDS
+top-level `getApprovalMode()`/`setApprovalMode()` and two `readonly` sub-controllers (`policy`,
+`tasks`), and EXTENDS three existing sub-controllers (`hooks`, `auth`, `mcp`) and one (`tools`, via a
+new nested `keys`).
+- Invariant: the facade owns NO engine state; it delegates to the bound `Config` / `OAuthManager`
+  per call (R-DELEGATE).
+
+### 1.2 ApprovalModeAccessor (NEW behavior on Agent)
+Top-level read/write of the bound `Config` approval mode.
+- Backing: `Config.getApprovalMode()` (`configBaseCore.ts:463`), `Config.setApprovalMode()`
+  (`config.ts:401`).
+- Invariant: `setApprovalMode` is a DIRECT delegation; the untrusted-folder throw propagates
+  (R-APPROVAL-THROW).
+
+### 1.3 AgentPolicyControl (NEW sub-controller)
+Read-only projection of the bound `PolicyEngine` (`Config.getPolicyEngine()`, `configBaseCore.ts:475`;
+engine in `packages/policy/src/policy-engine.ts`).
+- Entities returned: `PolicyRuleView` (projected from `PolicyRule`, `argsPattern: RegExp → string`),
+  `PolicyDecision` (VALUE enum).
+- Invariant: returns SNAPSHOTS; never the live engine; `argsPattern` is `.source` string
+  (R-POLICY-SNAPSHOT, R-ARGSPATTERN-STRING).
+
+### 1.4 AgentTasksControl (NEW sub-controller)
+Projection of `Config.getAsyncTaskManager()` (`config.ts:601`, nullable).
+- Entities returned: `AgentTaskInfo` (projected from `AsyncTaskInfo`, OMITS `abortController`).
+- Invariant: undefined-safe (R-UNDEFINED-SAFE); `AgentTaskInfo` never carries `abortController`
+  (R-NO-ABORTCONTROLLER); `cancelAllRunning` returns a COUNT (R-CANCEL-COUNT).
+
+### 1.5 AgentHookControl (EXISTING — extended for admin)
+Adds registry inspection + disabled-set administration to the existing execution/lifecycle control
+(`control/hooks.ts`).
+- Backing: `Config.getHookSystem()` (`config.ts:755`, nullable) →
+  `HookSystem.getRegistry().getAllHooks()` (`hookRegistry.ts:82`), `getHookName()`
+  (`hookRegistry.ts:118`), `HookRegistryEntry.enabled` (`hookRegistry.ts:41`); `Config.getDisabledHooks()`
+  (`config.ts:734`); `Config.setDisabledHooks()` (`configBase.ts:132`).
+- Entities returned: `HookInfo`.
+- Invariant: existing methods unchanged (R-NONBREAK); undefined-safe registry read
+  (R-UNDEFINED-SAFE).
+
+### 1.6 AgentAuthControl (EXISTING — extended for OAuth detail)
+Adds masked OAuth metadata using the OAuthManager ALREADY on `AgentDeps` (`agentImpl.ts:121`).
+- Backing: `OAuthManager.isAuthenticated()` (`oauth-manager.ts:199`), `isOAuthEnabled()` (`:300`),
+  `peekStoredToken()` (`:243`), `getHigherPriorityAuth()` (`:313`), `getAuthStatusWithBuckets()`
+  (`:395`).
+- Entities returned: `AuthProviderDetail`, `AuthBucketStatus`.
+- Invariant: MASKED metadata only — never raw token strings (R-NO-RAW-SECRETS).
+
+### 1.7 AgentMcpControl (EXISTING — extended for OAuth + detail + refresh parity)
+Adds the real MCP OAuth flow + deep detail + tool-refresh parity (`control/mcpControl.ts`).
+- Backing: `MCPOAuthProvider.authenticate()` (core barrel `index.ts:498`; flow mirrors
+  `mcpAuth.ts:82-136`), `manager.restartServer()`, `agentClient.setTools()`.
+- Entities returned: `McpServerAuthStatus` (EXISTING), `McpDetailStatus` (NEW).
+- Invariant: `refresh()` re-publishes tools (R-REFRESH-PARITY); existing methods unchanged
+  (R-NONBREAK); undefined-safe (R-UNDEFINED-SAFE).
+
+### 1.8 AgentToolKeysControl (NEW nested sub-controller on `tools`)
+Built-in tool-key storage via `ToolKeyStorage` (`tool-key-storage.ts:109`) + registry helpers
+(`getSupportedToolNames`/`getToolKeyEntry`/`isValidToolKeyName`/`maskKeyForDisplay`, core barrel
+`index.ts:472-475`).
+- Entities returned: `ToolKeyInfo`, `ToolKeyStatus`.
+- Invariant: MASKED key only (R-NO-RAW-SECRETS); distinct from provider-auth `Agent.auth.keys`
+  (R-KEYS-DISTINCT).
+
+### 1.9 PublicBarrel + CommandApiMap (EXISTING — extended)
+`packages/agents/src/api/index.ts` re-exports new projected types; `app-services/command-api-map.ts`
+registers the six migrated commands (kind `runtime`).
+- Invariant: type-only re-export for types; map stays orphan-free (R-MAP-VALID); no existing export
+  removed (R-NONBREAK).
+
+---
+
+## 2. Relationships
+
+```
+                         ┌──────────────────────────── Agent (facade) ───────────────────────────┐
+                         │                                                                        │
+   getApprovalMode()/setApprovalMode()         readonly policy        readonly tasks              │
+        │                                            │                     │                      │
+        ▼                                            ▼                     ▼                      │
+  Config.getApprovalMode()                   AgentPolicyControl     AgentTasksControl             │
+  Config.setApprovalMode() ──(throws)──►            │                     │                      │
+                                                    ▼                     ▼                      │
+                                          Config.getPolicyEngine()  Config.getAsyncTaskManager()  │
+                                          → PolicyEngine.getRules()  (nullable) → getAllTasks/…    │
+                                                                                                   │
+   readonly hooks (extended)   readonly auth (extended)   readonly mcp (extended)   tools.keys     │
+        │                           │                          │                        │          │
+        ▼                           ▼                          ▼                        ▼          │
+  Config.getHookSystem()      deps.oauthManager           MCPOAuthProvider.auth()  ToolKeyStorage  │
+  Config.get/setDisabledHooks (already on AgentDeps)      restartServer→setTools   + tool helpers  │
+                         └──────────────────────────────────────────────────────────────────────┘
+                                                  │
+                                                  ▼
+                              PublicBarrel (api/index.ts) re-exports projected types
+                              CommandApiMap registers /approval-mode /policies /task
+                                                 /hooks /toolkey /toolkeyfile
+```
+
+Shared-invariant notes:
+- ALL controllers share R-DELEGATE (resolve live backing per call) and R-UNDEFINED-SAFE (no-op when
+  the backing manager is absent — except policy/approval, whose backings are non-nullable on Config).
+- The two "extend" controllers (hooks/auth/mcp) and `tools.keys` share R-NONBREAK with the barrel:
+  no existing method/ export signature changes.
+- The projected types (`AgentTaskInfo`, `PolicyRuleView`, `Auth*`, `McpDetailStatus`, `ToolKey*`)
+  share R-NO-LEAK: omit non-serializable / secret internals (`abortController`, raw `RegExp`, raw
+  tokens/keys).
+
+---
+
+## 3. State Transitions
+
+### 3.1 Approval-mode write (REQ-001)
+Pre-conditions: bound Config; folder trust state known.
+- trusted folder: `setApprovalMode(YOLO)` ──► Config.approvalMode = YOLO ──► `getApprovalMode()` = YOLO
+- untrusted folder + non-DEFAULT: `setApprovalMode(YOLO)` ──► THROWS (no state change)
+Post-conditions: on success the live Config reflects the new mode; on throw the mode is unchanged and
+the error propagates uncaught.
+
+### 3.2 Async-task cancel-all (REQ-003.5)
+Pre-conditions: manager present with N running tasks.
+- `cancelAllRunning()` ──► for each running task: `cancelTask(id)` ──► returns count C (C ≤ N)
+Post-conditions: previously-running tasks are cancelled; `listRunning()` reflects the reduced set;
+return value equals the number actually cancelled.
+
+### 3.3 Async-task undefined manager (REQ-003.6)
+Pre-conditions: `getAsyncTaskManager()` returns `undefined`.
+- any method ──► no-op (`[]`/`undefined`/`false`/`0`)
+Post-conditions: no throw; deterministic empty results.
+
+### 3.4 Hooks disabled-set round-trip (REQ-004.2/.3/.4)
+Pre-conditions: bound Config (hook system may be present or absent).
+- `setDisabledHooks(["a"])` ──► Config disabled = ["a"] ──► `getDisabledHooks()` = ["a"]
+- `disable("b")` ──► Config disabled = ["a","b"] ; `enable("a")` ──► Config disabled = ["b"]
+Post-conditions: the disabled set reflects the operations; `listHooks()` reflects per-hook enabled
+flags when a system is present, `[]` otherwise.
+
+### 3.5 MCP authenticate (REQ-006.1)
+Pre-conditions: MCP manager present; server requires OAuth.
+- `authenticate(server)` ──► MCPOAuthProvider.authenticate ──► manager.restartServer(server) ──►
+  agentClient.setTools() ──► return auth status
+Post-conditions: server authenticated; tools re-published (parity with `mcpAuth.ts:136`).
+
+### 3.6 MCP refresh parity (REQ-006.2)
+Pre-conditions: MCP manager present.
+- `refresh(server?)` ──► restart ──► setTools()
+Post-conditions: tool declarations re-published (the previously-missing step).
+
+### 3.7 Tool-key save/mask (REQ-007.2/.3)
+Pre-conditions: supported, valid tool name.
+- `save(tool, "secret")` ──► ToolKeyStorage.saveKey ; `status(tool)` ──► hasKey=true,
+  maskedKey=mask("secret")
+Post-conditions: key persisted; status reports MASKED value; raw value never returned.
+
+---
+
+## 4. Business Rules (Named Invariants)
+
+1. **R-DELEGATE (REQ-001..007, C-DELEGATE-NO-CACHE):** every accessor resolves the live backing
+   (`this.deps.config.<getter>()` / injected closure) per call; no cached engine state. Testable: T1,
+   T20.
+2. **R-APPROVAL-THROW (REQ-001.2, C-APPROVAL-THROW):** `setApprovalMode` delegates directly; the
+   untrusted-folder throw propagates uncaught/unnormalized. Testable: T2.
+3. **R-POLICY-SNAPSHOT (REQ-002.1):** `policy.getRules()` returns read-only snapshots, not the live
+   engine or live rule objects. Testable: T4.
+4. **R-ARGSPATTERN-STRING (REQ-002.1, C-ARGSPATTERN-STRING):** `PolicyRuleView.argsPattern` is the
+   `.source` string (or `undefined`), never a raw `RegExp`. Testable: T5.
+5. **R-NO-ABORTCONTROLLER (REQ-003.7, C-NO-ABORTCONTROLLER):** `AgentTaskInfo` never contains an
+   `abortController` key (proved by `.strict()` schema + key assertion). Testable: T8.
+6. **R-CANCEL-COUNT (REQ-003.5):** `cancelAllRunning()` returns the integer count of tasks cancelled.
+   Testable: T7.
+7. **R-UNDEFINED-SAFE (REQ-003.6, REQ-004.5, REQ-006.4, C-UNDEFINED-SAFE):** when a backing manager is
+   absent, methods no-op deterministically (`[]`/`undefined`/`false`/`0`) with no throw. Testable: T9,
+   T12, T16.
+8. **R-HOOKS-ROUNDTRIP (REQ-004.2/.3/.4):** `setDisabledHooks`→`getDisabledHooks` round-trips;
+   `enable`/`disable` mutate the disabled set with exact `/hooks` semantics. Testable: T11.
+9. **R-NO-RAW-SECRETS (REQ-005, REQ-007.2, C-NO-RAW-SECRETS):** auth-detail and tool-key surfaces
+   return MASKED metadata only — no raw token strings, no raw key values. Testable: T13, T18.
+10. **R-REFRESH-PARITY (REQ-006.2):** `mcp.refresh()` re-publishes tool declarations (setTools) after
+    restart, matching `/mcp refresh`. Testable: T15.
+11. **R-MCP-OAUTH-FLOW (REQ-006.1):** `mcp.authenticate()` performs provider-auth → restart →
+    setTools → status, matching `mcpAuth.ts:82-136`. Testable: T14.
+12. **R-KEYS-DISTINCT (REQ-007.7):** `agent.tools.keys` is built-in tool-key storage, separate from
+    provider-auth `agent.auth.keys`; the latter is untouched. Testable: T17, T19.
+13. **R-NONBREAK (REQ-009):** no existing public export or controller method is removed/renamed/
+    retyped; extensions are additive. Testable: T21.
+14. **R-MAP-VALID (REQ-008.2):** `COMMAND_API_MAP` stays orphan-free, unique-named, durable-entries
+    importable, after the six new `runtime` rows. Testable: T22.
+15. **R-NO-DEEP-IMPORT (REQ-INT-005):** the public-consumer path imports only the public root; the
+    adequacy driver is a `.spec.ts` passing the T17 boundary guard. Testable: T23.
+16. **R-BARREL-TYPEONLY (REQ-008.1):** projected interface types are re-exported `export type`;
+    value enums are re-exported as values; no `any`/unsafe-`as`. Testable: T24.
+
+---
+
+## 5. Edge Cases
+
+- **5.1** Approval read when Config mode is the default → returns `ApprovalMode.DEFAULT` (no throw,
+  no fabrication).
+- **5.2** `setApprovalMode(DEFAULT)` in an untrusted folder → does NOT throw (only non-DEFAULT modes
+  throw, per `config.ts:402-405`).
+- **5.3** Policy engine with a rule whose `argsPattern` is absent → `PolicyRuleView.argsPattern` is
+  `undefined` (not `""`).
+- **5.4** Async `cancel(id)` called twice → second returns `false` (idempotent core, `cancelTask`).
+- **5.5** `cancelAllRunning()` with zero running tasks → returns `0` (not an error).
+- **5.6** Hooks `setDisabledHooks([])` (clear-all) → disabled set becomes empty (mirrors
+  `hooksCommand.ts:239`).
+- **5.7** `disable(name)` for an already-disabled hook → disabled set unchanged (no duplicate).
+- **5.8** Auth `detailedStatus` for a provider with no stored token → `authenticated:false`,
+  `expiry` absent; no token field present.
+- **5.9** MCP `authenticate` when the server doesn't require OAuth → returns a status indicating
+  no-auth-needed (no spurious restart side effects beyond the documented flow).
+- **5.10** MCP `details({})` with all flags false/absent → returns server list with names + auth
+  flags only (no tools/prompts/resources arrays).
+- **5.11** Tool-key `status` for a tool with a keyfile but no inline key → `hasKey` reflects resolved
+  presence; `keyFile` is the path; `maskedKey` absent or masked-empty.
+- **5.12** Tool-key `setKeyFile(tool, null)` → clears the keyfile (`clearKeyfilePath`).
+
+---
+
+## 6. Error Scenarios
+
+| Scenario | Expected behavior | Harness row |
+|---|---|---|
+| `setApprovalMode(YOLO)` in untrusted folder | THROWS untrusted-folder error, uncaught/unnormalized | T2 |
+| Async manager `undefined`, any task method | no-op (`[]`/`undefined`/`false`/`0`), no throw | T9 |
+| Hook system `undefined`, `listHooks()` | returns `[]`, no throw; disabled get/set still delegate | T12 |
+| MCP manager absent, `authenticate`/`details`/`refresh` | no-op safely, no throw | T16 |
+| Tool-key `save` with invalid tool name | rejects (validation `isValidToolKeyName`), no silent write | T18b |
+| Auth `detailedStatus` for unknown provider / no token | `authenticated:false`, no token field, no throw | T13b |
+| Public-consumer `.spec.ts` deep-imports internals | T17 boundary guard FAILS the suite | T23 |
+| Removed/renamed existing export | non-breaking characterization FAILS | T21 |
+
+---
+
+## 7. Requirement Coverage Map
+
+> Rows marked n/a are intentional: REQ-010 (docs) and REQ-008.1's type-only compile assertion are
+> validated by doc-accuracy review and `npm run typecheck` respectively, not a runtime transition.
+
+| REQ | Entities | Transition | Invariant | Harness row(s) | Phases |
+|---|---|---|---|---|---|
+| REQ-001 | 1.2 | 3.1 | R-DELEGATE, R-APPROVAL-THROW | T1, T2, T3 | P03/P04/P04a |
+| REQ-002 | 1.3 | (read) | R-POLICY-SNAPSHOT, R-ARGSPATTERN-STRING | T4, T5, T6 | P05/P06/P06a |
+| REQ-003 | 1.4 | 3.2, 3.3 | R-CANCEL-COUNT, R-NO-ABORTCONTROLLER, R-UNDEFINED-SAFE | T7, T8, T9, T10 | P07/P08/P08a |
+| REQ-004 | 1.5 | 3.4 | R-HOOKS-ROUNDTRIP, R-UNDEFINED-SAFE, R-NONBREAK | T11, T12 | P09/P10/P10a |
+| REQ-005 | 1.6 | (read) | R-NO-RAW-SECRETS, R-NONBREAK | T13, T13b | P11/P12/P12a |
+| REQ-006 | 1.7 | 3.5, 3.6 | R-MCP-OAUTH-FLOW, R-REFRESH-PARITY, R-UNDEFINED-SAFE | T14, T15, T16 | P13/P14/P14a |
+| REQ-007 | 1.8 | 3.7 | R-NO-RAW-SECRETS, R-KEYS-DISTINCT | T17, T18, T18b, T19 | P15/P16/P16a |
+| REQ-008 | 1.9 | (read) | R-MAP-VALID, R-BARREL-TYPEONLY | T22, T24 | P17/P17a |
+| REQ-009 | 1.1, 1.9 | (read) | R-NONBREAK | T21 | P18/P18a |
+| REQ-010 | n/a | n/a | (doc accuracy) | n/a | P19/P19a |
+| REQ-INT-001 | 1.2 | 3.1 | R-APPROVAL-THROW | T3 | P20-driver, P21 |
+| REQ-INT-002 | 1.3,1.4 | 3.2 | R-POLICY-SNAPSHOT, R-CANCEL-COUNT | T6, T10 | P20-driver, P21 |
+| REQ-INT-003 | 1.5,1.6 | 3.4 | R-HOOKS-ROUNDTRIP, R-NO-RAW-SECRETS | T11, T13 | P20-driver, P21 |
+| REQ-INT-004 | 1.7,1.8 | 3.5,3.7 | R-MCP-OAUTH-FLOW, R-KEYS-DISTINCT | T14, T19 | P20-driver, P21 |
+| REQ-INT-005 | 1.1 | (import) | R-NO-DEEP-IMPORT | T23 | P20-driver, P21/P21a |
+
+---
+
+## 8. Harness Row Cross-Reference (T1–T24)
+
+> Layers: L1 static/type, L2 characterization (non-breaking/export-surface), L3 behavior (unit
+> controller behavior), L4 integration (public-root-only adequacy driver), L5 resource/undefined-safe.
+
+| T-row | REQ(s) | Behavior | Layer |
+|---|---|---|---|
+| T1 | REQ-001.1 | `getApprovalMode()` returns live Config value | L3 |
+| T2 | REQ-001.2 | `setApprovalMode` untrusted-folder THROW propagates | L3 |
+| T3 | REQ-INT-001 | approval read/write parity via public root | L4 |
+| T4 | REQ-002.1 | `policy.getRules()` returns snapshots | L3 |
+| T5 | REQ-002.1 | `argsPattern` projected to `.source` string / undefined | L3 |
+| T6 | REQ-002.2/.3, REQ-INT-002 | default-decision + non-interactive read-through | L3/L4 |
+| T7 | REQ-003.5 | `cancelAllRunning()` returns cancelled COUNT | L3 |
+| T8 | REQ-003.7 | `AgentTaskInfo` omits `abortController` (strict) | L1/L3 |
+| T9 | REQ-003.6 | undefined manager → no-op everywhere | L5 |
+| T10 | REQ-003.1-.4, REQ-INT-002 | list/listRunning/get/cancel full-surface parity | L3/L4 |
+| T11 | REQ-004.2/.3/.4 | disabled-set round-trip + enable/disable | L3 |
+| T12 | REQ-004.1/.5 | `listHooks()` snapshot + undefined-system → `[]` | L3/L5 |
+| T13 | REQ-005.1/.3 | masked auth detail + bucket statuses (no token) | L3 |
+| T13b | REQ-005 edge | unknown provider/no token → not-authenticated, no token | L3 |
+| T14 | REQ-006.1 | `authenticate()` flow: auth→restart→setTools→status | L3 |
+| T15 | REQ-006.2 | `refresh()` re-publishes tools (setTools parity) | L3 |
+| T16 | REQ-006.4 | MCP absent → authenticate/details/refresh no-op | L5 |
+| T17 | REQ-007.1/.2 | `tools.keys.supported()/status()` masked | L3 |
+| T18 | REQ-007.3/.5/.6 | save/setKeyFile/getKeyFile round-trip (masked) | L3 |
+| T18b | REQ-007.3 edge | invalid tool name → reject (validation) | L3 |
+| T19 | REQ-007.7, REQ-INT-004 | `tools.keys` distinct from `auth.keys` | L3/L4 |
+| T20 | R-DELEGATE | re-read after Config change reflects new value (no cache) | L3 |
+| T21 | REQ-009 | non-breaking export-surface characterization | L2 |
+| T22 | REQ-008.2 | `COMMAND_API_MAP` six rows valid (orphan-free) | L2 |
+| T23 | REQ-INT-005 | adequacy driver `.spec.ts` passes T17 boundary | L4 |
+| T24 | REQ-008.1 | projected types re-exported (typecheck compile-anchor) | L1 |

--- a/project-plans/issue2143/analysis/pseudocode/approval-mode.md
+++ b/project-plans/issue2143/analysis/pseudocode/approval-mode.md
@@ -1,0 +1,106 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-001 -->
+# Pseudocode: Approval Mode (top-level `Agent` methods)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G1 — `Agent.getApprovalMode()` / `Agent.setApprovalMode(mode)`
+Source of truth: specification.md REQ-001; domain-model.md R-DELEGATE, R-APPROVAL-THROW.
+Analysis only — NO implementation code is written in this document.
+
+---
+
+## Interface Contracts
+
+These are top-level methods on the `Agent` interface (NOT a sub-controller) — approval mode has no
+per-agent sub-state, so it mirrors the ephemeral-settings one-liners (`agentImpl.ts:726-738`).
+
+```typescript
+// Added to the Agent interface in packages/agents/src/api/agent.ts
+// (near the existing getEphemeralSetting/setEphemeralSetting declarations at agent.ts:341-345)
+interface Agent {
+  // ...existing members unchanged (REQ-009)...
+  getApprovalMode(): ApprovalMode;
+  setApprovalMode(mode: ApprovalMode): void;
+}
+
+// ApprovalMode is ALREADY imported at agent.ts:11 and re-exported `export type` at agent.ts:387.
+// It is a VALUE enum from the core barrel (core/src/index.ts:18). No new import needed in agent.ts
+// for the type position; agentImpl.ts already has Config access via this.deps.config.
+```
+
+### Dependencies (NEVER stubbed)
+
+```typescript
+// AgentImpl already holds this.deps.config: Config (the live bound Config).
+// No new dependency object is introduced for this capability.
+//   - this.deps.config.getApprovalMode(): ApprovalMode      // configBaseCore.ts:463
+//   - this.deps.config.setApprovalMode(mode: ApprovalMode): void  // config.ts:401 (THROWS :404)
+```
+
+---
+
+## Numbered Pseudocode
+
+### METHOD getApprovalMode(): ApprovalMode
+
+```
+1: // @pseudocode REQ-001.1 — live read, no cache
+2: METHOD getApprovalMode() RETURNS ApprovalMode
+3:   RETURN this.deps.config.getApprovalMode()
+4: END METHOD
+```
+
+### METHOD setApprovalMode(mode: ApprovalMode): void
+
+```
+10: // @pseudocode REQ-001.2 — direct delegation; the untrusted-folder throw MUST propagate
+11: METHOD setApprovalMode(mode: ApprovalMode) RETURNS void
+12:   // NO try/catch, NO normalization, NO mode validation here — Config owns the guard.
+13:   // For any non-DEFAULT mode in an untrusted folder, config.setApprovalMode throws
+14:   // "Cannot enable privileged approval modes in an untrusted folder." (config.ts:404);
+15:   // that throw escapes this method UNCHANGED.
+16:   this.deps.config.setApprovalMode(mode)
+17: END METHOD
+```
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol / call | File:line (verified) |
+|---|---|---|
+| 3 | `Config.getApprovalMode(): ApprovalMode` | `packages/core/src/config/configBaseCore.ts:463` |
+| 16 | `Config.setApprovalMode(mode: ApprovalMode): void` (throws on untrusted, non-DEFAULT) | `packages/core/src/config/config.ts:401` (throw `:404`) |
+| n/a (wiring) | declarations added next to existing ephemeral one-liners | `agentImpl.ts:726-738` (getEphemeralSetting:726, setEphemeralSetting:731) |
+| n/a (type) | `ApprovalMode` value enum | core barrel `core/src/index.ts:18`; re-exported `export type` `agent.ts:387` |
+
+CLI consumer this unblocks (#1595, not modified here):
+`packages/cli/src/ui/hooks/useAutoAcceptIndicator.ts` (reads `config.getApprovalMode()`, writes
+`config.setApprovalMode(...)`).
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: wrap `config.setApprovalMode(mode)` in try/catch — swallowing the untrusted-folder
+  throw violates REQ-001.2 / C-APPROVAL-THROW.
+  [OK] DO: call it directly and let the error propagate.
+- [ERROR] DO NOT: cache the approval mode in an instance field and return the cached copy.
+  [OK] DO: read `this.deps.config.getApprovalMode()` live every call (R-DELEGATE).
+- [ERROR] DO NOT: normalize/clamp `mode` (e.g. coerce YOLO→DEFAULT) before delegating.
+  [OK] DO: pass `mode` through verbatim; Config is the single source of validation.
+- [ERROR] DO NOT: add a sub-controller (`agent.approval.*`) — approval has no sub-state.
+  [OK] DO: add two top-level `Agent` methods, mirroring the ephemeral-settings shape.
+
+---
+
+## Behavior Decision Table
+
+| GIVEN (folder trust) | mode arg | Config behavior | Method result |
+|---|---|---|---|
+| trusted | `DEFAULT` | sets, returns void | returns void; subsequent get → `DEFAULT` |
+| trusted | `AUTO_EDIT` | sets, returns void | returns void; subsequent get → `AUTO_EDIT` |
+| trusted | `YOLO` | sets, returns void | returns void; subsequent get → `YOLO` |
+| untrusted | `DEFAULT` | sets (DEFAULT allowed), returns void | returns void |
+| untrusted | `AUTO_EDIT` | THROWS (`config.ts:404`) | THROWS — same error propagates (REQ-001.2) |
+| untrusted | `YOLO` | THROWS (`config.ts:404`) | THROWS — same error propagates (REQ-001.2) |
+| (any) read | — | `getApprovalMode()` returns live value | exact live `ApprovalMode` (REQ-001.1) |

--- a/project-plans/issue2143/analysis/pseudocode/auth-detail.md
+++ b/project-plans/issue2143/analysis/pseudocode/auth-detail.md
@@ -1,0 +1,157 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-005 -->
+# Pseudocode: Auth Detail (extend `Agent.auth` with masked OAuth metadata)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G5 — extend the EXISTING `AgentAuthControl` / `AuthControl` with detailed, MASKED auth state.
+Source of truth: specification.md REQ-005; domain-model.md R-NO-RAW-SECRETS, R-DELEGATE.
+Analysis only — NO implementation code is written in this document.
+
+---
+
+## Interface Contracts
+
+```typescript
+// EXTEND the existing AgentAuthControl interface in packages/agents/src/api/agent.ts (:260-277).
+// Existing members stay EXACTLY as-is (REQ-009). ADD:
+interface AgentAuthControl {
+  // ...existing members unchanged...
+  detailedStatus(provider: string): Promise<AuthProviderDetail>;
+  getHigherPriorityAuth(provider: string): Promise<string | null>;
+  listBucketStatuses(provider: string): Promise<readonly AuthBucketStatus[]>;
+}
+
+// Projected public types (specification.md Data Schemas) — NEVER include token strings.
+interface AuthProviderDetail {
+  readonly provider: string;
+  readonly authenticated: boolean;
+  readonly oauthEnabled: boolean;
+  readonly expiry?: number;          // unix-seconds from OAuthToken.expiry; NO access_token
+}
+interface AuthBucketStatus {
+  readonly bucket: string;
+  readonly authenticated: boolean;
+  readonly expiry?: number;
+  readonly isSessionBucket: boolean;
+}
+```
+
+### Dependencies (NEVER stubbed)
+
+`OAuthManager` is ALREADY on `AgentDeps` (`agentImpl.ts:121`, non-nullable) but is NOT yet threaded
+into `AuthControlDeps`. The ONLY wiring change is to pass a closure resolving it into
+`buildAuthControl()` (`agentImpl.ts:431`) — no new constructor parameter on AgentImpl.
+
+```typescript
+// ADD to AuthControlDeps (control/authControl.ts:34):
+//   readonly getOAuthManager: () => OAuthManager
+// Wired in buildAuthControl(): getOAuthManager: () => this.deps.oauthManager
+//
+// Live OAuthManager calls used (all async, all MASKED outputs):
+//   isOAuthEnabled(provider): boolean                       // oauth-manager.ts:300 (sync)
+//   isAuthenticated(provider): Promise<boolean>             // oauth-manager.ts:199
+//   peekStoredToken(provider): Promise<OAuthToken | null>   // oauth-manager.ts:243 (token.expiry only)
+//   getHigherPriorityAuth(provider): Promise<string | null> // oauth-manager.ts:313
+//   getAuthStatusWithBuckets(provider): Promise<Array<{bucket,authenticated,expiry?,isSessionBucket}>>
+//                                                           // oauth-manager.ts:395
+// OAuthToken.expiry is a unix-seconds number (auth/src/types.ts OAuthTokenSchema.expiry:15).
+```
+
+---
+
+## Numbered Pseudocode
+
+### METHOD detailedStatus(provider): Promise<AuthProviderDetail>
+
+```
+1: // @pseudocode REQ-005.1 — masked detail: authenticated + oauthEnabled + expiry; NEVER the token
+2: METHOD detailedStatus(provider) RETURNS Promise<AuthProviderDetail>
+3:   SET mgr = this.deps.getOAuthManager()
+4:   SET oauthEnabled = mgr.isOAuthEnabled(provider)         // oauth-manager.ts:300
+5:   SET authenticated = AWAIT mgr.isAuthenticated(provider) // oauth-manager.ts:199
+6:   SET expiry = undefined
+7:   IF authenticated IS true THEN
+8:     SET token = AWAIT mgr.peekStoredToken(provider)       // oauth-manager.ts:243 (no refresh)
+9:     IF token IS NOT null THEN SET expiry = token.expiry   // ONLY the expiry number is read
+10:  END IF
+11:  RETURN {
+12:    provider: provider,
+13:    authenticated: authenticated,
+14:    oauthEnabled: oauthEnabled,
+15:    expiry: expiry,                                        // token.access_token is NEVER copied
+16:  }
+17: END METHOD
+```
+
+### METHOD getHigherPriorityAuth(provider): Promise<string | null>
+
+```
+30: // @pseudocode REQ-005.2 — direct read-through (returns a provider/source NAME, not a secret)
+31: METHOD getHigherPriorityAuth(provider) RETURNS Promise<string | null>
+32:   RETURN AWAIT this.deps.getOAuthManager().getHigherPriorityAuth(provider)  // oauth-manager.ts:313
+33: END METHOD
+```
+
+### METHOD listBucketStatuses(provider): Promise<readonly AuthBucketStatus[]>
+
+```
+40: // @pseudocode REQ-005.3 — project bucket status; copy ONLY the four public fields
+41: METHOD listBucketStatuses(provider) RETURNS Promise<readonly AuthBucketStatus[]>
+42:   SET raw = AWAIT this.deps.getOAuthManager().getAuthStatusWithBuckets(provider)  // :395
+43:   SET out = empty array
+44:   FOR EACH b IN raw
+45:     APPEND { bucket: b.bucket, authenticated: b.authenticated,
+46:              expiry: b.expiry, isSessionBucket: b.isSessionBucket } TO out
+47:   END FOR
+48:   RETURN out
+49: END METHOD
+```
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol / call | File:line (verified) |
+|---|---|---|
+| 3 (wiring) | `OAuthManager` on `AgentDeps` (already present) | `agentImpl.ts:121` |
+| 4 | `OAuthManager.isOAuthEnabled(provider): boolean` | `providers/src/auth/oauth-manager.ts:300` |
+| 5 | `OAuthManager.isAuthenticated(provider): Promise<boolean>` | `oauth-manager.ts:199` |
+| 8 | `OAuthManager.peekStoredToken(provider): Promise<OAuthToken \| null>` | `oauth-manager.ts:243` |
+| 9 | `OAuthToken.expiry: number` (unix-seconds) | `packages/auth/src/types.ts` `OAuthTokenSchema.expiry:15` |
+| 32 | `OAuthManager.getHigherPriorityAuth(provider): Promise<string \| null>` | `oauth-manager.ts:313` |
+| 42 | `OAuthManager.getAuthStatusWithBuckets(provider)` → `Array<{bucket,authenticated,expiry?,isSessionBucket}>` | `oauth-manager.ts:395` |
+| n/a (wiring) | thread `getOAuthManager` into `buildAuthControl()` | `agentImpl.ts:431` |
+
+CLI consumer this unblocks (#1595): `packages/cli/src/ui/commands/authCommand.ts`
+(`peekStoredToken`, `getHigherPriorityAuth`, `getAuthStatusWithBuckets`).
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: copy `token.access_token` / `token.refresh_token` onto any returned object.
+  [OK] DO: read ONLY `token.expiry` (a number) for `AuthProviderDetail.expiry` (R-NO-RAW-SECRETS).
+- [ERROR] DO NOT: return the raw `getAuthStatusWithBuckets` array (its shape may evolve / leak).
+  [OK] DO: project to `AuthBucketStatus` copying the four named fields only.
+- [ERROR] DO NOT: call `getToken()` (which may REFRESH / mint network calls) to read expiry.
+  [OK] DO: use `peekStoredToken()` (no refresh, no side effects).
+- [ERROR] DO NOT: skip the `authenticated` guard before peeking (avoid surfacing stale expiry for a
+  logged-out provider).
+  [OK] DO: only read expiry when `authenticated` is true.
+- [ERROR] DO NOT: cache the OAuthManager or its results.
+  [OK] DO: resolve `this.deps.getOAuthManager()` per call (R-DELEGATE).
+- [ERROR] DO NOT: add a new constructor parameter to AgentImpl for the OAuthManager.
+  [OK] DO: reuse the existing `this.deps.oauthManager` via a closure in `buildAuthControl()`.
+
+---
+
+## Behavior Decision Table
+
+| GIVEN provider state | Method | Result (MASKED) |
+|---|---|---|
+| oauth enabled + authenticated, token.expiry=1700000000 | `detailedStatus(p)` | `{provider:p, authenticated:true, oauthEnabled:true, expiry:1700000000}` (no token) |
+| oauth enabled, NOT authenticated | `detailedStatus(p)` | `{authenticated:false, oauthEnabled:true, expiry:undefined}` |
+| authenticated but `peekStoredToken` → null | `detailedStatus(p)` | `{authenticated:true, expiry:undefined}` |
+| api-key has higher precedence | `getHigherPriorityAuth(p)` | the source name string (e.g. `"key"`) |
+| oauth is the winner | `getHigherPriorityAuth(p)` | `null` |
+| two buckets, one session | `listBucketStatuses(p)` | length 2; each `{bucket,authenticated,expiry?,isSessionBucket}` only |
+| any returned object | (all methods) | contains NO `access_token`/`refresh_token` key (R-NO-RAW-SECRETS) |

--- a/project-plans/issue2143/analysis/pseudocode/barrel-exports.md
+++ b/project-plans/issue2143/analysis/pseudocode/barrel-exports.md
@@ -1,0 +1,116 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-008 -->
+# Pseudocode: Public Barrel Re-Exports (`packages/agents/src/api/index.ts`)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G8a — re-export all new public projected types + value enums from the agents api barrel.
+Source of truth: specification.md REQ-008; domain-model.md R-BARREL-TYPEONLY, R-NONBREAK.
+Analysis only — NO implementation code is written in this document.
+
+> The api barrel currently `export *`s the controller interfaces from `./agent.js` (so the NEW
+> control interfaces — `AgentPolicyControl`, `AgentTasksControl`, `AgentToolKeyControl`, plus the
+> extended `AgentMcpControl`/`AgentAuthControl`/`AgentHookControl` — surface automatically). This
+> phase adds the standalone PROJECTED public types + the two VALUE enums that consumers need by name.
+
+---
+
+## Interface Contracts
+
+```typescript
+// In packages/agents/src/api/index.ts (current barrel head at :10-20).
+// verbatimModuleSyntax is ON → `export type` for interfaces/type-aliases, plain `export` for VALUES.
+
+// --- VALUE enums (re-exported from the core barrel; NOT `type`) ---
+export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core';
+
+// --- TYPE-ONLY projected public types (defined in agent.ts; surfaced explicitly by name) ---
+export type {
+  PolicyRuleView,
+  AgentTaskInfo,
+  HookInfo,
+  AuthProviderDetail,
+  AuthBucketStatus,
+  McpServerAuthStatus,
+  McpDetailStatus,
+  McpServerDetail,
+  McpDetailsOptions,
+  McpPromptInfo,
+  McpResourceInfo,
+  McpBlockedServer,
+  ToolKeyInfo,
+  ToolKeyStatus,
+} from './agent.js';
+```
+
+### Dependencies (NEVER stubbed)
+
+```
+None — this is pure module re-export wiring. The projected types are DEFINED in agent.ts
+(co-located with the control interfaces); the two enums come from the core barrel.
+```
+
+---
+
+## Numbered Pseudocode
+
+```
+1: // @pseudocode REQ-008.1 — surface value enums (ApprovalMode already re-exported `export type`
+2: //                          at agent.ts:387; add the VALUE form so consumers can use enum members)
+3: ADD to api/index.ts: export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core'
+4:
+5: // @pseudocode REQ-008.2 — surface all projected public TYPES by name (type-only)
+6: ADD to api/index.ts: export type { PolicyRuleView, AgentTaskInfo, HookInfo,
+7:        AuthProviderDetail, AuthBucketStatus, McpServerAuthStatus, McpDetailStatus,
+8:        McpServerDetail, McpDetailsOptions, McpPromptInfo, McpResourceInfo, McpBlockedServer,
+9:        ToolKeyInfo, ToolKeyStatus } from './agent.js'
+10:
+11: // @pseudocode REQ-008.3 — control INTERFACES (AgentPolicyControl/AgentTasksControl/
+12: //   AgentToolKeyControl + extended Agent*Control) are surfaced by the EXISTING `export *
+13: //   from './agent.js'`; NO new line needed, but the non-breaking guard asserts their presence.
+14: VERIFY existing `export type * from './agent.js'` (or equivalent) still present (REQ-009)
+```
+
+> Value-vs-type classification is CRITICAL under `verbatimModuleSyntax` + `noUnusedLocals`:
+> `PolicyDecision`/`ApprovalMode` are runtime enums → plain `export`; everything else is a TS
+> interface → `export type` (else TS1205 / runtime "not exported" errors).
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol | File:line (verified) |
+|---|---|---|
+| 3 | `PolicyDecision` (enum) | core barrel `core/src/index.ts:17` |
+| 3 | `ApprovalMode` (enum) | core barrel `core/src/index.ts:18` |
+| 6-9 | projected types DEFINED alongside control interfaces | `agents/src/api/agent.ts` (added by component phases) |
+| 14 | existing barrel re-export of `./agent.js` | `agents/src/api/index.ts:12` (`export type * from './agent.js'`) |
+| n/a | barrel head where new lines land | `agents/src/api/index.ts:10-20` |
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: `export type { PolicyDecision }` (it's a VALUE enum → breaks enum-member use).
+  [OK] DO: plain `export { PolicyDecision, ApprovalMode }`.
+- [ERROR] DO NOT: `export { PolicyRuleView }` without `type` (TS1205 under verbatimModuleSyntax).
+  [OK] DO: `export type { PolicyRuleView, ... }`.
+- [ERROR] DO NOT: remove or reorder existing barrel exports.
+  [OK] DO: APPEND only; the non-breaking guard (REQ-009) asserts the prior set is a subset.
+- [ERROR] DO NOT: re-export raw core types that leak internals (`AsyncTaskInfo` with
+  `abortController`, raw `RegExp` `PolicyRule`).
+  [OK] DO: re-export the PROJECTED public types (`AgentTaskInfo`, `PolicyRuleView`).
+
+---
+
+## Behavior Decision Table
+
+| Symbol | export form | Rationale |
+|---|---|---|
+| `PolicyDecision` | `export { … }` | runtime enum value |
+| `ApprovalMode` | `export { … }` | runtime enum value (was type-only at agent.ts:387; value form added) |
+| `PolicyRuleView` | `export type { … }` | interface |
+| `AgentTaskInfo` | `export type { … }` | interface (omits abortController) |
+| `HookInfo` | `export type { … }` | interface |
+| `AuthProviderDetail`/`AuthBucketStatus` | `export type { … }` | interfaces (masked) |
+| `McpServerAuthStatus`/`McpDetailStatus`/`McpServerDetail`/`McpDetailsOptions`/`McpPromptInfo`/`McpResourceInfo`/`McpBlockedServer` | `export type { … }` | interfaces |
+| `ToolKeyInfo`/`ToolKeyStatus` | `export type { … }` | interfaces |
+| `AgentPolicyControl`/`AgentTasksControl`/`AgentToolKeyControl` | (none — via `export *`) | surfaced by existing star re-export |

--- a/project-plans/issue2143/analysis/pseudocode/command-map.md
+++ b/project-plans/issue2143/analysis/pseudocode/command-map.md
@@ -1,0 +1,113 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-008 -->
+# Pseudocode: COMMAND_API_MAP rows (`app-services/command-api-map.ts`)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G8b — add the 6 missing CLI slash-command → Agent-API-target rows so the canonical
+map documents how #1595 reaches each newly-exposed capability.
+Source of truth: specification.md REQ-008; domain-model.md R-MAP-VALID.
+Analysis only — NO implementation code is written in this document.
+
+> The 6 target commands (`/policies`, `/task`, `/hooks`, `/toolkey`, `/toolkeyfile`,
+> `/approval-mode`) are ALL currently ABSENT from `COMMAND_API_MAP` (verified: count 0 each).
+> Each maps to a NEW live Agent method path → `kind: 'runtime'` (NOT subpath/cli-local). Adding
+> `runtime` rows is SAFE under the boundary spec (`app-service-boundary.spec.ts`): its invariants
+> only require (a) every row has a valid kind, (b) the REQUIRED_DURABLE subpath set is present +
+> classified subpath, (c) unique command names — completeness is NOT enforced, and `runtime` rows
+> need no subpath import.
+
+---
+
+## Interface Contracts
+
+```typescript
+// CommandApiMapping (app-services/types.ts):
+interface CommandApiMapping {
+  readonly command: string;
+  readonly kind: 'runtime' | 'subpath' | 'cli-local';
+  readonly target: string;       // dotted Agent-method path for runtime rows
+  readonly exportName?: string;  // only used by subpath rows
+  readonly note?: string;
+}
+// Rows are appended to the existing `COMMAND_API_MAP: readonly CommandApiMapping[]`
+// (command-api-map.ts:37). No type change.
+```
+
+### Dependencies (NEVER stubbed)
+
+```
+None — static data rows. No runtime resolution; `runtime` rows are documentary target paths,
+unlike `subpath` rows which the T23 test dynamically imports.
+```
+
+---
+
+## Numbered Pseudocode
+
+```
+1: // @pseudocode REQ-008.4 — append 6 runtime rows to COMMAND_API_MAP (after existing entries)
+2: APPEND row { command: '/approval-mode', kind: 'runtime', target: 'agent.setApprovalMode',
+3:              note: 'Approval mode is a live engine setting on the active run' }
+4: APPEND row { command: '/policies', kind: 'runtime', target: 'agent.policy.getRules',
+5:              note: 'Policy inspection reads the active run policy engine' }
+6: APPEND row { command: '/task', kind: 'runtime', target: 'agent.tasks.list',
+7:              note: 'Async task list/inspect/cancel over the active run task manager' }
+8: APPEND row { command: '/hooks', kind: 'runtime', target: 'agent.hooks.listHooks',
+9:              note: 'Hook registry inspection + enable/disable on the active run' }
+10: APPEND row { command: '/toolkey', kind: 'runtime', target: 'agent.tools.keys.save',
+11:              note: 'Built-in tool key storage feeds the active run tools' }
+12: APPEND row { command: '/toolkeyfile', kind: 'runtime', target: 'agent.tools.keys.setKeyFile',
+13:              note: 'Built-in tool keyfile path feeds the active run tools' }
+14:
+15: // INVARIANTS that must still hold after the append (R-MAP-VALID):
+16: //   - every row.kind ∈ {runtime, subpath, cli-local}            (no orphan)
+17: //   - command names remain UNIQUE                                (no dup)
+18: //   - REQUIRED_DURABLE subpath set unchanged + still subpath      (non-breaking)
+19: //   - each new target dotted-path corresponds to a REAL Agent method added by this plan
+```
+
+> Target-path ground truth (each is a real Agent method created by this plan):
+> `agent.setApprovalMode` (REQ-001), `agent.policy.getRules` (REQ-002),
+> `agent.tasks.list` (REQ-003), `agent.hooks.listHooks` (REQ-004),
+> `agent.tools.keys.save` / `agent.tools.keys.setKeyFile` (REQ-007).
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real anchor | File:line (verified) |
+|---|---|---|
+| 1 | `COMMAND_API_MAP: readonly CommandApiMapping[]` | `app-services/command-api-map.ts:37` |
+| 2-13 | append point = after last existing row (`/quit` at `:267`) | `command-api-map.ts:267` (last entry block) |
+| 16 | VALID_KINDS guard (no orphan) | `app-service-boundary.spec.ts:27,46,74` |
+| 17 | unique-command guard | `app-service-boundary.spec.ts:48` |
+| 18 | REQUIRED_DURABLE subpath guard | `app-service-boundary.spec.ts:33,52,80` |
+| target paths | the Agent methods added by this plan | `agent.ts` (REQ-001..007 phases) |
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: classify these as `subpath` (the T23 test would try to dynamically import a named
+  export from the app-service subpath and FAIL — these are live Agent runtime paths).
+  [OK] DO: use `kind: 'runtime'` (no subpath import needed).
+- [ERROR] DO NOT: duplicate an existing `command` string (breaks the unique-name invariant).
+  [OK] DO: confirm each of the 6 is absent first (verified: count 0) before appending.
+- [ERROR] DO NOT: invent a `target` path that no Agent method backs.
+  [OK] DO: point each `target` at a REAL method this plan adds (see ground-truth list above).
+- [ERROR] DO NOT: touch the existing rows.
+  [OK] DO: append only (R-MAP-VALID / REQ-009 non-breaking).
+
+---
+
+## Behavior Decision Table
+
+| command | kind | target | backed by REQ |
+|---|---|---|---|
+| `/approval-mode` | runtime | `agent.setApprovalMode` | REQ-001 |
+| `/policies` | runtime | `agent.policy.getRules` | REQ-002 |
+| `/task` | runtime | `agent.tasks.list` | REQ-003 |
+| `/hooks` | runtime | `agent.hooks.listHooks` | REQ-004 |
+| `/toolkey` | runtime | `agent.tools.keys.save` | REQ-007 |
+| `/toolkeyfile` | runtime | `agent.tools.keys.setKeyFile` | REQ-007 |
+| (post-append) every row | ∈ valid kinds | unique command | — |
+| (post-append) REQUIRED_DURABLE | subpath | unchanged | REQ-009 |

--- a/project-plans/issue2143/analysis/pseudocode/hooks-admin.md
+++ b/project-plans/issue2143/analysis/pseudocode/hooks-admin.md
@@ -1,0 +1,166 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-004 -->
+# Pseudocode: Hooks Administration (extend `AgentHookControl` / `HookControl`)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G4 — extend the EXISTING hook control with registry inspection + enable/disable admin.
+Source of truth: specification.md REQ-004; domain-model.md R-HOOKS-ROUNDTRIP, R-UNDEFINED-SAFE.
+Analysis only — NO implementation code is written in this document.
+
+---
+
+## Interface Contracts
+
+```typescript
+// EXTEND the existing AgentHookControl interface in packages/agents/src/api/agent.ts (:314-321).
+// Existing members (onHookExecution / triggerSessionStart / triggerSessionEnd / clear) stay
+// EXACTLY as-is (REQ-009 non-breaking). ADD:
+interface AgentHookControl {
+  // ...existing members unchanged...
+  listHooks(): readonly HookInfo[];
+  getDisabledHooks(): readonly string[];
+  setDisabledHooks(names: readonly string[]): void;
+  enable(name: string): void;        // convenience over the disabled-set
+  disable(name: string): void;       // convenience over the disabled-set
+}
+
+// Projected public type (specification.md Data Schemas).
+interface HookInfo {
+  readonly name: string;             // = registry.getHookName(entry)  (hookRegistry.ts:118)
+  readonly eventName: string;        // = entry.eventName
+  readonly enabled: boolean;         // = entry.enabled                (hookRegistry.ts:41)
+  readonly source?: string;          // = String(entry.source)
+}
+```
+
+### Dependencies (NEVER stubbed)
+
+The existing `HookControl` already holds `this.deps.config: Config` — NO new constructor plumbing
+is required (confirmed: `control/hooks.ts` constructor stores deps incl. `config`). The admin
+methods resolve the live hook system from that Config per call.
+
+```typescript
+// Already available on HookControlDeps:
+//   readonly config: Config
+// Live resolutions used by the new methods (all PER CALL, undefined-safe):
+//   config.getHookSystem(): HookSystem | undefined          // config.ts:755 (nullable)
+//   config.getDisabledHooks(): string[]                     // config.ts:734
+//   config.setDisabledHooks(names: string[]): void          // configBase.ts:132
+//   hookSystem.isInitialized(): boolean                     // hookSystem.ts:158
+//   hookSystem.getRegistry(): HookRegistry                  // hookSystem.ts:137
+//   registry.getAllHooks(): HookRegistryEntry[]             // hookRegistry.ts:82
+//   registry.getHookName(entry): string                    // hookRegistry.ts:118
+```
+
+---
+
+## Numbered Pseudocode
+
+### METHOD listHooks(): readonly HookInfo[]
+
+```
+1: // @pseudocode REQ-004.1 — registry snapshot; undefined/uninitialised-safe
+2: METHOD listHooks() RETURNS readonly HookInfo[]
+3:   SET system = this.deps.config.getHookSystem()
+4:   IF system IS undefined THEN RETURN []                  // R-UNDEFINED-SAFE
+5:   IF system.isInitialized() IS false THEN RETURN []      // guard: getRegistry/getAllHooks safe only after init
+6:   SET registry = system.getRegistry()
+7:   SET entries = registry.getAllHooks()                   // HookRegistryEntry[] (hookRegistry.ts:82)
+8:   SET out = empty array
+9:   FOR EACH entry IN entries
+10:    SET info = {
+11:      name: registry.getHookName(entry),                 // hookRegistry.ts:118
+12:      eventName: entry.eventName,
+13:      enabled: entry.enabled,                             // hookRegistry.ts:41
+14:      source: String(entry.source),
+15:    }
+16:    APPEND info TO out
+17:  END FOR
+18:  RETURN out
+19: END METHOD
+```
+
+### METHOD getDisabledHooks(): readonly string[]
+
+```
+30: // @pseudocode REQ-004.2 — read-through; snapshot copy
+31: METHOD getDisabledHooks() RETURNS readonly string[]
+32:   RETURN [...this.deps.config.getDisabledHooks()]        // config.ts:734 (fresh copy, not live ref)
+33: END METHOD
+```
+
+### METHOD setDisabledHooks(names): void
+
+```
+40: // @pseudocode REQ-004.3 — write-through; round-trips with getDisabledHooks (R-HOOKS-ROUNDTRIP)
+41: METHOD setDisabledHooks(names) RETURNS void
+42:   this.deps.config.setDisabledHooks([...names])          // configBase.ts:132 (defensive copy)
+43: END METHOD
+```
+
+### METHOD enable(name): void  /  disable(name): void
+
+```
+50: // @pseudocode REQ-004.4 — convenience over the disabled-set; idempotent
+51: METHOD disable(name) RETURNS void
+52:   SET current = this.deps.config.getDisabledHooks()
+53:   IF current ALREADY CONTAINS name THEN RETURN           // idempotent (no duplicate)
+54:   this.deps.config.setDisabledHooks([...current, name])
+55: END METHOD
+56:
+57: METHOD enable(name) RETURNS void
+58:   SET current = this.deps.config.getDisabledHooks()
+59:   SET next = current.filter(n => n !== name)
+60:   this.deps.config.setDisabledHooks(next)                // idempotent if name absent
+61: END METHOD
+```
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol / call | File:line (verified) |
+|---|---|---|
+| 3 | `Config.getHookSystem(): HookSystem \| undefined` | `config.ts:755` |
+| 5 | `HookSystem.isInitialized(): boolean` | `hookSystem.ts:158` |
+| 6 | `HookSystem.getRegistry(): HookRegistry` | `hookSystem.ts:137` |
+| 7 | `HookRegistry.getAllHooks(): HookRegistryEntry[]` | `hookRegistry.ts:82` |
+| 11 | `HookRegistry.getHookName(entry): string` | `hookRegistry.ts:118` |
+| 13 | `HookRegistryEntry.enabled: boolean` | `hookRegistry.ts:41` |
+| 32 | `Config.getDisabledHooks(): string[]` | `config.ts:734` |
+| 42/54/60 | `Config.setDisabledHooks(names: string[]): void` | `configBase.ts:132` |
+| n/a | `HookRegistryEntry` (re-export) | core barrel `export * from './hooks/index.js'` `index.ts:36` |
+| n/a (wiring) | extend existing `buildHookControl()` | `agentImpl.ts:391` |
+
+CLI consumer this unblocks (#1595): `packages/cli/src/ui/commands/hooksCommand.ts`
+(`getHookSystem:31,74,144,211,279`, `getDisabledHooks:107,177`, `setDisabledHooks:111,180,239`).
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: call `system.getRegistry()` / `getAllHooks()` without an `isInitialized()` guard.
+  [OK] DO: return `[]` when `getHookSystem()` is undefined OR `isInitialized()` is false (R-UNDEFINED-SAFE).
+- [ERROR] DO NOT: return the live array from `config.getDisabledHooks()`.
+  [OK] DO: return a spread copy `[...]` so callers cannot mutate engine state.
+- [ERROR] DO NOT: push a duplicate name in `disable()`.
+  [OK] DO: short-circuit when the name is already present (idempotent).
+- [ERROR] DO NOT: break/replace the existing `onHookExecution`/`triggerSessionStart`/
+  `triggerSessionEnd`/`clear` methods.
+  [OK] DO: ADD the admin methods alongside them (REQ-009 non-breaking).
+- [ERROR] DO NOT: cache the registry or disabled set on the controller.
+  [OK] DO: resolve from `this.deps.config` per call (R-DELEGATE).
+
+---
+
+## Behavior Decision Table
+
+| GIVEN | Method | Result |
+|---|---|---|
+| `getHookSystem()` undefined | `listHooks()` | `[]` |
+| system present, `isInitialized()` false | `listHooks()` | `[]` |
+| system initialised, 2 hooks (1 enabled, 1 disabled) | `listHooks()` | length 2; `enabled` flags mirror entries |
+| disabled set `["a"]` | `getDisabledHooks()` | `["a"]` (fresh copy) |
+| call `setDisabledHooks(["a","b"])` then `getDisabledHooks()` | round-trip | `["a","b"]` (R-HOOKS-ROUNDTRIP) |
+| disabled `["a"]`, call `disable("a")` | idempotent | disabled stays `["a"]` |
+| disabled `["a","b"]`, call `enable("a")` | — | disabled becomes `["b"]` |
+| disabled `["a"]`, call `enable("zzz")` (absent) | idempotent | disabled stays `["a"]` |

--- a/project-plans/issue2143/analysis/pseudocode/hooks-admin.md
+++ b/project-plans/issue2143/analysis/pseudocode/hooks-admin.md
@@ -69,9 +69,9 @@ methods resolve the live hook system from that Config per call.
 9:   FOR EACH entry IN entries
 10:    SET info = {
 11:      name: registry.getHookName(entry),                 // hookRegistry.ts:118
-12:      eventName: entry.eventName,
+12:      eventName: String(entry.eventName),                // HookEventName enum → string
 13:      enabled: entry.enabled,                             // hookRegistry.ts:41
-14:      source: String(entry.source),
+14:      source: entry.source IS undefined ? undefined : String(entry.source),  // optional; never the literal "undefined"
 15:    }
 16:    APPEND info TO out
 17:  END FOR

--- a/project-plans/issue2143/analysis/pseudocode/hooks-admin.md
+++ b/project-plans/issue2143/analysis/pseudocode/hooks-admin.md
@@ -71,7 +71,7 @@ methods resolve the live hook system from that Config per call.
 11:      name: registry.getHookName(entry),                 // hookRegistry.ts:118
 12:      eventName: String(entry.eventName),                // HookEventName enum → string
 13:      enabled: entry.enabled,                             // hookRegistry.ts:41
-14:      source: entry.source IS undefined ? undefined : String(entry.source),  // optional; never the literal "undefined"
+14:      source: String(entry.source),                       // ConfigSource (NON-nullable, hookRegistry.ts:37) → string
 15:    }
 16:    APPEND info TO out
 17:  END FOR

--- a/project-plans/issue2143/analysis/pseudocode/mcp-oauth.md
+++ b/project-plans/issue2143/analysis/pseudocode/mcp-oauth.md
@@ -101,8 +101,10 @@ export interface McpPromptRegistryView {
 export interface McpResourceRegistryView {
   getAllResources(): ReadonlyArray<{ serverName: string; name?: string; uri: string }>;
 }
-// Type-only barrel imports in mcpControl.ts (source MAY import the bare core barrel):
-//   import type { MCPServerConfig, MCPOAuthConfig } from '@vybestack/llxprt-code-core';
+// Type-only imports in mcpControl.ts (VERIFIED ground truth — these differ by source):
+//   import type { MCPOAuthConfig } from '@vybestack/llxprt-code-core';            // bare barrel (core/src/index.ts:508)
+//   import type { MCPServerConfig } from '@vybestack/llxprt-code-core/config/config.js'; // NOT in bare barrel; deep path (mirrors agent.ts:13)
+//   // ToolInfo is ALREADY imported from '../agent.js' (mcpControl.ts:17) — do NOT re-import it.
 ```
 
 Wiring in `AgentImpl.buildMcpControl()` (`agentImpl.ts:476`):
@@ -111,7 +113,12 @@ Wiring in `AgentImpl.buildMcpControl()` (`agentImpl.ts:476`):
 - `getPromptRegistry: () => ({ getPromptsByServer: (s) => this.deps.config.getPromptRegistry().getPromptsByServer(s) })`
 - `getResourceRegistry: () => ({ getAllResources: () => this.deps.config.getResourceRegistry().getAllResources() })`
 - `refreshClientTools: () => this.deps.resolveClient().setTools()`
-- `performOAuth: (server, oauthConfig, mcpServerUrl) => MCPOAuthProvider.authenticate(server, oauthConfig, mcpServerUrl, undefined)`
+- `performOAuth: async (server, oauthConfig, mcpServerUrl) => { await MCPOAuthProvider.authenticate(server, oauthConfig, mcpServerUrl, undefined); }`
+  - MUST use the `async … => { await …; }` form (NOT a bare arrow returning the call): the closure type
+    is `Promise<void>` but `MCPOAuthProvider.authenticate(...)` returns `Promise<MCPOAuthToken>`. A bare
+    `() => authenticate(...)` is `Promise<MCPOAuthToken>` and is NOT assignable to `Promise<void>`
+    (TS only special-cases a bare `void` return, not `Promise<void>`). Awaiting and discarding also keeps
+    the token out of the closure result (R-NO-RAW-SECRETS — the token is a handshake side-effect only).
   - `MCPOAuthProvider` is a VALUE import from the bare core barrel `@vybestack/llxprt-code-core`
     (re-exported at `core/src/index.ts:498`) — NO new mcp dependency, NO deep import.
   - `events` arg is OMITTED (undefined): `appEvents` is CLI-only (`cli/src/utils/events.ts`) and

--- a/project-plans/issue2143/analysis/pseudocode/mcp-oauth.md
+++ b/project-plans/issue2143/analysis/pseudocode/mcp-oauth.md
@@ -1,0 +1,269 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-006 -->
+# Pseudocode: MCP OAuth + setTools parity + deep details (extend `Agent.mcp`)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G6 — extend the EXISTING `AgentMcpControl` / `McpControl` with:
+  (1) real OAuth `authenticate(server)`, (2) `refresh(server?)` setTools parity, (3) deep `details()`.
+Source of truth: specification.md REQ-006; domain-model.md R-REFRESH-PARITY, R-MCP-OAUTH-FLOW,
+R-UNDEFINED-SAFE, R-DELEGATE.
+Analysis only — NO implementation code is written in this document.
+
+---
+
+## Design rationale (READ FIRST — why `performOAuth` is an injected closure)
+
+`MCPOAuthProvider.authenticate(...)` (`packages/mcp/src/auth/oauth-provider.ts:874`) performs a REAL
+browser/network OAuth handshake and is a **static** method. If `McpControl.authenticate()` called it
+directly:
+- the only way to drive `authenticate()` in a hermetic test would be `vi.spyOn(MCPOAuthProvider, …)`
+  = **mock theater (BANNED)**, or a real network call (**non-hermetic / flaky**);
+- Stryker mutants that delete/reorder the post-auth `restartServer` / `setTools` steps could NOT be
+  killed (nothing observable).
+
+The whole existing `McpControl` surface already takes its external capabilities as **injected
+closures** (`getManager`, `getToolRegistry`, `isMcpAuthenticated`) — and this component already adds
+`refreshClientTools` as a perform-action closure. So we follow the SAME convention: inject
+`performOAuth` as a closure. The orchestration logic (unknown-server guard, ordering
+auth→restart→setTools, error propagation, undefined-safety) lives in the CONTROL where it is
+unit-tested + mutation-covered; the thin static binding
+(`MCPOAuthProvider.authenticate(server, cfg, url, undefined)`) lives in `buildMcpControl()` wiring,
+exactly like `getManager: () => this.deps.config.getMcpClientManager()`.
+
+---
+
+## Interface Contracts
+
+```typescript
+// EXTEND the existing AgentMcpControl interface in packages/agents/src/api/agent.ts (:232-239).
+// Existing members (listServers / status / toolsByServer / auth / discoveryState / refresh) stay
+// (REQ-009). `refresh` signature is UNCHANGED but its BEHAVIOUR gains setTools parity. ADD:
+interface AgentMcpControl {
+  // ...existing members unchanged in signature...
+  refresh(server?: string): Promise<void>;          // existing — now also re-publishes tools
+  authenticate(server: string): Promise<McpServerAuthStatus>;   // NEW: real OAuth flow
+  details(opts?: McpDetailsOptions): Promise<McpDetailStatus>;  // NEW: deep registry projection
+}
+
+// Projected public types (specification.md Data Schemas).
+interface McpDetailsOptions {
+  readonly includeTools?: boolean;       // default true
+  readonly includePrompts?: boolean;     // default false
+  readonly includeResources?: boolean;   // default false
+}
+interface McpDetailStatus {
+  readonly servers: readonly McpServerDetail[];
+  readonly blockedServers: readonly McpBlockedServer[];
+}
+interface McpServerDetail {
+  readonly name: string;
+  readonly authenticated: boolean;
+  readonly tools?: readonly ToolInfo[];       // reuse existing ToolInfo
+  readonly prompts?: readonly McpPromptInfo[];
+  readonly resources?: readonly McpResourceInfo[];
+}
+interface McpPromptInfo { readonly name: string; readonly description?: string; }
+interface McpResourceInfo { readonly name?: string; readonly uri: string; }
+interface McpBlockedServer { readonly name: string; readonly extensionName: string; }
+```
+
+### Dependencies (NEVER stubbed) — extend `McpControlDeps` (control/mcpControl.ts:45)
+
+```typescript
+// EXISTING (unchanged): isMcpAuthenticated, getManager, getToolRegistry.
+// ADD (each a narrow closure mirroring the existing getToolRegistry view pattern):
+export interface McpControlDeps {
+  // ...existing three closures...
+  /** Raw configured MCP servers (config.getMcpServers()). MAY be undefined pre-init. */
+  readonly getServerConfigs?: () => Record<string, MCPServerConfig> | undefined;
+  /** Blocked servers (config.getBlockedMcpServers() ?? []). */
+  readonly getBlockedServers?: () => readonly { name: string; extensionName: string }[];
+  /** Narrow prompt-registry view for per-server prompt projection. */
+  readonly getPromptRegistry?: () => McpPromptRegistryView | undefined;
+  /** Narrow resource-registry view for per-server resource projection. */
+  readonly getResourceRegistry?: () => McpResourceRegistryView | undefined;
+  /** Re-publishes the agent client's tool declarations (resolveClient().setTools()). */
+  readonly refreshClientTools?: () => Promise<void>;
+  /**
+   * Performs the REAL OAuth handshake for one server. Wired in buildMcpControl() to
+   * MCPOAuthProvider.authenticate(server, oauthConfig, mcpServerUrl, undefined). Injected (not a
+   * direct static import) so authenticate()'s orchestration is hermetically testable + mutation-
+   * killable. Errors PROPAGATE (the control does NOT catch).
+   */
+  readonly performOAuth?: (
+    server: string,
+    oauthConfig: MCPOAuthConfig,
+    mcpServerUrl: string | undefined,
+  ) => Promise<void>;
+}
+export interface McpPromptRegistryView {
+  getPromptsByServer(server: string): ReadonlyArray<{ name: string; description?: string }>;
+}
+export interface McpResourceRegistryView {
+  getAllResources(): ReadonlyArray<{ serverName: string; name?: string; uri: string }>;
+}
+// Type-only barrel imports in mcpControl.ts (source MAY import the bare core barrel):
+//   import type { MCPServerConfig, MCPOAuthConfig } from '@vybestack/llxprt-code-core';
+```
+
+Wiring in `AgentImpl.buildMcpControl()` (`agentImpl.ts:476`):
+- `getServerConfigs: () => this.deps.config.getMcpServers()`
+- `getBlockedServers: () => this.deps.config.getBlockedMcpServers() ?? []`
+- `getPromptRegistry: () => ({ getPromptsByServer: (s) => this.deps.config.getPromptRegistry().getPromptsByServer(s) })`
+- `getResourceRegistry: () => ({ getAllResources: () => this.deps.config.getResourceRegistry().getAllResources() })`
+- `refreshClientTools: () => this.deps.resolveClient().setTools()`
+- `performOAuth: (server, oauthConfig, mcpServerUrl) => MCPOAuthProvider.authenticate(server, oauthConfig, mcpServerUrl, undefined)`
+  - `MCPOAuthProvider` is a VALUE import from the bare core barrel `@vybestack/llxprt-code-core`
+    (re-exported at `core/src/index.ts:498`) — NO new mcp dependency, NO deep import.
+  - `events` arg is OMITTED (undefined): `appEvents` is CLI-only (`cli/src/utils/events.ts`) and
+    cannot be imported by the agents package; the handshake works without UI display events.
+
+---
+
+## Numbered Pseudocode
+
+### METHOD authenticate(server): Promise<McpServerAuthStatus>  (REAL OAuth flow, orchestration)
+
+```
+1: // @pseudocode REQ-006.1 — real OAuth (injected) → restart server → re-publish tools; errors PROPAGATE
+2: METHOD authenticate(server) RETURNS Promise<McpServerAuthStatus>
+3:   SET configs = this.deps?.getServerConfigs?.()
+4:   SET serverConfig = configs ? configs[server] : undefined
+5:   SET performOAuth = this.deps?.performOAuth
+6:   IF serverConfig IS undefined OR performOAuth IS undefined THEN
+7:     RETURN { server, authenticated: false, requiresAuth: true }   // unknown/unsupported — undefined-safe
+8:   END IF
+9:   SET oauthConfig = serverConfig.oauth ?? { enabled: false }       // mirrors mcpAuth.ts:107
+10:  SET mcpServerUrl = serverConfig.httpUrl ?? serverConfig.url       // mirrors mcpAuth.ts:109
+11:  AWAIT performOAuth(server, oauthConfig, mcpServerUrl)             // real handshake; a rejection PROPAGATES
+12:  SET manager = this.deps?.getManager()                            // post-auth parity (mcpAuth.ts:132-136)
+13:  IF manager IS NOT undefined THEN AWAIT manager.restartServer(server)
+14:  IF this.deps?.refreshClientTools IS DEFINED THEN AWAIT this.deps.refreshClientTools()
+15:  RETURN { server, authenticated: true, requiresAuth: true }
+16: END METHOD
+```
+
+> Ordering is load-bearing: OAuth MUST complete before restart, and restart before tool re-publish.
+> A rejected `performOAuth` MUST abort the flow (no restart, no setTools) and propagate.
+
+### METHOD refresh(server?): Promise<void>  (EXISTING + setTools parity)
+
+```
+30: // @pseudocode REQ-006.2 — existing restart behaviour PLUS re-publish tool declarations
+31: METHOD refresh(server?) RETURNS Promise<void>
+32:   SET manager = this.deps?.getManager()
+33:   IF manager IS undefined THEN RETURN                              // R-UNDEFINED-SAFE (unchanged)
+34:   IF server IS NOT undefined THEN
+35:     AWAIT manager.restartServer(server)
+36:   ELSE
+37:     AWAIT manager.restart()
+38:   END IF
+39:   // NEW (R-REFRESH-PARITY): mirror CLI /mcp refresh which calls agentClient.setTools() (mcpCommand)
+40:   IF this.deps?.refreshClientTools IS DEFINED THEN AWAIT this.deps.refreshClientTools()
+41: END METHOD
+```
+
+### METHOD details(opts?): Promise<McpDetailStatus>
+
+```
+50: // @pseudocode REQ-006.3 — deep per-server projection; opts gate prompts/resources; undefined-safe
+51: METHOD details(opts?) RETURNS Promise<McpDetailStatus>
+52:   SET includeTools = opts?.includeTools ?? true
+53:   SET includePrompts = opts?.includePrompts ?? false
+54:   SET includeResources = opts?.includeResources ?? false
+55:   SET configs = this.deps?.getServerConfigs?.() ?? {}
+56:   SET toolsByServer = this.toolsByServer()                         // reuse existing projection
+57:   SET resourcesAll = includeResources
+58:        ? (this.deps?.getResourceRegistry?.()?.getAllResources() ?? [])
+59:        : []
+60:   SET servers = empty array
+61:   FOR EACH name IN keys(configs)
+62:     SET detail = { name, authenticated: this.deps?.isMcpAuthenticated(name) ?? false }
+63:     IF includeTools THEN SET detail.tools = toolsByServer[name] ?? []
+64:     IF includePrompts THEN
+65:       SET prompts = this.deps?.getPromptRegistry?.()?.getPromptsByServer(name) ?? []
+66:       SET detail.prompts = prompts.map(p => ({ name: p.name, description: p.description }))
+67:     END IF
+68:     IF includeResources THEN
+69:       SET detail.resources = resourcesAll
+70:            .filter(r => r.serverName === name)
+71:            .map(r => ({ name: r.name, uri: r.uri }))
+72:     END IF
+73:     APPEND detail TO servers
+74:   END FOR
+75:   SET blocked = (this.deps?.getBlockedServers?.() ?? [])
+76:        .map(b => ({ name: b.name, extensionName: b.extensionName }))
+77:   RETURN { servers, blockedServers: blocked }
+78: END METHOD
+```
+
+> NOTE: `auth(server)` (existing per-agent-flag read) is UNCHANGED — REQ-009. The NEW `authenticate()`
+> is the active OAuth flow; the two coexist.
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol / call | File:line (verified) |
+|---|---|---|
+| 3 | `Config.getMcpServers(): Record<string, MCPServerConfig> \| undefined` | `configBaseCore.ts:436` |
+| 9 | `MCPServerConfig.oauth?: MCPOAuthConfig` | `configTypes.ts:229` |
+| 10 | `MCPServerConfig.httpUrl?`/`url?` | `configTypes.ts:203` / `:201` |
+| 11 (wiring) | `MCPOAuthProvider.authenticate(serverName, config, mcpServerUrl?, events?)` | `packages/mcp/src/auth/oauth-provider.ts:874`; barrel `core/src/index.ts:498` |
+| 13/35 | `McpClientManager.restartServer(server)` | core (used by `mcpControl.ts:241`, reference `mcpAuth.ts:132`) |
+| 14/40 | `AgentClientContract.setTools(): Promise<void>` via `resolveClient()` | `core/src/core/clientContract.ts:77`; `resolveClient` `agentImpl.ts:132` |
+| 37 | `McpClientManager.restart()` | core (used by `mcpControl.ts:244`) |
+| 58 | `Config.getResourceRegistry().getAllResources(): MCPResource[]` | `configBaseCore.ts:406`; `resource-registry.ts:44` |
+| 65 | `Config.getPromptRegistry().getPromptsByServer(name): DiscoveredMCPPrompt[]` | `configBaseCore.ts:403`; `prompt-registry.ts:48` |
+| 70 | `MCPResource.serverName` | `resource-registry.ts:13` |
+| 75 | `Config.getBlockedMcpServers(): Array<{name,extensionName}> \| undefined` | `configBaseCore.ts:445` |
+| n/a (wiring) | extend `buildMcpControl()` | `agentImpl.ts:476` |
+
+CLI flow this preserves parity with (#1595): `packages/cli/src/ui/commands/mcpAuth.ts`
+`performMcpOAuth` (`authenticate:108` → `restartServer:132` → `agentClient.setTools():136`).
+NOTE (spec correction): the real OAuth flow lives in `mcpAuth.ts` — the issue's "no such file" claim
+is FALSE; `listOAuthServers:49`, `performMcpOAuth:82` exist.
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: import `MCPOAuthProvider` directly into `mcpControl.ts` and call the static inside
+  `authenticate()` (untestable without mock theater; mutants survive).
+  [OK] DO: inject `performOAuth` as a closure dep; bind the static in `buildMcpControl()` wiring.
+- [ERROR] DO NOT: import `appEvents` / `AppEvent` (CLI-only `packages/cli/src/utils/events.ts`) to pass
+  as the `events` arg.
+  [OK] DO: pass `undefined` for the optional `events` param.
+- [ERROR] DO NOT: catch/swallow a `performOAuth` rejection into `{authenticated:false}`.
+  [OK] DO: let it PROPAGATE; on failure NO restart and NO setTools happen (R-MCP-OAUTH-FLOW).
+- [ERROR] DO NOT: change `auth(server)`'s existing semantics or remove it.
+  [OK] DO: ADD `authenticate(server)` as a separate method (REQ-009).
+- [ERROR] DO NOT: leave `refresh()` without a `setTools()` call (the original parity gap).
+  [OK] DO: call `refreshClientTools()` after restart in `refresh()` AND `authenticate()` (R-REFRESH-PARITY).
+- [ERROR] DO NOT: throw when the manager / registries / performOAuth are undefined.
+  [OK] DO: no-op / empty-project per REQ-006 (R-UNDEFINED-SAFE) — mirror the existing
+  `getManager() === undefined` guards (`mcpControl.ts:122,217,237`).
+- [ERROR] DO NOT: populate `prompts`/`resources` unconditionally (perf + surface noise).
+  [OK] DO: gate them behind `opts.includePrompts`/`includeResources` (default false).
+- [ERROR] DO NOT: leak raw `DiscoveredMCPPrompt` / `MCPResource` objects.
+  [OK] DO: project to `McpPromptInfo` / `McpResourceInfo` (named fields only).
+- [ERROR] DO NOT: cache the manager / registries / configs in a control field.
+  [OK] DO: resolve every dep closure per call (R-DELEGATE).
+
+---
+
+## Behavior Decision Table
+
+| GIVEN | Method | Result |
+|---|---|---|
+| server not in configs | `authenticate("nope")` | `{server:"nope", authenticated:false, requiresAuth:true}`; performOAuth NOT called; no restart |
+| performOAuth not wired (deps partial) | `authenticate("s")` | `{authenticated:false, requiresAuth:true}`; no restart/setTools |
+| server with oauth config, manager present | `authenticate("s")` | order: performOAuth("s") → restartServer("s") → refreshClientTools(); returns `authenticated:true` |
+| performOAuth REJECTS | `authenticate("s")` | the call REJECTS (propagates); restartServer NOT called; refreshClientTools NOT called |
+| server present, manager undefined | `authenticate("s")` | performOAuth runs; restart skipped; refreshClientTools still attempted; `authenticated:true` |
+| manager present | `refresh("s")` | restartServer("s") THEN refreshClientTools() (parity) |
+| manager present, no arg | `refresh()` | restart() THEN refreshClientTools() |
+| manager undefined | `refresh()` | no-op (returns); refreshClientTools NOT called |
+| 2 servers, opts default | `details()` | `servers` len 2, each has `tools`, no `prompts`/`resources`; `blockedServers` from config |
+| opts includePrompts:true | `details({includePrompts:true})` | each server detail includes projected `prompts` |
+| opts includeResources:true | `details({includeResources:true})` | each detail includes `resources` filtered by serverName |
+| getServerConfigs undefined | `details()` | `{servers:[], blockedServers:[...]}` (undefined-safe) |

--- a/project-plans/issue2143/analysis/pseudocode/policy-control.md
+++ b/project-plans/issue2143/analysis/pseudocode/policy-control.md
@@ -22,8 +22,8 @@ interface AgentPolicyControl {
 
 // Projected public type (specification.md Data Schemas) — argsPattern is a STRING, never RegExp.
 interface PolicyRuleView {
-  readonly priority: number;
-  readonly toolName: string;
+  readonly priority?: number;            // mirror core PolicyRule.priority? (types.ts:46)
+  readonly toolName?: string;            // mirror core PolicyRule.toolName? (types.ts:29)
   readonly decision: PolicyDecision;     // VALUE enum, re-exported from core barrel (index.ts:17)
   readonly argsPattern?: string;         // = rule.argsPattern?.source
   readonly source?: string;

--- a/project-plans/issue2143/analysis/pseudocode/policy-control.md
+++ b/project-plans/issue2143/analysis/pseudocode/policy-control.md
@@ -1,0 +1,142 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-002 -->
+# Pseudocode: Policy Control (read-only `agent.policy`)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G2 — `AgentPolicyControl` (new sub-controller, read-only)
+Source of truth: specification.md REQ-002; domain-model.md R-POLICY-SNAPSHOT, R-ARGSPATTERN-STRING.
+Analysis only — NO implementation code is written in this document.
+
+---
+
+## Interface Contracts
+
+```typescript
+// Declared in packages/agents/src/api/agent.ts alongside AgentMcpControl/AgentAuthControl (:223-321)
+interface AgentPolicyControl {
+  getRules(): readonly PolicyRuleView[];
+  getDefaultDecision(): PolicyDecision;
+  isNonInteractive(): boolean;
+}
+
+// Added to the Agent interface: `readonly policy: AgentPolicyControl;`
+
+// Projected public type (specification.md Data Schemas) — argsPattern is a STRING, never RegExp.
+interface PolicyRuleView {
+  readonly priority: number;
+  readonly toolName: string;
+  readonly decision: PolicyDecision;     // VALUE enum, re-exported from core barrel (index.ts:17)
+  readonly argsPattern?: string;         // = rule.argsPattern?.source
+  readonly source?: string;
+}
+```
+
+### Dependencies (NEVER stubbed)
+
+```typescript
+// packages/agents/src/api/control/policyControl.ts
+export interface PolicyControlDeps {
+  // Resolves the live PolicyEngine from the bound Config PER CALL (never cached).
+  // config.getPolicyEngine() is NON-optional (configBaseCore.ts:475) — but the closure
+  // form keeps the controller decoupled from Config and uniform with the other controls.
+  readonly getEngine: () => PolicyEngine;   // PolicyEngine from @vybestack/llxprt-code-policy
+}
+// Wired by AgentImpl.buildPolicyControl(): getEngine: () => this.deps.config.getPolicyEngine()
+```
+
+`PolicyEngine`, `PolicyDecision`, and `PolicyRule` come from `@vybestack/llxprt-code-policy`
+(an agents dependency, package.json:44) and are re-exported through the core barrel
+(`core/src/index.ts`: PolicyEngine:15, PolicyDecision:17, PolicyRule:19).
+
+---
+
+## Numbered Pseudocode
+
+### METHOD getRules(): readonly PolicyRuleView[]
+
+```
+1: // @pseudocode REQ-002.1 — read-only snapshot; project argsPattern RegExp → .source string
+2: METHOD getRules() RETURNS readonly PolicyRuleView[]
+3:   SET engine = this.deps.getEngine()
+4:   SET rules = engine.getRules()                      // readonly PolicyRule[] (policy-engine.ts:320)
+5:   SET out = empty array
+6:   FOR EACH rule IN rules
+7:     SET view = {
+8:       priority: rule.priority,
+9:       toolName: rule.toolName,
+10:      decision: rule.decision,
+11:      // R-ARGSPATTERN-STRING: project RegExp to its .source; undefined stays undefined
+12:      argsPattern: IF rule.argsPattern IS DEFINED THEN rule.argsPattern.source ELSE undefined,
+13:      source: rule.source,
+14:    }
+15:    APPEND view TO out
+16:  END FOR
+17:  RETURN out                                          // a fresh snapshot array (not the live list)
+18: END METHOD
+```
+
+### METHOD getDefaultDecision(): PolicyDecision
+
+```
+30: // @pseudocode REQ-002.2 — direct read-through
+31: METHOD getDefaultDecision() RETURNS PolicyDecision
+32:   RETURN this.deps.getEngine().getDefaultDecision()  // policy-engine.ts:329
+33: END METHOD
+```
+
+### METHOD isNonInteractive(): boolean
+
+```
+40: // @pseudocode REQ-002.3 — direct read-through
+41: METHOD isNonInteractive() RETURNS boolean
+42:   RETURN this.deps.getEngine().isNonInteractive()    // policy-engine.ts:338
+43: END METHOD
+```
+
+> REQ-002.4: rule MUTATION is OUT OF SCOPE — no `addRule`/`setRules`/`removeRule` on this controller.
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol / call | File:line (verified) |
+|---|---|---|
+| 3 | `Config.getPolicyEngine(): PolicyEngine` (non-optional) | `packages/core/src/config/configBaseCore.ts:475` |
+| 4 | `PolicyEngine.getRules(): readonly PolicyRule[]` | `packages/policy/src/policy-engine.ts:320` |
+| 12 | `PolicyRule.argsPattern?: RegExp` → `.source` | `packages/policy/src/types.ts:35` (argsPattern); CLI consumes `.source` at `policiesCommand.ts:111` |
+| 32 | `PolicyEngine.getDefaultDecision(): PolicyDecision` | `packages/policy/src/policy-engine.ts:329` |
+| 42 | `PolicyEngine.isNonInteractive(): boolean` | `packages/policy/src/policy-engine.ts:338` |
+| n/a | `PolicyDecision` enum (ALLOW/DENY/ASK_USER) | `packages/policy/src/types.ts:7`; core barrel `index.ts:17` |
+| n/a (wiring) | `buildPolicyControl()` near other builders | `agentImpl.ts:431-510`; field near `:194-200`; ctor assign near `:328-332` |
+
+CLI consumer this unblocks (#1595): `packages/cli/src/ui/commands/policiesCommand.ts`
+(`getPolicyEngine:60`, `getRules:61`, `argsPattern.source:110-111`, `getDefaultDecision:125`,
+`isNonInteractive:128`).
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: return `engine.getRules()` directly (leaks the live array + raw `RegExp`
+  `argsPattern`).
+  [OK] DO: build a fresh `PolicyRuleView[]` snapshot with `argsPattern` as `.source` string
+  (R-POLICY-SNAPSHOT, R-ARGSPATTERN-STRING).
+- [ERROR] DO NOT: expose a `RegExp` on the public type (not JSON-safe for non-TS consumers).
+  [OK] DO: project to `argsPattern?: string`.
+- [ERROR] DO NOT: cache the engine or the rules array on the controller.
+  [OK] DO: resolve `this.deps.getEngine()` per call (R-DELEGATE).
+- [ERROR] DO NOT: add rule mutation methods.
+  [OK] DO: keep the controller strictly read-only (REQ-002.4).
+- [ERROR] DO NOT: coerce a missing `argsPattern` to `""`.
+  [OK] DO: keep it `undefined` when the rule has no pattern.
+
+---
+
+## Behavior Decision Table
+
+| GIVEN | getRules() | getDefaultDecision() | isNonInteractive() |
+|---|---|---|---|
+| engine with 0 rules | `[]` | engine default decision | engine flag |
+| rule `{priority:0.5, toolName:"run_shell_command", decision:DENY, argsPattern:/"command":"npm test"/, source:"user"}` | one view with `argsPattern === '"command":"npm test"'` (string) | — | — |
+| rule with no `argsPattern` | view's `argsPattern === undefined` | — | — |
+| engine default = ASK_USER | — | `ASK_USER` | — |
+| engine non-interactive = true | — | — | `true` |

--- a/project-plans/issue2143/analysis/pseudocode/tasks-control.md
+++ b/project-plans/issue2143/analysis/pseudocode/tasks-control.md
@@ -1,0 +1,192 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-003 -->
+# Pseudocode: Tasks Control (`agent.tasks`)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G3 — `AgentTasksControl` (new sub-controller, undefined-safe)
+Source of truth: specification.md REQ-003; domain-model.md R-NO-ABORTCONTROLLER, R-CANCEL-COUNT,
+R-UNDEFINED-SAFE.
+Analysis only — NO implementation code is written in this document.
+
+---
+
+## Interface Contracts
+
+```typescript
+// Declared in packages/agents/src/api/agent.ts alongside the other controls (:223-321)
+interface AgentTasksControl {
+  list(): readonly AgentTaskInfo[];
+  listRunning(): readonly AgentTaskInfo[];
+  get(id: string): AgentTaskInfo | undefined;
+  cancel(id: string): boolean;
+  cancelAllRunning(): number;
+}
+
+// Added to the Agent interface: `readonly tasks: AgentTasksControl;`
+
+// Projected public type — OMITS abortController (asyncTaskManager.ts:28) and any other
+// non-serializable internal (REQ-003.7 / R-NO-ABORTCONTROLLER).
+interface AgentTaskInfo {
+  readonly id: string;
+  readonly subagentName: string;
+  readonly goalPrompt: string;
+  readonly status: 'running' | 'completed' | 'failed' | 'cancelled';  // = core AsyncTaskStatus
+  readonly launchedAt: number;
+  readonly completedAt?: number;
+  readonly error?: string;
+}
+```
+
+### Dependencies (NEVER stubbed)
+
+```typescript
+// packages/agents/src/api/control/tasksControl.ts
+export interface TasksControlDeps {
+  // Resolves the live AsyncTaskManager from the bound Config PER CALL. MAY be undefined
+  // (config.getAsyncTaskManager(): AsyncTaskManager | undefined — config.ts:601 / abstract
+  // configBase.ts:33). The controller MUST be undefined-safe.
+  readonly getManager: () => AsyncTaskManager | undefined;
+}
+// Wired by AgentImpl.buildTasksControl(): getManager: () => this.deps.config.getAsyncTaskManager()
+```
+
+`AsyncTaskManager` + `AsyncTaskInfo` (core) are re-exported through the core barrel
+(`core/src/index.ts:58,59`). The projection maps the core `AsyncTaskInfo` (which carries
+`abortController?` at `asyncTaskManager.ts:28`) to the public `AgentTaskInfo` (which does not).
+
+---
+
+## Numbered Pseudocode
+
+### PRIVATE project(task): AgentTaskInfo  (the abortController-omitting projection)
+
+```
+1: // @pseudocode REQ-003.7 — explicit field copy; abortController is NEVER copied
+2: METHOD project(task) RETURNS AgentTaskInfo
+3:   RETURN {
+4:     id: task.id,
+5:     subagentName: task.subagentName,
+6:     goalPrompt: task.goalPrompt,
+7:     status: task.status,
+8:     launchedAt: task.launchedAt,
+9:     completedAt: task.completedAt,           // optional; copied only if present
+10:    error: task.error,                        // optional; copied only if present
+11:    // NOTE: task.abortController is DELIBERATELY NOT copied (R-NO-ABORTCONTROLLER)
+12:  }
+13: END METHOD
+```
+
+### METHOD list(): readonly AgentTaskInfo[]
+
+```
+20: // @pseudocode REQ-003.1 + REQ-003.6 (undefined-safe)
+21: METHOD list() RETURNS readonly AgentTaskInfo[]
+22:   SET mgr = this.deps.getManager()
+23:   IF mgr IS undefined THEN RETURN []          // R-UNDEFINED-SAFE
+24:   RETURN mgr.getAllTasks().map(t => this.project(t))   // asyncTaskManager.ts:77
+25: END METHOD
+```
+
+### METHOD listRunning(): readonly AgentTaskInfo[]
+
+```
+30: // @pseudocode REQ-003.2 + REQ-003.6
+31: METHOD listRunning() RETURNS readonly AgentTaskInfo[]
+32:   SET mgr = this.deps.getManager()
+33:   IF mgr IS undefined THEN RETURN []
+34:   RETURN mgr.getRunningTasks().map(t => this.project(t))  // asyncTaskManager.ts:319
+35: END METHOD
+```
+
+### METHOD get(id): AgentTaskInfo | undefined
+
+```
+40: // @pseudocode REQ-003.3 + REQ-003.6
+41: METHOD get(id) RETURNS AgentTaskInfo | undefined
+42:   SET mgr = this.deps.getManager()
+43:   IF mgr IS undefined THEN RETURN undefined
+44:   SET task = mgr.getTask(id)                  // asyncTaskManager.ts:273
+45:   IF task IS undefined THEN RETURN undefined
+46:   RETURN this.project(task)
+47: END METHOD
+```
+
+### METHOD cancel(id): boolean
+
+```
+50: // @pseudocode REQ-003.4 + REQ-003.6
+51: METHOD cancel(id) RETURNS boolean
+52:   SET mgr = this.deps.getManager()
+53:   IF mgr IS undefined THEN RETURN false       // R-UNDEFINED-SAFE
+54:   RETURN mgr.cancelTask(id)                    // asyncTaskManager.ts:239 (idempotent boolean)
+55: END METHOD
+```
+
+### METHOD cancelAllRunning(): number
+
+```
+60: // @pseudocode REQ-003.5 — returns COUNT cancelled (R-CANCEL-COUNT); core has no native variant
+61: METHOD cancelAllRunning() RETURNS number
+62:   SET mgr = this.deps.getManager()
+63:   IF mgr IS undefined THEN RETURN 0
+64:   SET running = mgr.getRunningTasks()          // snapshot BEFORE cancelling
+65:   SET count = 0
+66:   FOR EACH task IN running
+67:     IF mgr.cancelTask(task.id) IS true THEN INCREMENT count
+68:   END FOR
+69:   RETURN count
+70: END METHOD
+```
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol / call | File:line (verified) |
+|---|---|---|
+| 22/32/42/52/62 | `Config.getAsyncTaskManager(): AsyncTaskManager \| undefined` | `config.ts:601`; abstract `configBase.ts:33` |
+| 24 | `AsyncTaskManager.getAllTasks(): AsyncTaskInfo[]` | `services/asyncTaskManager.ts:77` |
+| 34/64 | `AsyncTaskManager.getRunningTasks(): AsyncTaskInfo[]` | `services/asyncTaskManager.ts:319` |
+| 44 | `AsyncTaskManager.getTask(id): AsyncTaskInfo \| undefined` | `services/asyncTaskManager.ts:273` |
+| 54/67 | `AsyncTaskManager.cancelTask(id): boolean` (idempotent) | `services/asyncTaskManager.ts:239` |
+| 11 | core `AsyncTaskInfo.abortController?: AbortController` (OMITTED) | `services/asyncTaskManager.ts:28` |
+| 7 | core `AsyncTaskStatus = 'running'\|'completed'\|'failed'\|'cancelled'` | `services/asyncTaskManager.ts:16` |
+| n/a (wiring) | `buildTasksControl()` near other builders | `agentImpl.ts:431-510`; field near `:194-200`; ctor near `:328-332` |
+
+CLI consumers this unblocks (#1595): `tasksCommand.ts` (`getAllTasks:80,117`, `getTask:189`,
+`getTaskByPrefix:193` [prefix matched CLI-side over `list()`], `cancelTask:236`);
+`useGeminiStreamOrchestration.ts` ESC-cancel (`getRunningTasks().forEach(cancelTask)` → `cancelAllRunning()`).
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: return the core `AsyncTaskInfo` objects directly (leaks `abortController`).
+  [OK] DO: map through `project()` which copies only the public fields (R-NO-ABORTCONTROLLER).
+- [ERROR] DO NOT: spread `{ ...task }` in `project()` (that WOULD copy `abortController`).
+  [OK] DO: copy fields EXPLICITLY by name.
+- [ERROR] DO NOT: throw or return `null` when the manager is undefined.
+  [OK] DO: return `[]` / `undefined` / `false` / `0` per REQ-003.6 (R-UNDEFINED-SAFE).
+- [ERROR] DO NOT: make `cancelAllRunning()` return `void`.
+  [OK] DO: return the integer count cancelled (R-CANCEL-COUNT).
+- [ERROR] DO NOT: iterate the LIVE running list while cancelling (mutation-during-iteration hazard).
+  [OK] DO: snapshot `getRunningTasks()` into `running` first, then cancel by id.
+- [ERROR] DO NOT: add a `getByPrefix` to the public API.
+  [OK] DO: leave prefix matching to the CLI over `list()` (REQ-003 note).
+
+---
+
+## Behavior Decision Table
+
+| GIVEN manager state | Method | Result |
+|---|---|---|
+| undefined manager | `list()` / `listRunning()` | `[]` |
+| undefined manager | `get(id)` | `undefined` |
+| undefined manager | `cancel(id)` | `false` |
+| undefined manager | `cancelAllRunning()` | `0` |
+| 3 tasks (2 running, 1 completed) | `list()` | length 3, none has `abortController` key |
+| same | `listRunning()` | length 2 |
+| same | `cancelAllRunning()` | `2`; subsequent `listRunning()` → `[]` |
+| task "known" exists | `get("known")` | projected view (no `abortController`) |
+| no task "missing" | `get("missing")` | `undefined` |
+| cancellable "known" | `cancel("known")` | `true` |
+| absent "missing" | `cancel("missing")` | `false` |

--- a/project-plans/issue2143/analysis/pseudocode/tool-keys.md
+++ b/project-plans/issue2143/analysis/pseudocode/tool-keys.md
@@ -1,0 +1,201 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-007 -->
+# Pseudocode: Tool-Key Storage (`agent.tools.keys`)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Component: G7 — `AgentToolKeyControl` exposed as `agent.tools.keys` (new, masked).
+Source of truth: specification.md REQ-007; domain-model.md R-NO-RAW-SECRETS, R-KEYS-DISTINCT.
+Analysis only — NO implementation code is written in this document.
+
+> DISTINCT from `Agent.auth.keys` (provider-auth keys at `agent.ts:241-258`). This is built-in
+> TOOL key storage (Exa, etc.) backed by `ToolKeyStorage` — REQ-007 / R-KEYS-DISTINCT.
+
+---
+
+## Interface Contracts
+
+```typescript
+// Declared in packages/agents/src/api/agent.ts. ADD `readonly keys` to the EXISTING
+// AgentToolControl interface (:223-230) — non-breaking (REQ-009):
+interface AgentToolControl {
+  // ...existing members unchanged (list/enabled/confirmation/update/editor)...
+  readonly keys: AgentToolKeyControl;
+}
+
+interface AgentToolKeyControl {
+  supported(): readonly ToolKeyInfo[];
+  status(toolName: string): Promise<ToolKeyStatus>;   // MASKED only — never the raw key
+  save(toolName: string, key: string): Promise<void>;
+  delete(toolName: string): Promise<void>;
+  setKeyFile(toolName: string, path: string | null): Promise<void>;  // null => clear
+  getKeyFile(toolName: string): Promise<string | null>;
+}
+
+// Projected public types (specification.md Data Schemas).
+interface ToolKeyInfo {
+  readonly toolName: string;       // = ToolKeyRegistryEntry.toolKeyName
+  readonly displayName: string;
+  readonly description?: string;
+}
+interface ToolKeyStatus {
+  readonly toolName: string;
+  readonly hasKey: boolean;
+  readonly maskedKey?: string;     // maskKeyForDisplay(rawKey); present ONLY when hasKey
+  readonly keyFile?: string;       // configured keyfile path, if any
+}
+```
+
+### Dependencies (NEVER stubbed)
+
+```typescript
+// packages/agents/src/api/control/toolKeysControl.ts
+export interface ToolKeysControlDeps {
+  // The shared ToolKeyStorage instance (core lazy singleton getToolKeyStorage(), tool-key-storage.ts:81).
+  readonly getStorage: () => ToolKeyStorage;
+}
+// Wired by AgentImpl: getStorage: () => getToolKeyStorage()
+// AgentToolControl gains `keys: new ToolKeysControl({ getStorage: () => getToolKeyStorage() })`.
+```
+
+All symbols are re-exported through the core barrel `@vybestack/llxprt-code-core`
+(`ToolKeyStorage`/`getToolKeyStorage` at `index.ts:466-467`; `getSupportedToolNames`/`getToolKeyEntry`/
+`isValidToolKeyName`/`maskKeyForDisplay`/`ToolKeyRegistryEntry` at `index.ts:472-475`) — no deep import.
+
+---
+
+## Numbered Pseudocode
+
+### METHOD supported(): readonly ToolKeyInfo[]
+
+```
+1: // @pseudocode REQ-007.1 — registry projection from the tool-key registry helpers
+2: METHOD supported() RETURNS readonly ToolKeyInfo[]
+3:   SET names = getSupportedToolNames()                  // tool-key-storage-types.ts:72
+4:   SET out = empty array
+5:   FOR EACH name IN names
+6:     SET entry = getToolKeyEntry(name)                  // tool-key-storage-types.ts:62
+7:     IF entry IS undefined THEN CONTINUE                // defensive; registry is the source
+8:     APPEND { toolName: entry.toolKeyName, displayName: entry.displayName, description: entry.description } TO out
+9:   END FOR
+10:  RETURN out
+11: END METHOD
+```
+
+### METHOD status(toolName): Promise<ToolKeyStatus>  (MASKED)
+
+```
+20: // @pseudocode REQ-007.2 — masked status; raw key NEVER returned (R-NO-RAW-SECRETS)
+21: METHOD status(toolName) RETURNS Promise<ToolKeyStatus>
+22:   SET storage = this.deps.getStorage()
+23:   SET rawKey = AWAIT storage.getKey(toolName)         // tool-key-storage.ts:299 (string | null)
+24:   SET keyFile = AWAIT storage.getKeyfilePath(toolName) // tool-key-storage.ts:248 (string | null)
+25:   IF rawKey IS NOT null THEN
+26:     RETURN {
+27:       toolName,
+28:       hasKey: true,
+29:       maskedKey: maskKeyForDisplay(rawKey),           // tool-key-storage-types.ts:82
+30:       keyFile: keyFile ?? undefined,
+31:     }
+32:   END IF
+33:   RETURN { toolName, hasKey: false, keyFile: keyFile ?? undefined }
+34: END METHOD
+```
+
+### METHOD save(toolName, key): Promise<void>
+
+```
+40: // @pseudocode REQ-007.3 — persist; ToolKeyStorage validates the name (throws on invalid)
+41: METHOD save(toolName, key) RETURNS Promise<void>
+42:   AWAIT this.deps.getStorage().saveKey(toolName, key)  // tool-key-storage.ts:280
+43: END METHOD
+```
+
+### METHOD delete(toolName): Promise<void>
+
+```
+50: // @pseudocode REQ-007.4
+51: METHOD delete(toolName) RETURNS Promise<void>
+52:   AWAIT this.deps.getStorage().deleteKey(toolName)     // tool-key-storage.ts:314
+53: END METHOD
+```
+
+### METHOD setKeyFile(toolName, path): Promise<void>  (null => clear)
+
+```
+60: // @pseudocode REQ-007.5 — set or clear; CLI-side path expansion/existence stays UI-level
+61: METHOD setKeyFile(toolName, path) RETURNS Promise<void>
+62:   IF path IS null THEN
+63:     AWAIT this.deps.getStorage().clearKeyfilePath(toolName)  // tool-key-storage.ts:254
+64:   ELSE
+65:     AWAIT this.deps.getStorage().setKeyfilePath(toolName, path)  // tool-key-storage.ts:241
+66:   END IF
+67: END METHOD
+```
+
+### METHOD getKeyFile(toolName): Promise<string | null>
+
+```
+70: // @pseudocode REQ-007.6
+71: METHOD getKeyFile(toolName) RETURNS Promise<string | null>
+72:   RETURN AWAIT this.deps.getStorage().getKeyfilePath(toolName)  // tool-key-storage.ts:248
+73: END METHOD
+```
+
+---
+
+## Integration Points (Line-by-Line, REAL symbols)
+
+| Pseudocode line | Real symbol / call | File:line (verified) |
+|---|---|---|
+| 3 | `getSupportedToolNames(): string[]` | `packages/tools/src/utils/tool-key-storage-types.ts:72`; barrel `core/src/index.ts:473` |
+| 6 | `getToolKeyEntry(name): ToolKeyRegistryEntry \| undefined` | `tool-key-storage-types.ts:62`; barrel `index.ts:472` |
+| 8 | `ToolKeyRegistryEntry { toolKeyName, displayName, urlParamName, description }` | `tool-key-storage-types.ts:22` |
+| 23 | `ToolKeyStorage.getKey(toolName): Promise<string \| null>` | `packages/core/src/tools/tool-key-storage.ts:299` |
+| 24/72 | `ToolKeyStorage.getKeyfilePath(toolName): Promise<string \| null>` | `tool-key-storage.ts:248` |
+| 29 | `maskKeyForDisplay(key): string` (≤8 → fully masked; else first2+stars+last2) | `tool-key-storage-types.ts:82`; barrel `index.ts:475` |
+| 42 | `ToolKeyStorage.saveKey(toolName, key): Promise<void>` | `tool-key-storage.ts:280` |
+| 52 | `ToolKeyStorage.deleteKey(toolName): Promise<void>` | `tool-key-storage.ts:314` |
+| 63 | `ToolKeyStorage.clearKeyfilePath(toolName): Promise<void>` | `tool-key-storage.ts:254` |
+| 65 | `ToolKeyStorage.setKeyfilePath(toolName, filePath): Promise<void>` | `tool-key-storage.ts:241` |
+| n/a | `getToolKeyStorage(): ToolKeyStorage` (lazy singleton) | `tool-key-storage.ts:81`; barrel `index.ts:467` |
+
+CLI consumers this unblocks (#1595): `toolkeyCommand.ts` (`new ToolKeyStorage()` → `getKey/saveKey/
+deleteKey`) and `toolkeyfileCommand.ts` (`getKeyfilePath/setKeyfilePath/clearKeyfilePath`). CLI-side
+`~`-expansion / `path.resolve` / existence / non-empty checks (`toolkeyfileCommand.ts:124-150`) stay
+UI-level prevalidation BEFORE calling `setKeyFile(...)`.
+
+---
+
+## Anti-Pattern Warnings
+
+- [ERROR] DO NOT: return the raw key from `status()` (or any method).
+  [OK] DO: return `maskKeyForDisplay(rawKey)` as `maskedKey`; raw key never crosses the API boundary
+  (R-NO-RAW-SECRETS).
+- [ERROR] DO NOT: reuse / alias `Agent.auth.keys` for tool keys.
+  [OK] DO: expose a SEPARATE `agent.tools.keys` controller (R-KEYS-DISTINCT).
+- [ERROR] DO NOT: re-implement tool-name validation in the controller.
+  [OK] DO: let `ToolKeyStorage.assertValidToolName` (invoked inside save/get/delete/keyfile) own it;
+  let its throw propagate.
+- [ERROR] DO NOT: do `~`-expansion / `fs.access` existence / non-empty validation inside `setKeyFile`.
+  [OK] DO: keep those CLI-side (UI prevalidation); the Agent method just persists the given path.
+- [ERROR] DO NOT: cache a `ToolKeyStorage` instance field that bypasses the shared singleton.
+  [OK] DO: resolve `this.deps.getStorage()` (the shared `getToolKeyStorage()` singleton) per call.
+- [ERROR] DO NOT: construct `maskedKey` when `hasKey` is false.
+  [OK] DO: omit `maskedKey` entirely when there is no stored key.
+
+---
+
+## Behavior Decision Table
+
+| GIVEN | Method | Result |
+|---|---|---|
+| registry has Exa | `supported()` | includes `{toolName:"exa", displayName:"Exa Search", description:...}` |
+| key stored "abcd1234efgh" | `status("exa")` | `{toolName:"exa", hasKey:true, maskedKey:"ab********gh"}` (first2+stars+last2) |
+| key stored "short" (≤8) | `status("exa")` | `maskedKey:"*****"` (fully masked) |
+| no key, no keyfile | `status("exa")` | `{toolName:"exa", hasKey:false}` (no maskedKey, no keyFile) |
+| keyfile set, no stored key | `status("exa")` | `{toolName:"exa", hasKey:false, keyFile:"/path/key"}` |
+| valid name + key | `save("exa","k")` | persists via storage.saveKey |
+| invalid name | `save("nope","k")` | storage throws (assertValidToolName) — propagates |
+| `setKeyFile("exa", null)` | clear | `clearKeyfilePath("exa")` |
+| `setKeyFile("exa","/p")` | set | `setKeyfilePath("exa","/p")` |
+| keyfile "/p" configured | `getKeyFile("exa")` | `"/p"` |
+| none configured | `getKeyFile("exa")` | `null` |

--- a/project-plans/issue2143/plan-evaluation.json
+++ b/project-plans/issue2143/plan-evaluation.json
@@ -1,0 +1,15 @@
+{
+  "compliant": true,
+  "has_integration_plan": true,
+  "builds_in_isolation": false,
+  "gaps_closed": { "G1": true, "G2": true, "G3": true, "G4": true, "G5": true, "G6": true, "G7": true },
+  "additive_only_non_breaking": true,
+  "enables_1595": true,
+  "public_root_only_reachable": true,
+  "reverse_testing_found": false,
+  "mock_theater_found": false,
+  "property_ge_30": true,
+  "mutation_ge_80": true,
+  "docs_updated": true,
+  "violations": []
+}

--- a/project-plans/issue2143/plan/00-overview.md
+++ b/project-plans/issue2143/plan/00-overview.md
@@ -1,0 +1,269 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P00 @requirement:REQ-001..REQ-010,REQ-INT-001..REQ-INT-005 -->
+# Plan: Close Agent API engine-capability gaps (prereq for #1595)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Generated: 2026-06-22
+Issue: #2143 (prerequisite for #1595 "Refactor CLI to consume core API")
+Predecessor: PLAN-20260621-COREAPIREMED (#1594 remediation, merged) — this plan is ADDITIVE on top.
+Requirements: REQ-001 … REQ-010, REQ-INT-001 … REQ-INT-005.
+
+> Counting note: phases are numbered 00a, 01/01a, 02/02a, then per-component triplets
+> (TDD `NN` → impl `NN+1` → impl-verifier `(NN+1)a`) for REQ-001..007, then 17/17a … 22/22a,
+> then 23 (final eval). The seven TDD phases (03, 05, 07, 09, 11, 13, 15) self-enforce RED via
+> BLOCKING bash gates AND are retroactively re-audited (behavioral-RED, property ratio, no
+> mock-theater / no reverse-test) by their paired impl-verifier (04a, 06a, 08a, 10a, 12a, 14a, 16a)
+> — so every test file passes an independent architect gate even though TDD phases have no separate
+> `a` file. The `00-overview.md` index is not itself a phase.
+
+## Critical Reminders
+
+Before implementing ANY phase:
+
+1. Phase 00a (preflight) MUST pass first — every type / call-path / dependency assumption in the
+   pseudocode is re-verified against current source, including the TWO corrected issue assumptions:
+   (a) **`packages/cli/src/ui/commands/mcpAuth.ts` EXISTS** (`listOAuthServers:49`,
+   `performMcpOAuth:82`) — the issue body's "no such file `mcpAuth.ts`" claim is FALSE; the real MCP
+   OAuth flow is `MCPOAuthProvider.authenticate(:108)` → `manager.restartServer(:132)` →
+   `agentClient.setTools(:136)`; (b) **Item A (auth detail) needs NO new constructor plumbing** —
+   `OAuthManager` is ALREADY a field on `AgentDeps`/`AgentImpl` (`agentImpl.ts:121`); the
+   auth-detail methods are wired by threading `this.deps.oauthManager` into `buildAuthControl()`
+   (`agentImpl.ts:431`) via a closure only.
+2. This plan is **purely additive to `packages/agents/src/api/**`** and makes the public agents
+   surface ADEQUATE for the seven capabilities #1595's CLI commands drive directly from
+   `core.Config` today. It modifies ONLY: `agent.ts`, `agentImpl.ts`, three NEW
+   `control/<name>Control.ts` files, three EXTENDED control files, `api/index.ts`,
+   `app-services/command-api-map.ts`, and `docs/agent-api.md`. It does **NOT** modify
+   `packages/cli/**`, `packages/core/**`, `packages/providers/**`, `packages/policy/**`,
+   `packages/mcp/**`, or `packages/tools/**` (those are consumed read-only; the CLI rewrite is
+   #1595).
+3. **Non-breaking is a HARD constraint (REQ-009).** Every current export of
+   `@vybestack/llxprt-code-agents` keeps its exact shape; existing controller interfaces gain
+   members but lose/rename none. Backed by an export-surface characterization test written as its
+   own phase (P18) and re-asserted by the boundary phase.
+4. **Integration-first adequacy:** the #1595 contract is an executable adequacy driver
+   (`capabilityGaps.integration.spec.ts`, P20) that drives ALL seven capabilities through the
+   PUBLIC ROOT `@vybestack/llxprt-code-agents` ONLY — proving the CLI could consume them without a
+   single deep import or `agent.getConfig()` escape hatch. Because the controllers are implemented
+   by the time it runs (P03–P16), a PASSING driver is its success condition; any real adequacy gap
+   is fixed in the controllers (never by weakening the test). The boundary phase (P21) enforces the
+   existing T17 no-deep-import guard (`boundary.spec.ts`) over the new `.spec.ts`.
+5. **TDD discipline (gate-enforced):** TDD phases write BEHAVIORAL tests that FAIL for behavioral
+   reasons (RED is ENFORCED — a TDD phase FAILS if its new tests unexpectedly pass, or fail for
+   compile/import/setup reasons, per dev-docs/PLAN.md:733-737: reject only on
+   `Cannot find module|SyntaxError|Failed to resolve import|ReferenceError`; a missing-method
+   `TypeError` is ACCEPTABLE RED). ≥30% of tests are property-based (fast-check; the ratio is
+   COMPUTED and ENFORCED, MIN-2 distinct property cases); NO mock theater
+   (`toHaveBeenCalled`/`mockResolvedValue`/`mockReturnValue`); NO reverse tests
+   (`toThrow('NotYetImplemented')`/`not.toThrow()`); NO structure-only assertions
+   (`toHaveProperty`/`toBeDefined` as the sole assertion); no `any`. Impl phases cite pseudocode
+   line numbers (`@pseudocode lines N-M`).
+6. **Verification gates BLOCK:** every mandatory check EXITS NON-ZERO on violation (no
+   print-and-continue); `|| true` is used ONLY where a grep finding nothing is the PASS case.
+   Mutation ≥80% on each changed `src/api/**` file (Stryker, P22).
+7. **Comment discipline (N5):** production code carries ONLY `@plan` / `@requirement` /
+   `@pseudocode` marker blocks — no explanatory prose comments.
+8. **Canonical single-file test command:** `npx vitest run <file>` (with `set -o pipefail`). NEVER
+   `npm test --workspace pkg -- run <path>`. The monorepo-root `npm run test` oversubscribes CPU →
+   timing/property flakes; re-run any failing file IN ISOLATION to confirm (CI runs packages
+   separately).
+
+---
+
+## Summary
+
+#1594 (+ its remediation) shipped `createAgent` / `fromConfig` returning an `Agent` facade whose
+core interaction path (turn-drive, tools, streaming, settings, history, contract) is parity-proven.
+A capability-coverage audit of `packages/cli/src/**` against that surface found **seven engine
+capabilities the CLI drives directly from `core.Config` with no first-class `Agent` method**. If
+left unaddressed, #1595 must keep `agent.getConfig().<coreMethod>()` escape hatches, defeating its
+own acceptance criterion ("the CLI could be replaced with a different UI using the same core API").
+
+| Gap | Title | Evidence (current source, verified) | Resolved by |
+|---|---|---|---|
+| G1 | Approval mode read/write | `useAutoAcceptIndicator.ts:27` (read) / `:41-47,:53` (write) → `config.getApprovalMode()` (`configBaseCore.ts:463`) / `config.setApprovalMode()` (`config.ts:401`, THROWS in untrusted folder `:404`) | REQ-001 — P03/P04 |
+| G2 | Policy inspection (read-only) | `policiesCommand.ts:60` `getPolicyEngine()`, `:61` `getRules()`, `:110-111` `argsPattern.source`, `:125` `getDefaultDecision()`, `:128` `isNonInteractive()` | REQ-002 — P05/P06 |
+| G3 | Async-task admin (`/task`) | `tasksCommand.ts:80,:117` `getAllTasks`, `:189` `getTask`, `:193` `getTaskByPrefix`, `:236` `cancelTask`; ESC-cancel `useGeminiStreamOrchestration.ts:109-112` | REQ-003 — P07/P08 |
+| G4 | Hooks administration | `hooksCommand.ts` `getHookSystem()` (`:31,:74,…`), `getDisabledHooks()` (`:107,:177`), `setDisabledHooks()` (`:111,:180,…`) | REQ-004 — P09/P10 |
+| G5 | Detailed OAuth state | `authCommand.ts` `peekStoredToken()`, `getHigherPriorityAuth()`, `getAuthStatusWithBuckets()` (OAuthManager) | REQ-005 — P11/P12 |
+| G6 | MCP OAuth + deep detail | `mcpAuth.ts:82` real OAuth flow (authenticate→restartServer→setTools); `mcpControl.refresh()` lacks setTools parity (`mcpControl.ts:235-245`) | REQ-006 — P13/P14 |
+| G7 | Built-in tool-key storage | `new ToolKeyStorage()` direct in `toolkeyCommand.ts` / `toolkeyfileCommand.ts` | REQ-007 — P15/P16 |
+
+> The authoritative REQ→phase mapping is the table at the bottom of this file and the per-phase
+> Prerequisites.
+
+---
+
+## Architectural Decisions (recap from specification.md)
+
+- **Mirror the existing sub-controller convention EXACTLY — introduce no new patterns.** For each
+  capability: declare the interface in `agent.ts` (alongside `AgentToolControl` / `AgentAuthControl`
+  / `AgentMcpControl` / `AgentHookControl` at `agent.ts:223-321`); implement in
+  `control/<name>Control.ts` (mirrors `control/authControl.ts`, `control/mcpControl.ts`); wire into
+  `AgentImpl` as a `readonly <name>` field (near `:194-200`), instantiated in the ctor (near
+  `:328-332`) via a `private build<Name>Control()` (near `:431-510`).
+- **Three NEW sub-controllers, three EXTENDED, two top-level methods, two plumbing surfaces:**
+  - NEW: `AgentPolicyControl` (`policy`), `AgentTasksControl` (`tasks`), `AgentToolKeyControl`
+    (`tools.keys`).
+  - EXTEND: `AgentHookControl` (admin), `AgentAuthControl` (detail), `AgentMcpControl` (OAuth +
+    details + refresh parity) — existing members UNCHANGED.
+  - TOP-LEVEL on `Agent`: `getApprovalMode()` / `setApprovalMode()` (mirrors the ephemeral-setting
+    one-liners at `agentImpl.ts:726-738`; approval is a live engine setting, not a sub-state).
+  - PLUMBING: barrel re-exports (`api/index.ts`) + `COMMAND_API_MAP` rows
+    (`app-services/command-api-map.ts`).
+- **Delegate, never cache (R-DELEGATE).** Every method resolves through `this.deps.config` /
+  `this.deps.resolveClient()` / the injected closure PER CALL (mirrors `getConfig`/`getRuntimeId` at
+  `agentImpl.ts:716-723`). No engine state is cached in a controller, so a later Config mutation is
+  always reflected.
+- **Undefined-safe backing managers (R-UNDEFINED-SAFE).** `getAsyncTaskManager()`, `getHookSystem()`
+  and the MCP manager can all be absent; controllers return the idle/empty/no-op result
+  (`[]`/`undefined`/`false`/`0`) — mirroring the `McpControl` idle idiom (`mcpControl.ts:121-124`).
+- **Project public types that omit non-serializable internals.** `AgentTaskInfo` OMITS
+  `abortController` (`asyncTaskManager.ts:28`); `PolicyRuleView.argsPattern` is the `.source` STRING
+  (not a raw `RegExp`); auth/tool-key surfaces expose MASKED metadata only — NEVER raw token strings
+  or secret values (R-NO-RAW-SECRETS, R-NO-ABORTCONTROLLER, R-ARGSPATTERN-STRING).
+- **`setApprovalMode` delegates without try/catch (R-APPROVAL-THROW).** The untrusted-folder throw
+  (`config.ts:404`) MUST propagate faithfully — the Agent method neither normalizes nor swallows it.
+- **MCP `authenticate()` runs the REAL flow (R-MCP-OAUTH-FLOW)** —
+  `MCPOAuthProvider.authenticate(serverName, oauthConfig, mcpServerUrl, undefined)` (events param is
+  CLI-only; agents pass `undefined`) → `manager.restartServer(server)` →
+  `resolveClient().setTools()`; and `refresh()` gains setTools parity (R-REFRESH-PARITY). The
+  existing `mcp.auth(server)` per-agent-flag semantics are UNCHANGED.
+- **`tools.keys` is DISTINCT from `auth.keys` (R-KEYS-DISTINCT).** `auth.keys` is provider-auth
+  keys; `tools.keys` is built-in tool-key storage (`getToolKeyStorage()`).
+- **Barrel re-exports value-vs-type correctness (R-BARREL-TYPEONLY).** Enums (`PolicyDecision`,
+  `ApprovalMode`) re-export as VALUES; projected interfaces re-export `export type` (verbatimModule-
+  Syntax); each surfaced via the existing `export type * from './agent.js'` where already covered.
+
+---
+
+## Subagent Role Table
+
+| Role | Subagent | Phases |
+|---|---|---|
+| Implementation / worker | `typescriptexpert` | All `NN` worker phases (01, 02, 03–16, 17, 18, 19, 20, 21, 22) |
+| Verification / review | `architect` | Preflight `00a`; every `NNa` verifier; the pseudocode-compliance gates on impl phases (04a, 06a, 08a, 10a, 12a, 14a, 16a); and the final plan-quality evaluation (23) |
+
+> Each impl-verifier (`NNa`) independently re-audits the paired TDD phase's tests (behavioral-RED
+> was real, ≥30% property ratio, no mock theater, no reverse tests) in addition to the
+> pseudocode-compliance + mutation gate on the implementation.
+
+---
+
+## Requirements (full titles)
+
+- **REQ-001** Approval mode — top-level `getApprovalMode(): ApprovalMode` /
+  `setApprovalMode(mode): void` on `Agent`; untrusted-folder throw propagates (delegate, don't catch).
+- **REQ-002** Read-only policy inspection — `agent.policy.getRules()` (snapshots,
+  `argsPattern` → `.source` string) / `getDefaultDecision()` / `isNonInteractive()`.
+- **REQ-003** Async-task administration — `agent.tasks.list/listRunning/get/cancel/cancelAllRunning`;
+  undefined-safe; `cancelAllRunning()` returns the cancelled COUNT; `AgentTaskInfo` omits
+  `abortController`.
+- **REQ-004** Hooks administration — extend `AgentHookControl` with `listHooks` / `getDisabledHooks`
+  / `setDisabledHooks` (+ convenience enable/disable); undefined-safe; existing exec/lifecycle
+  members unchanged.
+- **REQ-005** Detailed OAuth state — extend `Agent.auth` with `detailedStatus` /
+  `getHigherPriorityAuth` / `listBucketStatuses`; MASKED metadata only (no raw tokens).
+- **REQ-006** MCP OAuth + deep detail + refresh parity — extend `Agent.mcp` with `authenticate`
+  (real flow) / `details` / `refresh()` setTools parity; undefined-safe.
+- **REQ-007** Built-in tool-key storage — `agent.tools.keys` (`supported` / `status` (masked) /
+  `save` / `delete` / `setKeyFile` / `getKeyFile`); distinct from `auth.keys`.
+- **REQ-008** Public barrel re-exports + `COMMAND_API_MAP` registration of the six target commands.
+- **REQ-009** Non-breaking guarantee — additive only; export-surface characterization.
+- **REQ-010** Documentation — `docs/agent-api.md` documents every new surface.
+- **REQ-INT-001..004** CLI-parity adequacy — each capability is reachable and behaves identically to
+  the CLI's current direct-`Config` path, driven through the PUBLIC ROOT only.
+- **REQ-INT-005** No-deep-import boundary — the adequacy driver imports ONLY
+  `@vybestack/llxprt-code-agents` (T17 `boundary.spec.ts`).
+
+---
+
+## Phase Index (CONTIGUOUS — NO SKIPPED NUMBERS)
+
+| Phase | File | Worker | Title |
+|---|---|---|---|
+| 00a | `00a-preflight-verification.md` | architect | Preflight: re-verify all anchors (incl. mcpAuth.ts-exists + oauthManager-already-on-deps) |
+| 01 | `01-analysis.md` | typescriptexpert | Domain analysis (confirm `analysis/domain-model.md`) |
+| 01a | `01a-analysis-verification.md` | architect | Verify analysis |
+| 02 | `02-pseudocode.md` | typescriptexpert | Pseudocode (confirm `analysis/pseudocode/*.md`) |
+| 02a | `02a-pseudocode-verification.md` | architect | Verify pseudocode (contract-first sections, real anchors) |
+| 03 | `03-approval-tdd.md` | typescriptexpert | REQ-001 approval mode — behavioral RED tests |
+| 04 | `04-approval-impl.md` | typescriptexpert | REQ-001 approval mode — impl (cite approval-mode.md) |
+| 04a | `04a-approval-impl-verification.md` | architect | Pseudocode-compliance gate + re-audit P03 tests |
+| 05 | `05-policy-tdd.md` | typescriptexpert | REQ-002 policy control — behavioral RED tests |
+| 06 | `06-policy-impl.md` | typescriptexpert | REQ-002 policy control — impl (cite policy-control.md) |
+| 06a | `06a-policy-impl-verification.md` | architect | Pseudocode-compliance gate + re-audit P05 tests |
+| 07 | `07-tasks-tdd.md` | typescriptexpert | REQ-003 tasks control — behavioral RED tests |
+| 08 | `08-tasks-impl.md` | typescriptexpert | REQ-003 tasks control — impl (cite tasks-control.md) |
+| 08a | `08a-tasks-impl-verification.md` | architect | Pseudocode-compliance gate + re-audit P07 tests |
+| 09 | `09-hooks-admin-tdd.md` | typescriptexpert | REQ-004 hooks admin — behavioral RED tests |
+| 10 | `10-hooks-admin-impl.md` | typescriptexpert | REQ-004 hooks admin — impl (cite hooks-admin.md) |
+| 10a | `10a-hooks-admin-impl-verification.md` | architect | Pseudocode-compliance gate + re-audit P09 tests |
+| 11 | `11-auth-detail-tdd.md` | typescriptexpert | REQ-005 auth detail — behavioral RED tests |
+| 12 | `12-auth-detail-impl.md` | typescriptexpert | REQ-005 auth detail — impl (cite auth-detail.md) |
+| 12a | `12a-auth-detail-impl-verification.md` | architect | Pseudocode-compliance gate + re-audit P11 tests |
+| 13 | `13-mcp-oauth-tdd.md` | typescriptexpert | REQ-006 MCP OAuth/details/refresh — behavioral RED tests |
+| 14 | `14-mcp-oauth-impl.md` | typescriptexpert | REQ-006 MCP OAuth/details/refresh — impl (cite mcp-oauth.md) |
+| 14a | `14a-mcp-oauth-impl-verification.md` | architect | Pseudocode-compliance gate + re-audit P13 tests |
+| 15 | `15-tool-keys-tdd.md` | typescriptexpert | REQ-007 tool keys — behavioral RED tests |
+| 16 | `16-tool-keys-impl.md` | typescriptexpert | REQ-007 tool keys — impl (cite tool-keys.md) |
+| 16a | `16a-tool-keys-impl-verification.md` | architect | Pseudocode-compliance gate + re-audit P15 tests |
+| 17 | `17-barrel-and-command-map.md` | typescriptexpert | REQ-008 barrel re-exports + `COMMAND_API_MAP` rows (cite barrel-exports.md, command-map.md) |
+| 17a | `17a-barrel-and-command-map-verification.md` | architect | Verify exports value/type-correct + map invariants |
+| 18 | `18-non-breaking.md` | typescriptexpert | REQ-009 export-surface non-breaking characterization |
+| 18a | `18a-non-breaking-verification.md` | architect | Verify nothing removed/renamed |
+| 19 | `19-docs.md` | typescriptexpert | REQ-010 `docs/agent-api.md` updates |
+| 19a | `19a-docs-verification.md` | architect | Verify docs accuracy against code |
+| 20 | `20-integration-adequacy-driver.md` | typescriptexpert | REQ-INT-001..004 `capabilityGaps.integration.spec.ts` (all 7 caps via public root) |
+| 20a | `20a-integration-adequacy-verification.md` | architect | Verify adequacy proven, public-root-only on driver path |
+| 21 | `21-boundary-and-nonbreaking.md` | typescriptexpert | REQ-INT-005 T17 no-deep-import boundary over new `.spec.ts` + final non-breaking sweep |
+| 21a | `21a-boundary-and-nonbreaking-verification.md` | architect | Verify boundary + non-breaking |
+| 22 | `22-quality-gates.md` | typescriptexpert | Full suite (test/lint/typecheck/format/build + smoke) + mutation ≥80% |
+| 22a | `22a-quality-gates-verification.md` | architect | Verify gates output |
+| 23 | `23-final-plan-quality-eval.md` | architect | Final plan-quality evaluation (integration-first, no isolation) |
+
+---
+
+## REQ → Phase Mapping (authoritative)
+
+| Requirement | Worker phases | Verifier phases |
+|---|---|---|
+| REQ-001 (approval) | 03, 04 | 04a |
+| REQ-002 (policy) | 05, 06 | 06a |
+| REQ-003 (tasks) | 07, 08 | 08a |
+| REQ-004 (hooks admin) | 09, 10 | 10a |
+| REQ-005 (auth detail) | 11, 12 | 12a |
+| REQ-006 (MCP OAuth) | 13, 14 | 14a |
+| REQ-007 (tool keys) | 15, 16 | 16a |
+| REQ-008 (barrel + map) | 17 | 17a |
+| REQ-009 (non-breaking) | 18 (+ every impl phase) | 18a, 21a |
+| REQ-010 (docs) | 19 | 19a |
+| REQ-INT-001..004 (CLI parity) | 20 | 20a |
+| REQ-INT-005 (no-deep-import) | 20, 21 | 20a, 21a |
+
+---
+
+## Gap → REQ → Phase (the seven gaps, explicit)
+
+| Gap | REQ | First proven adequate at |
+|---|---|---|
+| G1 (approval mode) | REQ-001, REQ-INT-001 | P04 impl; adequacy driver P20 |
+| G2 (policy inspection) | REQ-002, REQ-INT-002 | P06 impl; P20 |
+| G3 (async tasks) | REQ-003, REQ-INT-002 | P08 impl; P20 |
+| G4 (hooks admin) | REQ-004, REQ-INT-003 | P10 impl; P20 |
+| G5 (auth detail) | REQ-005, REQ-INT-003 | P12 impl; P20 |
+| G6 (MCP OAuth) | REQ-006, REQ-INT-004 | P14 impl; P20 |
+| G7 (tool keys) | REQ-007, REQ-INT-004 | P16 impl; P20 |
+
+---
+
+## #1595 Adequacy Statement
+
+When phases 03–21 are green, the public `@vybestack/llxprt-code-agents` surface provides everything
+#1595 needs to replace the seven `core.Config` escape hatches with first-class `Agent` calls:
+approval-mode read/write (preserving the untrusted-folder throw), read-only policy inspection, the
+full `/task` admin surface, hooks registry administration, masked detailed OAuth state, the real MCP
+OAuth flow + deep details + refresh-with-setTools parity, and masked built-in tool-key storage —
+each re-exported from the public root, registered in `COMMAND_API_MAP`, non-breaking, and proven by
+an executable adequacy driver that imports ONLY the public root (no `getConfig()` escape hatch, no
+deep import). The final evaluation (P23) rejects the plan if any capability still requires reaching
+through `agent.getConfig()` or a deep import to drive its CLI command.

--- a/project-plans/issue2143/plan/00a-preflight-verification.md
+++ b/project-plans/issue2143/plan/00a-preflight-verification.md
@@ -1,0 +1,233 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P00a @requirement:REQ-001..REQ-010,REQ-INT-001..005 -->
+# Phase 00a: Preflight Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P00a`
+
+## LLxprt Code Subagent: architect
+
+## Purpose
+
+Verify EVERY assumption this plan depends on against the actual current source BEFORE any
+implementation phase begins, including the TWO corrected issue assumptions. If any check fails,
+STOP and update the plan first.
+
+## Prerequisites
+
+- Branch `issue2143` derived from current `main` (post-#1594-remediation merge).
+- Required reading: `specification.md`, `analysis/domain-model.md`, all nine
+  `analysis/pseudocode/*.md`.
+
+## Dependency Verification
+
+Run and paste output:
+
+```bash
+set -o pipefail
+npm ls zod                         # schema-first dependency (AgentTaskInfoSchema / PolicyRuleViewSchema)
+npm ls fast-check                  # property-based testing (≥30% requirement)
+grep -nE "@stryker-mutator/core" packages/agents/package.json   # expect "^9.6.1"
+npm ls @stryker-mutator/core || { echo "FAIL: @stryker-mutator/core MISSING — restore the devDependency before proceeding."; exit 1; }
+# agents must already depend on policy + providers + core (the backing engines we re-export from):
+grep -nE ""@vybestack/llxprt-code-(core|policy|providers)"" packages/agents/package.json
+```
+
+| Dependency | Expected | Status |
+|---|---|---|
+| zod | installed | [ ] |
+| fast-check | installed | [ ] |
+| @stryker-mutator/core | installed (`^9.6.1`) | [ ] |
+| agents → core / policy / providers deps | present | [ ] |
+
+## CORRECTED ISSUE ASSUMPTIONS (must verify FIRST)
+
+```bash
+set -o pipefail
+# CORRECTION 1: the issue body claims "no such file mcpAuth.ts". That is FALSE — it EXISTS and holds
+# the real MCP OAuth reference flow. Confirm the file + the flow anchors:
+test -f packages/cli/src/ui/commands/mcpAuth.ts && echo "CONFIRMED: mcpAuth.ts EXISTS (issue claim FALSE)" || { echo "UNEXPECTED: mcpAuth.ts absent — re-confirm REQ-006 reference flow before P13"; exit 1; }
+grep -n "listOAuthServers" packages/cli/src/ui/commands/mcpAuth.ts          # expect ~:49
+grep -n "performMcpOAuth" packages/cli/src/ui/commands/mcpAuth.ts           # expect ~:82
+grep -n "MCPOAuthProvider.authenticate" packages/cli/src/ui/commands/mcpAuth.ts   # expect ~:108
+grep -n "restartServer" packages/cli/src/ui/commands/mcpAuth.ts             # expect ~:132
+grep -n "setTools" packages/cli/src/ui/commands/mcpAuth.ts                  # expect ~:136
+
+# CORRECTION 2: Item A (auth detail) needs NO new constructor plumbing — OAuthManager is ALREADY a
+# field on AgentImpl/AgentDeps; auth-detail is wired by threading this.deps.oauthManager into
+# buildAuthControl(). Confirm the field + the build site:
+grep -n "oauthManager" packages/agents/src/api/agentImpl.ts | head            # expect a field ~:121 + import ~:25
+grep -n "buildAuthControl" packages/agents/src/api/agentImpl.ts               # expect ~:431
+grep -n "oauthManager" packages/agents/src/api/control/authControl.ts || echo "CONFIRMED: AuthControlDeps lacks oauthManager today (P11/P12 add a getOAuthManager closure)"
+```
+
+| Corrected assumption | Expected | Actual | Match? |
+|---|---|---|---|
+| `mcpAuth.ts` EXISTS (issue "no such file" is FALSE) | yes | | [ ] |
+| mcpAuth flow: authenticate → restartServer → setTools | yes | | [ ] |
+| `oauthManager` already a field on `AgentImpl` (`:121`) | yes | | [ ] |
+| `buildAuthControl()` present (`:431`) — thread point | yes | | [ ] |
+| `AuthControlDeps` lacks `oauthManager` today (added by P11/P12 as a closure) | yes | | [ ] |
+
+## Type / Interface Verification — backing engines
+
+Run and confirm each MATCHES the plan's assumptions:
+
+```bash
+set -o pipefail
+# REQ-001 approval:
+grep -n "getApprovalMode" packages/core/src/config/configBaseCore.ts        # expect ~:463
+grep -n "setApprovalMode" packages/core/src/config/config.ts                # expect ~:401
+grep -n "untrusted" packages/core/src/config/config.ts | head               # expect the throw ~:404
+grep -nE "ApprovalMode" packages/agents/src/api/agent.ts                    # expect import :11 + re-export :387
+
+# REQ-002 policy:
+grep -n "getPolicyEngine" packages/core/src/config/configBaseCore.ts        # expect ~:475 (non-optional)
+grep -nE "getRules|getDefaultDecision|isNonInteractive" packages/policy/src/policy-engine.ts   # expect :320/:329/:338
+grep -nE "argsPattern" packages/policy/src/types.ts                         # expect RegExp field ~:35
+grep -nE "export (enum|const enum) PolicyDecision" packages/policy/src/types.ts   # value enum
+
+# REQ-003 tasks:
+grep -n "getAsyncTaskManager" packages/core/src/config/config.ts            # expect ~:601 (returns | undefined)
+grep -nE "getAllTasks|getRunningTasks|getTask\(|cancelTask" packages/core/src/services/asyncTaskManager.ts   # :77/:319/:273/:239
+grep -n "abortController" packages/core/src/services/asyncTaskManager.ts    # expect AsyncTaskInfo.abortController? ~:28 (MUST be omitted from public view)
+
+# REQ-004 hooks admin:
+grep -n "getHookSystem" packages/core/src/config/config.ts                  # expect ~:755 (| undefined)
+grep -n "getDisabledHooks" packages/core/src/config/config.ts               # expect ~:734
+grep -n "setDisabledHooks" packages/core/src/config/configBase.ts           # expect ~:132
+grep -nE "getRegistry|isInitialized" packages/core/src/hooks/hookSystem.ts  # expect :137/:158
+grep -nE "getAllHooks|setHookEnabled|getHookName" packages/core/src/hooks/hookRegistry.ts   # :82/:89/:118
+grep -nE "enabled" packages/core/src/hooks/hookRegistry.ts | head           # HookRegistryEntry.enabled ~:41
+# current AgentHookControl members (must remain unchanged; admin is ADDITIVE):
+grep -nE "onHookExecution|triggerSessionStart|triggerSessionEnd|clear" packages/agents/src/api/agent.ts
+
+# REQ-005 auth detail (OAuthManager surface):
+grep -nE "peekStoredToken|getHigherPriorityAuth|getAuthStatusWithBuckets|isOAuthEnabled|isAuthenticated" packages/providers/src/auth/oauth-manager.ts   # :243/:313/:395/:300/:199
+
+# REQ-006 MCP OAuth:
+grep -n "authenticate(" packages/mcp/src/auth/oauth-provider.ts | head      # MCPOAuthProvider.authenticate ~:874
+grep -n "MCPOAuthProvider" packages/core/src/index.ts                       # re-exported from core barrel ~:498
+grep -n "setTools(): Promise<void>" packages/core/src/core/clientContract.ts   # ~:77 (the refresh-parity target)
+grep -n "resolveClient" packages/agents/src/api/agentImpl.ts                # ~:132
+grep -nE "getMcpServers|getBlockedMcpServers|getPromptRegistry|getResourceRegistry" packages/core/src/config/configBaseCore.ts   # :436/:445/:403/:406
+# current McpControl + Deps (refresh lacks setTools today; auth(server) is per-agent flag only):
+grep -nE "McpControlDeps|isMcpAuthenticated|getManager|getToolRegistry|refresh|auth\(" packages/agents/src/api/control/mcpControl.ts | head
+
+# REQ-007 tool keys:
+grep -nE "getToolKeyStorage|class ToolKeyStorage" packages/core/src/tools/tool-key-storage.ts   # :81 / :109
+grep -nE "saveKey|getKey|deleteKey|setKeyfilePath|getKeyfilePath|clearKeyfilePath" packages/core/src/tools/tool-key-storage.ts
+grep -nE "getSupportedToolNames|getToolKeyEntry|isValidToolKeyName|maskKeyForDisplay" packages/tools/src/utils/tool-key-storage-types.ts   # :72/:62/.../:82
+grep -nE "ToolKeyStorage|getToolKeyStorage|maskKeyForDisplay|getSupportedToolNames" packages/core/src/index.ts   # core-barrel re-exports ~:466-475
+# auth.keys is a DIFFERENT surface (must stay distinct):
+grep -nE "AgentAuthKeysControl|keys" packages/agents/src/api/agent.ts | head
+
+# REQ-008 barrel + command map:
+grep -nE "COMMAND_API_MAP|APP_SERVICE_SUBPATH|CommandApiMapping" packages/agents/src/app-services/command-api-map.ts | head
+for c in "/policies" "/task" "/hooks" "/toolkey" "/toolkeyfile" "/approval-mode"; do
+  n=$(grep -c "command: '$c'" packages/agents/src/app-services/command-api-map.ts || true)
+  echo "COMMAND_API_MAP rows for $c = $n (expect 0 — all six ABSENT today)"
+done
+grep -nE "export \* |export type \*|AgentClientContract" packages/agents/src/api/index.ts | head
+```
+
+| Assumption | Expected | Actual | Match? |
+|---|---|---|---|
+| `getApprovalMode` (`configBaseCore.ts:463`) | yes | | [ ] |
+| `setApprovalMode` throws in untrusted folder (`config.ts:401-404`) | yes | | [ ] |
+| `ApprovalMode` imported (`agent.ts:11`) + re-exported (`:387`) | yes | | [ ] |
+| `getPolicyEngine` non-optional (`configBaseCore.ts:475`) | yes | | [ ] |
+| `PolicyEngine.getRules/getDefaultDecision/isNonInteractive` | yes | | [ ] |
+| `PolicyRule.argsPattern` is a raw `RegExp` (project to `.source`) | yes | | [ ] |
+| `getAsyncTaskManager(): … \| undefined` (`config.ts:601`) | yes | | [ ] |
+| `AsyncTaskInfo.abortController?` exists (`:28`) — MUST be omitted from public view | yes | | [ ] |
+| `getHookSystem(): … \| undefined`; `getDisabledHooks`; `setDisabledHooks` | yes | | [ ] |
+| `HookSystem.getRegistry/isInitialized`; `HookRegistry.getAllHooks/setHookEnabled/getHookName` | yes | | [ ] |
+| existing `AgentHookControl` members present (admin is additive) | yes | | [ ] |
+| OAuthManager `peekStoredToken/getHigherPriorityAuth/getAuthStatusWithBuckets` | yes | | [ ] |
+| `MCPOAuthProvider.authenticate` exists + re-exported from core barrel | yes | | [ ] |
+| `AgentClientContract.setTools(): Promise<void>` (`:77`); `resolveClient` (`:132`) | yes | | [ ] |
+| `McpControl.refresh()` lacks setTools today; `auth(server)` is per-agent flag | yes | | [ ] |
+| `getToolKeyStorage()` + `ToolKeyStorage` methods; tool-key helpers; core-barrel re-exports | yes | | [ ] |
+| `auth.keys` is a distinct provider-auth surface | yes | | [ ] |
+| all six target commands ABSENT from `COMMAND_API_MAP` (count 0 each) | yes | | [ ] |
+
+## Convention Verification (control-wiring + top-level delegation)
+
+```bash
+set -o pipefail
+# Existing sub-controller interfaces to mirror (declared in agent.ts):
+grep -nE "interface Agent(Tool|Mcp|Auth|Ide|Session|Profile|Hook)Control" packages/agents/src/api/agent.ts
+# Existing readonly controller fields + ctor wiring + build* methods in AgentImpl:
+grep -nE "readonly (profiles|tools|mcp|auth|ide|session|hooks)\b" packages/agents/src/api/agentImpl.ts
+grep -nE "this\.(auth|mcp|ide|session|hooks)\s*=\s*this\.build" packages/agents/src/api/agentImpl.ts
+grep -nE "private build(Auth|Mcp|Ide|Session|Hook)Control" packages/agents/src/api/agentImpl.ts
+# Top-level delegation one-liners to mirror for approval (ephemeral pattern):
+grep -nE "getEphemeralSetting|setEphemeralSetting|getEphemeralSettings|getConfig|getRuntimeId" packages/agents/src/api/agentImpl.ts | head
+```
+
+| Item | Expected | Status |
+|---|---|---|
+| 7 existing `Agent*Control` interfaces in `agent.ts` (mirror their shape) | yes | [ ] |
+| readonly fields + ctor wiring + `build*Control()` methods in `agentImpl.ts` | yes | [ ] |
+| ephemeral one-liner delegation pattern present (mirror for approval) | yes | [ ] |
+
+## Boundary / Test-Infra Verification
+
+```bash
+set -o pipefail
+ls packages/agents/src/api/__tests__/ | head
+grep -nE "isSpec|endsWith\('.spec.ts'\)|@vybestack/llxprt-code-agents|internals.js" packages/agents/src/api/__tests__/boundary.spec.ts | head
+# Confirm the non-breaking characterization test exists (we EXTEND it):
+ls packages/agents/src/api/__tests__/*nonbreaking* 2>/dev/null || echo "NOTE: nonbreaking test path to confirm in P18"
+# Stryker mutate glob covers src/api/** (new control files auto-included):
+grep -nE "mutate" packages/agents/stryker.conf.json
+# Canonical single-file run form smoke (MIN-1: capture real status):
+EXISTING=$(ls packages/agents/src/api/__tests__/*.test.ts packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null | head -1)
+if [ -n "$EXISTING" ]; then
+  npx vitest run "$EXISTING" > /tmp/p00a-canon.log 2>&1; CANON=$?
+  tail -5 /tmp/p00a-canon.log
+  [ "$CANON" -eq 0 ] || { echo "FAIL: canonical single-file run form did not succeed on a known spec"; exit 1; }
+fi
+echo "CANONICAL: npx vitest run <file>"
+npm run typecheck >/dev/null 2>&1 && echo "typecheck baseline OK" || echo "typecheck baseline BROKEN — fix before starting"
+```
+
+| Item | Expected | Status |
+|---|---|---|
+| `boundary.spec.ts` scans only `*.spec.ts`; allows public root; forbids internals/deep | yes | [ ] |
+| non-breaking characterization test located (extend in P18) | yes | [ ] |
+| Stryker `mutate` covers `src/api/**/*.ts` | yes | [ ] |
+| Canonical single-file form `npx vitest run <file>` works | yes | [ ] |
+| Baseline `npm run typecheck` clean | yes | [ ] |
+
+## Blocking Issues Found
+
+[List any mismatch that requires plan modification BEFORE Phase 01.]
+
+## Verification Gate
+
+- [ ] All dependencies verified (zod, fast-check, @stryker-mutator/core, core/policy/providers deps)
+- [ ] Both corrected issue assumptions confirmed (mcpAuth.ts exists; oauthManager already on deps)
+- [ ] All backing-engine types match plan assumptions
+- [ ] Control-wiring + top-level delegation conventions confirmed
+- [ ] Boundary guard + Stryker glob + canonical test command confirmed
+- [ ] Baseline typecheck clean
+
+IF ANY CHECKBOX IS UNCHECKED: STOP and update the plan before proceeding.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P00a.md`
+
+Contents (REQUIRED — the executor fills every field with REAL values, not placeholders):
+
+```markdown
+Phase: P00a
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats, e.g. +12/-3]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line verdict — PASS/FAIL with the key evidence that grounded it]
+```

--- a/project-plans/issue2143/plan/01-analysis.md
+++ b/project-plans/issue2143/plan/01-analysis.md
@@ -1,0 +1,98 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P01 @requirement:REQ-001..REQ-010,REQ-INT-001..005 -->
+# Phase 01: Domain Analysis
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P01`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 00a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P00a.md`
+
+## Requirements Implemented (Expanded)
+
+This phase produces/confirms `analysis/domain-model.md` covering ALL requirements (REQ-001..010,
+REQ-INT-001..005). No production code.
+
+## Implementation Tasks
+
+### Files to Create / Confirm
+
+- `project-plans/issue2143/analysis/domain-model.md` (already drafted) — confirm it contains:
+  - Entities: `Agent` (extended), the three NEW sub-controllers (`AgentPolicyControl`,
+    `AgentTasksControl`, `AgentToolKeyControl`), the three EXTENDED controllers
+    (`AgentHookControl`, `AgentAuthControl`, `AgentMcpControl`), the projected public view types
+    (`PolicyRuleView`, `AgentTaskInfo`, `HookInfo`, `AuthProviderDetail`, `AuthBucketStatus`,
+    `McpDetailStatus`/`McpServerDetail`, `ToolKeyInfo`/`ToolKeyStatus`), and the backing engine
+    collaborators (`Config`, `PolicyEngine`, `AsyncTaskManager`, `HookSystem`/`HookRegistry`,
+    `OAuthManager`, `MCPOAuthProvider`, `McpClientManager`, `ToolKeyStorage`).
+  - State transitions §3.1–§3.7 (approval read/write+throw; policy snapshot; task list/cancel;
+    hooks disabled-set round-trip; auth detail projection; MCP authenticate→restart→setTools;
+    tool-key save/keyfile round-trip).
+  - Named invariants R-DELEGATE, R-APPROVAL-THROW, R-POLICY-SNAPSHOT, R-ARGSPATTERN-STRING,
+    R-NO-ABORTCONTROLLER, R-CANCEL-COUNT, R-UNDEFINED-SAFE, R-HOOKS-ROUNDTRIP, R-NO-RAW-SECRETS,
+    R-NO-LEAK, R-REFRESH-PARITY, R-MCP-OAUTH-FLOW, R-KEYS-DISTINCT, R-NONBREAK, R-MAP-VALID,
+    R-NO-DEEP-IMPORT, R-BARREL-TYPEONLY — each with ≥1 testable harness row.
+  - Edge cases (§5) and error scenarios (§6) per requirement.
+  - Requirement coverage map §7 (REQ → entities/transition/invariant/harness/phases).
+  - Harness row cross-reference §8 (T1–T24, layers L1–L5).
+
+### Required Markers
+
+The `domain-model.md` top comment MUST include `@plan:PLAN-20260622-COREAPIGAP.P01`.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+test -f project-plans/issue2143/analysis/domain-model.md || { echo FAIL; exit 1; }
+for r in REQ-001 REQ-002 REQ-003 REQ-004 REQ-005 REQ-006 REQ-007 REQ-008 REQ-009 REQ-010 \
+         REQ-INT-001 REQ-INT-002 REQ-INT-003 REQ-INT-004 REQ-INT-005; do
+  grep -q "$r" project-plans/issue2143/analysis/domain-model.md || { echo "MISSING $r"; exit 1; }
+done
+for t in T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24; do
+  grep -q "| $t " project-plans/issue2143/analysis/domain-model.md || { echo "MISSING harness $t"; exit 1; }
+done
+for inv in R-DELEGATE R-APPROVAL-THROW R-POLICY-SNAPSHOT R-ARGSPATTERN-STRING R-NO-ABORTCONTROLLER \
+           R-CANCEL-COUNT R-UNDEFINED-SAFE R-HOOKS-ROUNDTRIP R-NO-RAW-SECRETS R-NO-LEAK \
+           R-REFRESH-PARITY R-MCP-OAUTH-FLOW R-KEYS-DISTINCT R-NONBREAK R-MAP-VALID \
+           R-NO-DEEP-IMPORT R-BARREL-TYPEONLY; do
+  grep -q "$inv" project-plans/issue2143/analysis/domain-model.md || { echo "MISSING invariant $inv"; exit 1; }
+done
+grep -q "@plan:PLAN-20260622-COREAPIGAP.P01" project-plans/issue2143/analysis/domain-model.md || { echo "MISSING plan marker"; exit 1; }
+echo "OK"
+```
+
+### Semantic Verification Checklist
+
+- [ ] Every REQ has a coverage-map row with entity, transition, invariant, harness row, phases.
+- [ ] No implementation code (analysis only).
+- [ ] The NEW-vs-EXTEND distinction is explicit for every controller (additive, REQ-009).
+- [ ] Projected-type invariants (R-NO-ABORTCONTROLLER, R-ARGSPATTERN-STRING, R-NO-RAW-SECRETS,
+      R-NO-LEAK) are present and testable.
+- [ ] Non-breaking invariant (R-NONBREAK) and no-deep-import invariant (R-NO-DEEP-IMPORT) present.
+
+## Success Criteria
+
+- `domain-model.md` present; all REQ + T-rows + invariants covered; plan marker present.
+
+## Failure Recovery
+
+- Revise `analysis/domain-model.md`; re-run verification.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P01.md`
+
+```markdown
+Phase: P01
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment of what was implemented and whether it satisfies the cited requirements]
+```

--- a/project-plans/issue2143/plan/01a-analysis-verification.md
+++ b/project-plans/issue2143/plan/01a-analysis-verification.md
@@ -1,0 +1,68 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P01a @requirement:REQ-001..REQ-010,REQ-INT-001..005 -->
+# Phase 01a: Analysis Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P01a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 01 completed
+- Verification: `test -f project-plans/issue2143/.completed/P01.md`
+
+## Verification Tasks
+
+Read `analysis/domain-model.md` IN FULL and confirm:
+
+```bash
+set -o pipefail
+for r in REQ-001 REQ-002 REQ-003 REQ-004 REQ-005 REQ-006 REQ-007 REQ-008 REQ-009 REQ-010 \
+         REQ-INT-001 REQ-INT-002 REQ-INT-003 REQ-INT-004 REQ-INT-005; do
+  grep -q "$r" project-plans/issue2143/analysis/domain-model.md || echo "MISSING $r"
+done
+grep -cE "R-DELEGATE|R-APPROVAL-THROW|R-POLICY-SNAPSHOT|R-ARGSPATTERN-STRING|R-NO-ABORTCONTROLLER|R-CANCEL-COUNT|R-UNDEFINED-SAFE|R-HOOKS-ROUNDTRIP|R-NO-RAW-SECRETS|R-NO-LEAK|R-REFRESH-PARITY|R-MCP-OAUTH-FLOW|R-KEYS-DISTINCT|R-NONBREAK|R-MAP-VALID|R-NO-DEEP-IMPORT|R-BARREL-TYPEONLY" project-plans/issue2143/analysis/domain-model.md
+```
+
+### Semantic Verification Checklist
+
+- [ ] All 15 requirements (10 REQ + 5 REQ-INT) covered with entities + transitions + invariants +
+      harness rows.
+- [ ] All 17 named invariants present, each mapped to ≥1 harness row.
+- [ ] The NEW-vs-EXTEND distinction (additive only) is unambiguous for every controller.
+- [ ] No implementation code leaked into analysis.
+- [ ] Coverage-map phase references match `plan/00-overview.md` (contiguous; REQ-001→P03/P04/P04a …
+      REQ-007→P15/P16/P16a; REQ-008→P17/P17a; REQ-009→P18/P18a; REQ-010→P19/P19a;
+      REQ-INT→P20/P20a/P21/P21a).
+- [ ] The two corrected issue assumptions (mcpAuth.ts exists; oauthManager already on deps) are
+      reflected in the relevant entities/transitions (MCP OAuth flow, auth-detail wiring).
+
+## Holistic Assessment (MANDATORY — write into completion marker)
+
+Answer in prose: What does the domain model describe? Does it capture all seven capability gaps
+(G1 approval, G2 policy, G3 tasks, G4 hooks-admin, G5 auth-detail, G6 MCP-OAuth, G7 tool-keys) plus
+the two plumbing surfaces (barrel, command-map) and the non-breaking/no-deep-import guarantees? Are
+there any gaps between the model and the spec? Verdict PASS/FAIL with reasons.
+
+## Success Criteria
+
+- All checks pass; holistic assessment written.
+
+## Failure Recovery
+
+- Return to Phase 01 with specific findings; do NOT proceed to Phase 02 until PASS.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P01a.md` (include the holistic assessment).
+
+```markdown
+Phase: P01a
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line verdict — PASS/FAIL with the key evidence that grounded it]
+```

--- a/project-plans/issue2143/plan/02-pseudocode.md
+++ b/project-plans/issue2143/plan/02-pseudocode.md
@@ -1,0 +1,99 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02 @requirement:REQ-001..REQ-010,REQ-INT-001..005 -->
+# Phase 02: Pseudocode
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P02`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 01a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P01a.md`
+
+## Purpose
+
+Produce/confirm contract-first NUMBERED pseudocode for every new/changed component. NO TypeScript.
+
+## Implementation Tasks
+
+### Files to Create / Confirm (under `analysis/pseudocode/`)
+
+- `approval-mode.md` — top-level `Agent.getApprovalMode`/`setApprovalMode` delegation; throw
+  propagates (REQ-001).
+- `policy-control.md` — NEW `AgentPolicyControl`: `getRules` (→ `PolicyRuleView`,
+  `argsPattern`→`.source`), `getDefaultDecision`, `isNonInteractive` (REQ-002).
+- `tasks-control.md` — NEW `AgentTasksControl`: `list`/`listRunning`/`get`/`cancel`/
+  `cancelAllRunning`; undefined-safe; project out `abortController` (REQ-003).
+- `hooks-admin.md` — EXTEND `AgentHookControl`: `listHooks`/`getDisabledHooks`/`setDisabledHooks`/
+  `enable`/`disable`; undefined-safe (REQ-004).
+- `auth-detail.md` — EXTEND `AgentAuthControl`: `detailedStatus`/`getHigherPriorityAuth`/
+  `listBucketStatuses`; masked; thread `oauthManager` closure (REQ-005).
+- `mcp-oauth.md` — EXTEND `AgentMcpControl`: `authenticate` (real flow)/`details`/`refresh()`
+  setTools parity; undefined-safe (REQ-006).
+- `tool-keys.md` — NEW `AgentToolKeyControl` (`tools.keys`): `supported`/`status`(masked)/`save`/
+  `delete`/`setKeyFile`/`getKeyFile`; distinct from `auth.keys` (REQ-007).
+- `barrel-exports.md` — `api/index.ts` value-vs-type re-exports of the new public surface
+  (REQ-008).
+- `command-map.md` — six new `COMMAND_API_MAP` rows (REQ-008).
+
+Each file MUST contain the mandatory sections: **Interface Contracts**, **Integration Points
+(line-by-line)**, **Anti-Pattern Warnings**, plus NUMBERED pseudocode lines (`^[0-9]+:`).
+
+### Required Markers
+
+Each pseudocode file's top comment MUST include `@plan:PLAN-20260622-COREAPIGAP.P02`.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+cd project-plans/issue2143/analysis/pseudocode
+for f in approval-mode policy-control tasks-control hooks-admin auth-detail mcp-oauth tool-keys barrel-exports command-map; do
+  test -f "$f.md" || { echo "MISSING $f.md"; exit 1; }
+  grep -q "Interface Contracts" "$f.md" || { echo "$f MISSING Interface Contracts"; exit 1; }
+  grep -q "Integration Points" "$f.md" || { echo "$f MISSING Integration Points"; exit 1; }
+  grep -q "Anti-Pattern Warnings" "$f.md" || { echo "$f MISSING Anti-Pattern Warnings"; exit 1; }
+  grep -qE "^[0-9]+:" "$f.md" || { echo "$f MISSING numbered lines"; exit 1; }
+  grep -q "@plan:PLAN-20260622-COREAPIGAP.P02" "$f.md" || { echo "$f MISSING plan marker"; exit 1; }
+done
+echo "OK"
+```
+
+### Anti-Pattern Self-Check
+
+- [ ] No actual TypeScript (only numbered pseudocode + contract sections).
+- [ ] Pseudocode references REAL symbols/lines: `config.getApprovalMode` (`configBaseCore.ts:463`),
+      `config.setApprovalMode` (`config.ts:401`), `getPolicyEngine` (`configBaseCore.ts:475`),
+      `getAsyncTaskManager` (`config.ts:601`), `getHookSystem`/`getDisabledHooks`/`setDisabledHooks`
+      (`config.ts:755`/`:734`/`configBase.ts:132`), OAuthManager
+      `peekStoredToken`/`getHigherPriorityAuth`/`getAuthStatusWithBuckets`
+      (`oauth-manager.ts:243`/`:313`/`:395`), `MCPOAuthProvider.authenticate`
+      (`oauth-provider.ts:874`), `resolveClient().setTools()` (`clientContract.ts:77`),
+      `getToolKeyStorage` (`tool-key-storage.ts:81`).
+- [ ] No hardcoded responses; dependencies are injected closures; errors propagate (esp.
+      `setApprovalMode`).
+- [ ] Projected types omit `abortController` / raw `RegExp` / raw secrets.
+
+## Success Criteria
+
+- All nine pseudocode files present, each with the mandatory sections + numbered lines + marker.
+
+## Failure Recovery
+
+- Revise the deficient pseudocode file(s); re-run verification.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P02.md`
+
+```markdown
+Phase: P02
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment of what was implemented and whether it satisfies the cited requirements]
+```

--- a/project-plans/issue2143/plan/02a-pseudocode-verification.md
+++ b/project-plans/issue2143/plan/02a-pseudocode-verification.md
@@ -1,0 +1,92 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P02a @requirement:REQ-001..REQ-010,REQ-INT-001..005 -->
+# Phase 02a: Pseudocode Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P02a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 02 completed
+- Verification: `test -f project-plans/issue2143/.completed/P02.md`
+
+## Verification Tasks
+
+Read all nine pseudocode files IN FULL. Confirm contract-first structure and fidelity to the
+ACTUAL source (cross-check the cited line numbers against the real files).
+
+```bash
+set -o pipefail
+# Structural presence (same loop as P02)
+cd project-plans/issue2143/analysis/pseudocode
+for f in approval-mode policy-control tasks-control hooks-admin auth-detail mcp-oauth tool-keys barrel-exports command-map; do
+  grep -q "Interface Contracts" "$f.md" && grep -q "Integration Points" "$f.md" && grep -q "Anti-Pattern Warnings" "$f.md" || echo "$f INCOMPLETE"
+done
+cd - >/dev/null
+# Fidelity spot-checks against real source (cited anchors MUST resolve)
+grep -n "getApprovalMode" packages/core/src/config/configBaseCore.ts
+grep -n "setApprovalMode" packages/core/src/config/config.ts
+grep -n "getPolicyEngine" packages/core/src/config/configBaseCore.ts
+grep -nE "getRules|getDefaultDecision|isNonInteractive" packages/policy/src/policy-engine.ts
+grep -n "getAsyncTaskManager" packages/core/src/config/config.ts
+grep -n "abortController" packages/core/src/services/asyncTaskManager.ts
+grep -nE "getHookSystem|getDisabledHooks" packages/core/src/config/config.ts
+grep -n "setDisabledHooks" packages/core/src/config/configBase.ts
+grep -nE "getAllHooks|setHookEnabled|getHookName" packages/core/src/hooks/hookRegistry.ts
+grep -nE "peekStoredToken|getHigherPriorityAuth|getAuthStatusWithBuckets" packages/providers/src/auth/oauth-manager.ts
+grep -n "authenticate(" packages/mcp/src/auth/oauth-provider.ts | head
+grep -n "setTools(): Promise<void>" packages/core/src/core/clientContract.ts
+grep -nE "getToolKeyStorage|class ToolKeyStorage" packages/core/src/tools/tool-key-storage.ts
+```
+
+### Semantic Verification Checklist
+
+- [ ] Every pseudocode file has all three mandatory sections + numbered lines.
+- [ ] Cited symbols/line numbers MATCH actual source for all nine components.
+- [ ] `approval-mode` pseudocode delegates directly and does NOT wrap `setApprovalMode` in
+      try/catch (throw propagates — R-APPROVAL-THROW).
+- [ ] `policy-control` projects `argsPattern` → `.source` string and returns read-only snapshots
+      (no live engine handle leaked).
+- [ ] `tasks-control` is undefined-safe and the projected `AgentTaskInfo` omits `abortController`;
+      `cancelAllRunning` returns a COUNT.
+- [ ] `hooks-admin` is undefined-safe (no hook system / not initialized → `[]`/no-op) and EXTENDS
+      (does not replace) the existing exec/lifecycle members.
+- [ ] `auth-detail` reads expiry via `peekStoredToken` (no refresh side-effect), masks output, and
+      threads `oauthManager` via a closure (no new ctor wiring).
+- [ ] `mcp-oauth` `authenticate` runs the real flow (authenticate→restartServer→setTools) and
+      `refresh()` gains setTools parity; both undefined-safe; `mcp.auth()` semantics unchanged.
+- [ ] `tool-keys` is DISTINCT from `auth.keys`, masks `status`, and treats `setKeyFile(tool, null)`
+      as clear.
+- [ ] `barrel-exports` re-exports enums as VALUES and projected interfaces as `export type`
+      (verbatimModuleSyntax); `command-map` adds six `kind:'runtime'` rows that preserve the
+      no-orphan / unique-command / durable-subpath invariants.
+
+## Holistic Assessment (MANDATORY — into completion marker)
+
+Explain whether the pseudocode, if implemented faithfully, would produce a public surface adequate
+for #1595 (every one of the seven CLI capabilities reachable through the public root with no
+`getConfig()` escape hatch). Note any line-number drift found and corrected. Verdict PASS/FAIL.
+
+## Success Criteria
+
+- All checks pass; line numbers reconciled; holistic assessment written.
+
+## Failure Recovery
+
+- Return to Phase 02 with specific corrections; do NOT proceed to Phase 03 until PASS.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P02a.md`
+
+```markdown
+Phase: P02a
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line verdict — PASS/FAIL with the key evidence that grounded it]
+```

--- a/project-plans/issue2143/plan/03-approval-tdd.md
+++ b/project-plans/issue2143/plan/03-approval-tdd.md
@@ -1,0 +1,209 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P03 @requirement:REQ-001 -->
+# Phase 03: Approval Mode — Behavioral TDD
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P03`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 02a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P02a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-001: Approval mode read/write on `Agent`
+
+**Full Text**: `Agent` MUST expose `getApprovalMode(): ApprovalMode` and
+`setApprovalMode(mode: ApprovalMode): void` as top-level methods that delegate DIRECTLY to the bound
+`Config.getApprovalMode()` (`configBaseCore.ts:463`) and `Config.setApprovalMode()` (`config.ts:401`).
+- **REQ-001.1**: `getApprovalMode()` returns the live Config value (no caching).
+- **REQ-001.2**: `setApprovalMode(mode)` delegates DIRECTLY — it MUST NOT normalize, swallow, or
+  catch. The untrusted-folder throw (`"Cannot enable privileged approval modes in an untrusted
+  folder."`, `config.ts:404`) MUST propagate faithfully for any non-`DEFAULT` mode in an untrusted
+  folder.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a Config whose approval mode is `AUTO_EDIT` → `agent.getApprovalMode()` returns
+  `ApprovalMode.AUTO_EDIT`.
+- GIVEN a trusted folder → `agent.setApprovalMode(YOLO)` makes a subsequent `getApprovalMode()`
+  return `YOLO` (no caching).
+- GIVEN an untrusted folder → `agent.setApprovalMode(YOLO)` THROWS the untrusted-folder error
+  (uncaught, unnormalized).
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts`
+  - This component drives ENTIRELY through the PUBLIC ROOT `@vybestack/llxprt-code-agents` using the
+    existing `buildAgent` harness (`__tests__/helpers/agentHarness.ts:79`) — NO deep imports, NO
+    mocking. Mirror `agent.sequenceModel.behavior.test.ts` structure (real agent, real Config,
+    assertions on real return values).
+  - The harness `buildAgent(fixtureRelPath, configOverrides)` accepts `Partial<AgentConfig>`. Two
+    blessed real seams (verified in P00a) make every case drivable with NO mock theater:
+    - `approvalMode: ApprovalMode.AUTO_EDIT` → `agentConfig.adapter.ts:204-205` →
+      `params.approvalMode` → `Config.getApprovalMode()` returns it (T1 setup).
+    - `folderTrust: false` → `agentConfig.adapter.ts:210-212` → `params.trustedFolder = false` →
+      `Config.isTrustedFolder()` returns `false` (`config.ts:512`) → the REAL untrusted-folder throw
+      fires from `Config.setApprovalMode` (`config.ts:402-405`) (T2 setup). This is the production
+      throw path driven through the public API — NOT a spy (core's own `config.d.test.ts:101` spies
+      `isTrustedFolder`; we MUST NOT — we drive the real Config flag instead).
+  - Use the existing committed fixture `plain-text.jsonl` (already used by the sequence-model suite).
+  - **`ApprovalMode` enum VALUE sourcing (IMPORTANT — verified in P00a/P02a):** the agents public
+    root currently re-exports `ApprovalMode` as a TYPE ONLY (`config-types.ts:25`, `agent.ts:387`),
+    so `ApprovalMode.AUTO_EDIT` (a VALUE) is NOT yet importable from `@vybestack/llxprt-code-agents`.
+    The value-export promotion is owned by Phase 17 (REQ-008 barrel). For THIS phase, import the enum
+    VALUE from the core barrel: `import { ApprovalMode } from '@vybestack/llxprt-code-core';`. This is
+    permitted because `.behavior.test.ts` is T17-EXEMPT (the boundary scan only governs `*.spec.ts`),
+    and the enum is a stable core value used the same way the harness `AgentConfig` accepts it. Do NOT
+    import `ApprovalMode` as a value from the public agents root in this phase — it would be a module
+    resolution error (a non-behavioral RED) and the RED-gate would (correctly) reject it.
+  - After Phase 17 promotes `ApprovalMode` to a value export, a later phase MAY switch this import to
+    the public root; that switch is NOT part of P03.
+  - Markers `@plan:PLAN-20260622-COREAPIGAP.P03`, `@requirement:REQ-001`.
+
+### Required scenarios
+
+```
+T1    build agent with { approvalMode: ApprovalMode.AUTO_EDIT } (trusted) →
+      agent.getApprovalMode() === ApprovalMode.AUTO_EDIT (live read)
+T2    build agent with { folderTrust: false } →
+      agent.setApprovalMode(ApprovalMode.YOLO) throws, and the thrown message is
+      "Cannot enable privileged approval modes in an untrusted folder." (real propagated throw)
+T3    build agent (trusted) → agent.setApprovalMode(ApprovalMode.YOLO);
+      agent.getApprovalMode() === ApprovalMode.YOLO (write-then-read parity via public root, no cache)
+PROP  round-trip (trusted): for any mode m in {DEFAULT, AUTO_EDIT, YOLO}, after
+      agent.setApprovalMode(m), agent.getApprovalMode() === m (use fc.constantFrom over the 3 enum
+      values; MIN-2 distinct cases)
+PROP  untrusted matrix: for any non-DEFAULT mode m in {AUTO_EDIT, YOLO} with { folderTrust: false },
+      agent.setApprovalMode(m) throws the untrusted-folder error; and setApprovalMode(DEFAULT) does
+      NOT throw (DEFAULT is always allowed — config.ts:402 guards only non-DEFAULT)
+```
+
+### Constraints
+
+- Assert real return VALUES / real thrown error messages — NEVER `toHaveBeenCalled`.
+- ≥30% property-based (fast-check), MIN-2 distinct property cases.
+- T2 / the untrusted PROP MUST assert the SPECIFIC message
+  `"Cannot enable privileged approval modes in an untrusted folder."` — asserting a real, faithful
+  throw is NOT a reverse test (it is the genuine REQ-001.2 contract). Do NOT use `not.toThrow()`
+  as a sole assertion shape anywhere; the DEFAULT-allowed leg of the untrusted PROP must additionally
+  assert a positive post-condition (e.g. `agent.getApprovalMode() === ApprovalMode.DEFAULT`).
+- RED for the right reason: the methods do not exist yet, so positive cases (T1/T3) fail with a
+  missing-method `TypeError`, and T2 fails because the thrown message is the missing-method error,
+  not the untrusted message. Both are acceptable behavioral RED (CRIT-3).
+- Do NOT spy/stub `isTrustedFolder` or `Config.setApprovalMode`; drive the real flag via `folderTrust`.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts
+test -f "$F"
+
+# Mock theater / reverse testing guards (BLOCKING)
+if grep -nE "toHaveBeenCalled" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater (spy/stub)"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test (bare not.toThrow)"; exit 1; fi
+
+# Property-based >= 30% (BLOCKING — count DISTINCT property test CASES; MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '
+  /(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 }
+  /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } }
+  END { print n+0 }
+' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+if [ "$TOTAL" -eq 0 ]; then echo "FAIL: no tests found"; exit 1; fi
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property-based CASES: $PROP / $TOTAL = ${PCT}% (it.prop/test.prop=$PROP_CASE_FORMS, classic-blocks=$CLASSIC_PROP_BLOCKS)"
+if [ "$PROP" -lt 2 ]; then echo "FAIL: <2 property cases (MIN-2)"; exit 1; fi
+if [ "$PCT" -lt 30 ]; then echo "FAIL: property-based ${PCT}% < 30%"; exit 1; fi
+
+# T17 boundary courtesy check: this .behavior.test.ts is T17-EXEMPT, but it SHOULD still import only
+# the public root for this all-public component. BLOCKING: no deep agents/core subpath imports.
+if grep -nE "from ['\"]@vybestack/llxprt-code-(core|providers|policy|tools|mcp)/" "$F"; then
+  echo "FAIL: deep import in an all-public-root component test"; exit 1
+fi
+if grep -nE "from ['\"]\.\./(control|agentImpl)" "$F"; then
+  echo "FAIL: internal import in an all-public-root component test"; exit 1
+fi
+
+# RED-state enforcement (BLOCKING): positive cases present and the suite is RED for a behavioral reason.
+grep -qE "T1|T3" "$F" || { echo "FAIL: positive cases (T1/T3) missing"; exit 1; }
+set +e
+npx vitest run "$F" > /tmp/p03_red.log 2>&1
+STATUS=$?
+set -e
+tail -30 /tmp/p03_red.log
+if [ "$STATUS" -eq 0 ]; then echo "FAIL: suite unexpectedly all-green before P04"; exit 1; fi
+# Missing-method TypeError is acceptable behavioral RED (CRIT-3). Reject only module/compile errors.
+if grep -qiE "Cannot find module|SyntaxError|Failed to resolve import|ReferenceError" /tmp/p03_red.log; then
+  echo "FAIL: RED is a module/compile/import error, not a behavioral assertion failure."; exit 1
+fi
+echo "RED confirmed for behavioral reasons (expected until P04)."
+```
+
+### Semantic Verification Checklist (BLOCKS progression)
+
+- [ ] All agent CONSTRUCTION + behavior drives through the public root `@vybestack/llxprt-code-agents`
+      (`buildAgent` harness). The ONLY non-public import permitted in this phase is the
+      `ApprovalMode` enum VALUE from the bare core barrel `@vybestack/llxprt-code-core` (no trailing
+      `/`, i.e. NOT a deep subpath) — a temporary sourcing closed by Phase 17. No deep `core/<path>`
+      and no `../control`/`../agentImpl` internal imports.
+- [ ] T2 (and the untrusted PROP) assert the SPECIFIC untrusted-folder message via the REAL `folderTrust`
+      flag — no spying on `isTrustedFolder`/`setApprovalMode`.
+- [ ] Positive cases (T1/T3) FAIL for a behavioral missing-method reason.
+- [ ] ≥30% property-based (computed, enforced); MIN-2 property cases.
+- [ ] No mock theater; no bare reverse tests.
+
+## Success Criteria
+
+- Behavioral tests authored; suite RED for behavioral reasons; ≥30% property-based; public-root-only.
+
+## Failure Recovery
+
+- `git checkout -- "$F"`; rewrite.
+
+## Deferred Implementation Detection (MANDATORY — scoped)
+
+Scoped to the NEW test file THIS phase creates.
+
+```bash
+set -o pipefail
+set -e
+for F in "packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts"; do
+  test -f "$F" || continue
+  if grep -nE "(TODO|FIXME|HACK|XXX|TEMPORARY|WIP|placeholder|for now|in a real|coming soon)" "$F"; then
+    echo "FAIL: deferred-implementation marker in $F"; exit 1
+  fi
+  if grep -niE "expect\(.*\)\.(not)\.toBeDefined|toThrow\(.*NotYetImplemented|should (not )?be implemented|reverse test|negative test \(expected\)" "$F"; then
+    echo "FAIL: reverse/weakened-test pattern in $F"; exit 1
+  fi
+  if grep -nE "\b(it|test|describe)\.skip\b|\bxit\b|\bxdescribe\b" "$F"; then
+    echo "FAIL: skipped/disabled test in $F"; exit 1
+  fi
+done
+echo "PASS: no deferred-implementation markers / reverse tests in the new test file."
+```
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P03.md`
+
+Contents (REQUIRED — per `dev-docs/PLAN-TEMPLATE.md` lines 199-211; fill every field with REAL values):
+
+```markdown
+Phase: P03
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/04-approval-impl.md
+++ b/project-plans/issue2143/plan/04-approval-impl.md
@@ -102,7 +102,7 @@ grep -qE "config\.setApprovalMode\(mode\)" packages/agents/src/api/agentImpl.ts 
 
 # No try/catch wrapping the set delegation (BLOCKING — the throw must propagate).
 # Extract the setApprovalMode method body and ensure it has no try/catch.
-if awk '/setApprovalMode\(mode: ApprovalMode\): void \{/{f=1} f{print} /^\s*\}/{if(f)exit}' packages/agents/src/api/agentImpl.ts | grep -qE "\btry\b|\bcatch\b"; then
+if awk '/setApprovalMode\(mode: ApprovalMode\): void \{/{f=1} f{print} f&&/^[[:space:]]*\}/{exit}' packages/agents/src/api/agentImpl.ts | grep -qE "\btry\b|\bcatch\b"; then
   echo "FAIL: setApprovalMode wraps a try/catch — the untrusted throw must propagate unchanged"; exit 1
 fi
 

--- a/project-plans/issue2143/plan/04-approval-impl.md
+++ b/project-plans/issue2143/plan/04-approval-impl.md
@@ -1,0 +1,160 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P04 @requirement:REQ-001 -->
+# Phase 04: Approval Mode — Implementation
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P04`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 03 completed (PASS, suite RED)
+- Verification: `test -f project-plans/issue2143/.completed/P03.md`
+- Pseudocode: `analysis/pseudocode/approval-mode.md` (getApprovalMode lines 1-4; setApprovalMode lines 10-17)
+
+## Requirements Implemented (Expanded)
+
+### REQ-001 / REQ-001.1 / REQ-001.2
+
+Add two top-level `Agent` methods that delegate DIRECTLY to the bound Config, making all Phase 03
+tests pass. The untrusted-folder throw propagates unchanged. See Phase 03 GIVEN/WHEN/THEN.
+
+## Implementation Tasks
+
+### Files to Modify
+
+1. `packages/agents/src/api/agent.ts` — add the two method declarations to the `Agent` interface,
+   immediately AFTER `getCurrentSequenceModel(): string | null;` (currently `agent.ts:331`) and
+   BEFORE the `getRuntimeId()` doc block:
+
+   ```typescript
+     getCurrentSequenceModel(): string | null;
+     /**
+      * Reads the live approval mode from the bound Config (no caching).
+      * @plan:PLAN-20260622-COREAPIGAP.P04
+      * @requirement:REQ-001
+      */
+     getApprovalMode(): ApprovalMode;
+     /**
+      * Sets the approval mode via the bound Config. Delegates directly: the
+      * untrusted-folder guard throw (config.ts:404) propagates unchanged.
+      * @plan:PLAN-20260622-COREAPIGAP.P04
+      * @requirement:REQ-001
+      */
+     setApprovalMode(mode: ApprovalMode): void;
+   ```
+
+   - `ApprovalMode` is ALREADY imported at `agent.ts:11` and re-exported `export type` at
+     `agent.ts:387`. No new import needed in this file.
+
+2. `packages/agents/src/api/agentImpl.ts` — add the two implementations directly AFTER the
+   `getEphemeralSettings()` one-liner (currently ends at `agentImpl.ts:738`), mirroring that exact
+   delegate-no-cache shape (`getEphemeralSetting` at `:726`):
+
+   ```typescript
+     /**
+      * @plan:PLAN-20260622-COREAPIGAP.P04
+      * @requirement:REQ-001
+      * @pseudocode lines 1-4
+      */
+     getApprovalMode(): ApprovalMode {
+       return this.deps.config.getApprovalMode();
+     }
+
+     /**
+      * @plan:PLAN-20260622-COREAPIGAP.P04
+      * @requirement:REQ-001
+      * @pseudocode lines 10-17
+      */
+     setApprovalMode(mode: ApprovalMode): void {
+       this.deps.config.setApprovalMode(mode);
+     }
+   ```
+
+   - `ApprovalMode` must be a usable TYPE in `agentImpl.ts`. Check the existing imports: if
+     `ApprovalMode` is not already imported there, add a type-only import from the core barrel
+     `@vybestack/llxprt-code-core` (it is a VALUE enum, but only the type position is used in the
+     signature, so `import { type ApprovalMode } from '@vybestack/llxprt-code-core'` or a value
+     import both compile; prefer matching the file's existing import style for Config-adjacent types).
+   - `this.deps.config` is the live bound `Config` (already used by `getConfig()`/ephemeral methods).
+
+### Constraints
+
+- Follow the pseudocode line-by-line; cite `@pseudocode lines 1-4` and `@pseudocode lines 10-17`.
+- `setApprovalMode` MUST NOT wrap the call in try/catch, MUST NOT normalize/clamp `mode`, MUST NOT
+  validate trust — Config owns the guard (R-APPROVAL-THROW).
+- `getApprovalMode` MUST read live every call — NO instance-field cache (R-DELEGATE).
+- Do NOT modify the Phase 03 tests.
+- No TODO/placeholder in changed lines.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+npx vitest run packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts
+npm run typecheck
+
+# Delegation present (BLOCKING)
+grep -qE "config\.getApprovalMode\(\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: getApprovalMode not delegating"; exit 1; }
+grep -qE "config\.setApprovalMode\(mode\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: setApprovalMode not delegating"; exit 1; }
+
+# No try/catch wrapping the set delegation (BLOCKING — the throw must propagate).
+# Extract the setApprovalMode method body and ensure it has no try/catch.
+if awk '/setApprovalMode\(mode: ApprovalMode\): void \{/{f=1} f{print} /^\s*\}/{if(f)exit}' packages/agents/src/api/agentImpl.ts | grep -qE "\btry\b|\bcatch\b"; then
+  echo "FAIL: setApprovalMode wraps a try/catch — the untrusted throw must propagate unchanged"; exit 1
+fi
+
+# Pseudocode markers present (BLOCKING)
+grep -q "@pseudocode lines 1-4" packages/agents/src/api/agentImpl.ts || { echo "FAIL: getApprovalMode pseudocode marker missing"; exit 1; }
+grep -q "@pseudocode lines 10-17" packages/agents/src/api/agentImpl.ts || { echo "FAIL: setApprovalMode pseudocode marker missing"; exit 1; }
+
+# Interface declarations present (BLOCKING)
+grep -qE "getApprovalMode\(\): ApprovalMode;" packages/agents/src/api/agent.ts || { echo "FAIL: interface getApprovalMode missing"; exit 1; }
+grep -qE "setApprovalMode\(mode: ApprovalMode\): void;" packages/agents/src/api/agent.ts || { echo "FAIL: interface setApprovalMode missing"; exit 1; }
+```
+
+### Deferred Implementation Detection (MANDATORY — scoped to CHANGED lines, MIN-3)
+
+```bash
+set -o pipefail
+for FILE in packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts; do
+  if git diff HEAD -- "$FILE" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)"; then
+    echo "FAIL: deferred-implementation marker in changed lines of $FILE"; exit 1
+  fi
+done
+echo "PASS: no deferred markers in changed lines."
+```
+
+### Semantic Verification Checklist
+
+- [ ] All Phase 03 tests pass (T1/T2/T3 + both PROPs).
+- [ ] `getApprovalMode` reads live; `setApprovalMode` delegates with NO try/catch, NO normalization.
+- [ ] Pseudocode cited (`lines 1-4`, `lines 10-17`); typecheck clean.
+- [ ] No new mock theater introduced anywhere.
+
+## Success Criteria
+
+- Approval-mode tests green; delegation in place; throw propagates; interface + impl markers present.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts`; re-implement
+  from pseudocode.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P04.md`
+
+Contents (REQUIRED — per `dev-docs/PLAN-TEMPLATE.md` lines 199-211; fill every field with REAL values):
+
+```markdown
+Phase: P04
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/04a-approval-impl-verification.md
+++ b/project-plans/issue2143/plan/04a-approval-impl-verification.md
@@ -1,0 +1,110 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P04a @requirement:REQ-001 -->
+# Phase 04a: Approval Mode Implementation Verification (Pseudocode-Compliance Gate)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P04a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 04 completed
+- Verification: `test -f project-plans/issue2143/.completed/P04.md`
+
+## Pseudocode-Compliance Verification (MANDATORY)
+
+Compare the new `getApprovalMode` / `setApprovalMode` against
+`analysis/pseudocode/approval-mode.md` (lines 1-4 and 10-17). This `a` phase ALSO re-audits the
+Phase 03 test suite for behavioral discipline (no mock theater, ≥30% property, no reverse tests,
+public-root-only).
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/agent.approvalMode.behavior.test.ts
+
+# 1. The component suite is GREEN.
+npx vitest run "$F"
+
+# 2. The whole agents api suite still passes (no regression).
+npx vitest run packages/agents/src/api/__tests__/
+
+# 3. Type + lint clean.
+npm run typecheck
+npm run lint
+
+# 4. Delegation present, no try/catch around the set (BLOCKING).
+grep -qE "config\.getApprovalMode\(\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: not delegating getApprovalMode"; exit 1; }
+grep -qE "config\.setApprovalMode\(mode\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: not delegating setApprovalMode"; exit 1; }
+if awk '/setApprovalMode\(mode: ApprovalMode\): void \{/{f=1} f{print} /^\s*\}/{if(f)exit}' packages/agents/src/api/agentImpl.ts | grep -qE "\btry\b|\bcatch\b"; then
+  echo "FAIL: setApprovalMode wraps try/catch"; exit 1
+fi
+
+# 5. No cached approval field (BLOCKING — must read live).
+if grep -nE "this\.(approvalMode|_approvalMode|cachedApprovalMode)\s*=" packages/agents/src/api/agentImpl.ts; then
+  echo "FAIL: approval mode appears cached in an instance field"; exit 1
+fi
+
+# 6. Re-audit the test suite (BLOCKING).
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater in test"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: bare reverse test"; exit 1; fi
+# T2 must assert the SPECIFIC untrusted message (genuine contract, not a missing-method accident).
+grep -qE "Cannot enable privileged approval modes in an untrusted folder" "$F" || { echo "FAIL: T2 does not assert the real untrusted-folder message"; exit 1; }
+# Public-root-only (no deep/internal imports).
+if grep -nE "from ['\"]@vybestack/llxprt-code-(core|providers|policy|tools|mcp)/" "$F"; then echo "FAIL: deep import in test"; exit 1; fi
+if grep -nE "from ['\"]\.\./(control|agentImpl)" "$F"; then echo "FAIL: internal import in test"; exit 1; fi
+
+# 7. Deferred-impl scan, scoped to CHANGED lines (MIN-3), BLOCKING.
+for FILE in packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts; do
+  if git diff HEAD -- "$FILE" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -nE "(TODO|FIXME|HACK|STUB|XXX|placeholder|for now|in a real)"; then
+    echo "FAIL: deferred-implementation marker in changed lines of $FILE"; exit 1
+  fi
+done
+echo "PASS: pseudocode-compliance + test-discipline checks."
+```
+
+### Line-by-Line Compliance Table
+
+| Pseudocode lines | Implemented at | Matches? |
+|---|---|---|
+| 1-4 getApprovalMode live read | | [ ] |
+| 10-17 setApprovalMode direct delegate (no try/catch, no normalize) | | [ ] |
+
+### Semantic Verification Checklist
+
+- [ ] Behavior decision table holds (trusted DEFAULT/AUTO_EDIT/YOLO set+read; untrusted non-DEFAULT throws).
+- [ ] No caching (R-DELEGATE); live read each call.
+- [ ] Untrusted throw propagates unchanged (R-APPROVAL-THROW) — verified via real `folderTrust` flag, not a spy.
+- [ ] Test suite is behavioral, ≥30% property-based, public-root-only; lint + typecheck clean; full api suite green.
+
+## Holistic Functionality Assessment (MANDATORY — into marker)
+
+Write into the marker:
+- **What was implemented?** (the two top-level Agent methods + interface decls)
+- **Satisfies REQ-001/.1/.2?** (cite evidence)
+- **Data flow** (Agent method → this.deps.config → Config → live value / propagated throw)
+- **Risks** (e.g. any accidental catch, any cache, any test mock theater)
+- **Verdict** (PASS/FAIL with the key grounding evidence)
+
+## Success Criteria
+
+- Compliance table complete; assessment written; suites + lint + typecheck green.
+
+## Failure Recovery
+
+- Return to Phase 04 (impl) or Phase 03 (tests); do not proceed to Phase 05.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P04a.md` (include assessment).
+
+```markdown
+Phase: P04a
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line verdict — PASS/FAIL with the key evidence]
+```

--- a/project-plans/issue2143/plan/04a-approval-impl-verification.md
+++ b/project-plans/issue2143/plan/04a-approval-impl-verification.md
@@ -37,7 +37,7 @@ npm run lint
 # 4. Delegation present, no try/catch around the set (BLOCKING).
 grep -qE "config\.getApprovalMode\(\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: not delegating getApprovalMode"; exit 1; }
 grep -qE "config\.setApprovalMode\(mode\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: not delegating setApprovalMode"; exit 1; }
-if awk '/setApprovalMode\(mode: ApprovalMode\): void \{/{f=1} f{print} /^\s*\}/{if(f)exit}' packages/agents/src/api/agentImpl.ts | grep -qE "\btry\b|\bcatch\b"; then
+if awk '/setApprovalMode\(mode: ApprovalMode\): void \{/{f=1} f{print} f&&/^[[:space:]]*\}/{exit}' packages/agents/src/api/agentImpl.ts | grep -qE "\btry\b|\bcatch\b"; then
   echo "FAIL: setApprovalMode wraps try/catch"; exit 1
 fi
 

--- a/project-plans/issue2143/plan/05-policy-tdd.md
+++ b/project-plans/issue2143/plan/05-policy-tdd.md
@@ -1,0 +1,174 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P05 @requirement:REQ-002 -->
+# Phase 05: Policy Control (read-only) — Behavioral TDD
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P05`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 04a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P04a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-002: Read-only policy inspection via `agent.policy`
+
+**Full Text**: `Agent` MUST expose a read-only `policy` sub-controller (`AgentPolicyControl`) with
+`getRules(): readonly PolicyRuleView[]`, `getDefaultDecision(): PolicyDecision`, and
+`isNonInteractive(): boolean`, each delegating to the live `Config.getPolicyEngine()`
+(`configBaseCore.ts:475`).
+- **REQ-002.1**: `getRules()` returns a fresh read-only snapshot; each `PolicyRuleView.argsPattern`
+  is the `RegExp.source` STRING (never a `RegExp`); a rule with no `argsPattern` projects `undefined`
+  (R-POLICY-SNAPSHOT, R-ARGSPATTERN-STRING).
+- **REQ-002.2**: `getDefaultDecision()` returns the engine default decision.
+- **REQ-002.3**: `isNonInteractive()` returns the engine non-interactive flag.
+- **REQ-002.4**: rule MUTATION is OUT OF SCOPE (no add/remove/set on the controller).
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN an engine seeded with a rule whose `argsPattern` is `/"command":"npm test"/` → the
+  corresponding `PolicyRuleView.argsPattern === '"command":"npm test"'` (string).
+- GIVEN a rule with no `argsPattern` → its view's `argsPattern === undefined`.
+- GIVEN `defaultDecision: ASK_USER`, `nonInteractive: true` → `getDefaultDecision() === ASK_USER`
+  and `isNonInteractive() === true`.
+- GIVEN the snapshot array → mutating it does NOT affect a subsequent `getRules()` (fresh array).
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/policyControl.behavior.test.ts`
+  - Drive through the PUBLIC ROOT via the `buildAgent` harness (`helpers/agentHarness.ts:79`). The
+    REAL `PolicyEngine` is SEEDED through the public config path with ZERO mocking (verified P00a):
+    - `AgentConfig.policy` (`config-types.ts:164`, type `PolicyEngineConfig`) →
+      `agentConfig.adapter.ts:207-208` → `params.policyEngineConfig` → `configConstructor.ts:469`
+      `new PolicyEngine(params.policyEngineConfig)` → `Config.getPolicyEngine()` returns it.
+    - So `buildAgent('plain-text.jsonl', { policy: { rules: [...], defaultDecision, nonInteractive } })`
+      yields a real engine with your seeded rules. Then assert `agent.policy.getRules()` etc.
+  - **`PolicyDecision` enum VALUE sourcing:** the agents public root does NOT yet export
+    `PolicyDecision` (added in Phase 17). Import the VALUE from the BARE core barrel:
+    `import { PolicyDecision } from '@vybestack/llxprt-code-core';`. `.behavior.test.ts` is T17-EXEMPT
+    and the bare barrel (no trailing `/`) is NOT a deep import. The `PolicyEngineConfig`/`PolicyRule`
+    TYPES needed to seed may be imported `import type { ... } from '@vybestack/llxprt-code-core';`.
+  - Markers `@plan:PLAN-20260622-COREAPIGAP.P05`, `@requirement:REQ-002`.
+
+### Required scenarios
+
+```
+T4    seed engine with 2 rules (one WITH argsPattern /"command":"npm test"/, one WITHOUT) →
+      agent.policy.getRules() returns 2 views; the first view's argsPattern === '"command":"npm test"'
+      (a STRING), the second view's argsPattern === undefined; and NO view's argsPattern is a RegExp
+      (assert typeof !== 'object' / instanceof RegExp === false)
+T4b   snapshot isolation: const a = agent.policy.getRules(); (a as PolicyRuleView[]).length mutation
+      attempt does not change agent.policy.getRules().length on a second call (fresh array each call)
+T6    seed { defaultDecision: PolicyDecision.ASK_USER, nonInteractive: true } →
+      agent.policy.getDefaultDecision() === PolicyDecision.ASK_USER AND
+      agent.policy.isNonInteractive() === true
+PROP  argsPattern projection: for a generated set of rule argsPattern sources (strings that are valid
+      regex bodies), after seeding rules new RegExp(src), every returned view.argsPattern === the
+      original src string (RegExp.source round-trip); MIN-2 cases
+PROP  rules count/order fidelity: for a generated list of N (1..5) rules, agent.policy.getRules()
+      has length N and the decisions line up positionally with the seeded rules; MIN-2 cases
+```
+
+### Constraints
+
+- Assert real return VALUES (rule fields, decision enum, boolean) — NEVER `toHaveBeenCalled`.
+- ≥30% property-based (fast-check), MIN-2 distinct property cases.
+- Seed the engine via `AgentConfig.policy` ONLY — do NOT construct a `PolicyEngine` directly in the
+  test, do NOT spy on `getPolicyEngine`/`getRules`.
+- Positive cases fail at RED because `agent.policy` does not exist yet → missing-property/missing-method
+  `TypeError` (acceptable behavioral RED).
+- Do NOT assert `argsPattern` equals a `RegExp`; assert it is the `.source` STRING (the R-ARGSPATTERN
+  contract).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+test -f "$F"
+
+if grep -nE "toHaveBeenCalled" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater (spy/stub)"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# Deep-import guard: bare core barrel allowed (enum value); deep core/<path> and internal not allowed.
+if grep -nE "from ['\"]@vybestack/llxprt-code-(core|providers|policy|tools|mcp)/" "$F"; then echo "FAIL: deep subpath import"; exit 1; fi
+if grep -nE "from ['\"]\.\./(control|agentImpl)" "$F"; then echo "FAIL: internal import"; exit 1; fi
+
+# Property-based >= 30% (BLOCKING; MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '
+  /(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 }
+  /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } }
+  END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+if [ "$TOTAL" -eq 0 ]; then echo "FAIL: no tests"; exit 1; fi
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+if [ "$PROP" -lt 2 ]; then echo "FAIL: <2 property cases"; exit 1; fi
+if [ "$PCT" -lt 30 ]; then echo "FAIL: property ${PCT}% < 30%"; exit 1; fi
+
+# argsPattern STRING contract asserted (BLOCKING — the test must check .source projection).
+grep -qE "argsPattern" "$F" || { echo "FAIL: argsPattern projection not tested"; exit 1; }
+
+# RED-state enforcement.
+set +e
+npx vitest run "$F" > /tmp/p05_red.log 2>&1
+STATUS=$?
+set -e
+tail -30 /tmp/p05_red.log
+if [ "$STATUS" -eq 0 ]; then echo "FAIL: unexpectedly all-green before P06"; exit 1; fi
+if grep -qiE "Cannot find module|SyntaxError|Failed to resolve import|ReferenceError" /tmp/p05_red.log; then
+  echo "FAIL: RED is module/compile error, not behavioral"; exit 1
+fi
+echo "RED confirmed behavioral (expected until P06)."
+```
+
+### Semantic Verification Checklist (BLOCKS progression)
+
+- [ ] Engine seeded ONLY via `AgentConfig.policy` through the public `buildAgent` harness (no direct
+      `new PolicyEngine`, no spies).
+- [ ] `argsPattern` asserted as STRING `.source` (and `undefined` when absent); never `RegExp`.
+- [ ] ≥30% property-based; MIN-2; no mock theater; no reverse tests.
+- [ ] RED for behavioral reasons.
+
+## Success Criteria
+
+- Behavioral RED suite; ≥30% property; engine seeded through the real public config path.
+
+## Failure Recovery
+
+- `git checkout -- "$F"`; rewrite.
+
+## Deferred Implementation Detection (MANDATORY — scoped)
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+test -f "$F" || { echo "missing test"; exit 1; }
+if grep -nE "(TODO|FIXME|HACK|XXX|TEMPORARY|WIP|placeholder|for now|in a real|coming soon)" "$F"; then echo "FAIL: deferred marker"; exit 1; fi
+if grep -niE "toThrow\(.*NotYetImplemented|should (not )?be implemented" "$F"; then echo "FAIL: reverse pattern"; exit 1; fi
+if grep -nE "\b(it|test|describe)\.skip\b|\bxit\b|\bxdescribe\b" "$F"; then echo "FAIL: skipped test"; exit 1; fi
+echo "PASS: no deferred markers."
+```
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P05.md`
+
+```markdown
+Phase: P05
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/06-policy-impl.md
+++ b/project-plans/issue2143/plan/06-policy-impl.md
@@ -1,0 +1,231 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P06 @requirement:REQ-002 -->
+# Phase 06: Policy Control (read-only) — Implementation
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P06`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 05 completed (PASS, suite RED)
+- Verification: `test -f project-plans/issue2143/.completed/P05.md`
+- Pseudocode: `analysis/pseudocode/policy-control.md` (getRules 1-18; getDefaultDecision 30-33; isNonInteractive 40-43)
+
+## Requirements Implemented (Expanded)
+
+### REQ-002 / .1 / .2 / .3 / .4
+
+Add the `AgentPolicyControl` interface + projected `PolicyRuleView` type to `agent.ts`, implement
+`PolicyControl` in a new `control/policyControl.ts`, and wire `readonly policy` into `AgentImpl`.
+See Phase 05 GIVEN/WHEN/THEN.
+
+## Implementation Tasks
+
+### Files to Modify / Create
+
+1. `packages/agents/src/api/agent.ts` — add the projected type + interface alongside the other
+   control interfaces (`AgentMcpControl`/`AgentAuthControl` region, `:223-321`), and add the readonly
+   field to the `Agent` interface in the controls block (after `readonly hooks: AgentHookControl;`,
+   currently `agent.ts:357`):
+
+   ```typescript
+   /**
+    * Read-only projection of a policy rule (REQ-002.1). `argsPattern` is the
+    * RegExp source STRING (JSON-safe), never a RegExp.
+    * @plan:PLAN-20260622-COREAPIGAP.P06
+    * @requirement:REQ-002
+    */
+   export interface PolicyRuleView {
+     readonly priority: number;
+     readonly toolName: string;
+     readonly decision: PolicyDecision;
+     readonly argsPattern?: string;
+     readonly source?: string;
+   }
+
+   /**
+    * Read-only inspection of the engine policy (REQ-002).
+    * @plan:PLAN-20260622-COREAPIGAP.P06
+    * @requirement:REQ-002
+    */
+   export interface AgentPolicyControl {
+     getRules(): readonly PolicyRuleView[];
+     getDefaultDecision(): PolicyDecision;
+     isNonInteractive(): boolean;
+   }
+   ```
+
+   - Add `readonly policy: AgentPolicyControl;` to the `Agent` interface controls block.
+   - Import `PolicyDecision` (VALUE — used in the type position here but it is an enum) and the
+     `PolicyRule`/`PolicyEngine` types as needed for the control file (see below). In `agent.ts` only
+     the TYPE `PolicyDecision` is referenced by `PolicyRuleView`/`AgentPolicyControl`; use
+     `import type { PolicyDecision } from '@vybestack/llxprt-code-core';` (or the existing core type
+     import style in this file).
+
+2. `packages/agents/src/api/control/policyControl.ts` — NEW. Mirror `control/ideControl.ts` structure
+   (header markers, `Deps` interface, class implementing the agent interface). Follow the pseudocode
+   EXACTLY:
+
+   ```typescript
+   /**
+    * @plan:PLAN-20260622-COREAPIGAP.P06
+    * @requirement:REQ-002
+    */
+   import type { AgentPolicyControl, PolicyRuleView } from '../agent.js';
+   import {
+     type PolicyEngine,
+     type PolicyDecision,
+   } from '@vybestack/llxprt-code-core';
+
+   export interface PolicyControlDeps {
+     readonly getEngine: () => PolicyEngine;
+   }
+
+   export class PolicyControl implements AgentPolicyControl {
+     constructor(private readonly deps: PolicyControlDeps) {}
+
+     /** @requirement:REQ-002 @pseudocode lines 1-18 */
+     getRules(): readonly PolicyRuleView[] {
+       const engine = this.deps.getEngine();
+       const rules = engine.getRules();
+       const out: PolicyRuleView[] = [];
+       for (const rule of rules) {
+         out.push({
+           priority: rule.priority,
+           toolName: rule.toolName,
+           decision: rule.decision,
+           ...(rule.argsPattern !== undefined
+             ? { argsPattern: rule.argsPattern.source }
+             : {}),
+           ...(rule.source !== undefined ? { source: rule.source } : {}),
+         });
+       }
+       return out;
+     }
+
+     /** @requirement:REQ-002 @pseudocode lines 30-33 */
+     getDefaultDecision(): PolicyDecision {
+       return this.deps.getEngine().getDefaultDecision();
+     }
+
+     /** @requirement:REQ-002 @pseudocode lines 40-43 */
+     isNonInteractive(): boolean {
+       return this.deps.getEngine().isNonInteractive();
+     }
+   }
+   ```
+
+   - VERIFY the real `PolicyRule` field names against `packages/policy/src/types.ts` (`priority`,
+     `toolName`, `decision`, `argsPattern?`, `source?` — `toolName` may be optional in core; if so,
+     project a sensible value, e.g. keep the same optionality on the view OR default to a documented
+     placeholder — prefer mirroring core's optionality by making `toolName?: string` on the view if
+     core's is optional, and update the Phase 05 test/pseudocode note accordingly during compliance).
+     Do NOT invent fields.
+
+3. `packages/agents/src/api/agentImpl.ts`:
+   - Add `readonly policy: PolicyControl;` to the controls field block (near `:194-200`).
+   - In the ctor controls-assignment block (near `:328-332`), add `this.policy = this.buildPolicyControl();`.
+   - Add the builder near the other `build*Control()` methods (e.g. after `buildMcpControl`, `:476-482`):
+
+     ```typescript
+     /**
+      * @plan:PLAN-20260622-COREAPIGAP.P06
+      * @requirement:REQ-002
+      */
+     private buildPolicyControl(): PolicyControl {
+       const policyDeps: PolicyControlDeps = {
+         getEngine: () => this.deps.config.getPolicyEngine(),
+       };
+       return new PolicyControl(policyDeps);
+     }
+     ```
+   - Import `PolicyControl` + `PolicyControlDeps` from `./control/policyControl.js` (match the other
+     control imports at the top of `agentImpl.ts`).
+
+### Constraints
+
+- Follow pseudocode line-by-line; cite `@pseudocode lines 1-18 / 30-33 / 40-43`.
+- `getRules` MUST build a fresh snapshot array and project `argsPattern` to `.source` (undefined stays
+  undefined). NEVER return `engine.getRules()` directly.
+- Resolve `getEngine()` per call; do NOT cache the engine or rules (R-DELEGATE).
+- No rule-mutation methods (REQ-002.4). No `RegExp` on the public type.
+- Do NOT modify Phase 05 tests.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+npx vitest run packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+npm run typecheck
+
+# New control file exists and delegates (BLOCKING).
+test -f packages/agents/src/api/control/policyControl.ts
+grep -qE "getEngine\(\)\.getRules\(\)" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: getRules not delegating"; exit 1; }
+grep -qE "getEngine\(\)\.getDefaultDecision\(\)" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: getDefaultDecision not delegating"; exit 1; }
+grep -qE "getEngine\(\)\.isNonInteractive\(\)" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: isNonInteractive not delegating"; exit 1; }
+
+# argsPattern projected to .source string (BLOCKING — no raw RegExp on the view).
+grep -qE "argsPattern\.source" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: argsPattern not projected to .source"; exit 1; }
+# Must NOT return the live engine array directly.
+if grep -nE "return\s+(engine|this\.deps\.getEngine\(\))\.getRules\(\)" packages/agents/src/api/control/policyControl.ts; then
+  echo "FAIL: getRules returns the live engine array (must snapshot)"; exit 1
+fi
+
+# Wiring present (BLOCKING).
+grep -qE "this\.policy = this\.buildPolicyControl\(\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: policy not wired in ctor"; exit 1; }
+grep -qE "readonly policy: PolicyControl;" packages/agents/src/api/agentImpl.ts || { echo "FAIL: policy field missing"; exit 1; }
+grep -qE "readonly policy: AgentPolicyControl;" packages/agents/src/api/agent.ts || { echo "FAIL: Agent.policy interface field missing"; exit 1; }
+
+# No rule mutation on the controller (REQ-002.4).
+if grep -nE "(addRule|removeRule|setRules)\b" packages/agents/src/api/control/policyControl.ts; then echo "FAIL: rule mutation present"; exit 1; fi
+
+# Pseudocode markers.
+grep -q "@pseudocode lines 1-18" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: getRules pseudocode marker missing"; exit 1; }
+```
+
+### Deferred Implementation Detection (MANDATORY — scoped to CHANGED + NEW files, MIN-3)
+
+```bash
+set -o pipefail
+NEW=packages/agents/src/api/control/policyControl.ts
+if grep -nE "(TODO|FIXME|HACK|STUB|XXX|placeholder|for now|in a real)" "$NEW"; then echo "FAIL: deferred marker in new control"; exit 1; fi
+for FILE in packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts; do
+  if git diff HEAD -- "$FILE" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)"; then
+    echo "FAIL: deferred marker in changed lines of $FILE"; exit 1
+  fi
+done
+echo "PASS: no deferred markers."
+```
+
+### Semantic Verification Checklist
+
+- [ ] Phase 05 tests pass (T4/T4b/T6 + both PROPs).
+- [ ] `getRules` snapshots + projects `argsPattern`→`.source`; `undefined` preserved.
+- [ ] Delegates per call (no cache); no mutation methods; no `RegExp` on public type.
+- [ ] Wired via `buildPolicyControl`; pseudocode cited; typecheck clean.
+
+## Success Criteria
+
+- Policy tests green; control file + interface + wiring in place; snapshot/projection correct.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts` and
+  `rm packages/agents/src/api/control/policyControl.ts`; re-implement from pseudocode.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P06.md`
+
+```markdown
+Phase: P06
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/06-policy-impl.md
+++ b/project-plans/issue2143/plan/06-policy-impl.md
@@ -38,8 +38,8 @@ See Phase 05 GIVEN/WHEN/THEN.
     * @requirement:REQ-002
     */
    export interface PolicyRuleView {
-     readonly priority: number;
-     readonly toolName: string;
+     readonly priority?: number;
+     readonly toolName?: string;
      readonly decision: PolicyDecision;
      readonly argsPattern?: string;
      readonly source?: string;
@@ -117,12 +117,16 @@ See Phase 05 GIVEN/WHEN/THEN.
    }
    ```
 
-   - VERIFY the real `PolicyRule` field names against `packages/policy/src/types.ts` (`priority`,
-     `toolName`, `decision`, `argsPattern?`, `source?` — `toolName` may be optional in core; if so,
-     project a sensible value, e.g. keep the same optionality on the view OR default to a documented
-     placeholder — prefer mirroring core's optionality by making `toolName?: string` on the view if
-     core's is optional, and update the Phase 05 test/pseudocode note accordingly during compliance).
-     Do NOT invent fields.
+   - GROUND TRUTH (verified `packages/policy/src/types.ts`): `PolicyRule` is
+     `{ name?: string; toolName?: string; argsPattern?: RegExp; decision: PolicyDecision;
+     priority?: number; allowRedirection?: boolean; source?: string }`. BOTH `priority` (`:46`) and
+     `toolName` (`:29`) are OPTIONAL, and `decision` is the only REQUIRED field. The repo does NOT set
+     `exactOptionalPropertyTypes`, but `strict` is on, so a required `priority: number` field CANNOT
+     receive `rule.priority` (type `number | undefined`). Therefore `PolicyRuleView` MUST mirror
+     core's optionality: `priority?`, `toolName?` (and keep `argsPattern?`, `source?`). Project each
+     field FAITHFULLY — copy `rule.priority`/`rule.toolName` through as-is (do NOT coerce a missing
+     value to `0`/`'*'`/any placeholder; the CLI consumer already renders undefined via `?? 0` /
+     `?? '*'` at `policiesCommand.ts:107/106`). Do NOT invent fields. `decision` stays required.
 
 3. `packages/agents/src/api/agentImpl.ts`:
    - Add `readonly policy: PolicyControl;` to the controls field block (near `:194-200`).
@@ -170,7 +174,7 @@ grep -qE "getEngine\(\)\.isNonInteractive\(\)" packages/agents/src/api/control/p
 # argsPattern projected to .source string (BLOCKING — no raw RegExp on the view).
 grep -qE "argsPattern\.source" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: argsPattern not projected to .source"; exit 1; }
 # Must NOT return the live engine array directly.
-if grep -nE "return\s+(engine|this\.deps\.getEngine\(\))\.getRules\(\)" packages/agents/src/api/control/policyControl.ts; then
+if grep -nE "return[[:space:]]+(engine|this\.deps\.getEngine\(\))\.getRules\(\)" packages/agents/src/api/control/policyControl.ts; then
   echo "FAIL: getRules returns the live engine array (must snapshot)"; exit 1
 fi
 
@@ -228,4 +232,6 @@ Files Modified: [list each changed file with diff stats]
 Tests Added: [count]
 Verification: [paste the actual output of THIS phase's verification commands]
 Semantic Assessment: [one-line holistic assessment]
+```
+ssment]
 ```

--- a/project-plans/issue2143/plan/06a-policy-impl-verification.md
+++ b/project-plans/issue2143/plan/06a-policy-impl-verification.md
@@ -1,0 +1,98 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P06a @requirement:REQ-002 -->
+# Phase 06a: Policy Control Implementation Verification (Pseudocode-Compliance Gate)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P06a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 06 completed
+- Verification: `test -f project-plans/issue2143/.completed/P06.md`
+
+## Pseudocode-Compliance Verification (MANDATORY)
+
+Compare `control/policyControl.ts` against `analysis/pseudocode/policy-control.md` (lines 1-18,
+30-33, 40-43). Re-audit the Phase 05 suite for behavioral discipline.
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+
+npx vitest run "$F"
+npx vitest run packages/agents/src/api/__tests__/
+npm run typecheck
+npm run lint
+
+# Delegation + snapshot + projection (BLOCKING).
+grep -qE "getEngine\(\)\.getRules\(\)" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: getRules delegate"; exit 1; }
+grep -qE "argsPattern\.source" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: argsPattern projection"; exit 1; }
+if grep -nE "return\s+(engine|this\.deps\.getEngine\(\))\.getRules\(\)" packages/agents/src/api/control/policyControl.ts; then echo "FAIL: live array returned"; exit 1; fi
+# No engine/rules caching field.
+if grep -nE "this\.(engine|_engine|rules|_rules)\s*=" packages/agents/src/api/control/policyControl.ts; then echo "FAIL: cached engine/rules"; exit 1; fi
+# No mutation.
+if grep -nE "(addRule|removeRule|setRules)\b" packages/agents/src/api/control/policyControl.ts; then echo "FAIL: mutation present"; exit 1; fi
+
+# Re-audit test discipline (BLOCKING).
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater in test"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+if grep -nE "from ['\"]@vybestack/llxprt-code-(core|providers|policy|tools|mcp)/" "$F"; then echo "FAIL: deep import in test"; exit 1; fi
+if grep -nE "from ['\"]\.\./(control|agentImpl)" "$F"; then echo "FAIL: internal import in test"; exit 1; fi
+# argsPattern must be asserted as a string, never compared to a RegExp literal.
+grep -qE "argsPattern" "$F" || { echo "FAIL: argsPattern not tested"; exit 1; }
+
+# Deferred scan (NEW + changed).
+NEW=packages/agents/src/api/control/policyControl.ts
+if grep -nE "(TODO|FIXME|HACK|STUB|XXX|placeholder|for now|in a real)" "$NEW"; then echo "FAIL: deferred marker in control"; exit 1; fi
+for FILE in packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts; do
+  if git diff HEAD -- "$FILE" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)"; then echo "FAIL: deferred in $FILE"; exit 1; fi
+done
+echo "PASS: pseudocode-compliance + discipline."
+```
+
+### Line-by-Line Compliance Table
+
+| Pseudocode lines | Implemented at | Matches? |
+|---|---|---|
+| 1-18 getRules snapshot + argsPattern→.source (undefined preserved) | | [ ] |
+| 30-33 getDefaultDecision delegate | | [ ] |
+| 40-43 isNonInteractive delegate | | [ ] |
+
+### Semantic Verification Checklist
+
+- [ ] Decision table holds (0-rule `[]`; argsPattern string; undefined preserved; default/non-interactive read-through).
+- [ ] Fresh snapshot per call (no cache); read-only (no mutation); no `RegExp` leak (R-POLICY-SNAPSHOT, R-ARGSPATTERN-STRING).
+- [ ] Engine seeded through the real public `AgentConfig.policy` path; test behavioral + ≥30% property; lint/typecheck/full-api-suite green.
+
+## Holistic Functionality Assessment (MANDATORY — into marker)
+
+- **What was implemented?** (PolicyControl + interface + wiring)
+- **Satisfies REQ-002/.1/.2/.3/.4?** (cite evidence — snapshot, projection, read-only)
+- **Data flow** (agent.policy → getEngine() → Config.getPolicyEngine() → real engine; views are fresh)
+- **Risks** (RegExp leak, live-array leak, caching, mutation surface)
+- **Verdict** (PASS/FAIL with evidence)
+
+## Success Criteria
+
+- Compliance table complete; assessment written; suites + lint + typecheck green.
+
+## Failure Recovery
+
+- Return to Phase 06 or 05; do not proceed to Phase 07.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P06a.md` (include assessment).
+
+```markdown
+Phase: P06a
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line verdict — PASS/FAIL with the key evidence]
+```

--- a/project-plans/issue2143/plan/06a-policy-impl-verification.md
+++ b/project-plans/issue2143/plan/06a-policy-impl-verification.md
@@ -28,9 +28,9 @@ npm run typecheck
 npm run lint
 
 # Delegation + snapshot + projection (BLOCKING).
-grep -qE "getEngine\(\)\.getRules\(\)" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: getRules delegate"; exit 1; }
+grep -qE "engine\.getRules\(\)|getEngine\(\)\.getRules\(\)" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: getRules delegate"; exit 1; }
 grep -qE "argsPattern\.source" packages/agents/src/api/control/policyControl.ts || { echo "FAIL: argsPattern projection"; exit 1; }
-if grep -nE "return\s+(engine|this\.deps\.getEngine\(\))\.getRules\(\)" packages/agents/src/api/control/policyControl.ts; then echo "FAIL: live array returned"; exit 1; fi
+if grep -nE "return[[:space:]]+(engine|this\.deps\.getEngine\(\))\.getRules\(\)" packages/agents/src/api/control/policyControl.ts; then echo "FAIL: live array returned"; exit 1; fi
 # No engine/rules caching field.
 if grep -nE "this\.(engine|_engine|rules|_rules)\s*=" packages/agents/src/api/control/policyControl.ts; then echo "FAIL: cached engine/rules"; exit 1; fi
 # No mutation.

--- a/project-plans/issue2143/plan/07-tasks-tdd.md
+++ b/project-plans/issue2143/plan/07-tasks-tdd.md
@@ -1,0 +1,197 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P07 @requirement:REQ-003 -->
+# Phase 07: Tasks Control (`agent.tasks`) — Behavioral TDD
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P07`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 06a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P06a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-003: Async-task administration via `agent.tasks`
+
+**Full Text**: `Agent` MUST expose an undefined-safe `tasks` sub-controller (`AgentTasksControl`):
+`list()`, `listRunning()`, `get(id)`, `cancel(id)`, `cancelAllRunning()`, each delegating to the live
+`Config.getAsyncTaskManager()` (`config.ts:601`, typed `AsyncTaskManager | undefined`).
+- **REQ-003.1-.4**: `list`/`listRunning`/`get`/`cancel` mirror manager `getAllTasks`/`getRunningTasks`/
+  `getTask`/`cancelTask` (`asyncTaskManager.ts:77/319/273/239`).
+- **REQ-003.5**: `cancelAllRunning(): number` returns the COUNT cancelled (R-CANCEL-COUNT).
+- **REQ-003.6**: every method is undefined-safe (manager absent → `[]`/`undefined`/`false`/`0`)
+  (R-UNDEFINED-SAFE).
+- **REQ-003.7**: the public `AgentTaskInfo` OMITS `abortController` and any non-serializable internal
+  (R-NO-ABORTCONTROLLER).
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a real manager with 2 running + 1 completed task → `list()` length 3, `listRunning()` length 2.
+- GIVEN those running tasks → `cancelAllRunning()` returns `2`; afterwards `listRunning()` is `[]`.
+- GIVEN any task view from `list()` → it has NO `abortController` key.
+- GIVEN a manager that is `undefined` → all methods no-op (`[]`/`undefined`/`false`/`0`), never throw.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/tasksControl.behavior.test.ts`
+
+  Two REAL drive modes (BOTH are real data, NO mock theater):
+
+  1. **Public-harness mode (T7/T8/T10)** — `buildAgent('plain-text.jsonl')` (`helpers/agentHarness.ts:79`).
+     The concrete `Config.getAsyncTaskManager()` lazily creates and returns a REAL `AsyncTaskManager`
+     (verified P00a: `getOrCreateAsyncTaskManager` always returns one). Obtain that SAME instance via
+     the PUBLIC `agent.getConfig().getAsyncTaskManager()` (`agent.ts:339`) and SEED real running tasks:
+     ```ts
+     const mgr = agent.getConfig().getAsyncTaskManager()!;
+     mgr.registerTask({ id, subagentName, goalPrompt, abortController: new AbortController() });
+     ```
+     `registerTask(RegisterTaskInput)` (`asyncTaskManager.ts:148`) marks the task running. Then assert
+     through `agent.tasks.list()/listRunning()/get(id)/cancel(id)/cancelAllRunning()`. This is the SAME
+     manager the control resolves (`buildTasksControl` closes over `this.deps.config.getAsyncTaskManager()`,
+     and `getConfig()` returns that same `this.deps.config`), so the read-path is causally real.
+
+  2. **Direct-construction mode (T9 undefined-safe)** — mirror the BLESSED precedent
+     `new McpControl(deps)` (`mcp-discovery.spec.ts:306+`). `.behavior.test.ts` is T17-EXEMPT, so deep
+     import is allowed: `import { TasksControl } from '../control/tasksControl.js';` then
+     `new TasksControl({ getManager: () => undefined })`. The closure RETURNS a real value (`undefined`)
+     — this is NOT a spy/stub. Assert every method no-ops.
+
+  - Markers `@plan:PLAN-20260622-COREAPIGAP.P07`, `@requirement:REQ-003`.
+
+### Required scenarios
+
+```
+T7    seed N running tasks on the real manager → agent.tasks.cancelAllRunning() === N AND a subsequent
+      agent.tasks.listRunning() has length 0 (count + idempotent terminal state)
+T8    seed 1 running task → const [info] = agent.tasks.list(); assert Object.keys(info) does NOT include
+      'abortController' (and the running task DID carry one on the core manager) — projection strips it
+T9    new TasksControl({ getManager: () => undefined }) → list()/listRunning() === [] ; get('x') ===
+      undefined ; cancel('x') === false ; cancelAllRunning() === 0 ; NONE throw
+T10   seed 2 running + complete 1 (registerTask then cancel/complete) → list() length reflects all;
+      listRunning() reflects only running; get(knownId) returns the projected view with matching id;
+      get('missing') === undefined ; cancel(knownId) === true ; cancel('missing') === false
+PROP  projection fidelity: for a generated list of N (1..5) running tasks (random ids/goalPrompts),
+      agent.tasks.list() length === N, the id set matches, and NO returned view has an 'abortController'
+      key; MIN-2 cases
+PROP  cancelAllRunning count: for a generated N (0..5) running tasks, cancelAllRunning() === N and
+      listRunning() afterwards is empty; MIN-2 cases
+```
+
+### Constraints
+
+- Assert real VALUES (counts, ids, key-absence, booleans) — NEVER `toHaveBeenCalled`, NEVER `vi.fn()`.
+- The undefined-safe deps closure `() => undefined` is a REAL closure (allowed), not a mock.
+- ≥30% property-based (fast-check), MIN-2 distinct property cases.
+- Use `Object.keys(view)` (or `'abortController' in view`) to PROVE the projection omits the field —
+  this is a behavioral assertion on real output, not structure-only theater (it is the REQ-003.7 contract).
+- Positive cases fail at RED because `agent.tasks` / `TasksControl` do not exist yet (missing-property /
+  missing-module → but NOTE: the direct-import T9 will be a `Cannot find module` until P08 creates the
+  file; therefore author T9 in the SAME file but ensure at least the public-harness positives produce a
+  behavioral RED. See RED note below.)
+
+### RED note (important)
+
+Because T9 deep-imports `../control/tasksControl.js` which does not exist until P08, the WHOLE file
+would fail to resolve at RED (a `Cannot find module` — which the RED gate REJECTS as non-behavioral).
+To keep RED behavioral, in THIS phase author T9 against the PUBLIC agent surface too: drive the
+undefined-safe branch by constructing a second agent and asserting the public `agent.tasks` methods are
+undefined-safe is NOT possible (real mgr is always defined). Therefore:
+- Author T9's direct-construction `import` as a **dynamic import inside the test body**
+  (`const { TasksControl } = await import('../control/tasksControl.js');`) so the file still PARSES and
+  the public-harness positives (T7/T8/T10) drive a behavioral RED (missing `agent.tasks` → TypeError).
+  The T9 dynamic import will throw `Cannot find module` at RED only INSIDE that one test — acceptable
+  because the GATE inspects the whole-file run for a behavioral failure among the positives and only
+  REJECTS if the ENTIRE failure set is module/compile errors. Confirm `/tmp/p07_red.log` shows the
+  TypeError positives, not solely module errors.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+test -f "$F"
+
+if grep -nE "toHaveBeenCalled" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater (spy/stub)"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# abortController omission asserted (BLOCKING — the REQ-003.7 contract).
+grep -qE "abortController" "$F" || { echo "FAIL: abortController omission not asserted"; exit 1; }
+
+# Property-based >= 30% (BLOCKING; MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '
+  /(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 }
+  /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } }
+  END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+if [ "$TOTAL" -eq 0 ]; then echo "FAIL: no tests"; exit 1; fi
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+if [ "$PROP" -lt 2 ]; then echo "FAIL: <2 property cases"; exit 1; fi
+if [ "$PCT" -lt 30 ]; then echo "FAIL: property ${PCT}% < 30%"; exit 1; fi
+
+# RED-state enforcement (positives must be behavioral, not solely module errors).
+set +e
+npx vitest run "$F" > /tmp/p07_red.log 2>&1
+STATUS=$?
+set -e
+tail -40 /tmp/p07_red.log
+if [ "$STATUS" -eq 0 ]; then echo "FAIL: unexpectedly all-green before P08"; exit 1; fi
+# There MUST be at least one behavioral failure (TypeError / assertion) among the positives,
+# not ONLY module-resolution errors.
+if ! grep -qiE "TypeError|AssertionError|expected|is not a function|Cannot read" /tmp/p07_red.log; then
+  echo "FAIL: RED shows no behavioral failure (only module/compile?)"; exit 1
+fi
+echo "RED confirmed behavioral (expected until P08)."
+```
+
+### Semantic Verification Checklist (BLOCKS progression)
+
+- [ ] T7/T8/T10 drive the REAL lazily-created manager via the public `agent.getConfig().getAsyncTaskManager()`
+      seam + `registerTask`; reads go through `agent.tasks`.
+- [ ] T9 uses direct `new TasksControl({ getManager: () => undefined })` (real closure) for the
+      undefined-safe branch.
+- [ ] `abortController` omission proven via key inspection on real output.
+- [ ] ≥30% property; MIN-2; no mock theater; no reverse tests; behavioral RED.
+
+## Success Criteria
+
+- Behavioral RED suite covering count/undefined-safety/projection through real data paths.
+
+## Failure Recovery
+
+- `git checkout -- "$F"`; rewrite.
+
+## Deferred Implementation Detection (MANDATORY — scoped)
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+test -f "$F" || { echo "missing test"; exit 1; }
+if grep -nE "(TODO|FIXME|HACK|XXX|TEMPORARY|WIP|placeholder|for now|in a real|coming soon)" "$F"; then echo "FAIL: deferred marker"; exit 1; fi
+if grep -niE "toThrow\(.*NotYetImplemented|should (not )?be implemented" "$F"; then echo "FAIL: reverse pattern"; exit 1; fi
+if grep -nE "\b(it|test|describe)\.skip\b|\bxit\b|\bxdescribe\b" "$F"; then echo "FAIL: skipped test"; exit 1; fi
+echo "PASS: no deferred markers."
+```
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P07.md`
+
+```markdown
+Phase: P07
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/08-tasks-impl.md
+++ b/project-plans/issue2143/plan/08-tasks-impl.md
@@ -1,0 +1,244 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P08 @requirement:REQ-003 -->
+# Phase 08: Tasks Control (`agent.tasks`) — Implementation
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P08`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 07 completed (PASS, suite RED)
+- Verification: `test -f project-plans/issue2143/.completed/P07.md`
+- Pseudocode: `analysis/pseudocode/tasks-control.md` (project 1-13; list 20-25; listRunning 30-35; get 40-47; cancel 50-55; cancelAllRunning 60-70)
+
+## Requirements Implemented (Expanded)
+
+### REQ-003 / .1-.7
+
+Add `AgentTasksControl` + projected `AgentTaskInfo` to `agent.ts`, implement `TasksControl` in
+`control/tasksControl.ts`, wire `readonly tasks` into `AgentImpl`. See Phase 07 GIVEN/WHEN/THEN.
+
+## Implementation Tasks
+
+### Files to Modify / Create
+
+1. `packages/agents/src/api/agent.ts` — add the projected type + interface near the other control
+   interfaces, and `readonly tasks: AgentTasksControl;` to the `Agent` controls block:
+
+   ```typescript
+   /**
+    * Projected public view of an async task. OMITS abortController and any
+    * non-serializable internal (REQ-003.7).
+    * @plan:PLAN-20260622-COREAPIGAP.P08
+    * @requirement:REQ-003
+    */
+   export interface AgentTaskInfo {
+     readonly id: string;
+     readonly subagentName: string;
+     readonly goalPrompt: string;
+     readonly status: 'running' | 'completed' | 'failed' | 'cancelled';
+     readonly launchedAt: number;
+     readonly completedAt?: number;
+     readonly error?: string;
+   }
+
+   /**
+    * Undefined-safe async-task administration (REQ-003).
+    * @plan:PLAN-20260622-COREAPIGAP.P08
+    * @requirement:REQ-003
+    */
+   export interface AgentTasksControl {
+     list(): readonly AgentTaskInfo[];
+     listRunning(): readonly AgentTaskInfo[];
+     get(id: string): AgentTaskInfo | undefined;
+     cancel(id: string): boolean;
+     cancelAllRunning(): number;
+   }
+   ```
+
+   Keep the `status` union identical to core `AsyncTaskStatus` (`asyncTaskManager.ts:16`).
+
+2. `packages/agents/src/api/control/tasksControl.ts` — NEW. Follow the pseudocode EXACTLY. The
+   `project()` helper copies fields BY NAME (never spreads — that would copy `abortController`):
+
+   ```typescript
+   /**
+    * @plan:PLAN-20260622-COREAPIGAP.P08
+    * @requirement:REQ-003
+    */
+   import type { AgentTasksControl, AgentTaskInfo } from '../agent.js';
+   import type { AsyncTaskManager, AsyncTaskInfo } from '@vybestack/llxprt-code-core';
+
+   export interface TasksControlDeps {
+     readonly getManager: () => AsyncTaskManager | undefined;
+   }
+
+   export class TasksControl implements AgentTasksControl {
+     constructor(private readonly deps: TasksControlDeps) {}
+
+     /** @requirement:REQ-003 @pseudocode lines 1-13 */
+     private project(task: AsyncTaskInfo): AgentTaskInfo {
+       return {
+         id: task.id,
+         subagentName: task.subagentName,
+         goalPrompt: task.goalPrompt,
+         status: task.status,
+         launchedAt: task.launchedAt,
+         ...(task.completedAt !== undefined ? { completedAt: task.completedAt } : {}),
+         ...(task.error !== undefined ? { error: task.error } : {}),
+       };
+     }
+
+     /** @requirement:REQ-003 @pseudocode lines 20-25 */
+     list(): readonly AgentTaskInfo[] {
+       const mgr = this.deps.getManager();
+       if (mgr === undefined) return [];
+       return mgr.getAllTasks().map((t) => this.project(t));
+     }
+
+     /** @requirement:REQ-003 @pseudocode lines 30-35 */
+     listRunning(): readonly AgentTaskInfo[] {
+       const mgr = this.deps.getManager();
+       if (mgr === undefined) return [];
+       return mgr.getRunningTasks().map((t) => this.project(t));
+     }
+
+     /** @requirement:REQ-003 @pseudocode lines 40-47 */
+     get(id: string): AgentTaskInfo | undefined {
+       const mgr = this.deps.getManager();
+       if (mgr === undefined) return undefined;
+       const task = mgr.getTask(id);
+       if (task === undefined) return undefined;
+       return this.project(task);
+     }
+
+     /** @requirement:REQ-003 @pseudocode lines 50-55 */
+     cancel(id: string): boolean {
+       const mgr = this.deps.getManager();
+       if (mgr === undefined) return false;
+       return mgr.cancelTask(id);
+     }
+
+     /** @requirement:REQ-003 @pseudocode lines 60-70 */
+     cancelAllRunning(): number {
+       const mgr = this.deps.getManager();
+       if (mgr === undefined) return 0;
+       const running = mgr.getRunningTasks();
+       let count = 0;
+       for (const task of running) {
+         if (mgr.cancelTask(task.id)) count++;
+       }
+       return count;
+     }
+   }
+   ```
+
+3. `packages/agents/src/api/agentImpl.ts`:
+   - Add `readonly tasks: TasksControl;` near the controls field block (`:194-200`).
+   - In the ctor controls block (`:328-332`), add `this.tasks = this.buildTasksControl();`.
+   - Add the builder near the other `build*Control()` methods:
+
+     ```typescript
+     /**
+      * @plan:PLAN-20260622-COREAPIGAP.P08
+      * @requirement:REQ-003
+      */
+     private buildTasksControl(): TasksControl {
+       const tasksDeps: TasksControlDeps = {
+         getManager: () => this.deps.config.getAsyncTaskManager(),
+       };
+       return new TasksControl(tasksDeps);
+     }
+     ```
+   - Import `TasksControl` + `TasksControlDeps` from `./control/tasksControl.js`.
+
+### Constraints
+
+- Follow pseudocode line-by-line; cite `@pseudocode` markers as shown.
+- `project()` copies fields BY NAME — NEVER `{ ...task }` (R-NO-ABORTCONTROLLER).
+- Every method undefined-safe (`[]`/`undefined`/`false`/`0`); never throw on absent manager.
+- `cancelAllRunning()` snapshots `getRunningTasks()` FIRST, returns the integer count.
+- Resolve `getManager()` per call; no cache. Do NOT add `getByPrefix` to the public API.
+- Do NOT modify Phase 07 tests.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+npx vitest run packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+npm run typecheck
+
+T=packages/agents/src/api/control/tasksControl.ts
+test -f "$T"
+
+# project() must NOT spread the task (would leak abortController) (BLOCKING).
+if grep -nE "\.\.\.task\b|\{\s*\.\.\.t\s*\}" "$T"; then echo "FAIL: project spreads task (abortController leak)"; exit 1; fi
+# abortController must never be referenced as a copied field.
+if grep -nE "abortController" "$T"; then echo "FAIL: abortController referenced in projection"; exit 1; fi
+
+# Undefined-safe guards present for all five methods (BLOCKING).
+for M in "getAllTasks" "getRunningTasks" "getTask" "cancelTask"; do
+  grep -qE "$M" "$T" || { echo "FAIL: missing delegate $M"; exit 1; }
+done
+grep -qE "if \(mgr === undefined\) return \[\];" "$T" || { echo "FAIL: missing []-guard"; exit 1; }
+grep -qE "return 0;" "$T" || { echo "FAIL: cancelAllRunning 0-guard missing"; exit 1; }
+
+# cancelAllRunning snapshots before iterating (BLOCKING).
+grep -qE "const running = mgr\.getRunningTasks\(\);" "$T" || { echo "FAIL: no running snapshot"; exit 1; }
+
+# Wiring present (BLOCKING).
+grep -qE "this\.tasks = this\.buildTasksControl\(\)" packages/agents/src/api/agentImpl.ts || { echo "FAIL: tasks not wired"; exit 1; }
+grep -qE "readonly tasks: TasksControl;" packages/agents/src/api/agentImpl.ts || { echo "FAIL: tasks field missing"; exit 1; }
+grep -qE "readonly tasks: AgentTasksControl;" packages/agents/src/api/agent.ts || { echo "FAIL: Agent.tasks interface field missing"; exit 1; }
+
+# Pseudocode markers.
+grep -q "@pseudocode lines 1-13" "$T" || { echo "FAIL: project pseudocode marker missing"; exit 1; }
+grep -q "@pseudocode lines 60-70" "$T" || { echo "FAIL: cancelAllRunning pseudocode marker missing"; exit 1; }
+```
+
+### Deferred Implementation Detection (MANDATORY — scoped to CHANGED + NEW files, MIN-3)
+
+```bash
+set -o pipefail
+NEW=packages/agents/src/api/control/tasksControl.ts
+if grep -nE "(TODO|FIXME|HACK|STUB|XXX|placeholder|for now|in a real)" "$NEW"; then echo "FAIL: deferred marker in new control"; exit 1; fi
+for FILE in packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts; do
+  if git diff HEAD -- "$FILE" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)"; then
+    echo "FAIL: deferred marker in changed lines of $FILE"; exit 1
+  fi
+done
+echo "PASS: no deferred markers."
+```
+
+### Semantic Verification Checklist
+
+- [ ] Phase 07 tests pass (T7/T8/T9/T10 + both PROPs).
+- [ ] `project()` copies by name; no spread; `abortController` never present on output.
+- [ ] All methods undefined-safe; `cancelAllRunning` snapshots + returns count.
+- [ ] Wired via `buildTasksControl`; delegates per call; pseudocode cited; typecheck clean.
+
+## Success Criteria
+
+- Tasks tests green; projection strips internals; undefined-safety holds; wiring in place.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts` and
+  `rm packages/agents/src/api/control/tasksControl.ts`; re-implement from pseudocode.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P08.md`
+
+```markdown
+Phase: P08
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/08-tasks-impl.md
+++ b/project-plans/issue2143/plan/08-tasks-impl.md
@@ -175,7 +175,7 @@ T=packages/agents/src/api/control/tasksControl.ts
 test -f "$T"
 
 # project() must NOT spread the task (would leak abortController) (BLOCKING).
-if grep -nE "\.\.\.task\b|\{\s*\.\.\.t\s*\}" "$T"; then echo "FAIL: project spreads task (abortController leak)"; exit 1; fi
+if grep -nE "\.\.\.task\b|\{[[:space:]]*\.\.\.t[[:space:]]*\}" "$T"; then echo "FAIL: project spreads task (abortController leak)"; exit 1; fi
 # abortController must never be referenced as a copied field.
 if grep -nE "abortController" "$T"; then echo "FAIL: abortController referenced in projection"; exit 1; fi
 

--- a/project-plans/issue2143/plan/08a-tasks-impl-verification.md
+++ b/project-plans/issue2143/plan/08a-tasks-impl-verification.md
@@ -39,7 +39,7 @@ grep -qE "return 0;" "$T" || { echo "FAIL: cancelAllRunning 0-guard"; exit 1; }
 grep -qE "const running = mgr\.getRunningTasks\(\);" "$T" || { echo "FAIL: snapshot-before-iterate"; exit 1; }
 
 # No cache (BLOCKING).
-if grep -nE "this\.(manager|_manager|tasks|_tasks)\s*=" "$T"; then echo "FAIL: cached manager/tasks"; exit 1; fi
+if grep -nE "this\.(manager|_manager|tasks|_tasks)[[:space:]]*=" "$T"; then echo "FAIL: cached manager/tasks"; exit 1; fi
 
 # Re-audit test discipline (BLOCKING).
 if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater in test"; exit 1; fi

--- a/project-plans/issue2143/plan/08a-tasks-impl-verification.md
+++ b/project-plans/issue2143/plan/08a-tasks-impl-verification.md
@@ -1,0 +1,105 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P08a @requirement:REQ-003 -->
+# Phase 08a: Tasks Control Implementation Verification (Pseudocode-Compliance Gate)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P08a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 08 completed
+- Verification: `test -f project-plans/issue2143/.completed/P08.md`
+
+## Pseudocode-Compliance Verification (MANDATORY)
+
+Compare `control/tasksControl.ts` against `analysis/pseudocode/tasks-control.md`. Re-audit the Phase 07
+suite for behavioral discipline.
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/tasksControl.behavior.test.ts
+T=packages/agents/src/api/control/tasksControl.ts
+
+npx vitest run "$F"
+npx vitest run packages/agents/src/api/__tests__/
+npm run typecheck
+npm run lint
+
+# Projection safety (BLOCKING).
+if grep -nE "\.\.\.task\b" "$T"; then echo "FAIL: spread leaks abortController"; exit 1; fi
+if grep -nE "abortController" "$T"; then echo "FAIL: abortController in control"; exit 1; fi
+
+# Undefined-safety (BLOCKING).
+grep -qE "if \(mgr === undefined\) return \[\];" "$T" || { echo "FAIL: []-guard"; exit 1; }
+grep -qE "return false;" "$T" || { echo "FAIL: cancel false-guard"; exit 1; }
+grep -qE "return 0;" "$T" || { echo "FAIL: cancelAllRunning 0-guard"; exit 1; }
+grep -qE "const running = mgr\.getRunningTasks\(\);" "$T" || { echo "FAIL: snapshot-before-iterate"; exit 1; }
+
+# No cache (BLOCKING).
+if grep -nE "this\.(manager|_manager|tasks|_tasks)\s*=" "$T"; then echo "FAIL: cached manager/tasks"; exit 1; fi
+
+# Re-audit test discipline (BLOCKING).
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater in test"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+grep -qE "abortController" "$F" || { echo "FAIL: omission not asserted in test"; exit 1; }
+# T9 direct-construction precedent present (real closure, undefined manager).
+grep -qE "new TasksControl\(" "$F" || { echo "FAIL: undefined-safe direct construction missing"; exit 1; }
+
+# Deferred scan (NEW + changed).
+if grep -nE "(TODO|FIXME|HACK|STUB|XXX|placeholder|for now|in a real)" "$T"; then echo "FAIL: deferred in control"; exit 1; fi
+for FILE in packages/agents/src/api/agentImpl.ts packages/agents/src/api/agent.ts; do
+  if git diff HEAD -- "$FILE" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)"; then echo "FAIL: deferred in $FILE"; exit 1; fi
+done
+echo "PASS: pseudocode-compliance + discipline."
+```
+
+### Line-by-Line Compliance Table
+
+| Pseudocode lines | Implemented at | Matches? |
+|---|---|---|
+| 1-13 project (by-name copy, abortController omitted) | | [ ] |
+| 20-25 list (undefined→[], map project) | | [ ] |
+| 30-35 listRunning | | [ ] |
+| 40-47 get (undefined→undefined, miss→undefined) | | [ ] |
+| 50-55 cancel (undefined→false) | | [ ] |
+| 60-70 cancelAllRunning (snapshot, count) | | [ ] |
+
+### Semantic Verification Checklist
+
+- [ ] Decision table holds (undefined→[]/undefined/false/0; 3 tasks→list 3/running 2; cancelAllRunning N then running empty; get hit/miss; cancel hit/miss).
+- [ ] `AgentTaskInfo` never carries `abortController` on REAL output (R-NO-ABORTCONTROLLER).
+- [ ] `cancelAllRunning` returns the integer count (R-CANCEL-COUNT); snapshots before iterating.
+- [ ] Delegates per call (no cache); test behavioral + ≥30% property; lint/typecheck/full-api-suite green.
+
+## Holistic Functionality Assessment (MANDATORY — into marker)
+
+- **What was implemented?** (TasksControl + projection + interface + wiring)
+- **Satisfies REQ-003/.1-.7?** (cite evidence — count, undefined-safety, projection key-absence)
+- **Data flow** (agent.tasks → getManager() → Config.getAsyncTaskManager() → real manager; views projected)
+- **Risks** (abortController leak via spread, mutation-during-iteration, manager caching, throw on undefined)
+- **Verdict** (PASS/FAIL with evidence)
+
+## Success Criteria
+
+- Compliance table complete; assessment written; suites + lint + typecheck green.
+
+## Failure Recovery
+
+- Return to Phase 08 or 07; do not proceed to Phase 09.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P08a.md` (include assessment).
+
+```markdown
+Phase: P08a
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line verdict — PASS/FAIL with the key evidence]
+```

--- a/project-plans/issue2143/plan/09-hooks-admin-tdd.md
+++ b/project-plans/issue2143/plan/09-hooks-admin-tdd.md
@@ -48,14 +48,46 @@ members (`onHookExecution`/`triggerSessionStart`/`triggerSessionEnd`/`clear`) EX
      hit the REAL `Config.setDisabledHooks` (configBase.ts:132) + `getDisabledHooks` (config.ts:734).
   2. **Undefined-safe `listHooks()` (T12a)** — a plain agent with hooks disabled → `getHookSystem()`
      returns `undefined` → `agent.hooks.listHooks()` is `[]`. (No initialise call.)
-  3. **Populated `listHooks()` (T12b)** — `buildAgent('plain-text.jsonl', { hooks: <one real hook def> })`
-     (mirror `fakeSessionHookDefinitions` shape in `helpers/fakeHook.ts`; ensure the enabling field is
-     set so `getHookSystem()` is defined). Then `await agent.hooks.triggerSessionStart()` to initialise
-     the registry (it calls `hookSystem.initialize()` → `registry.initialize()` which loads the seeded
-     hooks). Then assert `agent.hooks.listHooks()` reflects the seeded entry (length ≥ 1; `name`/
-     `eventName`/`enabled` mirror the registry entry). If the harness path does not enable hooks,
-     fall back to the BLESSED direct-construction precedent (`new HookControl(realDeps)` — `.behavior.test.ts`
-     is T17-exempt) over a real `Config` with hooks enabled+initialised.
+  3. **Populated `listHooks()` (T12b)** — MUST use the BLESSED direct-construction precedent
+     (`new HookControl(realDeps)`); the `buildAgent` harness path provably CANNOT populate the
+     registry and is FORBIDDEN for this case. Proven reasons (verified against source):
+       - The `AgentConfig`→`ConfigParameters` adapter maps only `hooks` (agentConfig.adapter.ts:175-176);
+         it never maps `enableHooks`, and `config.enableHooks = params.enableHooks ?? false`
+         (configConstructor.ts:474) ⇒ a harness agent's `getHookSystem()` returns `undefined`.
+       - `triggerSessionStartHook` gates on `config.getEnableHooks()` FIRST and returns early
+         (lifecycleHookTriggers.ts:47-50) ⇒ it never reaches `hookSystem.initialize()`, so the
+         registry is never loaded. (`triggerSessionStart()` still emits a SYNTHETIC lifecycle pair
+         to observers, so do NOT assert on that path for registry population — it would be vacuous.)
+     - Proven recipe for T12b (`.behavior.test.ts` is T17-exempt → deep imports allowed):
+       1. `import { Config } from '@vybestack/llxprt-code-core/config/config.js'`,
+          `import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js'`,
+          `import { HookEventName } from '@vybestack/llxprt-code-core/hooks/types.js'`,
+          `import { HookControl } from '../control/hooks.js'`.
+       2. Build a REAL Config with hooks ENABLED + a structurally-valid seeded def (mirror
+          `fakeSessionHookDefinitions` shape; `isTrustedFolder()` defaults `true` via
+          `this.trustedFolder ?? true` at config.ts:511 so the seeded `hooks` load):
+          ```ts
+          const config = new Config({
+            cwd: '/tmp', targetDir: '/tmp', debugMode: false,
+            sessionId: 'hooks-admin-test', model: 'gemini-2.0-flash',
+            usageStatisticsEnabled: false,
+            enableHooks: true,
+            hooks: {
+              [HookEventName.SessionStart]: [
+                { hooks: [{ type: 'command' as never, command: 'true', name: 'fake-session-start' }] },
+              ],
+            },
+          });
+          ```
+       3. Initialise the registry directly (use a guard, NOT a non-null `!` assertion):
+          ```ts
+          const system = config.getHookSystem();
+          if (!system) throw new Error('expected hook system (enableHooks:true)');
+          await system.initialize(); // loads the seeded hook; isInitialized() now true
+          ```
+       4. `const control = new HookControl({ config, messageBus: new MessageBus(), sessionId: () => 'hooks-admin-test', cwd: () => '/tmp' });`
+       5. Assert `control.listHooks()` has length ≥ 1 and the entry's `name === 'fake-session-start'`,
+          `eventName === HookEventName.SessionStart` (or its string value), and `enabled === true`.
 
   - Markers `@plan:PLAN-20260622-COREAPIGAP.P09`, `@requirement:REQ-004`.
 

--- a/project-plans/issue2143/plan/09-hooks-admin-tdd.md
+++ b/project-plans/issue2143/plan/09-hooks-admin-tdd.md
@@ -1,0 +1,170 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P09 @requirement:REQ-004 -->
+# Phase 09: Hooks Administration (extend `agent.hooks`) — Behavioral TDD
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P09`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 08a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P08a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-004: Hooks administration on `AgentHookControl`
+
+**Full Text**: EXTEND the existing `AgentHookControl` (agent.ts:314-321) — keeping its existing
+members (`onHookExecution`/`triggerSessionStart`/`triggerSessionEnd`/`clear`) EXACTLY as-is
+(REQ-009 non-breaking) — with registry inspection + enable/disable administration:
+- **REQ-004.1**: `listHooks(): readonly HookInfo[]` — snapshot of the live registry; undefined- AND
+  uninitialised-safe (R-UNDEFINED-SAFE).
+- **REQ-004.2**: `getDisabledHooks(): readonly string[]` — fresh copy of the Config disabled-set.
+- **REQ-004.3**: `setDisabledHooks(names: readonly string[]): void` — write-through, round-trips with
+  `getDisabledHooks` (R-HOOKS-ROUNDTRIP).
+- **REQ-004.4**: `enable(name)` / `disable(name)` — idempotent convenience over the disabled-set.
+- **REQ-004.5**: undefined/uninitialised hook system → `listHooks()` returns `[]`.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a plain agent (no hooks) → `listHooks()` is `[]` (system undefined or uninitialised).
+- GIVEN `setDisabledHooks(["a","b"])` → `getDisabledHooks()` deep-equals `["a","b"]` (round-trip).
+- GIVEN disabled `["a"]` + `disable("a")` → stays `["a"]` (idempotent); `disable("b")` → `["a","b"]`.
+- GIVEN disabled `["a","b"]` + `enable("a")` → `["b"]`; `enable("zzz")` (absent) → unchanged.
+- GIVEN an agent seeded with one real hook def, after `triggerSessionStart()` (initialises the
+  registry) → `listHooks()` contains an entry whose `name`/`eventName`/`enabled` mirror it.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts`
+
+  Drive REAL data through real Config (NO mock theater):
+
+  1. **Disabled-set round-trip + enable/disable (T11)** — `buildAgent('plain-text.jsonl')`; call the
+     public `agent.hooks.setDisabledHooks(...)` / `getDisabledHooks()` / `enable()` / `disable()`. These
+     hit the REAL `Config.setDisabledHooks` (configBase.ts:132) + `getDisabledHooks` (config.ts:734).
+  2. **Undefined-safe `listHooks()` (T12a)** — a plain agent with hooks disabled → `getHookSystem()`
+     returns `undefined` → `agent.hooks.listHooks()` is `[]`. (No initialise call.)
+  3. **Populated `listHooks()` (T12b)** — `buildAgent('plain-text.jsonl', { hooks: <one real hook def> })`
+     (mirror `fakeSessionHookDefinitions` shape in `helpers/fakeHook.ts`; ensure the enabling field is
+     set so `getHookSystem()` is defined). Then `await agent.hooks.triggerSessionStart()` to initialise
+     the registry (it calls `hookSystem.initialize()` → `registry.initialize()` which loads the seeded
+     hooks). Then assert `agent.hooks.listHooks()` reflects the seeded entry (length ≥ 1; `name`/
+     `eventName`/`enabled` mirror the registry entry). If the harness path does not enable hooks,
+     fall back to the BLESSED direct-construction precedent (`new HookControl(realDeps)` — `.behavior.test.ts`
+     is T17-exempt) over a real `Config` with hooks enabled+initialised.
+
+  - Markers `@plan:PLAN-20260622-COREAPIGAP.P09`, `@requirement:REQ-004`.
+
+### Required scenarios
+
+```
+T11   setDisabledHooks(["a","b"]) → getDisabledHooks() deep-equals ["a","b"]; mutating the returned
+      array does NOT change a subsequent getDisabledHooks() (fresh copy)
+T11b  enable/disable idempotency: from ["a"], disable("a") stays ["a"]; disable("b") → ["a","b"];
+      enable("a") → ["b"]; enable("zzz") → unchanged
+T12a  plain agent (hooks disabled) → agent.hooks.listHooks() === [] (does not throw)
+T12b  agent seeded with one real hook def + triggerSessionStart() → listHooks() length ≥ 1 and the
+      entry's name/eventName/enabled mirror the seeded hook
+PROP  disabled-set round-trip: for a generated unique string[] (len 0..5), setDisabledHooks(arr) then
+      getDisabledHooks() deep-equals arr; MIN-2 cases
+PROP  enable∘disable inverse: for a generated name + base set, disable(name) then enable(name) yields a
+      set WITHOUT name; and the returned arrays are always fresh copies; MIN-2 cases
+```
+
+### Constraints
+
+- Assert real VALUES (array contents, length, key mirrors) — NEVER `toHaveBeenCalled`, NEVER `vi.fn()`.
+- The existing `AgentHookControl` members MUST remain callable (do not assert their removal).
+- ≥30% property-based (fast-check), MIN-2 distinct property cases.
+- Prove the fresh-copy contract by mutating a returned array and re-reading (behavioral, not structure-only).
+- Positive cases fail at RED because the new methods do not exist on `AgentHookControl` yet
+  (missing-method TypeError = behavioral RED).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
+test -f "$F"
+
+if grep -nE "toHaveBeenCalled" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater (spy/stub)"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# Round-trip + listHooks both exercised (BLOCKING).
+grep -qE "setDisabledHooks" "$F" || { echo "FAIL: round-trip not exercised"; exit 1; }
+grep -qE "listHooks" "$F" || { echo "FAIL: listHooks not exercised"; exit 1; }
+
+# Property-based >= 30% (BLOCKING; MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '
+  /(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 }
+  /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } }
+  END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+if [ "$TOTAL" -eq 0 ]; then echo "FAIL: no tests"; exit 1; fi
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+if [ "$PROP" -lt 2 ]; then echo "FAIL: <2 property cases"; exit 1; fi
+if [ "$PCT" -lt 30 ]; then echo "FAIL: property ${PCT}% < 30%"; exit 1; fi
+
+# RED-state enforcement.
+set +e
+npx vitest run "$F" > /tmp/p09_red.log 2>&1
+STATUS=$?
+set -e
+tail -40 /tmp/p09_red.log
+if [ "$STATUS" -eq 0 ]; then echo "FAIL: unexpectedly all-green before P10"; exit 1; fi
+if grep -qiE "Cannot find module|SyntaxError|Failed to resolve import|ReferenceError" /tmp/p09_red.log; then
+  echo "FAIL: RED is a module/compile error, not behavioral"; exit 1
+fi
+echo "RED confirmed behavioral (expected until P10)."
+```
+
+### Semantic Verification Checklist (BLOCKS progression)
+
+- [ ] T11/T11b drive the REAL Config disabled-set through the public `agent.hooks` surface.
+- [ ] T12a undefined-safe; T12b populated snapshot mirrors a real seeded registry entry.
+- [ ] Fresh-copy contract proven by mutate-then-reread.
+- [ ] ≥30% property; MIN-2; no mock theater; no reverse tests; behavioral RED.
+
+## Success Criteria
+
+- Behavioral RED suite covering round-trip, idempotent enable/disable, undefined-safe + populated listHooks.
+
+## Failure Recovery
+
+- `git checkout -- "$F"`; rewrite.
+
+## Deferred Implementation Detection (MANDATORY — scoped)
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
+test -f "$F" || { echo "missing test"; exit 1; }
+if grep -nE "(TODO|FIXME|HACK|XXX|TEMPORARY|WIP|placeholder|for now|in a real|coming soon)" "$F"; then echo "FAIL: deferred marker"; exit 1; fi
+if grep -niE "toThrow\(.*NotYetImplemented|should (not )?be implemented" "$F"; then echo "FAIL: reverse pattern"; exit 1; fi
+if grep -nE "\b(it|test|describe)\.skip\b|\bxit\b|\bxdescribe\b" "$F"; then echo "FAIL: skipped test"; exit 1; fi
+echo "PASS: no deferred markers."
+```
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P09.md`
+
+```markdown
+Phase: P09
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/10-hooks-admin-impl.md
+++ b/project-plans/issue2143/plan/10-hooks-admin-impl.md
@@ -1,0 +1,174 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 -->
+# Phase 10: Hooks Administration — Implementation (GREEN)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P10`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 09 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P09.md`
+- Pseudocode: `project-plans/issue2143/analysis/pseudocode/hooks-admin.md`
+  (listHooks lines 1-19; getDisabledHooks 30-32; setDisabledHooks 40-42; disable 50-54; enable 57-61)
+
+## Purpose
+
+Make the P09 behavioral RED suite pass by EXTENDING `AgentHookControl` (interface) and `HookControl`
+(impl) with administration methods. Existing members are untouched (REQ-009 non-breaking). No new
+wiring: `HookControl` already holds `this.deps.config`.
+
+## Implementation Tasks
+
+### Files to Modify
+
+#### 1. `packages/agents/src/api/agent.ts` — extend the interface + add the projected type
+
+Add `HookInfo` near the other projected public types, and extend `AgentHookControl`:
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004
+export interface HookInfo {
+  readonly name: string;
+  readonly eventName: string;
+  readonly enabled: boolean;
+  readonly source?: string;
+}
+```
+
+Extend the existing interface (do NOT remove the existing four members):
+
+```ts
+export interface AgentHookControl {
+  onHookExecution(
+    cb: (req: HookExecutionRequest, resp: HookExecutionResponse) => void,
+  ): Unsubscribe;
+  triggerSessionStart(): Promise<void>;
+  triggerSessionEnd(): Promise<void>;
+  clear(): void;
+  // @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004
+  listHooks(): readonly HookInfo[];
+  getDisabledHooks(): readonly string[];
+  setDisabledHooks(names: readonly string[]): void;
+  enable(name: string): void;
+  disable(name: string): void;
+}
+```
+
+#### 2. `packages/agents/src/api/control/hooks.ts` — implement the five methods
+
+Add to the `HookControl` class body (it already has `this.deps.config`). Follow the pseudocode
+line-by-line.
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 1-19
+listHooks(): readonly HookInfo[] {
+  const system = this.deps.config.getHookSystem();
+  if (!system) return [];
+  if (!system.isInitialized()) return [];
+  const registry = system.getRegistry();
+  return registry.getAllHooks().map((entry) => ({
+    name: registry.getHookName(entry),
+    eventName: String(entry.eventName),
+    enabled: entry.enabled,
+    source: entry.source === undefined ? undefined : String(entry.source),
+  }));
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 30-32
+getDisabledHooks(): readonly string[] {
+  return [...this.deps.config.getDisabledHooks()];
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 40-42
+setDisabledHooks(names: readonly string[]): void {
+  this.deps.config.setDisabledHooks([...names]);
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 50-54
+disable(name: string): void {
+  const current = this.deps.config.getDisabledHooks();
+  if (current.includes(name)) return;
+  this.deps.config.setDisabledHooks([...current, name]);
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P10 @requirement:REQ-004 @pseudocode lines 57-61
+enable(name: string): void {
+  const current = this.deps.config.getDisabledHooks();
+  this.deps.config.setDisabledHooks(current.filter((n) => n !== name));
+}
+```
+
+Add the `HookInfo` import to the existing `import type { AgentHookControl, ... } from '../agent.js';`
+group. `getHookSystem`/`getDisabledHooks`/`setDisabledHooks` are already on the imported `Config` type.
+
+### Constraints
+
+- Do NOT modify the P09 test file.
+- Existing `AgentHookControl` members remain byte-identical (REQ-009).
+- No new wiring in `AgentImpl` (deps.config already present); `buildHookControl()` (agentImpl.ts:391)
+  is unchanged.
+- No cached registry/disabled-set state — read `this.deps.config` every call (R-DELEGATE).
+- `listHooks()` guards both `undefined` system AND `!isInitialized()` (registry access only after init).
+- Return fresh array copies (`[...]`) — never hand out the engine's internal arrays.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+H=packages/agents/src/api/control/hooks.ts
+F=packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
+
+# Interface extended, existing members preserved.
+grep -qE "listHooks\(\): readonly HookInfo\[\]" "$A" || { echo "FAIL: listHooks missing on interface"; exit 1; }
+grep -qE "triggerSessionStart\(\): Promise<void>" "$A" || { echo "FAIL: existing member removed"; exit 1; }
+
+# Impl present + delegates + markers.
+grep -qE "@pseudocode lines 1-19" "$H" || { echo "FAIL: listHooks marker missing"; exit 1; }
+grep -qE "getHookSystem\(\)" "$H" || { echo "FAIL: not delegating to config hook system"; exit 1; }
+grep -qE "isInitialized\(\)" "$H" || { echo "FAIL: missing isInitialized guard"; exit 1; }
+grep -qE "setDisabledHooks\(\[\.\.\." "$H" || { echo "FAIL: setDisabledHooks not fresh-copying"; exit 1; }
+
+# No cached field for hooks admin.
+if grep -nE "private .*(disabledHooks|hookCache|cachedHooks)\b" "$H"; then echo "FAIL: cached hook state"; exit 1; fi
+
+# Tests now GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run "$F" > /tmp/p10_green.log 2>&1 || { echo "FAIL: P09 suite not green"; tail -40 /tmp/p10_green.log; exit 1; }
+
+# Whole control dir still green (non-breaking).
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p10_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p10_all.log; exit 1; }
+
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+```
+
+### Deferred Implementation Detection (MANDATORY — scoped to changed lines)
+
+```bash
+set -o pipefail
+set -e
+for F in packages/agents/src/api/agent.ts packages/agents/src/api/control/hooks.ts; do
+  git diff HEAD -- "$F" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $F"; exit 1; } || true
+done
+echo "PASS: no deferred markers in changed lines."
+```
+
+## Success Criteria
+
+- P09 suite GREEN; whole `__tests__` dir GREEN; typecheck + lint clean.
+- Existing `AgentHookControl` members unchanged; five admin methods added and delegating.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/agent.ts packages/agents/src/api/control/hooks.ts`
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P10.md` (same field schema as P08).

--- a/project-plans/issue2143/plan/10-hooks-admin-impl.md
+++ b/project-plans/issue2143/plan/10-hooks-admin-impl.md
@@ -73,7 +73,7 @@ listHooks(): readonly HookInfo[] {
     name: registry.getHookName(entry),
     eventName: String(entry.eventName),
     enabled: entry.enabled,
-    source: entry.source === undefined ? undefined : String(entry.source),
+    source: String(entry.source), // ConfigSource is non-nullable (hookRegistry.ts:37)
   }));
 }
 

--- a/project-plans/issue2143/plan/10a-hooks-admin-impl-verification.md
+++ b/project-plans/issue2143/plan/10a-hooks-admin-impl-verification.md
@@ -1,0 +1,94 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P10a @requirement:REQ-004 -->
+# Phase 10a: Hooks Administration — Pseudocode-Compliance Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P10a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 10 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P10.md`
+
+## Purpose
+
+Independent gate. Confirm the P10 implementation matches `analysis/pseudocode/hooks-admin.md` line-by-line,
+preserves the existing `AgentHookControl` surface (non-breaking), is delegate-only (no cache), is
+undefined/uninitialised-safe, and that the P09 tests are genuinely behavioral (no mock theater, ≥30%
+property, no reverse tests).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+H=packages/agents/src/api/control/hooks.ts
+F=packages/agents/src/api/__tests__/hookAdmin.behavior.test.ts
+
+# 1. Target test + whole dir GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p10a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p10a_all.log; exit 1; }
+
+# 2. Project typecheck + lint clean.
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+
+# 3. Non-breaking: existing four members still declared on the interface.
+for m in "onHookExecution" "triggerSessionStart" "triggerSessionEnd" "clear"; do
+  grep -qE "$m" "$A" || { echo "FAIL: existing AgentHookControl member $m missing"; exit 1; }
+done
+
+# 4. Delegation + guards present; no cache.
+grep -qE "getHookSystem\(\)" "$H" || { echo "FAIL: not delegating"; exit 1; }
+grep -qE "isInitialized\(\)" "$H" || { echo "FAIL: missing init guard"; exit 1; }
+if grep -nE "private .*(disabledHooks|hookCache|cachedHooks)\b" "$H"; then echo "FAIL: cached state"; exit 1; fi
+
+# 5. Re-audit P09 tests are behavioral.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+
+# 6. Deferred scan on changed lines.
+for X in "$A" "$H"; do
+  git diff HEAD -- "$X" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $X"; exit 1; } || true
+done
+echo "PASS: gates green."
+```
+
+### Line-by-Line Compliance Table (fill in, fold into marker)
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1-19 | listHooks (undefined + isInitialized guards, project name/eventName/enabled/source) | hooks.ts:___ | |
+| 30-32 | getDisabledHooks (fresh copy) | hooks.ts:___ | |
+| 40-42 | setDisabledHooks (fresh-copy write-through) | hooks.ts:___ | |
+| 50-54 | disable (idempotent short-circuit) | hooks.ts:___ | |
+| 57-61 | enable (filter) | hooks.ts:___ | |
+
+## Holistic Functionality Assessment (MANDATORY — into marker)
+
+- **What was implemented**: five admin methods on `AgentHookControl`/`HookControl`.
+- **Satisfies REQ-004?**: list/getDisabled/setDisabled/enable/disable present; existing members intact?
+- **Data flow**: live `this.deps.config` every call; registry only after `isInitialized()`; fresh copies?
+- **Risks**: any cache; any leak of the engine's internal arrays; any change to existing members.
+- **Verdict**: PASS/FAIL with file:line evidence.
+
+## Success Criteria
+
+- All gates pass; compliance table complete; non-breaking confirmed; holistic verdict PASS.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P10a.md` including the completed compliance table + holistic
+assessment.

--- a/project-plans/issue2143/plan/11-auth-detail-tdd.md
+++ b/project-plans/issue2143/plan/11-auth-detail-tdd.md
@@ -1,0 +1,212 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P11 @requirement:REQ-005 -->
+# Phase 11: Auth Detail (extend `agent.auth` with masked OAuth metadata) — Behavioral TDD
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P11`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 10a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P10a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-005: Detailed (masked) auth state on `AgentAuthControl`
+
+**Full Text**: EXTEND the existing `AgentAuthControl` (agent.ts:264-276) — keeping ALL existing members
+(`login`/`logout`/`status`/`enableOAuth`/`disableOAuth`/`listBuckets`/`switchBucket`/`mcpLogin`/`keys`/
+`setBaseUrl`) EXACTLY as-is (REQ-009 non-breaking) — with detailed, MASKED auth metadata sourced from
+the live `OAuthManager`. NO raw secret strings are ever returned (R-NO-RAW-SECRETS).
+- **REQ-005.1**: `detailedStatus(provider): Promise<AuthProviderDetail>` — `{provider, authenticated,
+  oauthEnabled, expiry?}`. `expiry` is read ONLY from `peekStoredToken(...).expiry` (a unix-seconds
+  number) and ONLY when `authenticated === true`. `access_token` / `refresh_token` are NEVER copied.
+- **REQ-005.2**: `getHigherPriorityAuth(provider): Promise<string | null>` — read-through that returns a
+  source NAME (e.g. `"key"`) or `null`; never a secret.
+- **REQ-005.3**: `listBucketStatuses(provider): Promise<readonly AuthBucketStatus[]>` — projects each
+  bucket to `{bucket, authenticated, expiry?, isSessionBucket}` (the four public fields only).
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a provider with OAuth enabled + a stored non-expired token (expiry=E) → `detailedStatus(p)` is
+  `{provider:p, authenticated:true, oauthEnabled:true, expiry:E}` and contains NO `access_token` key.
+- GIVEN OAuth enabled but no stored token → `detailedStatus(p)` is `{authenticated:false,
+  oauthEnabled:true, expiry:undefined}`.
+- GIVEN OAuth NOT enabled for a provider → `detailedStatus(p).oauthEnabled === false`.
+- GIVEN a provider with two buckets (one a session bucket) → `listBucketStatuses(p)` has length 2 and
+  each element has exactly the four public fields.
+- GIVEN no higher-priority method → `getHigherPriorityAuth(p)` is `null`.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/authDetail.behavior.test.ts`
+
+  Drive REAL `OAuthManager` state hermetically — NO mock theater. The blessed hermetic seam (used across
+  many real provider tests, e.g. `oauthManager.proactive-renewal.test.ts:85`, behavioral
+  `test-utils.ts:138`) is an in-memory `TokenStore` + a real `OAuthManager`:
+
+  1. **Build a real, seedable OAuthManager** (`.behavior.test.ts` is T17-exempt — may import the
+     providers `auth.js` subpath and the control file directly):
+     - Implement a tiny in-memory `TokenStore` in the test (mirror `MemoryTokenStore` in
+       `packages/providers/src/auth/__tests__/behavioral/test-utils.ts:11` — `saveToken`/`getToken`/
+       `removeToken`/`listProviders`/`listBuckets`/`getBucketStats`/lock no-ops). Do NOT import the
+       providers internal `__tests__` file; declare the store inline in the behavior test (keeps imports
+       to the public `auth.js` types + node).
+     - `import { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js'` and
+       `import type { OAuthToken, OAuthProvider } from '@vybestack/llxprt-code-providers/auth.js'`.
+     - `const store = new MemoryTokenStore();` `const mgr = new OAuthManager(store);`
+     - Register a real `OAuthProvider` object (plain object literal implementing `name`/`initiateAuth`/
+       `getToken`/`refreshToken`) via `mgr.registerProvider(provider)` so `isOAuthEnabled(name)` is true.
+     - Seed authentication by `await store.saveToken('myprov', { access_token: 'SECRET-do-not-leak',
+       refresh_token: 'REFRESH-do-not-leak', expiry: <now+3600 unix-seconds>, token_type: 'Bearer',
+       scope: '' })`. After seeding, `mgr.isAuthenticated('myprov')` resolves true and
+       `mgr.peekStoredToken('myprov')` returns the token (no refresh).
+  2. **Construct the control directly over the real manager** (BLESSED direct-construction precedent —
+     `new HookControl(realDeps)` / `new McpControl(deps)`):
+     - `import { AuthControl } from '../control/authControl.js'` and build the minimal real
+       `AuthControlDeps` (the existing fields are easy to supply; the NEW field is
+       `getOAuthManager: () => mgr`). Then assert through `authControl.detailedStatus(...)` etc.
+     - Rationale: the buildAgent harness wires a keyring-backed shared store (non-hermetic), so the
+       detailed-OAuth path is driven via the real manager over an in-memory store. This is real
+       behavior (no spies/stubs), just a hermetic store — exactly the providers-package convention.
+  3. **Scenarios** below. Critically, the **no-leak property** must enumerate `Object.keys(...)` (deeply)
+     of every returned object across generated inputs and assert NO `access_token` / `refresh_token`
+     key appears.
+
+  - Markers `@plan:PLAN-20260622-COREAPIGAP.P11`, `@requirement:REQ-005`.
+
+### Required scenarios
+
+```
+T13   detailedStatus: oauth-enabled + seeded non-expired token (expiry=E) →
+      {provider, authenticated:true, oauthEnabled:true, expiry:E}; Object.keys has NO access_token/
+      refresh_token
+T13b  detailedStatus edge: (a) enabled but NO stored token → {authenticated:false, oauthEnabled:true,
+      expiry:undefined}; (b) provider with oauth NOT enabled → oauthEnabled:false
+T13c  listBucketStatuses: seed two buckets (default + a session bucket via setSessionBucket) → length 2,
+      each element keys === {bucket, authenticated, expiry?, isSessionBucket} (no extra/secret keys)
+T13d  getHigherPriorityAuth: with no higher-priority method configured → null (string-or-null contract)
+PROP  no-secret-leak: for a generated token (random access_token/refresh_token strings, expiry number),
+      seed + detailedStatus(p) → returned object (deep keys) contains neither access_token nor
+      refresh_token; and expiry, when present, strictly equals the seeded number; MIN-2 cases
+PROP  expiry-gating: for a generated boolean authed-state, detailedStatus only carries a defined expiry
+      when authenticated is true (authenticated=false ⇒ expiry===undefined); MIN-2 cases
+```
+
+### Constraints
+
+- Use a REAL `OAuthManager` over an in-memory `TokenStore`; register a REAL provider object. NEVER
+  `vi.fn()`, `vi.spyOn`, `mockResolvedValue`, or `toHaveBeenCalled`.
+- The no-leak assertions must walk the returned object's keys (deep) — a behavioral guarantee, not a
+  structure-only `toHaveProperty`.
+- Use `peekStoredToken` semantics: seeding a token + asserting `expiry` round-trips proves the value path
+  WITHOUT triggering a refresh (do not seed an expired token for the authed-detail positive case).
+- ≥30% property-based (fast-check), MIN-2 distinct property cases.
+- Existing `AgentAuthControl` members remain callable (do not assert their removal).
+- Positive cases fail at RED because `detailedStatus`/`getHigherPriorityAuth`/`listBucketStatuses` do not
+  exist on `AuthControl` yet (missing-method TypeError = behavioral RED).
+
+### RED-note (parses despite the not-yet-extended deps)
+
+`AuthControlDeps` will not have `getOAuthManager` until P12, so a statically-typed construction could be
+a *compile* error rather than a *behavioral* RED. To keep the RED behavioral: construct the deps object
+and cast through `unknown` to `AuthControlDeps` at the single construction site (e.g.
+`new AuthControl(deps as unknown as AuthControlDeps)`), so the file PARSES and the positive assertions
+fail at runtime with a missing-method `TypeError`. (P12 removes the need for the cast by adding the field;
+the impl-phase verification greps that the cast is gone.)
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/authDetail.behavior.test.ts
+test -f "$F"
+
+if grep -nE "toHaveBeenCalled" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater (spy/stub)"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# Real hermetic manager (not a fake) + the three methods exercised (BLOCKING).
+grep -qE "new OAuthManager\(" "$F" || { echo "FAIL: not driving a real OAuthManager"; exit 1; }
+grep -qE "detailedStatus" "$F" || { echo "FAIL: detailedStatus not exercised"; exit 1; }
+grep -qE "listBucketStatuses" "$F" || { echo "FAIL: listBucketStatuses not exercised"; exit 1; }
+grep -qE "getHigherPriorityAuth" "$F" || { echo "FAIL: getHigherPriorityAuth not exercised"; exit 1; }
+
+# No-leak assertion must enumerate keys (behavioral, not structure-only).
+grep -qE "Object\.keys|JSON\.stringify" "$F" || { echo "FAIL: no-leak not enumerated over keys"; exit 1; }
+grep -qE "access_token|refresh_token" "$F" || { echo "FAIL: no-leak does not name the secret keys"; exit 1; }
+
+# Property-based >= 30% (BLOCKING; MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '
+  /(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 }
+  /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } }
+  END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+if [ "$TOTAL" -eq 0 ]; then echo "FAIL: no tests"; exit 1; fi
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+if [ "$PROP" -lt 2 ]; then echo "FAIL: <2 property cases"; exit 1; fi
+if [ "$PCT" -lt 30 ]; then echo "FAIL: property ${PCT}% < 30%"; exit 1; fi
+
+# RED-state enforcement.
+set +e
+npx vitest run "$F" > /tmp/p11_red.log 2>&1
+STATUS=$?
+set -e
+tail -40 /tmp/p11_red.log
+if [ "$STATUS" -eq 0 ]; then echo "FAIL: unexpectedly all-green before P12"; exit 1; fi
+if grep -qiE "Cannot find module|SyntaxError|Failed to resolve import|ReferenceError" /tmp/p11_red.log; then
+  echo "FAIL: RED is a module/compile error, not behavioral"; exit 1
+fi
+echo "RED confirmed behavioral (expected until P12)."
+```
+
+### Semantic Verification Checklist (BLOCKS progression)
+
+- [ ] Drives a REAL `OAuthManager` over an in-memory `TokenStore` with a REAL registered provider.
+- [ ] No-leak property walks returned keys and names `access_token`/`refresh_token` as forbidden.
+- [ ] `expiry` round-trips the seeded number; gated behind `authenticated === true`.
+- [ ] Bucket projection asserts exactly the four public fields.
+- [ ] ≥30% property; MIN-2; no mock theater; no reverse tests; behavioral RED.
+
+## Success Criteria
+
+- Behavioral RED suite covering masked detailedStatus, bucket-status projection, higher-priority
+  read-through, and the no-raw-secrets guarantee.
+
+## Failure Recovery
+
+- `git checkout -- "$F"`; rewrite.
+
+## Deferred Implementation Detection (MANDATORY — scoped)
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/authDetail.behavior.test.ts
+test -f "$F" || { echo "missing test"; exit 1; }
+if grep -nE "(TODO|FIXME|HACK|XXX|TEMPORARY|WIP|placeholder|for now|in a real|coming soon)" "$F"; then echo "FAIL: deferred marker"; exit 1; fi
+if grep -niE "toThrow\(.*NotYetImplemented|should (not )?be implemented" "$F"; then echo "FAIL: reverse pattern"; exit 1; fi
+if grep -nE "\b(it|test|describe)\.skip\b|\bxit\b|\bxdescribe\b" "$F"; then echo "FAIL: skipped test"; exit 1; fi
+echo "PASS: no deferred markers."
+```
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P11.md`
+
+```markdown
+Phase: P11
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/12-auth-detail-impl.md
+++ b/project-plans/issue2143/plan/12-auth-detail-impl.md
@@ -1,0 +1,227 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005 -->
+# Phase 12: Auth Detail — Implementation (GREEN)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P12`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 11 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P11.md`
+- Pseudocode: `project-plans/issue2143/analysis/pseudocode/auth-detail.md`
+  (detailedStatus lines 1-17; getHigherPriorityAuth 30-33; listBucketStatuses 40-49)
+
+## Purpose
+
+Make the P11 behavioral RED suite pass by EXTENDING `AgentAuthControl` (interface) and `AuthControl`
+(impl) with three masked, delegating methods, and threading the already-present `OAuthManager` into
+`AuthControlDeps` via a closure in `buildAuthControl()`. No new `AgentImpl` constructor parameter:
+`OAuthManager` is already on `AgentDeps` (`agentImpl.ts:121`). Existing members are untouched
+(REQ-009 non-breaking).
+
+## Implementation Tasks
+
+### Files to Modify
+
+#### 1. `packages/agents/src/api/agent.ts` — add projected types + extend the interface
+
+Add the two projected public types near the other projected types. They NEVER include token strings:
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+export interface AuthProviderDetail {
+  readonly provider: string;
+  readonly authenticated: boolean;
+  readonly oauthEnabled: boolean;
+  readonly expiry?: number;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+export interface AuthBucketStatus {
+  readonly bucket: string;
+  readonly authenticated: boolean;
+  readonly expiry?: number;
+  readonly isSessionBucket: boolean;
+}
+```
+
+Extend the existing `AgentAuthControl` (do NOT remove or reorder existing members):
+
+```ts
+export interface AgentAuthControl {
+  login(provider: string, opts?: { readonly bucket?: string }): Promise<void>;
+  logout(
+    provider: string,
+    opts?: { readonly bucket?: string; readonly all?: boolean },
+  ): Promise<void>;
+  status(provider?: string): AuthStatus;
+  enableOAuth(provider: string): Promise<void>;
+  disableOAuth(provider: string): Promise<void>;
+  listBuckets(provider?: string): readonly AuthBucket[];
+  switchBucket(provider: string, bucket: string): Promise<void>;
+  mcpLogin(server: string): Promise<void>;
+  readonly keys: AgentAuthKeysControl;
+  setBaseUrl(
+    baseUrl: string | null,
+    opts?: { readonly provider?: string },
+  ): Promise<void>;
+  // @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+  detailedStatus(provider: string): Promise<AuthProviderDetail>;
+  getHigherPriorityAuth(provider: string): Promise<string | null>;
+  listBucketStatuses(provider: string): Promise<readonly AuthBucketStatus[]>;
+}
+```
+
+#### 2. `packages/agents/src/api/control/authControl.ts` — add the deps field + implement
+
+Add the new dep (the closure resolving the live manager) to `AuthControlDeps`:
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+/** Resolves the live OAuthManager (already on AgentDeps). Never cached. */
+readonly getOAuthManager: () => OAuthManager;
+```
+
+Add the import (type-only, via the providers `auth.js` subpath — the same path `agentImpl.ts:25` uses):
+
+```ts
+import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
+```
+
+Add the projected return types to the existing `import type { ... } from '../agent.js';` group:
+`AuthProviderDetail`, `AuthBucketStatus`.
+
+Implement the three methods on the `AuthControl` class, following the pseudocode line-by-line:
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005 @pseudocode lines 1-17
+async detailedStatus(provider: string): Promise<AuthProviderDetail> {
+  const mgr = this.deps.getOAuthManager();
+  const oauthEnabled = mgr.isOAuthEnabled(provider);
+  const authenticated = await mgr.isAuthenticated(provider);
+  let expiry: number | undefined;
+  if (authenticated) {
+    const token = await mgr.peekStoredToken(provider);
+    if (token !== null) {
+      expiry = token.expiry;
+    }
+  }
+  return { provider, authenticated, oauthEnabled, expiry };
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005 @pseudocode lines 30-33
+async getHigherPriorityAuth(provider: string): Promise<string | null> {
+  return this.deps.getOAuthManager().getHigherPriorityAuth(provider);
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005 @pseudocode lines 40-49
+async listBucketStatuses(
+  provider: string,
+): Promise<readonly AuthBucketStatus[]> {
+  const raw = await this.deps.getOAuthManager().getAuthStatusWithBuckets(provider);
+  return raw.map((b) => ({
+    bucket: b.bucket,
+    authenticated: b.authenticated,
+    expiry: b.expiry,
+    isSessionBucket: b.isSessionBucket,
+  }));
+}
+```
+
+#### 3. `packages/agents/src/api/agentImpl.ts` — thread the manager into `buildAuthControl()`
+
+In `buildAuthControl()` (`agentImpl.ts:431`), add ONE field to the `new AuthControl({...})` deps object
+(no new constructor parameter; reuse the already-present `this.deps.oauthManager`):
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P12 @requirement:REQ-005
+getOAuthManager: () => this.deps.oauthManager,
+```
+
+### Constraints
+
+- Do NOT modify the P11 test file.
+- Existing `AgentAuthControl` members remain byte-identical (REQ-009).
+- NEVER copy `token.access_token` / `token.refresh_token` onto any returned object — read ONLY
+  `token.expiry` (R-NO-RAW-SECRETS).
+- Use `peekStoredToken` (no refresh) — NOT `getToken` (which may refresh / make network calls).
+- Guard the expiry read behind `authenticated === true`.
+- Project `getAuthStatusWithBuckets` into `AuthBucketStatus` (four named fields) — do NOT return the raw
+  array.
+- No cached manager / results — resolve `this.deps.getOAuthManager()` every call (R-DELEGATE).
+- No new `AgentImpl` constructor parameter — reuse `this.deps.oauthManager`.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+C=packages/agents/src/api/control/authControl.ts
+I=packages/agents/src/api/agentImpl.ts
+F=packages/agents/src/api/__tests__/authDetail.behavior.test.ts
+
+# Interface extended, existing members preserved.
+grep -qE "detailedStatus\(provider: string\): Promise<AuthProviderDetail>" "$A" || { echo "FAIL: detailedStatus missing on interface"; exit 1; }
+grep -qE "listBucketStatuses\(provider: string\)" "$A" || { echo "FAIL: listBucketStatuses missing"; exit 1; }
+grep -qE "mcpLogin\(server: string\): Promise<void>" "$A" || { echo "FAIL: existing member removed"; exit 1; }
+
+# Deps field + wiring present.
+grep -qE "getOAuthManager: \(\) => OAuthManager" "$C" || { echo "FAIL: getOAuthManager dep missing"; exit 1; }
+grep -qE "getOAuthManager: \(\) => this\.deps\.oauthManager" "$I" || { echo "FAIL: buildAuthControl not threading oauthManager"; exit 1; }
+
+# Impl present + correct seam + markers.
+grep -qE "@pseudocode lines 1-17" "$C" || { echo "FAIL: detailedStatus marker missing"; exit 1; }
+grep -qE "peekStoredToken" "$C" || { echo "FAIL: not using peekStoredToken"; exit 1; }
+
+# R-NO-RAW-SECRETS: the control must NOT reference token secret fields anywhere.
+if grep -nE "access_token|refresh_token" "$C"; then echo "FAIL: control references a raw secret field"; exit 1; fi
+# Must NOT use the refreshing getToken for expiry.
+if grep -nE "\.getToken\(" "$C"; then echo "FAIL: used refreshing getToken instead of peekStoredToken"; exit 1; fi
+
+# No cached manager field.
+if grep -nE "private .*(oauthManager|cachedManager|authCache)\b" "$C"; then echo "FAIL: cached manager state"; exit 1; fi
+
+# RED-note cast must be gone from the test now that the dep exists.
+if grep -nE "as unknown as AuthControlDeps" "$F"; then echo "FAIL: RED-note cast still present (deps now typed)"; exit 1; fi
+
+# Tests now GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run "$F" > /tmp/p12_green.log 2>&1 || { echo "FAIL: P11 suite not green"; tail -40 /tmp/p12_green.log; exit 1; }
+
+# Whole dir still green (non-breaking).
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p12_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p12_all.log; exit 1; }
+
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+```
+
+### Deferred Implementation Detection (MANDATORY — scoped to changed lines)
+
+```bash
+set -o pipefail
+set -e
+for F in packages/agents/src/api/agent.ts packages/agents/src/api/control/authControl.ts packages/agents/src/api/agentImpl.ts; do
+  git diff HEAD -- "$F" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $F"; exit 1; } || true
+done
+echo "PASS: no deferred markers in changed lines."
+```
+
+## Success Criteria
+
+- P11 suite GREEN; whole `__tests__` dir GREEN; typecheck + lint clean.
+- Existing `AgentAuthControl` members unchanged; three masked methods added and delegating; manager
+  threaded via closure (no new ctor param); no raw secret fields referenced in the control.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/agent.ts packages/agents/src/api/control/authControl.ts packages/agents/src/api/agentImpl.ts`
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P12.md` (same field schema as P08).

--- a/project-plans/issue2143/plan/12a-auth-detail-impl-verification.md
+++ b/project-plans/issue2143/plan/12a-auth-detail-impl-verification.md
@@ -1,0 +1,115 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P12a @requirement:REQ-005 -->
+# Phase 12a: Auth Detail — Pseudocode-Compliance Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P12a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 12 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P12.md`
+
+## Purpose
+
+Independent gate. Confirm the P12 implementation matches `analysis/pseudocode/auth-detail.md`
+line-by-line, preserves the existing `AgentAuthControl` surface (non-breaking), is delegate-only
+(no cached manager/results), NEVER returns raw token secrets (R-NO-RAW-SECRETS), uses `peekStoredToken`
+(no refresh) for expiry, and that the P11 tests are genuinely behavioral (real `OAuthManager` over an
+in-memory `TokenStore`, no mock theater, ≥30% property, no reverse tests).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+C=packages/agents/src/api/control/authControl.ts
+I=packages/agents/src/api/agentImpl.ts
+F=packages/agents/src/api/__tests__/authDetail.behavior.test.ts
+
+# 1. Target test + whole dir GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p12a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p12a_all.log; exit 1; }
+
+# 2. Project typecheck + lint clean.
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+
+# 3. Non-breaking: existing AgentAuthControl members still declared.
+for m in "login" "logout" "status" "enableOAuth" "disableOAuth" "listBuckets" "switchBucket" "mcpLogin" "setBaseUrl"; do
+  grep -qE "$m" "$A" || { echo "FAIL: existing AgentAuthControl member $m missing"; exit 1; }
+done
+grep -qE "readonly keys: AgentAuthKeysControl" "$A" || { echo "FAIL: existing keys member missing"; exit 1; }
+
+# 4. R-NO-RAW-SECRETS: control must not reference secret token fields; must use peekStoredToken not getToken.
+if grep -nE "access_token|refresh_token" "$C"; then echo "FAIL: control references a raw secret field"; exit 1; fi
+grep -qE "peekStoredToken" "$C" || { echo "FAIL: not using peekStoredToken"; exit 1; }
+if grep -nE "\.getToken\(" "$C"; then echo "FAIL: used refreshing getToken"; exit 1; fi
+
+# 5. Delegation + wiring; no cache.
+grep -qE "getOAuthManager: \(\) => this\.deps\.oauthManager" "$I" || { echo "FAIL: buildAuthControl wiring missing"; exit 1; }
+grep -qE "this\.deps\.getOAuthManager\(\)" "$C" || { echo "FAIL: not resolving manager per call"; exit 1; }
+if grep -nE "private .*(oauthManager|cachedManager|authCache)\b" "$C"; then echo "FAIL: cached manager state"; exit 1; fi
+
+# 6. Expiry gated behind authenticated (the pseudocode contract).
+grep -qE "if \(authenticated\)" "$C" || { echo "FAIL: expiry not gated behind authenticated"; exit 1; }
+
+# 7. Re-audit P11 tests are behavioral + hermetic-real.
+grep -qE "new OAuthManager\(" "$F" || { echo "FAIL: not a real OAuthManager"; exit 1; }
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+if grep -nE "as unknown as AuthControlDeps" "$F"; then echo "FAIL: RED-note cast lingering"; exit 1; fi
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+# No-leak assertion is present in the test.
+grep -qE "access_token|refresh_token" "$F" || { echo "FAIL: no-leak assertion missing"; exit 1; }
+
+# 8. Deferred scan on changed lines.
+for X in "$A" "$C" "$I"; do
+  git diff HEAD -- "$X" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $X"; exit 1; } || true
+done
+echo "PASS: gates green."
+```
+
+### Line-by-Line Compliance Table (fill in, fold into marker)
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1-17 | detailedStatus (oauthEnabled + authenticated; expiry from peekStoredToken ONLY when authenticated; no secrets) | authControl.ts:___ | |
+| 30-33 | getHigherPriorityAuth (read-through string\|null) | authControl.ts:___ | |
+| 40-49 | listBucketStatuses (project bucket/authenticated/expiry/isSessionBucket) | authControl.ts:___ | |
+| wiring | buildAuthControl threads `getOAuthManager: () => this.deps.oauthManager` | agentImpl.ts:___ | |
+
+## Holistic Functionality Assessment (MANDATORY — into marker)
+
+- **What was implemented**: three masked detail methods on `AgentAuthControl`/`AuthControl`, plus the
+  `getOAuthManager` closure dep wired in `buildAuthControl()`.
+- **Satisfies REQ-005?**: detailedStatus / getHigherPriorityAuth / listBucketStatuses present; existing
+  members intact (non-breaking)?
+- **Data flow**: live `this.deps.getOAuthManager()` every call; `peekStoredToken` (no refresh); expiry
+  gated behind `authenticated`; bucket projection to four named fields.
+- **Security (R-NO-RAW-SECRETS)**: no `access_token`/`refresh_token` reachable on any returned object;
+  test enumerates keys to prove it. Verdict on leak risk with evidence.
+- **Risks**: any cached manager; any path that could surface a secret; any change to existing members;
+  any use of refreshing `getToken`.
+- **Verdict**: PASS/FAIL with file:line evidence.
+
+## Success Criteria
+
+- All gates pass; compliance table complete; non-breaking + no-raw-secrets confirmed; holistic verdict
+  PASS.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P12a.md` including the completed compliance table + holistic
+assessment.

--- a/project-plans/issue2143/plan/13-mcp-oauth-tdd.md
+++ b/project-plans/issue2143/plan/13-mcp-oauth-tdd.md
@@ -1,0 +1,221 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P13 @requirement:REQ-006 -->
+# Phase 13: MCP OAuth + refresh setTools parity + deep details (extend `agent.mcp`) — Behavioral TDD
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P13`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 12a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P12a.md`
+- Pseudocode (for context — DO NOT implement here): `analysis/pseudocode/mcp-oauth.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-006: OAuth + setTools parity + deep details on `AgentMcpControl`
+
+**Full Text**: EXTEND the existing `AgentMcpControl` (agent.ts:232-239) — keeping its existing
+members (`listServers`/`status`/`toolsByServer`/`auth`/`discoveryState`/`refresh`) EXACTLY as-is in
+SIGNATURE (REQ-009 non-breaking) — with the real OAuth flow, tool-publish parity, and deep details:
+
+- **REQ-006.1** `authenticate(server): Promise<McpServerAuthStatus>` — the REAL OAuth flow. Orchestrates
+  (in this exact order) the injected `performOAuth` → `manager.restartServer(server)` →
+  `refreshClientTools()`, then returns `{server, authenticated:true, requiresAuth:true}`. An unknown
+  server (or unwired `performOAuth`) is a no-op returning `{authenticated:false, requiresAuth:true}` —
+  NO OAuth attempted. A `performOAuth` rejection PROPAGATES (no restart, no setTools) — the control does
+  NOT catch (R-MCP-OAUTH-FLOW).
+- **REQ-006.2** `refresh(server?)` gains setTools parity: after the existing restart it ALSO calls
+  `refreshClientTools()` (R-REFRESH-PARITY). Signature unchanged.
+- **REQ-006.3** `details(opts?): Promise<McpDetailStatus>` — deep per-server projection; `includeTools`
+  default true, `includePrompts`/`includeResources` default false; projects prompts/resources to
+  named-field-only public types; includes `blockedServers`.
+- **REQ-006.4** undefined-safe: manager/registries/`performOAuth` absent → no-op / empty projection
+  (R-UNDEFINED-SAFE); existing `auth(server)` per-agent-flag read is UNCHANGED.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a configured server `s` + wired `performOAuth` + present manager → `authenticate("s")` records
+  the call order `oauth(s) → restart(s) → setTools` and returns `authenticated:true`.
+- GIVEN `authenticate("unknown")` (not in configs) → returns `authenticated:false`; `performOAuth` is
+  NEVER invoked; no restart/setTools.
+- GIVEN `performOAuth` rejects → `authenticate("s")` rejects; restart + setTools are NEVER invoked.
+- GIVEN a present manager → `refresh("s")` records `restart(s) → setTools`; `refresh()` records
+  `restart-all → setTools`.
+- GIVEN `getManager()` returns undefined → `refresh()` is a no-op; `setTools` is NEVER invoked.
+- GIVEN two configured servers → `details()` returns two `servers` each with `tools`, no
+  `prompts`/`resources`; `details({includePrompts:true})` adds projected prompts;
+  `details({includeResources:true})` adds resources filtered by server; undefined configs → empty
+  `servers`.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts`
+
+  `.behavior.test.ts` is **T17-exempt**, so it MAY deep-import the control + core types. Use the BLESSED
+  direct-construction precedent `new McpControl(deps)` (mirrors `mcp-discovery.spec.ts` /
+  `helpers/fakeMcpManager.ts`). Drive REAL ordering through observable closures — **NOT mock theater**:
+
+  1. **Observable-order deps (the no-mock-theater seam).** Build a local helper in the test that creates
+     an `McpControlDeps`-shaped object closing over a shared `callLog: string[]`:
+     - `performOAuth: async (server) => { callLog.push('oauth:' + server); }` (a variant that rejects:
+       `async () => { callLog.push('oauth:attempt'); throw new Error('oauth boom'); }`)
+     - `getManager: () => fakeManager` where `fakeManager = { restartServer: async (n) => { callLog.push('restart:' + n); }, restart: async () => { callLog.push('restart-all'); } } as unknown as McpClientManager`
+       (or `() => undefined` for the undefined-safe case)
+     - `refreshClientTools: async () => { callLog.push('setTools'); }`
+     - `getServerConfigs: () => ({ s: fakeServerConfig({ oauth: { enabled: true }, httpUrl: 'https://x' }) })`
+       (reuse `fakeServerConfig` from `helpers/fakeMcpManager.ts`)
+     - `getBlockedServers`, `getPromptRegistry`, `getResourceRegistry`, `isMcpAuthenticated`,
+       `getToolRegistry` as real small projections for the details tests.
+     Because the NEW closures are not yet on `McpControlDeps` at RED, construct via
+     `new McpControl(deps as unknown as McpControlDeps)` (RED-note cast — removed in P14). Asserting on
+     the ORDER/CONTENT of `callLog` is behavioral (mirrors `fakeMcpManager.restartedServers()`), never
+     `toHaveBeenCalled`.
+  2. **authenticate order (T14)** — success path: assert `callLog` deep-equals
+     `['oauth:s', 'restart:s', 'setTools']` AND the returned status is `{server:'s', authenticated:true,
+     requiresAuth:true}`.
+  3. **authenticate unknown server (T14b)** — `authenticate('nope')` returns `authenticated:false`;
+     `callLog` is empty (performOAuth NEVER ran).
+  4. **authenticate propagation (T14c)** — with the rejecting `performOAuth`, `await expect(
+     control.authenticate('s')).rejects.toThrow('oauth boom')`; `callLog` contains `'oauth:attempt'` but
+     NOT `'restart:s'` and NOT `'setTools'`.
+  5. **refresh parity (T15)** — `refresh('s')` → `callLog` deep-equals `['restart:s', 'setTools']`;
+     `refresh()` (no arg) → `['restart-all', 'setTools']`.
+  6. **refresh undefined-safe (T16)** — deps with `getManager: () => undefined` → `refresh()` resolves
+     and `callLog` is empty (`setTools` NOT called).
+  7. **details projection (T-details)** — two configured servers + a real tool registry view → `details()`
+     yields two `servers`, each `tools` defined, `prompts`/`resources` undefined; `blockedServers`
+     mirrors `getBlockedServers()`. `details({includePrompts:true})` → each server has projected
+     `prompts` (named-field-only). `details({includeResources:true})` → resources filtered by
+     `serverName`. `getServerConfigs:()=>undefined` → `servers` is `[]`.
+
+  - Markers `@plan:PLAN-20260622-COREAPIGAP.P13`, `@requirement:REQ-006`.
+
+### Required scenarios
+
+```
+T14    authenticate('s') success → callLog === ['oauth:s','restart:s','setTools']; returns
+       {server:'s', authenticated:true, requiresAuth:true}
+T14b   authenticate('nope') (not in configs) → returns authenticated:false; callLog === [] (no OAuth)
+T14c   performOAuth rejects → authenticate('s') rejects('oauth boom'); callLog has 'oauth:attempt' but
+       NOT 'restart:s' and NOT 'setTools'
+T15    refresh('s') → callLog === ['restart:s','setTools']; refresh() → ['restart-all','setTools']
+T16    getManager()===undefined → refresh() resolves; callLog === [] (setTools NOT called)
+Td1    details() (2 servers) → servers length 2; each tools defined; prompts/resources undefined;
+       blockedServers mirrors getBlockedServers()
+Td2    details({includePrompts:true}) → each server.prompts projected {name,description}; 
+       details({includeResources:true}) → each server.resources filtered by serverName, projected
+       {name?,uri}
+Td3    getServerConfigs()===undefined → details().servers === []
+PROP   for generated names NOT in a fixed config set, authenticate(name) → authenticated:false and
+       callLog stays [] (performOAuth never runs); MIN-2 cases
+PROP   for generated server names present in configs, authenticate(name) → callLog ===
+       ['oauth:'+name,'restart:'+name,'setTools'] and returns authenticated:true; MIN-2 cases
+PROP   for a generated config map (1..4 servers), details().servers length === number of config keys
+       and every server.name is a config key; MIN-2 cases
+```
+
+### Constraints
+
+- Assert real VALUES (callLog order/content, returned status fields, projected arrays) — NEVER
+  `toHaveBeenCalled`, NEVER `vi.fn()`/`vi.spyOn`/`mockResolvedValue`.
+- The observable closures record into a shared array (behavioral ordering seam) — this is the SAME
+  no-mock-theater idiom `helpers/fakeMcpManager.ts` already uses (`restartedServers()`).
+- Existing `AgentMcpControl` members (`listServers`/`status`/`toolsByServer`/`auth`/`discoveryState`)
+  MUST remain callable (do not assert their removal).
+- ≥30% property-based (fast-check), MIN-2 distinct property cases.
+- RED is behavioral: `authenticate`/`details` do not exist on `McpControl` yet (missing-method
+  TypeError), and `refresh` lacks the `setTools` step so the parity assertion fails on VALUE.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
+test -f "$F"
+
+if grep -nE "toHaveBeenCalled" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater (spy/stub)"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# Core behaviours all exercised (BLOCKING).
+grep -qE "authenticate\(" "$F" || { echo "FAIL: authenticate not exercised"; exit 1; }
+grep -qE "details\(" "$F" || { echo "FAIL: details not exercised"; exit 1; }
+grep -qE "\.refresh\(" "$F" || { echo "FAIL: refresh parity not exercised"; exit 1; }
+grep -qE "setTools" "$F" || { echo "FAIL: setTools-parity ordering not asserted"; exit 1; }
+grep -qE "callLog" "$F" || { echo "FAIL: observable ordering seam absent"; exit 1; }
+
+# Property-based >= 30% (BLOCKING; MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '
+  /(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 }
+  /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } }
+  END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+if [ "$TOTAL" -eq 0 ]; then echo "FAIL: no tests"; exit 1; fi
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+if [ "$PROP" -lt 2 ]; then echo "FAIL: <2 property cases"; exit 1; fi
+if [ "$PCT" -lt 30 ]; then echo "FAIL: property ${PCT}% < 30%"; exit 1; fi
+
+# RED-state enforcement.
+set +e
+npx vitest run "$F" > /tmp/p13_red.log 2>&1
+STATUS=$?
+set -e
+tail -40 /tmp/p13_red.log
+if [ "$STATUS" -eq 0 ]; then echo "FAIL: unexpectedly all-green before P14"; exit 1; fi
+if grep -qiE "Cannot find module|SyntaxError|Failed to resolve import|ReferenceError" /tmp/p13_red.log; then
+  echo "FAIL: RED is a module/compile error, not behavioral"; exit 1
+fi
+echo "RED confirmed behavioral (expected until P14)."
+```
+
+### Semantic Verification Checklist (BLOCKS progression)
+
+- [ ] T14/T14b/T14c drive the REAL orchestration order via the observable callLog seam.
+- [ ] T15 asserts setTools parity for both `refresh('s')` and `refresh()`.
+- [ ] T16 proves undefined-manager refresh is a no-op (setTools NOT called).
+- [ ] Td1-Td3 assert the deep-details projection (named fields only) + blockedServers + undefined-safe.
+- [ ] ≥30% property; MIN-2; no mock theater; no reverse tests; behavioral RED.
+
+## Success Criteria
+
+- Behavioral RED suite covering authenticate ordering + propagation + no-op, refresh setTools parity,
+  undefined-safety, and deep details projection.
+
+## Failure Recovery
+
+- `git checkout -- "$F"`; rewrite.
+
+## Deferred Implementation Detection (MANDATORY — scoped)
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
+test -f "$F" || { echo "missing test"; exit 1; }
+if grep -nE "(TODO|FIXME|HACK|XXX|TEMPORARY|WIP|placeholder|for now|in a real|coming soon)" "$F"; then echo "FAIL: deferred marker"; exit 1; fi
+if grep -niE "toThrow\(.*NotYetImplemented|should (not )?be implemented" "$F"; then echo "FAIL: reverse pattern"; exit 1; fi
+if grep -nE "\b(it|test|describe)\.skip\b|\bxit\b|\bxdescribe\b" "$F"; then echo "FAIL: skipped test"; exit 1; fi
+echo "PASS: no deferred markers."
+```
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P13.md`
+
+```markdown
+Phase: P13
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/14-mcp-oauth-impl.md
+++ b/project-plans/issue2143/plan/14-mcp-oauth-impl.md
@@ -107,15 +107,22 @@ export interface McpControlDeps {
 }
 ```
 
-Add the type-only barrel imports (source MAY import the bare core barrel):
+Add the type-only imports — **VERIFIED ground truth, these three come from THREE different sources;
+do NOT collapse them into one bare-barrel import (that fails to compile)**:
 
 ```ts
-import type {
-  MCPServerConfig,
-  MCPOAuthConfig,
-  ToolInfo,
-} from '@vybestack/llxprt-code-core';
+// MCPOAuthConfig IS exported as a type from the bare core barrel (core/src/index.ts:508).
+import type { MCPOAuthConfig } from '@vybestack/llxprt-code-core';
+// MCPServerConfig is NOT in the bare barrel — it lives at the deep config path
+// (this exactly mirrors how agent.ts:13 already imports it).
+import type { MCPServerConfig } from '@vybestack/llxprt-code-core/config/config.js';
 ```
+
+> `ToolInfo` is ALREADY imported from `'../agent.js'` at the top of `mcpControl.ts` (the existing
+> `import type { … ToolInfo } from '../agent.js'` block). Do **NOT** add a second `ToolInfo` import —
+> reuse the existing one. The new projected types (`McpDetailsOptions`, `McpServerDetail`,
+> `McpDetailStatus`, `McpPromptInfo`, `McpResourceInfo`, `McpBlockedServer`) must be ADDED to that
+> SAME existing `'../agent.js'` type-import group.
 
 Implement `authenticate` (NEW), modify `refresh` (parity), implement `details` (NEW), following the
 pseudocode line-by-line:
@@ -201,7 +208,7 @@ async details(opts?: McpDetailsOptions): Promise<McpDetailStatus> {
 > Adjust the exact shape access (`toolsByServer[name]`) to match the existing return type; if it
 > returns a `Map`/record, index accordingly — follow the existing method's real type.
 
-#### 3. `packages/agents/src/api/agentImpl.ts` — wire `buildMcpControl()` (around :476)
+#### 3. `packages/agents/src/api/agentImpl.ts` — wire `buildMcpControl()` (method def at `:487`)
 
 Extend the deps object passed to `new McpControl({...})` with the six closures (existing three stay):
 
@@ -217,9 +224,17 @@ getResourceRegistry: () => ({
   getAllResources: () => this.deps.config.getResourceRegistry().getAllResources(),
 }),
 refreshClientTools: () => this.deps.resolveClient().setTools(),
-performOAuth: (server, oauthConfig, mcpServerUrl) =>
-  MCPOAuthProvider.authenticate(server, oauthConfig, mcpServerUrl, undefined),
+performOAuth: async (server, oauthConfig, mcpServerUrl) => {
+  await MCPOAuthProvider.authenticate(server, oauthConfig, mcpServerUrl, undefined);
+},
 ```
+
+> The `performOAuth` closure MUST use the `async … => { await …; }` form (NOT a bare arrow returning
+> the call). The dep type is `Promise<void>`, but `MCPOAuthProvider.authenticate(...)` returns
+> `Promise<MCPOAuthToken>`; a bare `(…) => MCPOAuthProvider.authenticate(…)` is `Promise<MCPOAuthToken>`
+> and is NOT assignable to `Promise<void>` (TS only special-cases a bare `void`, not `Promise<void>`).
+> Awaiting + discarding also keeps the OAuth token out of the closure result (it is a handshake
+> side-effect only).
 
 Add the `MCPOAuthProvider` VALUE import from the bare core barrel at the top of `agentImpl.ts`:
 

--- a/project-plans/issue2143/plan/14-mcp-oauth-impl.md
+++ b/project-plans/issue2143/plan/14-mcp-oauth-impl.md
@@ -1,0 +1,318 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 -->
+# Phase 14: MCP OAuth + refresh setTools parity + deep details — Implementation (GREEN)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P14`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 13 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P13.md`
+- Pseudocode: `project-plans/issue2143/analysis/pseudocode/mcp-oauth.md`
+  (authenticate lines 1-16; refresh lines 30-41; details lines 50-78; Dependencies + buildMcpControl wiring)
+
+## Purpose
+
+Make the P13 behavioral RED suite pass by EXTENDING `AgentMcpControl` (interface) and `McpControl`
+(impl) with `authenticate` + `details`, giving `refresh` its setTools parity, extending `McpControlDeps`
+with six injected closures, and wiring them in `AgentImpl.buildMcpControl()`. Existing members and the
+existing `refresh` signature are untouched (REQ-009 non-breaking). `MCPOAuthProvider.authenticate` is
+bound ONLY in the wiring (injected as the `performOAuth` closure) so the control stays hermetically
+testable + mutation-killable.
+
+## Implementation Tasks
+
+### Files to Modify
+
+#### 1. `packages/agents/src/api/agent.ts` — add projected types + extend the interface
+
+Add the projected public types near the other projected types (reuse existing `ToolInfo`):
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpDetailsOptions {
+  readonly includeTools?: boolean;
+  readonly includePrompts?: boolean;
+  readonly includeResources?: boolean;
+}
+export interface McpPromptInfo {
+  readonly name: string;
+  readonly description?: string;
+}
+export interface McpResourceInfo {
+  readonly name?: string;
+  readonly uri: string;
+}
+export interface McpBlockedServer {
+  readonly name: string;
+  readonly extensionName: string;
+}
+export interface McpServerDetail {
+  readonly name: string;
+  readonly authenticated: boolean;
+  readonly tools?: readonly ToolInfo[];
+  readonly prompts?: readonly McpPromptInfo[];
+  readonly resources?: readonly McpResourceInfo[];
+}
+export interface McpDetailStatus {
+  readonly servers: readonly McpServerDetail[];
+  readonly blockedServers: readonly McpBlockedServer[];
+}
+```
+
+Extend the existing `AgentMcpControl` (do NOT remove or change the signature of any existing member —
+`listServers`/`status`/`toolsByServer`/`auth`/`discoveryState`/`refresh`):
+
+```ts
+export interface AgentMcpControl {
+  // ...existing members unchanged...
+  refresh(server?: string): Promise<void>;
+  // @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+  authenticate(server: string): Promise<McpServerAuthStatus>;
+  details(opts?: McpDetailsOptions): Promise<McpDetailStatus>;
+}
+```
+
+`McpServerAuthStatus` already exists (returned by the existing `auth`). Reuse it.
+
+#### 2. `packages/agents/src/api/control/mcpControl.ts` — extend deps + implement
+
+Add the two narrow view interfaces and SIX optional closures to `McpControlDeps` (existing three —
+`isMcpAuthenticated`/`getManager`/`getToolRegistry` — unchanged):
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006
+export interface McpPromptRegistryView {
+  getPromptsByServer(server: string): ReadonlyArray<{ name: string; description?: string }>;
+}
+export interface McpResourceRegistryView {
+  getAllResources(): ReadonlyArray<{ serverName: string; name?: string; uri: string }>;
+}
+
+export interface McpControlDeps {
+  // ...existing three closures unchanged...
+  readonly getServerConfigs?: () => Record<string, MCPServerConfig> | undefined;
+  readonly getBlockedServers?: () => readonly { name: string; extensionName: string }[];
+  readonly getPromptRegistry?: () => McpPromptRegistryView | undefined;
+  readonly getResourceRegistry?: () => McpResourceRegistryView | undefined;
+  readonly refreshClientTools?: () => Promise<void>;
+  readonly performOAuth?: (
+    server: string,
+    oauthConfig: MCPOAuthConfig,
+    mcpServerUrl: string | undefined,
+  ) => Promise<void>;
+}
+```
+
+Add the type-only barrel imports (source MAY import the bare core barrel):
+
+```ts
+import type {
+  MCPServerConfig,
+  MCPOAuthConfig,
+  ToolInfo,
+} from '@vybestack/llxprt-code-core';
+```
+
+Implement `authenticate` (NEW), modify `refresh` (parity), implement `details` (NEW), following the
+pseudocode line-by-line:
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 @pseudocode lines 1-16
+async authenticate(server: string): Promise<McpServerAuthStatus> {
+  const configs = this.deps?.getServerConfigs?.();
+  const serverConfig = configs ? configs[server] : undefined;
+  const performOAuth = this.deps?.performOAuth;
+  if (serverConfig === undefined || performOAuth === undefined) {
+    return { server, authenticated: false, requiresAuth: true };
+  }
+  const oauthConfig = serverConfig.oauth ?? { enabled: false };
+  const mcpServerUrl = serverConfig.httpUrl ?? serverConfig.url;
+  await performOAuth(server, oauthConfig, mcpServerUrl);
+  const manager = this.deps?.getManager();
+  if (manager !== undefined) {
+    await manager.restartServer(server);
+  }
+  if (this.deps?.refreshClientTools !== undefined) {
+    await this.deps.refreshClientTools();
+  }
+  return { server, authenticated: true, requiresAuth: true };
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 @pseudocode lines 30-41
+async refresh(server?: string): Promise<void> {
+  const manager = this.deps?.getManager();
+  if (manager === undefined) return;
+  if (server !== undefined) {
+    await manager.restartServer(server);
+  } else {
+    await manager.restart();
+  }
+  if (this.deps?.refreshClientTools !== undefined) {
+    await this.deps.refreshClientTools();
+  }
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 @pseudocode lines 50-78
+async details(opts?: McpDetailsOptions): Promise<McpDetailStatus> {
+  const includeTools = opts?.includeTools ?? true;
+  const includePrompts = opts?.includePrompts ?? false;
+  const includeResources = opts?.includeResources ?? false;
+  const configs = this.deps?.getServerConfigs?.() ?? {};
+  const toolsByServer = this.toolsByServer();
+  const resourcesAll = includeResources
+    ? (this.deps?.getResourceRegistry?.()?.getAllResources() ?? [])
+    : [];
+  const servers: McpServerDetail[] = [];
+  for (const name of Object.keys(configs)) {
+    const detail: {
+      name: string;
+      authenticated: boolean;
+      tools?: readonly ToolInfo[];
+      prompts?: readonly McpPromptInfo[];
+      resources?: readonly McpResourceInfo[];
+    } = { name, authenticated: this.deps?.isMcpAuthenticated(name) ?? false };
+    if (includeTools) {
+      detail.tools = toolsByServer[name] ?? [];
+    }
+    if (includePrompts) {
+      const prompts = this.deps?.getPromptRegistry?.()?.getPromptsByServer(name) ?? [];
+      detail.prompts = prompts.map((p) => ({ name: p.name, description: p.description }));
+    }
+    if (includeResources) {
+      detail.resources = resourcesAll
+        .filter((r) => r.serverName === name)
+        .map((r) => ({ name: r.name, uri: r.uri }));
+    }
+    servers.push(detail);
+  }
+  const blockedServers = (this.deps?.getBlockedServers?.() ?? []).map((b) => ({
+    name: b.name,
+    extensionName: b.extensionName,
+  }));
+  return { servers, blockedServers };
+}
+```
+
+> `toolsByServer()` is the EXISTING method; reuse it so per-server tool projection stays consistent.
+> Adjust the exact shape access (`toolsByServer[name]`) to match the existing return type; if it
+> returns a `Map`/record, index accordingly — follow the existing method's real type.
+
+#### 3. `packages/agents/src/api/agentImpl.ts` — wire `buildMcpControl()` (around :476)
+
+Extend the deps object passed to `new McpControl({...})` with the six closures (existing three stay):
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P14 @requirement:REQ-006 @pseudocode Dependencies/buildMcpControl
+getServerConfigs: () => this.deps.config.getMcpServers(),
+getBlockedServers: () => this.deps.config.getBlockedMcpServers() ?? [],
+getPromptRegistry: () => ({
+  getPromptsByServer: (s: string) =>
+    this.deps.config.getPromptRegistry().getPromptsByServer(s),
+}),
+getResourceRegistry: () => ({
+  getAllResources: () => this.deps.config.getResourceRegistry().getAllResources(),
+}),
+refreshClientTools: () => this.deps.resolveClient().setTools(),
+performOAuth: (server, oauthConfig, mcpServerUrl) =>
+  MCPOAuthProvider.authenticate(server, oauthConfig, mcpServerUrl, undefined),
+```
+
+Add the `MCPOAuthProvider` VALUE import from the bare core barrel at the top of `agentImpl.ts`:
+
+```ts
+import { MCPOAuthProvider } from '@vybestack/llxprt-code-core';
+```
+
+> `MCPOAuthProvider` is re-exported at `core/src/index.ts:498`; `MCPOAuthProvider.authenticate(
+> serverName, config, mcpServerUrl?, events?)` is defined at `packages/mcp/src/auth/oauth-provider.ts:874`.
+> Pass `undefined` for `events` (the CLI-only `appEvents` is NOT importable here). This binds the real
+> static ONLY in the wiring; the control receives it as the injected `performOAuth` closure.
+
+### Constraints
+
+- Do NOT modify the P13 test file.
+- Existing `AgentMcpControl` members + the existing `refresh` signature remain byte-identical (REQ-009).
+- Follow the pseudocode line-by-line; cite `@pseudocode lines N-M` on each method.
+- No cached manager/registry/config state — resolve each dep closure per call (R-DELEGATE).
+- `authenticate` MUST NOT catch a `performOAuth` rejection (it propagates; no restart/setTools on failure).
+- `refresh` AND `authenticate` BOTH call `refreshClientTools()` after restart (R-REFRESH-PARITY).
+- `details` projects prompts/resources to named-field-only public types (no raw `DiscoveredMCPPrompt`/
+  `MCPResource` leak); prompts/resources gated behind opts (default false).
+- All new closures are OPTIONAL on `McpControlDeps` and guarded with `?.` (undefined-safe; preserves the
+  existing direct-construct-with-partial-deps tests).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+M=packages/agents/src/api/control/mcpControl.ts
+I=packages/agents/src/api/agentImpl.ts
+F=packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
+
+# Interface extended, existing members preserved.
+grep -qE "authenticate\(server: string\): Promise<McpServerAuthStatus>" "$A" || { echo "FAIL: authenticate missing on interface"; exit 1; }
+grep -qE "details\(opts\?: McpDetailsOptions\): Promise<McpDetailStatus>" "$A" || { echo "FAIL: details missing on interface"; exit 1; }
+grep -qE "discoveryState" "$A" || { echo "FAIL: existing member removed"; exit 1; }
+
+# Impl present + markers + ordering + parity.
+grep -qE "@pseudocode lines 1-16" "$M" || { echo "FAIL: authenticate marker missing"; exit 1; }
+grep -qE "@pseudocode lines 30-41" "$M" || { echo "FAIL: refresh marker missing"; exit 1; }
+grep -qE "@pseudocode lines 50-78" "$M" || { echo "FAIL: details marker missing"; exit 1; }
+grep -qE "performOAuth" "$M" || { echo "FAIL: performOAuth closure not used"; exit 1; }
+grep -qE "refreshClientTools" "$M" || { echo "FAIL: setTools parity closure not used"; exit 1; }
+
+# refresh has BOTH restart and refreshClientTools (parity).
+awk '/async refresh\(/{f=1} f&&/refreshClientTools/{ok=1} /^  }/{if(f){f=0}} END{exit ok?0:1}' "$M" \
+  || { echo "FAIL: refresh() lacks setTools parity"; exit 1; }
+
+# Static OAuth provider is NOT imported into the control (only injected via wiring).
+if grep -nE "import .*MCPOAuthProvider" "$M"; then echo "FAIL: MCPOAuthProvider must NOT be imported into the control"; exit 1; fi
+grep -qE "import \{ MCPOAuthProvider \} from '@vybestack/llxprt-code-core'" "$I" || { echo "FAIL: MCPOAuthProvider not wired in agentImpl"; exit 1; }
+grep -qE "performOAuth:" "$I" || { echo "FAIL: performOAuth not wired in buildMcpControl"; exit 1; }
+
+# No cached field for mcp deep state.
+if grep -nE "private .*(cachedDetails|serverCache|mcpCache)\b" "$M"; then echo "FAIL: cached mcp state"; exit 1; fi
+
+# Tests now GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run "$F" > /tmp/p14_green.log 2>&1 || { echo "FAIL: P13 suite not green"; tail -40 /tmp/p14_green.log; exit 1; }
+
+# Whole control dir still green (non-breaking).
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p14_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p14_all.log; exit 1; }
+
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+```
+
+### Deferred Implementation Detection (MANDATORY — scoped to changed lines)
+
+```bash
+set -o pipefail
+set -e
+for F in packages/agents/src/api/agent.ts packages/agents/src/api/control/mcpControl.ts packages/agents/src/api/agentImpl.ts; do
+  git diff HEAD -- "$F" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $F"; exit 1; } || true
+done
+echo "PASS: no deferred markers in changed lines."
+```
+
+## Success Criteria
+
+- P13 suite GREEN; whole `__tests__` dir GREEN; typecheck + lint clean.
+- Existing `AgentMcpControl` members + `refresh` signature unchanged; `authenticate`/`details` added,
+  `refresh` gains setTools parity; six closures wired; `MCPOAuthProvider` bound only in the wiring.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/agent.ts packages/agents/src/api/control/mcpControl.ts packages/agents/src/api/agentImpl.ts`
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P14.md` (same field schema as P10).

--- a/project-plans/issue2143/plan/14a-mcp-oauth-impl-verification.md
+++ b/project-plans/issue2143/plan/14a-mcp-oauth-impl-verification.md
@@ -1,0 +1,133 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P14a @requirement:REQ-006 -->
+# Phase 14a: MCP OAuth + details — Pseudocode-Compliance Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P14a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 14 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P14.md`
+
+## Purpose
+
+Independent gate. Confirm the P14 implementation matches `analysis/pseudocode/mcp-oauth.md`
+line-by-line, preserves the existing `AgentMcpControl` surface + the existing `refresh` signature
+(non-breaking REQ-009), is delegate-only (no cache), is undefined-safe, enforces the OAuth
+orchestration ordering + error propagation, gives `refresh` AND `authenticate` setTools parity, projects
+prompts/resources to named-field-only public types (no raw leak), binds `MCPOAuthProvider` ONLY in the
+wiring (never imported into the control), and that the P13 tests are genuinely behavioral (observable
+callLog ordering — no mock theater, ≥30% property, no reverse tests).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+M=packages/agents/src/api/control/mcpControl.ts
+I=packages/agents/src/api/agentImpl.ts
+F=packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
+
+# 1. Target test + whole dir GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p14a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p14a_all.log; exit 1; }
+
+# 2. Project typecheck + lint clean.
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+
+# 3. Non-breaking: existing six members + existing refresh signature intact.
+for m in "listServers" "status" "toolsByServer" "auth" "discoveryState" "refresh"; do
+  grep -qE "$m" "$A" || { echo "FAIL: existing AgentMcpControl member $m missing"; exit 1; }
+done
+grep -qE "refresh\(server\?: string\): Promise<void>" "$A" || { echo "FAIL: refresh signature changed"; exit 1; }
+
+# 4. Ordering + propagation + parity (static structural checks).
+#    authenticate: performOAuth BEFORE restartServer BEFORE refreshClientTools.
+awk '/async authenticate\(/{f=1}
+     f&&/performOAuth\(/{o=NR}
+     f&&/restartServer\(/{r=NR}
+     f&&/refreshClientTools\(/{t=NR}
+     /^  }/{if(f){f=0}}
+     END{ if(o>0 && r>0 && t>0 && o<r && r<t) exit 0; else exit 1 }' "$M" \
+  || { echo "FAIL: authenticate ordering (oauth<restart<setTools) not satisfied"; exit 1; }
+
+#    authenticate must NOT wrap performOAuth in try/catch (errors propagate).
+awk '/async authenticate\(/{f=1} f&&/try[[:space:]]*\{/{c=1} /^  }/{if(f){f=0}} END{exit c?1:0}' "$M" \
+  || { echo "FAIL: authenticate swallows errors (try/catch present)"; exit 1; }
+
+#    refresh has setTools parity.
+awk '/async refresh\(/{f=1} f&&/refreshClientTools/{ok=1} /^  }/{if(f){f=0}} END{exit ok?0:1}' "$M" \
+  || { echo "FAIL: refresh lacks setTools parity"; exit 1; }
+
+# 5. MCPOAuthProvider bound ONLY in wiring, never imported into the control.
+if grep -nE "MCPOAuthProvider" "$M"; then echo "FAIL: control references MCPOAuthProvider directly"; exit 1; fi
+grep -qE "import \{ MCPOAuthProvider \} from '@vybestack/llxprt-code-core'" "$I" || { echo "FAIL: wiring import missing"; exit 1; }
+grep -qE "performOAuth:.*MCPOAuthProvider\.authenticate" "$I" || { echo "FAIL: performOAuth not bound to static in wiring"; exit 1; }
+
+# 6. Markers + delegation; no cache.
+grep -qE "@pseudocode lines 1-16" "$M" || { echo "FAIL: authenticate marker"; exit 1; }
+grep -qE "@pseudocode lines 30-41" "$M" || { echo "FAIL: refresh marker"; exit 1; }
+grep -qE "@pseudocode lines 50-78" "$M" || { echo "FAIL: details marker"; exit 1; }
+if grep -nE "private .*(cachedDetails|serverCache|mcpCache)\b" "$M"; then echo "FAIL: cached state"; exit 1; fi
+
+# 7. No raw prompt/resource leak: details projects named fields only.
+if grep -nE "getAllResources\(\)\s*;?\s*$" "$M" | grep -v "map("; then : ; fi  # informational
+
+# 8. Re-audit P13 tests are behavioral.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+grep -qE "callLog" "$F" || { echo "FAIL: observable ordering seam missing in tests"; exit 1; }
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+
+# 9. Deferred scan on changed lines.
+for X in "$A" "$M" "$I"; do
+  git diff HEAD -- "$X" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $X"; exit 1; } || true
+done
+echo "PASS: gates green."
+```
+
+### Line-by-Line Compliance Table (fill in, fold into marker)
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1-16 | authenticate (unknown/unwired guard; oauthConfig+url; performOAuth→restart→refreshClientTools; propagate) | mcpControl.ts:___ | |
+| 30-41 | refresh (existing restart + NEW refreshClientTools parity; undefined-safe) | mcpControl.ts:___ | |
+| 50-78 | details (opts gating; per-server projection; named-field prompts/resources; blockedServers) | mcpControl.ts:___ | |
+| Dependencies/wiring | six closures wired; performOAuth→MCPOAuthProvider.authenticate(...,undefined) | agentImpl.ts:___ | |
+
+## Holistic Functionality Assessment (MANDATORY — into marker)
+
+- **What was implemented**: `authenticate` (real injected OAuth flow), `refresh` setTools parity,
+  `details` deep projection on `AgentMcpControl`/`McpControl`; six injected closures + wiring.
+- **Satisfies REQ-006?**: ordering auth→restart→setTools enforced; error propagation (no try/catch);
+  refresh+authenticate both re-publish tools; details gates + projects named fields only; existing
+  members + refresh signature intact?
+- **Data flow**: live `this.deps` closures every call; `MCPOAuthProvider` bound only in wiring; no cache?
+- **Security**: no raw `DiscoveredMCPPrompt`/`MCPResource` leak; tokens never surfaced (OAuth side-effect
+  only)?
+- **Risks**: undefined-safety on all six closures; any ordering regression; any import of the static into
+  the control.
+- **Verdict**: PASS/FAIL with file:line evidence.
+
+## Success Criteria
+
+- All gates pass; compliance table complete; non-breaking confirmed; ordering + parity + propagation
+  proven; holistic verdict PASS.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P14a.md` including the completed compliance table + holistic
+assessment.

--- a/project-plans/issue2143/plan/14a-mcp-oauth-impl-verification.md
+++ b/project-plans/issue2143/plan/14a-mcp-oauth-impl-verification.md
@@ -30,6 +30,7 @@ set -e
 A=packages/agents/src/api/agent.ts
 M=packages/agents/src/api/control/mcpControl.ts
 I=packages/agents/src/api/agentImpl.ts
+W=packages/agents/src/api/control/mcpControlWiring.ts
 F=packages/agents/src/api/__tests__/mcpOAuth.behavior.test.ts
 
 # 1. Target test + whole dir GREEN.
@@ -64,10 +65,17 @@ awk '/async authenticate\(/{f=1} f&&/try[[:space:]]*\{/{c=1} /^  }/{if(f){f=0}} 
 awk '/async refresh\(/{f=1} f&&/refreshClientTools/{ok=1} /^  }/{if(f){f=0}} END{exit ok?0:1}' "$M" \
   || { echo "FAIL: refresh lacks setTools parity"; exit 1; }
 
-# 5. MCPOAuthProvider bound ONLY in wiring, never imported into the control.
+# 5. MCPOAuthProvider bound ONLY in the dedicated wiring module ($W), never in
+#    the control ($M) and never in agentImpl ($I). The closure bundle is built
+#    by buildMcpControlDeps and consumed by buildMcpControl.
 if grep -nE "MCPOAuthProvider" "$M"; then echo "FAIL: control references MCPOAuthProvider directly"; exit 1; fi
-grep -qE "import \{ MCPOAuthProvider \} from '@vybestack/llxprt-code-core'" "$I" || { echo "FAIL: wiring import missing"; exit 1; }
-grep -qE "performOAuth:.*MCPOAuthProvider\.authenticate" "$I" || { echo "FAIL: performOAuth not bound to static in wiring"; exit 1; }
+if grep -nE "MCPOAuthProvider" "$I"; then echo "FAIL: agentImpl references MCPOAuthProvider directly (should be in wiring module)"; exit 1; fi
+grep -qE "import \{ MCPOAuthProvider \} from '@vybestack/llxprt-code-core'" "$W" || { echo "FAIL: wiring import missing in mcpControlWiring.ts"; exit 1; }
+grep -qE "buildMcpControlDeps" "$I" || { echo "FAIL: agentImpl does not consume buildMcpControlDeps"; exit 1; }
+# performOAuth binding may be prettier-wrapped across lines -> flatten before matching.
+W_FLAT="$(tr '\n' ' ' < "$W" | tr -s '[:space:]' ' ')"
+echo "$W_FLAT" | grep -qE "performOAuth: async .* await MCPOAuthProvider\.authenticate\(" \
+  || { echo "FAIL: performOAuth not bound to MCPOAuthProvider.authenticate in wiring"; exit 1; }
 
 # 6. Markers + delegation; no cache.
 grep -qE "@pseudocode lines 1-16" "$M" || { echo "FAIL: authenticate marker"; exit 1; }
@@ -75,8 +83,15 @@ grep -qE "@pseudocode lines 30-41" "$M" || { echo "FAIL: refresh marker"; exit 1
 grep -qE "@pseudocode lines 50-78" "$M" || { echo "FAIL: details marker"; exit 1; }
 if grep -nE "private .*(cachedDetails|serverCache|mcpCache)\b" "$M"; then echo "FAIL: cached state"; exit 1; fi
 
-# 7. No raw prompt/resource leak: details projects named fields only.
-if grep -nE "getAllResources\(\)\s*;?\s*$" "$M" | grep -v "map("; then : ; fi  # informational
+# 7. No raw prompt/resource leak: details() MUST map registry rows to named fields, never spread/return raw.
+#    (formatting-tolerant: prettier may wrap the object literal across lines, so collapse whitespace first.
+#     tr+grep -E are portable on BSD/macOS, unlike grep -P/-z.)
+if grep -nE "\.\.\.(p|r|prompt|resource)\b" "$M"; then echo "FAIL: raw prompt/resource spread leaks internal fields"; exit 1; fi
+M_FLAT="$(tr '\n' ' ' < "$M" | tr -s '[:space:]' ' ')"
+echo "$M_FLAT" | grep -qE "prompts\.map\(\(p\) => \(\{ name: p\.name" \
+  || { echo "FAIL: prompts not projected to named fields"; exit 1; }
+echo "$M_FLAT" | grep -qE "map\(\(r\) => \(\{ name: r\.name, uri: r\.uri" \
+  || { echo "FAIL: resources not projected to named fields"; exit 1; }
 
 # 8. Re-audit P13 tests are behavioral.
 if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
@@ -106,7 +121,8 @@ echo "PASS: gates green."
 | 1-16 | authenticate (unknown/unwired guard; oauthConfig+url; performOAuth→restart→refreshClientTools; propagate) | mcpControl.ts:___ | |
 | 30-41 | refresh (existing restart + NEW refreshClientTools parity; undefined-safe) | mcpControl.ts:___ | |
 | 50-78 | details (opts gating; per-server projection; named-field prompts/resources; blockedServers) | mcpControl.ts:___ | |
-| Dependencies/wiring | six closures wired; performOAuth→MCPOAuthProvider.authenticate(...,undefined) | agentImpl.ts:___ | |
+| Dependencies/wiring | six closures wired via buildMcpControlDeps; performOAuth→MCPOAuthProvider.authenticate(...,undefined) | mcpControlWiring.ts:___ | |
+| Wiring consumption | buildMcpControl delegates to buildMcpControlDeps; MCPOAuthProvider NOT imported here | agentImpl.ts:___ | |
 
 ## Holistic Functionality Assessment (MANDATORY — into marker)
 

--- a/project-plans/issue2143/plan/15-tool-keys-tdd.md
+++ b/project-plans/issue2143/plan/15-tool-keys-tdd.md
@@ -1,0 +1,260 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P15 @requirement:REQ-007 -->
+# Phase 15: Tool-Key Storage (`agent.tools.keys`) — Behavioral TDD
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P15`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 14a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P14a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-007: Built-in tool-key storage via `agent.tools.keys` (masked)
+
+**Full Text**: EXTEND the existing `AgentToolControl` (`agent.ts:223-230`) — keeping ALL existing
+members (`list`/`setEnabled`/`onConfirmationRequest`/`respondToConfirmation`/`onToolUpdate`/
+`setEditorCallbacks`) EXACTLY as-is (REQ-009 non-breaking) — with a NEW nested `readonly keys`
+sub-controller (`AgentToolKeyControl`) backed by the core `ToolKeyStorage`. This is **DISTINCT** from
+`Agent.auth.keys` (provider-auth keys at `agent.ts:241-258`) — built-in TOOL keys (Exa, etc.) are a
+different concern (R-KEYS-DISTINCT). Raw key material is NEVER returned (R-NO-RAW-SECRETS).
+- **REQ-007.1**: `supported(): readonly ToolKeyInfo[]` — projects the static tool-key registry
+  (`getSupportedToolNames`/`getToolKeyEntry`) to `{toolName, displayName, description?}`.
+- **REQ-007.2**: `status(toolName): Promise<ToolKeyStatus>` — `{toolName, hasKey, maskedKey?, keyFile?}`.
+  `maskedKey` is `maskKeyForDisplay(rawKey)` and present ONLY when a key is stored. The raw key is
+  NEVER on the returned object.
+- **REQ-007.3**: `save(toolName, key): Promise<void>` — delegates to `storage.saveKey`.
+- **REQ-007.4**: `delete(toolName): Promise<void>` — delegates to `storage.deleteKey`.
+- **REQ-007.5**: `setKeyFile(toolName, path | null): Promise<void>` — `null` clears
+  (`clearKeyfilePath`); a string sets (`setKeyfilePath`).
+- **REQ-007.6**: `getKeyFile(toolName): Promise<string | null>` — delegates to `getKeyfilePath`.
+- **REQ-007.7**: tool-name validation is owned by `ToolKeyStorage.assertValidToolName` (invoked inside
+  every storage method); an invalid name's throw PROPAGATES (delegate, do not catch).
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN the registry contains Exa → `supported()` includes `{toolName:"exa", displayName:"Exa Search",
+  description: <string>}`.
+- GIVEN a stored key `"abcd1234efgh"` (length > 8) → `status("exa")` is `{toolName:"exa", hasKey:true,
+  maskedKey:"ab********gh"}` and `Object.keys(status)` contains NO raw key; `maskedKey !== "abcd1234efgh"`.
+- GIVEN a stored short key (length ≤ 8) → `status.maskedKey` is fully masked (all `*`).
+- GIVEN NO stored key and NO keyfile → `status("exa")` is `{toolName:"exa", hasKey:false}` (no
+  `maskedKey`).
+- GIVEN a keyfile path configured but no stored key → `status("exa").keyFile` equals the configured path
+  and `hasKey:false`.
+- GIVEN `save("exa", k)` then `delete("exa")` → `status("exa").hasKey` goes `true` then `false`.
+- GIVEN `setKeyFile("exa","/p")` then `getKeyFile("exa")` → `"/p"`; then `setKeyFile("exa", null)` →
+  `getKeyFile("exa")` is `null`.
+- GIVEN an unregistered tool name → `save/status/delete/getKeyFile` REJECT (the storage throws).
+- GIVEN the live agent → `agent.tools.keys` is a DISTINCT object from `agent.auth.keys`.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/toolKeys.behavior.test.ts`
+
+  Drive a REAL `ToolKeyStorage` hermetically — NO mock theater. The blessed hermetic seam (the EXACT
+  recipe used by `packages/core/src/tools/tool-key-storage.test.ts:172`) is a real `ToolKeyStorage`
+  constructed over a temp dir + an in-memory keyring ADAPTER (a real object implementing
+  `KeyringAdapter` over a `Map` — NOT a spy/stub):
+
+  1. **Hermetic storage helper** (declare inline in the test):
+     ```ts
+     import { promises as fs } from 'node:fs';
+     import * as os from 'node:os';
+     import * as path from 'node:path';
+     import { ToolKeyStorage } from '@vybestack/llxprt-code-core';
+     // KeyringAdapter is a structural type; declare a tiny real Map-backed adapter inline.
+     function memoryKeyring() {
+       const store = new Map<string, string>();
+       return {
+         getPassword: async (s: string, a: string) => store.get(`${s}:${a}`) ?? null,
+         setPassword: async (s: string, a: string, p: string) => { store.set(`${s}:${a}`, p); },
+         deletePassword: async (s: string, a: string) => store.delete(`${s}:${a}`),
+       };
+     }
+     async function hermeticStorage(): Promise<{ storage: ToolKeyStorage; dir: string }> {
+       const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'toolkeys-behavior-'));
+       const storage = new ToolKeyStorage({ toolsDir: dir, keyringLoader: async () => memoryKeyring() });
+       return { storage, dir };
+     }
+     ```
+     Clean each temp dir in `afterEach` with `fs.rm(dir, { recursive: true, force: true })`.
+
+  2. **Direct-construction mode (BLESSED precedent — `new McpControl(deps)` /
+     `new TasksControl({...})`).** `.behavior.test.ts` is T17-EXEMPT, so the control may be deep-imported.
+     Because the control file does not exist until P16, import it **dynamically inside each test body** so
+     the file PARSES at RED (mirrors P07's RED-note):
+     ```ts
+     const { ToolKeysControl } = await import('../control/toolKeysControl.js');
+     const keys = new ToolKeysControl({ getStorage: () => storage });
+     ```
+     The `getStorage` closure RETURNS the real hermetic `ToolKeyStorage` — a real closure, NOT a mock.
+     Assert through `keys.supported()/status(...)/save(...)/delete(...)/setKeyFile(...)/getKeyFile(...)`.
+
+  3. **RED-anchor via the PUBLIC surface (keeps RED behavioral).** Add ONE positive that drives the live
+     agent: `const { agent, cleanup } = await buildAgent('plain-text.jsonl');` then assert
+     `agent.tools.keys.supported()` includes `exa` AND `agent.tools.keys !== agent.auth.keys`
+     (R-KEYS-DISTINCT). `supported()` is a PURE static-registry projection (no keychain/disk), so it is
+     hermetic even through the real singleton. At RED `agent.tools.keys` is `undefined` → a behavioral
+     `TypeError` (NOT a module error). Do NOT drive `status/save/...` through the public agent (that would
+     hit the non-hermetic singleton storage) — only `supported()` + the distinct-object check.
+
+  4. **No-raw-secret enumeration.** For the mask scenarios, assert over `Object.values(status)` /
+     `JSON.stringify(status)` that the full raw key is NOT present (a behavioral guarantee, not
+     structure-only).
+
+  - Markers `@plan:PLAN-20260622-COREAPIGAP.P15`, `@requirement:REQ-007`.
+
+### Required scenarios
+
+```
+T17a  supported(): hermetic ToolKeysControl → supported() includes an entry with toolName==='exa',
+      a non-empty displayName, and a string description (registry projection)
+T18   status masked (len>8): save('exa','abcd1234efgh') → status('exa') === {toolName:'exa', hasKey:true,
+      maskedKey:'ab********gh'} ; JSON.stringify(status) does NOT contain 'abcd1234efgh' ;
+      Object.keys(status) has no 'rawKey'/'key'/'access_token'
+T18a  status short (len<=8): save('exa','short') → status('exa').maskedKey === '*****' (fully masked,
+      length === 5) ; maskedKey !== 'short'
+T18b  invalid tool name: keys.save('not-a-tool','k') REJECTS (storage assertValidToolName throws);
+      likewise keys.status('not-a-tool') REJECTS — the throw propagates (NOT swallowed)
+T18c  no key, no keyfile: status('exa') === {toolName:'exa', hasKey:false} (no maskedKey key present;
+      'maskedKey' not in Object.keys)
+T18d  keyfile-only: setKeyFile('exa','/tmp/exa.key') (no stored key) → status('exa') ===
+      {toolName:'exa', hasKey:false, keyFile:'/tmp/exa.key'} ; getKeyFile('exa') === '/tmp/exa.key' ;
+      then setKeyFile('exa', null) → getKeyFile('exa') === null
+T19   distinct: const {agent} = await buildAgent('plain-text.jsonl'); agent.tools.keys.supported()
+      includes 'exa' AND agent.tools.keys !== agent.auth.keys (R-KEYS-DISTINCT)
+PROP  save/delete round-trip: for a generated registered tool ('exa') + random non-empty key, after
+      save(key) status.hasKey===true and after delete() status.hasKey===false ; MIN-2 cases
+PROP  mask no-leak: for a generated key of length 9..40 (non-'*' chars), save+status →
+      maskedKey.length === key.length, maskedKey starts with key.slice(0,2), ends with key.slice(-2),
+      the middle is all '*', maskedKey !== key, and JSON.stringify(status) does not contain the raw key;
+      MIN-2 cases
+```
+
+### Constraints
+
+- Drive a REAL `ToolKeyStorage` over a temp dir + a real Map-backed `KeyringAdapter`. NEVER `vi.fn()`,
+  `vi.spyOn`, `mockResolvedValue`, or `toHaveBeenCalled`.
+- The `getStorage: () => storage` closure is a REAL closure returning a real instance (allowed), not a mock.
+- The no-leak assertions must inspect real output (`Object.keys`/`Object.values`/`JSON.stringify`) — not a
+  structure-only `toHaveProperty`.
+- Source `ToolKeyStorage` from the BARE core barrel `@vybestack/llxprt-code-core` (no trailing slash;
+  the deep-import guard only flags `@vybestack/llxprt-code-core/<path>`).
+- ≥30% property-based (fast-check), MIN-2 distinct property cases.
+- Existing `AgentToolControl` members remain callable (do not assert their removal).
+- Positive cases fail at RED because `agent.tools.keys` does not exist (public-surface TypeError) and the
+  `ToolKeysControl` module does not exist yet (dynamic-import failure in the hermetic tests). The PUBLIC
+  positive (T19) guarantees a BEHAVIORAL RED among the positives.
+
+### RED note (important)
+
+The hermetic tests dynamic-import `../control/toolKeysControl.js`, which does not exist until P16; that
+import throws `Cannot find module` INSIDE those tests. To keep the whole-file RED behavioral, T19 drives
+the PUBLIC `agent.tools.keys.supported()` / distinct-object check, which fails with a `TypeError`
+(`agent.tools.keys` is `undefined`) — a behavioral failure. Confirm `/tmp/p15_red.log` shows a
+`TypeError`/`AssertionError` among the positives, not SOLELY module-resolution errors. (P16 creates the
+control + wiring; the impl-phase verification greps that the dynamic import resolves and the suite is
+GREEN.)
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
+test -f "$F"
+
+if grep -nE "toHaveBeenCalled" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "mockResolvedValue|mockReturnValue|vi\.spyOn|vi\.fn\(" "$F"; then echo "FAIL: mock theater (spy/stub)"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# Real hermetic storage (not a fake) + the six methods exercised (BLOCKING).
+grep -qE "new ToolKeyStorage\(" "$F" || { echo "FAIL: not driving a real ToolKeyStorage"; exit 1; }
+grep -qE "keyringLoader" "$F" || { echo "FAIL: hermetic keyring seam missing"; exit 1; }
+for m in supported status save delete setKeyFile getKeyFile; do
+  grep -qE "\.$m\(" "$F" || { echo "FAIL: $m not exercised"; exit 1; }
+done
+
+# No-leak assertion must enumerate real output (behavioral, not structure-only).
+grep -qE "Object\.(keys|values)|JSON\.stringify" "$F" || { echo "FAIL: no-leak not enumerated"; exit 1; }
+
+# R-KEYS-DISTINCT asserted.
+grep -qE "agent\.tools\.keys !== agent\.auth\.keys|agent\.auth\.keys !== agent\.tools\.keys" "$F" || { echo "FAIL: distinct-object check missing"; exit 1; }
+
+# Property-based >= 30% (BLOCKING; MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '
+  /(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 }
+  /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } }
+  END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+if [ "$TOTAL" -eq 0 ]; then echo "FAIL: no tests"; exit 1; fi
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+if [ "$PROP" -lt 2 ]; then echo "FAIL: <2 property cases"; exit 1; fi
+if [ "$PCT" -lt 30 ]; then echo "FAIL: property ${PCT}% < 30%"; exit 1; fi
+
+# RED-state enforcement (positives must include a behavioral failure, not solely module errors).
+set +e
+npx vitest run "$F" > /tmp/p15_red.log 2>&1
+STATUS=$?
+set -e
+tail -40 /tmp/p15_red.log
+if [ "$STATUS" -eq 0 ]; then echo "FAIL: unexpectedly all-green before P16"; exit 1; fi
+if ! grep -qiE "TypeError|AssertionError|expected|is not a function|Cannot read" /tmp/p15_red.log; then
+  echo "FAIL: RED shows no behavioral failure (only module/compile?)"; exit 1
+fi
+echo "RED confirmed behavioral (expected until P16)."
+```
+
+### Semantic Verification Checklist (BLOCKS progression)
+
+- [ ] Drives a REAL `ToolKeyStorage` over a temp dir + a real Map-backed keyring adapter (no spies).
+- [ ] Mask scenarios prove the raw key never appears in the returned status (key/value enumeration).
+- [ ] `save→status→delete→status` and `setKeyFile→getKeyFile→clear` round-trips exercised on real storage.
+- [ ] Invalid tool name REJECTS (propagated throw), not swallowed.
+- [ ] `agent.tools.keys !== agent.auth.keys` (R-KEYS-DISTINCT) asserted via the public surface.
+- [ ] ≥30% property; MIN-2; no mock theater; no reverse tests; behavioral RED.
+
+## Success Criteria
+
+- Behavioral RED suite covering masked status, key/keyfile round-trips, invalid-name propagation, the
+  distinct-controller guarantee, and the no-raw-secret property — all over a real hermetic storage.
+
+## Failure Recovery
+
+- `git checkout -- "$F"`; rewrite.
+
+## Deferred Implementation Detection (MANDATORY — scoped)
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
+test -f "$F" || { echo "missing test"; exit 1; }
+if grep -nE "(TODO|FIXME|HACK|XXX|TEMPORARY|WIP|placeholder|for now|in a real|coming soon)" "$F"; then echo "FAIL: deferred marker"; exit 1; fi
+if grep -niE "toThrow\(.*NotYetImplemented|should (not )?be implemented" "$F"; then echo "FAIL: reverse pattern"; exit 1; fi
+if grep -nE "\b(it|test|describe)\.skip\b|\bxit\b|\bxdescribe\b" "$F"; then echo "FAIL: skipped test"; exit 1; fi
+echo "PASS: no deferred markers."
+```
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P15.md`
+
+```markdown
+Phase: P15
+Completed: YYYY-MM-DD HH:MM
+Files Created: [list each new file with its line count]
+Files Modified: [list each changed file with diff stats]
+Tests Added: [count]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic assessment]
+```

--- a/project-plans/issue2143/plan/16-tool-keys-impl.md
+++ b/project-plans/issue2143/plan/16-tool-keys-impl.md
@@ -1,0 +1,335 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 -->
+# Phase 16: Tool-Key Storage — Implementation (GREEN)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P16`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 15 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P15.md`
+- Pseudocode: `project-plans/issue2143/analysis/pseudocode/tool-keys.md`
+  (supported lines 1-11; status 20-34; save 40-43; delete 50-53; setKeyFile 60-67; getKeyFile 70-73)
+
+## Purpose
+
+Make the P15 behavioral RED suite pass by: (1) adding the two projected public types
+(`ToolKeyInfo`, `ToolKeyStatus`) + the `AgentToolKeyControl` interface to `agent.ts`, and a NEW
+`readonly keys: AgentToolKeyControl` member on the EXISTING `AgentToolControl`; (2) creating a NEW
+`control/toolKeysControl.ts` (`ToolKeysControl implements AgentToolKeyControl`) that delegates to the
+core `ToolKeyStorage`; (3) wiring it into the EXISTING `ToolControl` so `agent.tools.keys` is live.
+Existing members are untouched (REQ-009 non-breaking). `agent.tools.keys` is a DISTINCT object from
+`agent.auth.keys` (R-KEYS-DISTINCT). Raw key material never crosses the boundary (R-NO-RAW-SECRETS).
+
+## Implementation Tasks
+
+### Files to Create
+
+#### 1. `packages/agents/src/api/control/toolKeysControl.ts`
+
+Mirror the existing `authKeysControl.ts` shape (a small delegating sub-controller). Import the core
+symbols from the BARE barrel `@vybestack/llxprt-code-core` (VALUES: `ToolKeyStorage` type-only,
+`getSupportedToolNames`/`getToolKeyEntry`/`maskKeyForDisplay` as values).
+
+```ts
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260622-COREAPIGAP.P16
+ * @requirement:REQ-007
+ * @pseudocode tool-keys.md steps 1-73
+ *
+ * Built-in TOOL key storage (Exa, etc.), exposed as `agent.tools.keys`. DISTINCT
+ * from `agent.auth.keys` (provider-auth keys). Masked: the raw key never crosses
+ * the API boundary (R-NO-RAW-SECRETS). Tool-name validation is owned by
+ * ToolKeyStorage.assertValidToolName (invoked inside every storage call); its
+ * throw propagates (delegate, do not catch).
+ */
+
+import type { ToolKeyStorage } from '@vybestack/llxprt-code-core';
+import {
+  getSupportedToolNames,
+  getToolKeyEntry,
+  maskKeyForDisplay,
+} from '@vybestack/llxprt-code-core';
+import type {
+  AgentToolKeyControl,
+  ToolKeyInfo,
+  ToolKeyStatus,
+} from '../agent.js';
+
+/**
+ * Dependencies injected into {@link ToolKeysControl}.
+ *
+ * @plan:PLAN-20260622-COREAPIGAP.P16
+ * @requirement:REQ-007
+ */
+export interface ToolKeysControlDeps {
+  /** Resolves the shared ToolKeyStorage (core lazy singleton). Never cached. */
+  readonly getStorage: () => ToolKeyStorage;
+}
+
+/**
+ * The public built-in tool-key control surface (masked).
+ *
+ * @plan:PLAN-20260622-COREAPIGAP.P16
+ * @requirement:REQ-007
+ * @pseudocode tool-keys.md steps 1-73
+ */
+export class ToolKeysControl implements AgentToolKeyControl {
+  constructor(private readonly deps: ToolKeysControlDeps) {}
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 1-11
+  supported(): readonly ToolKeyInfo[] {
+    const out: ToolKeyInfo[] = [];
+    for (const name of getSupportedToolNames()) {
+      const entry = getToolKeyEntry(name);
+      if (entry === undefined) {
+        continue;
+      }
+      out.push({
+        toolName: entry.toolKeyName,
+        displayName: entry.displayName,
+        description: entry.description,
+      });
+    }
+    return out;
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 20-34
+  async status(toolName: string): Promise<ToolKeyStatus> {
+    const storage = this.deps.getStorage();
+    const rawKey = await storage.getKey(toolName);
+    const keyFile = await storage.getKeyfilePath(toolName);
+    if (rawKey !== null) {
+      return {
+        toolName,
+        hasKey: true,
+        maskedKey: maskKeyForDisplay(rawKey),
+        keyFile: keyFile ?? undefined,
+      };
+    }
+    return { toolName, hasKey: false, keyFile: keyFile ?? undefined };
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 40-43
+  async save(toolName: string, key: string): Promise<void> {
+    await this.deps.getStorage().saveKey(toolName, key);
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 50-53
+  async delete(toolName: string): Promise<void> {
+    await this.deps.getStorage().deleteKey(toolName);
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 60-67
+  async setKeyFile(toolName: string, path: string | null): Promise<void> {
+    if (path === null) {
+      await this.deps.getStorage().clearKeyfilePath(toolName);
+    } else {
+      await this.deps.getStorage().setKeyfilePath(toolName, path);
+    }
+  }
+
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007 @pseudocode lines 70-73
+  async getKeyFile(toolName: string): Promise<string | null> {
+    return this.deps.getStorage().getKeyfilePath(toolName);
+  }
+}
+```
+
+### Files to Modify
+
+#### 2. `packages/agents/src/api/agent.ts` — add projected types + interface, extend `AgentToolControl`
+
+Add the two projected public types near the other tool types (they NEVER include the raw key):
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+export interface ToolKeyInfo {
+  readonly toolName: string;
+  readonly displayName: string;
+  readonly description?: string;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+export interface ToolKeyStatus {
+  readonly toolName: string;
+  readonly hasKey: boolean;
+  readonly maskedKey?: string;
+  readonly keyFile?: string;
+}
+
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+export interface AgentToolKeyControl {
+  supported(): readonly ToolKeyInfo[];
+  status(toolName: string): Promise<ToolKeyStatus>;
+  save(toolName: string, key: string): Promise<void>;
+  delete(toolName: string): Promise<void>;
+  setKeyFile(toolName: string, path: string | null): Promise<void>;
+  getKeyFile(toolName: string): Promise<string | null>;
+}
+```
+
+Extend the EXISTING `AgentToolControl` (do NOT remove or reorder existing members) by adding the nested
+control — mirror how `AgentAuthControl` carries `readonly keys: AgentAuthKeysControl`:
+
+```ts
+export interface AgentToolControl {
+  list(): readonly ToolInfo[];
+  setEnabled(names: readonly string[]): Promise<void>;
+  onConfirmationRequest(cb: (req: ToolConfirmation) => void): Unsubscribe;
+  respondToConfirmation(confirmationId: string, decision: ToolDecision): void;
+  onToolUpdate(cb: (u: ToolUpdate) => void): Unsubscribe;
+  setEditorCallbacks(cbs: EditorCallbacks): void;
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+  readonly keys: AgentToolKeyControl;
+}
+```
+
+#### 3. `packages/agents/src/api/control/toolControl.ts` — wire the nested `keys`
+
+Mirror `AuthControl` (`authControl.ts:69-72`): take a `keysDeps` field, expose `readonly keys`, construct
+the sub-controller in the ctor.
+
+- Add to the `import type { ... } from '../agent.js';` group: `AgentToolKeyControl`.
+- Add the sub-controller import:
+  ```ts
+  import { ToolKeysControl } from './toolKeysControl.js';
+  import type { ToolKeysControlDeps } from './toolKeysControl.js';
+  ```
+- Add to `ToolControlDeps`:
+  ```ts
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+  /** The deps bundle for the constructed ToolKeysControl. */
+  readonly keysDeps: ToolKeysControlDeps;
+  ```
+- Add the field + ctor assignment (the ctor is currently the implicit
+  `constructor(private readonly deps: ToolControlDeps) {}` — convert it to a block that assigns `keys`):
+  ```ts
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+  readonly keys: AgentToolKeyControl;
+
+  constructor(private readonly deps: ToolControlDeps) {
+    this.keys = new ToolKeysControl(deps.keysDeps);
+  }
+  ```
+
+#### 4. `packages/agents/src/api/agentImpl.ts` — provide `keysDeps` to `ToolControl`
+
+Add the core-barrel import for the singleton resolver (VALUE import) near the other core imports:
+
+```ts
+// @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+import { getToolKeyStorage } from '@vybestack/llxprt-code-core';
+```
+
+In the ctor where `toolControlDeps` is assembled (`agentImpl.ts:309-314`), add the `keysDeps` field:
+
+```ts
+const toolControlDeps: ToolControlDeps = {
+  messageBus: deps.messageBus,
+  config: deps.config,
+  editorCallbacksHolder: this.editorCallbacksHolder,
+  // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
+  keysDeps: { getStorage: () => getToolKeyStorage() },
+};
+this.tools = new ToolControl(toolControlDeps);
+```
+
+### Constraints
+
+- Do NOT modify the P15 test file.
+- Existing `AgentToolControl` members remain byte-identical (REQ-009).
+- `status()` returns `maskKeyForDisplay(rawKey)` only; the raw key is NEVER copied onto any returned
+  object (R-NO-RAW-SECRETS). `maskedKey` is OMITTED when `hasKey` is false.
+- Tool-name validation stays in `ToolKeyStorage.assertValidToolName`; do NOT re-implement it and do NOT
+  catch its throw (it must propagate — REQ-007.7).
+- NO `~`-expansion / `fs.access` / non-empty checks inside `setKeyFile` — those stay CLI-side.
+- No cached `ToolKeyStorage` field — resolve `this.deps.getStorage()` per call (R-DELEGATE).
+- `agent.tools.keys` MUST be a different instance than `agent.auth.keys` (R-KEYS-DISTINCT) — guaranteed by
+  the separate controller; do not alias.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+K=packages/agents/src/api/control/toolKeysControl.ts
+T=packages/agents/src/api/control/toolControl.ts
+I=packages/agents/src/api/agentImpl.ts
+F=packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
+
+test -f "$K" || { echo "FAIL: toolKeysControl.ts not created"; exit 1; }
+
+# Interface extended, existing members preserved.
+grep -qE "interface AgentToolKeyControl" "$A" || { echo "FAIL: AgentToolKeyControl missing"; exit 1; }
+grep -qE "readonly keys: AgentToolKeyControl" "$A" || { echo "FAIL: nested keys not on AgentToolControl"; exit 1; }
+grep -qE "interface ToolKeyInfo" "$A" || { echo "FAIL: ToolKeyInfo missing"; exit 1; }
+grep -qE "interface ToolKeyStatus" "$A" || { echo "FAIL: ToolKeyStatus missing"; exit 1; }
+grep -qE "respondToConfirmation\(confirmationId: string, decision: ToolDecision\): void" "$A" || { echo "FAIL: existing AgentToolControl member changed"; exit 1; }
+
+# All six pseudocode markers present on the control.
+for L in "1-11" "20-34" "40-43" "50-53" "60-67" "70-73"; do
+  grep -qE "@pseudocode lines $L" "$K" || { echo "FAIL: pseudocode marker $L missing"; exit 1; }
+done
+
+# Delegation seam present; mask applied; raw key never returned.
+grep -qE "maskKeyForDisplay\(rawKey\)" "$K" || { echo "FAIL: status not masking"; exit 1; }
+grep -qE "getToolKeyStorage\(\)" "$I" || { echo "FAIL: agentImpl not wiring singleton"; exit 1; }
+grep -qE "this\.keys = new ToolKeysControl\(deps\.keysDeps\)" "$T" || { echo "FAIL: ToolControl not constructing nested keys"; exit 1; }
+
+# R-NO-RAW-SECRETS: the control must NOT spread the raw key or return it.
+if grep -nE "maskedKey: rawKey|key: rawKey|rawKey," "$K"; then echo "FAIL: control may be returning the raw key"; exit 1; fi
+# No re-implemented validation / no catch of the storage throw.
+if grep -nE "isValidToolKeyName|catch\b" "$K"; then echo "FAIL: control re-validates or catches (must delegate/propagate)"; exit 1; fi
+# No cached storage field.
+if grep -nE "private .*(storage|cachedStorage)\b" "$K"; then echo "FAIL: cached storage state"; exit 1; fi
+
+# RED-note dynamic import now resolves (file exists) and suite is GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run "$F" > /tmp/p16_green.log 2>&1 || { echo "FAIL: P15 suite not green"; tail -40 /tmp/p16_green.log; exit 1; }
+
+# Whole dir still green (non-breaking).
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p16_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p16_all.log; exit 1; }
+
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+```
+
+### Deferred Implementation Detection (MANDATORY — scoped to changed lines)
+
+```bash
+set -o pipefail
+set -e
+for F in packages/agents/src/api/agent.ts packages/agents/src/api/control/toolKeysControl.ts packages/agents/src/api/control/toolControl.ts packages/agents/src/api/agentImpl.ts; do
+  git diff HEAD -- "$F" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $F"; exit 1; } || true
+done
+echo "PASS: no deferred markers in changed lines."
+```
+
+## Success Criteria
+
+- P15 suite GREEN; whole `__tests__` dir GREEN; typecheck + lint clean.
+- `agent.tools.keys` exposes the six masked methods, delegating to the shared `ToolKeyStorage`; raw key
+  never returned; existing `AgentToolControl` members unchanged; `agent.tools.keys` distinct from
+  `agent.auth.keys`.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/agent.ts packages/agents/src/api/control/toolControl.ts packages/agents/src/api/agentImpl.ts`
+- `rm -f packages/agents/src/api/control/toolKeysControl.ts`
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P16.md` (same field schema as P08).

--- a/project-plans/issue2143/plan/16a-tool-keys-impl-verification.md
+++ b/project-plans/issue2143/plan/16a-tool-keys-impl-verification.md
@@ -1,0 +1,137 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P16a @requirement:REQ-007 -->
+# Phase 16a: Tool-Key Storage — Pseudocode-Compliance Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P16a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 16 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P16.md`
+
+## Purpose
+
+Independent gate. Confirm the P16 implementation matches `analysis/pseudocode/tool-keys.md`
+line-by-line, preserves the existing `AgentToolControl` surface (non-breaking), is delegate-only
+(no cached storage), NEVER returns raw key material (R-NO-RAW-SECRETS), exposes `agent.tools.keys` as a
+DISTINCT controller from `agent.auth.keys` (R-KEYS-DISTINCT), lets `ToolKeyStorage` own tool-name
+validation (propagated throw, not caught), and that the P15 tests are genuinely behavioral (real
+`ToolKeyStorage` over a temp dir + a real Map-backed keyring adapter, no mock theater, ≥30% property,
+no reverse tests).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+A=packages/agents/src/api/agent.ts
+K=packages/agents/src/api/control/toolKeysControl.ts
+T=packages/agents/src/api/control/toolControl.ts
+I=packages/agents/src/api/agentImpl.ts
+F=packages/agents/src/api/__tests__/toolKeys.behavior.test.ts
+
+# 1. Target test + whole dir GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p16a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p16a_all.log; exit 1; }
+
+# 2. Project typecheck + lint clean.
+npm run typecheck 2>&1 | tail -15
+npm run lint 2>&1 | tail -15
+
+# 3. Non-breaking: existing AgentToolControl members still declared.
+for m in "list" "setEnabled" "onConfirmationRequest" "respondToConfirmation" "onToolUpdate" "setEditorCallbacks"; do
+  grep -qE "$m" "$A" || { echo "FAIL: existing AgentToolControl member $m missing"; exit 1; }
+done
+grep -qE "readonly keys: AgentToolKeyControl" "$A" || { echo "FAIL: nested keys member missing"; exit 1; }
+
+# 4. All six pseudocode markers present, in the right methods.
+for L in "1-11" "20-34" "40-43" "50-53" "60-67" "70-73"; do
+  grep -qE "@pseudocode lines $L" "$K" || { echo "FAIL: pseudocode marker $L missing"; exit 1; }
+done
+
+# 5. R-NO-RAW-SECRETS: status masks; the raw key is never placed on a returned object.
+grep -qE "maskKeyForDisplay\(rawKey\)" "$K" || { echo "FAIL: status not masking"; exit 1; }
+if grep -nE "maskedKey: rawKey|key: rawKey|, rawKey[,}]|return rawKey" "$K"; then echo "FAIL: control may return the raw key"; exit 1; fi
+# maskedKey omitted on the no-key branch (the false branch must not set maskedKey).
+awk '/hasKey: false/{print}' "$K" | grep -qE "maskedKey" && { echo "FAIL: maskedKey present on no-key branch"; exit 1; } || true
+
+# 6. Validation delegated (not re-implemented) and throw NOT caught.
+if grep -nE "isValidToolKeyName|catch\b" "$K"; then echo "FAIL: control re-validates or catches (must delegate/propagate)"; exit 1; fi
+
+# 7. Delegation + wiring; no cache.
+grep -qE "this\.deps\.getStorage\(\)" "$K" || { echo "FAIL: not resolving storage per call"; exit 1; }
+if grep -nE "private .*(storage|cachedStorage)\b" "$K"; then echo "FAIL: cached storage state"; exit 1; fi
+grep -qE "this\.keys = new ToolKeysControl\(deps\.keysDeps\)" "$T" || { echo "FAIL: ToolControl not constructing nested keys"; exit 1; }
+grep -qE "keysDeps: \{ getStorage: \(\) => getToolKeyStorage\(\) \}" "$I" || { echo "FAIL: agentImpl not wiring the shared singleton"; exit 1; }
+
+# 8. R-KEYS-DISTINCT: a SEPARATE controller class; tools.keys is not aliased to auth.keys.
+grep -qE "class ToolKeysControl implements AgentToolKeyControl" "$K" || { echo "FAIL: ToolKeysControl class missing"; exit 1; }
+if grep -nE "AuthKeysControl" "$K"; then echo "FAIL: tool keys must not reuse the auth keys controller"; exit 1; fi
+
+# 9. Re-audit P15 tests are behavioral + hermetic-real.
+grep -qE "new ToolKeyStorage\(" "$F" || { echo "FAIL: not a real ToolKeyStorage"; exit 1; }
+grep -qE "keyringLoader" "$F" || { echo "FAIL: hermetic keyring seam missing"; exit 1; }
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+grep -qE "agent\.tools\.keys !== agent\.auth\.keys|agent\.auth\.keys !== agent\.tools\.keys" "$F" || { echo "FAIL: distinct-object check missing"; exit 1; }
+grep -qE "Object\.(keys|values)|JSON\.stringify" "$F" || { echo "FAIL: no-leak not enumerated"; exit 1; }
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+
+# 10. Deferred scan on changed lines.
+for X in "$A" "$K" "$T" "$I"; do
+  git diff HEAD -- "$X" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $X"; exit 1; } || true
+done
+echo "PASS: gates green."
+```
+
+### Line-by-Line Compliance Table (fill in, fold into marker)
+
+| Pseudocode lines | Method | Implemented at (file:line) | Matches? |
+| --- | --- | --- | --- |
+| 1-11 | supported (registry projection; skip undefined entries) | toolKeysControl.ts:___ | |
+| 20-34 | status (masked; maskedKey ONLY when hasKey; keyFile ?? undefined; raw key never returned) | toolKeysControl.ts:___ | |
+| 40-43 | save (delegate saveKey; validation propagates) | toolKeysControl.ts:___ | |
+| 50-53 | delete (delegate deleteKey) | toolKeysControl.ts:___ | |
+| 60-67 | setKeyFile (null → clearKeyfilePath; else setKeyfilePath) | toolKeysControl.ts:___ | |
+| 70-73 | getKeyFile (delegate getKeyfilePath) | toolKeysControl.ts:___ | |
+| wiring | ToolControl constructs `keys = new ToolKeysControl(deps.keysDeps)`; agentImpl provides `keysDeps: { getStorage: () => getToolKeyStorage() }` | toolControl.ts:___ / agentImpl.ts:___ | |
+
+## Holistic Functionality Assessment (MANDATORY — into marker)
+
+- **What was implemented**: the six-method masked `ToolKeysControl` delegating to core `ToolKeyStorage`,
+  nested under the existing `ToolControl` as `agent.tools.keys`, wired to the shared
+  `getToolKeyStorage()` singleton.
+- **Satisfies REQ-007?**: supported / status / save / delete / setKeyFile / getKeyFile present and
+  delegating; existing `AgentToolControl` members intact (non-breaking)?
+- **Data flow**: live `this.deps.getStorage()` every call; `status` masks via `maskKeyForDisplay`;
+  `maskedKey` omitted when no key; `setKeyFile(null)` clears.
+- **Security (R-NO-RAW-SECRETS)**: no path returns the raw key; the P15 test enumerates real output to
+  prove the raw key never appears. Verdict on leak risk with evidence.
+- **Distinctness (R-KEYS-DISTINCT)**: `agent.tools.keys` is a separate `ToolKeysControl` instance, not an
+  alias of `agent.auth.keys` — confirmed by the public-surface `!==` check. Evidence (file:line).
+- **Validation ownership (REQ-007.7)**: invalid tool name throw originates in `ToolKeyStorage` and
+  propagates uncaught through the control.
+- **Risks**: any cached storage; any path that surfaces the raw key; any change to existing members; any
+  re-implemented validation; any CLI-side path logic leaking into `setKeyFile`.
+- **Verdict**: PASS/FAIL with file:line evidence.
+
+## Success Criteria
+
+- All gates pass; compliance table complete; non-breaking + no-raw-secrets + keys-distinct confirmed;
+  holistic verdict PASS.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P16a.md` including the completed compliance table + holistic
+assessment.

--- a/project-plans/issue2143/plan/17-barrel-and-command-map.md
+++ b/project-plans/issue2143/plan/17-barrel-and-command-map.md
@@ -1,0 +1,256 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P17 @requirement:REQ-008,REQ-009 -->
+# Phase 17: Public Barrel Re-Exports + `COMMAND_API_MAP` Rows
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P17`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 16a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P16a.md`
+- Cite pseudocode: `analysis/pseudocode/barrel-exports.md`, `analysis/pseudocode/command-map.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-008: Public barrel re-exports + command-map registration
+
+**Full Text**: The public agents barrel (`packages/agents/src/api/index.ts`) MUST surface, BY NAME,
+the new VALUE enums (`PolicyDecision`, `ApprovalMode`) and every NEW projected public type so a
+consumer (#1595) can import them from the public root `@vybestack/llxprt-code-agents` without a deep
+import. `COMMAND_API_MAP` (`app-services/command-api-map.ts`) MUST register the six target slash
+commands (`/approval-mode`, `/policies`, `/task`, `/hooks`, `/toolkey`, `/toolkeyfile`) as
+`kind: 'runtime'` rows pointing at the real Agent-method paths added by REQ-001..007.
+**Behavior**:
+- GIVEN: a #1595 developer importing only `@vybestack/llxprt-code-agents`
+- WHEN: they reference `ApprovalMode.YOLO`, `PolicyDecision.ASK_USER`, or a projected type
+  (`AgentTaskInfo`, `PolicyRuleView`, `ToolKeyStatus`, …)
+- THEN: every symbol resolves from the public root (enums as runtime VALUES, projected types as
+  type-only) — no `@vybestack/llxprt-code-core/<path>` deep import is required
+- AND: `COMMAND_API_MAP` documents how each of the six commands reaches its Agent target
+**Why This Matters**: #1595's stated acceptance criterion is "no `getConfig()` escape hatch / no deep
+import". A consumer that cannot even NAME `ApprovalMode` as a value, or cannot discover the
+command→method mapping, is forced back to `-core`. This phase is the public-surface keystone.
+
+### REQ-009 (this phase's slice): Non-breaking append-only
+
+**Full Text**: Existing barrel exports and existing `COMMAND_API_MAP` rows keep their exact shape;
+this phase ADDS lines only.
+**Behavior**: GIVEN the current public surface, WHEN this phase lands, THEN every prior export/row is
+byte-identical and still present (the prior set is a SUBSET of the new set).
+
+## Background — verified current state (DO NOT re-derive; confirmed at authoring)
+
+- `api/index.ts:12` is `export * from './agent.js';` (star, NOT `export type *`). The control
+  interfaces and projected types defined in `agent.ts` therefore already surface by name through this
+  star — EXCEPT the two enum VALUES, which are currently **type-only**:
+  - `ApprovalMode` is re-exported `export type { ApprovalMode }` (`agent.ts:387`) and
+    `export type { ApprovalMode, … }` (`config-types.ts:27`). So `root.ApprovalMode` is NOT a runtime
+    value today.
+  - `PolicyDecision` is NOT exported from the agents public surface at all today (only used
+    internally at `confirmationForcing.ts:42`).
+- Real enum shapes (for the RED test): `ApprovalMode { DEFAULT='default', AUTO_EDIT='autoEdit',
+  YOLO='yolo' }` (`core/src/config/configTypes.ts:59`); `PolicyDecision { ALLOW='allow',
+  DENY='deny', ASK_USER='ask_user' }` (`policy/src/types.ts:7`). Both re-exported as VALUES from the
+  core barrel (`core/src/index.ts:17-18`).
+- `COMMAND_API_MAP: readonly CommandApiMapping[]` (`command-api-map.ts:37`) currently ends with the
+  `/quit` cli-local row; the six target commands are ABSENT (verified count 0 each).
+- The boundary spec `app-service-boundary.spec.ts` enforces: no orphan kind, unique command names,
+  REQUIRED_DURABLE subpath set present + classified `subpath`, every `subpath` row dynamically
+  importable. It does NOT enforce completeness; `runtime` rows need no subpath import. Adding six
+  `runtime` rows is therefore safe.
+
+## Implementation Tasks (TDD within the phase: write the test, observe RED, then implement GREEN)
+
+### Step 1 — Files to Create (the behavioral RED test FIRST)
+
+- `packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts` — marker
+  `@plan:PLAN-20260622-COREAPIGAP.P17 @requirement:REQ-008`. T17-EXEMPT `.test.ts` (it imports the
+  public root and the production map module by relative path — both permitted). It MUST:
+  - Import the two enums AS VALUES from the public root:
+    `import { ApprovalMode, PolicyDecision } from '@vybestack/llxprt-code-agents';` and assert their
+    real members round-trip: `expect(ApprovalMode.YOLO).toBe('yolo')`,
+    `expect(ApprovalMode.AUTO_EDIT).toBe('autoEdit')`, `expect(ApprovalMode.DEFAULT).toBe('default')`,
+    `expect(PolicyDecision.ASK_USER).toBe('ask_user')`, `expect(PolicyDecision.ALLOW).toBe('allow')`,
+    `expect(PolicyDecision.DENY).toBe('deny')`. (Importing a runtime VALUE that is currently
+    type-only yields `undefined` at runtime → the `.toBe(...)` assertions FAIL behaviorally — an
+    AssertionError, NOT a module-not-found error, because the star re-export means the NAME resolves,
+    just as a type with no runtime binding. This is ACCEPTABLE RED.)
+  - Assert the two enums are runtime keys of the namespace:
+    `import * as root from '@vybestack/llxprt-code-agents';` then
+    `expect(Object.prototype.hasOwnProperty.call(root, 'ApprovalMode')).toBe(true)` and the same for
+    `'PolicyDecision'`. (Currently false → behavioral RED.)
+  - Import the production map and assert the six rows by content:
+    `import { COMMAND_API_MAP } from '../../app-services/command-api-map.js';`
+    Build `const byCmd = new Map(COMMAND_API_MAP.map((e) => [e.command, e] as const));` and for each
+    of the six expected `{ command, target }` pairs assert the row exists, `kind === 'runtime'`, and
+    `target` equals the expected dotted path (table below). (Rows absent today → behavioral RED.)
+  - Re-assert the map invariants still hold AFTER the rows (proves non-breaking + no orphan):
+    every `e.kind` ∈ `{runtime, subpath, cli-local}`; command names unique
+    (`new Set(names).size === names.length`).
+  - **≥30% property-based (fast-check), MIN-2 distinct property cases**, e.g.:
+    1. Property over `fc.constantFrom(...Object.values(ApprovalMode))`: each member is a non-empty
+       lowercase string AND `ApprovalMode[key-for-value]` round-trips (value is a live enum member).
+    2. Property over the six expected commands `fc.constantFrom('/approval-mode','/policies','/task',
+       '/hooks','/toolkey','/toolkeyfile')`: each is present in `byCmd`, has `kind==='runtime'`, and a
+       non-empty `target` that starts with `'agent.'`.
+  - NO mock theater, NO reverse tests, NO `.skip`, no `any`.
+
+Expected `{ command → target }` rows:
+
+| command | kind | target |
+|---|---|---|
+| `/approval-mode` | runtime | `agent.setApprovalMode` |
+| `/policies` | runtime | `agent.policy.getRules` |
+| `/task` | runtime | `agent.tasks.list` |
+| `/hooks` | runtime | `agent.hooks.listHooks` |
+| `/toolkey` | runtime | `agent.tools.keys.save` |
+| `/toolkeyfile` | runtime | `agent.tools.keys.setKeyFile` |
+
+### Step 2 — Files to Modify (implement GREEN; cite pseudocode)
+
+- `packages/agents/src/api/index.ts` — APPEND (do not touch existing lines):
+  - `@pseudocode barrel-exports.md lines 1-4` (VALUE enums):
+    `export { PolicyDecision, ApprovalMode } from '@vybestack/llxprt-code-core';`
+  - `@pseudocode barrel-exports.md lines 5-9` (projected TYPES, type-only):
+    `export type { PolicyRuleView, AgentTaskInfo, HookInfo, AuthProviderDetail, AuthBucketStatus,
+    McpServerAuthStatus, McpDetailStatus, McpServerDetail, McpDetailsOptions, McpPromptInfo,
+    McpResourceInfo, McpBlockedServer, ToolKeyInfo, ToolKeyStatus } from './agent.js';`
+  - Add the `@plan`/`@requirement`/`@pseudocode` marker block referencing P17.
+  - **Collision note (verify, do not guess):** the direct VALUE `export { ApprovalMode } from
+    '...core'` deliberately SHADOWS the star-propagated `export type { ApprovalMode }` (an explicit
+    named re-export wins over a `export *` re-export). After editing, RUN `npm run typecheck` and
+    `npm run build`. If TS emits TS2308 ("already exported a member named 'ApprovalMode'"), the
+    resolution is to KEEP the explicit value export as the authoritative one (it is the intended
+    public shape) — do NOT remove the value export and do NOT delete the existing `config-types.ts`
+    type re-export; if the collision is genuinely unresolvable by shadowing, re-export the value from
+    a single explicit named export and confirm the type still resolves. Record the exact outcome in
+    the completion marker. (Projected types are all NET-NEW names, so they cannot collide.)
+- `packages/agents/src/app-services/command-api-map.ts` — APPEND the six rows after the last existing
+  entry (the `/quit` block), citing `@pseudocode command-map.md lines 1-13`. Each row uses
+  `kind: 'runtime'`, the `target` from the table above, and a one-line `note`. Add a P17 marker block
+  to the file header comment (do not remove the existing P27 marker).
+
+### Constraints
+
+- APPEND-ONLY. Do not reorder, retype, or remove any existing export or map row (REQ-009).
+- `verbatimModuleSyntax` is ON: enums → plain `export { … }`; projected interfaces → `export type
+  { … }`. (Mixing them up yields TS1205 for the types or a runtime "not exported" for the enums.)
+- The projected TYPES must already be DEFINED in `agent.ts` by P05/P07/P09/P11/P13/P15 (they are).
+  If any name does not yet exist in `agent.ts`, that is a missing dependency from an earlier phase —
+  STOP and fix the source phase; do NOT define the type here.
+- Production code carries ONLY marker comments (N5) — no prose.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+I=packages/agents/src/api/index.ts
+M=packages/agents/src/app-services/command-api-map.ts
+F=packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts
+
+test -f "$F"
+
+# 1. VALUE enums exported (plain export, NOT `export type`), projected types as `export type`.
+grep -qE "export \{ PolicyDecision, ApprovalMode \} from '@vybestack/llxprt-code-core'" "$I" \
+  || { echo "FAIL: value enums not re-exported"; exit 1; }
+# Guard against accidental `export type { … PolicyDecision …}` (would break enum-member use).
+if grep -nE "export type \{[^}]*\b(PolicyDecision|ApprovalMode)\b[^}]*\} from '@vybestack/llxprt-code-core'" "$I"; then
+  echo "FAIL: enums re-exported as type-only (must be VALUE export)"; exit 1
+fi
+for T in PolicyRuleView AgentTaskInfo HookInfo AuthProviderDetail AuthBucketStatus McpServerAuthStatus McpDetailStatus McpServerDetail McpDetailsOptions McpPromptInfo McpResourceInfo McpBlockedServer ToolKeyInfo ToolKeyStatus; do
+  grep -qE "\b$T\b" "$I" || { echo "FAIL: projected type $T not surfaced from barrel"; exit 1; }
+done
+grep -qE "export type \{" "$I" || { echo "FAIL: no `export type` block for projected types"; exit 1; }
+
+# 2. Existing barrel lines intact (non-breaking subset — spot-check the load-bearing ones).
+for L in "export \* from './agent.js'" "export \{ createAgent \} from './createAgent.js'" "export \{ fromConfig \} from './fromConfig.js'" "export type \{ AgentClientContract \}"; do
+  grep -qE "$L" "$I" || { echo "FAIL: existing barrel export missing: $L"; exit 1; }
+done
+
+# 3. Six runtime rows present with the right target + kind.
+for ROW in "/approval-mode:agent.setApprovalMode" "/policies:agent.policy.getRules" "/task:agent.tasks.list" "/hooks:agent.hooks.listHooks" "/toolkey:agent.tools.keys.save" "/toolkeyfile:agent.tools.keys.setKeyFile"; do
+  CMD="${ROW%%:*}"; TGT="${ROW#*:}"
+  grep -qE "command: '$CMD'" "$M" || { echo "FAIL: command-map row missing: $CMD"; exit 1; }
+  grep -qE "target: '$TGT'" "$M" || { echo "FAIL: command-map target missing: $TGT"; exit 1; }
+done
+# Each new command's row is kind 'runtime' (no accidental subpath/cli-local).
+node -e "const {COMMAND_API_MAP}=require('./packages/agents/dist/src/app-services/command-api-map.js'); const want=['/approval-mode','/policies','/task','/hooks','/toolkey','/toolkeyfile']; const m=new Map(COMMAND_API_MAP.map(e=>[e.command,e])); for(const c of want){const e=m.get(c); if(!e){console.error('MISSING '+c);process.exit(1);} if(e.kind!=='runtime'){console.error('WRONG KIND '+c+' '+e.kind);process.exit(1);}} const names=COMMAND_API_MAP.map(e=>e.command); if(new Set(names).size!==names.length){console.error('DUP command');process.exit(1);} console.log('map invariants OK');" 2>/dev/null \
+  || echo "(node dist check skipped until build; grep checks above are authoritative pre-build)"
+
+# 4. Target test GREEN + boundary spec still GREEN + whole dir GREEN.
+npx vitest run "$F" 2>&1 | tail -30
+npx vitest run packages/agents/src/api/__tests__/app-service-boundary.spec.ts 2>&1 | tail -20
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p17_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p17_all.log; exit 1; }
+
+# 5. Build + typecheck (CRITICAL: catches the ApprovalMode value/type collision if any).
+npm run typecheck 2>&1 | tail -15
+npm run build 2>&1 | tail -15
+
+# 6. Property gate on the new test (≥30%, MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+
+# 7. No mock theater / reverse tests in the new test.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)|toThrow\('NotYetImplemented'\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# 8. Deferred markers on changed lines only.
+for X in "$I" "$M" "$F"; do
+  git diff HEAD -- "$X" | grep -E "^\+" | grep -vE "^\+\+\+" \
+    | grep -nE "(TODO|FIXME|HACK|STUB|XXX|placeholder|for now|in a real)" \
+    && { echo "FAIL: deferred marker in $X"; exit 1; } || true
+done
+echo "PASS: P17 barrel + command-map green."
+```
+
+> RED capture (run BEFORE Step 2): `npx vitest run "$F" > /tmp/p17_red.log 2>&1` MUST exit non-zero,
+> and `/tmp/p17_red.log` MUST NOT contain `Cannot find module|SyntaxError|Failed to resolve import`
+> (the public-root NAMES resolve via the star re-export even when type-only; the failures must be
+> AssertionErrors on the enum members + missing map rows). Paste this into the completion marker.
+
+### Semantic Verification Checklist
+
+- [ ] `ApprovalMode` + `PolicyDecision` importable as runtime VALUES from the public root; members
+      round-trip.
+- [ ] All 14 projected types surfaced `export type` from the barrel.
+- [ ] Six `runtime` rows present, correct targets, unique, no orphan; REQUIRED_DURABLE subpath set
+      untouched (boundary spec green).
+- [ ] `npm run build` + `npm run typecheck` green (ApprovalMode value/type collision resolved by
+      shadowing or recorded).
+- [ ] Append-only: every prior export/row intact; whole `__tests__` dir green.
+
+## Success Criteria
+
+- Public root exposes the enums (values) + projected types (type-only); six command rows registered;
+  build/typecheck green; non-breaking; new behavioral test green with ≥30% property.
+
+## Failure Recovery
+
+- `git checkout -- packages/agents/src/api/index.ts packages/agents/src/app-services/command-api-map.ts`
+  and re-apply append-only; if a projected type name is missing from `agent.ts`, reopen the owning
+  component phase (do NOT define it here).
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P17.md`
+
+```markdown
+Phase: P17
+Completed: YYYY-MM-DD HH:MM
+Files Created: [barrelAndCommandMap.behavior.test.ts with line count]
+Files Modified: [api/index.ts +N/-0, app-services/command-api-map.ts +N/-0]
+Tests Added: [count]
+RED evidence: [paste /tmp/p17_red.log tail proving behavioral (non-module) failure]
+ApprovalMode collision outcome: [shadowed cleanly | resolved how]
+Verification: [paste the actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line: barrel + map now let #1595 name every new symbol from the public root]
+```

--- a/project-plans/issue2143/plan/17a-barrel-and-command-map-verification.md
+++ b/project-plans/issue2143/plan/17a-barrel-and-command-map-verification.md
@@ -1,0 +1,135 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P17a @requirement:REQ-008,REQ-009 -->
+# Phase 17a: Barrel + `COMMAND_API_MAP` — Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P17a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 17 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P17.md`
+
+## Purpose
+
+Independent gate. Confirm the public barrel surfaces the two enums as runtime VALUES and all
+projected types as type-only (value-vs-type correctness under `verbatimModuleSyntax`), that the six
+`COMMAND_API_MAP` rows are valid `runtime` rows pointing at REAL Agent-method paths, that the change
+is strictly append-only (REQ-009 non-breaking), and that the P17 test is genuinely behavioral
+(real public-root import, real production map, ≥30% property, no mock theater / reverse tests).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+I=packages/agents/src/api/index.ts
+M=packages/agents/src/app-services/command-api-map.ts
+F=packages/agents/src/api/__tests__/barrelAndCommandMap.behavior.test.ts
+
+# 1. Value-vs-type correctness in the barrel.
+grep -qE "export \{ PolicyDecision, ApprovalMode \} from '@vybestack/llxprt-code-core'" "$I" \
+  || { echo "FAIL: enums not VALUE-exported"; exit 1; }
+if grep -nE "export type \{[^}]*\b(PolicyDecision|ApprovalMode)\b" "$I"; then echo "FAIL: enums type-only"; exit 1; fi
+grep -qE "export type \{[^}]*\bToolKeyStatus\b" "$I" || { echo "FAIL: projected types not type-only block"; exit 1; }
+
+# 2. Append-only diff: NO existing line removed (deletions touching prior exports/rows are forbidden).
+#    Allow ONLY added lines + a marker-comment block; assert zero removed export/row lines.
+if git diff HEAD -- "$I" | grep -E "^-" | grep -vE "^---" | grep -E "export|from '"; then
+  echo "FAIL: an existing barrel export line was removed/changed"; exit 1
+fi
+if git diff HEAD -- "$M" | grep -E "^-" | grep -vE "^---" | grep -E "command:|target:|kind:"; then
+  echo "FAIL: an existing command-map row line was removed/changed"; exit 1
+fi
+echo "append-only confirmed for barrel + map"
+
+# 3. Build the package, then verify the BUILT barrel actually ships the enums as runtime values and
+#    the six rows resolve from the compiled artifact (the real consumer surface).
+npm run build 2>&1 | tail -10
+node -e "
+const root = require('./packages/agents/dist/src/api/index.js');
+for (const k of ['ApprovalMode','PolicyDecision']) {
+  if (!Object.prototype.hasOwnProperty.call(root,k)) { console.error('MISSING runtime value '+k); process.exit(1); }
+}
+if (root.ApprovalMode.YOLO !== 'yolo' || root.ApprovalMode.AUTO_EDIT !== 'autoEdit' || root.ApprovalMode.DEFAULT !== 'default') { console.error('ApprovalMode members wrong'); process.exit(1); }
+if (root.PolicyDecision.ASK_USER !== 'ask_user' || root.PolicyDecision.ALLOW !== 'allow' || root.PolicyDecision.DENY !== 'deny') { console.error('PolicyDecision members wrong'); process.exit(1); }
+console.log('built barrel exposes enum VALUES OK');
+"
+node -e "
+const { COMMAND_API_MAP } = require('./packages/agents/dist/src/app-services/command-api-map.js');
+const want = { '/approval-mode':'agent.setApprovalMode', '/policies':'agent.policy.getRules', '/task':'agent.tasks.list', '/hooks':'agent.hooks.listHooks', '/toolkey':'agent.tools.keys.save', '/toolkeyfile':'agent.tools.keys.setKeyFile' };
+const m = new Map(COMMAND_API_MAP.map(e => [e.command, e]));
+for (const [c,t] of Object.entries(want)) { const e=m.get(c); if(!e){console.error('MISSING '+c);process.exit(1);} if(e.kind!=='runtime'){console.error('WRONG KIND '+c);process.exit(1);} if(e.target!==t){console.error('WRONG TARGET '+c+' '+e.target);process.exit(1);} }
+const names = COMMAND_API_MAP.map(e=>e.command);
+if (new Set(names).size !== names.length) { console.error('DUP command'); process.exit(1); }
+const valid = new Set(['runtime','subpath','cli-local']);
+if (COMMAND_API_MAP.some(e=>!valid.has(e.kind))) { console.error('orphan kind'); process.exit(1); }
+console.log('built map: six runtime rows + invariants OK');
+"
+
+# 4. Each target dotted-path is backed by a REAL Agent method/controller (string-grep the source).
+grep -qE "setApprovalMode" packages/agents/src/api/agent.ts || { echo "FAIL: agent.setApprovalMode missing"; exit 1; }
+grep -qE "policy: AgentPolicyControl|readonly policy" packages/agents/src/api/agent.ts || { echo "FAIL: agent.policy missing"; exit 1; }
+grep -qE "tasks: AgentTasksControl|readonly tasks" packages/agents/src/api/agent.ts || { echo "FAIL: agent.tasks missing"; exit 1; }
+grep -qE "listHooks" packages/agents/src/api/agent.ts || { echo "FAIL: agent.hooks.listHooks missing"; exit 1; }
+grep -qE "keys: AgentToolKeyControl|readonly keys" packages/agents/src/api/agent.ts || { echo "FAIL: agent.tools.keys missing"; exit 1; }
+
+# 5. Full dir + boundary spec + typecheck green.
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p17a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p17a_all.log; exit 1; }
+npm run typecheck 2>&1 | tail -15
+
+# 6. Re-audit P17 test discipline.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+grep -qE "from '@vybestack/llxprt-code-agents'" "$F" || { echo "FAIL: test must import the PUBLIC ROOT (proves no deep import needed)"; exit 1; }
+grep -qE "ApprovalMode\.YOLO|ApprovalMode\.AUTO_EDIT" "$F" || { echo "FAIL: test must assert real enum members"; exit 1; }
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+echo "PASS: P17a gates green."
+```
+
+## Holistic Assessment (MANDATORY — into marker)
+
+- **Value-vs-type**: enums VALUE-exported, projected types type-only — confirmed against the BUILT
+  artifact (not just source grep), so a consumer `import { ApprovalMode } from
+  '@vybestack/llxprt-code-agents'` truly gets a runtime enum. Evidence (node output).
+- **Map adequacy**: the six `runtime` rows point at the REAL methods this plan added; #1595 can read
+  the command→method mapping from the public app-service map. Evidence (built-map node output).
+- **Non-breaking (REQ-009)**: append-only diff proven (no removed export/row line); boundary spec +
+  whole dir green.
+- **ApprovalMode collision**: confirm the P17 marker recorded the typecheck/build outcome; verify no
+  TS2308 in the build log.
+- **Test discipline**: behavioral (public-root import, real members, real production map), ≥30%
+  property, no mock theater / reverse tests.
+- **Verdict**: PASS/FAIL with file:line + node-output evidence.
+
+## Success Criteria
+
+- All gates pass; built artifact ships enum values + six runtime rows; append-only; holistic verdict
+  PASS.
+
+## Failure Recovery
+
+- Reopen P17 for the specific defect (value/type form, missing row/target, removed line, collision);
+  do not weaken the verification.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P17a.md` (include the node-output evidence + holistic
+verdict).
+
+```markdown
+Phase: P17a
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: none (verification only)
+Verification: [paste actual output incl. both node checks]
+Holistic Assessment: [PASS/FAIL with evidence]
+```

--- a/project-plans/issue2143/plan/18-non-breaking.md
+++ b/project-plans/issue2143/plan/18-non-breaking.md
@@ -1,0 +1,162 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P18 @requirement:REQ-009 -->
+# Phase 18: Non-Breaking Public-Surface Guard
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P18`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 17a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P17a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-009: The whole plan is additive — no existing public export removed or changed
+
+**Full Text**: After ALL of REQ-001..008 land, every #1594/#1594-remediate-era public export (root
+barrel values, projected types, the `internals.js` value exports, the existing sub-controller method
+signatures) MUST still be present with a COMPATIBLE shape. The surface may GROW; it may never SHRINK
+or change an existing member's shape.
+**Behavior**:
+- GIVEN: the public surface as shipped before this plan (the characterization baseline)
+- WHEN: this plan's additive members are present
+- THEN: the prior export set is a strict SUBSET of the current export set, and each prior
+  member's runtime kind (`function`/enum-value/object) and (where compile-checkable) type signature
+  is unchanged
+**Why This Matters**: #1595 and any other current consumer must not be broken by this prerequisite.
+This phase is the explicit regression fence around "additive only".
+
+## Background — verified current state
+
+- Two characterization tests already exist and MUST stay green:
+  - `__tests__/nonBreaking.exports.test.ts` (REQ-006-era runtime subset guard + internals identity).
+  - `__tests__/publicSurface.nonbreaking.test.ts` (REQ-006-era dynamic enumeration + `createAgent`
+    compile anchor + fast-check property over the #1594 key set).
+- This phase EXTENDS `publicSurface.nonbreaking.test.ts` (do NOT recreate it, do NOT duplicate the
+  existing assertions) by ADDING a NEW `describe('REQ-009 …')` block that fences THIS plan's surface:
+  the new value enums, the new projected types (compile anchors), and the unchanged shape of the
+  extended sub-controllers.
+
+## Implementation Tasks
+
+### Files to Modify
+
+- `packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts` — ADD a new
+  `describe('REQ-009 @plan:PLAN-20260622-COREAPIGAP.P18 — additive surface is non-breaking', …)`
+  block (append; leave the existing `describe` untouched). It MUST:
+  - **Prior-surface subset (runtime):** re-assert the full #1594-era load-bearing value set is still
+    present as runtime keys of the dynamically-enumerated root (`createAgent`, `fromConfig`,
+    `listProviders`, `listTools`, `mapLoopStream`, `mapStreamEvent`, `toConfigParameters`,
+    `createTaskToolRegistration`, `AdapterError`, `AgenticLoop`), and each is `typeof 'function'`.
+  - **internals identity unchanged:** `import * as internals from
+    '@vybestack/llxprt-code-agents/internals.js';` then assert `typeof internals.AgentClient ===
+    'function'`, `internals.PostTurnAction` is defined, and `root.AgentClient === internals.AgentClient`
+    (binding identity preserved).
+  - **New value enums are present (additive):** `root.ApprovalMode` and `root.PolicyDecision` are
+    runtime objects whose members round-trip (`root.ApprovalMode.YOLO === 'yolo'`,
+    `root.PolicyDecision.ASK_USER === 'ask_user'`). (This is the additive half: the surface GREW.)
+  - **Compile anchors for new projected types (no runtime shrink):** add type-level `const`
+    anchors that bind a value of the projected type to a local typed slot, then `void` it — exactly
+    the existing `_createAgentShape` idiom. At minimum anchor `AgentTaskInfo`, `PolicyRuleView`,
+    `ToolKeyStatus`, `HookInfo`, `AuthProviderDetail`, `McpDetailStatus`. Example:
+    `type _TaskInfoShape = import('@vybestack/llxprt-code-agents').AgentTaskInfo; const _t: (x:
+    _TaskInfoShape) => string = (x) => x.id; void _t;` (a removal/rename of the type, or dropping the
+    `id` field, breaks `npm run typecheck`).
+  - **Extended controller signatures unchanged (compile anchors):** bind the EXISTING method
+    signatures that were extended-around (not changed), e.g. the existing `Agent.mcp.refresh` is still
+    `(server?: string) => Promise<void>`; the existing `Agent.hooks.clear` is still `() => void`.
+    Use the `_shape` const-anchor idiom so any accidental signature change to a prior member fails
+    typecheck. (REQ-009's core promise: extending a controller did not alter its prior methods.)
+  - **≥30% property-based, MIN-2 cases** — e.g. (1) property over the prior load-bearing key set:
+    each sampled key is a live root key AND callable; (2) property over the new enum value sets: each
+    sampled member is a non-empty string equal to `EnumObject[memberName]`.
+  - NO mock theater, NO reverse tests, no `any` (the typed const-anchors are the opposite of `any`).
+
+### Constraints
+
+- Do NOT modify the production source in this phase — it is a TEST-ONLY regression fence. (If a real
+  non-breaking VIOLATION is discovered here, STOP and reopen the owning component phase; do not patch
+  it inside the test.)
+- Do NOT delete or weaken any existing assertion in either non-breaking test.
+- Keep `nonBreaking.exports.test.ts` as-is (it already passes); this phase only extends
+  `publicSurface.nonbreaking.test.ts`.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts
+
+# 1. The new REQ-009 describe block exists and is additive (old block still there).
+grep -qE "REQ-009 @plan:PLAN-20260622-COREAPIGAP.P18" "$F" || { echo "FAIL: new REQ-009 block missing"; exit 1; }
+grep -qE "REQ-006 @plan:PLAN-20260621-COREAPIREMED.P21" "$F" || { echo "FAIL: existing REQ-006 block was removed"; exit 1; }
+
+# 2. New enums + at least the named projected-type anchors are referenced.
+for SYM in ApprovalMode PolicyDecision AgentTaskInfo PolicyRuleView ToolKeyStatus HookInfo AuthProviderDetail McpDetailStatus; do
+  grep -qE "\b$SYM\b" "$F" || { echo "FAIL: $SYM not anchored in non-breaking test"; exit 1; }
+done
+
+# 3. Internals identity + prior subset still asserted.
+grep -qE "root\.AgentClient.*internals\.AgentClient|internals\.AgentClient.*root\.AgentClient" "$F" || { echo "FAIL: internals identity anchor missing"; exit 1; }
+
+# 4. Both non-breaking tests + whole dir GREEN; typecheck GREEN (compile anchors are load-bearing).
+npx vitest run packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts 2>&1 | tail -25
+npx vitest run packages/agents/src/api/__tests__/nonBreaking.exports.test.ts 2>&1 | tail -15
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p18_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p18_all.log; exit 1; }
+npm run typecheck 2>&1 | tail -15
+
+# 5. Property gate (≥30%, MIN-2) over the WHOLE file (existing prop counts too; new ones add).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+
+# 6. No mock theater / reverse tests in the file.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)|toThrow\('NotYetImplemented'\)" "$F"; then echo "FAIL: reverse test"; exit 1; fi
+
+# 7. No production source modified in this phase.
+if git diff HEAD --name-only | grep -vE "__tests__|project-plans/" | grep -E "packages/agents/src/"; then
+  echo "FAIL: P18 must not modify production source"; exit 1
+fi
+echo "PASS: P18 non-breaking guard green."
+```
+
+### Semantic Verification Checklist
+
+- [ ] Existing REQ-006 characterization block untouched and green.
+- [ ] New REQ-009 block fences: prior runtime subset, internals identity, new enum values, new
+      projected-type compile anchors, extended-controller signature anchors.
+- [ ] typecheck green (compile anchors actively guard prior + new shapes).
+- [ ] ≥30% property; no mock theater / reverse tests; no production source touched.
+
+## Success Criteria
+
+- Both non-breaking tests green; new REQ-009 regression fence in place; typecheck green; additive
+  surface proven (prior ⊂ current) and no prior member shape changed.
+
+## Failure Recovery
+
+- If a real non-breaking violation surfaces, STOP and reopen the owning component phase; never relax
+  the fence. Otherwise `git checkout -- <file>` and re-extend.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P18.md`
+
+```markdown
+Phase: P18
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: [publicSurface.nonbreaking.test.ts +N/-0]
+Tests Added: [count in the new describe block]
+Verification: [paste actual output]
+Semantic Assessment: [one-line: additive surface fenced; prior ⊂ current; no shape change]
+```

--- a/project-plans/issue2143/plan/18-non-breaking.md
+++ b/project-plans/issue2143/plan/18-non-breaking.md
@@ -132,8 +132,10 @@ echo "PASS: P18 non-breaking guard green."
 ### Semantic Verification Checklist
 
 - [ ] Existing REQ-006 characterization block untouched and green.
-- [ ] New REQ-009 block fences: prior runtime subset, internals identity, new enum values, new
-      projected-type compile anchors, extended-controller signature anchors.
+- [ ] New REQ-009 runtime block fences: prior runtime subset, internals identity, new enum values.
+- [ ] Compile anchors (new projected types + extended-controller signatures) live in
+      `additiveSurface.types.ts` (a `.types.ts`, NOT `.test.ts`) and are confirmed typecheck-visible —
+      so they are LOAD-BEARING, not vacuous.
 - [ ] typecheck green (compile anchors actively guard prior + new shapes).
 - [ ] ≥30% property; no mock theater / reverse tests; no production source touched.
 
@@ -154,9 +156,9 @@ Create: `project-plans/issue2143/.completed/P18.md`
 ```markdown
 Phase: P18
 Completed: YYYY-MM-DD HH:MM
-Files Created: none
-Files Modified: [publicSurface.nonbreaking.test.ts +N/-0]
+Files Created: [additiveSurface.types.ts +N (compile anchors; typecheck-visible, build-excluded, vitest-ignored)]
+Files Modified: [publicSurface.nonbreaking.test.ts +N/-0 (runtime assertions only)]
 Tests Added: [count in the new describe block]
-Verification: [paste actual output]
-Semantic Assessment: [one-line: additive surface fenced; prior ⊂ current; no shape change]
+Verification: [paste actual output — include proof the .types.ts anchor is load-bearing under typecheck]
+Semantic Assessment: [one-line: additive surface fenced; prior ⊂ current; no shape change; compile anchors load-bearing in .types.ts]
 ```

--- a/project-plans/issue2143/plan/18a-non-breaking-verification.md
+++ b/project-plans/issue2143/plan/18a-non-breaking-verification.md
@@ -1,0 +1,112 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P18a @requirement:REQ-009 -->
+# Phase 18a: Non-Breaking Guard — Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P18a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 18 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P18.md`
+
+## Purpose
+
+Independent gate on the additive-only promise. Confirm the regression fence actually CATCHES a
+removal/shape-change (not a vacuous test), that the existing #1594-era characterization is preserved,
+and that the new enum values + projected-type compile anchors are real (typecheck-load-bearing).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts
+
+# 1. Existing characterization preserved; new REQ-009 block present.
+grep -qE "REQ-006 @plan:PLAN-20260621-COREAPIREMED.P21" "$F" || { echo "FAIL: existing REQ-006 block removed"; exit 1; }
+grep -qE "REQ-009 @plan:PLAN-20260622-COREAPIGAP.P18" "$F" || { echo "FAIL: REQ-009 block missing"; exit 1; }
+
+# 2. Compile anchors are LOAD-BEARING: temporarily break a projected type usage and prove typecheck
+#    fails, then restore. (Mutation-style probe — confirms the fence is not vacuous.)
+cp "$F" /tmp/p18a_backup.ts
+# Flip an AgentTaskInfo field-access anchor to a non-existent field; typecheck MUST then fail.
+if grep -qE "AgentTaskInfo" "$F"; then
+  perl -0pi -e "s/(_TaskInfoShape\) => string = \(x\) => x\.)id/\${1}__nope_field__/g" "$F" || true
+  if npm run typecheck > /tmp/p18a_probe.log 2>&1; then
+    echo "FAIL: fence is vacuous — typecheck passed with a bogus AgentTaskInfo field"; cp /tmp/p18a_backup.ts "$F"; exit 1
+  fi
+  echo "fence is load-bearing: bogus projected-type field broke typecheck as expected"
+  cp /tmp/p18a_backup.ts "$F"
+fi
+# Restore + confirm green again.
+npm run typecheck 2>&1 | tail -10
+
+# 3. Built-artifact subset proof: prior #1594 keys ⊂ current built barrel keys.
+npm run build 2>&1 | tail -8
+node -e "
+const root = require('./packages/agents/dist/src/api/index.js');
+const prior = ['createAgent','fromConfig','listProviders','listTools','mapLoopStream','mapStreamEvent','toConfigParameters','createTaskToolRegistration','AdapterError','AgenticLoop'];
+const keys = new Set(Object.keys(root));
+const missing = prior.filter(k => !keys.has(k));
+if (missing.length) { console.error('SHRANK: missing prior keys '+JSON.stringify(missing)); process.exit(1); }
+for (const k of prior) { if (typeof root[k] !== 'function') { console.error('prior key not function: '+k); process.exit(1); } }
+const internals = require('./packages/agents/dist/src/internals.js');
+if (typeof internals.AgentClient !== 'function') { console.error('internals.AgentClient lost'); process.exit(1); }
+if (root.AgentClient !== internals.AgentClient) { console.error('AgentClient identity changed'); process.exit(1); }
+console.log('built-artifact subset + identity preserved');
+"
+
+# 4. Both non-breaking tests + whole dir GREEN.
+npx vitest run packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts 2>&1 | tail -20
+npx vitest run packages/agents/src/api/__tests__/nonBreaking.exports.test.ts 2>&1 | tail -12
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p18a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p18a_all.log; exit 1; }
+
+# 5. Discipline + no-production-change.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn|not\.toThrow\(\)" "$F"; then echo "FAIL: discipline"; exit 1; fi
+if git diff HEAD --name-only | grep -vE "__tests__|project-plans/" | grep -E "packages/agents/src/"; then echo "FAIL: production source changed in P18"; exit 1; fi
+
+# 6. Property gate.
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+echo "PASS: P18a gates green."
+```
+
+## Holistic Assessment (MANDATORY — into marker)
+
+- **Fence is non-vacuous**: the mutation probe (bogus projected-type field) broke typecheck and was
+  restored — the compile anchors really guard the new types. Evidence (`/tmp/p18a_probe.log` tail).
+- **No shrink**: built-artifact node check proves prior #1594 keys ⊂ current + internals identity
+  preserved. Evidence (node output).
+- **Existing characterization intact**: REQ-006 block preserved; both non-breaking tests green.
+- **Additive proven**: new enum values present; prior member shapes unchanged.
+- **Verdict**: PASS/FAIL with evidence.
+
+## Success Criteria
+
+- Fence proven load-bearing; no shrink; both tests + dir green; verdict PASS.
+
+## Failure Recovery
+
+- If the probe shows the fence is vacuous, reopen P18 to add a load-bearing anchor; if a real shrink
+  is found, reopen the owning component phase.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P18a.md` (include probe + node evidence + verdict).
+
+```markdown
+Phase: P18a
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: none (verification only; probe restored)
+Verification: [paste actual output incl. probe + node subset check]
+Holistic Assessment: [PASS/FAIL with evidence]
+```

--- a/project-plans/issue2143/plan/18a-non-breaking-verification.md
+++ b/project-plans/issue2143/plan/18a-non-breaking-verification.md
@@ -18,36 +18,56 @@ Independent gate on the additive-only promise. Confirm the regression fence actu
 removal/shape-change (not a vacuous test), that the existing #1594-era characterization is preserved,
 and that the new enum values + projected-type compile anchors are real (typecheck-load-bearing).
 
+CRITICAL — where compile anchors MUST live: the workspace `packages/agents/tsconfig.json` `exclude`
+drops `**/*.test.ts` and `**/*.spec.ts`, so `npm run typecheck` (tsc --noEmit) NEVER compiles a
+`.test.ts`; vitest also strips types at runtime. Therefore the projected-type + extended-controller
+compile anchors live in a sibling `additiveSurface.types.ts` (NO `.test`/`.spec` infix) under
+`__tests__/` — typecheck-VISIBLE, build-EXCLUDED (tsconfig.build.json excludes `src/**/__tests__/**`),
+and vitest-IGNORED. The runtime subset/identity/enum assertions stay in the `.test.ts`. This phase
+PROVES the `.types.ts` anchors are actually in the typecheck file set and are load-bearing.
+
 ## Verification Commands
 
 ```bash
 set -o pipefail
 set -e
 F=packages/agents/src/api/__tests__/publicSurface.nonbreaking.test.ts
+TYPES=packages/agents/src/api/__tests__/additiveSurface.types.ts
 
 # 1. Existing characterization preserved; new REQ-009 block present.
 grep -qE "REQ-006 @plan:PLAN-20260621-COREAPIREMED.P21" "$F" || { echo "FAIL: existing REQ-006 block removed"; exit 1; }
 grep -qE "REQ-009 @plan:PLAN-20260622-COREAPIGAP.P18" "$F" || { echo "FAIL: REQ-009 block missing"; exit 1; }
 
-# 2. Compile anchors are LOAD-BEARING: temporarily break a projected type usage and prove typecheck
-#    fails, then restore. (Mutation-style probe — confirms the fence is not vacuous.)
-cp "$F" /tmp/p18a_backup.ts
-# Flip an AgentTaskInfo field-access anchor to a non-existent field; typecheck MUST then fail.
-if grep -qE "AgentTaskInfo" "$F"; then
-  perl -0pi -e "s/(_TaskInfoShape\) => string = \(x\) => x\.)id/\${1}__nope_field__/g" "$F" || true
-  if npm run typecheck > /tmp/p18a_probe.log 2>&1; then
-    echo "FAIL: fence is vacuous — typecheck passed with a bogus AgentTaskInfo field"; cp /tmp/p18a_backup.ts "$F"; exit 1
-  fi
-  echo "fence is load-bearing: bogus projected-type field broke typecheck as expected"
-  cp /tmp/p18a_backup.ts "$F"
+# 2. Compile anchors MUST live in a typecheck-VISIBLE file (NOT a .test.ts, which tsconfig excludes).
+test -f "$TYPES" || { echo "FAIL: additiveSurface.types.ts missing — compile anchors would be vacuous"; exit 1; }
+case "$TYPES" in *.test.ts|*.spec.ts) echo "FAIL: anchor file is a .test.ts/.spec.ts (excluded from typecheck)"; exit 1;; esac
+( cd packages/agents && npx tsc --noEmit --listFilesOnly 2>/dev/null | grep -q "additiveSurface.types.ts" ) \
+  || { echo "FAIL: additiveSurface.types.ts is NOT in the typecheck file set (vacuous fence)"; exit 1; }
+
+# 2b. Prove the anchors are LOAD-BEARING: break the AgentTaskInfo field-access anchor in the .types.ts,
+#     confirm typecheck FAILS on THAT file, then restore + confirm green again.
+cp "$TYPES" /tmp/p18a_backup.ts
+grep -qE "AgentTaskInfo" "$TYPES" || { echo "FAIL: AgentTaskInfo anchor missing in .types.ts"; exit 1; }
+perl -0pi -e "s/(_TaskInfoShape\) => string = \(x\) => x\.)id/\${1}__nope_field__/g" "$TYPES" || true
+grep -qE "__nope_field__" "$TYPES" || { echo "FAIL: probe did not mutate the anchor (exact form drifted)"; cp /tmp/p18a_backup.ts "$TYPES"; exit 1; }
+if npm run typecheck > /tmp/p18a_probe.log 2>&1; then
+  echo "FAIL: fence is vacuous — typecheck passed with a bogus AgentTaskInfo field"; cp /tmp/p18a_backup.ts "$TYPES"; exit 1
 fi
+grep -qE "additiveSurface\.types\.ts|TS2339|__nope_field__" /tmp/p18a_probe.log \
+  || { echo "FAIL: typecheck failed but not on the expected anchor"; cp /tmp/p18a_backup.ts "$TYPES"; exit 1; }
+echo "fence is load-bearing: bogus projected-type field broke typecheck as expected"
 # Restore + confirm green again.
+cp /tmp/p18a_backup.ts "$TYPES"
+grep -qE "__nope_field__" "$TYPES" && { echo "FAIL: restore left bogus field behind"; exit 1; } || true
 npm run typecheck 2>&1 | tail -10
 
 # 3. Built-artifact subset proof: prior #1594 keys ⊂ current built barrel keys.
+#    The package "." export resolves to dist/index.js (package.json main: dist/index.js); the
+#    internals subpath ('./internals.js') resolves to dist/src/internals.js (package.json exports).
+#    Use those EXACT paths — the prior dist/src/api/index.js was an internal 38-key sub-barrel.
 npm run build 2>&1 | tail -8
 node -e "
-const root = require('./packages/agents/dist/src/api/index.js');
+const root = require('./packages/agents/dist/index.js');
 const prior = ['createAgent','fromConfig','listProviders','listTools','mapLoopStream','mapStreamEvent','toConfigParameters','createTaskToolRegistration','AdapterError','AgenticLoop'];
 const keys = new Set(Object.keys(root));
 const missing = prior.filter(k => !keys.has(k));
@@ -56,7 +76,7 @@ for (const k of prior) { if (typeof root[k] !== 'function') { console.error('pri
 const internals = require('./packages/agents/dist/src/internals.js');
 if (typeof internals.AgentClient !== 'function') { console.error('internals.AgentClient lost'); process.exit(1); }
 if (root.AgentClient !== internals.AgentClient) { console.error('AgentClient identity changed'); process.exit(1); }
-console.log('built-artifact subset + identity preserved');
+console.log('built-artifact subset + identity preserved (root keys='+keys.size+')');
 "
 
 # 4. Both non-breaking tests + whole dir GREEN.
@@ -68,7 +88,7 @@ npx vitest run packages/agents/src/api/__tests__/ > /tmp/p18a_all.log 2>&1 || { 
 if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn|not\.toThrow\(\)" "$F"; then echo "FAIL: discipline"; exit 1; fi
 if git diff HEAD --name-only | grep -vE "__tests__|project-plans/" | grep -E "packages/agents/src/"; then echo "FAIL: production source changed in P18"; exit 1; fi
 
-# 6. Property gate.
+# 6. Property gate (runtime assertions live in the .test.ts).
 TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
 PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
 CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
@@ -81,32 +101,36 @@ echo "PASS: P18a gates green."
 
 ## Holistic Assessment (MANDATORY — into marker)
 
-- **Fence is non-vacuous**: the mutation probe (bogus projected-type field) broke typecheck and was
-  restored — the compile anchors really guard the new types. Evidence (`/tmp/p18a_probe.log` tail).
-- **No shrink**: built-artifact node check proves prior #1594 keys ⊂ current + internals identity
-  preserved. Evidence (node output).
+- **Anchors typecheck-visible**: `additiveSurface.types.ts` is in the `tsc --listFilesOnly` set (a
+  `.test.ts` would NOT be — that was the prior vacuous-fence failure). Evidence (grep of listFilesOnly).
+- **Fence is non-vacuous**: the mutation probe (bogus projected-type field in the `.types.ts`) broke
+  typecheck and was restored — the compile anchors really guard the new types. Evidence
+  (`/tmp/p18a_probe.log` tail showing TS2339 on additiveSurface.types.ts).
+- **No shrink**: built-artifact node check against the REAL package root (`dist/index.js`) + internals
+  (`dist/src/internals.js`) proves prior #1594 keys ⊂ current + AgentClient identity preserved.
+  Evidence (node output, root keys count).
 - **Existing characterization intact**: REQ-006 block preserved; both non-breaking tests green.
 - **Additive proven**: new enum values present; prior member shapes unchanged.
 - **Verdict**: PASS/FAIL with evidence.
 
 ## Success Criteria
 
-- Fence proven load-bearing; no shrink; both tests + dir green; verdict PASS.
+- Anchor file proven typecheck-visible AND load-bearing; no shrink; both tests + dir green; verdict PASS.
 
 ## Failure Recovery
 
-- If the probe shows the fence is vacuous, reopen P18 to add a load-bearing anchor; if a real shrink
-  is found, reopen the owning component phase.
+- If the `.types.ts` is not in the typecheck set or the probe shows the fence is vacuous, reopen P18 to
+  relocate/repair the anchor; if a real shrink is found, reopen the owning component phase.
 
 ## Phase Completion Marker
 
-Create: `project-plans/issue2143/.completed/P18a.md` (include probe + node evidence + verdict).
+Create: `project-plans/issue2143/.completed/P18a.md` (include listFilesOnly + probe + node evidence + verdict).
 
 ```markdown
 Phase: P18a
 Completed: YYYY-MM-DD HH:MM
 Files Created: none
 Files Modified: none (verification only; probe restored)
-Verification: [paste actual output incl. probe + node subset check]
+Verification: [paste actual output incl. listFilesOnly grep + probe + node subset check]
 Holistic Assessment: [PASS/FAIL with evidence]
 ```

--- a/project-plans/issue2143/plan/19-docs.md
+++ b/project-plans/issue2143/plan/19-docs.md
@@ -1,0 +1,170 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P19 @requirement:REQ-010 -->
+# Phase 19: Public API Documentation
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P19`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 18a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P18a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-010: Document every new public capability
+
+**Full Text**: `docs/agent-api.md` MUST document the new public surface added by REQ-001..008 so a
+#1595 developer can discover and call it WITHOUT reading source: top-level approval-mode methods, the
+`policy`, `tasks` sub-controllers, the extended `hooks` administration, the extended `auth` detailed
+metadata, the extended `mcp` OAuth/details, and `tools.keys`; plus the new public enum values
+(`ApprovalMode`, `PolicyDecision`) and projected types; plus the six new `COMMAND_API_MAP` rows.
+**Behavior**:
+- GIVEN: a developer reading only `docs/agent-api.md`
+- WHEN: they look up any capability migrated off the `getConfig()` escape hatch
+- THEN: they find a code example that imports ONLY from `@vybestack/llxprt-code-agents`, calls the
+  documented method, and matches the real shipped signature
+**Why This Matters**: "clean & complete public API" includes discoverability. Undocumented surface is
+a de-facto escape hatch — #1595 would re-read `-core`. Docs are an acceptance criterion, not a
+nicety.
+
+## Background — verified current state
+
+- `docs/agent-api.md` exists (739 lines). Relevant anchors:
+  - `## The `Agent` Control Plane` (:176) → `### Top-level: turns/provider/model/history` (:184-209)
+    and `### Sub-surfaces` (:222) enumerating the existing controllers.
+  - `## Settings & Config Projection` (:495) incl. `### `agent.getConfig()`` (:503).
+  - `## Runtime vs App-Service` (:640) and `### `COMMAND_API_MAP`` (:672).
+  - `## Recorded Decisions` (:713).
+- This phase ADDS documentation; it does not rewrite existing sections. Insert new top-level method
+  docs under the `### Top-level:` group, new sub-surface docs under `### Sub-surfaces`, enum/type docs
+  in the appropriate reference area, and the six rows under `### COMMAND_API_MAP`.
+
+## Implementation Tasks
+
+### Files to Modify
+
+- `docs/agent-api.md` — ADD the following (additive; keep existing sections intact). Place each near
+  the matching existing section. Every code example imports ONLY from
+  `@vybestack/llxprt-code-agents` (NO `@vybestack/llxprt-code-core/...` deep import, NO
+  `agent.getConfig()`), and matches the shipped signatures:
+  1. **Approval mode** (under the `### Top-level:` group): document
+     `agent.getApprovalMode(): ApprovalMode` and `agent.setApprovalMode(mode: ApprovalMode): void`,
+     including the untrusted-folder throw ("Cannot enable privileged approval modes in an untrusted
+     folder.") and the `ApprovalMode` enum values (`DEFAULT`/`AUTO_EDIT`/`YOLO`).
+  2. **`agent.policy`** (under `### Sub-surfaces`): `getRules(): readonly PolicyRuleView[]`,
+     `getDefaultDecision(): PolicyDecision`, `isNonInteractive(): boolean`; note `PolicyRuleView`
+     projects `argsPattern` to a string (`argsPatternSource`) for JSON-safety.
+  3. **`agent.tasks`**: `list()`, `listRunning()`, `get(id)`, `cancel(id)`, `cancelAllRunning()`
+     returning the projected `AgentTaskInfo` (note `abortController` is intentionally NOT exposed);
+     undefined-safe when no async-task manager.
+  4. **`agent.hooks` administration** (extend the existing hooks doc): `listHooks(): readonly
+     HookInfo[]`, `getDisabledHooks()`, `setDisabledHooks(names)`, `enable(name)`/`disable(name)`/
+     `enableAll()`/`disableAll()`; undefined-safe when no hook system.
+  5. **`agent.auth` detailed metadata** (extend the existing auth doc): `detailedStatus(provider)`,
+     `getHigherPriorityAuth(provider)`, `listBucketStatuses(provider)` returning MASKED
+     `AuthProviderDetail`/`AuthBucketStatus` — explicitly state raw tokens are NEVER returned.
+  6. **`agent.mcp` OAuth + details** (extend the existing mcp doc): `authenticate(server):
+     Promise<McpServerAuthStatus>` (real OAuth + post-auth tool refresh), `details(opts?):
+     Promise<McpDetailStatus>`, and the `refresh(server?)` setTools-parity note.
+  7. **`agent.tools.keys`** (under tools): `supported()`, `status(tool)` (masked), `save(tool, key)`,
+     `delete(tool)`, `setKeyFile(tool, path|null)`, `getKeyFile(tool)`; state raw secrets are NEVER
+     returned (only `maskedKey`).
+  8. **Enums & projected types**: a short reference block listing the new public VALUE enums
+     (`ApprovalMode`, `PolicyDecision`) and projected types (`PolicyRuleView`, `AgentTaskInfo`,
+     `HookInfo`, `AuthProviderDetail`, `AuthBucketStatus`, `McpServerAuthStatus`, `McpDetailStatus`,
+     `McpServerDetail`, `McpDetailsOptions`, `McpPromptInfo`, `McpResourceInfo`, `McpBlockedServer`,
+     `ToolKeyInfo`, `ToolKeyStatus`), importable from the public root.
+  9. **`### COMMAND_API_MAP`** (:672): add the six new `runtime` rows to the documented table
+     (`/approval-mode`, `/policies`, `/task`, `/hooks`, `/toolkey`, `/toolkeyfile`) with their Agent
+     targets, matching `command-api-map.ts`.
+  10. **`## Recorded Decisions`** (:713): append a short decision note that this surface closes the
+      #2143 capability gaps as a prerequisite to #1595, with the masked-only / projected-type /
+      delegate-don't-cache constraints.
+
+### Constraints
+
+- ADDITIVE: do not delete or rewrite existing sections (the existing `getConfig()` section stays —
+  it documents an intentional escape hatch, now narrowed).
+- Every example must be COPY-PASTE accurate to the shipped signatures (verify against `agent.ts`).
+- No example may import `@vybestack/llxprt-code-core/...` (deep) or call `agent.getConfig()` to reach
+  a capability this plan made first-class.
+- This is a docs phase: no source/test code changes.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+D=docs/agent-api.md
+
+# 1. Each new symbol/method is documented (grep presence).
+for SYM in getApprovalMode setApprovalMode "agent.policy" getRules getDefaultDecision isNonInteractive \
+           "agent.tasks" listRunning cancelAllRunning AgentTaskInfo \
+           listHooks getDisabledHooks setDisabledHooks \
+           detailedStatus getHigherPriorityAuth listBucketStatuses \
+           "agent.mcp" "authenticate(" "details(" \
+           "agent.tools.keys" setKeyFile getKeyFile maskedKey \
+           ApprovalMode PolicyDecision PolicyRuleView ToolKeyStatus McpDetailStatus; do
+  grep -qF "$SYM" "$D" || { echo "FAIL: doc missing symbol: $SYM"; exit 1; }
+done
+
+# 2. Six command rows documented.
+for CMD in "/approval-mode" "/policies" "/task" "/hooks" "/toolkey" "/toolkeyfile"; do
+  grep -qF "$CMD" "$D" || { echo "FAIL: doc missing command row: $CMD"; exit 1; }
+done
+
+# 3. NO example reaches around the public API (no deep core import, no getConfig escape for new caps).
+if grep -nE "@vybestack/llxprt-code-core/" "$D"; then echo "FAIL: doc example uses a deep core import"; exit 1; fi
+# getConfig may be MENTIONED (its own section) but must not be the documented way to reach a new cap:
+# ensure the new-capability examples import from the public root.
+grep -qE "from '@vybestack/llxprt-code-agents'" "$D" || { echo "FAIL: examples must import the public root"; exit 1; }
+
+# 4. Existing sections preserved (append-only spot-check).
+for SEC in "## The .Agent. Control Plane" "### Sub-surfaces" "### .COMMAND_API_MAP." "## Recorded Decisions" "### .agent.getConfig.."; do
+  grep -qE "$SEC" "$D" || { echo "FAIL: existing doc section removed: $SEC"; exit 1; }
+done
+# Only additions to the doc (no removed content lines beyond pure formatting).
+git diff HEAD -- "$D" | grep -E "^-" | grep -vE "^---" | grep -E "^-#|^-\`\`\`|^-\| " \
+  && { echo "FAIL: a heading/code-fence/table-row was removed from docs"; exit 1; } || true
+
+# 5. Plan marker present in the doc (HTML comment is fine in markdown).
+grep -qE "PLAN-20260622-COREAPIGAP" "$D" || { echo "FAIL: plan marker missing in docs"; exit 1; }
+
+# 6. Lint/format pass for markdown if the repo gates it (no-op otherwise).
+npm run format 2>&1 | tail -5 || true
+echo "PASS: P19 docs green."
+```
+
+### Semantic Verification Checklist
+
+- [ ] All seven capability groups documented with public-root-only examples matching shipped
+      signatures.
+- [ ] New enums + projected types referenced; six command rows added to the map table.
+- [ ] No deep-core import or `getConfig()` escape in any new example.
+- [ ] Existing sections (incl. the `getConfig()` section) preserved; append-only.
+
+## Success Criteria
+
+- `docs/agent-api.md` documents the full new surface, public-root-only, append-only; format gate
+  green.
+
+## Failure Recovery
+
+- `git checkout -- docs/agent-api.md` and re-apply additively; fix any example whose signature drifts
+  from `agent.ts`.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P19.md`
+
+```markdown
+Phase: P19
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: [docs/agent-api.md +N/-0]
+Verification: [paste actual output]
+Semantic Assessment: [one-line: #1595 dev can discover+call every new cap from docs, public-root only]
+```

--- a/project-plans/issue2143/plan/19a-docs-verification.md
+++ b/project-plans/issue2143/plan/19a-docs-verification.md
@@ -1,0 +1,100 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P19a @requirement:REQ-010 -->
+# Phase 19a: Documentation — Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P19a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 19 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P19.md`
+
+## Purpose
+
+Independent gate on documentation correctness and completeness. The risk with docs is DRIFT
+(examples that don't match the shipped signatures) and ESCAPE (examples that quietly reach into
+`-core` or `getConfig()`), which would defeat the "clean public API" goal. Verify the docs are
+accurate, public-root-only, and complete for all seven capability groups + enums/types + map rows.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+D=docs/agent-api.md
+A=packages/agents/src/api/agent.ts
+
+# 1. Completeness: every documented method name actually exists in agent.ts (no doc for a
+#    non-existent method) AND every new method in agent.ts that this plan added is documented.
+for SYM in getApprovalMode setApprovalMode getRules getDefaultDecision isNonInteractive \
+           listRunning cancelAllRunning listHooks getDisabledHooks setDisabledHooks \
+           detailedStatus getHigherPriorityAuth listBucketStatuses \
+           setKeyFile getKeyFile; do
+  grep -qF "$SYM" "$D" || { echo "FAIL: doc omits $SYM"; exit 1; }
+  grep -qE "\b$SYM\b" "$A" || { echo "FAIL: $SYM documented but absent in agent.ts (drift)"; exit 1; }
+done
+
+# 2. Enums/types documented AND really on the public surface.
+for SYM in ApprovalMode PolicyDecision PolicyRuleView AgentTaskInfo HookInfo AuthProviderDetail \
+           AuthBucketStatus McpServerAuthStatus McpDetailStatus ToolKeyInfo ToolKeyStatus; do
+  grep -qF "$SYM" "$D" || { echo "FAIL: doc omits type/enum $SYM"; exit 1; }
+done
+grep -qE "export \{ PolicyDecision, ApprovalMode \}" packages/agents/src/api/index.ts || { echo "FAIL: enums not actually on barrel"; exit 1; }
+
+# 3. No escape hatch in examples.
+if grep -nE "@vybestack/llxprt-code-core/" "$D"; then echo "FAIL: deep-core import in docs"; exit 1; fi
+grep -qE "from '@vybestack/llxprt-code-agents'" "$D" || { echo "FAIL: examples not public-root"; exit 1; }
+
+# 4. Six command rows + map parity with the production map.
+for CMD in "/approval-mode" "/policies" "/task" "/hooks" "/toolkey" "/toolkeyfile"; do
+  grep -qF "$CMD" "$D" || { echo "FAIL: doc omits command $CMD"; exit 1; }
+  grep -qF "command: '$CMD'" packages/agents/src/app-services/command-api-map.ts || { echo "FAIL: $CMD documented but not in production map"; exit 1; }
+done
+
+# 5. Append-only: no existing heading/code-fence/table-row removed.
+git diff HEAD -- "$D" | grep -E "^-" | grep -vE "^---" | grep -E "^-#|^-\`\`\`|^-\| " \
+  && { echo "FAIL: doc content removed"; exit 1; } || true
+
+# 6. Masked-only promise stated for the secret-bearing surfaces.
+grep -qiE "never .*(raw|token|secret)|masked" "$D" || { echo "FAIL: docs must state secrets are masked/never raw"; exit 1; }
+
+# 7. Format gate green.
+npm run format 2>&1 | tail -5 || true
+echo "PASS: P19a gates green."
+```
+
+## Holistic Assessment (MANDATORY — into marker)
+
+- **Accuracy**: every documented method exists in `agent.ts` (no drift); spot-check 3 examples by
+  eye against the shipped signatures.
+- **No escape**: zero deep-core imports; all examples import the public root; `getConfig()` appears
+  only in its own (preserved) section, never as the way to reach a new capability.
+- **Completeness**: all seven groups + enums/types + six map rows documented; map parity with
+  production.
+- **Security**: masked-only / never-raw stated for auth + tool-keys.
+- **Append-only**: no removed headings/fences/rows.
+- **Verdict**: PASS/FAIL with file:line evidence.
+
+## Success Criteria
+
+- Docs accurate, complete, public-root-only, append-only; verdict PASS.
+
+## Failure Recovery
+
+- Reopen P19 for any drift/omission/escape; do not relax the checks.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P19a.md`
+
+```markdown
+Phase: P19a
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: none (verification only)
+Verification: [paste actual output]
+Holistic Assessment: [PASS/FAIL with evidence]
+```

--- a/project-plans/issue2143/plan/19a-docs-verification.md
+++ b/project-plans/issue2143/plan/19a-docs-verification.md
@@ -44,8 +44,16 @@ for SYM in ApprovalMode PolicyDecision PolicyRuleView AgentTaskInfo HookInfo Aut
 done
 grep -qE "export \{ PolicyDecision, ApprovalMode \}" packages/agents/src/api/index.ts || { echo "FAIL: enums not actually on barrel"; exit 1; }
 
-# 3. No escape hatch in examples.
-if grep -nE "@vybestack/llxprt-code-core/" "$D"; then echo "FAIL: deep-core import in docs"; exit 1; fi
+# 3. No NEW escape hatch. P19 is additive docs; it must not ADD any deep-core
+#    reference. NOTE: HEAD already contains intentional prose mentions of
+#    `@vybestack/llxprt-code-core/...` — the telemetry source path and the
+#    "Import Boundary for #1595" section that documents what NOT to import.
+#    The append-only constraint forbids removing them, so a blunt whole-file
+#    grep can never pass; gate only what THIS phase ADDED (the real escape risk:
+#    a new code example reaching around the public API).
+if git diff HEAD -- "$D" | grep -E "^\+" | grep -vE "^\+\+\+" | grep -qE "@vybestack/llxprt-code-core/"; then
+  echo "FAIL: P19 added a deep-core reference in docs"; exit 1
+fi
 grep -qE "from '@vybestack/llxprt-code-agents'" "$D" || { echo "FAIL: examples not public-root"; exit 1; }
 
 # 4. Six command rows + map parity with the production map.

--- a/project-plans/issue2143/plan/20-integration-adequacy-driver.md
+++ b/project-plans/issue2143/plan/20-integration-adequacy-driver.md
@@ -1,0 +1,222 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P20 @requirement:REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004 -->
+# Phase 20: Capability-Gap Integration Adequacy Driver
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P20`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 19a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P19a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-INT-001..004: CLI-parity capabilities are reachable on the PUBLIC-ROOT-ONLY path
+
+**Full Text**: Each of the seven engine capabilities the CLI drives today (approval-mode, policy,
+async-tasks, hooks-admin, auth-detail, MCP-OAuth/details, tool-keys) MUST be reachable on a real
+`fromConfig`/harness-built `Agent` using ONLY the public root `@vybestack/llxprt-code-agents` — with
+NO `agent.getConfig()` escape hatch and NO deep import. This is the EXECUTABLE form of the #1595
+adequacy criterion.
+**Behavior**:
+- GIVEN: a real Agent built through the public path (FakeProvider, no MCP manager, no real OAuth, no
+  async manager) — exactly the surface #1595 will hold
+- WHEN: the driver calls each capability's public method
+- THEN: every method is reachable directly on `agent` (or its sub-controllers) and returns a
+  correctly-typed, sane result for a safe call — including the approval untrusted-folder throw — and
+  NONE of it requires `agent.getConfig()`
+**Why This Matters**: the per-component `.behavior.test.ts` files prove each control's DEEP behavior
+(T17-exempt, may deep-import). THIS phase proves ADEQUACY/REACHABILITY across the whole new surface
+from the boundary the CLI actually imports from. If a capability is only reachable via `getConfig()`
+or a deep import, this driver fails — and #1595 would stall. It is the single most important
+acceptance artifact of the plan.
+
+## Background — boundary facts (verified)
+
+- The driver is a `.spec.ts`, so it is **T17-ENFORCED** by `boundary.spec.ts`: it may import ONLY the
+  public root `@vybestack/llxprt-code-agents`, `node:*`, `vitest`, `fast-check`, and relative paths
+  that resolve WITHIN `src/` (which includes `./helpers/agentHarness.js`). It MUST NOT import
+  `./internals.js`, any other `@vybestack/llxprt-code-agents/<subpath>`, `/dist/`, or any deep
+  `core/`, `providers/`, `tools/`, `auth/`, `settings/`, `ide-integration/`, `policy/` path. This is
+  precisely the #1595 import boundary, so the driver IS the adequacy proof.
+- `buildAgent('plain-text.jsonl', Partial<AgentConfig>)` (`__tests__/helpers/agentHarness.ts:79`)
+  builds a real Agent over the FakeProvider and returns `{ agent, cleanup }`. `folderTrust: false`
+  maps (agentConfig.adapter) to an UNTRUSTED Config, which makes `setApprovalMode(non-default)` throw
+  the real untrusted-folder error — drivable through the public harness with ZERO mocking.
+- Enum VALUES (`ApprovalMode`, `PolicyDecision`) and the projected TYPES are now (post-P17) importable
+  from the public root, so the driver types its assertions from the public root too.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/capabilityGaps.integration.spec.ts` — marker
+  `@plan:PLAN-20260622-COREAPIGAP.P20 @requirement:REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004`.
+  Imports (PUBLIC-ROOT ONLY for production symbols):
+  ```ts
+  import { describe, expect, it, afterEach } from 'vitest';
+  import * as fc from 'fast-check';
+  import { ApprovalMode, PolicyDecision } from '@vybestack/llxprt-code-agents';
+  import type {
+    AgentTaskInfo, PolicyRuleView, HookInfo, AuthProviderDetail,
+    AuthBucketStatus, McpDetailStatus, ToolKeyInfo, ToolKeyStatus,
+  } from '@vybestack/llxprt-code-agents';
+  import { buildAgent } from './helpers/agentHarness.js';
+  ```
+  It MUST exercise EACH capability on the public agent (build via harness; `afterEach` cleanup). Use
+  SAFE, deterministic calls (this is reachability/adequacy, not deep-state behavior):
+  1. **Approval (REQ-INT-001):** trusted agent → `agent.getApprovalMode()` returns an `ApprovalMode`;
+     `agent.setApprovalMode(ApprovalMode.YOLO)` then `getApprovalMode() === ApprovalMode.YOLO`.
+     Separately build an UNTRUSTED agent (`buildAgent('plain-text.jsonl', { folderTrust: false })`)
+     and assert `() => agent.setApprovalMode(ApprovalMode.YOLO)` throws with message matching
+     `/untrusted folder/i` (the delegated, uncaught throw).
+  2. **Policy (REQ-INT-002):** `agent.policy.getRules()` returns a readonly `PolicyRuleView[]` (each
+     element, if any, has a string `toolName` and a `decision` ∈ `Object.values(PolicyDecision)`);
+     `agent.policy.getDefaultDecision()` ∈ `Object.values(PolicyDecision)`;
+     `agent.policy.isNonInteractive()` is a boolean.
+  3. **Tasks (REQ-INT-002):** on a fresh agent with no submitted tasks:
+     `agent.tasks.list()` and `listRunning()` are arrays; `agent.tasks.get('nonexistent')` is
+     `undefined`; `agent.tasks.cancel('nonexistent')` is `false`; `agent.tasks.cancelAllRunning()` is
+     `0`. (Undefined-safe even if no async manager exists.) If any element is present, assert it is a
+     projected `AgentTaskInfo` WITHOUT an `abortController` key
+     (`expect('abortController' in task).toBe(false)`).
+  4. **Hooks-admin (REQ-INT-003):** `agent.hooks.listHooks()` returns a `HookInfo[]`;
+     disabled-set round-trip: `agent.hooks.setDisabledHooks(['demo-hook'])` then
+     `agent.hooks.getDisabledHooks()` contains `'demo-hook'`; `agent.hooks.enable('demo-hook')` then
+     `getDisabledHooks()` no longer contains it. (Undefined-safe if no hook system: `listHooks()` →
+     `[]`, setters are no-ops — assert no throw.)
+  5. **Auth-detail (REQ-INT-003):** `agent.auth.detailedStatus('openai')` resolves to an
+     `AuthProviderDetail` (a `authenticated` boolean field); `agent.auth.getHigherPriorityAuth('openai')`
+     resolves to `string | null`; `agent.auth.listBucketStatuses('openai')` resolves to a readonly
+     `AuthBucketStatus[]`. Masked invariant: the JSON-serialized result contains no field literally
+     named `token`/`accessToken`/`refreshToken` carrying a long secret (see property below).
+  6. **MCP (REQ-INT-004):** `agent.mcp.status()` resolves (idle when no manager);
+     `agent.mcp.details()` resolves to an `McpDetailStatus` (a `servers` array, empty when no
+     manager); `agent.mcp.authenticate('nonexistent-server')` resolves to a status with
+     `authenticated === false` (unknown server, undefined-safe — no throw).
+  7. **Tool-keys (REQ-INT-004):** `agent.tools.keys.supported()` returns a non-empty readonly
+     `ToolKeyInfo[]` (each with a string `toolName`); assert `typeof agent.tools.keys.save`,
+     `agent.tools.keys.status`, `agent.tools.keys.delete`, `agent.tools.keys.setKeyFile`,
+     `agent.tools.keys.getKeyFile` are all `'function'` (reachability). Do NOT mutate the real
+     keyring; a read-only `agent.tools.keys.status('exa')` may be called only to assert the result
+     has a boolean `hasKey` and (when present) a `maskedKey` that is NOT a full-length raw secret.
+  - **Adequacy assertion (the #1595 keystone):** across the whole file, NONE of the above used
+    `agent.getConfig()`. Add one explicit `it('exercises every capability without getConfig escape')`
+    that asserts each capability ENTRY is a function reachable directly on the public agent surface:
+    `typeof agent.setApprovalMode === 'function'`, `typeof agent.policy.getRules === 'function'`,
+    `typeof agent.tasks.list === 'function'`, `typeof agent.hooks.listHooks === 'function'`,
+    `typeof agent.auth.detailedStatus === 'function'`, `typeof agent.mcp.details === 'function'`,
+    `typeof agent.tools.keys.supported === 'function'`.
+  - **≥30% property-based, MIN-2 distinct cases:**
+    1. Property over `fc.constantFrom(...Object.values(ApprovalMode))` on a TRUSTED agent: for any
+       mode, `setApprovalMode(mode)` then `getApprovalMode() === mode` (all three modes are allowed
+       in a trusted folder; round-trip invariant).
+    2. Property over `fc.uniqueArray(fc.string({minLength:1}), {maxLength:5})` for hook names:
+       `setDisabledHooks(names)` then `getDisabledHooks()` set-equals the input (round-trip);
+       restore with `setDisabledHooks([])` after.
+    3. (Masked invariant) Property over `fc.constantFrom('openai','anthropic','gemini')`:
+       `await detailedStatus(p)` serialized via `JSON.stringify` contains no substring of length ≥ 20
+       that looks like a raw bearer token (assert the masked-only contract — no long opaque secret).
+  - NO mock theater (`vi.fn`/`vi.spyOn`/`mockResolvedValue`/`mockReturnValue`/`toHaveBeenCalled`), NO
+    reverse tests (`not.toThrow()`), NO `.skip`, no `any`, and NO `agent.getConfig()` anywhere.
+
+### Constraints
+
+- PUBLIC-ROOT ONLY for all production symbols. The ONLY non-public import permitted is the relative
+  `./helpers/agentHarness.js` (fixture plumbing, within `src/`, T17-allowed).
+- Every assertion must be on REAL results from a REAL Agent built through the public path — no fakes
+  injected at the control layer (that is the per-component behavior tests' job).
+- The file MUST contain zero occurrences of the string `getConfig` (gate-enforced).
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/capabilityGaps.integration.spec.ts
+test -f "$F"
+
+# 1. PUBLIC-ROOT-ONLY: no deep import, no internals, no other subpath. (Pre-empts the T17 guard.)
+if grep -nE "from '[^']*(/src/|core/|providers/|tools/|auth/|settings/|ide-integration/|policy/)" "$F" \
+   | grep -vE "from '@vybestack/llxprt-code-agents'"; then echo "FAIL: deep import in adequacy driver"; exit 1; fi
+if grep -nE "internals(\.js)?'|/dist/" "$F"; then echo "FAIL: internals/dist import"; exit 1; fi
+# The only allowed non-public, non-stdlib import is ./helpers/agentHarness.js.
+grep -qE "from './helpers/agentHarness\.js'" "$F" || { echo "FAIL: must build via the public harness"; exit 1; }
+# 2. The #1595 keystone: zero getConfig escape.
+if grep -nE "getConfig" "$F"; then echo "FAIL: adequacy driver used the getConfig escape hatch"; exit 1; fi
+# 3. Every capability entry exercised by name.
+for SYM in "agent.getApprovalMode" "agent.setApprovalMode" "agent.policy.getRules" "agent.tasks.list" \
+           "agent.hooks.listHooks" "agent.hooks.setDisabledHooks" "agent.auth.detailedStatus" \
+           "agent.mcp.details" "agent.tools.keys.supported"; do
+  grep -qF "$SYM" "$F" || { echo "FAIL: capability not exercised: $SYM"; exit 1; }
+done
+# 4. Untrusted-folder throw driven through the public harness.
+grep -qE "folderTrust: false" "$F" || { echo "FAIL: untrusted-folder path not driven"; exit 1; }
+grep -qiE "untrusted folder" "$F" || { echo "FAIL: untrusted throw not asserted"; exit 1; }
+# 5. abortController projected-out assertion present.
+grep -qE "abortController" "$F" || { echo "FAIL: must assert AgentTaskInfo omits abortController"; exit 1; }
+
+# 6. RED capture happens in the worker flow BEFORE controllers are wired through the harness; here
+#    (post-impl) it must be GREEN. Run the driver + the T17 boundary guard (proves it's clean).
+npx vitest run "$F" 2>&1 | tail -40
+npx vitest run packages/agents/src/api/__tests__/boundary.spec.ts 2>&1 | tail -20
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p20_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p20_all.log; exit 1; }
+npm run typecheck 2>&1 | tail -15
+
+# 7. Property gate (≥30%, MIN-2).
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+
+# 8. Discipline.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn" "$F"; then echo "FAIL: mock theater"; exit 1; fi
+if grep -nE "not\.toThrow\(\)|toThrow\('NotYetImplemented'\)|\.skip\(|xit\(|xdescribe\(" "$F"; then echo "FAIL: reverse/skip"; exit 1; fi
+echo "PASS: P20 adequacy driver green."
+```
+
+> RED note (worker runs this BEFORE all impl is wired, or on a scratch branch with one controller
+> un-wired): `npx vitest run "$F"` MUST fail with a BEHAVIORAL error (a missing method TypeError or an
+> AssertionError on a real result), NOT `Cannot find module`. Since this phase runs after P19a (all
+> controllers wired), the canonical state here is GREEN; capture a one-line note confirming the file
+> was authored test-first against the public surface.
+
+### Semantic Verification Checklist
+
+- [ ] All seven capabilities exercised on a REAL public-root-built Agent; each entry is a function on
+      the public surface.
+- [ ] Untrusted-folder throw driven through the public harness (delegated, uncaught).
+- [ ] `AgentTaskInfo` omits `abortController`; auth output masked (no long raw secret).
+- [ ] ZERO `getConfig`, zero deep import, zero internals — T17 boundary guard green on the file.
+- [ ] ≥30% property (MIN-2); no mock theater / reverse tests.
+
+## Success Criteria
+
+- The public-root-only adequacy driver is green, proving every #2143 capability is reachable for
+  #1595 without an escape hatch.
+
+## Failure Recovery
+
+- If a capability is NOT reachable from the public root (forces `getConfig`/deep import), STOP and
+  reopen the owning component phase (barrel P17 for a missing re-export; the control phase for a
+  missing method). Never add a `getConfig` escape to make this pass.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P20.md`
+
+```markdown
+Phase: P20
+Completed: YYYY-MM-DD HH:MM
+Files Created: [capabilityGaps.integration.spec.ts with line count]
+Files Modified: none
+Tests Added: [count]
+Verification: [paste actual output incl. driver + boundary.spec.ts green]
+Semantic Assessment: [one-line: all 7 caps reachable via public root only, no getConfig escape]
+```

--- a/project-plans/issue2143/plan/20a-integration-adequacy-verification.md
+++ b/project-plans/issue2143/plan/20a-integration-adequacy-verification.md
@@ -33,13 +33,20 @@ if grep -nE "internals(\.js)?'|/dist/" "$F"; then echo "FAIL: internals/dist imp
 if grep -nE "from '[^']*(/src/|core/|providers/|tools/|auth/|settings/|ide-integration/|policy/)" "$F" \
    | grep -vE "from '@vybestack/llxprt-code-agents'"; then echo "FAIL: deep import"; exit 1; fi
 # Only public root + node/vitest/fast-check + ./helpers/agentHarness.js may be imported.
-BAD=$(grep -nE "^import|from '" "$F" | grep -vE "@vybestack/llxprt-code-agents'|node:|'vitest'|'fast-check'|'\./helpers/agentHarness\.js'" || true)
+# Key off the `from '<specifier>'` clause (NOT a bare `^import`, which false-positives on the
+# prettier-mandated multi-line `import type {` opener whose specifier is on a later line).
+BAD=$(grep -nE "from '" "$F" | grep -vE "from '(@vybestack/llxprt-code-agents|node:[^']*|vitest|fast-check|\./helpers/agentHarness\.js)'" || true)
 [ -z "$BAD" ] || { echo "FAIL: unexpected import on the public-consumer path:"; echo "$BAD"; exit 1; }
 
 # 2. Behavioral, not a sham: it must CALL each capability and assert on REAL results (await + expect),
 #    not merely `typeof`. Require real-call evidence per capability.
-grep -qE "await agent\.auth\.detailedStatus\(" "$F" || { echo "FAIL: auth.detailedStatus not actually called"; exit 1; }
-grep -qE "await agent\.mcp\.details\(" "$F" || { echo "FAIL: mcp.details not actually called"; exit 1; }
+# NOTE: these two async checks keep the `await ` prefix (it distinguishes a REAL invocation from a
+# bare `typeof agent.mcp.details` reference) but are receiver-agnostic — the harness returns
+# `built`, so the natural call site is `await built.agent.mcp.details(`. Pinning a bare `agent`
+# receiver would brittly false-fail on the legitimate `built.agent.` form (the other five capability
+# checks below are already receiver-agnostic substring matches).
+grep -qE "await [A-Za-z_.]*auth\.detailedStatus\(" "$F" || { echo "FAIL: auth.detailedStatus not actually called"; exit 1; }
+grep -qE "await [A-Za-z_.]*mcp\.details\(" "$F" || { echo "FAIL: mcp.details not actually called"; exit 1; }
 grep -qE "agent\.tasks\.(list|cancelAllRunning)\(" "$F" || { echo "FAIL: tasks not actually called"; exit 1; }
 grep -qE "agent\.policy\.getRules\(" "$F" || { echo "FAIL: policy.getRules not actually called"; exit 1; }
 grep -qE "agent\.hooks\.setDisabledHooks\(" "$F" || { echo "FAIL: hooks round-trip not actually driven"; exit 1; }

--- a/project-plans/issue2143/plan/20a-integration-adequacy-verification.md
+++ b/project-plans/issue2143/plan/20a-integration-adequacy-verification.md
@@ -1,0 +1,105 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P20a @requirement:REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004 -->
+# Phase 20a: Capability-Gap Adequacy Driver — Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P20a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 20 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P20.md`
+
+## Purpose
+
+This is the plan's keystone gate. Confirm the adequacy driver genuinely proves the #1595 mission:
+EVERY new capability is reachable on a REAL `Agent` built through the PUBLIC ROOT, with NO
+`getConfig()` escape and NO deep import — and that the driver is behavioral (real Agent, real
+results), not a reachability sham (e.g. only `typeof` checks with no real calls). Verify the T17
+boundary guard actually polices this file.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/capabilityGaps.integration.spec.ts
+
+# 1. The #1595 keystone, restated as a hard gate: zero getConfig, zero deep import, zero internals.
+if grep -nE "getConfig" "$F"; then echo "FAIL: getConfig escape present"; exit 1; fi
+if grep -nE "internals(\.js)?'|/dist/" "$F"; then echo "FAIL: internals/dist import"; exit 1; fi
+if grep -nE "from '[^']*(/src/|core/|providers/|tools/|auth/|settings/|ide-integration/|policy/)" "$F" \
+   | grep -vE "from '@vybestack/llxprt-code-agents'"; then echo "FAIL: deep import"; exit 1; fi
+# Only public root + node/vitest/fast-check + ./helpers/agentHarness.js may be imported.
+BAD=$(grep -nE "^import|from '" "$F" | grep -vE "@vybestack/llxprt-code-agents'|node:|'vitest'|'fast-check'|'\./helpers/agentHarness\.js'" || true)
+[ -z "$BAD" ] || { echo "FAIL: unexpected import on the public-consumer path:"; echo "$BAD"; exit 1; }
+
+# 2. Behavioral, not a sham: it must CALL each capability and assert on REAL results (await + expect),
+#    not merely `typeof`. Require real-call evidence per capability.
+grep -qE "await agent\.auth\.detailedStatus\(" "$F" || { echo "FAIL: auth.detailedStatus not actually called"; exit 1; }
+grep -qE "await agent\.mcp\.details\(" "$F" || { echo "FAIL: mcp.details not actually called"; exit 1; }
+grep -qE "agent\.tasks\.(list|cancelAllRunning)\(" "$F" || { echo "FAIL: tasks not actually called"; exit 1; }
+grep -qE "agent\.policy\.getRules\(" "$F" || { echo "FAIL: policy.getRules not actually called"; exit 1; }
+grep -qE "agent\.hooks\.setDisabledHooks\(" "$F" || { echo "FAIL: hooks round-trip not actually driven"; exit 1; }
+grep -qE "agent\.setApprovalMode\(" "$F" || { echo "FAIL: approval not actually set"; exit 1; }
+grep -qE "agent\.tools\.keys\.(supported|status)\(" "$F" || { echo "FAIL: tool-keys not actually called"; exit 1; }
+# Untrusted-folder throw genuinely driven.
+grep -qE "folderTrust: false" "$F" && grep -qiE "untrusted folder" "$F" || { echo "FAIL: untrusted throw not driven"; exit 1; }
+
+# 3. The driver is GREEN and the T17 boundary guard PASSES on it (the file is in scope of the guard).
+npx vitest run "$F" 2>&1 | tail -40
+npx vitest run packages/agents/src/api/__tests__/boundary.spec.ts 2>&1 | tail -20
+# Prove the boundary guard actually scans this file: it must be a *.spec.ts (in-scope) not *.test.ts.
+case "$F" in *.spec.ts) echo "in T17 scope (.spec.ts)";; *) echo "FAIL: adequacy driver must be .spec.ts to be T17-policed"; exit 1;; esac
+
+# 4. Whole dir + typecheck green.
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p20a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p20a_all.log; exit 1; }
+npm run typecheck 2>&1 | tail -12
+
+# 5. Discipline + property gate.
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn|not\.toThrow\(\)|\.skip\(" "$F"; then echo "FAIL: discipline"; exit 1; fi
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+echo "PASS: P20a keystone gates green."
+```
+
+## Holistic Assessment (MANDATORY — into marker)
+
+- **Reachability proven**: each of the seven capabilities is actually CALLED (await/expect on real
+  results) on a public-root-built Agent — not a `typeof`-only sham. Cite the real-call lines.
+- **No escape**: zero `getConfig`, zero deep import, zero internals; import set is exactly {public
+  root, node, vitest, fast-check, agentHarness}. The file is `.spec.ts` so the T17 guard polices it,
+  and the guard is GREEN — the strongest possible evidence the #1595 boundary holds.
+- **Edge fidelity**: untrusted-folder throw driven through the public harness; `abortController`
+  projected out; auth/tool-keys masked.
+- **#1595 verdict**: state explicitly whether a CLI restricted to the public root could now drive all
+  seven capabilities. PASS/FAIL with evidence.
+
+## Success Criteria
+
+- Driver green; T17 guard green on it; behavioral (real calls); zero escape; verdict PASS.
+
+## Failure Recovery
+
+- If any capability is not genuinely reachable/called from the public root, reopen the owning
+  component phase (or P17 barrel). Never weaken the driver to pass.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P20a.md` (include real-call evidence + #1595 verdict).
+
+```markdown
+Phase: P20a
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: none (verification only)
+Verification: [paste actual output incl. driver + boundary.spec.ts green]
+Holistic Assessment: [PASS/FAIL; explicit #1595 reachability verdict with cited real-call lines]
+```

--- a/project-plans/issue2143/plan/21-boundary-and-nonbreaking.md
+++ b/project-plans/issue2143/plan/21-boundary-and-nonbreaking.md
@@ -1,0 +1,166 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P21 @requirement:REQ-INT-005 -->
+# Phase 21: No-Deep-Import Boundary (whole new surface)
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P21`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 20a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P20a.md`
+
+## Requirements Implemented (Expanded)
+
+### REQ-INT-005: No-deep-import boundary — the #1595 mission, enforced across the whole new set
+
+**Full Text**: Every new capability MUST be reachable using ONLY the public root
+`@vybestack/llxprt-code-agents`. The public-consumer path (the `.spec.ts` adequacy/boundary surface,
+and the eventual #1595 production CLI) MUST NOT import `./internals.js`, any other
+`@vybestack/llxprt-code-agents/<subpath>`, `/dist/`, or any deep `core/`, `providers/`, `tools/`,
+`auth/`, `settings/`, `ide-integration/`, `policy/` path. The NEW production source files (the three
+new controls + the extended controls + barrel + command-map) may import the CORE BARREL
+`@vybestack/llxprt-code-core` (the documented adapter seam) but MUST NOT introduce a NEW deep
+`core/src`/`providers/src` path.
+**Behavior**:
+- GIVEN: the full set of files this plan added/changed
+- WHEN: the boundary is scanned
+- THEN: no public-consumer `.spec.ts` deep-imports anything; the new production controls reach core
+  only through the `@vybestack/llxprt-code-core` barrel (never `core/src/...`); and the T17 guard
+  (`boundary.spec.ts`) is GREEN with the new `.spec.ts` files in its scan scope
+**Why This Matters**: deep imports are exactly what #1595 must eliminate. The adequacy driver (P20)
+proves ONE file is clean; this phase proves the WHOLE new surface is clean and that the standing T17
+guard polices it — so a future regression (a new deep import) is caught automatically.
+
+## Background — verified facts
+
+- `boundary.spec.ts` (the standing T17 guard) scans every `*.spec.ts` under `packages/agents/src/`,
+  allowing only: public root `@vybestack/llxprt-code-agents`, `@vybestack/llxprt-code-agents/app-service.js`,
+  `node:*`, `vitest`/`vitest/*`, `fast-check`/`fast-check/*`, and relative paths resolving within
+  `src/`. It FORBIDS `@vybestack/llxprt-code-agents/internals.js`, any other agents subpath, `/dist/`,
+  the seven deep prefixes, and src-escaping relatives. `.test.ts` files are EXEMPT (they may
+  deep-import — that is where the per-component `.behavior.test.ts` files live).
+- The new adequacy driver `capabilityGaps.integration.spec.ts` (P20) is a `.spec.ts`, so it is
+  already in scope. The per-component `.behavior.test.ts` files are `.test.ts`, intentionally exempt.
+- The new PRODUCTION controls (`control/policyControl.ts`, `tasksControl.ts`, `toolKeysControl.ts`)
+  and the extended controls/agentImpl import core via the `@vybestack/llxprt-code-core` BARREL (the
+  same adapter seam the existing controls use), NOT `core/src/...`. This phase pins that.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/agents/src/api/__tests__/capabilityBoundary.adequacy.test.ts` — a STATIC import-scan over
+  THIS plan's added/changed files (a `.test.ts`, so it is exempt from T17 itself but encodes the
+  REQ-INT-005 contract executably). Marker `@plan:PLAN-20260622-COREAPIGAP.P21
+  @requirement:REQ-INT-005`. It MUST:
+  - Read (via `node:fs`) the source text of the NEW production files and assert NONE imports a deep
+    `core/src`, `providers/src`, `tools/src`, or `policy/src` path (the barrel
+    `@vybestack/llxprt-code-core` IS allowed; a `core/src/...` deep path is NOT).
+  - Read the adequacy driver `capabilityGaps.integration.spec.ts` and assert it imports ONLY the
+    public root + node/vitest/fast-check + `./helpers/agentHarness.js` (mirror the P20 import
+    allow-list) and contains no `getConfig`.
+  - Assert the production controls reach core through the BARREL: each `control/*Control.ts` that
+    touches core imports from `'@vybestack/llxprt-code-core'` (exact specifier), never
+    `'@vybestack/llxprt-code-core/...'` deep.
+  - **≥30% property-based, MIN-2 cases**, e.g.: (1) property over the list of new production file
+    paths: each file's text contains zero deep `core/src|providers/src|tools/src|policy/src` matches;
+    (2) property over the list of public-consumer spec file paths: each imports only allow-listed
+    specifiers. (Both properties iterate a real `fc.constantFrom(...filePaths)`.)
+  - NO mock theater, NO reverse tests, no `any`.
+
+### Files to Modify
+
+- None in production unless the scan reveals a deep-import leak introduced by this plan; if so, route
+  the symbol through the `@vybestack/llxprt-code-core` barrel (additive) and record it here.
+
+### Constraints
+
+- The scan enumerates the plan's real changed files; do not hardcode a guessed list — derive it from
+  the known new/changed paths (the three new control files, the extended controls `mcpControl.ts`/
+  `authControl.ts`/`hooks.ts`/`toolControl.ts`, `agentImpl.ts`, `agent.ts`, `api/index.ts`,
+  `app-services/command-api-map.ts`) and the new `.spec.ts` driver.
+- This phase does not relax the standing T17 guard; it adds a complementary whole-set scan and proves
+  the guard is green.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/capabilityBoundary.adequacy.test.ts
+test -f "$F"
+
+# 1. Standing T17 guard is GREEN with the new .spec.ts driver in scope.
+npx vitest run packages/agents/src/api/__tests__/boundary.spec.ts 2>&1 | tail -20
+
+# 2. Whole-package shell boundary scan over the PUBLIC-CONSUMER spec surface: no deep imports
+#    anywhere in *.spec.ts (the T17-policed set). (.test.ts is intentionally exempt.)
+if grep -rnE "from '[^']*(/src/|core/src|providers/src|tools/src|policy/src)" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null | grep -vE "node_modules"; then
+  echo "FAIL: deep import in a public-consumer .spec.ts"; exit 1
+fi
+if grep -rnE "internals(\.js)?'" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null; then
+  echo "FAIL: a .spec.ts imports internals (public-consumer path forbidden)"; exit 1
+fi
+
+# 3. NEW production controls reach core via the BARREL, never a deep core/src path.
+for C in policyControl tasksControl toolKeysControl; do
+  P="packages/agents/src/api/control/$C.ts"
+  test -f "$P" || { echo "FAIL: missing new control $P"; exit 1; }
+  if grep -nE "from '@vybestack/llxprt-code-core/" "$P"; then echo "FAIL: $C deep-imports core (use the barrel)"; exit 1; fi
+done
+# Extended controls + agentImpl likewise must not introduce a NEW deep core/src path.
+for P in packages/agents/src/api/agentImpl.ts packages/agents/src/api/control/mcpControl.ts; do
+  if grep -nE "from '@vybestack/llxprt-code-core/src/|from '[^']*core/src/" "$P"; then echo "FAIL: $P deep-imports core/src"; exit 1; fi
+done
+
+# 4. The new scan test + whole dir GREEN; typecheck GREEN.
+npx vitest run "$F" 2>&1 | tail -25
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p21_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p21_all.log; exit 1; }
+npm run typecheck 2>&1 | tail -12
+
+# 5. Property gate + discipline.
+TOTAL=$(grep -cE "(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(|(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+PROP_CASE_FORMS=$(grep -cE "(^|[^A-Za-z0-9_])it\.prop\(|(^|[^A-Za-z0-9_])test\.prop\(" "$F" || true)
+CLASSIC_PROP_BLOCKS=$(awk '/(^|[^A-Za-z0-9_])it\(|(^|[^A-Za-z0-9_])test\(/ { blk++; counted[blk]=0 } /fc\.assert|fc\.property/ { if (blk>0 && counted[blk]==0) { counted[blk]=1; n++ } } END { print n+0 }' "$F")
+PROP=$(( PROP_CASE_FORMS + CLASSIC_PROP_BLOCKS ))
+PCT=$(( PROP * 100 / TOTAL ))
+echo "property CASES: $PROP / $TOTAL = ${PCT}%"
+[ "$PROP" -ge 2 ] && [ "$PCT" -ge 30 ] || { echo "FAIL: property gate"; exit 1; }
+if grep -nE "toHaveBeenCalled|mockResolvedValue|mockReturnValue|vi\.fn\(|vi\.spyOn|not\.toThrow\(\)" "$F"; then echo "FAIL: discipline"; exit 1; fi
+echo "PASS: P21 boundary green."
+```
+
+### Semantic Verification Checklist
+
+- [ ] Standing T17 `boundary.spec.ts` green with the new `.spec.ts` driver in scope.
+- [ ] No public-consumer `.spec.ts` deep-imports or imports internals.
+- [ ] New production controls reach core via the `@vybestack/llxprt-code-core` BARREL only (no
+      `core/src` deep path).
+- [ ] Whole-set static scan test green; ≥30% property; no mock theater.
+
+## Success Criteria
+
+- The whole new surface honors the no-deep-import boundary; the standing guard polices it; scan test
+  green.
+
+## Failure Recovery
+
+- Route any leaked deep import through the public root / core barrel (additive); never relax the
+  guard or exempt a public-consumer file.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P21.md`
+
+```markdown
+Phase: P21
+Completed: YYYY-MM-DD HH:MM
+Files Created: [capabilityBoundary.adequacy.test.ts with line count]
+Files Modified: [list or none]
+Tests Added: [count]
+Verification: [paste actual output incl. boundary.spec.ts green]
+Semantic Assessment: [one-line: whole new surface is deep-import-free; T17 guard polices it]
+```

--- a/project-plans/issue2143/plan/21-boundary-and-nonbreaking.md
+++ b/project-plans/issue2143/plan/21-boundary-and-nonbreaking.md
@@ -101,7 +101,7 @@ npx vitest run packages/agents/src/api/__tests__/boundary.spec.ts 2>&1 | tail -2
 if grep -rnE "from '[^']*(/src/|core/src|providers/src|tools/src|policy/src)" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null | grep -vE "node_modules"; then
   echo "FAIL: deep import in a public-consumer .spec.ts"; exit 1
 fi
-if grep -rnE "internals(\.js)?'" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null; then
+if grep -rnE "from '[^']*internals(\.js)?'" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null; then
   echo "FAIL: a .spec.ts imports internals (public-consumer path forbidden)"; exit 1
 fi
 

--- a/project-plans/issue2143/plan/21a-boundary-and-nonbreaking-verification.md
+++ b/project-plans/issue2143/plan/21a-boundary-and-nonbreaking-verification.md
@@ -49,7 +49,7 @@ echo "non-vacuity proven: injected deep import was caught; original restored."
 # 3. Whole-package shell scan agrees: no deep import / internals in any public-consumer .spec.ts.
 if grep -rnE "from '[^']*(/src/|core/src|providers/src|tools/src|policy/src)" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null | grep -vE "node_modules"; then
   echo "FAIL: deep import in a .spec.ts"; exit 1; fi
-if grep -rnE "internals(\.js)?'" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null; then
+if grep -rnE "from '[^']*internals(\.js)?'" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null; then
   echo "FAIL: .spec.ts imports internals"; exit 1; fi
 
 # 4. New controls use the barrel, not deep core/src.

--- a/project-plans/issue2143/plan/21a-boundary-and-nonbreaking-verification.md
+++ b/project-plans/issue2143/plan/21a-boundary-and-nonbreaking-verification.md
@@ -1,0 +1,92 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P21a @requirement:REQ-INT-005 -->
+# Phase 21a: No-Deep-Import Boundary — Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P21a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 21 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P21.md`
+
+## Purpose
+
+Confirm the no-deep-import boundary holds across the WHOLE new surface and that the scan test is
+non-vacuous — i.e. it would actually FAIL if a deep import were introduced. Prove the standing T17
+guard polices the new `.spec.ts` files, and that the new production controls reach core only through
+the documented barrel seam.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+F=packages/agents/src/api/__tests__/capabilityBoundary.adequacy.test.ts
+
+# 1. Standing T17 guard green; whole dir green; typecheck green.
+npx vitest run packages/agents/src/api/__tests__/boundary.spec.ts 2>&1 | tail -20
+npx vitest run "$F" 2>&1 | tail -25
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p21a_all.log 2>&1 || { echo "FAIL: regressions"; tail -60 /tmp/p21a_all.log; exit 1; }
+npm run typecheck 2>&1 | tail -12
+
+# 2. NON-VACUITY PROBE: inject a deep import into a NEW control, prove the scan test FAILS, then
+#    restore. (Proves the boundary fence has teeth.)
+PROBE=packages/agents/src/api/control/policyControl.ts
+cp "$PROBE" /tmp/policyControl.bak
+# Add a deep core/src import line at the top (syntactically harmless unused import).
+printf "%s\n" "import '@vybestack/llxprt-code-core/src/index.js';" | cat - "$PROBE" > /tmp/policyControl.probe && mv /tmp/policyControl.probe "$PROBE"
+if npx vitest run "$F" > /tmp/p21a_probe.log 2>&1; then
+  echo "FAIL: boundary scan did NOT catch an injected deep import (vacuous)"; cp /tmp/policyControl.bak "$PROBE"; exit 1
+fi
+cp /tmp/policyControl.bak "$PROBE"   # RESTORE
+# Re-confirm green after restore.
+npx vitest run "$F" 2>&1 | tail -10
+echo "non-vacuity proven: injected deep import was caught; original restored."
+
+# 3. Whole-package shell scan agrees: no deep import / internals in any public-consumer .spec.ts.
+if grep -rnE "from '[^']*(/src/|core/src|providers/src|tools/src|policy/src)" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null | grep -vE "node_modules"; then
+  echo "FAIL: deep import in a .spec.ts"; exit 1; fi
+if grep -rnE "internals(\.js)?'" packages/agents/src/api/__tests__/*.spec.ts 2>/dev/null; then
+  echo "FAIL: .spec.ts imports internals"; exit 1; fi
+
+# 4. New controls use the barrel, not deep core/src.
+for C in policyControl tasksControl toolKeysControl; do
+  P="packages/agents/src/api/control/$C.ts"
+  if grep -nE "from '@vybestack/llxprt-code-core/" "$P"; then echo "FAIL: $C deep-imports core"; exit 1; fi
+done
+echo "PASS: P21a boundary verification green."
+```
+
+## Holistic Assessment (MANDATORY — into marker)
+
+- **Whole-set coverage**: the scan covers ALL of this plan's new/changed files, not just the driver.
+- **Non-vacuity proven**: an injected deep import made the scan FAIL; restore returned it to green —
+  evidence the fence has teeth (cite the probe output).
+- **Barrel seam honored**: the new controls reach core through `@vybestack/llxprt-code-core` only.
+- **#1595 boundary verdict**: state explicitly that the public-consumer path (and a future CLI) can
+  reach everything via the public root with no deep import. PASS/FAIL.
+
+## Success Criteria
+
+- Guard green; scan test green AND proven non-vacuous; new controls use the barrel; verdict PASS.
+
+## Failure Recovery
+
+- If the probe does NOT fail, the scan is vacuous — fix the scan test (P21) so it genuinely inspects
+  the new files; re-run. If a real leak exists, reopen the owning phase.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P21a.md` (include the non-vacuity probe output).
+
+```markdown
+Phase: P21a
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: none (verification only; probe file restored)
+Verification: [paste actual output incl. non-vacuity probe FAIL-then-restore]
+Holistic Assessment: [PASS/FAIL; #1595 boundary verdict; non-vacuity evidence]
+```

--- a/project-plans/issue2143/plan/22-quality-gates.md
+++ b/project-plans/issue2143/plan/22-quality-gates.md
@@ -1,0 +1,137 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P22 @requirement:REQ-001,REQ-002,REQ-003,REQ-004,REQ-005,REQ-006,REQ-007,REQ-008,REQ-009,REQ-010,REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004,REQ-INT-005 -->
+# Phase 22: Full Verification Suite + Mutation Gate
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P22`
+
+## LLxprt Code Subagent: typescriptexpert
+
+## Prerequisites
+
+- Required: Phase 21a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P21a.md`
+
+## Purpose
+
+Run the project's full verification suite and the mutation gate over the new/changed production files
+to certify the additive API surface is production-quality and ready for PR. This is the last gate
+before the final adequacy evaluation.
+
+## Background — verified facts
+
+- The agents Stryker config (`packages/agents/stryker.conf.json`) already mutates
+  `src/api/**/*.ts` (excluding `__tests__`/`*.spec.ts`/`*.test.ts`) with `break: 80`. So the THREE
+  NEW control files (`control/policyControl.ts`, `control/tasksControl.ts`,
+  `control/toolKeysControl.ts`) and the EXTENDED control files (`control/mcpControl.ts`,
+  `control/authControl.ts`, `control/hooks.ts`, `control/toolControl.ts`) plus `agentImpl.ts` are
+  AUTOMATICALLY in the mutate set. No config change is required; the `test:mutation:api` script runs
+  the whole `src/api/**` mutate scope and fails under 80%.
+- Root `npm run test` oversubscribes CPU and can produce timing/property flakiness; failing files
+  MUST be re-run in isolation (`npx vitest run <file>`) to confirm they are load-contention flakes,
+  not real defects (CI runs packages separately and does not hit this).
+
+## Implementation Tasks
+
+### Commands to Run (all must pass)
+
+```bash
+set -e
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
+```
+
+> If `npm run test` reports failures, re-run EACH failing file in isolation:
+> `npx vitest run <path-to-failing-file>`. If it passes in isolation, it is a root-orchestrator
+> load-contention flake (documented behavior on this monorepo), not a code defect — record the
+> isolated-green evidence in the marker. If it STILL fails in isolation, it is a real defect: fix it
+> at its source phase (do not weaken the test).
+
+### Mutation Testing (≥80% on the new/changed API surface)
+
+The agents Stryker config already scopes `src/api/**`. Run it and assert ≥80%:
+
+```bash
+cd packages/agents
+npm run test:mutation:api
+SCORE=$(jq -r '.thresholds.high as $h | (.systemUnderTestMetrics?.metrics?.mutationScore // .files | length)' reports/mutation/mutation.json >/dev/null 2>&1; jq -r '.. | objects | .mutationScore? // empty' reports/mutation/mutation.json | tail -1)
+echo "agents api mutation score: $SCORE"
+awk -v s="$SCORE" 'BEGIN{ if (s+0 < 80) { print "FAIL: agents api mutation < 80%"; exit 1 } }'
+cd ../..
+```
+
+> Stryker MUST already be present. `@stryker-mutator/core` (`^9.6.1`) and
+> `@stryker-mutator/vitest-runner` (`^9.6.1`) are declared devDependencies of `packages/agents`
+> (verified). If absent, this is a BLOCKING regression — FAIL and point back to dependency
+> remediation; do NOT install it at the gate:
+>
+> ```bash
+> ( cd packages/agents && npm ls @stryker-mutator/core ) || { echo "FAIL: @stryker-mutator/core MISSING — BLOCKING regression; do NOT install at the gate."; exit 1; }
+> ```
+
+> Per-file focus (if the whole-`src/api/**` run is slow): the NEW files carry the most un-killed
+> mutants. After the full run, inspect the per-file scores in `reports/mutation/mutation.json` and
+> ensure EACH new control file (`policyControl.ts`, `tasksControl.ts`, `toolKeysControl.ts`) and each
+> extended control's NEW methods are individually ≥80%. Add behavioral cases to the owning
+> `.behavior.test.ts` (NOT to a separate file) to kill survivors; never relax the threshold.
+
+### Deferred Implementation Detection (whole new production set, BLOCKING)
+
+```bash
+if grep -rnE "(TODO|FIXME|HACK|STUB|XXX|TEMPORARY|WIP)" packages/agents/src/api --include="*.ts" | grep -vE "/__tests__/"; then
+  echo "FAIL: deferred-implementation marker in production code"; exit 1
+fi
+if grep -rnE "(in a real|in production|ideally|for now|placeholder|not yet implemented|coming soon)" packages/agents/src/api --include="*.ts" | grep -vE "/__tests__/"; then
+  echo "FAIL: deferred-implementation prose in production code"; exit 1
+fi
+echo "no deferred-implementation patterns"
+```
+
+### Comment-discipline (N5) on new production files (BLOCKING)
+
+```bash
+# New production control files carry ONLY @plan/@requirement/@pseudocode markers — no prose comments.
+for C in policyControl tasksControl toolKeysControl; do
+  P="packages/agents/src/api/control/$C.ts"
+  # Any // comment that is not a marker line is a violation.
+  if grep -nE "^\s*//" "$P" | grep -vE "@plan:|@requirement:|@pseudocode"; then
+    echo "FAIL: non-marker prose comment in $P (N5)"; exit 1
+  fi
+done
+echo "N5 comment discipline OK on new controls"
+```
+
+### Semantic Verification Checklist
+
+- [ ] All six core commands pass (test/lint/typecheck/format/build + smoke haiku).
+- [ ] Mutation score ≥80% over `src/api/**`; each NEW control file individually ≥80%.
+- [ ] No deferred-implementation patterns / non-marker prose comments in new production code.
+- [ ] Any `npm run test` flake reproduced-green in isolation and documented.
+
+## Success Criteria
+
+- Entire suite green; mutation ≥80%; no deferred work; smoke test prints a haiku.
+
+## Failure Recovery
+
+- Fix the failing gate at its source phase (do not weaken tests); re-run suite. For mutation
+  survivors, strengthen the owning `.behavior.test.ts` with real behavioral cases.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P22.md` (paste suite + mutation outputs + any isolated
+re-run evidence).
+
+```markdown
+Phase: P22
+Completed: YYYY-MM-DD HH:MM
+Files Created: none (or any test cases added to existing .behavior.test.ts — list them)
+Files Modified: [list with diff stats]
+Tests Added: [count]
+Verification: [paste actual output of suite + mutation score]
+Semantic Assessment: [one-line: suite green, mutation >=80%, smoke haiku printed]
+```

--- a/project-plans/issue2143/plan/22-quality-gates.md
+++ b/project-plans/issue2143/plan/22-quality-gates.md
@@ -57,8 +57,21 @@ The agents Stryker config already scopes `src/api/**`. Run it and assert ≥80%:
 
 ```bash
 cd packages/agents
+# Stryker's own break:80 already fails this run (non-zero exit) if the overall
+# mutation score < 80%, so under set -e the run itself is the primary gate.
 npm run test:mutation:api
-SCORE=$(jq -r '.thresholds.high as $h | (.systemUnderTestMetrics?.metrics?.mutationScore // .files | length)' reports/mutation/mutation.json >/dev/null 2>&1; jq -r '.. | objects | .mutationScore? // empty' reports/mutation/mutation.json | tail -1)
+M=reports/mutation/mutation.json
+test -f "$M" || { echo "FAIL: no mutation report"; exit 1; }
+# Stryker JSON schemaVersion 1.0 stores raw mutants[].status (Killed/Timeout/
+# Survived/NoCoverage) — there is NO precomputed .mutationScore field. Compute
+# the score the way Stryker does: detected=(Killed+Timeout),
+# valid=(detected+Survived+NoCoverage), score=detected/valid*100.
+SCORE=$(jq -r '
+  [ .files[].mutants[].status ] as $all
+  | ($all | map(select(. == "Killed" or . == "Timeout")) | length) as $detected
+  | ($all | map(select(. == "Killed" or . == "Timeout" or . == "Survived" or . == "NoCoverage")) | length) as $valid
+  | if $valid == 0 then 0 else ($detected * 100 / $valid) end
+' "$M")
 echo "agents api mutation score: $SCORE"
 awk -v s="$SCORE" 'BEGIN{ if (s+0 < 80) { print "FAIL: agents api mutation < 80%"; exit 1 } }'
 cd ../..

--- a/project-plans/issue2143/plan/22a-quality-gates-verification.md
+++ b/project-plans/issue2143/plan/22a-quality-gates-verification.md
@@ -35,15 +35,29 @@ npx vitest run packages/agents/src/api/__tests__/ > /tmp/p22a_api.log 2>&1 || { 
 echo "agents api suite green"
 
 # 3. Mutation evidence exists and is ≥80% AND non-vacuous for the NEW controls.
+# Stryker JSON schemaVersion 1.0 stores raw mutants[].status (Killed/Timeout/
+# Survived/NoCoverage) — there is NO precomputed .mutationScore field, so the
+# score MUST be computed: detected=(Killed+Timeout),
+# valid=(detected+Survived+NoCoverage), score=detected/valid*100.
 M=packages/agents/reports/mutation/mutation.json
 test -f "$M" || { echo "FAIL: no mutation report (P22 must run Stryker)"; exit 1; }
-OVERALL=$(jq -r '.. | objects | .mutationScore? // empty' "$M" | tail -1)
+OVERALL=$(jq -r '
+  [ .files[].mutants[].status ] as $all
+  | ($all | map(select(. == "Killed" or . == "Timeout")) | length) as $d
+  | ($all | map(select(. == "Killed" or . == "Timeout" or . == "Survived" or . == "NoCoverage")) | length) as $v
+  | if $v == 0 then 0 else ($d * 100 / $v) end
+' "$M")
 echo "overall api mutation: $OVERALL"
 awk -v s="$OVERALL" 'BEGIN{ if (s+0 < 80) { print "FAIL: overall < 80%"; exit 1 } }'
 # Non-vacuity: each new control file must have a NON-ZERO mutant count and per-file score >=80.
 for C in policyControl tasksControl toolKeysControl; do
   KEY="src/api/control/$C.ts"
-  FSCORE=$(jq -r --arg k "$KEY" '.files | to_entries[] | select(.key|endswith($k)) | .value.mutationScore' "$M" 2>/dev/null | head -1)
+  FSCORE=$(jq -r --arg k "$KEY" '
+    (.files | to_entries[] | select(.key|endswith($k)) | .value.mutants) as $m
+    | ($m | map(select(.status == "Killed" or .status == "Timeout")) | length) as $d
+    | ($m | map(select(.status == "Killed" or .status == "Timeout" or .status == "Survived" or .status == "NoCoverage")) | length) as $v
+    | if $v == 0 then 0 else ($d * 100 / $v) end
+  ' "$M" 2>/dev/null | head -1)
   MUTS=$(jq -r --arg k "$KEY" '.files | to_entries[] | select(.key|endswith($k)) | (.value.mutants|length)' "$M" 2>/dev/null | head -1)
   echo "$C: score=$FSCORE mutants=$MUTS"
   [ -n "$MUTS" ] && [ "$MUTS" -gt 0 ] || { echo "FAIL: $C has zero mutants (vacuous)"; exit 1; }

--- a/project-plans/issue2143/plan/22a-quality-gates-verification.md
+++ b/project-plans/issue2143/plan/22a-quality-gates-verification.md
@@ -1,0 +1,96 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P22a @requirement:REQ-001,REQ-002,REQ-003,REQ-004,REQ-005,REQ-006,REQ-007,REQ-008,REQ-009,REQ-010,REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004,REQ-INT-005 -->
+# Phase 22a: Quality Gates — Verification
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P22a`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 22 completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P22.md`
+
+## Purpose
+
+Independently re-confirm the full suite is green and the mutation gate genuinely cleared ≥80% over
+the new/changed API surface — and that the mutation pass is non-vacuous (the new controls actually
+have killed mutants, not zero-mutant files). Confirm no deferred work / prose comments slipped into
+production.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+
+# 1. Re-run the deterministic core gates (fast, non-flaky).
+npm run typecheck 2>&1 | tail -12
+npm run lint 2>&1 | tail -20
+npm run build 2>&1 | tail -15
+
+# 2. Agents API test surface green in isolation (avoids root-orchestrator contention).
+npx vitest run packages/agents/src/api/__tests__/ > /tmp/p22a_api.log 2>&1 || { echo "FAIL: agents api suite"; tail -80 /tmp/p22a_api.log; exit 1; }
+echo "agents api suite green"
+
+# 3. Mutation evidence exists and is ≥80% AND non-vacuous for the NEW controls.
+M=packages/agents/reports/mutation/mutation.json
+test -f "$M" || { echo "FAIL: no mutation report (P22 must run Stryker)"; exit 1; }
+OVERALL=$(jq -r '.. | objects | .mutationScore? // empty' "$M" | tail -1)
+echo "overall api mutation: $OVERALL"
+awk -v s="$OVERALL" 'BEGIN{ if (s+0 < 80) { print "FAIL: overall < 80%"; exit 1 } }'
+# Non-vacuity: each new control file must have a NON-ZERO mutant count and per-file score >=80.
+for C in policyControl tasksControl toolKeysControl; do
+  KEY="src/api/control/$C.ts"
+  FSCORE=$(jq -r --arg k "$KEY" '.files | to_entries[] | select(.key|endswith($k)) | .value.mutationScore' "$M" 2>/dev/null | head -1)
+  MUTS=$(jq -r --arg k "$KEY" '.files | to_entries[] | select(.key|endswith($k)) | (.value.mutants|length)' "$M" 2>/dev/null | head -1)
+  echo "$C: score=$FSCORE mutants=$MUTS"
+  [ -n "$MUTS" ] && [ "$MUTS" -gt 0 ] || { echo "FAIL: $C has zero mutants (vacuous)"; exit 1; }
+  awk -v s="$FSCORE" -v c="$C" 'BEGIN{ if (s+0 < 80) { print "FAIL: "c" per-file mutation < 80%"; exit 1 } }'
+done
+echo "per-file mutation non-vacuous and >=80%"
+
+# 4. No deferred work / non-marker prose comments in new production code.
+if grep -rnE "(TODO|FIXME|HACK|STUB|XXX|TEMPORARY|WIP|not yet implemented|placeholder|for now)" packages/agents/src/api --include="*.ts" | grep -vE "/__tests__/"; then
+  echo "FAIL: deferred marker in production"; exit 1; fi
+for C in policyControl tasksControl toolKeysControl; do
+  P="packages/agents/src/api/control/$C.ts"
+  if grep -nE "^\s*//" "$P" | grep -vE "@plan:|@requirement:|@pseudocode"; then echo "FAIL: prose comment in $P"; exit 1; fi
+done
+echo "PASS: P22a quality gates verified."
+```
+
+> NOTE on `npm run test` flakes: if P22's marker documents a root-orchestrator flake that passed in
+> isolation, re-run that SAME file in isolation here to confirm. Do NOT accept a "flaky, ignored"
+> claim without an isolated-green reproduction.
+
+## Holistic Assessment (MANDATORY — into marker)
+
+- **Suite**: deterministic gates (typecheck/lint/build) green; agents API suite green in isolation.
+- **Mutation**: overall ≥80% AND each new control non-vacuous (non-zero mutants) and individually
+  ≥80% — cite the per-file scores. The smoke haiku printed (cite from P22 marker).
+- **Hygiene**: no deferred work / non-marker comments in new production code.
+- **Verdict**: PASS/FAIL with evidence.
+
+## Success Criteria
+
+- All gates re-confirmed; mutation ≥80% and non-vacuous on new controls; verdict PASS.
+
+## Failure Recovery
+
+- Reopen the owning component phase to strengthen behavioral tests for mutation survivors; never
+  relax the threshold or weaken a test.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P22a.md` (paste per-file mutation scores + verdict).
+
+```markdown
+Phase: P22a
+Completed: YYYY-MM-DD HH:MM
+Files Created: none
+Files Modified: none (verification only)
+Verification: [paste actual output incl. per-file mutation scores]
+Holistic Assessment: [PASS/FAIL; mutation non-vacuity evidence; suite-green confirmation]
+```

--- a/project-plans/issue2143/plan/23-final-plan-quality-eval.md
+++ b/project-plans/issue2143/plan/23-final-plan-quality-eval.md
@@ -1,0 +1,167 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP.P23 @requirement:REQ-001,REQ-002,REQ-003,REQ-004,REQ-005,REQ-006,REQ-007,REQ-008,REQ-009,REQ-010,REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004,REQ-INT-005 -->
+# Phase 23: Final Plan-Quality & Adequacy Evaluation
+
+## Phase ID
+
+`PLAN-20260622-COREAPIGAP.P23`
+
+## LLxprt Code Subagent: architect
+
+## Prerequisites
+
+- Required: Phase 22a completed (PASS)
+- Verification: `test -f project-plans/issue2143/.completed/P22a.md`
+
+## Purpose
+
+Final gate. Evaluate the COMPLETED additive surface against `dev-docs/PLAN.md`'s rejection criteria
+and against the core mission: is the public agents API now ADEQUATE to enable issue #1595 (CLI as a
+thin UI with NO `getConfig()` escape hatches and NO deep imports)? This phase writes no production
+code — it renders a defensible verdict with evidence, and (if any check fails) names the exact
+phase(s) to redo.
+
+## Evaluation — Integration-First (CHECK FIRST; if any fail, REJECT)
+
+- [ ] Plan modifies SPECIFIC existing files (`agent.ts`, `agentImpl.ts`, `control/mcpControl.ts`,
+      `control/authControl.ts`, `control/hooks.ts`, `control/toolControl.ts`, `api/index.ts`,
+      `app-services/command-api-map.ts`, `docs/agent-api.md`) and adds THREE new controls under the
+      EXISTING `control/` convention — not an isolated parallel surface.
+- [ ] The adequacy driver (`capabilityGaps.integration.spec.ts`) CANNOT be written without the new
+      public methods (proves the seams are load-bearing for #1595).
+- [ ] There IS a consumer path for #1595: every one of the seven capabilities is reachable on a real
+      `fromConfig`/harness-built Agent via the public root ONLY (P20/P20a).
+- [ ] No capability is "reachable" only via `getConfig()` or a deep import (P20 forbids `getConfig`;
+      P21 enforces the T17 no-deep-import boundary).
+
+## Evaluation — Gap Closure (each must be YES with evidence)
+
+| Gap | Capability | Requirement | Phases | Closed? (evidence) |
+|---|---|---|---|---|
+| G1 | Approval mode read/write (+ untrusted throw) | REQ-001 / REQ-INT-001 | 03,04,04a,20,20a | [ ] |
+| G2 | Policy inspection (read-only, argsPattern→source) | REQ-002 / REQ-INT-002 | 05,06,06a,20,20a | [ ] |
+| G3 | Async-task admin (full `/task`) | REQ-003 / REQ-INT-002 | 07,08,08a,20,20a | [ ] |
+| G4 | Hooks administration (registry + enable/disable) | REQ-004 / REQ-INT-003 | 09,10,10a,20,20a | [ ] |
+| G5 | Detailed OAuth state (masked) | REQ-005 / REQ-INT-003 | 11,12,12a,20,20a | [ ] |
+| G6 | MCP OAuth + deep detail + refresh setTools parity | REQ-006 / REQ-INT-004 | 13,14,14a,20,20a | [ ] |
+| G7 | Built-in tool-key storage (`agent.tools.keys`, masked) | REQ-007 / REQ-INT-004 | 15,16,16a,20,20a | [ ] |
+| — | Barrel re-exports + `COMMAND_API_MAP` six rows | REQ-008 | 17,17a | [ ] |
+| — | Non-breaking guarantee | REQ-009 | 18,18a,21,21a | [ ] |
+| — | Documentation | REQ-010 | 19,19a | [ ] |
+| — | No-deep-import boundary | REQ-INT-005 | 20,20a,21,21a | [ ] |
+
+### Capability-closure acceptance (evaluate against the EXPLICIT spec interpretation)
+
+For EACH gap G1–G7, "closed" requires ALL of:
+- [ ] (a) the public method(s) exist on the documented surface (top-level for approval; sub-controller
+      for policy/tasks/tool-keys; extended controller for hooks/auth/mcp) and are re-exported/typed
+      from the public root where applicable (P17);
+- [ ] (b) DEEP behavior is proven by the owning `.behavior.test.ts` (real Config/objects, no mock
+      theater, ≥30% property), and the impl cites the pseudocode line numbers (NNa gate passed);
+- [ ] (c) REACHABILITY is proven by the public-root-only adequacy driver (P20) — the method is
+      callable on a real Agent with no `getConfig`/deep import;
+- [ ] (d) the documented CONSTRAINTS hold: approval untrusted-throw delegated-not-caught;
+      `AgentTaskInfo` omits `abortController`; policy `argsPattern` projected to `.source`; auth /
+      tool-keys masked (no raw secret); MCP `refresh()` has setTools parity; undefined-safe backing
+      managers.
+
+## Evaluation — TDD/Quality Discipline
+
+- [ ] No reverse testing (no `toThrow('NotYetImplemented')`, no `not.toThrow()`).
+- [ ] No mock theater (no `toHaveBeenCalled`/`mockResolvedValue`/`mockReturnValue`/`vi.fn`/`vi.spyOn`
+      in behavioral suites).
+- [ ] ≥30% property-based across new behavioral suites (each ≥2 distinct cases).
+- [ ] Impl phases cite pseudocode line numbers; the pseudocode-compliance gates ran (04a, 06a, 08a,
+      10a, 12a, 14a, 16a).
+- [ ] Mutation ≥80% over `src/api/**`, non-vacuous on each NEW control (Phase 22 evidence;
+      independently re-confirmed 22a).
+- [ ] Non-breaking proven by characterization + built-artifact subset (Phases 18/18a, swept again in
+      21/21a).
+- [ ] No V2/New/parallel files; existing files UPDATED; new controls follow the existing convention.
+- [ ] Comment-discipline N5 on new production files (only @plan/@requirement/@pseudocode markers).
+
+## Evaluation — #1595 Adequacy (the mission)
+
+Answer explicitly with evidence:
+- [ ] Can a CLI restricted to the public root read/write approval mode (incl. the untrusted-folder
+      throw)? (REQ-INT-001)
+- [ ] Can it inspect policy rules/defaults and drive the full `/task` surface? (REQ-INT-002)
+- [ ] Can it administer hooks (registry + enable/disable) and render detailed (masked) auth status?
+      (REQ-INT-003)
+- [ ] Can it perform MCP OAuth (with post-auth setTools parity), read deep MCP detail, and manage
+      built-in tool keys (masked)? (REQ-INT-004)
+- [ ] Is there a clear, documented import boundary (public root only) so #1595 can delete its deep
+      imports and `getConfig()` escapes? (REQ-INT-005, REQ-010)
+
+## Output
+
+Write `project-plans/issue2143/plan-evaluation.json`:
+
+```json
+{
+  "compliant": true,
+  "has_integration_plan": true,
+  "builds_in_isolation": false,
+  "gaps_closed": { "G1": true, "G2": true, "G3": true, "G4": true, "G5": true, "G6": true, "G7": true },
+  "additive_only_non_breaking": true,
+  "enables_1595": true,
+  "public_root_only_reachable": true,
+  "reverse_testing_found": false,
+  "mock_theater_found": false,
+  "property_ge_30": true,
+  "mutation_ge_80": true,
+  "docs_updated": true,
+  "violations": []
+}
+```
+
+If `builds_in_isolation` is true OR any gap is unclosed OR `enables_1595` is false OR
+`public_root_only_reachable` is false OR `additive_only_non_breaking` is false → **REJECT** and list
+the responsible phase(s) to redo in `violations`.
+
+## Verification Commands
+
+```bash
+set -o pipefail
+set -e
+# All phase markers present (00..22a) — the plan actually ran end to end.
+for P in 00 00a 01 01a 02 02a 03 04 04a 05 06 06a 07 08 08a 09 10 10a 11 12 12a 13 14 14a 15 16 16a 17 17a 18 18a 19 19a 20 20a 21 21a 22 22a; do
+  test -f "project-plans/issue2143/.completed/P$P.md" || { echo "FAIL: missing marker P$P"; exit 1; }
+done
+# The evaluation artifact exists and asserts success.
+test -f project-plans/issue2143/plan-evaluation.json
+node -e '
+  const e = require("./project-plans/issue2143/plan-evaluation.json");
+  const must = ["compliant","has_integration_plan","enables_1595","public_root_only_reachable","additive_only_non_breaking","docs_updated"];
+  for (const k of must) if (e[k] !== true) { console.error("FAIL: "+k+" !== true"); process.exit(1); }
+  if (e.builds_in_isolation !== false) { console.error("FAIL: builds_in_isolation must be false"); process.exit(1); }
+  for (const [g,v] of Object.entries(e.gaps_closed)) if (v !== true) { console.error("FAIL: gap "+g+" unclosed"); process.exit(1); }
+  if (e.reverse_testing_found || e.mock_theater_found) { console.error("FAIL: discipline violation flagged"); process.exit(1); }
+  if (e.violations.length) { console.error("FAIL: violations present", e.violations); process.exit(1); }
+  console.log("plan-evaluation.json asserts full closure + #1595 adequacy");
+'
+echo "PASS: P23 final evaluation green."
+```
+
+## Success Criteria
+
+- Verdict rendered with evidence; all seven gaps closed; additive/non-breaking; #1595 adequacy
+  affirmed on the public-root-only path; no rejection triggers.
+
+## Failure Recovery
+
+- Reopen the specific phase(s) named in `violations`; do not mark the plan complete until the
+  evaluation asserts success with evidence.
+
+## Phase Completion Marker
+
+Create: `project-plans/issue2143/.completed/P23.md` (include the JSON + narrative verdict).
+
+```markdown
+Phase: P23
+Completed: YYYY-MM-DD HH:MM
+Files Created: [plan-evaluation.json]
+Files Modified: none
+Tests Added: none (evaluation phase)
+Verification: [paste actual output of THIS phase's verification commands]
+Semantic Assessment: [one-line holistic verdict: all 7 gaps closed, additive, #1595 reachable via public root only]
+```

--- a/project-plans/issue2143/specification.md
+++ b/project-plans/issue2143/specification.md
@@ -474,10 +474,12 @@ Zod schemas are provided for the projected DATA types that cross the public boun
 (callbacks and class instances are NOT Zod-validated, per #1594 precedent).
 
 ```typescript
-// Policy (REQ-002) — argsPattern projected to string (never raw RegExp)
+// Policy (REQ-002) — argsPattern projected to string (never raw RegExp).
+// priority/toolName mirror core PolicyRule optionality (types.ts:29,46) — projected
+// faithfully (NOT coerced to a placeholder); CLI renders undefined as `?? 0` / `?? '*'`.
 export interface PolicyRuleView {
-  readonly priority: number;
-  readonly toolName: string;
+  readonly priority?: number;
+  readonly toolName?: string;
   readonly decision: PolicyDecision;          // VALUE enum (core barrel)
   readonly argsPattern?: string;              // = rule.argsPattern?.source
   readonly source?: string;

--- a/project-plans/issue2143/specification.md
+++ b/project-plans/issue2143/specification.md
@@ -1,0 +1,619 @@
+<!-- @plan:PLAN-20260622-COREAPIGAP @requirement:REQ-001,REQ-002,REQ-003,REQ-004,REQ-005,REQ-006,REQ-007,REQ-008,REQ-009,REQ-010,REQ-INT-001,REQ-INT-002,REQ-INT-003,REQ-INT-004,REQ-INT-005 -->
+# Feature Specification: Close Agent API Engine-Capability Gaps (prerequisite for #1595)
+
+Plan ID: PLAN-20260622-COREAPIGAP
+Generated: 2026-06-22
+Predecessor: PLAN-20260621-COREAPIREMED (#1594 remediate, merged) — which itself follows
+PLAN-20260617-COREAPI (#1594 original). This plan is ADDITIVE on top of that merged surface.
+Scope: `packages/agents/src/api/**` (the public `@vybestack/llxprt-code-agents` surface) ONLY.
+No CLI production source is modified (that is #1595). No core/providers/policy source is modified.
+
+---
+
+## Purpose
+
+#1594 (PR #2108, then remediated by PLAN-20260621-COREAPIREMED) shipped the public Agent API:
+`createAgent(AgentConfig)` / `fromConfig(Config)` returning an `Agent` facade
+(`packages/agents/src/api/agent.ts`). The **core interaction path is parity-proven**: the
+CLI-turn-parity harness drives a real `read_file` tool call through `fromConfig → agent.stream()`
+and asserts the projected event stream is byte-identical to the CLI's reference `AgenticLoop` drive.
+
+Issue #1595 ("Refactor CLI to consume core API") will rewire `packages/cli/src/**` to consume ONLY
+the public agents surface, so that — per its own acceptance criterion — "the CLI could theoretically
+be replaced with a different UI using the same core API." A capability-coverage audit of the CLI
+against the current `Agent` surface found a **small, bounded set of engine capabilities the CLI
+drives DIRECTLY from `core.Config` today that have NO first-class `Agent` method**. If left
+unaddressed, #1595 must keep `agent.getConfig().<core method>()` escape hatches — defeating its own
+acceptance criterion.
+
+This issue is a **prerequisite for #1595** and is **purely additive** to the API surface (no
+breaking changes). It closes those gaps with new first-class `Agent` methods / sub-controllers,
+following the EXISTING sub-controller convention exactly.
+
+### Why the shipped surface is inadequate (evidence, current post-merge source)
+
+Each row was ground-truthed against the working tree on the `issue2143` branch.
+
+| Gap | Evidence (file:line, verified) | Why it blocks #1595 |
+|---|---|---|
+| **G1 Approval mode** | CLI reads/writes directly: `useAutoAcceptIndicator.ts` (read `config.getApprovalMode()`, write `config.setApprovalMode(...)`). Backing core: `getApprovalMode()` `configBaseCore.ts:463`; `setApprovalMode()` `config.ts:401` (THROWS on untrusted folder, `:404`). No `Agent.getApprovalMode`/`setApprovalMode`. | CLI would need `agent.getConfig().setApprovalMode()` — a deep escape hatch, and must preserve the untrusted-folder throw. |
+| **G2 Policy inspection** | `/policies` reaches `config.getPolicyEngine()` then `getRules()`/`getDefaultDecision()`/`isNonInteractive()`, and reads `rule.argsPattern.source` (`policiesCommand.ts:60-61,110-111,125,128`). Backing: `getPolicyEngine()` `configBaseCore.ts:475`; `PolicyEngine.getRules():320`/`getDefaultDecision():329`/`isNonInteractive():338` (`packages/policy/src/policy-engine.ts`). No `Agent.policy`. | CLI would deep-import the policy engine through `getConfig()`. |
+| **G3 Async tasks** | `/task` drives `getAllTasks()` (`tasksCommand.ts:80,117`), `getTask()` (`:189`), `getTaskByPrefix()` (`:193`), `cancelTask()` (`:236`); ESC-cancel drives `getRunningTasks().forEach(cancelTask)` (`useGeminiStreamOrchestration.ts`). Backing: `Config.getAsyncTaskManager(): AsyncTaskManager \| undefined` (`config.ts:601`; abstract `configBase.ts:33`). No `Agent.tasks`. | Full `/task` surface + ESC-cancel would all go through `getConfig()`. |
+| **G4 Hooks administration** | `/hooks` drives `config.getHookSystem()` (`hooksCommand.ts:31,74,144,211,279`), `getDisabledHooks()` (`:107,177`), `setDisabledHooks()` (`:111,180,239`). Backing: `getHookSystem()` `config.ts:755`; `getDisabledHooks()` `config.ts:734`; `setDisabledHooks()` `configBase.ts:132`. Current `AgentHookControl` (`agent.ts:314-321`) only has execution/lifecycle (`onHookExecution`/`triggerSessionStart`/`triggerSessionEnd`/`clear`) — NO registry/enable-disable admin. | Hook admin would deep-import the hook system through `getConfig()`. |
+| **G5 (A) Detailed OAuth state** | `/auth` needs token expiry `peekStoredToken()` (`authCommand.ts`), higher-priority warning `getHigherPriorityAuth()`, bucket status `getAuthStatusWithBuckets()`. Backing OAuthManager: `peekStoredToken():243`/`getHigherPriorityAuth():313`/`getAuthStatusWithBuckets():395`/`isOAuthEnabled():300`/`isAuthenticated():199` (`packages/providers/src/auth/oauth-manager.ts`). Current `AgentAuthControl.status()` is per-agent state, not OAuthManager token metadata. | Detailed `/auth` UX would reach the OAuthManager outside the Agent surface. |
+| **G6 (B) MCP OAuth + deep detail** | Real flow `mcpAuth.ts:82 performMcpOAuth` → `MCPOAuthProvider.authenticate():108` → `mcpClientManager.restartServer():132` → `agentClient.setTools():136`. `Agent.mcp.auth()` only reports a per-agent flag (`mcpControl.ts:199-205`); `Agent.mcp.refresh()` restarts but does NOT re-publish tools (`mcpControl.ts:236-245`) whereas `/mcp refresh` calls `setTools()`. Deep `/mcp list desc/schema` reads tool/prompt/resource registries. | MCP OAuth + post-auth tool refresh + deep detail have no public equivalent. |
+| **G7 (C) Built-in tool-key storage** | `/toolkey` + `/toolkeyfile` directly `new ToolKeyStorage()` and call `getKey`/`saveKey`/`deleteKey`/`getKeyfilePath`/`setKeyfilePath`/`clearKeyfilePath` (`toolkeyCommand.ts`, `toolkeyfileCommand.ts`). Backing: `ToolKeyStorage` (`tool-key-storage.ts:109`, methods `saveKey:280`/`getKey:299`/`deleteKey:314`/`getKeyfilePath:248`/`setKeyfilePath:241`/`clearKeyfilePath:254`); helpers `getSupportedToolNames`/`maskKeyForDisplay`/`getToolKeyEntry`/`isValidToolKeyName` (`@vybestack/llxprt-code-tools`, re-exported core `index.ts:472-475`). `Agent.tools` has no `keys`; `Agent.auth.keys` is provider-auth keys (a different concern). | Built-in tool-key management has no public equivalent. |
+
+> The shipped event model and the turn-drive/tool-execution/settings/history/compression/profiles
+> path are SUFFICIENT and are NOT re-planned. This plan adds ONLY the seven gap surfaces above plus
+> their public projected types, barrel re-exports, and `COMMAND_API_MAP` registrations.
+
+### Two issue claims corrected by ground-truthing (recorded so the plan is accurate)
+
+1. **`mcpAuth.ts` EXISTS.** The issue body says "the real MCP OAuth flow lives in
+   `mcpCommand.ts:679-714`, not a separate `mcpAuth.ts`." Ground truth: `mcpAuth.ts` is present at
+   `packages/cli/src/ui/commands/mcpAuth.ts` and contains `listOAuthServers:49` + `performMcpOAuth:82`
+   (which calls `MCPOAuthProvider.authenticate:108`, `restartServer:132`, `setTools:136`). The
+   substance (the real OAuth flow shape) is correct; the file claim is not. This plan cites
+   `mcpAuth.ts`.
+2. **Item A needs NO new plumbing.** `OAuthManager` is ALREADY on `AgentDeps`
+   (`agentImpl.ts:121 readonly oauthManager: OAuthManager`, imported `:25`). `buildAuthControl()`
+   (`agentImpl.ts:431`) can thread `this.deps.oauthManager` into the auth control with zero new
+   constructor wiring — only an added closure on the existing deps object.
+
+---
+
+## Architectural Decisions
+
+- **Pattern: Facade + Adapter, additive sub-controllers.** Every new capability follows the EXISTING
+  convention with NO new patterns introduced:
+  1. Declare the interface in `packages/agents/src/api/agent.ts` (alongside `AgentToolControl`,
+     `AgentMcpControl`, `AgentAuthControl`, `AgentHookControl` at `:223-321`).
+  2. Implement in `packages/agents/src/api/control/<name>Control.ts` (mirrors `control/mcpControl.ts`,
+     `control/authControl.ts`).
+  3. Wire into `AgentImpl`: add `readonly <name>: <Name>Control` near `agentImpl.ts:194-200`;
+     instantiate in the constructor near `:328-332` (alongside `auth`/`mcp`/`ide`/`session`/`hooks`),
+     via a `private build<Name>Control()` near `:431-510`.
+  - Top-level capabilities with no sub-state (approval mode) become direct top-level `Agent` methods
+    mirroring the ephemeral-settings one-liners (`agentImpl.ts:726-738`).
+- **Non-breaking is a HARD CONSTRAINT (REQ-009).** Additive only. The shipped
+  `createAgent(AgentConfig)` / `fromConfig(Config)` signatures, every current public export, every
+  current `./internals.js` / `./app-service.js` export keep working unchanged. Backed by a
+  characterization test extended BEFORE/ALONGSIDE the new surface (the existing
+  `publicSurface.nonbreaking.test.ts`).
+- **Delegate, never cache.** Each controller resolves through `this.deps.config.<getter>()` (or the
+  injected closure over the live Config/OAuthManager) PER CALL — mirroring `getConfig`/`getRuntimeId`
+  (`agentImpl.ts:716-723`). No cached engine state in any controller. Every controller is
+  **undefined-safe** for its backing manager (async-task manager / hook system / MCP manager can all
+  be absent — mirror the idle/empty/no-op idiom at `mcpControl.ts:121-124,216-219,236-239`).
+- **Project public types; omit non-serializable internals.** New public types are PROJECTED views
+  that omit non-serializable / unsafe internals: `AgentTaskInfo` omits `abortController`
+  (`asyncTaskManager.ts:28`); `PolicyRuleView` projects `argsPattern: RegExp` to its `.source` string
+  (the CLI already consumes `.source`, `policiesCommand.ts:111`); auth/tool-key views expose MASKED
+  metadata only — NEVER raw token strings or raw secret values.
+- **Type-safety: zero-assertion.** New re-exports use `export` for VALUES (enums/classes/functions)
+  and `export type` for interfaces/type-aliases, matching `verbatimModuleSyntax` and the
+  `AgentClientContract` type-only precedent (`api/index.ts:20`). No `any`, no unsafe `as`.
+- **Comment discipline (N5).** Production code carries ONLY `@plan` / `@requirement` / `@pseudocode`
+  marker blocks — no explanatory prose comments.
+
+---
+
+## Project Structure
+
+> **Reconciliation note:** This plan UPDATES existing files; it does NOT create `*V2`/`*New`/parallel
+> surfaces. New files are permitted ONLY where they are a NET-NEW entrypoint that the existing
+> convention demands — i.e. one `control/<name>Control.ts` per genuinely new sub-controller (policy,
+> tasks, tool-keys), exactly as #1594 added one file per controller. Capabilities that EXTEND an
+> existing controller (hooks-admin, auth-detail, mcp-oauth) MODIFY that controller's existing file.
+
+```
+packages/agents/src/api/
+  agent.ts                       MODIFY  add AgentPolicyControl, AgentTasksControl,
+                                         AgentToolKeysControl interfaces; extend AgentHookControl,
+                                         AgentAuthControl, AgentMcpControl, AgentToolControl;
+                                         add getApprovalMode/setApprovalMode + readonly policy/tasks
+                                         on Agent; add projected public types
+  agentImpl.ts                   MODIFY  add readonly policy/tasks fields; getApprovalMode/
+                                         setApprovalMode delegations; build<Name>Control() builders;
+                                         thread oauthManager into buildAuthControl
+  index.ts                       MODIFY  re-export new projected public types + any new VALUE
+                                         (none expected; enums already re-exported by core barrel)
+  control/
+    policyControl.ts             CREATE  AgentPolicyControl impl (read-only snapshots)
+    tasksControl.ts              CREATE  AgentTasksControl impl (undefined-safe)
+    toolKeysControl.ts           CREATE  AgentToolKeysControl impl (masked)
+    hooks.ts                     MODIFY  extend HookControl with admin (list/disabled get-set/enable-disable)
+    authControl.ts               MODIFY  add detailedStatus/getHigherPriorityAuth/listBucketStatuses
+    mcpControl.ts                MODIFY  add authenticate(server) (real OAuth) + details(opts);
+                                         refresh() setTools parity
+  __tests__/
+    agent.approvalMode.behavior.test.ts        CREATE
+    policyControl.behavior.test.ts             CREATE
+    tasksControl.behavior.test.ts              CREATE
+    hooksAdmin.behavior.test.ts                CREATE
+    authDetail.behavior.test.ts                CREATE
+    mcpOAuth.behavior.test.ts                  CREATE
+    toolKeysControl.behavior.test.ts           CREATE
+    capabilityGaps.integration.spec.ts         CREATE  (public-root-only; the #1595 adequacy driver)
+    publicSurface.nonbreaking.test.ts          MODIFY  assert new methods present + nothing removed
+app-services/
+  command-api-map.ts             MODIFY  register /approval-mode, /policies, /task, /hooks,
+                                         /toolkey, /toolkeyfile (kind: runtime)
+docs/
+  agent-api.md                   MODIFY  document the new surfaces (REQ-010)
+```
+
+CONFIRM (read-only, NOT modified): `packages/core/**`, `packages/providers/**`, `packages/policy/**`,
+`packages/cli/**`.
+
+---
+
+## Technical Environment
+
+- Type: TypeScript monorepo (npm workspaces), ESM, `verbatimModuleSyntax`, `noUnusedLocals`.
+- Runtime: Node ≥ 20.
+- Test: Vitest (`agents` package `test` script = `vitest run`). Single-file: `npx vitest run <file>`.
+- Property testing: `fast-check` ^4.2.0 (devDep present). Schema: `zod` ^3.25.76.
+- Mutation: Stryker (`@stryker-mutator/core` ^9.6.1 + `@stryker-mutator/vitest-runner`) via
+  `packages/agents/stryker.conf.json` (`mutate: ["src/api/**/*.ts", ...exclusions]`) — new
+  `control/*.ts` files are auto-included in the mutation set.
+- Dependencies available to `packages/agents` (verified `package.json:42-45`):
+  `@vybestack/llxprt-code-core`, `@vybestack/llxprt-code-policy`, `@vybestack/llxprt-code-providers`.
+- Boundary guard: `api/__tests__/boundary.spec.ts` (T17) scans ONLY `*.spec.ts`. Behavioral
+  `*.spec.ts` on the public-consumer path may import ONLY the public root
+  `@vybestack/llxprt-code-agents` (+ `node:`/`vitest`/`fast-check`/relative-within-src). `*.test.ts`
+  is T17-exempt (may use `./internals.js` / reference-drive). The new public-adequacy driver is a
+  `.spec.ts` importing ONLY the public root.
+
+---
+
+## Integration Points (MANDATORY SECTION)
+
+### Existing Code That Will Use This Feature
+
+- **#1595 CLI refactor (the consumer).** After this plan, #1595 rewires these CLI call sites to the
+  new Agent surface instead of `core.Config`:
+  - `packages/cli/src/ui/hooks/useAutoAcceptIndicator.ts` → `agent.getApprovalMode()` /
+    `agent.setApprovalMode()`.
+  - `packages/cli/src/ui/commands/policiesCommand.ts` → `agent.policy.getRules()` /
+    `getDefaultDecision()` / `isNonInteractive()`.
+  - `packages/cli/src/ui/commands/tasksCommand.ts` + `useGeminiStreamOrchestration.ts` →
+    `agent.tasks.list()` / `listRunning()` / `get()` / `cancel()` / `cancelAllRunning()`.
+  - `packages/cli/src/ui/commands/hooksCommand.ts` → `agent.hooks.listHooks()` /
+    `getDisabledHooks()` / `setDisabledHooks()` / `enable()` / `disable()`.
+  - `packages/cli/src/ui/commands/authCommand.ts` → `agent.auth.detailedStatus()` /
+    `getHigherPriorityAuth()` / `listBucketStatuses()`.
+  - `packages/cli/src/ui/commands/mcpAuth.ts` + `mcpCommand.ts` → `agent.mcp.authenticate()` /
+    `agent.mcp.details()` / `agent.mcp.refresh()`.
+  - `packages/cli/src/ui/commands/toolkeyCommand.ts` + `toolkeyfileCommand.ts` →
+    `agent.tools.keys.*`.
+- **`COMMAND_API_MAP`** (`app-services/command-api-map.ts`) — the machine-checkable registry #1595
+  uses to know each slash command's API backing. New `runtime`-kind rows for the six commands.
+
+### Existing Code To Be Replaced/Removed
+
+- NONE in this plan. The CLI deep-import call sites above are replaced by #1595, NOT here. This plan
+  only makes the replacement POSSIBLE by providing the public surface. No production code is removed.
+
+### User Access Points
+
+- Public package root `@vybestack/llxprt-code-agents`: `agent.getApprovalMode()`,
+  `agent.setApprovalMode()`, `agent.policy.*`, `agent.tasks.*`, `agent.hooks.*` (admin),
+  `agent.auth.*` (detail), `agent.mcp.*` (oauth/details), `agent.tools.keys.*`, and the new projected
+  public types.
+- No CLI-visible behavior change ships in this plan (the CLI still uses its current code until #1595).
+
+### Migration Requirements
+
+- Additive: existing consumers of `@vybestack/llxprt-code-agents` require NO migration. The
+  `publicSurface.nonbreaking.test.ts` guard proves every #1594-era export is unchanged.
+- The new projected types are NEW names; they do not shadow or rename existing exports.
+
+---
+
+## Formal Requirements
+
+### [REQ-001] Approval mode read/write on `Agent`
+
+**Full Text**: `Agent` MUST expose `getApprovalMode(): ApprovalMode` and
+`setApprovalMode(mode: ApprovalMode): void` as top-level methods that delegate directly to the bound
+`Config.getApprovalMode()` (`configBaseCore.ts:463`) and `Config.setApprovalMode()` (`config.ts:401`).
+- **[REQ-001.1]** `getApprovalMode()` returns the live Config value (no caching).
+- **[REQ-001.2]** `setApprovalMode(mode)` delegates DIRECTLY — it MUST NOT normalize, swallow, or
+  catch. The untrusted-folder throw (`"Cannot enable privileged approval modes in an untrusted
+  folder."`, `config.ts:404`) MUST propagate faithfully to the caller for any non-`DEFAULT` mode in
+  an untrusted folder.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a Config whose approval mode is `AUTO_EDIT`
+- WHEN `agent.getApprovalMode()` is called
+- THEN it returns `ApprovalMode.AUTO_EDIT`
+- GIVEN a trusted folder
+- WHEN `agent.setApprovalMode(ApprovalMode.YOLO)` is called
+- THEN the bound Config's approval mode becomes `YOLO` and a subsequent `getApprovalMode()` reflects it
+- GIVEN an untrusted folder
+- WHEN `agent.setApprovalMode(ApprovalMode.YOLO)` is called
+- THEN it THROWS the untrusted-folder error (not caught/normalized)
+
+### [REQ-002] Read-only policy inspection controller
+
+**Full Text**: `Agent` MUST expose a read-only `policy: AgentPolicyControl` sub-controller that
+projects the bound `Config.getPolicyEngine()` (`configBaseCore.ts:475`).
+- **[REQ-002.1]** `getRules(): readonly PolicyRuleView[]` returns read-only SNAPSHOTS of
+  `PolicyEngine.getRules()` (`policy-engine.ts:320`), with `argsPattern` projected to its `.source`
+  string (or `undefined` when absent) so the public type is JSON-safe and never leaks a raw `RegExp`.
+- **[REQ-002.2]** `getDefaultDecision(): PolicyDecision` delegates to `getDefaultDecision()`
+  (`policy-engine.ts:329`).
+- **[REQ-002.3]** `isNonInteractive(): boolean` delegates to `isNonInteractive()`
+  (`policy-engine.ts:338`).
+- **[REQ-002.4]** Rule MUTATION is OUT OF SCOPE (no CLI write path exists). The controller is
+  read-only.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a policy engine with zero rules → `getRules()` returns `[]`; `getDefaultDecision()` returns
+  the engine default; `isNonInteractive()` returns the engine flag
+- GIVEN a rule with `argsPattern = /"command":"npm test"/` → the projected `PolicyRuleView.argsPattern`
+  equals the string `"command":"npm test"` (i.e. `rule.argsPattern.source`), NOT a `RegExp`
+- GIVEN a rule with no `argsPattern` → the projected view's `argsPattern` is `undefined`
+
+### [REQ-003] Async-task administration controller (full `/task` surface)
+
+**Full Text**: `Agent` MUST expose a `tasks: AgentTasksControl` sub-controller projecting the bound
+`Config.getAsyncTaskManager()` (`config.ts:601`, `AsyncTaskManager | undefined`), undefined-safe.
+- **[REQ-003.1]** `list(): readonly AgentTaskInfo[]` projects `getAllTasks()`
+  (`asyncTaskManager.ts:77`).
+- **[REQ-003.2]** `listRunning(): readonly AgentTaskInfo[]` projects `getRunningTasks()`
+  (`asyncTaskManager.ts:319`).
+- **[REQ-003.3]** `get(id): AgentTaskInfo | undefined` projects `getTask(id)`
+  (`asyncTaskManager.ts:273`).
+- **[REQ-003.4]** `cancel(id): boolean` delegates to `cancelTask(id)` (`asyncTaskManager.ts:239`,
+  idempotent boolean).
+- **[REQ-003.5]** `cancelAllRunning(): number` cancels every running task (iterate `getRunningTasks()`
+  → `cancelTask()`) and returns the COUNT cancelled (better than `void` for behavioral assertions —
+  core has no native `cancelAllRunning`).
+- **[REQ-003.6]** When the async-task manager is `undefined`, every method is a SAFE no-op:
+  `list()`/`listRunning()` → `[]`; `get()` → `undefined`; `cancel()` → `false`;
+  `cancelAllRunning()` → `0`.
+- **[REQ-003.7]** The public `AgentTaskInfo` projection MUST OMIT `abortController`
+  (`asyncTaskManager.ts:28`) and any other non-serializable internal.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a manager with 3 tasks (2 running, 1 completed) → `list()` has length 3; `listRunning()` has
+  length 2; `cancelAllRunning()` returns 2 and a subsequent `listRunning()` is empty
+- GIVEN `get("known-id")` → returns that task projected (no `abortController` key); `get("missing")`
+  → `undefined`
+- GIVEN `cancel("known")` → `true`; `cancel("missing")` → `false`
+- GIVEN `getAsyncTaskManager()` returns `undefined` → all methods no-op per REQ-003.6
+
+### [REQ-004] Hooks administration (extend `AgentHookControl`)
+
+**Full Text**: `AgentHookControl` MUST be EXTENDED with registry inspection + enable/disable
+administration (distinct from its existing execution/lifecycle surface at `agent.ts:314-321`),
+undefined-safe when there is no hook system (`Config.getHookSystem()`, `config.ts:755`, nullable).
+- **[REQ-004.1]** `listHooks(): readonly HookInfo[]` snapshots the registry
+  (`HookSystem.getRegistry().getAllHooks()`, `hookRegistry.ts:82`; each entry's name via
+  `getHookName()`, `hookRegistry.ts:118`; `enabled` flag from `HookRegistryEntry.enabled`,
+  `hookRegistry.ts:41`).
+- **[REQ-004.2]** `getDisabledHooks(): readonly string[]` delegates to `Config.getDisabledHooks()`
+  (`config.ts:734`).
+- **[REQ-004.3]** `setDisabledHooks(names: readonly string[]): void` delegates to
+  `Config.setDisabledHooks()` (`configBase.ts:132`).
+- **[REQ-004.4]** Convenience `enable(name)` / `disable(name)` over the disabled-set (compute the new
+  disabled array and call `setDisabledHooks`) — exact `/hooks enable|disable` semantics
+  (`hooksCommand.ts:107-111,177-180`).
+- **[REQ-004.5]** When `getHookSystem()` is `undefined`, `listHooks()` → `[]`; the disabled-set
+  get/set still delegate to Config (which owns the disabled list independent of an initialized
+  system).
+- **[REQ-004.6]** The existing `AgentHookControl` methods (`onHookExecution`/`triggerSessionStart`/
+  `triggerSessionEnd`/`clear`) MUST remain unchanged (non-breaking).
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a hook system with hooks `[a (enabled), b (disabled)]` → `listHooks()` returns both with
+  correct names + `enabled` flags
+- GIVEN `setDisabledHooks(["a"])` then `getDisabledHooks()` → returns `["a"]` (round-trip)
+- GIVEN `disable("b")` when disabled is `["a"]` → disabled becomes `["a","b"]`; `enable("a")` →
+  disabled becomes `["b"]`
+- GIVEN `getHookSystem()` is `undefined` → `listHooks()` returns `[]` (no throw)
+
+### [REQ-005] (Item A) Detailed OAuth state (extend `Agent.auth`)
+
+**Full Text**: `AgentAuthControl` MUST be EXTENDED with sanitized OAuth metadata methods backed by
+the OAuthManager ALREADY available on `AgentDeps` (`agentImpl.ts:121`), threaded into the auth
+control via the existing `buildAuthControl()` builder (`agentImpl.ts:431`). NO raw token strings are
+ever exposed.
+- **[REQ-005.1]** `detailedStatus(provider): Promise<AuthProviderDetail>` — authenticated flag
+  (`isAuthenticated()`, `oauth-manager.ts:199`), OAuth-enabled flag (`isOAuthEnabled()`, `:300`),
+  token expiry (from `peekStoredToken()`, `:243` — expiry timestamp ONLY, never the token string).
+- **[REQ-005.2]** `getHigherPriorityAuth(provider): Promise<string | null>` delegates to
+  `getHigherPriorityAuth()` (`oauth-manager.ts:313`).
+- **[REQ-005.3]** `listBucketStatuses(provider): Promise<readonly AuthBucketStatus[]>` projects
+  `getAuthStatusWithBuckets()` (`oauth-manager.ts:395`) to `{ bucket, authenticated, expiry?,
+  isSessionBucket }` — masked metadata, never token strings.
+- **[REQ-005.4]** The existing `AgentAuthControl` methods remain unchanged (non-breaking).
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN an authenticated provider with a token expiring at epoch T → `detailedStatus()` returns
+  `{ authenticated: true, oauthEnabled: <flag>, expiry: T }` and NO field contains the raw token
+- GIVEN a provider shadowed by a higher-priority auth → `getHigherPriorityAuth()` returns that
+  source name; otherwise `null`
+- GIVEN two buckets → `listBucketStatuses()` returns one entry each, with `isSessionBucket` set
+  correctly and no token strings present
+
+### [REQ-006] (Item B) MCP OAuth + deep detail + refresh parity (extend `Agent.mcp`)
+
+**Full Text**: `AgentMcpControl` MUST be EXTENDED to cover the real MCP OAuth flow and deep detail,
+and `refresh()` MUST achieve tool-declaration parity with the CLI.
+- **[REQ-006.1]** `authenticate(server): Promise<McpServerAuthStatus>` performs the REAL OAuth flow
+  mirroring `mcpAuth.ts:82 performMcpOAuth`: `MCPOAuthProvider.authenticate()` (`mcpAuth.ts:108`) →
+  `manager.restartServer(server)` (`:132`) → re-publish tools (`agentClient.setTools()`, `:136`) →
+  return the resulting auth status. (`MCPOAuthProvider` is re-exported from the core barrel
+  `index.ts:498` — no new dependency.)
+- **[REQ-006.2]** `refresh(server?)` MUST re-publish tool declarations after restart (setTools
+  parity) — closing the confirmed gap where `mcpControl.ts:236-245` restarts but never calls
+  `setTools()`, whereas `/mcp refresh` does.
+- **[REQ-006.3]** `details(opts?: { includeTools?; includePrompts?; includeResources?;
+  includeSchemas? }): Promise<McpDetailStatus>` projects deep registry detail (tools/prompts/
+  resources/schemas) for the migrated `/mcp list desc|schema` views.
+- **[REQ-006.4]** All methods undefined-safe when the MCP manager is absent (idle/empty/no-op idiom,
+  `mcpControl.ts:121-124`).
+- **[REQ-006.5]** The existing `AgentMcpControl` methods (`listServers`/`status`/`toolsByServer`/
+  `auth`/`discoveryState`) remain unchanged in signature (non-breaking); `auth()` retains its
+  per-agent flag semantics and the NEW real flow is `authenticate()`.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a server requiring OAuth → `authenticate(server)` runs the provider auth, restarts the
+  server, re-publishes tools, and returns an authenticated status
+- GIVEN a refresh → after `refresh(server?)`, the agent client's tools are re-published (parity with
+  `/mcp refresh`)
+- GIVEN `details({ includeTools: true })` → returns the tool detail for configured servers
+- GIVEN no MCP manager → `authenticate()`/`details()`/`refresh()` no-op safely
+
+### [REQ-007] (Item C) Built-in tool-key storage (`Agent.tools.keys`)
+
+**Full Text**: `AgentToolControl` MUST be EXTENDED with a `keys: AgentToolKeysControl` sub-controller
+for built-in tool-key storage, backed by `ToolKeyStorage` (`tool-key-storage.ts:109`) and the tool
+registry helpers (`getSupportedToolNames`/`getToolKeyEntry`/`isValidToolKeyName`/`maskKeyForDisplay`,
+core barrel `index.ts:472-475`). MASKED metadata only — raw secret values are NEVER returned.
+- **[REQ-007.1]** `supported(): readonly ToolKeyInfo[]` lists tool-key-capable tools
+  (`getSupportedToolNames()` + `getToolKeyEntry()`).
+- **[REQ-007.2]** `status(toolName): Promise<ToolKeyStatus>` returns whether a key/keyfile is set,
+  with the key MASKED (`maskKeyForDisplay()`, `index.ts:475`) — never the raw value.
+- **[REQ-007.3]** `save(toolName, key): Promise<void>` → `ToolKeyStorage.saveKey()`
+  (`tool-key-storage.ts:280`); validates the name (`isValidToolKeyName()`).
+- **[REQ-007.4]** `delete(toolName): Promise<void>` → `deleteKey()` (`tool-key-storage.ts:314`).
+- **[REQ-007.5]** `setKeyFile(toolName, path | null): Promise<void>` → `setKeyfilePath()` /
+  `clearKeyfilePath()` (`tool-key-storage.ts:241,254`).
+- **[REQ-007.6]** `getKeyFile(toolName): Promise<string | null>` → `getKeyfilePath()`
+  (`tool-key-storage.ts:248`).
+- **[REQ-007.7]** CLI-side path expansion / existence / non-empty validation stays UI-level
+  prevalidation (remains in the CLI), NOT in the Agent API. `Agent.auth.keys` (provider-auth) is
+  untouched and distinct.
+
+**Behavior (GIVEN/WHEN/THEN)**:
+- GIVEN a supported tool with no key → `status(tool)` reports not-set; after `save(tool, "secret")`,
+  `status(tool)` reports set with a MASKED value (raw `"secret"` never returned)
+- GIVEN `setKeyFile(tool, "/p")` then `getKeyFile(tool)` → `"/p"`; `setKeyFile(tool, null)` then
+  `getKeyFile(tool)` → `null`
+- GIVEN an invalid tool name → `save()` rejects (validation), no silent write
+
+### [REQ-008] Public barrel re-exports + `COMMAND_API_MAP` registration
+
+**Full Text**: All new PROJECTED public types MUST be re-exported from the agents api barrel
+(`packages/agents/src/api/index.ts`), type-only where they are types (matching the
+`AgentClientContract` precedent `index.ts:20`); and the six migrated commands MUST be registered in
+`COMMAND_API_MAP` (`app-services/command-api-map.ts`).
+- **[REQ-008.1]** Re-export `PolicyRuleView`, `AgentTaskInfo`, `HookInfo`, `AuthProviderDetail`,
+  `AuthBucketStatus`, `McpDetailStatus`, `ToolKeyInfo`, `ToolKeyStatus` (projected types), plus any
+  enums needed by consumers that are NOT already surfaced (`ApprovalMode` is already re-exported as a
+  type at `agent.ts:387`; `PolicyDecision` is a VALUE enum re-exported from the core barrel —
+  surface it for consumers if not already reachable).
+- **[REQ-008.2]** Add `COMMAND_API_MAP` rows (kind `runtime`) for `/approval-mode`, `/policies`,
+  `/task`, `/hooks`, `/toolkey`, `/toolkeyfile`. The map's boundary test
+  (`app-service-boundary.spec.ts`) MUST stay green (no orphan, unique names, durable entries
+  importable).
+
+### [REQ-009] Non-breaking guarantee
+
+**Full Text**: The change MUST be purely additive. The shipped `createAgent(AgentConfig)` /
+`fromConfig(Config)` signatures and behavior, every current public export, and every current
+`./internals.js` / `./app-service.js` export MUST keep working unchanged. No existing export is
+removed, renamed, or retyped.
+- **Behavior**: GIVEN a consumer written against the prior public surface, WHEN this plan lands,
+  THEN it compiles and behaves identically.
+- **[REQ-009.1]** The existing methods on extended controllers (`AgentHookControl`,
+  `AgentAuthControl`, `AgentMcpControl`, `AgentToolControl`) keep their exact signatures; new methods
+  are ADDED, not substituted.
+
+### [REQ-010] Documentation
+
+**Full Text**: `docs/agent-api.md` MUST document the new surfaces: approval mode, `policy`, `tasks`,
+hooks-admin, auth-detail, MCP OAuth/details, and `tools.keys`, with the masked/projected-type
+contract and the undefined-safe semantics.
+
+---
+
+### Integration Requirements
+
+> Acceptance-interpretation note: the integration requirements are the EXECUTABLE form of the #1595
+> adequacy criterion. Each is satisfied by a behavioral test on the PUBLIC-ROOT-ONLY path
+> (`capabilityGaps.integration.spec.ts`), driving a real `fromConfig`-built Agent — NOT a mock.
+
+### [REQ-INT-001] Approval-mode CLI parity
+The value read/written through `agent.getApprovalMode()` / `setApprovalMode()` is identical to what
+the CLI's current `useAutoAcceptIndicator` direct `Config` calls would observe, INCLUDING the
+untrusted-folder throw (REQ-001.2).
+
+### [REQ-INT-002] Policy + async-task CLI parity
+`agent.policy.*` returns the same rules/default/non-interactive the `/policies` command renders today
+(with `argsPattern` as `.source`); `agent.tasks.*` covers the full `/task` surface
+(list/listRunning/get/cancel/cancelAllRunning) the CLI drives today.
+
+### [REQ-INT-003] Hooks-admin + auth-detail CLI parity
+`agent.hooks.listHooks()/getDisabledHooks()/setDisabledHooks()/enable()/disable()` round-trips
+exactly as `/hooks` does; `agent.auth.detailedStatus()/getHigherPriorityAuth()/listBucketStatuses()`
+exposes the same masked metadata the `/auth` UX needs (no raw tokens).
+
+### [REQ-INT-004] MCP-OAuth + tool-keys CLI parity
+`agent.mcp.authenticate()/refresh()/details()` matches the `mcpAuth.ts`/`/mcp` flow including
+post-auth `setTools()` parity; `agent.tools.keys.*` matches `/toolkey`+`/toolkeyfile` (masked).
+
+### [REQ-INT-005] No-deep-import boundary (the #1595 mission)
+Every new capability MUST be reachable using ONLY the public root `@vybestack/llxprt-code-agents`
+(the boundary the #1595 CLI imports from). The new public-adequacy driver
+(`capabilityGaps.integration.spec.ts`) is a `.spec.ts` that imports ONLY the public root and is
+enforced by the T17 boundary guard (`boundary.spec.ts`). No new deep `/src/`/`core/src`/
+`providers/src`/`internals.js` import on the public-consumer path.
+
+---
+
+## Data Schemas
+
+New PROJECTED public types (TypeScript). Interfaces are `export type`-re-exported from the barrel.
+Zod schemas are provided for the projected DATA types that cross the public boundary as values
+(callbacks and class instances are NOT Zod-validated, per #1594 precedent).
+
+```typescript
+// Policy (REQ-002) — argsPattern projected to string (never raw RegExp)
+export interface PolicyRuleView {
+  readonly priority: number;
+  readonly toolName: string;
+  readonly decision: PolicyDecision;          // VALUE enum (core barrel)
+  readonly argsPattern?: string;              // = rule.argsPattern?.source
+  readonly source?: string;
+}
+
+// Async tasks (REQ-003) — omits abortController and other internals
+export interface AgentTaskInfo {
+  readonly id: string;
+  readonly subagentName: string;
+  readonly goalPrompt: string;
+  readonly status: 'running' | 'completed' | 'failed' | 'cancelled';  // = AsyncTaskStatus
+  readonly launchedAt: number;
+  readonly completedAt?: number;
+  readonly error?: string;
+}
+
+// Hooks admin (REQ-004)
+export interface HookInfo {
+  readonly name: string;
+  readonly eventName: string;
+  readonly enabled: boolean;
+  readonly source?: string;
+}
+
+// Auth detail (REQ-005) — masked metadata, NEVER token strings
+export interface AuthProviderDetail {
+  readonly provider: string;
+  readonly authenticated: boolean;
+  readonly oauthEnabled: boolean;
+  readonly expiry?: number;                   // epoch seconds/ms from peekStoredToken; NO token
+}
+export interface AuthBucketStatus {
+  readonly bucket: string;
+  readonly authenticated: boolean;
+  readonly expiry?: number;
+  readonly isSessionBucket: boolean;
+}
+
+// MCP detail (REQ-006)
+export interface McpDetailStatus {
+  readonly servers: readonly McpServerDetail[];
+}
+export interface McpServerDetail {
+  readonly name: string;
+  readonly authenticated: boolean;
+  readonly tools?: readonly ToolInfo[];
+  readonly prompts?: readonly string[];
+  readonly resources?: readonly string[];
+}
+// McpServerAuthStatus is the EXISTING type already returned by AgentMcpControl.auth().
+
+// Tool keys (REQ-007) — masked only
+export interface ToolKeyInfo {
+  readonly toolName: string;
+  readonly description?: string;
+}
+export interface ToolKeyStatus {
+  readonly toolName: string;
+  readonly hasKey: boolean;
+  readonly maskedKey?: string;                // maskKeyForDisplay(); NEVER raw
+  readonly keyFile?: string | null;
+}
+```
+
+```typescript
+// Zod (data types crossing the boundary as values). Callbacks/instances are NOT validated.
+import { z } from 'zod';
+
+export const AgentTaskInfoSchema = z.object({
+  id: z.string(),
+  subagentName: z.string(),
+  goalPrompt: z.string(),
+  status: z.enum(['running', 'completed', 'failed', 'cancelled']),
+  launchedAt: z.number(),
+  completedAt: z.number().optional(),
+  error: z.string().optional(),
+}).strict();   // .strict() PROVES abortController cannot leak (REQ-003.7)
+
+export const PolicyRuleViewSchema = z.object({
+  priority: z.number(),
+  toolName: z.string(),
+  decision: z.nativeEnum(PolicyDecision),
+  argsPattern: z.string().optional(),         // string, not RegExp (REQ-002.1)
+  source: z.string().optional(),
+}).strict();
+```
+
+---
+
+## Example Data
+
+```json
+{
+  "policyRuleView": {
+    "priority": 0.5,
+    "toolName": "run_shell_command",
+    "decision": "deny",
+    "argsPattern": "\"command\":\"npm test\"",
+    "source": "user-settings"
+  },
+  "agentTaskInfo": {
+    "id": "task-7f3a",
+    "subagentName": "researcher",
+    "goalPrompt": "summarize the repo",
+    "status": "running",
+    "launchedAt": 1750000000000
+  },
+  "hookInfo": { "name": "format-on-save", "eventName": "PostToolUse", "enabled": true },
+  "authProviderDetail": { "provider": "anthropic", "authenticated": true, "oauthEnabled": true, "expiry": 1750003600000 },
+  "toolKeyStatus": { "toolName": "web_search", "hasKey": true, "maskedKey": "sk-…last4", "keyFile": null }
+}
+```
+
+---
+
+## Constraints
+
+- **C-APPROVAL-THROW**: `setApprovalMode` delegates directly; the untrusted-folder throw propagates
+  (REQ-001.2). NO try/catch, NO normalization.
+- **C-NO-ABORTCONTROLLER**: `AgentTaskInfo` MUST NOT contain `abortController` (REQ-003.7);
+  `.strict()` Zod proves it.
+- **C-ARGSPATTERN-STRING**: `PolicyRuleView.argsPattern` is the `.source` STRING, never a raw
+  `RegExp` (REQ-002.1).
+- **C-NO-RAW-SECRETS**: Auth-detail and tool-key surfaces expose MASKED metadata only — never raw
+  token strings (REQ-005) or raw key values (REQ-007.2).
+- **C-UNDEFINED-SAFE**: Every controller is undefined-safe for its backing manager (async-task / hook
+  system / MCP manager / policy engine where nullable).
+- **C-DELEGATE-NO-CACHE**: Resolve through the live Config/OAuthManager per call; no cached engine
+  state.
+- **C-NON-BREAKING**: No existing export removed/renamed/retyped (REQ-009).
+- **C-NO-DEEP-IMPORT**: The public-consumer path imports only the public root (REQ-INT-005); behavioral
+  drivers are `.spec.ts` under the T17 guard.
+- **C-COMMENT-DISCIPLINE**: Production code carries only `@plan`/`@requirement`/`@pseudocode` markers.
+
+## Performance Requirements
+
+- All new methods are thin projections/delegations; no added latency beyond the underlying Config /
+  manager call. `cancelAllRunning()` is O(running tasks). `details()` is O(servers × tools) and is
+  only invoked on explicit `/mcp list desc|schema`. No polling, no background work introduced.


### PR DESCRIPTION
## Summary

Closes the bounded set of **engine-capability gaps** between the public `Agent` API (`@vybestack/llxprt-code-agents`, delivered in #1594 / PR #2108) and the capabilities the CLI currently drives directly from `core.Config`. This is a **prerequisite for #1595** (the CLI refactor to consume only the public API) and is **purely additive** — no existing public export was removed or changed.

After this PR a future thin-UI client (the #1595 CLI, or any other) can reach **every** engine capability through the public root `@vybestack/llxprt-code-agents` with **no `agent.getConfig()` escape hatch and no deep `core/src` import**.

Fixes #2143.

## What changed (the 7 gaps)

All production changes are confined to `packages/agents/` (12 files, +3990/-12).

| # | Gap | Surface added | Key constraint honored |
|---|-----|---------------|------------------------|
| G1 | **Approval mode** | top-level `agent.getApprovalMode()` / `agent.setApprovalMode(mode)` | `setApprovalMode` **delegates directly** (no try/catch) so the untrusted-folder throw propagates faithfully |
| G2 | **Policy inspection** | `agent.policy.{getRules, getDefaultDecision, isNonInteractive}` (read-only) | `argsPattern` projected to its `.source` **string** (JSON-safe `PolicyRuleView`, never a raw `RegExp`) |
| G3 | **Async tasks** | `agent.tasks.{list, listRunning, get, cancel, cancelAllRunning}` | projected `AgentTaskInfo` **omits** `abortController`; `cancelAllRunning()` returns a count; fully undefined-safe |
| G4 | **Hooks administration** | `agent.hooks.{listHooks, getDisabledHooks, setDisabledHooks, enable, disable}` | undefined-safe when no hook system; distinct from the existing execution/lifecycle surface |
| G5 | **Detailed OAuth state** | `agent.auth.{detailedStatus, getHigherPriorityAuth, listBucketStatuses}` | **masked metadata only** (authenticated / oauthEnabled / expiry) — **never copies token secret strings** |
| G6 | **Deep MCP detail + OAuth** | `agent.mcp.{details, authenticate}` + `refresh()` setTools parity | `refresh()` now calls `refreshClientTools()` after restart (setTools parity); `authenticate()` = performOAuth → restartServer → refreshClientTools |
| G7 | **Built-in tool keys** | `agent.tools.keys.{supported, status, save, delete, setKeyFile, getKeyFile}` | **masked** (`maskKeyForDisplay`); distinct from `agent.auth.keys` (provider-auth); raw secrets never exposed |

### Barrel + command map (REQ-008)

- `packages/agents/src/api/index.ts` now exports `ApprovalMode` and `PolicyDecision` as **value** exports, plus 14 projected public types (`PolicyRuleView`, `AgentTaskInfo`, `HookInfo`, `AuthProviderDetail`, `AuthBucketStatus`, `McpServerAuthStatus`, `McpDetailStatus`, `ToolKeyInfo`, `ToolKeyStatus`, …) type-only.
- `COMMAND_API_MAP` gains 6 rows mapping the affected slash commands (`/approval-mode`, `/policies`, `/task`, `/hooks`, `/toolkey`, `/toolkeyfile`) to their public API entry points, so #1595 has a direct command-to-API index.

## Design discipline

- **Delegate, never cache.** Every new controller resolves through `this.deps.resolveClient()` / `config` per call (mirrors the existing `getRuntimeId` / `getConfig` idiom). No cached engine state.
- **Existing sub-controller convention exactly.** Interface in `agent.ts`; impl in `control/<name>Control.ts`; `readonly <name>` on `AgentImpl` wired in the constructor via a `build<Name>Control()` — identical to `auth` / `mcp` / `ide` / `session` / `hooks`.
- **Undefined-safe** for every backing manager (async-task / hook-system / MCP manager can all be absent — same idle/empty/no-op idiom as `mcpControl`).
- **Projected public types** that omit non-serializable internals (`abortController`, raw `RegExp`, token strings).

## Boundary enforcement (REQ-INT-005 — the #1595 mission)

- A standing static import-scan adequacy test (`capabilityBoundary.adequacy.test.ts`) asserts the whole new surface reaches core only through the documented `@vybestack/llxprt-code-core` barrel seam — **no new deep `core/src` / `providers/src` / `tools/src` / `policy/src` path**.
- The keystone integration driver (`capabilityGaps.integration.spec.ts`) drives **all 7 capabilities on a real harness-built `Agent`** using **only the public root**, with zero `getConfig` and zero deep imports — proving the #1595 acceptance criterion ("the CLI could be replaced by a different UI on the same core API") is satisfiable.
- The standing T17 boundary guard (`boundary.spec.ts`) polices every `.spec.ts`, so a future regression (a new deep import) is caught automatically.

## Test strategy & quality gates

- **Behavioral tests only** — no mock theater (`mockResolvedValue` / `toHaveBeenCalled` / `vi.fn` / spies), no reverse tests, no `any`. All driven through real `createAgent` / `buildAgent` over the `LLXPRT_FAKE_RESPONSES` FakeProvider seam.
- **Property-based ≥ 30%** (fast-check) on every new suite (MIN-2 cases): approvalMode 4/5, policy 4/6, tasks 6/8, hookAdmin 4/6, authDetail 4/6, mcpOAuth 8/12, toolKeys 8/13, barrel 4/6, integration 12/18, boundary 7/7.
- **Mutation ≥ 80%** (Stryker, `test:mutation:api`) on each new control file: **policyControl 100%**, **tasksControl 100%**, **toolKeysControl 91.18%** (overall agents-api 89.25%).
- **Agents API suite: 640/640** in isolation.
- **Non-breaking guard** (`additiveSurface` fence) asserts the new methods exist and **no existing export was removed or changed**.
- Full verification green: `typecheck` / `lint` / `format` / `build` all EXIT=0; ollamakimi haiku smoke EXIT=0.

## Acceptance criteria (all met)

- [x] `getApprovalMode` / `setApprovalMode` with untrusted-folder throw preserved (delegated, not caught) and tested.
- [x] read-only `policy` controller; rules as read-only snapshots with `argsPattern` JSON-safety addressed.
- [x] async-task controller covering the full `/task` surface, undefined-safe, projected `AgentTaskInfo` omits `abortController`.
- [x] `Agent.hooks` extended with registry inspection + enable/disable administration, undefined-safe.
- [x] A → `Agent.auth` detailed masked metadata; B → `Agent.mcp` OAuth `authenticate` + deep `details` + `refresh()` setTools parity; C → masked `Agent.tools.keys`.
- [x] all new methods delegate (no cached state), follow the existing control convention, undefined-safe, behavioral + ≥30% property + ≥80% mutation.
- [x] no existing public export removed or changed (non-breaking diff guard passes).
- [x] full verification suite green.

## Relationships

- **Follows:** #1594 (public Core Agent API, PR #2108).
- **Blocks / enables:** #1595 (refactor CLI to consume the core API).
