### PR TITLE
Make search_file_content respect gitignore/llxprtignore via config (Fixes #2110)

### DIFF
--- a/packages/tools/src/__tests__/filesystem-tools.test.ts
+++ b/packages/tools/src/__tests__/filesystem-tools.test.ts
@@ -42,6 +42,7 @@ import {
   LSTool,
   ReadFileTool,
   ReadLineRangeTool,
+  RipGrepTool,
   WriteFileTool,
 } from '../index.js';
 import {
@@ -106,6 +107,24 @@ function _createFakeFileHost(targetDir: string): IToolHost {
     getLlxprtIgnorePatterns: () => [],
     getEphemeralSettings: () => ({}),
     getDebugMode: () => false,
+  };
+}
+
+function createGrepHost(
+  targetDir: string,
+  options: {
+    respectGitIgnore: boolean;
+    respectLlxprtIgnore: boolean;
+    llxprtIgnoreFilePath: string | null;
+  },
+): IToolHost {
+  return {
+    ..._createFakeFileHost(targetDir),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: options.respectGitIgnore,
+      respectLlxprtIgnore: options.respectLlxprtIgnore,
+    }),
+    getLlxprtIgnoreFilePath: () => options.llxprtIgnoreFilePath,
   };
 }
 
@@ -303,6 +322,40 @@ describe('Filesystem Tool Group Behavioral Tests @plan:PLAN-20260608-ISSUE1585.P
       expect(result.error).toBeUndefined();
       expect(result.llmContent).toContain('Hello World');
       expect(result.llmContent).toContain('Hello Again');
+    });
+
+    it('respects .llxprtignore by default and overrides via file_filtering_options', async () => {
+      writeFileSync(join(tempDir, 'keep.ts'), 'needle found', 'utf-8');
+      writeFileSync(join(tempDir, 'skip.ts'), 'needle skip', 'utf-8');
+      const ignoreFilePath = join(tempDir, '.llxprtignore');
+      writeFileSync(ignoreFilePath, 'skip.ts', 'utf-8');
+
+      const host = createGrepHost(tempDir, {
+        respectGitIgnore: true,
+        respectLlxprtIgnore: true,
+        llxprtIgnoreFilePath: ignoreFilePath,
+      });
+
+      const defaultResult = await executeDeclarativeToolForBehavioralAssertion(
+        new RipGrepTool(host),
+        { pattern: 'needle', path: tempDir },
+      );
+
+      expect(defaultResult.llmContent).toContain('keep.ts');
+      expect(defaultResult.llmContent).not.toContain('skip.ts');
+
+      const overriddenResult =
+        await executeDeclarativeToolForBehavioralAssertion(
+          new RipGrepTool(host),
+          {
+            pattern: 'needle',
+            path: tempDir,
+            file_filtering_options: { respect_llxprt_ignore: false },
+          },
+        );
+
+      expect(overriddenResult.llmContent).toContain('keep.ts');
+      expect(overriddenResult.llmContent).toContain('skip.ts');
     });
   });
 

--- a/packages/tools/src/__tests__/ripGrep-args.test.ts
+++ b/packages/tools/src/__tests__/ripGrep-args.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildRipgrepArgs,
+  type RipgrepIgnoreOptions,
+} from '../tools/ripGrep.js';
+
+const defaultIgnore: RipgrepIgnoreOptions = {
+  respectGitIgnore: true,
+  respectLlxprtIgnore: true,
+  llxprtIgnoreFilePath: null,
+};
+
+function indexOfPair(args: readonly string[], flag: string): number {
+  for (let i = 0; i < args.length - 1; i += 1) {
+    if (args[i] === flag) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function pairValue(args: readonly string[], flag: string): string | undefined {
+  const idx = indexOfPair(args, flag);
+  return idx === -1 ? undefined : args[idx + 1];
+}
+
+function hasFlag(args: readonly string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+const PATTERN = 'needle';
+const ABS_PATH = '/tmp/search-root';
+
+describe('buildRipgrepArgs', () => {
+  it('does not include --no-ignore when respectGitIgnore is true', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, defaultIgnore);
+    expect(hasFlag(args, '--no-ignore')).toBe(false);
+  });
+
+  it('includes --no-ignore when respectGitIgnore is false', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, {
+      ...defaultIgnore,
+      respectGitIgnore: false,
+    });
+    expect(hasFlag(args, '--no-ignore')).toBe(true);
+  });
+
+  it('includes --ignore-file with the path when respectLlxprtIgnore is true and a path is provided', () => {
+    const ignorePath = '/repo/.llxprtignore';
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, {
+      ...defaultIgnore,
+      respectLlxprtIgnore: true,
+      llxprtIgnoreFilePath: ignorePath,
+    });
+    expect(pairValue(args, '--ignore-file')).toBe(ignorePath);
+  });
+
+  it('does not include --ignore-file when respectLlxprtIgnore is false', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, {
+      ...defaultIgnore,
+      respectLlxprtIgnore: false,
+      llxprtIgnoreFilePath: '/repo/.llxprtignore',
+    });
+    expect(hasFlag(args, '--ignore-file')).toBe(false);
+  });
+
+  it('does not include --ignore-file when respectLlxprtIgnore is true but path is null', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, {
+      ...defaultIgnore,
+      respectLlxprtIgnore: true,
+      llxprtIgnoreFilePath: null,
+    });
+    expect(hasFlag(args, '--ignore-file')).toBe(false);
+  });
+
+  it('includes both --no-ignore and --ignore-file when respectGitIgnore=false and respectLlxprtIgnore=true with a path', () => {
+    const ignorePath = '/repo/.llxprtignore';
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, {
+      respectGitIgnore: false,
+      respectLlxprtIgnore: true,
+      llxprtIgnoreFilePath: ignorePath,
+    });
+    expect(hasFlag(args, '--no-ignore')).toBe(true);
+    expect(pairValue(args, '--ignore-file')).toBe(ignorePath);
+  });
+
+  it('always includes baseline --glob excludes regardless of ignore flags', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, {
+      respectGitIgnore: false,
+      respectLlxprtIgnore: false,
+      llxprtIgnoreFilePath: null,
+    });
+    const globValues = args.filter((_value, idx) => args[idx - 1] === '--glob');
+    const expectedExcludes = [
+      '!.git',
+      '!node_modules',
+      '!bower_components',
+      '!*.log',
+      '!*.tmp',
+      '!build',
+      '!dist',
+      '!coverage',
+    ];
+    expectedExcludes.forEach((ex) => expect(globValues).toContain(ex));
+  });
+
+  it('includes the include glob when an include pattern is provided', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, '*.ts', defaultIgnore);
+    const positiveGlobs = args.filter(
+      (_value, idx) => args[idx - 1] === '--glob' && !args[idx].startsWith('!'),
+    );
+    expect(positiveGlobs).toContain('*.ts');
+  });
+
+  it('does not add a positive include glob when include is undefined', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, defaultIgnore);
+    const positiveGlobs = args.filter(
+      (_value, idx) => args[idx - 1] === '--glob' && !args[idx].startsWith('!'),
+    );
+    expect(positiveGlobs).toEqual([]);
+  });
+
+  it('places the pattern after --regexp', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, defaultIgnore);
+    expect(pairValue(args, '--regexp')).toBe(PATTERN);
+  });
+
+  it('appends the absolute path as the final positional argument', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, defaultIgnore);
+    expect(args[args.length - 1]).toBe(ABS_PATH);
+  });
+});

--- a/packages/tools/src/tools/ripGrep.ts
+++ b/packages/tools/src/tools/ripGrep.ts
@@ -50,6 +50,67 @@ export interface RipGrepToolParams {
    * File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")
    */
   include?: string;
+
+  /**
+   * Whether to respect .gitignore and .llxprtignore patterns (optional, defaults to true)
+   */
+  file_filtering_options?: {
+    respect_git_ignore?: boolean;
+    respect_llxprt_ignore?: boolean;
+  };
+}
+
+export interface RipgrepIgnoreOptions {
+  respectGitIgnore: boolean;
+  respectLlxprtIgnore: boolean;
+  llxprtIgnoreFilePath: string | null;
+}
+
+const BASELINE_EXCLUDES: readonly string[] = Object.freeze([
+  '.git',
+  'node_modules',
+  'bower_components',
+  '*.log',
+  '*.tmp',
+  'build',
+  'dist',
+  'coverage',
+]);
+
+export function buildRipgrepArgs(
+  pattern: string,
+  absolutePath: string,
+  include: string | undefined,
+  ignoreOptions: RipgrepIgnoreOptions,
+): string[] {
+  const rgArgs = [
+    '--line-number',
+    '--no-heading',
+    '--with-filename',
+    '--ignore-case',
+    '--regexp',
+    pattern,
+  ];
+
+  if (include) {
+    rgArgs.push('--glob', include);
+  }
+
+  BASELINE_EXCLUDES.forEach((exclude) => {
+    rgArgs.push('--glob', `!${exclude}`);
+  });
+
+  if (ignoreOptions.respectGitIgnore === false) {
+    rgArgs.push('--no-ignore');
+  }
+
+  if (ignoreOptions.respectLlxprtIgnore && ignoreOptions.llxprtIgnoreFilePath) {
+    rgArgs.push('--ignore-file', ignoreOptions.llxprtIgnoreFilePath);
+  }
+
+  rgArgs.push('--threads', '4');
+  rgArgs.push(absolutePath);
+  return rgArgs;
 }
 
 /**
@@ -130,6 +191,24 @@ File: ${resolved.basename}
     return [searchDirAbs];
   }
 
+  private resolveIgnoreOptions(): RipgrepIgnoreOptions {
+    const defaults = this.host.getFileFilteringOptions();
+    const respectGitIgnore =
+      this.params.file_filtering_options?.respect_git_ignore ??
+      defaults.respectGitIgnore;
+    const respectLlxprtIgnore =
+      this.params.file_filtering_options?.respect_llxprt_ignore ??
+      defaults.respectLlxprtIgnore;
+    const llxprtIgnoreFilePath = respectLlxprtIgnore
+      ? this.host.getLlxprtIgnoreFilePath()
+      : null;
+    return {
+      respectGitIgnore,
+      respectLlxprtIgnore,
+      llxprtIgnoreFilePath,
+    };
+  }
+
   private collectDirectoryMatches(
     searchDirectories: readonly string[],
     signal: AbortSignal,
@@ -138,6 +217,7 @@ File: ${resolved.basename}
       searchDirectories,
       signal,
       DEFAULT_TOTAL_MAX_MATCHES,
+      this.resolveIgnoreOptions(),
     );
   }
 
@@ -145,6 +225,7 @@ File: ${resolved.basename}
     searchDirectories: readonly string[],
     signal: AbortSignal,
     totalMaxMatches: number,
+    ignoreOptions: RipgrepIgnoreOptions,
   ): Promise<GrepMatch[]> {
     let allMatches: GrepMatch[] = [];
 
@@ -158,6 +239,7 @@ File: ${resolved.basename}
         path: searchDir,
         include: this.params.include,
         signal,
+        ignoreOptions,
       });
 
       if (searchDirectories.length > 1) {
@@ -304,14 +386,6 @@ File: ${resolved.basename}
     return results;
   }
 
-  /**
-   * Returns the path to .llxprtignore file if it exists and has patterns.
-   * Only returns path if patterns are non-empty (excluding comments/blank lines).
-   */
-  private getLlxprtIgnorePath(): string | null {
-    return this.host.getLlxprtIgnoreFilePath();
-  }
-
   private async runRipgrepProcess(
     rgArgs: string[],
     signal: AbortSignal,
@@ -362,59 +436,27 @@ File: ${resolved.basename}
     });
   }
 
-  private buildRipgrepArgs(
-    pattern: string,
-    absolutePath: string,
-    include: string | undefined,
-  ): string[] {
-    const rgArgs = [
-      '--line-number',
-      '--no-heading',
-      '--with-filename',
-      '--ignore-case',
-      '--regexp',
-      pattern,
-    ];
-
-    if (include) {
-      rgArgs.push('--glob', include);
-    }
-
-    const excludes = [
-      '.git',
-      'node_modules',
-      'bower_components',
-      '*.log',
-      '*.tmp',
-      'build',
-      'dist',
-      'coverage',
-    ];
-    excludes.forEach((exclude) => {
-      rgArgs.push('--glob', `!${exclude}`);
-    });
-
-    if (this.host.getFileFilteringRespectLlxprtIgnore()) {
-      const llxprtIgnorePath = this.getLlxprtIgnorePath();
-      if (llxprtIgnorePath) {
-        rgArgs.push('--ignore-file', llxprtIgnorePath);
-      }
-    }
-
-    rgArgs.push('--threads', '4');
-    rgArgs.push(absolutePath);
-    return rgArgs;
-  }
-
   private async performRipgrepSearch(options: {
     pattern: string;
     path: string;
     include?: string;
     signal: AbortSignal;
+    ignoreOptions: RipgrepIgnoreOptions;
   }): Promise<GrepMatch[]> {
-    const { pattern, path: absolutePath, include, signal } = options;
+    const {
+      pattern,
+      path: absolutePath,
+      include,
+      signal,
+      ignoreOptions,
+    } = options;
 
-    const rgArgs = this.buildRipgrepArgs(pattern, absolutePath, include);
+    const rgArgs = buildRipgrepArgs(
+      pattern,
+      absolutePath,
+      include,
+      ignoreOptions,
+    );
 
     try {
       const output = await this.runRipgrepProcess(rgArgs, signal);
@@ -516,7 +558,7 @@ export class RipGrepTool extends BaseDeclarativeTool<
     super(
       RipGrepTool.Name,
       'SearchText',
-      'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers. Total results limited to 20,000 matches like VSCode.',
+      'Searches for a regular expression pattern within the content of files in a specified directory (or current working directory). Can filter files by a glob pattern. Returns the lines containing matches, along with their file paths and line numbers. Total results limited to 20,000 matches like VSCode. Ignore patterns from .gitignore and .llxprtignore are respected by default and can be overridden via file_filtering_options.',
       Kind.Search,
       {
         properties: {
@@ -534,6 +576,23 @@ export class RipGrepTool extends BaseDeclarativeTool<
             description:
               "Optional: A glob pattern to filter which files are searched (e.g., '*.js', '*.{ts,tsx}', 'src/**'). If omitted, searches all files (respecting potential global ignores).",
             type: 'string',
+          },
+          file_filtering_options: {
+            description:
+              'Optional: Whether to respect ignore patterns from .gitignore or .llxprtignore',
+            type: 'object',
+            properties: {
+              respect_git_ignore: {
+                description:
+                  'Optional: Whether to respect .gitignore patterns when searching files. Only available in git repositories. Defaults to true.',
+                type: 'boolean',
+              },
+              respect_llxprt_ignore: {
+                description:
+                  'Optional: Whether to respect .llxprtignore patterns when searching files. Defaults to true.',
+                type: 'boolean',
+              },
+            },
           },
         },
         required: ['pattern'],


### PR DESCRIPTION
## Summary

Fixes #2110 (the search-tool facet — Scenario 2).

Issue #2110 reported opaque `API Error: fetch failed` after the scrollback was overwhelmed. Root-cause analysis (see CodeRabbit's breakdown in the issue) identified two scenarios:

1. **Transient `fetch failed` network drops during streaming** — **already fixed on `main`** by #2161 (which also removed the obsolete `retryFetchErrors` config). `fetch failed` is now a `TRANSIENT_ERROR_PHRASE` that is always retried. This PR does **not** touch retry logic.

2. **Searches traversing ignored paths (e.g. `node_modules`)** producing enormous output that blew out the context window, then surfaced as a 400/context error lost in the scrollback. The user's explicit direction for the fix:

   > on the ripgrep we have the gitignore and llpxrt ignore, and it should be made to respect those depending on config and/or take arguments like other tools.

This PR addresses Scenario 2.

## Problem

The ripgrep-backed `search_file_content` tool (`packages/tools/src/tools/ripGrep.ts`) was inconsistent with its sibling tools (`ls`, `read-many-files`, `glob`):

- It respected `.gitignore` **only** via the ripgrep binary default. Nothing passed `--no-ignore` when the host config had `respectGitIgnore: false`, so the config flag was silently ignored.
- It respected `.llxprtignore` via the **legacy** `IToolHost.getFileFilteringRespectLlxprtIgnore()` path rather than the unified `getFileFilteringOptions()` used everywhere else.
- It had **no per-invocation override arguments**, unlike `ls`/`read-many-files` which expose a `file_filtering_options` object.

## Fix

Made `search_file_content` consistent with `ls` and `read-many-files`:

- **Config-driven**: both `.gitignore` and `.llxprtignore` respect now flow from `getFileFilteringOptions()` (`respectGitIgnore` / `respectLlxprtIgnore`).
- **Per-invocation override**: added a `file_filtering_options` param (`respect_git_ignore` / `respect_llxprt_ignore`) mirroring the sibling tools exactly, so a caller can opt into searching ignored paths for a single call.
- **Wiring**:
  - `respectGitIgnore: false` now emits `--no-ignore` so the config flag actually takes effect.
  - `respectLlxprtIgnore: true` (+ an existing ignore file) emits `--ignore-file <path>`, replacing the legacy accessor.
  - The baseline glob excludes (`node_modules`, `.git`, `dist`, etc.) are retained as an **always-on safety net** (frozen) — they are independent of the ignore flags and prevent the exact node_modules explosion from the issue even in non-git repos.
- **Testability**: extracted `buildRipgrepArgs` into a pure, exported function so the flag logic is unit-testable without spawning ripgrep.

## Tests

- **New** `packages/tools/src/__tests__/ripGrep-args.test.ts` — 11 pure unit tests covering: `--no-ignore` on/off, `--ignore-file` presence/absence (incl. null-path no-op), both flags coexisting, all 8 baseline excludes, include-glob, and pattern/path placement.
- **Added behavioral test** to `GrepTool behavioral contract` in `filesystem-tools.test.ts` — proves end-to-end with the real ripgrep binary that `.llxprtignore` is respected by default and overridden via `file_filtering_options.respect_llxprt_ignore: false`.

## Verification

All gates pass locally:
- `npm run format` / `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build` — success
- `npm run test` — full suite green (no failures)
- `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — smoke test green
- Open Code Review (`ocr`, 20m timeout) — 4 comments raised, all addressed (frozen baseline excludes, full-coverage exclude assertion, de-brittled include-glob assertion, added `--no-ignore` + `--ignore-file` coexistence test).
