### PR TITLE
test(storage): assert public behavior instead of private getFilePathHash (Fixes #1990)

### DIFF
--- a/packages/storage/src/config/storage.test.ts
+++ b/packages/storage/src/config/storage.test.ts
@@ -114,48 +114,71 @@ describe('Storage – additional helpers', () => {
     expect(storage.getExtensionsConfigPath()).toBe(expected);
   });
 
-  it('getProjectTempDir returns hashed temp dir', () => {
-    const hash = (
-      storage as unknown as { getFilePathHash: (p: string) => string }
-    ).getFilePathHash(projectRoot);
-    const expected = path.join(os.homedir(), '.llxprt', 'tmp', hash);
-    expect(storage.getProjectTempDir()).toBe(expected);
-  });
-
-  it('getHistoryDir returns hashed history dir', () => {
-    const hash = (
-      storage as unknown as { getFilePathHash: (p: string) => string }
-    ).getFilePathHash(projectRoot);
-    const expected = path.join(os.homedir(), '.llxprt', 'history', hash);
-    expect(storage.getHistoryDir()).toBe(expected);
-  });
-
-  it('getHistoryFilePath returns shell_history in project temp dir', () => {
-    const hash = (
-      storage as unknown as { getFilePathHash: (p: string) => string }
-    ).getFilePathHash(projectRoot);
-    const expected = path.join(
-      os.homedir(),
-      '.llxprt',
-      'tmp',
-      hash,
-      'shell_history',
+  it('getProjectTempDir is located directly under the global temp dir', () => {
+    expect(path.dirname(storage.getProjectTempDir())).toBe(
+      Storage.getGlobalTempDir(),
     );
-    expect(storage.getHistoryFilePath()).toBe(expected);
   });
 
-  it('getProjectTempCheckpointsDir returns checkpoints in project temp dir', () => {
-    const hash = (
-      storage as unknown as { getFilePathHash: (p: string) => string }
-    ).getFilePathHash(projectRoot);
-    const expected = path.join(
-      os.homedir(),
-      '.llxprt',
-      'tmp',
-      hash,
-      'checkpoints',
+  it('getProjectTempDir is deterministic for a given project root', () => {
+    const a = new Storage(projectRoot).getProjectTempDir();
+    const b = new Storage(projectRoot).getProjectTempDir();
+    expect(a).toBe(b);
+  });
+
+  it('getProjectTempDir is unique per project root', () => {
+    const dirA = new Storage('/tmp/projectA').getProjectTempDir();
+    const dirB = new Storage('/tmp/projectB').getProjectTempDir();
+    expect(dirA).not.toBe(dirB);
+  });
+
+  it('getProjectTempDir directory-name segment is the sha256 of the project root (golden master / on-disk compatibility contract)', () => {
+    // Golden master: sha256 hex of the raw, unnormalized string '/tmp/project'
+    // (the exact projectRoot passed to the constructor; no path normalization).
+    // Hard-coded (not recomputed) so this test fails if the temp-dir naming
+    // scheme ever silently changes, which would orphan users' existing
+    // on-disk project temp directories.
+    const expectedSegment =
+      'f630ad93b344dd6bd04d44ecde70b128e7e77f9ecc28ee90b62b018734a7e8c4';
+    expect(path.basename(storage.getProjectTempDir())).toBe(expectedSegment);
+  });
+
+  it('getHistoryDir is located directly under the global history dir', () => {
+    expect(path.dirname(storage.getHistoryDir())).toBe(
+      path.join(Storage.getGlobalLlxprtDir(), 'history'),
     );
-    expect(storage.getProjectTempCheckpointsDir()).toBe(expected);
+  });
+
+  it('getHistoryDir shares the same per-project segment as the temp dir', () => {
+    expect(path.basename(storage.getHistoryDir())).toBe(
+      path.basename(storage.getProjectTempDir()),
+    );
+  });
+
+  it('getHistoryDir is deterministic for a given project root', () => {
+    const a = new Storage(projectRoot).getHistoryDir();
+    const b = new Storage(projectRoot).getHistoryDir();
+    expect(a).toBe(b);
+  });
+
+  it('getHistoryDir is unique per project root', () => {
+    const dirA = new Storage('/tmp/projectA').getHistoryDir();
+    const dirB = new Storage('/tmp/projectB').getHistoryDir();
+    expect(dirA).not.toBe(dirB);
+  });
+
+  it('getHistoryFilePath returns shell_history under the global temp dir', () => {
+    const result = storage.getHistoryFilePath();
+    expect(result).toBe(
+      path.join(storage.getProjectTempDir(), 'shell_history'),
+    );
+    expect(result.startsWith(Storage.getGlobalTempDir())).toBe(true);
+  });
+
+  it('getProjectTempCheckpointsDir returns checkpoints under the global temp dir', () => {
+    const result = storage.getProjectTempCheckpointsDir();
+    expect(result).toBe(path.join(storage.getProjectTempDir(), 'checkpoints'));
+    expect(result.startsWith(Storage.getGlobalTempDir())).toBe(true);
   });
 
   it('getInstallationIdPath returns ~/.llxprt/installation_id', () => {


### PR DESCRIPTION
## Summary

Fixes #1990 — a test-quality follow-up deferred from PR #1982 (storage extraction).

packages/storage/src/config/storage.test.ts reached into the **private** getFilePathHash method of the Storage class via "as unknown as { getFilePathHash: ... }" casts to construct expected temp/history paths in four tests (getProjectTempDir, getHistoryDir, getHistoryFilePath, getProjectTempCheckpointsDir).

Beyond testing an implementation detail (forbidden by dev-docs/RULES.md), those assertions were **circular**: the expected value was derived from the very method the production code uses internally, so a regression in the hashing would break both the expectation and the actual identically and slip through undetected.

## What changed

Only the test file changed — production storage.ts is untouched and getFilePathHash stays private. The four private-access tests are replaced with public-behavior assertions:

- **getProjectTempDir** — located directly under the public Storage.getGlobalTempDir(); deterministic across two Storage instances; unique per project root.
- **getHistoryDir** — located directly under Storage.getGlobalLlxprtDir()/history; shares the same per-project segment as the temp dir; deterministic; unique per project root.
- **getHistoryFilePath / getProjectTempCheckpointsDir** — public composition under getProjectTempDir(), plus a containment assertion under Storage.getGlobalTempDir() so a base-location regression is caught locally rather than only by the parent-dir test.
- A single **golden-master sha256 literal** pins the temp-dir name segment as an on-disk compatibility contract (so a silent change to the naming scheme that would orphan users' existing temp directories fails the test), without recomputing the hash in-test.

No any, no "as unknown as", no type assertions, no ts-ignore/ts-expect-error/ts-nocheck, no eslint-disable, and no node:crypto import in the test.

## Review process

- Implemented test-first and reviewed by a deepthinker pass for compliance and issue intent. Its one refinement — replacing a dynamically-recomputed sha256 oracle with a hard-coded golden-master literal — was applied.
- Ran Alibaba open-code-review (ocr) over the diff **with test files included**. Of 5 comments: the history-dir base-dir method, the two containment assertions, and the golden-master comment clarification were accepted and applied. Two suggestions to swap the fixed /tmp/projectA and /tmp/projectB literals for os.tmpdir() were declined — the hashing is a pure string operation and the determinism/golden-master design depends on fixed, platform-independent literal inputs.

## Verification

- packages/storage tests: **257 passed** (3 skipped); the storage config suite is **27 passed** (was 21; the 4 problematic tests became 10 focused behavioral tests).
- Root npm run typecheck clean across all workspaces.
- eslint packages/storage clean; scripts/check-eslint-guard.js passes (no suppression directives, no threshold/severity loosening).
- prettier --check clean; packages/storage build succeeds.
- Smoke test (node scripts/start.js --profile-load ollamakimi) produces a valid haiku.
