### PR TITLE
refactor(providers): eliminate all 27 as-unknown-as type-escape casts (Fixes #2212)

### DIFF
--- a/packages/providers/src/BaseProviderNormalization.ts
+++ b/packages/providers/src/BaseProviderNormalization.ts
@@ -35,6 +35,12 @@ interface RuntimeGuardResult {
   metadata: Record<string, unknown>;
 }
 
+interface ResolvedRuntimeShape {
+  model?: unknown;
+  baseURL?: unknown;
+  authToken?: unknown;
+}
+
 interface NormalizationDependencies {
   providerName: string;
   defaultSettingsService: SettingsService;
@@ -68,23 +74,21 @@ function findResolvedRuntimeGaps(
   }
 
   const missing: string[] = [];
-  const resolvedRecord = resolved as unknown as Record<string, unknown>;
+  const r = resolved as ResolvedRuntimeShape;
   if (
-    typeof resolvedRecord['model'] !== 'string' ||
-    resolved.model.trim() === ''
+    typeof r.model !== 'string' ||
+    (typeof r.model === 'string' && r.model.trim() === '')
   ) {
     missing.push('resolved.model');
   }
-  const baseURL = resolvedRecord['baseURL'];
   if (
-    baseURL !== undefined &&
-    baseURL !== null &&
-    typeof baseURL !== 'string'
+    r.baseURL !== undefined &&
+    r.baseURL !== null &&
+    typeof r.baseURL !== 'string'
   ) {
     missing.push('resolved.baseURL');
   }
-  const authToken = resolvedRecord['authToken'];
-  if (authToken === undefined || authToken === null) {
+  if (r.authToken === undefined || r.authToken === null) {
     missing.push('resolved.authToken');
   }
   return missing;

--- a/packages/providers/src/anthropic/AnthropicApiExecution.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.ts
@@ -12,6 +12,7 @@
  */
 
 import type Anthropic from '@anthropic-ai/sdk';
+import type { MessageCreateParamsBase } from '@anthropic-ai/sdk/resources/messages/index.js';
 import type { DumpMode } from '../utils/dumpContext.js';
 import {
   shouldDumpSDKContext,
@@ -96,6 +97,30 @@ export function buildAnthropicCustomHeaders(params: {
 }
 
 /**
+ * The request body built by buildAnthropicRequestBody, which includes the
+ * required SDK base fields (model, messages, max_tokens) plus optional
+ * dynamic overrides from modelParams. The index signature preserves the
+ * ability to carry dynamic fields at runtime while being assignable to
+ * the SDK's create() overload that accepts MessageCreateParamsBase.
+ */
+type AnthropicRequestBody = MessageCreateParamsBase & {
+  [key: string]: unknown;
+};
+
+/**
+ * Narrows the dynamically-built request body to the SDK-accepted type.
+ * The body is constructed by buildAnthropicRequestBody at runtime with
+ * valid base fields. Since AnthropicRequestBody includes the index
+ * signature, the single `as` narrowing from Record<string, unknown>
+ * is structurally justified (the source carries all base fields).
+ */
+function asMessageCreateParams(
+  body: Record<string, unknown>,
+): AnthropicRequestBody {
+  return body as AnthropicRequestBody;
+}
+
+/**
  * Create API call closure with response headers
  */
 export function createAnthropicApiCall(
@@ -106,20 +131,12 @@ export function createAnthropicApiCall(
   data: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>;
   response: Response | undefined;
 }> {
+  const params = asMessageCreateParams(requestBody);
   return async () => {
     const apiCall = () =>
       Object.keys(customHeaders).length > 0
-        ? client.messages.create(
-            requestBody as unknown as Parameters<
-              typeof client.messages.create
-            >[0],
-            { headers: customHeaders },
-          )
-        : client.messages.create(
-            requestBody as unknown as Parameters<
-              typeof client.messages.create
-            >[0],
-          );
+        ? client.messages.create(params, { headers: customHeaders })
+        : client.messages.create(params);
 
     const promise = apiCall();
     // The promise has a withResponse() method we can call

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
@@ -157,11 +157,8 @@ export async function* processAnthropicStream(
           retryResult.data as AsyncIterable<Anthropic.MessageStreamEvent>;
       }
 
-      const stream =
-        currentResponse as unknown as AsyncIterable<Anthropic.MessageStreamEvent>;
-
       logger.debug(() => 'Processing streaming response');
-      yield* processStreamEvents(stream, options, state);
+      yield* processStreamEvents(currentResponse, options, state);
       return;
     } catch (error) {
       const canRetryStream = isNetworkTransientError(error);
@@ -199,59 +196,42 @@ export async function* processAnthropicStream(
 }
 
 function* handleMessageStart(
-  chunk: Anthropic.MessageStreamEvent,
+  chunk: Anthropic.MessageStreamEvent & { type: 'message_start' },
   cacheLogger: { debug: (fn: () => string) => void },
 ): Generator<IContent> {
-  const usage = (
-    chunk as unknown as {
-      message?: {
-        usage?: {
-          input_tokens?: number;
-          output_tokens?: number;
-          cache_read_input_tokens?: number;
-          cache_creation_input_tokens?: number;
-        };
-      };
-    }
-  ).message?.usage;
+  const usage = chunk.message.usage;
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const cacheCreation = usage.cache_creation_input_tokens ?? 0;
 
-  if (usage) {
-    const cacheRead = usage.cache_read_input_tokens ?? 0;
-    const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+  cacheLogger.debug(
+    () =>
+      `[AnthropicProvider streaming] Emitting usage metadata: cacheRead=${cacheRead}, cacheCreation=${cacheCreation}, raw values: cache_read_input_tokens=${usage.cache_read_input_tokens}, cache_creation_input_tokens=${usage.cache_creation_input_tokens}`,
+  );
 
-    cacheLogger.debug(
-      () =>
-        `[AnthropicProvider streaming] Emitting usage metadata: cacheRead=${cacheRead}, cacheCreation=${cacheCreation}, raw values: cache_read_input_tokens=${usage.cache_read_input_tokens}, cache_creation_input_tokens=${usage.cache_creation_input_tokens}`,
-    );
-
-    if (cacheRead > 0 || cacheCreation > 0) {
-      cacheLogger.debug(() => {
-        const hitRate =
-          cacheRead + (usage.input_tokens ?? 0) > 0
-            ? (cacheRead / (cacheRead + (usage.input_tokens ?? 0))) * 100
-            : 0;
-        return `Cache metrics: read=${cacheRead}, creation=${cacheCreation}, hit_rate=${hitRate.toFixed(1)}%`;
-      });
-    }
-
-    yield {
-      speaker: 'ai',
-      blocks: [],
-      metadata: {
-        usage: {
-          promptTokens: (usage.input_tokens ?? 0) + cacheRead + cacheCreation,
-          completionTokens: usage.output_tokens ?? 0,
-          totalTokens:
-            (usage.input_tokens ?? 0) +
-            (usage.output_tokens ?? 0) +
-            cacheRead +
-            cacheCreation,
-          cache_read_input_tokens: cacheRead,
-          cache_creation_input_tokens: cacheCreation,
-        },
-      },
-    } as IContent;
+  if (cacheRead > 0 || cacheCreation > 0) {
+    cacheLogger.debug(() => {
+      const hitRate =
+        cacheRead + usage.input_tokens > 0
+          ? (cacheRead / (cacheRead + usage.input_tokens)) * 100
+          : 0;
+      return `Cache metrics: read=${cacheRead}, creation=${cacheCreation}, hit_rate=${hitRate.toFixed(1)}%`;
+    });
   }
+
+  yield {
+    speaker: 'ai',
+    blocks: [],
+    metadata: {
+      usage: {
+        promptTokens: usage.input_tokens + cacheRead + cacheCreation,
+        completionTokens: usage.output_tokens,
+        totalTokens:
+          usage.input_tokens + usage.output_tokens + cacheRead + cacheCreation,
+        cache_read_input_tokens: cacheRead,
+        cache_creation_input_tokens: cacheCreation,
+      },
+    },
+  } as IContent;
 }
 
 function handleContentBlockStart(
@@ -420,6 +400,24 @@ function completeToolCall(
   } as IContent;
 }
 
+interface StopEventContentBlock {
+  type?: string;
+  thinking?: string;
+  signature?: string;
+}
+
+function readStopEventContentBlock(
+  chunk: unknown,
+): StopEventContentBlock | undefined {
+  if (typeof chunk === 'object' && chunk !== null && 'content_block' in chunk) {
+    const cb = (chunk as { content_block?: unknown }).content_block;
+    if (typeof cb === 'object' && cb !== null) {
+      return cb as StopEventContentBlock;
+    }
+  }
+  return undefined;
+}
+
 function completeThinkingBlock(
   currentThinkingBlock: { thinking: string; signature?: string },
   chunk: Anthropic.MessageStreamEvent & { type: 'content_block_stop' },
@@ -430,15 +428,7 @@ function completeThinkingBlock(
       `Completed thinking block: ${currentThinkingBlock.thinking.length} chars`,
   );
 
-  const contentBlock = (
-    chunk as unknown as {
-      content_block?: {
-        type: string;
-        thinking?: string;
-        signature?: string;
-      };
-    }
-  ).content_block;
+  const contentBlock = readStopEventContentBlock(chunk);
   if (contentBlock?.signature) {
     currentThinkingBlock.signature = contentBlock.signature;
   }
@@ -496,6 +486,20 @@ function handleContentBlockStop(
   return { currentToolCall, currentThinkingBlock };
 }
 
+/**
+ * Reads stop_reason from a message_delta event defensively.
+ * The SDK type declares delta as required, but some test/runtime
+ * streams may omit it. Treating the field as possibly-absent runtime
+ * data avoids a crash while preserving the original optional-chaining
+ * semantics.
+ */
+function readMessageDeltaStopReason(
+  chunk: Anthropic.MessageStreamEvent & { type: 'message_delta' },
+): string | null | undefined {
+  const delta = (chunk as { delta?: { stop_reason?: string | null } }).delta;
+  return delta?.stop_reason;
+}
+
 function* handleMessageDelta(
   chunk: Anthropic.MessageStreamEvent & { type: 'message_delta' },
   logger: { debug: (fn: () => string) => void },
@@ -510,8 +514,7 @@ function* handleMessageDelta(
       }
     | undefined;
 
-  const stopReason = (chunk as unknown as { delta?: { stop_reason?: string } })
-    .delta?.stop_reason;
+  const stopReason = readMessageDeltaStopReason(chunk);
 
   if (!usage) {
     logger.debug(

--- a/packages/providers/src/openai-vercel/OpenAIVercelProvider.ts
+++ b/packages/providers/src/openai-vercel/OpenAIVercelProvider.ts
@@ -172,11 +172,7 @@ export class OpenAIVercelProvider extends BaseProvider implements IProvider {
         ? getToolIdStrategy(toolFormat).createMapper(contents)
         : undefined;
 
-    return convertToVercelMessages(
-      contents,
-      toolIdMapper,
-      options,
-    ) as unknown as ModelMessage[];
+    return convertToVercelMessages(contents, toolIdMapper, options);
   }
 
   private getClientConfig(

--- a/packages/providers/src/openai-vercel/messageConversion.ts
+++ b/packages/providers/src/openai-vercel/messageConversion.ts
@@ -82,9 +82,20 @@ function inferMediaEncoding(imageData: string): {
   return { encoding: 'base64', mimeType: 'image/*' };
 }
 
+type CoreMessageWithReasoning = CoreMessage & { reasoning_content?: string };
+
+type MessageWithToolInvocations = CoreMessage & {
+  toolInvocations?: Array<{
+    state: string;
+    toolCallId: string;
+    toolName: string;
+    args: unknown;
+  }>;
+};
+
 function pushWithReasoning(
   messages: CoreMessage[],
-  baseMessage: Record<string, unknown>,
+  baseMessage: CoreMessage,
   options: { includeReasoningInContext?: boolean } | undefined,
   thinkingBlocks: ThinkingBlock[],
 ): void {
@@ -94,17 +105,15 @@ function pushWithReasoning(
   ) {
     const reasoningText = thinkingToReasoningField(thinkingBlocks);
     if (reasoningText) {
-      const messageWithReasoning = baseMessage as unknown as Record<
-        string,
-        unknown
-      >;
-      messageWithReasoning.reasoning_content =
-        cleanKimiTokensFromThinking(reasoningText);
-      messages.push(messageWithReasoning as unknown as CoreMessage);
+      const messageWithReasoning: CoreMessageWithReasoning = {
+        ...baseMessage,
+        reasoning_content: cleanKimiTokensFromThinking(reasoningText),
+      };
+      messages.push(messageWithReasoning);
       return;
     }
   }
-  messages.push(baseMessage as unknown as CoreMessage);
+  messages.push(baseMessage);
 }
 
 function hasReasoningForContext(
@@ -403,14 +412,7 @@ function convertFromVercelAssistant(message: CoreMessage): IContent | null {
     }
   }
 
-  const extendedMessage = message as unknown as {
-    toolInvocations?: Array<{
-      state: string;
-      toolCallId: string;
-      toolName: string;
-      args: unknown;
-    }>;
-  };
+  const extendedMessage = message as MessageWithToolInvocations;
   if (
     extendedMessage.toolInvocations &&
     extendedMessage.toolInvocations.length > 0

--- a/packages/providers/src/openai-vercel/vercelModelClient.test.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.test.ts
@@ -101,10 +101,14 @@ describe('buildVercelTools', () => {
 
     const result = buildVercelTools(tools);
     expect(result).toBeDefined();
-    const tool = result!.weather as {
-      description?: string;
-      inputSchema?: unknown;
-    };
-    expect(tool).toBeDefined();
+    expect(result!.weather).toMatchObject({
+      description: 'Get weather',
+      inputSchema: {
+        jsonSchema: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+        },
+      },
+    });
   });
 });

--- a/packages/providers/src/openai-vercel/vercelModelClient.test.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.test.ts
@@ -82,6 +82,7 @@ describe('buildVercelTools', () => {
     const result = buildVercelTools(tools);
     expect(result).toBeDefined();
     expect(Object.keys(result!)).toStrictEqual(['dup_tool']);
+    expect(result!.dup_tool).toMatchObject({ description: 'first' });
   });
 
   it('produces a tool object with description and inputSchema', () => {
@@ -107,6 +108,31 @@ describe('buildVercelTools', () => {
         jsonSchema: {
           type: 'object',
           properties: { city: { type: 'string' } },
+        },
+      },
+    });
+  });
+
+  it('defaults to an empty-object schema when parameters are absent', () => {
+    const tools: OpenAIVercelTool[] = [
+      {
+        type: 'function',
+        function: {
+          name: 'no_params',
+          description: 'No parameters',
+        },
+      },
+    ];
+
+    const result = buildVercelTools(tools);
+    expect(result).toBeDefined();
+    expect(result!.no_params).toMatchObject({
+      description: 'No parameters',
+      inputSchema: {
+        jsonSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
         },
       },
     });

--- a/packages/providers/src/openai-vercel/vercelModelClient.test.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildVercelTools } from './vercelModelClient.js';
+import type { OpenAIVercelTool } from './schemaConverter.js';
+
+describe('buildVercelTools', () => {
+  it('returns undefined when no tools are provided', () => {
+    expect(buildVercelTools(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when tools array is empty', () => {
+    expect(buildVercelTools([])).toBeUndefined();
+  });
+
+  it('produces a tools record keyed by tool name', () => {
+    const tools: OpenAIVercelTool[] = [
+      {
+        type: 'function',
+        function: {
+          name: 'search',
+          description: 'Search the web',
+          parameters: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'read_file',
+          description: 'Read a file',
+          parameters: {
+            type: 'object',
+            properties: { path: { type: 'string' } },
+          },
+        },
+      },
+    ];
+
+    const result = buildVercelTools(tools);
+    expect(result).toBeDefined();
+    expect(Object.keys(result!)).toStrictEqual(['search', 'read_file']);
+    expect(result!.search).toBeDefined();
+    expect(result!.read_file).toBeDefined();
+  });
+
+  it('deduplicates tools with the same name', () => {
+    const tools: OpenAIVercelTool[] = [
+      {
+        type: 'function',
+        function: {
+          name: 'dup_tool',
+          description: 'first',
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'dup_tool',
+          description: 'second',
+        },
+      },
+    ];
+
+    const result = buildVercelTools(tools);
+    expect(result).toBeDefined();
+    expect(Object.keys(result!)).toStrictEqual(['dup_tool']);
+  });
+
+  it('produces a tool object with description and inputSchema', () => {
+    const tools: OpenAIVercelTool[] = [
+      {
+        type: 'function',
+        function: {
+          name: 'weather',
+          description: 'Get weather',
+          parameters: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+          },
+        },
+      },
+    ];
+
+    const result = buildVercelTools(tools);
+    expect(result).toBeDefined();
+    const tool = result!.weather as {
+      description?: string;
+      inputSchema?: unknown;
+    };
+    expect(tool).toBeDefined();
+  });
+});

--- a/packages/providers/src/openai-vercel/vercelModelClient.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.ts
@@ -90,12 +90,14 @@ export function buildVercelTools(
   }
 
   const jsonSchemaFn =
-    getAiJsonSchema() ??
-    ((schema: JSONSchema7) => schema as unknown as JSONSchema7);
+    getAiJsonSchema() ?? ((schema: JSONSchema7): unknown => schema);
   const toolFn =
     getAiTool() ??
     ((config: { description?: string; inputSchema?: unknown }) =>
-      config as unknown as Tool<unknown, never>);
+      ({
+        description: config.description,
+        inputSchema: config.inputSchema ?? {},
+      }) as Tool<unknown, never>);
 
   const toolsRecord: VercelTools = {};
 
@@ -223,22 +225,15 @@ export async function createConfiguredModel(
     customFetch,
   );
   const modelId = options.resolved.model || defaultModel;
-  const providerWithChat = openaiProvider as unknown as {
-    chat?: (modelId: string) => unknown;
-    (modelId: string): unknown;
-  };
-  const baseModel = (
-    providerWithChat.chat
-      ? providerWithChat.chat(modelId)
-      : providerWithChat(modelId)
-  ) as LanguageModel;
+  const baseModel: LanguageModel =
+    typeof openaiProvider.chat === 'function'
+      ? openaiProvider.chat(modelId)
+      : openaiProvider(modelId);
 
   const useMiddlewareForNonStreaming = rsEnabled && !streamingEnabled;
   const model = useMiddlewareForNonStreaming
     ? wrapLanguageModel({
-        model: baseModel as unknown as Parameters<
-          typeof wrapLanguageModel
-        >[0]['model'],
+        model: baseModel,
         middleware: extractReasoningMiddleware({
           tagName: 'think',
           separator: '\n',

--- a/packages/providers/src/openai/OpenAIRequestBuilder.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestBuilder.test.ts
@@ -335,6 +335,125 @@ describe('buildMessagesWithReasoning', () => {
     const toolMsg = messages[0] as Record<string, unknown>;
     expect(toolMsg.name).toBeUndefined();
   });
+
+  it('converts user image media block to image_url content array part', () => {
+    const contents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          { type: 'text', text: 'What is this?' },
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: 'imgdata',
+            encoding: 'base64',
+          },
+        ],
+      },
+    ];
+    const options = createMockOptions({
+      'reasoning.includeInContext': false,
+      'reasoning.stripFromContext': 'none',
+    });
+
+    const messages = buildMessagesWithReasoning(contents, options);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('user');
+    const userMsg = messages[0] as OpenAI.Chat.ChatCompletionUserMessageParam;
+    expect(Array.isArray(userMsg.content)).toBe(true);
+    const parts = userMsg.content as Array<{ type: string }>;
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toStrictEqual({ type: 'text', text: 'What is this?' });
+    expect(parts[1]).toStrictEqual({
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,imgdata' },
+    });
+  });
+
+  it('converts user pdf media block to file content array part', () => {
+    const contents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'application/pdf',
+            data: 'pdfbytes',
+            encoding: 'base64',
+            filename: 'doc.pdf',
+          },
+        ],
+      },
+    ];
+    const options = createMockOptions({
+      'reasoning.includeInContext': false,
+      'reasoning.stripFromContext': 'none',
+    });
+
+    const messages = buildMessagesWithReasoning(contents, options);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('user');
+    const userMsg = messages[0] as OpenAI.Chat.ChatCompletionUserMessageParam;
+    expect(Array.isArray(userMsg.content)).toBe(true);
+    const parts = userMsg.content as Array<{ type: string }>;
+    expect(parts[0]).toStrictEqual({
+      type: 'file',
+      file: {
+        filename: 'doc.pdf',
+        file_data: 'data:application/pdf;base64,pdfbytes',
+      },
+    });
+  });
+
+  it('flushes pending tool images as image_url content array parts', () => {
+    const contents: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call_1',
+            name: 'screenshot',
+            parameters: {},
+          } as ToolCallBlock,
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_1',
+            toolName: 'screenshot',
+            result: 'captured',
+          } as ToolResponseBlock,
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: 'shot',
+            encoding: 'base64',
+          },
+        ],
+      },
+    ];
+    const options = createMockOptions({
+      'reasoning.includeInContext': false,
+      'reasoning.stripFromContext': 'none',
+    });
+
+    const messages = buildMessagesWithReasoning(contents, options);
+    const userMsgs = messages.filter((m) => m.role === 'user');
+    expect(userMsgs.length).toBeGreaterThanOrEqual(1);
+    const imageUserMsg = userMsgs[userMsgs.length - 1];
+    expect(Array.isArray(imageUserMsg.content)).toBe(true);
+    const parts = imageUserMsg.content as Array<{
+      type: string;
+      image_url?: { url: string };
+    }>;
+    const imageParts = parts.filter((p) => p.type === 'image_url');
+    expect(imageParts.length).toBeGreaterThanOrEqual(1);
+    expect(imageParts[0].image_url!.url).toBe('data:image/png;base64,shot');
+  });
 });
 
 describe('validateToolMessageSequence', () => {

--- a/packages/providers/src/openai/OpenAIRequestBuilder.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestBuilder.test.ts
@@ -136,7 +136,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options);
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      undefined,
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     expect(messages[0].role).toBe('user');
     expect(
@@ -187,7 +192,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options);
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      undefined,
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     expect(messages[0].role).toBe('assistant');
     const assistant =
@@ -215,7 +225,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options);
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      undefined,
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     expect(messages[0].role).toBe('tool');
     expect(
@@ -248,7 +263,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options);
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      undefined,
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     const msg = messages[0] as unknown as Record<string, unknown>;
     expect(msg.reasoning_content).toBeDefined();
@@ -279,7 +299,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options, 'openai');
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      'openai',
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     const msg = messages[0] as unknown as Record<string, unknown>;
     expect(msg.reasoning_content).toBeUndefined();
@@ -304,7 +329,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options, 'mistral');
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      'mistral',
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     const toolMsg = messages[0] as Record<string, unknown>;
     expect(toolMsg.role).toBe('tool');
@@ -330,7 +360,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options, 'openai');
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      'openai',
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     const toolMsg = messages[0] as Record<string, unknown>;
     expect(toolMsg.name).toBeUndefined();
@@ -356,7 +391,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options);
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      undefined,
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     expect(messages[0].role).toBe('user');
     const userMsg = messages[0] as OpenAI.Chat.ChatCompletionUserMessageParam;
@@ -390,7 +430,12 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options);
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      undefined,
+      undefined,
+    );
     expect(messages).toHaveLength(1);
     expect(messages[0].role).toBe('user');
     const userMsg = messages[0] as OpenAI.Chat.ChatCompletionUserMessageParam;
@@ -441,10 +486,22 @@ describe('buildMessagesWithReasoning', () => {
       'reasoning.stripFromContext': 'none',
     });
 
-    const messages = buildMessagesWithReasoning(contents, options);
-    const userMsgs = messages.filter((m) => m.role === 'user');
-    expect(userMsgs.length).toBeGreaterThanOrEqual(1);
-    const imageUserMsg = userMsgs[userMsgs.length - 1];
+    const messages = buildMessagesWithReasoning(
+      contents,
+      options,
+      undefined,
+      undefined,
+    );
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe('assistant');
+    expect(messages[1].role).toBe('tool');
+    expect(messages[2].role).toBe('user');
+
+    const toolMsg = messages[1] as OpenAI.Chat.ChatCompletionToolMessageParam;
+    expect(String(toolMsg.content)).toContain('captured');
+
+    const imageUserMsg =
+      messages[2] as OpenAI.Chat.ChatCompletionUserMessageParam;
     expect(Array.isArray(imageUserMsg.content)).toBe(true);
     const parts = imageUserMsg.content as Array<{
       type: string;

--- a/packages/providers/src/openai/OpenAIRequestBuilder.ts
+++ b/packages/providers/src/openai/OpenAIRequestBuilder.ts
@@ -18,7 +18,6 @@ import type OpenAI from 'openai';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ContentBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ToolFormat } from '@vybestack/llxprt-code-tools/IToolFormatter.js';
-import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import {
@@ -112,12 +111,18 @@ export function buildToolResponseContent(
     }),
   );
 }
-type OpenAIPart =
-  | { type: 'text'; text: string }
-  | { type: 'image_url'; image_url: { url: string } }
-  | { type: 'file'; file: { filename: string; file_data: string } };
+type AssistantMessageWithReasoning =
+  OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+    reasoning_content?: string;
+  };
 
-function convertBlockToPart(block: ContentBlock): OpenAIPart | null {
+type ToolMessageWithName = OpenAI.Chat.ChatCompletionToolMessageParam & {
+  name?: string;
+};
+
+function convertBlockToPart(
+  block: ContentBlock,
+): OpenAI.Chat.ChatCompletionContentPart | null {
   if (block.type === 'text' && block.text) {
     return { type: 'text', text: block.text };
   }
@@ -162,11 +167,7 @@ function processUserMessage(
   const hasMedia = content.blocks.some((b) => b.type === 'media');
 
   if (hasMedia) {
-    const parts: Array<
-      | { type: 'text'; text: string }
-      | { type: 'image_url'; image_url: { url: string } }
-      | { type: 'file'; file: { filename: string; file_data: string } }
-    > = [];
+    const parts: OpenAI.Chat.ChatCompletionContentPart[] = [];
 
     for (const block of content.blocks) {
       const part = convertBlockToPart(block);
@@ -178,7 +179,7 @@ function processUserMessage(
     if (parts.length > 0) {
       return {
         role: 'user',
-        content: parts as unknown as string,
+        content: parts,
       };
     }
   } else {
@@ -232,13 +233,11 @@ function processAssistantMessage(
       if (isStrictOpenAI) {
         return baseMessage;
       }
-      const messageWithReasoning = baseMessage as unknown as Record<
-        string,
-        unknown
-      >;
-      messageWithReasoning.reasoning_content =
-        thinkingToReasoningField(thinkingBlocks);
-      return messageWithReasoning as unknown as OpenAI.Chat.ChatCompletionMessageParam;
+      const messageWithReasoning: AssistantMessageWithReasoning = {
+        ...baseMessage,
+        reasoning_content: thinkingToReasoningField(thinkingBlocks),
+      };
+      return messageWithReasoning;
     }
     return baseMessage;
   } else if (textBlocks.length > 0 || thinkingBlocks.length > 0) {
@@ -248,13 +247,11 @@ function processAssistantMessage(
     };
 
     if (includeInContext && thinkingBlocks.length > 0) {
-      const messageWithReasoning = baseMessage as unknown as Record<
-        string,
-        unknown
-      >;
-      messageWithReasoning.reasoning_content =
-        thinkingToReasoningField(thinkingBlocks);
-      return messageWithReasoning as unknown as OpenAI.Chat.ChatCompletionMessageParam;
+      const messageWithReasoning: AssistantMessageWithReasoning = {
+        ...baseMessage,
+        reasoning_content: thinkingToReasoningField(thinkingBlocks),
+      };
+      return messageWithReasoning;
     }
     return baseMessage;
   }
@@ -304,7 +301,7 @@ function processToolResponses(
       toolContent = toolContent + '\n' + mediaFallback;
     }
 
-    const toolMessage: Record<string, unknown> = {
+    const toolMessage: ToolMessageWithName = {
       role: 'tool',
       content: toolContent,
       tool_call_id: resolveToolResponseId(tr),
@@ -314,9 +311,7 @@ function processToolResponses(
       toolMessage.name = tr.toolName;
     }
 
-    messages.push(
-      toolMessage as unknown as OpenAI.Chat.ChatCompletionToolMessageParam,
-    );
+    messages.push(toolMessage);
   }
 
   return messages;
@@ -328,10 +323,7 @@ function flushPendingToolImages(
 ): void {
   if (pendingToolImages.length === 0) return;
 
-  const imageParts: Array<
-    | { type: 'text'; text: string }
-    | { type: 'image_url'; image_url: { url: string } }
-  > = [
+  const imageParts: OpenAI.Chat.ChatCompletionContentPart[] = [
     { type: 'text', text: '[Images from tool response]' },
     ...pendingToolImages.map((mb) => ({
       type: 'image_url' as const,
@@ -340,7 +332,7 @@ function flushPendingToolImages(
   ];
   messages.push({
     role: 'user',
-    content: imageParts as unknown as string,
+    content: imageParts,
   });
   pendingToolImages.length = 0;
 }
@@ -392,6 +384,10 @@ function processContentMessages(
   flushPendingToolImages(pendingToolImages, messages);
 }
 
+export interface ReasoningMessageOptions {
+  settings: { get(key: string): unknown };
+}
+
 /**
  * Build messages with optional reasoning_content based on settings.
  *
@@ -400,7 +396,7 @@ function processContentMessages(
  */
 export function buildMessagesWithReasoning(
   contents: IContent[],
-  options: NormalizedGenerateChatOptions,
+  options: ReasoningMessageOptions,
   toolFormat: ToolFormat | undefined,
   config: Config | undefined,
 ): OpenAI.Chat.ChatCompletionMessageParam[] {

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
@@ -28,6 +28,7 @@ vi.mock('../utils/userMemory.js', () => ({
 function createMockOptions(
   overrides: Partial<NormalizedGenerateChatOptions> = {},
   modelBehavior: Record<string, unknown> = {},
+  modelParams: Record<string, unknown> = {},
 ): NormalizedGenerateChatOptions {
   const settings = new SettingsService();
   return {
@@ -40,6 +41,7 @@ function createMockOptions(
       requestId: 'test-request',
       timestamp: Date.now(),
       modelBehavior,
+      modelParams,
     },
     resolved: {
       model: 'gpt-4o',
@@ -367,6 +369,32 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
       'openai',
     );
 
+    expect(result.requestBody).not.toHaveProperty('thinking');
+  });
+
+  it('does not overwrite reasoning_effort with thinking when reasoning_effort is already present', async () => {
+    const settings = new SettingsService();
+    const options = createMockOptions(
+      {
+        settings,
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
+      },
+      { 'reasoning.enabled': true },
+      { reasoning_effort: 'high' },
+    );
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    expect(result.requestBody).toHaveProperty('reasoning_effort', 'high');
     expect(result.requestBody).not.toHaveProperty('thinking');
   });
 });

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
@@ -27,6 +27,7 @@ vi.mock('../utils/userMemory.js', () => ({
 
 function createMockOptions(
   overrides: Partial<NormalizedGenerateChatOptions> = {},
+  modelBehavior: Record<string, unknown> = {},
 ): NormalizedGenerateChatOptions {
   const settings = new SettingsService();
   return {
@@ -38,6 +39,7 @@ function createMockOptions(
     invocation: {
       requestId: 'test-request',
       timestamp: Date.now(),
+      modelBehavior,
     },
     resolved: {
       model: 'gpt-4o',
@@ -298,18 +300,16 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
 
   it('sets thinking enabled on request body when reasoning.enabled is true', async () => {
     const settings = new SettingsService();
-    const options = createMockOptions({
-      settings,
-      invocation: {
-        requestId: 'test-request',
-        timestamp: Date.now(),
-        modelBehavior: { 'reasoning.enabled': true },
-      } as unknown as NormalizedGenerateChatOptions['invocation'],
-      resolved: {
-        model: 'gpt-4o',
-        authToken: { token: 'test-token', type: 'api-key' },
+    const options = createMockOptions(
+      {
+        settings,
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
       },
-    });
+      { 'reasoning.enabled': true },
+    );
 
     const result = await prepareRequest(
       options,
@@ -319,26 +319,21 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
       'openai',
     );
 
-    const thinking = (
-      result.requestBody as unknown as { thinking?: { type: string } }
-    ).thinking;
-    expect(thinking).toStrictEqual({ type: 'enabled' });
+    expect(result.requestBody).toHaveProperty('thinking', { type: 'enabled' });
   });
 
   it('sets thinking disabled on request body when reasoning.enabled is false', async () => {
     const settings = new SettingsService();
-    const options = createMockOptions({
-      settings,
-      invocation: {
-        requestId: 'test-request',
-        timestamp: Date.now(),
-        modelBehavior: { 'reasoning.enabled': false },
-      } as unknown as NormalizedGenerateChatOptions['invocation'],
-      resolved: {
-        model: 'gpt-4o',
-        authToken: { token: 'test-token', type: 'api-key' },
+    const options = createMockOptions(
+      {
+        settings,
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
       },
-    });
+      { 'reasoning.enabled': false },
+    );
 
     const result = await prepareRequest(
       options,
@@ -348,26 +343,21 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
       'openai',
     );
 
-    const thinking = (
-      result.requestBody as unknown as { thinking?: { type: string } }
-    ).thinking;
-    expect(thinking).toStrictEqual({ type: 'disabled' });
+    expect(result.requestBody).toHaveProperty('thinking', { type: 'disabled' });
   });
 
   it('does not set thinking on request body when reasoning.enabled is undefined', async () => {
     const settings = new SettingsService();
-    const options = createMockOptions({
-      settings,
-      invocation: {
-        requestId: 'test-request',
-        timestamp: Date.now(),
-        modelBehavior: {},
-      } as unknown as NormalizedGenerateChatOptions['invocation'],
-      resolved: {
-        model: 'gpt-4o',
-        authToken: { token: 'test-token', type: 'api-key' },
+    const options = createMockOptions(
+      {
+        settings,
+        resolved: {
+          model: 'gpt-4o',
+          authToken: { token: 'test-token', type: 'api-key' },
+        },
       },
-    });
+      {},
+    );
 
     const result = await prepareRequest(
       options,
@@ -377,9 +367,6 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
       'openai',
     );
 
-    const thinking = (
-      result.requestBody as unknown as { thinking?: { type: string } }
-    ).thinking;
-    expect(thinking).toBeUndefined();
+    expect(result.requestBody).not.toHaveProperty('thinking');
   });
 });

--- a/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.issue1943.test.ts
@@ -295,4 +295,91 @@ describe('OpenAIRequestPreparation.prepareRequest (issue #1943)', () => {
 
     expect(result.detectedFormat).toBe('kimi'); // auto overrides → auto-detect
   });
+
+  it('sets thinking enabled on request body when reasoning.enabled is true', async () => {
+    const settings = new SettingsService();
+    const options = createMockOptions({
+      settings,
+      invocation: {
+        requestId: 'test-request',
+        timestamp: Date.now(),
+        modelBehavior: { 'reasoning.enabled': true },
+      } as unknown as NormalizedGenerateChatOptions['invocation'],
+      resolved: {
+        model: 'gpt-4o',
+        authToken: { token: 'test-token', type: 'api-key' },
+      },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const thinking = (
+      result.requestBody as unknown as { thinking?: { type: string } }
+    ).thinking;
+    expect(thinking).toStrictEqual({ type: 'enabled' });
+  });
+
+  it('sets thinking disabled on request body when reasoning.enabled is false', async () => {
+    const settings = new SettingsService();
+    const options = createMockOptions({
+      settings,
+      invocation: {
+        requestId: 'test-request',
+        timestamp: Date.now(),
+        modelBehavior: { 'reasoning.enabled': false },
+      } as unknown as NormalizedGenerateChatOptions['invocation'],
+      resolved: {
+        model: 'gpt-4o',
+        authToken: { token: 'test-token', type: 'api-key' },
+      },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const thinking = (
+      result.requestBody as unknown as { thinking?: { type: string } }
+    ).thinking;
+    expect(thinking).toStrictEqual({ type: 'disabled' });
+  });
+
+  it('does not set thinking on request body when reasoning.enabled is undefined', async () => {
+    const settings = new SettingsService();
+    const options = createMockOptions({
+      settings,
+      invocation: {
+        requestId: 'test-request',
+        timestamp: Date.now(),
+        modelBehavior: {},
+      } as unknown as NormalizedGenerateChatOptions['invocation'],
+      resolved: {
+        model: 'gpt-4o',
+        authToken: { token: 'test-token', type: 'api-key' },
+      },
+    });
+
+    const result = await prepareRequest(
+      options,
+      'gpt-4o',
+      undefined,
+      logger,
+      'openai',
+    );
+
+    const thinking = (
+      result.requestBody as unknown as { thinking?: { type: string } }
+    ).thinking;
+    expect(thinking).toBeUndefined();
+  });
 });

--- a/packages/providers/src/openai/OpenAIRequestPreparation.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.ts
@@ -135,6 +135,10 @@ type OpenAIInvocationRuntime = {
   modelBehavior?: Record<string, unknown>;
 };
 
+type RequestBodyWithThinking = OpenAI.Chat.ChatCompletionCreateParams & {
+  thinking?: { type: 'enabled' | 'disabled' };
+};
+
 function resolveReasoningConfig(
   requestBody: OpenAI.Chat.ChatCompletionCreateParams,
   options: NormalizedGenerateChatOptions,
@@ -146,14 +150,11 @@ function resolveReasoningConfig(
   const reasoningEnabled = invocation.modelBehavior?.['reasoning.enabled'] as
     | boolean
     | undefined;
+  const body = requestBody as RequestBodyWithThinking;
   if (reasoningEnabled === true) {
-    (requestBody as unknown as Record<string, unknown>)['thinking'] = {
-      type: 'enabled',
-    };
+    body.thinking = { type: 'enabled' };
   } else if (reasoningEnabled === false) {
-    (requestBody as unknown as Record<string, unknown>)['thinking'] = {
-      type: 'disabled',
-    };
+    body.thinking = { type: 'disabled' };
   }
 }
 

--- a/packages/providers/src/openai/OpenAIResponseParser.ts
+++ b/packages/providers/src/openai/OpenAIResponseParser.ts
@@ -30,6 +30,11 @@ const CODE_FENCE_END_SOURCE = '```$';
 const CODE_FENCE_START = new RegExp(CODE_FENCE_START_SOURCE, 'm');
 const CODE_FENCE_END = new RegExp(CODE_FENCE_END_SOURCE, 'm');
 
+type DeltaWithReasoning =
+  OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta & {
+    reasoning_content?: unknown;
+  };
+
 /**
  * Returns true for parts that carry no textual content and should be skipped.
  */
@@ -403,8 +408,7 @@ export function parseStreamingReasoningDelta(
   }
 
   // Access reasoning_content via type assertion since OpenAI SDK doesn't declare it
-  const reasoningContent = (delta as unknown as Record<string, unknown>)
-    .reasoning_content;
+  const reasoningContent = (delta as DeltaWithReasoning).reasoning_content;
 
   // Handle absent, null, or non-string
   if (

--- a/packages/providers/src/utils/providerRequestConversion.ts
+++ b/packages/providers/src/utils/providerRequestConversion.ts
@@ -10,8 +10,10 @@ import type { IContent } from '@vybestack/llxprt-code-core/services/history/ICon
 import type { SettingsService } from '@vybestack/llxprt-code-settings';
 import { convertToAnthropicMessages } from '../anthropic/AnthropicMessageNormalizer.js';
 import { convertHistoryToGeminiFormat } from '../gemini/GeminiMessageConverter.js';
-import { buildMessagesWithReasoning } from '../openai/OpenAIRequestBuilder.js';
-import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import {
+  buildMessagesWithReasoning,
+  type ReasoningMessageOptions,
+} from '../openai/OpenAIRequestBuilder.js';
 
 interface MinimalSettings {
   get?: (key: string) => unknown;
@@ -39,24 +41,11 @@ function createSettings(overrides?: unknown): SettingsService {
 function createOptions(
   history: IContent[],
   settings?: unknown,
-): NormalizedGenerateChatOptions {
+): ReasoningMessageOptions {
   return {
     contents: history,
     settings: createSettings(settings),
-    invocation: {
-      ephemerals: {},
-      getModelBehavior: () => undefined,
-      getCliSetting: () => undefined,
-      getEphemeral: () => undefined,
-      getModelParam: () => undefined,
-      getProviderOverrides: () => undefined,
-    },
-    metadata: {},
-    resolved: {
-      model: '',
-      authToken: { token: '', source: 'none' },
-    },
-  } as unknown as NormalizedGenerateChatOptions;
+  } as ReasoningMessageOptions;
 }
 
 export function buildOpenAIDumpMessages(

--- a/packages/providers/src/utils/providerRequestConversion.ts
+++ b/packages/providers/src/utils/providerRequestConversion.ts
@@ -38,14 +38,10 @@ function createSettings(overrides?: unknown): SettingsService {
   } as SettingsService;
 }
 
-function createOptions(
-  history: IContent[],
-  settings?: unknown,
-): ReasoningMessageOptions {
+function createOptions(settings?: unknown): ReasoningMessageOptions {
   return {
-    contents: history,
     settings: createSettings(settings),
-  } as ReasoningMessageOptions;
+  };
 }
 
 export function buildOpenAIDumpMessages(
@@ -55,7 +51,7 @@ export function buildOpenAIDumpMessages(
 ): unknown[] {
   return buildMessagesWithReasoning(
     history,
-    createOptions(history, settings),
+    createOptions(settings),
     'openai',
     config,
   );


### PR DESCRIPTION
## Summary

Eliminates ALL 27 \`as unknown as\` double-casts from 10 production files in \`packages/providers/src\`, replacing them with honest TypeScript type contracts (provider-local wire DTOs, SDK-accurate types, intersection extension types, and proper type guards). This follows the precedent of merged PR #2170 which did the same cleanup for the CLI package.

## What Changed (per file)

### OpenAIRequestBuilder.ts (7 casts removed)
- **processUserMessage**: typed \`parts\` as \`OpenAI.Chat.ChatCompletionContentPart[]\` and changed \`convertBlockToPart\` to return \`ChatCompletionContentPart | null\`. No more \`as unknown as string\` on content.
- **processAssistantMessage** (tool_calls + text branches): replaced \`baseMessage as unknown as Record\` mutation pattern with \`AssistantMessageWithReasoning = ChatCompletionAssistantMessageParam & { reasoning_content?: string }\` intersection type. Build message with spread, return directly.
- **processToolResponses**: \`ToolMessageWithName = ChatCompletionToolMessageParam & { name?: string }\` type. Build toolMessage as this type, push without cast.
- **flushPendingToolImages**: typed \`imageParts\` as \`ChatCompletionContentPart[]\`, assign to \`content\` with no cast.

### OpenAIRequestPreparation.ts (2 casts removed)
- **resolveReasoningConfig**: \`RequestBodyWithThinking = ChatCompletionCreateParams & { thinking?: { type: 'enabled' | 'disabled' } }\` intersection type. Single typed alias \`body\` at top, then \`body.thinking = { type: 'enabled' }\`.

### OpenAIResponseParser.ts (1 cast removed)
- **parseStreamingReasoningDelta**: \`DeltaWithReasoning = ChatCompletionChunk.Choice.Delta & { reasoning_content?: unknown }\` type. Single \`as\` narrow to read \`reasoning_content\`.

### messageConversion.ts (4 casts removed)
- **pushWithReasoning**: changed \`baseMessage\` param type to \`CoreMessage\`. \`CoreMessageWithReasoning = CoreMessage & { reasoning_content?: string }\` intersection type. No more double-cast to Record and back.
- **convertFromVercelAssistant**: \`MessageWithToolInvocations = CoreMessage & { toolInvocations?: ... }\` type. Single \`as\` narrow.

### vercelModelClient.ts (4 casts removed)
- **buildVercelTools**: jsonSchema fallback is identity returning \`unknown\` (\`(schema): unknown => schema\`). Tool fallback builds structurally-close object with single \`as Tool<unknown, never>\`.
- **createConfiguredModel**: runtime feature detection (\`typeof openaiProvider.chat === 'function'\`) replaces the \`as unknown as\` provider cast. Preserves original fallback behavior (prefer \`.chat()\`, fall back to calling provider) needed by test mocks.

### OpenAIVercelProvider.ts (1 cast removed)
- **convertToModelMessages**: removed redundant \`as unknown as ModelMessage[]\` cast (\`CoreMessage = ModelMessage\` is a type alias).

### AnthropicApiExecution.ts (2 casts removed)
- **createAnthropicApiCall**: \`AnthropicRequestBody = MessageCreateParamsBase & { [key: string]: unknown }\` type. Single \`as\` narrowing from \`Record<string, unknown>\` at the SDK boundary via \`asMessageCreateParams()\` helper.

### AnthropicStreamProcessor.ts (4 casts removed)
- **processAnthropicStream**: removed redundant cast on already-typed \`currentResponse\`.
- **handleMessageStart**: typed \`chunk\` param as \`MessageStreamEvent & { type: 'message_start' }\`, read \`chunk.message.usage\` fields directly.
- **completeThinkingBlock**: \`readStopEventContentBlock()\` type guard for defensive \`content_block?.signature\` read on \`content_block_stop\` events.
- **handleMessageDelta**: \`readMessageDeltaStopReason()\` helper reads \`stop_reason\` defensively (SDK declares delta required but test mocks may omit it).

### providerRequestConversion.ts (1 cast removed)
- **createOptions**: returns \`ReasoningMessageOptions\` (minimal structural interface with just \`settings\`) instead of building a fake \`NormalizedGenerateChatOptions\` stub. Narrowed \`buildMessagesWithReasoning\` param type accordingly.

### BaseProviderNormalization.ts (1 cast removed)
- **findResolvedRuntimeGaps**: \`ResolvedRuntimeShape\` interface with \`unknown\` fields. Single \`as\` narrow to treat typed resolved as untrusted runtime data for validation.

## Tests Added

- **OpenAIRequestBuilder.test.ts**: 3 new behavioral tests for media content arrays (image_url part, file part, pending tool image flush). These are the FIRST tests covering the \`type: 'media'\` user-message path.
- **OpenAIRequestPreparation.issue1943.test.ts**: 3 new behavioral tests for thinking enable/disable logic.
- **vercelModelClient.test.ts** (new file): 5 behavioral tests for \`buildVercelTools\` (tool record shape, deduplication, description/inputSchema).

## Verification

- [x] \`grep -rn "as unknown as" <10 files>\` → 0 matches
- [x] \`npm run typecheck\` → clean (only pre-existing errors in core/mcp unrelated to this PR)
- [x] \`npm run lint\` → clean
- [x] \`npm run lint:eslint-guard\` → passes
- [x] \`npm run test\` (providers) → 379 passed, 1 skipped, 0 failed
- [x] \`npm run format\` → applied
- [x] \`npm run build\` → succeeds
- [x] Smoke test → returns haiku

Closes #2212