### PR TITLE
Harden ESLint policy guard (Fixes #2189)

### DIFF
--- a/scripts/check-eslint-guard.js
+++ b/scripts/check-eslint-guard.js
@@ -58,13 +58,28 @@ function resolveBase(base, head) {
   }
 }
 
+// A generous unified context (20 lines) ensures that common multiline rule
+// config changes in eslint.config.js include the enclosing rules: { block
+// and rule key context lines, so multiline severity/threshold detection
+// (which relies on rulesBraceDepth and currentCeilingRuleKey/currentRuleKey
+// context tracking) works in production CI, not just in context-rich test
+// fixtures. Multiline rule config objects in this project can have the rule
+// key more than 5 lines above the changed severity/max field (e.g. a
+// ceiling rule with many options), so a 5-line context would drop the rule
+// key outside the hunk and lose rule attribution. 20 lines comfortably
+// covers the widest realistic single-rule config object while keeping diffs
+// reviewable. Guard behavior is more important than minimizing the diff
+// size. This limit is documented and exercised by tests with >5 lines
+// between the rule key and the changed field.
+const DIFF_CONTEXT_LINES = '20';
+
 function diffFromGit(base, head) {
   const resolvedBase = resolveBase(base, head);
 
   if (head === 'HEAD') {
     return git([
       'diff',
-      '--unified=0',
+      '--unified=' + DIFF_CONTEXT_LINES,
       '--no-ext-diff',
       resolvedBase,
       '--',
@@ -74,7 +89,7 @@ function diffFromGit(base, head) {
 
   return git([
     'diff',
-    '--unified=0',
+    '--unified=' + DIFF_CONTEXT_LINES,
     '--no-ext-diff',
     resolvedBase + '...' + head,
     '--',
@@ -113,7 +128,63 @@ function isNewOffRule(line) {
   return (
     /:\s*['"]off['"]/.test(line) ||
     /:\s*0\b/.test(line) ||
-    /\[\s*['"]off['"]/.test(line)
+    /\[\s*['"]off['"]/.test(line) ||
+    /\[\s*0\b/.test(line)
+  );
+}
+
+/**
+ * Returns true when the line is a rule-assignment-shaped entry: it has an
+ * extractable rule key (e.g. "'no-console': ...") so the off/0 value is the
+ * rule's severity, not an unrelated config field. This gates off/0 detection
+ * so that fields like "mode: 'off'" or "level: 0" outside rule contexts do not
+ * produce false positives.
+ */
+function isRuleAssignmentLine(line) {
+  return extractRuleKey(line) !== null;
+}
+
+/**
+ * Returns true when the line is a rule off/0 entry suitable for the off/0
+ * policy gate. When insideRulesBlock is true, any extractable rule key
+ * qualifies (structural context disambiguates option fields). When false
+ * (zero-context or after a closed rules block), only quoted rule keys or known
+ * ceiling rules qualify, so unquoted unknown identifiers like
+ * `experimental: "off"` in unrelated objects are not mistaken for rule
+ * severities.
+ *
+ * When insideRuleEntry is true (we are inside an existing multiline rule config
+ * object), this returns false entirely: STRUCTURAL_KEYS cannot cover every
+ * custom/plugin-specific option field, so an extractable key such as
+ * customOption would be mistaken for a rule assignment. Only the standalone
+ * multiline severity form (isStandaloneOffRuleValue) applies inside a rule
+ * config object, for actual first-element 'off' or 0 values.
+ */
+function isRuleOffEntry(line, insideRulesBlock, insideRuleEntry = false) {
+  if (insideRuleEntry) {
+    return false;
+  }
+  if (!isRuleAssignmentLine(line)) {
+    return false;
+  }
+  if (insideRulesBlock) {
+    return true;
+  }
+  const key = extractRuleKey(line);
+  if (key === null) {
+    return false;
+  }
+  if (CEILING_RULES.has(key)) {
+    return true;
+  }
+  // A quoted rule key (e.g. 'no-console') is a strong rule-assignment signal.
+  // Unquoted identifiers (e.g. experimental) are ambiguous outside a rules
+  // block and are excluded to avoid false positives. Uses the same centralized
+  // RULE_ID_CHARS character class (including the @ scope marker) as
+  // extractRuleKey so scoped rule keys like '@typescript-eslint/no-explicit-any'
+  // are recognized consistently (#2189 review finding).
+  return new RegExp('[\'"]\\s*[' + RULE_ID_CHARS + ']+\\s*[\'"]\\s*:').test(
+    line,
   );
 }
 
@@ -125,6 +196,22 @@ function shouldCheckInlineDirective(file) {
   if (isGeneratedGuardFixture(file)) {
     return false;
   }
+  return /\.(?:cjs|mjs|js|jsx|ts|tsx)$/.test(file);
+}
+
+/**
+ * Determines whether TypeScript suppression directives in a file should be
+ * scanned. Unlike shouldCheckInlineDirective, this does NOT exempt the guard
+ * implementation/test fixture files: TS suppression detection
+ * (hasTypeScriptSuppression) skips string, template, and regex literals, so
+ * directive text used as data in fixture strings cannot trigger a false
+ * positive. This ensures a real TS suppression directive (at-ts-ignore,
+ * at-ts-expect-error, at-ts-nocheck) added to scripts/check-eslint-guard.js or
+ * its test is still rejected, splitting the ESLint-directive fixture exemption
+ * (which is needed because eslint-disable text appears in fixture
+ * strings/regexes) from TS suppression scanning.
+ */
+function shouldCheckTypeScriptSuppression(file) {
   return /\.(?:cjs|mjs|js|jsx|ts|tsx)$/.test(file);
 }
 
@@ -158,6 +245,14 @@ function skipQuoted(line, start, quote) {
 }
 
 function skipRegex(line, start) {
+  // Limitation: this is a single-line, character-class-aware regex skipper,
+  // not a full lexer. It does not handle division-vs-regex disambiguation via
+  // ASI (the canStartRegex heuristic suffices for this project's source), nor
+  // template literals with embedded ${}. These trade-offs are acceptable
+  // because the guard scans one diff line at a time and the target patterns
+  // (eslint directives, TS suppressions) are never valid regex/division
+  // operands in practice. Lines with exotic constructs are rare and any
+  // residual false positive is caught by review.
   let inCharacterClass = false;
   for (let i = start + 1; i < line.length; i++) {
     const ch = line[i];
@@ -181,6 +276,17 @@ function skipRegex(line, start) {
 }
 
 const DIRECTIVE_PATTERN = /eslint-(?:disable|enable)(?:-next-line|-line)?\b/;
+
+// TypeScript suppression directives (@ts-ignore, @ts-expect-error, @ts-nocheck)
+// are only effective when they appear at the START of the comment text (after
+// optional whitespace). This was verified against TypeScript 5.8.3 (the repo's
+// version) via focused compiler tests: a directive preceded by leading prose
+// (e.g. "// see notes @ts-ignore" or "/* prose @ts-ignore */") is NOT an
+// effective suppression and the compiler reports the error as usual. This
+// start-of-comment anchoring is therefore compiler-accurate: it matches exactly
+// the directives the TypeScript compiler would treat as effective suppressions.
+const TS_SUPPRESSION_START_PATTERN =
+  /^\s*@(?:ts-ignore|ts-expect-error|ts-nocheck)\b/;
 const TYPE_ESCAPE_PATTERNS = [
   { pattern: /@ts-expect-error\b/, label: '@ts-expect-error' },
   { pattern: /@ts-ignore\b/, label: '@ts-ignore' },
@@ -246,8 +352,1710 @@ export function hasInlineEslintDirective(line) {
   return false;
 }
 
+/**
+ * Returns true when the line contains a TypeScript suppression directive
+ * (@ts-ignore, @ts-expect-error, @ts-nocheck) inside a real comment. String
+ * and regex literals are skipped so text mentioning these directives does not
+ * produce false positives. This reuses the same string/regex-aware scanning
+ * approach as hasInlineEslintDirective.
+ *
+ * Multiline block-comment behavior (verified against TypeScript 5.8.3):
+ * TypeScript only recognizes these directives as effective suppressions when
+ * they appear in a line comment or a single-line block comment where the
+ * directive is at the start of the comment text (after optional whitespace).
+ * A directive on a continuation line of a multiline block comment (e.g.
+ * "* @ts-ignore" on line 2 of a multi-line comment) is NOT an effective
+ * suppression and is not flagged here, avoiding false positives on prose that
+ * merely mentions the directive. The guard processes one line at a time, so a
+ * multiline block comment opener like "/* @ts-ignore" (without a same-line
+ * closer) IS flagged as a conservative measure — while TS 5.8.3 does not treat
+ * it as an effective suppression, flagging it errs on the side of
+ * caution and avoids any risk of a real suppression slipping through.
+ */
+export function hasTypeScriptSuppression(line) {
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipQuoted(line, i, ch);
+      continue;
+    }
+    if (ch !== '/') {
+      continue;
+    }
+    const next = line[i + 1];
+    if (next === '/') {
+      return TS_SUPPRESSION_START_PATTERN.test(line.slice(i + 2));
+    }
+    if (next === '*') {
+      const end = line.indexOf('*/', i + 2);
+      const comment = line.slice(i + 2, end === -1 ? undefined : end);
+      if (TS_SUPPRESSION_START_PATTERN.test(comment)) {
+        return true;
+      }
+      if (end === -1) {
+        return false;
+      }
+      i = end + 1;
+      continue;
+    }
+    if (canStartRegex(line, i)) {
+      i = skipRegex(line, i);
+    }
+  }
+  return false;
+}
+
+/**
+ * Scans a line for a real TypeScript suppression directive
+ * (@ts-ignore/@ts-expect-error/@ts-nocheck) in executable code, given the
+ * template-literal state at the start of the line. This is the template-aware
+ * counterpart to hasTypeScriptSuppression: it distinguishes template literal
+ * TEXT (where directive text is inert) from template ${ ... } EXPRESSION code
+ * (where an at-ts-ignore line comment is a real, effective comment) and from
+ * code outside any template.
+ *
+ * A suppression is reported only when a line or block comment containing the
+ * directive is found in EXECUTABLE context (outside a template, or inside a
+ * template ${ ... } expression). Directive text in template literal text is
+ * inert and not reported.
+ *
+ * The incoming state { inTemplate, exprDepth } mirrors scanTemplateLiteralState
+ * so a line can start inside an already-open expression (exprDepth > 0) and a
+ * real suppression comment there is still caught (#2189 review finding).
+ */
+export function hasTypeScriptSuppressionInState(line, incoming) {
+  const initialState =
+    typeof incoming === 'boolean'
+      ? { inTemplate: incoming, exprDepth: 0 }
+      : incoming;
+  let inTemplate = initialState.inTemplate;
+  let exprDepth = initialState.exprDepth;
+  let quote = null;
+  let escaped = false;
+  let i = 0;
+
+  while (i < line.length) {
+    const ch = line[i];
+    const next = line[i + 1];
+
+    if (escaped) {
+      escaped = false;
+      i += 1;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      i += 1;
+      continue;
+    }
+
+    // Inside a quote (within expression code): skip until the matching quote.
+    if (quote !== null) {
+      if (ch === quote) {
+        quote = null;
+      }
+      i += 1;
+      continue;
+    }
+
+    // Comments in EXECUTABLE context only: outside a template, or inside a
+    // template ${ ... } expression (exprDepth > 0). Inside template literal
+    // TEXT (inTemplate && exprDepth === 0), // and /* are inert characters.
+    const inExecutable = !inTemplate || exprDepth > 0;
+    if (inExecutable) {
+      if (ch === '/' && next === '/') {
+        // Line comment in executable code: check for a TS suppression.
+        return TS_SUPPRESSION_START_PATTERN.test(line.slice(i + 2));
+      }
+      if (ch === '/' && next === '*') {
+        const end = line.indexOf('*/', i + 2);
+        const comment = line.slice(i + 2, end === -1 ? undefined : end);
+        if (TS_SUPPRESSION_START_PATTERN.test(comment)) {
+          return true;
+        }
+        if (end === -1) {
+          return false;
+        }
+        i = end + 2;
+        continue;
+      }
+      // Regex disambiguation in executable code (outside template text).
+      if (!inTemplate && ch === '/' && canStartRegex(line, i)) {
+        i = skipRegex(line, i);
+        continue;
+      }
+    }
+
+    // Track quotes inside expression code so a // or ${ inside a string is
+    // not mistaken for a comment or expression opener.
+    if (inExecutable && (ch === '"' || ch === "'")) {
+      quote = ch;
+      i += 1;
+      continue;
+    }
+
+    if (!inTemplate) {
+      // Outside any template: a backtick opens a template literal.
+      if (ch === '`') {
+        inTemplate = true;
+        exprDepth = 0;
+      }
+      i += 1;
+      continue;
+    }
+
+    // Inside a template literal.
+    if (exprDepth === 0) {
+      // Literal text context.
+      if (ch === '$' && next === '{') {
+        exprDepth += 1;
+        i += 2;
+        continue;
+      }
+      if (ch === '`') {
+        inTemplate = false;
+      }
+      i += 1;
+      continue;
+    }
+
+    // Inside a template ${ ... } expression (exprDepth > 0).
+    if (ch === '`') {
+      // A nested template literal inside the expression. Skip its body to
+      // its closing backtick so its contents do not affect outer state.
+      // Nested templates may themselves contain ${...}; track depth.
+      i += 1;
+      let nExpr = 0;
+      let nQuote = null;
+      let nEscaped = false;
+      while (i < line.length) {
+        const nch = line[i];
+        const nnext = line[i + 1];
+        if (nEscaped) {
+          nEscaped = false;
+          i += 1;
+          continue;
+        }
+        if (nch === '\\') {
+          nEscaped = true;
+          i += 1;
+          continue;
+        }
+        if (nQuote !== null) {
+          if (nch === nQuote) {
+            nQuote = null;
+          }
+          i += 1;
+          continue;
+        }
+        if (nch === '"' || nch === "'") {
+          nQuote = nch;
+          i += 1;
+          continue;
+        }
+        if (nch === '$' && nnext === '{') {
+          nExpr += 1;
+          i += 2;
+          continue;
+        }
+        if (nch === '{') {
+          nExpr += 1;
+          i += 1;
+          continue;
+        }
+        if (nch === '}' && nExpr > 0) {
+          nExpr -= 1;
+          i += 1;
+          continue;
+        }
+        if (nch === '`' && nExpr === 0) {
+          // Position at the closing backtick; the outer loop will advance
+          // past it on the next iteration.
+          break;
+        }
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === '{') {
+      exprDepth += 1;
+      i += 1;
+      continue;
+    }
+    if (ch === '}') {
+      if (exprDepth > 0) {
+        exprDepth -= 1;
+      }
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+  return false;
+}
+
+/**
+ * Tracks template literal state across diff lines so the guard can tell whether
+ * an added line starts inside template literal TEXT (where directive text like
+ * an at-ts-ignore line comment is inert) or inside a template ${ ... }
+ * EXPRESSION (where such a comment is real, effective executable code).
+ *
+ * The incoming state is { inTemplate, exprDepth } carried from the previous
+ * diff line (or the initial { inTemplate: false, exprDepth: 0 }). This returns
+ * the state after processing the content line:
+ *   - inTemplate: true when the line ends inside an unclosed backtick template
+ *     literal.
+ *   - exprDepth: when inTemplate is true, tracks the depth of ${ ... }
+ *     substitution expressions at the end of the line. At exprDepth > 0 the
+ *     line ends inside an expression inside a template (not in the literal
+ *     text), so a following line that opens a suppression comment is real
+ *     executable code that must be flagged.
+ *
+ * Carrying exprDepth across lines is essential: a line can start inside an
+ * already-open ${ ... } expression (exprDepth > 0), and only by preserving
+ * that depth can a subsequent line's } correctly return to literal-text
+ * context. A boolean-only inTemplate flag loses this, causing directive text
+ * inside a multiline ${ ... } expression to be mistaken for inert template
+ * body text (#2189 review finding).
+ *
+ * The optional incoming state defaults to { inTemplate: false, exprDepth: 0 }.
+ * For backward compatibility a bare boolean may be passed (treated as the
+ * inTemplate flag with exprDepth 0), which is used by the internal recursive
+ * nested-template scan.
+ *
+ * Limitations (documented, acceptable for directive scanning):
+ *   - Does not perform full JS lexing (ASI, regex disambiguation, etc.). The
+ *     heuristic tracks quotes, comments, backticks, and ${} nesting, which is
+ *     sufficient for this project's source where template literals with
+ *     directive text are the concern.
+ *   - A // comment inside a template line is treated as literal text (correct:
+ *     // has no special meaning inside a template literal).
+ */
+export function scanTemplateLiteralState(content, incoming) {
+  const initialState =
+    typeof incoming === 'boolean'
+      ? { inTemplate: incoming, exprDepth: 0 }
+      : incoming;
+  let inTemplate = initialState.inTemplate;
+  let i = 0;
+  let exprDepth = initialState.exprDepth;
+  let quote = null;
+  let escaped = false;
+
+  while (i < content.length) {
+    const ch = content[i];
+    const next = content[i + 1];
+
+    if (escaped) {
+      escaped = false;
+      i += 1;
+      continue;
+    }
+
+    // Skip comments so their contents do not affect state. Outside a
+    // template and inside a template ${ ... } expression (exprDepth > 0),
+    // // and /* are real comments. Inside template literal text
+    // (inTemplate && exprDepth === 0) they are literal characters with no
+    // special meaning. A // comment always ends the line, and a /* ...
+    // */ comment may span the rest of the line (a multiline /* that does
+    // not close is treated as consuming the remainder).
+    if (quote === null && (inTemplate ? exprDepth > 0 : !inTemplate)) {
+      if (ch === '/' && next === '/') {
+        break;
+      }
+      if (ch === '/' && next === '*') {
+        const end = content.indexOf('*/', i + 2);
+        i = end === -1 ? content.length : end + 2;
+        continue;
+      }
+    }
+
+    // Handle escape sequences inside quotes/templates.
+    if (ch === '\\') {
+      escaped = true;
+      i += 1;
+      continue;
+    }
+
+    // Inside a template literal, ${ opens a substitution expression and }
+    // closes it. At exprDepth > 0 we are in expression context where quotes
+    // and nested backticks are code, not literal text.
+    if (inTemplate) {
+      if (exprDepth === 0) {
+        // In literal text context: only } does not close anything, ${ opens
+        // an expression, and a backtick closes the template.
+        if (ch === '$' && next === '{') {
+          exprDepth += 1;
+          i += 2;
+          continue;
+        }
+        if (ch === '`') {
+          inTemplate = false;
+          i += 1;
+          continue;
+        }
+        i += 1;
+        continue;
+      }
+      // exprDepth > 0: inside a ${...} expression. Track braces, quotes, and
+      // nested backticks (which open a nested template tracked via recursion
+      // of the same state machine).
+      if (quote !== null) {
+        if (ch === quote) {
+          quote = null;
+        }
+        i += 1;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        i += 1;
+        continue;
+      }
+      if (ch === '`') {
+        // Nested template: recursively find its close.
+        const nested = scanTemplateLiteralState(content.slice(i + 1), true);
+        // scanTemplateLiteralState returns the state after the remaining
+        // substring; we need to advance past the nested template's close
+        // backtick. Since the recursive call operates on a suffix, we count
+        // how many chars it consumed. If the nested template is unclosed on
+        // this line, the entire remaining line is consumed inside it.
+        // Determine consumed length: if the nested call returned
+        // inTemplate=false, a closing backtick was found; find its position.
+        if (!nested.inTemplate) {
+          // Find the matching close backtick at exprDepth 0 of the nested
+          // template. scanTemplateLiteralState already consumed it, but we
+          // need the index. Re-scan to find the close position.
+          let ni = i + 1;
+          let nExpr = 0;
+          let nQuote = null;
+          let nEscaped = false;
+          while (ni < content.length) {
+            const nch = content[ni];
+            const nnext = content[ni + 1];
+            if (nEscaped) {
+              nEscaped = false;
+              ni += 1;
+              continue;
+            }
+            if (nch === '\\') {
+              nEscaped = true;
+              ni += 1;
+              continue;
+            }
+            if (nQuote !== null) {
+              if (nch === nQuote) {
+                nQuote = null;
+              }
+              ni += 1;
+              continue;
+            }
+            if (nch === '"' || nch === "'") {
+              nQuote = nch;
+              ni += 1;
+              continue;
+            }
+            if (nch === '$' && nnext === '{') {
+              nExpr += 1;
+              ni += 2;
+              continue;
+            }
+            if (nch === '{') {
+              nExpr += 1;
+              ni += 1;
+              continue;
+            }
+            if (nch === '}' && nExpr > 0) {
+              nExpr -= 1;
+              ni += 1;
+              continue;
+            }
+            if (nch === '`' && nExpr === 0) {
+              ni += 1;
+              break;
+            }
+            ni += 1;
+          }
+          i = ni;
+          continue;
+        }
+        // Nested template is unclosed on this line; the entire remaining
+        // content is inside it, so we stay in the outer template's expression
+        // at the current exprDepth. There is nothing more to process.
+        return { inTemplate: true, exprDepth };
+      }
+      if (ch === '{') {
+        exprDepth += 1;
+        i += 1;
+        continue;
+      }
+      if (ch === '}') {
+        exprDepth -= 1;
+        if (exprDepth === 0) {
+          // Exited the ${...} expression back to literal text context.
+        }
+        i += 1;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+
+    // Not inside a template literal. Track single-line quotes and backticks.
+    if (quote !== null) {
+      if (ch === quote) {
+        quote = null;
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '`') {
+      inTemplate = true;
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+
+  return { inTemplate, exprDepth };
+}
+
 function addViolation(violations, file, lineNumber, message, content) {
   violations.push({ file, lineNumber, message, content });
+}
+
+// --- ESLint config severity and ceiling-threshold detection (#2189) ---
+
+const CEILING_RULES = new Set([
+  'complexity',
+  'max-lines',
+  'max-lines-per-function',
+  'max-statements',
+  'max-params',
+  'max-depth',
+  'sonarjs/cognitive-complexity',
+]);
+
+const SEVERITY_RANK = { off: 0, 0: 0, warn: 1, 1: 1, error: 2, 2: 2 };
+
+// Centralized rule-id character class matching the full syntax of ESLint rule
+// IDs. Accepts:
+//   - Core rules: no-console, max-depth
+//   - Plugin rules (slash-separated): sonarjs/cognitive-complexity
+//   - Scoped plugin rules (npm-scope prefix): @typescript-eslint/no-explicit-any
+//   - Scoped rules with multiple path segments: @scope/plugin/rule-name
+// Used by extractRuleKey(), extractDirectValueAfterKey(), and isRuleOffEntry
+// () quoted-key detection so all three share identical rule-ID parsing
+// semantics, including the @ scope marker that was previously excluded
+// (#2189 review finding).
+const RULE_ID_CHARS = '@a-zA-Z0-9/_-';
+
+// Property keys that are clearly not rule names (e.g. files, rules, ignores,
+// settings, plugins, languageOptions, linterOptions) and common ESLint
+// rule-option properties (e.g. max, allow, skipBlankLines) that appear inside
+// rule config objects but are not rule keys themselves. Hoisted to module
+// scope so it is not recreated on every extractRuleKey call.
+const STRUCTURAL_KEYS = new Set([
+  'files',
+  'rules',
+  'ignores',
+  'settings',
+  'plugins',
+  'languageOptions',
+  'linterOptions',
+  'globals',
+  'parserOptions',
+  'reportUnusedDisableDirectives',
+  'processor',
+  'allow',
+  'name',
+  'message',
+  'selector',
+  'paths',
+  'patterns',
+  'group',
+  'importNames',
+  'max',
+  'min',
+  'maxDepth',
+  'maxLen',
+  'skipBlankLines',
+  'skipComments',
+  'IIFEs',
+  'ignoreTopLevelFunctions',
+  'ignorePattern',
+  'ignorePatterns',
+  'options',
+  'properties',
+  'property',
+  'var',
+  'before',
+  'after',
+  'level',
+  'type',
+  'value',
+  'description',
+  'mode',
+  'limit',
+  'count',
+  'threshold',
+  'severity',
+  'depth',
+  'env',
+  'rulesdir',
+  'extends',
+  'overrides',
+  'excludedFiles',
+]);
+
+/**
+ * Extracts the ESLint rule key from a config line or inline segment. Handles
+ * quoted and unquoted keys, including namespaced rules like
+ * 'sonarjs/cognitive-complexity'. Returns null if no rule key is found.
+ *
+ * The extraction is ANCHORED: the rule key must appear at the START of the
+ * trimmed input (after leading whitespace). This prevents misparsing nested
+ * properties as rule keys — a segment like
+ * `'custom-rules': { complexity: ['error', 50] }` yields `custom-rules` (the
+ * top-level key), never `complexity` (a nested property). Without anchoring,
+ * extractRuleKey would take the first rule-like property anywhere in the
+ * segment, producing false positives for unrelated nested config fields
+ * (#2189 review finding).
+ *
+ * Examples:
+ *   "      'no-console': 'error'," -> "no-console"
+ *   "      complexity: ['error', 25]," -> "complexity"
+ *   "'custom-rules': { complexity: [...] }" -> "custom-rules" (not complexity)
+ */
+export function extractRuleKey(line) {
+  const match = new RegExp('^[\'"]?([' + RULE_ID_CHARS + ']+)[\'"]?\\s*:').exec(
+    line.trim(),
+  );
+  if (match === null) {
+    return null;
+  }
+  // Reject property keys that are clearly not rule names (e.g. files, rules,
+  // ignores, settings, plugins, languageOptions, linterOptions) and common
+  // ESLint rule-option properties (e.g. max, allow, skipBlankLines) that
+  // appear inside rule config objects but are not rule keys themselves.
+  const key = match[1];
+  if (STRUCTURAL_KEYS.has(key)) {
+    return null;
+  }
+  return key;
+}
+
+/**
+ * Extracts the first severity value from an ESLint rule config line.
+ * Recognises string severities ('error', 'warn', 'off') and numeric severities
+ * (2, 1, 0), in both colon form and array form.
+ *
+ * Returns the severity string ('error', 'warn', 'off') or null if not found.
+ */
+function extractSeverityValue(line) {
+  // Array form: ['error', ...] or [2, ...] or [ 'error', ...
+  const arrayMatch = /\[\s*['"]?(error|warn|off|2|1|0)['"]?\s*[,\]]/.exec(line);
+  if (arrayMatch !== null) {
+    return normalizeSeverity(arrayMatch[1]);
+  }
+  // Colon form: 'rule': 'error'  or  'rule': 2
+  const colonMatch = /:\s*['"]?(error|warn|off|2|1|0)['"]?\s*[,\]}]/.exec(line);
+  if (colonMatch !== null) {
+    return normalizeSeverity(colonMatch[1]);
+  }
+  return null;
+}
+
+function normalizeSeverity(raw) {
+  switch (raw) {
+    case 'error':
+    case '2':
+      return 'error';
+    case 'warn':
+    case '1':
+      return 'warn';
+    case 'off':
+    case '0':
+      return 'off';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extracts a numeric threshold from an ESLint rule config line.
+ *
+ * Supports two forms for ceiling rules:
+ *   1. Simple numeric array: complexity: ['error', 25] -> 25
+ *   2. Object max form: 'max-lines': ['error', { max: 800 }] -> 800
+ *
+ * Returns { value, form } where form is 'numeric' or 'max', or null.
+ */
+function extractThresholdValue(line, ruleKey) {
+  if (!CEILING_RULES.has(ruleKey)) {
+    return null;
+  }
+
+  // Object max form: { max: 800 } or {max: 800}
+  const maxMatch = /\bmax\s*:\s*(\d+)/.exec(line);
+  if (maxMatch !== null) {
+    return { value: Number(maxMatch[1]), form: 'max' };
+  }
+
+  // Simple numeric array form: ['error', 25]
+  // The numeric value is the second element after the severity.
+  const numericMatch =
+    /\[\s*['"]?(?:error|warn|off|2|1|0)['"]?\s*,\s*(\d+)\s*[,\]]/.exec(line);
+  if (numericMatch !== null) {
+    return { value: Number(numericMatch[1]), form: 'numeric' };
+  }
+
+  return null;
+}
+
+/**
+ * Builds a normalized rule-state snapshot from a diff content line and its
+ * surrounding rule context. This unifies severity and threshold extraction
+ * across ALL ESLint rule config representations (keyed same-line, keyed opener,
+ * standalone multiline severity, standalone numeric threshold, standalone/object
+ * max) so that cross-form comparisons work: a removed multiline severity can be
+ * matched against an added same-line downgrade, and a removed standalone
+ * numeric threshold can be matched against an added same-line threshold
+ * increase (#2189 review finding).
+ *
+ * Parameters:
+ *   - content: the diff content line (without +/- prefix).
+ *   - ruleKey: the rule key attributed to this line by context tracking (may
+ *     be null for standalone lines with no key on the same line). For keyed
+ *     lines, extractRuleKey(content) takes precedence.
+ *   - isStandaloneSeverity: true when this line is a standalone multiline
+ *     severity value (isMultilineArraySeverityEntry or
+ *     isMultilineNumericSeverityEntry).
+ *   - isStandaloneNumericThreshold: true when this line is a standalone numeric
+ *     threshold line (isStandaloneNumericThresholdLine) inside a ceiling rule.
+ *   - isStandaloneMax: true when this line is a standalone max or object-form
+ *     max line (isStandaloneMaxLine or isObjectFormMaxLine).
+ *
+ * Returns { ruleKey, severity, threshold, thresholdForm } where severity is
+ * 'error'/'warn'/'off' or null, threshold is a number or null, thresholdForm
+ * is 'numeric' or 'max' or null, and ruleKey is the extracted/attributed key
+ * or null. Returns null when no rule key can be determined and no standalone
+ * severity/threshold form is recognized.
+ */
+function buildRuleState(
+  content,
+  ruleKey,
+  isStandaloneSeverity,
+  isStandaloneNumericThreshold,
+  isStandaloneMax,
+) {
+  // Keyed lines: the key on the line takes precedence over the context key.
+  const keyedRuleKey = extractRuleKey(content);
+  const effectiveKey = keyedRuleKey !== null ? keyedRuleKey : ruleKey;
+
+  let severity = null;
+  let threshold = null;
+  let thresholdForm = null;
+
+  if (isStandaloneSeverity) {
+    severity = normalizeMultilineSeverity(content);
+  } else if (effectiveKey !== null) {
+    // Keyed same-line or opener: extract severity and threshold from the
+    // full line. extractSeverityValue handles colon form, array form, etc.
+    severity = extractSeverityValue(content);
+    if (effectiveKey !== null && CEILING_RULES.has(effectiveKey)) {
+      const thresholdResult = extractThresholdValue(content, effectiveKey);
+      if (thresholdResult !== null) {
+        threshold = thresholdResult.value;
+        thresholdForm = thresholdResult.form;
+      }
+    }
+  }
+
+  if (isStandaloneNumericThreshold) {
+    threshold = extractStandaloneNumericThresholdValue(content);
+    thresholdForm = 'numeric';
+  }
+
+  if (isStandaloneMax) {
+    threshold = extractMaxValueFromStandaloneLine(content);
+    thresholdForm = 'max';
+  }
+
+  if (effectiveKey === null && severity === null && threshold === null) {
+    return null;
+  }
+
+  return { ruleKey: effectiveKey, severity, threshold, thresholdForm };
+}
+
+/**
+ * Returns true when a line has the shape of an ESLint rule severity assignment
+ * (a rule-like key whose value is a severity) and is NOT a general JS
+ * declaration/assignment statement. This is the stricter no-context fallback
+ * heuristic used by compareRuleConfigChanges to avoid false positives on
+ * unrelated object data that happens to use rule-like keys (e.g.
+ * `const docs = { 'no-console': 'error' }` or `docs = { ... }`).
+ *
+ * A line qualifies when it:
+ *   1. Extracts a rule key (extractRuleKey filters structural/option keys).
+ *   2. Carries a severity value (string or numeric, in colon or array form).
+ *   3. Does not begin with a JS statement keyword (const/let/var/function/
+ *      export/import/return/throw/if/for/while/switch) or contain an assignment
+ *      operator (= or =>) that would indicate arbitrary code rather than a
+ *      bare rule entry inside a rules object.
+ *
+ * The assignment-operator check rejects ordinary assignments such as
+ * `docs = { 'no-console': 'error' }` and `settings.rules = { ... }` while
+ * still allowing comparisons (==, ===, !=, <=, >=) and compound operators
+ * (+=, -=, etc.). This is essential because a bare rule entry inside a rules
+ * object never contains a `=` token.
+ */
+function isRuleSeverityAssignmentShape(line) {
+  if (extractRuleKey(line) === null) {
+    return false;
+  }
+  if (extractSeverityValue(line) === null) {
+    return false;
+  }
+  const trimmed = line.trim();
+  if (
+    /^(?:const|let|var|function|export|import|return|throw|if|for|while|switch|class|interface|type|enum)\b/.test(
+      trimmed,
+    )
+  ) {
+    return false;
+  }
+  if (/=>/.test(line) || hasAssignmentOperator(line)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns true when the line contains an ordinary assignment operator (=)
+ * that is NOT part of a comparison (==, ===, !=, <=, >=) or a compound
+ * operator (+=, -=, *=, etc.) or an arrow (=>). Used to reject statements
+ * like `docs = { ... }` or `settings.rules = { ... }` that are not bare rule
+ * entries inside a rules object.
+ */
+function hasAssignmentOperator(line) {
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] !== '=') {
+      continue;
+    }
+    const prev = line[i - 1];
+    const next = line[i + 1];
+    // Skip == and === (loose/strict equality): current '=' is followed by '='.
+    if (next === '=') {
+      continue;
+    }
+    // Skip !=, <=, >= and arrow =>: a comparison/arrow '=' is preceded by one
+    // of these operators.
+    if (prev === '=' || prev === '!' || prev === '<' || prev === '>') {
+      continue;
+    }
+    // Skip compound assignment operators (+=, -=, *=, /=, %=, &=, |=, ^=, etc.).
+    if (/[+\-*/%&|^~]/.test(prev)) {
+      continue;
+    }
+    // A bare '=' (not part of ==, =>, <=, >=, !=, or a compound op) is an
+    // ordinary assignment, which a bare rule entry never contains.
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Compares a removed line and an added line from eslint.config.js to detect
+ * severity downgrades and ceiling threshold loosening. Returns an array of
+ * violation message strings (empty if no violation).
+ *
+ * Both lines must be rule-severity-assignment-shaped: a rule-like key followed
+ * by a severity value, without the trappings of a general JS statement (const,
+ * let, var, function, or an = assignment operator). This stricter shape check
+ * prevents false positives on unrelated object data that happens to use
+ * rule-like keys, e.g. `const docs = { 'no-console': 'error' }` changed to
+ * `'warn'`, while still matching real rule assignment lines such as
+ * `      'no-console': 'warn',`.
+ *
+ * Ceiling threshold detection (for CEILING_RULES only):
+ *   1. Cross-form threshold increases: both the numeric array form
+ *      (complexity: ['error', 25]) and the object max form ('max-lines':
+ *      ['error', { max: 800 }]) are supported ceiling forms. A threshold
+ *      increase is reported whenever addedThreshold.value >
+ *      removedThreshold.value, regardless of form, so a rule cannot be
+ *      loosened by switching forms while raising the effective ceiling
+ *      (e.g. { max: 800 } -> 900, or 25 -> { max: 30 }).
+ *   2. Scalar-to-threshold addition: for CEILING_RULES, transitioning from a
+ *      scalar severity with no threshold (e.g. 'complexity': 'error') to any
+ *      explicit threshold (e.g. 'complexity': ['error', 999]) is forbidden
+ *      because it introduces a loose ceiling that did not exist before.
+ */
+function compareRuleConfigChanges(removedContent, addedContent) {
+  const messages = [];
+
+  if (
+    !isRuleSeverityAssignmentShape(removedContent) ||
+    !isRuleSeverityAssignmentShape(addedContent)
+  ) {
+    return messages;
+  }
+
+  const removedKey = extractRuleKey(removedContent);
+  const addedKey = extractRuleKey(addedContent);
+
+  // Only compare lines that target the same rule key.
+  if (removedKey === null || addedKey === null || removedKey !== addedKey) {
+    return messages;
+  }
+
+  const removedSeverity = extractSeverityValue(removedContent);
+  const addedSeverity = extractSeverityValue(addedContent);
+
+  if (removedSeverity !== null && addedSeverity !== null) {
+    const removedRank = SEVERITY_RANK[removedSeverity];
+    const addedRank = SEVERITY_RANK[addedSeverity];
+    if (addedRank < removedRank) {
+      messages.push(
+        `ESLint severity downgrade for '${addedKey}' (${removedSeverity} -> ${addedSeverity}) is forbidden by #2189.`,
+      );
+    }
+  }
+
+  const removedThreshold = extractThresholdValue(removedContent, removedKey);
+  const addedThreshold = extractThresholdValue(addedContent, addedKey);
+
+  // Reject transitions where a known ceiling rule that previously had only a
+  // scalar severity gains an explicit ceiling threshold. A scalar form like
+  // 'complexity': 'error' has no threshold (extractThresholdValue returns
+  // null), so the rule previously enforced the plugin default ceiling (or no
+  // ceiling). Adding any explicit threshold — even a small one — introduces a
+  // loose ceiling that did not exist before, which is forbidden for ceiling
+  // rules. This is strictly more restrictive than comparing numeric values:
+  // every threshold addition for a known ceiling rule is rejected regardless
+  // of the value.
+  if (
+    removedThreshold === null &&
+    addedThreshold !== null &&
+    CEILING_RULES.has(addedKey)
+  ) {
+    messages.push(
+      `Adding a ceiling threshold to '${addedKey}' is forbidden by #2189; ceiling rules must not gain an explicit loose ceiling.`,
+    );
+  }
+
+  // Compare addedThreshold.value > removedThreshold.value whenever both
+  // thresholds are non-null and the rule key matches, REGARDLESS of form. Both
+  // the numeric array form (complexity: ['error', 25]) and the object max form
+  // ('max-lines': ['error', { max: 800 }]) are supported ceiling forms, so a
+  // rule can be loosened by switching forms while increasing the effective
+  // ceiling (e.g. { max: 800 } -> 900, or 25 -> { max: 30 }). Comparing values
+  // across forms catches these cross-form increases; equal or decreased values
+  // are not flagged.
+  if (
+    removedThreshold !== null &&
+    addedThreshold !== null &&
+    addedThreshold.value > removedThreshold.value
+  ) {
+    messages.push(
+      `Ceiling threshold increase for '${addedKey}' (${removedThreshold.value} -> ${addedThreshold.value}) is forbidden by #2189.`,
+    );
+  }
+
+  return messages;
+}
+
+/**
+ * Checks whether an added eslint.config.js line is the first array element of
+ * a multiline rule config (e.g. a standalone severity string on its own line
+ * inside a [ ... ] array). Used to detect severity changes in multiline arrays
+ * where the removal and addition appear as separate diff lines but cannot be
+ * paired by key (they have no rule key on the same line).
+ */
+function isMultilineArraySeverityEntry(line) {
+  return /^\s*['"](error|warn|off)['"]\s*,?\s*(?:\/\/.*)?$/.test(line.trim());
+}
+
+function isMultilineNumericSeverityEntry(line) {
+  return /^\s*(2|1|0)\s*,?\s*(?:\/\/.*)?$/.test(line.trim());
+}
+
+function normalizeMultilineSeverity(line) {
+  const stringMatch = /^\s*['"](error|warn|off)['"]/.exec(line);
+  if (stringMatch !== null) {
+    return stringMatch[1];
+  }
+  const numericMatch = /^\s*(2|1|0)\b/.exec(line);
+  if (numericMatch !== null) {
+    return normalizeSeverity(numericMatch[1]);
+  }
+  return null;
+}
+
+/**
+ * Detects a standalone max threshold line inside a multiline ceiling rule
+ * config (e.g. "max: 800,"). Such lines have no rule key on the same line
+ * and must be correlated with context tracking to detect threshold increases.
+ * Accepts an optional quote around the key (e.g. "'max': 800,") since ESLint
+ * config object keys may be quoted.
+ */
+function isStandaloneMaxLine(line) {
+  return /^\s*['"]?max['"]?\s*:\s*\d+\s*,?\s*$/.test(line.trim());
+}
+
+/**
+ * Detects the project-common max object line shape inside a multiline ceiling
+ * rule config array, e.g. "{ max: 800, skipBlankLines: true, skipComments:
+ * true }". Such lines have no rule key on the same line (the key is the
+ * structural `max` option property) and must be correlated with context
+ * tracking (currentCeilingRuleKey) to detect threshold increases without
+ * matching unrelated max fields outside ceiling rules. Accepts an optional
+ * quote around the key (e.g. "{ 'max': 800, ... }") since ESLint config
+ * object keys may be quoted.
+ */
+function isObjectFormMaxLine(line) {
+  return /^\s*\{?\s*['"]?max['"]?\s*:\s*\d+\b/.test(line.trim());
+}
+
+/**
+ * Extracts the numeric value from a standalone max threshold line like
+ * "max: 800," or an object-form max line like "{ max: 800, skipBlankLines:
+ * true }". Accepts an optional quote around the key (e.g. "'max': 800").
+ * Returns null if no value is found.
+ */
+function extractMaxValueFromStandaloneLine(line) {
+  const match = /^\s*\{?\s*['"]?max['"]?\s*:\s*(\d+)/.exec(line);
+  return match !== null ? Number(match[1]) : null;
+}
+
+/**
+ * Detects a standalone numeric threshold line inside a multiline ceiling rule
+ * config in numeric-array form, e.g. "25," or "25". Such lines have no rule
+ * key on the same line and must be correlated with context tracking
+ * (expectingCeilingThreshold + currentCeilingRuleKey) to detect threshold
+ * increases without matching unrelated standalone numeric values. This matches
+ * any bare positive integer (including 0) on its own line, but the gating
+ * (expectingCeilingThreshold) ensures it is only treated as a threshold when
+ * it is the second array element after a severity (#2189 review finding).
+ */
+function isStandaloneNumericThresholdLine(line) {
+  return /^\s*\d+\s*,?\s*$/.test(line.trim());
+}
+
+/**
+ * Extracts the numeric value from a standalone numeric threshold line like
+ * "25," or "25". Returns null if no value is found.
+ */
+function extractStandaloneNumericThresholdValue(line) {
+  const match = /^\s*(\d+)\s*,?\s*$/.exec(line.trim());
+  return match !== null ? Number(match[1]) : null;
+}
+
+/**
+ * Returns true when a line closes a rule entry, clearing the ceiling rule key
+ * context so a subsequent standalone max line is not attributed to a prior
+ * ceiling rule. Covers common rule-entry closure shapes found in multiline
+ * ESLint rule configs:
+ *   - Array form:        "],"  or  "]"
+ *   - Object form:       "}],"  "} ],",  "}",  "} ,"
+ * The match is whitespace-tolerant and allows an optional trailing comma.
+ */
+
+/**
+ * Returns true when a line is a complete single-line rule entry that does not
+ * open a multiline config (i.e. all brackets/braces opened on the line are also
+ * closed on the line). This covers scalar entries like
+ *   "'no-console': 'error',"
+ * and inline-array/object entries like
+ *   "complexity: ['error', 25]," or "'max-lines': ['error', { max: 800 }],"
+ * which are fully closed on one line. Such entries do not need a subsequent
+ * closure line, so insideRuleEntry must NOT be set for them — otherwise a
+ * following multiline rule opener (e.g. "'max-lines': ['error', {") would be
+ * ignored (insideRuleEntry still pinned), causing the multiline rule's max
+ * changes to be missed (false negative) or mis-attributed.
+ *
+ * Returns false when the line carries a rule key but has unclosed brackets or
+ * braces (a multiline opener), or when it has no rule key at all.
+ *
+ * Note: unlike countDiffBraceDelta (which only tracks braces for rules-block
+ * depth), this function tracks BOTH brackets and braces because a rule entry
+ * opener may use either form ("'rule': [" or "'rule': {") and both indicate an
+ * unclosed multiline config.
+ */
+function isCompleteSingleLineRuleEntry(content) {
+  if (extractRuleKey(content) === null) {
+    return false;
+  }
+  return countDiffBracketAndBraceDelta(content) === 0;
+}
+
+/**
+ * Returns true when a multiline rule-entry opener line (e.g. "'rule': [") opens
+ * a bracket-delimited config array but does NOT contain the first array element
+ * (the severity) on the same line. In ESLint rule configs the first element of
+ * the array is always the severity, so when the opener has content after the
+ * opening bracket (e.g. "'rule': ['error',"), the severity is already present
+ * and subsequent standalone 'off'/0 lines are option values, not severities.
+ *
+ * This is used by updateStructuralContext to set the expectingFirstSeverity
+ * Element flag: when true, the next non-comment/non-blank line inside the rule
+ * entry is the first (severity) element, so standalone off/0 detection is
+ * valid; when false, the severity was already seen and standalone off/0 lines
+ * are option values (#2189 review finding).
+ *
+ * Returns false when the line does not open an unclosed bracket at all (e.g.
+ * a scalar entry or an object-form opener).
+ */
+function openerExpectsFirstArrayElement(content) {
+  // Only consider lines that open a rule-entry array (unclosed bracket).
+  if (countDiffBracketAndBraceDelta(content) <= 0) {
+    return false;
+  }
+  // Find the first opening bracket [ on the line and check if there is
+  // meaningful content (a severity value or any element) after it, respecting
+  // string literals and comments.
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+    const next = content[i + 1];
+    if (quote === null && ch === '/' && next === '/') {
+      break;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '[') {
+      // Check for non-whitespace, non-comment content after the bracket.
+      for (let j = i + 1; j < content.length; j++) {
+        const after = content[j];
+        if (after === '/' && content[j + 1] === '/') {
+          return false;
+        }
+        if (!/\s/.test(after)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Counts the net bracket+brace delta ({ } and [ ] minus their closings) of a
+ * diff content line, respecting string literals and // comments. Used by
+ * isCompleteSingleLineRuleEntry to determine whether a rule entry opens a
+ * multiline config (non-zero delta) or is complete on one line (zero delta).
+ */
+function countDiffBracketAndBraceDelta(line) {
+  let delta = 0;
+  let quote = null;
+  let escaped = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    const next = line[i + 1];
+    if (quote === null && ch === '/' && next === '/') {
+      break;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+    } else if (ch === '{' || ch === '[') {
+      delta += 1;
+    } else if (ch === '}' || ch === ']') {
+      delta -= 1;
+    }
+  }
+
+  return delta;
+}
+
+/**
+ * Returns true when the text preceding the `rules:` keyword at matchIndex in
+ * line indicates a valid ESLint flat-config export context. Recognizes three
+ * valid export-default config forms:
+ *   1. `export default [...]` — array of config objects
+ *   2. `export default { ... }` — a single config object
+ *   3. `export default tseslint.config(...)` / `export default eslint.config(
+ *      ...)` — the flat-config function-call wrapper used by this project
+ *      (see eslint.config.js). This form wraps config objects in a function
+ *      call that may itself take a plain config object argument, so the
+ *      `rules:` property inside it IS the policy rules block.
+ *
+ * The check is narrowly scoped: it only matches `export default` (not bare
+ * `export` or `export const`), and the text between `export default` and the
+ * `rules:` keyword must be only structural config syntax (the function-call
+ * wrapper identifier + `(`, or array/object openers, brackets, braces,
+ * commas, whitespace). This prevents a false positive on arbitrary exports
+ * like `export const config = { rules: { ... } }` (which has an identifier
+ * `config` and an assignment `=` between export and rules) and
+ * `export default someConfig` (which has an arbitrary identifier, not a
+ * recognized config wrapper or structural opener).
+ *
+ * Returns true when the line starts with `export default` followed by either
+ * a structural object/array opener (`[` / `{`) or a recognized flat-config
+ * function-call wrapper (e.g. `tseslint.config(` / `eslint.config(`) up to the
+ * rules: keyword match position.
+ */
+function isExportDefaultConfigContext(line, matchIndex) {
+  const before = line.slice(0, matchIndex);
+  const exportDefaultMatch = /^export\s+default\s+/.exec(before);
+  if (exportDefaultMatch === null) {
+    return false;
+  }
+  const afterExportDefault = before.slice(exportDefaultMatch[0].length);
+  // Form 1 & 2: the text immediately after `export default` starts with an
+  // array or object opener ([ or {). This matches the valid flat-config
+  // export forms `export default [...]` and `export default { ... }`. It
+  // rejects `export const config = {` (has `const config =` after export) and
+  // `export default someConfig` (has an identifier, not a structural opener).
+  if (/^[[{]/.test(afterExportDefault)) {
+    return true;
+  }
+  // Form 3: the flat-config function-call wrapper used by this project:
+  // `export default tseslint.config(` or `export default eslint.config(`. The
+  // config objects are passed as arguments to the config() helper, so a
+  // `rules:` property inside the call IS the policy rules block. The wrapper
+  // is narrowly matched: a dotted identifier (e.g. `tseslint.config`,
+  // `eslint.config`) immediately followed by `(`. Everything after the opening
+  // paren is treated as structural config syntax. This rejects arbitrary
+  // identifiers like `export default someConfig` (no `.config(` wrapper) and
+  // `export default foo({ rules: ... })` (unrecognized wrapper name).
+  return /^[$A-Za-z_][\w$]*\.config\s*\(/.test(afterExportDefault);
+}
+
+/**
+ * Returns true if the text preceding the `rules:` keyword at matchIndex in
+ * line indicates an arbitrary JS declaration/assignment rather than a bare
+ * property inside an ESLint config object. This gates `rules: {` detection so
+ * unrelated objects with a property named `rules` (e.g.
+ * `const meta = { rules: { 'no-console': 'error' } }` or
+ * `settings.rules = { ... }`) are not mistaken for an ESLint rule policy
+ * block.
+ *
+ * The check mirrors isRuleSeverityAssignmentShape: a real ESLint config rules
+ * property appears as a bare `rules: {` inside a config object, never preceded
+ * by a declaration keyword (const/let/var/function/etc.) or an ordinary
+ * assignment operator (=). This rejects obvious arbitrary declarations and
+ * assignments while allowing the bare property form used in eslint.config.js.
+ */
+function isRulesInArbitraryContext(line, matchIndex) {
+  const before = line.slice(0, matchIndex);
+  const trimmed = before.trim();
+  if (
+    /(?:const|let|var|function|export|import|return|throw|if|for|while|switch|class|interface|type|enum)\s/.test(
+      before,
+    )
+  ) {
+    return true;
+  }
+  // A bare `=` (not part of ==, ===, =>, <=, >=, !=, or compound ops) before
+  // the rules: keyword indicates an assignment, not a config property. This
+  // catches `settings.rules = { ... }` and `config = { rules: { ... } }`.
+  if (hasAssignmentOperator(before)) {
+    return true;
+  }
+  // An arrow function => before rules: indicates arbitrary code, not a
+  // config property.
+  if (/=>/.test(trimmed)) {
+    return true;
+  }
+  // A known non-rule container key (settings, languageOptions, plugins, etc.)
+  // opened earlier on the same line indicates the `rules:` property is nested
+  // inside application data, not an ESLint policy rules block. This catches
+  // single-line forms like `settings: { rules: { 'no-console': 'off' } }` and
+  // quoted-key forms like `'settings': { rules: { ... } }`
+  // (#2189 review finding 2).
+  //
+  // However, the container must STILL BE OPEN at the `rules:` match position.
+  // A closed container with a sibling `rules:` (e.g.
+  // `{ languageOptions: {}, rules: { complexity: ['error', 25] } }` or
+  // `export default [{ settings: {}, rules: { 'no-console': 'off' } }]`) is a
+  // valid ESLint flat-config object where `rules:` IS the policy rules block.
+  // Treating a merely-preceding (but closed) container as proof of nesting
+  // caused a false negative that suppressed real policy violations
+  // (#2189 review finding). The structural scan walks from each container
+  // opener to the `rules:` match, respecting strings, // comments, braces and
+  // brackets, and reports non-rule ONLY when the container object remains open
+  // (brace depth > 0) at `rules:`.
+  if (isRulesNestedInNonRuleContainer(line, matchIndex)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true when the `rules:` keyword at matchIndex in line is structurally
+ * nested inside a known non-rule container object (settings, languageOptions,
+ * plugins, etc.) that is still open at matchIndex. This is the structural
+ * counterpart to the previous "any container key appears before rules:" check
+ * in isRulesInArbitraryContext.
+ *
+ * For each non-rule container key found as `key: {` (an opener) before
+ * matchIndex, the function scans forward from that opener's opening brace to
+ * matchIndex, tracking net brace/bracket depth while skipping string literals
+ * and // comments. If the container remains open (depth > 0) at matchIndex,
+ * then `rules:` is nested inside application data (e.g.
+ * `settings: { rules: { ... } }`) and is NOT the ESLint policy rules block.
+ *
+ * If the container closes before matchIndex (depth <= 0), then `rules:` is a
+ * SIBLING (e.g. `{ languageOptions: {}, rules: { ... } }`) and IS the policy
+ * rules block — the function returns false so detection proceeds
+ * (#2189 review finding).
+ *
+ * Only the OUTERMOST still-open container at matchIndex matters: if a container
+ * opens, closes, and then `rules:` follows as a sibling, it returns false even
+ * if other container keys also appear earlier on the line. This is correct
+ * because a sibling `rules:` after ANY closed container is a real flat-config
+ * rules block.
+ */
+function isRulesNestedInNonRuleContainer(line, matchIndex) {
+  for (const key of NON_RULE_CONTAINER_KEYS) {
+    const openerPattern = propertyKeyRegex(key, true);
+    let searchFrom = 0;
+    // A line may contain the same container key more than once; check each
+    // occurrence as a potential opener.
+    for (;;) {
+      const match = openerPattern.exec(line.slice(searchFrom));
+      if (match === null) {
+        break;
+      }
+      const openerStart = searchFrom + match.index;
+      // The opener must precede the rules: match.
+      if (openerStart >= matchIndex) {
+        break;
+      }
+      // Find the opening brace '{' of the container value (the regex already
+      // requires it, so it is at openerStart + match[0].length - 1).
+      const bracePos = openerStart + match[0].length - 1;
+      if (line[bracePos] !== '{') {
+        searchFrom = openerStart + match[0].length;
+        continue;
+      }
+      if (containerOpenAtPosition(line, bracePos, matchIndex)) {
+        return true;
+      }
+      searchFrom = openerStart + match[0].length;
+    }
+  }
+  return false;
+}
+
+/**
+ * Scans from an opening brace at bracePos toward targetPos, tracking net
+ * brace/bracket depth while skipping string literals and // comments. Returns
+ * true when the object opened at bracePos is still open (depth > 0) at
+ * targetPos — i.e. targetPos falls structurally inside the container.
+ *
+ * Brackets ([ ]) are tracked alongside braces ({ }) so a closed bracketed
+ * value inside the container (e.g. an array in `settings: { a: [1], rules: {
+ * ... } }`) does not affect the brace-only nesting decision. The depth is
+ * brace-and-bracket combined; since the opener is a '{' (depth starts at 1),
+ * reaching depth 0 means the container closed.
+ */
+function containerOpenAtPosition(line, bracePos, targetPos) {
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  for (let i = bracePos; i < targetPos; i++) {
+    const ch = line[i];
+    const next = line[i + 1];
+    if (quote === null && ch === '/' && next === '/') {
+      // A // comment ends the line; the container is still open (its closing
+      // brace cannot appear after a // comment on the same line).
+      break;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '{' || ch === '[') {
+      depth += 1;
+    } else if (ch === '}' || ch === ']') {
+      depth -= 1;
+      if (depth <= 0) {
+        return false;
+      }
+    }
+  }
+  return depth > 0;
+}
+
+/**
+ * ESLint config property keys whose object value is a known non-rule container.
+ * A `rules:` property nested inside one of these (e.g.
+ * `settings: { rules: { 'no-console': 'off' } }`) is NOT the ESLint policy
+ * rules object — it is application data consumed by plugins/shared configs.
+ * Hoisted to module scope so it is not recreated on every call (#2189 review
+ * finding 2).
+ */
+const NON_RULE_CONTAINER_KEYS = new Set([
+  'settings',
+  'languageOptions',
+  'plugins',
+  'linterOptions',
+  'processor',
+  'globals',
+  'parserOptions',
+  'parser',
+  'env',
+  'extends',
+  'overrides',
+  'ecmaFeatures',
+  'sourceType',
+]);
+
+/**
+ * Builds a RegExp that matches a JavaScript property key followed by a colon
+ * and (optionally) an opening brace, accepting the key with optional
+ * single/double quotes around it. This shared helper centralizes the
+ * property-key regex construction that was previously duplicated as
+ * `\bKEY\s*:\s*\{` literal patterns in isRulesInArbitraryContext and
+ * isNonRuleContainerOpen, which missed quoted config keys such as
+ * `'settings': {` or `"languageOptions": {` (#2189 review finding).
+ *
+ * Parameters:
+ *   - key: the unquoted property key name (e.g. 'settings', 'rules').
+ *   - openBrace: when true, the pattern requires `\s*:\s*\{` (the key is
+ *     opening an object); when false (default), it requires just `\s*:` (the
+ *     key is present with a colon, no brace requirement).
+ *
+ * Returns a RegExp.
+ */
+function propertyKeyRegex(key, openBrace = false) {
+  const suffix = openBrace ? '\\s*:\\s*\\{' : '\\s*:';
+  // (?:^|[^\w]) ensures the key is not a substring of a larger identifier
+  // (e.g. so 'parser' does not match inside 'parserOptions'), while still
+  // allowing the key to be preceded by a quote, whitespace, or start of line.
+  // The optional quotes around the key support quoted config keys such as
+  // 'settings' or "languageOptions" (#2189 review finding).
+  return new RegExp('(?:^|[^\\w])[\'"]?' + key + '[\'"]?' + suffix);
+}
+
+/**
+ * Returns true when the line opens a known non-rule container property
+ * (e.g. `settings: {`, `languageOptions: {`) whose object value may legally
+ * contain a nested `rules:` property that is NOT the ESLint policy rules
+ * block. This is the context-tracking counterpart to isRulesBlockOpen: when
+ * inside such a container, a nested `rules: {` must not be treated as a
+ * policy rules block (#2189 review finding 2).
+ *
+ * Detects a bare property key from NON_RULE_CONTAINER_KEYS followed by an
+ * opening brace. Rejects declaration/assignment contexts (mirrors
+ * isRulesInArbitraryContext) so a const declaration with a settings property
+ * is handled by the arbitrary-object tracker instead.
+ */
+function isNonRuleContainerOpen(line) {
+  for (const key of NON_RULE_CONTAINER_KEYS) {
+    const pattern = propertyKeyRegex(key, true);
+    const match = pattern.exec(line);
+    if (match !== null && !isRulesInArbitraryContext(line, match.index)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if the line opens a rules: { ... } object in an eslint.config.js
+ * config block. Detects the "rules:" key followed by an opening brace. Rejects
+ * arbitrary declarations/assignments (e.g. const meta = { rules: { ... } })
+ * so unrelated config fields named "rules" do not produce false positives
+ * (#2189 review finding). The export-default flat-config form (e.g.
+ * `export default { rules: { ... } }`) is a valid ESLint config export and is
+ * allowed via isExportDefaultConfigContext (#2189 review finding).
+ */
+function isRulesBlockOpen(line) {
+  const match = propertyKeyRegex('rules', true).exec(line);
+  if (match === null) {
+    return false;
+  }
+  if (
+    isRulesInArbitraryContext(line, match.index) &&
+    !isExportDefaultConfigContext(line, match.index)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns true when a line opens an arbitrary JS object literal via a
+ * declaration keyword (const/let/var) or an assignment operator (=) followed
+ * by an opening brace, e.g. `const meta = {` or `meta = {`. This is used to
+ * track arbitrary object nesting so a nested `rules: {` property inside the
+ * object is NOT mistaken for an ESLint config rules block (#2189 review
+ * finding 1).
+ *
+ * Only matches single-line openers where the brace is opened but the `rules:`
+ * keyword is NOT on the same line (the `rules:` case is already handled by
+ * isRulesInArbitraryContext). If the line opens a brace but also contains
+ * `rules:`, isRulesBlockOpen / isRulesInArbitraryContext handles it.
+ */
+function isArbitraryObjectOpener(line) {
+  const trimmed = line.trim();
+  // Must start with a declaration keyword or contain an assignment operator.
+  const isDeclaration = /^(?:export\s+)?(?:const|let|var)\s+/.test(trimmed);
+  const hasAssign = hasAssignmentOperator(line);
+  if (!isDeclaration && !hasAssign) {
+    return false;
+  }
+  // Must open an object brace on this line.
+  if (!/\{\s*$/.test(trimmed) && !/\{[^}]*$/.test(trimmed)) {
+    return false;
+  }
+  // Must NOT contain `rules:` on this line (that's handled by
+  // isRulesBlockOpen / isRulesInArbitraryContext).
+  if (/\brules\s*:/.test(line)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Extracts the DIRECT value of the top-level key in a segment — the text that
+ * immediately follows the key's colon. This is used by extractInlineRules
+ * Entries to anchor severity detection to the rule's own value, not to nested
+ * properties inside a container value.
+ *
+ * For a segment like `'custom-rules': { complexity: ['error', 50] }`, the
+ * direct value is `{ complexity: ['error', 50] }` (a plain object container),
+ * so the caller can detect that this is NOT a rule entry. For
+ * `complexity: ['error', 50]`, the direct value is `['error', 50]` (a rule
+ * config array). For `'no-console': 'error'`, the direct value is `'error'`
+ * (a scalar severity).
+ *
+ * Returns the trimmed value text after the colon, or null if no top-level
+ * key: colon is found at the start of the trimmed segment (#2189 review
+ * finding).
+ */
+function extractDirectValueAfterKey(segment) {
+  const trimmed = segment.trim();
+  // Match the top-level key (quoted or unquoted) followed by a colon. This
+  // mirrors the anchored extractRuleKey regex and uses the same centralized
+  // RULE_ID_CHARS character class so scoped rule IDs are recognized
+  // consistently (#2189 review finding).
+  const keyMatch = new RegExp(
+    '^[\'"]?([' + RULE_ID_CHARS + ']+)[\'"]?\\s*:',
+  ).exec(trimmed);
+  if (keyMatch === null) {
+    return null;
+  }
+  return trimmed.slice(keyMatch[0].length).trim();
+}
+
+/**
+ * Extracts inline rule entries from a single-line nested rules object such as
+ * `rules: { 'no-console': 'off', complexity: ['error', 50] }`. Returns an
+ * array of { key, content } where content is the inline segment text for each
+ * rule-like key/severity pair found after the `rules: {` opener and before the
+ * matching close brace on the same line. Returns an empty array when the line
+ * does not open a rules object or has no inline rule entries.
+ *
+ * This covers the single-line nested rules form that extractRuleKey and the
+ * off/severity checks otherwise bypass (extractRuleKey returns the first key
+ * on the line, which is `rules`, a structural key that yields null).
+ */
+function extractInlineRulesEntries(line) {
+  const openMatch = propertyKeyRegex('rules', true).exec(line);
+  if (openMatch === null) {
+    return [];
+  }
+  // Reject arbitrary declarations/assignments (e.g. const meta = { rules: {
+  // 'no-console': 'error' } }) so unrelated config fields named "rules" do not
+  // produce false positives. Mirrors isRulesBlockOpen gating (#2189 review
+  // finding). The export-default flat-config form (e.g.
+  // `export default [{ rules: { ... } }]`) is a valid ESLint config export and
+  // is allowed via isExportDefaultConfigContext (#2189 review finding).
+  if (
+    isRulesInArbitraryContext(line, openMatch.index) &&
+    !isExportDefaultConfigContext(line, openMatch.index)
+  ) {
+    return [];
+  }
+  let start = openMatch.index + openMatch[0].length;
+  // Walk to the matching close brace on the same line, respecting nested
+  // braces/brackets and string literals so an inline `}` inside a value does
+  // not terminate the scan early.
+  let depth = 1;
+  let quote = null;
+  let escaped = false;
+  let end = line.length;
+  for (let i = start; i < line.length; i++) {
+    const ch = line[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+    } else if (ch === '{' || ch === '[') {
+      depth += 1;
+    } else if (ch === '}' || ch === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  const inline = line.slice(start, end);
+  // Split into comma-separated segments at the top level (depth 0 relative to
+  // the inline content) so array/object values are kept whole.
+  const segments = [];
+  let segStart = 0;
+  let segDepth = 0;
+  let segQuote = null;
+  let segEscaped = false;
+  for (let i = 0; i < inline.length; i++) {
+    const ch = inline[i];
+    if (segEscaped) {
+      segEscaped = false;
+      continue;
+    }
+    if (segQuote !== null) {
+      if (ch === '\\') {
+        segEscaped = true;
+      } else if (ch === segQuote) {
+        segQuote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      segQuote = ch;
+    } else if (ch === '{' || ch === '[') {
+      segDepth += 1;
+    } else if (ch === '}' || ch === ']') {
+      segDepth -= 1;
+    } else if (ch === ',' && segDepth === 0) {
+      segments.push(inline.slice(segStart, i));
+      segStart = i + 1;
+    }
+  }
+  segments.push(inline.slice(segStart));
+  const entries = [];
+  for (const segment of segments) {
+    const key = extractRuleKey(segment);
+    if (key === null) {
+      continue;
+    }
+    // Extract only the DIRECT value of the top-level key (the text after the
+    // key's colon) so severity detection does not misparse nested properties
+    // inside a container value. A segment like
+    // `'custom-rules': { complexity: ['error', 50] }` has a direct value
+    // starting with `{` (a plain object container), so it is NOT a rule
+    // entry and must be skipped. A real rule entry's direct value is either a
+    // scalar severity (e.g. `'error'`) or a rule config array (starts with
+    // `[`). This anchoring prevents false positives where a nested
+    // severity-like value inside an unrelated container is mistaken for the
+    // rule's severity (#2189 review finding).
+    const directValue = extractDirectValueAfterKey(segment);
+    if (directValue === null || /^\{/.test(directValue.trim())) {
+      // No direct value, or the direct value is a plain object container
+      // (not a rule config array or scalar severity): skip this segment.
+      continue;
+    }
+    // Append a sentinel terminator so extractSeverityValue (which expects a
+    // trailing ,/}/] after the severity) matches the last inline entry before
+    // the closing brace, where the raw segment has no trailing delimiter.
+    const padded = segment.trim() + ',';
+    if (extractSeverityValue(padded) !== null) {
+      entries.push({ key, content: padded });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Counts the net brace delta ({ minus }) of a diff content line, respecting
+ * string and regex literals and // comments so braces inside quotes or
+ * comments are not counted. Used for contextual rules-block tracking in diffs.
+ */
+function countDiffBraceDelta(line) {
+  let delta = 0;
+  let quote = null;
+  let escaped = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    const next = line[i + 1];
+    if (quote === null && ch === '/' && next === '/') {
+      break;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+    } else if (ch === '{') {
+      delta += 1;
+    } else if (ch === '}') {
+      delta -= 1;
+    }
+  }
+
+  return delta;
 }
 
 export function checkDiff(diff) {
@@ -262,12 +2070,761 @@ export function checkDiff(diff) {
   let newLine = 0;
   let oldLine = 0;
 
+  // Buffer for removed eslint.config.js rule lines pending correlation with
+  // added lines in the same hunk. Each entry: { content, lineNumber }.
+  let pendingRemovedConfigs = [];
+
+  // Unified normalized rule-state buffer for cross-form correlation. When a
+  // rule's representation changes between removed and added (e.g. multiline
+  // removed severity -> same-line added, or same-line removed -> multiline
+  // added), the form-specific buffers (pendingRemovedConfigs,
+  // pendingRemovedMultilineSeverity, etc.) do not match up because removed and
+  // added lines go into different buffers. This buffer collects the normalized
+  // severity and threshold values for each rule key across ALL forms on the
+  // removed side, and the added side compares against it by rule key. Each
+  // entry: { ruleKey, severity, threshold, thresholdForm, lineNumber }. The
+  // severity is 'error'/'warn'/'off' or null; threshold is a number or null;
+  // thresholdForm is 'numeric' or 'max' or null (#2189 review finding).
+  let pendingRemovedRuleState = [];
+
+  // Buffer for removed multiline array severity entries (standalone severity
+  // values on their own line inside a [ ... ] array, e.g. 'error',). These
+  // have no rule key on the same line so they cannot be paired by key.
+  let pendingRemovedMultilineSeverity = [];
+
+  // Buffer for removed standalone max threshold lines (e.g. "max: 800,") from
+  // multiline ceiling rule configs. Correlated against added max lines using
+  // currentCeilingRuleKey context to detect threshold increases.
+  let pendingRemovedMultilineMax = [];
+
+  // Buffer for removed standalone numeric threshold lines (e.g. "25,") from
+  // multiline ceiling rule configs in numeric-array form (severity and
+  // threshold on separate lines). Correlated against added numeric threshold
+  // lines using currentCeilingRuleKey context to detect threshold increases
+  // (#2189 review finding).
+  let pendingRemovedMultilineNumericThreshold = [];
+
+  // Buffer for removed inline rule entries from single-line nested rules
+  // objects (e.g. "rules: { 'no-console': 'error' }"). Each entry is
+  // { key, content } so added inline entries can be correlated by key for
+  // severity/threshold detection in single-line nested rules forms.
+  let pendingRemovedInlineRules = [];
+
+  // Context tracking for multiline eslint.config.js diffs. rulesBraceDepth is
+  // non-null while we are inside a rules: { ... } block (gates multiline
+  // severity detection to avoid false positives on unrelated arrays). The
+  // brace delta is approximated from diff content lines.
+  let rulesBraceDepth = null;
+
+  // Current ceiling rule key for the most recent rule-entry context (from
+  // lines carrying a rule key). Allows standalone max: N lines without a key
+  // to be attributed to the enclosing ceiling rule for threshold-increase
+  // detection. Reset to null on non-ceiling rule keys and rule-entry closure.
+  let currentCeilingRuleKey = null;
+
+  // Current rule key for the most recent rule-entry context (any rule, not
+  // just ceiling rules). Allows standalone multiline severity values (which
+  // carry no rule key on their own line) to be attributed to their enclosing
+  // rule so removed/added multiline severities from different rules are not
+  // cross-paired. Reset to null on rule-entry closure and rules-block close.
+  let currentRuleKey = null;
+
+  // True while inside a rule entry's config (between the rule-entry opener key
+  // and the rule-entry closure). Used so a custom option key not in
+  // STRUCTURAL_KEYS (e.g. "customOption") inside a ceiling rule config does not
+  // replace currentRuleKey/currentCeilingRuleKey, which would cause false
+  // negatives for later multiline severity/max changes. Cleared on rule-entry
+  // closure and rules-block close.
+  let insideRuleEntry = false;
+
+  // Per-rule-entry bracket+brace depth. When a rule-entry opener with unclosed
+  // brackets/braces is detected (e.g. "'rule': [" or "'rule': ['error', {"),
+  // this is set to the net bracket+brace delta opened on that opener line. Each
+  // subsequent line adjusts the depth by its bracket+brace delta. When the
+  // depth returns to <= 0, the rule entry is closed. This correctly handles
+  // NESTED option objects inside a multiline rule config: a bare "}" that
+  // closes a nested object (e.g. the option object in
+  //   'max-lines': ['error', {
+  //     nested: { ... },   // <- this } does NOT close the rule entry
+  //     max: 900,
+  //   }]
+  // reduces the depth but does NOT close the rule entry, so later max/severity
+  // lines in the same rule are still correctly attributed. The previous
+  // isRuleEntryClosure heuristic treated any bare } / }, as closing the whole
+  // rule entry, clearing currentRuleKey/currentCeilingRuleKey too early
+  // (#2189 review finding). Null when not inside a rule entry.
+  let ruleEntryDepth = null;
+
+  // True when the current multiline rule entry is still expecting its first
+  // array element (the severity). ESLint rule config arrays have the form
+  // [severity, options...], so only the FIRST element can be a severity value.
+  // Standalone off/0 detection (isStandaloneOffRuleValue) is only valid in this
+  // state: once the first element is seen, subsequent standalone 'off' or 0
+  // lines are option values (e.g. modes: ['off'] inside ['error', { ... }]),
+  // not rule severities. Set when a multiline rule-entry array opener (e.g.
+  // "'rule': [") is detected without a severity on the opener line; cleared
+  // after the first non-comment/non-blank element, on rule-entry closure, and
+  // on rules-block close. This fixes a false positive where a rule option
+  // array containing 'off' or 0 inside an error-level rule config was
+  // incorrectly rejected (#2189 review finding).
+  let expectingFirstSeverityElement = false;
+
+  // True when the current multiline ceiling rule entry has seen its severity
+  // element and is expecting a standalone numeric threshold line (the second
+  // array element, e.g. 25 in complexity: ['error', 25] split across lines).
+  // Set when the severity element is seen for a ceiling rule in a multiline
+  // array (either as a standalone line or on the opener), cleared after the
+  // numeric threshold is seen, on rule-entry closure, and on rules-block
+  // close. This tracks the common multiline numeric-array shape where the
+  // severity and threshold are separate array elements on separate lines
+  // (#2189 review finding).
+  let expectingCeilingThreshold = false;
+
+  // --- Removed-side rule context (mirrors post-change context for removed
+  // lines). In realistic Git unified-diff ordering, adjacent changed opener
+  // and value lines are emitted as removed-then-added:
+  //   - 'no-console': [
+  //   -   'error',
+  //   + 'no-console': [
+  //   +   'warn',
+  // The removed severity is processed BEFORE the added opener sets the
+  // post-change currentRuleKey, so bufferRemovedConfig would see a null key
+  // and skip buffering — causing a false negative. To fix this, removed
+  // eslint.config.js lines maintain their own parallel rule context that
+  // reflects the pre-change file view. These are NEVER used for brace-depth
+  // tracking (removed lines must not mutate rulesBraceDepth to avoid
+  // double-counting), only for attributing removed multiline severity/max
+  // values to their enclosing rule on the removed side.
+  let removedRulesBraceDepth = null;
+  let removedCurrentRuleKey = null;
+  let removedCurrentCeilingRuleKey = null;
+  let removedInsideRuleEntry = false;
+
+  // Removed-side counterpart to ruleEntryDepth. Tracks the per-rule-entry
+  // bracket+brace depth for the removed (pre-change) side so the removed-side
+  // rule context correctly handles nested option objects inside multiline rule
+  // configs (#2189 review finding).
+  let removedRuleEntryDepth = null;
+
+  // Removed-side counterpart to expectingFirstSeverityElement. Tracks whether
+  // the current removed-side multiline rule entry is still expecting its first
+  // severity element, so removed standalone severity entries are only buffered
+  // when they are actual severities (the first array element), not option
+  // values (#2189 review finding).
+  let removedExpectingFirstSeverityElement = false;
+
+  // Removed-side counterpart to expectingCeilingThreshold. Tracks whether the
+  // current removed-side multiline ceiling rule entry has seen its severity and
+  // is expecting a standalone numeric threshold line, so removed standalone
+  // numeric threshold lines are buffered with the removed-side ceiling rule key
+  // for correlation against added threshold lines (#2189 review finding).
+  let removedExpectingCeilingThreshold = false;
+
+  // Tracks brace depth inside arbitrary JS object declarations/assignments
+  // outside an ESLint rules block (e.g. `const meta = { ... }` or
+  // `meta = { ... }`). When non-null and > 0, a `rules: {` property inside the
+  // arbitrary object is NOT treated as an ESLint config rules block, preventing
+  // false positives for unrelated config fields named `rules`. This is set when
+  // a line opens an object via a declaration keyword (const/let/var) or an
+  // assignment operator (=) while rulesBraceDepth is null. It is cleared
+  // (returned to null) when the braces close back to the base level. Only
+  // applied when rulesBraceDepth is null (not already inside a tracked ESLint
+  // rules block). (#2189 review finding 1.)
+  let arbitraryObjectDepth = null;
+
+  // Removed-side counterpart to arbitraryObjectDepth. Tracks brace depth
+  // inside arbitrary JS object declarations on the removed (pre-change) side
+  // so a removed `rules: {` property inside an arbitrary object is NOT
+  // treated as an ESLint config rules block on the removed side either
+  // (#2189 review finding 1).
+  let removedArbitraryObjectDepth = null;
+
+  // Tracks brace depth inside a known non-rule container property
+  // (e.g. settings: { ... }, languageOptions: { ... }) outside an ESLint rules
+  // block. When non-null and > 0, a nested `rules: {` property is NOT treated
+  // as an ESLint config rules block, because it is application data consumed by
+  // plugins/shared configs (e.g. settings: { rules: { 'no-console': 'off' } }).
+  // This closes the gap where isRulesInArbitraryContext only caught
+  // declaration/assignment contexts, not bare property nesting inside config
+  // option objects. Set when a line opens a non-rule container
+  // (isNonRuleContainerOpen) while rulesBraceDepth is null; cleared when the
+  // braces close back to the base level. Only applied when rulesBraceDepth is
+  // null (#2189 review finding 2).
+  let nonRuleContainerDepth = null;
+
+  // Removed-side counterpart to nonRuleContainerDepth. Tracks brace depth
+  // inside a known non-rule container property on the removed (pre-change)
+  // side so a removed nested `rules: {` is NOT treated as an ESLint config
+  // rules block on the removed side either (#2189 review finding 2).
+  let removedNonRuleContainerDepth = null;
+
+  // True when the current hunk has at least one unchanged context line. The
+  // zero-context fallback for compareRuleConfigChanges only fires when the
+  // hunk has NO context lines (a truly minimal hunk where we cannot determine
+  // rules-block membership). When context lines are present but rulesBraceDepth
+  // is still null, we are definitively outside a rules block, so the fallback
+  // must NOT fire (prevents false positives on multiline unrelated objects like
+  // const thresholds = { complexity: ['error', 25] -> ['error', 26] }).
+  let hasHunkContext = false;
+
+  // Template literal tracking for TS suppression detection (#2189 review
+  // finding 2). Template literals can span multiple diff lines; the
+  // single-line hasTypeScriptSuppression scanner only skips backticks within
+  // one line. This tracks the full template literal state across added and
+  // context lines so:
+  //   - directive text inside a multiline template body (literal text,
+  //     exprDepth === 0) does not produce a false positive, AND
+  //   - a real suppression comment inside a multiline ${ ... } expression
+  //     (exprDepth > 0) IS still flagged because it is executable code.
+  // A boolean-only inTemplate flag loses the expression/text distinction,
+  // causing real suppressions inside template expressions to be missed.
+  // Reset on file and hunk boundaries.
+  let templateLiteralState = { inTemplate: false, exprDepth: 0 };
+
+  function flushPendingConfigs() {
+    pendingRemovedConfigs = [];
+    pendingRemovedRuleState = [];
+    pendingRemovedMultilineSeverity = [];
+    pendingRemovedMultilineMax = [];
+    pendingRemovedMultilineNumericThreshold = [];
+    pendingRemovedInlineRules = [];
+    rulesBraceDepth = null;
+    currentCeilingRuleKey = null;
+    currentRuleKey = null;
+    insideRuleEntry = false;
+    ruleEntryDepth = null;
+    expectingFirstSeverityElement = false;
+    expectingCeilingThreshold = false;
+    removedRulesBraceDepth = null;
+    removedCurrentCeilingRuleKey = null;
+    removedCurrentRuleKey = null;
+    removedInsideRuleEntry = false;
+    removedRuleEntryDepth = null;
+    removedExpectingFirstSeverityElement = false;
+    removedExpectingCeilingThreshold = false;
+    arbitraryObjectDepth = null;
+    removedArbitraryObjectDepth = null;
+    nonRuleContainerDepth = null;
+    removedNonRuleContainerDepth = null;
+    hasHunkContext = false;
+    templateLiteralState = { inTemplate: false, exprDepth: 0 };
+  }
+
+  /**
+   * Updates the removed-side rule context from a removed eslint.config.js
+   * line. This is a parallel context tracker to updateStructuralContext but
+   * for the removed (pre-change) side. It mirrors the post-change logic:
+   *   - Opens the removed rules block on "rules: {".
+   *   - Tracks removedRulesBraceDepth via brace deltas (NOT shared with the
+   *     post-change rulesBraceDepth, so a changed opener containing { does
+   *     not double-count brace depth on the post-change side).
+   *   - Tracks removedCurrentRuleKey / removedCurrentCeilingRuleKey with
+   *     removedInsideRuleEntry gating so nested option keys inside a removed
+   *     rule config object do not replace the enclosing rule key.
+   *   - Resets the removed rule keys on rule-entry closure and rules-block
+   *     close.
+   *
+   * This mirrors updateStructuralContext exactly except it writes the
+   * removed-prefixed state. Keeping the two contexts separate is essential:
+   * the post-change context reflects the new-file brace nesting (used for
+   * added-line gating and brace-depth double-count avoidance), while the
+   * removed context reflects the pre-change rule attribution so removed
+   * multiline severity/max values are correctly attributed even when the
+   * removed opener precedes the added opener in Git diff ordering.
+   */
+  function updateRemovedStructuralContext(content) {
+    if (file !== 'eslint.config.js') {
+      return;
+    }
+    // Track arbitrary object declarations on the removed side too, mirroring
+    // updateStructuralContext, so a removed `rules: {` property inside an
+    // arbitrary object is NOT treated as an ESLint config rules block
+    // (#2189 review finding 1).
+    if (removedRulesBraceDepth === null) {
+      if (
+        removedArbitraryObjectDepth === null &&
+        isArbitraryObjectOpener(content) &&
+        !isRulesBlockOpen(content)
+      ) {
+        removedArbitraryObjectDepth = 0;
+      }
+      if (removedArbitraryObjectDepth !== null) {
+        removedArbitraryObjectDepth += countDiffBraceDelta(content);
+        if (removedArbitraryObjectDepth <= 0) {
+          removedArbitraryObjectDepth = null;
+        }
+      }
+      // Track known non-rule containers (settings, languageOptions, etc.) on
+      // the removed side so a nested `rules: {` inside one is NOT treated as
+      // an ESLint config rules block (#2189 review finding 2).
+      if (
+        removedNonRuleContainerDepth === null &&
+        isNonRuleContainerOpen(content)
+      ) {
+        removedNonRuleContainerDepth = 0;
+      }
+      if (removedNonRuleContainerDepth !== null) {
+        removedNonRuleContainerDepth += countDiffBraceDelta(content);
+        if (removedNonRuleContainerDepth <= 0) {
+          removedNonRuleContainerDepth = null;
+        }
+      }
+    }
+    const rulesOpensHere =
+      isRulesBlockOpen(content) &&
+      removedRulesBraceDepth === null &&
+      removedArbitraryObjectDepth === null &&
+      removedNonRuleContainerDepth === null;
+    if (rulesOpensHere) {
+      removedRulesBraceDepth = 0;
+      removedInsideRuleEntry = false;
+      removedExpectingFirstSeverityElement = false;
+      removedExpectingCeilingThreshold = false;
+    }
+    if (removedRulesBraceDepth !== null) {
+      const delta = countDiffBraceDelta(content);
+      removedRulesBraceDepth += delta;
+      if (removedRulesBraceDepth <= 0) {
+        removedRulesBraceDepth = null;
+        removedCurrentCeilingRuleKey = null;
+        removedCurrentRuleKey = null;
+        removedInsideRuleEntry = false;
+        removedExpectingFirstSeverityElement = false;
+        removedExpectingCeilingThreshold = false;
+        return;
+      }
+      // Per-rule-entry depth-based closure tracking. When inside a rule entry,
+      // adjust the bracket+brace depth. A NESTED option object's closing brace
+      // (e.g. a bare "}," inside a multiline rule config) reduces the depth but
+      // does NOT close the rule entry unless the depth reaches zero. The
+      // previous isRuleEntryClosure heuristic treated any bare } / }, as
+      // closing the whole rule entry, clearing currentCeilingRuleKey too early
+      // so later max/severity-like lines in the same rule were missed or
+      // misclassified (#2189 review finding).
+      //
+      // A duplicate opener (a changed opener line, e.g. when a rule's
+      // representation changes between multiline and same-line) carries the
+      // SAME rule key as the current entry and would double-count its brackets
+      // if added to the depth. Such lines are skipped.
+      if (
+        removedInsideRuleEntry &&
+        removedRuleEntryDepth !== null &&
+        !(
+          removedCurrentRuleKey !== null &&
+          extractRuleKey(content) === removedCurrentRuleKey
+        )
+      ) {
+        removedRuleEntryDepth += countDiffBracketAndBraceDelta(content);
+        if (removedRuleEntryDepth <= 0) {
+          removedCurrentCeilingRuleKey = null;
+          removedCurrentRuleKey = null;
+          removedInsideRuleEntry = false;
+          removedRuleEntryDepth = null;
+          removedExpectingFirstSeverityElement = false;
+          removedExpectingCeilingThreshold = false;
+        } else if (removedExpectingFirstSeverityElement) {
+          if (
+            isMultilineArraySeverityEntry(content) ||
+            isMultilineNumericSeverityEntry(content)
+          ) {
+            removedExpectingFirstSeverityElement = false;
+            // The severity element was just seen. For a ceiling rule, the next
+            // standalone numeric line is the threshold.
+            removedExpectingCeilingThreshold =
+              removedCurrentCeilingRuleKey !== null;
+          }
+        } else if (removedExpectingCeilingThreshold) {
+          // A standalone numeric threshold line was seen (buffered by
+          // bufferRemovedConfig). Clear the expectation so a subsequent numeric
+          // line (an option value) is not mistaken for a second threshold.
+          if (isStandaloneNumericThresholdLine(content)) {
+            removedExpectingCeilingThreshold = false;
+          }
+        }
+      }
+      if (!removedInsideRuleEntry) {
+        const key = extractRuleKey(content);
+        if (key !== null) {
+          removedCurrentRuleKey = key;
+          removedCurrentCeilingRuleKey = CEILING_RULES.has(key) ? key : null;
+          if (!isCompleteSingleLineRuleEntry(content)) {
+            removedInsideRuleEntry = true;
+            removedRuleEntryDepth = countDiffBracketAndBraceDelta(content);
+            removedExpectingFirstSeverityElement =
+              openerExpectsFirstArrayElement(content);
+            // When the severity is already on the opener line (e.g.
+            // "'complexity': ['error',"), the next standalone numeric line is
+            // the threshold for a ceiling rule. When the opener has no
+            // severity, expectingFirstSeverityElement is true and the
+            // threshold expectation is set only after the severity is seen
+            // below.
+            removedExpectingCeilingThreshold =
+              !removedExpectingFirstSeverityElement &&
+              removedCurrentCeilingRuleKey !== null;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Buffers removed eslint.config.js rule config entries (same-key rule lines,
+   * standalone multiline severities, standalone max threshold lines, and inline
+   * rules entries) for later correlation with added lines in the same hunk.
+   *
+   * Critically, removed lines do NOT mutate the post-change structural brace
+   * context (rulesBraceDepth) or the post-change current rule/ceiling-rule
+   * key. This avoids double-counting brace depth when a multiline rule opener
+   * containing { is both removed and added (a change), which would otherwise
+   * leave the guard falsely inside a rules block after it closes. Only context
+   * and added lines update post-change structural context
+   * (see updateStructuralContext), producing the correct post-change/new-file
+   * view of brace nesting.
+   *
+   * Removed multiline severity/max values are attributed using the
+   * REMOVED-SIDE rule context (removedCurrentRuleKey /
+   * removedCurrentCeilingRuleKey), which mirrors the post-change context but
+   * reflects the pre-change file view. This is essential for realistic Git
+   * diff ordering where adjacent changed opener and value lines are emitted
+   * removed-then-added (e.g. "- 'no-console': [", "-   'error',",
+   * "+ 'no-console': [", "+   'warn',"): the removed severity is processed
+   * before the added opener sets the post-change currentRuleKey, so without
+   * a separate removed-side context the removed severity would be unbuffered
+   * and the downgrade missed (false negative).
+   *
+   * The removed-side rule key is stored with each buffered entry so
+   * removed/added multiline entries from different rules in the same hunk are
+   * not cross-paired.
+   */
+  function bufferRemovedConfig(content, currentLine) {
+    if (file !== 'eslint.config.js') {
+      return;
+    }
+    // Do not buffer keyed entries while inside an existing rule-entry config
+    // object (removedInsideRuleEntry). STRUCTURAL_KEYS cannot cover every
+    // custom/plugin-specific option field, so a keyed entry such as
+    // customOption: 'error' would be mistaken for a rule assignment and
+    // buffered for same-rule severity comparison. Only the actual rule-entry
+    // opener at the rules-object level (when removedInsideRuleEntry is false)
+    // qualifies.
+    if (!removedInsideRuleEntry && extractRuleKey(content) !== null) {
+      pendingRemovedConfigs.push({ content, lineNumber: currentLine });
+    }
+    // Only buffer standalone severity values when inside a rules: { ... }
+    // context (removed-side) to avoid false positives on unrelated arrays.
+    // The removed-side rule key is stored with the entry so removed/added
+    // severities from different multiline rules in the same hunk are not
+    // cross-paired. Gated to removedExpectingFirstSeverityElement: only the
+    // first array element is the severity; subsequent standalone severity-like
+    // lines are option values (#2189 review finding).
+    if (
+      removedRulesBraceDepth !== null &&
+      removedCurrentRuleKey !== null &&
+      removedExpectingFirstSeverityElement &&
+      (isMultilineArraySeverityEntry(content) ||
+        isMultilineNumericSeverityEntry(content))
+    ) {
+      pendingRemovedMultilineSeverity.push({
+        content,
+        lineNumber: currentLine,
+        ruleKey: removedCurrentRuleKey,
+      });
+    }
+    // Buffer standalone max threshold lines and project-common object-form
+    // max lines for multiline ceiling rule threshold-increase correlation.
+    // The removed-side ceiling rule key is stored with the entry so
+    // removed/added max lines from different ceiling rules in the same
+    // hunk are not cross-attributed.
+    if (
+      removedRulesBraceDepth !== null &&
+      removedCurrentCeilingRuleKey !== null &&
+      (isStandaloneMaxLine(content) || isObjectFormMaxLine(content))
+    ) {
+      pendingRemovedMultilineMax.push({
+        content,
+        lineNumber: currentLine,
+        ruleKey: removedCurrentCeilingRuleKey,
+      });
+    }
+    // Buffer standalone numeric threshold lines (e.g. "25,") from multiline
+    // ceiling rule configs in numeric-array form where the severity and
+    // threshold are on separate lines. Gated to removedExpectingCeilingThreshold
+    // so only the second array element (the threshold after the severity) is
+    // buffered, not subsequent unrelated standalone numeric values (#2189
+    // review finding). The removed-side ceiling rule key is stored so
+    // removed/added numeric thresholds from different ceiling rules in the
+    // same hunk are not cross-attributed.
+    if (
+      removedRulesBraceDepth !== null &&
+      removedCurrentCeilingRuleKey !== null &&
+      removedExpectingCeilingThreshold &&
+      isStandaloneNumericThresholdLine(content)
+    ) {
+      pendingRemovedMultilineNumericThreshold.push({
+        content,
+        lineNumber: currentLine,
+        ruleKey: removedCurrentCeilingRuleKey,
+      });
+    }
+    // Buffer inline rule entries from single-line nested rules objects for
+    // severity/threshold correlation with added inline entries. Gated to
+    // removedArbitraryObjectDepth === null so a `rules:` property inside an
+    // arbitrary object on the removed side is not treated as an ESLint config
+    // rules block (#2189 review finding 1).
+    if (removedArbitraryObjectDepth === null) {
+      for (const entry of extractInlineRulesEntries(content)) {
+        pendingRemovedInlineRules.push({
+          key: entry.key,
+          content: entry.content,
+          lineNumber: currentLine,
+        });
+      }
+    }
+    // Collect the normalized rule state for cross-form correlation. This
+    // unifies severity and threshold extraction across ALL forms (keyed
+    // same-line, keyed opener, standalone multiline severity, standalone
+    // numeric threshold, standalone/object max) so that when a rule's
+    // representation changes between removed and added, the removed state is
+    // still matched against the added state by rule key (#2189 review finding).
+    // The standalone forms are gated to the removed-side rules-block context
+    // to avoid false positives on unrelated arrays.
+    if (
+      removedRulesBraceDepth !== null ||
+      (!removedInsideRuleEntry && extractRuleKey(content) !== null)
+    ) {
+      const removedIsStandaloneSeverity =
+        removedRulesBraceDepth !== null &&
+        removedCurrentRuleKey !== null &&
+        removedExpectingFirstSeverityElement &&
+        (isMultilineArraySeverityEntry(content) ||
+          isMultilineNumericSeverityEntry(content));
+      const removedIsStandaloneNumericThreshold =
+        removedRulesBraceDepth !== null &&
+        removedCurrentCeilingRuleKey !== null &&
+        removedExpectingCeilingThreshold &&
+        isStandaloneNumericThresholdLine(content);
+      const removedIsStandaloneMax =
+        removedRulesBraceDepth !== null &&
+        removedCurrentCeilingRuleKey !== null &&
+        (isStandaloneMaxLine(content) || isObjectFormMaxLine(content));
+      const ruleState = buildRuleState(
+        content,
+        removedCurrentRuleKey,
+        removedIsStandaloneSeverity,
+        removedIsStandaloneNumericThreshold,
+        removedIsStandaloneMax,
+      );
+      if (ruleState !== null && ruleState.ruleKey !== null) {
+        // consumed (deprecated) is kept for backward compatibility with the
+        // standalone-removed -> keyed-added block below, which still uses a
+        // single consumed flag (a standalone removed entry carries only ONE
+        // field — either a severity OR a threshold, never both — so a single
+        // consumption flag is sufficient there). severityConsumed and
+        // thresholdConsumed are used by the keyed-removed -> standalone-added
+        // block so that a standalone added SEVERITY line consuming the
+        // severity does not prevent a later standalone added THRESHOLD line
+        // from comparing against the removed threshold on the SAME keyed
+        // entry (#2189 review finding).
+        pendingRemovedRuleState.push({
+          ...ruleState,
+          content,
+          lineNumber: currentLine,
+          consumed: false,
+          severityConsumed: false,
+          thresholdConsumed: false,
+        });
+      }
+    }
+    // Update the removed-side structural context AFTER buffering so this
+    // line's rule key is available for subsequent removed lines (e.g. a
+    // removed opener sets the removed rule key, then a removed standalone
+    // severity is attributed to it). Mirrors the post-change pattern where
+    // updateStructuralContext runs after added-line detection.
+    updateRemovedStructuralContext(content);
+  }
+
+  /**
+   * Updates structural context-tracking state (rulesBraceDepth, current rule
+   * key, current ceiling rule key) from a diff content line (without the
+   * leading +/-). Called ONLY for context and added lines so that structural
+   * brace nesting reflects the post-change/new-file view of the file. Removed
+   * lines are never passed here — they only buffer configs
+   * (bufferRemovedConfig) — so a changed multiline rule opener containing {
+   * does not double-count brace depth.
+   *
+   * Ceiling context (currentCeilingRuleKey) is reset whenever a different rule
+   * key appears or a rule-entry closes, preventing stale attribution of
+   * multiline max changes to a prior ceiling rule.
+   *
+   * Rule-key tracking (currentRuleKey/currentCeilingRuleKey) is gated by the
+   * insideRuleEntry flag so nested option properties inside a rule config
+   * object cannot replace the enclosing rule key.
+   */
+  function updateStructuralContext(content) {
+    if (file !== 'eslint.config.js') {
+      return;
+    }
+    // Track arbitrary object declarations/assignments outside rules blocks. A
+    // `rules: {` property inside an arbitrary object (e.g. const meta = { ...
+    // rules: { ... } ... }) must NOT be treated as an ESLint config rules
+    // block (#2189 review finding 1). When arbitraryObjectDepth is non-null
+    // and > 0, we are inside such an arbitrary object, so isRulesBlockOpen is
+    // suppressed.
+    if (rulesBraceDepth === null) {
+      if (
+        arbitraryObjectDepth === null &&
+        isArbitraryObjectOpener(content) &&
+        !isRulesBlockOpen(content)
+      ) {
+        arbitraryObjectDepth = 0;
+      }
+      if (arbitraryObjectDepth !== null) {
+        arbitraryObjectDepth += countDiffBraceDelta(content);
+        if (arbitraryObjectDepth <= 0) {
+          arbitraryObjectDepth = null;
+        }
+      }
+      // Track known non-rule containers (settings, languageOptions, etc.) so a
+      // nested `rules: {` inside one is NOT treated as an ESLint config rules
+      // block (#2189 review finding 2).
+      if (nonRuleContainerDepth === null && isNonRuleContainerOpen(content)) {
+        nonRuleContainerDepth = 0;
+      }
+      if (nonRuleContainerDepth !== null) {
+        nonRuleContainerDepth += countDiffBraceDelta(content);
+        if (nonRuleContainerDepth <= 0) {
+          nonRuleContainerDepth = null;
+        }
+      }
+    }
+    const rulesOpensHere =
+      isRulesBlockOpen(content) &&
+      rulesBraceDepth === null &&
+      arbitraryObjectDepth === null &&
+      nonRuleContainerDepth === null;
+    if (rulesOpensHere) {
+      rulesBraceDepth = 0;
+      insideRuleEntry = false;
+      expectingFirstSeverityElement = false;
+      expectingCeilingThreshold = false;
+    }
+    if (rulesBraceDepth !== null) {
+      const delta = countDiffBraceDelta(content);
+      rulesBraceDepth += delta;
+      // When the rules block closes the brace depth returns to 0 (or below on
+      // an over-close). Reset both the depth tracker and the ceiling rule key
+      // so subsequent unrelated arrays/objects outside the rules block are not
+      // mistaken for rules context (stale false positives).
+      if (rulesBraceDepth <= 0) {
+        rulesBraceDepth = null;
+        currentCeilingRuleKey = null;
+        currentRuleKey = null;
+        insideRuleEntry = false;
+        expectingFirstSeverityElement = false;
+        expectingCeilingThreshold = false;
+        return;
+      }
+      // Per-rule-entry depth-based closure tracking. When inside a rule entry,
+      // adjust the bracket+brace depth. A NESTED option object's closing brace
+      // (e.g. a bare "}," inside a multiline rule config) reduces the depth but
+      // does NOT close the rule entry unless the depth reaches zero. The
+      // previous isRuleEntryClosure heuristic treated any bare } / }, as
+      // closing the whole rule entry, clearing currentCeilingRuleKey too early
+      // so later max/severity-like lines in the same rule were missed or
+      // misclassified (#2189 review finding).
+      //
+      // A duplicate opener (a changed opener line emitted as removed-then-added,
+      // e.g. when a rule's representation changes between multiline and same-line)
+      // carries the SAME rule key as the current entry and would double-count
+      // its brackets if added to the depth. Such lines are skipped: the entry
+      // was already opened by the context/removed line, and the added opener is
+      // a change-replacement of that line, not a new entry.
+      if (
+        insideRuleEntry &&
+        ruleEntryDepth !== null &&
+        !(currentRuleKey !== null && extractRuleKey(content) === currentRuleKey)
+      ) {
+        ruleEntryDepth += countDiffBracketAndBraceDelta(content);
+        if (ruleEntryDepth <= 0) {
+          currentCeilingRuleKey = null;
+          currentRuleKey = null;
+          insideRuleEntry = false;
+          ruleEntryDepth = null;
+          expectingFirstSeverityElement = false;
+          expectingCeilingThreshold = false;
+        } else if (expectingFirstSeverityElement) {
+          // Still inside a rule entry and still expecting the first severity
+          // element. The first standalone severity value (string or numeric)
+          // IS the severity element; clear the expectation so subsequent
+          // standalone 'off'/0 lines (option values inside nested arrays, not
+          // severities) are not flagged. A keyed property line (e.g.
+          // customLabel: true) is NOT a severity value and does not clear the
+          // expectation, so an unusual config with option-like content before
+          // the severity still detects the severity (#2189 review finding).
+          if (
+            isMultilineArraySeverityEntry(content) ||
+            isMultilineNumericSeverityEntry(content)
+          ) {
+            expectingFirstSeverityElement = false;
+            // The severity element was just seen. For a ceiling rule, the next
+            // standalone numeric line is the threshold.
+            expectingCeilingThreshold = currentCeilingRuleKey !== null;
+          }
+        } else if (expectingCeilingThreshold) {
+          // A standalone numeric threshold line was seen. Clear the expectation
+          // so a subsequent numeric line (an option value) is not mistaken for
+          // a second threshold.
+          if (isStandaloneNumericThresholdLine(content)) {
+            expectingCeilingThreshold = false;
+          }
+        }
+      }
+      if (!insideRuleEntry) {
+        // Only update the rule key when NOT already inside a rule entry. Once
+        // a rule-entry opener sets the key, nested option properties inside
+        // that rule's config object (e.g. a custom key not in STRUCTURAL_KEYS)
+        // must NOT replace the enclosing rule key. The flag is cleared on
+        // rule-entry closure (above) or rules-block close, so the next rule
+        // key at the rules-object level is correctly tracked.
+        //
+        // A complete single-line rule entry (e.g. "'no-console': 'error',"
+        // or "complexity: ['error', 25],") opens and closes all its
+        // brackets/braces on one line. It must NOT set insideRuleEntry,
+        // because there is no subsequent closure line to clear the flag.
+        // Without this check, the flag would stay pinned and a following
+        // multiline rule opener (e.g. "'max-lines': ['error', {") would be
+        // ignored, causing its max changes to be missed (false negative).
+        const key = extractRuleKey(content);
+        if (key !== null) {
+          currentRuleKey = key;
+          currentCeilingRuleKey = CEILING_RULES.has(key) ? key : null;
+          if (!isCompleteSingleLineRuleEntry(content)) {
+            insideRuleEntry = true;
+            ruleEntryDepth = countDiffBracketAndBraceDelta(content);
+            // Set the first-severity-element expectation only when the opener
+            // opens a bracket array WITHOUT the severity already on this line.
+            // When the severity is on the opener (e.g. "'rule': ['error',"),
+            // subsequent standalone 'off'/0 lines are option values, so the
+            // expectation is cleared (#2189 review finding).
+            expectingFirstSeverityElement =
+              openerExpectsFirstArrayElement(content);
+            // When the severity is already on the opener line, the next
+            // standalone numeric line is the threshold for a ceiling rule.
+            expectingCeilingThreshold =
+              !expectingFirstSeverityElement && currentCeilingRuleKey !== null;
+          }
+        }
+      }
+    }
+  }
+
   for (const line of diff.split('\n')) {
     const fileMatch = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
     if (fileMatch) {
       file = fileMatch[2];
       newLine = 0;
       oldLine = 0;
+      flushPendingConfigs();
       continue;
     }
 
@@ -275,6 +2832,7 @@ export function checkDiff(diff) {
     if (hunkMatch) {
       oldLine = Number(hunkMatch[1]);
       newLine = Number(hunkMatch[2]);
+      flushPendingConfigs();
       continue;
     }
 
@@ -299,6 +2857,35 @@ export function checkDiff(diff) {
         );
       }
 
+      // TypeScript suppression directives (#2189). The template-state-aware
+      // scanner hasTypeScriptSuppressionInState distinguishes template literal
+      // TEXT (where directive text is inert) from template ${ ... } EXPRESSION
+      // code (where an at-ts-ignore line comment is a real, effective
+      // comment). It also handles lines that START in template text but
+      // transition into an expression mid-line where a directive appears, and
+      // lines that start inside an already-open expression carried from a
+      // prior diff line. The full template state is carried across added and
+      // context lines so the text/expression distinction is preserved (#2189
+      // review finding).
+      if (
+        shouldCheckTypeScriptSuppression(file) &&
+        hasTypeScriptSuppressionInState(content, templateLiteralState)
+      ) {
+        addViolation(
+          violations,
+          file,
+          currentLine,
+          'TypeScript suppression directives (@ts-ignore/@ts-expect-error/@ts-nocheck) are forbidden by #2189.',
+          content,
+        );
+      }
+      if (shouldCheckTypeScriptSuppression(file)) {
+        templateLiteralState = scanTemplateLiteralState(
+          content,
+          templateLiteralState,
+        );
+      }
+
       if (
         file === 'eslint.config.js' &&
         content.includes('packages/cli/src') &&
@@ -313,10 +2900,646 @@ export function checkDiff(diff) {
         );
       }
 
+      // Severity downgrade and ceiling threshold increase detection (#2189)
+      // Runs before the isNewOffRule check so that severity downgrades to off
+      // are reported as downgrades rather than double-reported.
+      //
+      // Same-rule-key comparison (compareRuleConfigChanges) normally requires
+      // actual rules-block context (rulesBraceDepth !== null) to avoid false
+      // positives on multiline unrelated config/data objects whose entries
+      // look like rule entries (e.g. const docs = { 'no-console': 'error' } or
+      // const thresholds = { complexity: ['error', 25] }). A narrowly scoped
+      // zero-context fallback covers ONLY truly minimal hunks that have no
+      // context lines at all (hasHunkContext === false) and where both lines
+      // are rule-severity-assignment-shaped (bare rule entries, not
+      // const/let/var declarations or assignments containing =). When context
+      // lines are present but rulesBraceDepth is null, the hunk is definitively
+      // outside a rules block and the fallback must NOT fire. Production uses
+      // git diff --unified=20 so the rules: { line is almost always present
+      // and the fallback rarely fires, preferring correctness/no false
+      // positives over over-broad detection.
+      //
+      // Ambiguous multiline standalone entries (severity values and max: lines
+      // that have no rule key on the same line) are always gated to
+      // rulesBraceDepth to avoid false positives on unrelated arrays.
+      let severityDowngradeDetected = false;
+      if (file === 'eslint.config.js') {
+        // Same-rule-key comparison: normally requires rules-block context
+        // (rulesBraceDepth !== null). When there is no rules-block context, the
+        // zero-context fallback only fires for truly minimal hunks that have
+        // NO context lines at all (hasHunkContext === false). If context lines
+        // are present but rulesBraceDepth is still null, we are definitively
+        // outside a rules block and the fallback must NOT fire — this prevents
+        // false positives on multiline unrelated objects like
+        // const thresholds = { complexity: ['error', 25] -> ['error', 26] }.
+        // For the fallback, both the removed and added lines must also be
+        // rule-severity-assignment-shaped (bare rule entries, not
+        // const/let/var declarations or assignments containing =).
+        //
+        // Removed entries are paired with the added line by extracted rule key
+        // and the matching removed entry is consumed whether or not violations
+        // are emitted. Consuming no-op (same-severity/threshold) pairs prevents
+        // stale pending removed entries from causing order-dependent false
+        // positives (e.g. a leftover removed entry matching a later added line
+        // of a different change).
+        const addedKey = extractRuleKey(content);
+        // Do not compare keyed entries while inside an existing rule-entry
+        // config object (insideRuleEntry). STRUCTURAL_KEYS cannot cover every
+        // custom/plugin-specific option field, so a keyed entry such as
+        // customOption: 'warn' would be mistaken for a rule assignment and
+        // compared as if customOption were an ESLint rule key (producing a
+        // false severity-downgrade violation). Only the actual rule-entry
+        // opener at the rules-object level (when insideRuleEntry is false)
+        // qualifies for same-rule-key comparison. Removed-side buffering is
+        // gated symmetrically in bufferRemovedConfig.
+        if (addedKey !== null && !insideRuleEntry) {
+          const useZeroContextFallback =
+            rulesBraceDepth === null &&
+            !hasHunkContext &&
+            isRuleSeverityAssignmentShape(content);
+          for (let pi = 0; pi < pendingRemovedConfigs.length; pi++) {
+            const removed = pendingRemovedConfigs[pi];
+            const removedKey = extractRuleKey(removed.content);
+            if (removedKey !== addedKey) {
+              continue;
+            }
+            // Skip the pair entirely if neither rules-block context nor the
+            // zero-context fallback applies. This prevents false positives on
+            // multiline unrelated objects outside a rules block whose entries
+            // carry rule-like keys (e.g. const docs = { 'no-console': ... }).
+            if (!useZeroContextFallback && rulesBraceDepth === null) {
+              continue;
+            }
+            // When the zero-context fallback is active, require the removed
+            // line to also be rule-severity-assignment-shaped so a removed
+            // const/assignment declaration is not compared.
+            if (
+              rulesBraceDepth === null &&
+              !isRuleSeverityAssignmentShape(removed.content)
+            ) {
+              continue;
+            }
+            const changeMessages = compareRuleConfigChanges(
+              removed.content,
+              content,
+            );
+            for (const msg of changeMessages) {
+              addViolation(violations, file, currentLine, msg, content);
+              if (msg.includes('severity downgrade')) {
+                severityDowngradeDetected = true;
+              }
+            }
+            // Consume the matching removed entry whether or not violations
+            // were emitted, so no-op comparisons do not leave stale entries.
+            pendingRemovedConfigs.splice(pi, 1);
+            break;
+          }
+        }
+
+        // Multiline array severity detection: standalone severity values on
+        // their own line. Gated to rules: { ... } context because these lines
+        // carry no rule key and could match unrelated arrays. Removed entries
+        // are buffered with the enclosing rule key (currentRuleKey) at the
+        // time of removal, and an added severity is only compared against a
+        // removed entry whose rule key matches the current rule key. This
+        // prevents pairing removed and added severities from two different
+        // multiline rules in the same hunk.
+        //
+        // Also gated to expectingFirstSeverityElement: only the FIRST element
+        // of a rule's [severity, options...] array is the severity. A
+        // standalone 'error'/'warn'/'off'/0 line that is NOT the first element
+        // is an option value (e.g. modes: ['error'] inside ['error', { ... }]),
+        // not a severity, and must not be compared as a severity downgrade
+        // (#2189 review finding).
+        if (
+          rulesBraceDepth !== null &&
+          currentRuleKey !== null &&
+          expectingFirstSeverityElement &&
+          (isMultilineArraySeverityEntry(content) ||
+            isMultilineNumericSeverityEntry(content)) &&
+          pendingRemovedMultilineSeverity.length > 0
+        ) {
+          const addedSeverity = normalizeMultilineSeverity(content);
+          for (const removed of pendingRemovedMultilineSeverity) {
+            if (removed.ruleKey !== currentRuleKey) {
+              continue;
+            }
+            const removedSeverity = normalizeMultilineSeverity(removed.content);
+            if (
+              removedSeverity !== null &&
+              addedSeverity !== null &&
+              SEVERITY_RANK[addedSeverity] < SEVERITY_RANK[removedSeverity]
+            ) {
+              addViolation(
+                violations,
+                file,
+                currentLine,
+                `ESLint severity downgrade for '${currentRuleKey}' (${removedSeverity} -> ${addedSeverity}) in multiline rule config is forbidden by #2189.`,
+                content,
+              );
+              severityDowngradeDetected = true;
+            }
+          }
+          pendingRemovedMultilineSeverity =
+            pendingRemovedMultilineSeverity.filter(
+              (entry) => entry.ruleKey !== currentRuleKey,
+            );
+        }
+
+        // Multiline max threshold detection: standalone "max: N" lines and
+        // project-common object-form max lines (e.g. "{ max: 800,
+        // skipBlankLines: true }") inside a ceiling rule config. Removed
+        // entries are buffered with the enclosing ceiling rule key, and an
+        // added max line is only compared against a removed entry whose rule
+        // key matches the current ceiling rule key. This prevents
+        // misattributing a max increase across two different ceiling rules in
+        // the same hunk.
+        if (
+          rulesBraceDepth !== null &&
+          currentCeilingRuleKey !== null &&
+          (isStandaloneMaxLine(content) || isObjectFormMaxLine(content)) &&
+          pendingRemovedMultilineMax.length > 0
+        ) {
+          const addedMaxValue = extractMaxValueFromStandaloneLine(content);
+          for (const removed of pendingRemovedMultilineMax) {
+            if (removed.ruleKey !== currentCeilingRuleKey) {
+              continue;
+            }
+            const removedMaxValue = extractMaxValueFromStandaloneLine(
+              removed.content,
+            );
+            if (
+              removedMaxValue !== null &&
+              addedMaxValue !== null &&
+              addedMaxValue > removedMaxValue
+            ) {
+              addViolation(
+                violations,
+                file,
+                currentLine,
+                `Ceiling threshold increase for '${removed.ruleKey}' (${removedMaxValue} -> ${addedMaxValue}) in multiline rule config is forbidden by #2189.`,
+                content,
+              );
+            }
+          }
+          pendingRemovedMultilineMax = pendingRemovedMultilineMax.filter(
+            (entry) => entry.ruleKey !== currentCeilingRuleKey,
+          );
+        }
+
+        // Multiline numeric-array threshold detection: standalone numeric
+        // threshold lines (e.g. "25,") inside a ceiling rule config where the
+        // severity and threshold are separate array elements on separate lines.
+        // Gated to expectingCeilingThreshold so only the second array element
+        // (the threshold after the severity) is treated as a threshold, not
+        // subsequent unrelated standalone numeric values (#2189 review
+        // finding). Removed entries are buffered with the enclosing ceiling
+        // rule key, and an added numeric threshold line is only compared
+        // against a removed entry whose rule key matches the current ceiling
+        // rule key.
+        const preUpdateExpectingCeilingThreshold = expectingCeilingThreshold;
+        if (
+          rulesBraceDepth !== null &&
+          currentCeilingRuleKey !== null &&
+          preUpdateExpectingCeilingThreshold &&
+          isStandaloneNumericThresholdLine(content) &&
+          pendingRemovedMultilineNumericThreshold.length > 0
+        ) {
+          const addedThresholdValue =
+            extractStandaloneNumericThresholdValue(content);
+          for (const removed of pendingRemovedMultilineNumericThreshold) {
+            if (removed.ruleKey !== currentCeilingRuleKey) {
+              continue;
+            }
+            const removedThresholdValue =
+              extractStandaloneNumericThresholdValue(removed.content);
+            if (
+              removedThresholdValue !== null &&
+              addedThresholdValue !== null &&
+              addedThresholdValue > removedThresholdValue
+            ) {
+              addViolation(
+                violations,
+                file,
+                currentLine,
+                `Ceiling threshold increase for '${removed.ruleKey}' (${removedThresholdValue} -> ${addedThresholdValue}) in multiline numeric-array rule config is forbidden by #2189.`,
+                content,
+              );
+            }
+          }
+          pendingRemovedMultilineNumericThreshold =
+            pendingRemovedMultilineNumericThreshold.filter(
+              (entry) => entry.ruleKey !== currentCeilingRuleKey,
+            );
+        }
+
+        // Single-line nested rules detection: inline rule entries within a
+        // rules: { ... } opener on one line (e.g. "rules: { 'no-console':
+        // 'warn' }"). These bypass the same-rule-key and standalone checks
+        // because extractRuleKey returns null for the `rules` structural key,
+        // so they are handled explicitly here. Correlates added inline entries
+        // with buffered removed inline entries by key to detect severity
+        // downgrades and ceiling threshold increases, and flags new off/0
+        // entries. Gated to arbitraryObjectDepth === null so a `rules:`
+        // property inside an arbitrary object (e.g. const meta = { rules: ...
+        // }) is not treated as an ESLint config rules block (#2189 review
+        // finding 1).
+        const addedInlineEntries =
+          arbitraryObjectDepth === null
+            ? extractInlineRulesEntries(content)
+            : [];
+        if (addedInlineEntries.length > 0) {
+          for (const added of addedInlineEntries) {
+            if (isNewOffRule(added.content) && !isAllowedPolicyOff(content)) {
+              addViolation(
+                violations,
+                file,
+                currentLine,
+                'New ESLint off/0 entries must be explicitly justified with eslint-policy-allow-off.',
+                content,
+              );
+              severityDowngradeDetected = true;
+            }
+            for (let pi = 0; pi < pendingRemovedInlineRules.length; pi++) {
+              const removed = pendingRemovedInlineRules[pi];
+              if (removed.key !== added.key) {
+                continue;
+              }
+              const changeMessages = compareRuleConfigChanges(
+                removed.content,
+                added.content,
+              );
+              for (const msg of changeMessages) {
+                addViolation(violations, file, currentLine, msg, content);
+                if (msg.includes('severity downgrade')) {
+                  severityDowngradeDetected = true;
+                }
+              }
+              // Consume the matching removed entry whether or not violations
+              // were emitted, so a no-op (same-severity) match does not leave
+              // a stale entry that could later produce a false positive.
+              pendingRemovedInlineRules.splice(pi, 1);
+              break;
+            }
+          }
+        }
+
+        // Cross-form normalized rule-state comparison. When a rule's
+        // representation changes between removed and added (e.g. multiline
+        // removed severity -> same-line added, or same-line removed -> multiline
+        // added), the form-specific buffers above do not match up because
+        // removed and added lines go into different buffers. This block
+        // compares the normalized severity/threshold of the added line against
+        // ALL removed rule-state entries by rule key, consuming matched entries.
+        // It only fires when the added line carries a rule key (same-line or
+        // opener) OR is a standalone form attributed to a current rule, and it
+        // avoids double-reporting when a form-specific check already detected
+        // the violation (#2189 review finding). updateStructuralContext has not
+        // run yet at this point, so expectingFirstSeverityElement and
+        // expectingCeilingThreshold are the pre-update values for this line.
+        const crossFormIsStandaloneSeverity =
+          rulesBraceDepth !== null &&
+          currentRuleKey !== null &&
+          expectingFirstSeverityElement &&
+          (isMultilineArraySeverityEntry(content) ||
+            isMultilineNumericSeverityEntry(content));
+        const crossFormIsStandaloneNumericThreshold =
+          rulesBraceDepth !== null &&
+          currentCeilingRuleKey !== null &&
+          expectingCeilingThreshold &&
+          isStandaloneNumericThresholdLine(content);
+        const crossFormIsStandaloneMax =
+          rulesBraceDepth !== null &&
+          currentCeilingRuleKey !== null &&
+          (isStandaloneMaxLine(content) || isObjectFormMaxLine(content));
+        const addedRuleState = buildRuleState(
+          content,
+          currentRuleKey,
+          crossFormIsStandaloneSeverity,
+          crossFormIsStandaloneNumericThreshold,
+          crossFormIsStandaloneMax,
+        );
+        if (
+          addedRuleState !== null &&
+          addedRuleState.ruleKey !== null &&
+          !crossFormIsStandaloneSeverity &&
+          !crossFormIsStandaloneNumericThreshold &&
+          !crossFormIsStandaloneMax
+        ) {
+          for (const removed of pendingRemovedRuleState) {
+            if (
+              removed.consumed ||
+              removed.ruleKey !== addedRuleState.ruleKey
+            ) {
+              continue;
+            }
+            // Only compare against removed entries that were STANDALONE forms
+            // (no rule key on the same line). The keyed-removed -> keyed-added
+            // case is already handled by compareRuleConfigChanges above, so
+            // comparing against keyed removed entries here would double-report.
+            // The normalized comparison is specifically for the cross-form gap:
+            // standalone-removed -> keyed-added.
+            const removedWasStandalone =
+              removed.content !== undefined &&
+              extractRuleKey(removed.content) === null;
+            if (!removedWasStandalone) {
+              continue;
+            }
+            // Severity downgrade cross-form comparison.
+            if (
+              removed.severity !== null &&
+              addedRuleState.severity !== null &&
+              SEVERITY_RANK[addedRuleState.severity] <
+                SEVERITY_RANK[removed.severity]
+            ) {
+              addViolation(
+                violations,
+                file,
+                currentLine,
+                `ESLint severity downgrade for '${addedRuleState.ruleKey}' (${removed.severity} -> ${addedRuleState.severity}) is forbidden by #2189.`,
+                content,
+              );
+              severityDowngradeDetected = true;
+            }
+            // Ceiling threshold addition cross-form comparison: a ceiling rule
+            // that had only a scalar severity (removed threshold null) gains an
+            // explicit threshold.
+            if (
+              removed.threshold === null &&
+              addedRuleState.threshold !== null &&
+              CEILING_RULES.has(addedRuleState.ruleKey) &&
+              removed.severity !== null
+            ) {
+              addViolation(
+                violations,
+                file,
+                currentLine,
+                `Adding a ceiling threshold to '${addedRuleState.ruleKey}' is forbidden by #2189; ceiling rules must not gain an explicit loose ceiling.`,
+                content,
+              );
+            }
+            // Ceiling threshold increase cross-form comparison.
+            if (
+              removed.threshold !== null &&
+              addedRuleState.threshold !== null &&
+              addedRuleState.threshold > removed.threshold
+            ) {
+              addViolation(
+                violations,
+                file,
+                currentLine,
+                `Ceiling threshold increase for '${addedRuleState.ruleKey}' (${removed.threshold} -> ${addedRuleState.threshold}) is forbidden by #2189.`,
+                content,
+              );
+            }
+            removed.consumed = true;
+            break;
+          }
+        }
+
+        // Cross-form comparison for STANDALONE added forms (multiline severity,
+        // standalone numeric threshold, standalone/object max). When the added
+        // line is a standalone form attributed to a current rule, compare it
+        // against removed normalized entries that were KEYED (same-line/opener)
+        // forms. This handles same-line-removed -> multiline-added
+        // representation changes that the form-specific buffers miss
+        // (#2189 review finding). The form-specific checks above already
+        // handle standalone-removed -> standalone-added, so this only compares
+        // against removed entries that had a key on the same line.
+        //
+        // Consumption is split by field (severityConsumed / thresholdConsumed)
+        // rather than a single consumed flag. A keyed-removed entry carries
+        // BOTH a severity AND a threshold (e.g. complexity: ['error', 25] has
+        // severity 'error' and threshold 25). When a rule's representation
+        // changes from a single-line keyed form to a multiline form, the
+        // severity and threshold become separate standalone added lines. The
+        // standalone severity line must only consume the severity so the later
+        // standalone threshold line can still compare against the removed
+        // threshold on the same keyed entry. A single consumed flag would
+        // suppress the threshold comparison, producing a false negative
+        // (complexity: ['error', 25] -> multiline [ 'error', 30 ] was missed)
+        // (#2189 review finding).
+        if (addedRuleState !== null && addedRuleState.ruleKey !== null) {
+          const isStandaloneAdded =
+            crossFormIsStandaloneSeverity ||
+            crossFormIsStandaloneNumericThreshold ||
+            crossFormIsStandaloneMax;
+          if (isStandaloneAdded) {
+            for (const removed of pendingRemovedRuleState) {
+              if (removed.ruleKey !== addedRuleState.ruleKey) {
+                continue;
+              }
+              // Only compare against removed entries that were keyed
+              // (same-line/opener) forms — standalone-removed -> standalone-
+              // added is already handled by the form-specific checks.
+              const removedWasKeyed =
+                removed.content !== undefined &&
+                extractRuleKey(removed.content) !== null;
+              if (!removedWasKeyed) {
+                continue;
+              }
+              // Severity downgrade cross-form (keyed-removed -> standalone-
+              // added). Only applies when the added line is a standalone
+              // severity form, so a standalone threshold/max line does not
+              // spuriously consume the severity field.
+              if (
+                crossFormIsStandaloneSeverity &&
+                !removed.severityConsumed &&
+                removed.severity !== null &&
+                addedRuleState.severity !== null &&
+                SEVERITY_RANK[addedRuleState.severity] <
+                  SEVERITY_RANK[removed.severity]
+              ) {
+                addViolation(
+                  violations,
+                  file,
+                  currentLine,
+                  `ESLint severity downgrade for '${addedRuleState.ruleKey}' (${removed.severity} -> ${addedRuleState.severity}) is forbidden by #2189.`,
+                  content,
+                );
+                severityDowngradeDetected = true;
+              }
+              // Ceiling threshold addition cross-form (keyed-removed ->
+              // standalone-added): a ceiling rule that had only a scalar
+              // severity (removed threshold null) gains an explicit standalone
+              // threshold line (numeric or object max). Only applies when the
+              // added line is a standalone threshold/max form. This mirrors
+              // the standalone-removed -> keyed-added block's threshold-
+              // addition check, closing the false negative where
+              // complexity: 'error' -> multiline ['error', 999] was missed
+              // (#2189 review finding).
+              if (
+                (crossFormIsStandaloneNumericThreshold ||
+                  crossFormIsStandaloneMax) &&
+                !removed.thresholdConsumed &&
+                removed.threshold === null &&
+                addedRuleState.threshold !== null &&
+                CEILING_RULES.has(addedRuleState.ruleKey) &&
+                removed.severity !== null
+              ) {
+                addViolation(
+                  violations,
+                  file,
+                  currentLine,
+                  `Adding a ceiling threshold to '${addedRuleState.ruleKey}' is forbidden by #2189; ceiling rules must not gain an explicit loose ceiling.`,
+                  content,
+                );
+              }
+              // Ceiling threshold increase cross-form (keyed-removed ->
+              // standalone-added). Only applies when the added line is a
+              // standalone threshold/max form, so a standalone severity line
+              // does not spuriously consume the threshold field.
+              if (
+                (crossFormIsStandaloneNumericThreshold ||
+                  crossFormIsStandaloneMax) &&
+                !removed.thresholdConsumed &&
+                removed.threshold !== null &&
+                addedRuleState.threshold !== null &&
+                addedRuleState.threshold > removed.threshold
+              ) {
+                addViolation(
+                  violations,
+                  file,
+                  currentLine,
+                  `Ceiling threshold increase for '${addedRuleState.ruleKey}' (${removed.threshold} -> ${addedRuleState.threshold}) is forbidden by #2189.`,
+                  content,
+                );
+              }
+              // Mark only the field(s) actually compared this pass as
+              // consumed. A standalone severity line marks severityConsumed;
+              // a standalone threshold/max line marks thresholdConsumed. This
+              // leaves the other field available for a subsequent standalone
+              // line of the opposite kind on the same keyed-removed entry.
+              if (crossFormIsStandaloneSeverity) {
+                removed.severityConsumed = true;
+              }
+              if (
+                crossFormIsStandaloneNumericThreshold ||
+                crossFormIsStandaloneMax
+              ) {
+                removed.thresholdConsumed = true;
+              }
+              break;
+            }
+          }
+        }
+      }
+
+      // Update context tracking after detection so structural state reflects
+      // this line for subsequent lines in the hunk.
+      //
+      // Capture the pre-update insideRuleEntry state BEFORE
+      // updateStructuralContext runs. A newly added keyed multiline opener
+      // such as "'no-console': ['off'," is a rule-entry opener that sets
+      // insideRuleEntry = true inside updateStructuralContext. The off/0
+      // policy gate below must evaluate this opener line as a rule entry
+      // (the pre-update state, where insideRuleEntry was false for the
+      // preceding closed entry), NOT the post-update state where the opener
+      // has already pinned insideRuleEntry. Using the pre-update state lets
+      // isRuleOffEntry recognize the keyed opener's off/0 severity and reject
+      // it, fixing the multiline keyed opener false negative (#2189 review
+      // finding). The standalone multiline off/0 detection remains gated to
+      // rulesBraceDepth !== null so unrelated standalone values outside rules
+      // blocks are not flagged.
+      //
+      // preUpdateExpectingFirstSeverity captures whether the current rule entry
+      // was still expecting its first severity element BEFORE this line was
+      // processed. A standalone 'off'/0 line is only a severity (and thus
+      // rejectable) when it IS the first element of the rule array. Once the
+      // first element is seen, expectingFirstSeverityElement is cleared and
+      // subsequent standalone 'off'/0 lines are option values, not severities
+      // (#2189 review finding).
+      const preUpdateInsideRuleEntry = insideRuleEntry;
+      const preUpdateExpectingFirstSeverity = expectingFirstSeverityElement;
+      if (file === 'eslint.config.js') {
+        updateStructuralContext(content);
+      }
+
+      // Off/0 policy gate (#2189). isNewOffRule(content) matches same-line
+      // rule-assignment off/0 values (e.g. "'rule': 'off'") but does NOT match
+      // standalone multiline off/0 severity entries (e.g. "'off'," or "0,")
+      // that have no rule key on the same line. The standalone form is added
+      // to the off-policy predicate so newly added multiline standalone
+      // off/0 entries are also rejected. Both forms are still gated to actual
+      // rule severity shapes (isRuleOffEntry or isStandaloneOffRuleValue under
+      // rulesBraceDepth) so arbitrary option fields (e.g. mode: 'off') do not
+      // produce false positives.
+      //
+      // Keyed off/0 rule-entry detection only applies at the rules-object
+      // entry level, not while inside an existing multiline rule config object
+      // (insideRuleEntry). STRUCTURAL_KEYS cannot cover every custom/plugin
+      // option field, so isRuleOffEntry would treat an extractable custom
+      // option key (e.g. customOption: "off") as a rule assignment. The
+      // insideRuleEntry flag (tracked by updateStructuralContext) disambiguates
+      // this: when true, isRuleOffEntry returns false entirely, leaving only
+      // the standalone severity detection for actual first-element 'off'/0
+      // values.
+      //
+      // For a newly added keyed multiline opener (e.g. "'no-console':
+      // ['off',"), updateStructuralContext has just set insideRuleEntry = true
+      // for THIS opener line. Using the post-update state would cause
+      // isRuleOffEntry to return false (the opener is treated as a nested
+      // option field), missing the off/0 severity. The PRE-update state
+      // (preUpdateInsideRuleEntry) reflects whether we were already inside a
+      // rule entry before this line, so the keyed opener is correctly
+      // evaluated as a rule entry and its off/0 severity is rejected.
+      //
+      // Zero-context gating mirrors the same approach used for
+      // compareRuleConfigChanges: when rulesBraceDepth is null (not inside a
+      // tracked rules block), the off/0 gate is split into:
+      //   - rulesBraceDepth !== null: structural detection applies
+      //     (preUpdateInsideRuleEntry gates nested option fields;
+      //     isRuleOffEntry disambiguates quoted keys).
+      //   - rulesBraceDepth === null && !hasHunkContext (zero-context
+      //     fallback): only bare rule-entry-shaped lines qualify — the line
+      //     must be rule-severity-assignment-shaped
+      //     (isRuleSeverityAssignmentShape) and not a comment-only line. This
+      //     rejects unrelated JS declarations
+      //     (const docs = { 'no-console': 'off' }) and comment-only lines
+      //     (// docs: 'no-console': 'off') that carry rule-like keys.
+      //   - rulesBraceDepth === null && hasHunkContext: context exists but no
+      //     rules block is tracked, so we are definitively outside a rules
+      //     block; the off/0 gate does NOT fire (prevents false positives on
+      //     multiline unrelated objects).
+      // A comment-only line (e.g. "// docs: 'no-console': 'off' remains
+      // disabled elsewhere") is never a real rule assignment, but its text
+      // can satisfy isNewOffRule and isRuleOffEntry because the directive
+      // detection uses regex/extractRuleKey which does not distinguish
+      // comments from code. The !isCommentOnlyLine(content) guard in the
+      // final policy gate applies to ALL contexts (rules block and
+      // zero-context) so a comment-only line inside a tracked rules block
+      // is not falsely rejected (#2189 review finding).
+      // Standalone off/0 detection is only valid when the current rule entry
+      // is still expecting its first severity element (the first element of the
+      // [severity, options...] array). A standalone 'off'/0 line that is NOT
+      // the first element is an option value (e.g. modes: ['off'] inside
+      // ['error', { ... }]), not a rule severity, and must not be flagged
+      // (#2189 review finding). preUpdateExpectingFirstSeverity is the state
+      // BEFORE updateStructuralContext processed this line, so for a standalone
+      // severity line that IS the first element, it is still true.
+      const isNewOffPolicyEntry =
+        isNewOffRule(content) ||
+        (rulesBraceDepth !== null &&
+          preUpdateExpectingFirstSeverity &&
+          isStandaloneOffRuleValue(content));
+      const offZeroContextEligible =
+        !hasHunkContext &&
+        isRuleSeverityAssignmentShape(content) &&
+        !isCommentOnlyLine(content);
+      const isRuleSeverityOffShape =
+        rulesBraceDepth !== null
+          ? isRuleOffEntry(content, true, preUpdateInsideRuleEntry) ||
+            (preUpdateExpectingFirstSeverity &&
+              isStandaloneOffRuleValue(content))
+          : offZeroContextEligible &&
+            isRuleOffEntry(content, false, preUpdateInsideRuleEntry);
       if (
         file === 'eslint.config.js' &&
-        isNewOffRule(content) &&
-        !isAllowedPolicyOff(content)
+        isNewOffPolicyEntry &&
+        !isCommentOnlyLine(content) &&
+        !isAllowedPolicyOff(content) &&
+        !severityDowngradeDetected &&
+        isRuleSeverityOffShape
       ) {
         addViolation(
           violations,
@@ -345,6 +3568,16 @@ export function checkDiff(diff) {
     if (startsWithRemovedContent(line)) {
       const content = removedContent(line);
       const currentLine = oldLine;
+
+      // Buffer removed eslint.config.js rule config entries for severity/
+      // threshold correlation with added lines in the same hunk. Removed lines
+      // do NOT update structural context (rulesBraceDepth, currentRuleKey,
+      // currentCeilingRuleKey) — only context and added lines do — so a
+      // changed multiline rule opener containing { does not double-count brace
+      // depth. This produces the correct post-change/new-file view of brace
+      // nesting.
+      bufferRemovedConfig(content, currentLine);
+
       if (
         file === 'eslint.config.js' &&
         content.includes('eslint-comments/no-use') &&
@@ -369,6 +3602,27 @@ export function checkDiff(diff) {
     }
 
     if (!line.startsWith('\\')) {
+      // Update context tracking for unchanged context lines so that
+      // structural state (rules block, ceiling rule key) is maintained
+      // across the full hunk, not just added lines. Context lines exist in
+      // BOTH the pre-change and post-change file, so they update both the
+      // post-change context (updateStructuralContext) and the removed-side
+      // context (updateRemovedStructuralContext). The removed-side context
+      // is essential for attributing removed multiline severity/max values
+      // when the opener is an unchanged context line (not a removed line).
+      hasHunkContext = true;
+      updateStructuralContext(line);
+      updateRemovedStructuralContext(line);
+      // Advance template literal state from context lines so an added line
+      // inside a template (opened on a context line) is correctly recognized.
+      // The full state (inTemplate + exprDepth) is carried forward so the
+      // text/expression distinction is preserved across context lines.
+      if (shouldCheckTypeScriptSuppression(file)) {
+        templateLiteralState = scanTemplateLiteralState(
+          line,
+          templateLiteralState,
+        );
+      }
       oldLine += 1;
       newLine += 1;
     }
@@ -398,11 +3652,18 @@ export function checkDiff(diff) {
   return violations;
 }
 
+// Directories excluded from all recursive source scans. These are either
+// dependency/build output (node_modules, dist, coverage, .git) or local-only
+// vendored content (tmp). tmp/ is gitignored and holds vendored copies of
+// upstream repos; it is excluded so durable full-tree scans (e.g.
+// scanRootTypeScriptSuppressions) mirror the diff-based checkDiff coverage
+// universe, which only sees tracked files (#2189 review finding).
 const GENERATED_DIRECTORIES = new Set([
   'node_modules',
   'dist',
   'coverage',
   '.git',
+  'tmp',
 ]);
 
 const BINARY_EXTENSIONS = new Set([
@@ -610,6 +3871,81 @@ export function listTsFiles(rootDir) {
 }
 
 /**
+ * Recursively lists all checked source files (same extensions as
+ * shouldCheckTypeScriptSuppression) under rootDir, excluding generated
+ * directories (node_modules, dist, coverage, .git). Used by
+ * scanPackageTypeScriptSuppressions so the full-tree durable scan covers the
+ * same file extensions as the diff-based checkDiff detection, not just
+ * .ts/.tsx.
+ */
+export function listCheckedSourceFiles(rootDir) {
+  const results = [];
+  if (!existsSync(rootDir)) {
+    return results;
+  }
+  const entries = readdirSync(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory() && GENERATED_DIRECTORIES.has(entry.name)) {
+      continue;
+    }
+    const fullPath = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...listCheckedSourceFiles(fullPath));
+    } else if (
+      entry.isFile() &&
+      /\.(?:cjs|mjs|js|jsx|ts|tsx)$/.test(entry.name)
+    ) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Returns true when a checked source file is a production file (not a test
+ * or test-helper file). Covers the same extensions as
+ * shouldCheckTypeScriptSuppression (.js/.jsx/.ts/.tsx/.mjs/.cjs) and preserves
+ * the test-file exclusions of isCliProductionTypeScriptFile (which only
+ * handles .ts/.tsx). Used by scanPackageTypeScriptSuppressions so the
+ * full-tree durable scan covers the same checked source extensions as the
+ * diff-based checkDiff detection.
+ */
+function isProductionCheckedSourceFile(filePath) {
+  if (!/\.(?:cjs|mjs|js|jsx|ts|tsx)$/.test(filePath)) {
+    return false;
+  }
+  const normalized = filePath.replace(/\\/g, '/');
+  const parts = normalized.split('/');
+  const fileName = parts[parts.length - 1];
+  return (
+    !parts.includes('__tests__') &&
+    !parts.includes('test-utils') &&
+    !fileName.endsWith('.test.ts') &&
+    !fileName.endsWith('.test.tsx') &&
+    !fileName.endsWith('.test.js') &&
+    !fileName.endsWith('.test.jsx') &&
+    !fileName.endsWith('.test.mjs') &&
+    !fileName.endsWith('.test.cjs') &&
+    !fileName.endsWith('.spec.ts') &&
+    !fileName.endsWith('.spec.tsx') &&
+    !fileName.endsWith('.spec.js') &&
+    !fileName.endsWith('.spec.jsx') &&
+    !fileName.endsWith('.spec.mjs') &&
+    !fileName.endsWith('.spec.cjs') &&
+    !fileName.endsWith('-test-helpers.ts') &&
+    !fileName.endsWith('-test-helpers.tsx') &&
+    !fileName.endsWith('-test-helpers.js') &&
+    !fileName.endsWith('-test-helpers.jsx') &&
+    !fileName.endsWith('test-setup.ts') &&
+    !fileName.endsWith('test-setup.tsx') &&
+    !fileName.endsWith('test-setup.js') &&
+    !fileName.endsWith('test-setup.jsx') &&
+    !fileName.endsWith('test-setup.mjs') &&
+    !fileName.endsWith('test-setup.cjs')
+  );
+}
+
+/**
  * Scans an arbitrary package source directory for inline ESLint disable/enable
  * directives. Each violation references the supplied issueNumber so guard test
  * failures point at the originating cleanup issue.
@@ -633,6 +3969,125 @@ export function scanPackageDirectives(packageDir, issueNumber) {
           content: line,
         });
       }
+    }
+  }
+  return violations;
+}
+
+/**
+ * Durable full-tree scan for TypeScript suppression directives
+ * (@ts-ignore, @ts-expect-error, @ts-nocheck) in protected package source.
+ * Unlike the diff-based checkDiff detection, this scans the entire checked-in
+ * tree so that pre-existing suppressions are also caught. Returns violations
+ * referencing the supplied issueNumber.
+ *
+ * Covers the same checked source extensions (.js/.jsx/.ts/.tsx/.mjs/.cjs) as
+ * the diff-based shouldCheckTypeScriptSuppression so a JS file with a TS
+ * suppression directive is caught by the full-tree scan, not just by
+ * diff-based detection.
+ *
+ * Test files are excluded because @ts-expect-error is a legitimate testing
+ * pattern (asserting that invalid types are rejected by the compiler). This
+ * matches the production-only approach of scanCliProductionTypeEscapes.
+ *
+ * Template literal state is carried across lines within each file (using
+ * hasTypeScriptSuppressionInState plus scanTemplateLiteralState), mirroring the
+ * diff-based checkDiff detection. This avoids false positives on inert
+ * documentation text inside a multiline template literal body (where // or
+ * directive text is just template text, not a real comment) while still
+ * flagging a real suppression comment after a closed template or inside a
+ * template ${ ... } expression (#2189 review finding).
+ */
+export function scanPackageTypeScriptSuppressions(packageDir, issueNumber) {
+  const target = packageDir;
+  if (!existsSync(target)) {
+    return [];
+  }
+  const files = listCheckedSourceFiles(target);
+  const violations = [];
+  for (const file of files) {
+    const relativePath = relative(process.cwd(), file).replace(/\\/g, '/');
+    if (!isProductionCheckedSourceFile(relativePath)) {
+      continue;
+    }
+    const lines = readFileSync(file, 'utf8').split(String.fromCharCode(10));
+    let templateLiteralState = { inTemplate: false, exprDepth: 0 };
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (hasTypeScriptSuppressionInState(line, templateLiteralState)) {
+        violations.push({
+          file: relativePath,
+          lineNumber: i + 1,
+          message: `TypeScript suppression directives (@ts-ignore/@ts-expect-error/@ts-nocheck) are forbidden in this module (#${issueNumber}).`,
+          content: line,
+        });
+      }
+      templateLiteralState = scanTemplateLiteralState(
+        line,
+        templateLiteralState,
+      );
+    }
+  }
+  return violations;
+}
+
+/**
+ * Durable full-tree scan for TypeScript suppression directives
+ * (@ts-ignore, @ts-expect-error, @ts-nocheck) across the entire repository
+ * root, mirroring the diff-based checkDiff coverage universe (POLICY_PATHS is
+ * '.'). This closes the gap where scanPackageTypeScriptSuppressions only
+ * scanned selected packages src directories: checkDiff rejects newly-added
+ * real TS suppressions anywhere in the repo, so the durable scan must also
+ * cover root-level scripts, config files, and other top-level source to keep
+ * the durable guard as strong as the diff-based acceptance criteria (#2189
+ * review finding).
+ *
+ * Coverage:
+ *   - Same checked source extensions as shouldCheckTypeScriptSuppression
+ *     (.js/.jsx/.ts/.tsx/.mjs/.cjs).
+ *   - Excludes generated directories (node_modules, dist, coverage, .git) via
+ *     listCheckedSourceFiles.
+ *   - Does NOT exempt the guard implementation/test fixture files:
+ *     hasTypeScriptSuppressionInState skips string, template, and regex
+ *     literals, so directive text used as fixture data cannot trigger a false
+ *     positive. This matches shouldCheckTypeScriptSuppression, which also
+ *     does not call isGeneratedGuardFixture.
+ *   - Excludes test/spec/helper files via isProductionCheckedSourceFile,
+ *     matching scanPackageTypeScriptSuppressions, because @ts-expect-error is
+ *     a legitimate testing pattern.
+ *
+ * Template literal state is carried across lines within each file (using
+ * hasTypeScriptSuppressionInState plus scanTemplateLiteralState), mirroring
+ * scanPackageTypeScriptSuppressions and the diff-based checkDiff detection.
+ */
+export function scanRootTypeScriptSuppressions(rootDir, issueNumber) {
+  const target = rootDir;
+  if (!existsSync(target)) {
+    return [];
+  }
+  const files = listCheckedSourceFiles(target);
+  const violations = [];
+  for (const file of files) {
+    const relativePath = relative(target, file).replace(/\\/g, '/');
+    if (!isProductionCheckedSourceFile(relativePath)) {
+      continue;
+    }
+    const lines = readFileSync(file, 'utf8').split(String.fromCharCode(10));
+    let templateLiteralState = { inTemplate: false, exprDepth: 0 };
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (hasTypeScriptSuppressionInState(line, templateLiteralState)) {
+        violations.push({
+          file: relativePath,
+          lineNumber: i + 1,
+          message: `TypeScript suppression directives (@ts-ignore/@ts-expect-error/@ts-nocheck) are forbidden in checked source (#${issueNumber}).`,
+          content: line,
+        });
+      }
+      templateLiteralState = scanTemplateLiteralState(
+        line,
+        templateLiteralState,
+      );
     }
   }
   return violations;
@@ -1094,6 +4549,17 @@ function main() {
   // disable/enable directives and must not be present in central directive
   // cleanup scope lists.
   violations.push(...scanModuleDirectives('packages/policy', '2122'));
+
+  // Issue #2189 durable guard: all checked source in the repository must
+  // contain zero TypeScript suppression directives
+  // (@ts-ignore/@ts-expect-error/@ts-nocheck). The root scan mirrors the
+  // diff-based checkDiff coverage universe (the whole repo, excluding
+  // generated directories), so the durable guard is as strong as the
+  // diff-based acceptance criteria. This supersedes the earlier per-package
+  // scanPackageTypeScriptSuppressions loop, which only covered selected
+  // packages src directories and left root-level scripts and config files
+  // unguarded (#2189 review finding).
+  violations.push(...scanRootTypeScriptSuppressions(process.cwd(), '2189'));
 
   const configPath = join(process.cwd(), 'eslint.config.js');
   if (existsSync(configPath)) {

--- a/scripts/tests/eslint-guard.test.js
+++ b/scripts/tests/eslint-guard.test.js
@@ -15,13 +15,17 @@ import {
   checkCoreDirectiveScopesInConfig,
   checkModuleCentralBypassesInConfig,
   checkModuleDirectiveScopesInConfig,
+  extractRuleKey,
   extractScopeArray,
   formatViolations,
   hasInlineEslintDirective,
+  hasTypeScriptSuppression,
   scanCliProductionTypeEscapes,
   scanCoreDirectives,
   scanModuleDirectives,
   scanPackageDirectives,
+  scanPackageTypeScriptSuppressions,
+  scanRootTypeScriptSuppressions,
 } from '../check-eslint-guard.js';
 
 const repoRoot = resolve(__dirname, '..', '..');
@@ -52,6 +56,452 @@ describe('check-eslint-guard', () => {
     );
   });
 
+  describe('TypeScript suppression directives (#2189)', () => {
+    it('rejects newly added @ts-ignore in a line comment', () => {
+      const violations = checkDiff(
+        diffFor(
+          'packages/core/src/example.ts',
+          'const x = value as any; // @ts-ignore broken overload',
+        ),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('TypeScript suppression');
+      expect(violations[0].content).toContain('@ts-ignore');
+    });
+
+    it('rejects newly added @ts-expect-error in a block comment', () => {
+      const violations = checkDiff(
+        diffFor(
+          'packages/core/src/example.ts',
+          '/* @ts-expect-error legacy overload */',
+        ),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('TypeScript suppression');
+      expect(violations[0].content).toContain('@ts-expect-error');
+    });
+
+    it('rejects newly added @ts-nocheck directive', () => {
+      const violations = checkDiff(
+        diffFor('packages/core/src/example.ts', '// @ts-nocheck'),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('TypeScript suppression');
+      expect(violations[0].content).toContain('@ts-nocheck');
+    });
+
+    it('does not flag @ts-ignore inside string literals', () => {
+      const violations = checkDiff(
+        diffFor(
+          'packages/core/src/example.ts',
+          "const msg = 'use @ts-ignore to silence errors';",
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag @ts-nocheck inside template literals', () => {
+      const violations = checkDiff(
+        diffFor(
+          'packages/core/src/example.ts',
+          'const msg = `@ts-nocheck directive`;',
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag @ts-ignore inside regex literals', () => {
+      const violations = checkDiff(
+        diffFor('packages/core/src/example.ts', 'const re = /@ts-ignore/;'),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag @ts-nocheck inside a block comment string content', () => {
+      const violations = checkDiff(
+        diffFor(
+          'packages/core/src/example.ts',
+          'const doc = "/* @ts-nocheck */";',
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('flags suppressions in JavaScript files too', () => {
+      const violations = checkDiff(
+        diffFor('scripts/example.js', '// @ts-ignore'),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('TypeScript suppression');
+    });
+
+    it('rejects a real @ts-ignore added to the guard implementation file', () => {
+      // The guard implementation file is an ESLint-directive fixture
+      // exemption (shouldCheckInlineDirective returns false for it), but TS
+      // suppression scanning must NOT inherit that exemption. hasTypeScript
+      // Suppression skips string/template/regex literals, so fixture data is
+      // safe, but a real // @ts-ignore comment added to the file must be
+      // rejected.
+      const violations = checkDiff(
+        diffFor('scripts/check-eslint-guard.js', '// @ts-ignore real bug'),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].file).toBe('scripts/check-eslint-guard.js');
+      expect(violations[0].message).toContain('TypeScript suppression');
+    });
+
+    it('rejects a real @ts-nocheck added to the guard test fixture file', () => {
+      const violations = checkDiff(
+        diffFor('scripts/tests/eslint-guard.test.js', '// @ts-nocheck'),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].file).toBe('scripts/tests/eslint-guard.test.js');
+      expect(violations[0].message).toContain('TypeScript suppression');
+    });
+
+    it('does not flag TS suppression text inside strings in the guard test fixture', () => {
+      // Directive text used as fixture data (inside a string literal) must not
+      // trigger a false positive. This proves the literal-skipping in
+      // hasTypeScriptSuppression keeps the fixture data safe even though TS
+      // suppression scanning is no longer exempted for the guard test file.
+      const violations = checkDiff(
+        diffFor(
+          'scripts/tests/eslint-guard.test.js',
+          "const fixture = 'use // @ts-ignore here';",
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag TS suppression text inside template literals in the guard implementation file', () => {
+      const violations = checkDiff(
+        diffFor(
+          'scripts/check-eslint-guard.js',
+          'const msg = `@ts-expect-error directive`;',
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag TS suppression text inside regex literals in the guard test fixture', () => {
+      const violations = checkDiff(
+        diffFor(
+          'scripts/tests/eslint-guard.test.js',
+          'const re = /@ts-ignore/;',
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag TS suppression text inside a multiline template literal body', () => {
+      // Directive text on a continuation line of a multiline template literal
+      // must not be flagged. The template opener (backtick) is on the
+      // preceding added line; the guard tracks the template state across
+      // lines so the @ts-ignore text in the template body is skipped.
+      const diff = [
+        'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+        'index 0000000..1111111 100644',
+        '--- a/packages/core/src/example.ts',
+        '+++ b/packages/core/src/example.ts',
+        '@@ -1,0 +1,3 @@',
+        '+const msg = `',
+        '+  This describes @ts-ignore usage in docs',
+        '+`;',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('TypeScript suppression'),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag TS suppression text in a template opened on a context line', () => {
+      // The template literal opens on a context line (unchanged) and the
+      // added line is inside the template body. The guard must track the
+      // template state from context lines so the added directive text is
+      // skipped.
+      const diff = [
+        'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+        'index 0000000..1111111 100644',
+        '--- a/packages/core/src/example.ts',
+        '+++ b/packages/core/src/example.ts',
+        '@@ -1,1 +1,2 @@',
+        '  const msg = `',
+        '+  More text with @ts-ignore inside template',
+        '  `;',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('TypeScript suppression'),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag TS suppression text in a template with ${} expression', () => {
+      // Template literal with a ${} expression that contains the directive
+      // text in its body. The ${} tracking ensures we correctly identify the
+      // literal text vs expression context.
+      const diff = [
+        'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+        'index 0000000..1111111 100644',
+        '--- a/packages/core/src/example.ts',
+        '+++ b/packages/core/src/example.ts',
+        '@@ -1,0 +1,4 @@',
+        '+const msg = `',
+        '+  prefix ${value} suffix',
+        '+  @ts-expect-error in template body',
+        '+`;',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('TypeScript suppression'),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('still flags a real TS suppression after a closed template literal', () => {
+      // A template literal opens and closes, then a real // @ts-ignore
+      // comment appears on a later added line. The template state must be
+      // cleared after the closing backtick so the real directive is caught.
+      const diff = [
+        'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+        'index 0000000..1111111 100644',
+        '--- a/packages/core/src/example.ts',
+        '+++ b/packages/core/src/example.ts',
+        '@@ -1,0 +1,4 @@',
+        '+const msg = `text`;',
+        '+const x = 1;',
+        '+// @ts-ignore real suppression',
+        '+const y = x as any;',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('TypeScript suppression'),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].content).toContain('@ts-ignore');
+    });
+
+    describe('template expression context (#2189 review finding)', () => {
+      // A line can start inside a template literal while ALSO being inside
+      // executable ${ ... } expression code, where an at-ts-ignore line
+      // comment is a real/effective suppression. The guard tracks full
+      // template state (inTemplate + exprDepth) so it distinguishes template
+      // literal TEXT (inert directive text) from template ${ ... } EXPRESSION
+      // code (real directive comments). These are the end-to-end checkDiff
+      // cases for that distinction.
+
+      it('does not flag directive text in a multiline template body', () => {
+        // Directive text on a continuation line of a multiline template
+        // literal body (literal text, exprDepth === 0) is inert and must not
+        // be flagged.
+        const diff = [
+          'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+          'index 0000000..1111111 100644',
+          '--- a/packages/core/src/example.ts',
+          '+++ b/packages/core/src/example.ts',
+          '@@ -1,0 +1,3 @@',
+          '+const msg = `',
+          '+  docs mention @ts-ignore here',
+          '+`;',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('TypeScript suppression'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('flags a real at-ts-ignore inside a multiline template expression', () => {
+        // The template opens on line 1. Line 2 starts in template text but
+        // opens a ${ ... } expression and ends inside it (unclosed on the
+        // line), with a real at-ts-ignore line comment AFTER the ${ on the
+        // same line. Because the comment is in executable expression code it
+        // is a real, effective suppression and must be flagged. The directive
+        // text appears only as fixture diff data (string content of the test),
+        // not as a real source directive.
+        const diff = [
+          'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+          'index 0000000..1111111 100644',
+          '--- a/packages/core/src/example.ts',
+          '+++ b/packages/core/src/example.ts',
+          '@@ -1,0 +1,3 @@',
+          '+const msg = `',
+          '+  prefix ${(() => { // @ts-ignore',
+          '+    return 1',
+          '+  })()} suffix',
+          '+`;',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('TypeScript suppression'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].content).toContain('@ts-ignore');
+      });
+
+      it('flags a real at-ts-expect-error inside a template expression', () => {
+        // The expression is opened by ${ on a prior line, so the added line
+        // starts inside the expression (exprDepth > 0). An
+        // at-ts-expect-error comment there is executable code and must be
+        // flagged.
+        const diff = [
+          'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+          'index 0000000..1111111 100644',
+          '--- a/packages/core/src/example.ts',
+          '+++ b/packages/core/src/example.ts',
+          '@@ -1,0 +1,4 @@',
+          '+const msg = `${',
+          '+  // @ts-expect-error real suppression',
+          '+  value',
+          '+}`;',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('TypeScript suppression'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].content).toContain('@ts-expect-error');
+      });
+
+      it('flags a real at-ts-nocheck inside a template expression', () => {
+        // Same as above but for at-ts-nocheck, which is also a real
+        // suppression when it appears in executable expression code.
+        const diff = [
+          'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+          'index 0000000..1111111 100644',
+          '--- a/packages/core/src/example.ts',
+          '+++ b/packages/core/src/example.ts',
+          '@@ -1,0 +1,4 @@',
+          '+const msg = `${',
+          '+  // @ts-nocheck real suppression',
+          '+  value',
+          '+}`;',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('TypeScript suppression'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].content).toContain('@ts-nocheck');
+      });
+
+      it('does not flag template body text after transitioning back from an expression', () => {
+        // The template opens, a ${ ... } expression opens and closes on the
+        // same line, then a later line is back in template literal text
+        // (exprDepth === 0). Directive text on that later line is inert and
+        // must not be flagged. This proves the guard correctly tracks the
+        // transition back to template text after an expression closes.
+        const diff = [
+          'diff --git a/packages/core/src/example.ts b/packages/core/src/example.ts',
+          'index 0000000..1111111 100644',
+          '--- a/packages/core/src/example.ts',
+          '+++ b/packages/core/src/example.ts',
+          '@@ -1,0 +1,4 @@',
+          '+const msg = `',
+          '+  prefix ${value} suffix',
+          '+  docs mention @ts-ignore here',
+          '+`;',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('TypeScript suppression'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('TypeScript directive comment-start semantics (#2189 review finding)', () => {
+      // TypeScript only recognizes @ts-ignore / @ts-expect-error / @ts-nocheck
+      // as effective suppressions when the directive appears at the START of
+      // the comment text (after optional whitespace). This was verified against
+      // TypeScript 5.8.3 (the repo's version) via focused compiler tests in
+      // /tmp: a directive preceded by leading prose in a // or /* */ comment
+      // is NOT an effective suppression (the compiler reports the error as
+      // usual). The guard's TS_SUPPRESSION_START_PATTERN is anchored to the
+      // start of the comment, so it matches exactly the directives the
+      // TypeScript compiler would treat as effective suppressions — no false
+      // negatives for effective suppressions, no false positives for inert
+      // prose that merely mentions the directive.
+
+      it('does not flag @ts-ignore after leading prose in a line comment (compiler-inert)', () => {
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '// see notes @ts-ignore is mentioned here',
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag @ts-expect-error after leading prose in a block comment (compiler-inert)', () => {
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '/* prose @ts-expect-error inert */',
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag @ts-nocheck after leading prose in a line comment (compiler-inert)', () => {
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '// note: @ts-nocheck appears later in this comment',
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('still flags @ts-ignore at the start of a line comment (compiler-effective)', () => {
+        const violations = checkDiff(
+          diffFor('packages/core/src/example.ts', '// @ts-ignore real'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('TypeScript suppression');
+      });
+
+      it('still flags @ts-expect-error at the start of a block comment (compiler-effective)', () => {
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '/* @ts-expect-error real */',
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('TypeScript suppression');
+      });
+    });
+  });
+
   it('rejects new eslint config off entries without explicit policy marker', () => {
     const violations = checkDiff(
       diffFor('eslint.config.js', "      'complexity': 'off',"),
@@ -70,6 +520,345 @@ describe('check-eslint-guard', () => {
     );
 
     expect(violations).toEqual([]);
+  });
+
+  it('rejects new numeric array-form off rule entries like [0]', () => {
+    const violations = checkDiff(
+      diffFor('eslint.config.js', "      'no-console': [0],"),
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('eslint-policy-allow-off');
+  });
+
+  it('rejects new numeric array-form off rule entries like [0, ...]', () => {
+    const violations = checkDiff(
+      diffFor('eslint.config.js', "      'no-console': [0, { allow: [] }],"),
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('eslint-policy-allow-off');
+  });
+
+  describe('keyed multiline opener off/0 detection (#2189 review finding)', () => {
+    // A newly added keyed multiline opener where the rule key and the off/0
+    // severity are on the same opener line (e.g. "'no-console': ['off',")
+    // must be rejected. Previously, updateStructuralContext ran before the
+    // off/0 gate and set insideRuleEntry = true for the unclosed opener,
+    // causing isRuleOffEntry to return false (treating the opener as a nested
+    // option field) and missing the off/0 severity. The fix captures the
+    // pre-update insideRuleEntry state so the keyed opener is evaluated as a
+    // rule entry.
+
+    function rulesBlockOpenerDiff(addedLine) {
+      return [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,2 @@',
+        '  rules: {',
+        '+' + addedLine,
+      ].join(String.fromCharCode(10));
+    }
+
+    it('rejects newly added keyed multiline opener with string off', () => {
+      const violations = checkDiff(
+        rulesBlockOpenerDiff("      'no-console': ['off',"),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('off/0');
+      expect(violations[0].message).toContain('eslint-policy-allow-off');
+    });
+
+    it('rejects newly added keyed multiline opener with numeric 0', () => {
+      const violations = checkDiff(
+        rulesBlockOpenerDiff("      'no-console': [0,"),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('off/0');
+      expect(violations[0].message).toContain('eslint-policy-allow-off');
+    });
+
+    it('rejects keyed multiline opener off with double-quoted severity', () => {
+      const violations = checkDiff(
+        rulesBlockOpenerDiff('      "no-console": ["off",'),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('off/0');
+    });
+
+    it('rejects keyed multiline opener with ceiling rule and numeric 0', () => {
+      const violations = checkDiff(
+        rulesBlockOpenerDiff('      complexity: [0,'),
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('off/0');
+    });
+
+    it('allows keyed multiline opener off with eslint-policy-allow-off', () => {
+      const violations = checkDiff(
+        rulesBlockOpenerDiff(
+          "      'no-console': ['off', // eslint-policy-allow-off: #2199",
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('allows keyed multiline opener numeric 0 with eslint-policy-allow-off', () => {
+      const violations = checkDiff(
+        rulesBlockOpenerDiff(
+          "      'no-console': [0, // eslint-policy-allow-off: #2199",
+        ),
+      );
+
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag unrelated option fields inside existing multiline rule configs', () => {
+      // An option field (customOption: 0) inside an already-opened multiline
+      // rule config must NOT be flagged as an off/0 entry. The pre-update
+      // insideRuleEntry state is true (we are inside the rule config opened
+      // by "'no-console': ['error', {"), so isRuleOffEntry returns false and
+      // only standalone severity detection applies, which customOption: 0 is
+      // not.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,4 @@',
+        '  rules: {',
+        "        'no-console': ['error', {",
+        '+          customOption: 0,',
+        '        }],',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag unrelated string off field inside existing multiline rule config', () => {
+      // A string-valued option field (mode: "off") inside an already-opened
+      // multiline rule config must NOT be flagged. Same gating as the numeric
+      // case: pre-update insideRuleEntry is true.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,4 @@',
+        '  rules: {',
+        "        'no-console': ['error', {",
+        '+          mode: "off",',
+        '        }],',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('still detects standalone multiline off after a separate keyed opener', () => {
+      // Regression guard: the pre-update-state fix must not break standalone
+      // multiline off detection. A rule opens with 'error' (not off), then a
+      // standalone 'off', is added on a later line. The standalone detection
+      // (gated to rulesBraceDepth) must still fire.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,3 @@',
+        '  rules: {',
+        "        'no-console': [",
+        "+          'off',",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+  });
+  describe('nested option array off/0 values (#2189 review finding)', () => {
+    // A standalone 'off' or 0 line inside a rule option array (e.g.
+    // modes: ['off'] inside ['error', { ... }]) is an option VALUE, not a rule
+    // severity. The off/0 policy gate must only apply to the FIRST element of a
+    // rule's [severity, options...] array. Once the first element (severity)
+    // is seen, subsequent standalone 'off'/0 lines must not be flagged. These
+    // tests verify the expectingFirstSeverityElement tracking prevents false
+    // positives while still detecting actual standalone severity off/0 lines.
+
+    it('does not flag off inside a nested array option when severity is on the opener line', () => {
+      // The opener "'no-console': ['error', {" has the severity 'error' on the
+      // same line, so expectingFirstSeverityElement is false. The nested
+      // 'off', inside modes: ['off', is an option value and must not be
+      // flagged.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,6 @@',
+        '  rules: {',
+        "        'no-console': ['error', {",
+        '          modes: [',
+        "+            'off',",
+        '+          ],',
+        '+        }],',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag numeric 0 inside a nested array option when severity is on the opener line', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,6 @@',
+        '  rules: {',
+        "        'no-console': ['error', {",
+        '          levels: [',
+        '+            0,',
+        '+          ],',
+        '+        }],',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag off inside a nested array option when severity is a separate first line', () => {
+      // The opener "'no-console': [" opens the array without severity, so
+      // expectingFirstSeverityElement starts true. The first standalone
+      // 'error', line is the severity — it clears the expectation. The
+      // subsequent 'off', inside modes: ['off'] is an option value and must
+      // not be flagged.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,7 @@',
+        '  rules: {',
+        "        'no-console': [",
+        "+          'error',",
+        '+          {',
+        '            modes: [',
+        "+              'off',",
+        '+            ],',
+        '+          },',
+        '+        ],',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('still detects an actual standalone severity off as the first element', () => {
+      // The opener "'no-console': [" opens the array without severity.
+      // expectingFirstSeverityElement is true, so the first standalone 'off',
+      // IS the severity and must be flagged.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,3 @@',
+        '  rules: {',
+        "        'no-console': [",
+        "+          'off',",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('still detects an actual standalone numeric 0 as the first element', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,3 @@',
+        '  rules: {',
+        "        'no-console': [",
+        '+          0,',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('does not flag a second standalone off after the severity was already seen', () => {
+      // After the severity 'error' is seen as the first element, a second
+      // standalone 'off', is not a severity (it's a stray option-like value)
+      // and must not be flagged.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,5 @@',
+        '  rules: {',
+        "        'no-console': [",
+        "          'error',",
+        "+          'off',",
+        '+        ],',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag off inside a nested array with context-line severity', () => {
+      // The severity 'error' is on a context line (unchanged), so
+      // expectingFirstSeverityElement is cleared before the added 'off', line.
+      // The added 'off', inside a nested option array is an option value and
+      // must not be flagged.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,4 +1,5 @@',
+        '  rules: {',
+        "        'no-console': ['error', {",
+        '          modes: [',
+        "+            'off',",
+        '          ],',
+        '        }],',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
   });
 
   it('rejects removing the inline-disable ban', () => {
@@ -206,6 +995,4057 @@ describe('check-eslint-guard', () => {
     expect(violations).toHaveLength(0);
   });
 
+  describe('ESLint config loosening (#2189)', () => {
+    function configDiff(file, removedLine, addedLine) {
+      return [
+        'diff --git a/' + file + ' b/' + file,
+        'index 0000000..1111111 100644',
+        '--- a/' + file,
+        '+++ b/' + file,
+        '@@ -1,1 +1,1 @@',
+        '  rules: {',
+        '-' + removedLine,
+        '+' + addedLine,
+        '  },',
+      ].join(String.fromCharCode(10));
+    }
+
+    describe('severity downgrades', () => {
+      it('catches string severity downgrade from error to warn', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': 'error',",
+            "      'no-console': 'warn',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches string severity downgrade from error to off', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': 'error',",
+            "      'no-console': 'off',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches numeric severity downgrade from 2 to 1', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': 2,",
+            "      'no-console': 1,",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches numeric severity downgrade from 2 to 0', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': 2,",
+            "      'no-console': 0,",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches array-form severity downgrade error to warn', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': ['error', { max: 5 }],",
+            "      'no-console': ['warn', { max: 5 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches numeric array-form severity downgrade 2 to 1', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': [2, { max: 5 }],",
+            "      'no-console': [1, { max: 5 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches multiline array severity downgrade', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "      'no-console': [",
+          '-        "error",',
+          '+        "warn",',
+          '        { max: 5 },',
+          '      ],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('does not flag severity upgrades', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': 'warn',",
+            "      'no-console': 'error',",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag unchanged severity', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': 'error',",
+            "      'no-console': 'error',",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('ceiling threshold increases', () => {
+      it('catches numeric array threshold increase for complexity', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: ['error', 25],",
+            "      complexity: ['error', 26],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('complexity');
+      });
+
+      it('catches max object threshold increase for max-lines', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-lines': ['error', { max: 800 }],",
+            "        'max-lines': ['error', { max: 900 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('catches max object threshold increase for max-lines-per-function', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-lines-per-function': ['error', { max: 80 }],",
+            "        'max-lines-per-function': ['error', { max: 120 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-lines-per-function');
+      });
+
+      it('catches numeric array threshold increase for sonarjs/cognitive-complexity', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'sonarjs/cognitive-complexity': ['error', 30],",
+            "      'sonarjs/cognitive-complexity': ['error', 40],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+      });
+
+      it('catches numeric array threshold increase for max-statements', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'max-statements': ['error', 10],",
+            "      'max-statements': ['error', 15],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+      });
+
+      it('catches numeric array threshold increase for max-params', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'max-params': ['error', 3],",
+            "      'max-params': ['error', 5],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+      });
+
+      it('catches numeric array threshold increase for max-depth', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'max-depth': ['error', 4],",
+            "      'max-depth': ['error', 6],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+      });
+
+      it('does not flag non-threshold option changes in multiline ceiling rule configs', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'max-lines': ['error', {",
+          '          max: 800,',
+          '-          skipBlankLines: true,',
+          '+          skipBlankLines: false,',
+          '        }],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toEqual([]);
+      });
+
+      it('catches multiline max threshold increase for max-lines', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          '+          max: 900,',
+          '          skipBlankLines: true,',
+          '        }],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('does not flag threshold decreases', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-lines': ['error', { max: 800 }],",
+            "        'max-lines': ['error', { max: 700 }],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag threshold decreases for complexity', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: ['error', 25],",
+            "      complexity: ['error', 20],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag unchanged thresholds', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: ['error', 25],",
+            "      complexity: ['error', 25],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag unrelated max field increases', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'no-restricted-syntax': ['error', { max: 5 }],",
+            "        'no-restricted-syntax': ['error', { max: 10 }],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag unrelated max field increases under non-ceiling rules', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'import/no-internal-modules': ['error', { max: 10 }],",
+            "      'import/no-internal-modules': ['error', { max: 20 }],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('cross-form ceiling threshold increases (#2189 review)', () => {
+      // Both the numeric array form (complexity: ['error', 25]) and the object
+      // max form ('max-lines': ['error', { max: 800 }]) are supported ceiling
+      // forms. A rule can be loosened by switching forms while increasing the
+      // effective ceiling. The guard compares values across forms so these
+      // cross-form increases are caught.
+
+      it('catches object max -> numeric array cross-form increase', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-lines': ['error', { max: 800 }],",
+            "        'max-lines': ['error', 900],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-lines');
+        expect(violations[0].message).toContain('800');
+        expect(violations[0].message).toContain('900');
+      });
+
+      it('catches numeric array -> object max cross-form increase', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: ['error', 25],",
+            "      complexity: ['error', { max: 30 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('complexity');
+        expect(violations[0].message).toContain('25');
+        expect(violations[0].message).toContain('30');
+      });
+
+      it('catches object max -> numeric cross-form increase for max-statements', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-statements': ['error', { max: 10 }],",
+            "        'max-statements': ['error', 20],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-statements');
+      });
+
+      it('catches numeric -> object max cross-form increase for max-params', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'max-params': ['error', 3],",
+            "      'max-params': ['error', { max: 5 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-params');
+      });
+
+      it('does not flag cross-form decreases (object max -> numeric)', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-lines': ['error', { max: 800 }],",
+            "        'max-lines': ['error', 700],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag cross-form decreases (numeric -> object max)', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: ['error', 25],",
+            "      complexity: ['error', { max: 20 }],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag cross-form equal values (object max -> numeric)', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-lines': ['error', { max: 800 }],",
+            "        'max-lines': ['error', 800],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag cross-form equal values (numeric -> object max)', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: ['error', 25],",
+            "      complexity: ['error', { max: 25 }],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('representation-changing diffs (#2189 review finding)', () => {
+      // When a rule's representation changes between removed and added forms
+      // (e.g. multiline removed severity -> same-line added, or same-line
+      // removed -> multiline added), the form-specific buffers do not match
+      // up. The normalized rule-state comparison handles these cross-form
+      // representation changes by keying on the rule name rather than the line
+      // shape.
+
+      it('catches multiline removed severity -> same-line added downgrade', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'no-console': [",
+          '-        "error",',
+          "+        'no-console': 'warn',",
+          '        { allow: [] },',
+          '      ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+        expect(violations[0].message).toContain('no-console');
+        expect(violations[0].message).toContain('error');
+        expect(violations[0].message).toContain('warn');
+      });
+
+      it('catches same-line removed severity -> multiline added downgrade', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "-        'no-console': 'error',",
+          "+        'no-console': [",
+          "+          'warn',",
+          '+          { allow: [] },',
+          '+        ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+        expect(violations[0].message).toContain('no-console');
+      });
+
+      it('catches multiline removed numeric threshold -> same-line added threshold increase', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          '        complexity: [',
+          "          'error',",
+          '-          25,',
+          "+        complexity: ['error', 30],",
+          '      ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('complexity');
+        expect(violations[0].message).toContain('25');
+        expect(violations[0].message).toContain('30');
+      });
+
+      it('catches same-line removed threshold -> multiline added threshold increase (object max form)', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "-        'max-lines': ['error', { max: 800 }],",
+          "+        'max-lines': ['error', {",
+          '+          max: 900,',
+          '+          skipBlankLines: true,',
+          '+        }],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-lines');
+        expect(violations[0].message).toContain('800');
+        expect(violations[0].message).toContain('900');
+      });
+
+      it('catches same-line removed threshold -> multiline added threshold increase (numeric-array form)', () => {
+        // complexity: ['error', 25] (single-line numeric-array) changed to a
+        // multiline numeric-array form with the threshold increased to 30.
+        // The keyed-removed entry carries both severity ('error') and
+        // threshold (25); the standalone added severity line must only
+        // consume the severity so the standalone added threshold line can
+        // still compare against the removed threshold of 25 (#2189 review
+        // finding). End-to-end behavior: exactly one threshold-increase
+        // violation containing both 25 and 30.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "-      complexity: ['error', 25],",
+          '+      complexity: [',
+          "+        'error',",
+          '+        30,',
+          '+      ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('complexity');
+        expect(violations[0].message).toContain('25');
+        expect(violations[0].message).toContain('30');
+      });
+
+      it('catches multiline removed max -> same-line added max increase', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          "+        'max-lines': ['error', { max: 900 }],",
+          '          skipBlankLines: true,',
+          '        }],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('does not flag representation-changing threshold decreases', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          '        complexity: [',
+          "          'error',",
+          '-          30,',
+          "+        complexity: ['error', 25],",
+          '      ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      it('does not flag representation-changing threshold no-ops', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          '        complexity: [',
+          "          'error',",
+          '-          25,',
+          "+        complexity: ['error', 25],",
+          '      ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      it('does not flag representation-changing severity upgrades', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'no-console': [",
+          "-        'warn',",
+          "+        'no-console': 'error',",
+          '        { allow: [] },',
+          '      ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      it('does not flag representation-changing severity no-ops', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'no-console': [",
+          "-        'error',",
+          "+        'no-console': 'error',",
+          '        { allow: [] },',
+          '      ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+    });
+
+    describe('nested option objects inside multiline rule configs (#2189 review finding)', () => {
+      // A bare } or }, line that closes a NESTED option object inside a
+      // multiline ceiling rule config must NOT clear the rule-entry context
+      // (currentCeilingRuleKey/currentRuleKey/insideRuleEntry). The per-rule-
+      // entry bracket+brace depth tracking ensures the rule entry only closes
+      // when the depth returns to zero, so later max/severity lines in the same
+      // rule remain correctly attributed.
+
+      it('attributes later max increase to ceiling rule after a nested object closes', () => {
+        // The inner { filter: true } object closes with a bare }, line BEFORE
+        // the max: 800 -> max: 900 change. The rule entry must NOT be closed
+        // by the inner }, so the max increase is still attributed to max-lines.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'max-lines': ['error', {",
+          '          options: {',
+          '            filter: true,',
+          '          },',
+          '-          max: 800,',
+          '+          max: 900,',
+          '          skipBlankLines: true,',
+          '        }],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('threshold increase');
+        expect(violations[0].message).toContain('max-lines');
+        expect(violations[0].message).toContain('800');
+        expect(violations[0].message).toContain('900');
+      });
+
+      it('does not flag unrelated nested max field increases in non-ceiling rules', () => {
+        // A nested max field inside a non-ceiling rule (no-restricted-syntax)
+        // must NOT be flagged even though it sits inside a multiline rule config
+        // with a nested option object.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'no-restricted-syntax': ['error', {",
+          '          options: {',
+          '            filter: true,',
+          '          },',
+          '-          max: 5,',
+          '+          max: 10,',
+          '          skipBlankLines: true,',
+          '        }],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      it('detects severity downgrade after a nested object closes within the rule', () => {
+        // The rule entry for 'no-console' has a nested options object that
+        // closes before a standalone severity change. The rule entry must
+        // remain open so the severity change is correctly attributed.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '      rules: {',
+          "        'no-console': [",
+          "          'error',",
+          '          {',
+          '            options: {',
+          '              allow: true,',
+          '            },',
+          "            mode: 'verbose',",
+          '-          warnExtra: true',
+          '+          warnExtra: false',
+          '          }',
+          '        ],',
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        // This is an option change (not a severity/threshold change), so no
+        // violation is expected. The test confirms the nested object tracking
+        // does not crash or misattribute.
+        expect(checkDiff(diff)).toEqual([]);
+      });
+    });
+
+    describe('scalar-to-threshold addition for ceiling rules (#2189 review)', () => {
+      // A known ceiling rule that previously had only a scalar severity (e.g.
+      // 'complexity': 'error') must not gain an explicit ceiling threshold.
+      // extractThresholdValue returns null for scalar severity forms, so
+      // without this guard the rule could move from 'complexity': 'error' to
+      // 'complexity': ['error', 999] without a violation. Preferred behavior:
+      // reject ALL threshold additions for known ceiling rules because they
+      // introduce explicit loose ceilings.
+
+      it('rejects scalar severity -> numeric threshold addition for complexity', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: 'error',",
+            "      complexity: ['error', 999],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+        expect(violations[0].message).toContain('complexity');
+      });
+
+      it('rejects scalar severity -> object max threshold addition for max-lines', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-lines': 'error',",
+            "        'max-lines': ['error', { max: 999 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('rejects scalar numeric severity -> threshold addition for max-statements', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "        'max-statements': 2,",
+            "        'max-statements': ['error', 50],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+        expect(violations[0].message).toContain('max-statements');
+      });
+
+      it('rejects scalar severity -> object max threshold for sonarjs/cognitive-complexity', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'sonarjs/cognitive-complexity': 'error',",
+            "      'sonarjs/cognitive-complexity': ['error', { max: 100 }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+      });
+
+      it('does not flag scalar severity additions for non-ceiling rules', () => {
+        // Adding a threshold-like option to a non-ceiling rule (e.g.
+        // no-console) must NOT be treated as a ceiling threshold addition.
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      'no-console': 'error',",
+            "      'no-console': ['error', { allow: [] }],",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag removing a threshold from a ceiling rule', () => {
+        // Transitioning from a threshold form to a scalar severity removes the
+        // ceiling threshold, which is not a loosening. This must NOT be
+        // flagged as an addition.
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: ['error', 999],",
+            "      complexity: 'error',",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not double-report scalar->small threshold as both addition and increase', () => {
+        // A scalar -> threshold transition only reports the "Adding a ceiling
+        // threshold" violation, not a threshold increase, because the removed
+        // side has no threshold value to compare against.
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      complexity: 'error',",
+            "      complexity: ['error', 5],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+      });
+
+      it('rejects scalar severity -> multiline numeric threshold for complexity', () => {
+        // A scalar severity form (complexity: 'error') changed to a multiline
+        // numeric-array form that introduces an explicit ceiling threshold.
+        // The removed keyed entry has threshold === null; the added standalone
+        // numeric threshold line (999) must be caught by the keyed-removed ->
+        // standalone-added cross-form block (#2189 review finding).
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,5 @@',
+          '  rules: {',
+          "-    complexity: 'error',",
+          '+    complexity: [',
+          "+      'error',",
+          '+      999,',
+          '    ],',
+          '  },',
+        ].join('\n');
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+        expect(violations[0].message).toContain('complexity');
+      });
+
+      it('rejects scalar severity -> multiline object max threshold for max-lines', () => {
+        // A scalar severity form ('max-lines': 'error') changed to a multiline
+        // object-max form that introduces an explicit ceiling threshold. The
+        // removed keyed entry has threshold === null; the added standalone max
+        // line must be caught by the keyed-removed -> standalone-added
+        // cross-form block (#2189 review finding).
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,6 @@',
+          '  rules: {',
+          "-    'max-lines': 'error',",
+          "+    'max-lines': ['error', {",
+          '+      max: 999,',
+          '+    }],',
+          '  },',
+        ].join('\n');
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('rejects numeric scalar severity -> multiline threshold for complexity', () => {
+        // A numeric scalar severity (complexity: 2) changed to a multiline
+        // numeric-array form that introduces an explicit ceiling threshold.
+        // The removed keyed entry has threshold === null; the added standalone
+        // numeric threshold line must be caught by the keyed-removed ->
+        // standalone-added cross-form block (#2189 review finding).
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,5 @@',
+          '  rules: {',
+          '-    complexity: 2,',
+          '+    complexity: [',
+          "+      'error',",
+          '+      999,',
+          '    ],',
+          '  },',
+        ].join('\n');
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('Adding a ceiling threshold');
+        expect(violations[0].message).toContain('complexity');
+      });
+    });
+
+    describe('end-to-end checkDiff behavior', () => {
+      it('detects multiple violations across rules in a single diff', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,2 +1,2 @@',
+          '  rules: {',
+          "-      'no-console': 'error',",
+          "-      complexity: ['error', 25],",
+          "+      'no-console': 'warn',",
+          "+      complexity: ['error', 26],",
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(2);
+        const messages = violations.map((v) => v.message);
+        expect(messages.some((m) => m.includes('severity downgrade'))).toBe(
+          true,
+        );
+        expect(messages.some((m) => m.includes('threshold increase'))).toBe(
+          true,
+        );
+      });
+
+      it('reports each real loosening exactly once with reordered unchanged, downgraded, and threshold-increased rules', () => {
+        // A hunk mixes a no-op same-key pair (no-console stays 'warn'), a real
+        // severity downgrade (no-unused error -> warn), and a real ceiling
+        // threshold increase (complexity 25 -> 26), with removed/added lines
+        // interleaved in a different order. Each real loosening must be
+        // reported exactly once, and the no-op must not cause a stale removed
+        // entry to produce an extra or spurious violation.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,5 +1,5 @@',
+          '  rules: {',
+          "-    'no-unused': 'error',",
+          "-    'no-console': 'warn',",
+          "-    complexity: ['error', 25],",
+          "+    'no-unused': 'warn',",
+          "+    'no-console': 'warn',",
+          "+    complexity: ['error', 26],",
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+
+        expect(violations).toHaveLength(2);
+        const downgrades = violations.filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+        const thresholds = violations.filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+        expect(downgrades).toHaveLength(1);
+        expect(downgrades[0].message).toContain('no-unused');
+        expect(thresholds).toHaveLength(1);
+        expect(thresholds[0].message).toContain('complexity');
+      });
+
+      it('does not produce spurious violations from unconsumed no-op removed entries', () => {
+        // Removed lines include a no-op same-key pair (no-console warn) before
+        // a removed downgrade (no-console error in a duplicate scenario). The
+        // added line matches the no-op first; consuming it prevents the stale
+        // error entry from producing a false downgrade on the same added line.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,4 +1,3 @@',
+          '  rules: {',
+          "-    'no-console': 'warn',",
+          "-    'no-console': 'error',",
+          "+    'no-console': 'warn',",
+          '  },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag off entries that already have allow markers in the diff', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          "-      'sonarjs/os-command': 'off', // eslint-policy-allow-off: #2079",
+          "+      'sonarjs/os-command': 'off', // eslint-policy-allow-off: #2079",
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      it('does not flag severity changes in unrelated config arrays outside rules blocks', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,3 +1,3 @@',
+          '  const severityMap = {',
+          '    fatal: [',
+          '-     "error",',
+          '+     "warn",',
+          '    ],',
+          '  };',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      it('does not flag severity-like values in unrelated config object fields', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      message: 'error something went wrong',",
+            "      message: 'warn something went wrong',",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag numeric severity-like fields outside rules blocks', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '  const logConfig = {',
+          '-   level: 2,',
+          '+   level: 1,',
+          '  };',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      it('does not flag non-rule object keys with error-like values outside rules blocks', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -1,1 +1,1 @@',
+          '  const messages = {',
+          "-    description: 'error threshold reached',",
+          "+    description: 'warn threshold reached',",
+          '  };',
+        ].join(String.fromCharCode(10));
+
+        expect(checkDiff(diff)).toEqual([]);
+      });
+
+      describe('zero-context diffs (edge case for minimal-context hunks)', () => {
+        // Production uses git diff --unified=5 (DIFF_CONTEXT_LINES in
+        // check-eslint-guard.js), which normally includes enough context for
+        // the rules: { block and rule key lines. These tests exercise the
+        // minimal-context edge case (hunks with no surrounding context lines)
+        // so the same-rule-key fallback heuristic stays correct even when a
+        // hunk happens to omit the enclosing rules: { line.
+        function zeroContextDiff(removedLine, addedLine) {
+          return [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10 +10 @@',
+            '-' + removedLine,
+            '+' + addedLine,
+          ].join(String.fromCharCode(10));
+        }
+
+        it('catches string severity downgrade error to warn in zero-context diff', () => {
+          const violations = checkDiff(
+            zeroContextDiff(
+              "      'no-console': 'error',",
+              "      'no-console': 'warn',",
+            ),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('severity downgrade');
+        });
+
+        it('catches numeric severity downgrade 2 to 1 in zero-context diff', () => {
+          const violations = checkDiff(
+            zeroContextDiff("      'no-console': 2,", "      'no-console': 1,"),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('severity downgrade');
+        });
+
+        it('catches array-form severity downgrade error to warn in zero-context diff', () => {
+          const violations = checkDiff(
+            zeroContextDiff(
+              "      'no-console': ['error', { max: 5 }],",
+              "      'no-console': ['warn', { max: 5 }],",
+            ),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('severity downgrade');
+        });
+
+        it('catches complexity threshold increase in zero-context diff', () => {
+          const violations = checkDiff(
+            zeroContextDiff(
+              "      complexity: ['error', 25],",
+              "      complexity: ['error', 26],",
+            ),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('threshold increase');
+          expect(violations[0].message).toContain('complexity');
+        });
+
+        it('catches max-lines max object threshold increase in zero-context diff', () => {
+          const violations = checkDiff(
+            zeroContextDiff(
+              "        'max-lines': ['error', { max: 800 }],",
+              "        'max-lines': ['error', { max: 900 }],",
+            ),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('threshold increase');
+          expect(violations[0].message).toContain('max-lines');
+        });
+      });
+
+      describe('off/0 detection gating to rule entries', () => {
+        it('does not flag mode: off in unrelated config fields', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -5 +5 @@',
+            '-  mode: "production",',
+            '+  mode: "off",',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag bare off string outside rule contexts', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -5 +5 @@',
+            "-  const value = 'on',",
+            "+  const value = 'off',",
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag bare 0 number outside rule contexts', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -5 +5 @@',
+            '-  const count = 1,',
+            '+  const count = 0,',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag [0] array outside rule contexts', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -5 +5 @@',
+            '-  const arr = [1],',
+            '+  const arr = [0],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag { mode: off } object literal outside rule contexts', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -5 +5 @@',
+            '+  const config = { mode: "off" };',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+          expect(violations).toEqual([]);
+        });
+
+        it('still flags new off rule entries in zero-context diffs', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10 +10 @@',
+            "+      'complexity': 'off',",
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+          expect(violations).toHaveLength(1);
+        });
+
+        describe('quoted rule-like keys in unrelated objects (#2189 review finding 1)', () => {
+          // A quoted rule-like key (e.g. 'no-console') inside an unrelated
+          // object literal (const docs = { 'no-console': 'off' }) must NOT be
+          // flagged as a new off/0 rule entry. The zero-context fallback now
+          // requires isRuleSeverityAssignmentShape, which rejects JS
+          // declarations (const/let/var) and ordinary assignments (=).
+
+          it('does not flag quoted off value in a const docs object literal', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10 +10 @@',
+              "+const docs = { 'no-console': 'off' };",
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toEqual([]);
+          });
+
+          it('does not flag quoted numeric 0 value in a const docs object literal', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10 +10 @@',
+              "+const docs = { 'no-console': 0 };",
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toEqual([]);
+          });
+
+          it('does not flag quoted [0] array value in a const docs object literal', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10 +10 @@',
+              "+const docs = { 'no-console': [0] };",
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toEqual([]);
+          });
+
+          it('does not flag comment-only line with rule-like key and off value', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10 +10 @@',
+              "+// docs: 'no-console': 'off'",
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toEqual([]);
+          });
+
+          it('does not flag unrelated single-line object with quoted off rule key', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10 +10 @@',
+              "+const ref = { 'no-console': 'off', depth: 2 };",
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toEqual([]);
+          });
+
+          it('does not flag assignment to docs object with quoted off rule key', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10 +10 @@',
+              "+docs = { 'no-console': 'off' };",
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toEqual([]);
+          });
+
+          it('does not flag quoted off rule key in a multiline unrelated object with context', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,3 +10,3 @@',
+              '  const docs = {',
+              "+    'no-console': 'off',",
+              '  };',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toEqual([]);
+          });
+
+          it('still flags a bare quoted off rule entry in a zero-context diff', () => {
+            // A bare rule entry (no const/let/var/=) with a quoted rule key
+            // must still be flagged in a zero-context diff. This proves the
+            // zero-context gating does not over-suppress real rule entries.
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10 +10 @@',
+              "+      'no-unused': 'off',",
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+            expect(violations).toHaveLength(1);
+          });
+        });
+      });
+
+      describe('multiline ceiling threshold attribution', () => {
+        it('does not attribute non-ceiling multiline max to a prior ceiling rule', () => {
+          // A ceiling rule (max-lines) is followed by a non-ceiling rule
+          // (some-other-rule). The max change on some-other-rule must NOT be
+          // attributed to max-lines.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,8 +10,8 @@',
+            '      rules: {',
+            "        'max-lines': ['error', {",
+            '          max: 800,',
+            '        }],',
+            "        'some-other-rule': ['error', {",
+            '-          max: 100,',
+            '+          max: 500,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+          expect(violations).toEqual([]);
+        });
+
+        it('still catches ceiling rule multiline max threshold increase', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,6 +10,6 @@',
+            '      rules: {',
+            "        'max-lines': ['error', {",
+            '-          max: 800,',
+            '+          max: 900,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('max-lines');
+        });
+      });
+
+      describe('multiline severity cross-rule attribution (#2189 review)', () => {
+        // Standalone multiline severity values (e.g. 'error',) carry no rule
+        // key, so they must be attributed to their enclosing rule. When two
+        // different multiline rules change severity in the same hunk, a
+        // removed severity from one rule must NOT be paired with an added
+        // severity from the other rule.
+
+        it('does not pair removed/added multiline severities across two different rules', () => {
+          // Rule A ('no-console') removes 'error' (a real downgrade target),
+          // and rule B ('no-unused') adds 'warn'. Without per-rule attribution
+          // the removed 'error' from no-console would pair with the added
+          // 'warn' under no-unused and falsely report a downgrade.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,12 +10,12 @@',
+            '      rules: {',
+            "        'no-console': [",
+            '-        "error",',
+            '+        "off",',
+            '          { allow: [] },',
+            '        ],',
+            "        'no-unused': [",
+            '          "warn",',
+            '+        "warn",',
+            '        ],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('severity downgrade'),
+          );
+
+          // Only the real downgrade (no-console error -> off) is reported; the
+          // cross-rule pairing (no-console 'error' vs no-unused 'warn') must
+          // NOT produce a spurious second violation.
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('no-console');
+        });
+
+        it('still reports a same-rule multiline severity downgrade with two rules present', () => {
+          // Two rules in one hunk; only one of them is actually downgraded.
+          // The real downgrade must still be reported exactly once, and the
+          // other rule (unchanged severity) must not interfere.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,12 +10,12 @@',
+            '      rules: {',
+            "        'no-console': [",
+            '-        "error",',
+            '+        "warn",',
+            '          { allow: [] },',
+            '        ],',
+            "        'no-unused': [",
+            '          "error",',
+            '        ],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('severity downgrade'),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('no-console');
+        });
+      });
+
+      describe('multiline max threshold cross-rule attribution (#2189 review)', () => {
+        // Standalone multiline max: N lines carry no rule key and must be
+        // attributed to their enclosing ceiling rule. When two different
+        // ceiling rules change max in the same hunk, a removed max from one
+        // rule must NOT be paired with an added max from the other rule.
+
+        it('does not pair removed/added multiline max across two different ceiling rules', () => {
+          // max-lines removes max: 800; max-statements adds max: 900.
+          // Without per-rule attribution, the removed 800 from max-lines would
+          // pair with the added 900 under max-statements and falsely report a
+          // threshold increase.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,14 +10,14 @@',
+            '      rules: {',
+            "        'max-lines': ['error', {",
+            '-          max: 800,',
+            '          skipBlankLines: true,',
+            '        }],',
+            "        'max-statements': ['error', {",
+            '+          max: 900,',
+            '          skipBlankLines: true,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('still reports a same-rule multiline max increase with two ceiling rules present', () => {
+          // Two ceiling rules in one hunk; only max-lines is actually
+          // increased. The real increase must still be reported exactly once.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,14 +10,14 @@',
+            '      rules: {',
+            "        'max-lines': ['error', {",
+            '-          max: 800,',
+            '+          max: 900,',
+            '          skipBlankLines: true,',
+            '        }],',
+            "        'max-statements': ['error', {",
+            '          max: 10,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('max-lines');
+        });
+
+        it('uses the stored rule key in the violation message for multiline max changes', () => {
+          // Removed max-lines 800 -> added max-lines 900. The stored removed
+          // rule key must label the violation correctly.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,8 +10,8 @@',
+            '      rules: {',
+            "        'max-lines': ['error', {",
+            '-          max: 800,',
+            '          skipBlankLines: true,',
+            '+          max: 900,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('max-lines');
+          expect(violations[0].message).toContain('800');
+          expect(violations[0].message).toContain('900');
+        });
+      });
+
+      describe('multiline max threshold with reordered max-lines/max-statements in one hunk', () => {
+        // Exercises the stored-key comparison for two ceiling rules whose
+        // removed/added max lines are interleaved in the same hunk.
+
+        it('attributes each max increase to its own rule even when interleaved', () => {
+          // Two ceiling rules, each properly closed. The removed max-statements
+          // line appears before the added max-lines line, so naive (FIFO)
+          // pairing would misattribute. Per-rule key matching ensures each
+          // rule's own removed/added pair is compared.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,14 +10,14 @@',
+            '      rules: {',
+            "        'max-statements': ['error', {",
+            '-          max: 10,',
+            '        }],',
+            "        'max-lines': ['error', {",
+            '-          max: 800,',
+            '+          max: 900,',
+            '        }],',
+            "        'max-statements-2': ['error', {",
+            '+          max: 20,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+
+          // max-lines 800 -> 900 is a real increase and must be reported with
+          // the correct rule key. max-statements' removed 10 and the separate
+          // added 20 (under a different key) must NOT cross-pair.
+          const maxLinesIncreases = violations.filter((v) =>
+            v.message.includes("'max-lines'"),
+          );
+          expect(maxLinesIncreases).toHaveLength(1);
+          expect(maxLinesIncreases[0].message).toContain('800');
+          expect(maxLinesIncreases[0].message).toContain('900');
+        });
+
+        describe('project-common multiline max object threshold (#2189 review)', () => {
+          // The project's eslint.config.js uses the object-line shape
+          // "{ max: 800, skipBlankLines: true, skipComments: true }" inside
+          // ceiling rule arrays. These lines have no rule key on the same line,
+          // so they must be detected via currentCeilingRuleKey context, not the
+          // bare "max: N," standalone form.
+
+          it('catches a project-style multiline max object threshold increase', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,6 +10,6 @@',
+              '      rules: {',
+              "        'max-lines': ['error', {",
+              '-          { max: 800, skipBlankLines: true, skipComments: true },',
+              '+          { max: 900, skipBlankLines: true, skipComments: true },',
+              '        }],',
+              '      },',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('threshold increase'),
+            );
+
+            expect(violations).toHaveLength(1);
+            expect(violations[0].message).toContain('max-lines');
+            expect(violations[0].message).toContain('800');
+            expect(violations[0].message).toContain('900');
+          });
+
+          it('does not flag a project-style multiline max object threshold decrease', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,6 +10,6 @@',
+              '      rules: {',
+              "        'max-lines': ['error', {",
+              '-          { max: 800, skipBlankLines: true, skipComments: true },',
+              '+          { max: 700, skipBlankLines: true, skipComments: true },',
+              '        }],',
+              '      },',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('threshold increase'),
+            );
+
+            expect(violations).toEqual([]);
+          });
+
+          it('does not flag project-style max object changes under non-ceiling rules', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,6 +10,6 @@',
+              '      rules: {',
+              "        'no-restricted-syntax': ['error', {",
+              '-          { max: 5, allow: [] },',
+              '+          { max: 10, allow: [] },',
+              '        }],',
+              '      },',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('threshold increase'),
+            );
+
+            expect(violations).toEqual([]);
+          });
+        });
+
+        describe('newly added multiline standalone off/0 entries (#2189 review)', () => {
+          it('rejects a newly added multiline standalone off string entry', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,5 +10,6 @@',
+              '      rules: {',
+              "        'no-console': [",
+              "+        'off',",
+              '          { allow: [] },',
+              '      ],',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+
+            expect(violations).toHaveLength(1);
+          });
+
+          it('rejects a newly added multiline standalone numeric 0 entry', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,5 +10,6 @@',
+              '      rules: {',
+              "        'no-console': [",
+              '+        0,',
+              '          { allow: [] },',
+              '      ],',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+
+            expect(violations).toHaveLength(1);
+          });
+
+          it('rejects a newly added multiline standalone off entry with trailing comment', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,5 +10,6 @@',
+              '      rules: {',
+              "        'no-console': [",
+              "+        'off', // eslint-policy-allow-off NOT present",
+              '          { allow: [] },',
+              '      ],',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+
+            expect(violations).toHaveLength(1);
+          });
+
+          it('does not flag standalone off entries outside a rules block', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -10,3 +10,4 @@',
+              '  const flags = [',
+              "+    'off',",
+              '  ];',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('off/0'),
+            );
+
+            expect(violations).toEqual([]);
+          });
+        });
+
+        describe('multiline severity downgrades with trailing comments (#2189 review)', () => {
+          it('catches a commented multiline string severity downgrade', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -50,5 +50,5 @@',
+              '    rules: {',
+              "      'no-console': [",
+              '-        "error", // keep as error',
+              '+        "warn", // downgraded',
+              '        { allow: [] },',
+              '      ],',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('severity downgrade'),
+            );
+
+            expect(violations).toHaveLength(1);
+          });
+
+          it('catches a commented multiline numeric severity downgrade', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -50,5 +50,5 @@',
+              '    rules: {',
+              "      'no-console': [",
+              '-        2, // severity two',
+              '+        1, // severity one',
+              '        { allow: [] },',
+              '      ],',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('severity downgrade'),
+            );
+
+            expect(violations).toHaveLength(1);
+          });
+
+          it('catches a commented multiline numeric severity downgrade 2 to 0', () => {
+            const diff = [
+              'diff --git a/eslint.config.js b/eslint.config.js',
+              'index 0000000..1111111 100644',
+              '--- a/eslint.config.js',
+              '+++ b/eslint.config.js',
+              '@@ -50,5 +50,5 @@',
+              '    rules: {',
+              "      'no-console': [",
+              '-        2, // was error',
+              '+        0, // now off',
+              '        { allow: [] },',
+              '      ],',
+            ].join(String.fromCharCode(10));
+
+            const violations = checkDiff(diff).filter((v) =>
+              v.message.includes('severity downgrade'),
+            );
+
+            expect(violations).toHaveLength(1);
+          });
+        });
+      });
+
+      describe('wide multiline rule config context (DIFF_CONTEXT_LINES)', () => {
+        // Production uses git diff --unified=20 (DIFF_CONTEXT_LINES) so that a
+        // ceiling rule whose max field is more than 5 lines below the rule key
+        // still includes the rule key within the hunk. These tests lock that
+        // behavior with a config object that has >5 lines between the rule key
+        // and the changed max field. Option lines use real structural option
+        // keys (skipBlankLines, skipComments, etc.) so they do not reset the
+        // ceiling rule context.
+
+        it('catches a max increase when the rule key is more than 5 lines above the max field', () => {
+          // 8 option lines sit between the rule key opener and the max field,
+          // which would exceed a 5-line context window but is within 20.
+          const optionLines = [
+            '          skipBlankLines: true,',
+            '          skipComments: false,',
+            '          ignorePattern: [],',
+            '          ignorePatterns: [],',
+            '          maxDepth: 4,',
+            '          maxLen: 120,',
+            '          IIFEs: true,',
+            '          ignoreTopLevelFunctions: false,',
+          ];
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,' +
+              (optionLines.length + 6) +
+              ' +' +
+              (optionLines.length + 6) +
+              ' @@',
+            '      rules: {',
+            "        'max-lines': ['error', {",
+            ...optionLines,
+            '-          max: 800,',
+            '+          max: 900,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('max-lines');
+        });
+
+        it('catches a max increase with many option lines for max-statements', () => {
+          // Exercises the same wide-context behavior for a different ceiling
+          // rule with >5 lines between the rule key and the max field.
+          const optionLines = [
+            '          skipBlankLines: true,',
+            '          skipComments: false,',
+            '          ignorePattern: [],',
+            '          ignorePatterns: [],',
+            '          maxDepth: 4,',
+            '          maxLen: 120,',
+            '          IIFEs: true,',
+            '          ignoreTopLevelFunctions: false,',
+            '          options: [],',
+            '          properties: [],',
+          ];
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -10,' +
+              (optionLines.length + 6) +
+              ' +' +
+              (optionLines.length + 6) +
+              ' @@',
+            '      rules: {',
+            "        'max-statements': ['error', {",
+            ...optionLines,
+            '-          max: 30,',
+            '+          max: 40,',
+            '        }],',
+            '      },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('max-statements');
+        });
+      });
+
+      describe('multiline rule loosening with production diff context (#2189 review)', () => {
+        // Production uses git diff --unified=20 (DIFF_CONTEXT_LINES) which
+        // includes enough context for the rules: { block and rule key lines,
+        // even for wide multiline rule config objects. These tests use
+        // realistic context lines matching that output shape.
+
+        it('catches multiline string severity downgrade error to warn', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,5 +50,5 @@',
+            '    rules: {',
+            "      'no-console': [",
+            '-        "error",',
+            '+        "warn",',
+            '        { allow: [] },',
+            '      ],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('severity downgrade'),
+          );
+
+          expect(violations).toHaveLength(1);
+        });
+
+        it('catches multiline numeric severity downgrade 2 to 1', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,5 +50,5 @@',
+            '    rules: {',
+            "      'no-console': [",
+            '-        2,',
+            '+        1,',
+            '        { allow: [] },',
+            '      ],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('severity downgrade'),
+          );
+
+          expect(violations).toHaveLength(1);
+        });
+
+        it('catches standalone max threshold increase in multiline config', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,6 +50,6 @@',
+            '    rules: {',
+            "        'max-lines': ['error', {",
+            '-          max: 800,',
+            '+          max: 900,',
+            '          skipBlankLines: true,',
+            '        }],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('threshold increase'),
+          );
+
+          expect(violations).toHaveLength(1);
+          expect(violations[0].message).toContain('max-lines');
+        });
+
+        it('catches multiline numeric severity downgrade 2 to 0', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,5 +50,5 @@',
+            '    rules: {',
+            "      'no-console': [",
+            '-        2,',
+            '+        0,',
+            '        { allow: [] },',
+            '      ],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('severity downgrade'),
+          );
+
+          expect(violations).toHaveLength(1);
+        });
+      });
+
+      describe('off/0 detection false-positive gating on option fields (#2189 review)', () => {
+        it('does not flag mode: off option field inside a rule config object', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,6 +50,6 @@',
+            '    rules: {',
+            "      'no-restricted-syntax': ['error', {",
+            '-        mode: "strict",',
+            '+        mode: "off",',
+            '      }],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag limit: 0 option field inside a rule config object', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,6 +50,6 @@',
+            '    rules: {',
+            "      'import/no-default-export': ['error', {",
+            '-        limit: 5,',
+            '+        limit: 0,',
+            '      }],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag severity-like option field in a non-ceiling rule config', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,6 +50,6 @@',
+            '    rules: {',
+            "      'no-restricted-syntax': ['error', {",
+            '-        level: "error",',
+            '+        level: "off",',
+            '      }],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag customOption: "off" inside a rule config object', () => {
+          // customOption is not in STRUCTURAL_KEYS, so before the fix
+          // isRuleOffEntry treated it as a rule assignment while
+          // insideRulesBlock was true. With insideRuleEntry tracking, keyed
+          // off/0 detection is suppressed inside a rule config object.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,6 +50,6 @@',
+            '    rules: {',
+            "      'no-restricted-syntax': ['error', {",
+            '-        customOption: "strict",',
+            '+        customOption: "off",',
+            '      }],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag customOption: 0 inside a rule config object', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,6 +50,6 @@',
+            '    rules: {',
+            "      'no-restricted-syntax': ['error', {",
+            '-        customOption: 5,',
+            '+        customOption: 0,',
+            '      }],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag a quoted custom option key with off value inside a rule config', () => {
+          // Even a quoted custom option key must not be mistaken for a rule
+          // off entry when inside a multiline rule config object.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,6 +50,6 @@',
+            '    rules: {',
+            "      'no-restricted-syntax': ['error', {",
+            "-        'customOption': 'strict',",
+            "+        'customOption': 'off',",
+            '      }],',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('still flags an actual rule-level off entry inside a rules block', () => {
+          // A newly added rule off entry at the rules-object entry level (not
+          // inside a rule config object) must still be flagged. This uses a
+          // pure addition (no removed severity pair) so the off/0 gate is
+          // exercised directly, proving the insideRuleEntry suppression does
+          // not over-suppress real rule off entries.
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,3 +50,4 @@',
+            '    rules: {',
+            "      'no-console': 'error',",
+            "+      'no-unused': 'off',",
+            '    },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toHaveLength(1);
+        });
+
+        it('still flags an actual rule-level numeric off entry inside a rules block', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,3 +50,4 @@',
+            '    rules: {',
+            "      'no-console': 'error',",
+            "+      'no-unused': 0,",
+            '    },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toHaveLength(1);
+        });
+
+        it('still flags a new rule off entry with a rule key in production context diff', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,2 +50,3 @@',
+            '    rules: {',
+            "+      'complexity': 'off',",
+            '    },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toHaveLength(1);
+        });
+
+        it('still flags standalone off severity inside a rules block', () => {
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,5 +50,5 @@',
+            '    rules: {',
+            "      'no-console': [",
+            '-        "error",',
+            "+        'off',",
+            '        { allow: [] },',
+            '      ],',
+          ].join(String.fromCharCode(10));
+
+          // This is both a severity downgrade (error -> off) and a new off
+          // entry. The severity downgrade should be reported.
+          const downgradeViolations = checkDiff(diff).filter((v) =>
+            v.message.includes('severity downgrade'),
+          );
+          expect(downgradeViolations).toHaveLength(1);
+        });
+
+        it('does not flag a comment-only line mentioning a quoted off rule inside a rules block', () => {
+          // A comment-only line inside a tracked rules: { ... } block (with
+          // context lines so rulesBraceDepth is non-null) that happens to
+          // mention a quoted off rule must NOT be rejected as a new off/0
+          // entry. The directive detectors (isNewOffRule / isRuleOffEntry)
+          // use regex/extractRuleKey which do not distinguish comments from
+          // code, so the comment text satisfies their predicates. The
+          // !isCommentOnlyLine guard in the off/0 policy gate applies to all
+          // contexts (rules block and zero-context) so this comment is not
+          // falsely flagged (#2189 review finding).
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,3 +50,4 @@',
+            '    rules: {',
+            "+      // docs: 'no-console': 'off' remains disabled elsewhere",
+            "      'no-console': 'error',",
+            '    },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+
+        it('does not flag a comment-only line mentioning a numeric 0 rule inside a rules block', () => {
+          // Same gating as the quoted-off case but for the numeric 0 form
+          // (e.g. a comment mentioning 'no-console': [0]).
+          const diff = [
+            'diff --git a/eslint.config.js b/eslint.config.js',
+            'index 0000000..1111111 100644',
+            '--- a/eslint.config.js',
+            '+++ b/eslint.config.js',
+            '@@ -50,3 +50,4 @@',
+            '    rules: {',
+            "+      // note: 'no-console': [0] is intentionally avoided here",
+            "      'no-console': 'error',",
+            '    },',
+          ].join(String.fromCharCode(10));
+
+          const violations = checkDiff(diff).filter((v) =>
+            v.message.includes('off/0'),
+          );
+
+          expect(violations).toEqual([]);
+        });
+      });
+    });
+  });
+
+  describe('review remediation regressions (#2189)', () => {
+    describe('rulesBraceDepth reset on rules block close', () => {
+      it('does not flag unrelated standalone severity values after a closed rules block', () => {
+        // A rules block opens and closes within the hunk, then an unrelated
+        // array below it changes a severity-like value. The closed rules block
+        // must reset rulesBraceDepth so the standalone severity is not treated
+        // as a multiline rule severity.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,10 +10,10 @@',
+          '    rules: {',
+          "      'no-console': 'error',",
+          '    },',
+          '    const severityMap = {',
+          '      fatal: [',
+          '-       "error",',
+          '+       "warn",',
+          '    ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag unrelated standalone max values after a closed rules block', () => {
+        // A rules block with a ceiling rule closes, then an unrelated object
+        // below changes a standalone max field. The closed rules block must
+        // reset currentCeilingRuleKey so the max change is not attributed to
+        // the prior ceiling rule.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,12 +10,12 @@',
+          '    rules: {',
+          "      'max-lines': ['error', { max: 800 }],",
+          '    },',
+          '    const limits = {',
+          '      budget: {',
+          '-        max: 100,',
+          '+        max: 500,',
+          '      },',
+          '    };',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag new off entries in unrelated objects after a closed rules block', () => {
+        // After a rules block closes, an unrelated object with an off-like
+        // value must not be treated as a new rule off entry.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "      'no-console': 'error',",
+          '    },',
+          '    const featureFlags = {',
+          '+      experimental: "off",',
+          '    };',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('currentCeilingRuleKey reset on common rule-entry closures', () => {
+      it('does not attribute a later max change to a max-lines rule ending with }],', () => {
+        // A max-lines rule ends with "}],". Then an unrelated object below
+        // changes a max field. The }], closure must clear ceiling context.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,10 +10,10 @@',
+          '    rules: {',
+          "      'max-lines': ['error', {",
+          '        max: 800,',
+          '      }],',
+          '    },',
+          '    const other = {',
+          '-      max: 5,',
+          '+      max: 50,',
+          '    };',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not attribute a later max change to a max-lines rule ending with } ],', () => {
+        // Same as above but with a space before the bracket: "} ],".
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,10 +10,10 @@',
+          '    rules: {',
+          "      'max-lines': ['error', {",
+          '        max: 800,',
+          '      } ],',
+          '    },',
+          '    const other = {',
+          '-      max: 5,',
+          '+      max: 50,',
+          '    };',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('still catches a real max-lines threshold increase ending with }],', () => {
+        // Ensure the }], closure recognition does not suppress a legitimate
+        // threshold increase within the same ceiling rule.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "      'max-lines': ['error', {",
+          '-        max: 800,',
+          '+        max: 900,',
+          '      }],',
+          '    },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+      });
+    });
+
+    describe('stricter rule-shaped heuristic for no-context fallback', () => {
+      it('does not flag rule-like keys inside const declarations', () => {
+        // const docs = { 'no-console': 'error' } changed to 'warn' must NOT be
+        // treated as a severity downgrade because it is not inside a rules
+        // block and is a const declaration, not a rule assignment.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,3 +10,3 @@',
+          "-const docs = { 'no-console': 'error' };",
+          "+const docs = { 'no-console': 'warn' };",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag rule-like keys inside object assignments', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,3 +10,3 @@',
+          "-  const cfg = { 'no-console': 2 };",
+          "+  const cfg = { 'no-console': 1 };",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag ordinary assignment docs = {...} with rule-like keys', () => {
+        // docs = { 'no-console': 'error' } changed to 'warn' must NOT be
+        // treated as a severity downgrade because an ordinary assignment (=)
+        // is not a bare rule entry inside a rules object.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,3 +10,3 @@',
+          "-docs = { 'no-console': 'error' };",
+          "+docs = { 'no-console': 'warn' };",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag settings.rules assignment with rule-like keys', () => {
+        // settings.rules = { 'no-console': 2 } changed to 1 must NOT be
+        // treated as a severity downgrade because a dotted assignment (=) is
+        // not a bare rule entry inside a rules object.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,3 +10,3 @@',
+          "-settings.rules = { 'no-console': 2 };",
+          "+settings.rules = { 'no-console': 1 };",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag multiline unrelated docs object with rule-like key and severity', () => {
+        // A multiline unrelated const object whose entries look like rule
+        // entries (e.g. const docs = { 'no-console': 'error' -> 'warn' }) must
+        // NOT be treated as a severity downgrade. The hunk HAS context lines
+        // (const docs = { and };) but no rules: { context line, so
+        // hasHunkContext is true and the zero-context fallback does NOT fire.
+        // Since rulesBraceDepth is null (no rules: { context), the comparison
+        // is gated to require rules-block context, preventing the false
+        // positive.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,4 +10,4 @@',
+          '  const docs = {',
+          "-    'no-console': 'error',",
+          "+    'no-console': 'warn',",
+          '  };',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag multiline unrelated thresholds object with ceiling-rule-like key', () => {
+        // A multiline unrelated const object whose entries look like ceiling
+        // threshold entries (e.g. const thresholds = { complexity: ['error',
+        // 25] -> ['error', 26] }) must NOT be treated as a ceiling threshold
+        // increase. The hunk HAS context lines (const thresholds = { and };)
+        // but no rules: { context line, so hasHunkContext is true and the
+        // zero-context fallback does NOT fire. Since rulesBraceDepth is null,
+        // the comparison is gated to require rules-block context, preventing
+        // the false positive.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,4 +10,4 @@',
+          '  const thresholds = {',
+          "-    complexity: ['error', 25],",
+          "+    complexity: ['error', 26],",
+          '  };',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('still preserves valid rule entries like quoted warn and array complexity', () => {
+        // Bare rule entries (no const/let/var/=) must still be detected so
+        // valid rule configs are not silently allowed to loosen.
+        const downgradeDiff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-      'no-console': 'warn',",
+          "+      'no-console': 'off',",
+        ].join(String.fromCharCode(10));
+        const thresholdDiff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-      complexity: ['error', 25],",
+          "+      complexity: ['error', 26],",
+        ].join(String.fromCharCode(10));
+
+        expect(
+          checkDiff(downgradeDiff).filter((v) =>
+            v.message.includes('severity downgrade'),
+          ),
+        ).toHaveLength(1);
+        expect(
+          checkDiff(thresholdDiff).filter((v) =>
+            v.message.includes('threshold increase'),
+          ),
+        ).toHaveLength(1);
+      });
+
+      it('still catches a real rule severity downgrade in a zero-context hunk', () => {
+        // A real rule assignment line (bare, no const/=) must still be caught.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-      'no-console': 'error',",
+          "+      'no-console': 'warn',",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('still catches a real ceiling threshold increase in a zero-context hunk', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-      complexity: ['error', 25],",
+          "+      complexity: ['error', 30],",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+    });
+
+    describe('single-line nested rules objects', () => {
+      it('catches a new off entry in a single-line nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+    rules: { 'no-console': 'off' },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a new numeric off entry in a single-line nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+    rules: { 'no-console': 0 },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a severity downgrade in a single-line nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-    rules: { 'no-console': 'error' },",
+          "+    rules: { 'no-console': 'warn' },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a ceiling threshold increase in a single-line nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-    rules: { complexity: ['error', 25] },",
+          "+    rules: { complexity: ['error', 50] },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a max object threshold increase in a single-line nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-    rules: { 'max-lines': ['error', { max: 800 }] },",
+          "+    rules: { 'max-lines': ['error', { max: 900 }] },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('does not flag a severity upgrade in a single-line nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-    rules: { 'no-console': 'warn' },",
+          "+    rules: { 'no-console': 'error' },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag an allowed-off single-line nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+    rules: { 'no-console': 'off' }, // eslint-policy-allow-off: #2079",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('catches a cross-form threshold increase in a single-line nested rules object', () => {
+        // object max -> numeric cross-form increase within a single-line
+        // nested rules: { ... } object.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-    rules: { 'max-lines': ['error', { max: 800 }] },",
+          "+    rules: { 'max-lines': ['error', 900] },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('catches a scalar-to-threshold addition in a single-line nested rules object', () => {
+        // Scalar severity -> explicit threshold for a ceiling rule within a
+        // single-line nested rules: { ... } object must be rejected.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-    rules: { complexity: 'error' },",
+          "+    rules: { complexity: ['error', 999] },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('Adding a ceiling threshold'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('complexity');
+      });
+    });
+
+    describe('TypeScript multiline block-comment suppression directives', () => {
+      // TypeScript 5.8.x only recognizes @ts-ignore/@ts-expect-error/@ts-nocheck
+      // when the directive appears on a single comment line (either a // line
+      // comment or a single-line /* ... */ block comment). A directive inside a
+      // multiline block comment (on a line other than the opener that also
+      // closes) is NOT an effective suppression, so the guard must not flag it
+      // (avoiding false positives on prose that merely mentions the directive).
+      //
+      // Verified against TypeScript 5.8.3:
+      //   - // @ts-ignore             → effective suppression (flagged)
+      //   - /* @ts-ignore */          → effective suppression (flagged)
+      //   - /* leading @ts-ignore */  → NOT effective (not flagged)
+      //   - /*\n * @ts-ignore\n */    → NOT effective (not flagged)
+      //   - /* @ts-ignore\n */        → NOT effective (opener flagged conservatively)
+      //   - reason @ts-ignore */      → NOT effective (not flagged)
+      it('does not flag @ts-ignore mentioned inside a multiline block comment body', () => {
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '   /* leading prose mentioning @ts-ignore here',
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag @ts-expect-error at the end of a multiline block comment', () => {
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '   reason text @ts-expect-error */',
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag @ts-nocheck in a continuation line of a multiline block comment', () => {
+        // In a multiline block comment, the directive on a continuation line
+        // (after a leading *) is NOT an effective TS suppression.
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            ' * @ts-nocheck some note about the directive',
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag @ts-ignore not at the start of a single-line block comment', () => {
+        // TypeScript does not recognize the directive when it is not at the
+        // start of the comment text (after optional whitespace), even in a
+        // single-line block comment.
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '/* leading text @ts-ignore */',
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('still flags @ts-ignore in a single-line block comment', () => {
+        const violations = checkDiff(
+          diffFor(
+            'packages/core/src/example.ts',
+            '/* @ts-ignore single-line reason */',
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('TypeScript suppression');
+      });
+
+      it('still flags @ts-ignore in a line comment', () => {
+        const violations = checkDiff(
+          diffFor('packages/core/src/example.ts', '// @ts-ignore reason'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('TypeScript suppression');
+      });
+    });
+
+    describe('structural context: removed lines do not mutate brace context', () => {
+      // Finding 1 (#2189 review): removed lines must not update
+      // rulesBraceDepth/currentRuleKey/currentCeilingRuleKey. Only context
+      // and added lines update structural context (the post-change view). A
+      // changed multiline rule opener containing { is both removed and added;
+      // if both sides mutated brace depth, the depth would be double-counted
+      // and the guard would stay falsely inside a rules block after it
+      // closes, flagging unrelated severity-like arrays/objects below.
+
+      it('does not flag a severity-like array after a changed multiline rule opener', () => {
+        // The rule opener "'no-console': [" is changed (removed and added).
+        // After the rules block closes, an unrelated array changes an
+        // error-like value. Without the fix, the double-counted brace delta
+        // keeps rulesBraceDepth non-null after the block closes and the
+        // standalone "warn" is falsely flagged as a multiline downgrade.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,12 +10,12 @@',
+          '    rules: {',
+          "-      'no-console': [",
+          "+      'no-console': [",
+          '        "error",',
+          '      ],',
+          '    },',
+          '    const severityMap = {',
+          '      fatal: [',
+          '-       "error",',
+          '+       "warn",',
+          '    ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag a standalone max after a changed multiline ceiling rule opener', () => {
+        // A ceiling rule opener "'max-lines': ['error', {" is changed (removed
+        // and added). After the rules block closes, an unrelated object below
+        // changes a standalone max field. Without the fix, the double-counted
+        // brace depth keeps currentCeilingRuleKey alive and the unrelated max
+        // increase is falsely attributed to max-lines.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,14 +10,14 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          '+          max: 900,',
+          '        }],',
+          '    },',
+          '    const other = {',
+          '      budget: {',
+          '-        max: 100,',
+          '+        max: 500,',
+          '      },',
+          '    };',
+        ].join(String.fromCharCode(10));
+
+        // Only the real max-lines increase (800 -> 900) should be reported.
+        // The unrelated budget max change must NOT be attributed to max-lines.
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+        expect(violations[0].message).toContain('800');
+        expect(violations[0].message).toContain('900');
+      });
+
+      it('still detects a real multiline severity downgrade with a changed opener', () => {
+        // Ensure the removed-line fix does not suppress a legitimate
+        // multiline severity downgrade when the rule opener is also changed.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "-      'no-console': [",
+          "+      'no-console': [",
+          '-        "error",',
+          '+        "warn",',
+          '        { allow: [] },',
+          '      ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+    });
+
+    describe('structural context: nested option keys do not reset rule key', () => {
+      // Finding 2 (#2189 review): a custom option key not in STRUCTURAL_KEYS
+      // (e.g. "customHint") inside a ceiling rule config must NOT replace
+      // currentRuleKey/currentCeilingRuleKey. Without rule-entry depth
+      // tracking, extractRuleKey would treat the option key as a rule key and
+      // reset the ceiling context, causing later multiline max changes to be
+      // missed (false negative).
+
+      it('still attributes a later max change to the ceiling rule with a custom option key', () => {
+        // The ceiling rule max-lines has a custom option key "customHint"
+        // between the rule opener and the max field. The max increase must
+        // still be attributed to max-lines.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '      rules: {',
+          "        'max-lines': ['error', {",
+          '          customHint: "enforce",',
+          '-          max: 800,',
+          '+          max: 900,',
+          '          skipBlankLines: true,',
+          '        }],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('still attributes a later multiline severity change with a custom option key', () => {
+        // A non-ceiling rule 'no-console' has a custom option key before the
+        // standalone severity line. The severity downgrade must still be
+        // attributed to no-console.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '      rules: {',
+          "        'no-console': [",
+          '          customLabel: true,',
+          '-        "error",',
+          '+        "warn",',
+          '        ],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-console');
+      });
+
+      it('recognizes a new sibling rule entry after a prior rule with custom options closes', () => {
+        // After a ceiling rule with a custom option key closes, a second
+        // ceiling rule (max-statements) must still be tracked as the current
+        // ceiling rule for its own max increase.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,14 +10,14 @@',
+          '      rules: {',
+          "        'max-lines': ['error', {",
+          '          customHint: "x",',
+          '          max: 800,',
+          '        }],',
+          "        'max-statements': ['error', {",
+          '          customHint: "y",',
+          '-          max: 30,',
+          '+          max: 40,',
+          '        }],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-statements');
+      });
+    });
+
+    describe('scalar rule preceding multiline rule (insideRuleEntry pin fix)', () => {
+      // Finding (#2189 review): a single-line scalar rule entry like
+      // "'no-console': 'error'," must NOT pin insideRuleEntry, because it
+      // opens and closes on the same line. Previously, insideRuleEntry was
+      // set for any rule key and only cleared on a closure line or rules-block
+      // close. A single-line scalar entry has no subsequent closure line, so
+      // the flag stayed pinned and the next multiline rule opener (e.g.
+      // "'max-lines': ['error', {") was ignored — its max/severity changes were
+      // missed (false negative). These end-to-end tests exercise the mixed
+      // scalar/multiline scenario.
+
+      it('catches a multiline ceiling threshold increase after a scalar rule', () => {
+        // 'no-console': 'error', is a complete single-line scalar entry.
+        // 'max-lines': ['error', { opens a multiline ceiling rule. Without the
+        // fix, insideRuleEntry stays pinned from no-console and max-lines is
+        // never tracked as the current ceiling rule, so the 800 -> 900 max
+        // increase is missed.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '      rules: {',
+          "      'no-console': 'error',",
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          '+          max: 900,',
+          '        }],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+        expect(violations[0].message).toContain('800');
+        expect(violations[0].message).toContain('900');
+      });
+
+      it('catches a multiline severity downgrade after a scalar rule', () => {
+        // 'no-console': 'error', is a complete single-line scalar entry.
+        // 'no-unused': [ opens a multiline rule whose standalone severity
+        // changes from error to warn. Without the fix, insideRuleEntry stays
+        // pinned from no-console and no-unused is never tracked as the current
+        // rule key, so the severity downgrade is missed.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '      rules: {',
+          "      'no-console': 'error',",
+          "        'no-unused': [",
+          '-        "error",',
+          '+        "warn",',
+          '          { args: "none" },',
+          '        ],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-unused');
+      });
+
+      it('does not create a broad max false positive from a scalar ceiling rule followed by an unrelated max field', () => {
+        // 'max-lines': ['error', { max: 800 }], is a complete single-line
+        // ceiling rule entry. It must NOT pin insideRuleEntry or leave
+        // currentCeilingRuleKey set, so a subsequent unrelated max field in a
+        // non-ceiling context is NOT falsely attributed to max-lines.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '      rules: {',
+          "        'max-lines': ['error', { max: 800 }],",
+          "        'no-restricted-syntax': ['error', {",
+          '-          max: 5,',
+          '+          max: 15,',
+          '        }],',
+          '      },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        // The max field under no-restricted-syntax is NOT a ceiling rule, so
+        // the max 5 -> 15 increase must NOT be attributed to max-lines or
+        // reported as a ceiling threshold increase.
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('inline rules: consume removed entry on key match regardless of violation', () => {
+      // Finding 3 (#2189 review): once an added inline entry matches a removed
+      // inline entry by key, the removed entry must be consumed whether or not
+      // compareRuleConfigChanges returns messages. Otherwise a no-op match
+      // (same severity) leaves the removed entry stale and can cause false
+      // positives or mis-attribution later.
+
+      it('consumes a no-op inline match so a later separate downgrade is not double-counted', () => {
+        // Two inline rules objects in one hunk. The first is a no-op
+        // (no-console stays 'warn'); the second is a real downgrade
+        // (no-unused error -> warn). The no-op must be consumed so its stale
+        // removed entry does not interfere.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,3 +10,3 @@',
+          "-    rules: { 'no-console': 'warn' },",
+          "-    rules: { 'no-unused': 'error' },",
+          "+    rules: { 'no-console': 'warn' },",
+          "+    rules: { 'no-unused': 'warn' },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-unused');
+      });
+
+      it('consumes a no-op inline match so a later downgrade is attributed to the right rule', () => {
+        // Two removed inline entries for 'no-console': a no-op warn entry
+        // followed by a real error entry. Two added inline entries: a no-op
+        // warn entry followed by a warn entry. The first added (warn) must
+        // consume the first removed (warn) no-op entry, so the second added
+        // (warn) pairs with the second removed (error) and the real downgrade
+        // is detected exactly once.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,3 +10,3 @@',
+          "-    rules: { 'no-console': 'warn' },",
+          "-    rules: { 'no-console': 'error' },",
+          "+    rules: { 'no-console': 'warn' },",
+          "+    rules: { 'no-console': 'warn' },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        // The stale warn entry is consumed by the no-op add, so it does not
+        // mask the real error->warn downgrade.
+        expect(violations).toHaveLength(1);
+      });
+    });
+
+    describe('removed-side rule context for realistic Git ordering (#2189 review)', () => {
+      // In realistic Git unified-diff ordering, adjacent changed opener and
+      // value lines are emitted as removed-then-added:
+      //   - 'no-console': [
+      //   -   'error',
+      //   + 'no-console': [
+      //   +   'warn',
+      // The removed severity is processed BEFORE the added opener sets the
+      // post-change currentRuleKey/currentCeilingRuleKey. Without a separate
+      // removed-side rule context, bufferRemovedConfig would see a null key
+      // and skip buffering the removed severity/max — causing a false negative
+      // for realistic severity downgrades and max threshold increases.
+      //
+      // The fix maintains parallel removed-side rule context
+      // (removedCurrentRuleKey/removedCurrentCeilingRuleKey) that tracks the
+      // pre-change file view from removed lines, so removed multiline
+      // severity/max values are correctly attributed to their enclosing rule
+      // regardless of Git ordering.
+
+      it('catches a multiline severity downgrade with realistic Git ordering (removed opener+value before added opener+value)', () => {
+        // The removed opener and removed 'error' precede the added opener and
+        // added 'warn'. The removed-side context must attribute the removed
+        // 'error' to no-console before the post-change side sees the opener.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "-      'no-console': [",
+          '-        "error",',
+          "+      'no-console': [",
+          '+        "warn",',
+          '        { allow: [] },',
+          '      ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-console');
+      });
+
+      it('catches a multiline max threshold increase with realistic Git ordering (removed opener+max before added opener+max)', () => {
+        // The removed opener and removed max: 800 precede the added opener and
+        // added max: 900. The removed-side ceiling context must attribute the
+        // removed max to max-lines before the post-change side sees the opener.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          "        'max-lines': ['error', {",
+          '+          max: 900,',
+          '          skipBlankLines: true,',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+        expect(violations[0].message).toContain('800');
+        expect(violations[0].message).toContain('900');
+      });
+
+      it('catches a multiline numeric severity downgrade with realistic Git ordering', () => {
+        // Same realistic ordering but with numeric severities (2 -> 1).
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "-      'no-console': [",
+          '-        2,',
+          "+      'no-console': [",
+          '+        1,',
+          '        { allow: [] },',
+          '      ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-console');
+      });
+
+      it('catches a multiline ceiling max increase for max-statements with realistic Git ordering', () => {
+        // Different ceiling rule with numeric array form and realistic
+        // removed-before-added ordering.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "        'max-statements': ['error', {",
+          '-          max: 10,',
+          "        'max-statements': ['error', {",
+          '+          max: 20,',
+          '          skipBlankLines: true,',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-statements');
+      });
+
+      it('does not double-count brace depth when opener is changed (removed+added)', () => {
+        // The changed opener ('no-console': [) is both removed and added. The
+        // post-change rulesBraceDepth must NOT be double-counted (removed
+        // lines never mutate post-change context). After the rules block
+        // closes, an unrelated array below must NOT be flagged.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,12 +10,12 @@',
+          '    rules: {',
+          "-      'no-console': [",
+          '-        "error",',
+          "+      'no-console': [",
+          '+        "warn",',
+          '        { allow: [] },',
+          '      ],',
+          '    },',
+          '    const severityMap = {',
+          '      fatal: [',
+          '-       "error",',
+          '+       "warn",',
+          '    ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        // Only the real no-console downgrade (error -> warn) should be
+        // reported. The unrelated severityMap array must NOT produce a second
+        // downgrade after the rules block closes.
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-console');
+      });
+
+      it('does not cross-pair removed/added multiline severities across two rules with realistic ordering', () => {
+        // Two multiline rules, each with realistic removed-before-added
+        // ordering. Only no-console is actually downgraded; the removed
+        // 'error' from no-console must NOT pair with an added severity from
+        // another rule.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,14 +10,14 @@',
+          '    rules: {',
+          "        'no-console': [",
+          '-        "error",',
+          "+        'no-console': [",
+          '+        "warn",',
+          '          { allow: [] },',
+          '        ],',
+          "        'no-unused': [",
+          '-        "error",',
+          "+        'no-unused': [",
+          '+        "error",',
+          '        ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        // Only the real downgrade (no-console error -> warn) is reported.
+        // no-unused is unchanged (error -> error) and must not be flagged.
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-console');
+      });
+
+      it('does not attribute a removed max to a non-matching ceiling rule with realistic ordering', () => {
+        // A removed max-lines opener+max precedes an added max-statements
+        // opener+max. The removed max from max-lines must NOT be attributed
+        // to max-statements (different ceiling rule key).
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,14 +10,14 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          "        'max-lines': ['error', {",
+          '+          max: 800,',
+          '          skipBlankLines: true,',
+          '        }],',
+          "        'max-statements': ['error', {",
+          '-          max: 10,',
+          "        'max-statements': ['error', {",
+          '+          max: 20,',
+          '          skipBlankLines: true,',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        // Only max-statements (10 -> 20) is a real increase. max-lines is
+        // unchanged (800 -> 800) and must not be flagged.
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-statements');
+      });
+
+      it('does not flag a removed max under a non-ceiling rule with realistic ordering', () => {
+        // A removed max under a non-ceiling rule (no-restricted-syntax) with
+        // realistic ordering must NOT be buffered as a ceiling threshold, so
+        // the added max under the same non-ceiling rule is not flagged.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "        'no-restricted-syntax': ['error', {",
+          '-          max: 5,',
+          "        'no-restricted-syntax': ['error', {",
+          '+          max: 15,',
+          '          allow: [],',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('still catches a standalone max threshold increase with unchanged opener (regression)', () => {
+        // Regression: the realistic-ordering fix must not break the existing
+        // case where the opener is unchanged (only the max line changes).
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          '+          max: 900,',
+          '          skipBlankLines: true,',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('still catches a standalone multiline severity downgrade with unchanged opener (regression)', () => {
+        // Regression: the realistic-ordering fix must not break the existing
+        // case where the opener is unchanged (only the severity line changes).
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "      'no-console': [",
+          '-        "error",',
+          '+        "warn",',
+          '        { allow: [] },',
+          '      ],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-console');
+      });
+    });
+
+    describe('insideRuleEntry gating for same-rule comparison and buffering (#2189 review finding 1)', () => {
+      // Finding 1: The off/0 gate suppresses keyed option fields while
+      // insideRuleEntry is true, but the same-rule severity/threshold
+      // comparison path (pendingRemovedConfigs buffering +
+      // compareRuleConfigChanges) did not. A multiline rule option such as
+      // customOption: 'error' changed to customOption: 'warn' inside
+      // no-restricted-syntax was buffered and compared as if customOption
+      // were an ESLint rule key, producing a false severity-downgrade
+      // violation. The fix applies the same insideRuleEntry gating to
+      // pendingRemovedConfigs (bufferRemovedConfig) and the added-side
+      // same-rule-key comparison, so keyed entries are not buffered or
+      // compared while inside an existing rule-entry config object (unless
+      // the key is the actual rule-entry opener at the rules-object level).
+
+      it('does not flag customOption severity downgrade inside a multiline rule config object (no-restricted-syntax)', () => {
+        // no-restricted-syntax has a customOption field that changes from
+        // 'error' to 'warn'. customOption is not in STRUCTURAL_KEYS, so
+        // before the fix it was treated as a rule key and the severity
+        // comparison produced a false positive.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "      'no-restricted-syntax': ['error', {",
+          "-        customOption: 'error',",
+          "+        customOption: 'warn',",
+          '        selector: ' + "'Literal'" + ',',
+          '      }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag a quoted customOption severity downgrade inside a multiline rule config object', () => {
+        // A quoted custom option key must also not be treated as a rule key
+        // while inside a rule-entry config object.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,8 +10,8 @@',
+          '    rules: {',
+          "      'no-restricted-syntax': ['error', {",
+          "-        'customOption': 'error',",
+          "+        'customOption': 'warn',",
+          '        selector: ' + "'Literal'" + ',',
+          '      }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('still catches a real severity downgrade on a neighboring rule (detection still works)', () => {
+        // A neighboring real rule (no-unused) is downgraded from 'error' to
+        // 'warn' at the rules-object entry level, while a customOption inside
+        // no-restricted-syntax also changes. The real downgrade (removed
+        // 'no-unused': 'error' paired with added 'no-unused': 'warn') must
+        // still be detected, proving the insideRuleEntry gating does not
+        // over-suppress legitimate rule-entry-level downgrades.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,10 +10,10 @@',
+          '    rules: {',
+          "-      'no-unused': 'error',",
+          "      'no-restricted-syntax': ['error', {",
+          "-        customOption: 'error',",
+          "+        customOption: 'warn',",
+          '      }],',
+          "+      'no-unused': 'warn',",
+          '    },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-unused');
+      });
+
+      it('still catches a real threshold increase on a neighboring ceiling rule', () => {
+        // A real ceiling threshold increase (max-lines 800 -> 900) must still
+        // be detected when a customOption inside no-restricted-syntax changes
+        // in the same hunk. The insideRuleEntry gating must not suppress real
+        // ceiling rule detection.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,10 +10,10 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          '-          max: 800,',
+          '+          max: 900,',
+          '        }],',
+          "      'no-restricted-syntax': ['error', {",
+          "-        customOption: 'error',",
+          "+        customOption: 'warn',",
+          '      }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+      });
+
+      it('still catches a real rule-entry-level severity downgrade in the same hunk', () => {
+        // A rule at the rules-object entry level (not inside a config object)
+        // is downgraded. insideRuleEntry must be false at that point so the
+        // real downgrade is caught.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,4 +10,4 @@',
+          '    rules: {',
+          "-      'no-console': 'error',",
+          "+      'no-console': 'warn',",
+          '    },',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('no-console');
+      });
+    });
+
+    describe('quoted multiline max threshold detection (#2189 review finding 2)', () => {
+      // Finding 2: The multiline max threshold helpers
+      // (isStandaloneMaxLine, isObjectFormMaxLine,
+      // extractMaxValueFromStandaloneLine) handled only unquoted max keys.
+      // ESLint config object keys may be quoted, e.g. { 'max': 800 }. The
+      // helpers now accept an optional quote around the key while retaining
+      // currentCeilingRuleKey gating so broad max false positives remain
+      // avoided.
+
+      it('catches a quoted standalone max threshold increase for max-lines', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          "-          'max': 800,",
+          "+          'max': 900,",
+          '          skipBlankLines: true,',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+        expect(violations[0].message).toContain('800');
+        expect(violations[0].message).toContain('900');
+      });
+
+      it('does not flag a quoted standalone max threshold decrease for max-lines', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          "-          'max': 800,",
+          "+          'max': 700,",
+          '          skipBlankLines: true,',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('catches a quoted object-form max threshold increase for max-statements', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "        'max-statements': ['error', {",
+          "-          { 'max': 30, skipBlankLines: true },",
+          "+          { 'max': 40, skipBlankLines: true },",
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-statements');
+        expect(violations[0].message).toContain('30');
+        expect(violations[0].message).toContain('40');
+      });
+
+      it('does not flag a quoted object-form max threshold decrease for max-lines', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "        'max-lines': ['error', {",
+          "-          { 'max': 800, skipBlankLines: true },",
+          "+          { 'max': 700, skipBlankLines: true },",
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag a quoted standalone max increase under a non-ceiling rule', () => {
+        // A quoted max field under a non-ceiling rule (no-restricted-syntax)
+        // must NOT be attributed to a ceiling rule. This exercises the
+        // currentCeilingRuleKey gating with quoted keys.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "      'no-restricted-syntax': ['error', {",
+          "-          'max': 5,",
+          "+          'max': 50,",
+          '        allow: [],',
+          '      }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag a quoted object-form max increase under a non-ceiling rule', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          "      'no-restricted-syntax': ['error', {",
+          "-          { 'max': 5, allow: [] },",
+          "+          { 'max': 50, allow: [] },",
+          '      }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toEqual([]);
+      });
+
+      it('catches a double-quoted standalone max threshold increase for max-lines', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 100644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10,6 +10,6 @@',
+          '    rules: {',
+          '        "max-lines": ["error", {',
+          '-          "max": 800,',
+          '+          "max": 900,',
+          '          skipBlankLines: true,',
+          '        }],',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('max-lines');
+      });
+    });
+  });
+
   it('keeps the checked-in cli source policy clean', () => {
     expect(checkCliSourcePolicy()).toEqual([]);
   });
@@ -247,6 +5087,1612 @@ describe('check-eslint-guard', () => {
     );
 
     expect(scanCliProductionTypeEscapes(tmpDir)).toEqual([]);
+  });
+
+  describe('unrelated rules config fields (#2189 review finding 1)', () => {
+    // A `rules: { ... }` property inside an unrelated object (e.g.
+    // const meta = { rules: { 'no-console': 'off' } }) must NOT be treated
+    // as an ESLint config rules block. Both single-line and multiline forms
+    // must be rejected, while actual ESLint config rules blocks still flag
+    // downgrades (#2189 review finding 1).
+
+    it('does not flag single-line const meta object with rules property', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+const meta = { rules: { 'no-console': 'off' } };",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag assignment object with rules property (single line)', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+meta = { rules: { 'no-console': 'off' } };",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag multiline const meta object with rules property on context line', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,3 +10,3 @@',
+        '  const meta = {',
+        "    rules: { 'no-console': 'off' },",
+        '  };',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag multiline const meta object with rules property as added line', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,3 +10,4 @@',
+        '  const meta = {',
+        "+    rules: { 'no-console': 'off' },",
+        '  };',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag multiline const meta with multiline rules object', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,3 +10,6 @@',
+        '  const meta = {',
+        '+    rules: {',
+        "+      'no-console': 'off',",
+        '+    },',
+        '  };',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('still flags severity downgrade in actual ESLint config rules block', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,3 +1,3 @@',
+        '  rules: {',
+        "-    'no-console': 'error',",
+        "+    'no-console': 'warn',",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('severity downgrade');
+    });
+
+    it('still flags off/0 entry in actual ESLint config rules block', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,2 +1,3 @@',
+        '  rules: {',
+        "+    'no-console': 'off',",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('still flags threshold increase in actual ESLint config rules block', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,3 +1,3 @@',
+        '  rules: {',
+        "-    complexity: ['error', 25],",
+        "+    complexity: ['error', 30],",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('threshold increase');
+    });
+
+    it('still flags inline rules downgrade in actual config context', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,2 +1,2 @@',
+        "-    rules: { 'no-console': 'error' },",
+        "+    rules: { 'no-console': 'warn' },",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('severity downgrade');
+    });
+  });
+
+  describe('nested non-rule container properties (#2189 review finding 2)', () => {
+    // A `rules:` property nested inside a known non-rule container
+    // (settings, languageOptions, plugins, etc.) is NOT the ESLint policy
+    // rules object — it is application data consumed by plugins/shared
+    // configs. Both single-line and multiline forms must be rejected, while
+    // actual top-level ESLint config rules blocks still flag downgrades and
+    // off/0 entries (#2189 review finding 2).
+
+    it('does not flag single-line settings.rules off entry', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+  settings: { rules: { 'no-console': 'off' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag single-line settings.rules severity downgrade', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "-  settings: { rules: { 'no-console': 'error' } },",
+        "+  settings: { rules: { 'no-console': 'warn' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag single-line languageOptions.rules off entry', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+  languageOptions: { rules: { complexity: 'off' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag multiline settings.rules off entry', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,1 +10,4 @@',
+        '  settings: {',
+        '+    rules: {',
+        "+      'no-console': 'off',",
+        '+    },',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag multiline settings.rules severity downgrade', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,4 +10,4 @@',
+        '  settings: {',
+        '    rules: {',
+        "-      'no-console': 'error',",
+        "+      'no-console': 'warn',",
+        '    },',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag multiline languageOptions.rules threshold increase', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,4 +10,4 @@',
+        '  languageOptions: {',
+        '    rules: {',
+        "-      complexity: ['error', 25],",
+        "+      complexity: ['error', 50],",
+        '    },',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('threshold increase'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag single-line plugins.rules off entry', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+  plugins: { rules: { 'no-console': 'off' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag a sibling top-level rules block after settings closes', () => {
+      // settings: { ... } closes, then a sibling top-level rules: { ... }
+      // block opens. The sibling rules block IS the ESLint policy rules
+      // object and must still be checked. This proves the non-rule container
+      // tracking correctly closes when settings closes and does not suppress
+      // a legitimate sibling rules block.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,4 +10,5 @@',
+        '  settings: { shared: true },',
+        '  rules: {',
+        "+    'no-console': 'off',",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('still flags a real top-level rules block severity downgrade', () => {
+      // Regression guard: tightening the rules-block context must not break
+      // detection of real top-level rules blocks.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,3 +1,3 @@',
+        '  rules: {',
+        "-    'no-console': 'error',",
+        "+    'no-console': 'warn',",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('severity downgrade');
+    });
+
+    it('still flags a real top-level rules block threshold increase', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,3 +1,3 @@',
+        '  rules: {',
+        "-    complexity: ['error', 25],",
+        "+    complexity: ['error', 30],",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('threshold increase');
+    });
+  });
+
+  describe('quoted non-rule container keys (#2189 review finding)', () => {
+    // Quoted container keys ('settings': { ... }, "languageOptions": { ... })
+    // must be recognized just like unquoted ones, so a nested rules: property
+    // inside a quoted container is NOT treated as the ESLint policy rules
+    // block. This covers the same-line container check in
+    // isRulesInArbitraryContext and isNonRuleContainerOpen, which previously
+    // built patterns like \bsettings\s*:\s*\{ missing quoted config keys
+    // (#2189 review finding).
+
+    it('does not flag quoted single-line settings.rules off entry', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+  'settings': { rules: { 'no-console': 'off' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag double-quoted single-line languageOptions.rules off entry', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        '+  "languageOptions": { rules: { complexity: 0 } },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag quoted single-line settings.rules severity downgrade', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "-  'settings': { rules: { 'no-console': 'error' } },",
+        "+  'settings': { rules: { 'no-console': 'warn' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag double-quoted single-line languageOptions.rules threshold increase', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        '-  "languageOptions": { rules: { complexity: [2, 25] } },',
+        '+  "languageOptions": { rules: { complexity: [2, 50] } },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('threshold increase'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag multiline quoted settings.rules off entry', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,1 +10,4 @@',
+        "  'settings': {",
+        '+    rules: {',
+        "+      'no-console': 'off',",
+        '+    },',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('still flags a real top-level rules block with quoted container sibling', () => {
+      // A quoted settings: { ... } closes, then a sibling top-level rules:
+      // { ... } block opens. The sibling rules block IS the ESLint policy
+      // rules object and must still be checked even though the preceding
+      // container was quoted.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10,4 +10,5 @@',
+        "  'settings': { shared: true },",
+        '  rules: {',
+        "+    'no-console': 'off',",
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+  });
+
+  describe('single-line sibling rules after a closed non-rule container (#2189 review finding)', () => {
+    // A `rules:` property that is a SIBLING after a closed non-rule container
+    // on the same line (e.g. `{ languageOptions: {}, rules: { ... } }` or
+    // `export default [{ settings: {}, rules: { ... } }]`) is the ESLint policy
+    // rules block and MUST be checked. The previous logic in
+    // isRulesInArbitraryContext treated any known non-rule container key
+    // appearing before `rules:` on the same line as proof of nesting, even
+    // when the container's braces had already closed. This caused a false
+    // negative that suppressed real severity downgrades, threshold increases,
+    // and new off/0 entries in valid flat-config rule blocks. The fix performs
+    // a structural scan from each container opener to the `rules:` match and
+    // only suppresses detection when the container object remains open (brace
+    // depth > 0) at `rules:` (#2189 review finding).
+
+    it('flags a severity downgrade in a sibling rules block after closed languageOptions', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-  { languageOptions: {}, rules: { 'no-console': 'error' } },",
+        "+  { languageOptions: {}, rules: { 'no-console': 'warn' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('flags a threshold increase in a sibling rules block after closed languageOptions', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-  { languageOptions: {}, rules: { complexity: ['error', 20] } },",
+        "+  { languageOptions: {}, rules: { complexity: ['error', 25] } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('threshold increase'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('flags a new off/0 entry in a sibling rules block after closed languageOptions', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-  { languageOptions: {}, rules: { 'no-console': 'error' } },",
+        "+  { languageOptions: {}, rules: { 'no-console': 'off' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('flags a severity downgrade in a sibling rules block after closed settings', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-  { settings: {}, rules: { 'no-console': 'error' } },",
+        "+  { settings: {}, rules: { 'no-console': 'warn' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('flags a new off/0 entry in export default sibling rules after closed settings', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-export default [{ settings: {}, rules: { 'no-console': 'error' } }]",
+        "+export default [{ settings: {}, rules: { 'no-console': 'off' } }]",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('flags a threshold increase in export default sibling rules after closed settings', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-export default [{ settings: {}, rules: { complexity: ['error', 10] } }]",
+        "+export default [{ settings: {}, rules: { complexity: ['error', 30] } }]",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('threshold increase'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('still suppresses detection for truly nested settings.rules on one line', () => {
+      // settings: { rules: { ... } } — rules IS nested inside settings and is
+      // application data, NOT the policy rules block. This must NOT be flagged.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-  settings: { rules: { 'no-console': 'error' } },",
+        "+  settings: { rules: { 'no-console': 'warn' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toEqual([]);
+    });
+
+    it('still suppresses detection for truly nested languageOptions.rules on one line', () => {
+      // languageOptions: { rules: { ... } } — rules IS nested inside
+      // languageOptions and is application data, NOT the policy rules block.
+      // This must NOT be flagged.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-  languageOptions: { rules: { complexity: ['error', 25] } },",
+        "+  languageOptions: { rules: { complexity: ['error', 50] } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toEqual([]);
+    });
+
+    it('still suppresses detection for truly nested quoted settings.rules on one line', () => {
+      // Quoted nested form: 'settings': { rules: { ... } }. rules IS nested.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "-  'settings': { rules: { 'no-console': 'error' } },",
+        "+  'settings': { rules: { 'no-console': 'off' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('treats a closed nested-array container value as a sibling rules block', () => {
+      // The container value contains a closed array before rules:, so rules is
+      // a sibling: settings: { a: [1], rules: { ... } } is actually nested,
+      // BUT here we test that a fully-closed settings object followed by a
+      // sibling rules (with an intervening array literal) is detected.
+      // settings: { data: [1, 2] } closes, then rules: { ... } is a sibling.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1 +1 @@',
+        "-  { settings: { data: [1, 2] }, rules: { 'no-console': 'error' } },",
+        "+  { settings: { data: [1, 2] }, rules: { 'no-console': 'warn' } },",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+  });
+
+  describe('extractRuleKey table-driven parser tests (#2189 review finding)', () => {
+    // Table-driven tests covering the full syntax of ESLint rule IDs that
+    // extractRuleKey must parse: core rules, plugin rules (slash-separated),
+    // and scoped plugin rules (@scope/plugin/rule). The centralized rule-id
+    // regex must accept the leading @ so scoped rules like
+    // @typescript-eslint/no-explicit-any are recognized.
+    const CASES = [
+      {
+        label: 'core rule (unquoted)',
+        input: "no-console: 'error',",
+        expected: 'no-console',
+      },
+      {
+        label: 'core rule (single-quoted)',
+        input: "'no-console': 'error',",
+        expected: 'no-console',
+      },
+      {
+        label: 'core rule (double-quoted)',
+        input: '"no-console": "error",',
+        expected: 'no-console',
+      },
+      {
+        label: 'core rule with hyphen',
+        input: "'no-unused-vars': 2,",
+        expected: 'no-unused-vars',
+      },
+      {
+        label: 'plugin rule (slash-separated, single-quoted)',
+        input: "'sonarjs/cognitive-complexity': ['error', 30],",
+        expected: 'sonarjs/cognitive-complexity',
+      },
+      {
+        label: 'plugin rule (slash-separated, unquoted)',
+        input: 'sonarjs/cognitive-complexity: 2,',
+        expected: 'sonarjs/cognitive-complexity',
+      },
+      {
+        label: 'scoped plugin rule (@scope/plugin/rule, single-quoted)',
+        input: "'@typescript-eslint/no-explicit-any': 'error',",
+        expected: '@typescript-eslint/no-explicit-any',
+      },
+      {
+        label: 'scoped plugin rule (@scope/plugin/rule, double-quoted)',
+        input: '"@typescript-eslint/no-explicit-any": "warn",',
+        expected: '@typescript-eslint/no-explicit-any',
+      },
+      {
+        label: 'scoped plugin rule (unquoted)',
+        input: '@typescript-eslint/no-explicit-any: 2,',
+        expected: '@typescript-eslint/no-explicit-any',
+      },
+      {
+        label: 'scoped rule with underscore',
+        input: "'@typescript-eslint/ban_ts_comment': 'off',",
+        expected: '@typescript-eslint/ban_ts_comment',
+      },
+      {
+        label: 'custom scoped plugin',
+        input: "'@my-scope/custom-rule': 'error',",
+        expected: '@my-scope/custom-rule',
+      },
+      {
+        label: 'array-form scoped rule',
+        input: "'@typescript-eslint/no-explicit-any': ['error'],",
+        expected: '@typescript-eslint/no-explicit-any',
+      },
+      {
+        label: 'object-form scoped rule opener',
+        input: "'@typescript-eslint/no-explicit-any': {",
+        expected: '@typescript-eslint/no-explicit-any',
+      },
+    ];
+
+    for (const testCase of CASES) {
+      it('parses ' + testCase.label, () => {
+        expect(extractRuleKey(testCase.input)).toBe(testCase.expected);
+      });
+    }
+
+    it('returns null for structural keys', () => {
+      expect(extractRuleKey('rules: {')).toBeNull();
+      expect(extractRuleKey('files: [')).toBeNull();
+      expect(extractRuleKey('settings: {')).toBeNull();
+      expect(extractRuleKey('plugins: {}')).toBeNull();
+    });
+
+    it('returns null for option property keys', () => {
+      expect(extractRuleKey('max: 800,')).toBeNull();
+      expect(extractRuleKey('allow: [],')).toBeNull();
+      expect(extractRuleKey('skipBlankLines: true,')).toBeNull();
+    });
+
+    it('returns null for non-key lines', () => {
+      expect(extractRuleKey("'error',")).toBeNull();
+      expect(extractRuleKey('800,')).toBeNull();
+      expect(extractRuleKey('// comment')).toBeNull();
+    });
+
+    it('anchors to the first key (does not extract nested keys)', () => {
+      expect(
+        extractRuleKey("'custom-rules': { complexity: ['error', 50] }"),
+      ).toBe('custom-rules');
+    });
+  });
+
+  describe('scoped ESLint rule IDs (#2189 review finding)', () => {
+    // Scoped ESLint rule IDs beginning with @ (e.g.
+    // @typescript-eslint/no-explicit-any) must be parsed by the rule-key
+    // regex. Previously the character class [a-zA-Z0-9/_-] excluded @,
+    // causing extractRuleKey to return null for scoped rules and bypassing
+    // same-line severity downgrade detection, new off/0 detection, multiline
+    // context attribution, and inline rules extraction. These end-to-end
+    // checkDiff tests prove scoped rules are now handled consistently across
+    // all detection paths.
+
+    function configDiff(file, removedLine, addedLine) {
+      return [
+        'diff --git a/' + file + ' b/' + file,
+        'index 0000000..1111111 100644',
+        '--- a/' + file,
+        '+++ b/' + file,
+        '@@ -1,1 +1,1 @@',
+        '  rules: {',
+        '-' + removedLine,
+        '+' + addedLine,
+        '  },',
+      ].join(String.fromCharCode(10));
+    }
+
+    function rulesBlockOpenerDiff(addedLine) {
+      return [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,0 +1,2 @@',
+        '  rules: {',
+        '+' + addedLine,
+      ].join(String.fromCharCode(10));
+    }
+
+    describe('severity downgrades for scoped rules', () => {
+      it('catches string severity downgrade for @typescript-eslint/no-explicit-any', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': 'error',",
+            "      '@typescript-eslint/no-explicit-any': 'warn',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+        expect(violations[0].message).toContain(
+          '@typescript-eslint/no-explicit-any',
+        );
+      });
+
+      it('catches numeric severity downgrade (2 -> 1) for a scoped rule', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': 2,",
+            "      '@typescript-eslint/no-explicit-any': 1,",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches array-form severity downgrade for a scoped rule', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': ['error', { ignoreArgs: [] }],",
+            "      '@typescript-eslint/no-explicit-any': ['warn', { ignoreArgs: [] }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches numeric array-form severity downgrade (2 -> 1) for a scoped rule', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': [2],",
+            "      '@typescript-eslint/no-explicit-any': [1],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches double-quoted scoped rule severity downgrade', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            '      "@typescript-eslint/no-explicit-any": "error",',
+            '      "@typescript-eslint/no-explicit-any": "warn",',
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('does not flag severity upgrade for a scoped rule', () => {
+        const violations = checkDiff(
+          configDiff(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': 'warn',",
+            "      '@typescript-eslint/no-explicit-any': 'error',",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('new off/0 entries for scoped rules', () => {
+      it('rejects new string off entry for a scoped rule', () => {
+        const violations = checkDiff(
+          diffFor(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': 'off',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('off/0');
+      });
+
+      it('rejects new numeric 0 entry for a scoped rule', () => {
+        const violations = checkDiff(
+          diffFor(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': 0,",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('off/0');
+      });
+
+      it('rejects new array-form [0] entry for a scoped rule', () => {
+        const violations = checkDiff(
+          diffFor(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': [0],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('off/0');
+      });
+
+      it('rejects new array-form [0, ...] entry for a scoped rule', () => {
+        const violations = checkDiff(
+          diffFor(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': [0, { ignoreArgs: [] }],",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('off/0');
+      });
+
+      it('rejects new string off entry for a scoped rule inside a rules block', () => {
+        const violations = checkDiff(
+          rulesBlockOpenerDiff(
+            "      '@typescript-eslint/no-explicit-any': 'off',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('off/0');
+      });
+
+      it('rejects keyed multiline opener off for a scoped rule', () => {
+        const violations = checkDiff(
+          rulesBlockOpenerDiff(
+            "      '@typescript-eslint/no-explicit-any': ['off',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('off/0');
+      });
+
+      it('allows scoped rule off with eslint-policy-allow-off marker', () => {
+        const violations = checkDiff(
+          diffFor(
+            'eslint.config.js',
+            "      '@typescript-eslint/no-explicit-any': 'off', // eslint-policy-allow-off: #2199",
+          ),
+        );
+
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('scoped rules inside single-line nested rules objects', () => {
+      it('catches a new off entry for a scoped rule in a nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+    rules: { '@typescript-eslint/no-explicit-any': 'off' },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a severity downgrade for a scoped rule in a nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-    rules: { '@typescript-eslint/no-explicit-any': 'error' },",
+          "+    rules: { '@typescript-eslint/no-explicit-any': 'warn' },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a numeric off entry for a scoped rule in a nested rules object', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+    rules: { '@typescript-eslint/no-explicit-any': 0 },",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+    });
+
+    describe('scoped rules in zero-context diffs', () => {
+      function scopedZeroContextDiff(removedLine, addedLine) {
+        return [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          '-' + removedLine,
+          '+' + addedLine,
+        ].join(String.fromCharCode(10));
+      }
+
+      it('catches scoped rule severity downgrade in zero-context diff', () => {
+        const violations = checkDiff(
+          scopedZeroContextDiff(
+            "      '@typescript-eslint/no-explicit-any': 'error',",
+            "      '@typescript-eslint/no-explicit-any': 'warn',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('severity downgrade');
+      });
+
+      it('catches scoped rule new off entry in zero-context diff', () => {
+        const violations = checkDiff(
+          scopedZeroContextDiff(
+            "      '@typescript-eslint/no-explicit-any': 'error',",
+            "      '@typescript-eslint/no-explicit-any': 'off',",
+          ),
+        );
+
+        expect(violations).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('export default flat-config rules objects (#2189 review finding)', () => {
+    // The `export default [{ rules: { ... } }]` (and the object form
+    // `export default { rules: { ... } }`) is a valid ESLint flat-config
+    // export form. Single-line severity downgrades and new off/0 entries in
+    // this export form must be detected. The guard must distinguish the valid
+    // export-default config context from arbitrary object data (const/let/var
+    // declarations and assignments) without reintroducing false positives
+    // (#2189 review finding).
+
+    it('catches a new off entry in an export default array config', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+export default [{ rules: { 'no-console': 'off' } }];",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('catches a severity downgrade in an export default array config', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "-export default [{ rules: { 'no-console': 'error' } }];",
+        "+export default [{ rules: { 'no-console': 'warn' } }];",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('catches a ceiling threshold increase in an export default array config', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        '-export default [{ rules: { complexity: [2, 25] } }];',
+        '+export default [{ rules: { complexity: [2, 50] } }];',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('threshold increase'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('catches a new off entry in an export default object config', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+export default { rules: { 'no-console': 'off' } };",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('catches a severity downgrade in an export default object config', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        '-export default { rules: { "no-console": "error" } };',
+        '+export default { rules: { "no-console": "warn" } };',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('severity downgrade'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('catches a ceiling threshold increase in an export default object config', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        '-export default { rules: { complexity: ["error", 25] } };',
+        '+export default { rules: { complexity: ["error", 30] } };',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('threshold increase'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+
+    it('still rejects const declaration with rules property as arbitrary data', () => {
+      // export const config = { rules: { ... } } must NOT be treated as a
+      // valid flat-config export form because it has an identifier (config)
+      // and assignment between export and rules. Only `export default`
+      // followed by structural object/array syntax is a valid config export.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+export const config = { rules: { 'no-console': 'off' } };",
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('still rejects export default with an identifier before rules as arbitrary data', () => {
+      // `export default someConfig` followed by a rules property on another
+      // line or via an identifier is NOT a direct flat-config export. The
+      // text between `export default` and `rules:` must be only structural
+      // object/array syntax.
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -10 +10 @@',
+        "+export default [{ otherKey: true, rules: { 'no-console': 'off' } }];",
+      ].join(String.fromCharCode(10));
+
+      // This SHOULD still be detected because the identifier `otherKey` is
+      // a property key inside the config object, not before the config export.
+      // The structural-syntax check only applies to the text between
+      // `export default` and the first object/array opener.
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('off/0'),
+      );
+      expect(violations).toHaveLength(1);
+    });
+  });
+
+  describe('multiline numeric-array threshold detection (#2189 review finding 2)', () => {
+    // The common multiline numeric-array shape where severity and threshold
+    // are separate array elements on separate lines (e.g.
+
+    describe('export default tseslint.config function-call wrapper (#2189 review finding)', () => {
+      // This project uses `export default tseslint.config(...)` as its flat
+      // config export form (see eslint.config.js). A single-line config entry
+      // such as `export default tseslint.config({ rules: { complexity: ['error',
+      // 25] } })` changed to 50 must be detected. The function-call wrapper
+      // form must be recognized as a valid config context so inline rules inside
+      // it are checked, while severity downgrades, threshold increases, and new
+      // off/0 entries are all caught.
+
+      it('catches a new off entry in an export default tseslint.config call', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+export default tseslint.config({ rules: { 'no-console': 'off' } });",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a severity downgrade in an export default tseslint.config call', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "-export default tseslint.config({ rules: { 'no-console': 'error' } });",
+          "+export default tseslint.config({ rules: { 'no-console': 'warn' } });",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('severity downgrade'),
+        );
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a ceiling threshold increase in an export default tseslint.config call', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          '-export default tseslint.config({ rules: { complexity: ["error", 25] } });',
+          '+export default tseslint.config({ rules: { complexity: ["error", 50] } });',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+        expect(violations).toHaveLength(1);
+      });
+
+      it('catches a new off entry in an export default eslint.config call', () => {
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          '+export default eslint.config({ rules: { "no-console": "off" } });',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+        expect(violations).toHaveLength(1);
+      });
+
+      it('still rejects export default with an unrecognized wrapper as arbitrary data', () => {
+        // An arbitrary function call like `export default foo({ rules: ... })`
+        // is NOT a recognized flat-config wrapper (only `.config(` is). The
+        // `export` keyword before `rules:` marks it as arbitrary context, so
+        // inline rules inside it are NOT extracted.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+export default foo({ rules: { 'no-console': 'off' } });",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+        expect(violations).toEqual([]);
+      });
+    });
+
+    describe('anchored inline rule-key extraction (#2189 review finding)', () => {
+      // extractRuleKey and extractInlineRulesEntries must be anchored so that
+      // nested properties inside an unrelated container value are NOT mistaken
+      // for top-level rule entries. A segment like
+      // `'custom-rules': { complexity: ['error', 50] }` has a top-level key
+      // `custom-rules` whose direct value is a plain object `{ ... }`. The
+      // nested `complexity` property inside it must NOT be extracted as a rule
+      // key, and the nested severity-like value must NOT be treated as the
+      // container's severity.
+
+      it('does not flag nested complexity inside a custom-rules container object', () => {
+        // The `'custom-rules': { complexity: ['error', 50] }` segment is a
+        // container with a nested rule-like property. The direct value is a
+        // plain object `{ ... }`, so it is NOT a rule entry. The nested
+        // complexity threshold must NOT be flagged as a ceiling threshold.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+export default { rules: { 'custom-rules': { complexity: ['error', 50] } } };",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag nested no-console off inside a custom-rules container object', () => {
+        // The `'custom-rules': { 'no-console': 'off' }` segment is a container
+        // with a nested off entry. The direct value is a plain object, so the
+        // nested 'off' must NOT be treated as a new off/0 rule entry.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+export default { rules: { 'custom-rules': { 'no-console': 'off' } } };",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+        expect(violations).toEqual([]);
+      });
+
+      it('does not flag nested complexity inside a custom-rules container in a config call', () => {
+        // Same false-positive guard but inside `export default tseslint.config(
+        // { rules: { 'custom-rules': { complexity: ['error', 50] } } })`.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          '+export default tseslint.config({ rules: { "custom-rules": { complexity: ["error", 50] } } });',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff);
+        expect(violations).toEqual([]);
+      });
+
+      it('still detects a real top-level complexity threshold increase alongside a container', () => {
+        // A real top-level complexity entry AND a custom-rules container in the
+        // same inline rules object. The real complexity increase must be
+        // detected; the nested one inside custom-rules must NOT.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          '-export default { rules: { complexity: ["error", 25], "custom-rules": { complexity: ["error", 50] } } };',
+          '+export default { rules: { complexity: ["error", 30], "custom-rules": { complexity: ["error", 50] } } };',
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('threshold increase'),
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0].message).toContain('complexity');
+        expect(violations[0].message).toContain('25');
+        expect(violations[0].message).toContain('30');
+      });
+
+      it('still detects a real top-level off entry alongside a container', () => {
+        // A real top-level 'no-console': 'off' entry AND a custom-rules
+        // container with a nested off in the same inline rules object. The real
+        // top-level off must be detected; the nested one must NOT.
+        const diff = [
+          'diff --git a/eslint.config.js b/eslint.config.js',
+          'index 0000000..1111111 644',
+          '--- a/eslint.config.js',
+          '+++ b/eslint.config.js',
+          '@@ -10 +10 @@',
+          "+export default { rules: { 'no-console': 'off', 'custom-rules': { 'no-console': 'off' } } };",
+        ].join(String.fromCharCode(10));
+
+        const violations = checkDiff(diff).filter((v) =>
+          v.message.includes('off/0'),
+        );
+        expect(violations).toHaveLength(1);
+      });
+    });
+    //   complexity: [
+    //     'error',
+    //     25,
+    //   ]
+    // changed to 30) must be detected. Threshold increases are rejected,
+    // decreases/equality are allowed, and unrelated standalone numeric
+    // values are not false-positive flagged (#2189 review finding 2).
+
+    it('rejects multiline numeric threshold increase for complexity', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,5 +1,5 @@',
+        '  rules: {',
+        "    complexity: ['error',",
+        '-    25,',
+        '+    30,',
+        '    ],',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('threshold increase');
+      expect(violations[0].message).toContain('complexity');
+    });
+
+    it('rejects multiline numeric threshold increase for max-lines', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,5 +1,5 @@',
+        '  rules: {',
+        "    'max-lines': ['error',",
+        '-    800,',
+        '+    900,',
+        '    ],',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('threshold increase');
+      expect(violations[0].message).toContain('max-lines');
+    });
+
+    it('rejects multiline numeric threshold increase for sonarjs/cognitive-complexity', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,5 +1,5 @@',
+        '  rules: {',
+        "    'sonarjs/cognitive-complexity': ['error',",
+        '-    30,',
+        '+    40,',
+        '    ],',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain('threshold increase');
+    });
+
+    it('allows multiline numeric threshold decrease', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,5 +1,5 @@',
+        '  rules: {',
+        "    complexity: ['error',",
+        '-    30,',
+        '+    25,',
+        '    ],',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toEqual([]);
+    });
+
+    it('allows multiline numeric threshold equality (unchanged value)', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,5 +1,5 @@',
+        '  rules: {',
+        "    complexity: ['error',",
+        '-    25,',
+        '+    25,',
+        '    ],',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag unrelated standalone numeric option values outside rules blocks', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,5 +1,5 @@',
+        '  const thresholds = {',
+        "    count: ['init',",
+        '-    25,',
+        '+    30,',
+        '    ],',
+        '  };',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toEqual([]);
+    });
+
+    it('does not flag standalone numeric values inside non-ceiling rule configs', () => {
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,5 +1,5 @@',
+        '  rules: {',
+        "    'no-console': ['error',",
+        '-    25,',
+        '+    30,',
+        '    ],',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff);
+      expect(violations).toEqual([]);
+    });
+
+    it('does not false-positive flag a second numeric value after the threshold', () => {
+      // After the threshold (25) is seen, a second standalone numeric line
+      // (an option value like maxWarnings) must not be treated as a second
+      // threshold for comparison (#2189 review finding).
+      const diff = [
+        'diff --git a/eslint.config.js b/eslint.config.js',
+        'index 0000000..1111111 100644',
+        '--- a/eslint.config.js',
+        '+++ b/eslint.config.js',
+        '@@ -1,6 +1,6 @@',
+        '  rules: {',
+        "    complexity: ['error',",
+        '      25,',
+        '-      { maxWarnings: 10 },',
+        '+      { maxWarnings: 20 },',
+        '    ],',
+        '  },',
+      ].join(String.fromCharCode(10));
+
+      const violations = checkDiff(diff).filter((v) =>
+        v.message.includes('threshold increase'),
+      );
+      expect(violations).toEqual([]);
+    });
   });
 
   describe('#2115 packages/core directive ban', () => {
@@ -541,6 +6987,652 @@ describe('hasInlineEslintDirective', () => {
   it('does not match unrelated lines', () => {
     expect(hasInlineEslintDirective('const x = 1;')).toBe(false);
     expect(hasInlineEslintDirective('')).toBe(false);
+  });
+});
+
+describe('hasTypeScriptSuppression', () => {
+  it('detects @ts-ignore in line comments', () => {
+    expect(hasTypeScriptSuppression('// @ts-ignore broken overload')).toBe(
+      true,
+    );
+    expect(
+      hasTypeScriptSuppression('const x = 1; // @ts-ignore bad type'),
+    ).toBe(true);
+  });
+
+  it('detects @ts-expect-error in block comments', () => {
+    expect(hasTypeScriptSuppression('/* @ts-expect-error legacy */')).toBe(
+      true,
+    );
+    expect(
+      hasTypeScriptSuppression('code(); /* @ts-expect-error reason */'),
+    ).toBe(true);
+  });
+
+  it('detects @ts-nocheck', () => {
+    expect(hasTypeScriptSuppression('// @ts-nocheck')).toBe(true);
+    expect(hasTypeScriptSuppression('/* @ts-nocheck */')).toBe(true);
+  });
+
+  it('does not match suppression text inside string literals', () => {
+    expect(
+      hasTypeScriptSuppression("const msg = '@ts-ignore is banned';"),
+    ).toBe(false);
+    expect(
+      hasTypeScriptSuppression('const msg = "use @ts-nocheck here";'),
+    ).toBe(false);
+    expect(hasTypeScriptSuppression('const msg = `@ts-expect-error`);')).toBe(
+      false,
+    );
+  });
+
+  it('does not match suppression text inside regex literals', () => {
+    expect(hasTypeScriptSuppression('const re = /@ts-ignore/;')).toBe(false);
+  });
+
+  it('does not match unrelated lines', () => {
+    expect(hasTypeScriptSuppression('const x = 1;')).toBe(false);
+    expect(hasTypeScriptSuppression('')).toBe(false);
+    expect(
+      hasTypeScriptSuppression('// regular comment with no suppression'),
+    ).toBe(false);
+  });
+
+  it('does not match @ts-expect-error mentioned in the middle of a comment', () => {
+    expect(
+      hasTypeScriptSuppression(
+        '// Backward-compat shim: accessed via @ts-expect-error in test.ts',
+      ),
+    ).toBe(false);
+    expect(
+      hasTypeScriptSuppression(
+        '/* This test uses @ts-ignore to verify behavior */',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not match directives in non-effective multiline block-comment forms', () => {
+    // TypeScript 5.8.3 does NOT treat directives as effective suppressions
+    // when they appear on a continuation line of a multiline block comment or
+    // when they are not at the start of a single-line block comment. The guard
+    // must not flag these non-effective forms (verified against tsc 5.8.3).
+    // Continuation line of a multiline block comment:
+    expect(hasTypeScriptSuppression(' * @ts-ignore some reason')).toBe(false);
+    expect(
+      hasTypeScriptSuppression('   leading text @ts-nocheck here */'),
+    ).toBe(false);
+    // Not at the start of a single-line block comment:
+    expect(hasTypeScriptSuppression('/* leading @ts-ignore */')).toBe(false);
+  });
+
+  it('conservatively flags the opener line of a multiline block comment with a directive', () => {
+    // TypeScript 5.8.3 does NOT treat "/* @ts-ignore\n   reason */" as an
+    // effective suppression, but the guard flags the opener line
+    // conservatively to avoid any risk of a real suppression slipping through.
+    expect(hasTypeScriptSuppression('/* @ts-ignore multiline reason')).toBe(
+      true,
+    );
+  });
+});
+
+describe('scanPackageTypeScriptSuppressions (#2189)', () => {
+  it('reports violations when package files contain TS suppressions', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-ts-suppress-'));
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.ts'),
+      [
+        'export const x = 1;',
+        '// @ts-ignore broken overload',
+        'export const y = x as any;',
+      ].join('\n'),
+    );
+
+    const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('#2189');
+    expect(violations[0].message).toContain('TypeScript suppression');
+    expect(violations[0].lineNumber).toBe(2);
+  });
+
+  it('passes when package files contain no TS suppressions', () => {
+    const tmpDir = mkdtempSync(
+      join(tmpdir(), 'eslint-guard-ts-suppress-clean-'),
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'clean.ts'),
+      ['export const x = 1;', 'export const y = 2;'].join('\n'),
+    );
+
+    expect(scanPackageTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('ignores test files (production-only scan)', () => {
+    const tmpDir = mkdtempSync(
+      join(tmpdir(), 'eslint-guard-ts-suppress-test-'),
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.test.ts'),
+      [
+        'export function testOnly() {',
+        '  // @ts-expect-error testing invalid input',
+        '  const x: number = "string";',
+        '}',
+      ].join('\n'),
+    );
+
+    expect(scanPackageTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('returns empty for non-existent directories', () => {
+    expect(
+      scanPackageTypeScriptSuppressions(
+        join(repoRoot, 'nonexistent-package', 'src'),
+        '2189',
+      ),
+    ).toEqual([]);
+  });
+
+  it('reports violations in JavaScript source files (.js)', () => {
+    // The full-tree scan must cover the same checked source extensions as the
+    // diff-based checkDiff detection (.js/.jsx/.ts/.tsx/.mjs/.cjs), not just
+    // .ts/.tsx. A .js file with a real @ts-ignore comment must be caught.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-ts-suppress-js-'));
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.js'),
+      [
+        'export const x = 1;',
+        '// @ts-ignore missing types',
+        'export const y = x.untypedMethod();',
+      ].join(String.fromCharCode(10)),
+    );
+
+    const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('#2189');
+    expect(violations[0].message).toContain('TypeScript suppression');
+    expect(violations[0].lineNumber).toBe(2);
+  });
+
+  it('reports violations in JSX source files (.jsx)', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-ts-suppress-jsx-'));
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.jsx'),
+      [
+        'export const Component = () => null;',
+        '// @ts-nocheck legacy jsx file',
+        'export const x = 1;',
+      ].join(String.fromCharCode(10)),
+    );
+
+    const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('#2189');
+  });
+
+  it('reports violations in MJS source files (.mjs)', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-ts-suppress-mjs-'));
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.mjs'),
+      [
+        'export const x = 1;',
+        '// @ts-expect-error intentional for mjs',
+        'export const y = x.bad;',
+      ].join(String.fromCharCode(10)),
+    );
+
+    const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('#2189');
+  });
+
+  it('reports violations in CJS source files (.cjs)', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-ts-suppress-cjs-'));
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.cjs'),
+      [
+        'module.exports = { x: 1 };',
+        '// @ts-ignore cjs untyped',
+        'module.exports.y = 2;',
+      ].join(String.fromCharCode(10)),
+    );
+
+    const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('#2189');
+  });
+
+  it('excludes JavaScript test files from production-only scan', () => {
+    // .test.js files must be excluded just like .test.ts files are, because
+    // TS suppression directives are legitimate testing patterns.
+    const tmpDir = mkdtempSync(
+      join(tmpdir(), 'eslint-guard-ts-suppress-jstest-'),
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.test.js'),
+      [
+        'export function testOnly() {',
+        '  // @ts-expect-error testing invalid input',
+        '  const x = "string";',
+        '}',
+      ].join(String.fromCharCode(10)),
+    );
+
+    expect(scanPackageTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('still reports violations in TypeScript source files (.ts)', () => {
+    // Regression: extending coverage to JS must not break existing .ts
+    // detection.
+    const tmpDir = mkdtempSync(
+      join(tmpdir(), 'eslint-guard-ts-suppress-ts-regression-'),
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'example.ts'),
+      [
+        'export const x = 1;',
+        '// @ts-ignore regression test',
+        'export const y = x as any;',
+      ].join(String.fromCharCode(10)),
+    );
+
+    const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('#2189');
+  });
+
+  describe('multiline template literal state (#2189 review finding)', () => {
+    // The full-tree scanner must carry template literal state across lines
+    // within a file (mirroring the diff-based checkDiff detection) so that
+    // inert documentation text inside a multiline template literal body is
+    // not flagged, while real suppression comments in executable code are
+    // still caught.
+
+    it('does not flag inert // @ts-ignore text inside a multiline template body', () => {
+      // A // @ts-ignore line inside template literal TEXT (exprDepth === 0)
+      // is just template content, not a real comment. The stateful scanner
+      // must skip it.
+      const tmpDir = mkdtempSync(
+        join(tmpdir(), 'eslint-guard-ts-templ-inert-'),
+      );
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'example.ts'),
+        [
+          'export const docs = `',
+          '  // @ts-ignore is mentioned here in docs',
+          '  but this is inert template literal text',
+          '`;',
+        ].join(String.fromCharCode(10)),
+      );
+
+      expect(scanPackageTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+    });
+
+    it('does not flag inert @ts-nocheck text inside a multiline template body', () => {
+      const tmpDir = mkdtempSync(
+        join(tmpdir(), 'eslint-guard-ts-templ-nocheck-'),
+      );
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'example.ts'),
+        [
+          'export const docs = `',
+          '  /* @ts-nocheck described in prose */',
+          '  more inert template text',
+          '`;',
+        ].join(String.fromCharCode(10)),
+      );
+
+      expect(scanPackageTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+    });
+
+    it('still flags a real suppression after a closed template literal', () => {
+      // A template literal opens and closes on one line, then a real
+      // // @ts-ignore comment appears on a later line. The template state
+      // must be cleared after the closing backtick so the real directive is
+      // caught.
+      const tmpDir = mkdtempSync(
+        join(tmpdir(), 'eslint-guard-ts-templ-after-'),
+      );
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'example.ts'),
+        [
+          'export const docs = `closed template`;',
+          '// @ts-ignore real suppression',
+          'export const y = docs.bad;',
+        ].join(String.fromCharCode(10)),
+      );
+
+      const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].lineNumber).toBe(2);
+      expect(violations[0].content).toContain('@ts-ignore');
+    });
+
+    it('still flags a real suppression inside a template ${} expression', () => {
+      // The template opens and a ${ ... } expression opens (unclosed on the
+      // opener line), then a real // @ts-expect-error comment appears inside
+      // the expression on the next line. Because the comment is in executable
+      // expression code it is a real, effective suppression and must be
+      // flagged.
+      const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-ts-templ-expr-'));
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'example.ts'),
+        [
+          'export const docs = `${',
+          '  // @ts-expect-error real in expression',
+          '  value',
+          '}`;',
+        ].join(String.fromCharCode(10)),
+      );
+
+      const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].lineNumber).toBe(2);
+      expect(violations[0].content).toContain('@ts-expect-error');
+    });
+
+    it('resets template state between files', () => {
+      // Two files in the same scan: one ends inside an unclosed template
+      // (malformed), the next file starts with a real suppression. The
+      // scanner must reset template state per file so the real suppression in
+      // the second file is caught and not mistaken for template text.
+      const tmpDir = mkdtempSync(
+        join(tmpdir(), 'eslint-guard-ts-templ-reset-'),
+      );
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'unclosed.ts'),
+        [
+          'export const docs = `',
+          '  // @ts-ignore inert text in an unclosed template',
+        ].join(String.fromCharCode(10)),
+      );
+      writeFileSync(
+        join(tmpDir, 'real.ts'),
+        [
+          '// @ts-ignore real suppression in a new file',
+          'export const y = 1;',
+        ].join(String.fromCharCode(10)),
+      );
+
+      const violations = scanPackageTypeScriptSuppressions(tmpDir, '2189');
+
+      // Only the real suppression in real.ts is flagged; the inert text in
+      // the unclosed template of unclosed.ts is skipped.
+      expect(violations).toHaveLength(1);
+      expect(violations[0].file).toContain('real.ts');
+      expect(violations[0].lineNumber).toBe(1);
+    });
+  });
+
+  const tsGuardedPackages = [
+    'packages/cli/src',
+    'packages/core/src',
+    'packages/policy/src',
+    'packages/agents/src',
+    'packages/storage/src',
+    'packages/auth/src',
+    'packages/settings/src',
+    'packages/a2a-server/src',
+  ];
+
+  for (const pkg of tsGuardedPackages) {
+    it(`has zero TypeScript suppression directives in ${pkg}`, () => {
+      const offenders = scanPackageTypeScriptSuppressions(
+        join(repoRoot, ...pkg.split('/')),
+        '2189',
+      ).map((v) => `${v.file}:${v.lineNumber}`);
+      expect(
+        offenders,
+        'Found TS suppressions: ' + offenders.join(', '),
+      ).toEqual([]);
+    });
+  }
+});
+
+describe('scanRootTypeScriptSuppressions (#2189 review finding)', () => {
+  // The durable root scan mirrors the diff-based checkDiff coverage universe
+  // (the whole repo, excluding generated directories). It must catch real TS
+  // suppression directives anywhere in checked source — including root-level
+  // scripts and config files that the per-package scans did not cover — while
+  // ignoring directive text inside strings, templates, and regexes.
+
+  it('reports violations for TS suppressions in nested package source', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-pkg-'));
+    mkdirSync(join(tmpDir, 'packages', 'core', 'src'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'packages', 'core', 'src', 'example.ts'),
+      [
+        'export const x = 1;',
+        '// @ts-ignore broken overload',
+        'export const y = x as any;',
+      ].join('\n'),
+    );
+
+    const violations = scanRootTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].file).toBe('packages/core/src/example.ts');
+    expect(violations[0].lineNumber).toBe(2);
+    expect(violations[0].message).toContain('#2189');
+  });
+
+  it('reports violations for TS suppressions in root-level scripts', () => {
+    // Root-level scripts (outside packages src) were NOT covered by the
+    // per-package scanPackageTypeScriptSuppressions loop. The root scan must
+    // catch real suppressions here too.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-scripts-'));
+    mkdirSync(join(tmpDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'helper.js'),
+      [
+        'export const x = 1;',
+        '// @ts-expect-error missing types in script',
+        'export const y = x.bad;',
+      ].join('\n'),
+    );
+
+    const violations = scanRootTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].file).toBe('scripts/helper.js');
+    expect(violations[0].lineNumber).toBe(2);
+  });
+
+  it('reports violations for TS suppressions in the guard implementation file', () => {
+    // The guard implementation file is an ESLint-directive fixture exemption
+    // (shouldCheckInlineDirective returns false), but TS suppression scanning
+    // must NOT inherit that exemption. hasTypeScriptSuppressionInState skips
+    // string/template/regex literals, so fixture data is safe, but a real
+    // at-ts-ignore comment added to the file must be caught.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-guard-'));
+    mkdirSync(join(tmpDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'check-eslint-guard.js'),
+      [
+        'export function check() {',
+        '  // @ts-ignore real suppression in guard file',
+        '  return 1;',
+        '}',
+      ].join('\n'),
+    );
+
+    const violations = scanRootTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].file).toBe('scripts/check-eslint-guard.js');
+    expect(violations[0].message).toContain('TypeScript suppression');
+  });
+
+  it('reports violations for TS suppressions in a non-test file under scripts/tests/', () => {
+    // A non-test-named file under scripts/tests/ (e.g. a helper module) must
+    // be scanned by the root scan. Note: files ending in .test.js are excluded
+    // by isProductionCheckedSourceFile because @ts-expect-error is a legitimate
+    // testing pattern; this test uses a non-test-named file to prove the
+    // scripts/tests/ path is covered for production source.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-testfix-'));
+    mkdirSync(join(tmpDir, 'scripts', 'tests'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'tests', 'helper.js'),
+      [
+        'export const x = 1;',
+        '// @ts-nocheck real suppression in scripts/tests helper',
+        'export const y = x.bad;',
+      ].join('\n'),
+    );
+
+    const violations = scanRootTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].file).toBe('scripts/tests/helper.js');
+    expect(violations[0].message).toContain('TypeScript suppression');
+  });
+
+  it('does not flag TS suppression text inside strings in a root-level file', () => {
+    // Directive text used as fixture data (inside a string literal) must not
+    // trigger a false positive. This proves the literal-skipping in
+    // hasTypeScriptSuppressionInState keeps fixture data safe even in root-
+    // level files covered by the root scan.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-string-'));
+    mkdirSync(join(tmpDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'helper.js'),
+      [
+        'export const fixture = "use // @ts-ignore here as docs";',
+        'export const x = 1;',
+      ].join('\n'),
+    );
+
+    expect(scanRootTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('does not flag TS suppression text inside template literals in a root-level file', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-template-'));
+    mkdirSync(join(tmpDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'helper.js'),
+      [
+        'export const msg = `@ts-expect-error directive in docs`;',
+        'export const x = 1;',
+      ].join('\n'),
+    );
+
+    expect(scanRootTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('does not flag TS suppression text inside regex literals in a root-level file', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-regex-'));
+    mkdirSync(join(tmpDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'helper.js'),
+      ['export const re = /@ts-ignore/;', 'export const x = 1;'].join('\n'),
+    );
+
+    expect(scanRootTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('does not flag inert TS suppression text inside a multiline template body', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-tmplbody-'));
+    mkdirSync(join(tmpDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'helper.js'),
+      [
+        'export const docs = `',
+        '  // @ts-ignore is mentioned here in docs',
+        '  but this is inert template literal text',
+        '`;',
+      ].join('\n'),
+    );
+
+    expect(scanRootTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('still flags a real suppression after a closed template literal in root scan', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-tmplafter-'));
+    mkdirSync(join(tmpDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'scripts', 'helper.js'),
+      [
+        'export const docs = `closed template`;',
+        '// @ts-ignore real suppression',
+        'export const y = docs.bad;',
+      ].join('\n'),
+    );
+
+    const violations = scanRootTypeScriptSuppressions(tmpDir, '2189');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].lineNumber).toBe(2);
+  });
+
+  it('excludes generated directories from the root scan', () => {
+    // Files inside node_modules, dist, coverage, and .git must be skipped.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-gen-'));
+    mkdirSync(join(tmpDir, 'node_modules', 'pkg'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'node_modules', 'pkg', 'bad.js'),
+      ['// @ts-ignore from a dependency', 'export const x = 1;'].join('\n'),
+    );
+
+    expect(scanRootTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('excludes test files from the root scan', () => {
+    // .test.js files must be excluded because @ts-expect-error is a legitimate
+    // testing pattern, matching the per-package scan semantics.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'eslint-guard-root-testfile-'));
+    mkdirSync(join(tmpDir, 'packages', 'core', 'src'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'packages', 'core', 'src', 'example.test.js'),
+      [
+        'export function testOnly() {',
+        '  // @ts-expect-error testing invalid input',
+        '  const x: number = "string";',
+        '}',
+      ].join('\n'),
+    );
+
+    expect(scanRootTypeScriptSuppressions(tmpDir, '2189')).toEqual([]);
+  });
+
+  it('returns empty for non-existent directories', () => {
+    expect(
+      scanRootTypeScriptSuppressions(
+        join(repoRoot, 'nonexistent-root-dir'),
+        '2189',
+      ),
+    ).toEqual([]);
+  });
+
+  it('covers the same checked-in repo with zero suppressions', () => {
+    // The real checked-in repo must have zero TS suppression directives in
+    // production checked source. This is the durable guarantee.
+    const offenders = scanRootTypeScriptSuppressions(repoRoot, '2189').map(
+      (v) => `${v.file}:${v.lineNumber}`,
+    );
+    expect(offenders, 'Found TS suppressions: ' + offenders.join(', ')).toEqual(
+      [],
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Hardens the ESLint policy guard against new TypeScript suppression directives.
- Detects ESLint severity downgrades, new off/0 entries, and complexity or size threshold increases in eslint.config.js.
- Adds behavior coverage for multiline rule configs, string/regex false positives, nested option objects, non-policy rule containers, and end-to-end diff checks.

## Verification

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
- npm run lint:eslint-guard
- npm run test:scripts -- scripts/tests/eslint-guard.test.js
- Open Code Review: no comments generated

fixes #2189
