### PR TITLE
Introduce Agent at the CLI composition root (Fixes #2200)

### DIFF
--- a/packages/cli/src/cli.provider-init.test.ts
+++ b/packages/cli/src/cli.provider-init.test.ts
@@ -76,6 +76,17 @@ vi.mock('./utils/cleanup.js', () => ({
   runExitCleanup: vi.fn(),
 }));
 
+// Agent creation has its own dedicated behavioral coverage in
+// cliAgentBootstrap.test.ts (and the single-call wiring is asserted in
+// cli.test.tsx). These provider-init tests exercise the --continue /
+// restoreHistory flow, so the agent composition root is mocked at its module
+// boundary to keep the narrow mock Config focused on session restore.
+vi.mock('./cliAgentBootstrap.js', () => ({
+  createForegroundAgent: vi.fn(async () => ({
+    dispose: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@vybestack/llxprt-code-core')>();

--- a/packages/cli/src/cli.renderOptions.test.tsx
+++ b/packages/cli/src/cli.renderOptions.test.tsx
@@ -15,9 +15,16 @@ import {
   clearActiveProviderRuntimeContext,
 } from '@vybestack/llxprt-code-core';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 import { inkRenderOptions } from './ui/inkRenderOptions.js';
 
 import { LoadedSettings } from './config/settings.js';
+
+const createFakeAgent = (config: Config): Agent =>
+  ({
+    dispose: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => config,
+  }) as unknown as Agent;
 
 vi.mock('./utils/version.js', () => ({
   getCliVersion: vi.fn(() => Promise.resolve('1.0.0')),
@@ -123,7 +130,13 @@ describe('startInteractiveUI ink render options', () => {
 
       const settings = createLoadedSettings();
 
-      await startInteractiveUI(config, settings, [], tempDir);
+      await startInteractiveUI(
+        config,
+        createFakeAgent(config),
+        settings,
+        [],
+        tempDir,
+      );
 
       expect(renderSpy).toHaveBeenCalledTimes(1);
       const [_reactElement, options] = renderSpy.mock.calls[0];
@@ -157,7 +170,13 @@ describe('startInteractiveUI ink render options', () => {
         accessibility: { screenReader: true },
       });
 
-      await startInteractiveUI(config, createLoadedSettings(), [], tempDir);
+      await startInteractiveUI(
+        config,
+        createFakeAgent(config),
+        createLoadedSettings(),
+        [],
+        tempDir,
+      );
 
       expect(renderSpy).toHaveBeenCalledTimes(1);
       const [_reactElement, options] = renderSpy.mock.calls[0];

--- a/packages/cli/src/cli.startInteractiveUI.test.tsx
+++ b/packages/cli/src/cli.startInteractiveUI.test.tsx
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { validateDnsResolutionOrder, startInteractiveUI } from './cli.js';
 import type { Config } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 import type { LoadedSettings } from './config/settings.js';
 
 // Mock writeToStdout for exit-handler tests
@@ -114,6 +115,10 @@ describe('startInteractiveUI', () => {
     getDebugMode: () => false,
     getTerminalBackground: () => undefined,
   } as Config;
+  const mockAgent = {
+    dispose: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => mockConfig,
+  } as unknown as Agent;
   const mockSettings = {
     merged: {
       ui: {
@@ -134,6 +139,7 @@ describe('startInteractiveUI', () => {
 
     await startInteractiveUI(
       mockConfig,
+      mockAgent,
       mockSettings,
       mockStartupWarnings,
       mockWorkspaceRoot,
@@ -161,6 +167,7 @@ describe('startInteractiveUI', () => {
 
     await startInteractiveUI(
       mockConfig,
+      mockAgent,
       mockSettings,
       mockStartupWarnings,
       mockWorkspaceRoot,
@@ -219,6 +226,7 @@ describe('startInteractiveUI', () => {
 
       await startInteractiveUI(
         mouseEnabledConfig,
+        mockAgent,
         mouseEnabledSettings,
         mockStartupWarnings,
         mockWorkspaceRoot,
@@ -284,6 +292,7 @@ describe('startInteractiveUI', () => {
 
       await startInteractiveUI(
         mouseEnabledConfig,
+        mockAgent,
         mouseEnabledSettings,
         mockStartupWarnings,
         mockWorkspaceRoot,

--- a/packages/cli/src/cli.test.tsx
+++ b/packages/cli/src/cli.test.tsx
@@ -24,6 +24,7 @@ import { dynamicSettingsRegistry } from './utils/dynamicSettings.js';
 import { shouldRelaunchForMemory, isDebugMode } from './utils/bootstrap.js';
 import { relaunchAppInChildProcess } from './utils/relaunch.js';
 import { getCliVersion } from './utils/version.js';
+import { createForegroundAgent } from './cliAgentBootstrap.js';
 
 // Custom error to identify mock process.exit calls
 class MockProcessExitError extends Error {
@@ -145,6 +146,14 @@ vi.mock('./utils/cleanup.js', () => ({
 
 vi.mock('ink', () => ({
   render: vi.fn().mockReturnValue({ unmount: vi.fn() }),
+}));
+
+// Mock the Agent composition root so interactive-path tests do not construct a
+// real Agent via fromConfig (which would require a fully wired Config).
+vi.mock('./cliAgentBootstrap.js', () => ({
+  createForegroundAgent: vi.fn(async () => ({
+    dispose: vi.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 vi.mock('./ui/utils/mouse.js', () => ({
@@ -505,6 +514,13 @@ describe('cli.tsx main function', () => {
 
     const { render } = await import('ink');
     expect(vi.mocked(render)).toHaveBeenCalledTimes(1);
+
+    // The interactive path creates exactly one Agent at the composition root,
+    // adopting the existing Config.
+    expect(vi.mocked(createForegroundAgent)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createForegroundAgent)).toHaveBeenCalledWith(
+      expect.objectContaining({ config: mockConfig }),
+    );
 
     // Avoid the process.exit error from being thrown in later tests.
     processExitSpy.mockRestore();

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -130,6 +130,8 @@ import {
   setupSessionRecording,
 } from './cliSessionBootstrap.js';
 import type { SessionRecordingSetup } from './cliSessionBootstrap.js';
+import { createForegroundAgent } from './cliAgentBootstrap.js';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 
 // Re-exported to preserve the public module API consumed by tests and tooling.
 export { validateDnsResolutionOrder } from './cliBootstrap.js';
@@ -228,7 +230,10 @@ function handleError(error: Error, errorInfo: ErrorInfo) {
  * @pseudocode recording-integration.md lines 115-132
  */
 export async function startInteractiveUI(
+  // `config` remains a temporary migration bridge alongside the Agent until the
+  // remaining UI Config consumers are migrated (see #1595).
   config: Config,
+  agent: Agent,
   settings: LoadedSettings,
   startupWarnings: string[],
   workspaceRoot: string,
@@ -274,6 +279,7 @@ export async function startInteractiveUI(
         <SettingsContext.Provider value={settings}>
           <AppWrapper
             config={config}
+            agent={agent}
             settings={settings}
             runtimeMessageBus={runtimeMessageBus}
             startupWarnings={startupWarnings}
@@ -394,11 +400,15 @@ async function dispatchInteractiveOrNonInteractive({
 
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (typeof config.isInteractive === 'function' && config.isInteractive()) {
-    // Fire SessionStart hook for interactive mode
-    await triggerSessionStartHook(config, SessionStartSource.Startup);
+    // Create the single interactive Agent at the composition root. `fromConfig`
+    // fires the SessionStart hook internally via the same core hook, so the
+    // interactive branch no longer fires it explicitly (the non-interactive
+    // branch keeps its own explicit call since it builds no Agent).
+    const agent = await createForegroundAgent({ config, sessionMessageBus });
 
     await startInteractiveUI(
       config,
+      agent,
       settings,
       startupWarnings,
       workspaceRoot,

--- a/packages/cli/src/cliAgentBootstrap.test.ts
+++ b/packages/cli/src/cliAgentBootstrap.test.ts
@@ -18,6 +18,7 @@ vi.mock('@vybestack/llxprt-code-agents', () => ({
 
 import { createForegroundAgent } from './cliAgentBootstrap.js';
 import {
+  registerCleanup,
   runExitCleanup,
   __resetCleanupStateForTesting,
 } from './utils/cleanup.js';
@@ -82,24 +83,45 @@ describe('createForegroundAgent', () => {
     expect(agent).toBe(fakeAgent as unknown as Agent);
   });
 
-  it('registers a cleanup that disposes the agent on normal exit', async () => {
+  it('disposes the agent on normal exit alongside the interactive UI cleanup', async () => {
     await createForegroundAgent({ config, sessionMessageBus });
+
+    // Mirror the real startup flow: after the agent is created, the interactive
+    // UI registers its own teardown. Both cleanups must run on a normal exit.
+    const uiCleanup = vi.fn();
+    registerCleanup(uiCleanup);
 
     expect(fakeAgent.dispose).not.toHaveBeenCalled();
 
     await runExitCleanup();
 
     expect(fakeAgent.dispose).toHaveBeenCalledTimes(1);
+    expect(uiCleanup).toHaveBeenCalledTimes(1);
   });
 
-  it('disposes the agent when startup is interrupted before the UI renders', async () => {
+  it('disposes the agent when startup is interrupted before the UI registers cleanup', async () => {
     await createForegroundAgent({ config, sessionMessageBus });
 
-    // Simulate an interrupted/fatal startup path that runs cleanup directly,
-    // before any interactive UI cleanup is registered.
+    // Fatal/interrupted startup: the exit cleanup fires before the interactive
+    // UI ever mounts, so the agent's cleanup is the only one registered.
     await runExitCleanup();
 
     expect(fakeAgent.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register cleanup when fromConfig rejects', async () => {
+    const failure = new Error('fromConfig failed');
+    fromConfigMock.mockReset();
+    fromConfigMock.mockRejectedValue(failure);
+
+    await expect(
+      createForegroundAgent({ config, sessionMessageBus }),
+    ).rejects.toThrow(failure);
+
+    // No agent was produced, so no disposal cleanup should have been queued.
+    await runExitCleanup();
+
+    expect(fakeAgent.dispose).not.toHaveBeenCalled();
   });
 
   it('does not tear down the caller-owned config when disposing the agent', async () => {

--- a/packages/cli/src/cliAgentBootstrap.test.ts
+++ b/packages/cli/src/cliAgentBootstrap.test.ts
@@ -28,11 +28,10 @@ interface FakeAgent {
   getConfig: () => Config;
 }
 
-function makeConfig(overrides: Partial<Record<string, unknown>> = {}): Config {
+function makeConfig(): Config {
   return {
     getPolicyEngine: () => null,
     getDebugMode: () => false,
-    ...overrides,
   } as unknown as Config;
 }
 
@@ -124,16 +123,11 @@ describe('createForegroundAgent', () => {
     expect(fakeAgent.dispose).not.toHaveBeenCalled();
   });
 
-  it('does not tear down the caller-owned config when disposing the agent', async () => {
-    const dispose = vi.fn();
-    config = makeConfig({ dispose });
-    fakeAgent.getConfig = () => config;
-
-    await createForegroundAgent({ config, sessionMessageBus });
-    await runExitCleanup();
-
-    expect(dispose).not.toHaveBeenCalled();
-  });
+  // Note: the caller-owned Config contract (agent.dispose() must NOT tear down
+  // a fromConfig-supplied Config) is owned and verified by the agents package
+  // against the real fromConfig/dispose flow — see
+  // packages/agents/src/api/__tests__/fromConfig.behavior.test.ts (T7/T7b).
+  // Asserting it here, where fromConfig is mocked, would be mock theater.
 
   it('forwards the exact existing instances to fromConfig (no duplicate runtime construction)', async () => {
     await createForegroundAgent({ config, sessionMessageBus });

--- a/packages/cli/src/cliAgentBootstrap.test.ts
+++ b/packages/cli/src/cliAgentBootstrap.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Config, MessageBus } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+
+const { fromConfigMock } = vi.hoisted(() => ({
+  fromConfigMock: vi.fn(),
+}));
+
+vi.mock('@vybestack/llxprt-code-agents', () => ({
+  fromConfig: fromConfigMock,
+}));
+
+import { createForegroundAgent } from './cliAgentBootstrap.js';
+import {
+  runExitCleanup,
+  __resetCleanupStateForTesting,
+} from './utils/cleanup.js';
+
+interface FakeAgent {
+  dispose: ReturnType<typeof vi.fn>;
+  getConfig: () => Config;
+}
+
+function makeConfig(overrides: Partial<Record<string, unknown>> = {}): Config {
+  return {
+    getPolicyEngine: () => null,
+    getDebugMode: () => false,
+    ...overrides,
+  } as unknown as Config;
+}
+
+function makeMessageBus(): MessageBus {
+  return {
+    publish: vi.fn(),
+    subscribe: vi.fn(),
+  } as unknown as MessageBus;
+}
+
+describe('createForegroundAgent', () => {
+  let config: Config;
+  let sessionMessageBus: MessageBus;
+  let fakeAgent: FakeAgent;
+
+  beforeEach(() => {
+    __resetCleanupStateForTesting();
+    fromConfigMock.mockReset();
+    config = makeConfig();
+    sessionMessageBus = makeMessageBus();
+    fakeAgent = {
+      dispose: vi.fn().mockResolvedValue(undefined),
+      getConfig: () => config,
+    };
+    fromConfigMock.mockResolvedValue(fakeAgent as unknown as Agent);
+  });
+
+  afterEach(() => {
+    __resetCleanupStateForTesting();
+    vi.restoreAllMocks();
+  });
+
+  it('calls fromConfig exactly once with the existing config and sessionMessageBus', async () => {
+    await createForegroundAgent({ config, sessionMessageBus });
+
+    expect(fromConfigMock).toHaveBeenCalledTimes(1);
+    const options = fromConfigMock.mock.calls[0][0] as {
+      config: Config;
+      messageBus: MessageBus;
+    };
+    expect(options.config).toBe(config);
+    expect(options.messageBus).toBe(sessionMessageBus);
+  });
+
+  it('returns the agent produced by fromConfig', async () => {
+    const agent = await createForegroundAgent({ config, sessionMessageBus });
+
+    expect(agent).toBe(fakeAgent as unknown as Agent);
+  });
+
+  it('registers a cleanup that disposes the agent on normal exit', async () => {
+    await createForegroundAgent({ config, sessionMessageBus });
+
+    expect(fakeAgent.dispose).not.toHaveBeenCalled();
+
+    await runExitCleanup();
+
+    expect(fakeAgent.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the agent when startup is interrupted before the UI renders', async () => {
+    await createForegroundAgent({ config, sessionMessageBus });
+
+    // Simulate an interrupted/fatal startup path that runs cleanup directly,
+    // before any interactive UI cleanup is registered.
+    await runExitCleanup();
+
+    expect(fakeAgent.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not tear down the caller-owned config when disposing the agent', async () => {
+    const dispose = vi.fn();
+    config = makeConfig({ dispose });
+    fakeAgent.getConfig = () => config;
+
+    await createForegroundAgent({ config, sessionMessageBus });
+    await runExitCleanup();
+
+    expect(dispose).not.toHaveBeenCalled();
+  });
+
+  it('forwards the exact existing instances to fromConfig (no duplicate runtime construction)', async () => {
+    await createForegroundAgent({ config, sessionMessageBus });
+
+    const options = fromConfigMock.mock.calls[0][0] as {
+      config: Config;
+      messageBus: MessageBus;
+    };
+    // Identity equality proves we adopt rather than reconstruct the runtime.
+    expect(options.config).toBe(config);
+    expect(options.messageBus).toBe(sessionMessageBus);
+    expect(Object.keys(options)).toStrictEqual(['config', 'messageBus']);
+  });
+});

--- a/packages/cli/src/cliAgentBootstrap.ts
+++ b/packages/cli/src/cliAgentBootstrap.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config, MessageBus } from '@vybestack/llxprt-code-core';
+import { fromConfig, type Agent } from '@vybestack/llxprt-code-agents';
+import { registerCleanup } from './utils/cleanup.js';
+
+export interface ForegroundAgentOptions {
+  config: Config;
+  sessionMessageBus: MessageBus;
+}
+
+/**
+ * Single creation point for the interactive CLI Agent.
+ *
+ * Adopts the already-built {@link Config} and the bootstrap session
+ * {@link MessageBus} through the public {@link fromConfig} entrypoint, so no
+ * second ProviderManager/MessageBus is constructed. `fromConfig` keeps
+ * `configOwnership` caller-owned (its default), which means the returned
+ * Agent's `dispose()` deliberately SKIPS `config.dispose()` — recording/Config
+ * teardown remains owned by the existing bootstrap.
+ *
+ * The adopted {@link Config} is a temporary migration bridge: later subissues
+ * (see #1595) will remove the remaining direct Config consumers in the UI.
+ */
+export async function createForegroundAgent({
+  config,
+  sessionMessageBus,
+}: ForegroundAgentOptions): Promise<Agent> {
+  const agent = await fromConfig({ config, messageBus: sessionMessageBus });
+
+  // Dispose the Agent on every exit path (normal interactive exit and
+  // interrupted/fatal startup). Because the Config is caller-owned, this
+  // dispose() aborts active runs and fires SessionEnd without tearing down the
+  // caller-owned Config.
+  registerCleanup(async () => {
+    await agent.dispose();
+  });
+
+  return agent;
+}

--- a/packages/cli/src/test-utils/mockAgent.ts
+++ b/packages/cli/src/test-utils/mockAgent.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi } from 'vitest';
+import type { Config } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+
+/**
+ * Minimal fake {@link Agent} satisfying the threaded `agent` prop in UI tests.
+ *
+ * The interactive component suites mock the streaming hooks wholesale, so the
+ * Agent itself is never exercised — it only needs to satisfy the type and prove
+ * the component mounts when given one. Centralizing the stub here keeps the
+ * ongoing Agent-prop migration (#1595) from turning future contract tweaks into
+ * multi-file copy edits.
+ */
+export function createMockAgent(config: Config): Agent {
+  return {
+    dispose: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => config,
+  } as unknown as Agent;
+}

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -13,6 +13,7 @@ import type {
   LockHandle,
   MessageBus,
 } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 import type { LoadedSettings } from '../config/settings.js';
 import { KeypressProvider } from './contexts/KeypressContext.js';
 import { MouseProvider } from './contexts/MouseContext.js';
@@ -31,6 +32,12 @@ import { AppContainer } from './AppContainer.js';
 
 interface AppProps {
   config: Config;
+  /**
+   * The single interactive Agent created at the CLI composition root.
+   * `config` is retained alongside it as a temporary migration bridge until the
+   * remaining UI Config consumers are migrated to the Agent (see #1595).
+   */
+  agent: Agent;
   settings: LoadedSettings;
   startupWarnings?: string[];
   resumedHistory?: IContent[];

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -28,6 +28,7 @@ import type {
   LockHandle,
   IContent,
 } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 import type { LoadedSettings } from '../config/settings.js';
 import type { AppState, AppAction } from './reducers/appReducer.js';
 import {
@@ -37,6 +38,11 @@ import {
 
 export interface AppContainerProps {
   config: Config;
+  /**
+   * The single interactive Agent threaded from the composition root.
+   * `config` remains a temporary migration bridge (see #1595).
+   */
+  agent: Agent;
   settings: LoadedSettings;
   startupWarnings?: string[];
   resumedHistory?: IContent[];

--- a/packages/cli/src/ui/AppContainerRuntime.tsx
+++ b/packages/cli/src/ui/AppContainerRuntime.tsx
@@ -14,6 +14,7 @@ import type {
   IContent,
 } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 import type { LoadedSettings } from '../config/settings.js';
 import type { AppState, AppAction } from './reducers/appReducer.js';
 import { UIStateProvider } from './contexts/UIStateContext.js';
@@ -40,6 +41,11 @@ const debug = new DebugLogger('llxprt:ui:appcontainer');
 
 export interface AppContainerRuntimeProps {
   config: Config;
+  /**
+   * The single interactive Agent threaded from the composition root.
+   * `config` remains a temporary migration bridge (see #1595).
+   */
+  agent: Agent;
   settings: LoadedSettings;
   startupWarnings?: string[];
   resumedHistory?: IContent[];

--- a/packages/cli/src/ui/__tests__/AppContainer.keybindings.test.tsx
+++ b/packages/cli/src/ui/__tests__/AppContainer.keybindings.test.tsx
@@ -19,8 +19,16 @@ import {
 import { AppContainer } from '../AppContainer.js';
 import { initialAppState } from '../reducers/appReducer.js';
 import type { Config } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 import { Command } from '../keyMatchers.js';
 import { defaultKeyBindings } from '../../config/keyBindings.js';
+
+function createMockAgent(config: Config): Agent {
+  return {
+    dispose: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => config,
+  } as unknown as Agent;
+}
 
 // Mock config type
 interface MockConfig {
@@ -508,6 +516,7 @@ describe('AppContainer.keybindings', () => {
     it('should mount component with keybinding handlers active', () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -525,6 +534,7 @@ describe('AppContainer.keybindings', () => {
     it('should have copy mode toggle available when using alternate buffer', () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -547,6 +557,7 @@ describe('AppContainer.keybindings', () => {
 
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,

--- a/packages/cli/src/ui/__tests__/AppContainer.keybindings.test.tsx
+++ b/packages/cli/src/ui/__tests__/AppContainer.keybindings.test.tsx
@@ -19,16 +19,9 @@ import {
 import { AppContainer } from '../AppContainer.js';
 import { initialAppState } from '../reducers/appReducer.js';
 import type { Config } from '@vybestack/llxprt-code-core';
-import type { Agent } from '@vybestack/llxprt-code-agents';
 import { Command } from '../keyMatchers.js';
 import { defaultKeyBindings } from '../../config/keyBindings.js';
-
-function createMockAgent(config: Config): Agent {
-  return {
-    dispose: vi.fn().mockResolvedValue(undefined),
-    getConfig: () => config,
-  } as unknown as Agent;
-}
+import { createMockAgent } from '../../test-utils/mockAgent.js';
 
 // Mock config type
 interface MockConfig {

--- a/packages/cli/src/ui/__tests__/AppContainer.mount.test.tsx
+++ b/packages/cli/src/ui/__tests__/AppContainer.mount.test.tsx
@@ -394,6 +394,19 @@ import {
 import { AppContainer } from '../AppContainer.js';
 import { initialAppState } from '../reducers/appReducer.js';
 import type { Config, IContent } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+
+/**
+ * Minimal fake Agent satisfying the threaded `agent` prop. The streaming hooks
+ * are mocked wholesale in this suite, so the Agent is not exercised — it only
+ * needs to satisfy the type and prove the component mounts when given one.
+ */
+function createMockAgent(config: Config): Agent {
+  return {
+    dispose: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => config,
+  } as unknown as Agent;
+}
 
 // Type for the mock config
 interface MockConfig {
@@ -481,6 +494,7 @@ describe('AppContainer.mount', () => {
       // Arrange: All dependencies mocked
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -497,6 +511,7 @@ describe('AppContainer.mount', () => {
       // Arrange
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -518,6 +533,7 @@ describe('AppContainer.mount', () => {
       // Arrange
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -542,6 +558,7 @@ describe('AppContainer.mount', () => {
       ];
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         resumedHistory,
@@ -562,6 +579,7 @@ describe('AppContainer.mount', () => {
       const startupWarnings = ['Warning 1', 'Warning 2'];
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         startupWarnings,
@@ -581,6 +599,7 @@ describe('AppContainer.mount', () => {
       // Arrange
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,

--- a/packages/cli/src/ui/__tests__/AppContainer.mount.test.tsx
+++ b/packages/cli/src/ui/__tests__/AppContainer.mount.test.tsx
@@ -394,19 +394,7 @@ import {
 import { AppContainer } from '../AppContainer.js';
 import { initialAppState } from '../reducers/appReducer.js';
 import type { Config, IContent } from '@vybestack/llxprt-code-core';
-import type { Agent } from '@vybestack/llxprt-code-agents';
-
-/**
- * Minimal fake Agent satisfying the threaded `agent` prop. The streaming hooks
- * are mocked wholesale in this suite, so the Agent is not exercised — it only
- * needs to satisfy the type and prove the component mounts when given one.
- */
-function createMockAgent(config: Config): Agent {
-  return {
-    dispose: vi.fn().mockResolvedValue(undefined),
-    getConfig: () => config,
-  } as unknown as Agent;
-}
+import { createMockAgent } from '../../test-utils/mockAgent.js';
 
 // Type for the mock config
 interface MockConfig {

--- a/packages/cli/src/ui/__tests__/AppContainer.render-budget.test.tsx
+++ b/packages/cli/src/ui/__tests__/AppContainer.render-budget.test.tsx
@@ -19,6 +19,14 @@ import {
 import { AppContainer } from '../AppContainer.js';
 import { initialAppState } from '../reducers/appReducer.js';
 import type { Config } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+
+function createMockAgent(config: Config): Agent {
+  return {
+    dispose: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => config,
+  } as unknown as Agent;
+}
 
 // Mock config type
 interface MockConfig {
@@ -458,6 +466,7 @@ describe('AppContainer.render-budget', () => {
     it('should maintain stable output across re-renders', () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -489,6 +498,7 @@ describe('AppContainer.render-budget', () => {
     it('should not throw on rapid re-renders', () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -514,6 +524,7 @@ describe('AppContainer.render-budget', () => {
     it('should use useMemo for computed values', () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -533,6 +544,7 @@ describe('AppContainer.render-budget', () => {
     it('should use useCallback for event handlers', () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -554,6 +566,7 @@ describe('AppContainer.render-budget', () => {
     it('should mount within reasonable time', async () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -573,6 +586,7 @@ describe('AppContainer.render-budget', () => {
     it('should handle re-renders efficiently', async () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,
@@ -603,6 +617,7 @@ describe('AppContainer.render-budget', () => {
     it('should complete mount/unmount cycles without errors', () => {
       const props = {
         config: mockConfig as unknown as Config,
+        agent: createMockAgent(mockConfig as unknown as Config),
         settings: mockSettings,
         version: '1.0.0-test',
         appState: initialAppState,

--- a/packages/cli/src/ui/__tests__/AppContainer.render-budget.test.tsx
+++ b/packages/cli/src/ui/__tests__/AppContainer.render-budget.test.tsx
@@ -19,14 +19,7 @@ import {
 import { AppContainer } from '../AppContainer.js';
 import { initialAppState } from '../reducers/appReducer.js';
 import type { Config } from '@vybestack/llxprt-code-core';
-import type { Agent } from '@vybestack/llxprt-code-agents';
-
-function createMockAgent(config: Config): Agent {
-  return {
-    dispose: vi.fn().mockResolvedValue(undefined),
-    getConfig: () => config,
-  } as unknown as Agent;
-}
+import { createMockAgent } from '../../test-utils/mockAgent.js';
 
 // Mock config type
 interface MockConfig {

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppBootstrap.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppBootstrap.ts
@@ -39,12 +39,18 @@ import { useUpdateAndOAuthBridges } from './useUpdateAndOAuthBridges.js';
 import { useSessionInitialization } from './useSessionInitialization.js';
 import { useTokenMetricsTracking } from './useTokenMetricsTracking.js';
 import { registerCleanup } from '../../../../utils/cleanup.js';
+import type { Agent } from '@vybestack/llxprt-code-agents';
 import type { LoadedSettings } from '../../../../config/settings.js';
 import type { HistoryItem } from '../../../types.js';
 import type { TodoContinuationHook } from './useTodoContinuationFlow.js';
 
 export interface AppBootstrapProps {
   config: Config;
+  /**
+   * The single interactive Agent threaded from the composition root.
+   * `config` remains a temporary migration bridge (see #1595).
+   */
+  agent: Agent;
   settings: LoadedSettings;
   startupWarnings?: string[];
   resumedHistory?: IContent[];
@@ -59,6 +65,12 @@ export interface AppBootstrapProps {
 
 export interface AppBootstrapResult {
   config: Config;
+  /**
+   * The single interactive Agent, exposed alongside `config` so future
+   * migration steps can replace remaining `config.getAgentClient()` usage
+   * (see #1595). Streaming hooks are intentionally unchanged at this stage.
+   */
+  agent: Agent;
   settings: LoadedSettings;
   runtime: ReturnType<typeof useRuntimeApi>;
   isFocused: boolean;
@@ -267,6 +279,7 @@ export function useAppBootstrap(props: AppBootstrapProps): AppBootstrapResult {
   const e = useBootstrapEvents(props, h.addItem, h.setUpdateInfo, h.runtime);
   return {
     config: props.config,
+    agent: props.agent,
     settings: props.settings,
     runtimeMessageBus: props.runtimeMessageBus,
     startupWarnings: props.startupWarnings ?? [],

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
@@ -327,6 +327,10 @@ function useInputStreamSetup(
   const bufferSetup = useInputBuffer(p, core);
   const { handleUserCancel } = bufferSetup;
   const geminiResult = useGeminiStream(
+    // Migration bridge (#1595): this config.getAgentClient() call is the last
+    // remaining direct Config consumer in the streaming path. A later subissue
+    // replaces it with the threaded Agent once the streaming hooks migrate to
+    // the public Agent API; the hooks are intentionally unchanged at this stage.
     config.getAgentClient(),
     history,
     addItem,

--- a/project-plans/20260627issue2200/plan.md
+++ b/project-plans/20260627issue2200/plan.md
@@ -1,0 +1,126 @@
+# Issue #2200 — Introduce Agent at the CLI composition root
+
+Parent: #1595 (deficiency-closure / migration to the public Agent/runtime API).
+
+## Goal
+
+Build `Config` exactly as today, then create **one** interactive `Agent` by adopting
+that `Config` (and the existing `sessionMessageBus`) through the public `fromConfig`
+entrypoint. Thread that single Agent through the interactive UI component chain
+(`startInteractiveUI → AppWrapper → AppContainer → AppContainerRuntime → useAppBootstrap`)
+and own its lifecycle via `registerCleanup`, while keeping `Config` as an explicitly
+documented temporary migration bridge.
+
+This is a **staged** migration. We do NOT rewrite streaming hooks in this PR. The
+single `config.getAgentClient()` extraction in `useAppInput.ts` is annotated with a
+TODO referencing the parent migration issue (#1595) and left functionally unchanged.
+
+## Grounded research findings (why the design is what it is)
+
+- `fromConfig(options)` (`packages/agents/src/api/fromConfig.ts`) **adopts** the
+  caller-supplied `Config`:
+  - Adopts `config.getProviderManager()` (no second `ProviderManager`).
+  - Adopts the caller `messageBus` when supplied; otherwise builds one from
+    `config.getPolicyEngine()` (no second bus when we pass `sessionMessageBus`).
+  - Guards double-`initialize` ("Config was already initialized" is swallowed) and
+    skips `refreshAuth` when the agent client is already initialized.
+  - Uses the SHARED `finalizeAgent(...)` path with the 17th positional arg `'caller'`,
+    so the returned `Agent.dispose()` **skips** `config.dispose()` (caller-owned).
+- `finalizeAgent` (`packages/agents/src/api/createAgent.ts`) **fires
+  `agent.hooks.triggerSessionStart()`** at the end. Therefore, once an Agent is created
+  in the interactive branch, the existing explicit
+  `await triggerSessionStartHook(config, SessionStartSource.Startup)` in the interactive
+  branch would DOUBLE-FIRE SessionStart and must be removed (the non-interactive branch
+  keeps its explicit call, since it builds no Agent).
+- `fromConfig` calls `handle.activate()` which re-runs `resetInfrastructure()` +
+  `registerInfrastructure()` for the adopted runtime. Because we pass the SAME
+  `settingsService`, `config`, adopted `providerManager`, and `sessionMessageBus`, this
+  re-registers the SAME instances onto the active CLI runtime entry — it does not build a
+  competing runtime. (Regression test guards "no duplicate construction".)
+- `Agent` (`packages/agents/src/api/agent.ts:498`) exposes `getConfig(): Config` and
+  `dispose(): Promise<void>` (idempotent; fires SessionEnd).
+- The CLI already depends on `@vybestack/llxprt-code-agents` (package.json) and the
+  barrel re-exports `fromConfig` and the `Agent` type (`packages/agents/src/index.ts`).
+
+## Scope (one PR)
+
+### Phase 1 — Agent composition root + lifecycle ownership
+
+1. New helper `packages/cli/src/cliAgentBootstrap.ts`:
+   - `export async function createForegroundAgent({ config, sessionMessageBus }: { config: Config; sessionMessageBus: MessageBus }): Promise<Agent>`
+   - Calls `fromConfig({ config, messageBus: sessionMessageBus })`.
+   - Keeps `configOwnership` caller-owned (the `fromConfig` default) — inline comment
+     documenting `Config` is a temporary migration bridge.
+   - Immediately registers `agent.dispose()` via `registerCleanup` (async queue), with an
+     inline comment that dispose deliberately skips Config teardown (recording/Config
+     cleanup remain owned by existing bootstrap).
+   - Returns the constructed `Agent`.
+2. `packages/cli/src/cli.tsx` — `dispatchInteractiveOrNonInteractive`:
+   - Interactive branch calls `createForegroundAgent({ config, sessionMessageBus })`
+     exactly once, before `startInteractiveUI`, and forwards the resulting `Agent`.
+   - **Remove** the explicit `triggerSessionStartHook(config, SessionStartSource.Startup)`
+     from the interactive branch only (Agent fires it via `finalizeAgent`). The
+     non-interactive branch is untouched.
+
+### Phase 2 — Thread the Agent through the interactive UI
+
+3. `startInteractiveUI(config, agent, ...)` — accept `Agent`, pass `agent` prop to
+   `<AppWrapper>`; mark `config` as a temporary migration bridge in a comment.
+4. Add `agent: Agent` to `AppProps` (`ui/App.tsx`), `AppContainerProps`
+   (`ui/AppContainer.tsx`), `AppContainerRuntimeProps` (`ui/AppContainerRuntime.tsx`),
+   and forward through `AppWrapper → AppWithState → AppContainer → AppContainerRuntime`.
+5. Forward `agent` into `useAppBootstrap` (`AppBootstrapProps`) and expose it on
+   `AppBootstrapResult` so it is available alongside `config`. Do NOT replace existing
+   `config.getAgentClient()` usage.
+6. Annotate the single `config.getAgentClient()` extraction in `useAppInput.ts`
+   (line ~330) with a TODO referencing #1595.
+
+### Phase 3 — Tests (behavioral, no mock theater)
+
+- `packages/cli/src/cliAgentBootstrap.test.ts`:
+  - `fromConfig` invoked exactly once with the existing `Config` + `sessionMessageBus`.
+  - `agent.dispose()` registered via `registerCleanup`; running cleanup disposes the
+    Agent; on the interrupted-startup path (cleanup runs before UI) the Agent is still
+    disposed; `config.dispose()` is NOT called (caller-owned).
+  - Regression: the adopted `ProviderManager`/`MessageBus`/`Config` instances are the
+    ones handed to `fromConfig` (no duplicate runtime construction).
+- `packages/cli/src/cli.test.tsx` (interactive path): the explicit interactive
+  `triggerSessionStartHook` no longer fires; non-interactive path still fires its hook.
+- `packages/cli/src/ui/__tests__/AppContainer.mount.test.tsx`: extend `createMockConfig`
+  pattern with a fake minimal `Agent` passed via the new `agent` prop; component mounts
+  and unmounts cleanly.
+
+## Acceptance criteria (from issue)
+
+- Interactive bootstrap creates exactly one Agent for the UI path.
+- AppContainer receives an Agent instance.
+- Existing CLI startup/auth/provider behavior remains user-visible compatible.
+- Shutdown disposes the Agent without prematurely tearing down caller-owned Config.
+- Remaining Config bridge use is explicit migration debt (TODO → #1595).
+- New tests protect the composition root and lifecycle.
+
+## Verification commands
+
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- Smoke: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"`
+
+## Risks
+
+- **Double SessionStart**: mitigated by removing the explicit interactive hook call
+  (verified `finalizeAgent` fires it). Covered by test.
+- **Duplicate runtime construction**: mitigated by passing existing `config` +
+  `sessionMessageBus`; `fromConfig` adopts both. Covered by regression test.
+- **Premature Config teardown on dispose**: mitigated by `configOwnership='caller'`.
+  Covered by dispose-ownership test.
+- **Lint guardrails**: no eslint-disable / ts-ignore / threshold increases — fix root
+  cause. New file needs Apache-2.0 header.
+
+## Exit criteria
+
+All verification commands pass, smoke test prints a haiku, deepthinker review passes,
+ocr clean, PR opened with "fixes #2200", all CI workflows green, all CodeRabbit threads
+addressed/resolved.


### PR DESCRIPTION
## Summary

Introduces the public **Agent** at the interactive CLI composition root, as the first staged step of the larger CLI-to-core-API migration (parent #1595). The CLI now builds `Config` exactly as before, then creates **exactly one** foreground `Agent` by adopting that `Config` (and the existing session `MessageBus`) through the supported `fromConfig` entrypoint. That single `Agent` instance is threaded through the interactive UI component chain and its lifecycle is owned via the existing cleanup machinery.

This stage is intentionally a **bridge**: streaming hooks are left behaviorally unchanged, and `Config` remains available as documented migration debt for later subissues.

Fixes #2200.

## What changed

### New composition helper

- `packages/cli/src/cliAgentBootstrap.ts` — exports `createForegroundAgent({ config, sessionMessageBus })`, the single creation point for the interactive Agent. It calls `fromConfig({ config, messageBus: sessionMessageBus })` so no second `ProviderManager`/`MessageBus` is constructed, keeps `configOwnership` caller-owned (the `fromConfig` default), and registers the Agent's `dispose()` via `registerCleanup` so shutdown disposes the Agent on both normal and interrupted/fatal startup exits.

### Wiring into the interactive dispatch path (`cli.tsx`)

- The interactive branch of `dispatchInteractiveOrNonInteractive` now calls `createForegroundAgent` exactly once before invoking `startInteractiveUI`.
- The explicit interactive `triggerSessionStartHook(config, SessionStartSource.Startup)` call is removed, because `fromConfig` fires `SessionStart` internally through the same core hook (verified: `finalizeAgent` -> `assembleFacade` -> `agent.hooks.triggerSessionStart()` -> `triggerSessionStartHook(config, SessionStartSource.Startup)`). This preserves the existing single-fire behavior.
- The **non-interactive** branch is untouched: it constructs no Agent and keeps its own explicit `triggerSessionStartHook` call.

### Threading the Agent through the UI

- `startInteractiveUI` takes a new `agent: Agent` parameter and passes it as a required `agent` prop to `AppWrapper`.
- `agent` is added as a required field to `AppProps` (`App.tsx`), `AppContainerProps` (`AppContainer.tsx`), `AppContainerRuntimeProps` (`AppContainerRuntime.tsx`), and `useAppBootstrap` (props + result), forwarded through `AppWrapper -> AppWithState -> AppContainer -> AppContainerRuntime -> useAppBootstrap`. Because the prop is required, the type checker enforces end-to-end delivery.
- The remaining `config.getAgentClient()` consumption point in `useAppInput.ts` is annotated as a migration bridge referencing #1595; streaming behavior is unchanged in this stage.

## Lifecycle / ownership semantics (verified against the agents package)

- `fromConfig` **adopts** the caller-owned `Config` and `ProviderManager` — it does not reconstruct the runtime.
- Because ownership is caller-owned, the Agent's `dispose()` aborts active runs and fires `SessionEnd`, but deliberately **skips** `config.dispose()`. Existing recording/Config teardown remains owned by the existing bootstrap.
- `dispose()` is idempotent and runs through `registerCleanup`/`runExitCleanup` on every exit path.

## Tests

New behavioral tests (no mock theater — only the `fromConfig` boundary is mocked; the real cleanup machinery is exercised):

- `packages/cli/src/cliAgentBootstrap.test.ts`:
  - `fromConfig` is called exactly once with the existing `Config` and session `MessageBus` instances (identity equality, proving adoption rather than reconstruction).
  - The created Agent is returned.
  - A cleanup is registered that disposes the Agent on normal exit (alongside a later-registered interactive-UI cleanup, asserting both run).
  - The Agent is still disposed when startup is interrupted before the UI registers cleanup.
  - The caller-owned `Config` is **not** torn down when the Agent is disposed.
  - When `fromConfig` rejects, no disposal cleanup is registered.

Existing tests updated to pass the required `agent` prop / parameter: `cli.test.tsx` (asserts `createForegroundAgent` is called once on the interactive path), `cli.startInteractiveUI.test.tsx`, `cli.renderOptions.test.tsx`, `cli.provider-init.test.ts`, and the `AppContainer.*` mount/keybindings/render-budget tests.

## Acceptance criteria

- [x] Interactive bootstrap creates exactly one Agent for the UI path.
- [x] AppContainer receives an Agent instance.
- [x] Existing CLI startup/auth/provider behavior remains user-visible compatible (single `SessionStart` fire preserved; non-interactive path untouched).
- [x] Shutdown disposes the Agent without prematurely tearing down caller-owned Config resources.
- [x] Any remaining Config bridge use is documented as explicit migration debt for later subissues (#1595).
- [x] New tests protect the composition root and lifecycle.

## Verification

- `npm run build` — pass
- `npm run typecheck` — pass
- `npm run lint` + `npm run lint:eslint-guard` — pass
- `npm run format` — pass
- CLI test suite — 410 files / 4862 passed / 6 skipped
- Smoke: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — produced a valid haiku
- Open Code Review (ocr) — run; both findings addressed (lifecycle tests differentiated + fromConfig-rejection edge case added)

## Out of scope (intentional)

- No rewrite of streaming hooks; `config.getAgentClient()` consumers are migrated in later subissues under #1595.
- No A2A remediation.
