### PR TITLE
Convert ConversationFileWriter to async I/O to unblock event loop (Fixes #1988)

### DIFF
--- a/packages/providers/src/LoggingProviderWrapper.test.ts
+++ b/packages/providers/src/LoggingProviderWrapper.test.ts
@@ -195,7 +195,7 @@ describe('LoggingProviderWrapper — behavioral JSONL output', () => {
     };
 
     const writer = new ConversationFileWriter(badLogPath, testLogger);
-    writer.writeRequest('test-provider', []);
+    await writer.writeRequest('test-provider', []);
 
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0].message).toContain('Failed to write log entry');

--- a/packages/providers/src/LoggingProviderWrapper.ts
+++ b/packages/providers/src/LoggingProviderWrapper.ts
@@ -727,7 +727,7 @@ export class LoggingProviderWrapper implements IProvider {
         success,
         error,
       );
-      this.writeConversationLog(
+      await this.writeConversationLog(
         config,
         redactedContent,
         promptId,
@@ -770,15 +770,15 @@ export class LoggingProviderWrapper implements IProvider {
   }
 
   /** Write conversation response event to telemetry and disk. */
-  private writeConversationLog(
+  private async writeConversationLog(
     config: Config,
     redactedContent: string,
     promptId: string,
     duration: number,
     success: boolean,
     error: unknown,
-  ): void {
-    writeConversationLog(
+  ): Promise<void> {
+    await writeConversationLog(
       config,
       redactedContent,
       promptId,

--- a/packages/providers/src/logging/conversationLogger.ts
+++ b/packages/providers/src/logging/conversationLogger.ts
@@ -53,7 +53,7 @@ export async function logConversationRequestEntry(
   logConversationRequest(config, event);
 
   const fileWriter = getConversationFileWriter(config.getConversationLogPath());
-  fileWriter.writeRequest(ctx.providerName, redactedContent, {
+  await fileWriter.writeRequest(ctx.providerName, redactedContent, {
     conversationId: ctx.conversationId,
     turnNumber: ctx.turnNumber,
     promptId: resolvedPromptId,
@@ -96,7 +96,7 @@ export async function logToolCallEntry(
     : (params as object);
 
   const fileWriter = getConversationFileWriter(config.getConversationLogPath());
-  fileWriter.writeToolCall(ctx.providerName, toolName, {
+  await fileWriter.writeToolCall(ctx.providerName, toolName, {
     conversationId: ctx.conversationId,
     turnNumber: ctx.turnNumber,
     params: redactedParams,

--- a/packages/providers/src/logging/telemetryEmitter.ts
+++ b/packages/providers/src/logging/telemetryEmitter.ts
@@ -121,7 +121,7 @@ export function emitResponseTelemetry(
 }
 
 /** Write conversation response event to telemetry and disk. */
-export function writeConversationLog(
+export async function writeConversationLog(
   config: Config,
   redactedContent: string,
   promptId: string,
@@ -129,7 +129,7 @@ export function writeConversationLog(
   success: boolean,
   error: unknown,
   ctx: ResponseTelemetryContext,
-): void {
+): Promise<void> {
   const event = new ConversationResponseEvent(
     ctx.providerName,
     ctx.conversationId,
@@ -143,7 +143,7 @@ export function writeConversationLog(
   logConversationResponse(config, event);
 
   const fileWriter = getConversationFileWriter(config.getConversationLogPath());
-  fileWriter.writeResponse(ctx.providerName, redactedContent, {
+  await fileWriter.writeResponse(ctx.providerName, redactedContent, {
     conversationId: ctx.conversationId,
     turnNumber: ctx.turnNumber,
     promptId,

--- a/packages/storage/src/conversation/ConversationFileWriter.test.ts
+++ b/packages/storage/src/conversation/ConversationFileWriter.test.ts
@@ -421,4 +421,23 @@ describe('ConversationFileWriter — Multiple Writes', () => {
       expect(lines[i].seq).toBe(i);
     }
   });
+
+  it('serializes concurrent un-awaited writes in invocation order', async () => {
+    // Concurrent writes fired without awaiting must still land on disk in the
+    // order they were invoked, matching the guarantee the synchronous
+    // implementation provided implicitly.
+    const writer = new ConversationFileWriter(tmpDir);
+    const promises: Array<Promise<void>> = [];
+    for (let i = 0; i < 50; i++) {
+      promises.push(writer.writeEntry({ type: 'concurrent', seq: i }));
+    }
+    await Promise.all(promises);
+
+    const lines = await readJsonlLines(tmpDir);
+    expect(lines).toHaveLength(50);
+    for (let i = 0; i < 50; i++) {
+      expect(lines[i].type).toBe('concurrent');
+      expect(lines[i].seq).toBe(i);
+    }
+  });
 });

--- a/packages/storage/src/conversation/ConversationFileWriter.test.ts
+++ b/packages/storage/src/conversation/ConversationFileWriter.test.ts
@@ -441,3 +441,42 @@ describe('ConversationFileWriter — Multiple Writes', () => {
     }
   });
 });
+
+// ─── Never-Rejects Contract ─────────────────────────────────────────────────
+
+describe('ConversationFileWriter — Never-Rejects Contract', () => {
+  it('resolves (never rejects) when the injected logger throws during a failed write, and does not poison the chain', async () => {
+    const { parentIsFilePath, cleanup } = await createInvalidParentPath();
+    // A real logger whose error() throws. In the buggy chain this rejected the
+    // write promise and permanently poisoned the chain so every later write was
+    // silently dropped (its .then callback skipped on the rejected chain).
+    const throwingLogger: StorageLogger = {
+      debug: () => {},
+      warn: () => {},
+      error: () => {
+        throw new Error('logger exploded');
+      },
+    };
+
+    try {
+      const writer = new ConversationFileWriter(
+        parentIsFilePath,
+        throwingLogger,
+      );
+
+      // First failing write: the filesystem op fails and logger.error() throws,
+      // but the returned promise must still resolve (best-effort, never rejects).
+      await expect(
+        writer.writeEntry({ type: 'doomed-first' }),
+      ).resolves.toBeUndefined();
+
+      // Second write must also resolve — the prior failure must not have
+      // poisoned the chain. (Pre-fix this rejected and skipped appendEntry.)
+      await expect(
+        writer.writeEntry({ type: 'doomed-second' }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/storage/src/conversation/ConversationFileWriter.test.ts
+++ b/packages/storage/src/conversation/ConversationFileWriter.test.ts
@@ -150,7 +150,7 @@ describe('ConversationFileWriter — Request Write', () => {
 
   it('writes a request entry with type, provider, messages, context, and timestamp', async () => {
     const writer = new ConversationFileWriter(tmpDir);
-    writer.writeRequest('openai', [{ role: 'user', content: 'hi' }], {
+    await writer.writeRequest('openai', [{ role: 'user', content: 'hi' }], {
       sessionId: 's1',
     });
 
@@ -185,7 +185,7 @@ describe('ConversationFileWriter — Response Write', () => {
 
   it('writes a response entry with type, provider, response payload, metadata, and timestamp', async () => {
     const writer = new ConversationFileWriter(tmpDir);
-    writer.writeResponse('openai', { text: 'ok' }, { tokens: 2 });
+    await writer.writeResponse('openai', { text: 'ok' }, { tokens: 2 });
 
     const lines = await readJsonlLines(tmpDir);
     expect(lines).toHaveLength(1);
@@ -216,7 +216,7 @@ describe('ConversationFileWriter — Tool Call Write', () => {
 
   it('writes a tool_call entry with context spread at top level, not nested under context', async () => {
     const writer = new ConversationFileWriter(tmpDir);
-    writer.writeToolCall('openai', 'read_file', { path: 'README.md' });
+    await writer.writeToolCall('openai', 'read_file', { path: 'README.md' });
 
     const lines = await readJsonlLines(tmpDir);
     expect(lines).toHaveLength(1);
@@ -267,7 +267,7 @@ describe('ConversationFileWriter — Singleton Reuse', () => {
     expect(second).toBe(first);
 
     // Prove dirA wins by observing where output is actually written.
-    second.writeEntry({ type: 'probe' });
+    await second.writeEntry({ type: 'probe' });
 
     const today = new Date().toISOString().split('T')[0];
     const expectedFile = path.join(dirA, `conversation-${today}.jsonl`);
@@ -286,7 +286,7 @@ describe('ConversationFileWriter — Zero-Arg Backward Compat', () => {
   it('constructs without error and writes to the default .llxprt conversations path', async () => {
     await withTempHome(async (tmpHome) => {
       const writer = new ConversationFileWriter();
-      writer.writeEntry({ type: 'probe' });
+      await writer.writeEntry({ type: 'probe' });
 
       const lines = await readJsonlLines(
         path.join(tmpHome, '.llxprt', 'conversations'),
@@ -298,7 +298,7 @@ describe('ConversationFileWriter — Zero-Arg Backward Compat', () => {
   it('treats an empty log path as a request for the default path', async () => {
     await withTempHome(async (tmpHome) => {
       const writer = new ConversationFileWriter('');
-      writer.writeEntry({ type: 'empty-path-probe' });
+      await writer.writeEntry({ type: 'empty-path-probe' });
 
       const lines = await readJsonlLines(
         path.join(tmpHome, '.llxprt', 'conversations'),
@@ -323,7 +323,7 @@ describe('ConversationFileWriter — One-Arg Backward Compat', () => {
 
   it('constructs with a custom path and writes a valid JSONL entry', async () => {
     const writer = new ConversationFileWriter(tmpDir);
-    writer.writeResponse('anthropic', { text: 'hello' });
+    await writer.writeResponse('anthropic', { text: 'hello' });
 
     const lines = await readJsonlLines(tmpDir);
     expect(lines).toHaveLength(1);
@@ -348,7 +348,7 @@ describe('ConversationFileWriter — writeEntry Error Path', () => {
     try {
       // Construct with invalid path + injected logger
       const writer = new ConversationFileWriter(parentIsFilePath, logger);
-      writer.writeEntry({ type: 'test', data: 'hello' });
+      await writer.writeEntry({ type: 'test', data: 'hello' });
 
       // The error should have been logged via the injected logger
       expect(errorEntries.length).toBeGreaterThan(0);
@@ -368,7 +368,7 @@ describe('ConversationFileWriter — Logger Injection', () => {
 
     try {
       const writer = new ConversationFileWriter(parentIsFilePath, logger);
-      writer.writeEntry({ type: 'test', data: 'hello' });
+      await writer.writeEntry({ type: 'test', data: 'hello' });
 
       // Verify error was recorded in the observable array
       expect(errorEntries.length).toBeGreaterThan(0);
@@ -395,9 +395,9 @@ describe('ConversationFileWriter — Multiple Writes', () => {
 
   it('appends multiple entries as separate JSONL lines', async () => {
     const writer = new ConversationFileWriter(tmpDir);
-    writer.writeRequest('openai', [{ role: 'user', content: 'first' }]);
-    writer.writeResponse('openai', { text: 'first-response' });
-    writer.writeToolCall('openai', 'read_file', { path: 'test.txt' });
+    await writer.writeRequest('openai', [{ role: 'user', content: 'first' }]);
+    await writer.writeResponse('openai', { text: 'first-response' });
+    await writer.writeToolCall('openai', 'read_file', { path: 'test.txt' });
 
     const lines = await readJsonlLines(tmpDir);
     expect(lines).toHaveLength(3);
@@ -405,5 +405,20 @@ describe('ConversationFileWriter — Multiple Writes', () => {
     expect(lines[0].type).toBe('request');
     expect(lines[1].type).toBe('response');
     expect(lines[2].type).toBe('tool_call');
+  });
+
+  it('preserves order across sequential awaited writes (async flush behavior)', async () => {
+    // Awaited writes must flush in call order.
+    const writer = new ConversationFileWriter(tmpDir);
+    for (let i = 0; i < 10; i++) {
+      await writer.writeEntry({ type: 'ordered', seq: i });
+    }
+
+    const lines = await readJsonlLines(tmpDir);
+    expect(lines).toHaveLength(10);
+    for (let i = 0; i < 10; i++) {
+      expect(lines[i].type).toBe('ordered');
+      expect(lines[i].seq).toBe(i);
+    }
   });
 });

--- a/packages/storage/src/conversation/ConversationFileWriter.ts
+++ b/packages/storage/src/conversation/ConversationFileWriter.ts
@@ -25,6 +25,7 @@ export class ConversationFileWriter {
   private logPath: string;
   private currentLogFile: string;
   private logger: StorageLogger;
+  private writeChain: Promise<void> = Promise.resolve();
 
   constructor(logPath?: string, logger?: StorageLogger) {
     this.logPath = resolveConversationLogPath(logPath);
@@ -36,6 +37,14 @@ export class ConversationFileWriter {
   }
 
   async writeEntry(entry: Record<string, unknown>): Promise<void> {
+    // Serialize writes through a per-instance chain so concurrent callers
+    // append in invocation order, preserving the guarantee the synchronous
+    // implementation had implicitly.
+    this.writeChain = this.writeChain.then(() => this.appendEntry(entry));
+    return this.writeChain;
+  }
+
+  private async appendEntry(entry: Record<string, unknown>): Promise<void> {
     try {
       const logEntry = {
         timestamp: new Date().toISOString(),

--- a/packages/storage/src/conversation/ConversationFileWriter.ts
+++ b/packages/storage/src/conversation/ConversationFileWriter.ts
@@ -39,8 +39,12 @@ export class ConversationFileWriter {
   async writeEntry(entry: Record<string, unknown>): Promise<void> {
     // Serialize writes through a per-instance chain so concurrent callers
     // append in invocation order, preserving the guarantee the synchronous
-    // implementation had implicitly.
-    this.writeChain = this.writeChain.then(() => this.appendEntry(entry));
+    // implementation had implicitly. The trailing .catch() guarantees the
+    // chain and the returned promise never reject — a throwing logger or a
+    // filesystem error cannot poison subsequent writes.
+    this.writeChain = this.writeChain
+      .then(() => this.appendEntry(entry))
+      .catch(() => {});
     return this.writeChain;
   }
 

--- a/packages/storage/src/conversation/ConversationFileWriter.ts
+++ b/packages/storage/src/conversation/ConversationFileWriter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs';
+import { promises as fsp } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import type { StorageLogger } from '../types/logger.js';
@@ -35,26 +35,26 @@ export class ConversationFileWriter {
     this.logger = logger ?? new NullStorageLoggerImpl();
   }
 
-  writeEntry(entry: Record<string, unknown>): void {
+  async writeEntry(entry: Record<string, unknown>): Promise<void> {
     try {
       const logEntry = {
         timestamp: new Date().toISOString(),
         ...entry,
       };
       const line = JSON.stringify(logEntry) + '\n';
-      fs.mkdirSync(this.logPath, { recursive: true });
-      fs.appendFileSync(this.currentLogFile, line);
+      await fsp.mkdir(this.logPath, { recursive: true });
+      await fsp.appendFile(this.currentLogFile, line);
     } catch (error) {
       this.logger.error('Failed to write log entry:', error);
     }
   }
 
-  writeRequest(
+  async writeRequest(
     provider: string,
     messages: unknown[],
     context?: Record<string, unknown>,
-  ): void {
-    this.writeEntry({
+  ): Promise<void> {
+    await this.writeEntry({
       type: 'request',
       provider,
       messages,
@@ -62,12 +62,12 @@ export class ConversationFileWriter {
     });
   }
 
-  writeResponse(
+  async writeResponse(
     provider: string,
     response: unknown,
     metadata?: Record<string, unknown>,
-  ): void {
-    this.writeEntry({
+  ): Promise<void> {
+    await this.writeEntry({
       type: 'response',
       provider,
       response,
@@ -75,12 +75,12 @@ export class ConversationFileWriter {
     });
   }
 
-  writeToolCall(
+  async writeToolCall(
     provider: string,
     toolName: string,
     context?: Record<string, unknown>,
-  ): void {
-    this.writeEntry({
+  ): Promise<void> {
+    await this.writeEntry({
       type: 'tool_call',
       provider,
       tool: toolName,


### PR DESCRIPTION
## Summary

Converts `ConversationFileWriter` from synchronous filesystem I/O to async `fs.promises` to stop blocking the Node.js event loop on every logged conversation entry. Fixes #1988.

This is the deferred follow-up tracked from the storage extraction (PR #1982). Previously `writeEntry` called `fs.mkdirSync` + `fs.appendFileSync` on every request/response/tool-call write, synchronously stalling the event loop. The async conversion changes the public contract (methods now return `Promise<void>`), so every caller is updated to `await`.

## Changes

**Core (`packages/storage`)**
- `ConversationFileWriter.writeEntry` is now `async`, using `fsp.mkdir` + `fsp.appendFile`.
- `writeRequest` / `writeResponse` / `writeToolCall` are now `async` and `await writeEntry(...)`.
- The best-effort **never-rejects** contract is preserved: errors are still caught and reported via the injected logger (no rethrow), so callers do not need `try/catch` solely for log-write failures.
- `getConversationFileWriter` / `resetConversationFileWriterForTesting` remain synchronous (construction/reset only, no I/O).

**Callers (`packages/providers`)**
- `conversationLogger.logConversationRequestEntry` / `logToolCallEntry` (already async) now `await` the writer.
- `telemetryEmitter.writeConversationLog` is now `async` and `await`s the writer.
- `LoggingProviderWrapper`: private `writeConversationLog` is now `async`; its call site inside the already-async `logResponse` now `await`s it.

**Tests**
- Updated every now-async writer call site to `await` before reading the JSONL file (storage + providers tests).
- Added a behavioral test asserting on-disk order is preserved across sequential awaited writes.

## Why preserve the never-rejects contract

Logging is best-effort. The original sync implementation swallowed errors via try/catch and never threw. Changing that error contract is out of scope for this issue and would force every caller to add error handling for what is non-critical telemetry logging. The async version resolves normally even when the underlying write fails.

## Verification

- `npm run typecheck` — clean (all packages)
- `npm run lint` — clean
- `npm run format` — no changes
- `npm run test` — all conversation/logging tests pass. The only failing tests in the run are pre-existing failures in core `filesearch` crawler/directory tests (7 tests), which are unrelated to this change. Verified pre-existing by stashing this change and re-running the same files — identical failures occur on a clean tree.
- `npm run build` — all packages built
- Smoke test (`node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"`) — produced a haiku.

Closes #1988
