### PR TITLE
Clean shared CLI type-escape seams — eliminate as-unknown-as casts (Fixes #2170)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -46,6 +46,7 @@ research/
 .docker
 .env
 .llxprt/
+.llxprt/**
 eslint.config.js
 gha-creds-*.json
 junit.xml

--- a/packages/agents/src/core/subagentScheduler.ts
+++ b/packages/agents/src/core/subagentScheduler.ts
@@ -12,15 +12,21 @@ import type {
   ToolCallsUpdateHandler,
 } from './coreToolScheduler.js';
 
-export type SubagentSchedulerFactory = (args: {
-  schedulerConfig: Config;
-  onAllToolCallsComplete: (calls: CompletedToolCall[]) => Promise<void>;
-  outputUpdateHandler: OutputUpdateHandler;
-  onToolCallsUpdate?: ToolCallsUpdateHandler;
-}) => {
+/**
+ * Handle returned by a subagent scheduler factory.
+ * Allows scheduling tool calls and optionally disposing of the scheduler.
+ */
+export interface SubagentSchedulerHandle {
   schedule(
     request: ToolCallRequestInfo | ToolCallRequestInfo[],
     signal: AbortSignal,
   ): Promise<void> | void;
   dispose?: () => void;
-};
+}
+
+export type SubagentSchedulerFactory = (args: {
+  schedulerConfig: Config;
+  onAllToolCallsComplete: (calls: CompletedToolCall[]) => Promise<void>;
+  outputUpdateHandler: OutputUpdateHandler;
+  onToolCallsUpdate?: ToolCallsUpdateHandler;
+}) => SubagentSchedulerHandle | Promise<SubagentSchedulerHandle>;

--- a/packages/cli/src/runtime/agentRuntimeAdapter.ts
+++ b/packages/cli/src/runtime/agentRuntimeAdapter.ts
@@ -218,13 +218,7 @@ export class AgentRuntimeAdapter {
       throw new Error('Provider manager not initialized');
     }
 
-    const provider = (
-      providerManager as unknown as {
-        getProviderByName: (
-          name: string,
-        ) => { getDefaultModel: () => string } | undefined;
-      }
-    ).getProviderByName(providerName);
+    const provider = providerManager.getProviderByName(providerName);
     if (!provider) {
       const available = providerManager.listProviders().join(', ');
       throw new Error(
@@ -233,7 +227,12 @@ export class AgentRuntimeAdapter {
     }
 
     // Get default model for provider
-    const defaultModel = provider.getDefaultModel();
+    const defaultModel = provider.getDefaultModel?.();
+    if (!defaultModel) {
+      throw new Error(
+        `Provider '${providerName}' has no default model configured.`,
+      );
+    }
 
     // Batch update: provider + model + clear baseUrl
     const updates: Partial<RuntimeStateParams> = {
@@ -308,13 +307,7 @@ export class AgentRuntimeAdapter {
       throw new Error('Provider manager not initialized');
     }
 
-    const provider = (
-      providerManager as unknown as {
-        getProviderByName: (
-          name: string,
-        ) => { getDefaultModel: () => string } | undefined;
-      }
-    ).getProviderByName(providerName);
+    const provider = providerManager.getProviderByName(providerName);
     if (!provider) {
       const available = providerManager.listProviders().join(', ');
       throw new Error(
@@ -323,7 +316,12 @@ export class AgentRuntimeAdapter {
     }
 
     // Determine model (explicit or default)
-    const targetModel = options?.model ?? provider.getDefaultModel();
+    const targetModel = options?.model ?? provider.getDefaultModel?.();
+    if (!targetModel) {
+      throw new Error(
+        `Provider '${providerName}' has no default model configured.`,
+      );
+    }
 
     // Build batch update
     const updates: Partial<RuntimeStateParams> = {

--- a/packages/cli/src/ui/commands/mcpDisplay.ts
+++ b/packages/cli/src/ui/commands/mcpDisplay.ts
@@ -61,17 +61,11 @@ export const getResourceName = (resource: DiscoveredMCPResource): string => {
   return runtimeResource.name ?? runtimeResource.uri;
 };
 
-/** Narrow interface for the dynamically-imported token storage static method. */
-interface TokenStorageStatic {
-  isTokenExpired(token: unknown): boolean;
-}
-
-function resolveTokenStatus(
-  tokenStorage: TokenStorageStatic,
-  token: unknown,
-): { suffix: string; needsAuthHint: boolean } {
-  const isExpired = tokenStorage.isTokenExpired(token);
-  if (isExpired === true) {
+function resolveTokenStatus(isExpired: boolean): {
+  suffix: string;
+  needsAuthHint: boolean;
+} {
+  if (isExpired) {
     return {
       suffix: ` ${COLOR_YELLOW}(OAuth token expired)${RESET_COLOR}`,
       needsAuthHint: true,
@@ -99,11 +93,10 @@ async function buildOAuthStatusSuffix(
         '@vybestack/llxprt-code-core'
       );
       const tokenStorage = new MCPOAuthTokenStorage();
-      const credentials = await tokenStorage.getCredentials(serverName);
+      const credentials = await tokenStorage.getToken(serverName);
       if (credentials !== null) {
         ({ suffix, needsAuthHint } = resolveTokenStatus(
-          MCPOAuthTokenStorage as unknown as TokenStorageStatic,
-          credentials.token,
+          MCPOAuthTokenStorage.isTokenExpired(credentials.token),
         ));
       } else {
         suffix = ` ${COLOR_RED}(OAuth not authenticated)${RESET_COLOR}`;

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -17,6 +17,7 @@ import {
   type ToolCallsUpdateHandler,
   type ToolCall,
   type EditorType,
+  type SubagentSchedulerFactory,
   DEFAULT_AGENT_ID,
   DebugLogger,
   type AnsiOutput,
@@ -27,18 +28,6 @@ import type { CoreToolScheduler } from '@vybestack/llxprt-code-agents';
 
 import type { HistoryItemWithoutId } from '../types.js';
 import { ToolCallStatus } from '../types.js';
-
-type ExternalSchedulerFactory = (args: {
-  schedulerConfig: Config;
-  onAllToolCallsComplete: (calls: CompletedToolCall[]) => Promise<void>;
-  outputUpdateHandler: OutputUpdateHandler;
-  onToolCallsUpdate?: ToolCallsUpdateHandler;
-}) => {
-  schedule(
-    request: ToolCallRequestInfo | ToolCallRequestInfo[],
-    signal: AbortSignal,
-  ): Promise<void> | void;
-};
 
 type SchedulerConfigWithExplicitMessageBus = Config & {
   getOrCreateScheduler(
@@ -305,7 +294,7 @@ function createMainSchedulerCallbacks(
 function createSubagentCallbacks(
   schedulerId: symbol,
   refs: SchedulerRefs,
-  args: Parameters<ExternalSchedulerFactory>[0],
+  args: Parameters<SubagentSchedulerFactory>[0],
 ): Parameters<
   SchedulerConfigWithExplicitMessageBus['getOrCreateScheduler']
 >[1] {
@@ -524,9 +513,9 @@ function useScheduler(
 function useExternalSchedulerFactoryCreator(
   refs: SchedulerRefs,
   runtimeMessageBus: MessageBus | undefined,
-): ExternalSchedulerFactory {
+): SubagentSchedulerFactory {
   const factory = useCallback(
-    async (args: Parameters<ExternalSchedulerFactory>[0]) => {
+    async (args: Parameters<SubagentSchedulerFactory>[0]) => {
       const schedulerId = Symbol('subagent-scheduler');
       const schedulerSessionId = args.schedulerConfig.getSessionId();
       const instance = await (
@@ -548,7 +537,7 @@ function useExternalSchedulerFactoryCreator(
     },
     [refs, runtimeMessageBus],
   );
-  return factory as unknown as ExternalSchedulerFactory;
+  return factory;
 }
 
 /**
@@ -556,12 +545,12 @@ function useExternalSchedulerFactoryCreator(
  */
 function useExternalSchedulerSetup(
   config: Config,
-  createExternalScheduler: ExternalSchedulerFactory,
+  createExternalScheduler: SubagentSchedulerFactory,
   setExternalSchedulerRegistered: (registered: boolean) => void,
 ): void {
   type ConfigWithSchedulerFactory = Config & {
     setInteractiveSubagentSchedulerFactory?: (
-      factory: ExternalSchedulerFactory | undefined,
+      factory: SubagentSchedulerFactory | undefined,
     ) => void;
   };
 

--- a/packages/core/src/core/subagentTypes.ts
+++ b/packages/core/src/core/subagentTypes.ts
@@ -34,22 +34,31 @@ import type {
 } from './toolSchedulerContract.js';
 
 /**
+ * Handle returned by a subagent scheduler factory.
+ * Allows scheduling tool calls and optionally disposing of the scheduler.
+ */
+export interface SubagentSchedulerHandle {
+  schedule(
+    request: ToolCallRequestInfo | ToolCallRequestInfo[],
+    signal: AbortSignal,
+  ): Promise<void> | void;
+  dispose?: () => void;
+}
+
+/**
  * @plan PLAN-20260610-ISSUE1592.P03
  * Relocated from core/subagentScheduler.ts (which moves to agents).
  * Core config stayers import this type from here.
+ *
+ * The factory may return synchronously or asynchronously — the runtime call site
+ * wraps the result in Promise.resolve() to normalize both shapes.
  */
 export type SubagentSchedulerFactory = (args: {
   schedulerConfig: Config;
   onAllToolCallsComplete: (calls: CompletedToolCall[]) => Promise<void>;
   outputUpdateHandler: OutputUpdateHandler;
   onToolCallsUpdate?: ToolCallsUpdateHandler;
-}) => {
-  schedule(
-    request: ToolCallRequestInfo | ToolCallRequestInfo[],
-    signal: AbortSignal,
-  ): Promise<void> | void;
-  dispose?: () => void;
-};
+}) => SubagentSchedulerHandle | Promise<SubagentSchedulerHandle>;
 
 /**
  * Describes the possible termination modes for a subagent.

--- a/scripts/check-eslint-guard.js
+++ b/scripts/check-eslint-guard.js
@@ -189,29 +189,7 @@ const TYPE_ESCAPE_PATTERNS = [
   { pattern: /\bas\s+unknown\s+as\b/, label: 'as unknown as' },
 ];
 
-const CLI_TYPE_ESCAPE_ALLOWLIST = [
-  {
-    file: 'packages/cli/src/runtime/agentRuntimeAdapter.ts',
-    label: 'as unknown as',
-    content: 'providerManager as unknown as {',
-    issue: '2171',
-    max: 2,
-  },
-  {
-    file: 'packages/cli/src/ui/commands/mcpDisplay.ts',
-    label: 'as unknown as',
-    content: 'MCPOAuthTokenStorage as unknown as TokenStorageStatic,',
-    issue: '2173',
-    max: 1,
-  },
-  {
-    file: 'packages/cli/src/ui/hooks/useReactToolScheduler.ts',
-    label: 'as unknown as',
-    content: 'return factory as unknown as ExternalSchedulerFactory;',
-    issue: '2172',
-    max: 1,
-  },
-];
+const CLI_TYPE_ESCAPE_ALLOWLIST = [];
 
 export function hasInlineEslintDirective(line) {
   for (let i = 0; i < line.length; i++) {

--- a/scripts/tests/eslint-guard.test.js
+++ b/scripts/tests/eslint-guard.test.js
@@ -210,28 +210,35 @@ describe('check-eslint-guard', () => {
     expect(checkCliSourcePolicy()).toEqual([]);
   });
 
-  it('keeps checked-in CLI production type escape policy clean except tracked shared seams', () => {
+  it('keeps checked-in CLI production type escape policy clean (#2174)', () => {
     expect(scanCliProductionTypeEscapes()).toEqual([]);
   });
 
-  it('rejects production CLI TypeScript escape hatches in cleaned scopes', () => {
-    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-cli-types-'));
-    const sourceDir = join(tmpDir, 'packages', 'cli', 'src', 'ui');
-    mkdirSync(sourceDir, { recursive: true });
-    writeFileSync(
-      join(sourceDir, 'example.ts'),
-      [
-        'export function unsafe(value: unknown): string {',
-        '  return value as unknown as string;',
-        '}',
-      ].join('\n'),
-    );
+  it.each([
+    ['as unknown as', 'return value as unknown as string;'],
+    ['as any', 'return value as any;'],
+    ['@ts-ignore', '// @ts-ignore\nreturn value;'],
+    ['@ts-expect-error', '// @ts-expect-error\nreturn value;'],
+    ['@ts-nocheck', '// @ts-nocheck\nexport const value = 1;'],
+  ])(
+    'rejects production CLI TypeScript escape hatch: %s (#2174)',
+    (_label, source) => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-cli-types-'));
+      const sourceDir = join(tmpDir, 'packages', 'cli', 'src', 'ui');
+      mkdirSync(sourceDir, { recursive: true });
+      writeFileSync(
+        join(sourceDir, 'example.ts'),
+        ['export function unsafe(value: unknown): string {', source, '}'].join(
+          '\n',
+        ),
+      );
 
-    const violations = scanCliProductionTypeEscapes(tmpDir);
+      const violations = scanCliProductionTypeEscapes(tmpDir);
 
-    expect(violations).toHaveLength(1);
-    expect(violations[0].message).toContain('#2174');
-  });
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('#2174');
+    },
+  );
 
   it('ignores CLI test files when checking production type escape policy', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-cli-test-types-'));


### PR DESCRIPTION
## Summary

Eliminates the last four \`as unknown as\` type-escape hatches from CLI production code by aligning shared package type contracts. Also adds a ratchet guard (#2174) to prevent regressions.

Parent issue: #2170
Sub-issues closed: #2171, #2172, #2173, #2174

## Changes by sub-issue

### #2171 — Type provider-manager capabilities for CLI agent runtime adapter

**File:** \`packages/cli/src/runtime/agentRuntimeAdapter.ts\`

The \`RuntimeProviderManager\` interface in core already declares \`getProviderByName(name: string): RuntimeProvider | undefined\`, and \`RuntimeProvider\` already has optional \`getDefaultModel?(): string\`. The two \`as unknown as\` casts at the provider-lookup sites were unnecessary — they existed because the code didn't trust the shared contract. Now uses \`providerManager.getProviderByName()\` directly and \`provider.getDefaultModel?.()\` with optional chaining, plus an explicit undefined guard with a clear error message.

### #2172 — Align CLI React tool scheduler factory contract

**Files:** \`packages/cli/src/ui/hooks/useReactToolScheduler.ts\`, \`packages/core/src/core/subagentTypes.ts\`, \`packages/agents/src/core/subagentScheduler.ts\`

The CLI defined a local \`ExternalSchedulerFactory\` type that duplicated the shared \`SubagentSchedulerFactory\` from core, then used \`as unknown as\` to bridge a subtle mismatch (the CLI factory was async while the shared type was sync-only). 

- Imported \`SubagentSchedulerFactory\` from \`@vybestack/llxprt-code-core\` and removed the local duplicate.
- Introduced \`SubagentSchedulerHandle\` interface in both core and agents copies.
- Changed \`SubagentSchedulerFactory\` return type to \`SubagentSchedulerHandle | Promise<SubagentSchedulerHandle>\` — this accurately models the runtime call site in \`initInteractiveScheduler\` which wraps the result in \`Promise.resolve()\` to normalize both sync and async factory shapes.
- The CLI's async factory now type-checks without any cast.

### #2173 — Type MCP OAuth token storage static contract

**File:** \`packages/cli/src/ui/commands/mcpDisplay.ts\`

\`MCPOAuthTokenStorage\` already exports a properly-typed static \`isTokenExpired(token: MCPOAuthToken): boolean\` method and an instance \`getToken(serverName): Promise<MCPOAuthCredentials | null>\` method. The cast through \`TokenStorageStatic\` + \`unknown\` token existed because the code used \`getCredentials()\` (which returns \`OAuthCredentials | null\` with an \`unknown\` token shape) instead of \`getToken()\`.

- Switched from \`getCredentials()\` to \`getToken()\` to get properly typed \`MCPOAuthCredentials\` with a \`.token\` of type \`MCPOAuthToken\`.
- Call \`MCPOAuthTokenStorage.isTokenExpired(credentials.token)\` directly — no cast needed.
- Removed the local \`TokenStorageStatic\` interface and simplified \`resolveTokenStatus\` to take a boolean.

### #2174 — Add ratchet guard for TypeScript escape hatches

**Files:** \`scripts/check-eslint-guard.js\`, \`scripts/tests/eslint-guard.test.js\`

- Emptied \`CLI_TYPE_ESCAPE_ALLOWLIST\` (previously tracked the three seams above).
- Expanded the guard test from a single \`as unknown as\` fixture to a table-driven \`it.each\` test covering all five forbidden patterns: \`as unknown as\`, \`as any\`, \`@ts-ignore\`, \`@ts-expect-error\`, \`@ts-nocheck\`.

## Verification

- \`npm run typecheck\` — all 15 packages pass
- \`npm run lint\` — 4 pre-existing \`await-thenable\` errors in \`packages/providers/src/\` (verified pre-existing on main, unrelated to this PR)
- \`npm run format\` — clean (source files only)
- \`npm run build\` — all packages build successfully
- \`npm run test\` — all 518 affected tests pass (1 pre-existing e2e failure in \`session-browser-e2e.test.js\` unrelated to this PR)
- \`node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"\` — smoke test passes
- \`npm run lint:eslint-guard\` — ratchet guard passes with empty allowlist (70 guard tests pass)
- Open code review (ocr) — 0 findings after addressing error message clarity

Fixes #2170
Closes #2171
Closes #2172
Closes #2173
Closes #2174