### PR TITLE
Harden secure-store fallback encryption (Fixes #1986)

### DIFF
--- a/packages/agents/src/api/__tests__/capabilityGaps.integration.spec.ts
+++ b/packages/agents/src/api/__tests__/capabilityGaps.integration.spec.ts
@@ -34,6 +34,13 @@ const FIXTURE = 'plain-text.jsonl';
 const ALL_APPROVAL_MODES = Object.values(ApprovalMode);
 const ALL_POLICY_DECISIONS = Object.values(PolicyDecision);
 
+function isSafeMaskedKey(masked: string | undefined): boolean {
+  if (masked === undefined) {
+    return true;
+  }
+  return masked.includes('*') === true || masked.length < 20;
+}
+
 describe('P20 capability-gap integration adequacy (REQ-INT-001..004) @plan:PLAN-20260622-COREAPIGAP.P20', () => {
   let built: BuiltAgent | undefined;
 
@@ -168,10 +175,7 @@ describe('P20 capability-gap integration adequacy (REQ-INT-001..004) @plan:PLAN-
     // Masked-only contract: a masked key carries a `*` or is short — never a
     // full-length raw secret. When maskedKey is absent the contract holds
     // vacuously; when present it must satisfy the mask shape.
-    const masked = status.maskedKey;
-    const maskedSafe =
-      masked === undefined || masked.includes('*') || masked.length < 20;
-    expect(maskedSafe).toBe(true);
+    expect(isSafeMaskedKey(status.maskedKey)).toBe(true);
   });
 
   // ─── #1595 Keystone: every capability entry is a function on the public root ─

--- a/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/policyControl.behavior.test.ts
@@ -152,17 +152,18 @@ describe('agent.policy read-only control @plan:PLAN-20260622-COREAPIGAP.P05 @req
       // toolNames are unique to this test).
       const omitted = rules.find((r) => r.toolName === 'omit-source-probe');
       const present = rules.find((r) => r.toolName === 'present-source-probe');
+      if (omitted === undefined || present === undefined) {
+        throw new Error('Expected seeded policy rules to be present');
+      }
       // The no-source rule's view OMITS the source key entirely.
-      expect(omitted).toBeDefined();
-      expect('source' in omitted!).toBe(false);
-      expect(Object.keys(omitted!)).not.toContain('source');
+      expect('source' in omitted).toBe(false);
+      expect(Object.keys(omitted)).not.toContain('source');
       // Belt-and-suspenders: argsPattern key also absent (no argsPattern seeded).
-      expect('argsPattern' in omitted!).toBe(false);
-      expect(Object.keys(omitted!)).not.toContain('argsPattern');
+      expect('argsPattern' in omitted).toBe(false);
+      expect(Object.keys(omitted)).not.toContain('argsPattern');
       // The present-source rule's view CARRIES source with the seeded value.
-      expect(present).toBeDefined();
-      expect(present!.source).toBe('present-probe');
-      expect('source' in present!).toBe(true);
+      expect(present.source).toBe('present-probe');
+      expect('source' in present).toBe(true);
     } finally {
       await cleanup();
     }

--- a/packages/storage/src/config/storage.test.ts
+++ b/packages/storage/src/config/storage.test.ts
@@ -181,4 +181,9 @@ describe('Storage – additional helpers', () => {
     const expected = path.join(os.homedir(), '.llxprt', 'tmp');
     expect(Storage.getGlobalTempDir()).toBe(expected);
   });
+
+  it('getMachineSecretPath returns ~/.llxprt/machine_secret', () => {
+    const expected = path.join(os.homedir(), '.llxprt', 'machine_secret');
+    expect(Storage.getMachineSecretPath()).toBe(expected);
+  });
 });

--- a/packages/storage/src/config/storage.ts
+++ b/packages/storage/src/config/storage.ts
@@ -41,6 +41,10 @@ export class Storage {
     return path.join(Storage.getGlobalLlxprtDir(), 'installation_id');
   }
 
+  static getMachineSecretPath(): string {
+    return path.join(Storage.getGlobalLlxprtDir(), 'machine_secret');
+  }
+
   static getProviderAccountsPath(): string {
     return path.join(Storage.getGlobalLlxprtDir(), PROVIDER_ACCOUNTS_FILENAME);
   }

--- a/packages/storage/src/secure-store/envelope.test.ts
+++ b/packages/storage/src/secure-store/envelope.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the envelope module: version validation, crypto
+ * parameter validation, and KDF input derivation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'node:crypto';
+import {
+  isValidEnvelope,
+  deriveV1KdfInput,
+  deriveV2KdfInput,
+  SCRYPT_PARAMS,
+  type Envelope,
+} from './envelope.js';
+
+function makeValidEnvelope(
+  version: number,
+  overrides?: Partial<Envelope>,
+): Envelope {
+  return {
+    v: version,
+    crypto: {
+      alg: 'aes-256-gcm',
+      kdf: 'scrypt',
+      N: SCRYPT_PARAMS.N,
+      r: SCRYPT_PARAMS.r,
+      p: SCRYPT_PARAMS.p,
+      saltLen: 16,
+    },
+    data: crypto.randomBytes(64).toString('base64'),
+    ...overrides,
+  };
+}
+
+describe('isValidEnvelope', () => {
+  it('accepts a well-formed v:1 envelope', () => {
+    expect(isValidEnvelope(makeValidEnvelope(1))).toBe(true);
+  });
+
+  it('accepts a well-formed v:2 envelope', () => {
+    expect(isValidEnvelope(makeValidEnvelope(2))).toBe(true);
+  });
+
+  it('rejects unknown versions', () => {
+    expect(isValidEnvelope(makeValidEnvelope(3))).toBe(false);
+    expect(isValidEnvelope(makeValidEnvelope(0))).toBe(false);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isValidEnvelope(null)).toBe(false);
+    expect(isValidEnvelope('string')).toBe(false);
+    expect(isValidEnvelope(42)).toBe(false);
+    expect(isValidEnvelope(undefined)).toBe(false);
+  });
+
+  it('rejects unsupported cipher', () => {
+    const env = makeValidEnvelope(1, {
+      crypto: {
+        alg: 'aes-128-gcm',
+        kdf: 'scrypt',
+        N: 16384,
+        r: 8,
+        p: 1,
+        saltLen: 16,
+      },
+    });
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+
+  it('rejects unsupported KDF', () => {
+    const env = makeValidEnvelope(1, {
+      crypto: {
+        alg: 'aes-256-gcm',
+        kdf: 'pbkdf2',
+        N: 16384,
+        r: 8,
+        p: 1,
+        saltLen: 16,
+      },
+    });
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+
+  it('rejects unexpected scrypt N parameter', () => {
+    const env = makeValidEnvelope(1, {
+      crypto: {
+        alg: 'aes-256-gcm',
+        kdf: 'scrypt',
+        N: 1024,
+        r: 8,
+        p: 1,
+        saltLen: 16,
+      },
+    });
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+
+  it('rejects unexpected scrypt r parameter', () => {
+    const env = makeValidEnvelope(1, {
+      crypto: {
+        alg: 'aes-256-gcm',
+        kdf: 'scrypt',
+        N: 16384,
+        r: 4,
+        p: 1,
+        saltLen: 16,
+      },
+    });
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+
+  it('rejects unexpected scrypt p parameter', () => {
+    const env = makeValidEnvelope(1, {
+      crypto: {
+        alg: 'aes-256-gcm',
+        kdf: 'scrypt',
+        N: 16384,
+        r: 8,
+        p: 2,
+        saltLen: 16,
+      },
+    });
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+
+  it('rejects unexpected saltLen', () => {
+    const env = makeValidEnvelope(1, {
+      crypto: {
+        alg: 'aes-256-gcm',
+        kdf: 'scrypt',
+        N: 16384,
+        r: 8,
+        p: 1,
+        saltLen: 32,
+      },
+    });
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+
+  it('rejects missing data field', () => {
+    const env = makeValidEnvelope(1);
+    delete (env as Partial<Envelope>).data;
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+
+  it('rejects non-string data', () => {
+    const env = makeValidEnvelope(1);
+    (env as unknown as { data: number }).data = 123;
+    expect(isValidEnvelope(env)).toBe(false);
+  });
+});
+
+describe('KDF input derivation', () => {
+  it('v:1 derivation is deterministic for the same service name', () => {
+    const a = deriveV1KdfInput('svc');
+    const b = deriveV1KdfInput('svc');
+    expect(a).toBe(b);
+  });
+
+  it('v:2 derivation is deterministic for same service + secret', () => {
+    const secret = crypto.randomBytes(32);
+    const a = deriveV2KdfInput('svc', secret);
+    const b = deriveV2KdfInput('svc', secret);
+    expect(a).toBe(b);
+  });
+
+  it('v:2 derivation differs for different secrets', () => {
+    const secretA = crypto.randomBytes(32);
+    const secretB = crypto.randomBytes(32);
+    const a = deriveV2KdfInput('svc', secretA);
+    const b = deriveV2KdfInput('svc', secretB);
+    expect(a).not.toBe(b);
+  });
+
+  it('v:2 derivation differs for different service names', () => {
+    const secret = crypto.randomBytes(32);
+    const a = deriveV2KdfInput('svc-a', secret);
+    const b = deriveV2KdfInput('svc-b', secret);
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/storage/src/secure-store/envelope.ts
+++ b/packages/storage/src/secure-store/envelope.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Encryption envelope primitives for the SecureStore file fallback.
+ *
+ * Centralizes the on-disk envelope shape, versioning, scrypt KDF parameters,
+ * and the per-version KDF input derivation so that SecureStore can remain
+ * focused on the keyring/file lifecycle. The envelope versions are:
+ *
+ *   - v:1: KDF input = serviceName + '-' + sha256(hostname + username)
+ *   - v:2: KDF input = machineSecretHex + '|' + serviceName + '|' +
+ *           sha256(hostname + username)
+ *
+ * AES-256-GCM and scrypt parameters are identical for both versions.
+ *
+ * @plan PLAN-20260211-SECURESTORE.P06
+ */
+
+import * as crypto from 'node:crypto';
+import * as os from 'node:os';
+
+/** Envelope versions that this implementation can read. */
+export const ENVELOPE_VERSIONS = new Set<number>([1, 2]);
+
+/** scrypt cost parameters. Shared by v:1 and v:2 envelopes. */
+export const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const;
+
+export interface Envelope {
+  v: number;
+  crypto: {
+    alg: string;
+    kdf: string;
+    N: number;
+    r: number;
+    p: number;
+    saltLen: number;
+  };
+  data: string;
+}
+
+/**
+ * Promisified node:crypto.scrypt. Returns a Buffer of length `keyLen`.
+ */
+export function scryptAsync(
+  password: string,
+  salt: Buffer,
+  keyLen: number,
+  options: { N: number; r: number; p: number },
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    crypto.scrypt(password, salt, keyLen, options, (err, key) => {
+      if (err) reject(err);
+      else resolve(key);
+    });
+  });
+}
+
+/**
+ * Resolves the OS username in a way that never throws, falling back to the
+ * numeric uid (or 'unknown') when userInfo() fails.
+ */
+function safeUsername(): string {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return String(process.getuid?.() ?? 'unknown');
+  }
+}
+
+/**
+ * Stable per-machine identifier: sha256(hostname + username). Used as a
+ * component in both v:1 and v:2 KDF inputs.
+ */
+function machineId(): string {
+  return crypto
+    .createHash('sha256')
+    .update(os.hostname() + safeUsername())
+    .digest('hex');
+}
+
+/**
+ * v:1 KDF input. Remains exactly `serviceName + '-' + machineId()` for
+ * backwards compatibility with existing fallback files.
+ */
+export function deriveV1KdfInput(serviceName: string): string {
+  return serviceName + '-' + machineId();
+}
+
+/**
+ * v:2 KDF input. The machine secret hex is the dominant entropy source so
+ * that confidentiality does not depend solely on filesystem permissions.
+ */
+export function deriveV2KdfInput(
+  serviceName: string,
+  machineSecret: Buffer,
+): string {
+  return machineSecret.toString('hex') + '|' + serviceName + '|' + machineId();
+}
+
+/** Expected salt length (bytes) for the fallback envelope. */
+export const SALT_LEN = 16;
+
+/**
+ * Type guard: the envelope has a recognized version and the crypto fields
+ * reference AES-256-GCM over scrypt with the expected parameters. Does not
+ * validate the data payload.
+ */
+export function isValidEnvelope(envelope: unknown): envelope is Envelope {
+  if (typeof envelope !== 'object' || envelope === null) return false;
+  const env = envelope as Record<string, unknown>;
+  if (typeof env.v !== 'number' || !ENVELOPE_VERSIONS.has(env.v)) {
+    return false;
+  }
+  if (typeof env.crypto !== 'object' || env.crypto === null) return false;
+  const c = env.crypto as Record<string, unknown>;
+  if (c.alg !== 'aes-256-gcm') return false;
+
+  if (c.kdf !== 'scrypt') return false;
+  // Validate scrypt parameters against the expected values so that a
+  // downgraded or tampered envelope is rejected on read rather than being
+  // silently decrypted with weaker/incorrect parameters.
+  if (c.N !== SCRYPT_PARAMS.N) return false;
+  if (c.r !== SCRYPT_PARAMS.r) return false;
+  if (c.p !== SCRYPT_PARAMS.p) return false;
+  if (c.saltLen !== SALT_LEN) return false;
+  if (typeof env.data !== 'string') return false;
+  return true;
+}

--- a/packages/storage/src/secure-store/machine-secret.test.ts
+++ b/packages/storage/src/secure-store/machine-secret.test.ts
@@ -1,0 +1,486 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the machine-secret provider.
+ *
+ * The machine secret is a 32-byte high-entropy secret used as the root of
+ * trust for the SecureStore fallback encryption (envelope v:2). It is
+ * resolved in this order: in-memory cache → OS keyring → file → generate
+ * (persist and return).
+ *
+ * Infrastructure (keyring adapter, filesystem path) is injected so the real
+ * provider logic is exercised; the module under test is never mocked.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as crypto from 'node:crypto';
+import type { KeyringAdapter } from './secure-store.js';
+import {
+  getMachineSecret,
+  resetMachineSecretCache,
+  type MachineSecretOptions,
+} from './machine-secret.js';
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+function createMockKeyring(): KeyringAdapter & {
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getPassword: async (service: string, account: string) =>
+      store.get(`${service}:${account}`) ?? null,
+    setPassword: async (service: string, account: string, password: string) => {
+      store.set(`${service}:${account}`, password);
+    },
+    deletePassword: async (service: string, account: string) =>
+      store.delete(`${service}:${account}`),
+  };
+}
+
+async function createTempFilePath(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'machine-secret-test-'));
+  return path.join(dir, 'machine_secret');
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Machine Secret Provider', () => {
+  let tempFilePath: string;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempFilePath = await createTempFilePath();
+    tempDir = path.dirname(tempFilePath);
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('first call generates a 32-byte secret when keyring is available', async () => {
+    const keyring = createMockKeyring();
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => keyring,
+    };
+
+    const secret = await getMachineSecret(options);
+
+    expect(secret).not.toBeNull();
+    expect(secret!.length).toBe(32);
+
+    // Secret should be persisted to the keyring (preferred durable store)
+    const stored = await keyring.getPassword(
+      'llxprt-code-machine-secret',
+      'default',
+    );
+    expect(stored).not.toBeNull();
+    expect(Buffer.compare(Buffer.from(stored!, 'base64'), secret!)).toBe(0);
+  });
+
+  it('first call without keyring generates a 32-byte secret and persists it to the file', async () => {
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => null,
+    };
+
+    const secret = await getMachineSecret(options);
+
+    expect(secret).not.toBeNull();
+    expect(secret!.length).toBe(32);
+
+    // File should now exist on disk
+    const written = await fs.readFile(tempFilePath, 'utf8');
+    const decoded = Buffer.from(written, 'base64');
+    expect(decoded.length).toBe(32);
+    expect(Buffer.compare(decoded, secret!)).toBe(0);
+  });
+
+  it('second call returns the cached secret without touching the keyring or file', async () => {
+    const keyring = createMockKeyring();
+    let keyringReads = 0;
+    const wrappedKeyring: KeyringAdapter = {
+      getPassword: async (service: string, account: string) => {
+        keyringReads++;
+        return keyring.getPassword(service, account);
+      },
+      setPassword: keyring.setPassword.bind(keyring),
+      deletePassword: keyring.deletePassword.bind(keyring),
+    };
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => wrappedKeyring,
+    };
+
+    const first = await getMachineSecret(options);
+    const readsAfterFirst = keyringReads;
+
+    const second = await getMachineSecret(options);
+
+    expect(second).not.toBeNull();
+    expect(Buffer.compare(second!, first!)).toBe(0);
+    expect(keyringReads).toBe(readsAfterFirst);
+  });
+
+  it('prefers the OS keyring over the file when both are available', async () => {
+    const keyring = createMockKeyring();
+    const keyringSecret = crypto.randomBytes(32);
+    await keyring.setPassword(
+      'llxprt-code-machine-secret',
+      'default',
+      keyringSecret.toString('base64'),
+    );
+
+    // Also place a different secret in the file
+    const fileSecret = crypto.randomBytes(32);
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(tempFilePath, fileSecret.toString('base64'));
+
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => keyring,
+    };
+
+    const secret = await getMachineSecret(options);
+
+    expect(secret).not.toBeNull();
+    expect(Buffer.compare(secret!, keyringSecret)).toBe(0);
+    expect(Buffer.compare(secret!, fileSecret)).not.toBe(0);
+  });
+
+  it('falls back to the file when the keyring has no secret', async () => {
+    const keyring = createMockKeyring();
+    const fileSecret = crypto.randomBytes(32);
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(tempFilePath, fileSecret.toString('base64'));
+
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => keyring,
+    };
+
+    const secret = await getMachineSecret(options);
+
+    expect(secret).not.toBeNull();
+    expect(Buffer.compare(secret!, fileSecret)).toBe(0);
+  });
+
+  it('persists a newly generated secret to the keyring when keyring is available', async () => {
+    const keyring = createMockKeyring();
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => keyring,
+    };
+
+    const secret = await getMachineSecret(options);
+
+    const stored = await keyring.getPassword(
+      'llxprt-code-machine-secret',
+      'default',
+    );
+    expect(stored).not.toBeNull();
+    expect(Buffer.compare(Buffer.from(stored!, 'base64'), secret!)).toBe(0);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'file fallback is written with 0o600 permissions on Unix',
+    async () => {
+      const options: MachineSecretOptions = {
+        filePath: tempFilePath,
+        keyringLoader: async () => null,
+      };
+
+      await getMachineSecret(options);
+
+      const stat = await fs.stat(tempFilePath);
+      expect(stat.mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'parent directory is created with 0o700 permissions on Unix',
+    async () => {
+      const nestedDir = path.join(tempDir, 'nested', 'subdir');
+      const nestedFile = path.join(nestedDir, 'machine_secret');
+
+      const options: MachineSecretOptions = {
+        filePath: nestedFile,
+        keyringLoader: async () => null,
+      };
+
+      await getMachineSecret(options);
+
+      const stat = await fs.stat(nestedDir);
+      expect(stat.mode & 0o777).toBe(0o700);
+    },
+  );
+
+  it('returns null (graceful degradation) when neither keyring nor file are usable and generation cannot persist', async () => {
+    // Point filePath at a path whose parent cannot be created (use an
+    // existing file as a "directory" to force mkdir to fail).
+    const blockerFile = path.join(tempDir, 'blocker');
+    await fs.writeFile(blockerFile, 'x');
+    const impossiblePath = path.join(blockerFile, 'child', 'machine_secret');
+
+    const options: MachineSecretOptions = {
+      filePath: impossiblePath,
+      keyringLoader: async () => null,
+    };
+
+    const secret = await getMachineSecret(options);
+    expect(secret).toBeNull();
+  });
+
+  it('returns null when keyring loader throws and file cannot be read', async () => {
+    const options: MachineSecretOptions = {
+      filePath: path.join(tempDir, 'nonexistent', 'machine_secret'),
+      keyringLoader: async () => {
+        throw new Error('keyring exploded');
+      },
+    };
+
+    // Make the directory unwritable so persistence also fails
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.chmod(tempDir, 0o500);
+    try {
+      const secret = await getMachineSecret(options);
+      expect(secret).toBeNull();
+    } finally {
+      await fs.chmod(tempDir, 0o700);
+    }
+  });
+
+  it('does not throw when keyringLoader returns null and generates+persists to file', async () => {
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => null,
+    };
+
+    const secret = await getMachineSecret(options);
+    expect(secret).not.toBeNull();
+    expect(secret!.length).toBe(32);
+
+    const onDisk = await fs.readFile(tempFilePath, 'utf8');
+    expect(Buffer.from(onDisk, 'base64').length).toBe(32);
+  });
+
+  it('resetMachineSecretCache forces re-read from keyring/file on next call', async () => {
+    const keyring = createMockKeyring();
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => keyring,
+    };
+
+    const first = await getMachineSecret(options);
+
+    // Rotate the keyring secret out-of-band and clear the file
+    const newSecret = crypto.randomBytes(32);
+    await keyring.setPassword(
+      'llxprt-code-machine-secret',
+      'default',
+      newSecret.toString('base64'),
+    );
+    await fs.unlink(tempFilePath).catch(() => {});
+
+    resetMachineSecretCache();
+    const second = await getMachineSecret(options);
+
+    expect(Buffer.compare(second!, newSecret)).toBe(0);
+    expect(Buffer.compare(second!, first!)).not.toBe(0);
+  });
+});
+
+// ─── Concurrency race on first-time generation ──────────────────────────────
+
+describe('Machine Secret Provider — Concurrency', () => {
+  let tempFilePath: string;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempFilePath = await createTempFilePath();
+    tempDir = path.dirname(tempFilePath);
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('concurrent first-call calls all return the same secret matching persisted', async () => {
+    const keyring = createMockKeyring();
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => keyring,
+    };
+
+    // Fire N concurrent first-time calls. Without a mutex, each may
+    // generate a different secret and the loser may return a non-durable
+    // value while another wins persistence.
+    const N = 16;
+    const results = await Promise.all(
+      Array.from({ length: N }, () => getMachineSecret(options)),
+    );
+
+    // Every result must be non-null and identical.
+    for (const secret of results) {
+      expect(secret).not.toBeNull();
+      expect(Buffer.compare(secret!, results[0]!)).toBe(0);
+    }
+
+    // The persisted keyring secret must match what was returned.
+    const stored = await keyring.getPassword(
+      'llxprt-code-machine-secret',
+      'default',
+    );
+    expect(stored).not.toBeNull();
+    expect(Buffer.compare(Buffer.from(stored!, 'base64'), results[0]!)).toBe(0);
+  });
+
+  it('concurrent first-call calls with file fallback all share the persisted secret', async () => {
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => null,
+    };
+
+    const N = 16;
+    const results = await Promise.all(
+      Array.from({ length: N }, () => getMachineSecret(options)),
+    );
+
+    for (const secret of results) {
+      expect(secret).not.toBeNull();
+      expect(Buffer.compare(secret!, results[0]!)).toBe(0);
+    }
+
+    const onDisk = await fs.readFile(tempFilePath, 'utf8');
+    expect(Buffer.compare(Buffer.from(onDisk, 'base64'), results[0]!)).toBe(0);
+  });
+});
+
+// ─── Cache scoping by durable source identity ───────────────────────────────
+
+describe('Machine Secret Provider — Cache scoping', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'machine-secret-cache-test-'),
+    );
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('two distinct filePaths return and use distinct persisted secrets', async () => {
+    const pathA = path.join(tempDir, 'a', 'machine_secret');
+    const pathB = path.join(tempDir, 'b', 'machine_secret');
+
+    const optsA: MachineSecretOptions = {
+      filePath: pathA,
+      keyringLoader: async () => null,
+    };
+    const optsB: MachineSecretOptions = {
+      filePath: pathB,
+      keyringLoader: async () => null,
+    };
+
+    const secretA = await getMachineSecret(optsA);
+    const secretB = await getMachineSecret(optsB);
+
+    expect(secretA).not.toBeNull();
+    expect(secretB).not.toBeNull();
+    expect(Buffer.compare(secretA!, secretB!)).not.toBe(0);
+
+    const onDiskA = await fs.readFile(pathA, 'utf8');
+    const onDiskB = await fs.readFile(pathB, 'utf8');
+    expect(Buffer.compare(Buffer.from(onDiskA, 'base64'), secretA!)).toBe(0);
+    expect(Buffer.compare(Buffer.from(onDiskB, 'base64'), secretB!)).toBe(0);
+  });
+
+  it('clearing one source does not poison the other', async () => {
+    const pathA = path.join(tempDir, 'a', 'machine_secret');
+    const pathB = path.join(tempDir, 'b', 'machine_secret');
+
+    const optsA: MachineSecretOptions = {
+      filePath: pathA,
+      keyringLoader: async () => null,
+    };
+    const optsB: MachineSecretOptions = {
+      filePath: pathB,
+      keyringLoader: async () => null,
+    };
+
+    const secretA = await getMachineSecret(optsA);
+    const secretB = await getMachineSecret(optsB);
+
+    // Wipe source A and clear the cache.
+    await fs.unlink(pathA).catch(() => {});
+    resetMachineSecretCache();
+
+    // Source B should still resolve its persisted secret unaffected.
+    const secretBReRead = await getMachineSecret(optsB);
+    expect(secretBReRead).not.toBeNull();
+    expect(Buffer.compare(secretBReRead!, secretB!)).toBe(0);
+    // And should NOT accidentally be source A's value.
+    expect(Buffer.compare(secretBReRead!, secretA!)).not.toBe(0);
+  });
+});
+
+// ─── Existing file permission repair ────────────────────────────────────────
+
+describe('Machine Secret Provider — Permission repair', () => {
+  let tempFilePath: string;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempFilePath = await createTempFilePath();
+    tempDir = path.dirname(tempFilePath);
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'pre-existing 0o644 file is repaired to 0o600 before acceptance',
+    async () => {
+      const preExisting = crypto.randomBytes(32);
+      await fs.mkdir(tempDir, { recursive: true });
+      await fs.writeFile(tempFilePath, preExisting.toString('base64'), {
+        mode: 0o644,
+      });
+      // Ensure the file is actually 0o644 (some platforms may adjust).
+      await fs.chmod(tempFilePath, 0o644);
+
+      const options: MachineSecretOptions = {
+        filePath: tempFilePath,
+        keyringLoader: async () => null,
+      };
+
+      const secret = await getMachineSecret(options);
+
+      expect(secret).not.toBeNull();
+      expect(Buffer.compare(secret!, preExisting)).toBe(0);
+
+      const stat = await fs.stat(tempFilePath);
+      expect(stat.mode & 0o777).toBe(0o600);
+    },
+  );
+});

--- a/packages/storage/src/secure-store/machine-secret.test.ts
+++ b/packages/storage/src/secure-store/machine-secret.test.ts
@@ -242,23 +242,19 @@ describe('Machine Secret Provider', () => {
     expect(secret).toBeNull();
   });
 
-  it('returns null when keyring loader throws and file cannot be read', async () => {
+  it('returns null when keyring loader throws and file persistence cannot create the parent path', async () => {
+    const blockerFile = path.join(tempDir, 'blocker-for-loader-throw');
+    await fs.writeFile(blockerFile, 'x');
+    const impossiblePath = path.join(blockerFile, 'child', 'machine_secret');
     const options: MachineSecretOptions = {
-      filePath: path.join(tempDir, 'nonexistent', 'machine_secret'),
+      filePath: impossiblePath,
       keyringLoader: async () => {
         throw new Error('keyring exploded');
       },
     };
 
-    // Make the directory unwritable so persistence also fails
-    await fs.mkdir(tempDir, { recursive: true });
-    await fs.chmod(tempDir, 0o500);
-    try {
-      const secret = await getMachineSecret(options);
-      expect(secret).toBeNull();
-    } finally {
-      await fs.chmod(tempDir, 0o700);
-    }
+    const secret = await getMachineSecret(options);
+    expect(secret).toBeNull();
   });
 
   it('does not throw when keyringLoader returns null and generates+persists to file', async () => {
@@ -439,6 +435,41 @@ describe('Machine Secret Provider — Cache scoping', () => {
     // And should NOT accidentally be source A's value.
     expect(Buffer.compare(secretBReRead!, secretA!)).not.toBe(0);
   });
+
+  it('two injected keyring loaders using the same filePath keep separate cached secrets', async () => {
+    const sharedPath = path.join(tempDir, 'shared', 'machine_secret');
+    const keyringA = createMockKeyring();
+    const keyringB = createMockKeyring();
+    const secretA = crypto.randomBytes(32);
+    const secretB = crypto.randomBytes(32);
+    await keyringA.setPassword(
+      'llxprt-code-machine-secret',
+      'default',
+      secretA.toString('base64'),
+    );
+    await keyringB.setPassword(
+      'llxprt-code-machine-secret',
+      'default',
+      secretB.toString('base64'),
+    );
+
+    const optsA: MachineSecretOptions = {
+      filePath: sharedPath,
+      keyringLoader: async () => keyringA,
+    };
+    const optsB: MachineSecretOptions = {
+      filePath: sharedPath,
+      keyringLoader: async () => keyringB,
+    };
+
+    const resolvedA = await getMachineSecret(optsA);
+    const resolvedB = await getMachineSecret(optsB);
+
+    expect(resolvedA).not.toBeNull();
+    expect(resolvedB).not.toBeNull();
+    expect(Buffer.compare(resolvedA!, secretA)).toBe(0);
+    expect(Buffer.compare(resolvedB!, secretB)).toBe(0);
+  });
 });
 
 // ─── Existing file permission repair ────────────────────────────────────────
@@ -483,4 +514,45 @@ describe('Machine Secret Provider — Permission repair', () => {
       expect(stat.mode & 0o777).toBe(0o600);
     },
   );
+
+  it.skipIf(process.platform === 'win32')(
+    'pre-existing 0o777 parent directory is repaired to 0o700 before file acceptance',
+    async () => {
+      const preExisting = crypto.randomBytes(32);
+      await fs.mkdir(tempDir, { recursive: true, mode: 0o777 });
+      await fs.chmod(tempDir, 0o777);
+      await fs.writeFile(tempFilePath, preExisting.toString('base64'), {
+        mode: 0o600,
+      });
+
+      const options: MachineSecretOptions = {
+        filePath: tempFilePath,
+        keyringLoader: async () => null,
+      };
+
+      const secret = await getMachineSecret(options);
+
+      expect(secret).not.toBeNull();
+      expect(Buffer.compare(secret!, preExisting)).toBe(0);
+
+      const stat = await fs.stat(tempDir);
+      expect(stat.mode & 0o777).toBe(0o700);
+    },
+  );
+
+  it('invalid existing file degrades instead of rotating the machine secret', async () => {
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(tempFilePath, 'not-a-valid-32-byte-secret');
+
+    const options: MachineSecretOptions = {
+      filePath: tempFilePath,
+      keyringLoader: async () => null,
+    };
+
+    const secret = await getMachineSecret(options);
+
+    expect(secret).toBeNull();
+    const onDisk = await fs.readFile(tempFilePath, 'utf8');
+    expect(onDisk).toBe('not-a-valid-32-byte-secret');
+  });
 });

--- a/packages/storage/src/secure-store/machine-secret.ts
+++ b/packages/storage/src/secure-store/machine-secret.ts
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Machine secret provider.
+ *
+ * Supplies a stable 32-byte high-entropy secret that serves as the root of
+ * trust for the SecureStore fallback encryption envelope (v:2). The secret is
+ * resolved in this order:
+ *
+ *   1. In-memory cache (scoped by durable source identity so distinct
+ *      filePaths / injected keyring sources never contaminate each other).
+ *   2. OS keyring (preferred durable store) under a fixed service/account.
+ *   3. File fallback at Storage.getMachineSecretPath() (or injected path).
+ *   4. Generate crypto.randomBytes(32); persist to keyring (if available) or
+ *      file; then return it.
+ *
+ * If the secret cannot be read, generated, or persisted, the provider returns
+ * null rather than throwing, so SecureStore can degrade gracefully.
+ *
+ * Concurrency safety: concurrent first-time calls for the same durable source
+ * share a single in-flight generation promise, and after it resolves the
+ * provider re-reads the persisted winner so no caller ever returns a
+ * non-durable secret.
+ *
+ * Existing-file permission repair: on Unix-like platforms, a pre-existing
+ * machine_secret file is repaired to 0o600 before acceptance; if the repair
+ * fails the secret is rejected (degrades to null) so an insecure secret is
+ * never used.
+ */
+
+import * as crypto from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import type { FileHandle } from 'node:fs/promises';
+import * as path from 'node:path';
+import { Storage } from '../config/storage.js';
+import {
+  createDefaultKeyringAdapter,
+  type KeyringAdapter,
+} from './secure-store.js';
+
+const MACHINE_SECRET_SERVICE = 'llxprt-code-machine-secret';
+const MACHINE_SECRET_ACCOUNT = 'default';
+const SECRET_BYTE_LENGTH = 32;
+
+export interface MachineSecretOptions {
+  /**
+   * Overrides the on-disk path used for the file fallback. Defaults to
+   * Storage.getMachineSecretPath(). Exposed for deterministic tests.
+   */
+  filePath?: string;
+  /**
+   * Overrides the OS keyring loader. Defaults to createDefaultKeyringAdapter.
+   * Exposed for deterministic tests.
+   */
+  keyringLoader?: () => Promise<KeyringAdapter | null>;
+}
+
+/**
+ * Cache entry: holds a resolved secret (Buffer when available, null on
+ * graceful degradation) and an in-flight promise used to deduplicate
+ * concurrent first-time generation for the same durable source.
+ */
+interface CacheEntry {
+  secret: Buffer | null;
+  inFlight: Promise<Buffer | null> | null;
+}
+
+/**
+ * Cache scoped by durable source identity. The key is derived from the
+ * resolved filePath plus whether a non-default (injected) keyring loader is
+ * in use, so that tests/instances pointing at different paths or keyring
+ * sources never contaminate each other.
+ */
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Sentinel key used when the default (production) file path is in use
+ * without an injected keyring loader. Kept distinct from any injected
+ * path to avoid accidental collisions.
+ */
+const DEFAULT_SOURCE_KEY = '__default__';
+
+/**
+ * Computes a durable cache key from the resolved options. Two option sets
+ * that resolve to the same persisted location (or both use the default
+ * location with the default keyring loader) share a key; everything else
+ * is isolated.
+ */
+function sourceKeyOf(options?: MachineSecretOptions): string {
+  const filePath = options?.filePath ?? Storage.getMachineSecretPath();
+  const resolved = path.resolve(filePath);
+  // Injected keyring loaders represent a distinct durable source (e.g. an
+  // in-memory test keyring); they must not collide with production's
+  // default keyring-backed source.
+  const injected = options?.keyringLoader !== undefined;
+  if (!injected && resolved === path.resolve(Storage.getMachineSecretPath())) {
+    return DEFAULT_SOURCE_KEY;
+  }
+  return `file:${resolved}|injected:${injected ? '1' : '0'}`;
+}
+
+export function resetMachineSecretCache(): void {
+  cache.clear();
+}
+
+export async function getMachineSecret(
+  options?: MachineSecretOptions,
+): Promise<Buffer | null> {
+  const key = sourceKeyOf(options);
+  const entry = cache.get(key);
+  // Resolved cache hit: return the durable secret.
+  if (entry?.inFlight === null) {
+    return entry.secret;
+  }
+  // In-flight generation: piggyback on the existing promise so concurrent
+  // callers for the same source share a single resolution.
+  if (entry?.inFlight) {
+    return entry.inFlight;
+  }
+
+  const promise = resolveAndPersist(options);
+  cache.set(key, { secret: null, inFlight: promise });
+
+  const secret = await promise;
+  cache.set(key, { secret, inFlight: null });
+  return secret;
+}
+
+/**
+ * Resolves the secret for the given options. Handles the read → generate →
+ * persist flow, and enforces that no caller returns a generated secret
+ * unless that exact secret is durably persisted. Concurrent
+ * callers for the same source share this in-flight promise; after it
+ * completes, the winner is whatever was durably persisted.
+ */
+async function resolveAndPersist(
+  options?: MachineSecretOptions,
+): Promise<Buffer | null> {
+  const filePath = options?.filePath ?? Storage.getMachineSecretPath();
+  const keyringLoader = options?.keyringLoader ?? createDefaultKeyringAdapter;
+
+  const keyring = await loadKeyring(keyringLoader);
+
+  // 1. Try the keyring (preferred durable store).
+  let secret: Buffer | null = null;
+  if (keyring !== null) {
+    secret = await readFromKeyring(keyring);
+  }
+
+  // 2. Try the file fallback.
+  secret ??= await readFromFile(filePath);
+
+  // 3. Nothing found — generate, persist, then RE-READ the winner so every
+  //    concurrent caller converges on the durably persisted value.
+  if (secret === null) {
+    return generatePersistAndReread(keyring, filePath);
+  }
+
+  return secret;
+}
+
+/**
+ * Generates a new secret, persists it, then re-reads whatever is now durably
+ * persisted at the primary durable source. This guarantees that even under a
+ * race (two callers both generating), every caller returns the persisted
+ * winner rather than a transient in-memory value that may have lost the
+ * durability race.
+ */
+async function generatePersistAndReread(
+  keyring: KeyringAdapter | null,
+  filePath: string,
+): Promise<Buffer | null> {
+  const secret = crypto.randomBytes(SECRET_BYTE_LENGTH);
+  const encoded = secret.toString('base64');
+
+  if (keyring !== null) {
+    const persisted = await persistToKeyring(keyring, encoded);
+    if (persisted) {
+      // Re-read the keyring winner in case a concurrent writer persisted a
+      // different secret first.
+      const winner = await readFromKeyring(keyring);
+      return winner ?? secret;
+    }
+  }
+
+  const filePersisted = await persistToFile(filePath, encoded);
+  if (!filePersisted) {
+    return null;
+  }
+  // Re-read the file winner.
+  const winner = await readFromFile(filePath);
+  return winner ?? secret;
+}
+
+async function loadKeyring(
+  keyringLoader: () => Promise<KeyringAdapter | null>,
+): Promise<KeyringAdapter | null> {
+  try {
+    return await keyringLoader();
+  } catch {
+    return null;
+  }
+}
+
+async function readFromKeyring(
+  keyring: KeyringAdapter,
+): Promise<Buffer | null> {
+  try {
+    const stored = await keyring.getPassword(
+      MACHINE_SECRET_SERVICE,
+      MACHINE_SECRET_ACCOUNT,
+    );
+    if (stored === null) {
+      return null;
+    }
+    return decodeSecret(stored);
+  } catch {
+    return null;
+  }
+}
+
+async function readFromFile(filePath: string): Promise<Buffer | null> {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    const decoded = decodeSecret(content);
+    if (decoded === null) {
+      return null;
+    }
+    // Repair permissions on existing files before accepting.
+    if (!(await ensureSecurePermissions(filePath))) {
+      return null;
+    }
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+function decodeSecret(encoded: string): Buffer | null {
+  const buf = Buffer.from(encoded, 'base64');
+  if (buf.length !== SECRET_BYTE_LENGTH) {
+    return null;
+  }
+  return buf;
+}
+
+/**
+ * Ensures an existing machine_secret file has restrictive permissions
+ * (0o600 on Unix). On Windows this is a no-op (permissions are enforced via
+ * ACLs, not POSIX modes). If the chmod fails, returns false so the caller
+ * rejects the secret rather than using an insecure one.
+ */
+async function ensureSecurePermissions(filePath: string): Promise<boolean> {
+  if (process.platform === 'win32') {
+    return true;
+  }
+  try {
+    const stat = await fs.stat(filePath);
+    const currentMode = stat.mode & 0o777;
+    if (currentMode !== 0o600) {
+      await fs.chmod(filePath, 0o600);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function persistToKeyring(
+  keyring: KeyringAdapter,
+  encoded: string,
+): Promise<boolean> {
+  try {
+    await keyring.setPassword(
+      MACHINE_SECRET_SERVICE,
+      MACHINE_SECRET_ACCOUNT,
+      encoded,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function persistToFile(
+  filePath: string,
+  encoded: string,
+): Promise<boolean> {
+  const dir = path.dirname(filePath);
+  try {
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  } catch {
+    return false;
+  }
+
+  const tempPath = filePath + '.tmp.' + crypto.randomUUID().substring(0, 8);
+
+  let fd: FileHandle | null = null;
+  try {
+    fd = await fs.open(tempPath, 'w', 0o600);
+    await fd.writeFile(encoded);
+    await fd.sync();
+    await fd.close();
+    fd = null;
+
+    await renameWithRetry(tempPath, filePath);
+    await fs.chmod(filePath, 0o600).catch(() => {});
+    return true;
+  } catch {
+    if (fd !== null) {
+      await fd.close().catch(() => {});
+    }
+    await fs.unlink(tempPath).catch(() => {});
+    return false;
+  }
+}
+
+async function renameWithRetry(
+  tempPath: string,
+  finalPath: string,
+): Promise<void> {
+  let attempts = 0;
+  while (attempts < 3) {
+    try {
+      await fs.rename(tempPath, finalPath);
+      return;
+    } catch (error) {
+      attempts++;
+      if (attempts >= 3 || (error as NodeJS.ErrnoException).code !== 'EPERM') {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+}

--- a/packages/storage/src/secure-store/machine-secret.ts
+++ b/packages/storage/src/secure-store/machine-secret.ts
@@ -69,6 +69,11 @@ interface CacheEntry {
   inFlight: Promise<Buffer | null> | null;
 }
 
+type SecretReadResult =
+  | { status: 'found'; secret: Buffer }
+  | { status: 'missing' }
+  | { status: 'unusable' };
+
 /**
  * Cache scoped by durable source identity. The key is derived from the
  * resolved filePath plus whether a non-default (injected) keyring loader is
@@ -83,6 +88,23 @@ const cache = new Map<string, CacheEntry>();
  * path to avoid accidental collisions.
  */
 const DEFAULT_SOURCE_KEY = '__default__';
+const keyringLoaderIds = new WeakMap<
+  NonNullable<MachineSecretOptions['keyringLoader']>,
+  number
+>();
+let nextKeyringLoaderId = 1;
+
+function keyringLoaderIdOf(
+  loader: NonNullable<MachineSecretOptions['keyringLoader']>,
+): number {
+  const existing = keyringLoaderIds.get(loader);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const id = nextKeyringLoaderId++;
+  keyringLoaderIds.set(loader, id);
+  return id;
+}
 
 /**
  * Computes a durable cache key from the resolved options. Two option sets
@@ -93,14 +115,17 @@ const DEFAULT_SOURCE_KEY = '__default__';
 function sourceKeyOf(options?: MachineSecretOptions): string {
   const filePath = options?.filePath ?? Storage.getMachineSecretPath();
   const resolved = path.resolve(filePath);
-  // Injected keyring loaders represent a distinct durable source (e.g. an
-  // in-memory test keyring); they must not collide with production's
-  // default keyring-backed source.
-  const injected = options?.keyringLoader !== undefined;
-  if (!injected && resolved === path.resolve(Storage.getMachineSecretPath())) {
+  if (
+    options?.keyringLoader === undefined &&
+    resolved === path.resolve(Storage.getMachineSecretPath())
+  ) {
     return DEFAULT_SOURCE_KEY;
   }
-  return `file:${resolved}|injected:${injected ? '1' : '0'}`;
+  const keyringSource =
+    options?.keyringLoader === undefined
+      ? 'default'
+      : `injected:${keyringLoaderIdOf(options.keyringLoader)}`;
+  return `file:${resolved}|keyring:${keyringSource}`;
 }
 
 export function resetMachineSecretCache(): void {
@@ -146,21 +171,27 @@ async function resolveAndPersist(
   const keyring = await loadKeyring(keyringLoader);
 
   // 1. Try the keyring (preferred durable store).
-  let secret: Buffer | null = null;
+  let keyringRead: SecretReadResult = { status: 'missing' };
   if (keyring !== null) {
-    secret = await readFromKeyring(keyring);
+    keyringRead = await readFromKeyring(keyring);
+    if (keyringRead.status === 'found') {
+      return keyringRead.secret;
+    }
   }
 
   // 2. Try the file fallback.
-  secret ??= await readFromFile(filePath);
+  const fileRead = await readFromFile(filePath);
+  if (fileRead.status === 'found') {
+    return fileRead.secret;
+  }
+
+  if (keyringRead.status === 'unusable' || fileRead.status === 'unusable') {
+    return null;
+  }
 
   // 3. Nothing found — generate, persist, then RE-READ the winner so every
   //    concurrent caller converges on the durably persisted value.
-  if (secret === null) {
-    return generatePersistAndReread(keyring, filePath);
-  }
-
-  return secret;
+  return generatePersistAndReread(keyring, filePath);
 }
 
 /**
@@ -183,7 +214,7 @@ async function generatePersistAndReread(
       // Re-read the keyring winner in case a concurrent writer persisted a
       // different secret first.
       const winner = await readFromKeyring(keyring);
-      return winner ?? secret;
+      return winner.status === 'found' ? winner.secret : secret;
     }
   }
 
@@ -193,7 +224,7 @@ async function generatePersistAndReread(
   }
   // Re-read the file winner.
   const winner = await readFromFile(filePath);
-  return winner ?? secret;
+  return winner.status === 'found' ? winner.secret : secret;
 }
 
 async function loadKeyring(
@@ -208,35 +239,44 @@ async function loadKeyring(
 
 async function readFromKeyring(
   keyring: KeyringAdapter,
-): Promise<Buffer | null> {
+): Promise<SecretReadResult> {
   try {
     const stored = await keyring.getPassword(
       MACHINE_SECRET_SERVICE,
       MACHINE_SECRET_ACCOUNT,
     );
     if (stored === null) {
-      return null;
+      return { status: 'missing' };
     }
-    return decodeSecret(stored);
+    const decoded = decodeSecret(stored);
+    return decoded === null
+      ? { status: 'unusable' }
+      : { status: 'found', secret: decoded };
   } catch {
-    return null;
+    return { status: 'unusable' };
   }
 }
 
-async function readFromFile(filePath: string): Promise<Buffer | null> {
+async function readFromFile(filePath: string): Promise<SecretReadResult> {
   try {
     const content = await fs.readFile(filePath, 'utf8');
     const decoded = decodeSecret(content);
     if (decoded === null) {
-      return null;
+      return { status: 'unusable' };
+    }
+    if (!(await ensureSecureDirectory(path.dirname(filePath)))) {
+      return { status: 'unusable' };
     }
     // Repair permissions on existing files before accepting.
     if (!(await ensureSecurePermissions(filePath))) {
-      return null;
+      return { status: 'unusable' };
     }
-    return decoded;
-  } catch {
-    return null;
+    return { status: 'found', secret: decoded };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { status: 'missing' };
+    }
+    return { status: 'unusable' };
   }
 }
 
@@ -270,6 +310,24 @@ async function ensureSecurePermissions(filePath: string): Promise<boolean> {
   }
 }
 
+async function ensureSecureDirectory(dirPath: string): Promise<boolean> {
+  if (process.platform === 'win32') {
+    return true;
+  }
+  try {
+    const stat = await fs.stat(dirPath);
+    if (!stat.isDirectory()) {
+      return false;
+    }
+    const currentMode = stat.mode & 0o777;
+    if (currentMode !== 0o700) {
+      await fs.chmod(dirPath, 0o700);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
 async function persistToKeyring(
   keyring: KeyringAdapter,
   encoded: string,
@@ -293,6 +351,9 @@ async function persistToFile(
   const dir = path.dirname(filePath);
   try {
     await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+    if (!(await ensureSecureDirectory(dir))) {
+      return false;
+    }
   } catch {
     return false;
   }

--- a/packages/storage/src/secure-store/secure-store-integration.test.ts
+++ b/packages/storage/src/secure-store/secure-store-integration.test.ts
@@ -27,6 +27,7 @@ import {
   SecureStoreError,
   type KeyringAdapter,
 } from './secure-store.js';
+import { resetMachineSecretCache } from './machine-secret.js';
 /**
  * Inline helper replaces core-owned tool masking behavior without importing
  * core-owned tool modules into the storage package.
@@ -603,5 +604,50 @@ describe('SecureStore — Legacy Format Detection', () => {
     expect(err).toBeDefined();
     expect(err).toBeInstanceOf(SecureStoreError);
     expect((err as SecureStoreError).code).toBe('CORRUPT');
+  });
+});
+
+// ─── Default getMachineSecret integration (machine secret root of trust) ─────
+
+describe('SecureStore — Default machine secret integration', () => {
+  let tempDir: string;
+  let machineSecretPath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempFallbackDir();
+    machineSecretPath = path.join(tempDir, '.machine_secret');
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('uses the default getMachineSecret (no injected loader) to write and read a v:2 fallback', async () => {
+    // No injected machineSecretLoader: the default loader in SecureStore
+    // calls getMachineSecret({ filePath: machineSecretPath }). This
+    // exercises the real provider end-to-end (keyring-preferred with file
+    // fallback) against a temp path. The machine secret is resolved from
+    // either the real OS keyring or the file fallback; either way the
+    // fallback .enc file must be a v:2 envelope and round-trip correctly.
+    const store = new SecureStore('test-service-default-secret', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretPath,
+    });
+
+    await store.set('integration-key', 'integration-value');
+
+    // The fallback file should be a v:2 envelope (machine secret resolved).
+    const filePath = path.join(tempDir, 'integration-key.enc');
+    const content = await fs.readFile(filePath, 'utf8');
+    const envelope = JSON.parse(content);
+    expect(envelope.v).toBe(2);
+
+    // The value must round-trip using the same default loader.
+    const result = await store.get('integration-key');
+    expect(result).toBe('integration-value');
   });
 });

--- a/packages/storage/src/secure-store/secure-store.fallback-v2.test.ts
+++ b/packages/storage/src/secure-store/secure-store.fallback-v2.test.ts
@@ -1,0 +1,437 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for SecureStore fallback envelope versioning (v:1/v:2).
+ *
+ * v:2 envelopes incorporate a machine secret as the dominant KDF entropy so
+ * that the confidentiality of fallback files depends on a proper secret
+ * rather than solely on filesystem permissions. v:1 envelopes remain
+ * decryptable for backwards compatibility.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as crypto from 'node:crypto';
+import { SecureStore, SecureStoreError } from './secure-store.js';
+import { resetMachineSecretCache } from './machine-secret.js';
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+async function createTempFallbackDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'secure-store-v2-test-'));
+}
+
+const FIXED_SECRET_A = crypto.randomBytes(32);
+const FIXED_SECRET_B = crypto.randomBytes(32);
+
+function makeSecretProvider(secret: Buffer): {
+  loader: () => Promise<Buffer | null>;
+} {
+  return {
+    loader: async () => secret,
+  };
+}
+
+function nullSecretProvider(): {
+  loader: () => Promise<Buffer | null>;
+} {
+  return {
+    loader: async () => null,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SecureStore — Fallback Envelope v:2 (machine secret)', () => {
+  let tempDir: string;
+  let machineSecretPath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempFallbackDir();
+    machineSecretPath = path.join(tempDir, '.machine_secret');
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('new writes produce a v:2 envelope when a machine secret is available', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    await store.set('v2-key', 'v2-value');
+
+    const file = path.join(tempDir, 'v2-key.enc');
+    const content = await fs.readFile(file, 'utf8');
+    const envelope = JSON.parse(content);
+    expect(envelope.v).toBe(2);
+    expect(envelope.crypto.alg).toBe('aes-256-gcm');
+    expect(envelope.crypto.kdf).toBe('scrypt');
+  });
+
+  it('v:2 fallback data round-trips through set/get', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    await store.set('roundtrip', 'super-secret-roundtrip');
+    const result = await store.get('roundtrip');
+    expect(result).toBe('super-secret-roundtrip');
+  });
+
+  it('v:2 fallback is readable by a second instance sharing the machine secret', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const store1 = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+    const store2 = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    await store1.set('shared', 'shared-secret');
+    const result = await store2.get('shared');
+    expect(result).toBe('shared-secret');
+  });
+
+  it('v:2 fallback fails with CORRUPT when machine secret differs', async () => {
+    const providerA = makeSecretProvider(FIXED_SECRET_A);
+    const providerB = makeSecretProvider(FIXED_SECRET_B);
+    const writer = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: providerA.loader,
+      machineSecretPath,
+    });
+    const reader = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: providerB.loader,
+      machineSecretPath,
+    });
+
+    await writer.set('divergent', 'written-with-A');
+
+    let err: unknown;
+    try {
+      await reader.get('divergent');
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeDefined();
+    expect(err).toBeInstanceOf(SecureStoreError);
+    expect((err as SecureStoreError).code).toBe('CORRUPT');
+  });
+
+  it('v:2 read throws CORRUPT when machine secret is unavailable', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const writer = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    await writer.set('unavailable', 'value');
+
+    const reader = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: nullSecretProvider().loader,
+      machineSecretPath,
+    });
+
+    let err: unknown;
+    try {
+      await reader.get('unavailable');
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeDefined();
+    expect(err).toBeInstanceOf(SecureStoreError);
+    expect((err as SecureStoreError).code).toBe('CORRUPT');
+  });
+
+  it('writes v:1 envelope when machine secret is unavailable', async () => {
+    const provider = nullSecretProvider();
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    await store.set('v1-degraded', 'value');
+
+    const file = path.join(tempDir, 'v1-degraded.enc');
+    const content = await fs.readFile(file, 'utf8');
+    const envelope = JSON.parse(content);
+    expect(envelope.v).toBe(1);
+  });
+});
+
+// ─── Prevent v:2 → v:1 downgrade on overwrite ───────────────────────────────
+
+describe('SecureStore — No v:2 downgrade on overwrite with unavailable secret', () => {
+  let tempDir: string;
+  let machineSecretPath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempFallbackDir();
+    machineSecretPath = path.join(tempDir, '.machine_secret');
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('v:2 overwrite attempt with unavailable secret throws and leaves existing v:2 readable with original secret', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const writer = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    // Write a v:2 file.
+    await writer.set('protected', 'original-value');
+
+    const filePath = path.join(tempDir, 'protected.enc');
+    const beforeContent = await fs.readFile(filePath, 'utf8');
+    const beforeEnvelope = JSON.parse(beforeContent);
+    expect(beforeEnvelope.v).toBe(2);
+
+    // Now attempt to set the same key with the machine secret unavailable.
+    // This must NOT silently overwrite the v:2 file with a v:1 envelope.
+    const degradedWriter = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: nullSecretProvider().loader,
+      machineSecretPath,
+    });
+
+    let err: unknown;
+    try {
+      await degradedWriter.set('protected', 'attacker-value');
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeDefined();
+    expect(err).toBeInstanceOf(SecureStoreError);
+    // Must be CORRUPT or UNAVAILABLE — a secure rejection, never a silent
+    // overwrite.
+    const code = (err as SecureStoreError).code;
+    expect(code === 'CORRUPT' || code === 'UNAVAILABLE').toBe(true);
+
+    // The on-disk file must still be v:2 and byte-identical (not overwritten).
+    const afterContent = await fs.readFile(filePath, 'utf8');
+    expect(afterContent).toBe(beforeContent);
+
+    // And the original secret must still decrypt the original value.
+    const reader = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+    const recovered = await reader.get('protected');
+    expect(recovered).toBe('original-value');
+  });
+
+  it('new file with unavailable secret still writes v:1 (no existing v:2 to protect)', async () => {
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: nullSecretProvider().loader,
+      machineSecretPath,
+    });
+
+    await store.set('fresh', 'fresh-value');
+
+    const filePath = path.join(tempDir, 'fresh.enc');
+    const content = await fs.readFile(filePath, 'utf8');
+    const envelope = JSON.parse(content);
+    expect(envelope.v).toBe(1);
+  });
+
+  it('existing v:1 file with unavailable secret can be overwritten with v:1', async () => {
+    // First write a v:1 file.
+    const v1Writer = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: nullSecretProvider().loader,
+      machineSecretPath,
+    });
+    await v1Writer.set('v1key', 'v1-original');
+
+    const filePath = path.join(tempDir, 'v1key.enc');
+    let content = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    expect(content.v).toBe(1);
+
+    // Overwriting another v:1 while secret is unavailable is allowed.
+    await v1Writer.set('v1key', 'v1-updated');
+
+    content = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    expect(content.v).toBe(1);
+    const result = await v1Writer.get('v1key');
+    expect(result).toBe('v1-updated');
+  });
+});
+
+describe('SecureStore — Legacy v:1 envelope compatibility', () => {
+  let tempDir: string;
+  let machineSecretPath: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempFallbackDir();
+    machineSecretPath = path.join(tempDir, '.machine_secret');
+    resetMachineSecretCache();
+  });
+
+  afterEach(async () => {
+    resetMachineSecretCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('legacy v:1 files remain decryptable with v:2-capable store', async () => {
+    // First write a v:1 file using a store that has no machine secret
+    const v1Writer = new SecureStore('legacy-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: nullSecretProvider().loader,
+      machineSecretPath,
+    });
+    await v1Writer.set('legacy', 'legacy-value');
+
+    // Confirm it's v:1
+    const file = path.join(tempDir, 'legacy.enc');
+    const before = JSON.parse(await fs.readFile(file, 'utf8'));
+    expect(before.v).toBe(1);
+
+    // Now read it with a store that DOES have a machine secret (v:2 capable)
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const reader = new SecureStore('legacy-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    const result = await reader.get('legacy');
+    expect(result).toBe('legacy-value');
+  });
+
+  it('unknown envelope versions still throw CORRUPT with upgrade remediation', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const store = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    const badEnvelope = JSON.stringify({ v: 99, crypto: {}, data: 'abc' });
+    await fs.writeFile(path.join(tempDir, 'bad-version.enc'), badEnvelope);
+
+    let err: unknown;
+    try {
+      await store.get('bad-version');
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeDefined();
+    expect(err).toBeInstanceOf(SecureStoreError);
+    expect((err as SecureStoreError).code).toBe('CORRUPT');
+    expect((err as SecureStoreError).remediation).toContain('upgrade');
+  });
+
+  it('cross-service: different serviceNames derive different keys for the same machine secret', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+
+    const storeA = new SecureStore('service-a', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+    const storeB = new SecureStore('service-b', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+
+    // Both write to the same fallbackDir but under sanitized key names.
+    // service-a writes 'shared' which becomes 'shared.enc'.
+    await storeA.set('shared', 'from-a');
+
+    // service-b cannot decrypt service-a's file because serviceName is part
+    // of the derivation, AND because each serviceName writes into its own
+    // fallbackDir by default. Here we forced the same dir, so we instead
+    // verify a key written by storeA is readable by storeA but not storeB
+    // when the key collides — but to keep the test deterministic, we just
+    // confirm storeA can read its own write.
+    const own = await storeA.get('shared');
+    expect(own).toBe('from-a');
+
+    // storeB writing 'shared' should not be decryptable by storeA
+    await storeB.set('shared', 'from-b');
+    const other = await storeB.get('shared');
+    expect(other).toBe('from-b');
+
+    // storeA now sees storeB's file content for the same key; it must not
+    // decrypt with service-a's key.
+    let err: unknown;
+    try {
+      await storeA.get('shared');
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(SecureStoreError);
+    expect((err as SecureStoreError).code).toBe('CORRUPT');
+  });
+});

--- a/packages/storage/src/secure-store/secure-store.fallback-v2.test.ts
+++ b/packages/storage/src/secure-store/secure-store.fallback-v2.test.ts
@@ -13,7 +13,7 @@
  * decryptable for backwards compatibility.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -275,6 +275,51 @@ describe('SecureStore — No v:2 downgrade on overwrite with unavailable secret'
     expect(recovered).toBe('original-value');
   });
 
+  it('v:2 overwrite attempt with unreadable existing envelope fails closed', async () => {
+    const provider = makeSecretProvider(FIXED_SECRET_A);
+    const writer = new SecureStore('test-service', {
+      keyringLoader: async () => null,
+      fallbackDir: tempDir,
+      fallbackPolicy: 'allow',
+      machineSecretLoader: provider.loader,
+      machineSecretPath,
+    });
+    await writer.set('read-error', 'original-value');
+
+    const filePath = path.join(tempDir, 'read-error.enc');
+    const beforeContent = await fs.readFile(filePath, 'utf8');
+    const readFailure = new Error('permission denied') as NodeJS.ErrnoException;
+    readFailure.code = 'EACCES';
+    const originalReadFile = fs.readFile.bind(fs);
+    const readFileSpy = vi.spyOn(fs, 'readFile').mockImplementation((async (
+      target: Parameters<typeof fs.readFile>[0],
+      options?: Parameters<typeof fs.readFile>[1],
+    ) => {
+      if (target === filePath) {
+        throw readFailure;
+      }
+      return originalReadFile(target, options);
+    }) as typeof fs.readFile);
+
+    try {
+      const degradedWriter = new SecureStore('test-service', {
+        keyringLoader: async () => null,
+        fallbackDir: tempDir,
+        fallbackPolicy: 'allow',
+        machineSecretLoader: nullSecretProvider().loader,
+        machineSecretPath,
+      });
+
+      await expect(
+        degradedWriter.set('read-error', 'new-value'),
+      ).rejects.toThrow('permission denied');
+    } finally {
+      readFileSpy.mockRestore();
+    }
+
+    const afterContent = await fs.readFile(filePath, 'utf8');
+    expect(afterContent).toBe(beforeContent);
+  });
   it('new file with unavailable secret still writes v:1 (no existing v:2 to protect)', async () => {
     const store = new SecureStore('test-service', {
       keyringLoader: async () => null,

--- a/packages/storage/src/secure-store/secure-store.fallback2.test.ts
+++ b/packages/storage/src/secure-store/secure-store.fallback2.test.ts
@@ -107,6 +107,7 @@ describe('SecureStore — Encrypted File Fallback', () => {
       keyringLoader: async () => null,
       fallbackDir: tempDir,
       fallbackPolicy: 'allow',
+      machineSecretLoader: async () => null,
     });
 
     await store.set('envelope-key', 'envelope-value');
@@ -433,6 +434,7 @@ describe('SecureStore — Resilience', () => {
       keyringLoader: async () => null,
       fallbackDir: tempDir,
       fallbackPolicy: 'allow',
+      machineSecretLoader: async () => null,
     });
 
     // Write a value successfully

--- a/packages/storage/src/secure-store/secure-store.ts
+++ b/packages/storage/src/secure-store/secure-store.ts
@@ -841,8 +841,11 @@ export class SecureStore {
     let content: string;
     try {
       content = await fs.readFile(filePath, 'utf8');
-    } catch {
-      return null;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      throw error;
     }
     let parsed: unknown;
     try {

--- a/packages/storage/src/secure-store/secure-store.ts
+++ b/packages/storage/src/secure-store/secure-store.ts
@@ -17,10 +17,20 @@
 import * as crypto from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import envPaths from 'env-paths';
 import type { StorageLogger } from '../types/logger.js';
 import { NullStorageLoggerImpl } from '../types/logger.js';
+import { getMachineSecret } from './machine-secret.js';
+import {
+  deriveV1KdfInput,
+  deriveV2KdfInput,
+  ENVELOPE_VERSIONS,
+  isValidEnvelope,
+  scryptAsync,
+  SCRYPT_PARAMS,
+  SALT_LEN,
+  type Envelope,
+} from './envelope.js';
 
 // Platform-standard paths for llxprt-code app data (no suffix to match documented paths)
 const platformPaths = envPaths('llxprt-code', { suffix: '' });
@@ -79,17 +89,11 @@ export interface SecureStoreOptions {
   fallbackPolicy?: 'allow' | 'deny';
   keyringLoader?: () => Promise<KeyringAdapter | null>;
   logger?: StorageLogger;
+  machineSecretLoader?: () => Promise<Buffer | null>;
+  machineSecretPath?: string;
 }
 
 // ─── Helper Functions ────────────────────────────────────────────────────────
-
-function safeUsername(): string {
-  try {
-    return os.userInfo().username;
-  } catch {
-    return String(process.getuid?.() ?? 'unknown');
-  }
-}
 
 function isErrorWithCode(value: unknown): value is { code: string } {
   return (
@@ -161,35 +165,9 @@ function isTransientError(error: unknown): boolean {
   return classifyError(error) === 'TIMEOUT';
 }
 
-interface Envelope {
-  v: number;
-  crypto: {
-    alg: string;
-    kdf: string;
-    N: number;
-    r: number;
-    p: number;
-    saltLen: number;
-  };
-  data: string;
-}
-
 type FindCredentialsFunction = (
   service: string,
 ) => Promise<Array<{ account: string; password: string }>>;
-
-function isValidEnvelope(envelope: unknown): envelope is Envelope {
-  if (typeof envelope !== 'object' || envelope === null) return false;
-  const env = envelope as Record<string, unknown>;
-  if (env.v !== 1) return false;
-  if (typeof env.crypto !== 'object' || env.crypto === null) return false;
-  const c = env.crypto as Record<string, unknown>;
-  if (c.alg !== 'aes-256-gcm') return false;
-
-  if (c.kdf !== 'scrypt') return false;
-  if (typeof env.data !== 'string') return false;
-  return true;
-}
 
 function withFindCredentials(
   adapter: KeyringAdapter,
@@ -263,20 +241,6 @@ export async function createDefaultKeyringAdapter(): Promise<KeyringAdapter | nu
   }
 }
 
-function scryptAsync(
-  password: string,
-  salt: Buffer,
-  keyLen: number,
-  options: { N: number; r: number; p: number },
-): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    crypto.scrypt(password, salt, keyLen, options, (err, key) => {
-      if (err) reject(err);
-      else resolve(key);
-    });
-  });
-}
-
 // ─── SecureStore Class ───────────────────────────────────────────────────────
 
 /**
@@ -291,6 +255,8 @@ export class SecureStore {
   private readonly keyringLoaderFn: () => Promise<KeyringAdapter | null>;
   private readonly fallbackDir: string;
   private readonly logger: StorageLogger;
+  private readonly machineSecretLoaderFn: () => Promise<Buffer | null>;
+  private readonly machineSecretFilePath: string | undefined;
 
   private keyringInstance: KeyringAdapter | null | undefined = undefined;
   private keyringLoadAttempted = false;
@@ -308,8 +274,16 @@ export class SecureStore {
     this.keyringLoaderFn =
       options?.keyringLoader ?? createDefaultKeyringAdapter;
     this.logger = options?.logger ?? new NullStorageLoggerImpl();
+    this.machineSecretLoaderFn =
+      options?.machineSecretLoader ?? this.defaultMachineSecretLoader;
+    this.machineSecretFilePath = options?.machineSecretPath;
     setSecureStoreModuleLogger(this.logger);
   }
+
+  private defaultMachineSecretLoader = async (): Promise<Buffer | null> =>
+    getMachineSecret({
+      filePath: this.machineSecretFilePath,
+    });
 
   // ─── Keyring Loading ──────────────────────────────────────────────────────
 
@@ -786,17 +760,33 @@ export class SecureStore {
   private async writeFallbackFile(key: string, value: string): Promise<void> {
     await fs.mkdir(this.fallbackDir, { recursive: true, mode: 0o700 });
 
-    const salt = crypto.randomBytes(16);
-    const machineId = crypto
-      .createHash('sha256')
-      .update(os.hostname() + safeUsername())
-      .digest('hex');
-    const kdfInput = this.serviceName + '-' + machineId;
-    const encKey = await scryptAsync(kdfInput, salt, 32, {
-      N: 16384,
-      r: 8,
-      p: 1,
-    });
+    const salt = crypto.randomBytes(SALT_LEN);
+
+    const machineSecret = await this.machineSecretLoaderFn();
+    const useV2 = machineSecret !== null;
+
+    // Never downgrade an existing v:2 file to v:1. If the machine secret is
+    // unavailable, inspect the existing target envelope; if it is v:2, refuse
+    // to overwrite it with a weaker v:1 envelope rather than silently
+    // destroying the stronger root of trust. v:1 fallback is still allowed for
+    // new files or existing v:1 files.
+    if (!useV2) {
+      const finalPathForCheck = this.getFallbackFilePath(key);
+      const existingVersion =
+        await this.readExistingEnvelopeVersion(finalPathForCheck);
+      if (existingVersion === 2) {
+        throw new SecureStoreError(
+          'Refusing to overwrite v:2 fallback file with a weaker v:1 envelope while the machine secret is unavailable',
+          'UNAVAILABLE',
+          'Restore the machine secret and re-save the key, or remove the existing file if intentional.',
+        );
+      }
+    }
+
+    const kdfInput = useV2
+      ? deriveV2KdfInput(this.serviceName, machineSecret)
+      : deriveV1KdfInput(this.serviceName);
+    const encKey = await scryptAsync(kdfInput, salt, 32, SCRYPT_PARAMS);
 
     const iv = crypto.randomBytes(12);
     const cipher = crypto.createCipheriv('aes-256-gcm', encKey, iv);
@@ -808,14 +798,14 @@ export class SecureStore {
 
     const ciphertext = Buffer.concat([salt, iv, authTag, encrypted]);
     const envelope: Envelope = {
-      v: 1,
+      v: useV2 ? 2 : 1,
       crypto: {
         alg: 'aes-256-gcm',
         kdf: 'scrypt',
-        N: 16384,
-        r: 8,
-        p: 1,
-        saltLen: 16,
+        N: SCRYPT_PARAMS.N,
+        r: SCRYPT_PARAMS.r,
+        p: SCRYPT_PARAMS.p,
+        saltLen: SALT_LEN,
       },
       data: ciphertext.toString('base64'),
     };
@@ -836,6 +826,34 @@ export class SecureStore {
       await fs.unlink(tempPath).catch(() => {});
       throw error;
     }
+  }
+
+  /**
+   * Reads only the version field of an existing fallback envelope without
+   * attempting decryption. Returns the version (1 or 2) if the file exists
+   * and parses as a valid envelope, or null if it does not exist or is not
+   * a recognized envelope. Used by writeFallbackFile to detect v:2 files
+   * that must not be downgraded to v:1.
+   */
+  private async readExistingEnvelopeVersion(
+    filePath: string,
+  ): Promise<number | null> {
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, 'utf8');
+    } catch {
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      return null;
+    }
+    if (!isValidEnvelope(parsed)) {
+      return null;
+    }
+    return parsed.v;
   }
 
   private async renameWithRetry(
@@ -894,7 +912,7 @@ export class SecureStore {
     }
 
     const env = envelope as Record<string, unknown>;
-    if (env.v !== 1) {
+    if (typeof env.v !== 'number' || !ENVELOPE_VERSIONS.has(env.v)) {
       throw new SecureStoreError(
         'Unrecognized envelope version: ' +
           String(env.v) +
@@ -913,21 +931,26 @@ export class SecureStore {
     }
 
     const ciphertext = Buffer.from(envelope.data, 'base64');
-    const salt = ciphertext.subarray(0, 16);
-    const iv = ciphertext.subarray(16, 28);
+    const salt = ciphertext.subarray(0, SALT_LEN);
+    const iv = ciphertext.subarray(SALT_LEN, SALT_LEN + 12);
     const authTag = ciphertext.subarray(28, 44);
     const encryptedData = ciphertext.subarray(44);
 
-    const machineId = crypto
-      .createHash('sha256')
-      .update(os.hostname() + safeUsername())
-      .digest('hex');
-    const kdfInput = this.serviceName + '-' + machineId;
-    const decKey = await scryptAsync(kdfInput, salt, 32, {
-      N: 16384,
-      r: 8,
-      p: 1,
-    });
+    let kdfInput: string;
+    if (envelope.v === 2) {
+      const machineSecret = await this.machineSecretLoaderFn();
+      if (machineSecret === null) {
+        throw new SecureStoreError(
+          'v:2 fallback file requires a machine secret that is unavailable',
+          'CORRUPT',
+          'Re-save the key or re-authenticate. The machine secret may have changed or been removed.',
+        );
+      }
+      kdfInput = deriveV2KdfInput(this.serviceName, machineSecret);
+    } else {
+      kdfInput = deriveV1KdfInput(this.serviceName);
+    }
+    const decKey = await scryptAsync(kdfInput, salt, 32, SCRYPT_PARAMS);
 
     try {
       const decipher = crypto.createDecipheriv('aes-256-gcm', decKey, iv);


### PR DESCRIPTION
## TLDR

Hardened SecureStore fallback encryption by adding a shared high-entropy machine secret and writing new fallback envelopes as v:2 when that secret is available. Legacy v:1 fallback files remain readable, and SecureStore refuses to silently downgrade an existing v:2 fallback file to v:1 when the machine secret is unavailable.

## Dive Deeper

This PR adds a machine-secret root of trust for SecureStore file fallback encryption. The new provider prefers OS keyring storage and falls back to a restrictive file at ~/.llxprt/machine_secret with atomic writes, 0700 parent directories, 0600 file permissions, source-scoped caching, and concurrent first-call deduplication.

The encrypted fallback envelope logic is now version-aware:

- v:1 keeps the existing derivation exactly for backward compatibility.
- v:2 mixes the machine secret into the KDF input while preserving AES-256-GCM and scrypt parameters.
- New writes use v:2 when the machine secret resolves.
- If the secret cannot resolve, new/legacy v:1 behavior remains available for availability.
- Existing v:2 files are protected from silent weaker rewrites when the machine secret is unavailable.

The change also adds focused coverage for envelope validation, machine-secret persistence/cache/permissions, v:1 compatibility, v:2 read/write behavior, wrong or missing machine secrets, and downgrade prevention.

Two agents test files were adjusted only to satisfy full-repo lint rules that were exposed while running the prescribed verification; their behavior is unchanged.

## Reviewer Test Plan

Recommended validation:

- Run the storage tests and inspect the new v:2 fallback coverage.
- Create a SecureStore with keyring unavailable and a deterministic machine secret, set a key, and confirm the .enc envelope has v:2.
- Read a v:1 test envelope to confirm legacy compatibility.
- Try reading v:2 with a different or unavailable machine secret and confirm SecureStoreError code CORRUPT.
- Try overwriting an existing v:2 file with the machine secret unavailable and confirm it is rejected without replacing the original file.

Local verification performed:

- npm run format: passed
- npm run lint: passed
- npm run typecheck: passed
- npm run build: passed
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else": passed
- npm run test --workspace @vybestack/llxprt-code-storage: passed, 247 passed / 3 skipped
- npm run test --workspace @vybestack/llxprt-code-agents -- src/api/__tests__/capabilityGaps.integration.spec.ts src/api/__tests__/policyControl.behavior.test.ts: passed, 24 passed
- npm run test --workspaces --if-present -- --maxWorkers=1: attempted; tools/storage/auth/settings/telemetry/ide-integration/policy/mcp suites completed green, then the local shell received SIGTERM during the core workspace without an assertion failure. CI should provide the authoritative full-suite result.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1986
