### PR TITLE
Detect actual image format from magic bytes for Anthropic (Fixes #2130)

### DIFF
--- a/packages/providers/src/anthropic/AnthropicMessageNormalizer.ts
+++ b/packages/providers/src/anthropic/AnthropicMessageNormalizer.ts
@@ -26,6 +26,7 @@ import { buildToolResponsePayload } from '../utils/toolResponsePayload.js';
 import {
   classifyMediaBlock,
   buildUnsupportedMediaPlaceholder,
+  detectImageMimeTypeFromBase64,
 } from '../utils/mediaUtils.js';
 import {
   validateToolResults,
@@ -98,11 +99,14 @@ export function mediaBlockToAnthropicImage(
       ? media.data.split(';base64,')[1]
       : media.data;
 
+  const detected = detectImageMimeTypeFromBase64(rawData);
+  const media_type = detected ?? (media.mimeType || 'image/png');
+
   return {
     type: 'image',
     source: {
       type: 'base64',
-      media_type: media.mimeType || 'image/png',
+      media_type,
       data: rawData,
     },
   };

--- a/packages/providers/src/anthropic/AnthropicProvider.mediaBlock.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.mediaBlock.test.ts
@@ -351,6 +351,137 @@ describe('AnthropicProvider MediaBlock support', () => {
     });
   });
 
+  it('should correct mismatched declared MIME type to actual format detected from image bytes (issue #2130)', async () => {
+    mockMessagesCreate.mockResolvedValue(createMockStream('I see the image'));
+
+    const pngBytesDeclaredAsJpeg = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52,
+    ]).toString('base64');
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          { type: 'text', text: 'Describe this image' },
+          {
+            type: 'media',
+            mimeType: 'image/jpeg',
+            data: pngBytesDeclaredAsJpeg,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    const generator = provider.generateChatCompletion(
+      buildCallOptions(messages),
+    );
+    for await (const _chunk of generator) {
+      // consume
+    }
+
+    const request = mockMessagesCreate.mock.calls[0][0];
+    const anthropicMessages = request.messages as AnthropicMessage[];
+    const userMsg = anthropicMessages.find((m) => m.role === 'user');
+    const contentArray = userMsg!.content as AnthropicContentBlock[];
+
+    const imageBlock = contentArray.find(
+      (b) => b.type === 'image',
+    ) as AnthropicImageBlock;
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock.source).toStrictEqual({
+      type: 'base64',
+      media_type: 'image/png',
+      data: pngBytesDeclaredAsJpeg,
+    });
+  });
+
+  it('should correct mismatched declared MIME type inside tool_result images (issue #2130)', async () => {
+    mockMessagesCreate.mockResolvedValue(createMockStream('I see the image'));
+
+    const pngBytesDeclaredAsJpeg = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52,
+    ]).toString('base64');
+
+    const toolCallId = 'hist_tool_readfile_2130';
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Read that image' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: toolCallId,
+            name: 'read_file',
+            parameters: { path: 'photo.jpg' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: toolCallId,
+            toolName: 'read_file',
+            result: { output: 'Binary content provided (1 item(s)).' },
+          },
+          {
+            type: 'media',
+            mimeType: 'image/jpeg',
+            data: pngBytesDeclaredAsJpeg,
+            encoding: 'base64' as const,
+          },
+        ],
+      },
+    ];
+
+    const generator = provider.generateChatCompletion(
+      buildCallOptions(messages),
+    );
+    for await (const _chunk of generator) {
+      // consume
+    }
+
+    const request = mockMessagesCreate.mock.calls[0][0];
+    const anthropicMessages = request.messages as AnthropicMessage[];
+
+    const toolResultMsg = anthropicMessages.find(
+      (msg) =>
+        msg.role === 'user' &&
+        Array.isArray(msg.content) &&
+        msg.content.some((b) => b.type === 'tool_result'),
+    );
+    expect(toolResultMsg).toBeDefined();
+
+    const toolResultBlock = (
+      toolResultMsg!.content as AnthropicContentBlock[]
+    ).find((b) => b.type === 'tool_result') as AnthropicContentBlock & {
+      type: 'tool_result';
+    };
+    expect(toolResultBlock).toBeDefined();
+    expect(Array.isArray(toolResultBlock.content)).toBe(true);
+
+    const contentParts = toolResultBlock.content as Array<
+      | { type: 'text'; text: string }
+      | AnthropicImageBlock
+      | AnthropicDocumentBlock
+    >;
+    const imagePart = contentParts.find(
+      (p) => p.type === 'image',
+    ) as AnthropicImageBlock;
+    expect(imagePart).toBeDefined();
+    expect(imagePart.source).toStrictEqual({
+      type: 'base64',
+      media_type: 'image/png',
+      data: pngBytesDeclaredAsJpeg,
+    });
+  });
   it('should use url source type for URL-encoded media', async () => {
     mockMessagesCreate.mockResolvedValue(createMockStream('OK'));
 

--- a/packages/providers/src/utils/mediaUtils.test.ts
+++ b/packages/providers/src/utils/mediaUtils.test.ts
@@ -19,6 +19,7 @@ import {
   normalizeMediaToDataUri,
   classifyMediaBlock,
   buildUnsupportedMediaPlaceholder,
+  detectImageMimeTypeFromBase64,
 } from './mediaUtils.js';
 import type { MediaBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 
@@ -239,5 +240,101 @@ describe('buildUnsupportedMediaPlaceholder', () => {
     const result = buildUnsupportedMediaPlaceholder(media, 'Test');
     expect(result).toContain('media');
     expect(result).toContain('application/octet-stream');
+  });
+
+  describe('detectImageMimeTypeFromBase64', () => {
+    it('returns image/png for PNG magic bytes', () => {
+      const pngBase64 = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00,
+      ]).toString('base64');
+      expect(detectImageMimeTypeFromBase64(pngBase64)).toBe('image/png');
+    });
+
+    it('returns image/jpeg for JPEG magic bytes', () => {
+      const jpegBase64 = Buffer.from([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+      ]).toString('base64');
+      expect(detectImageMimeTypeFromBase64(jpegBase64)).toBe('image/jpeg');
+    });
+
+    it('returns image/gif for GIF magic bytes', () => {
+      const gifBase64 = Buffer.from([
+        0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00,
+      ]).toString('base64');
+      expect(detectImageMimeTypeFromBase64(gifBase64)).toBe('image/gif');
+    });
+
+    it('returns image/webp for WEBP magic bytes (RIFF....WEBP)', () => {
+      const webpBase64 = Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ]).toString('base64');
+      expect(detectImageMimeTypeFromBase64(webpBase64)).toBe('image/webp');
+    });
+
+    it('returns null for non-image data (PDF magic bytes)', () => {
+      const pdfBase64 = Buffer.from([
+        0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34,
+      ]).toString('base64');
+      expect(detectImageMimeTypeFromBase64(pdfBase64)).toBe(null);
+    });
+
+    it('returns null for empty string', () => {
+      expect(detectImageMimeTypeFromBase64('')).toBe(null);
+    });
+
+    it('returns null for whitespace-only input', () => {
+      expect(detectImageMimeTypeFromBase64('    ')).toBe(null);
+    });
+
+    it('returns null for plain text data', () => {
+      const textBase64 = Buffer.from('hello world', 'utf-8').toString('base64');
+      expect(detectImageMimeTypeFromBase64(textBase64)).toBe(null);
+    });
+
+    it('detects format correctly even with many trailing bytes (PNG)', () => {
+      const longBuffer = Buffer.concat([
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        Buffer.alloc(512, 0xab),
+      ]);
+      const longBase64 = longBuffer.toString('base64');
+      expect(detectImageMimeTypeFromBase64(longBase64)).toBe('image/png');
+    });
+
+    it('detects format correctly even with many trailing bytes (JPEG)', () => {
+      const longBuffer = Buffer.concat([
+        Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+        Buffer.alloc(512, 0xcd),
+      ]);
+      const longBase64 = longBuffer.toString('base64');
+      expect(detectImageMimeTypeFromBase64(longBase64)).toBe('image/jpeg');
+    });
+
+    it('detects wrapped/whitespace base64 by ignoring whitespace before decoding (WEBP)', () => {
+      const webpBuffer = Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ]);
+      const webpBase64 = webpBuffer.toString('base64');
+      const wrapped = `
+  ${webpBase64.slice(0, 8)}
+${webpBase64.slice(8)}
+`;
+      expect(detectImageMimeTypeFromBase64(wrapped)).toBe('image/webp');
+    });
+
+    it('corrects mismatched declared MIME: declared JPEG but actual PNG bytes detects as image/png (issue #2130)', () => {
+      const pngBytesDeclaredAsJpeg = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+        0x49, 0x48, 0x44, 0x52,
+      ]).toString('base64');
+      expect(detectImageMimeTypeFromBase64(pngBytesDeclaredAsJpeg)).toBe(
+        'image/png',
+      );
+    });
+
+    it('returns null when malformed base64 does not decode to known image bytes', () => {
+      expect(detectImageMimeTypeFromBase64('!!!not-valid-base64-!@#$')).toBe(
+        null,
+      );
+    });
   });
 });

--- a/packages/providers/src/utils/mediaUtils.test.ts
+++ b/packages/providers/src/utils/mediaUtils.test.ts
@@ -241,100 +241,100 @@ describe('buildUnsupportedMediaPlaceholder', () => {
     expect(result).toContain('media');
     expect(result).toContain('application/octet-stream');
   });
+});
 
-  describe('detectImageMimeTypeFromBase64', () => {
-    it('returns image/png for PNG magic bytes', () => {
-      const pngBase64 = Buffer.from([
-        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00,
-      ]).toString('base64');
-      expect(detectImageMimeTypeFromBase64(pngBase64)).toBe('image/png');
-    });
+describe('detectImageMimeTypeFromBase64', () => {
+  it('returns image/png for PNG magic bytes', () => {
+    const pngBase64 = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00,
+    ]).toString('base64');
+    expect(detectImageMimeTypeFromBase64(pngBase64)).toBe('image/png');
+  });
 
-    it('returns image/jpeg for JPEG magic bytes', () => {
-      const jpegBase64 = Buffer.from([
-        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
-      ]).toString('base64');
-      expect(detectImageMimeTypeFromBase64(jpegBase64)).toBe('image/jpeg');
-    });
+  it('returns image/jpeg for JPEG magic bytes', () => {
+    const jpegBase64 = Buffer.from([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+    ]).toString('base64');
+    expect(detectImageMimeTypeFromBase64(jpegBase64)).toBe('image/jpeg');
+  });
 
-    it('returns image/gif for GIF magic bytes', () => {
-      const gifBase64 = Buffer.from([
-        0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00,
-      ]).toString('base64');
-      expect(detectImageMimeTypeFromBase64(gifBase64)).toBe('image/gif');
-    });
+  it('returns image/gif for GIF magic bytes', () => {
+    const gifBase64 = Buffer.from([
+      0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00,
+    ]).toString('base64');
+    expect(detectImageMimeTypeFromBase64(gifBase64)).toBe('image/gif');
+  });
 
-    it('returns image/webp for WEBP magic bytes (RIFF....WEBP)', () => {
-      const webpBase64 = Buffer.from([
-        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
-      ]).toString('base64');
-      expect(detectImageMimeTypeFromBase64(webpBase64)).toBe('image/webp');
-    });
+  it('returns image/webp for WEBP magic bytes (RIFF....WEBP)', () => {
+    const webpBase64 = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]).toString('base64');
+    expect(detectImageMimeTypeFromBase64(webpBase64)).toBe('image/webp');
+  });
 
-    it('returns null for non-image data (PDF magic bytes)', () => {
-      const pdfBase64 = Buffer.from([
-        0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34,
-      ]).toString('base64');
-      expect(detectImageMimeTypeFromBase64(pdfBase64)).toBe(null);
-    });
+  it('returns null for non-image data (PDF magic bytes)', () => {
+    const pdfBase64 = Buffer.from([
+      0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34,
+    ]).toString('base64');
+    expect(detectImageMimeTypeFromBase64(pdfBase64)).toBe(null);
+  });
 
-    it('returns null for empty string', () => {
-      expect(detectImageMimeTypeFromBase64('')).toBe(null);
-    });
+  it('returns null for empty string', () => {
+    expect(detectImageMimeTypeFromBase64('')).toBe(null);
+  });
 
-    it('returns null for whitespace-only input', () => {
-      expect(detectImageMimeTypeFromBase64('    ')).toBe(null);
-    });
+  it('returns null for whitespace-only input', () => {
+    expect(detectImageMimeTypeFromBase64('    ')).toBe(null);
+  });
 
-    it('returns null for plain text data', () => {
-      const textBase64 = Buffer.from('hello world', 'utf-8').toString('base64');
-      expect(detectImageMimeTypeFromBase64(textBase64)).toBe(null);
-    });
+  it('returns null for plain text data', () => {
+    const textBase64 = Buffer.from('hello world', 'utf-8').toString('base64');
+    expect(detectImageMimeTypeFromBase64(textBase64)).toBe(null);
+  });
 
-    it('detects format correctly even with many trailing bytes (PNG)', () => {
-      const longBuffer = Buffer.concat([
-        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-        Buffer.alloc(512, 0xab),
-      ]);
-      const longBase64 = longBuffer.toString('base64');
-      expect(detectImageMimeTypeFromBase64(longBase64)).toBe('image/png');
-    });
+  it('detects format correctly even with many trailing bytes (PNG)', () => {
+    const longBuffer = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.alloc(512, 0xab),
+    ]);
+    const longBase64 = longBuffer.toString('base64');
+    expect(detectImageMimeTypeFromBase64(longBase64)).toBe('image/png');
+  });
 
-    it('detects format correctly even with many trailing bytes (JPEG)', () => {
-      const longBuffer = Buffer.concat([
-        Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
-        Buffer.alloc(512, 0xcd),
-      ]);
-      const longBase64 = longBuffer.toString('base64');
-      expect(detectImageMimeTypeFromBase64(longBase64)).toBe('image/jpeg');
-    });
+  it('detects format correctly even with many trailing bytes (JPEG)', () => {
+    const longBuffer = Buffer.concat([
+      Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+      Buffer.alloc(512, 0xcd),
+    ]);
+    const longBase64 = longBuffer.toString('base64');
+    expect(detectImageMimeTypeFromBase64(longBase64)).toBe('image/jpeg');
+  });
 
-    it('detects wrapped/whitespace base64 by ignoring whitespace before decoding (WEBP)', () => {
-      const webpBuffer = Buffer.from([
-        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
-      ]);
-      const webpBase64 = webpBuffer.toString('base64');
-      const wrapped = `
+  it('detects wrapped/whitespace base64 by ignoring whitespace before decoding (WEBP)', () => {
+    const webpBuffer = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]);
+    const webpBase64 = webpBuffer.toString('base64');
+    const wrapped = `
   ${webpBase64.slice(0, 8)}
 ${webpBase64.slice(8)}
 `;
-      expect(detectImageMimeTypeFromBase64(wrapped)).toBe('image/webp');
-    });
+    expect(detectImageMimeTypeFromBase64(wrapped)).toBe('image/webp');
+  });
 
-    it('corrects mismatched declared MIME: declared JPEG but actual PNG bytes detects as image/png (issue #2130)', () => {
-      const pngBytesDeclaredAsJpeg = Buffer.from([
-        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
-        0x49, 0x48, 0x44, 0x52,
-      ]).toString('base64');
-      expect(detectImageMimeTypeFromBase64(pngBytesDeclaredAsJpeg)).toBe(
-        'image/png',
-      );
-    });
+  it('corrects mismatched declared MIME: declared JPEG but actual PNG bytes detects as image/png (issue #2130)', () => {
+    const pngBytesDeclaredAsJpeg = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52,
+    ]).toString('base64');
+    expect(detectImageMimeTypeFromBase64(pngBytesDeclaredAsJpeg)).toBe(
+      'image/png',
+    );
+  });
 
-    it('returns null when malformed base64 does not decode to known image bytes', () => {
-      expect(detectImageMimeTypeFromBase64('!!!not-valid-base64-!@#$')).toBe(
-        null,
-      );
-    });
+  it('returns null when malformed base64 does not decode to known image bytes', () => {
+    expect(detectImageMimeTypeFromBase64('!!!not-valid-base64-!@#$')).toBe(
+      null,
+    );
   });
 });

--- a/packages/providers/src/utils/mediaUtils.ts
+++ b/packages/providers/src/utils/mediaUtils.ts
@@ -34,7 +34,7 @@ const RIFF_SIGNATURE: readonly number[] = [0x52, 0x49, 0x46, 0x46];
 const WEBP_TAG: readonly number[] = [0x57, 0x45, 0x42, 0x50];
 
 function bytesStartWith(
-  bytes: readonly number[],
+  bytes: Uint8Array,
   signature: readonly number[],
   offset: number,
 ): boolean {
@@ -55,10 +55,10 @@ export function detectImageMimeTypeFromBase64(
   if (typeof base64Data !== 'string' || base64Data.trim() === '') {
     return null;
   }
-  let bytes: readonly number[];
+  let bytes: Uint8Array;
   try {
     const normalized = base64Data.replace(/\s/g, '');
-    bytes = Array.from(Buffer.from(normalized.slice(0, 16), 'base64'));
+    bytes = Buffer.from(normalized.slice(0, 24), 'base64');
   } catch {
     return null;
   }

--- a/packages/providers/src/utils/mediaUtils.ts
+++ b/packages/providers/src/utils/mediaUtils.ts
@@ -27,6 +27,59 @@ export function classifyMediaBlock(media: MediaBlock): MediaCategory {
   return 'unknown';
 }
 
+const PNG_SIGNATURE: readonly number[] = [0x89, 0x50, 0x4e, 0x47];
+const JPEG_SIGNATURE: readonly number[] = [0xff, 0xd8, 0xff];
+const GIF_SIGNATURE: readonly number[] = [0x47, 0x49, 0x46, 0x38];
+const RIFF_SIGNATURE: readonly number[] = [0x52, 0x49, 0x46, 0x46];
+const WEBP_TAG: readonly number[] = [0x57, 0x45, 0x42, 0x50];
+
+function bytesStartWith(
+  bytes: readonly number[],
+  signature: readonly number[],
+  offset: number,
+): boolean {
+  if (bytes.length < offset + signature.length) {
+    return false;
+  }
+  for (let i = 0; i < signature.length; i++) {
+    if (bytes[offset + i] !== signature[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function detectImageMimeTypeFromBase64(
+  base64Data: string,
+): string | null {
+  if (typeof base64Data !== 'string' || base64Data.trim() === '') {
+    return null;
+  }
+  let bytes: readonly number[];
+  try {
+    const normalized = base64Data.replace(/\s/g, '');
+    bytes = Array.from(Buffer.from(normalized.slice(0, 16), 'base64'));
+  } catch {
+    return null;
+  }
+  if (bytesStartWith(bytes, PNG_SIGNATURE, 0)) {
+    return 'image/png';
+  }
+  if (bytesStartWith(bytes, JPEG_SIGNATURE, 0)) {
+    return 'image/jpeg';
+  }
+  if (bytesStartWith(bytes, GIF_SIGNATURE, 0)) {
+    return 'image/gif';
+  }
+  if (
+    bytesStartWith(bytes, RIFF_SIGNATURE, 0) &&
+    bytesStartWith(bytes, WEBP_TAG, 8)
+  ) {
+    return 'image/webp';
+  }
+  return null;
+}
+
 export function buildUnsupportedMediaPlaceholder(
   media: MediaBlock,
   providerName: string,


### PR DESCRIPTION
## Summary

Fixes #2130

The Anthropic API rejected requests with HTTP 400 when an image's declared MIME type did not match its actual binary content:

> The image was specified using the image/jpeg media type, but the image appears to be a image/png image

This happened because the declared `mimeType` is derived from the file extension via `mime.lookup` (purely extension-based). A file named `photo.jpg` whose bytes are actually PNG got tagged `image/jpeg`, and `mediaBlockToAnthropicImage()` trusted that declared type verbatim and passed it to the API, which inspects the real binary header and rejects mismatches.

## Root cause / call chain

1. `fileUtils.ts` (`processMediaFile`) sets `mimeType` via `mime.lookup(filePath)` — extension-based only.
2. This propagates into a `MediaBlock` with the wrong `mimeType` but correct base64 bytes.
3. `AnthropicMessageNormalizer.mediaBlockToAnthropicImage()` blindly used `media.mimeType || 'image/png'` as the API `media_type`.
4. Anthropic inspects the real binary header, detects the mismatch, and returns 400.

## Fix

Detect the actual image format from the binary magic bytes **before** sending to the API, and use the detected (correct) MIME type instead of the declared one:

- **`packages/providers/src/utils/mediaUtils.ts`** — new pure function `detectImageMimeTypeFromBase64(base64Data): string | null`. It decodes only the first ~16 characters of base64 (whitespace-normalized) and inspects magic bytes for PNG (`89 50 4E 47`), JPEG (`FF D8 FF`), GIF (`47 49 46 38`), and WEBP (`RIFF....WEBP`). Returns `null` for unrecognized/non-image/empty/invalid input.
- **`packages/providers/src/anthropic/AnthropicMessageNormalizer.ts`** — `mediaBlockToAnthropicImage()` now computes `media_type = detectImageMimeTypeFromBase64(rawData) ?? (media.mimeType || 'image/png')`. Detection wins when conclusive; the declared type is only a fallback. This covers **both** the user-message image path and the tool_result image path, since both route through this single function. URL-encoded media is left unchanged.

The detection is cheap (decodes ~12 bytes) and prevents the rejection entirely rather than reacting to it after a failed turn.

## Behavior

- A valid PNG declared as `image/jpeg` is now sent with `media_type: image/png`.
- Correctly-declared images are unaffected (a real JPEG still detects as `image/jpeg`).
- When bytes cannot be classified (e.g. truncated data, non-image content), prior behavior is preserved via the declared-type fallback.

## Scope decisions

- This change addresses **image** MIME mismatches for the Anthropic provider, which is exactly where the reported 400 error manifests. GIF/WEBP (also supported by Anthropic) are handled in addition to PNG/JPEG.
- Documents/PDFs (`mediaBlockToAnthropicDocument`) are intentionally left unchanged — the issue is image-specific.
- A lower-level normalization at `ContentConverters.processPartToBlocks` (where MediaBlocks are first created) was considered but deferred: provider-specific supported formats differ, and fixing at the Anthropic request-construction boundary is the targeted fix for the reported error.

## Test plan

Followed TDD per `dev-docs/RULES.md` (behavior, not implementation; no mock theater).

- `packages/providers/src/utils/mediaUtils.test.ts` — added `detectImageMimeTypeFromBase64` suite: PNG/JPEG/GIF/WEBP detection, PDF/text → `null`, empty/whitespace → `null`, long buffers, wrapped (whitespace-containing) base64, and the exact issue scenario (declared JPEG, actual PNG bytes → `image/png`).
- `packages/providers/src/anthropic/AnthropicProvider.mediaBlock.test.ts` — added integration-style tests asserting the produced Anthropic request uses the corrected `media_type: image/png` for both the **user-message** image path and the **tool_result** image path when bytes are PNG but declared as JPEG.

## Verification

- `npm run lint` — clean for changed files (6 pre-existing errors in `scripts/tests/eslint-guard.test.js` are unrelated, introduced by HEAD / PR #2151).
- `npm run typecheck` — pass.
- `npm run format` — clean.
- `npm run build` — pass.
- `npm run test` — all packages pass.
- Smoke: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — pass.
