### PR TITLE
fix(config): make legacy path migration marker-based so subagents/commands/policies migrate (Fixes #2237)

### DIFF
--- a/packages/cli/src/config/pathMigration.test.ts
+++ b/packages/cli/src/config/pathMigration.test.ts
@@ -552,7 +552,12 @@ describe('performMigration — edge cases', () => {
         const result = performMigration(legacyDir, destinations);
 
         expect(result.error).toBe(true);
+        // A partial failure must NOT be reported as a completed migration,
+        // otherwise logMigrationStatus prints success and cli.tsx skips the
+        // legacy-dir fallback for the stranded categories.
+        expect(result.migrated).toBe(false);
         // The readable entry was still migrated (best-effort copy continues).
+        expect(result.filesCopied).toBeGreaterThanOrEqual(1);
         expect(
           fs.existsSync(path.join(destinations.configDir, 'settings.json')),
         ).toBe(true);

--- a/packages/cli/src/config/pathMigration.test.ts
+++ b/packages/cli/src/config/pathMigration.test.ts
@@ -16,6 +16,8 @@ import * as os from 'os';
 import {
   shouldMigrate,
   performMigration,
+  isMigrationComplete,
+  markMigrationComplete,
   type MigrationDestinations,
   type MigrationResult,
 } from './pathMigration.js';
@@ -86,13 +88,110 @@ describe('shouldMigrate', () => {
     expect(shouldMigrate(legacyDir, destinations)).toBe(false);
   });
 
-  it('returns false when config dir already has content (already migrated)', async () => {
-    writeFiles(legacyDir, { 'settings.json': '{}' });
+  // Regression for #2237: the config dir is populated independently of the
+  // migration (PromptService installs prompts, ProfileManager saves profiles,
+  // oauth/settings writers, etc.). Content in the config dir must NOT be
+  // treated as "migration already done", otherwise read-only categories like
+  // subagents/ are never copied.
+  it('returns true when config dir has content but no completion marker (pre-seeded by app)', async () => {
+    writeFiles(legacyDir, {
+      'settings.json': '{}',
+      'subagents/researcher.json': '{"name": "researcher"}',
+    });
+    // Simulate the app having seeded prompts/profiles before migration ran.
     writeFiles(destinations.configDir, {
-      'settings.json': '{"migrated": true}',
+      'prompts/core.md': '# seeded by PromptService',
+      'profiles/p.json': '{"seeded": true}',
     });
 
+    expect(shouldMigrate(legacyDir, destinations)).toBe(true);
+  });
+
+  it('returns false once the migration-completion marker is present', async () => {
+    writeFiles(legacyDir, { 'settings.json': '{}' });
+    markMigrationComplete(destinations);
+
     expect(shouldMigrate(legacyDir, destinations)).toBe(false);
+  });
+});
+
+describe('migration-completion marker (#2237)', () => {
+  let legacyDir: string;
+  let destBase: string;
+  let destinations: MigrationDestinations;
+
+  beforeEach(async () => {
+    legacyDir = await makeTempDir();
+    destBase = await makeTempDir();
+    await fs.promises.rm(destBase, { recursive: true, force: true });
+    destinations = makeDestinations(destBase);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(legacyDir, { recursive: true, force: true });
+    await fs.promises.rm(destBase, { recursive: true, force: true });
+  });
+
+  it('isMigrationComplete is false before any migration', () => {
+    expect(isMigrationComplete(destinations)).toBe(false);
+  });
+
+  it('markMigrationComplete makes isMigrationComplete return true', () => {
+    markMigrationComplete(destinations);
+    expect(isMigrationComplete(destinations)).toBe(true);
+  });
+
+  it('marker survives unrelated config-dir content (independent of config dir)', () => {
+    markMigrationComplete(destinations);
+    writeFiles(destinations.configDir, { 'prompts/core.md': '# seeded' });
+    expect(isMigrationComplete(destinations)).toBe(true);
+  });
+
+  it('markMigrationComplete creates the data dir if it does not exist', () => {
+    expect(fs.existsSync(destinations.dataDir)).toBe(false);
+    markMigrationComplete(destinations);
+    expect(isMigrationComplete(destinations)).toBe(true);
+  });
+
+  // The marker constant is intentionally not exported; tests reference the
+  // documented on-disk filename directly.
+  const MARKER_FILE = '.migration-complete.json';
+
+  function writeMarker(content: string): void {
+    fs.mkdirSync(destinations.dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(destinations.dataDir, MARKER_FILE),
+      content,
+      'utf-8',
+    );
+  }
+
+  it('treats a corrupt marker as NOT complete so migration re-runs (self-heal #2237)', () => {
+    writeMarker('{ this is not valid json');
+    expect(isMigrationComplete(destinations)).toBe(false);
+  });
+
+  it('treats a marker with no numeric version as NOT complete', () => {
+    writeMarker(JSON.stringify({ completedAt: '2025-01-01T00:00:00.000Z' }));
+    expect(isMigrationComplete(destinations)).toBe(false);
+  });
+
+  it('treats a marker with an older scheme version as NOT complete', () => {
+    writeMarker(JSON.stringify({ version: 0 }));
+    expect(isMigrationComplete(destinations)).toBe(false);
+  });
+
+  it('treats a marker with a newer scheme version as complete', () => {
+    writeMarker(JSON.stringify({ version: 999 }));
+    expect(isMigrationComplete(destinations)).toBe(true);
+  });
+
+  it('does not leave a temp file behind after writing the marker', () => {
+    markMigrationComplete(destinations);
+    const leftovers = fs
+      .readdirSync(destinations.dataDir)
+      .filter((name) => name.includes('.tmp'));
+    expect(leftovers).toStrictEqual([]);
   });
 });
 
@@ -433,6 +532,36 @@ describe('performMigration — edge cases', () => {
       fs.existsSync(path.join(destinations.configDir, 'settings.json')),
     ).toBe(true);
   });
+
+  // Partial-failure semantics (#2237): if ANY entry cannot be copied the pass
+  // must report error:true so runStartupMigration does not stamp the marker —
+  // otherwise the failed categories would be permanently stranded. root can
+  // read 0o000 dirs, so skip when running as root.
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'reports error:true when an entry cannot be read (does not silently succeed)',
+    () => {
+      // A readable entry that should still be copied...
+      writeFiles(legacyDir, { 'settings.json': '{}' });
+      // ...and an unreadable subagents/ dir that will fail to copy.
+      const unreadable = path.join(legacyDir, 'subagents');
+      fs.mkdirSync(unreadable, { recursive: true });
+      fs.writeFileSync(path.join(unreadable, 'a.json'), '{}');
+      fs.chmodSync(unreadable, 0o000);
+
+      try {
+        const result = performMigration(legacyDir, destinations);
+
+        expect(result.error).toBe(true);
+        // The readable entry was still migrated (best-effort copy continues).
+        expect(
+          fs.existsSync(path.join(destinations.configDir, 'settings.json')),
+        ).toBe(true);
+      } finally {
+        // Restore perms so afterEach cleanup can remove the tree.
+        fs.chmodSync(unreadable, 0o755);
+      }
+    },
+  );
 });
 
 describe('performMigration — merge mode', () => {
@@ -501,6 +630,67 @@ describe('performMigration — merge mode', () => {
         'utf-8',
       ),
     ).toContain('"v": 3');
+  });
+});
+
+describe('performMigration — #2237 pre-seeded config dir backfill', () => {
+  let legacyDir: string;
+  let destBase: string;
+  let destinations: MigrationDestinations;
+
+  beforeEach(async () => {
+    legacyDir = await makeTempDir();
+    destBase = await makeTempDir();
+    await fs.promises.rm(destBase, { recursive: true, force: true });
+    destinations = makeDestinations(destBase);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(legacyDir, { recursive: true, force: true });
+    await fs.promises.rm(destBase, { recursive: true, force: true });
+  });
+
+  it('backfills subagents/ (and other read-only categories) into a config dir already seeded by the app', () => {
+    // App already seeded prompts + profiles into the config dir before
+    // migration ran (the exact #2237 trigger).
+    writeFiles(destinations.configDir, {
+      'prompts/core.md': '# seeded',
+      'profiles/seeded.json': '{"seeded": true}',
+    });
+    // Legacy still holds the read-only categories the app never self-creates.
+    writeFiles(legacyDir, {
+      'subagents/researcher.json': '{"name": "researcher"}',
+      'commands/oc.toml': 'cmd = true',
+      'policies/auto.toml': 'policy = true',
+      'LLXPRT.md': '# memory',
+    });
+
+    const result = performMigration(legacyDir, destinations);
+
+    expect(result.migrated).toBe(true);
+    // Backfilled entries now present.
+    expect(
+      fs.readFileSync(
+        path.join(destinations.configDir, 'subagents/researcher.json'),
+        'utf-8',
+      ),
+    ).toContain('researcher');
+    expect(
+      fs.existsSync(path.join(destinations.configDir, 'commands/oc.toml')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(destinations.configDir, 'policies/auto.toml')),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(destinations.configDir, 'LLXPRT.md'))).toBe(
+      true,
+    );
+    // Pre-seeded files left untouched.
+    expect(
+      fs.readFileSync(
+        path.join(destinations.configDir, 'profiles/seeded.json'),
+        'utf-8',
+      ),
+    ).toContain('seeded');
   });
 });
 

--- a/packages/cli/src/config/pathMigration.ts
+++ b/packages/cli/src/config/pathMigration.ts
@@ -332,7 +332,7 @@ export function performMigration(
   }
 
   return {
-    migrated: true,
+    migrated: !hadErrors,
     reason: hadErrors
       ? 'migration incomplete (some entries failed)'
       : 'migration complete',
@@ -511,8 +511,14 @@ function pathEntryExists(p: string): boolean {
 /**
  * Copies a single regular file to `destPath`, then best-effort preserves the
  * source mode. Records any copy failure in `errors`. Returns 1 when the file
- * was copied, 0 when the copy failed. The mode-preservation step never affects
- * the return value (a failed chmod still counts as a successful copy).
+ * was copied, 0 when the copy was skipped or failed. The mode-preservation step
+ * never affects the return value (a failed chmod still counts as a successful
+ * copy).
+ *
+ * Uses `COPYFILE_EXCL` so the copy fails atomically if the destination already
+ * exists. This closes the time-of-check/time-of-use gap left by the caller's
+ * {@link pathEntryExists} guard: a file that appears between the check and the
+ * copy is preserved (the `EEXIST` is treated as a benign skip, not an error).
  */
 function copyFileWithMode(
   srcPath: string,
@@ -521,8 +527,12 @@ function copyFileWithMode(
 ): number {
   try {
     fs.mkdirSync(path.dirname(destPath), { recursive: true });
-    fs.copyFileSync(srcPath, destPath);
+    fs.copyFileSync(srcPath, destPath, fs.constants.COPYFILE_EXCL);
   } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      // Destination appeared after the caller's existence check; preserve it.
+      return 0;
+    }
     errors.push(`${srcPath}: ${String(error)}`);
     logger.debug(`Cannot copy file ${srcPath}: ${String(error)}`);
     return 0;

--- a/packages/cli/src/config/pathMigration.ts
+++ b/packages/cli/src/config/pathMigration.ts
@@ -77,6 +77,21 @@ const EXCLUDED_ENTRIES = new Set(['secure-store']);
  */
 const TMP_SKILLS_DIR = 'skills';
 
+/**
+ * Filename of the migration-completion marker. Stored in the data dir so that
+ * unrelated writes to the config dir (prompt installs, profile saves, oauth,
+ * etc.) cannot be mistaken for "migration already done" (#2237). The data dir
+ * is app-managed state, which is the natural home for a one-time stamp.
+ */
+const MIGRATION_MARKER_FILE = '.migration-complete.json';
+
+/**
+ * Current migration scheme version recorded in the marker. Bumping this in a
+ * future migration scheme allows a fresh pass to run even if an older marker
+ * exists.
+ */
+const MIGRATION_MARKER_VERSION = 1;
+
 export interface MigrationDestinations {
   readonly configDir: string;
   readonly dataDir: string;
@@ -123,15 +138,92 @@ function getDestDir(
 }
 
 /**
- * Returns true when the legacy `~/.llxprt/` directory has content and the
- * config category directory does not yet exist (or is empty). The config
- * dir is used as the primary indicator of whether migration was already
- * performed, since it contains the most critical files (settings.json,
- * profiles, etc.).
+ * Path to the migration-completion marker for a given set of destinations.
+ */
+function migrationMarkerPath(destinations: MigrationDestinations): string {
+  return path.join(destinations.dataDir, MIGRATION_MARKER_FILE);
+}
+
+/**
+ * Returns true when a migration-completion marker of the current scheme
+ * version (or newer) is present. This is the authoritative "already migrated"
+ * signal — it is independent of unrelated config-dir writes (#2237).
+ */
+export function isMigrationComplete(
+  destinations: MigrationDestinations,
+): boolean {
+  const markerPath = migrationMarkerPath(destinations);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(markerPath, 'utf-8');
+  } catch (error) {
+    const nodeErr = error as NodeJS.ErrnoException;
+    if (nodeErr.code !== 'ENOENT') {
+      logger.debug(`Cannot read migration marker ${markerPath}: ${nodeErr}`);
+    }
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { version?: number };
+    return (
+      typeof parsed.version === 'number' &&
+      parsed.version >= MIGRATION_MARKER_VERSION
+    );
+  } catch {
+    // Corrupt marker — treat as NOT complete so the (merge-safe) migration
+    // re-runs and self-heals (#2237). A successful re-run writes a fresh, valid
+    // marker, so this cannot loop. Permanently trusting a corrupt marker would
+    // strand the very config this migration exists to recover.
+    logger.debug(
+      `Migration marker ${markerPath} is corrupt; re-running migration to self-heal.`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Writes the migration-completion marker into the data dir, creating the
+ * directory if necessary. Best-effort: failures are logged, not thrown.
+ */
+export function markMigrationComplete(
+  destinations: MigrationDestinations,
+): void {
+  const markerPath = migrationMarkerPath(destinations);
+  try {
+    fs.mkdirSync(destinations.dataDir, { recursive: true });
+    const payload = JSON.stringify(
+      {
+        version: MIGRATION_MARKER_VERSION,
+        completedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    );
+    // Write atomically (temp file + rename) so a crash mid-write cannot leave a
+    // truncated/corrupt marker behind.
+    const tmpPath = `${markerPath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, payload, 'utf-8');
+    fs.renameSync(tmpPath, markerPath);
+  } catch (error) {
+    logger.debug(`Cannot write migration marker ${markerPath}: ${error}`);
+  }
+}
+
+/**
+ * Returns true when the legacy `~/.llxprt/` directory has migratable content
+ * and no migration-completion marker exists yet.
+ *
+ * The marker (not config-dir content) is the "already migrated" signal: many
+ * subsystems write the config dir independently of the migration (prompt
+ * installs, profile saves, oauth), so config-dir content must NOT short-circuit
+ * the migration (#2237). Because {@link performMigration} merges without
+ * overwriting, re-running on an already-partially-populated config dir safely
+ * backfills only the missing entries (subagents/, commands/, etc.).
  *
  * Returns false when:
  * - The legacy directory does not exist or is empty (fresh install)
- * - The config directory already has content (migration already done)
+ * - The migration-completion marker is already present
  */
 export function shouldMigrate(
   legacyDir: string,
@@ -145,10 +237,7 @@ export function shouldMigrate(
     return false;
   }
 
-  if (
-    fs.existsSync(destinations.configDir) &&
-    directoryHasContent(destinations.configDir)
-  ) {
+  if (isMigrationComplete(destinations)) {
     return false;
   }
 
@@ -177,6 +266,10 @@ export function performMigration(
 
   let filesCopied = 0;
   const visited = new Set<string>();
+  // Accumulates a message for every entry that could not be copied. A non-empty
+  // list means the pass was partial, so the caller must NOT stamp the
+  // completion marker — the next launch retries and self-heals (#2237).
+  const errors: string[] = [];
 
   let entries: fs.Dirent[];
   try {
@@ -187,6 +280,7 @@ export function performMigration(
       migrated: false,
       reason: 'cannot read legacy directory',
       filesCopied: 0,
+      error: true,
     };
   }
 
@@ -203,7 +297,7 @@ export function performMigration(
         entry.isDirectory() &&
         !entry.isSymbolicLink()
       ) {
-        filesCopied += migrateTmpDir(legacyDir, destinations, visited);
+        filesCopied += migrateTmpDir(legacyDir, destinations, visited, errors);
       } else {
         const destDir = getDestDir(category, destinations);
         fs.mkdirSync(destDir, { recursive: true });
@@ -215,25 +309,35 @@ export function performMigration(
           legacyDir,
           destDir,
           visited,
+          errors,
         );
       }
     } catch (error) {
+      errors.push(`${entry.name}: ${String(error)}`);
       logger.debug(`Failed to migrate entry '${entry.name}': ${String(error)}`);
     }
   }
 
+  const hadErrors = errors.length > 0;
+
   if (filesCopied === 0) {
     return {
       migrated: false,
-      reason: 'no files to migrate (only excluded entries)',
+      reason: hadErrors
+        ? 'migration incomplete (no files copied; some entries failed)'
+        : 'no files to migrate (only excluded entries)',
       filesCopied: 0,
+      error: hadErrors || undefined,
     };
   }
 
   return {
     migrated: true,
-    reason: 'migration complete',
+    reason: hadErrors
+      ? 'migration incomplete (some entries failed)'
+      : 'migration complete',
     filesCopied,
+    error: hadErrors || undefined,
   };
 }
 
@@ -245,6 +349,7 @@ function migrateTmpDir(
   legacyDir: string,
   destinations: MigrationDestinations,
   visited: Set<string>,
+  errors: string[],
 ): number {
   let count = 0;
   const tmpPath = path.join(legacyDir, 'tmp');
@@ -253,6 +358,7 @@ function migrateTmpDir(
   try {
     tmpEntries = fs.readdirSync(tmpPath, { withFileTypes: true });
   } catch (error) {
+    errors.push(`tmp: ${String(error)}`);
     logger.debug(`Cannot read tmp directory ${tmpPath}: ${String(error)}`);
     return 0;
   }
@@ -267,6 +373,7 @@ function migrateTmpDir(
         legacyDir,
         destinations.configDir,
         visited,
+        errors,
       );
     } else {
       // Route tmp/<x> → logDir/tmp/<x>
@@ -278,6 +385,7 @@ function migrateTmpDir(
         legacyDir,
         destinations.logDir,
         visited,
+        errors,
       );
     }
   }
@@ -307,12 +415,9 @@ export function runStartupMigration(): MigrationResult {
   };
 
   if (!shouldMigrate(legacyDir, destinations)) {
-    if (
-      fs.existsSync(destinations.configDir) &&
-      directoryHasContent(destinations.configDir)
-    ) {
+    if (isMigrationComplete(destinations)) {
       logger.debug(
-        'Platform config already populated; skipping migration from legacy path.',
+        'Migration marker present; skipping migration from legacy path.',
       );
     }
     return { migrated: false, reason: 'no migration needed', filesCopied: 0 };
@@ -327,6 +432,14 @@ export function runStartupMigration(): MigrationResult {
   try {
     const result = performMigration(legacyDir, destinations);
     logMigrationStatus(legacyDir, destinations, result);
+    // Record completion so unrelated config-dir writes can't re-trigger or
+    // (previously) permanently block migration (#2237). Written whenever the
+    // pass did not error — including the benign "nothing left to copy" case —
+    // so healthy installs are stamped and don't re-scan every startup. Failed
+    // passes intentionally leave no marker so the next launch retries.
+    if (result.error !== true) {
+      markMigrationComplete(destinations);
+    }
     return result;
   } catch (error) {
     logger.error('Configuration migration failed:', error);
@@ -362,21 +475,6 @@ export function logMigrationStatus(
 
 // ─── internal helpers ───────────────────────────────────────────────────────
 
-function directoryHasContent(dir: string): boolean {
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(dir);
-  } catch (error) {
-    const nodeErr = error as NodeJS.ErrnoException;
-    if (nodeErr.code === 'ENOENT') {
-      return false;
-    }
-    logger.debug(`Cannot read directory ${dir}: ${String(error)}`);
-    return true;
-  }
-  return entries.length > 0;
-}
-
 /**
  * Returns true when the directory contains at least one entry that would
  * actually be copied (i.e. is not in {@link EXCLUDED_ENTRIES}).
@@ -411,6 +509,34 @@ function pathEntryExists(p: string): boolean {
 }
 
 /**
+ * Copies a single regular file to `destPath`, then best-effort preserves the
+ * source mode. Records any copy failure in `errors`. Returns 1 when the file
+ * was copied, 0 when the copy failed. The mode-preservation step never affects
+ * the return value (a failed chmod still counts as a successful copy).
+ */
+function copyFileWithMode(
+  srcPath: string,
+  destPath: string,
+  errors: string[],
+): number {
+  try {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.copyFileSync(srcPath, destPath);
+  } catch (error) {
+    errors.push(`${srcPath}: ${String(error)}`);
+    logger.debug(`Cannot copy file ${srcPath}: ${String(error)}`);
+    return 0;
+  }
+  try {
+    const { mode } = fs.statSync(srcPath);
+    fs.chmodSync(destPath, mode);
+  } catch {
+    // mode preservation is best-effort; the file copy already succeeded
+  }
+  return 1;
+}
+
+/**
  * Copies a single entry (file, directory, or symlink) from `srcPath` to
  * `destPath`, using merge semantics — existing destination files are never
  * overwritten. Returns the count of regular files copied.
@@ -421,11 +547,13 @@ function copyEntry(
   legacyRoot: string,
   destRoot: string,
   visited: Set<string>,
+  errors: string[],
 ): number {
   let stat: fs.Stats;
   try {
     stat = fs.lstatSync(srcPath);
   } catch (error) {
+    errors.push(`${srcPath}: ${String(error)}`);
     logger.debug(`Skipping inaccessible entry: ${srcPath}: ${String(error)}`);
     return 0;
   }
@@ -434,26 +562,25 @@ function copyEntry(
     if (pathEntryExists(destPath)) {
       return 0;
     }
-    createSymlinkClone(srcPath, destPath, legacyRoot, destRoot);
-    return 1;
+    return createSymlinkClone(srcPath, destPath, legacyRoot, destRoot, errors);
   }
 
   if (stat.isFile()) {
     if (pathEntryExists(destPath)) {
       return 0;
     }
-    fs.mkdirSync(path.dirname(destPath), { recursive: true });
-    fs.copyFileSync(srcPath, destPath);
-    try {
-      fs.chmodSync(destPath, stat.mode);
-    } catch {
-      // chmod is best-effort; file copy succeeded
-    }
-    return 1;
+    return copyFileWithMode(srcPath, destPath, errors);
   }
 
   if (stat.isDirectory()) {
-    return copyDirFiltered(srcPath, destPath, legacyRoot, destRoot, visited);
+    return copyDirFiltered(
+      srcPath,
+      destPath,
+      legacyRoot,
+      destRoot,
+      visited,
+      errors,
+    );
   }
 
   return 0;
@@ -471,11 +598,13 @@ function copyDirFiltered(
   legacyRoot: string,
   destRoot: string,
   visited: Set<string>,
+  errors: string[],
 ): number {
   let realSrc: string;
   try {
     realSrc = fs.realpathSync(src);
   } catch (error) {
+    errors.push(`${src}: ${String(error)}`);
     logger.debug(
       `Skipping inaccessible entry (broken symlink?): ${src}: ${String(error)}`,
     );
@@ -493,6 +622,7 @@ function copyDirFiltered(
   try {
     entries = fs.readdirSync(src, { withFileTypes: true });
   } catch (error) {
+    errors.push(`${src}: ${String(error)}`);
     logger.debug(`Cannot read directory ${src}: ${String(error)}`);
     return count;
   }
@@ -508,19 +638,18 @@ function copyDirFiltered(
         legacyRoot,
         destRoot,
         visited,
+        errors,
       );
     } else if (entry.isFile() && !pathEntryExists(destPath)) {
-      fs.copyFileSync(srcPath, destPath);
-      const srcStat = fs.statSync(srcPath);
-      try {
-        fs.chmodSync(destPath, srcStat.mode);
-      } catch {
-        // chmod is best-effort; file copy succeeded
-      }
-      count++;
+      count += copyFileWithMode(srcPath, destPath, errors);
     } else if (entry.isSymbolicLink() && !pathEntryExists(destPath)) {
-      createSymlinkClone(srcPath, destPath, legacyRoot, destRoot);
-      count++;
+      count += createSymlinkClone(
+        srcPath,
+        destPath,
+        legacyRoot,
+        destRoot,
+        errors,
+      );
     }
   }
 
@@ -538,13 +667,15 @@ function createSymlinkClone(
   destPath: string,
   legacyRoot: string,
   newRoot: string,
-): void {
+  errors: string[],
+): number {
   let target: string;
   try {
     target = fs.readlinkSync(srcPath);
   } catch (error) {
+    errors.push(`${srcPath}: ${String(error)}`);
     logger.debug(`Cannot read symlink ${srcPath}: ${String(error)}`);
-    return;
+    return 0;
   }
   try {
     if (path.isAbsolute(target)) {
@@ -565,7 +696,10 @@ function createSymlinkClone(
         fs.symlinkSync(rebased, destPath);
       }
     }
+    return 1;
   } catch (error) {
+    errors.push(`${destPath}: ${String(error)}`);
     logger.debug(`Cannot create symlink at ${destPath}: ${String(error)}`);
+    return 0;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2237.

The 0.10.0 startup migration that copies the legacy `~/.llxprt/` directory into the new platform-standard config/data/cache/log directories used **"the config dir already has content"** as its *already-migrated* signal. That signal is unreliable: several subsystems populate the config dir **independently of the migration** during normal startup:

- PromptService installs `prompts/`
- ProfileManager saves `profiles/`
- oauth / settings writers create their files

As soon as any of those ran (which happens on essentially every launch), the gate flipped to "already migrated" and the migration body never executed. The categories the app **never self-creates** were therefore left stranded in the legacy dir with no way to ever be backfilled:

- `subagents/`
- `commands/`
- `policies/`
- `hooks/`
- `LLXPRT.md`, `.LLXPRT_SYSTEM`
- `settings.json`

This is why subagents (and the others) "didn't migrate" on the nightly even though the new standard paths were in use.

## Fix

Replace the content-based gate with an explicit, versioned **completion marker** (`.migration-complete.json`) stored in the **data** dir (app-managed state). The marker is independent of unrelated config-dir writes:

- **Healthy install:** migrate once → stamp marker → never re-scan on later launches.
- **Install broken by the old gate** (config pre-seeded, no marker): on next launch the migration re-runs and **backfills only the missing entries**. `performMigration` merges *without overwriting*, so existing files are never clobbered. This self-heals already-broken 0.10.0 installs.

## Robustness hardening (surfaced during review)

- **Partial-failure reporting:** `performMigration` now threads an `errors[]` accumulator through every copy helper and returns `error: true` if **any** entry fails. `runStartupMigration` only writes the marker when the pass did not error, so a partial migration can never be mistaken for a complete one — the next launch retries.
- **Atomic marker write:** marker is written to a temp file then renamed, so a crash mid-write can't leave a corrupt marker.
- **Corrupt-marker self-heal:** an unreadable/corrupt marker is treated as *not complete*, so the merge-safe migration re-runs instead of permanently trusting bad state. A successful re-run rewrites a valid marker, so it can't loop.

## Refactor

Extracted `copyFileWithMode()` (copy + best-effort mode preservation) shared by `copyEntry` and `copyDirFiltered`, removing duplication and keeping nesting within lint limits (no rule loosening, no suppressions).

## Tests

Added behavioral coverage:

- Marker lifecycle: absent/present, survives unrelated config-dir content, creates the data dir, atomic write leaves no temp file behind.
- Corrupt marker and versioned marker (older version re-migrates, newer version is honored, missing/ non-numeric version re-migrates).
- Pre-seeded config-dir **backfill** of the read-only categories (the exact #2237 trigger), with pre-seeded files left untouched.
- Partial-failure error reporting (POSIX-only; skipped on Windows and when running as root).

## Verification

- `npm run build` — pass
- `npm run typecheck` — pass
- `npm run lint` + `npm run lint:eslint-guard` — pass
- `npm run format` — clean
- `npm run test` — full suite green (one pre-existing, unrelated local-only failure in `profileOverridePrecedenceParity.test.ts` caused by leaked profile fixtures in the real macOS config home from earlier un-isolated runs; passes with an isolated `LLXPRT_CONFIG_HOME`, and CI runs in a clean environment)
- Smoke: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — pass
