### PR TITLE
Route non-interactive prompt mode through Agent stream (Fixes #2202)

### DIFF
--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -4,7 +4,7 @@
  * @plan:PLAN-20260621-COREAPIREMED.P06
  */
 
-import type { Content } from '@google/genai';
+import type { Content, Part } from '@google/genai';
 import type { UserTierId } from '@vybestack/llxprt-code-core/code_assist/types.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type {
@@ -37,6 +37,7 @@ export type AgentHistoryItem = IContent;
 
 export type AgentInput =
   | string
+  | readonly Part[]
   | Readonly<{ readonly text: string; readonly role?: 'user' | 'system' }>;
 
 export type McpDiscoveryMode = 'await' | 'skip';

--- a/packages/agents/src/api/agentBootstrap.ts
+++ b/packages/agents/src/api/agentBootstrap.ts
@@ -187,7 +187,8 @@ export function deriveDisplayCallbacks(
 }
 
 /**
- * Maps an AgentInput (string | structured) to a PartListUnion for run().
+ * Maps an AgentInput (string | readonly Part[] | structured {text, role?})
+ * to a PartListUnion for run().
  */
 function isPartArray(input: AgentInput): input is readonly Part[] {
   return Array.isArray(input);

--- a/packages/agents/src/api/agentBootstrap.ts
+++ b/packages/agents/src/api/agentBootstrap.ts
@@ -15,7 +15,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { PartListUnion } from '@google/genai';
+import type { PartListUnion, Part } from '@google/genai';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import type { AgentClientContract } from '@vybestack/llxprt-code-core/core/clientContract.js';
@@ -189,9 +189,16 @@ export function deriveDisplayCallbacks(
 /**
  * Maps an AgentInput (string | structured) to a PartListUnion for run().
  */
+function isPartArray(input: AgentInput): input is readonly Part[] {
+  return Array.isArray(input);
+}
+
 export function toPartListUnion(input: AgentInput): PartListUnion {
   if (typeof input === 'string') {
     return input;
+  }
+  if (isPartArray(input)) {
+    return [...input];
   }
   return input.text;
 }

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -594,7 +594,13 @@ export class AgentImpl implements Agent {
     // by exactly ONE done{reason:'error'} and stops — no model turn runs.
     const gateError = await this.awaitMcpDiscoveryGate(opts);
     if (gateError !== undefined) {
-      yield { type: 'error', error: { message: gateError.message } };
+      // StructuredError has no `code` field, so the typed AgentError code
+      // (e.g. 'mcp_discovery_failed') is prefixed onto the message to keep it
+      // programmatically distinguishable without widening the public type.
+      yield {
+        type: 'error',
+        error: { message: `[${gateError.code}] ${gateError.message}` },
+      };
       yield { type: 'done', reason: 'error' };
       return;
     }

--- a/packages/agents/src/api/agentImpl.ts
+++ b/packages/agents/src/api/agentImpl.ts
@@ -589,10 +589,12 @@ export class AgentImpl implements Agent {
   ): AsyncIterable<AgentEvent> {
     // @plan:PLAN-20260617-COREAPI.P22 @requirement:REQ-013
     // MCP discovery gate: by default await readiness before the model turn. On
-    // discovery FAILURE the stream yields exactly ONE done{reason:'error'} and
-    // stops — no model turn runs.
+    // discovery FAILURE the stream yields a structured `error` event (carrying
+    // the failure message so consumers can surface useful diagnostics) followed
+    // by exactly ONE done{reason:'error'} and stops — no model turn runs.
     const gateError = await this.awaitMcpDiscoveryGate(opts);
     if (gateError !== undefined) {
+      yield { type: 'error', error: { message: gateError.message } };
       yield { type: 'done', reason: 'error' };
       return;
     }

--- a/packages/agents/src/api/event-schema.ts
+++ b/packages/agents/src/api/event-schema.ts
@@ -69,6 +69,7 @@ export const AgentToolResultSchema = z.object({
   isError: z.boolean().optional(),
   display: z.unknown().optional(),
   suppressDisplay: z.boolean().optional(),
+  errorType: z.string().optional(),
 });
 
 export const ToolConfirmationSchema = z.object({

--- a/packages/agents/src/api/event-schema.ts
+++ b/packages/agents/src/api/event-schema.ts
@@ -67,6 +67,8 @@ export const AgentToolResultSchema = z.object({
   name: z.string(),
   output: z.unknown().optional(),
   isError: z.boolean().optional(),
+  display: z.unknown().optional(),
+  suppressDisplay: z.boolean().optional(),
 });
 
 export const ToolConfirmationSchema = z.object({

--- a/packages/agents/src/api/event-types.ts
+++ b/packages/agents/src/api/event-types.ts
@@ -55,6 +55,8 @@ export type AgentToolResult = Readonly<{
   name: string;
   output?: unknown;
   isError?: boolean;
+  display?: unknown;
+  suppressDisplay?: boolean;
 }>;
 
 export type ToolConfirmation = Readonly<{

--- a/packages/agents/src/api/event-types.ts
+++ b/packages/agents/src/api/event-types.ts
@@ -57,6 +57,7 @@ export type AgentToolResult = Readonly<{
   isError?: boolean;
   display?: unknown;
   suppressDisplay?: boolean;
+  errorType?: string;
 }>;
 
 export type ToolConfirmation = Readonly<{

--- a/packages/agents/src/api/eventAdapter.ts
+++ b/packages/agents/src/api/eventAdapter.ts
@@ -79,6 +79,10 @@ function projectToolResult(
         x.status === 'error' ||
         (x.status === 'cancelled' &&
           x.outcome === ToolConfirmationOutcome.Cancel),
+      ...(x.response.resultDisplay !== undefined
+        ? { display: x.response.resultDisplay }
+        : {}),
+      ...(x.response.suppressDisplay === true ? { suppressDisplay: true } : {}),
     };
   }
   return {
@@ -86,6 +90,8 @@ function projectToolResult(
     name: '',
     output: x.responseParts,
     isError: x.error !== undefined,
+    ...(x.resultDisplay !== undefined ? { display: x.resultDisplay } : {}),
+    ...(x.suppressDisplay === true ? { suppressDisplay: true } : {}),
   };
 }
 

--- a/packages/agents/src/api/eventAdapter.ts
+++ b/packages/agents/src/api/eventAdapter.ts
@@ -83,6 +83,9 @@ function projectToolResult(
         ? { display: x.response.resultDisplay }
         : {}),
       ...(x.response.suppressDisplay === true ? { suppressDisplay: true } : {}),
+      ...(x.response.errorType !== undefined
+        ? { errorType: x.response.errorType }
+        : {}),
     };
   }
   return {

--- a/packages/agents/src/api/eventAdapter.ts
+++ b/packages/agents/src/api/eventAdapter.ts
@@ -95,6 +95,7 @@ function projectToolResult(
     isError: x.error !== undefined,
     ...(x.resultDisplay !== undefined ? { display: x.resultDisplay } : {}),
     ...(x.suppressDisplay === true ? { suppressDisplay: true } : {}),
+    ...(x.errorType !== undefined ? { errorType: x.errorType } : {}),
   };
 }
 

--- a/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
+++ b/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
@@ -11,7 +11,11 @@ import {
   DebugLogger,
 } from '@vybestack/llxprt-code-core';
 import type { Part } from '@google/genai';
-import type { Agent, AgentEvent } from '@vybestack/llxprt-code-agents';
+import type {
+  Agent,
+  AgentEvent,
+  AgentInput,
+} from '@vybestack/llxprt-code-agents';
 import { runNonInteractive } from './nonInteractiveCli.js';
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -21,7 +25,10 @@ import type { LoadedSettings } from './config/settings.js';
 // Captures the resolved query handed to the fake Agent's stream(), and the
 // AgentEvents it should emit. Reset per-test in beforeEach.
 const agentState = vi.hoisted(() => ({
-  streamInput: null as unknown,
+  // runNonInteractive passes the resolved query to agent.stream(); typed as
+  // AgentInput | null (matching the stream() parameter type) so assertions get
+  // compile-time checking instead of the looser `unknown`.
+  streamInput: null as AgentInput | null,
   events: [] as AgentEvent[],
 }));
 
@@ -59,9 +66,13 @@ vi.mock('./services/CommandService.js', () => ({
  * currently staged in agentState.events. Drives runNonInteractive end-to-end
  * without a real Agent/Config round-trip.
  */
+// Only `stream` and `dispose` are exercised by runNonInteractive; the cast
+// back to the full Agent interface is needed because fromConfig() is typed to
+// return a complete Agent. If production code calls a new Agent method, extend
+// this fake accordingly.
 function buildFakeAgent(): Agent {
   return {
-    stream: (input: unknown) => {
+    stream: (input: AgentInput) => {
       agentState.streamInput = input;
       return (async function* generateFakeStream(): AsyncIterable<AgentEvent> {
         for (const event of agentState.events) {
@@ -320,8 +331,11 @@ describe('runNonInteractive - slash commands and thinking output', () => {
   it('should render tool-call and tool-result events through the Agent stream', async () => {
     // After migration, tool execution is owned by the Agent. This verifies the
     // tool-call/tool-result AgentEvents render their display end-to-end through
-    // runNonInteractive (allowlist governance itself is covered by the
-    // run_shell_command integration test).
+    // runNonInteractive.
+    // Allowlist governance (--allowed-tools overriding ShellTool/EditTool/
+    // WriteFile exclusion) is config-level and covered by the fast unit suite
+    // config/__tests__/toolGovernanceParity.test.ts (getExcludeTools parity) and
+    // the integration-tests/run_shell_command.test.ts scenarios.
     agentState.events = [
       {
         type: 'tool-call',

--- a/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
+++ b/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
@@ -200,7 +200,7 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     });
 
     // The PROCESSED parts (not the raw input) must reach the Agent stream.
-    expect(agentState.streamInput).toBe(processedParts);
+    expect(agentState.streamInput).toStrictEqual(processedParts);
     expect(processStdoutSpy).toHaveBeenCalledWith('Summary complete.');
   });
 

--- a/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
+++ b/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
@@ -4,40 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  Config,
-  ToolRegistry,
-  ServerGeminiStreamEvent,
-} from '@vybestack/llxprt-code-core';
+import type { Config } from '@vybestack/llxprt-code-core';
 import {
   shutdownTelemetry,
   isTelemetrySdkInitialized,
-  GeminiEventType,
   DebugLogger,
 } from '@vybestack/llxprt-code-core';
 import type { Part } from '@google/genai';
+import type { Agent, AgentEvent } from '@vybestack/llxprt-code-agents';
 import { runNonInteractive } from './nonInteractiveCli.js';
-
-import { executeToolCall } from '@vybestack/llxprt-code-agents';
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { Mock, MockInstance } from 'vitest';
 import type { LoadedSettings } from './config/settings.js';
-import {
-  createCompletedToolCallResponse,
-  createStreamFromEvents,
-} from './nonInteractiveCli.test-helpers.js';
 
-// Mock core modules
-vi.mock('./ui/hooks/atCommandProcessor.js');
+// Captures the resolved query handed to the fake Agent's stream(), and the
+// AgentEvents it should emit. Reset per-test in beforeEach.
+const agentState = vi.hoisted(() => ({
+  streamInput: null as unknown,
+  events: [] as AgentEvent[],
+}));
+
 vi.mock('@vybestack/llxprt-code-agents', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('@vybestack/llxprt-code-agents')>();
   return {
     ...original,
-    executeToolCall: vi.fn(),
+    fromConfig: vi.fn(),
   };
 });
+
+// Mock core modules
+vi.mock('./ui/hooks/atCommandProcessor.js');
 vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
@@ -45,9 +43,6 @@ vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
     ...original,
     shutdownTelemetry: vi.fn(),
     isTelemetrySdkInitialized: vi.fn().mockReturnValue(true),
-    delay: original.delay,
-    nextStreamEventWithIdleTimeout: original.nextStreamEventWithIdleTimeout,
-    StreamIdleTimeoutError: original.StreamIdleTimeoutError,
   };
 });
 
@@ -59,19 +54,33 @@ vi.mock('./services/CommandService.js', () => ({
   },
 }));
 
+/**
+ * Builds a fake Agent whose stream() records its input and yields the events
+ * currently staged in agentState.events. Drives runNonInteractive end-to-end
+ * without a real Agent/Config round-trip.
+ */
+function buildFakeAgent(): Agent {
+  return {
+    stream: (input: unknown) => {
+      agentState.streamInput = input;
+      return (async function* generateFakeStream(): AsyncIterable<AgentEvent> {
+        for (const event of agentState.events) {
+          yield event;
+        }
+      })();
+    },
+    dispose: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Agent;
+}
+
 describe('runNonInteractive - slash commands and thinking output', () => {
   let mockConfig: Config;
   let mockSettings: LoadedSettings;
-  let mockToolRegistry: ToolRegistry;
-  let mockCoreExecuteToolCall: Mock;
   let mockShutdownTelemetry: Mock;
   let mockIsTelemetrySdkInitialized: Mock;
   let processStdoutSpy: MockInstance;
-  let mockAgentClient: {
-    sendMessageStream: Mock;
-  };
+
   beforeEach(async () => {
-    mockCoreExecuteToolCall = vi.mocked(executeToolCall);
     mockShutdownTelemetry = vi.mocked(shutdownTelemetry);
     mockShutdownTelemetry.mockResolvedValue(undefined);
     mockIsTelemetrySdkInitialized = vi.mocked(isTelemetrySdkInitialized);
@@ -88,22 +97,18 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       .mockImplementation(() => true);
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
-    mockToolRegistry = {
-      getTool: vi.fn(),
-      getFunctionDeclarations: vi.fn().mockReturnValue([]),
-    } as unknown as ToolRegistry;
+    const { fromConfig } = await import('@vybestack/llxprt-code-agents');
+    vi.mocked(fromConfig).mockResolvedValue(buildFakeAgent());
 
-    mockAgentClient = {
-      sendMessageStream: vi.fn(),
-    };
+    // Default: the Agent emits a clean stop completion. Individual tests
+    // override agentState.events to stage thinking/tool/text sequences.
+    agentState.streamInput = null;
+    agentState.events = [{ type: 'done', reason: 'stop' }];
 
     mockConfig = {
       initialize: vi.fn().mockResolvedValue(undefined),
-      getAgentClient: vi.fn().mockReturnValue(mockAgentClient),
-      getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
       getMaxSessionTurns: vi.fn().mockReturnValue(10),
       getIdeMode: vi.fn().mockReturnValue(false),
-
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
       getDebugMode: vi.fn().mockReturnValue(false),
       getProviderManager: vi.fn().mockReturnValue(undefined),
@@ -154,35 +159,28 @@ describe('runNonInteractive - slash commands and thinking output', () => {
   });
 
   it('should preprocess @include commands before sending to the model', async () => {
-    // 1. Mock the imported atCommandProcessor
     const { handleAtCommand } = await import(
       './ui/hooks/atCommandProcessor.js'
     );
     const mockHandleAtCommand = vi.mocked(handleAtCommand);
 
-    // 2. Define the raw input and the expected processed output
     const rawInput = 'Summarize @file.txt';
     const processedParts: Part[] = [
       { text: 'Summarize @file.txt' },
       { text: '\n--- Content from referenced files ---\n' },
       { text: 'This is the content of the file.' },
-      { text: '\n--- End of content ---' },
+      { text: '\n--- End of content ---\n' },
     ];
 
-    // 3. Setup the mock to return the processed parts
     mockHandleAtCommand.mockResolvedValue({
       processedQuery: processedParts,
     });
 
-    // Mock a simple stream response from the Gemini client
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'Summary complete.' },
+    agentState.events = [
+      { type: 'text', text: 'Summary complete.' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
-    // 4. Run the non-interactive mode with the raw input
     await runNonInteractive({
       config: mockConfig,
       settings: mockSettings,
@@ -190,14 +188,8 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       prompt_id: 'prompt-id-7',
     });
 
-    // 5. Assert that sendMessageStream was called with the PROCESSED parts, not the raw input
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledWith(
-      processedParts,
-      expect.any(AbortSignal),
-      'prompt-id-7',
-    );
-
-    // 6. Assert the final output is correct
+    // The PROCESSED parts (not the raw input) must reach the Agent stream.
+    expect(agentState.streamInput).toBe(processedParts);
     expect(processStdoutSpy).toHaveBeenCalledWith('Summary complete.');
   });
 
@@ -212,12 +204,10 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     };
     mockGetCommands.mockReturnValue([mockCommand]);
 
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'Response from command' },
+    agentState.events = [
+      { type: 'text', text: 'Response from command' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
     await runNonInteractive({
       config: mockConfig,
@@ -226,13 +216,10 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       prompt_id: 'prompt-id-slash',
     });
 
-    // Ensure the prompt sent to the model is from the command, not the raw input
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledWith(
-      [{ text: 'Prompt from command' }],
-      expect.any(AbortSignal),
-      'prompt-id-slash',
-    );
-
+    // The prompt sent to the Agent is from the command, not the raw input.
+    expect(agentState.streamInput).toStrictEqual([
+      { text: 'Prompt from command' },
+    ]);
     expect(processStdoutSpy).toHaveBeenCalledWith('Response from command');
   });
 
@@ -263,12 +250,10 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     // No commands are mocked, so any slash command is "unknown"
     mockGetCommands.mockReturnValue([]);
 
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'Response to unknown' },
+    agentState.events = [
+      { type: 'text', text: 'Response to unknown' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
     await runNonInteractive({
       config: mockConfig,
@@ -277,13 +262,8 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       prompt_id: 'prompt-id-unknown',
     });
 
-    // Ensure the raw input is sent to the model
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledWith(
-      [{ text: '/unknowncommand' }],
-      expect.any(AbortSignal),
-      'prompt-id-unknown',
-    );
-
+    // The raw input is sent to the Agent.
+    expect(agentState.streamInput).toStrictEqual([{ text: '/unknowncommand' }]);
     expect(processStdoutSpy).toHaveBeenCalledWith('Response to unknown');
   });
 
@@ -321,12 +301,10 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     };
     mockGetCommands.mockReturnValue([mockCommand]);
 
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'Acknowledged' },
+    agentState.events = [
+      { type: 'text', text: 'Acknowledged' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
     await runNonInteractive({
       config: mockConfig,
@@ -336,55 +314,35 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     });
 
     expect(mockAction).toHaveBeenCalledWith(expect.any(Object), 'arg1 arg2');
-
     expect(processStdoutSpy).toHaveBeenCalledWith('Acknowledged');
   });
 
-  it('should allow a normally-excluded tool when --allowed-tools is set', async () => {
-    // By default, ShellTool is excluded in non-interactive mode.
-    // This test ensures that --allowed-tools overrides this exclusion.
-    vi.mocked(mockConfig.getToolRegistry).mockReturnValue({
-      getTool: vi.fn().mockReturnValue({
-        name: 'ShellTool',
-        description: 'A shell tool',
-        run: vi.fn(),
-      }),
-      getFunctionDeclarations: vi.fn().mockReturnValue([{ name: 'ShellTool' }]),
-    } as unknown as ToolRegistry);
-
-    const toolCallEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.ToolCallRequest,
-      value: {
-        callId: 'tool-shell-1',
-        name: 'ShellTool',
-        args: { command: 'ls' },
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-allowed',
-      },
-    };
-    const toolResponse: Part[] = [{ text: 'file.txt' }];
-    mockCoreExecuteToolCall.mockResolvedValue(
-      createCompletedToolCallResponse({
-        callId: 'tool-shell-1',
-        responseParts: toolResponse,
-      }),
-    );
-
-    const firstCallEvents: ServerGeminiStreamEvent[] = [toolCallEvent];
-    const secondCallEvents: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'file.txt' },
+  it('should render tool-call and tool-result events through the Agent stream', async () => {
+    // After migration, tool execution is owned by the Agent. This verifies the
+    // tool-call/tool-result AgentEvents render their display end-to-end through
+    // runNonInteractive (allowlist governance itself is covered by the
+    // run_shell_command integration test).
+    agentState.events = [
       {
-        type: GeminiEventType.Finished,
-        value: {
-          reason: undefined,
-          usageMetadata: { totalTokenCount: 10 },
+        type: 'tool-call',
+        call: {
+          id: 'tool-shell-1',
+          name: 'ShellTool',
+          args: { command: 'ls' },
         },
-      } as unknown as ServerGeminiStreamEvent,
+      },
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-shell-1',
+          name: 'ShellTool',
+          display: 'file.txt',
+          output: 'file.txt',
+        },
+      },
+      { type: 'text', text: 'file.txt' },
+      { type: 'done', reason: 'stop' },
     ];
-
-    mockAgentClient.sendMessageStream
-      .mockReturnValueOnce(createStreamFromEvents(firstCallEvents))
-      .mockReturnValueOnce(createStreamFromEvents(secondCallEvents));
 
     await runNonInteractive({
       config: mockConfig,
@@ -393,50 +351,22 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       prompt_id: 'prompt-id-allowed',
     });
 
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({ name: 'ShellTool' }),
-      expect.any(AbortSignal),
-      expect.objectContaining({ messageBus: undefined }),
-    );
-    expect(processStdoutSpy).toHaveBeenCalledWith('file.txt');
+    expect(processStdoutSpy).toHaveBeenCalledWith('file.txt\n');
   });
 
   it('should accumulate multiple Thought events and flush once on content boundary', async () => {
-    const thoughtEvent1: ServerGeminiStreamEvent = {
-      type: GeminiEventType.Thought,
-      value: {
-        subject: 'First',
-        description: 'thought',
+    agentState.events = [
+      {
+        type: 'thinking',
+        thought: { subject: 'First', description: 'thought' },
       },
-    };
-    const thoughtEvent2: ServerGeminiStreamEvent = {
-      type: GeminiEventType.Thought,
-      value: {
-        subject: 'Second',
-        description: 'thought',
+      {
+        type: 'thinking',
+        thought: { subject: 'Second', description: 'thought' },
       },
-    };
-    const contentEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.Content,
-      value: 'Response text',
-    };
-    const finishedEvent = {
-      type: GeminiEventType.Finished,
-      value: {
-        reason: undefined,
-        usageMetadata: { totalTokenCount: 10 },
-      },
-    } as unknown as ServerGeminiStreamEvent;
-
-    mockAgentClient.sendMessageStream.mockReturnValueOnce(
-      createStreamFromEvents([
-        thoughtEvent1,
-        thoughtEvent2,
-        contentEvent,
-        finishedEvent,
-      ]),
-    );
+      { type: 'text', text: 'Response text' },
+      { type: 'done', reason: 'stop' },
+    ];
 
     await runNonInteractive({
       config: mockConfig,
@@ -458,40 +388,12 @@ describe('runNonInteractive - slash commands and thinking output', () => {
   });
 
   it('should NOT emit pyramid-style repeated prefixes in non-interactive CLI', async () => {
-    const thoughtEvent1: ServerGeminiStreamEvent = {
-      type: GeminiEventType.Thought,
-      value: {
-        subject: 'Analyzing',
-        description: '',
-      },
-    };
-    const thoughtEvent2: ServerGeminiStreamEvent = {
-      type: GeminiEventType.Thought,
-      value: {
-        subject: 'request',
-        description: '',
-      },
-    };
-    const contentEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.Content,
-      value: 'Response',
-    };
-    const finishedEvent = {
-      type: GeminiEventType.Finished,
-      value: {
-        reason: undefined,
-        usageMetadata: { totalTokenCount: 10 },
-      },
-    } as unknown as ServerGeminiStreamEvent;
-
-    mockAgentClient.sendMessageStream.mockReturnValueOnce(
-      createStreamFromEvents([
-        thoughtEvent1,
-        thoughtEvent2,
-        contentEvent,
-        finishedEvent,
-      ]),
-    );
+    agentState.events = [
+      { type: 'thinking', thought: { subject: 'Analyzing', description: '' } },
+      { type: 'thinking', thought: { subject: 'request', description: '' } },
+      { type: 'text', text: 'Response' },
+      { type: 'done', reason: 'stop' },
+    ];
 
     await runNonInteractive({
       config: mockConfig,
@@ -508,7 +410,6 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     expect(thinkingOutputs).toHaveLength(1);
     const thinkingText = thinkingOutputs[0][0];
     // "Analyzing" should appear exactly once — not repeated for each subsequent thought
-
     const thoughtCount = (thinkingText.match(/Analyzing/g) ?? []).length;
     expect(thoughtCount).toBe(1);
   });
@@ -523,19 +424,17 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       mockGetEphemeralSetting,
     );
 
-    const events: ServerGeminiStreamEvent[] = [
+    agentState.events = [
       {
-        type: GeminiEventType.Thought,
-        value: {
+        type: 'thinking',
+        thought: {
           subject: 'Planning \u{1F914} the approach',
           description: 'Let me think \u{1F4AD} carefully',
         },
       },
-      { type: GeminiEventType.Content, value: 'Here is my answer' },
+      { type: 'text', text: 'Here is my answer' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
     await runNonInteractive({
       config: mockConfig,
@@ -567,19 +466,17 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       mockGetEphemeralSetting,
     );
 
-    const events: ServerGeminiStreamEvent[] = [
+    agentState.events = [
       {
-        type: GeminiEventType.Thought,
-        value: {
+        type: 'thinking',
+        thought: {
           subject: 'Planning \u{1F914}',
           description: 'Think carefully \u{1F4AD}',
         },
       },
-      { type: GeminiEventType.Content, value: 'Here is my answer' },
+      { type: 'text', text: 'Here is my answer' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
     await runNonInteractive({
       config: mockConfig,
@@ -604,19 +501,17 @@ describe('runNonInteractive - slash commands and thinking output', () => {
       mockGetEphemeralSetting,
     );
 
-    const events: ServerGeminiStreamEvent[] = [
+    agentState.events = [
       {
-        type: GeminiEventType.Thought,
-        value: {
+        type: 'thinking',
+        thought: {
           subject: 'Planning \u{1F914}',
           description: 'Think carefully \u{1F4AD}',
         },
       },
-      { type: GeminiEventType.Content, value: 'Here is my answer' },
+      { type: 'text', text: 'Here is my answer' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
     await runNonInteractive({
       config: mockConfig,

--- a/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
+++ b/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
@@ -15,6 +15,7 @@ import type {
   Agent,
   AgentEvent,
   AgentInput,
+  TurnOptions,
 } from '@vybestack/llxprt-code-agents';
 import { runNonInteractive } from './nonInteractiveCli.js';
 
@@ -29,6 +30,9 @@ const agentState = vi.hoisted(() => ({
   // AgentInput | null (matching the stream() parameter type) so assertions get
   // compile-time checking instead of the looser `unknown`.
   streamInput: null as AgentInput | null,
+  // The TurnOptions (signal/promptId/maxTurns) handed to agent.stream(), so
+  // tests can assert runNonInteractive still forwards prompt_id and maxTurns.
+  streamOpts: null as TurnOptions | null,
   events: [] as AgentEvent[],
 }));
 
@@ -72,8 +76,9 @@ vi.mock('./services/CommandService.js', () => ({
 // this fake accordingly.
 function buildFakeAgent(): Agent {
   return {
-    stream: (input: AgentInput) => {
+    stream: (input: AgentInput, opts?: TurnOptions) => {
       agentState.streamInput = input;
+      agentState.streamOpts = opts ?? null;
       return (async function* generateFakeStream(): AsyncIterable<AgentEvent> {
         for (const event of agentState.events) {
           yield event;
@@ -114,6 +119,7 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     // Default: the Agent emits a clean stop completion. Individual tests
     // override agentState.events to stage thinking/tool/text sequences.
     agentState.streamInput = null;
+    agentState.streamOpts = null;
     agentState.events = [{ type: 'done', reason: 'stop' }];
 
     mockConfig = {
@@ -201,6 +207,11 @@ describe('runNonInteractive - slash commands and thinking output', () => {
 
     // The PROCESSED parts (not the raw input) must reach the Agent stream.
     expect(agentState.streamInput).toStrictEqual(processedParts);
+    // runNonInteractive must forward prompt_id and maxTurns to agent.stream().
+    expect(agentState.streamOpts?.promptId).toBe('prompt-id-7');
+    expect(agentState.streamOpts?.maxTurns).toBe(
+      mockConfig.getMaxSessionTurns(),
+    );
     expect(processStdoutSpy).toHaveBeenCalledWith('Summary complete.');
   });
 
@@ -328,10 +339,12 @@ describe('runNonInteractive - slash commands and thinking output', () => {
     expect(processStdoutSpy).toHaveBeenCalledWith('Acknowledged');
   });
 
-  it('should render tool-call and tool-result events through the Agent stream', async () => {
+  it('should render tool-result display output through the Agent stream', async () => {
     // After migration, tool execution is owned by the Agent. This verifies the
-    // tool-call/tool-result AgentEvents render their display end-to-end through
-    // runNonInteractive.
+    // tool-result AgentEvent renders its display end-to-end through
+    // runNonInteractive. (The tool-call event only writes to the stream-json
+    // formatter, which is null here; its rendering is covered by the
+    // stream-json unit tests in nonInteractiveCli.test.ts.)
     // Allowlist governance (--allowed-tools overriding ShellTool/EditTool/
     // WriteFile exclusion) is config-level and covered by the fast unit suite
     // config/__tests__/toolGovernanceParity.test.ts (getExcludeTools parity) and

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -93,14 +93,18 @@ describe('processAgentStream', () => {
     emojiFilter?: EmojiFilter | undefined;
     config?: Config;
   }) {
+    const streamFormatter =
+      overrides?.streamFormatter === undefined
+        ? null
+        : overrides.streamFormatter;
     return {
       config: overrides?.config ?? createMockConfig(),
       jsonOutput: overrides?.jsonOutput ?? false,
-      streamJsonOutput: overrides?.streamJsonOutput ?? false,
-      streamFormatter:
-        overrides?.streamFormatter === undefined
-          ? null
-          : overrides.streamFormatter,
+      // In production, streamJsonOutput and streamFormatter are always set
+      // together; derive streamJsonOutput from the formatter unless a test
+      // explicitly overrides it, so the test context matches production.
+      streamJsonOutput: overrides?.streamJsonOutput ?? streamFormatter !== null,
+      streamFormatter,
       emojiFilter: overrides?.emojiFilter,
       createProfileNameWriter: () => () => {},
     };
@@ -473,5 +477,85 @@ describe('processAgentStream', () => {
       (event) => event.type === JsonStreamEventType.RESULT,
     );
     expect(result).toBeDefined();
+  });
+
+  it('writes a warning to stderr and continues on a hook-blocked event', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'partial' },
+      {
+        type: 'hook-blocked',
+        info: { reason: 'policy', systemMessage: '  blocked by hook  ' },
+      },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      '[WARNING] Agent execution blocked: blocked by hook\n',
+    );
+    expect(processStdoutSpy).toHaveBeenCalledWith('partial');
+    expect(processStdoutSpy).toHaveBeenCalledWith('\n');
+  });
+
+  it('emits a stream-json error and throws on an idle-timeout event', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const events: AgentEvent[] = [
+      {
+        type: 'idle-timeout',
+        error: { message: 'no response received within the allowed time.' },
+      },
+    ];
+
+    await expect(
+      processAgentStream(
+        streamFromEvents(events),
+        createContext({ streamFormatter }),
+        Date.now(),
+        () => uiTelemetryService.getMetrics(),
+      ),
+    ).rejects.toThrow('no response received within the allowed time.');
+
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const streamError = jsonEvents.find(
+      (event) => event.type === JsonStreamEventType.ERROR,
+    );
+    expect(streamError?.message).toContain('Stream idle timeout');
+  });
+
+  it('preserves the tool errorType in the stream-json TOOL_RESULT record', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const events: AgentEvent[] = [
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-perm-1',
+          name: 'editTool',
+          isError: true,
+          display: 'Permission denied',
+          errorType: 'PERMISSION_DENIED',
+        },
+      },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ streamFormatter }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const toolResult = jsonEvents.find(
+      (event) => event.type === JsonStreamEventType.TOOL_RESULT,
+    );
+    expect(toolResult?.status).toBe('error');
+    expect(toolResult?.error?.type).toBe('PERMISSION_DENIED');
   });
 });

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -4,68 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  Config,
-  ToolRegistry,
-  ServerGeminiStreamEvent,
-} from '@vybestack/llxprt-code-core';
 import {
-  ToolErrorType,
-  shutdownTelemetry,
-  isTelemetrySdkInitialized,
-  GeminiEventType,
-  StreamIdleTimeoutError,
+  type Config,
+  EmojiFilter,
   DebugLogger,
+  FatalTurnLimitedError,
   JsonStreamEventType,
-  OutputFormat,
+  StreamJsonFormatter,
+  uiTelemetryService,
 } from '@vybestack/llxprt-code-core';
-import type { Part } from '@google/genai';
-import { runNonInteractive } from './nonInteractiveCli.js';
-import { executeToolCall } from '@vybestack/llxprt-code-agents';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import { processAgentStream } from './nonInteractiveCliSupport.js';
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import type { LoadedSettings } from './config/settings.js';
-import {
-  createCompletedToolCallResponse,
-  createStreamFromEvents,
-} from './nonInteractiveCli.test-helpers.js';
-
-// Mock core modules
-vi.mock('./ui/hooks/atCommandProcessor.js');
-vi.mock('@vybestack/llxprt-code-agents', async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import('@vybestack/llxprt-code-agents')>();
-  return {
-    ...original,
-    executeToolCall: vi.fn(),
-  };
-});
-vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import('@vybestack/llxprt-code-settings')>();
-  return {
-    ...original,
-    shutdownTelemetry: vi.fn(),
-    isTelemetrySdkInitialized: vi.fn().mockReturnValue(true),
-    delay: original.delay,
-    nextStreamEventWithIdleTimeout: original.nextStreamEventWithIdleTimeout,
-    StreamIdleTimeoutError: original.StreamIdleTimeoutError,
-  };
-});
-
-const mockGetCommands = vi.hoisted(() => vi.fn());
-const mockCommandServiceCreate = vi.hoisted(() => vi.fn());
-vi.mock('./services/CommandService.js', () => ({
-  CommandService: {
-    create: mockCommandServiceCreate,
-  },
-}));
 
 type ParsedStreamEvent = {
   type: string;
   role?: string;
   content?: string;
+  tool_name?: string;
+  tool_id?: string;
+  status?: string;
+  severity?: string;
+  message?: string;
 };
+
+async function* streamFromEvents(
+  events: AgentEvent[],
+): AsyncIterable<AgentEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
 
 function parseJsonStdoutEvents(
   calls: Array<[unknown, ...unknown[]]>,
@@ -82,247 +52,125 @@ function parseJsonStdoutEvents(
     });
 }
 
-describe('runNonInteractive', () => {
-  let mockConfig: Config;
-  let mockSettings: LoadedSettings;
-  let mockToolRegistry: ToolRegistry;
-  let mockCoreExecuteToolCall: vi.Mock;
-  let mockShutdownTelemetry: vi.Mock;
-  let mockIsTelemetrySdkInitialized: vi.Mock;
+function createMockConfig(overrides?: {
+  sessionId?: string;
+  includeInResponse?: boolean;
+}): Config {
+  return {
+    getSessionId: () => overrides?.sessionId ?? 'test-session',
+    getEphemeralSetting: (key: string) =>
+      key === 'reasoning.includeInResponse'
+        ? overrides?.includeInResponse
+        : undefined,
+  } as unknown as Config;
+}
+
+describe('processAgentStream', () => {
   let consoleErrorSpy: vi.SpyInstance;
   let processStdoutSpy: vi.SpyInstance;
-  let mockAgentClient: {
-    sendMessageStream: vi.Mock;
-  };
-  beforeEach(async () => {
-    mockCoreExecuteToolCall = vi.mocked(executeToolCall);
-    mockShutdownTelemetry = vi.mocked(shutdownTelemetry);
-    mockShutdownTelemetry.mockResolvedValue(undefined);
-    mockIsTelemetrySdkInitialized = vi.mocked(isTelemetrySdkInitialized);
-    mockIsTelemetrySdkInitialized.mockReturnValue(true);
+  let processStderrSpy: vi.SpyInstance;
 
-    mockCommandServiceCreate.mockResolvedValue({
-      getCommands: mockGetCommands,
-    });
-    mockGetCommands.mockReturnValue([]);
-
+  beforeEach(() => {
     consoleErrorSpy = vi
       .spyOn(DebugLogger.prototype, 'error')
       .mockImplementation(() => {});
     processStdoutSpy = vi
       .spyOn(process.stdout, 'write')
       .mockImplementation(() => true);
-    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-
-    mockToolRegistry = {
-      getTool: vi.fn(),
-      getFunctionDeclarations: vi.fn().mockReturnValue([]),
-    } as unknown as ToolRegistry;
-
-    mockAgentClient = {
-      sendMessageStream: vi.fn(),
-    };
-
-    mockConfig = {
-      initialize: vi.fn().mockResolvedValue(undefined),
-      getAgentClient: vi.fn().mockReturnValue(mockAgentClient),
-      getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
-      getMaxSessionTurns: vi.fn().mockReturnValue(10),
-      getIdeMode: vi.fn().mockReturnValue(false),
-
-      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
-      getDebugMode: vi.fn().mockReturnValue(false),
-      getProviderManager: vi.fn().mockReturnValue(undefined),
-      getOutputFormat: vi.fn().mockReturnValue('text'),
-      getModel: vi.fn().mockReturnValue('test-model'),
-      getFolderTrust: vi.fn().mockReturnValue(false),
-      isTrustedFolder: vi.fn().mockReturnValue(false),
-      getProjectRoot: vi.fn().mockReturnValue('/tmp/test-project'),
-      getSessionId: vi.fn().mockReturnValue('test-session'),
-      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
-      getSettingsService: vi
-        .fn()
-        .mockReturnValue({ get: vi.fn(), set: vi.fn() }),
-      storage: {
-        getDir: vi.fn().mockReturnValue('/tmp/.llxprt'),
-      },
-    } as unknown as Config;
-
-    mockSettings = {
-      system: { path: '', settings: {} },
-      systemDefaults: { path: '', settings: {} },
-      user: { path: '', settings: {} },
-      workspace: { path: '', settings: {} },
-      errors: [],
-      setValue: vi.fn(),
-      merged: {
-        security: {
-          auth: {
-            enforcedType: undefined,
-          },
-        },
-      },
-      isTrusted: true,
-      migratedInMemorScopes: new Set(),
-      forScope: vi.fn(),
-      computeMergedSettings: vi.fn(),
-    } as unknown as LoadedSettings;
-
-    const { handleAtCommand } = await import(
-      './ui/hooks/atCommandProcessor.js'
-    );
-    vi.mocked(handleAtCommand).mockImplementation(async ({ query }) => ({
-      processedQuery: [{ text: query }],
-    }));
+    processStderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should cancel the turn when the stream goes idle after partial output with explicit timeout', async () => {
-    vi.useFakeTimers();
-    const testTimeoutMs = 30_000; // 30 second timeout for this test
-    try {
-      // Configure mock to return explicit timeout
-      const mockGetEphemeralSetting = vi.fn((key: string) => {
-        if (key === 'stream-idle-timeout-ms') {
-          return testTimeoutMs;
-        }
-        return undefined;
-      });
+  function createContext(overrides?: {
+    jsonOutput?: boolean;
+    streamJsonOutput?: boolean;
+    streamFormatter?: StreamJsonFormatter | null;
+    emojiFilter?: EmojiFilter | undefined;
+    config?: Config;
+  }) {
+    return {
+      config: overrides?.config ?? createMockConfig(),
+      jsonOutput: overrides?.jsonOutput ?? false,
+      streamJsonOutput: overrides?.streamJsonOutput ?? false,
+      streamFormatter:
+        overrides?.streamFormatter === undefined
+          ? null
+          : overrides.streamFormatter,
+      emojiFilter: overrides?.emojiFilter,
+      createProfileNameWriter: () => () => {},
+    };
+  }
 
-      let capturedSignal: AbortSignal | undefined;
-      mockAgentClient.sendMessageStream.mockImplementation(
-        (_messages: Part[], signal: AbortSignal) => {
-          capturedSignal = signal;
-          return (async function* (): AsyncGenerator<ServerGeminiStreamEvent> {
-            yield { type: GeminiEventType.Content, value: 'Partial output' };
-            await new Promise<void>(() => {});
-          })();
-        },
-      );
-
-      const runPromise = runNonInteractive({
-        config: {
-          ...mockConfig,
-          getEphemeralSetting: mockGetEphemeralSetting,
-        } as unknown as Config,
-        settings: mockSettings,
-        input: 'Test input',
-        prompt_id: 'prompt-id-idle',
-      });
-
-      await vi.advanceTimersByTimeAsync(0);
-
-      // Capture rejection before advancing timers so it doesn't become
-      // an unhandled rejection (the promise rejects during timer advance)
-      let caughtError: unknown;
-      runPromise.catch((err: unknown) => {
-        caughtError = err;
-      });
-
-      await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
-      await runPromise.catch(() => {});
-
-      expect(caughtError).toBeInstanceOf(StreamIdleTimeoutError);
-      expect(capturedSignal?.aborted).toBe(true);
-      expect(consoleErrorSpy).toHaveBeenCalledWith('Operation cancelled.');
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('should process input and write text output', async () => {
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'Hello' },
-      { type: GeminiEventType.Content, value: ' World' },
+  it('writes text content to stdout and a trailing newline on normal completion', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'Hello' },
+      { type: 'text', text: ' World' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
     );
 
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Test input',
-      prompt_id: 'prompt-id-1',
-    });
-
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledWith(
-      [{ text: 'Test input' }],
-      expect.any(AbortSignal),
-      'prompt-id-1',
-    );
     const meaningfulWrites = processStdoutSpy.mock.calls
       .map(([value]) => value)
       .filter((value) => value !== '');
-
-    // Content may be buffered/processed, check total output
     expect(meaningfulWrites.join('')).toBe('Hello World\n');
-    expect(mockShutdownTelemetry).toHaveBeenCalled();
   });
 
-  it('should emit stream-json message records for newline-only chunks', async () => {
-    mockConfig.getOutputFormat = vi
-      .fn()
-      .mockReturnValue(OutputFormat.STREAM_JSON);
-    mockConfig.getEphemeralSetting = vi.fn((key: string) =>
-      key === 'emojifilter' ? 'allowed' : undefined,
-    );
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'LLXPRT2208_ALPHA' },
-      { type: GeminiEventType.Content, value: '\n\n' },
-      { type: GeminiEventType.Content, value: 'Alpha paragraph one.' },
+  it('emits stream-json message records for each text chunk', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'LLXPRT2208_ALPHA' },
+      { type: 'text', text: '\n\n' },
+      { type: 'text', text: 'Alpha paragraph one.' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Test input',
-      prompt_id: 'prompt-id-stream-json',
-    });
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ streamFormatter }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
 
     const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
     const messages = jsonEvents.filter(
       (event) => event.type === JsonStreamEventType.MESSAGE,
     );
-
     expect(
       messages.map((event) => ({ role: event.role, content: event.content })),
     ).toStrictEqual([
-      { role: 'user', content: 'Test input' },
       { role: 'assistant', content: 'LLXPRT2208_ALPHA' },
       { role: 'assistant', content: '\n\n' },
       { role: 'assistant', content: 'Alpha paragraph one.' },
     ]);
   });
 
-  it('should emit emoji-filter buffered stream-json content as JSON records', async () => {
-    mockConfig.getOutputFormat = vi
-      .fn()
-      .mockReturnValue(OutputFormat.STREAM_JSON);
-    mockConfig.getEphemeralSetting = vi.fn((key: string) =>
-      key === 'emojifilter' ? 'auto' : undefined,
-    );
-    const events: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'LLXPRT2208_ALPHA' },
-      { type: GeminiEventType.Content, value: '\n\n' },
-      { type: GeminiEventType.Content, value: 'Alpha paragraph one.' },
+  it('emits emoji-filter buffered stream-json content as JSON records', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const emojiFilter = new EmojiFilter({ mode: 'auto' });
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'LLXPRT2208_ALPHA' },
+      { type: 'text', text: '\n\n' },
+      { type: 'text', text: 'Alpha paragraph one.' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
-    );
 
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Test input',
-      prompt_id: 'prompt-id-stream-json-buffered',
-    });
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ streamFormatter, emojiFilter }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
 
     const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
     const assistantOutput = jsonEvents
@@ -333,128 +181,53 @@ describe('runNonInteractive', () => {
       )
       .map((event) => event.content)
       .join('');
-
     expect(assistantOutput).toBe('LLXPRT2208_ALPHA\n\nAlpha paragraph one.');
   });
 
-  it('should coalesce thought output before content', async () => {
-    mockConfig.getEphemeralSetting = vi
-      .fn<(key: string) => boolean | undefined>()
-      .mockReturnValue(true);
-
-    const events: ServerGeminiStreamEvent[] = [
-      {
-        type: GeminiEventType.Thought,
-        value: { subject: 'First', description: '' },
-      },
-      {
-        type: GeminiEventType.Thought,
-        value: { subject: 'Second', description: '' },
-      },
-      { type: GeminiEventType.Content, value: 'Content' },
+  it('coalesces thinking events before content into a single think block', async () => {
+    const events: AgentEvent[] = [
+      { type: 'thinking', thought: { subject: 'First', description: '' } },
+      { type: 'thinking', thought: { subject: 'Second', description: '' } },
+      { type: 'text', text: 'Content' },
+      { type: 'done', reason: 'stop' },
     ];
-    mockAgentClient.sendMessageStream.mockReturnValue(
-      createStreamFromEvents(events),
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ config: createMockConfig({ includeInResponse: true }) }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
     );
 
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Test input',
-      prompt_id: 'prompt-id-thought',
-    });
-
-    const writes = processStdoutSpy.mock.calls.map(([value]) => value);
-    const output = writes.join('');
+    const output = processStdoutSpy.mock.calls.map(([value]) => value).join('');
     expect(output).toContain('<think>First Second</think>');
   });
 
-  it('should handle a single tool call and respond', async () => {
-    const toolCallEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.ToolCallRequest,
-      value: {
-        callId: 'tool-1',
-        name: 'testTool',
-        args: { arg1: 'value1' },
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-2',
+  it('emits a tool-use record and prints successful tool display output', async () => {
+    const events: AgentEvent[] = [
+      {
+        type: 'tool-call',
+        call: { id: 'tool-1', name: 'testTool', args: { arg1: 'value1' } },
       },
-    };
-    const toolResponse: Part[] = [{ text: 'Tool response' }];
-    mockCoreExecuteToolCall.mockResolvedValue(
-      createCompletedToolCallResponse({
-        callId: 'tool-1',
-        responseParts: toolResponse,
-      }),
-    );
-
-    const firstCallEvents: ServerGeminiStreamEvent[] = [toolCallEvent];
-    const secondCallEvents: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'Final answer' },
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-1',
+          name: 'testTool',
+          display: 'BeforeTool: File operation logged',
+          isError: false,
+        },
+      },
+      { type: 'text', text: 'Final answer' },
+      { type: 'done', reason: 'stop' },
     ];
 
-    mockAgentClient.sendMessageStream
-      .mockReturnValueOnce(createStreamFromEvents(firstCallEvents))
-      .mockReturnValueOnce(createStreamFromEvents(secondCallEvents));
-
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Use a tool',
-      prompt_id: 'prompt-id-2',
-    });
-
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledTimes(2);
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({ name: 'testTool', agentId: 'primary' }),
-      expect.any(AbortSignal),
-      expect.objectContaining({ messageBus: undefined }),
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
     );
-    expect(mockAgentClient.sendMessageStream).toHaveBeenNthCalledWith(
-      2,
-      [{ text: 'Tool response' }],
-      expect.any(AbortSignal),
-      'prompt-id-2',
-    );
-    expect(processStdoutSpy).toHaveBeenCalledWith('Final answer');
-    expect(processStdoutSpy).toHaveBeenCalledWith('\n');
-  });
-
-  it('should print successful tool resultDisplay output in text mode', async () => {
-    const toolCallEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.ToolCallRequest,
-      value: {
-        callId: 'tool-display-1',
-        name: 'testTool',
-        args: { arg1: 'value1' },
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-display',
-      },
-    };
-
-    mockCoreExecuteToolCall.mockResolvedValue(
-      createCompletedToolCallResponse({
-        callId: 'tool-display-1',
-        responseParts: [{ text: 'Tool response' }],
-        resultDisplay: 'BeforeTool: File operation logged',
-      }),
-    );
-
-    mockAgentClient.sendMessageStream
-      .mockReturnValueOnce(createStreamFromEvents([toolCallEvent]))
-      .mockReturnValueOnce(
-        createStreamFromEvents([
-          { type: GeminiEventType.Content, value: 'Final answer' },
-        ]),
-      );
-
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Use a tool',
-      prompt_id: 'prompt-id-display',
-    });
 
     expect(processStdoutSpy).toHaveBeenCalledWith(
       'BeforeTool: File operation logged\n',
@@ -463,41 +236,67 @@ describe('runNonInteractive', () => {
     expect(processStdoutSpy).toHaveBeenCalledWith('\n');
   });
 
-  it('should not print tool resultDisplay when suppressDisplay is true', async () => {
-    const toolCallEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.ToolCallRequest,
-      value: {
-        callId: 'tool-display-2',
-        name: 'testTool',
-        args: { arg1: 'value1' },
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-display-suppress',
+  it('emits a tool-use stream-json record in stream-json mode', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const events: AgentEvent[] = [
+      {
+        type: 'tool-call',
+        call: { id: 'tool-1', name: 'testTool', args: { arg1: 'value1' } },
       },
-    };
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-1',
+          name: 'testTool',
+          isError: false,
+        },
+      },
+      { type: 'done', reason: 'stop' },
+    ];
 
-    mockCoreExecuteToolCall.mockResolvedValue(
-      createCompletedToolCallResponse({
-        callId: 'tool-display-2',
-        responseParts: [{ text: 'Tool response' }],
-        resultDisplay: 'This should not be shown',
-        suppressDisplay: true,
-      }),
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ streamFormatter }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
     );
 
-    mockAgentClient.sendMessageStream
-      .mockReturnValueOnce(createStreamFromEvents([toolCallEvent]))
-      .mockReturnValueOnce(
-        createStreamFromEvents([
-          { type: GeminiEventType.Content, value: 'Final answer' },
-        ]),
-      );
-
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Use a tool',
-      prompt_id: 'prompt-id-display-suppress',
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const toolUse = jsonEvents.find(
+      (event) => event.type === JsonStreamEventType.TOOL_USE,
+    );
+    expect(toolUse).toMatchObject({ tool_name: 'testTool', tool_id: 'tool-1' });
+    const toolResult = jsonEvents.find(
+      (event) => event.type === JsonStreamEventType.TOOL_RESULT,
+    );
+    expect(toolResult).toMatchObject({
+      tool_id: 'tool-1',
+      status: 'success',
     });
+  });
+
+  it('does not print tool display when suppressDisplay is true', async () => {
+    const events: AgentEvent[] = [
+      {
+        type: 'tool-result',
+        result: {
+          id: 'tool-display-2',
+          name: 'testTool',
+          display: 'This should not be shown',
+          isError: false,
+          suppressDisplay: true,
+        },
+      },
+      { type: 'text', text: 'Final answer' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
 
     expect(processStdoutSpy).not.toHaveBeenCalledWith(
       'This should not be shown\n',
@@ -506,296 +305,173 @@ describe('runNonInteractive', () => {
     expect(processStdoutSpy).toHaveBeenCalledWith('\n');
   });
 
-  it('should execute tool calls in non-interactive mode via AgentClient stream path', async () => {
-    const firstCallEvents: ServerGeminiStreamEvent[] = [
+  it('logs a tool error and allows the model to continue', async () => {
+    const events: AgentEvent[] = [
       {
-        type: GeminiEventType.ToolCallRequest,
-        value: {
-          callId: 'call-1',
-          name: 'testTool',
-          args: { arg: 'value' },
-          isClientInitiated: false,
-          prompt_id: 'prompt-provider',
+        type: 'tool-result',
+        result: {
+          id: 'tool-1',
+          name: 'errorTool',
+          display: 'Execution failed',
+          isError: true,
         },
       },
-    ];
-    const secondCallEvents: ServerGeminiStreamEvent[] = [
-      { type: GeminiEventType.Content, value: 'All done' },
-    ];
-
-    mockAgentClient.sendMessageStream
-      .mockReturnValueOnce(createStreamFromEvents(firstCallEvents))
-      .mockReturnValueOnce(createStreamFromEvents(secondCallEvents));
-
-    mockCoreExecuteToolCall.mockResolvedValue({
-      response: {
-        callId: 'call-1',
-        responseParts: [
-          {
-            functionResponse: {
-              id: 'call-1',
-              name: 'testTool',
-              response: { output: 'tool result' },
-            },
-          },
-        ],
-        resultDisplay: undefined,
-        error: undefined,
-        errorType: undefined,
-        agentId: 'primary',
-      },
-    });
-
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Use the non-gemini provider',
-      prompt_id: 'prompt-provider',
-    });
-
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledTimes(2);
-    expect(mockAgentClient.sendMessageStream).toHaveBeenNthCalledWith(
-      1,
-      [{ text: 'Use the non-gemini provider' }],
-      expect.any(AbortSignal),
-      'prompt-provider',
-    );
-    expect(mockAgentClient.sendMessageStream).toHaveBeenNthCalledWith(
-      2,
-      [
-        {
-          functionResponse: {
-            id: 'call-1',
-            name: 'testTool',
-            response: { output: 'tool result' },
-          },
-        },
-      ],
-      expect.any(AbortSignal),
-      'prompt-provider',
-    );
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({
-        name: 'testTool',
-        callId: 'call-1',
-        agentId: 'primary',
-      }),
-      expect.any(AbortSignal),
-      expect.objectContaining({ messageBus: undefined }),
-    );
-    expect(processStdoutSpy).toHaveBeenCalledWith('All done');
-    expect(processStdoutSpy).toHaveBeenCalledWith('\n');
-  });
-
-  it('should count tool-call turns toward max session turns in stream path', async () => {
-    vi.mocked(mockConfig.getMaxSessionTurns).mockReturnValue(1);
-    const firstCallEvents: ServerGeminiStreamEvent[] = [
-      {
-        type: GeminiEventType.ToolCallRequest,
-        value: {
-          callId: 'call-1',
-          name: 'testTool',
-          args: { arg: 'value' },
-          isClientInitiated: false,
-          prompt_id: 'prompt-provider',
-        },
-      },
+      { type: 'text', text: 'Sorry, let me try again.' },
+      { type: 'done', reason: 'stop' },
     ];
 
-    mockAgentClient.sendMessageStream.mockReturnValueOnce(
-      createStreamFromEvents(firstCallEvents),
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
     );
 
-    mockCoreExecuteToolCall.mockResolvedValue({
-      response: {
-        callId: 'call-1',
-        responseParts: [
-          {
-            functionResponse: {
-              id: 'call-1',
-              name: 'testTool',
-              response: { output: 'tool result' },
-            },
-          },
-        ],
-        resultDisplay: undefined,
-        error: undefined,
-        errorType: undefined,
-        agentId: 'primary',
-      },
-    });
-
-    await expect(
-      runNonInteractive({
-        config: mockConfig,
-        settings: mockSettings,
-        input: 'Use the non-gemini provider',
-        prompt_id: 'prompt-provider',
-      }),
-    ).rejects.toThrow(
-      'Reached max session turns for this session. Increase the number of turns by specifying maxSessionTurns in settings.json.',
-    );
-
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledTimes(1);
-  });
-
-  it('should handle error during tool execution and should send error back to the model', async () => {
-    const toolCallEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.ToolCallRequest,
-      value: {
-        callId: 'tool-1',
-        name: 'errorTool',
-        args: {},
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-3',
-      },
-    };
-    mockCoreExecuteToolCall.mockResolvedValue({
-      response: {
-        callId: 'tool-1',
-        responseParts: [
-          {
-            functionResponse: {
-              name: 'errorTool',
-              response: {
-                output: 'Error: Execution failed',
-              },
-            },
-          },
-        ],
-        resultDisplay: 'Execution failed',
-        error: new Error('Execution failed'),
-        errorType: ToolErrorType.EXECUTION_FAILED,
-        agentId: 'primary',
-      },
-    });
-    const finalResponse: ServerGeminiStreamEvent[] = [
-      {
-        type: GeminiEventType.Content,
-        value: 'Sorry, let me try again.',
-      },
-    ];
-    mockAgentClient.sendMessageStream
-      .mockReturnValueOnce(createStreamFromEvents([toolCallEvent]))
-      .mockReturnValueOnce(createStreamFromEvents(finalResponse));
-
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Trigger tool error',
-      prompt_id: 'prompt-id-3',
-    });
-
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({ name: 'errorTool', agentId: 'primary' }),
-      expect.any(AbortSignal),
-      expect.objectContaining({ messageBus: undefined }),
-    );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Error executing tool errorTool: Execution failed',
-    );
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledTimes(2);
-    expect(mockAgentClient.sendMessageStream).toHaveBeenNthCalledWith(
-      2,
-      [
-        {
-          functionResponse: {
-            name: 'errorTool',
-            response: {
-              output: 'Error: Execution failed',
-            },
-          },
-        },
-      ],
-      expect.any(AbortSignal),
-      'prompt-id-3',
     );
     expect(processStdoutSpy).toHaveBeenCalledWith('Sorry, let me try again.');
   });
 
-  it('should exit with error if sendMessageStream throws initially', async () => {
-    const apiError = new Error('API connection failed');
-    mockAgentClient.sendMessageStream.mockImplementation(() => {
-      throw apiError;
-    });
+  it('throws FatalTurnLimitedError when the agent reports max-turns', async () => {
+    const events: AgentEvent[] = [{ type: 'done', reason: 'max-turns' }];
 
     await expect(
-      runNonInteractive({
-        config: mockConfig,
-        settings: mockSettings,
-        input: 'Initial fail',
-        prompt_id: 'prompt-id-4',
-      }),
-    ).rejects.toThrow(apiError);
+      processAgentStream(
+        streamFromEvents(events),
+        createContext(),
+        Date.now(),
+        () => uiTelemetryService.getMetrics(),
+      ),
+    ).rejects.toThrow(FatalTurnLimitedError);
   });
 
-  it('should not exit if a tool is not found, and should send error back to model', async () => {
-    const toolCallEvent: ServerGeminiStreamEvent = {
-      type: GeminiEventType.ToolCallRequest,
-      value: {
-        callId: 'tool-1',
-        name: 'nonexistentTool',
-        args: {},
-        isClientInitiated: false,
-        prompt_id: 'prompt-id-5',
-      },
-    };
-    mockCoreExecuteToolCall.mockResolvedValue({
-      response: {
-        callId: 'tool-1',
-        responseParts: [],
-        resultDisplay: 'Tool "nonexistentTool" not found in registry.',
-        error: new Error('Tool "nonexistentTool" not found in registry.'),
-        errorType: ToolErrorType.TOOL_NOT_REGISTERED,
-        agentId: 'primary',
-      },
+  it('throws when the agent reports an error event', async () => {
+    const events: AgentEvent[] = [
+      { type: 'error', error: { message: 'API connection failed' } },
+    ];
+
+    await expect(
+      processAgentStream(
+        streamFromEvents(events),
+        createContext(),
+        Date.now(),
+        () => uiTelemetryService.getMetrics(),
+      ),
+    ).rejects.toThrow('API connection failed');
+  });
+
+  it('emits a flat JSON object with session_id, response, and stats on completion', async () => {
+    const metrics = uiTelemetryService.getMetrics();
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'The capital is Paris.' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({
+        jsonOutput: true,
+        config: createMockConfig({ sessionId: 'json-session' }),
+      }),
+      Date.now(),
+      () => metrics,
+    );
+
+    const jsonLine = processStdoutSpy.mock.calls
+      .map(([value]) => String(value).trimEnd())
+      .filter((value) => value.startsWith('{'))
+      .join('');
+    const parsed = JSON.parse(jsonLine);
+    expect(parsed).toHaveProperty('session_id', 'json-session');
+    expect(parsed).toHaveProperty('response', 'The capital is Paris.');
+    expect(parsed).toHaveProperty('stats');
+    expect(typeof parsed.stats).toBe('object');
+  });
+
+  it('emits a loop-detected stream warning and completes', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const events: AgentEvent[] = [
+      { type: 'loop-detected' },
+      { type: 'text', text: 'partial' },
+      { type: 'done', reason: 'loop-detected' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ streamFormatter }),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const warning = jsonEvents.find(
+      (event) =>
+        event.type === JsonStreamEventType.ERROR &&
+        event.severity === 'warning',
+    );
+    expect(warning).toMatchObject({
+      message: 'Loop detected, stopping execution',
     });
-    const finalResponse: ServerGeminiStreamEvent[] = [
+  });
+
+  it('writes no final result on an aborted completion', async () => {
+    const events: AgentEvent[] = [{ type: 'done', reason: 'aborted' }];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Operation cancelled.');
+    const meaningfulWrites = processStdoutSpy.mock.calls
+      .map(([value]) => value)
+      .filter((value) => value !== '');
+    expect(meaningfulWrites).toHaveLength(0);
+  });
+
+  it('writes a stop message to stderr on hook-stopped completion', async () => {
+    const events: AgentEvent[] = [
       {
-        type: GeminiEventType.Content,
-        value: "Sorry, I can't find that tool.",
+        type: 'done',
+        reason: 'hook-stopped',
+        stop: { reason: 'policy', systemMessage: '  blocked by hook  ' },
       },
     ];
 
-    mockAgentClient.sendMessageStream
-      .mockReturnValueOnce(createStreamFromEvents([toolCallEvent]))
-      .mockReturnValueOnce(createStreamFromEvents(finalResponse));
-
-    await runNonInteractive({
-      config: mockConfig,
-      settings: mockSettings,
-      input: 'Trigger tool not found',
-      prompt_id: 'prompt-id-5',
-    });
-
-    expect(mockCoreExecuteToolCall).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({ name: 'nonexistentTool', agentId: 'primary' }),
-      expect.any(AbortSignal),
-      expect.objectContaining({ messageBus: undefined }),
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
     );
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error executing tool nonexistentTool: Tool "nonexistentTool" not found in registry.',
-    );
-    expect(mockAgentClient.sendMessageStream).toHaveBeenCalledTimes(2);
-    expect(processStdoutSpy).toHaveBeenCalledWith(
-      "Sorry, I can't find that tool.",
+
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      'Agent execution stopped: blocked by hook\n',
     );
   });
 
-  it('should exit when max session turns are exceeded', async () => {
-    vi.mocked(mockConfig.getMaxSessionTurns).mockReturnValue(0);
-    await expect(
-      runNonInteractive({
-        config: mockConfig,
-        settings: mockSettings,
-        input: 'Trigger loop',
-        prompt_id: 'prompt-id-6',
-      }),
-    ).rejects.toThrow(
-      'Reached max session turns for this session. Increase the number of turns by specifying maxSessionTurns in settings.json.',
+  it('emits a stream-json RESULT event with stats on completion', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const metrics = uiTelemetryService.getMetrics();
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'done' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ streamFormatter }),
+      1000,
+      () => metrics,
     );
+
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const result = jsonEvents.find(
+      (event) => event.type === JsonStreamEventType.RESULT,
+    );
+    expect(result).toBeDefined();
   });
 });

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -27,6 +27,7 @@ type ParsedStreamEvent = {
   status?: string;
   severity?: string;
   message?: string;
+  error?: { type?: string; message?: string };
 };
 
 async function* streamFromEvents(

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -24,6 +24,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { type Part } from '@google/genai';
 import { activateSettingsRuntimeContext } from '@vybestack/llxprt-code-core/runtime/settingsRuntimeAdapter.js';
+import { fromConfig } from '@vybestack/llxprt-code-agents';
 
 import readline from 'node:readline';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
@@ -33,7 +34,6 @@ import { handleSlashCommand } from './nonInteractiveCliCommands.js';
 import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
 import { processAgentStream } from './nonInteractiveCliSupport.js';
-import { fromConfig } from '@vybestack/llxprt-code-agents';
 import {
   getActiveProviderNameForApiError,
   getErrorFallbackModel,

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -24,7 +24,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { type Part } from '@google/genai';
 import { activateSettingsRuntimeContext } from '@vybestack/llxprt-code-core/runtime/settingsRuntimeAdapter.js';
-import { fromConfig } from '@vybestack/llxprt-code-agents';
+import { fromConfig, type Agent } from '@vybestack/llxprt-code-agents';
 
 import readline from 'node:readline';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
@@ -234,12 +234,13 @@ async function processQuery(
     startTime: number;
   },
 ): Promise<void> {
-  const agent = await fromConfig({
-    config: params.config,
-    messageBus: params.runtimeMessageBus,
-    sessionId: params.config.getSessionId(),
-  });
+  let agent: Agent | undefined;
   try {
+    agent = await fromConfig({
+      config: params.config,
+      messageBus: params.runtimeMessageBus,
+      sessionId: params.config.getSessionId(),
+    });
     const eventStream = agent.stream(query, {
       signal: options.abortController.signal,
       promptId: params.prompt_id,
@@ -264,7 +265,21 @@ async function processQuery(
       () => uiTelemetryService.getMetrics(),
     );
   } finally {
-    await agent.dispose();
+    if (agent !== undefined) {
+      // Dispose in its own try/catch so a disposal failure never masks the
+      // original error thrown by the stream/turn loop above.
+      try {
+        await agent.dispose();
+      } catch (disposeError) {
+        debugLogger.error(
+          `Failed to dispose agent: ${
+            disposeError instanceof Error
+              ? disposeError.message
+              : String(disposeError)
+          }`,
+        );
+      }
+    }
   }
 }
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -32,7 +32,8 @@ import type { LoadedSettings } from './config/settings.js';
 import { handleSlashCommand } from './nonInteractiveCliCommands.js';
 import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
-import { processResponseTurns } from './nonInteractiveCliSupport.js';
+import { processAgentStream } from './nonInteractiveCliSupport.js';
+import { fromConfig } from '@vybestack/llxprt-code-agents';
 import {
   getActiveProviderNameForApiError,
   getErrorFallbackModel,
@@ -233,28 +234,38 @@ async function processQuery(
     startTime: number;
   },
 ): Promise<void> {
-  await processResponseTurns(
-    query,
-    {
-      config: params.config,
-      abortController: options.abortController,
-      prompt_id: params.prompt_id,
-      jsonOutput: options.jsonOutput,
-      streamJsonOutput: options.streamJsonOutput,
-      streamFormatter: options.streamFormatter,
-      emojiFilter: options.emojiFilter,
-      runtimeMessageBus: params.runtimeMessageBus,
-      createProfileNameWriter: () =>
-        createProfileNameWriter(
-          params.config,
-          options.jsonOutput,
-          options.streamFormatter,
-        ),
-      maxSessionTurns: params.config.getMaxSessionTurns(),
-    },
-    options.startTime,
-    () => uiTelemetryService.getMetrics(),
-  );
+  const agent = await fromConfig({
+    config: params.config,
+    messageBus: params.runtimeMessageBus,
+    sessionId: params.config.getSessionId(),
+  });
+  try {
+    const eventStream = agent.stream(query, {
+      signal: options.abortController.signal,
+      promptId: params.prompt_id,
+      maxTurns: params.config.getMaxSessionTurns(),
+    });
+    await processAgentStream(
+      eventStream,
+      {
+        config: params.config,
+        jsonOutput: options.jsonOutput,
+        streamJsonOutput: options.streamJsonOutput,
+        streamFormatter: options.streamFormatter,
+        emojiFilter: options.emojiFilter,
+        createProfileNameWriter: () =>
+          createProfileNameWriter(
+            params.config,
+            options.jsonOutput,
+            options.streamFormatter,
+          ),
+      },
+      options.startTime,
+      () => uiTelemetryService.getMetrics(),
+    );
+  } finally {
+    await agent.dispose();
+  }
 }
 
 export async function runNonInteractive(

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -16,7 +16,9 @@ import {
 import type {
   AgentEvent,
   AgentToolResult,
+  StructuredError,
 } from '@vybestack/llxprt-code-agents';
+import { MAX_TURNS_MESSAGE } from './utils/errors.js';
 
 type StreamConsumerContext = {
   config: Config;
@@ -26,9 +28,6 @@ type StreamConsumerContext = {
   emojiFilter: EmojiFilter | undefined;
   createProfileNameWriter: () => () => void;
 };
-
-const MAX_TURNS_MESSAGE =
-  'Reached max session turns for this session. Increase the number of turns by specifying maxSessionTurns in settings.json.';
 
 function formatThoughtText(thought: {
   subject?: string;
@@ -270,10 +269,7 @@ function emitFinalResult(
  * GeminiEventType.Error throw path. The optional HTTP status is preserved as a
  * property without a type assertion.
  */
-function reconstructError(structured: {
-  readonly message: string;
-  readonly status?: number;
-}): Error {
+function reconstructError(structured: StructuredError): Error {
   const err: Error & { status?: number } = new Error(structured.message);
   if (structured.status !== undefined) {
     err.status = structured.status;
@@ -308,7 +304,12 @@ function handleDone(
     case 'max-turns':
       throw new FatalTurnLimitedError(MAX_TURNS_MESSAGE);
     case 'error':
-      throw new Error('Agent execution failed');
+      // processAgentStream normally throws the preceding 'error' AgentEvent
+      // (carrying the StructuredError) before this terminal done arrives.
+      // Reaching here means done{reason:'error'} had no error event.
+      throw new Error(
+        'Agent execution failed with no structured error details provided.',
+      );
     default:
       return;
   }
@@ -375,8 +376,7 @@ export async function processAgentStream(
         const blockMessage = `Agent execution blocked: ${
           info.systemMessage?.trim() ?? info.reason
         }`;
-        process.stderr.write(`[WARNING] ${blockMessage}
-`);
+        process.stderr.write(`[WARNING] ${blockMessage}\n`);
         break;
       }
       case 'idle-timeout':

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -181,7 +181,7 @@ function emitToolResult(
   const error =
     result.isError === true
       ? {
-          type: 'TOOL_EXECUTION_ERROR',
+          type: result.errorType ?? 'TOOL_EXECUTION_ERROR',
           message:
             typeof result.display === 'string'
               ? result.display
@@ -370,6 +370,22 @@ export async function processAgentStream(
           'Loop detected, stopping execution',
         );
         break;
+      case 'hook-blocked': {
+        const info = event.info;
+        const blockMessage = `Agent execution blocked: ${
+          info.systemMessage?.trim() ?? info.reason
+        }`;
+        process.stderr.write(`[WARNING] ${blockMessage}
+`);
+        break;
+      }
+      case 'idle-timeout':
+        emitStreamError(
+          context.streamFormatter,
+          'error',
+          'Stream idle timeout: no response received within the allowed time.',
+        );
+        throw reconstructError(event.error);
       case 'error':
         throw reconstructError(event.error);
       case 'done':

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -1,78 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   type Config,
-  type ToolCallRequestInfo,
-  GeminiEventType,
   JsonStreamEventType,
-  type MessageBus,
-  type ServerGeminiStreamEvent,
-  StreamIdleTimeoutError,
-  FatalTurnLimitedError,
-  debugLogger,
-  nextStreamEventWithIdleTimeout,
-  resolveStreamIdleTimeoutMs,
   type StreamJsonFormatter,
   type EmojiFilter,
   type SessionMetrics,
+  FatalTurnLimitedError,
+  debugLogger,
 } from '@vybestack/llxprt-code-core';
-import type { Part } from '@google/genai';
-import { executeToolCall } from '@vybestack/llxprt-code-agents';
+import type {
+  AgentEvent,
+  AgentToolResult,
+} from '@vybestack/llxprt-code-agents';
 
-type RuntimeToolCallRequest = Omit<ToolCallRequestInfo, 'args' | 'callId'> & {
-  args: unknown;
-  callId?: string;
-};
-
-type ResponseProcessingContext = {
+type StreamConsumerContext = {
   config: Config;
-  abortController: AbortController;
-  prompt_id: string;
   jsonOutput: boolean;
   streamJsonOutput: boolean;
   streamFormatter: StreamJsonFormatter | null;
   emojiFilter: EmojiFilter | undefined;
-  runtimeMessageBus?: MessageBus;
   createProfileNameWriter: () => () => void;
-  maxSessionTurns: number;
 };
 
-type TurnResult =
-  | { kind: 'continue'; messages: Part[]; jsonResponseText: string }
-  | { kind: 'complete'; jsonResponseText: string; emitFinal: boolean };
-
-function normalizeToolCallArgs(args: unknown): Record<string, unknown> {
-  if (typeof args === 'object' && args !== null && !Array.isArray(args)) {
-    return args as Record<string, unknown>;
-  }
-  return {};
-}
-
-function normalizeRequestArgs(
-  rawArgs: unknown,
-  toolName: string,
-): Record<string, unknown> {
-  if (typeof rawArgs === 'string') {
-    try {
-      const parsed = JSON.parse(rawArgs) as unknown;
-      return typeof parsed === 'object' && parsed !== null
-        ? (parsed as Record<string, unknown>)
-        : {};
-    } catch (error) {
-      debugLogger.error(
-        `Failed to parse tool arguments for ${toolName}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {};
-    }
-  }
-  if (Array.isArray(rawArgs)) {
-    debugLogger.error(
-      `Unexpected array arguments for tool ${toolName}; coercing to empty object.`,
-    );
-    return {};
-  }
-  return typeof rawArgs === 'object' && rawArgs !== null
-    ? (rawArgs as Record<string, unknown>)
-    : {};
-}
+const MAX_TURNS_MESSAGE =
+  'Reached max session turns for this session. Increase the number of turns by specifying maxSessionTurns in settings.json.';
 
 function formatThoughtText(thought: {
   subject?: string;
@@ -97,18 +53,54 @@ function emitStreamError(
   });
 }
 
-function handleThoughtEvent(
-  event: ServerGeminiStreamEvent,
-  context: ResponseProcessingContext,
+function flushThoughtBuffer(
+  thoughtBuffer: string,
+  includeThinking: boolean,
+): string {
+  if (!includeThinking || !thoughtBuffer.trim()) {
+    return '';
+  }
+  process.stdout.write(`<think>${thoughtBuffer.trim()}</think>\n`);
+  return '';
+}
+
+function flushEmojiBuffer(
+  context: StreamConsumerContext,
+  jsonResponseText: string,
+): string {
+  const remainingBuffered = context.emojiFilter?.flushBuffer();
+  if (!remainingBuffered) {
+    return jsonResponseText;
+  }
+  if (context.streamFormatter) {
+    context.streamFormatter.emitEvent({
+      type: JsonStreamEventType.MESSAGE,
+      timestamp: new Date().toISOString(),
+      role: 'assistant',
+      content: remainingBuffered,
+      delta: true,
+    });
+    return jsonResponseText;
+  }
+  if (context.jsonOutput) {
+    return jsonResponseText + remainingBuffered;
+  }
+  process.stdout.write(remainingBuffered);
+  return jsonResponseText;
+}
+
+function handleThinking(
+  thought: { subject?: string; description?: string },
+  context: StreamConsumerContext,
   writeProfileName: () => void,
   thoughtBuffer: string,
   includeThinking: boolean,
 ): string {
-  if (event.type !== GeminiEventType.Thought || !includeThinking) {
+  if (!includeThinking) {
     return thoughtBuffer;
   }
   writeProfileName();
-  let thoughtText = formatThoughtText(event.value);
+  let thoughtText = formatThoughtText(thought);
   if (!thoughtText.trim()) {
     return thoughtBuffer;
   }
@@ -124,17 +116,14 @@ function handleThoughtEvent(
   return thoughtBuffer ? `${thoughtBuffer} ${thoughtText}` : thoughtText;
 }
 
-function handleContentEvent(
-  event: ServerGeminiStreamEvent,
-  context: ResponseProcessingContext,
+function handleText(
+  text: string,
+  context: StreamConsumerContext,
   writeProfileName: () => void,
   jsonResponseText: string,
 ): string {
-  if (event.type !== GeminiEventType.Content) {
-    return jsonResponseText;
-  }
   writeProfileName();
-  let outputValue = event.value;
+  let outputValue = text;
   if (context.emojiFilter) {
     const filterResult = context.emojiFilter.filterStreamChunk(outputValue);
     if (filterResult.blocked) {
@@ -170,215 +159,80 @@ function handleContentEvent(
   return jsonResponseText;
 }
 
-function collectToolCall(
-  event: ServerGeminiStreamEvent,
-  functionCalls: RuntimeToolCallRequest[],
+function emitToolUse(
+  call: { id: string; name: string; args: Readonly<Record<string, unknown>> },
   formatter: StreamJsonFormatter | null,
 ): void {
-  if (event.type !== GeminiEventType.ToolCallRequest) {
-    return;
-  }
-  const toolCallRequest = event.value as RuntimeToolCallRequest;
-  const callId =
-    toolCallRequest.callId ?? `${toolCallRequest.name}-${Date.now()}`;
   formatter?.emitEvent({
     type: JsonStreamEventType.TOOL_USE,
     timestamp: new Date().toISOString(),
-    tool_name: toolCallRequest.name,
-    tool_id: callId,
-    parameters: normalizeToolCallArgs(toolCallRequest.args),
+    tool_name: call.name,
+    tool_id: call.id,
+    parameters: { ...call.args },
   });
-  functionCalls.push({
-    ...toolCallRequest,
-    callId,
-    args: toolCallRequest.args,
-    agentId: toolCallRequest.agentId ?? 'primary',
-  });
-}
-
-function handleControlEvent(
-  event: ServerGeminiStreamEvent,
-  formatter: StreamJsonFormatter | null,
-): void {
-  if (event.type === GeminiEventType.LoopDetected) {
-    emitStreamError(formatter, 'warning', 'Loop detected, stopping execution');
-  } else if (event.type === GeminiEventType.MaxSessionTurns) {
-    emitStreamError(formatter, 'error', 'Maximum session turns exceeded');
-  } else if (event.type === GeminiEventType.Error) {
-    throw event.value.error;
-  } else if (event.type === GeminiEventType.AgentExecutionStopped) {
-    const stopMessage = `Agent execution stopped: ${event.systemMessage?.trim() ?? event.reason}`;
-    process.stderr.write(`${stopMessage}\n`);
-  } else if (event.type === GeminiEventType.AgentExecutionBlocked) {
-    const blockMessage = `Agent execution blocked: ${event.systemMessage?.trim() ?? event.reason}`;
-    process.stderr.write(`[WARNING] ${blockMessage}\n`);
-  }
-}
-
-async function nextStreamEvent(
-  iterator: AsyncIterator<ServerGeminiStreamEvent>,
-  context: ResponseProcessingContext,
-): Promise<IteratorResult<ServerGeminiStreamEvent>> {
-  const effectiveTimeoutMs = resolveStreamIdleTimeoutMs(context.config);
-  if (effectiveTimeoutMs <= 0) {
-    return iterator.next();
-  }
-  return nextStreamEventWithIdleTimeout({
-    iterator,
-    timeoutMs: effectiveTimeoutMs,
-    signal: context.abortController.signal,
-  });
-}
-
-function handleStreamReadError(
-  error: unknown,
-  context: ResponseProcessingContext,
-): void {
-  if (error instanceof StreamIdleTimeoutError) {
-    context.abortController.abort();
-    debugLogger.error('Operation cancelled.');
-    emitStreamError(
-      context.streamFormatter,
-      'error',
-      'Stream idle timeout: no response received within the allowed time.',
-    );
-  }
-}
-
-function flushThoughtBuffer(
-  thoughtBuffer: string,
-  includeThinking: boolean,
-): string {
-  if (!includeThinking || !thoughtBuffer.trim()) {
-    return '';
-  }
-  process.stdout.write(`<think>${thoughtBuffer.trim()}</think>\n`);
-  return '';
-}
-
-function flushEmojiBuffer(
-  context: ResponseProcessingContext,
-  jsonResponseText: string,
-): string {
-  const remainingBuffered = context.emojiFilter?.flushBuffer();
-  if (!remainingBuffered) {
-    return jsonResponseText;
-  }
-  if (context.streamFormatter) {
-    context.streamFormatter.emitEvent({
-      type: JsonStreamEventType.MESSAGE,
-      timestamp: new Date().toISOString(),
-      role: 'assistant',
-      content: remainingBuffered,
-      delta: true,
-    });
-    return jsonResponseText;
-  }
-  if (context.jsonOutput) {
-    return jsonResponseText + remainingBuffered;
-  }
-  process.stdout.write(remainingBuffered);
-  return jsonResponseText;
-}
-
-async function handleToolCalls(
-  requests: RuntimeToolCallRequest[],
-  context: ResponseProcessingContext,
-): Promise<Part[]> {
-  const toolResponseParts: Part[] = [];
-  for (const requestFromModel of requests) {
-    const requestInfo: ToolCallRequestInfo = {
-      callId:
-        requestFromModel.callId ?? `${requestFromModel.name}-${Date.now()}`,
-      name: requestFromModel.name,
-      args: normalizeRequestArgs(requestFromModel.args, requestFromModel.name),
-      isClientInitiated: false,
-      prompt_id: requestFromModel.prompt_id,
-      agentId: requestFromModel.agentId ?? 'primary',
-    };
-    const completed = await executeToolCall(
-      context.config,
-      requestInfo,
-      context.abortController.signal,
-      { messageBus: context.runtimeMessageBus },
-    );
-    emitToolResult(
-      requestInfo.callId,
-      completed.response,
-      context.streamFormatter,
-    );
-    displayToolResult(requestFromModel.name, completed.response, context);
-    toolResponseParts.push(...completed.response.responseParts);
-  }
-  return toolResponseParts;
 }
 
 function emitToolResult(
-  toolId: string,
-  toolResponse: Awaited<ReturnType<typeof executeToolCall>>['response'],
+  result: AgentToolResult,
   formatter: StreamJsonFormatter | null,
 ): void {
   const output =
-    typeof toolResponse.resultDisplay === 'string'
-      ? toolResponse.resultDisplay
+    typeof result.display === 'string' ? result.display : undefined;
+  const error =
+    result.isError === true
+      ? {
+          type: 'TOOL_EXECUTION_ERROR',
+          message:
+            typeof result.display === 'string'
+              ? result.display
+              : `${result.name} failed`,
+        }
       : undefined;
-  const error = toolResponse.error
-    ? {
-        type: toolResponse.errorType ?? 'TOOL_EXECUTION_ERROR',
-        message: toolResponse.error.message,
-      }
-    : undefined;
   formatter?.emitEvent({
     type: JsonStreamEventType.TOOL_RESULT,
     timestamp: new Date().toISOString(),
-    tool_id: toolId,
-    status: toolResponse.error ? 'error' : 'success',
+    tool_id: result.id,
+    status: result.isError === true ? 'error' : 'success',
     output,
     error,
   });
 }
 
 function shouldDisplayToolResult(
-  toolResponse: Awaited<ReturnType<typeof executeToolCall>>['response'],
-  context: ResponseProcessingContext,
+  result: AgentToolResult,
+  context: StreamConsumerContext,
 ): boolean {
-  if (context.jsonOutput !== false || context.streamJsonOutput !== false) {
+  if (context.jsonOutput || context.streamJsonOutput) {
     return false;
   }
-  if (toolResponse.suppressDisplay === true) {
+  if (result.suppressDisplay === true) {
     return false;
   }
-  return (
-    typeof toolResponse.resultDisplay === 'string' &&
-    toolResponse.resultDisplay.length !== 0
-  );
+  return typeof result.display === 'string' && result.display.length > 0;
 }
 
 function displayToolResult(
-  toolName: string,
-  toolResponse: Awaited<ReturnType<typeof executeToolCall>>['response'],
-  context: ResponseProcessingContext,
+  result: AgentToolResult,
+  context: StreamConsumerContext,
 ): void {
-  if (toolResponse.error != null) {
-    if (context.jsonOutput === false && context.streamJsonOutput === false) {
-      const display = toolResponse.resultDisplay;
-      const hasDisplay =
-        typeof display === 'string' ? display.length > 0 : display != null;
-      debugLogger.error(
-        `Error executing tool ${toolName}: ${
-          hasDisplay ? display : toolResponse.error.message
-        }`,
-      );
+  if (result.isError === true) {
+    if (!context.jsonOutput && !context.streamJsonOutput) {
+      const display = result.display;
+      const msg =
+        typeof display === 'string' && display.length > 0
+          ? display
+          : `${result.name} failed`;
+      debugLogger.error(`Error executing tool ${result.name}: ${msg}`);
     }
     return;
   }
-  if (shouldDisplayToolResult(toolResponse, context)) {
-    process.stdout.write(`${toolResponse.resultDisplay}\n`);
+  if (shouldDisplayToolResult(result, context)) {
+    process.stdout.write(`${result.display}\n`);
   }
 }
 
 function emitFinalResult(
-  context: ResponseProcessingContext,
+  context: StreamConsumerContext,
   jsonResponseText: string,
   startTime: number,
   metrics: SessionMetrics,
@@ -410,120 +264,127 @@ function emitFinalResult(
   }
 }
 
-function assertTurnLimit(turnCount: number, maxSessionTurns: number): void {
-  if (maxSessionTurns >= 0 && turnCount > maxSessionTurns) {
-    throw new FatalTurnLimitedError(
-      'Reached max session turns for this session. Increase the number of turns by specifying maxSessionTurns in settings.json.',
-    );
+/**
+ * Rebuilds an Error from a public StructuredError so the caller's catch
+ * (parseAndFormatApiError) receives an Error instance, matching the legacy
+ * GeminiEventType.Error throw path. The optional HTTP status is preserved as a
+ * property without a type assertion.
+ */
+function reconstructError(structured: {
+  readonly message: string;
+  readonly status?: number;
+}): Error {
+  const err: Error & { status?: number } = new Error(structured.message);
+  if (structured.status !== undefined) {
+    err.status = structured.status;
+  }
+  return err;
+}
+
+function handleDone(
+  event: Extract<AgentEvent, { type: 'done' }>,
+  context: StreamConsumerContext,
+  jsonResponseText: string,
+  startTime: number,
+  getMetrics: () => SessionMetrics,
+): void {
+  switch (event.reason) {
+    case 'stop':
+    case 'loop-detected':
+    case 'context-overflow':
+      emitFinalResult(context, jsonResponseText, startTime, getMetrics());
+      return;
+    case 'hook-stopped': {
+      const stop = event.stop;
+      const stopMessage = `Agent execution stopped: ${
+        stop?.systemMessage?.trim() ?? stop?.reason ?? ''
+      }`;
+      process.stderr.write(`${stopMessage}\n`);
+      return;
+    }
+    case 'aborted':
+      debugLogger.error('Operation cancelled.');
+      return;
+    case 'max-turns':
+      throw new FatalTurnLimitedError(MAX_TURNS_MESSAGE);
+    case 'error':
+      throw new Error('Agent execution failed');
+    default:
+      return;
   }
 }
 
-export async function processResponseTurns(
-  initialMessages: Part[],
-  context: ResponseProcessingContext,
+/**
+ * Consumes a public {@link AgentEvent} stream produced by `agent.stream()` and
+ * maps each event onto the existing non-interactive output helpers (stdout
+ * write, JSON accumulation, stream-JSON emission), preserving the user-visible
+ * output, exit-code, and stderr behavior of the legacy manual turn loop.
+ */
+export async function processAgentStream(
+  events: AsyncIterable<AgentEvent>,
+  context: StreamConsumerContext,
   startTime: number,
   getMetrics: () => SessionMetrics,
 ): Promise<void> {
-  let currentMessages = initialMessages;
-  let turnCount = 0;
-  let jsonResponseText = '';
-  for (;;) {
-    turnCount++;
-    assertTurnLimit(turnCount, context.maxSessionTurns);
-    const result = await processOneTurn(
-      currentMessages,
-      context,
-      jsonResponseText,
-    );
-    if (result.kind === 'continue') {
-      currentMessages = result.messages;
-      jsonResponseText = result.jsonResponseText;
-    } else {
-      if (result.emitFinal) {
-        emitFinalResult(
-          context,
-          result.jsonResponseText,
-          startTime,
-          getMetrics(),
-        );
-      }
-      return;
-    }
-  }
-}
-
-async function processOneTurn(
-  currentMessages: Part[],
-  context: ResponseProcessingContext,
-  jsonResponseText: string,
-): Promise<TurnResult> {
-  const functionCalls: RuntimeToolCallRequest[] = [];
   const writeProfileName = context.createProfileNameWriter();
-  let thoughtBuffer = '';
   const includeThinking =
     !context.jsonOutput &&
     !context.streamJsonOutput &&
     context.config.getEphemeralSetting('reasoning.includeInResponse') !== false;
-  const responseIterator = context.config
-    .getAgentClient()
-    .sendMessageStream(
-      currentMessages,
-      context.abortController.signal,
-      context.prompt_id,
-    )
-    [Symbol.asyncIterator]();
-  for (;;) {
-    let nextEvent: IteratorResult<ServerGeminiStreamEvent>;
-    try {
-      nextEvent = await nextStreamEvent(responseIterator, context);
-    } catch (error) {
-      if (context.abortController.signal.aborted) {
-        debugLogger.error('Operation cancelled.');
-        return { kind: 'complete', jsonResponseText, emitFinal: false };
-      }
-      handleStreamReadError(error, context);
-      throw error;
-    }
-    if (nextEvent.done === true) {
-      break;
-    }
-    if (context.abortController.signal.aborted) {
-      debugLogger.error('Operation cancelled.');
-      return { kind: 'complete', jsonResponseText, emitFinal: false };
-    }
-    thoughtBuffer = handleThoughtEvent(
-      nextEvent.value,
-      context,
-      writeProfileName,
-      thoughtBuffer,
-      includeThinking,
-    );
-    if (nextEvent.value.type === GeminiEventType.Content) {
-      thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
-      jsonResponseText = handleContentEvent(
-        nextEvent.value,
-        context,
-        writeProfileName,
-        jsonResponseText,
-      );
-    } else if (nextEvent.value.type === GeminiEventType.ToolCallRequest) {
-      thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
-      collectToolCall(nextEvent.value, functionCalls, context.streamFormatter);
-    } else {
-      handleControlEvent(nextEvent.value, context.streamFormatter);
-      if (nextEvent.value.type === GeminiEventType.AgentExecutionStopped) {
-        return { kind: 'complete', jsonResponseText, emitFinal: false };
-      }
+  let thoughtBuffer = '';
+  let jsonResponseText = '';
+
+  for await (const event of events) {
+    switch (event.type) {
+      case 'thinking':
+        thoughtBuffer = handleThinking(
+          event.thought,
+          context,
+          writeProfileName,
+          thoughtBuffer,
+          includeThinking,
+        );
+        break;
+      case 'text':
+        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
+        jsonResponseText = handleText(
+          event.text,
+          context,
+          writeProfileName,
+          jsonResponseText,
+        );
+        break;
+      case 'tool-call':
+        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
+        emitToolUse(event.call, context.streamFormatter);
+        break;
+      case 'tool-result':
+        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
+        emitToolResult(event.result, context.streamFormatter);
+        displayToolResult(event.result, context);
+        break;
+      case 'loop-detected':
+        emitStreamError(
+          context.streamFormatter,
+          'warning',
+          'Loop detected, stopping execution',
+        );
+        break;
+      case 'error':
+        throw reconstructError(event.error);
+      case 'done':
+        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
+        jsonResponseText = flushEmojiBuffer(context, jsonResponseText);
+        handleDone(event, context, jsonResponseText, startTime, getMetrics);
+        return;
+      default:
+        break;
     }
   }
-  flushThoughtBuffer(thoughtBuffer, includeThinking);
+
+  // Defensive: emit a final result if the stream ended without a terminal
+  // done event (the Agent stream always ends with one, but guard regardless).
+  thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
   jsonResponseText = flushEmojiBuffer(context, jsonResponseText);
-  if (functionCalls.length === 0) {
-    return { kind: 'complete', jsonResponseText, emitFinal: true };
-  }
-  return {
-    kind: 'continue',
-    messages: await handleToolCalls(functionCalls, context),
-    jsonResponseText,
-  };
+  emitFinalResult(context, jsonResponseText, startTime, getMetrics());
 }

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -315,11 +315,116 @@ function handleDone(
   }
 }
 
+function finalizeStream(
+  thoughtBuffer: string,
+  jsonResponseText: string,
+  pendingDone: Extract<AgentEvent, { type: 'done' }> | null,
+  context: StreamConsumerContext,
+  includeThinking: boolean,
+  startTime: number,
+  getMetrics: () => SessionMetrics,
+): void {
+  flushThoughtBuffer(thoughtBuffer, includeThinking);
+  const finalText = flushEmojiBuffer(context, jsonResponseText);
+  if (pendingDone !== null) {
+    handleDone(pendingDone, context, finalText, startTime, getMetrics);
+  } else {
+    emitFinalResult(context, finalText, startTime, getMetrics());
+  }
+}
+
+interface StreamState {
+  thoughtBuffer: string;
+  jsonResponseText: string;
+  pendingDone: Extract<AgentEvent, { type: 'done' }> | null;
+}
+
+function dispatchAgentEvent(
+  event: AgentEvent,
+  state: StreamState,
+  context: StreamConsumerContext,
+  writeProfileName: () => void,
+  includeThinking: boolean,
+): void {
+  switch (event.type) {
+    case 'thinking':
+      state.thoughtBuffer = handleThinking(
+        event.thought,
+        context,
+        writeProfileName,
+        state.thoughtBuffer,
+        includeThinking,
+      );
+      return;
+    case 'text':
+      state.thoughtBuffer = flushThoughtBuffer(
+        state.thoughtBuffer,
+        includeThinking,
+      );
+      state.jsonResponseText = handleText(
+        event.text,
+        context,
+        writeProfileName,
+        state.jsonResponseText,
+      );
+      return;
+    case 'tool-call':
+      state.thoughtBuffer = flushThoughtBuffer(
+        state.thoughtBuffer,
+        includeThinking,
+      );
+      emitToolUse(event.call, context.streamFormatter);
+      return;
+    case 'tool-result':
+      state.thoughtBuffer = flushThoughtBuffer(
+        state.thoughtBuffer,
+        includeThinking,
+      );
+      emitToolResult(event.result, context.streamFormatter);
+      displayToolResult(event.result, context);
+      return;
+    case 'loop-detected':
+      emitStreamError(
+        context.streamFormatter,
+        'warning',
+        'Loop detected, stopping execution',
+      );
+      return;
+    case 'hook-blocked': {
+      const info = event.info;
+      const blockMessage = `Agent execution blocked: ${
+        info.systemMessage?.trim() ?? info.reason
+      }`;
+      process.stderr.write(`[WARNING] ${blockMessage}\n`);
+      return;
+    }
+    case 'idle-timeout':
+      emitStreamError(
+        context.streamFormatter,
+        'error',
+        'Stream idle timeout: no response received within the allowed time.',
+      );
+      throw reconstructError(event.error);
+    case 'error':
+      throw reconstructError(event.error);
+    case 'done':
+      state.pendingDone = event;
+      return;
+    default:
+      return;
+  }
+}
+
 /**
  * Consumes a public {@link AgentEvent} stream produced by `agent.stream()` and
  * maps each event onto the existing non-interactive output helpers (stdout
  * write, JSON accumulation, stream-JSON emission), preserving the user-visible
  * output, exit-code, and stderr behavior of the legacy manual turn loop.
+ *
+ * The loop emits a per-turn `done` (from `Finished`); when a tool is requested
+ * the loop continues past it. This consumer records each `done` and acts only
+ * on the final one at stream exhaustion — returning early would abandon the
+ * generator mid-loop and prevent tool execution.
  */
 export async function processAgentStream(
   events: AsyncIterable<AgentEvent>,
@@ -332,75 +437,27 @@ export async function processAgentStream(
     !context.jsonOutput &&
     !context.streamJsonOutput &&
     context.config.getEphemeralSetting('reasoning.includeInResponse') !== false;
-  let thoughtBuffer = '';
-  let jsonResponseText = '';
-
+  const state: StreamState = {
+    thoughtBuffer: '',
+    jsonResponseText: '',
+    pendingDone: null,
+  };
   for await (const event of events) {
-    switch (event.type) {
-      case 'thinking':
-        thoughtBuffer = handleThinking(
-          event.thought,
-          context,
-          writeProfileName,
-          thoughtBuffer,
-          includeThinking,
-        );
-        break;
-      case 'text':
-        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
-        jsonResponseText = handleText(
-          event.text,
-          context,
-          writeProfileName,
-          jsonResponseText,
-        );
-        break;
-      case 'tool-call':
-        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
-        emitToolUse(event.call, context.streamFormatter);
-        break;
-      case 'tool-result':
-        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
-        emitToolResult(event.result, context.streamFormatter);
-        displayToolResult(event.result, context);
-        break;
-      case 'loop-detected':
-        emitStreamError(
-          context.streamFormatter,
-          'warning',
-          'Loop detected, stopping execution',
-        );
-        break;
-      case 'hook-blocked': {
-        const info = event.info;
-        const blockMessage = `Agent execution blocked: ${
-          info.systemMessage?.trim() ?? info.reason
-        }`;
-        process.stderr.write(`[WARNING] ${blockMessage}\n`);
-        break;
-      }
-      case 'idle-timeout':
-        emitStreamError(
-          context.streamFormatter,
-          'error',
-          'Stream idle timeout: no response received within the allowed time.',
-        );
-        throw reconstructError(event.error);
-      case 'error':
-        throw reconstructError(event.error);
-      case 'done':
-        thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
-        jsonResponseText = flushEmojiBuffer(context, jsonResponseText);
-        handleDone(event, context, jsonResponseText, startTime, getMetrics);
-        return;
-      default:
-        break;
-    }
+    dispatchAgentEvent(
+      event,
+      state,
+      context,
+      writeProfileName,
+      includeThinking,
+    );
   }
-
-  // Defensive: emit a final result if the stream ended without a terminal
-  // done event (the Agent stream always ends with one, but guard regardless).
-  thoughtBuffer = flushThoughtBuffer(thoughtBuffer, includeThinking);
-  jsonResponseText = flushEmojiBuffer(context, jsonResponseText);
-  emitFinalResult(context, jsonResponseText, startTime, getMetrics());
+  finalizeStream(
+    state.thoughtBuffer,
+    state.jsonResponseText,
+    state.pendingDone,
+    context,
+    includeThinking,
+    startTime,
+    getMetrics,
+  );
 }

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -136,12 +136,18 @@ export function handleCancellationError(_config: Config): never {
 }
 
 /**
+ * Shared message used when the max-session-turns limit is reached. Single
+ * source of truth for both the non-interactive Agent stream path and the
+ * {@link handleMaxTurnsExceededError} handler.
+ */
+export const MAX_TURNS_MESSAGE =
+  'Reached max session turns for this session. Increase the number of turns by specifying maxSessionTurns in settings.json.';
+
+/**
  * Handles max session turns exceeded consistently.
  */
 export function handleMaxTurnsExceededError(_config: Config): never {
-  const maxTurnsError = new FatalTurnLimitedError(
-    'Reached max session turns for this session. Increase the number of turns by specifying maxSessionTurns in settings.json.',
-  );
+  const maxTurnsError = new FatalTurnLimitedError(MAX_TURNS_MESSAGE);
 
   globalThis.console.error(maxTurnsError.message);
   process.exit(maxTurnsError.exitCode);


### PR DESCRIPTION
## Summary

Route non-interactive prompt execution (`--prompt` mode) through the public `Agent.stream()` API instead of the legacy manual `config.getAgentClient().sendMessageStream()` turn loop. This is the first non-UI client migration under #1595 and proves the shared Agent runtime is not only an Ink/React concern.

The manual per-turn loop, `executeToolCall` tool wiring, and `assertTurnLimit` recursion are gone. Tool scheduling, the multi-turn loop, turn limits, and approval/policy now all flow through the Agent, while every user-visible output format, exit code, and stderr behavior is preserved.

Fixes #2202.

## What changed

**`packages/cli/src/nonInteractiveCli.ts`** — `processQuery` now builds an `Agent` from the existing (already-bootstrapped) `Config` via `fromConfig({ config, messageBus, sessionId })`, consumes a single `agent.stream(query, { signal, promptId, maxTurns })`, and disposes the agent in a `finally` block. `fromConfig` is called inside the `try` (so a partially-initialized agent is always disposed) and `dispose()` is wrapped in its own `try/catch` so a disposal failure can never mask the original stream/turn error. `resolveNonInteractiveQuery`, slash-command handling, auth validation, session hooks, and telemetry shutdown are untouched. `RunNonInteractiveParams` is unchanged.

**`packages/cli/src/nonInteractiveCliSupport.ts`** — rewritten as a single-pass `processAgentStream(events, context, startTime, getMetrics)` consumer over the typed `AgentEvent` union. It dispatches each event onto the existing output helpers:
- `text` → stdout write / JSON accumulate / stream-JSON delta
- `thinking` → `<think>…</think>` coalescing/flush
- `tool-call` → stream-JSON `TOOL_USE`
- `tool-result` → stream-JSON `TOOL_RESULT` + display (preserving `errorType`)
- `loop-detected`, `hook-blocked`, `idle-timeout`, `hook-stopped` → the legacy stderr / stream-json notices
- `error` → `reconstructError(StructuredError)` (preserves HTTP status)
- `done` → `emitFinalResult`, with `max-turns` → `FatalTurnLimitedError` and cancellation preserved

The removed legacy functions (`processResponseTurns`, `processOneTurn`, `handleToolCalls`, `executeToolCall` wiring, `assertTurnLimit`) are fully owned by the Agent now.

**`packages/agents/src/api/`** (public API additions, additive only):
- `AgentInput` additionally accepts a `readonly Part[]` so the resolved slash-command/`@file` query flows through the Agent API without loss; `toPartListUnion` passes it through.
- `AgentToolResult` gains optional `display`, `suppressDisplay`, and `errorType`, projected by `eventAdapter.ts` from the loop's tool result (both the `CompletedToolCall` and raw `ToolCallResponseInfo` branches).
- The MCP discovery-gate failure now yields a structured `error` event (with the typed error code prefixed onto the message) before the terminal `done{reason:'error'}`, so non-interactive callers get useful diagnostics instead of a bare stop.

**`packages/cli/src/utils/errors.ts`** — `MAX_TURNS_MESSAGE` is now a single exported constant shared by both the non-interactive stream path and `handleMaxTurnsExceededError`.

## Approval / policy behavior

Non-interactive policy semantics (`ASK_USER → DENY`, no `onApproval`, no confirmation-forcing) are inherited automatically: `fromConfig` adopts the same `Config`, whose policy engine already carries the `nonInteractive` flag. No special non-interactive runtime wiring bypasses the public Agent API.

## Tests

- `nonInteractiveCli.test.ts` and `nonInteractiveCli.slashCommandsAndThinking.test.ts` were migrated to drive `processAgentStream` / `runNonInteractive` through a fake Agent that captures `stream()` input and `TurnOptions`, with staged `AgentEvent[]`. New tests lock in hook-blocked stderr, idle-timeout handling, `errorType` preservation, and prompt-id/max-turns forwarding.
- The error-type fidelity, the `done{error}` contract, and the MCP gate invariants are covered.

## Verification

- `npm run typecheck` — all packages clean
- `npm run lint` (agents + cli) + `npm run lint:eslint-guard` — clean
- `npm run format` — clean
- `npm run build` — success
- Smoke: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — haiku printed via the non-interactive Agent path
- 671 agents API tests pass; 4818 CLI unit tests pass (5 skipped)
- `integration-tests/json-output.test.ts` — 3/3 pass (text/JSON output, `session_id`, `stats`, and tool-error self-correction with `stats.tools.totalCalls=1, totalFail=1, totalSuccess=0` and no top-level `error`)
- Open Code Review (ocr) — 0 findings after iterative remediation

## Acceptance criteria

- [x] Prompt mode uses Agent `stream()`
- [x] Existing non-interactive CLI tests pass
- [x] User-visible output and exit behavior remain compatible
- [x] Non-interactive mode respects approval and policy behavior through the Agent path
- [x] No separate non-interactive runtime assembly path remains for behavior the Agent API covers
