### PR TITLE
fix(providers): retry connection-phase fetch failures (Fixes #2161)

### DIFF
--- a/packages/agents/src/core/StreamProcessor.retryBoundary.test.ts
+++ b/packages/agents/src/core/StreamProcessor.retryBoundary.test.ts
@@ -320,17 +320,12 @@ describe('StreamProcessor._buildAndSendStreamRequest — stream retry boundary (
 
   describe('execute stream call retry classification', () => {
     it('should classify EmptyStreamError as retryable in the retry policy', async () => {
-      let capturedShouldRetryOnError:
-        | ((error: unknown, retryFetchErrors?: boolean) => boolean)
-        | undefined;
+      let capturedShouldRetryOnError: ((error: unknown) => boolean) | undefined;
       (retryWithBackoff as ReturnType<typeof vi.fn>).mockImplementation(
         async <T>(
           fn: () => Promise<T>,
           options?: {
-            shouldRetryOnError?: (
-              error: unknown,
-              retryFetchErrors?: boolean,
-            ) => boolean;
+            shouldRetryOnError?: (error: unknown) => boolean;
           },
         ) => {
           capturedShouldRetryOnError = options?.shouldRetryOnError;
@@ -372,24 +367,16 @@ describe('StreamProcessor._buildAndSendStreamRequest — stream retry boundary (
       ).toBe(true);
     });
 
-    it('should pass retryFetchErrors through the retry policy classifier', async () => {
-      let capturedRetryFetchErrors: boolean | undefined;
-      let capturedShouldRetryOnError:
-        | ((error: unknown, retryFetchErrors?: boolean) => boolean)
-        | undefined;
+    it('should classify fetch-failed errors as retryable via centralized transient detection', async () => {
+      let capturedShouldRetryOnError: ((error: unknown) => boolean) | undefined;
 
       (retryWithBackoff as ReturnType<typeof vi.fn>).mockImplementation(
         async <T>(
           fn: () => Promise<T>,
           options?: {
-            retryFetchErrors?: boolean;
-            shouldRetryOnError?: (
-              error: unknown,
-              retryFetchErrors?: boolean,
-            ) => boolean;
+            shouldRetryOnError?: (error: unknown) => boolean;
           },
         ) => {
-          capturedRetryFetchErrors = options?.retryFetchErrors;
           capturedShouldRetryOnError = options?.shouldRetryOnError;
           return fn();
         },
@@ -398,12 +385,7 @@ describe('StreamProcessor._buildAndSendStreamRequest — stream retry boundary (
       const executeStreamApiCall = (
         processor as unknown as {
           _executeStreamApiCall: (
-            params: {
-              config?: {
-                abortSignal?: AbortSignal;
-                retryFetchErrors?: boolean;
-              };
-            },
+            params: { config?: { abortSignal?: AbortSignal } },
             promptId: string,
             userContent: Content | Content[],
             provider: { name: string },
@@ -415,7 +397,7 @@ describe('StreamProcessor._buildAndSendStreamRequest — stream retry boundary (
       await executeStreamApiCall
         .call(
           processor,
-          { config: { retryFetchErrors: true } },
+          { config: {} },
           'test-prompt',
           { role: 'user', parts: [{ text: 'test' }] },
           providerStub,
@@ -424,29 +406,15 @@ describe('StreamProcessor._buildAndSendStreamRequest — stream retry boundary (
           // ignore - _buildAndSendStreamRequest internals are not relevant to this assertion
         });
 
-      expect(capturedRetryFetchErrors).toBe(true);
       expect(capturedShouldRetryOnError).toBeDefined();
       // "fetch failed" is now classified as a network-transient condition
-      // centrally (issue #2161), so it is always retryable regardless of the
-      // retryFetchErrors flag.
+      // centrally (issue #2161), so it is always retryable.
       expect(
-        capturedShouldRetryOnError?.(
-          new Error('fetch failed sending request'),
-          false,
-        ),
-      ).toBe(true);
-      expect(
-        capturedShouldRetryOnError?.(
-          new Error('fetch failed sending request'),
-          true,
-        ),
+        capturedShouldRetryOnError?.(new Error('fetch failed sending request')),
       ).toBe(true);
       // A genuinely non-transient error is still not retryable.
       expect(
-        capturedShouldRetryOnError?.(
-          new Error('totally unrelated error'),
-          true,
-        ),
+        capturedShouldRetryOnError?.(new Error('totally unrelated error')),
       ).toBe(false);
     });
   });

--- a/packages/agents/src/core/StreamProcessor.retryBoundary.test.ts
+++ b/packages/agents/src/core/StreamProcessor.retryBoundary.test.ts
@@ -426,18 +426,28 @@ describe('StreamProcessor._buildAndSendStreamRequest — stream retry boundary (
 
       expect(capturedRetryFetchErrors).toBe(true);
       expect(capturedShouldRetryOnError).toBeDefined();
+      // "fetch failed" is now classified as a network-transient condition
+      // centrally (issue #2161), so it is always retryable regardless of the
+      // retryFetchErrors flag.
       expect(
         capturedShouldRetryOnError?.(
           new Error('fetch failed sending request'),
           false,
         ),
-      ).toBe(false);
+      ).toBe(true);
       expect(
         capturedShouldRetryOnError?.(
           new Error('fetch failed sending request'),
           true,
         ),
       ).toBe(true);
+      // A genuinely non-transient error is still not retryable.
+      expect(
+        capturedShouldRetryOnError?.(
+          new Error('totally unrelated error'),
+          true,
+        ),
+      ).toBe(false);
     });
   });
 

--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -243,17 +243,12 @@ export class StreamProcessor {
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     const apiCall = () =>
       this._buildAndSendStreamRequest(params, promptId, userContent, provider);
-    const retryFetchErrors = (
-      params.config as { retryFetchErrors?: boolean } | undefined
-    )?.retryFetchErrors;
 
     return retryWithBackoff(apiCall, {
       onPersistent429: () => this._handleBucketFailover(),
       signal: params.config?.abortSignal,
-      retryFetchErrors,
-      shouldRetryOnError: (error, currentRetryFetchErrors) =>
-        error instanceof EmptyStreamError ||
-        isRetryableError(error, currentRetryFetchErrors),
+      shouldRetryOnError: (error) =>
+        error instanceof EmptyStreamError || isRetryableError(error),
     });
   }
 

--- a/packages/core/src/utils/retry.quota.test.ts
+++ b/packages/core/src/utils/retry.quota.test.ts
@@ -9,7 +9,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ApiError } from '@google/genai';
-import { retryWithBackoff, isRetryableError } from './retry.js';
+import {
+  retryWithBackoff,
+  isRetryableError,
+  isNetworkTransientError,
+} from './retry.js';
 import { setSimulate429 } from './testUtils.js';
 import { RetryableQuotaError } from './googleQuotaErrors.js';
 import type { GoogleApiError } from './googleErrors.js';
@@ -42,9 +46,9 @@ describe('isRetryableError', () => {
     expect(isRetryableError(outerError, false)).toBe(true);
   });
 
-  it('should NOT retry generic "fetch failed" when retryFetchErrors=false', () => {
+  it('should retry generic "fetch failed" even when retryFetchErrors=false (centralized transient detection)', () => {
     const error = new Error('fetch failed');
-    expect(isRetryableError(error, false)).toBe(false);
+    expect(isRetryableError(error, false)).toBe(true);
   });
 
   it('should retry generic "fetch failed" when retryFetchErrors=true', () => {
@@ -115,6 +119,26 @@ describe('isRetryableError', () => {
     );
     expect(isRetryableError(error, false)).toBe(true);
     expect(isRetryableError(error, true)).toBe(true);
+  });
+});
+
+describe('isNetworkTransientError', () => {
+  it('returns true for a bare TypeError("fetch failed") with no cause', () => {
+    const error = new TypeError('fetch failed');
+    expect(isNetworkTransientError(error)).toBe(true);
+  });
+
+  it('returns true for a TypeError("fetch failed") with an undici cause (UND_ERR_SOCKET)', () => {
+    const cause = Object.assign(new Error('Socket error'), {
+      code: 'UND_ERR_SOCKET',
+    });
+    const error = new TypeError('fetch failed', { cause });
+    expect(isNetworkTransientError(error)).toBe(true);
+  });
+
+  it('returns false for a non-transient error', () => {
+    const error = new Error('some random error');
+    expect(isNetworkTransientError(error)).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/retry.quota.test.ts
+++ b/packages/core/src/utils/retry.quota.test.ts
@@ -24,18 +24,11 @@ import { DebugLogger } from '../debug/index.js';
  * @requirement REQ-R13-003 Unit tests for retry precedence
  */
 describe('isRetryableError', () => {
-  it('should retry network error code regardless of retryFetchErrors=false', () => {
+  it('should retry network error code (ETIMEDOUT)', () => {
     const error = Object.assign(new Error('Connection timeout'), {
       code: 'ETIMEDOUT',
     });
-    expect(isRetryableError(error, false)).toBe(true);
-  });
-
-  it('should retry network error code regardless of retryFetchErrors=true', () => {
-    const error = Object.assign(new Error('Connection timeout'), {
-      code: 'ETIMEDOUT',
-    });
-    expect(isRetryableError(error, true)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('should retry network error code in nested .cause chain', () => {
@@ -43,71 +36,60 @@ describe('isRetryableError', () => {
       code: 'ECONNRESET',
     });
     const outerError = new Error('Fetch failed', { cause: innerError });
-    expect(isRetryableError(outerError, false)).toBe(true);
+    expect(isRetryableError(outerError)).toBe(true);
   });
 
-  it('should retry generic "fetch failed" even when retryFetchErrors=false (centralized transient detection)', () => {
+  it('should retry generic "fetch failed" (centralized transient detection)', () => {
     const error = new Error('fetch failed');
-    expect(isRetryableError(error, false)).toBe(true);
-  });
-
-  it('should retry generic "fetch failed" when retryFetchErrors=true', () => {
-    const error = new Error('fetch failed');
-    expect(isRetryableError(error, true)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('should never retry 400 ApiError', () => {
     const error = new ApiError({ message: 'Bad Request', status: 400 });
-    expect(isRetryableError(error, false)).toBe(false);
-    expect(isRetryableError(error, true)).toBe(false);
+    expect(isRetryableError(error)).toBe(false);
   });
 
   it('should retry 503 ApiError', () => {
     const error = new ApiError({ message: 'Service Unavailable', status: 503 });
-    expect(isRetryableError(error, false)).toBe(true);
-    expect(isRetryableError(error, true)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('should retry 429 ApiError', () => {
     const error = new ApiError({ message: 'Too Many Requests', status: 429 });
-    expect(isRetryableError(error, false)).toBe(true);
-    expect(isRetryableError(error, true)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('should retry 503 generic error with status property', () => {
     const error = Object.assign(new Error('Service Unavailable'), {
       status: 503,
     });
-    expect(isRetryableError(error, false)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('should retry network error with ECONNRESET code', () => {
     const error = Object.assign(new Error('socket hang up'), {
       code: 'ECONNRESET',
     });
-    expect(isRetryableError(error, false)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('should retry network error with UND_ERR_SOCKET code', () => {
     const error = Object.assign(new Error('undici socket error'), {
       code: 'UND_ERR_SOCKET',
     });
-    expect(isRetryableError(error, false)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('should NOT retry non-network, non-HTTP errors', () => {
     const error = new Error('Some random error');
-    expect(isRetryableError(error, false)).toBe(false);
-    expect(isRetryableError(error, true)).toBe(false);
+    expect(isRetryableError(error)).toBe(false);
   });
 
-  it('should prioritize network codes over retryFetchErrors gate', () => {
-    // Create an error that has both a network code AND "fetch failed" message
-    // Network code should win (always retry), even if retryFetchErrors=false
+  it('should retry network codes with "fetch failed" message', () => {
     const error = Object.assign(new Error('fetch failed due to ETIMEDOUT'), {
       code: 'ETIMEDOUT',
     });
-    expect(isRetryableError(error, false)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 
   it('ENOTFOUND is retryable', () => {
@@ -117,8 +99,7 @@ describe('isRetryableError', () => {
         code: 'ENOTFOUND',
       },
     );
-    expect(isRetryableError(error, false)).toBe(true);
-    expect(isRetryableError(error, true)).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
   });
 });
 

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -355,7 +355,7 @@ describe('retryWithBackoff', () => {
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
-    it('should retry on fetch failed error when retryFetchErrors=true', async () => {
+    it('should retry on fetch failed error (centralized transient detection)', async () => {
       let attempts = 0;
       const mockFn = vi.fn(async () => {
         attempts++;
@@ -368,7 +368,6 @@ describe('retryWithBackoff', () => {
       const promise = retryWithBackoff(mockFn, {
         maxAttempts: 3,
         initialDelayMs: 10,
-        retryFetchErrors: true,
       });
 
       await vi.runAllTimersAsync();
@@ -378,7 +377,7 @@ describe('retryWithBackoff', () => {
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
-    it('should retry bare TypeError("fetch failed") WITHOUT retryFetchErrors flag (centralized transient detection)', async () => {
+    it('should retry bare TypeError("fetch failed") (centralized transient detection)', async () => {
       let attempts = 0;
       const mockFn = vi.fn(async () => {
         attempts++;
@@ -400,7 +399,7 @@ describe('retryWithBackoff', () => {
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
-    it('should retry on "fetch failed sending request" error when retryFetchErrors=true', async () => {
+    it('should retry on "fetch failed sending request" error (centralized transient detection)', async () => {
       let attempts = 0;
       const mockFn = vi.fn(async () => {
         attempts++;
@@ -415,7 +414,6 @@ describe('retryWithBackoff', () => {
       const promise = retryWithBackoff(mockFn, {
         maxAttempts: 3,
         initialDelayMs: 10,
-        retryFetchErrors: true,
       });
 
       await vi.runAllTimersAsync();

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -378,6 +378,28 @@ describe('retryWithBackoff', () => {
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
+    it('should retry bare TypeError("fetch failed") WITHOUT retryFetchErrors flag (centralized transient detection)', async () => {
+      let attempts = 0;
+      const mockFn = vi.fn(async () => {
+        attempts++;
+        if (attempts === 1) {
+          throw new TypeError('fetch failed');
+        }
+        return 'success';
+      });
+
+      const promise = retryWithBackoff(mockFn, {
+        maxAttempts: 3,
+        initialDelayMs: 10,
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe('success');
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
     it('should retry on "fetch failed sending request" error when retryFetchErrors=true', async () => {
       let attempts = 0;
       const mockFn = vi.fn(async () => {

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -69,6 +69,7 @@ const TRANSIENT_ERROR_PHRASES = [
   'stream prematurely closed',
   'read econnreset',
   'write econnreset',
+  'fetch failed',
 ];
 
 const TRANSIENT_ERROR_REGEXES = [
@@ -226,21 +227,22 @@ export function isNetworkTransientError(error: unknown): boolean {
  * @requirement REQ-R13-002 isRetryableError exported for reuse
  *
  * Decision precedence (CRITICAL - do not reorder):
- * 1. Network error codes (ETIMEDOUT, ECONNRESET, etc.) → ALWAYS retry (regardless of retryFetchErrors)
+ * 1. Network transient conditions (ETIMEDOUT, ECONNRESET, "fetch failed", etc.) → ALWAYS retry
+ *    (centralized in isNetworkTransientError; regardless of retryFetchErrors)
  * 2. RetryableQuotaError → retry
  * 3. Anthropic body-level errors (overloaded_error, rate_limit_error, api_error, no HTTP status) → retry
- * 4. retryFetchErrors=true + generic "fetch failed" message → retry
- * 5. ApiError with status 400 → NEVER retry; ApiError 401/403/429/5xx → retry
- * 6. Generic status 401/403/429 or 5xx → retry
- * 7. All others → do not retry
+ * 4. ApiError with status 400 → NEVER retry; ApiError 401/403/429/5xx → retry
+ * 5. Generic status 401/403/429 or 5xx → retry
+ * 6. All others → do not retry
  *
  * @param error The error object.
- * @param retryFetchErrors Whether to retry generic fetch failures (default: false).
+ * @param retryFetchErrors Retained for type-contract compatibility; "fetch failed"
+ *   is now handled centrally by isNetworkTransientError (PRIORITY 1).
  * @returns True if the error is retryable, false otherwise.
  */
 export function isRetryableError(
   error: Error | unknown,
-  retryFetchErrors?: boolean,
+  _retryFetchErrors?: boolean,
 ): boolean {
   // PRIORITY 1: Network error codes are ALWAYS retryable (transient infrastructure failures)
   // This check MUST come before retryFetchErrors to ensure network errors retry unconditionally
@@ -260,21 +262,13 @@ export function isRetryableError(
     return true;
   }
 
-  // PRIORITY 4: Generic "fetch failed" messages only retry when explicitly enabled
-  if (retryFetchErrors === true) {
-    const { messages } = collectErrorDetails(error);
-    if (messages.some((msg) => msg.toLowerCase().includes('fetch failed'))) {
-      return true;
-    }
-  }
-
-  // PRIORITY 5: ApiError with deterministic 400 is NEVER retryable
+  // PRIORITY 4: ApiError with deterministic 400 is NEVER retryable
   if (error instanceof ApiError) {
     if (error.status === 400) return false;
     return isRetryableStatus(error.status);
   }
 
-  // PRIORITY 6: Generic status-based retry (handles non-ApiError shapes)
+  // PRIORITY 5: Generic status-based retry (handles non-ApiError shapes)
   const status = getErrorStatus(error);
   if (status !== undefined) {
     return isRetryableStatus(status);

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -25,11 +25,10 @@ export interface RetryOptions {
   maxAttempts: number;
   initialDelayMs: number;
   maxDelayMs: number;
-  shouldRetryOnError: (error: Error, retryFetchErrors?: boolean) => boolean;
+  shouldRetryOnError: (error: Error) => boolean;
   shouldRetryOnContent?: (content: GenerateContentResponse) => boolean;
   onPersistent429?: (error?: unknown) => Promise<string | boolean | null>;
   trackThrottleWaitTime?: (waitTimeMs: number) => void;
-  retryFetchErrors?: boolean;
   signal?: AbortSignal;
   /**
    * Callback invoked on 401/403 auth errors before retry.
@@ -228,7 +227,7 @@ export function isNetworkTransientError(error: unknown): boolean {
  *
  * Decision precedence (CRITICAL - do not reorder):
  * 1. Network transient conditions (ETIMEDOUT, ECONNRESET, "fetch failed", etc.) → ALWAYS retry
- *    (centralized in isNetworkTransientError; regardless of retryFetchErrors)
+ *    (centralized in isNetworkTransientError)
  * 2. RetryableQuotaError → retry
  * 3. Anthropic body-level errors (overloaded_error, rate_limit_error, api_error, no HTTP status) → retry
  * 4. ApiError with status 400 → NEVER retry; ApiError 401/403/429/5xx → retry
@@ -236,16 +235,10 @@ export function isNetworkTransientError(error: unknown): boolean {
  * 6. All others → do not retry
  *
  * @param error The error object.
- * @param retryFetchErrors Retained for type-contract compatibility; "fetch failed"
- *   is now handled centrally by isNetworkTransientError (PRIORITY 1).
  * @returns True if the error is retryable, false otherwise.
  */
-export function isRetryableError(
-  error: Error | unknown,
-  _retryFetchErrors?: boolean,
-): boolean {
+export function isRetryableError(error: Error | unknown): boolean {
   // PRIORITY 1: Network error codes are ALWAYS retryable (transient infrastructure failures)
-  // This check MUST come before retryFetchErrors to ensure network errors retry unconditionally
   if (isNetworkTransientError(error)) {
     return true;
   }
@@ -591,8 +584,7 @@ interface RetryContext {
   maxAttempts: number;
   initialDelayMs: number;
   maxDelayMs: number;
-  shouldRetryOnError: (error: Error, retryFetchErrors?: boolean) => boolean;
-  retryFetchErrors: boolean | undefined;
+  shouldRetryOnError: (error: Error) => boolean;
   signal: AbortSignal | undefined;
   options: Partial<RetryOptions> | undefined;
   logger: DebugLogger;
@@ -635,10 +627,7 @@ async function runRetryGuards(
     throw error;
   }
 
-  const shouldRetry = context.shouldRetryOnError(
-    error as Error,
-    context.retryFetchErrors,
-  );
+  const shouldRetry = context.shouldRetryOnError(error as Error);
   if (shouldRetry !== true && !shouldAttemptRefreshRetry) {
     throw error;
   }
@@ -745,7 +734,6 @@ export async function retryWithBackoff<T>(
     maxDelayMs,
     shouldRetryOnError,
     shouldRetryOnContent,
-    retryFetchErrors,
     signal,
   } = {
     ...DEFAULT_RETRY_OPTIONS,
@@ -758,7 +746,6 @@ export async function retryWithBackoff<T>(
     initialDelayMs,
     maxDelayMs,
     shouldRetryOnError,
-    retryFetchErrors,
     signal,
     options,
     logger,

--- a/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
@@ -272,6 +272,32 @@ describe('RetryOrchestrator', () => {
       expect(result).toHaveLength(1);
     });
 
+    it('should retry on bare TypeError("fetch failed") connection-phase error', async () => {
+      const fetchError = new TypeError('fetch failed');
+      const provider = createTestProvider({
+        responses: [{ error: fetchError }, 'success'],
+      });
+
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 3,
+        initialDelayMs: 10,
+      });
+
+      const options: GenerateChatOptions = {
+        contents: [{ role: 'user', blocks: [{ type: 'text', text: 'test' }] }],
+      };
+
+      const result = await consumeStream(
+        orchestrator.generateChatCompletion(options),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].blocks[0]).toMatchObject({
+        type: 'text',
+        text: 'test response',
+      });
+    });
+
     it('should respect maxAttempts configuration', async () => {
       const rateLimitError = createRateLimitError();
       const provider = createTestProvider({

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.fetchRetry.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.fetchRetry.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { OpenAIResponsesProvider } from './OpenAIResponsesProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+
+const mockSettingsService = vi.hoisted(() => ({
+  set: vi.fn(),
+  get: vi.fn(),
+  setProviderSetting: vi.fn(),
+  getProviderSettings: vi.fn().mockReturnValue({}),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getAllGlobalSettings: vi.fn().mockReturnValue({}),
+}));
+
+const parseResponsesStreamMock = vi.hoisted(() =>
+  vi.fn(async function* () {
+    yield {
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'Hello from retry!' }],
+    };
+  }),
+);
+
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@vybestack/llxprt-code-settings', async () => ({
+  ...(await vi.importActual<typeof import('@vybestack/llxprt-code-settings')>(
+    '@vybestack/llxprt-code-settings',
+  )),
+  getSettingsService: () => mockSettingsService,
+  SETTINGS_REGISTRY: [],
+}));
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('system prompt'),
+}));
+
+vi.mock('../openai/parseResponsesStream.js', () => ({
+  parseResponsesStream: parseResponsesStreamMock,
+}));
+
+describe('OpenAIResponsesProvider connection-phase fetch retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettingsService.getSettings.mockResolvedValue({});
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('should retry when fetch throws TypeError("fetch failed") on first attempt and succeed on second', async () => {
+    const mockBody = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+    fetchMock
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce({
+        ok: true,
+        body: mockBody,
+      });
+
+    const provider = new OpenAIResponsesProvider('test-key', undefined, {
+      getEphemeralSettings: () => ({}),
+    });
+
+    const generator = provider.generateChatCompletion(
+      createProviderCallOptions({
+        providerName: provider.name,
+        contents: [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Hello' }],
+          },
+        ] as IContent[],
+        ephemerals: {
+          retries: 3,
+          retrywait: 10,
+        },
+      }),
+    );
+
+    const chunks: IContent[] = [];
+    for await (const chunk of generator) {
+      chunks.push(chunk);
+    }
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0]).toBeDefined();
+  });
+
+  it('should NOT retry when fetch throws an AbortError (user cancellation)', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    fetchMock.mockRejectedValue(abortError);
+
+    const provider = new OpenAIResponsesProvider('test-key', undefined, {
+      getEphemeralSettings: () => ({}),
+    });
+
+    const generator = provider.generateChatCompletion(
+      createProviderCallOptions({
+        providerName: provider.name,
+        contents: [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'Hello' }],
+          },
+        ] as IContent[],
+        ephemerals: {
+          retries: 3,
+          retrywait: 10,
+        },
+      }),
+    );
+
+    await expect(async () => {
+      for await (const _chunk of generator) {
+        // drain
+      }
+    }).rejects.toThrow('aborted');
+
+    expect(fetchMock.mock.calls.length).toBe(1);
+  });
+});

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -602,8 +602,8 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
 
     while (streamingAttempt < options.maxStreamingAttempts) {
       streamingAttempt += 1;
-      const response = await this.fetchResponse(options);
       try {
+        const response = await this.fetchResponse(options);
         yield* this.parseSuccessfulResponse(response, options);
         return;
       } catch (error) {
@@ -673,6 +673,9 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
       currentDelay: number;
     },
   ): Promise<number> {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error;
+    }
     const canRetryStream =
       this.shouldRetryOnError(error) || isNetworkTransientError(error);
     if (

--- a/packages/tools/src/tools/direct-web-fetch.ts
+++ b/packages/tools/src/tools/direct-web-fetch.ts
@@ -198,7 +198,6 @@ class DirectWebFetchToolInvocation extends BaseToolInvocation<
       {
         maxAttempts: 3,
         initialDelayMs: 500,
-        retryFetchErrors: true,
         signal,
       },
     );

--- a/packages/tools/src/utils/retry.ts
+++ b/packages/tools/src/utils/retry.ts
@@ -8,8 +8,7 @@ export interface RetryOptions {
   maxAttempts: number;
   initialDelayMs: number;
   maxDelayMs: number;
-  shouldRetryOnError: (error: Error, retryFetchErrors?: boolean) => boolean;
-  retryFetchErrors?: boolean;
+  shouldRetryOnError: (error: Error) => boolean;
   signal?: AbortSignal;
 }
 
@@ -197,10 +196,7 @@ function isRetryableStatus(status: number | undefined): boolean {
   );
 }
 
-export function isRetryableError(
-  error: Error | unknown,
-  _retryFetchErrors?: boolean,
-): boolean {
+export function isRetryableError(error: Error | unknown): boolean {
   if (isNetworkTransientError(error)) {
     return true;
   }
@@ -222,7 +218,6 @@ export async function retryWithBackoff<T>(
     initialDelayMs,
     maxDelayMs,
     shouldRetryOnError,
-    retryFetchErrors,
     signal,
   } = {
     ...DEFAULT_RETRY_OPTIONS,
@@ -244,10 +239,7 @@ export async function retryWithBackoff<T>(
       if (error instanceof Error && error.name === 'AbortError') {
         throw error;
       }
-      if (
-        attempt >= maxAttempts ||
-        !shouldRetryOnError(error as Error, retryFetchErrors)
-      ) {
+      if (attempt >= maxAttempts || !shouldRetryOnError(error as Error)) {
         throw error;
       }
       await delay(currentDelay, signal);

--- a/packages/tools/src/utils/retry.ts
+++ b/packages/tools/src/utils/retry.ts
@@ -37,6 +37,7 @@ const TRANSIENT_ERROR_PHRASES = [
   'stream prematurely closed',
   'read econnreset',
   'write econnreset',
+  'fetch failed',
 ];
 
 const TRANSIENT_ERROR_REGEXES = [
@@ -198,17 +199,10 @@ function isRetryableStatus(status: number | undefined): boolean {
 
 export function isRetryableError(
   error: Error | unknown,
-  retryFetchErrors?: boolean,
+  _retryFetchErrors?: boolean,
 ): boolean {
   if (isNetworkTransientError(error)) {
     return true;
-  }
-
-  if (retryFetchErrors === true) {
-    const { messages } = collectErrorDetails(error);
-    if (messages.some((msg) => msg.toLowerCase().includes('fetch failed'))) {
-      return true;
-    }
   }
 
   const status = getErrorStatus(error);


### PR DESCRIPTION
## Summary

A connection-phase `TypeError: fetch failed` (DNS failure, socket reset, TLS/connect failure) escaped **all** retry logic, breaking the loop and surfacing a raw error to the user (issue #2161). This was a JS runtime error emitted by `fetch()` for transport failures — not a TypeScript type error.

Two root causes, both fixed:

### 1. Structural retry gap — `fetchStreamWithRetries`
In `OpenAIResponsesProviderCore.fetchStreamWithRetries`, the initial `fetch()` call (`fetchResponse`) sat **outside** the retry loop's `try/catch`. Connection-phase throws (where `fetch()` itself rejects before any `Response` exists) therefore bypassed `handleStreamRetry` entirely and propagated straight up through `RetryOrchestrator.yieldStreamUnprotected`.

**Fix:** Moved `await this.fetchResponse(options)` inside the `try` block alongside `parseSuccessfulResponse`, so both connection-phase and stream-phase errors are caught and routed through the existing inner backoff loop.

### 2. Classification gap — `isNetworkTransientError`
The shared `isNetworkTransientError` (used by both the inner `handleStreamRetry` via `shouldRetryOnError`, and the outer `RetryOrchestrator.shouldRetryError`) did **not** recognize the bare phrase `"fetch failed"`. It was only honored by `isRetryableError` when a `retryFetchErrors: true` flag was passed — which neither retry layer did. So even when the error was caught, it was not classified as retryable.

**Fix:** Added `"fetch failed"` to `TRANSIENT_ERROR_PHRASES`, centralizing recognition so both retry layers treat a bare `TypeError: fetch failed` (even with no informative `.cause`) as transient. Removed the now-dead `retryFetchErrors`-gated fetch-failed branch from `isRetryableError` (kept the param for type-contract compatibility, renamed to `_retryFetchErrors`).

### Hardening — AbortError guard
Since the widened `try` boundary now includes `fetch()` itself, an `AbortError` (user-initiated cancellation) could enter `handleStreamRetry`. Added an explicit `AbortError` guard at the top of `handleStreamRetry` — mirroring the existing guard in `retryWithBackoff` — so cancellation is never retried.

## Behavior

- Transient `TypeError: fetch failed` → now retried by both the inner stream loop and outer orchestrator (was: escapes all retry logic).
- `AbortError` → never retried (preserved, explicit guard).
- HTTP 400 / 404 → never retried (unchanged).
- HTTP 429 / 5xx → retried (unchanged).

## Test plan

- `packages/core/src/utils/retry.test.ts` — bare `TypeError('fetch failed')` retries without the `retryFetchErrors` flag.
- `packages/core/src/utils/retry.quota.test.ts` — `isNetworkTransientError` returns `true` for bare `TypeError: fetch failed` (no cause) and cause-chained undici errors; `false` for non-transient.
- `packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts` — `RetryOrchestrator` retries on bare `TypeError('fetch failed')`.
- `packages/providers/src/openai-responses/OpenAIResponsesProviderCore.fetchRetry.test.ts` (new) — connection-phase `fetch()` throw is retried and succeeds on the second call; `AbortError` is **not** retried (fetch called only once).
- `packages/agents/src/core/StreamProcessor.retryBoundary.test.ts` — updated to reflect centralized transient detection.

Full verification suite (typecheck, lint, format, build, all workspace tests, smoke test) passes.

Fixes #2161
