### PR TITLE
Fix context overflow preflight after model switch (Fixes #2139)

### DIFF
--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -21,7 +21,10 @@ import type { TodoContinuationService } from './TodoContinuationService.js';
 import type { IdeContextTracker } from './IdeContextTracker.js';
 import type { AgentHookManager } from './AgentHookManager.js';
 import type { AfterAgentHookOutput } from '@vybestack/llxprt-code-core/hooks/types.js';
-import { estimateTextOnlyLength, extractPromptText } from './clientHelpers.js';
+import {
+  estimateRequestTokensStructured,
+  extractPromptText,
+} from './clientHelpers.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import type { Todo } from '@vybestack/llxprt-code-tools';
 import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
@@ -281,13 +284,38 @@ export class MessageStreamOrchestrator {
       );
     }
 
-    const modelForLimitCheck = getEffectiveModel();
-    const estimatedRequestTokenCount = Math.floor(
-      estimateTextOnlyLength(initialRequest) / 4,
-    );
+    const chat = getChat();
     const remainingTokenCount =
-      getTokenLimitForConfiguredContext(modelForLimitCheck, config) -
-      getChat().getLastPromptTokenCount();
+      getTokenLimitForConfiguredContext(getEffectiveModel(), config) -
+      chat.getLastPromptTokenCount();
+
+    // When history already exceeds the current model's limit (e.g. after a
+    // provider/profile switch to a smaller context window), remaining capacity
+    // is zero or negative. The preflight guard must NOT short-circuit: even a
+    // 0-token tool-response continuation would otherwise trip it
+    // (0 > negative * 0.95), emitting a bogus ContextWindowWillOverflow before
+    // the downstream compression path can resolve the overflow with the
+    // switched model's tokenizer. Defer to the normal send path.
+    if (remainingTokenCount <= 0) {
+      return undefined;
+    }
+
+    // Use the model-aware tokenizer for request sizing rather than a naive
+    // text-only estimate, which under-counts functionResponse-only
+    // continuations as 0 tokens. When the chat session does not expose the
+    // tokenizer-backed methods (e.g. a minimal test double), or the tokenizer
+    // throws (e.g. uninitialized internals during early preflight), fall back
+    // to the structured payload-aware estimate so the guard still functions
+    // while counting functionResponse/functionCall JSON payloads.
+    const { estimatePendingTokens: est, convertPartListUnionToIContent: conv } =
+      chat;
+    const fallback = estimateRequestTokensStructured(initialRequest);
+    const estimatedRequestTokenCount =
+      typeof est === 'function' && typeof conv === 'function'
+        ? await est
+            .call(chat, [conv.call(chat, initialRequest)])
+            .catch(() => fallback)
+        : fallback;
 
     if (estimatedRequestTokenCount > remainingTokenCount * 0.95) {
       yield {

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -312,8 +312,9 @@ export class MessageStreamOrchestrator {
     const fallback = estimateRequestTokensStructured(initialRequest);
     const estimatedRequestTokenCount =
       typeof est === 'function' && typeof conv === 'function'
-        ? await est
-            .call(chat, [conv.call(chat, initialRequest)])
+        ? await Promise.resolve()
+            .then(() => conv.call(chat, initialRequest))
+            .then((content) => est.call(chat, [content]))
             .catch(() => fallback)
         : fallback;
 

--- a/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
@@ -239,7 +239,7 @@ describe('Gemini Client (client.ts)', () => {
       // A string of length 400 is roughly 100 tokens.
       const longText = 'a'.repeat(400);
       const request: Part[] = [{ text: longText }];
-      // estimateTextOnlyLength counts only text content (400 chars), not JSON structure
+      // Structured fallback counts the text content (400 chars), not JSON structure.
       const estimatedRequestTokenCount = Math.floor(longText.length / 4);
       const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
 
@@ -531,6 +531,53 @@ describe('Gemini Client (client.ts)', () => {
       ).toBeGreaterThan(950);
     });
 
+    it('should use structured fallback when request conversion throws before tokenizer sizing', async () => {
+      // Arrange — convertPartListUnionToIContent is synchronous. If it throws,
+      // the fallback still needs to run instead of rejecting the stream.
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      const lastPromptTokenCount = 0;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        convertPartListUnionToIContent: vi.fn(() => {
+          throw new Error('conversion unavailable');
+        }),
+        estimatePendingTokens: vi.fn().mockResolvedValue(1),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const request: Part[] = [
+        {
+          functionResponse: {
+            name: 'someTool',
+            response: { result: 'x'.repeat(4000) },
+          },
+        },
+      ];
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-conversion-fallback',
+      );
+      const events = await fromAsync(stream);
+
+      // Assert — fallback counted the functionResponse payload and emitted the
+      // same preflight overflow event rather than throwing.
+      const overflow = events.find(
+        (e) => e.type === GeminiEventType.ContextWindowWillOverflow,
+      );
+      expect(overflow).toBeDefined();
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
     it('should ignore inlineData/fileData in the structured fallback to avoid false positives', async () => {
       // Arrange — large binary payloads must not inflate the fallback estimate.
       const MOCKED_TOKEN_LIMIT = 1000;
@@ -617,7 +664,7 @@ describe('Gemini Client (client.ts)', () => {
       // We need a request > 95 tokens.
       const longText = 'a'.repeat(400);
       const request: Part[] = [{ text: longText }];
-      // estimateTextOnlyLength counts only text content (400 chars), not JSON structure
+      // Structured fallback counts the text content (400 chars), not JSON structure.
       const estimatedRequestTokenCount = Math.floor(longText.length / 4);
       const remainingTokenCount = STICKY_MODEL_LIMIT - lastPromptTokenCount;
 

--- a/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
@@ -264,6 +264,321 @@ describe('Gemini Client (client.ts)', () => {
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
+    it('should NOT emit ContextWindowWillOverflow when remaining capacity is already negative (issue 2139)', async () => {
+      // Arrange — simulate a provider/profile switch where the prior session's
+      // lastPromptTokenCount exceeds the switched model's limit. Remaining is
+      // therefore negative, and the preflight guard must NOT short-circuit;
+      // the normal send/compression/enforcement path should attempt to resolve
+      // the overflow with the switched model's tokenizer.
+      const MOCKED_TOKEN_LIMIT = 200000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      // e.g. 249,442 stored tokens against a 200,000-token model.
+      const lastPromptTokenCount = 249442;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        convertPartListUnionToIContent: vi
+          .fn()
+          .mockReturnValue({ speaker: 'human', blocks: [] }),
+        estimatePendingTokens: vi.fn().mockResolvedValue(0),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      // A small "continue" request — remaining is -49,442.
+      const request: Part[] = [{ text: 'continue' }];
+
+      const mockStream = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-negative-remaining',
+      );
+      const events = await fromAsync(stream);
+
+      // Assert — no bogus overflow; the turn proceeds.
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ContextWindowWillOverflow,
+        }),
+      );
+      expect(mockTurnRunFn).toHaveBeenCalled();
+    });
+
+    it('should NOT emit ContextWindowWillOverflow for a functionResponse-only continuation when remaining is negative (issue 2139)', async () => {
+      // Arrange — after a tool call completes, the continuation request is a
+      // bare functionResponse part. The negative-remaining short-circuit must
+      // defer to the send path rather than tripping a bogus guard.
+      const MOCKED_TOKEN_LIMIT = 200000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const lastPromptTokenCount = 249442;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        convertPartListUnionToIContent: vi.fn().mockReturnValue({
+          speaker: 'tool',
+          blocks: [],
+        }),
+        estimatePendingTokens: vi.fn().mockResolvedValue(0),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      // Pure functionResponse continuation — 0 tokens by text estimate.
+      const request: Part[] = [
+        {
+          functionResponse: {
+            name: 'someTool',
+            response: { result: 'done' },
+          },
+        },
+      ];
+
+      const mockStream = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-tool-response-continuation',
+      );
+      const events = await fromAsync(stream);
+
+      // Assert — the 0-token guard must not block the continuation.
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ContextWindowWillOverflow,
+        }),
+      );
+      expect(mockTurnRunFn).toHaveBeenCalled();
+    });
+
+    it('should use the model-aware tokenizer (estimatePendingTokens + convertPartListUnionToIContent) when remaining capacity is positive', async () => {
+      // Arrange — proves the positive-remaining path routes through the
+      // tokenizer-backed sizing path rather than the text-only fallback.
+      const MOCKED_TOKEN_LIMIT = 10000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      const lastPromptTokenCount = 1000;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const convertSpy = vi.fn().mockReturnValue({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'hi' }],
+      });
+      const estimateSpy = vi.fn().mockResolvedValue(50);
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        convertPartListUnionToIContent: convertSpy,
+        estimatePendingTokens: estimateSpy,
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockStream = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const request: Part[] = [{ text: 'continue' }];
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-tokenizer-positive-remaining',
+      );
+      await fromAsync(stream);
+
+      // Assert — tokenizer path was used; text-only fallback was not needed.
+      expect(convertSpy).toHaveBeenCalledWith(request);
+      expect(estimateSpy).toHaveBeenCalledTimes(1);
+      expect(estimateSpy).toHaveBeenCalledWith([
+        { speaker: 'human', blocks: [{ type: 'text', text: 'hi' }] },
+      ]);
+      // No overflow since 50 < (9000 * 0.95).
+      expect(mockTurnRunFn).toHaveBeenCalled();
+    });
+
+    it('should NOT invoke the tokenizer when remaining capacity is already negative (issue 2139)', async () => {
+      // Arrange — proves the negative-remaining short-circuit avoids the
+      // tokenizer-backed sizing path entirely (it returns before sizing).
+      const MOCKED_TOKEN_LIMIT = 200000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      const lastPromptTokenCount = 249442;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const convertSpy = vi.fn();
+      const estimateSpy = vi.fn();
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        convertPartListUnionToIContent: convertSpy,
+        estimatePendingTokens: estimateSpy,
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockStream = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      // Act
+      const stream = client.sendMessageStream(
+        [{ text: 'continue' }],
+        new AbortController().signal,
+        'prompt-id-tokenizer-skipped-negative',
+      );
+      const events = await fromAsync(stream);
+
+      // Assert — preflight deferred to the send path; tokenizer never called.
+      expect(convertSpy).not.toHaveBeenCalled();
+      expect(estimateSpy).not.toHaveBeenCalled();
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ContextWindowWillOverflow,
+        }),
+      );
+      expect(mockTurnRunFn).toHaveBeenCalled();
+    });
+
+    it('should count functionResponse payload tokens in the structured fallback (no tokenizer available)', async () => {
+      // Arrange — a minimal chat double WITHOUT tokenizer methods forces the
+      // structured fallback. A functionResponse-only request must be estimated
+      // as > 0 tokens (its JSON payload), unlike the old text-only estimate.
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      const lastPromptTokenCount = 0;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockStream = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      // Build a functionResponse payload large enough that its JSON/4 exceeds
+      // the 95% threshold of the full limit (1000 * 0.95 = 950 tokens).
+      const largeResult = 'x'.repeat(4000);
+      const request: Part[] = [
+        {
+          functionResponse: {
+            name: 'someTool',
+            response: { result: largeResult },
+          },
+        },
+      ];
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-structured-fallback-fn-response',
+      );
+      const events = await fromAsync(stream);
+
+      // Assert — the payload is counted (would be 0 under the old text-only
+      // estimate), so the guard correctly fires.
+      const overflow = events.find(
+        (e) => e.type === GeminiEventType.ContextWindowWillOverflow,
+      );
+      expect(overflow).toBeDefined();
+      // JSON of the functionResponse is well over 4000 chars → > 950 tokens.
+      expect(
+        (overflow as { value: { estimatedRequestTokenCount: number } }).value
+          .estimatedRequestTokenCount,
+      ).toBeGreaterThan(950);
+    });
+
+    it('should ignore inlineData/fileData in the structured fallback to avoid false positives', async () => {
+      // Arrange — large binary payloads must not inflate the fallback estimate.
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      const lastPromptTokenCount = 0;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockStream = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const request: Part[] = [
+        { text: 'short' }, // 5 chars → 1 token
+        {
+          inlineData: {
+            mimeType: 'application/pdf',
+            data: 'A'.repeat(11 * 1024 * 1024), // ignored
+          },
+        },
+      ];
+
+      // Act
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-structured-fallback-ignore-binary',
+      );
+      const events = await fromAsync(stream);
+
+      // Assert — no overflow despite the huge (ignored) inlineData payload.
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ContextWindowWillOverflow,
+        }),
+      );
+      expect(mockTurnRunFn).toHaveBeenCalled();
+    });
+
     it("should use the sticky model's token limit for the overflow check", async () => {
       // Arrange
       const STICKY_MODEL = 'gemini-1.5-flash';

--- a/packages/agents/src/core/clientHelpers.test.ts
+++ b/packages/agents/src/core/clientHelpers.test.ts
@@ -9,7 +9,7 @@ import type { Content } from '@google/genai';
 import {
   isThinkingSupported,
   findCompressSplitPoint,
-  estimateTextOnlyLength,
+  estimateRequestTokensStructured,
 } from './clientHelpers.js';
 
 describe('isThinkingSupported', () => {
@@ -111,86 +111,64 @@ describe('findCompressSplitPoint', () => {
   });
 });
 
-describe('estimateTextOnlyLength', () => {
-  it('returns string length for string input', () => {
-    expect(estimateTextOnlyLength('hello world')).toBe(11);
+describe('estimateRequestTokensStructured', () => {
+  it('estimates string input from character length', () => {
+    expect(estimateRequestTokensStructured('hello world')).toBe(2);
   });
 
-  it('returns 0 for empty string', () => {
-    expect(estimateTextOnlyLength('')).toBe(0);
-  });
-
-  it('returns 0 for a single non-text Part object (not array)', () => {
+  it('estimates text parts from text length', () => {
     expect(
-      estimateTextOnlyLength({
-        inlineData: { mimeType: 'image/png', data: 'abc' },
-      }),
-    ).toBe(0);
-  });
-
-  it('returns 0 for empty array', () => {
-    expect(estimateTextOnlyLength([])).toBe(0);
-  });
-
-  it('sums text lengths from Part array', () => {
-    expect(
-      estimateTextOnlyLength([{ text: 'hello' }, { text: ' world' }]),
-    ).toBe(11);
-  });
-
-  it('handles string elements within array', () => {
-    expect(estimateTextOnlyLength(['hello', ' ', 'world'])).toBe(11);
-  });
-
-  it('handles mixed text Parts and string elements', () => {
-    expect(estimateTextOnlyLength(['hello', { text: ' world' }])).toBe(11);
-  });
-
-  it('ignores non-text Parts such as inlineData', () => {
-    expect(
-      estimateTextOnlyLength([
-        { text: 'hi' },
-        { inlineData: { mimeType: 'image/png', data: 'binary-data' } },
-      ]),
+      estimateRequestTokensStructured([{ text: 'hello' }, { text: ' world' }]),
     ).toBe(2);
   });
 
-  it('ignores functionCall parts', () => {
-    expect(
-      estimateTextOnlyLength([
-        { text: 'result: ' },
-        { functionCall: { name: 'myFn', args: {} } },
-      ]),
-    ).toBe(8);
+  it('handles single-object text input', () => {
+    expect(estimateRequestTokensStructured({ text: 'hello world' })).toBe(2);
   });
 
-  it('ignores fileData parts', () => {
+  it('counts functionResponse JSON payloads', () => {
+    const payload = {
+      name: 'toolResult',
+      response: { result: 'x'.repeat(40) },
+    };
+
+    expect(estimateRequestTokensStructured({ functionResponse: payload })).toBe(
+      Math.floor(JSON.stringify(payload).length / 4),
+    );
+  });
+
+  it('counts functionCall JSON payloads', () => {
+    const payload = {
+      name: 'toolCall',
+      args: { query: 'x'.repeat(40) },
+    };
+
+    expect(estimateRequestTokensStructured({ functionCall: payload })).toBe(
+      Math.floor(JSON.stringify(payload).length / 4),
+    );
+  });
+
+  it('ignores inlineData and fileData payloads', () => {
     expect(
-      estimateTextOnlyLength([
-        { text: 'check this: ' },
+      estimateRequestTokensStructured([
+        { text: 'abcd' },
+        { inlineData: { mimeType: 'image/png', data: 'x'.repeat(10_000) } },
         { fileData: { fileUri: 'gs://bucket/file' } },
       ]),
-    ).toBe(12);
+    ).toBe(1);
   });
 
-  it('handles array with only non-text parts', () => {
+  it('sums mixed strings, text parts, and function payloads', () => {
+    const response = { name: 'tool', response: { value: 'abcd' } };
+    const expectedChars =
+      'hello'.length + 'world'.length + JSON.stringify(response).length;
+
     expect(
-      estimateTextOnlyLength([
-        { inlineData: { mimeType: 'image/jpeg', data: 'data' } },
-        { functionCall: { name: 'fn', args: {} } },
+      estimateRequestTokensStructured([
+        'hello',
+        { text: 'world' },
+        { functionResponse: response },
       ]),
-    ).toBe(0);
-  });
-
-  it('handles singular {text} object (non-array)', () => {
-    expect(estimateTextOnlyLength({ text: 'hello world' })).toBe(11);
-  });
-
-  it('returns 0 for singular non-text object', () => {
-    expect(
-      estimateTextOnlyLength({
-        inlineData: { mimeType: 'image/png', data: 'binary' },
-      }),
-    ).toBe(0);
+    ).toBe(Math.floor(expectedChars / 4));
   });
 });

--- a/packages/agents/src/core/clientHelpers.ts
+++ b/packages/agents/src/core/clientHelpers.ts
@@ -116,39 +116,16 @@ export function extractPromptText(request: PartListUnion): string {
   return '';
 }
 
-export function estimateTextOnlyLength(request: PartListUnion): number {
-  if (typeof request === 'string') {
-    return request.length;
-  }
-
-  if (!Array.isArray(request)) {
-    if (hasTextProperty(request) && request.text) {
-      return request.text.length;
-    }
-    return 0;
-  }
-
-  let textLength = 0;
-  for (const part of request) {
-    if (typeof part === 'string') {
-      textLength += part.length;
-    } else if (hasTextProperty(part) && part.text) {
-      textLength += part.text.length;
-    }
-  }
-  return textLength;
-}
-
 /**
  * Structured, payload-aware token estimate for a pending request, used as a
  * fallback when the model-aware tokenizer (ChatSession.estimatePendingTokens)
  * is unavailable — e.g. with minimal test doubles.
  *
- * Unlike `estimateTextOnlyLength`, this accounts for `functionResponse` and
- * `functionCall` payloads by serializing their JSON, so a bare
- * functionResponse continuation is no longer estimated as 0 tokens. Binary
- * payloads (`inlineData`/`fileData`) are intentionally ignored so that large
- * base64 blobs do not produce false-positive overflow estimates.
+ * This accounts for `functionResponse` and `functionCall` payloads by
+ * serializing their JSON, so a bare functionResponse continuation is no longer
+ * estimated as 0 tokens. Binary payloads (`inlineData`/`fileData`) are
+ * intentionally ignored so that large base64 blobs do not produce
+ * false-positive overflow estimates.
  */
 export function estimateRequestTokensStructured(
   request: PartListUnion,
@@ -170,22 +147,17 @@ function charLengthForPart(part: Part | string): number {
   if (typeof part === 'string') {
     return part.length;
   }
-  const record = part as Record<string, unknown>;
-  const keys = Object.keys(record);
-  if (keys.includes('inlineData') || keys.includes('fileData')) {
+  if ('inlineData' in part || 'fileData' in part) {
     return 0;
   }
-  if (typeof record.text === 'string') {
-    return record.text.length;
+  if ('text' in part && typeof part.text === 'string') {
+    return part.text.length;
   }
-  if (
-    record.functionResponse !== undefined &&
-    record.functionResponse !== null
-  ) {
-    return safeJsonLength(record.functionResponse);
+  if ('functionResponse' in part && part.functionResponse != null) {
+    return safeJsonLength(part.functionResponse);
   }
-  if (record.functionCall !== undefined && record.functionCall !== null) {
-    return safeJsonLength(record.functionCall);
+  if ('functionCall' in part && part.functionCall != null) {
+    return safeJsonLength(part.functionCall);
   }
   return 0;
 }

--- a/packages/agents/src/core/clientHelpers.ts
+++ b/packages/agents/src/core/clientHelpers.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type PartListUnion, type Content } from '@google/genai';
+import { type PartListUnion, type Part, type Content } from '@google/genai';
 
 export function isThinkingSupported(model: string) {
   return !model.startsWith('gemini-2.0');
@@ -137,4 +137,68 @@ export function estimateTextOnlyLength(request: PartListUnion): number {
     }
   }
   return textLength;
+}
+
+/**
+ * Structured, payload-aware token estimate for a pending request, used as a
+ * fallback when the model-aware tokenizer (ChatSession.estimatePendingTokens)
+ * is unavailable — e.g. with minimal test doubles.
+ *
+ * Unlike `estimateTextOnlyLength`, this accounts for `functionResponse` and
+ * `functionCall` payloads by serializing their JSON, so a bare
+ * functionResponse continuation is no longer estimated as 0 tokens. Binary
+ * payloads (`inlineData`/`fileData`) are intentionally ignored so that large
+ * base64 blobs do not produce false-positive overflow estimates.
+ */
+export function estimateRequestTokensStructured(
+  request: PartListUnion,
+): number {
+  const parts = normalizeToParts(request);
+  let charLength = 0;
+  for (const part of parts) {
+    charLength += charLengthForPart(part);
+  }
+  return Math.floor(charLength / 4);
+}
+
+/**
+ * Computes the character length contribution of a single part for the
+ * structured fallback. Returns 0 for binary payloads (inlineData/fileData)
+ * so large base64 blobs do not inflate the estimate.
+ */
+function charLengthForPart(part: Part | string): number {
+  if (typeof part === 'string') {
+    return part.length;
+  }
+  const record = part as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.includes('inlineData') || keys.includes('fileData')) {
+    return 0;
+  }
+  if (typeof record.text === 'string') {
+    return record.text.length;
+  }
+  if (
+    record.functionResponse !== undefined &&
+    record.functionResponse !== null
+  ) {
+    return safeJsonLength(record.functionResponse);
+  }
+  if (record.functionCall !== undefined && record.functionCall !== null) {
+    return safeJsonLength(record.functionCall);
+  }
+  return 0;
+}
+
+function normalizeToParts(request: PartListUnion): Array<Part | string> {
+  if (typeof request === 'string') return [request];
+  return Array.isArray(request) ? request : [request];
+}
+
+function safeJsonLength(value: unknown): number {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return 0;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #2139.

This changes the context overflow preflight so an already-over-limit conversation after a provider, profile, or model switch is allowed to continue into the normal send path. That path can use the switched model tokenizer and the existing compression/context enforcement machinery instead of stopping early with a misleading negative remaining-token warning.

Key changes:

- If remaining context capacity is zero or negative, skip the early ContextWindowWillOverflow preflight guard so downstream compression/enforcement can try to recover.
- For positive remaining capacity, size the pending request with the chat session tokenizer-backed pending-token estimator instead of the prior text-only estimate.
- Add a structured fallback for minimal/test chat doubles that counts function call and function response JSON payloads while still ignoring binary inline/file data to avoid false positives.
- Cover issue 2139 regressions, tokenizer-backed sizing, fallback behavior, and binary payload behavior with tests.

## Verification

- Targeted agents tests: passed
- Workspace tests run sequentially: passed for all workspaces with test scripts
- CLI package tests: passed
- VS Code companion tests: passed
- npm run lint: passed
- npm run typecheck: passed
- npm run format: passed
- npm run build: passed
- Smoke test with ollamakimi profile: passed

Note: root npm run test was also attempted directly, but concurrent workspace execution was killed by the OS in this environment. The same workspace tests were then run sequentially to completion.
