### PR TITLE
Harden hard-limit compression fallback (Fixes #2067)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -15,6 +15,7 @@ import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/r
 import type {
   CompressionContext,
   CompressionProviderResult,
+  CompressionResult,
   DensityConfig,
 } from '@vybestack/llxprt-code-core/core/compression/types.js';
 import {
@@ -25,6 +26,7 @@ import {
   getCompressionStrategy,
   parseCompressionStrategyName,
 } from './compressionStrategyFactory.js';
+import { buildContextOverflowError } from './contextOverflowError.js';
 /**
  * @plan:PLAN-20260603-ISSUE1584.P05
  * @requirement:REQ-DEP-001
@@ -456,12 +458,8 @@ export class CompressionHandler {
     }
 
     const preCompressionProjected = postOptProjected;
-
-    await this.performCompression(promptId, {
-      bypassCooldown: true,
-      trigger: 'auto',
-    });
-    await this.historyService.waitForTokenUpdates();
+    const compressionFailure =
+      await this.tryAutoCompressionForHardLimit(promptId);
 
     let recomputed = this.computeProjectedTokens(
       pendingTokens,
@@ -475,111 +473,244 @@ export class CompressionHandler {
       return;
     }
 
-    // If compression barely reduced tokens, force truncation fallback
-    recomputed = await this.forceTruncationIfIneffective(
+    const reductionResult = await this.reduceHardLimitOverflow(
       promptId,
       preCompressionProjected,
       recomputed,
       marginAdjustedLimit,
       pendingTokens,
       completionBudget,
+      compressionFailure,
     );
+    recomputed = reductionResult.projected;
     if (recomputed <= marginAdjustedLimit) {
       return;
     }
 
-    throw this.buildContextOverflowError(
+    throw buildContextOverflowError({
       limit,
       initialProjected,
-      recomputed,
+      finalProjected: recomputed,
       marginAdjustedLimit,
       completionBudget,
-    );
+      truncationFailure: reductionResult.truncationFailure,
+      compressionFailure: reductionResult.compressionFailure,
+    });
   }
 
-  /**
-   * Force truncation fallback when primary compression was ineffective.
-   * Returns the recomputed projected token count after fallback attempt.
-   */
-  private async forceTruncationIfIneffective(
+  private async tryAutoCompressionForHardLimit(
+    promptId: string,
+  ): Promise<Error | undefined> {
+    try {
+      const result = await this.performCompression(promptId, {
+        bypassCooldown: true,
+        trigger: 'auto',
+      });
+      await this.historyService.waitForTokenUpdates();
+      if (result === PerformCompressionResult.FAILED) {
+        const failedError = new Error(
+          'Auto compression failed during hard-limit enforcement',
+        );
+        this.logger.warn(
+          () =>
+            '[CompressionHandler] Auto compression failed during hard-limit enforcement, trying fallback reduction',
+          failedError,
+        );
+        return failedError;
+      }
+      return undefined;
+    } catch (error) {
+      const compressionError = this.normalizeError(error);
+      this.recordCompressionFailure();
+      this.logger.warn(
+        () =>
+          '[CompressionHandler] Auto compression failed during hard-limit enforcement, trying fallback reduction',
+        compressionError,
+      );
+      await this.historyService.waitForTokenUpdates();
+      return compressionError;
+    }
+  }
+
+  private async reduceHardLimitOverflow(
     promptId: string,
     preCompressionProjected: number,
     postCompressionProjected: number,
     marginAdjustedLimit: number,
     pendingTokens: number,
     completionBudget: number,
-  ): Promise<number> {
+    compressionFailure: Error | undefined,
+  ): Promise<{
+    projected: number;
+    truncationFailure?: Error;
+    compressionFailure?: Error;
+  }> {
+    const compressionRetryResult = await this.retryFullCompressionIfIneffective(
+      promptId,
+      preCompressionProjected,
+      postCompressionProjected,
+      marginAdjustedLimit,
+      pendingTokens,
+      completionBudget,
+      compressionFailure,
+    );
+    if (compressionRetryResult.projected <= marginAdjustedLimit) {
+      return compressionRetryResult;
+    }
+
+    return this.forceTruncationIfStillOverLimit(
+      promptId,
+      compressionRetryResult.projected,
+      marginAdjustedLimit,
+      pendingTokens,
+      completionBudget,
+      compressionRetryResult.compressionFailure,
+    );
+  }
+
+  private async retryFullCompressionIfIneffective(
+    promptId: string,
+    preCompressionProjected: number,
+    postCompressionProjected: number,
+    marginAdjustedLimit: number,
+    pendingTokens: number,
+    completionBudget: number,
+    compressionFailure: Error | undefined,
+  ): Promise<{ projected: number; compressionFailure?: Error }> {
     const reduction = preCompressionProjected - postCompressionProjected;
     const reductionRatio =
       preCompressionProjected > 0 ? reduction / preCompressionProjected : 0;
     if (
+      compressionFailure !== undefined ||
       reductionRatio >=
         CompressionHandler.INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD ||
       postCompressionProjected <= marginAdjustedLimit
     ) {
-      return postCompressionProjected;
+      return { projected: postCompressionProjected, compressionFailure };
     }
 
     this.logger.warn(
       () =>
-        '[CompressionHandler] Primary compression was ineffective, forcing truncation fallback',
+        '[CompressionHandler] Auto compression remained ineffective, retrying full compression before truncation',
       {
         preCompressionProjected,
         postCompressionProjected,
         reductionRatio,
+        tokensStillNeeded: postCompressionProjected - marginAdjustedLimit,
+      },
+    );
+
+    try {
+      const result = await this.performCompression(promptId, {
+        bypassCooldown: true,
+        trigger: 'auto',
+      });
+      await this.historyService.waitForTokenUpdates();
+      if (result === PerformCompressionResult.FAILED) {
+        const retryError = new Error(
+          'Additional hard-limit compression attempt failed',
+        );
+        this.logger.warn(
+          () =>
+            '[CompressionHandler] Additional hard-limit compression attempt failed',
+          retryError,
+        );
+        return {
+          projected: this.computeProjectedTokens(
+            pendingTokens,
+            completionBudget,
+          ),
+          compressionFailure: retryError,
+        };
+      }
+      return {
+        projected: this.computeProjectedTokens(pendingTokens, completionBudget),
+      };
+    } catch (error) {
+      const retryError = this.normalizeError(error);
+      this.recordCompressionFailure();
+      this.logger.warn(
+        () =>
+          '[CompressionHandler] Additional hard-limit compression attempt failed',
+        retryError,
+      );
+      return {
+        projected: this.computeProjectedTokens(pendingTokens, completionBudget),
+        compressionFailure: retryError,
+      };
+    }
+  }
+
+  private async forceTruncationIfStillOverLimit(
+    promptId: string,
+    postCompressionProjected: number,
+    marginAdjustedLimit: number,
+    pendingTokens: number,
+    completionBudget: number,
+    compressionFailure: Error | undefined,
+  ): Promise<{
+    projected: number;
+    truncationFailure?: Error;
+    compressionFailure?: Error;
+  }> {
+    if (postCompressionProjected <= marginAdjustedLimit) {
+      return { projected: postCompressionProjected, compressionFailure };
+    }
+
+    this.logger.warn(
+      () =>
+        '[CompressionHandler] Context remains over limit, forcing truncation fallback',
+      {
+        postCompressionProjected,
+        marginAdjustedLimit,
+        tokensStillNeeded: postCompressionProjected - marginAdjustedLimit,
       },
     );
     this._suppressDensityDirty = true;
+    let truncationFailure: Error | undefined;
     try {
       const context = await this.buildCompressionContext(promptId);
-      await this.performFallbackCompression(
-        context,
-        new Error('Primary compression was ineffective'),
-        (newHistory) => {
-          this.historyService.clear();
-          for (const content of newHistory) {
-            this.historyService.add(content, this.runtimeContext.state.model);
-          }
-          this.lastPromptTokenCount = null;
-        },
+      const result = await this.compressWithFallbackStrategy(context);
+      this.applyFallbackCompressionResult(result, (newHistory) => {
+        this.historyService.clear();
+        for (const content of newHistory) {
+          this.historyService.add(content, this.runtimeContext.state.model);
+        }
+        this.lastPromptTokenCount = null;
+      });
+      this.logger.debug(
+        'Compression completed with hard-limit fallback (TopDownTruncation)',
       );
       await this.historyService.waitForTokenUpdates();
     } catch (error) {
+      truncationFailure = this.normalizeError(error);
+      this.recordCompressionFailure();
       this.logger.warn(
         () =>
           '[CompressionHandler] Truncation fallback failed during hard-limit enforcement',
-        error,
+        truncationFailure,
       );
     } finally {
       this._suppressDensityDirty = false;
     }
 
-    return this.computeProjectedTokens(pendingTokens, completionBudget);
+    return {
+      projected: this.computeProjectedTokens(pendingTokens, completionBudget),
+      truncationFailure,
+      compressionFailure,
+    };
   }
 
-  /**
-   * Build a diagnostic error for context window overflow after all reduction attempts.
-   */
-  private buildContextOverflowError(
-    limit: number,
-    initialProjected: number,
-    finalProjected: number,
-    marginAdjustedLimit: number,
-    completionBudget: number,
-  ): Error {
-    const totalReduction = Math.max(0, initialProjected - finalProjected);
-    const tokensStillNeeded = finalProjected - marginAdjustedLimit;
-    const parts: string[] = [
-      `Request still exceeds the safety-adjusted context limit (${marginAdjustedLimit} tokens).`,
-      `density optimization and compression reduced ${totalReduction} tokens (from ${initialProjected} to ${finalProjected} projected).`,
-      `completionBudget=${completionBudget}, tokensStillNeeded=${tokensStillNeeded}.`,
-    ];
-    if (completionBudget > 0.8 * limit) {
-      parts.push(
-        `The completion budget (${completionBudget}) consumes more than 80% of the context window (${limit}). Consider lowering maxOutputTokens.`,
-      );
+  private normalizeError(error: unknown): Error {
+    if (error instanceof Error) {
+      return error;
     }
-    return new Error(parts.join(' '));
+    return new Error(String(error));
+  }
+
+  private recordCompressionFailure(): void {
+    this.compressionFailureCount++;
+    this.lastCompressionFailureTime = Date.now();
   }
 
   /**
@@ -759,6 +890,23 @@ export class CompressionHandler {
     return this.performFallbackCompression(context, primaryError, applyResult);
   }
 
+  private applyFallbackCompressionResult(
+    result: CompressionResult,
+    applyResult: (newHistory: IContent[]) => void,
+  ): void {
+    applyResult(result.newHistory);
+    this.compressionFailureCount = 0;
+    this.lastCompressionFailureTime = null;
+    this.lastSuccessfulCompressionTime = Date.now();
+  }
+
+  private async compressWithFallbackStrategy(
+    context: CompressionContext,
+  ): Promise<CompressionResult> {
+    const fallback = getCompressionStrategy('top-down-truncation');
+    return fallback.compress(context);
+  }
+
   /**
    * Attempt fallback compression using TopDownTruncationStrategy.
    *
@@ -772,13 +920,8 @@ export class CompressionHandler {
   ): Promise<boolean> {
     try {
       // Use the strategy factory so tests can intercept
-      const fallback = getCompressionStrategy('top-down-truncation');
-      const result = await fallback.compress(context);
-      applyResult(result.newHistory);
-      // Fallback succeeded — reset failure counters
-      this.compressionFailureCount = 0;
-      this.lastCompressionFailureTime = null;
-      this.lastSuccessfulCompressionTime = Date.now();
+      const result = await this.compressWithFallbackStrategy(context);
+      this.applyFallbackCompressionResult(result, applyResult);
       this.logger.debug(
         'Compression completed with fallback (TopDownTruncation)',
       );

--- a/packages/agents/src/compression/__tests__/compression-retry-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-hardlimit.test.ts
@@ -26,7 +26,20 @@ import {
 import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import * as providerRuntime from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { EmptySummaryError } from '@vybestack/llxprt-code-core/core/compression/types.js';
 import { makeHttpError } from './compression-retry-helpers.js';
+
+vi.mock('@vybestack/llxprt-code-settings', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@vybestack/llxprt-code-settings')>();
+  return {
+    ...original,
+    Storage: {
+      ...original.Storage,
+      getGlobalConfigDir: vi.fn(() => '/tmp/llxprt-test-config'),
+    },
+  };
+});
 
 // Mock the delay utility so retryWithBackoff doesn't actually wait in tests
 vi.mock('@vybestack/llxprt-code-core/utils/delay.js', () => ({
@@ -285,9 +298,9 @@ describe('Hard-limit compression behavior (Issue #1791)', () => {
 
   /**
    * @requirement REQ-1791.2
-   * When primary compression barely reduces tokens, fallback truncation is triggered.
+   * When compression remains insufficient, fallback truncation is triggered.
    */
-  it('forces fallback truncation when compression barely reduces tokens', async () => {
+  it('forces fallback truncation when compression remains over limit', async () => {
     // totalTokens=150000, pendingTokens=50000, completionBudget=65536
     // projected = 150000 + 50000 + 65536 = 265536 > 199000
     const chat = makeChatForEnforceContextWindow({ totalTokens: 150_000 });
@@ -354,10 +367,285 @@ describe('Hard-limit compression behavior (Issue #1791)', () => {
   });
 
   /**
+   * @requirement REQ-2067.3
+   * Ineffective auto compression gets one more full compression pass before truncation.
+   */
+  it('retries full compression before truncating when auto compression is ineffective', async () => {
+    const chat = makeChatForEnforceContextWindow({
+      totalTokens: 155_000,
+      contextLimit: 200_000,
+      maxOutputTokens: 40_000,
+    });
+
+    let primaryCallCount = 0;
+    let truncationCalled = false;
+
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      (name) => {
+        if (name === 'top-down-truncation') {
+          return {
+            name: 'top-down-truncation' as const,
+            requiresLLM: false,
+            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+            compress: vi.fn().mockImplementation(async () => {
+              truncationCalled = true;
+              return {
+                newHistory: [{ role: 'user', parts: [{ text: 'truncated' }] }],
+                metadata: {
+                  originalMessageCount: 10,
+                  compressedMessageCount: 1,
+                  strategyUsed: 'top-down-truncation' as const,
+                  llmCallMade: false,
+                },
+              };
+            }),
+          };
+        }
+
+        return {
+          name: 'middle-out' as const,
+          requiresLLM: true,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi.fn().mockImplementation(async () => {
+            primaryCallCount++;
+            return {
+              newHistory: [{ role: 'user', parts: [{ text: 'compressed' }] }],
+              metadata: {
+                originalMessageCount: 10,
+                compressedMessageCount: 1,
+                strategyUsed: 'middle-out' as const,
+                llmCallMade: true,
+              },
+            };
+          }),
+        };
+      },
+    );
+
+    vi.spyOn(chat['historyService'], 'getTotalTokens').mockImplementation(
+      () => {
+        if (primaryCallCount >= 2) {
+          return 140_000;
+        }
+        return 155_000;
+      },
+    );
+
+    await expect(
+      chat['enforceContextWindow'](10_000, 'test-prompt'),
+    ).resolves.toBeUndefined();
+
+    expect(primaryCallCount).toBe(2);
+    expect(truncationCalled).toBe(false);
+  });
+
+  /**
+   * @requirement REQ-2067.3
+   * Failed retry compression is surfaced before hard-limit truncation diagnostics.
+   */
+  it('surfaces failed retry compression diagnostics before truncation failure details', async () => {
+    const chat = makeChatForEnforceContextWindow({
+      totalTokens: 155_000,
+      contextLimit: 200_000,
+      maxOutputTokens: 40_000,
+    });
+
+    let primaryCallCount = 0;
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      (name) => {
+        if (name === 'top-down-truncation') {
+          return {
+            name: 'top-down-truncation' as const,
+            requiresLLM: false,
+            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+            compress: vi.fn().mockRejectedValue(new Error('truncation broke')),
+          };
+        }
+
+        return {
+          name: 'middle-out' as const,
+          requiresLLM: true,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi.fn().mockImplementation(async () => {
+            primaryCallCount++;
+            if (primaryCallCount === 1) {
+              return {
+                newHistory: [{ role: 'user', parts: [{ text: 'compressed' }] }],
+                metadata: {
+                  originalMessageCount: 10,
+                  compressedMessageCount: 1,
+                  strategyUsed: 'middle-out' as const,
+                  llmCallMade: true,
+                },
+              };
+            }
+            throw makeHttpError(500);
+          }),
+        };
+      },
+    );
+    vi.spyOn(chat['historyService'], 'getTotalTokens').mockReturnValue(155_000);
+
+    await expect(
+      chat['enforceContextWindow'](10_000, 'test-prompt'),
+    ).rejects.toThrow(
+      'Automatic compression failed before fallback: Error: Additional hard-limit compression attempt failed.',
+    );
+
+    expect(primaryCallCount).toBeGreaterThan(1);
+  });
+  /**
+   * @requirement REQ-2067.4
+   * Permanent auto-compression failures still allow hard-limit truncation fallback.
+   */
+  it('tries truncation when auto compression returns an empty summary', async () => {
+    const chat = makeChatForEnforceContextWindow({
+      totalTokens: 155_000,
+      contextLimit: 200_000,
+      maxOutputTokens: 40_000,
+    });
+
+    let fallbackApplied = false;
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      (name) => {
+        if (name === 'top-down-truncation') {
+          return {
+            name: 'top-down-truncation' as const,
+            requiresLLM: false,
+            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+            compress: vi.fn().mockImplementation(async () => {
+              fallbackApplied = true;
+              return {
+                newHistory: [{ role: 'user', parts: [{ text: 'truncated' }] }],
+                metadata: {
+                  originalMessageCount: 10,
+                  compressedMessageCount: 1,
+                  strategyUsed: 'top-down-truncation' as const,
+                  llmCallMade: false,
+                },
+              };
+            }),
+          };
+        }
+
+        return {
+          name: 'middle-out' as const,
+          requiresLLM: true,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi
+            .fn()
+            .mockRejectedValue(new EmptySummaryError('middle-out')),
+        };
+      },
+    );
+
+    vi.spyOn(chat['historyService'], 'getTotalTokens').mockImplementation(() =>
+      fallbackApplied ? 140_000 : 155_000,
+    );
+
+    await expect(
+      chat['enforceContextWindow'](10_000, 'test-prompt'),
+    ).resolves.toBeUndefined();
+
+    expect(fallbackApplied).toBe(true);
+  });
+
+  /**
+   * @requirement REQ-2067.4
+   * Non-throwing auto-compression failures are diagnosed and do not trigger a redundant full retry.
+   */
+  it('surfaces non-throwing auto compression failures without retrying full compression', async () => {
+    const chat = makeChatForEnforceContextWindow({
+      totalTokens: 155_000,
+      contextLimit: 200_000,
+      maxOutputTokens: 40_000,
+    });
+
+    let primaryCallCount = 0;
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      (name) => {
+        if (name === 'top-down-truncation') {
+          return {
+            name: 'top-down-truncation' as const,
+            requiresLLM: false,
+            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+            compress: vi.fn().mockRejectedValue(new Error('truncation broke')),
+          };
+        }
+
+        return {
+          name: 'middle-out' as const,
+          requiresLLM: true,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi.fn().mockImplementation(async () => {
+            primaryCallCount++;
+            throw makeHttpError(500);
+          }),
+        };
+      },
+    );
+    vi.spyOn(chat['historyService'], 'getTotalTokens').mockReturnValue(155_000);
+
+    await expect(
+      chat['enforceContextWindow'](10_000, 'test-prompt'),
+    ).rejects.toThrow(
+      'Automatic compression failed before fallback: Error: Auto compression failed during hard-limit enforcement.',
+    );
+
+    expect(primaryCallCount).toBe(3);
+  });
+  /**
+   * @requirement REQ-2067.5
+   * Hard-limit overflow errors include truncation fallback failure details.
+   */
+  it('surfaces truncation failure details in hard-limit overflow errors', async () => {
+    const chat = makeChatForEnforceContextWindow({
+      totalTokens: 155_000,
+      contextLimit: 200_000,
+      maxOutputTokens: 40_000,
+    });
+
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      (name) => {
+        if (name === 'top-down-truncation') {
+          return {
+            name: 'top-down-truncation' as const,
+            requiresLLM: false,
+            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+            compress: vi.fn().mockRejectedValue(new Error('truncation broke')),
+          };
+        }
+
+        return {
+          name: 'middle-out' as const,
+          requiresLLM: true,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi.fn().mockResolvedValue({
+            newHistory: [{ role: 'user', parts: [{ text: 'compressed' }] }],
+            metadata: {
+              originalMessageCount: 10,
+              compressedMessageCount: 1,
+              strategyUsed: 'middle-out' as const,
+              llmCallMade: true,
+            },
+          }),
+        };
+      },
+    );
+    vi.spyOn(chat['historyService'], 'getTotalTokens').mockReturnValue(155_000);
+
+    await expect(
+      chat['enforceContextWindow'](10_000, 'test-prompt'),
+    ).rejects.toThrow(
+      'Truncation fallback failed during hard-limit enforcement: Error: truncation broke',
+    );
+  });
+
+  /**
    * @requirement REQ-1791.6
    * Hard-limit fallback rewrite clears stale API prompt baseline.
    */
-  it('clears lastPromptTokenCount when forceTruncationIfIneffective rewrites history', async () => {
+  it('clears lastPromptTokenCount when hard-limit truncation rewrites history', async () => {
     const chat = makeChatForEnforceContextWindow({
       totalTokens: 150_000,
       contextLimit: 200_000,
@@ -398,7 +686,7 @@ describe('Hard-limit compression behavior (Issue #1791)', () => {
           requiresLLM: true,
           trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
           compress: vi.fn().mockResolvedValue({
-            // Ineffective primary compression triggers forceTruncationIfIneffective.
+            // Insufficient compression triggers hard-limit truncation.
             newHistory: [
               { role: 'user', parts: [{ text: 'hello' }] },
               { role: 'model', parts: [{ text: 'hi' }] },

--- a/packages/agents/src/compression/contextOverflowError.ts
+++ b/packages/agents/src/compression/contextOverflowError.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ContextOverflowErrorParams {
+  limit: number;
+  initialProjected: number;
+  finalProjected: number;
+  marginAdjustedLimit: number;
+  completionBudget: number;
+  truncationFailure?: Error;
+  compressionFailure?: Error;
+}
+
+export function buildContextOverflowError({
+  limit,
+  initialProjected,
+  finalProjected,
+  marginAdjustedLimit,
+  completionBudget,
+  truncationFailure,
+  compressionFailure,
+}: ContextOverflowErrorParams): Error {
+  const totalReduction = Math.max(0, initialProjected - finalProjected);
+  const tokensStillNeeded = finalProjected - marginAdjustedLimit;
+  const parts: string[] = [
+    `Request still exceeds the safety-adjusted context limit (${marginAdjustedLimit} tokens).`,
+    `density optimization and compression reduced ${totalReduction} tokens (from ${initialProjected} to ${finalProjected} projected).`,
+    `completionBudget=${completionBudget}, tokensStillNeeded=${tokensStillNeeded}.`,
+  ];
+  if (completionBudget > 0.8 * limit) {
+    parts.push(
+      `The completion budget (${completionBudget}) consumes more than 80% of the context window (${limit}). Consider lowering maxOutputTokens.`,
+    );
+  }
+  if (compressionFailure !== undefined) {
+    parts.push(
+      `Automatic compression failed before fallback: ${String(compressionFailure)}.`,
+    );
+  }
+  if (truncationFailure !== undefined) {
+    parts.push(
+      `Truncation fallback failed during hard-limit enforcement: ${String(truncationFailure)}.`,
+    );
+  }
+  return new Error(parts.join(' '));
+}


### PR DESCRIPTION
## Summary

- Retry a full auto compression pass when hard-limit auto compression is ineffective but still over the safety-adjusted limit.
- Fall back to hard-limit top-down truncation when compression fails, returns an empty summary, or remains over limit.
- Preserve actionable overflow diagnostics by including compression and truncation fallback failures.
- Add behavioral coverage for ineffective compression retry, empty-summary fallback, failed retry diagnostics, truncation diagnostics, and stale prompt-token baseline clearing.

Fixes #2067

## Verification

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
- Open Code Review preview with timeout 20
- Open Code Review detached with timeout 20 (final pass: 0 comments)
