### PR TITLE
Fix cross-provider ephemeral leak in mixed load balancers (Fixes #2182)

### DIFF
--- a/packages/core/src/runtime/__tests__/RuntimeInvocationContext.separation.test.ts
+++ b/packages/core/src/runtime/__tests__/RuntimeInvocationContext.separation.test.ts
@@ -331,4 +331,65 @@ describe('RuntimeInvocationContext Settings Separation', () => {
 
     expect(context.modelBehavior['reasoning.enabled']).toBe(true);
   });
+
+  /**
+   * @issue #2182
+   * Mixed-provider load balancers leak provider-specific settings into the
+   * modelParams bucket, which providers spread verbatim into API request
+   * bodies. The two reported leaks were the nested `text` object and the
+   * camelCase `streamIdleTimeoutMs`. Neither may reach modelParams, regardless
+   * of provider, because modelParams is what gets serialized into the request.
+   */
+  describe('issue #2182: modelParams must stay free of leaked settings', () => {
+    it('does not place a nested text object into modelParams for anthropic', () => {
+      const context = createRuntimeInvocationContext({
+        runtime: createMockRuntime(),
+        settings: createMockSettings(),
+        providerName: 'anthropic',
+        ephemeralsSnapshot: { text: { verbosity: 'medium' } },
+      });
+
+      expect(context.modelParams['text']).toBeUndefined();
+      expect(context.modelParams['text.verbosity']).toBeUndefined();
+      expect(context.modelBehavior['text.verbosity']).toBe('medium');
+    });
+
+    it('does not place streamIdleTimeoutMs into modelParams for any provider', () => {
+      for (const provider of ['anthropic', 'codex', 'openai']) {
+        const context = createRuntimeInvocationContext({
+          runtime: createMockRuntime(),
+          settings: createMockSettings(),
+          providerName: provider,
+          ephemeralsSnapshot: { streamIdleTimeoutMs: 60_000 },
+        });
+
+        expect(context.modelParams['streamIdleTimeoutMs']).toBeUndefined();
+        expect(context.modelParams['stream_idle_timeout_ms']).toBeUndefined();
+        expect(context.cliSettings['stream-idle-timeout-ms']).toBe(60_000);
+      }
+    });
+
+    it('reproduces the full opusfirst ephemeral snapshot without leaking to modelParams', () => {
+      const context = createRuntimeInvocationContext({
+        runtime: createMockRuntime(),
+        settings: createMockSettings(),
+        providerName: 'anthropic',
+        ephemeralsSnapshot: {
+          streamIdleTimeoutMs: 60_000,
+          text: { verbosity: 'medium' },
+          reasoning: { enabled: true, effort: 'high' },
+          'prompt-caching': '24h',
+        },
+      });
+
+      expect(Object.keys(context.modelParams)).toStrictEqual([]);
+      // Positive routing assertions: each setting must land in its intended
+      // bucket, so a regression that silently drops settings still fails.
+      expect(context.cliSettings['stream-idle-timeout-ms']).toBe(60_000);
+      expect(context.modelBehavior['text.verbosity']).toBe('medium');
+      expect(context.modelBehavior['reasoning.enabled']).toBe(true);
+      expect(context.modelBehavior['reasoning.effort']).toBe('high');
+      expect(context.modelBehavior['prompt-caching']).toBe('24h');
+    });
+  });
 });

--- a/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
@@ -321,6 +321,101 @@ describe('LoadBalancingProvider', () => {
       });
     });
 
+    describe('issue #2182: cross-provider ephemerals must not leak into modelParams', () => {
+      it('does not surface a nested text object or streamIdleTimeoutMs on the delegate invocation', async () => {
+        const resolvedSubProfiles: ResolvedSubProfile[] = [
+          {
+            name: 'opusthinking',
+            providerName: 'anthropic',
+            model: 'claude-opus-4-8',
+            ephemeralSettings: {
+              'reasoning.enabled': true,
+              'reasoning.effort': 'xhigh',
+            },
+            modelParams: {},
+          },
+          {
+            name: 'gpt55high',
+            providerName: 'codex',
+            model: 'gpt-5.5',
+            ephemeralSettings: {
+              'reasoning.enabled': true,
+              'reasoning.effort': 'high',
+              'text.verbosity': 'medium',
+            },
+            modelParams: {},
+          },
+        ];
+
+        const provider = new LoadBalancingProvider(
+          {
+            profileName: 'opusfirst',
+            strategy: 'failover',
+            subProfiles: resolvedSubProfiles,
+            // LB-level nested object + the global camelCase setting from
+            // settings.json that previously leaked verbatim into the body.
+            lbProfileEphemeralSettings: {
+              reasoning: { enabled: true, effort: 'high' },
+              text: { verbosity: 'medium' },
+              'prompt-caching': '24h',
+              streamIdleTimeoutMs: 60000,
+            },
+          },
+          providerManager,
+        );
+
+        let capturedOptions: GenerateChatOptions | undefined;
+        const mockProvider = {
+          name: 'anthropic',
+          async *generateChatCompletion(
+            options: GenerateChatOptions,
+          ): AsyncIterableIterator<IContent> {
+            capturedOptions = options;
+            yield { role: 'model', parts: [{ text: 'response' }] };
+          },
+          getModels: async () => [],
+          getDefaultModel: () => 'claude-opus-4-8',
+          getServerTools: () => [],
+          invokeServerTool: async () => ({}),
+        };
+
+        const originalGetProvider =
+          providerManager.getProviderByName.bind(providerManager);
+        providerManager.getProviderByName = () => mockProvider as IProvider;
+
+        try {
+          const iterator = provider.generateChatCompletion({
+            contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+            settings: settingsService,
+            config,
+            runtime: { settingsService, config },
+          });
+          for await (const _chunk of iterator) {
+            // Consume
+          }
+
+          expect(capturedOptions?.invocation?.modelParams).toBeDefined();
+          const modelParams = capturedOptions!.invocation!
+            .modelParams as Record<string, unknown>;
+          expect(modelParams['text']).toBeUndefined();
+          expect(modelParams['text.verbosity']).toBeUndefined();
+          expect(modelParams['streamIdleTimeoutMs']).toBeUndefined();
+          expect(modelParams['stream_idle_timeout_ms']).toBeUndefined();
+          expect(modelParams['reasoning']).toBeUndefined();
+          // text.verbosity survives as model-behavior, not a raw model-param.
+          expect(
+            capturedOptions?.invocation?.getModelBehavior('text.verbosity'),
+          ).toBe('medium');
+          expect(
+            capturedOptions?.invocation?.getCliSetting(
+              'stream-idle-timeout-ms',
+            ),
+          ).toBe(60000);
+        } finally {
+          providerManager.getProviderByName = originalGetProvider;
+        }
+      });
+    });
     describe('ephemeralSettings merge (dumb merge)', () => {
       it('should merge LB profile ephemeralSettings over sub-profile ephemeralSettings', async () => {
         const resolvedSubProfiles: ResolvedSubProfile[] = [

--- a/packages/settings/src/__tests__/settingsRegistry.issue2182.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2182.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @issue #2182 - Mixed-provider load balancer profiles (e.g. opusfirst,
+ * gptfirst) fail with 400 "text: Extra inputs are not permitted" and
+ * "streamIdleTimeoutMs: Extra inputs are not permitted".
+ *
+ * Root cause: unrecognized ephemeral setting keys default to the modelParams
+ * bucket (API pass-through). Two specific gaps caused both reported errors:
+ *
+ *  1. `streamIdleTimeoutMs` (camelCase, written from settings.json) is never
+ *     aliased to its canonical `stream-idle-timeout-ms`, so it has no spec and
+ *     leaks into modelParams, then into every provider's request body.
+ *  2. The nested object form `text: { verbosity: "medium" }` is not flattened
+ *     into the registered flat key `text.verbosity`, so the whole `text`
+ *     object leaks into modelParams as an unknown key.
+ *
+ * These tests pin the robust behavior: the registry resolves the camelCase
+ * alias and flattens any nested object whose key is a known registry prefix,
+ * so neither value ever reaches the API request body (modelParams).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAlias,
+  getSettingSpec,
+  separateSettings,
+} from '../settings/settingsRegistry.js';
+
+describe('issue #2182: streamIdleTimeoutMs camelCase alias', () => {
+  it('resolves streamIdleTimeoutMs to the canonical stream-idle-timeout-ms', () => {
+    expect(resolveAlias('streamIdleTimeoutMs')).toBe('stream-idle-timeout-ms');
+  });
+
+  it('finds the cli-behavior spec for streamIdleTimeoutMs via the alias', () => {
+    const spec = getSettingSpec('streamIdleTimeoutMs');
+    expect(spec?.key).toBe('stream-idle-timeout-ms');
+    expect(spec?.category).toBe('cli-behavior');
+  });
+
+  it('does not leak streamIdleTimeoutMs into modelParams for anthropic', () => {
+    const result = separateSettings(
+      { streamIdleTimeoutMs: 60_000 },
+      'anthropic',
+    );
+    expect(result.modelParams['streamIdleTimeoutMs']).toBeUndefined();
+    expect(result.modelParams['stream_idle_timeout_ms']).toBeUndefined();
+    expect(result.modelParams['stream-idle-timeout-ms']).toBeUndefined();
+  });
+
+  it('classifies streamIdleTimeoutMs into cliSettings for every provider', () => {
+    for (const provider of ['anthropic', 'codex', 'openai', 'gemini']) {
+      const result = separateSettings(
+        { streamIdleTimeoutMs: 60_000 },
+        provider,
+      );
+      expect(result.cliSettings['stream-idle-timeout-ms']).toBe(60_000);
+      expect(Object.keys(result.modelParams)).not.toContain(
+        'streamIdleTimeoutMs',
+      );
+    }
+  });
+
+  it('treats the canonical hyphenated key identically', () => {
+    const canonical = separateSettings(
+      { 'stream-idle-timeout-ms': 60_000 },
+      'anthropic',
+    );
+    const camel = separateSettings(
+      { streamIdleTimeoutMs: 60_000 },
+      'anthropic',
+    );
+    expect(camel.cliSettings['stream-idle-timeout-ms']).toBe(
+      canonical.cliSettings['stream-idle-timeout-ms'],
+    );
+  });
+});
+
+describe('issue #2182: nested object flattening for registry prefixes', () => {
+  it('flattens nested text object into text.verbosity (model-behavior)', () => {
+    const result = separateSettings(
+      { text: { verbosity: 'medium' } },
+      'anthropic',
+    );
+    expect(result.modelBehavior['text.verbosity']).toBe('medium');
+  });
+
+  it('does not leak a nested text object into modelParams', () => {
+    const result = separateSettings(
+      { text: { verbosity: 'medium' } },
+      'anthropic',
+    );
+    expect(result.modelParams['text']).toBeUndefined();
+    expect(result.modelParams['text.verbosity']).toBeUndefined();
+  });
+
+  it('does not leak a nested text object for the openai provider either', () => {
+    const result = separateSettings(
+      { text: { verbosity: 'medium' } },
+      'openai-responses',
+    );
+    expect(result.modelParams['text']).toBeUndefined();
+    expect(result.modelBehavior['text.verbosity']).toBe('medium');
+  });
+
+  it('flattens nested compression object into registered dotted keys', () => {
+    const result = separateSettings(
+      { compression: { strategy: 'middle-out', profile: 'default' } },
+      'anthropic',
+    );
+    expect(result.cliSettings['compression.strategy']).toBe('middle-out');
+    expect(result.cliSettings['compression.profile']).toBe('default');
+    expect(result.modelParams['compression']).toBeUndefined();
+  });
+
+  it('flattens deeply nested compression.density objects', () => {
+    const result = separateSettings(
+      {
+        compression: {
+          density: { optimizeThreshold: 0.5 },
+          strategy: 'one-shot',
+        },
+      },
+      'anthropic',
+    );
+    expect(result.cliSettings['compression.density.optimizeThreshold']).toBe(
+      0.5,
+    );
+    expect(result.cliSettings['compression.strategy']).toBe('one-shot');
+    expect(result.modelParams['compression']).toBeUndefined();
+  });
+
+  it('keeps explicit flat keys winning over nested object extraction', () => {
+    const result = separateSettings(
+      {
+        'text.verbosity': 'low',
+        text: { verbosity: 'high' },
+      },
+      'anthropic',
+    );
+    expect(result.modelBehavior['text.verbosity']).toBe('low');
+  });
+
+  it('lets provider overrides win over base-level flat keys (cross-source precedence)', () => {
+    // Base exposes a flat key; the provider-specific override arrives as a
+    // nested container of the same prefix. The override must win.
+    const result = separateSettings(
+      {
+        'text.verbosity': 'low',
+        openai: { text: { verbosity: 'high' } },
+      },
+      'openai',
+    );
+    expect(result.modelBehavior['text.verbosity']).toBe('high');
+  });
+
+  it('preserves an explicit top-level reasoning object alongside its flattened keys', () => {
+    const result = separateSettings(
+      { reasoning: { enabled: true, effort: 'high' } },
+      'anthropic',
+    );
+    expect(result.modelBehavior['reasoning.enabled']).toBe(true);
+    expect(result.modelBehavior['reasoning.effort']).toBe('high');
+  });
+
+  it('does not flatten arbitrary unknown object model-params', () => {
+    const result = separateSettings(
+      { response_format: { type: 'json_object' } },
+      'openai',
+    );
+    expect(result.modelParams['response_format']).toStrictEqual({
+      type: 'json_object',
+    });
+  });
+});

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -31,6 +31,10 @@ const ALIAS_NORMALIZATION_RULES: Record<string, string> = {
   'tool-choice': 'tool_choice',
   toolChoice: 'tool_choice',
   'disabled-tools': 'tools.disabled',
+  // settings.json stores this under the camelCase key; without an alias it is
+  // treated as an unknown pass-through model-param and leaks into API bodies.
+  // @issue #2182
+  streamIdleTimeoutMs: 'stream-idle-timeout-ms',
 };
 
 const HEADER_PRESERVE_SET = new Set([
@@ -146,26 +150,107 @@ function extractCustomHeaders(
   return customHeaders;
 }
 
-/** Flatten provider overrides and reasoning sub-keys into a merged settings object. */
+/**
+ * Flatten nested objects whose key is a known registry prefix (e.g. `text`,
+ * `compression`, `compression.density`) into their registered dotted keys.
+ *
+ * Previously only `reasoning.*` was flattened, so a nested `text` object (or
+ * any other prefix) leaked into modelParams as an unknown pass-through key and
+ * was spread verbatim into provider request bodies — rejected by Anthropic as
+ * "text: Extra inputs are not permitted". @issue #2182
+ *
+ * Semantics:
+ *  - A registry prefix is any ancestor of a registered dotted key
+ *    (`text.verbosity` -> prefix `text`).
+ *  - Nested objects under a prefix are expanded into dotted keys; the original
+ *    container is kept only when it has its own bare spec (e.g. `reasoning`),
+ *    so a prefix-only container never falls through to modelParams.
+ *  - Explicit flat keys always win over values extracted from a nested object.
+ */
+function flattenRegistryPrefixedObjects(
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const { prefixes, bareKeys } = getRegistryStructure();
+  const result: Record<string, unknown> = { ...source };
+
+  for (const [key, value] of Object.entries(source)) {
+    if (!isPlainObject(value) || !prefixes.has(key)) {
+      continue;
+    }
+    emitFlattenedEntries(result, key, value);
+    if (!bareKeys.has(key)) {
+      delete result[key];
+    }
+  }
+
+  return result;
+}
+
+function emitFlattenedEntries(
+  result: Record<string, unknown>,
+  dottedKey: string,
+  value: Record<string, unknown>,
+): void {
+  const { prefixes, bareKeys } = getRegistryStructure();
+  for (const [subKey, subValue] of Object.entries(value)) {
+    const childKey = `${dottedKey}.${subKey}`;
+    if (isPlainObject(subValue) && prefixes.has(childKey)) {
+      emitFlattenedEntries(result, childKey, subValue);
+      if (!bareKeys.has(childKey)) {
+        continue;
+      }
+    }
+    if (!(childKey in result)) {
+      result[childKey] = subValue;
+    }
+  }
+}
+
+let registryStructureCache: {
+  prefixes: Set<string>;
+  bareKeys: Set<string>;
+} | null = null;
+
+function getRegistryStructure(): {
+  prefixes: Set<string>;
+  bareKeys: Set<string>;
+} {
+  if (registryStructureCache !== null) {
+    return registryStructureCache;
+  }
+  const prefixes = new Set<string>();
+  const bareKeys = new Set<string>();
+  for (const spec of SETTINGS_REGISTRY) {
+    bareKeys.add(spec.key);
+    let prefix = spec.key;
+    let dotIndex = prefix.lastIndexOf('.');
+    while (dotIndex > 0) {
+      prefix = prefix.slice(0, dotIndex);
+      prefixes.add(prefix);
+      dotIndex = prefix.lastIndexOf('.');
+    }
+  }
+  registryStructureCache = { prefixes, bareKeys };
+  return registryStructureCache;
+}
+
+/**
+ * Flatten provider overrides and reasoning sub-keys into a merged settings object.
+ *
+ * Base settings are flattened first, then provider overrides are flattened
+ * separately and spread on top so provider-specific values always win —
+ * including when an override arrives as a nested container (e.g. `text` →
+ * `text.verbosity`) against a base-level flat key of the same name.
+ */
 function mergeProviderSettings(
   mixed: Record<string, unknown>,
   providerOverrides: Record<string, unknown>,
 ): Record<string, unknown> {
-  const merged = { ...mixed, ...providerOverrides };
-
-  if (isPlainObject(merged['reasoning'])) {
-    const reasoningObj = merged['reasoning'];
-
-    for (const [subKey, subValue] of Object.entries(reasoningObj)) {
-      const fullKey = `reasoning.${subKey}`;
-
-      if (!(fullKey in merged)) {
-        merged[fullKey] = subValue;
-      }
-    }
-  }
-
-  return merged;
+  const baseFlattened = flattenRegistryPrefixedObjects({ ...mixed });
+  const overridesFlattened = flattenRegistryPrefixedObjects({
+    ...providerOverrides,
+  });
+  return { ...baseFlattened, ...overridesFlattened };
 }
 
 /** Categorize a single setting entry into the appropriate bucket. */

--- a/scripts/lb-profiles-tmux.sh
+++ b/scripts/lb-profiles-tmux.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# tmux helpers for the issue #2182 mixed-provider load-balancer profiles
+# (opusfirst, gptfirst, glm).
+#
+# Usage:
+#   scripts/lb-profiles-tmux.sh launch [profile]   # open an interactive tmux
+#                                                  # session per profile
+#   scripts/lb-profiles-tmux.sh smoke  [profile]   # non-interactive prompt,
+#                                                  # assert no 400 leak
+#
+# A "profile" is one of: opusfirst, gptfirst, glm. Omit to target all three.
+#
+# Why tmux: `node scripts/start.js` keeps stdin as a TTY inside tmux so it
+# stays interactive (piping stdin would force non-interactive mode). This
+# lets you drive each profile by hand to reproduce/verify the failover fix.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+ALL_PROFILES=(opusfirst gptfirst glm)
+MODE="${1:-launch}"
+PROFILE_ARG="${2:-}"
+
+# Validate the optional profile argument against the allow-list so typos or
+# anything containing shell metacharacters cannot reach the tmux/ node command.
+if [[ -n "$PROFILE_ARG" ]]; then
+  valid=0
+  for candidate in "${ALL_PROFILES[@]}"; do
+    if [[ "$PROFILE_ARG" == "$candidate" ]]; then
+      valid=1
+      break
+    fi
+  done
+  if [[ $valid -eq 0 ]]; then
+    echo "Unknown profile '$PROFILE_ARG'. Valid: ${ALL_PROFILES[*]}" >&2
+    exit 2
+  fi
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: 'node' was not found on PATH." >&2
+  exit 127
+fi
+
+if [[ "$MODE" == "smoke" ]]; then
+  PROFILES=("${ALL_PROFILES[@]}")
+  if [[ -n "$PROFILE_ARG" ]]; then PROFILES=("$PROFILE_ARG"); fi
+
+  # Aggregate results across all profiles instead of aborting on the first
+  # failure, so a transient issue with one provider does not hide the rest.
+  smoke_failed=0
+
+  for p in "${PROFILES[@]}"; do
+    echo "=== smoke: $p ==="
+    # Non-interactive: a positional prompt makes start.js run once and exit.
+    set +e
+    output="$(node scripts/start.js --profile-load "$p" \
+      "Reply with only the word: ok" 2>&1)"
+    rc=$?
+    set -e
+    if echo "$output" | grep -Eq "Extra inputs are not permitted|failover exhausted|Unsupported parameter"; then
+      echo "FAIL: $p still emits a cross-provider 400 leak:"
+      echo "$output" | grep -E "Extra inputs are not permitted|failover exhausted|Unsupported parameter" | head -5
+      smoke_failed=1
+      continue
+    fi
+    if [[ $rc -ne 0 ]]; then
+      if echo "$output" | grep -q "command not found"; then
+        echo "ERROR: $p could not run — node or a dependency is missing (rc=$rc)."
+      else
+        echo "WARN: $p exited non-zero (rc=$rc); confirm whether the provider credentials/network are healthy."
+      fi
+    else
+      echo "PASS: $p produced no cross-provider 400 leak."
+    fi
+  done
+  exit "$smoke_failed"
+fi
+
+if [[ "$MODE" != "launch" ]]; then
+  echo "Unknown mode '$MODE'. Use 'launch' or 'smoke'." >&2
+  exit 2
+fi
+
+PROFILES=("${ALL_PROFILES[@]}")
+if [[ -n "$PROFILE_ARG" ]]; then PROFILES=("$PROFILE_ARG"); fi
+
+for p in "${PROFILES[@]}"; do
+  session="llxprt-${p}"
+  if tmux has-session -t "$session" 2>/dev/null; then
+    echo "tmux session '$session' already exists; attaching."
+  else
+    # Quote ${p} in the tmux command string — it is now validated against the
+    # allow-list, but quoting keeps the command safe and unambiguous.
+    tmux new-session -d -s "$session" -c "$ROOT" \
+      "node scripts/start.js --profile-load '${p}'; echo '(exited)'; bash"
+    echo "Created tmux session '$session' for profile '$p'."
+  fi
+done
+
+echo
+echo "Attach with, e.g.:  tmux attach -t llxprt-opusfirst"
+echo "List sessions:      tmux ls"
+echo "Kill one:           tmux kill-session -t llxprt-gptfirst"

--- a/scripts/lb-profiles-tmux.sh
+++ b/scripts/lb-profiles-tmux.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT"
+cd "${ROOT}"
 
 ALL_PROFILES=(opusfirst gptfirst glm)
 MODE="${1:-launch}"
@@ -26,16 +26,16 @@ PROFILE_ARG="${2:-}"
 
 # Validate the optional profile argument against the allow-list so typos or
 # anything containing shell metacharacters cannot reach the tmux/ node command.
-if [[ -n "$PROFILE_ARG" ]]; then
+if [[ -n "${PROFILE_ARG}" ]]; then
   valid=0
   for candidate in "${ALL_PROFILES[@]}"; do
-    if [[ "$PROFILE_ARG" == "$candidate" ]]; then
+    if [[ "${PROFILE_ARG}" == "${candidate}" ]]; then
       valid=1
       break
     fi
   done
-  if [[ $valid -eq 0 ]]; then
-    echo "Unknown profile '$PROFILE_ARG'. Valid: ${ALL_PROFILES[*]}" >&2
+  if [[ ${valid} -eq 0 ]]; then
+    echo "Unknown profile '${PROFILE_ARG}'. Valid: ${ALL_PROFILES[*]}" >&2
     exit 2
   fi
 fi
@@ -45,59 +45,59 @@ if ! command -v node >/dev/null 2>&1; then
   exit 127
 fi
 
-if [[ "$MODE" == "smoke" ]]; then
+if [[ "${MODE}" == "smoke" ]]; then
   PROFILES=("${ALL_PROFILES[@]}")
-  if [[ -n "$PROFILE_ARG" ]]; then PROFILES=("$PROFILE_ARG"); fi
+  if [[ -n "${PROFILE_ARG}" ]]; then PROFILES=("${PROFILE_ARG}"); fi
 
   # Aggregate results across all profiles instead of aborting on the first
   # failure, so a transient issue with one provider does not hide the rest.
   smoke_failed=0
 
   for p in "${PROFILES[@]}"; do
-    echo "=== smoke: $p ==="
+    echo "=== smoke: ${p} ==="
     # Non-interactive: a positional prompt makes start.js run once and exit.
     set +e
-    output="$(node scripts/start.js --profile-load "$p" \
+    output="$(node scripts/start.js --profile-load "${p}" \
       "Reply with only the word: ok" 2>&1)"
     rc=$?
     set -e
-    if echo "$output" | grep -Eq "Extra inputs are not permitted|failover exhausted|Unsupported parameter"; then
-      echo "FAIL: $p still emits a cross-provider 400 leak:"
-      echo "$output" | grep -E "Extra inputs are not permitted|failover exhausted|Unsupported parameter" | head -5
+    if echo "${output}" | grep -Eq "Extra inputs are not permitted|failover exhausted|Unsupported parameter"; then
+      echo "FAIL: ${p} still emits a cross-provider 400 leak:"
+      echo "${output}" | grep -E "Extra inputs are not permitted|failover exhausted|Unsupported parameter" | head -5
       smoke_failed=1
       continue
     fi
-    if [[ $rc -ne 0 ]]; then
-      if echo "$output" | grep -q "command not found"; then
-        echo "ERROR: $p could not run — node or a dependency is missing (rc=$rc)."
+    if [[ ${rc} -ne 0 ]]; then
+      if echo "${output}" | grep -q "command not found"; then
+        echo "ERROR: ${p} could not run — node or a dependency is missing (rc=${rc})."
       else
-        echo "WARN: $p exited non-zero (rc=$rc); confirm whether the provider credentials/network are healthy."
+        echo "WARN: ${p} exited non-zero (rc=${rc}); confirm whether the provider credentials/network are healthy."
       fi
     else
-      echo "PASS: $p produced no cross-provider 400 leak."
+      echo "PASS: ${p} produced no cross-provider 400 leak."
     fi
   done
-  exit "$smoke_failed"
+  exit "${smoke_failed}"
 fi
 
-if [[ "$MODE" != "launch" ]]; then
-  echo "Unknown mode '$MODE'. Use 'launch' or 'smoke'." >&2
+if [[ "${MODE}" != "launch" ]]; then
+  echo "Unknown mode '${MODE}'. Use 'launch' or 'smoke'." >&2
   exit 2
 fi
 
 PROFILES=("${ALL_PROFILES[@]}")
-if [[ -n "$PROFILE_ARG" ]]; then PROFILES=("$PROFILE_ARG"); fi
+if [[ -n "${PROFILE_ARG}" ]]; then PROFILES=("${PROFILE_ARG}"); fi
 
 for p in "${PROFILES[@]}"; do
   session="llxprt-${p}"
-  if tmux has-session -t "$session" 2>/dev/null; then
-    echo "tmux session '$session' already exists; attaching."
+  if tmux has-session -t "${session}" 2>/dev/null; then
+    echo "tmux session '${session}' already exists; attaching."
   else
-    # Quote ${p} in the tmux command string — it is now validated against the
-    # allow-list, but quoting keeps the command safe and unambiguous.
-    tmux new-session -d -s "$session" -c "$ROOT" \
+    # ${p} is validated against the allow-list above; quoting keeps the
+    # command unambiguous and safe.
+    tmux new-session -d -s "${session}" -c "${ROOT}" \
       "node scripts/start.js --profile-load '${p}'; echo '(exited)'; bash"
-    echo "Created tmux session '$session' for profile '$p'."
+    echo "Created tmux session '${session}' for profile '${p}'."
   fi
 done
 

--- a/scripts/tmux-script.issue2182-glm.json
+++ b/scripts/tmux-script.issue2182-glm.json
@@ -1,0 +1,48 @@
+{
+  "tmux": {
+    "cols": 120,
+    "rows": 40,
+    "historyLimit": 100000,
+    "scrollbackLines": 20000,
+    "initialWaitMs": 8000
+  },
+  "startCommand": ["node", "scripts/start.js", "--profile-load", "glm"],
+  "yolo": true,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 60000
+    },
+    { "type": "capture", "label": "00-startup", "scope": "screen" },
+
+    {
+      "type": "line",
+      "text": "Reply with exactly the two words: glm ok",
+      "submitKeys": ["Enter"]
+    },
+    {
+      "type": "waitFor",
+      "scope": "scrollback",
+      "contains": "esc to cancel",
+      "timeoutMs": 60000
+    },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "esc to cancel",
+      "timeoutMs": 240000
+    },
+    { "type": "wait", "ms": 2000 },
+    { "type": "capture", "label": "01-response-screen", "scope": "screen" },
+    {
+      "type": "capture",
+      "label": "01-response-scrollback",
+      "scope": "scrollback"
+    },
+
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}

--- a/scripts/tmux-script.issue2182-gptfirst.json
+++ b/scripts/tmux-script.issue2182-gptfirst.json
@@ -1,0 +1,48 @@
+{
+  "tmux": {
+    "cols": 120,
+    "rows": 40,
+    "historyLimit": 100000,
+    "scrollbackLines": 20000,
+    "initialWaitMs": 8000
+  },
+  "startCommand": ["node", "scripts/start.js", "--profile-load", "gptfirst"],
+  "yolo": true,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 60000
+    },
+    { "type": "capture", "label": "00-startup", "scope": "screen" },
+
+    {
+      "type": "line",
+      "text": "Reply with exactly the two words: gpt ok",
+      "submitKeys": ["Enter"]
+    },
+    {
+      "type": "waitFor",
+      "scope": "scrollback",
+      "contains": "esc to cancel",
+      "timeoutMs": 60000
+    },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "esc to cancel",
+      "timeoutMs": 240000
+    },
+    { "type": "wait", "ms": 2000 },
+    { "type": "capture", "label": "01-response-screen", "scope": "screen" },
+    {
+      "type": "capture",
+      "label": "01-response-scrollback",
+      "scope": "scrollback"
+    },
+
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}

--- a/scripts/tmux-script.issue2182-opusfirst.json
+++ b/scripts/tmux-script.issue2182-opusfirst.json
@@ -1,0 +1,48 @@
+{
+  "tmux": {
+    "cols": 120,
+    "rows": 40,
+    "historyLimit": 100000,
+    "scrollbackLines": 20000,
+    "initialWaitMs": 8000
+  },
+  "startCommand": ["node", "scripts/start.js", "--profile-load", "opusfirst"],
+  "yolo": true,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 60000
+    },
+    { "type": "capture", "label": "00-startup", "scope": "screen" },
+
+    {
+      "type": "line",
+      "text": "Reply with exactly the two words: opus ok",
+      "submitKeys": ["Enter"]
+    },
+    {
+      "type": "waitFor",
+      "scope": "scrollback",
+      "contains": "esc to cancel",
+      "timeoutMs": 60000
+    },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "esc to cancel",
+      "timeoutMs": 240000
+    },
+    { "type": "wait", "ms": 2000 },
+    { "type": "capture", "label": "01-response-screen", "scope": "screen" },
+    {
+      "type": "capture",
+      "label": "01-response-scrollback",
+      "scope": "scrollback"
+    },
+
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes cross-provider ephemeral settings leaking into delegate request bodies in mixed-provider failover load balancers (`opusfirst`, `gptfirst`, `glm`), which caused the failures reported in #2182:

- `text: Extra inputs are not permitted`
- `streamIdleTimeoutMs: Extra inputs are not permitted`

Closes #2182.

## Root cause

All providers (Anthropic, OpenAI Responses, Codex, Gemini) build their request body by spreading `...options.invocation.modelParams` verbatim. The `modelParams` bucket comes from `separateSettings()`, which classifies every **unrecognized** ephemeral key as a model-param (API pass-through). Two gaps caused the leaks:

1. **`streamIdleTimeoutMs` never aliased.** `settings.json` stores it in camelCase (`streamIdleTimeoutMs`), but the canonical registry key is the hyphenated `stream-idle-timeout-ms`. With no alias, the camelCase form was unknown → classified as a model-param → sent to every provider (rejected by Anthropic/Codex).
2. **Nested container objects not flattened.** Only the `reasoning.*` prefix was flattened; other registry-prefix containers (`text`, `compression`, `tools`, ...) passed through whole as unknown model-params. So `text: { verbosity: "medium" }` reached Anthropic as a top-level `text` field → `text: Extra inputs are not permitted`.

In a mixed LB (e.g. `opusfirst` = anthropic + codex), the LB's merged ephemerals get applied to whichever sub-profile failover selects, so a leak surfaces against whichever provider receives the request.

## The fix

A single load-side chokepoint (`separateSettings` in the settings package) so **every source** — profiles, `settings.json`, CLI args, and LB merges — is robust regardless of how it was stored:

- **Alias** `streamIdleTimeoutMs` → `stream-idle-timeout-ms` (so it routes to `cliSettings`, not `modelParams`).
- **Generalize nested-object flattening**: registry prefixes and bare keys are now derived directly from `SETTINGS_REGISTRY`. Every container whose prefix is known is flattened; prefix-only containers (`text`, `compression`) are dropped after flattening, while containers that have a bare spec (`reasoning`, `model`) are preserved.
- **Provider-override precedence**: base and provider-override settings are flattened separately and overrides spread on top, so provider-specific values always win (a real precedence bug found during review).
- `text.verbosity` correctly lands in `modelBehavior` (consumed only by the OpenAI Responses provider) and is never sent to Anthropic.

## Why this is robust for saving & using profiles

The fix is on the **load/classification** side, not the save side. Profiles are saved as-is (the nested object form and the camelCase key remain valid), and `separateSettings` normalizes them on read. This means existing profiles work without any migration, and mixed-provider LBs no longer need provider-specific keys stripped from the LB profile.

## Testing

- New behavioral tests at **three layers**:
  - `settingsRegistry.issue2182.test.ts` — 14 unit tests (alias resolution, no-leak for nested `text`/`compression`/`tools` objects, deep nesting, flat-key precedence, cross-source provider-override precedence, unknown-object pass-through preserved).
  - `RuntimeInvocationContext.separation.test.ts` — 3 boundary tests (modelParams empty + positive routing assertions for each setting's destination).
  - `LoadBalancingProvider.settings-merge.test.ts` — LB delegate integration test asserting the delegate `invocation.modelParams` stays clean when LB ephemerals contain a nested `text` object + global `streamIdleTimeoutMs`.
- Full suites: settings 256 pass, providers 3471 pass. (Core has pre-existing, unrelated failures from the storage package extraction — `Storage.getGlobalConfigDir is not a function` — in files this PR does not touch.)
- Smoke test (`node scripts/start.js --profile-load ollamakimi ...`) passes.

## tmux harness

Adds `scripts/lb-profiles-tmux.sh` (two modes: `launch` interactive tmux sessions, `smoke` non-interactive leak assertion) and three `tmux-script.issue2182-*.json` scripts to drive the `opusfirst`, `gptfirst`, and `glm` profiles through `scripts/tmux-harness.js`, matching the project's existing tmux-script convention.

## Verification

`npm run test` (affected packages), `npm run lint`, `npm run typecheck` (changed files clean), `npm run format`, full `npm run build`, smoke test, plus an Open Code Review pass — all 5 review findings addressed.
