### PR TITLE
Forward Agent confirmation payloads (Fixes #2201)

### DIFF
--- a/packages/agents/src/api/__tests__/core-tools.spec.ts
+++ b/packages/agents/src/api/__tests__/core-tools.spec.ts
@@ -458,6 +458,33 @@ describe('ToolControl unit @plan:PLAN-20260617-COREAPI.P17 @requirement:REQ-006 
     expect(responses[0].outcome).toBe(ToolConfirmationOutcome.ProceedOnce);
   });
 
+  it('T12 respondToConfirmation forwards payload overrides and user-confirmation requests through the shared bus @plan:PLAN-20260617-COREAPI.P17 @requirement:REQ-006', () => {
+    const handle = createToolControlDeps(sampleTools);
+    const control = new ToolControl(handle.deps);
+    control.notifyConfirmation({
+      confirmationId: 'corr-payload',
+      toolCallId: 'call-payload',
+      name: 'shell',
+      details: {},
+    });
+
+    control.respondToConfirmation(
+      'corr-payload',
+      ToolConfirmationOutcome.SuggestEdit,
+      { editedCommand: 'npm run test -- --runInBand' },
+      true,
+    );
+
+    const responses = handle.responses();
+    expect(responses).toHaveLength(1);
+    expect(responses[0].correlationId).toBe('corr-payload');
+    expect(responses[0].outcome).toBe(ToolConfirmationOutcome.SuggestEdit);
+    expect(responses[0].payload).toStrictEqual({
+      editedCommand: 'npm run test -- --runInBand',
+    });
+    expect(responses[0].requiresUserConfirmation).toBe(true);
+  });
+
   it('respondToConfirmation throws ToolControlError for an id that was never surfaced and does not publish @plan:PLAN-20260617-COREAPI.P17 @requirement:REQ-006', () => {
     const handle = createToolControlDeps(sampleTools);
     const control = new ToolControl(handle.deps);

--- a/packages/agents/src/api/__tests__/helpers/fakeToolControlDeps.ts
+++ b/packages/agents/src/api/__tests__/helpers/fakeToolControlDeps.ts
@@ -19,10 +19,17 @@
  */
 
 import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
-import { MessageBusType } from '@vybestack/llxprt-code-core/confirmation-bus/types.js';
+import {
+  MessageBusType,
+  type ToolConfirmationResponse,
+} from '@vybestack/llxprt-code-core/confirmation-bus/types.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007
 import { getToolKeyStorage } from '@vybestack/llxprt-code-core';
+import type {
+  ToolConfirmationOutcome,
+  ToolConfirmationPayload,
+} from '@vybestack/llxprt-code-tools';
 import type { EditorCallbacks } from '../../config-types.js';
 import type { ToolControlDeps } from '../../control/toolControl.js';
 
@@ -44,7 +51,9 @@ export interface ToolControlDepsHandle {
   /** All TOOL_CONFIRMATION_RESPONSE messages the bus published. */
   responses(): ReadonlyArray<{
     readonly correlationId: string;
-    readonly outcome: string;
+    readonly outcome?: ToolConfirmationOutcome;
+    readonly payload?: ToolConfirmationPayload;
+    readonly requiresUserConfirmation?: boolean;
   }>;
 }
 
@@ -60,12 +69,14 @@ export function createToolControlDeps(
   const messageBus = new MessageBus();
   let allowed: readonly string[] | undefined;
   const editorCallbacksHolder = { editorCallbacks: noopEditorCallbacks };
-  const responses: Array<{ correlationId: string; outcome: string }> = [];
+  const responses: ToolConfirmationResponse[] = [];
 
-  messageBus.subscribe(MessageBusType.TOOL_CONFIRMATION_RESPONSE, (msg) => {
-    const m = msg as unknown as { correlationId: string; outcome: string };
-    responses.push({ correlationId: m.correlationId, outcome: m.outcome });
-  });
+  messageBus.subscribe<ToolConfirmationResponse>(
+    MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+    (msg) => {
+      responses.push(msg);
+    },
+  );
 
   const allTools = tools.map((t) => ({
     name: t.name,

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -17,7 +17,10 @@ import type {
   HookInput,
   HookOutput,
 } from '@vybestack/llxprt-code-core/hooks/types.js';
-import type { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
+import type {
+  ToolConfirmationOutcome,
+  ToolConfirmationPayload,
+} from '@vybestack/llxprt-code-tools';
 import type { PolicyDecision } from '@vybestack/llxprt-code-core';
 // @plan:PLAN-20260622-MCPOAUTHTRUTH.P06 @requirement:REQ-004 @pseudocode agents-projection.md line 95
 import type { McpOAuthStatus } from '@vybestack/llxprt-code-core';
@@ -128,6 +131,7 @@ export interface ProviderStatus {
 }
 
 export type ToolDecision = ToolConfirmationOutcome;
+export type ToolDecisionPayload = ToolConfirmationPayload;
 
 export type McpDiscoveryState =
   | 'idle'
@@ -316,7 +320,12 @@ export interface AgentToolControl {
   list(): readonly ToolInfo[];
   setEnabled(names: readonly string[]): Promise<void>;
   onConfirmationRequest(cb: (req: ToolConfirmation) => void): Unsubscribe;
-  respondToConfirmation(confirmationId: string, decision: ToolDecision): void;
+  respondToConfirmation(
+    confirmationId: string,
+    decision: ToolDecision,
+    payload?: ToolDecisionPayload,
+    requiresUserConfirmation?: boolean,
+  ): void;
   onToolUpdate(cb: (u: ToolUpdate) => void): Unsubscribe;
   setEditorCallbacks(cbs: EditorCallbacks): void;
   // @plan:PLAN-20260622-COREAPIGAP.P16 @requirement:REQ-007

--- a/packages/agents/src/api/control/toolControl.ts
+++ b/packages/agents/src/api/control/toolControl.ts
@@ -21,6 +21,7 @@
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
+import type { ToolConfirmationPayload } from '@vybestack/llxprt-code-tools';
 import type { EditorCallbacks } from '../config-types.js';
 import type {
   AgentToolControl,
@@ -145,17 +146,29 @@ export class ToolControl implements AgentToolControl {
    * {@link ToolControlError} for an unknown confirmationId.
    *
    * For `ModifyWithEditor`, the confirmationId is retired (the coordinator
-   * issues a new correlationId).
+   * issues a new correlationId). Optional payloads carry editor/suggest-edit
+   * overrides, and requiresUserConfirmation flags decisions that should be
+   * re-surfaced to the user by the bus consumer.
    *
    * @plan:PLAN-20260617-COREAPI.P17
    * @requirement:REQ-006
    * @pseudocode tool-confirmation-merge.md steps 80-91
    */
-  respondToConfirmation(confirmationId: string, decision: ToolDecision): void {
+  respondToConfirmation(
+    confirmationId: string,
+    decision: ToolDecision,
+    payload?: ToolConfirmationPayload,
+    requiresUserConfirmation?: boolean,
+  ): void {
     if (!this.seen.has(confirmationId)) {
       throw new ToolControlError('unknown confirmationId: ' + confirmationId);
     }
-    this.deps.messageBus.respondToConfirmation(confirmationId, decision);
+    this.deps.messageBus.respondToConfirmation(
+      confirmationId,
+      decision,
+      payload,
+      requiresUserConfirmation,
+    );
     if (decision === ToolConfirmationOutcome.ModifyWithEditor) {
       // editor-modify retires the correlationId; the coordinator issues a new one.
       this.seen.delete(confirmationId);


### PR DESCRIPTION
## Summary

- Extends the public Agent tool confirmation response API to accept optional payload and user-confirmation metadata.
- Forwards edited command/content payloads through the shared MessageBus so the scheduler confirmation coordinator can consume them.
- Adds behavioral coverage proving SuggestEdit payloads and requiresUserConfirmation are published on the bus.

## Verification

- npx vitest run src/api/__tests__/core-tools.spec.ts --testNamePattern "respondToConfirmation forwards payload"
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
- ocr review --audience agent --timeout 20 HEAD (detached; final run clean)

Fixes #2201
