### PR TITLE
Replace deprecated Vitest timeout option syntax in auth tests (Fixes #2152)

### DIFF
--- a/packages/auth/src/__tests__/codex-device-flow.test.ts
+++ b/packages/auth/src/__tests__/codex-device-flow.test.ts
@@ -310,6 +310,7 @@ describe('CodexDeviceFlow - PKCE OAuth Flow', () => {
    */
   it(
     'should refresh token using refresh grant type with Zod validation',
+    { timeout: 10000 },
     async () => {
       const refreshToken = 'old-refresh-token';
       const mockTokenResponse = {
@@ -363,7 +364,6 @@ describe('CodexDeviceFlow - PKCE OAuth Flow', () => {
 
       global.fetch = originalFetch;
     },
-    { timeout: 10000 },
   );
 
   // NOTE: Token expiry buffer test removed per dev-docs/RULES.md


### PR DESCRIPTION
## Summary

Removes the last deprecated Vitest third-argument options-object usage in the auth package, ensuring compatibility with Vitest 4 which will reject it(name, fn, options) in favor of it(name, options, fn).

Fixes #2152

## Problem

Vitest emits the following deprecation warning in the auth test suite:

    Using an object as a third argument is deprecated. Vitest 4 will throw an
    error if the third argument is not a timeout number. Please use the second
    argument for options.

## Root Cause

The test "should refresh token using refresh grant type with Zod validation" in packages/auth/src/__tests__/codex-device-flow.test.ts passed the options object { timeout: 10000 } as the THIRD argument (after the async function body):

    it(
      "...",
      async () => { ... },
      { timeout: 10000 },   // deprecated third-argument form
    );

## Fix

Moved the options object to the supported SECOND-argument position, preserving the exact 10000ms timeout value:

    it(
      "...",
      { timeout: 10000 },   // correct second-argument form
      async () => { ... },
    );

## Scope Verification

The issue listed four inventory lines. I verified every one against the actual source, rather than relying on the issue inventory alone:

- codex-device-flow.test.ts:366 — was the deprecated third-argument form; NOW FIXED.
- qwen-device-flow.spec.ts:363, 474, 700 — already use the correct second-argument form; no change needed.

I also scanned the ENTIRE codebase (all test/spec files) for the { timeout } pattern to find similar occurrences outside auth, as the issue requested. Every other occurrence falls into one of two categories, neither of which is the deprecated it/test form:

1. Already-correct second-argument it/test usage (e.g. density-history, memoryDiscovery, prompt-service-edge-cases, chatSession-density, lsp orchestrator, AnthropicProvider tests).
2. Legitimate non-it usages where { timeout } is a real API argument, not a test options object (e.g. vi.waitFor(fn, { timeout }) and assert .toHaveBeenCalledWith(..., { timeout })).

Therefore codex-device-flow.test.ts was the only deprecated instance in the whole repo; no follow-up issues are needed.

## Verification

- npm run test (auth package): 36 files, 428 passed, 2 skipped — and NO "deprecated" warning in output.
- npm run lint (auth): passes.
- npm run typecheck (auth): passes.
- prettier --check on changed file: clean.
- npm run build (full project): succeeds.
- Smoke test (node scripts/start.js --profile-load ollamakimi): produces expected output.

## Acceptance Criteria

- [x] Auth tests no longer use the deprecated Vitest third-argument options object form.
- [x] Timeout options are preserved by moving them to the supported second-argument options position (value unchanged: 10000ms).
- [x] The relevant auth tests pass without the Vitest deprecation warning.
- [x] Verification run for the touched scope (auth tests + lint/typecheck/format/build).