### PR TITLE
Preserve streaming newlines in assistant output (Fixes #2208)

### DIFF
--- a/packages/agents/src/core/turn.debug-responses.test.ts
+++ b/packages/agents/src/core/turn.debug-responses.test.ts
@@ -403,7 +403,7 @@ describe('Turn - debug responses and finished event outcome', () => {
         });
       });
 
-      it('should not emit content for whitespace-only text', async () => {
+      it('should emit whitespace-only text without counting it as visible output', async () => {
         const mockResponseStream = (async function* () {
           yield {
             type: StreamEventType.CHUNK,
@@ -427,9 +427,11 @@ describe('Turn - debug responses and finished event outcome', () => {
           events.push(event);
         }
 
-        expect(
-          events.some((event) => event.type === GeminiEventType.Content),
-        ).toBe(false);
+        expect(events).toContainEqual({
+          type: GeminiEventType.Content,
+          value: '   ',
+          traceId: undefined,
+        });
         const finishedEvent = findFinishedEvent(events);
         expect(finishedEvent).toBeDefined();
         expect(finishedEvent?.value.outcome).toStrictEqual({

--- a/packages/agents/src/core/turn.test.ts
+++ b/packages/agents/src/core/turn.test.ts
@@ -152,6 +152,94 @@ describe('Turn', () => {
       expect(turn.getDebugResponses().length).toBe(2);
     });
 
+    it('should yield content events for newline-only chunks after visible text', async () => {
+      const mockResponseStream = (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [
+              { content: { parts: [{ text: 'LLXPRT2208_ALPHA' }] } },
+            ],
+          } as GenerateContentResponse,
+        };
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [{ content: { parts: [{ text: '\n\n' }] } }],
+          } as GenerateContentResponse,
+        };
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [
+              { content: { parts: [{ text: 'Alpha paragraph one.' }] } },
+            ],
+          } as GenerateContentResponse,
+        };
+      })();
+      mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+      const events = [];
+      const reqParts: Part[] = [{ text: 'Hi' }];
+      for await (const event of turn.run(
+        reqParts,
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      expect(events).toStrictEqual([
+        {
+          type: GeminiEventType.Content,
+          value: 'LLXPRT2208_ALPHA',
+          traceId: undefined,
+        },
+        { type: GeminiEventType.Content, value: '\n\n', traceId: undefined },
+        {
+          type: GeminiEventType.Content,
+          value: 'Alpha paragraph one.',
+          traceId: undefined,
+        },
+      ]);
+    });
+
+    it('should yield content events for leading newline-only chunks', async () => {
+      const mockResponseStream = (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [{ content: { parts: [{ text: '\n\n' }] } }],
+          } as GenerateContentResponse,
+        };
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [
+              { content: { parts: [{ text: 'LLXPRT2208_ALPHA' }] } },
+            ],
+          } as GenerateContentResponse,
+        };
+      })();
+      mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+      const events = [];
+      const reqParts: Part[] = [{ text: 'Hi' }];
+      for await (const event of turn.run(
+        reqParts,
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      expect(events).toStrictEqual([
+        { type: GeminiEventType.Content, value: '\n\n', traceId: undefined },
+        {
+          type: GeminiEventType.Content,
+          value: 'LLXPRT2208_ALPHA',
+          traceId: undefined,
+        },
+      ]);
+    });
     it('should yield tool_call_request events for function calls', async () => {
       const mockResponseStream = (async function* () {
         yield {

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -322,22 +322,24 @@ export class Turn {
       }
     }
 
-    const chunkOutcome = analyzeResponseOutcome(allowedParts);
+    const finishReason = resp.candidates?.[0]?.finishReason;
     const text = allowedParts
       .filter((part) => !isThoughtPart(part))
       .map((part) => part.text)
       .filter((partText): partText is string => typeof partText === 'string')
       .join('');
-    if (chunkOutcome.hasVisibleText && text !== '') {
+    if (text !== '') {
       yield { type: GeminiEventType.Content, value: text, traceId };
 
-      // Emit citation event if conditions are met
-      // Based on upstream implementation - emit citation after content
-      const citationEvent = this.emitCitation(
-        'Response may contain information from external sources. Please verify important details independently.',
-      );
-      if (citationEvent) {
-        yield citationEvent;
+      if (text.trim() !== '') {
+        // Emit citation event if conditions are met
+        // Based on upstream implementation - emit citation after content
+        const citationEvent = this.emitCitation(
+          'Response may contain information from external sources. Please verify important details independently.',
+        );
+        if (citationEvent) {
+          yield citationEvent;
+        }
       }
     }
 
@@ -357,9 +359,6 @@ export class Turn {
         yield event;
       }
     }
-
-    // Check if response was truncated or stopped for various reasons
-    const finishReason = resp.candidates?.[0]?.finishReason;
 
     // This is the key change: Only yield 'Finished' if there is a finishReason.
     // Pass only allowed function calls so logging/outcome reflect executable calls.

--- a/packages/cli/src/config/__tests__/outputFormat.test.ts
+++ b/packages/cli/src/config/__tests__/outputFormat.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ApprovalMode,
+  DEFAULT_FILE_FILTERING_OPTIONS,
+  DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
+  OutputFormat,
+} from '@vybestack/llxprt-code-core';
+import { resolveIntermediateConfig } from '../intermediateConfig.js';
+import type { CliArgs } from '../cliArgParser.js';
+import type { Settings } from '../settings.js';
+import type { ContextResolutionResult } from '../interactiveContext.js';
+
+vi.mock('../policy.js', () => ({
+  createPolicyEngineConfig: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
+  return {
+    ...original,
+    isRipgrepAvailable: vi.fn().mockResolvedValue(false),
+  };
+});
+
+const baseArgv: CliArgs = {
+  model: undefined,
+  sandbox: undefined,
+  sandboxImage: undefined,
+  sandboxEngine: undefined,
+  sandboxProfileLoad: undefined,
+  debug: undefined,
+  prompt: undefined,
+  promptInteractive: undefined,
+  outputFormat: undefined,
+  showMemoryUsage: undefined,
+  yolo: undefined,
+  approvalMode: undefined,
+  telemetry: undefined,
+  checkpointing: undefined,
+  telemetryTarget: undefined,
+  telemetryOtlpEndpoint: undefined,
+  telemetryLogPrompts: undefined,
+  telemetryOutfile: undefined,
+  allowedMcpServerNames: undefined,
+  allowedTools: undefined,
+  experimentalAcp: undefined,
+  experimentalUi: undefined,
+  extensions: undefined,
+  listExtensions: undefined,
+  provider: undefined,
+  key: undefined,
+  keyfile: undefined,
+  baseurl: undefined,
+  proxy: undefined,
+  includeDirectories: undefined,
+  profileLoad: undefined,
+  loadMemoryFromIncludeDirectories: undefined,
+  ideMode: undefined,
+  screenReader: undefined,
+  sessionSummary: undefined,
+  dumponerror: undefined,
+  promptWords: undefined,
+  query: undefined,
+  set: undefined,
+  continue: undefined,
+  nobrowser: undefined,
+  listSessions: undefined,
+  deleteSession: undefined,
+};
+
+const baseContext: ContextResolutionResult = {
+  debugMode: false,
+  memoryImportFormat: 'tree',
+  ideMode: false,
+  folderTrust: false,
+  trustedFolder: true,
+  fileService: {} as ContextResolutionResult['fileService'],
+  fileFiltering: DEFAULT_FILE_FILTERING_OPTIONS,
+  memoryFileFiltering: DEFAULT_MEMORY_FILE_FILTERING_OPTIONS,
+  includeDirectories: [],
+  resolvedLoadMemoryFromIncludeDirectories: false,
+  jitContextEnabled: false,
+  interactive: false,
+  allExtensions: [],
+  activeExtensions: [],
+  extensionContextFilePaths: [],
+};
+
+async function resolveOutputFormat(outputFormat: string | undefined) {
+  const result = await resolveIntermediateConfig(
+    { ...baseArgv, outputFormat },
+    {} as Settings,
+    {} as Settings,
+    baseContext,
+    ApprovalMode.DEFAULT,
+  );
+  return result.outputFormat;
+}
+
+describe('resolveIntermediateConfig output format', () => {
+  it('preserves stream-json output format', async () => {
+    await expect(resolveOutputFormat(OutputFormat.STREAM_JSON)).resolves.toBe(
+      OutputFormat.STREAM_JSON,
+    );
+  });
+
+  it('preserves json output format', async () => {
+    await expect(resolveOutputFormat(OutputFormat.JSON)).resolves.toBe(
+      OutputFormat.JSON,
+    );
+  });
+
+  it('defaults omitted output format to text', async () => {
+    await expect(resolveOutputFormat(undefined)).resolves.toBe(
+      OutputFormat.TEXT,
+    );
+  });
+
+  it('defaults unknown output format to text', async () => {
+    await expect(resolveOutputFormat('yaml')).resolves.toBe(OutputFormat.TEXT);
+  });
+
+  it('defaults empty string output format to text', async () => {
+    await expect(resolveOutputFormat('')).resolves.toBe(OutputFormat.TEXT);
+  });
+
+  it('defaults whitespace-padded output format to text', async () => {
+    await expect(resolveOutputFormat(' json ')).resolves.toBe(
+      OutputFormat.TEXT,
+    );
+  });
+
+  it('defaults case-variant output format to text', async () => {
+    await expect(resolveOutputFormat('JSON')).resolves.toBe(OutputFormat.TEXT);
+  });
+});

--- a/packages/cli/src/config/intermediateConfig.ts
+++ b/packages/cli/src/config/intermediateConfig.ts
@@ -50,9 +50,14 @@ function resolveScreenReaderSetting(
 }
 
 function resolveOutputFormat(argv: CliArgs): OutputFormat {
-  return argv.outputFormat === OutputFormat.JSON
-    ? OutputFormat.JSON
-    : OutputFormat.TEXT;
+  switch (argv.outputFormat) {
+    case OutputFormat.JSON:
+      return OutputFormat.JSON;
+    case OutputFormat.STREAM_JSON:
+      return OutputFormat.STREAM_JSON;
+    default:
+      return OutputFormat.TEXT;
+  }
 }
 
 export async function resolveIntermediateConfig(

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -16,6 +16,8 @@ import {
   GeminiEventType,
   StreamIdleTimeoutError,
   DebugLogger,
+  JsonStreamEventType,
+  OutputFormat,
 } from '@vybestack/llxprt-code-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCli.js';
@@ -58,6 +60,27 @@ vi.mock('./services/CommandService.js', () => ({
     create: mockCommandServiceCreate,
   },
 }));
+
+type ParsedStreamEvent = {
+  type: string;
+  role?: string;
+  content?: string;
+};
+
+function parseJsonStdoutEvents(
+  calls: Array<[unknown, ...unknown[]]>,
+): ParsedStreamEvent[] {
+  return calls
+    .map(([value]) => String(value).trimEnd())
+    .filter((value) => value.startsWith('{'))
+    .map((value) => {
+      try {
+        return JSON.parse(value) as ParsedStreamEvent;
+      } catch {
+        throw new Error(`Failed to parse stdout line as JSON: ${value}`);
+      }
+    });
+}
 
 describe('runNonInteractive', () => {
   let mockConfig: Config;
@@ -111,6 +134,7 @@ describe('runNonInteractive', () => {
       getDebugMode: vi.fn().mockReturnValue(false),
       getProviderManager: vi.fn().mockReturnValue(undefined),
       getOutputFormat: vi.fn().mockReturnValue('text'),
+      getModel: vi.fn().mockReturnValue('test-model'),
       getFolderTrust: vi.fn().mockReturnValue(false),
       isTrustedFolder: vi.fn().mockReturnValue(false),
       getProjectRoot: vi.fn().mockReturnValue('/tmp/test-project'),
@@ -237,6 +261,80 @@ describe('runNonInteractive', () => {
     // Content may be buffered/processed, check total output
     expect(meaningfulWrites.join('')).toBe('Hello World\n');
     expect(mockShutdownTelemetry).toHaveBeenCalled();
+  });
+
+  it('should emit stream-json message records for newline-only chunks', async () => {
+    mockConfig.getOutputFormat = vi
+      .fn()
+      .mockReturnValue(OutputFormat.STREAM_JSON);
+    mockConfig.getEphemeralSetting = vi.fn((key: string) =>
+      key === 'emojifilter' ? 'allowed' : undefined,
+    );
+    const events: ServerGeminiStreamEvent[] = [
+      { type: GeminiEventType.Content, value: 'LLXPRT2208_ALPHA' },
+      { type: GeminiEventType.Content, value: '\n\n' },
+      { type: GeminiEventType.Content, value: 'Alpha paragraph one.' },
+    ];
+    mockAgentClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents(events),
+    );
+
+    await runNonInteractive({
+      config: mockConfig,
+      settings: mockSettings,
+      input: 'Test input',
+      prompt_id: 'prompt-id-stream-json',
+    });
+
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const messages = jsonEvents.filter(
+      (event) => event.type === JsonStreamEventType.MESSAGE,
+    );
+
+    expect(
+      messages.map((event) => ({ role: event.role, content: event.content })),
+    ).toStrictEqual([
+      { role: 'user', content: 'Test input' },
+      { role: 'assistant', content: 'LLXPRT2208_ALPHA' },
+      { role: 'assistant', content: '\n\n' },
+      { role: 'assistant', content: 'Alpha paragraph one.' },
+    ]);
+  });
+
+  it('should emit emoji-filter buffered stream-json content as JSON records', async () => {
+    mockConfig.getOutputFormat = vi
+      .fn()
+      .mockReturnValue(OutputFormat.STREAM_JSON);
+    mockConfig.getEphemeralSetting = vi.fn((key: string) =>
+      key === 'emojifilter' ? 'auto' : undefined,
+    );
+    const events: ServerGeminiStreamEvent[] = [
+      { type: GeminiEventType.Content, value: 'LLXPRT2208_ALPHA' },
+      { type: GeminiEventType.Content, value: '\n\n' },
+      { type: GeminiEventType.Content, value: 'Alpha paragraph one.' },
+    ];
+    mockAgentClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents(events),
+    );
+
+    await runNonInteractive({
+      config: mockConfig,
+      settings: mockSettings,
+      input: 'Test input',
+      prompt_id: 'prompt-id-stream-json-buffered',
+    });
+
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const assistantOutput = jsonEvents
+      .filter(
+        (event) =>
+          event.type === JsonStreamEventType.MESSAGE &&
+          event.role === 'assistant',
+      )
+      .map((event) => event.content)
+      .join('');
+
+    expect(assistantOutput).toBe('LLXPRT2208_ALPHA\n\nAlpha paragraph one.');
   });
 
   it('should coalesce thought output before content', async () => {

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -152,13 +152,15 @@ function handleContentEvent(
     }
   }
   if (context.streamFormatter) {
-    context.streamFormatter.emitEvent({
-      type: JsonStreamEventType.MESSAGE,
-      timestamp: new Date().toISOString(),
-      role: 'assistant',
-      content: outputValue,
-      delta: true,
-    });
+    if (outputValue !== '') {
+      context.streamFormatter.emitEvent({
+        type: JsonStreamEventType.MESSAGE,
+        timestamp: new Date().toISOString(),
+        role: 'assistant',
+        content: outputValue,
+        delta: true,
+      });
+    }
     return jsonResponseText;
   }
   if (context.jsonOutput) {
@@ -260,6 +262,16 @@ function flushEmojiBuffer(
 ): string {
   const remainingBuffered = context.emojiFilter?.flushBuffer();
   if (!remainingBuffered) {
+    return jsonResponseText;
+  }
+  if (context.streamFormatter) {
+    context.streamFormatter.emitEvent({
+      type: JsonStreamEventType.MESSAGE,
+      timestamp: new Date().toISOString(),
+      role: 'assistant',
+      content: remainingBuffered,
+      delta: true,
+    });
     return jsonResponseText;
   }
   if (context.jsonOutput) {

--- a/packages/core/src/utils/filesearch/crawler.ts
+++ b/packages/core/src/utils/filesearch/crawler.ts
@@ -104,7 +104,7 @@ export async function crawl(options: CrawlOptions): Promise<string[]> {
       });
 
     if (options.maxDepth !== undefined) {
-      api.withMaxDepth(options.maxDepth);
+      api.withMaxDepth(options.maxDepth + 1);
     }
 
     results = await api.crawl(options.crawlDirectory).withPromise();

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -151,7 +151,10 @@ class RecursiveFileSearch implements FileSearch {
       ignore: this.ignore,
       cache: this.options.cache,
       cacheTtl: this.options.cacheTtl,
-      maxDepth: this.options.maxDepth,
+      maxDepth:
+        this.options.maxDepth === undefined
+          ? undefined
+          : Math.max(0, this.options.maxDepth - 1),
       maxFiles: this.options.maxFiles ?? 20000,
     });
 
@@ -291,7 +294,14 @@ class DirectoryFileSearch implements FileSearch {
       throw error;
     }
 
-    const filteredResults = await filter(results, pattern, options.signal);
+    const directResults = results.filter((candidate) =>
+      isDirectSearchResult(candidate, dir),
+    );
+    const filteredResults = await filter(
+      directResults,
+      pattern,
+      options.signal,
+    );
 
     const fileFilter = this.ignore.getFileFilter();
     const finalResults: string[] = [];
@@ -312,6 +322,18 @@ export class FileSearchFactory {
     }
     return new DirectoryFileSearch(options);
   }
+}
+
+function isDirectSearchResult(candidate: string, dir: string): boolean {
+  if (candidate === '.') {
+    return true;
+  }
+  const normalizedDir = dir.replace(/\\/g, '/');
+  const relativeCandidate =
+    normalizedDir === '.'
+      ? candidate
+      : path.posix.relative(normalizedDir, candidate);
+  return !relativeCandidate.replace(/\/$/, '').includes('/');
 }
 
 function addCandidateIfIncluded(

--- a/packages/core/src/utils/output-format.test.ts
+++ b/packages/core/src/utils/output-format.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  JsonStreamEventType,
+  StreamJsonFormatter,
+  type MessageEvent,
+} from './output-format.js';
+
+describe('StreamJsonFormatter', () => {
+  it('emits newline-delimited JSON records with escaped content newlines', () => {
+    const formatter = new StreamJsonFormatter();
+    const event: MessageEvent = {
+      type: JsonStreamEventType.MESSAGE,
+      timestamp: '2026-06-26T00:00:00.000Z',
+      role: 'assistant',
+      content: '## LLXPRT2208_ALPHA\n\nAlpha paragraph one.',
+      delta: true,
+    };
+
+    const formatted = formatter.formatEvent(event);
+
+    expect(formatted.endsWith('\n')).toBe(true);
+    expect(formatted.endsWith('\\n')).toBe(false);
+    expect(formatted.split('\n')).toHaveLength(2);
+    expect(JSON.parse(formatted.trimEnd())).toStrictEqual(event);
+
+    const newlineOnlyEvent: MessageEvent = {
+      type: JsonStreamEventType.MESSAGE,
+      timestamp: '2026-06-26T00:00:00.000Z',
+      role: 'assistant',
+      content: '\n\n',
+      delta: true,
+    };
+    const newlineFormatted = formatter.formatEvent(newlineOnlyEvent);
+
+    expect(newlineFormatted.split('\n')).toHaveLength(2);
+    expect(JSON.parse(newlineFormatted.trimEnd())).toStrictEqual(
+      newlineOnlyEvent,
+    );
+  });
+});

--- a/packages/core/src/utils/output-format.ts
+++ b/packages/core/src/utils/output-format.ts
@@ -142,7 +142,7 @@ export class StreamJsonFormatter {
    * @returns JSON string with trailing newline
    */
   formatEvent(event: JsonStreamEvent): string {
-    return JSON.stringify(event) + '\\n';
+    return JSON.stringify(event) + '\n';
   }
 
   /**

--- a/scripts/fixtures/issue2208-newlines.responses.jsonl
+++ b/scripts/fixtures/issue2208-newlines.responses.jsonl
@@ -1,0 +1,1 @@
+{"chunks":[{"speaker":"ai","blocks":[{"type":"text","text":"## LLXPRT2208_ALPHA\n\nAlpha paragraph one.\n\n## LLXPRT2208_BETA\n\n- beta item one\n- beta item two\n\nLLXPRT2208_DONE"}]}]}

--- a/scripts/issue2208-noninteractive-repro.mjs
+++ b/scripts/issue2208-noninteractive-repro.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const startScript = path.join(scriptDir, 'start.js');
+const DEFAULT_PROFILES = ['gptfirst', 'gpt55high', 'opusthinking', 'glm'];
+const EXPECTED =
+  'LLXPRT2208_ALPHA\n\n' +
+  'Alpha paragraph one.\n\n' +
+  'LLXPRT2208_BETA\n\n' +
+  '- beta item one\n' +
+  '- beta item two\n\n' +
+  'LLXPRT2208_DONE';
+const PROMPT = `Return exactly this text and nothing else, preserving every line break: ${EXPECTED}`;
+
+function parseProfiles(argv) {
+  const profiles = argv.slice(2);
+  return profiles.length === 0 ? DEFAULT_PROFILES : profiles;
+}
+
+function parseAssistantOutput(stdout) {
+  return stdout
+    .split(/\n/)
+    .filter((line) => line.startsWith('{'))
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter((event) => event?.type === 'message' && event.role === 'assistant')
+    .map((event) => event.content)
+    .join('');
+}
+
+function runProfile(profile) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      startScript,
+      '--profile-load',
+      profile,
+      '--set',
+      'emojifilter=allowed',
+      '--output-format',
+      'stream-json',
+      '--prompt',
+      PROMPT,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: { ...process.env, FORCE_COLOR: '0' },
+      timeout: 300_000,
+    },
+  );
+
+  const assistant = parseAssistantOutput(result.stdout ?? '');
+  const passed = result.status === 0 && assistant === EXPECTED;
+  return { profile, result, assistant, passed };
+}
+
+function printFailure({ profile, result, assistant }) {
+  console.error(`\n[${profile}] failed`);
+  console.error(`exit status: ${String(result.status)}`);
+  console.error(`signal: ${String(result.signal ?? 'none')}`);
+  if (result.error) {
+    console.error(result.error.message);
+  }
+  console.error('--- expected ---');
+  console.error(JSON.stringify(EXPECTED));
+  console.error('--- actual ---');
+  console.error(JSON.stringify(assistant));
+  console.error('--- stderr ---');
+  console.error(result.stderr ?? '');
+}
+
+let failed = false;
+for (const profile of parseProfiles(process.argv)) {
+  const outcome = runProfile(profile);
+  if (outcome.passed) {
+    console.log(`[${profile}] preserved issue2208 line breaks`);
+    continue;
+  }
+  failed = true;
+  printFailure(outcome);
+}
+
+if (failed) {
+  process.exitCode = 1;
+}

--- a/scripts/issue2208-noninteractive-repro.mjs
+++ b/scripts/issue2208-noninteractive-repro.mjs
@@ -34,11 +34,13 @@ function parseAssistantOutput(stdout) {
     .map((line) => {
       try {
         return JSON.parse(line);
-      } catch {
-        return null;
+      } catch (error) {
+        throw new Error(
+          `Failed to parse stream-json line: ${line}\n${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     })
-    .filter((event) => event?.type === 'message' && event.role === 'assistant')
+    .filter((event) => event.type === 'message' && event.role === 'assistant')
     .map((event) => event.content)
     .join('');
 }

--- a/scripts/issue2208-tui-repro.mjs
+++ b/scripts/issue2208-tui-repro.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+
+const DEFAULT_PROFILES = ['gptfirst', 'gpt55high', 'opusthinking', 'glm'];
+const EXPECTED =
+  'LLXPRT2208_ALPHA\n\n' +
+  'Alpha paragraph one.\n\n' +
+  'LLXPRT2208_BETA\n\n' +
+  '- beta item one\n' +
+  '- beta item two\n\n' +
+  'LLXPRT2208_DONE';
+const PROMPT = `Return exactly this text and nothing else, preserving every line break: ${EXPECTED}`;
+
+function parseProfiles(argv) {
+  const profiles = argv.slice(2);
+  return profiles.length === 0 ? DEFAULT_PROFILES : profiles;
+}
+
+function validateProfile(profile) {
+  if (!/^[A-Za-z0-9._-]+$/.test(profile)) {
+    throw new Error(`Invalid profile name: ${profile}`);
+  }
+}
+
+function createScenario(profile) {
+  validateProfile(profile);
+  return {
+    tmux: {
+      cols: 72,
+      rows: 32,
+      historyLimit: 20000,
+      scrollbackLines: 3000,
+      initialWaitMs: 6000,
+    },
+    startCommand: [
+      `env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true node scripts/start.js --profile-load ${profile} --set emojifilter=allowed`,
+    ],
+    yolo: false,
+    steps: [
+      {
+        type: 'waitFor',
+        scope: 'screen',
+        contains: 'Type your message',
+        timeoutMs: 60000,
+      },
+      {
+        type: 'line',
+        text: PROMPT,
+        submitKeys: ['Enter'],
+        postTypeMs: 1000,
+      },
+      {
+        type: 'waitFor',
+        scope: 'scrollback',
+        contains: 'LLXPRT2208_DONE',
+        timeoutMs: 180000,
+      },
+      {
+        type: 'capture',
+        label: `issue2208-newlines-${profile}`,
+        scope: 'scrollback',
+      },
+      {
+        type: 'expect',
+        scope: 'scrollback',
+        regex:
+          'LLXPRT2208_ALPHA[\\s\\S]*Alpha paragraph one\\.[\\s\\S]*LLXPRT2208_BETA[\\s\\S]*[-*] beta item one[\\s\\S]*[-*] beta item two[\\s\\S]*LLXPRT2208_DONE',
+      },
+      { type: 'key', key: 'Escape' },
+      { type: 'key', key: 'C-c' },
+      { type: 'key', key: 'C-c' },
+      { type: 'line', text: '/quit', submitKeys: ['Enter'] },
+      { type: 'waitForExit', timeoutMs: 15000 },
+    ],
+  };
+}
+
+function runProfile(profile) {
+  validateProfile(profile);
+  const outDir = mkdtempSync(
+    path.join(tmpdir(), `llxprt-issue2208-tui-${profile}-`),
+  );
+  const scriptPath = path.join(outDir, 'scenario.json');
+  writeFileSync(scriptPath, JSON.stringify(createScenario(profile), null, 2));
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      'scripts/tmux-harness.js',
+      '--script',
+      scriptPath,
+      '--out-dir',
+      outDir,
+      '--assert',
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      stdio: 'inherit',
+      timeout: 300_000,
+    },
+  );
+
+  if (result.error) {
+    console.error(`[${profile}] ${result.error.message}`);
+  }
+  if (result.status === null && result.signal) {
+    console.error(`[${profile}] timed out or was terminated: ${result.signal}`);
+  }
+  if (result.status === 0) {
+    console.log(`[${profile}] TUI preserved issue2208 line breaks`);
+    rmSync(outDir, { recursive: true, force: true });
+    return true;
+  }
+  console.error(`[${profile}] TUI repro failed; artifacts: ${outDir}`);
+  return false;
+}
+
+let failed = false;
+for (const profile of parseProfiles(process.argv)) {
+  if (!runProfile(profile)) {
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exitCode = 1;
+}

--- a/scripts/issue2208-tui-repro.mjs
+++ b/scripts/issue2208-tui-repro.mjs
@@ -5,7 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -30,6 +36,60 @@ function validateProfile(profile) {
   if (!/^[A-Za-z0-9._-]+$/.test(profile)) {
     throw new Error(`Invalid profile name: ${profile}`);
   }
+}
+
+function normalizeCapturedLine(line) {
+  return line
+    .replace(/█/g, '')
+    .replace(/^\s*│\s?/, '')
+    .trimEnd();
+}
+
+function normalizeCapturedAssistantText(text) {
+  return text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(normalizeCapturedLine)
+    .join('\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n[ \t]+/g, '\n')
+    .trim();
+}
+
+function extractAssistantOutput(scrollback) {
+  const normalized = normalizeCapturedAssistantText(scrollback);
+  const alphaIndex = normalized.lastIndexOf('LLXPRT2208_ALPHA');
+  if (alphaIndex < 0) {
+    throw new Error('Captured scrollback did not contain LLXPRT2208_ALPHA');
+  }
+  const doneIndex = normalized.indexOf('LLXPRT2208_DONE', alphaIndex);
+  if (doneIndex < 0) {
+    throw new Error(
+      'Captured scrollback did not contain LLXPRT2208_DONE after LLXPRT2208_ALPHA',
+    );
+  }
+  return normalized.slice(alphaIndex, doneIndex + 'LLXPRT2208_DONE'.length);
+}
+
+function validateCapturedOutput(profile, outDir) {
+  const captureFile = readdirSync(outDir).find((fileName) =>
+    fileName.endsWith(`-issue2208-newlines-${profile}-scrollback.txt`),
+  );
+  if (!captureFile) {
+    throw new Error(`Missing issue2208 capture file in ${outDir}`);
+  }
+  const actual = extractAssistantOutput(
+    readFileSync(path.join(outDir, captureFile), 'utf8'),
+  );
+  if (actual !== EXPECTED) {
+    console.error(`[${profile}] captured assistant output mismatch`);
+    console.error('--- expected ---');
+    console.error(JSON.stringify(EXPECTED));
+    console.error('--- actual ---');
+    console.error(JSON.stringify(actual));
+    return false;
+  }
+  return true;
 }
 
 function createScenario(profile) {
@@ -69,12 +129,6 @@ function createScenario(profile) {
         type: 'capture',
         label: `issue2208-newlines-${profile}`,
         scope: 'scrollback',
-      },
-      {
-        type: 'expect',
-        scope: 'scrollback',
-        regex:
-          'LLXPRT2208_ALPHA[\\s\\S]*Alpha paragraph one\\.[\\s\\S]*LLXPRT2208_BETA[\\s\\S]*[-*] beta item one[\\s\\S]*[-*] beta item two[\\s\\S]*LLXPRT2208_DONE',
       },
       { type: 'key', key: 'Escape' },
       { type: 'key', key: 'C-c' },
@@ -117,7 +171,7 @@ function runProfile(profile) {
   if (result.status === null && result.signal) {
     console.error(`[${profile}] timed out or was terminated: ${result.signal}`);
   }
-  if (result.status === 0) {
+  if (result.status === 0 && validateCapturedOutput(profile, outDir)) {
     console.log(`[${profile}] TUI preserved issue2208 line breaks`);
     rmSync(outDir, { recursive: true, force: true });
     return true;

--- a/scripts/tests/interactive-ui.test.ts
+++ b/scripts/tests/interactive-ui.test.ts
@@ -160,4 +160,23 @@ describe('Interactive UI (tmux harness)', () => {
     },
     300_000,
   );
+
+  runTmuxE2E(
+    'preserves assistant markdown hard line breaks',
+    () => {
+      const result = runHarness(
+        'tmux-script.issue2208-newlines.fake.json',
+        'issue2208-newlines',
+        [],
+        {
+          LLXPRT_FAKE_RESPONSES: path.join(
+            projectRoot,
+            'scripts/fixtures/issue2208-newlines.responses.jsonl',
+          ),
+        },
+      );
+      assertHarnessSuccess(result);
+    },
+    300_000,
+  );
 });

--- a/scripts/tmux-script.issue2208-newlines.fake.json
+++ b/scripts/tmux-script.issue2208-newlines.fake.json
@@ -1,0 +1,64 @@
+{
+  "tmux": {
+    "cols": 72,
+    "rows": 32,
+    "historyLimit": 20000,
+    "scrollbackLines": 3000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_CODE_WELCOME_CONFIG_PATH=scripts/fixtures/welcome-completed.json LLXPRT_CODE_SYSTEM_SETTINGS_PATH=scripts/system-settings.interactive-ui.json LLXPRT_FAKE_RESPONSES=scripts/fixtures/issue2208-newlines.responses.jsonl ${node} packages/cli/dist/index.js --provider fake --model fake-model"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 30000
+    },
+    {
+      "type": "line",
+      "text": "Echo the LLXPRT2208 markdown fixture exactly.",
+      "submitKeys": ["Enter"],
+      "postTypeMs": 1000
+    },
+    {
+      "type": "waitFor",
+      "scope": "scrollback",
+      "contains": "LLXPRT2208_DONE",
+      "timeoutMs": 30000
+    },
+    { "type": "capture", "label": "issue2208-newlines", "scope": "scrollback" },
+    {
+      "type": "expect",
+      "scope": "scrollback",
+      "regex": "LLXPRT2208_ALPHA\\n\\s*\\n\\s*Alpha paragraph one\\."
+    },
+    {
+      "type": "expect",
+      "scope": "scrollback",
+      "regex": "LLXPRT2208_BETA\\n\\s*\\n\\s*[-*] beta item one"
+    },
+    {
+      "type": "expect",
+      "scope": "scrollback",
+      "regex": "beta item two\\n\\s*\\n\\s*LLXPRT2208_DONE"
+    },
+    {
+      "type": "expect",
+      "scope": "scrollback",
+      "regex": "LLXPRT2208_ALPHA(?!Alpha paragraph one)"
+    },
+    {
+      "type": "expect",
+      "scope": "scrollback",
+      "regex": "LLXPRT2208_BETA(?![-*] beta item one)"
+    },
+    { "type": "key", "key": "Escape" },
+    { "type": "key", "key": "C-c" },
+    { "type": "key", "key": "C-c" },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #2208.

- preserve assistant text chunks that are only whitespace/newlines through Turn streaming
- fix stream-json output-format resolution and JSONL newline delimiters
- ensure stream-json emits emoji-filter flushes as JSON records
- add fake-provider TUI regression coverage plus live repro helpers for the affected profiles

## Evidence

- Raw provider SSE for gpt55high emitted newline-only deltas; the bug was in llxprt dropping trimmed-empty content chunks before stream-json/non-interactive/UI saw them.
- `node scripts/issue2208-noninteractive-repro.mjs gptfirst gpt55high opusthinking glm` preserved the expected hard line breaks for all four profiles.
- `node scripts/issue2208-tui-repro.mjs gpt55high glm` preserved the expected line breaks in live TUI repros.

## Verification

- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run build`
- `npm run lint:eslint-guard`
- `LLXPRT_E2E_TMUX=1 npm run test:interactive-ui`
- `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"`
- Open Code Review completed; actionable findings were addressed.
