### PR TITLE
fix(storage): normalize filter fast-path paths (Fixes #1989)

### DIFF
--- a/packages/storage/src/services/fileDiscoveryService.test.ts
+++ b/packages/storage/src/services/fileDiscoveryService.test.ts
@@ -193,6 +193,55 @@ describe('FileDiscoveryService', () => {
         fsSync.realpathSync(visiblePath),
       ]);
     });
+
+    it('should treat a symlink into an ignored directory consistently between fast path and non-fast path', async () => {
+      await createTestFile('.gitignore', 'ignored-target/\n');
+      await createTestFile('ignored-target/real.txt', 'data');
+      const symlinkPath = path.join(projectRoot, 'link-to-ignored.txt');
+      await fs.symlink(
+        path.join(projectRoot, 'ignored-target', 'real.txt'),
+        symlinkPath,
+      );
+
+      const service = new FileDiscoveryService(projectRoot);
+      const fastPath = service.filterFiles([symlinkPath], {
+        respectGitIgnore: true,
+        respectLlxprtIgnore: true,
+      });
+      const nonFastPath = service.filterFiles([symlinkPath], {
+        respectGitIgnore: true,
+        respectLlxprtIgnore: false,
+      });
+
+      expect(fastPath).toStrictEqual([]);
+      expect(nonFastPath).toStrictEqual([]);
+      expect(fastPath).toStrictEqual(nonFastPath);
+    });
+
+    it('should resolve relative symlink input paths against projectRoot consistently in both branches', async () => {
+      await createTestFile('.gitignore', 'ignored-target/\n');
+      await createTestFile('ignored-target/real.txt', 'data');
+      await fs.symlink(
+        path.join(projectRoot, 'ignored-target'),
+        path.join(projectRoot, 'linked-target'),
+        'dir',
+      );
+      const relativeSymlinkPath = path.join('linked-target', 'real.txt');
+
+      const service = new FileDiscoveryService(projectRoot);
+      const fastPath = service.filterFiles([relativeSymlinkPath], {
+        respectGitIgnore: true,
+        respectLlxprtIgnore: true,
+      });
+      const nonFastPath = service.filterFiles([relativeSymlinkPath], {
+        respectGitIgnore: true,
+        respectLlxprtIgnore: false,
+      });
+
+      expect(fastPath).toStrictEqual([]);
+      expect(nonFastPath).toStrictEqual([]);
+      expect(fastPath).toStrictEqual(nonFastPath);
+    });
   });
 
   describe('filterFilesWithReport', () => {

--- a/packages/storage/src/services/fileDiscoveryService.test.ts
+++ b/packages/storage/src/services/fileDiscoveryService.test.ts
@@ -242,6 +242,39 @@ describe('FileDiscoveryService', () => {
       expect(nonFastPath).toStrictEqual([]);
       expect(fastPath).toStrictEqual(nonFastPath);
     });
+
+    it('should keep visible symlink targets consistently between fast path and non-fast path', async () => {
+      await createTestFile('visible-target/real.txt', 'data');
+      const absoluteSymlinkPath = path.join(projectRoot, 'link-to-visible.txt');
+      await fs.symlink(
+        path.join(projectRoot, 'visible-target', 'real.txt'),
+        absoluteSymlinkPath,
+      );
+      await fs.symlink(
+        path.join(projectRoot, 'visible-target'),
+        path.join(projectRoot, 'linked-visible-target'),
+        'dir',
+      );
+      const relativeSymlinkPath = path.join(
+        'linked-visible-target',
+        'real.txt',
+      );
+      const files = [absoluteSymlinkPath, relativeSymlinkPath];
+
+      const service = new FileDiscoveryService(projectRoot);
+      const fastPath = service.filterFiles(files, {
+        respectGitIgnore: true,
+        respectLlxprtIgnore: true,
+      });
+      const nonFastPath = service.filterFiles(files, {
+        respectGitIgnore: true,
+        respectLlxprtIgnore: false,
+      });
+
+      expect(fastPath).toStrictEqual(files);
+      expect(nonFastPath).toStrictEqual(files);
+      expect(fastPath).toStrictEqual(nonFastPath);
+    });
   });
 
   describe('filterFilesWithReport', () => {

--- a/packages/storage/src/services/fileDiscoveryService.ts
+++ b/packages/storage/src/services/fileDiscoveryService.ts
@@ -78,7 +78,8 @@ export class FileDiscoveryService {
         respectLlxprtIgnore &&
         this.combinedIgnoreFilter
       ) {
-        return !this.combinedIgnoreFilter.isIgnored(filePath);
+        const absolutePath = this.resolveAbsolutePath(filePath);
+        return !this.combinedIgnoreFilter.isIgnored(absolutePath);
       }
 
       const absolutePath = this.resolveAbsolutePath(filePath);


### PR DESCRIPTION
## TLDR

Normalizes FileDiscoveryService.filterFiles combined-filter fast path so it resolves each input path through the existing absolute-path helper before ignore matching. This aligns symlink and relative-path behavior with the non-fast-path branch.

## Dive Deeper

The combined-filter branch used when both gitignore and llxprtignore handling are enabled was passing the caller-provided path directly to the combined ignore filter. The non-fast-path branch first canonicalizes through the service helper, which resolves relative paths against projectRoot and dereferences symlinks when possible.

This PR keeps the production change intentionally small: the fast path now reuses that same helper before calling the combined ignore filter. The tests add behavioral coverage for an absolute symlink into an ignored directory and a relative symlink path, comparing fast-path and non-fast-path results.

## Reviewer Test Plan

Review the two FileDiscoveryService tests added under packages/storage/src/services/fileDiscoveryService.test.ts. To validate manually, run the storage test file and confirm both fast-path and non-fast-path calls filter the symlinked ignored target identically.

Commands used:

    npm --workspace @vybestack/llxprt-code-storage exec -- vitest run src/services/fileDiscoveryService.test.ts
    npm run test
    npm run lint
    npm run typecheck
    npm run format
    npm run build
    node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

The smoke command confirmed the build was up-to-date, then the external model invocation did not complete before the command timeout in this environment.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1989
