### PR TITLE
Add #2136 regression coverage; gate prepareQueryForGemini on own signal

### DIFF
--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/queryPreparer.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/queryPreparer.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for prepareQueryForGemini's proceed gate (issue #2136).
+ *
+ * The gate depends on THIS turn's own abort signal, not the shared
+ * turnCancelledRef. A fresh turn must proceed; only a turn whose own signal was
+ * aborted before preparation is skipped.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  type Config,
+  type MessageSenderType,
+} from '@vybestack/llxprt-code-core';
+import {
+  prepareQueryForGemini,
+  type PrepareQueryDeps,
+} from '../queryPreparer.js';
+import type { SlashCommandProcessorResult } from '../../../types.js';
+
+// logUserPrompt performs telemetry/config I/O; neutralize it like the dedup
+// test does so the gate logic is exercised in isolation.
+vi.mock('@vybestack/llxprt-code-core', async () => {
+  const actual = await vi.importActual('@vybestack/llxprt-code-core');
+  return { ...actual, logUserPrompt: vi.fn() };
+});
+
+function createDeps(
+  overrides: Partial<PrepareQueryDeps> = {},
+): PrepareQueryDeps {
+  return {
+    config: { getModel: () => 'test-model' } as unknown as Config,
+    addItem: vi.fn(),
+    onDebugMessage: vi.fn(),
+    handleShellCommand: vi.fn(() => false),
+    handleSlashCommand: vi.fn(
+      async (): Promise<SlashCommandProcessorResult | false> => false,
+    ),
+    logger: {
+      logMessage: async (_s: MessageSenderType, _t: string) => {},
+    },
+    shellModeActive: false,
+    scheduleToolCalls: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('prepareQueryForGemini proceed gate (issue #2136)', () => {
+  // The gate's sole input is the turn's OWN abort signal. These two cases fully
+  // specify it: not-aborted → proceed, aborted → skip. (turnCancelledRef is no
+  // longer consulted here, so there is no "prior cancellation" state to model —
+  // a stale shared flag can no longer drop a fresh turn.)
+  it('proceeds for a fresh turn whose own signal is not aborted', async () => {
+    const controller = new AbortController();
+    const result = await prepareQueryForGemini(
+      'hello',
+      1000,
+      controller.signal,
+      'p1',
+      createDeps(),
+    );
+    expect(result.shouldProceed).toBe(true);
+    expect(result.queryToSend).toBe('hello');
+  });
+
+  it('skips a turn whose own abort signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const result = await prepareQueryForGemini(
+      'hello',
+      1000,
+      controller.signal,
+      'p1',
+      createDeps(),
+    );
+    expect(result.shouldProceed).toBe(false);
+    expect(result.queryToSend).toBeNull();
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.test.tsx
@@ -735,4 +735,120 @@ describe('useAgenticLoop — engine-owned loop drives CLI state', () => {
     // callback: continuation does not depend on (or trigger) display clearing.
     expect(markedDisplayCleared.flat()).not.toContain('primary-call');
   });
+
+  it('does not route a stale UserCancelled from an aborted turn to the stream handler (issue #2136)', async () => {
+    // #2136 (a cancelled turn's stale "User cancelled the request." leaking
+    // into the next turn) is prevented by iterateLoop's `if (signal.aborted)
+    // break` guard (added in #2050): when a turn is aborted, iteration stops
+    // before routing ANY further event, so the engine's trailing UserCancelled
+    // never reaches the CLI stream handler. This locks that behavior in.
+    let releaseA: () => void = () => {};
+    const aGate = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const abortedClient: AgentClientContract = {
+      async initialize() {},
+      isInitialized: () => true,
+      hasChatInitialized: () => true,
+      async getHistory() {
+        return [];
+      },
+      getChat: () =>
+        ({
+          recordCompletedToolCalls: vi.fn(),
+        }) as never,
+      getHistoryService: () => null,
+      storeHistoryServiceForReuse: () => {},
+      storeHistoryForLaterUse: () => {},
+      dispose: () => {},
+      setTools: async () => {},
+      clearTools: () => {},
+      updateSystemInstruction: async () => {},
+      addHistory: async () => {},
+      resetChat: async () => {},
+      resumeChat: async () => {},
+      setHistory: async () => {},
+      restoreHistory: async () => {},
+      addDirectoryContext: async () => {},
+      getContentGenerator: () => {
+        throw new Error('not used');
+      },
+      startChat: async () => {
+        throw new Error('not used');
+      },
+      generateDirectMessage: () => {
+        throw new Error('not used');
+      },
+      generateJson: async () => ({}),
+      generateContent: () => {
+        throw new Error('not used');
+      },
+      generateEmbedding: async () => [],
+      async *sendMessageStream(
+        _req: PartListUnion,
+        signal: AbortSignal,
+        _promptId: string,
+      ): AsyncGenerator<ServerGeminiStreamEvent> {
+        yield { type: GeminiEventType.Content, value: 'A-content' };
+        // Park until aborted, then emit the engine's trailing UserCancelled.
+        await Promise.race([
+          aGate,
+          new Promise<void>((resolve) => {
+            if (signal.aborted) {
+              resolve();
+              return;
+            }
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          }),
+        ]);
+        yield { type: GeminiEventType.UserCancelled };
+      },
+      getUserTier: () => undefined,
+      getCurrentSequenceModel: () => 'test-model',
+    } as unknown as AgentClientContract;
+
+    const routedTypes: string[] = [];
+    const { result } = renderHook(() =>
+      useAgenticLoop({
+        config,
+        agentClient: abortedClient,
+        messageBus,
+        interactiveMode: true,
+        addItem: vi.fn(),
+        onToolCallsUpdate: () => {},
+        outputUpdateHandler: () => {},
+        getPreferredEditor: () => undefined,
+        onEditorOpen: () => {},
+        onEditorClose: () => {},
+        onTodoPause: () => {},
+        processStreamEventRef: {
+          current: (event: ServerGeminiStreamEvent) => {
+            routedTypes.push(event.type);
+          },
+        },
+        flushPendingHistoryItem: () => {},
+        clearPendingHistoryItem: () => {},
+        performMemoryRefresh: async () => {},
+      }),
+    );
+
+    const controllerA = new AbortController();
+    await act(async () => {
+      const aPromise = result.current.runLoop('A', controllerA.signal, 'p1');
+      await Promise.race([
+        aPromise,
+        new Promise((resolve) => setTimeout(resolve, 50)),
+      ]);
+      controllerA.abort();
+      releaseA();
+      await aPromise.catch(() => {});
+    });
+
+    // A's pre-abort Content WAS routed (legitimate), but the stale trailing
+    // UserCancelled was NOT routed — proving the duplicate-message symptom is
+    // suppressed at iteration time.
+    expect(routedTypes).toContain(GeminiEventType.Content);
+    expect(routedTypes).not.toContain(GeminiEventType.UserCancelled);
+  });
 });

--- a/packages/cli/src/ui/hooks/geminiStream/queryPreparer.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/queryPreparer.ts
@@ -42,7 +42,6 @@ export interface PrepareQueryDeps {
     requests: ToolCallRequestInfo[],
     signal: AbortSignal,
   ) => Promise<void>;
-  turnCancelledRef: React.MutableRefObject<boolean>;
 }
 
 export async function prepareQueryForGemini(
@@ -52,8 +51,12 @@ export async function prepareQueryForGemini(
   promptId: string,
   deps: PrepareQueryDeps,
 ): Promise<{ queryToSend: PartListUnion | null; shouldProceed: boolean }> {
-  const { turnCancelledRef, onDebugMessage } = deps;
-  if (turnCancelledRef.current) {
+  const { onDebugMessage } = deps;
+  // Gate on THIS turn's own abort signal, not the shared turnCancelledRef: a
+  // turn's own signal is the precise indicator of whether that specific turn
+  // was cancelled (including abort paths that don't flip turnCancelledRef), so
+  // it is more exact than the shared flag. See issue #2136.
+  if (abortSignal.aborted) {
     return { queryToSend: null, shouldProceed: false };
   }
   if (typeof query === 'string' && query.trim().length === 0) {

--- a/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
@@ -512,7 +512,6 @@ function usePrepareQueryDeps(deps: StreamEventHandlerDeps): PrepareQueryDeps {
       logger: deps.logger,
       shellModeActive: deps.shellModeActive,
       scheduleToolCalls: deps.scheduleToolCalls,
-      turnCancelledRef: deps.turnCancelledRef,
     }),
     [
       deps.config,
@@ -523,7 +522,6 @@ function usePrepareQueryDeps(deps: StreamEventHandlerDeps): PrepareQueryDeps {
       deps.logger,
       deps.shellModeActive,
       deps.scheduleToolCalls,
-      deps.turnCancelledRef,
     ],
   );
 }


### PR DESCRIPTION
## Summary

Investigation of #2136 ("double cancellation still happens") showed the user-facing symptom is **already fixed by #2050**, not by any change in this PR. This PR adds a regression test that locks that fix in, plus one small correctness cleanup.

## Root cause & timeline

- **Symptom:** cancelling a turn (ESC), then submitting a new prompt, emitted a duplicate "User cancelled the request." from the previous turn's stale `UserCancelled` event.
- **#2050** ("Consolidate agentic turn loop into engine") added the `if (signal.aborted) break` guard in `iterateLoop` (`useAgenticLoop.ts`). Because the engine only emits the trailing `UserCancelled` once the signal is already aborted, iteration stops before routing it — so the stale event never reaches the CLI stream handler.
- The reporter was on **nightly 260613**, which **predates #2050** (merged 2026-06-16, shipped in nightly **260617+**). That is why it reproduced then and does not now.

This was verified empirically: the new regression test passes with the PR's source change removed, proving the symptom is suppressed by the #2050 guard, not by any cancellation-ref relocation.

## What this PR does

1. **Regression test** (`useAgenticLoop.test.tsx`): "does not route a stale UserCancelled from an aborted turn to the stream handler" — drives a turn, aborts it, and asserts the pre-abort `Content` was routed but the trailing `UserCancelled` was not. Locks in #2050's suppression so a regression is caught.
2. **Gate cleanup** (`queryPreparer.ts`): `prepareQueryForGemini`'s proceed gate now checks the turn's own `AbortSignal.aborted` instead of the shared `turnCancelledRef`. A turn's own signal is the authoritative indicator of whether that specific turn was cancelled (including abort paths that don't flip `turnCancelledRef`), making the gate more precise.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format`, `npm run build` — clean.
- `npx vitest run` (cli package) — 4739 passed, 3 skipped.
- Smoke: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — ok.

Refs #2136.
