### PR TITLE
Fix LSP unknown bridge boundaries (Fixes #2209)

### DIFF
--- a/packages/lsp/src/channels/mcp-channel.ts
+++ b/packages/lsp/src/channels/mcp-channel.ts
@@ -13,24 +13,32 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 
-import type { Orchestrator } from '../service/orchestrator.js';
+import type {
+  LspDocumentSymbol,
+  LspLocation,
+  LspWorkspaceSymbol,
+} from '../service/lsp-dto.js';
+import type { Diagnostic } from '../service/diagnostics.js';
 
-type Position = { line: number; character: number };
-type Range = { start: Position; end: Position };
-type Location = { uri: string; range: Range };
-type DocumentSymbol = {
-  name: string;
-  kind: number;
-  range: Range;
-  selectionRange: Range;
-};
-type WorkspaceSymbol = { name: string; kind: number; location: Location };
-type Diagnostic = {
-  source: string;
-  code: string;
-  message: string;
-  severity: number;
-  range: Range;
+export type McpOrchestrator = {
+  gotoDefinition: (
+    filePath: string,
+    line: number,
+    character: number,
+  ) => Promise<LspLocation[]>;
+  findReferences: (
+    filePath: string,
+    line: number,
+    character: number,
+  ) => Promise<LspLocation[]>;
+  hover: (
+    filePath: string,
+    line: number,
+    character: number,
+  ) => Promise<string | null>;
+  documentSymbols: (filePath: string) => Promise<LspDocumentSymbol[]>;
+  workspaceSymbols: (query: string) => Promise<LspWorkspaceSymbol[]>;
+  getAllDiagnostics: () => Promise<Record<string, Diagnostic[]>>;
 };
 
 type TextResult = {
@@ -57,15 +65,6 @@ const toTextResult = (text: string, isError = false): TextResult => ({
   ...(isError ? { isError: true } : {}),
 });
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
-
-const getNumber = (value: unknown, fallback = 0): number =>
-  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-
-const getString = (value: unknown, fallback = ''): string =>
-  typeof value === 'string' ? value : fallback;
-
 const toDisplayPath = (value: string, workspaceRoot: string): string => {
   const filePath = value.startsWith('file://')
     ? decodeURIComponent(value.slice('file://'.length))
@@ -80,192 +79,25 @@ const toDisplayPath = (value: string, workspaceRoot: string): string => {
       : rel;
 };
 
-const formatLineCol = (position: Position): string =>
-  `${position.line + 1}:${position.character + 1}`;
+const formatLineCol = (line: number, character: number): string =>
+  `${line + 1}:${character + 1}`;
 
-const parsePosition = (value: unknown): Position => {
-  if (!isRecord(value)) {
-    return { line: 0, character: 0 };
-  }
-  return {
-    line: getNumber(value.line, 0),
-    character: getNumber(value.character, 0),
-  };
-};
-
-const parseRange = (value: unknown): Range => {
-  if (!isRecord(value)) {
-    return {
-      start: { line: 0, character: 0 },
-      end: { line: 0, character: 0 },
-    };
-  }
-  return {
-    start: parsePosition(value.start),
-    end: parsePosition(value.end),
-  };
-};
-
-const parseLocation = (value: unknown): Location => {
-  if (!isRecord(value)) {
-    return {
-      uri: '',
-      range: {
-        start: { line: 0, character: 0 },
-        end: { line: 0, character: 0 },
-      },
-    };
-  }
-
-  if (typeof value.file === 'string') {
-    const line = getNumber(value.line, 0);
-    const character = getNumber(value.char, getNumber(value.character, 0));
-    return {
-      uri: value.file,
-      range: {
-        start: { line, character },
-        end: { line, character },
-      },
-    };
-  }
-
-  return {
-    uri: getString(value.uri, ''),
-    range: parseRange(value.range),
-  };
-};
-
-const parseDocumentSymbol = (value: unknown): DocumentSymbol => {
-  if (!isRecord(value)) {
-    return {
-      name: '',
-      kind: 0,
-      range: {
-        start: { line: 0, character: 0 },
-        end: { line: 0, character: 0 },
-      },
-      selectionRange: {
-        start: { line: 0, character: 0 },
-        end: { line: 0, character: 0 },
-      },
-    };
-  }
-
-  const name = getString(value.name, '');
-  const kind = getNumber(value.kind, 0);
-
-  if ('selectionRange' in value || 'range' in value) {
-    return {
-      name,
-      kind,
-      range: parseRange(value.range),
-      selectionRange: parseRange(value.selectionRange ?? value.range),
-    };
-  }
-
-  const line = getNumber(value.line, 0);
-  const character = getNumber(value.char, getNumber(value.character, 0));
-  const pos = { line, character };
-  return {
-    name,
-    kind,
-    range: { start: pos, end: pos },
-    selectionRange: { start: pos, end: pos },
-  };
-};
-
-const parseWorkspaceSymbol = (value: unknown): WorkspaceSymbol => {
-  if (!isRecord(value)) {
-    return {
-      name: '',
-      kind: 0,
-      location: {
-        uri: '',
-        range: {
-          start: { line: 0, character: 0 },
-          end: { line: 0, character: 0 },
-        },
-      },
-    };
-  }
-
-  const name = getString(value.name, '');
-  const kind = getNumber(value.kind, 0);
-
-  if (isRecord(value.location)) {
-    return {
-      name,
-      kind,
-      location: parseLocation(value.location),
-    };
-  }
-
-  const line = getNumber(value.line, 0);
-  const character = getNumber(value.char, getNumber(value.character, 0));
-  return {
-    name,
-    kind,
-    location: {
-      uri: getString(value.file, ''),
-      range: {
-        start: { line, character },
-        end: { line, character },
-      },
-    },
-  };
-};
-
-const parseDiagnostic = (value: unknown): Diagnostic => {
-  if (!isRecord(value)) {
-    return {
-      source: '',
-      code: '',
-      message: '',
-      severity: 0,
-      range: {
-        start: { line: 0, character: 0 },
-        end: { line: 0, character: 0 },
-      },
-    };
-  }
-
-  let range = parseRange(value.range);
-  if (!('range' in value)) {
-    const line = getNumber(value.line, 0);
-    const character = getNumber(
-      value.column,
-      getNumber(value.char, getNumber(value.character, 0)),
-    );
-    range = {
-      start: { line, character },
-      end: { line, character },
-    };
-  }
-
-  return {
-    source: getString(value.source, ''),
-    code: getString(value.code, ''),
-    message: getString(value.message, ''),
-    severity: getNumber(value.severity, 0),
-    range,
-  };
-};
-
-const formatLocation = (location: Location, workspaceRoot: string): string => {
+const formatLocation = (
+  location: LspLocation,
+  workspaceRoot: string,
+): string => {
   const path = toDisplayPath(location.uri, workspaceRoot);
-  return `${path}:${formatLineCol(location.range.start)}`;
+  return `${path}:${formatLineCol(location.range.start.line, location.range.start.character)}`;
 };
 
 const formatSymbol = (
-  symbol:
-    | Pick<DocumentSymbol, 'name' | 'selectionRange'>
-    | Pick<WorkspaceSymbol, 'name' | 'location'>,
+  symbol: LspDocumentSymbol | LspWorkspaceSymbol,
   workspaceRoot: string,
 ): string => {
   if ('location' in symbol) {
     return `${symbol.name} - ${formatLocation(symbol.location, workspaceRoot)}`;
   }
-  return `${symbol.name} - ${formatLineCol(symbol.selectionRange.start)}`;
+  return `${symbol.name} - ${formatLineCol(symbol.selectionRange.start.line, symbol.selectionRange.start.character)}`;
 };
 
 const formatDiagnostic = (
@@ -274,7 +106,7 @@ const formatDiagnostic = (
   workspaceRoot: string,
 ): string => {
   const display = toDisplayPath(filePath, workspaceRoot);
-  return `${display}:${formatLineCol(diagnostic.range.start)} ${diagnostic.message}`;
+  return `${display}:${diagnostic.line}:${diagnostic.column} ${diagnostic.message}`;
 };
 
 export const validateFilePath = (
@@ -292,7 +124,7 @@ export const validateFilePath = (
 };
 
 export async function createMcpChannel(
-  orchestrator: Orchestrator,
+  orchestrator: McpOrchestrator,
   workspaceRoot: string,
   inputStream: Readable,
   outputStream: Writable,
@@ -305,14 +137,11 @@ export async function createMcpChannel(
   server.tool('lsp_goto_definition', filePositionSchema, async (args) => {
     try {
       const filePath = validateFilePath(args.filePath, workspaceRoot);
-      const locationsRaw = (await orchestrator.gotoDefinition(
+      const locations = await orchestrator.gotoDefinition(
         filePath,
         args.line,
         args.character,
-      )) as unknown;
-      const locations = Array.isArray(locationsRaw)
-        ? locationsRaw.map(parseLocation)
-        : [];
+      );
       const text = locations
         .map((loc) => formatLocation(loc, workspaceRoot))
         .join('\n');
@@ -328,14 +157,11 @@ export async function createMcpChannel(
   server.tool('lsp_find_references', filePositionSchema, async (args) => {
     try {
       const filePath = validateFilePath(args.filePath, workspaceRoot);
-      const locationsRaw = (await orchestrator.findReferences(
+      const locations = await orchestrator.findReferences(
         filePath,
         args.line,
         args.character,
-      )) as unknown;
-      const locations = Array.isArray(locationsRaw)
-        ? locationsRaw.map(parseLocation)
-        : [];
+      );
       const text = locations
         .map((loc) => formatLocation(loc, workspaceRoot))
         .join('\n');
@@ -368,12 +194,7 @@ export async function createMcpChannel(
   server.tool('lsp_document_symbols', fileSchema, async (args) => {
     try {
       const filePath = validateFilePath(args.filePath, workspaceRoot);
-      const symbolsRaw = (await orchestrator.documentSymbols(
-        filePath,
-      )) as unknown;
-      const symbols = Array.isArray(symbolsRaw)
-        ? symbolsRaw.map(parseDocumentSymbol)
-        : [];
+      const symbols = await orchestrator.documentSymbols(filePath);
       const text = symbols
         .map((symbol) => formatSymbol(symbol, workspaceRoot))
         .join('\n');
@@ -388,12 +209,7 @@ export async function createMcpChannel(
 
   server.tool('lsp_workspace_symbols', querySchema, async (args) => {
     try {
-      const symbolsRaw = (await orchestrator.workspaceSymbols(
-        args.query,
-      )) as unknown;
-      const symbols = Array.isArray(symbolsRaw)
-        ? symbolsRaw.map(parseWorkspaceSymbol)
-        : [];
+      const symbols = await orchestrator.workspaceSymbols(args.query);
       const text = symbols
         .map((symbol) => formatSymbol(symbol, workspaceRoot))
         .join('\n');
@@ -408,15 +224,11 @@ export async function createMcpChannel(
 
   server.tool('lsp_diagnostics', async () => {
     try {
-      const allRaw = (await orchestrator.getAllDiagnostics()) as unknown;
-      const all = isRecord(allRaw) ? allRaw : {};
+      const all = await orchestrator.getAllDiagnostics();
       const files = Object.keys(all).sort((a, b) => a.localeCompare(b));
       const lines: string[] = [];
       for (const filePath of files) {
-        const diagnosticsRaw = all[filePath];
-        const diagnostics = Array.isArray(diagnosticsRaw)
-          ? diagnosticsRaw.map(parseDiagnostic)
-          : [];
+        const diagnostics = all[filePath];
         for (const diagnostic of diagnostics) {
           lines.push(formatDiagnostic(filePath, diagnostic, workspaceRoot));
         }

--- a/packages/lsp/src/main.ts
+++ b/packages/lsp/src/main.ts
@@ -125,6 +125,24 @@ const validateServers = (
     };
   });
 };
+export const toServerRegistryEntries = (
+  servers: readonly LspServerConfig[] | undefined,
+  builtins: readonly ServerRegistryEntry[] = getBuiltinServers(),
+): ServerRegistryEntry[] => {
+  if (!servers) {
+    return [];
+  }
+  return servers.map((server) => {
+    const builtin = builtins.find((entry) => entry.id === server.id);
+    return {
+      id: server.id,
+      displayName: builtin?.displayName ?? server.id,
+      command: server.command,
+      extensions: server.extensions ?? builtin?.extensions ?? [],
+      ...(server.args ? { args: server.args } : {}),
+    };
+  });
+};
 
 const validateOptionalPositiveTimeout = (
   value: unknown,
@@ -239,10 +257,16 @@ function createWriteStreamFromFd(fd: number) {
 
 export async function main(): Promise<void> {
   const bootstrap = parseBootstrapFromEnv();
-  const mergedServers = mergeUserConfig(
-    getBuiltinServers(),
-    bootstrap.config.servers as unknown as ServerRegistryEntry[],
-  ).map((s) => ({
+  const builtins = getBuiltinServers();
+  const bootstrapServerEntries = toServerRegistryEntries(
+    bootstrap.config.servers,
+    builtins,
+  );
+  const registryServers =
+    bootstrapServerEntries.length > 0
+      ? bootstrapServerEntries
+      : mergeUserConfig(builtins, bootstrapServerEntries);
+  const mergedServers = registryServers.map((s) => ({
     id: s.id,
     command: s.command,
     args: s.args ? [...s.args] : undefined,

--- a/packages/lsp/src/service/lsp-client.ts
+++ b/packages/lsp/src/service/lsp-client.ts
@@ -6,6 +6,10 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { Diagnostic } from './diagnostics.js';
 import { getLanguageId } from './language-map.js';
+import {
+  isPublishDiagnosticsParams,
+  parsePublishDiagnostics,
+} from './lsp-diagnostic-parser.js';
 import type { LspServerConfig } from '../types.js';
 
 export class LspRequestTimeoutError extends Error {
@@ -840,19 +844,18 @@ export class LspClient {
       'method' in message &&
       message.method === 'textDocument/publishDiagnostics'
     ) {
-      const params = message.params as
-        | { uri?: string; diagnostics?: Diagnostic[] }
-        | undefined;
-      if (!params?.uri) {
+      if (!isPublishDiagnosticsParams(message.params)) {
         return;
       }
 
-      const path = fromFileUri(params.uri);
+      const path = fromFileUri(message.params.uri);
       this.diagnosticsByFile.set(
         path,
-        Array.isArray(params.diagnostics)
-          ? params.diagnostics
-          : EMPTY_DIAGNOSTICS,
+        parsePublishDiagnostics(
+          message.params.diagnostics,
+          path,
+          this.workspaceRoot,
+        ),
       );
       this.eventBus.emit(`diagnostics:${path}`);
     }

--- a/packages/lsp/src/service/lsp-client.ts
+++ b/packages/lsp/src/service/lsp-client.ts
@@ -42,7 +42,7 @@ export interface Location {
 
 export interface DocumentSymbol {
   name: string;
-  kind: string;
+  kind: number;
   line: number;
   char: number;
 }
@@ -76,6 +76,9 @@ const DEBOUNCE_MS = 120;
 const DEADLINE_SAFETY_MARGIN_MS = 5;
 const TOUCH_CRASH_OBSERVATION_WINDOW_MS = 25;
 const HEADER_SEPARATOR = Buffer.from([0x0d, 0x0a, 0x0d, 0x0a]);
+
+const toSymbolKind = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : 0;
 
 function toFileUri(filePath: string): string {
   if (filePath.startsWith('file://')) {
@@ -505,7 +508,7 @@ export class LspClient {
       if (!item || typeof item !== 'object') return EMPTY_SYMBOLS;
       const symbol = item as Record<string, unknown>;
       const name = typeof symbol.name === 'string' ? symbol.name : '';
-      const kind = String(symbol.kind ?? 'unknown');
+      const kind = toSymbolKind(symbol.kind);
       const range = symbol.range as
         | { start?: { line?: number; character?: number } }
         | undefined;

--- a/packages/lsp/src/service/lsp-diagnostic-parser.ts
+++ b/packages/lsp/src/service/lsp-diagnostic-parser.ts
@@ -1,0 +1,74 @@
+import {
+  normalizeLspDiagnostic,
+  type Diagnostic,
+  type RawLspDiagnostic,
+} from './diagnostics.js';
+
+const EMPTY_DIAGNOSTICS: Diagnostic[] = [];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isRawDiagnosticCode = (value: unknown): value is string | number =>
+  typeof value === 'string' || isFiniteNumber(value);
+
+const toRawDiagnostic = (value: unknown): RawLspDiagnostic | null => {
+  if (!isRecord(value) || typeof value.message !== 'string') {
+    return null;
+  }
+
+  const range = value.range;
+  if (!isRecord(range)) {
+    return null;
+  }
+
+  const start = range.start;
+  if (
+    !isRecord(start) ||
+    !isFiniteNumber(start.line) ||
+    !isFiniteNumber(start.character)
+  ) {
+    return null;
+  }
+
+  const severity = isFiniteNumber(value.severity) ? value.severity : undefined;
+  const code = isRawDiagnosticCode(value.code) ? value.code : undefined;
+
+  return {
+    message: value.message,
+    ...(typeof severity === 'number' ? { severity } : {}),
+    ...(code !== undefined ? { code } : {}),
+    range: {
+      start: {
+        line: start.line,
+        character: start.character,
+      },
+    },
+  };
+};
+
+export const isPublishDiagnosticsParams = (
+  value: unknown,
+): value is { readonly uri: string; readonly diagnostics?: unknown[] } =>
+  isRecord(value) &&
+  typeof value.uri === 'string' &&
+  (value.diagnostics === undefined || Array.isArray(value.diagnostics));
+
+export function parsePublishDiagnostics(
+  rawDiagnostics: unknown[] | undefined,
+  file: string,
+  workspaceRoot: string,
+): Diagnostic[] {
+  if (!Array.isArray(rawDiagnostics)) {
+    return EMPTY_DIAGNOSTICS;
+  }
+  return rawDiagnostics.flatMap((raw) => {
+    const diagnostic = toRawDiagnostic(raw);
+    return diagnostic
+      ? [normalizeLspDiagnostic(diagnostic, file, workspaceRoot)]
+      : [];
+  });
+}

--- a/packages/lsp/src/service/lsp-dto.ts
+++ b/packages/lsp/src/service/lsp-dto.ts
@@ -1,0 +1,27 @@
+export interface LspPosition {
+  readonly line: number;
+  readonly character: number;
+}
+
+export interface LspRange {
+  readonly start: LspPosition;
+  readonly end: LspPosition;
+}
+
+export interface LspLocation {
+  readonly uri: string;
+  readonly range: LspRange;
+}
+
+export interface LspDocumentSymbol {
+  readonly name: string;
+  readonly kind: number;
+  readonly range: LspRange;
+  readonly selectionRange: LspRange;
+}
+
+export interface LspWorkspaceSymbol {
+  readonly name: string;
+  readonly kind: number;
+  readonly location: LspLocation;
+}

--- a/packages/lsp/src/service/orchestrator.ts
+++ b/packages/lsp/src/service/orchestrator.ts
@@ -54,13 +54,11 @@ const toLspLocation = (location: Location): LspLocation => {
 };
 
 const toLspDocumentSymbol = (symbol: DocumentSymbol): LspDocumentSymbol => {
-  const numericKind = Number.parseInt(symbol.kind, 10);
-  const kind = Number.isFinite(numericKind) ? numericKind : 0;
   const position = { line: symbol.line, character: symbol.char };
   const range = { start: position, end: position };
   return {
     name: symbol.name,
-    kind,
+    kind: symbol.kind,
     range,
     selectionRange: range,
   };

--- a/packages/lsp/src/service/orchestrator.ts
+++ b/packages/lsp/src/service/orchestrator.ts
@@ -11,11 +11,12 @@
 import { readFile } from 'node:fs/promises';
 import { extname, normalize, resolve } from 'node:path';
 
-import {
-  normalizeLspDiagnostic,
-  type Diagnostic,
-  type RawLspDiagnostic,
-} from './diagnostics.js';
+import type { Diagnostic } from './diagnostics.js';
+import type {
+  LspDocumentSymbol,
+  LspLocation,
+  LspWorkspaceSymbol,
+} from './lsp-dto.js';
 import { LspClient, type DocumentSymbol, type Location } from './lsp-client.js';
 import type { LspServerConfig } from '../types.js';
 
@@ -26,16 +27,11 @@ export interface ServerStatus {
   state: 'ok' | 'broken' | 'starting' | 'idle';
 }
 
-export interface WorkspaceSymbol {
-  name: string;
-  file: string;
-  line: number;
-  char: number;
-}
-
 type ClientKey = string;
 
 const DEFAULT_WAIT_MS = 1200;
+const EMPTY_LOCATIONS: Location[] = [];
+const EMPTY_DOCUMENT_SYMBOLS: DocumentSymbol[] = [];
 
 interface OrchestratorServerConfig extends LspServerConfig {
   extensions?: string[];
@@ -48,6 +44,27 @@ interface OrchestratorConfig {
   navigationTimeoutMs?: number;
   requestTimeoutMs?: number;
 }
+
+const toLspLocation = (location: Location): LspLocation => {
+  const position = { line: location.line, character: location.char };
+  return {
+    uri: location.file,
+    range: { start: position, end: position },
+  };
+};
+
+const toLspDocumentSymbol = (symbol: DocumentSymbol): LspDocumentSymbol => {
+  const numericKind = Number.parseInt(symbol.kind, 10);
+  const kind = Number.isFinite(numericKind) ? numericKind : 0;
+  const position = { line: symbol.line, character: symbol.char };
+  const range = { start: position, end: position };
+  return {
+    name: symbol.name,
+    kind,
+    range,
+    selectionRange: range,
+  };
+};
 
 export class Orchestrator {
   private static readonly MAX_DIAGNOSTIC_EVENTS = 1000;
@@ -135,13 +152,7 @@ export class Orchestrator {
               this.startupPromises.delete(key);
               return [];
             }
-            return output.map((raw) =>
-              normalizeLspDiagnostic(
-                raw as unknown as RawLspDiagnostic,
-                normalizedFile,
-                this.workspaceRootAbs,
-              ),
-            );
+            return output;
           } catch {
             this.brokenServers.add(key);
             this.clients.delete(key);
@@ -242,7 +253,7 @@ export class Orchestrator {
     file: string,
     line: number,
     char: number,
-  ): Promise<Location[]> {
+  ): Promise<LspLocation[]> {
     const client = await this.getClientForNavigation(file);
     if (!client) {
       return [];
@@ -253,13 +264,13 @@ export class Orchestrator {
         client.gotoDefinition(normalizedFile, line, char, {
           abortSignal: signal,
         }),
-      [] as Location[],
+      EMPTY_LOCATIONS,
     );
     if (result.length > 0) {
-      return result;
+      return result.map(toLspLocation);
     }
     if (this.isInsideWorkspace(normalizedFile)) {
-      return [{ file: normalizedFile, line, char }];
+      return [toLspLocation({ file: normalizedFile, line, char })];
     }
     return [];
   }
@@ -268,19 +279,20 @@ export class Orchestrator {
     file: string,
     line: number,
     char: number,
-  ): Promise<Location[]> {
+  ): Promise<LspLocation[]> {
     const client = await this.getClientForNavigation(file);
     if (!client) {
       return [];
     }
     const normalizedFile = this.normalizeAbsolutePath(file);
-    return await this.withTimeout(
+    const result = await this.withTimeout(
       (signal) =>
         client.findReferences(normalizedFile, line, char, {
           abortSignal: signal,
         }),
-      [] as Location[],
+      EMPTY_LOCATIONS,
     );
+    return result.map(toLspLocation);
   }
 
   public async hover(
@@ -300,20 +312,21 @@ export class Orchestrator {
     );
   }
 
-  public async documentSymbols(file: string): Promise<DocumentSymbol[]> {
+  public async documentSymbols(file: string): Promise<LspDocumentSymbol[]> {
     const client = await this.getClientForNavigation(file);
     if (!client) {
       return [];
     }
     const normalizedFile = this.normalizeAbsolutePath(file);
-    return await this.withTimeout(
+    const result = await this.withTimeout(
       (signal) =>
         client.documentSymbols(normalizedFile, { abortSignal: signal }),
-      [] as DocumentSymbol[],
+      EMPTY_DOCUMENT_SYMBOLS,
     );
+    return result.map(toLspDocumentSymbol);
   }
 
-  public async workspaceSymbols(query: string): Promise<WorkspaceSymbol[]> {
+  public async workspaceSymbols(query: string): Promise<LspWorkspaceSymbol[]> {
     void query;
     return [];
   }

--- a/packages/lsp/test/fixtures/fake-lsp-server.ts
+++ b/packages/lsp/test/fixtures/fake-lsp-server.ts
@@ -16,7 +16,7 @@ type Diagnostic = {
 
 type PublishDiagnosticsParams = {
   uri: string;
-  diagnostics: Diagnostic[];
+  diagnostics: unknown[];
 };
 
 type JsonRpcRequest = {
@@ -254,7 +254,12 @@ async function handleRequest(message: JsonRpcRequest): Promise<void> {
     documents.set(uri, text);
     await sendPublishDiagnostics({
       uri,
-      diagnostics: createDiagnosticsForText(text),
+      diagnostics: [
+        ...createDiagnosticsForText(text),
+        { message: 123, range: { start: { line: 99, character: 99 } } },
+        { message: 'invalid missing range' },
+        null,
+      ],
     });
     return;
   }

--- a/packages/lsp/test/fixtures/fake-lsp-server.ts
+++ b/packages/lsp/test/fixtures/fake-lsp-server.ts
@@ -160,6 +160,30 @@ function createDiagnosticsForText(text: string): Diagnostic[] {
         },
       });
     }
+
+    if (line.includes('INFO')) {
+      diagnostics.push({
+        message: 'Simulated info',
+        severity: 3,
+        code: 'FAKE3001',
+        range: {
+          start: { line: index, character: 0 },
+          end: { line: index, character: Math.max(1, line.length) },
+        },
+      });
+    }
+
+    if (line.includes('HINT')) {
+      diagnostics.push({
+        message: 'Simulated hint',
+        severity: 4,
+        code: 'FAKE4001',
+        range: {
+          start: { line: index, character: 0 },
+          end: { line: index, character: Math.max(1, line.length) },
+        },
+      });
+    }
   }
 
   return diagnostics;
@@ -317,7 +341,16 @@ async function handleRequest(message: JsonRpcRequest): Promise<void> {
     send({
       jsonrpc: '2.0',
       id: message.id,
-      result: [],
+      result: [
+        {
+          name: 'fakeSymbol',
+          kind: 12,
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 10 },
+          },
+        },
+      ],
     });
     return;
   }

--- a/packages/lsp/test/lsp-client.test.ts
+++ b/packages/lsp/test/lsp-client.test.ts
@@ -399,6 +399,92 @@ describe('LspClient unit TDD edge cases and internal behaviors', () => {
   });
 });
 
+describe('LspClient diagnostics boundary normalization', () => {
+  it('waitForDiagnostics returns normalized project diagnostics with severity mapped to strings', async () => {
+    const client = createLspClient(createConfig(), WORKSPACE_ROOT);
+    createdClients.push(client);
+
+    await client.initialize();
+    await client.touchFile(
+      '/workspace/src/norm-error.ts',
+      'const x = TYPE_ERROR',
+    );
+
+    const diagnostics = await client.waitForDiagnostics(
+      '/workspace/src/norm-error.ts',
+      2000,
+    );
+
+    expect(diagnostics.length).toBeGreaterThan(0);
+    const error = diagnostics.find((d) => d.message.includes('type error'));
+    expect(error).toBeDefined();
+    expect(error?.severity).toBe('error');
+    expect(error?.code).toBe('FAKE1001');
+  });
+
+  it('waitForDiagnostics normalizes line and column to 1-based offsets', async () => {
+    const client = createLspClient(createConfig(), WORKSPACE_ROOT);
+    createdClients.push(client);
+
+    await client.initialize();
+    await client.touchFile(
+      '/workspace/src/norm-line.ts',
+      'const x = TYPE_ERROR',
+    );
+
+    const diagnostics = await client.waitForDiagnostics(
+      '/workspace/src/norm-line.ts',
+      2000,
+    );
+
+    const error = diagnostics.find((d) => d.message.includes('type error'));
+    expect(error).toBeDefined();
+    expect(error?.line).toBe(1);
+    expect(error?.column).toBe(1);
+  });
+
+  it('waitForDiagnostics maps warning severity to the warning string', async () => {
+    const client = createLspClient(createConfig(), WORKSPACE_ROOT);
+    createdClients.push(client);
+
+    await client.initialize();
+    await client.touchFile(
+      '/workspace/src/norm-warn.ts',
+      ['const x = TYPE_ERROR', '// WARN'].join('\n'),
+    );
+
+    const diagnostics = await client.waitForDiagnostics(
+      '/workspace/src/norm-warn.ts',
+      2000,
+    );
+
+    const warning = diagnostics.find((d) => d.message.includes('warning'));
+    expect(warning).toBeDefined();
+    expect(warning?.severity).toBe('warning');
+    expect(warning?.code).toBe('FAKE2001');
+    expect(warning?.line).toBe(2);
+  });
+
+  it('waitForDiagnostics drops malformed diagnostics at the client boundary', async () => {
+    const client = createLspClient(createConfig(), WORKSPACE_ROOT);
+    createdClients.push(client);
+
+    await client.initialize();
+    await client.touchFile(
+      '/workspace/src/malformed-boundary.ts',
+      'const x = TYPE_ERROR',
+    );
+
+    const diagnostics = await client.waitForDiagnostics(
+      '/workspace/src/malformed-boundary.ts',
+      2000,
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toBe('Simulated type error (TYPE_ERROR)');
+  });
+});
+
 const CONTENT_LENGTH_FIXTURE_PATH = fileURLToPath(
   new URL('./fixtures/fake-lsp-server-content-length.ts', import.meta.url),
 );

--- a/packages/lsp/test/lsp-client.test.ts
+++ b/packages/lsp/test/lsp-client.test.ts
@@ -465,6 +465,29 @@ describe('LspClient diagnostics boundary normalization', () => {
     expect(warning?.line).toBe(2);
   });
 
+  it('waitForDiagnostics maps info and hint severities to strings', async () => {
+    const client = createLspClient(createConfig(), WORKSPACE_ROOT);
+    createdClients.push(client);
+
+    await client.initialize();
+    await client.touchFile(
+      '/workspace/src/norm-info-hint.ts',
+      ['// INFO', '// HINT'].join('\n'),
+    );
+
+    const diagnostics = await client.waitForDiagnostics(
+      '/workspace/src/norm-info-hint.ts',
+      2000,
+    );
+
+    const info = diagnostics.find((d) => d.message.includes('info'));
+    const hint = diagnostics.find((d) => d.message.includes('hint'));
+    expect(info?.severity).toBe('info');
+    expect(info?.code).toBe('FAKE3001');
+    expect(hint?.severity).toBe('hint');
+    expect(hint?.code).toBe('FAKE4001');
+  });
+
   it('waitForDiagnostics drops malformed diagnostics at the client boundary', async () => {
     const client = createLspClient(createConfig(), WORKSPACE_ROOT);
     createdClients.push(client);
@@ -647,6 +670,20 @@ describe('Content-Length framing with multi-byte UTF-8', () => {
       );
       expect(Array.isArray(symbols)).toBe(true);
       expect(client.isAlive()).toBe(true);
+    });
+
+    it('documentSymbols preserves numeric symbol kinds from the LSP server', async () => {
+      const client = createLspClient(createConfig(), WORKSPACE_ROOT);
+      createdClients.push(client);
+
+      await client.initialize();
+      await client.touchFile('/workspace/src/symbol-kind.ts', 'const x = 1;');
+
+      const symbols = await client.documentSymbols(
+        '/workspace/src/symbol-kind.ts',
+      );
+
+      expect(symbols[0]?.kind).toBe(12);
     });
 
     it('uses DEFAULT_REQUEST_TIMEOUT_MS (30s) when no requestTimeoutMs is configured', () => {

--- a/packages/lsp/test/main.test.ts
+++ b/packages/lsp/test/main.test.ts
@@ -368,15 +368,13 @@ describe('main channel wiring', () => {
     const mod = await import('../src/main.js');
     await mod.main();
 
-    expect(createOrchestrator.mock.calls[0]?.[0]).toMatchObject({
-      servers: [
-        {
-          id: 'tsserver',
-          command: 'typescript-language-server',
-          extensions: [],
-        },
-      ],
-    });
+    expect(createOrchestrator.mock.calls[0]?.[0].servers).toEqual([
+      {
+        id: 'tsserver',
+        command: 'typescript-language-server',
+        extensions: [],
+      },
+    ]);
   });
 
   it('navigationTools false skips mcp', async () => {

--- a/packages/lsp/test/main.test.ts
+++ b/packages/lsp/test/main.test.ts
@@ -311,9 +311,10 @@ describe('main channel wiring', () => {
     const createMcpChannel = vi
       .fn()
       .mockResolvedValue({ close: vi.fn().mockResolvedValue(undefined) });
+    const createOrchestrator = vi.fn(() => orchestrator);
 
     vi.doMock('../src/service/orchestrator.js', () => ({
-      createOrchestrator: vi.fn(() => orchestrator),
+      createOrchestrator,
     }));
     vi.doMock('../src/channels/rpc-channel.js', () => ({ setupRpcChannel }));
     vi.doMock('../src/channels/mcp-channel.js', () => ({ createMcpChannel }));
@@ -330,10 +331,52 @@ describe('main channel wiring', () => {
     const mod = await import('../src/main.js');
     await mod.main();
 
+    expect(createOrchestrator.mock.calls[0]?.[0]).toMatchObject({
+      servers: expect.arrayContaining([expect.objectContaining({ id: 'ts' })]),
+    });
     expect(setupRpcChannel).toHaveBeenCalledTimes(1);
     expect(setupRpcChannel.mock.calls[0]?.[1]).toBe(orchestrator);
     expect(createMcpChannel).toHaveBeenCalledTimes(1);
     expect(createMcpChannel.mock.calls[0]?.[0]).toBe(orchestrator);
+  });
+
+  it('passes explicit bootstrap servers to the orchestrator without adding builtins', async () => {
+    process.env.LSP_BOOTSTRAP = JSON.stringify({
+      workspaceRoot: '/tmp/ws',
+      config: {
+        navigationTools: false,
+        servers: [{ id: 'tsserver', command: 'typescript-language-server' }],
+      },
+    });
+
+    const orchestrator = { shutdown: vi.fn().mockResolvedValue(undefined) };
+    const createOrchestrator = vi.fn(() => orchestrator);
+
+    vi.doMock('../src/service/orchestrator.js', () => ({
+      createOrchestrator,
+    }));
+    vi.doMock('vscode-jsonrpc/node.js', () => ({
+      StreamMessageReader: vi.fn(),
+      StreamMessageWriter: vi.fn(),
+      createMessageConnection: vi.fn(() => ({
+        listen: vi.fn(),
+        dispose: vi.fn(),
+        sendNotification: vi.fn(),
+      })),
+    }));
+
+    const mod = await import('../src/main.js');
+    await mod.main();
+
+    expect(createOrchestrator.mock.calls[0]?.[0]).toMatchObject({
+      servers: [
+        {
+          id: 'tsserver',
+          command: 'typescript-language-server',
+          extensions: [],
+        },
+      ],
+    });
   });
 
   it('navigationTools false skips mcp', async () => {
@@ -419,5 +462,83 @@ describe('main channel wiring', () => {
     await mod.main();
 
     expect(sendNotification).toHaveBeenCalledWith('lsp/ready');
+  });
+});
+
+describe('toServerRegistryEntries conversion', () => {
+  const loadMain = async () => import('../src/main.js');
+
+  it('converts a validated user server config into a ServerRegistryEntry with displayName', async () => {
+    const mod = await loadMain();
+    const entries = mod.toServerRegistryEntries([
+      {
+        id: 'custom-ts',
+        command: 'typescript-language-server',
+        extensions: ['.ts'],
+      },
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe('custom-ts');
+    expect(entries[0]?.displayName).toBe('custom-ts');
+    expect(entries[0]?.command).toBe('typescript-language-server');
+    expect(entries[0]?.extensions).toEqual(['.ts']);
+  });
+
+  it('produces entries that mergeUserConfig accepts without casts', async () => {
+    const { mergeUserConfig, getBuiltinServers } = await import(
+      '../src/service/server-registry.js'
+    );
+    const mod = await loadMain();
+    const builtins = getBuiltinServers();
+    const entries = mod.toServerRegistryEntries(
+      [
+        {
+          id: 'ts',
+          command: 'override-ts',
+          args: ['--stdio'],
+          extensions: ['.ts'],
+        },
+      ],
+      builtins,
+    );
+
+    const merged = mergeUserConfig(builtins, entries);
+    const tsEntry = merged.find((e) => e.id === 'ts');
+    expect(tsEntry?.command).toBe('override-ts');
+    expect(tsEntry?.args).toEqual(['--stdio']);
+  });
+
+  it('carries args through conversion as a readonly array', async () => {
+    const mod = await loadMain();
+    const entries = mod.toServerRegistryEntries([
+      {
+        id: 'with-args',
+        command: 'langserver',
+        args: ['--stdio', '--verbose'],
+        extensions: ['.js'],
+      },
+    ]);
+
+    expect(entries[0]?.args).toEqual(['--stdio', '--verbose']);
+  });
+
+  it('inherits builtin displayName and extensions for partial builtin overrides', async () => {
+    const { getBuiltinServers } = await import(
+      '../src/service/server-registry.js'
+    );
+    const mod = await loadMain();
+    const entries = mod.toServerRegistryEntries(
+      [{ id: 'ts', command: 'custom-typescript-language-server' }],
+      getBuiltinServers(),
+    );
+
+    expect(entries[0]?.displayName).toBe('TypeScript Language Server');
+    expect(entries[0]?.extensions).toEqual(['.ts', '.tsx', '.js', '.jsx']);
+  });
+
+  it('returns an empty array for undefined input', async () => {
+    const mod = await loadMain();
+    expect(mod.toServerRegistryEntries(undefined)).toEqual([]);
   });
 });

--- a/packages/lsp/test/mcp-channel.test.ts
+++ b/packages/lsp/test/mcp-channel.test.ts
@@ -11,61 +11,14 @@ import { PassThrough } from 'node:stream';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
-import { createMcpChannel } from '../src/channels/mcp-channel.js';
-
-type Location = {
-  uri: string;
-  range: {
-    start: { line: number; character: number };
-    end: { line: number; character: number };
-  };
-};
-
-type DocumentSymbol = {
-  name: string;
-  kind: number;
-  range: Location['range'];
-  selectionRange: Location['range'];
-};
-
-type WorkspaceSymbol = {
-  name: string;
-  kind: number;
-  location: Location;
-};
-
-type Diagnostic = {
-  source: string;
-  code: string;
-  message: string;
-  severity: number;
-  range: Location['range'];
-};
+import {
+  createMcpChannel,
+  type McpOrchestrator,
+} from '../src/channels/mcp-channel.js';
 
 type ToolCallResult = {
   content?: Array<{ type: string; text?: string }>;
   isError?: boolean;
-};
-
-type TestOrchestrator = {
-  gotoDefinition: (
-    filePath: string,
-    line: number,
-    character: number,
-  ) => Promise<Location[]>;
-  findReferences: (
-    filePath: string,
-    line: number,
-    character: number,
-  ) => Promise<Location[]>;
-  hover: (
-    filePath: string,
-    line: number,
-    character: number,
-  ) => Promise<string | null>;
-  documentSymbols: (filePath: string) => Promise<DocumentSymbol[]>;
-  workspaceSymbols: (query: string) => Promise<WorkspaceSymbol[]>;
-  getAllDiagnostics: () => Promise<Record<string, Diagnostic[]>>;
 };
 
 class LineDelimitedTransport implements Transport {
@@ -152,11 +105,11 @@ function createTransportPair(): {
 }
 
 async function createHarness(
-  orchestrator: TestOrchestrator,
+  orchestrator: McpOrchestrator,
 ): Promise<{ client: Client; close: () => Promise<void> }> {
   const { clientTransport, serverInput, serverOutput } = createTransportPair();
   const server = await createMcpChannel(
-    orchestrator as never,
+    orchestrator,
     '/workspace',
     serverInput,
     serverOutput,
@@ -460,26 +413,22 @@ describe('MCP channel behavior', () => {
       getAllDiagnostics: async () => ({
         '/workspace/src/z.ts': [
           {
-            source: 'ts',
-            code: 'TS2',
+            file: 'src/z.ts',
             message: 'z issue',
-            severity: 2,
-            range: {
-              start: { line: 1, character: 0 },
-              end: { line: 1, character: 3 },
-            },
+            severity: 'warning',
+            line: 2,
+            column: 1,
+            code: 'TS2',
           },
         ],
         '/workspace/src/a.ts': [
           {
-            source: 'ts',
-            code: 'TS1',
+            file: 'src/a.ts',
             message: 'a issue',
-            severity: 1,
-            range: {
-              start: { line: 0, character: 1 },
-              end: { line: 0, character: 4 },
-            },
+            severity: 'error',
+            line: 1,
+            column: 2,
+            code: 'TS1',
           },
         ],
       }),
@@ -497,6 +446,8 @@ describe('MCP channel behavior', () => {
     expect(zIndex).toBeGreaterThan(aIndex);
     expect(text).toContain('a issue');
     expect(text).toContain('z issue');
+    expect(text).toContain('src/a.ts:1:2');
+    expect(text).toContain('src/z.ts:2:1');
 
     await harness.close();
   });

--- a/packages/lsp/test/orchestrator.test.ts
+++ b/packages/lsp/test/orchestrator.test.ts
@@ -141,9 +141,13 @@ describe('Orchestrator unit tests against real implementation', () => {
     expect(typeof hover === 'string' || hover === null).toBe(true);
   });
 
-  it('documentSymbols returns array', async () => {
+  it('documentSymbols returns typed LSP symbols with numeric kind', async () => {
     const symbols = await orchestrator.documentSymbols('/workspace/src/a.ts');
-    expect(Array.isArray(symbols)).toBe(true);
+    expect(symbols[0]).toMatchObject({
+      name: 'fakeSymbol',
+      kind: 12,
+      selectionRange: { start: { line: 0, character: 0 } },
+    });
   });
 
   it('getAllDiagnostics returns touched files only', async () => {


### PR DESCRIPTION
Summary
- Adds canonical LSP DTOs for Orchestrator navigation and symbol results consumed directly by the MCP channel.
- Moves publishDiagnostics validation and normalization to the LSP client boundary so Orchestrator stores trusted project diagnostics.
- Replaces the bootstrap server registry cast with explicit conversion and preserves explicit bootstrap server lists.

Verification
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- npm run lint:eslint-guard
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"

Fixes #2209
