### PR TITLE
Bring packages/test-utils under lint coverage (Fixes #2246)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,7 +64,6 @@ export default tseslint.config(
       'packages/ui/**',
       'packages/lsp/**',
       'evals/**',
-      'packages/test-utils/**',
     ],
   },
   {

--- a/packages/cli/src/config/__tests__/profileOverridePrecedenceParity.test.ts
+++ b/packages/cli/src/config/__tests__/profileOverridePrecedenceParity.test.ts
@@ -502,8 +502,8 @@ describe('profileOverridePrecedenceParity: --provider skips profile ephemeral se
   it('without --provider, explicit profile load is attempted before settings.defaultProfile', async () => {
     const settings: Settings = { defaultProfile: 'default-profile' };
     await expect(
-      runConfig(settings, ['--profile-load', 'env-profile']),
-    ).rejects.toThrow("Profile 'env-profile' not found");
+      runConfig(settings, ['--profile-load', 'missing-cli-profile']),
+    ).rejects.toThrow("Profile 'missing-cli-profile' not found");
     const defaultProfileCall = profileSnapshotCalls.find(
       (c) => c.profileName === 'default-profile',
     );

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './src/file-system-test-helpers.js';
+export * from './src/test-rig.js';

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "node ../../scripts/build_package.js",
+    "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "node ../../scripts/build_package.js",
     "lint": "eslint . --ext .ts,.tsx",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/test-utils/src/cli-args.test.ts
+++ b/packages/test-utils/src/cli-args.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  assertProviderConfig,
+  buildChildEnv,
+  buildExtraArgs,
+  getCommandAndArgs,
+  getProfileName,
+} from './cli-args.js';
+
+describe('cli-args helpers', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses fake provider args when fake responses are configured', () => {
+    expect(buildExtraArgs('/tmp/fake-responses.json', true)).toStrictEqual([
+      '--yolo',
+      '--ide-mode',
+      'disable',
+      '--provider',
+      'fake',
+      '--model',
+      'fake-model',
+    ]);
+  });
+
+  it('requires non-empty provider configuration without fake responses', () => {
+    vi.stubEnv('LLXPRT_DEFAULT_PROVIDER', '');
+    vi.stubEnv('LLXPRT_DEFAULT_MODEL', 'model');
+    vi.stubEnv('OPENAI_API_KEY', 'key');
+
+    expect(() => assertProviderConfig(undefined)).toThrow(
+      'LLXPRT_DEFAULT_PROVIDER environment variable is required but not set',
+    );
+  });
+
+  it('accepts a key file as authentication when no API key is present', () => {
+    vi.stubEnv('LLXPRT_DEFAULT_PROVIDER', 'openai');
+    vi.stubEnv('LLXPRT_DEFAULT_MODEL', 'model');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('LLXPRT_TEST_PROFILE_KEYFILE', '/tmp/keyfile');
+
+    expect(() => assertProviderConfig(undefined)).not.toThrow();
+  });
+
+  it('adds provider, model, base URL, and key args for real provider runs', () => {
+    vi.stubEnv('LLXPRT_DEFAULT_PROVIDER', 'openai');
+    vi.stubEnv('LLXPRT_DEFAULT_MODEL', 'gpt-test');
+    vi.stubEnv('OPENAI_BASE_URL', 'https://example.test/v1');
+    vi.stubEnv('OPENAI_API_KEY', 'secret');
+
+    expect(buildExtraArgs(undefined, false)).toStrictEqual([
+      '--ide-mode',
+      'disable',
+      '--provider',
+      'openai',
+      '--model',
+      'gpt-test',
+      '--baseurl',
+      'https://example.test/v1',
+      '--key',
+      'secret',
+    ]);
+  });
+
+  it('builds child env without IDE detection variables and with fake response path', () => {
+    vi.stubEnv('TERM_PROGRAM', 'vscode');
+    vi.stubEnv('TERM_PROGRAM_VERSION', '1.0.0');
+    vi.stubEnv('KEEP_ME', 'yes');
+
+    const childEnv = buildChildEnv('/tmp/test-dir', '/tmp/fake.json');
+
+    expect(childEnv['TERM_PROGRAM']).toBeUndefined();
+    expect(childEnv['TERM_PROGRAM_VERSION']).toBeUndefined();
+    expect(childEnv['KEEP_ME']).toBe('yes');
+    expect(childEnv['NO_BROWSER']).toBe('true');
+    expect(childEnv['LLXPRT_FAKE_RESPONSES']).toBe('/tmp/fake.json');
+    expect(childEnv['LLXPRT_CODE_WELCOME_CONFIG_PATH']).toBe(
+      '/tmp/test-dir/welcomeConfig.json',
+    );
+  });
+
+  it('resolves installed binary and profile names from environment', () => {
+    vi.stubEnv('INTEGRATION_TEST_USE_INSTALLED_LLXPRT', 'true');
+    vi.stubEnv('LLXPRT_TEST_PROFILE', ' profile-name ');
+
+    expect(getCommandAndArgs('/bundle/llxprt.js', ['--flag'])).toStrictEqual({
+      command: 'llxprt',
+      initialArgs: ['--flag'],
+    });
+    expect(getProfileName()).toBe('profile-name');
+  });
+});

--- a/packages/test-utils/src/cli-args.ts
+++ b/packages/test-utils/src/cli-args.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { env } from 'node:process';
+import { join } from 'node:path';
+
+const WELCOME_CONFIG_FILENAME = 'welcomeConfig.json';
+
+/**
+ * Fail fast if required provider configuration is missing (unless fake
+ * responses are in use).
+ */
+export function assertProviderConfig(
+  fakeResponsesPath: string | undefined,
+): void {
+  if (fakeResponsesPath !== undefined) {
+    return;
+  }
+  requireEnvString('LLXPRT_DEFAULT_PROVIDER');
+  requireEnvString('LLXPRT_DEFAULT_MODEL');
+  const apiKey = readEnvString('OPENAI_API_KEY');
+  const keyFile =
+    readEnvString('OPENAI_API_KEYFILE') ??
+    readEnvString('LLXPRT_TEST_PROFILE_KEYFILE');
+
+  if (apiKey === undefined && keyFile === undefined) {
+    throw new Error(
+      'Either OPENAI_API_KEY or OPENAI_API_KEYFILE/LLXPRT_TEST_PROFILE_KEYFILE environment variable is required but not set',
+    );
+  }
+}
+
+/**
+ * Build the base CLI extra args (yolo + ide flags, provider/model/key flags).
+ */
+export function buildExtraArgs(
+  fakeResponsesPath: string | undefined,
+  yolo: boolean,
+): string[] {
+  const extraArgs: string[] = [];
+  if (yolo) {
+    extraArgs.push('--yolo');
+  }
+  extraArgs.push('--ide-mode', 'disable');
+
+  if (fakeResponsesPath !== undefined) {
+    // FakeProvider is activated via LLXPRT_FAKE_RESPONSES env var. Pass
+    // --provider fake so bootstrap's switchActiveProvider('fake') is a no-op.
+    extraArgs.push('--provider', 'fake', '--model', 'fake-model');
+    return extraArgs;
+  }
+
+  const provider = requireEnvString('LLXPRT_DEFAULT_PROVIDER');
+  const model = requireEnvString('LLXPRT_DEFAULT_MODEL');
+  const baseUrl = readEnvString('OPENAI_BASE_URL');
+  const apiKey = readEnvString('OPENAI_API_KEY');
+  const keyFile =
+    readEnvString('OPENAI_API_KEYFILE') ??
+    readEnvString('LLXPRT_TEST_PROFILE_KEYFILE');
+
+  extraArgs.push('--provider', provider);
+  extraArgs.push('--model', model);
+
+  if (provider === 'openai' && baseUrl !== undefined) {
+    extraArgs.push('--baseurl', baseUrl);
+  }
+
+  if (apiKey !== undefined) {
+    extraArgs.push('--key', apiKey);
+  } else if (keyFile !== undefined) {
+    extraArgs.push('--keyfile', keyFile);
+  }
+
+  return extraArgs;
+}
+
+/**
+ * Compute the command and its base args, choosing the installed `llxprt`
+ * binary for npm release tests and `node bundle/llxprt.js` otherwise.
+ */
+export function getCommandAndArgs(
+  bundlePath: string,
+  extraInitialArgs: string[] = [],
+): { command: string; initialArgs: string[] } {
+  const isNpmReleaseTest =
+    env['INTEGRATION_TEST_USE_INSTALLED_LLXPRT'] === 'true';
+  const command = isNpmReleaseTest ? 'llxprt' : 'node';
+  const initialArgs = isNpmReleaseTest
+    ? extraInitialArgs
+    : [bundlePath, ...extraInitialArgs];
+  return { command, initialArgs };
+}
+
+/**
+ * Build the child-process environment, filtering IDE-detection vars and
+ * injecting test harness defaults.
+ */
+export function buildChildEnv(
+  testDir: string,
+  fakeResponsesPath: string | undefined,
+): NodeJS.ProcessEnv {
+  const filteredEnv = Object.entries(process.env).reduce(
+    (acc, [key, value]) => {
+      if (
+        value !== undefined &&
+        key !== 'TERM_PROGRAM' &&
+        key !== 'TERM_PROGRAM_VERSION'
+      ) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {} as NodeJS.ProcessEnv,
+  );
+
+  return {
+    ...filteredEnv,
+    NO_BROWSER: 'true',
+    LLXPRT_NO_BROWSER_AUTH: 'true',
+    CI: 'true',
+    LLXPRT_SANDBOX: 'false',
+    LLXPRT_CODE_WELCOME_CONFIG_PATH: join(testDir, WELCOME_CONFIG_FILENAME),
+    ...(fakeResponsesPath !== undefined
+      ? { LLXPRT_FAKE_RESPONSES: fakeResponsesPath }
+      : {}),
+  };
+}
+
+/**
+ * Resolve the `--profile-load` flag name when the test profile env var is set.
+ */
+export function getProfileName(): string | undefined {
+  const raw = env['LLXPRT_TEST_PROFILE'];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readEnvString(key: string): string | undefined {
+  const value = env[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? value : undefined;
+}
+
+function requireEnvString(key: string): string {
+  const value = readEnvString(key);
+  if (value === undefined) {
+    throw new Error(`${key} environment variable is required but not set`);
+  }
+  return value;
+}

--- a/packages/test-utils/src/command-run.ts
+++ b/packages/test-utils/src/command-run.ts
@@ -1,0 +1,247 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execSync, spawn, type ChildProcess } from 'node:child_process';
+import type { Readable } from 'node:stream';
+import type { InteractiveRunOptions, InteractiveRunResult } from './types.js';
+
+/**
+ * Return a guaranteed-non-null stream. Used with `stdio: 'pipe'` spawns,
+ * which always allocate stdout/stderr streams.
+ */
+function getStream(stream: Readable | null): Readable {
+  if (stream === null) {
+    throw new Error('Expected spawn stdio stream but received null');
+  }
+  return stream;
+}
+
+/**
+ * Command-based run for non-PTY process management.
+ * Supports timeout, graceful kill escalation, and cross-platform handling.
+ */
+export class CommandRun {
+  private _process: ChildProcess | null = null;
+  private _stdout = '';
+  private _stderr = '';
+  private _exitCode: number | null = null;
+  private _killed = false;
+  private _timedOut = false;
+  private _exited = false;
+
+  /**
+   * Get the process ID if running.
+   */
+  get pid(): number | undefined {
+    return this._process?.pid;
+  }
+
+  /**
+   * Get the exit code after process completes.
+   */
+  get exitCode(): number | null {
+    return this._exitCode;
+  }
+
+  /**
+   * Check if the process was killed.
+   */
+  get killed(): boolean {
+    return this._killed;
+  }
+
+  /**
+   * Run a command with optional timeout.
+   */
+  async run(
+    command: string,
+    args: string[],
+    options?: InteractiveRunOptions,
+  ): Promise<InteractiveRunResult> {
+    const timeout = options?.timeout ?? 30000;
+    const cwd = process.cwd();
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, {
+        cwd,
+        stdio: 'pipe',
+      });
+      this._process = child;
+
+      // stdio: 'pipe' guarantees non-null streams.
+      const stdout = getStream(child.stdout);
+      stdout.on('data', (data: Buffer) => {
+        this._stdout += data.toString();
+      });
+
+      const stderr = getStream(child.stderr);
+      stderr.on('data', (data: Buffer) => {
+        this._stderr += data.toString();
+      });
+
+      child.on('error', (error) => {
+        const err = new Error(
+          `Failed to spawn '${command}': ${error.message} (errno: ${(error as NodeJS.ErrnoException).errno ?? 'unknown'})`,
+        );
+        reject(err);
+      });
+
+      const timer = setTimeout(() => {
+        this._timedOut = true;
+        this.kill(options?.gracefulKillTimeout ?? 5000).catch(() => {
+          // Ignore kill errors on timeout
+        });
+      }, timeout);
+
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        this._exited = true;
+        this._exitCode = code;
+        resolve({
+          exitCode: this._exitCode,
+          stdout: this._stdout,
+          stderr: this._stderr,
+          timedOut: this._timedOut,
+          killed: this._killed,
+        });
+      });
+    });
+  }
+
+  /**
+   * Kill the process with graceful escalation.
+   * First sends SIGTERM, then SIGKILL after timeout.
+   * On Windows, uses taskkill with /T flag for process tree.
+   */
+  async kill(gracefulTimeout?: number): Promise<void> {
+    if (this._exited || this._process === null) {
+      return;
+    }
+
+    const timeout = gracefulTimeout ?? 5000;
+    this._killed = true;
+    const pid = this._process.pid;
+
+    if (pid === undefined) {
+      return;
+    }
+
+    if (process.platform === 'win32') {
+      await killProcessTreeWindows(pid);
+    } else {
+      await killProcessTreeUnix(pid, timeout, () => this._exited);
+    }
+  }
+}
+
+/**
+ * Safely extract a string message from a caught value of unknown shape.
+ */
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+/**
+ * Safely read the errno code from a caught value.
+ */
+function errorCode(error: unknown): string | undefined {
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string'
+  ) {
+    return (error as { code: string }).code;
+  }
+  return undefined;
+}
+
+/**
+ * Windows process-tree kill using taskkill with the /T flag.
+ */
+function killProcessTreeWindows(pid: number): Promise<void> {
+  try {
+    execSync(`taskkill /pid ${pid} /T /F`, {
+      timeout: 10000,
+    });
+  } catch (error) {
+    const message = errorMessage(error);
+    if (
+      message.includes('not found') ||
+      message.includes('no running instance')
+    ) {
+      return Promise.resolve();
+    }
+    if (message.includes('Access is denied')) {
+      throw new Error(
+        `Permission denied when trying to kill process ${pid}. Try running with elevated privileges.`,
+      );
+    }
+    throw error;
+  }
+  return Promise.resolve();
+}
+
+/**
+ * Unix graceful kill: SIGTERM, then SIGKILL after timeout.
+ */
+async function killProcessTreeUnix(
+  pid: number,
+  timeout: number,
+  hasExited: () => boolean,
+): Promise<void> {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (error) {
+    const code = errorCode(error);
+    if (code === 'ESRCH') {
+      return;
+    }
+    if (code === 'EPERM') {
+      throw new Error(
+        `Permission denied when trying to kill process ${pid}. Try running with elevated privileges.`,
+      );
+    }
+    throw error;
+  }
+
+  const startTime = Date.now();
+  const exited = await new Promise<boolean>((resolve) => {
+    const checkInterval = setInterval(() => {
+      if (hasExited()) {
+        clearInterval(checkInterval);
+        resolve(true);
+        return;
+      }
+
+      try {
+        process.kill(pid, 0);
+      } catch {
+        clearInterval(checkInterval);
+        resolve(true);
+        return;
+      }
+
+      if (Date.now() - startTime >= timeout) {
+        clearInterval(checkInterval);
+        resolve(false);
+      }
+    }, 100);
+  });
+
+  if (!exited) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch (error) {
+      if (errorCode(error) !== 'ESRCH') {
+        throw error;
+      }
+    }
+  }
+}

--- a/packages/test-utils/src/diagnostics.test.ts
+++ b/packages/test-utils/src/diagnostics.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDiagnosticsSink, logVerbose } from './diagnostics.js';
+
+describe('diagnostics sink', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes warnings and dumps to the harness diagnostics log', () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'test-utils-diagnostics-'));
+    tempDirs.push(testDir);
+    const sink = createDiagnosticsSink(testDir);
+
+    sink.warn('Cleanup warning:', 'permission denied');
+    sink.dump('result preview', 'hello world');
+
+    const log = readFileSync(join(testDir, 'harness-diagnostics.log'), 'utf-8');
+    expect(log).toContain('--- Cleanup warning: ---');
+    expect(log).toContain('permission denied');
+    expect(log).toContain('--- result preview ---');
+    expect(log).toContain('hello world');
+  });
+
+  it('keeps process streams quiet unless verbose output is enabled', () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const sink = createDiagnosticsSink(null);
+
+    sink.verbose('hidden');
+    sink.warn('hidden warning');
+    sink.error('hidden error');
+    logVerbose('also hidden');
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('emits to process streams when VERBOSE is true', () => {
+    vi.stubEnv('VERBOSE', 'true');
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const sink = createDiagnosticsSink(null);
+
+    sink.verbose('visible');
+    sink.error('visible error', 'detail');
+    logVerbose('standalone');
+
+    expect(stdout).toHaveBeenCalledWith('visible\n');
+    expect(stdout).toHaveBeenCalledWith('standalone\n');
+    expect(stderr).toHaveBeenCalledWith('visible error\n');
+    expect(stderr).toHaveBeenCalledWith('detail\n');
+  });
+});

--- a/packages/test-utils/src/diagnostics.ts
+++ b/packages/test-utils/src/diagnostics.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { env } from 'node:process';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Local diagnostic-output helper for the test harness.
+ *
+ * The package source is covered by the repo-wide `no-console` policy. To keep
+ * failure diagnostics available without scattered bare `console.*` calls, every
+ * diagnostic route is routed through this helper. Output is emitted only when
+ * explicitly requested (VERBOSE/KEEP_OUTPUT), and detailed dumps are written to
+ * a log file inside the active test directory when a TestRig directory is set.
+ */
+export interface DiagnosticsSink {
+  /**
+   * Human-readable message intended for a process stream. Emitted to stdout
+   * only when verbose output is enabled.
+   */
+  verbose(message: string): void;
+  /**
+   * Warning-level diagnostic. Emitted to stderr only when verbose output is
+   * enabled.
+   */
+  warn(message: string, detail?: unknown): void;
+  /**
+   * Error-level diagnostic used for parse failures / failure dumps. Emitted to
+   * stderr only when verbose output is enabled.
+   */
+  error(message: string, detail?: unknown): void;
+  /**
+   * Writes a structured dump (file contents, result preview, etc.) to the log
+   * file under the active test directory when one is configured, otherwise to
+   * stderr when verbose output is enabled.
+   */
+  dump(label: string, content: string): void;
+}
+
+function isVerbose(): boolean {
+  return env['VERBOSE'] === 'true' || env['KEEP_OUTPUT'] === 'true';
+}
+
+function appendToTestLog(
+  testDir: string | null,
+  label: string,
+  content: string,
+): void {
+  if (testDir === null) {
+    return;
+  }
+  try {
+    writeFileSync(
+      join(testDir, 'harness-diagnostics.log'),
+      `\n--- ${label} ---\n${content}\n`,
+      { flag: 'a' },
+    );
+  } catch {
+    // Diagnostic logging must never fail a test.
+  }
+}
+
+/**
+ * Creates a diagnostics sink bound to a test directory. The directory may be
+ * `null` before setup completes; the returned sink degrades gracefully.
+ */
+export function createDiagnosticsSink(testDir: string | null): DiagnosticsSink {
+  return {
+    verbose(message) {
+      if (isVerbose()) {
+        process.stdout.write(`${message}\n`);
+      }
+    },
+    warn(message, detail) {
+      if (isVerbose()) {
+        process.stderr.write(`${message}\n`);
+        if (detail !== undefined) {
+          process.stderr.write(`${String(detail)}\n`);
+        }
+      }
+      appendToTestLog(
+        testDir,
+        message,
+        detail === undefined ? '' : String(detail),
+      );
+    },
+    error(message, detail) {
+      if (isVerbose()) {
+        process.stderr.write(`${message}\n`);
+        if (detail !== undefined) {
+          process.stderr.write(`${String(detail)}\n`);
+        }
+      }
+      appendToTestLog(
+        testDir,
+        message,
+        detail === undefined ? '' : String(detail),
+      );
+    },
+    dump(label, content) {
+      appendToTestLog(testDir, label, content);
+      if (isVerbose()) {
+        process.stderr.write(`--- ${label} ---\n${content}\n`);
+      }
+    },
+  };
+}
+
+/**
+ * Standalone verbose log used before any TestRig directory exists.
+ */
+export function logVerbose(message: string): void {
+  if (isVerbose()) {
+    process.stdout.write(`${message}\n`);
+  }
+}

--- a/packages/test-utils/src/file-system-test-helpers.ts
+++ b/packages/test-utils/src/file-system-test-helpers.ts
@@ -58,20 +58,43 @@ export type FileSystemStructure = {
 async function create(dir: string, structure: FileSystemStructure) {
   for (const [name, content] of Object.entries(structure)) {
     const newPath = path.join(dir, name);
-    if (typeof content === 'string') {
-      await fs.writeFile(newPath, content);
-    } else if (Array.isArray(content)) {
-      await fs.mkdir(newPath, { recursive: true });
-      for (const item of content) {
-        if (typeof item === 'string') {
-          await fs.writeFile(path.join(newPath, item), '');
-        } else {
-          await create(newPath, item);
-        }
-      }
-    } else if (typeof content === 'object' && content !== null) {
-      await fs.mkdir(newPath, { recursive: true });
-      await create(newPath, content);
+    await createEntry(newPath, content);
+  }
+}
+
+/**
+ * Create a single filesystem entry (file, empty-file array, or subdirectory).
+ */
+async function createEntry(
+  newPath: string,
+  content: string | FileSystemStructure | Array<string | FileSystemStructure>,
+): Promise<void> {
+  if (typeof content === 'string') {
+    await fs.writeFile(newPath, content);
+    return;
+  }
+  if (Array.isArray(content)) {
+    await createArrayEntries(newPath, content);
+    return;
+  }
+  await fs.mkdir(newPath, { recursive: true });
+  await create(newPath, content);
+}
+
+/**
+ * Create an array of empty files and subdirectories under a directory.
+ */
+async function createArrayEntries(
+  dir: string,
+  entries: Array<string | FileSystemStructure>,
+): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  for (const item of entries) {
+    if (typeof item === 'string') {
+      await fs.writeFile(path.join(dir, item), '');
+    } else {
+      await fs.mkdir(dir, { recursive: true });
+      await create(dir, item);
     }
   }
 }

--- a/packages/test-utils/src/interactive-run.ts
+++ b/packages/test-utils/src/interactive-run.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import { env } from 'node:process';
+import type * as pty from '@lydell/node-pty';
+import stripAnsi from 'strip-ansi';
+import type { DiagnosticsSink } from './diagnostics.js';
+import { getDefaultTimeout, poll } from './util.js';
+
+/**
+ * Manages a PTY-backed interactive CLI session for e2e/integration tests.
+ */
+export class InteractiveRun {
+  readonly ptyProcess: pty.IPty;
+  private readonly _output: string[] = [];
+  private _exited = false;
+  private _exitCode: number | null = null;
+  private _killed = false;
+  private readonly _diagnostics: DiagnosticsSink;
+
+  constructor(ptyProcess: pty.IPty, diagnostics: DiagnosticsSink) {
+    this.ptyProcess = ptyProcess;
+    this._diagnostics = diagnostics;
+    ptyProcess.onData((data) => {
+      this._output.push(data);
+      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
+        process.stdout.write(data);
+      }
+    });
+    ptyProcess.onExit(({ exitCode }) => {
+      this._exited = true;
+      this._exitCode = exitCode;
+    });
+  }
+
+  /**
+   * Combined raw output captured so far (ANSI not stripped).
+   */
+  get output(): string {
+    return this._output.join('');
+  }
+
+  /** Whether the underlying PTY process has exited. */
+  get exited(): boolean {
+    return this._exited;
+  }
+
+  /**
+   * Get the process ID of the PTY process.
+   */
+  get pid(): number | undefined {
+    return this.ptyProcess.pid;
+  }
+
+  /**
+   * Get the exit code after the process exits.
+   */
+  get exitCode(): number | null {
+    return this._exitCode;
+  }
+
+  /**
+   * Check if the process was killed.
+   */
+  get killed(): boolean {
+    return this._killed;
+  }
+
+  async expectText(text: string, timeout?: number) {
+    const effectiveTimeout = timeout ?? getDefaultTimeout();
+    await poll(
+      () => stripAnsi(this.output).toLowerCase().includes(text.toLowerCase()),
+      effectiveTimeout,
+      200,
+    );
+    expect(stripAnsi(this.output).toLowerCase()).toContain(text.toLowerCase());
+  }
+
+  // This types slowly to make sure command is correct, but only work for short
+  // commands that are not multi-line, use sendKeys to type long prompts
+  async type(text: string) {
+    let typedSoFar = '';
+    for (const char of text) {
+      this.ptyProcess.write(char);
+      typedSoFar += char;
+
+      const found = await poll(
+        () => stripAnsi(this.output).includes(typedSoFar),
+        5000,
+        10,
+      );
+
+      if (!found) {
+        throw new Error(
+          `Timed out waiting for typed text to appear in output: "${typedSoFar}".\nStripped output:\n${stripAnsi(
+            this.output,
+          )}`,
+        );
+      }
+    }
+  }
+
+  // Types an entire string at once, necessary for some things like commands
+  // but may run into paste detection issues for larger strings.
+  async sendText(text: string) {
+    this.ptyProcess.write(text);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  // Simulates typing a string one character at a time to avoid paste detection.
+  async sendKeys(text: string) {
+    const delay = 5;
+    for (const char of text) {
+      this.ptyProcess.write(char);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  /**
+   * Kill the process with graceful escalation.
+   * First sends SIGTERM, then SIGKILL after gracePeriodMs.
+   * On Windows, uses taskkill with /T flag for process tree.
+   * @param gracePeriodMs - Time to wait after SIGTERM before SIGKILL (default: 5000ms)
+   */
+  async kill(gracePeriodMs = 5000): Promise<void> {
+    if (this._exited) {
+      return;
+    }
+    this._killed = true;
+
+    if (process.platform === 'win32') {
+      await this._killWindows();
+    } else {
+      await this._killUnix(gracePeriodMs);
+    }
+  }
+
+  private _killWindows(): Promise<void> {
+    try {
+      const pid = this.ptyProcess.pid;
+      execSync(`taskkill /pid ${pid} /T /F`, { timeout: 10000 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        !message.includes('not found') &&
+        !message.includes('no running instance')
+      ) {
+        this._diagnostics.warn('Failed to kill PTY process:', message);
+      }
+    }
+    return Promise.resolve();
+  }
+
+  private async _killUnix(gracePeriodMs: number): Promise<void> {
+    try {
+      this.ptyProcess.kill('SIGTERM');
+      const exited = await poll(() => this._exited, gracePeriodMs, 100);
+      if (!exited) {
+        this.ptyProcess.kill('SIGKILL');
+      }
+    } catch {
+      // Process may already be dead — ignore
+    }
+  }
+
+  expectExit(timeout?: number): Promise<number> {
+    const effectiveTimeout = timeout ?? getDefaultTimeout();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () =>
+          reject(
+            new Error(
+              `Test timed out: process did not exit within ${effectiveTimeout}ms.`,
+            ),
+          ),
+        effectiveTimeout,
+      );
+      this.ptyProcess.onExit(({ exitCode }) => {
+        clearTimeout(timer);
+        resolve(exitCode);
+      });
+    });
+  }
+}

--- a/packages/test-utils/src/process-run.ts
+++ b/packages/test-utils/src/process-run.ts
@@ -1,0 +1,180 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawn } from 'node:child_process';
+import { env } from 'node:process';
+import type { Writable } from 'node:stream';
+
+/**
+ * Stream handler that accumulates stdout/stderr and mirrors them to the
+ * terminal when verbose output is enabled.
+ */
+interface StreamAccumulator {
+  stdout: string;
+  stderr: string;
+}
+
+function createStreamHandlers(): {
+  onStdout: (data: Buffer) => void;
+  onStderr: (data: Buffer) => void;
+  accumulator: StreamAccumulator;
+} {
+  const accumulator: StreamAccumulator = { stdout: '', stderr: '' };
+  return {
+    accumulator,
+    onStdout(data: Buffer) {
+      accumulator.stdout += data;
+      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
+        process.stdout.write(data);
+      }
+    },
+    onStderr(data: Buffer) {
+      accumulator.stderr += data;
+      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
+        process.stderr.write(data);
+      }
+    },
+  };
+}
+
+export interface RunOptions {
+  args?: string | string[];
+  stdin?: string;
+  stdinDoesNotEnd?: boolean;
+  yolo?: boolean;
+}
+
+export interface RunContext {
+  command: string;
+  commandArgs: string[];
+  testDir: string;
+  childEnv?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Spawn a child process for `TestRig.run` / `runCommand` and resolve with the
+ * captured stdout. Mirrors output when verbose mode is enabled.
+ */
+export function spawnRun(
+  ctx: RunContext,
+  options: RunOptions,
+  isJsonOutput: boolean,
+  transform: (stdout: string) => string,
+): Promise<string> {
+  const { onStdout, onStderr, accumulator } = createStreamHandlers();
+
+  const child = spawn(ctx.command, ctx.commandArgs, {
+    cwd: ctx.testDir,
+    stdio: 'pipe',
+    env: ctx.childEnv,
+  });
+
+  pipeStdin(child, options);
+
+  child.stdout.on('data', onStdout);
+  child.stderr.on('data', onStderr);
+
+  return new Promise<string>((resolve, reject) => {
+    child.on('close', (code: number) => {
+      if (code === 0) {
+        const transformed = transform(accumulator.stdout);
+        resolve(
+          maybeAppendStderr(transformed, accumulator.stderr, isJsonOutput),
+        );
+      } else {
+        reject(
+          new Error(`Process exited with code ${code}:\n${accumulator.stderr}`),
+        );
+      }
+    });
+  });
+}
+
+/**
+ * Spawn a child process with a timeout for `TestRig.run`.
+ */
+export function spawnRunWithTimeout(
+  ctx: RunContext,
+  options: RunOptions,
+  isJsonOutput: boolean,
+  transform: (stdout: string) => string,
+  timeoutMs: number,
+): Promise<string> {
+  const { onStdout, onStderr, accumulator } = createStreamHandlers();
+
+  const child = spawn(ctx.command, ctx.commandArgs, {
+    cwd: ctx.testDir,
+    stdio: 'pipe',
+    env: ctx.childEnv,
+  });
+
+  pipeStdin(child, options);
+
+  child.stdout.on('data', onStdout);
+  child.stderr.on('data', onStderr);
+
+  let timeoutHandle: NodeJS.Timeout;
+  const processPromise = new Promise<string>((resolve, reject) => {
+    child.on('close', (code: number) => {
+      clearTimeout(timeoutHandle);
+      if (code === 0) {
+        const transformed = transform(accumulator.stdout);
+        resolve(
+          maybeAppendStderr(transformed, accumulator.stderr, isJsonOutput),
+        );
+      } else {
+        reject(
+          new Error(`Process exited with code ${code}:\n${accumulator.stderr}`),
+        );
+      }
+    });
+  });
+
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`TestRig.run() timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  return Promise.race([processPromise, timeoutPromise]);
+}
+
+function maybeAppendStderr(
+  result: string,
+  stderr: string,
+  isJsonOutput: boolean,
+): string {
+  if (stderr.length > 0 && !isJsonOutput) {
+    return `${result}\n\nStdErr:\n${stderr}`;
+  }
+  return result;
+}
+
+/**
+ * Write stdin to a child process and close the stream unless the caller opted
+ * to keep it open (`stdinDoesNotEnd`).
+ */
+function pipeStdin(child: ReturnType<typeof spawn>, options: RunOptions): void {
+  const stdin = getWritable(child.stdin);
+  if (options.stdin !== undefined) {
+    stdin.write(options.stdin);
+  }
+  if (options.stdinDoesNotEnd !== true) {
+    stdin.end();
+  }
+}
+
+/**
+ * Return a guaranteed-non-null writable stream. Used with `stdio: 'pipe'`
+ * spawns, which always allocate a stdin stream.
+ */
+function getWritable(stream: Writable | null): Writable {
+  if (stream === null) {
+    throw new Error('Expected spawn stdio stream but received null');
+  }
+  return stream;
+}

--- a/packages/test-utils/src/stdout-filter.ts
+++ b/packages/test-utils/src/stdout-filter.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as os from 'node:os';
+
+interface FilterState {
+  inTelemetryObject: boolean;
+  braceDepth: number;
+}
+
+/**
+ * Strip Podman telemetry JSON objects (multi-line `{ ... }` blocks) from
+ * captured stdout. Podman emits telemetry to stdout even when writing to a
+ * file, so these must be removed to recover the real CLI output.
+ */
+export function stripTelemetryFromStdout(stdout: string): string {
+  const lines = stdout.split(os.EOL);
+  const filteredLines: string[] = [];
+  const state: FilterState = { inTelemetryObject: false, braceDepth: 0 };
+
+  for (const line of lines) {
+    const kept = processLine(line, state);
+    if (kept !== null) {
+      filteredLines.push(kept);
+    }
+  }
+
+  return filteredLines.join('\n');
+}
+
+/**
+ * Process a single line, mutating filter state. Returns the line to keep, or
+ * null when the line is part of a telemetry object and should be dropped.
+ */
+function processLine(line: string, state: FilterState): string | null {
+  if (!state.inTelemetryObject && line.trim() === '{') {
+    state.inTelemetryObject = true;
+    state.braceDepth = 1;
+    return null;
+  }
+  if (!state.inTelemetryObject) {
+    return line;
+  }
+
+  for (const char of line) {
+    if (char === '{') {
+      state.braceDepth++;
+    } else if (char === '}') {
+      state.braceDepth--;
+    }
+  }
+
+  if (state.braceDepth === 0) {
+    state.inTelemetryObject = false;
+  }
+  return null;
+}

--- a/packages/test-utils/src/telemetry-parsing.test.ts
+++ b/packages/test-utils/src/telemetry-parsing.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DiagnosticsSink } from './diagnostics.js';
+import {
+  extractApiRequests,
+  extractToolLogsFromTelemetry,
+  findMetric,
+  readAndParseTelemetryLog,
+  splitTelemetryObjects,
+} from './telemetry-parsing.js';
+import type { ParsedLog } from './types.js';
+
+function createSilentDiagnostics(): DiagnosticsSink {
+  return {
+    verbose: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    dump: vi.fn(),
+  };
+}
+
+describe('telemetry parsing helpers', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('splits adjacent telemetry JSON objects without dropping braces', () => {
+    const objects = splitTelemetryObjects('{"a":1}\n{"b":2}\n');
+
+    expect(objects).toStrictEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it('reads telemetry logs and reports malformed objects', () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'test-utils-telemetry-'));
+    tempDirs.push(testDir);
+    writeFileSync(
+      join(testDir, 'telemetry.log'),
+      '{"attributes":{"event.name":"llxprt_code.api_request"}}\n{bad json}\n',
+    );
+    const diagnostics = createSilentDiagnostics();
+
+    const logs = readAndParseTelemetryLog(testDir, diagnostics);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.attributes?.['event.name']).toBe('llxprt_code.api_request');
+    expect(diagnostics.error).toHaveBeenCalledOnce();
+  });
+
+  it('extracts tool calls, API requests, and metrics from parsed telemetry', () => {
+    const parsedLogs: ParsedLog[] = [
+      {
+        attributes: {
+          'event.name': 'llxprt_code.tool_call',
+          function_name: 'write_file',
+          function_args: '{"path":"file.txt"}',
+          success: true,
+          duration_ms: 42,
+        },
+      },
+      {
+        attributes: {
+          'event.name': 'llxprt_code.api_request',
+          request_text: 'hello',
+        },
+      },
+      {
+        scopeMetrics: [
+          {
+            metrics: [
+              {
+                descriptor: { name: 'llxprt.requests' },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(extractToolLogsFromTelemetry(parsedLogs)).toStrictEqual([
+      {
+        toolRequest: {
+          name: 'write_file',
+          args: '{"path":"file.txt"}',
+          success: true,
+          duration_ms: 42,
+        },
+      },
+    ]);
+    expect(extractApiRequests(parsedLogs)).toHaveLength(1);
+    expect(findMetric(parsedLogs, 'llxprt.requests')).toMatchObject({
+      descriptor: { name: 'llxprt.requests' },
+    });
+  });
+});

--- a/packages/test-utils/src/telemetry-parsing.ts
+++ b/packages/test-utils/src/telemetry-parsing.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DiagnosticsSink } from './diagnostics.js';
+import type { ParsedLog } from './types.js';
+
+/**
+ * Split the raw telemetry log content into individual JSON object strings.
+ * Entries are separated by "}{" boundaries.
+ */
+export function splitTelemetryObjects(content: string): string[] {
+  return content
+    .split(/}\n{/)
+    .map((obj, index, array) => {
+      // Re-add the braces removed during split.
+      let entry = obj;
+      if (index > 0) {
+        entry = '{' + entry;
+      }
+      if (index < array.length - 1) {
+        entry = entry + '}';
+      }
+      return entry.trim();
+    })
+    .filter((obj) => obj.length > 0);
+}
+
+/**
+ * Read and parse the telemetry.log file for a test directory.
+ */
+export function readAndParseTelemetryLog(
+  testDir: string,
+  diagnostics: DiagnosticsSink,
+): ParsedLog[] {
+  const logFilePath = join(testDir, 'telemetry.log');
+
+  if (!existsSync(logFilePath)) {
+    return [];
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(logFilePath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const jsonObjects = splitTelemetryObjects(content);
+  const logs: ParsedLog[] = [];
+
+  for (const jsonStr of jsonObjects) {
+    try {
+      const logData = JSON.parse(jsonStr) as ParsedLog;
+      logs.push(logData);
+    } catch (e) {
+      diagnostics.error('Failed to parse telemetry object:', e);
+    }
+  }
+
+  return logs;
+}
+
+/**
+ * Extract tool-call entries from parsed telemetry logs.
+ */
+export function extractToolLogsFromTelemetry(
+  parsedLogs: readonly ParsedLog[],
+): Array<{
+  toolRequest: {
+    name: string;
+    args: string;
+    success: boolean;
+    duration_ms: number;
+  };
+}> {
+  const logs: Array<{
+    toolRequest: {
+      name: string;
+      args: string;
+      success: boolean;
+      duration_ms: number;
+    };
+  }> = [];
+
+  for (const logData of parsedLogs) {
+    const attributes = logData.attributes;
+    if (
+      attributes !== undefined &&
+      attributes['event.name'] === 'llxprt_code.tool_call'
+    ) {
+      const toolName = attributes.function_name ?? '<unknown>';
+      logs.push({
+        toolRequest: {
+          name: toolName,
+          args: attributes.function_args ?? '{}',
+          success: attributes.success ?? false,
+          duration_ms: attributes.duration_ms ?? 0,
+        },
+      });
+    }
+  }
+
+  return logs;
+}
+
+/**
+ * Extract API request entries from parsed telemetry logs.
+ */
+export function extractApiRequests(
+  parsedLogs: readonly ParsedLog[],
+): ParsedLog[] {
+  return parsedLogs.filter(
+    (logData) =>
+      logData.attributes !== undefined &&
+      logData.attributes['event.name'] === 'llxprt_code.api_request',
+  );
+}
+
+/**
+ * Search parsed logs for a metric with the given full name.
+ */
+export function findMetric(
+  parsedLogs: readonly ParsedLog[],
+  fullName: string,
+): Record<string, unknown> | null {
+  for (const logData of parsedLogs) {
+    const found = findMetricInLog(logData, fullName);
+    if (found !== null) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Search a single parsed log entry for a metric with the given name.
+ */
+function findMetricInLog(
+  logData: ParsedLog,
+  fullName: string,
+): Record<string, unknown> | null {
+  if (logData.scopeMetrics === undefined) {
+    return null;
+  }
+  for (const scopeMetric of logData.scopeMetrics) {
+    for (const metric of scopeMetric.metrics) {
+      if (metric.descriptor.name === fullName) {
+        return metric as unknown as Record<string, unknown>;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/test-utils/src/test-rig-setup.ts
+++ b/packages/test-utils/src/test-rig-setup.ts
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdirSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { env } from 'node:process';
+
+const LLXPRT_DIR = '.llxprt';
+const WELCOME_CONFIG_FILENAME = 'welcomeConfig.json';
+
+export interface TestDirectoryConfig {
+  testDir: string;
+  fakeResponsesPath: string | undefined;
+  originalFakeResponsesPath: string | undefined;
+}
+
+/**
+ * Create the base test directory, welcome config, and fake responses file.
+ */
+export function setupTestDirectory(
+  testDir: string,
+  options: {
+    fakeResponsesPath?: string;
+  },
+): TestDirectoryConfig {
+  mkdirSync(testDir, { recursive: true });
+
+  let fakeResponsesPath: string | undefined;
+  let originalFakeResponsesPath: string | undefined;
+  if (options.fakeResponsesPath !== undefined) {
+    fakeResponsesPath = join(testDir, 'fake-responses.json');
+    originalFakeResponsesPath = options.fakeResponsesPath;
+    if (env['REGENERATE_MODEL_GOLDENS'] !== 'true') {
+      copyFileSync(options.fakeResponsesPath, fakeResponsesPath);
+    }
+  }
+
+  writeFileSync(
+    join(testDir, WELCOME_CONFIG_FILENAME),
+    JSON.stringify({ welcomeCompleted: true }, null, 2),
+  );
+
+  return { testDir, fakeResponsesPath, originalFakeResponsesPath };
+}
+
+/**
+ * Write the settings.json file pointing the CLI at the local telemetry
+ * collector and applying caller-provided overrides.
+ */
+export function writeSettingsFile(
+  testDir: string,
+  packageDir: string,
+  settingsOverridesRaw: Record<string, unknown> | undefined,
+): void {
+  const llxprtDir = join(testDir, LLXPRT_DIR);
+  mkdirSync(llxprtDir, { recursive: true });
+
+  const telemetryPath = join(testDir, 'telemetry.log');
+
+  const overrides = splitSettingsOverrides(settingsOverridesRaw);
+  const settings = buildSettings(
+    telemetryPath,
+    packageDir,
+    overrides.ui,
+    overrides.withoutUi,
+  );
+
+  writeFileSync(
+    join(llxprtDir, 'settings.json'),
+    JSON.stringify(settings, null, 2),
+  );
+}
+
+function splitSettingsOverrides(raw: Record<string, unknown> | undefined): {
+  ui: Record<string, unknown> | undefined;
+  withoutUi: Record<string, unknown>;
+} {
+  if (raw === undefined) {
+    return { ui: undefined, withoutUi: {} };
+  }
+  const { ui: uiOverridesRaw, ...settingsOverridesWithoutUi } = raw;
+  return {
+    ui: isPlainObject(uiOverridesRaw) ? uiOverridesRaw : undefined,
+    withoutUi: settingsOverridesWithoutUi,
+  };
+}
+
+/**
+ * Type guard narrowing an unknown value to a plain string-keyed object.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function resolvePromptBaseDir(packageDir: string): string {
+  return existsSync(join(packageDir, '..', 'bundle'))
+    ? join(packageDir, '..', 'bundle')
+    : join(
+        packageDir,
+        '..',
+        'packages',
+        'core',
+        'src',
+        'prompt-config',
+        'defaults',
+      );
+}
+
+function buildSettings(
+  telemetryPath: string,
+  packageDir: string,
+  ui: Record<string, unknown> | undefined,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const sandbox =
+    env['LLXPRT_SANDBOX'] !== 'false' ? env['LLXPRT_SANDBOX'] : false;
+  return {
+    general: {
+      enableAutoUpdate: false,
+    },
+    ui: {
+      theme: 'Green Screen',
+      useAlternateBuffer: true,
+      ...ui,
+    },
+    telemetry: {
+      enabled: true,
+      target: 'local',
+      otlpEndpoint: '',
+      outfile: telemetryPath,
+    },
+    promptService: {
+      baseDir: resolvePromptBaseDir(packageDir),
+    },
+    sandbox,
+    provider: env['LLXPRT_DEFAULT_PROVIDER'],
+    debug: true,
+    ide: { enabled: false, hasSeenNudge: true },
+    ...overrides,
+  };
+}
+
+/**
+ * Write a profile JSON file if the test profile env var is set.
+ */
+export function writeProfileFile(testDir: string): void {
+  const profileName = env['LLXPRT_TEST_PROFILE']?.trim();
+  if (profileName === undefined || profileName.length === 0) {
+    return;
+  }
+
+  const profilesDir = join(testDir, LLXPRT_DIR, 'profiles');
+  mkdirSync(profilesDir, { recursive: true });
+
+  const profile = buildProfile();
+  writeFileSync(
+    join(profilesDir, `${profileName}.json`),
+    JSON.stringify(profile, null, 2),
+  );
+}
+
+function buildProfile(): Record<string, unknown> {
+  const profileProvider = resolveEnvString('LLXPRT_DEFAULT_PROVIDER', 'openai');
+  const profileModel = resolveEnvString('LLXPRT_DEFAULT_MODEL', 'gpt-4o-mini');
+
+  const ephemeralEntries = collectEphemeralEntries();
+
+  return {
+    version: 1,
+    provider: profileProvider,
+    model: profileModel,
+    modelParams: {},
+    ephemeralSettings: Object.fromEntries(
+      ephemeralEntries.filter(([, value]) => value !== undefined),
+    ),
+  };
+}
+
+function resolveEnvString(key: string, fallback: string): string {
+  const value = env[key];
+  if (value !== undefined && value.trim().length > 0) {
+    return value;
+  }
+  return fallback;
+}
+
+function collectEphemeralEntries(): Array<[string, unknown]> {
+  const entries: Array<[string, unknown]> = [];
+
+  const baseUrl = env['OPENAI_BASE_URL'];
+  if (baseUrl !== undefined && baseUrl.trim().length > 0) {
+    entries.push(['base-url', baseUrl]);
+  }
+
+  const apiKey = env['OPENAI_API_KEY'];
+  if (apiKey !== undefined && apiKey.trim().length > 0) {
+    entries.push(['auth-key', apiKey]);
+  }
+
+  const keyFile = env['LLXPRT_TEST_PROFILE_KEYFILE'];
+  if (keyFile !== undefined) {
+    entries.push(['auth-keyfile', keyFile]);
+  }
+
+  const contextLimit = env['LLXPRT_CONTEXT_LIMIT'];
+  if (contextLimit !== undefined) {
+    const parsedLimit = Number(contextLimit);
+    if (Number.isFinite(parsedLimit) && parsedLimit > 0) {
+      entries.push(['context-limit', parsedLimit]);
+    }
+  }
+
+  return entries;
+}
+
+export { LLXPRT_DIR, WELCOME_CONFIG_FILENAME };

--- a/packages/test-utils/src/test-rig.test.ts
+++ b/packages/test-utils/src/test-rig.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TestRig } from './test-rig.js';
+
+describe('TestRig setup and cleanup behavior', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function createRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), 'test-rig-behavior-'));
+    tempDirs.push(root);
+    vi.stubEnv('INTEGRATION_TEST_FILE_DIR', root);
+    return root;
+  }
+
+  it('preserves fake responses when setup is called again with settings only', () => {
+    const root = createRoot();
+    const fakeResponsesPath = join(root, 'responses.json');
+    writeFileSync(fakeResponsesPath, '[]');
+    const rig = new TestRig();
+
+    rig.setup('repeated setup', { fakeResponsesPath });
+    const firstCopiedPath = rig.fakeResponsesPath;
+
+    rig.setup('repeated setup', { settings: { debug: true } });
+
+    expect(rig.fakeResponsesPath).toBe(firstCopiedPath);
+    expect(rig.originalFakeResponsesPath).toBe(fakeResponsesPath);
+  });
+
+  it('cleans test directories when KEEP_OUTPUT is unset or empty', async () => {
+    createRoot();
+    const rig = new TestRig();
+    rig.setup('cleanup empty keep output');
+    const testDir = rig.testDir;
+    vi.stubEnv('KEEP_OUTPUT', '');
+
+    await rig.cleanup();
+
+    expect(testDir).not.toBeNull();
+    expect(existsSync(testDir as string)).toBe(false);
+  });
+
+  it('keeps test directories when KEEP_OUTPUT is truthy', async () => {
+    createRoot();
+    const rig = new TestRig();
+    rig.setup('cleanup truthy keep output');
+    const testDir = rig.testDir;
+    vi.stubEnv('KEEP_OUTPUT', '1');
+
+    await rig.cleanup();
+
+    expect(testDir).not.toBeNull();
+    expect(existsSync(testDir as string)).toBe(true);
+  });
+});

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -119,8 +119,10 @@ export class TestRig {
     const dirConfig = setupTestDirectory(testDir, {
       fakeResponsesPath: options.fakeResponsesPath,
     });
-    this.fakeResponsesPath = dirConfig.fakeResponsesPath;
-    this.originalFakeResponsesPath = dirConfig.originalFakeResponsesPath;
+    if (dirConfig.fakeResponsesPath !== undefined) {
+      this.fakeResponsesPath = dirConfig.fakeResponsesPath;
+      this.originalFakeResponsesPath = dirConfig.originalFakeResponsesPath;
+    }
 
     writeSettingsFile(testDir, __dirname, options.settings);
     writeProfileFile(testDir);

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -237,7 +237,7 @@ export class TestRig {
     ) {
       fs.copyFileSync(this.fakeResponsesPath, this.originalFakeResponsesPath);
     }
-    if (this.testDir !== null && env['KEEP_OUTPUT'] === undefined) {
+    if (this.testDir !== null && !env['KEEP_OUTPUT']) {
       try {
         fs.rmSync(this.testDir, { recursive: true, force: true });
       } catch (error) {

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -5,7 +5,7 @@
  */
 
 import { expect } from 'vitest';
-import { execSync, spawn, type ChildProcess } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -13,579 +13,93 @@ import { env } from 'node:process';
 import fs from 'node:fs';
 import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
-import * as os from 'node:os';
+import { createDiagnosticsSink } from './diagnostics.js';
+import { InteractiveRun } from './interactive-run.js';
+import { getDefaultTimeout, poll, sanitizeTestName } from './util.js';
+import {
+  assertProviderConfig,
+  buildExtraArgs,
+  getCommandAndArgs,
+  buildChildEnv,
+  getProfileName,
+} from './cli-args.js';
+import {
+  readAndParseTelemetryLog,
+  extractToolLogsFromTelemetry,
+  extractApiRequests,
+  findMetric,
+} from './telemetry-parsing.js';
+import {
+  parseToolLogsFromStdout,
+  extractHookLogs,
+} from './tool-log-parsing.js';
+import {
+  setupTestDirectory,
+  writeSettingsFile,
+  writeProfileFile,
+} from './test-rig-setup.js';
+import { stripTelemetryFromStdout } from './stdout-filter.js';
+import {
+  spawnRun,
+  spawnRunWithTimeout,
+  type RunContext,
+} from './process-run.js';
+import type { ParsedLog } from './types.js';
 
-const LLXPRT_DIR = '.llxprt';
-const WELCOME_CONFIG_FILENAME = 'welcomeConfig.json';
-
-/**
- * Options for running a command with timeout support.
- */
-export interface InteractiveRunOptions {
-  /** Maximum time to wait for the command to complete (default: 30000ms) */
-  timeout?: number;
-  /** Time to wait after SIGTERM before sending SIGKILL (default: 5000ms) */
-  gracefulKillTimeout?: number;
-}
-
-/**
- * Result of running a command.
- */
-export interface InteractiveRunResult {
-  /** The exit code of the process, or null if it was killed */
-  exitCode: number | null;
-  /** Standard output from the process */
-  stdout: string;
-  /** Standard error from the process */
-  stderr: string;
-  /** Whether the process timed out */
-  timedOut: boolean;
-  /** Whether the process was killed */
-  killed: boolean;
-}
-
-/**
- * Command-based InteractiveRun for non-PTY process management.
- * Supports timeout, graceful kill escalation, and cross-platform handling.
- */
-export class CommandRun {
-  private _process: ChildProcess | null = null;
-  private _stdout = '';
-  private _stderr = '';
-  private _exitCode: number | null = null;
-  private _killed = false;
-  private _timedOut = false;
-  private _exited = false;
-
-  /**
-   * Get the process ID if running.
-   */
-  get pid(): number | undefined {
-    return this._process?.pid;
-  }
-
-  /**
-   * Get the exit code after process completes.
-   */
-  get exitCode(): number | null {
-    return this._exitCode;
-  }
-
-  /**
-   * Check if the process was killed.
-   */
-  get killed(): boolean {
-    return this._killed;
-  }
-
-  /**
-   * Run a command with optional timeout.
-   */
-  async run(
-    command: string,
-    args: string[],
-    options?: InteractiveRunOptions,
-  ): Promise<InteractiveRunResult> {
-    const timeout = options?.timeout ?? 30000;
-    const cwd = process.cwd();
-
-    return new Promise((resolve, reject) => {
-      this._process = spawn(command, args, {
-        cwd,
-        stdio: 'pipe',
-      });
-
-      this._process.stdout?.on('data', (data: Buffer) => {
-        this._stdout += data.toString();
-      });
-
-      this._process.stderr?.on('data', (data: Buffer) => {
-        this._stderr += data.toString();
-      });
-
-      this._process.on('error', (error) => {
-        // Handle spawn failures with actionable error
-        const err = new Error(
-          `Failed to spawn '${command}': ${error.message} (errno: ${(error as NodeJS.ErrnoException).errno ?? 'unknown'})`,
-        );
-        reject(err);
-      });
-
-      this._process.on('close', (code) => {
-        this._exited = true;
-        this._exitCode = code;
-        resolve({
-          exitCode: this._exitCode,
-          stdout: this._stdout,
-          stderr: this._stderr,
-          timedOut: this._timedOut,
-          killed: this._killed,
-        });
-      });
-
-      // Set up timeout
-      const timer = setTimeout(() => {
-        this._timedOut = true;
-        this.kill(options?.gracefulKillTimeout ?? 5000).catch(() => {
-          // Ignore kill errors on timeout
-        });
-      }, timeout);
-
-      // Clean up timer on completion
-      this._process.on('close', () => {
-        clearTimeout(timer);
-      });
-    });
-  }
-
-  /**
-   * Kill the process with graceful escalation.
-   * First sends SIGTERM, then SIGKILL after timeout.
-   * On Windows, uses taskkill with /T flag for process tree.
-   */
-  async kill(gracefulTimeout?: number): Promise<void> {
-    if (this._exited || !this._process) {
-      return;
-    }
-
-    const timeout = gracefulTimeout ?? 5000;
-    this._killed = true;
-    const pid = this._process.pid;
-
-    if (pid === undefined) {
-      return;
-    }
-
-    if (process.platform === 'win32') {
-      // Windows: use taskkill with /T flag for process tree
-      await this._killWindows(pid, timeout);
-    } else {
-      // Darwin/Linux: standard SIGTERM/SIGKILL
-      await this._killUnix(pid, timeout);
-    }
-  }
-
-  private async _killWindows(pid: number, _timeout: number): Promise<void> {
-    try {
-      // Use taskkill with /T to kill process tree
-      execSync(`taskkill /pid ${pid} /T /F`, {
-        timeout: 10000,
-      });
-    } catch (error) {
-      // Check if process already exited (ESRCH equivalent on Windows)
-      const err = error as NodeJS.ErrnoException;
-      if (
-        err.message?.includes('not found') ||
-        err.message?.includes('no running instance')
-      ) {
-        // Process already exited - treat as success
-        return;
-      }
-      // Permission denied or other error
-      if (err.message?.includes('Access is denied')) {
-        throw new Error(
-          `Permission denied when trying to kill process ${pid}. Try running with elevated privileges.`,
-        );
-      }
-      throw error;
-    }
-  }
-
-  private async _killUnix(pid: number, timeout: number): Promise<void> {
-    try {
-      // Send SIGTERM first
-      process.kill(pid, 'SIGTERM');
-    } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      // ESRCH: no such process - already exited, no error
-      if (err.code === 'ESRCH') {
-        return;
-      }
-      // EPERM: permission denied
-      if (err.code === 'EPERM') {
-        throw new Error(
-          `Permission denied when trying to kill process ${pid}. Try running with elevated privileges.`,
-        );
-      }
-      throw error;
-    }
-
-    // Wait for graceful shutdown
-    const startTime = Date.now();
-    const exited = await new Promise<boolean>((resolve) => {
-      const checkInterval = setInterval(() => {
-        if (this._exited) {
-          clearInterval(checkInterval);
-          resolve(true);
-          return;
-        }
-
-        // Check if process still exists
-        try {
-          process.kill(pid, 0); // Signal 0 = check if process exists
-        } catch {
-          // Process no longer exists
-          clearInterval(checkInterval);
-          resolve(true);
-          return;
-        }
-
-        if (Date.now() - startTime >= timeout) {
-          clearInterval(checkInterval);
-          resolve(false);
-        }
-      }, 100);
-    });
-
-    // If still running after timeout, send SIGKILL
-    if (!exited) {
-      try {
-        process.kill(pid, 'SIGKILL');
-      } catch (error) {
-        const err = error as NodeJS.ErrnoException;
-        // ESRCH is fine - process already exited
-        if (err.code !== 'ESRCH') {
-          throw error;
-        }
-      }
-    }
-  }
-}
+// Re-export public types and helpers so existing importers keep working.
+export type {
+  InteractiveRunOptions,
+  InteractiveRunResult,
+  ParsedLog,
+  ToolLogEntry,
+  HookLogEntry,
+  TelemetryAttributes,
+} from './types.js';
+export { CommandRun } from './command-run.js';
+export { InteractiveRun } from './interactive-run.js';
+export {
+  getDefaultTimeout,
+  poll,
+  sanitizeTestName,
+  createToolCallErrorMessage,
+  printDebugInfo,
+  validateModelOutput,
+} from './util.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLE_PATH = join(__dirname, '..', '..', '..', 'bundle/llxprt.js');
 
-// Get timeout based on environment
-export function getDefaultTimeout() {
-  if (env['CI']) return 60000; // 1 minute in CI
-  if (env['LLXPRT_SANDBOX']) return 30000; // 30s in containers
-  return 15000; // 15s locally
+interface RunMethodOptions {
+  args?: string | string[];
+  stdin?: string;
+  stdinDoesNotEnd?: boolean;
+  yolo?: boolean;
 }
 
-export async function poll(
-  predicate: () => boolean,
-  timeout: number,
-  interval: number,
-): Promise<boolean> {
-  const startTime = Date.now();
-  let attempts = 0;
-  while (Date.now() - startTime < timeout) {
-    attempts++;
-    const result = predicate();
-    if (env['VERBOSE'] === 'true' && attempts % 5 === 0) {
-      console.log(
-        `Poll attempt ${attempts}: ${result ? 'success' : 'waiting...'}`,
-      );
-    }
-    if (result) {
-      return true;
-    }
-    await new Promise((resolve) => setTimeout(resolve, interval));
-  }
-  if (env['VERBOSE'] === 'true') {
-    console.log(`Poll timed out after ${attempts} attempts`);
-  }
-  return false;
-}
-
-export function sanitizeTestName(name: string) {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, '-')
-    .replace(/-+/g, '-');
-}
-
-// Helper to create detailed error messages
-export function createToolCallErrorMessage(
-  expectedTools: string | string[],
-  foundTools: string[],
-  result: string,
-) {
-  const expectedStr = Array.isArray(expectedTools)
-    ? expectedTools.join(' or ')
-    : expectedTools;
-  return (
-    `Expected to find ${expectedStr} tool call(s). ` +
-    `Found: ${foundTools.length > 0 ? foundTools.join(', ') : 'none'}. ` +
-    `Output preview: ${result ? result.substring(0, 200) + '...' : 'no output'}`
-  );
-}
-
-// Helper to print debug information when tests fail
-export function printDebugInfo(
-  rig: TestRig,
-  result: string,
-  context: Record<string, unknown> = {},
-) {
-  console.error('Test failed - Debug info:');
-  console.error('Result length:', result.length);
-  console.error('Result (first 500 chars):', result.substring(0, 500));
-  console.error(
-    'Result (last 500 chars):',
-    result.substring(result.length - 500),
-  );
-
-  // Print any additional context provided
-  Object.entries(context).forEach(([key, value]) => {
-    console.error(`${key}:`, value);
-  });
-
-  // Check what tools were actually called
-  const allTools = rig.readToolLogs();
-  console.error(
-    'All tool calls found:',
-    allTools.map((t) => t.toolRequest.name),
-  );
-
-  return allTools;
-}
-
-// Helper to validate model output and warn about unexpected content
-export function validateModelOutput(
-  result: string,
-  expectedContent: string | (string | RegExp)[] | null = null,
-  testName = '',
-) {
-  // First, check if there's any output at all (this should fail the test if missing)
-  if (!result || result.trim().length === 0) {
-    throw new Error('Expected LLM to return some output');
-  }
-
-  // If expectedContent is provided, check for it and warn if missing
-  if (expectedContent) {
-    const contents = Array.isArray(expectedContent)
-      ? expectedContent
-      : [expectedContent];
-    const missingContent = contents.filter((content) => {
-      if (typeof content === 'string') {
-        return !result.toLowerCase().includes(content.toLowerCase());
-      } else if (content instanceof RegExp) {
-        return !content.test(result);
-      }
-      return false;
-    });
-
-    if (missingContent.length > 0) {
-      console.warn(
-        `Warning: LLM did not include expected content in response: ${missingContent.join(
-          ', ',
-        )}.`,
-        'This is not ideal but not a test failure.',
-      );
-      console.warn(
-        'The tool was called successfully, which is the main requirement.',
-      );
-      console.warn('Expected content:', expectedContent);
-      console.warn('Actual output:', result);
-      return false;
-    } else if (env['VERBOSE'] === 'true') {
-      console.log(`${testName}: Model output validated successfully.`);
-    }
-    return true;
-  }
-
-  return true;
-}
-
-interface ParsedLog {
-  attributes?: {
-    'event.name'?: string;
-    function_name?: string;
-    function_args?: string;
-    success?: boolean;
-    duration_ms?: number;
-    request_text?: string;
-    hook_event_name?: string;
-    hook_name?: string;
-    hook_input?: Record<string, unknown>;
-    hook_output?: Record<string, unknown>;
-    exit_code?: number;
-    stdout?: string;
-    stderr?: string;
-    error?: string;
-  };
-  scopeMetrics?: {
-    metrics: {
-      descriptor: {
-        name: string;
-      };
-    }[];
-  }[];
-}
-
-export class InteractiveRun {
-  ptyProcess: pty.IPty;
-  public output = '';
-  private _exited = false;
-  private _exitCode: number | null = null;
-  private _killed = false;
-
-  constructor(ptyProcess: pty.IPty) {
-    this.ptyProcess = ptyProcess;
-    ptyProcess.onData((data) => {
-      this.output += data;
-      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
-        process.stdout.write(data);
-      }
-    });
-    ptyProcess.onExit(({ exitCode }) => {
-      this._exited = true;
-      this._exitCode = exitCode;
-    });
-  }
-
-  /**
-   * Get the process ID of the PTY process.
-   */
-  get pid(): number | undefined {
-    return this.ptyProcess.pid;
-  }
-
-  /**
-   * Get the exit code after the process exits.
-   */
-  get exitCode(): number | null {
-    return this._exitCode;
-  }
-
-  /**
-   * Check if the process was killed.
-   */
-  get killed(): boolean {
-    return this._killed;
-  }
-
-  async expectText(text: string, timeout?: number) {
-    if (!timeout) {
-      timeout = getDefaultTimeout();
-    }
-    await poll(
-      () => stripAnsi(this.output).toLowerCase().includes(text.toLowerCase()),
-      timeout,
-      200,
-    );
-    expect(stripAnsi(this.output).toLowerCase()).toContain(text.toLowerCase());
-  }
-
-  // This types slowly to make sure command is correct, but only work for short
-  // commands that are not multi-line, use sendKeys to type long prompts
-  async type(text: string) {
-    let typedSoFar = '';
-    for (const char of text) {
-      this.ptyProcess.write(char);
-      typedSoFar += char;
-
-      // Wait for the typed sequence so far to be echoed back.
-      const found = await poll(
-        () => stripAnsi(this.output).includes(typedSoFar),
-        5000, // 5s timeout per character (generous for CI)
-        10, // check frequently
-      );
-
-      if (!found) {
-        throw new Error(
-          `Timed out waiting for typed text to appear in output: "${typedSoFar}".\nStripped output:\n${stripAnsi(
-            this.output,
-          )}`,
-        );
-      }
-    }
-  }
-
-  // Types an entire string at once, necessary for some things like commands
-  // but may run into paste detection issues for larger strings.
-  async sendText(text: string) {
-    this.ptyProcess.write(text);
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-
-  // Simulates typing a string one character at a time to avoid paste detection.
-  async sendKeys(text: string) {
-    const delay = 5;
-    for (const char of text) {
-      this.ptyProcess.write(char);
-      await new Promise((resolve) => setTimeout(resolve, delay));
-    }
-  }
-
-  /**
-   * Kill the process with graceful escalation.
-   * First sends SIGTERM, then SIGKILL after gracePeriodMs.
-   * On Windows, uses taskkill with /T flag for process tree.
-   * @param gracePeriodMs - Time to wait after SIGTERM before SIGKILL (default: 5000ms)
-   */
-  async kill(gracePeriodMs = 5000): Promise<void> {
-    if (this._exited) return;
-    this._killed = true;
-
-    if (process.platform === 'win32') {
-      await this._killWindows(gracePeriodMs);
-    } else {
-      await this._killUnix(gracePeriodMs);
-    }
-  }
-
-  private async _killWindows(_gracePeriodMs: number): Promise<void> {
-    try {
-      // Windows: use taskkill with /T flag for process tree
-      const pid = this.ptyProcess.pid;
-      execSync(`taskkill /pid ${pid} /T /F`, { timeout: 10000 });
-    } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      // Process may already be dead — ignore
-      if (
-        !err.message?.includes('not found') &&
-        !err.message?.includes('no running instance')
-      ) {
-        // Log but don't throw for cleanup
-        if (env['VERBOSE'] === 'true') {
-          console.warn('Failed to kill PTY process:', err.message);
-        }
-      }
-    }
-  }
-
-  private async _killUnix(gracePeriodMs: number): Promise<void> {
-    try {
-      this.ptyProcess.kill('SIGTERM');
-      const exited = await poll(() => this._exited, gracePeriodMs, 100);
-      if (!exited) {
-        this.ptyProcess.kill('SIGKILL');
-      }
-    } catch {
-      // Process may already be dead — ignore
-    }
-  }
-
-  expectExit(timeout?: number): Promise<number> {
-    const effectiveTimeout = timeout ?? getDefaultTimeout();
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(
-        () =>
-          reject(
-            new Error(
-              `Test timed out: process did not exit within ${effectiveTimeout}ms.`,
-            ),
-          ),
-        effectiveTimeout,
-      );
-      this.ptyProcess.onExit(({ exitCode }) => {
-        clearTimeout(timer);
-        resolve(exitCode);
-      });
-    });
-  }
-}
-
+/**
+ * Test harness for integration/e2e CLI tests. Manages test directories,
+ * spawns the CLI, parses telemetry, and provides polling helpers.
+ */
 export class TestRig {
   testDir: string | null = null;
-  testName?: string;
-  _lastRunStdout?: string;
-  // Path to the copied fake responses file for this test.
-  fakeResponsesPath?: string;
-  // Original fake responses file path for rewriting goldens in record mode.
-  originalFakeResponsesPath?: string;
+  testName: string | undefined;
+  _lastRunStdout: string | undefined;
+  fakeResponsesPath: string | undefined;
+  originalFakeResponsesPath: string | undefined;
   private _interactiveRuns: InteractiveRun[] = [];
+
+  /**
+   * Diagnostics sink bound to the current test directory. Recomputed on each
+   * access so that setup() establishing a directory takes effect immediately.
+   */
+  private get _diagnostics(): ReturnType<typeof createDiagnosticsSink> {
+    return createDiagnosticsSink(this.testDir);
+  }
+
+  /** Expose a structured diagnostic dump for helpers in other modules. */
+  dumpDiagnostic(label: string, content: string): void {
+    this._diagnostics.dump(label, content);
+  }
 
   setup(
     testName: string,
@@ -596,526 +110,162 @@ export class TestRig {
   ) {
     this.testName = testName;
     const sanitizedName = sanitizeTestName(testName);
-    this.testDir = join(env['INTEGRATION_TEST_FILE_DIR']!, sanitizedName);
-    mkdirSync(this.testDir, { recursive: true });
-    if (options.fakeResponsesPath) {
-      this.fakeResponsesPath = join(this.testDir, 'fake-responses.json');
-      this.originalFakeResponsesPath = options.fakeResponsesPath;
-      if (process.env['REGENERATE_MODEL_GOLDENS'] !== 'true') {
-        fs.copyFileSync(options.fakeResponsesPath, this.fakeResponsesPath);
-      }
-    }
-
-    // Create a settings file to point the CLI to the local collector
-    const llxprtDir = join(this.testDir, LLXPRT_DIR);
-    mkdirSync(llxprtDir, { recursive: true });
-
-    const welcomeConfigPath = join(this.testDir, WELCOME_CONFIG_FILENAME);
-    writeFileSync(
-      welcomeConfigPath,
-      JSON.stringify({ welcomeCompleted: true }, null, 2),
+    const testDir = join(
+      env['INTEGRATION_TEST_FILE_DIR'] as string,
+      sanitizedName,
     );
-    // In sandbox mode, use an absolute path for telemetry inside the container
-    // The container mounts the test directory at the same path as the host
-    const telemetryPath = join(this.testDir, 'telemetry.log'); // Always use test directory for telemetry
+    this.testDir = testDir;
 
-    const settingsOverrides = (options.settings ?? {}) as Record<
-      string,
-      unknown
-    >;
-    const { ui: uiOverridesRaw, ...settingsOverridesWithoutUi } =
-      settingsOverrides;
-    const uiOverrides =
-      uiOverridesRaw && typeof uiOverridesRaw === 'object'
-        ? (uiOverridesRaw as Record<string, unknown>)
-        : undefined;
+    const dirConfig = setupTestDirectory(testDir, {
+      fakeResponsesPath: options.fakeResponsesPath,
+    });
+    this.fakeResponsesPath = dirConfig.fakeResponsesPath;
+    this.originalFakeResponsesPath = dirConfig.originalFakeResponsesPath;
 
-    const settings = {
-      general: {
-        // Nightly releases sometimes becomes out of sync with local code and
-        // triggers auto-update, which causes tests to fail.
-        enableAutoUpdate: false,
-      },
-      ui: {
-        theme: 'Green Screen',
-        useAlternateBuffer: true,
-        ...uiOverrides,
-      },
-      telemetry: {
-        enabled: true,
-        target: 'local',
-        otlpEndpoint: '',
-        outfile: telemetryPath,
-      },
-      promptService: {
-        // In bundled environment, prompts are in the bundle directory
-        baseDir: fs.existsSync(join(__dirname, '..', 'bundle'))
-          ? join(__dirname, '..', 'bundle')
-          : join(
-              __dirname,
-              '..',
-              'packages',
-              'core',
-              'src',
-              'prompt-config',
-              'defaults',
-            ),
-      },
-      sandbox:
-        env['LLXPRT_SANDBOX'] !== 'false' ? env['LLXPRT_SANDBOX'] : false,
-      provider: env['LLXPRT_DEFAULT_PROVIDER'], // No default - must be set explicitly
-      debug: true, // Enable debug logging
-      // Don't show the IDE connection dialog when running from VsCode
-      ide: { enabled: false, hasSeenNudge: true },
-      ...settingsOverridesWithoutUi, // Allow tests to override/add settings
-    };
-    writeFileSync(
-      join(llxprtDir, 'settings.json'),
-      JSON.stringify(settings, null, 2),
-    );
-
-    const profileName = env['LLXPRT_TEST_PROFILE']?.trim();
-    if (profileName) {
-      const profilesDir = join(llxprtDir, 'profiles');
-      mkdirSync(profilesDir, { recursive: true });
-
-      const profileProvider =
-        env['LLXPRT_DEFAULT_PROVIDER'] &&
-        env['LLXPRT_DEFAULT_PROVIDER'].trim().length
-          ? env['LLXPRT_DEFAULT_PROVIDER']
-          : 'openai';
-      const profileModel =
-        env['LLXPRT_DEFAULT_MODEL'] && env['LLXPRT_DEFAULT_MODEL'].trim().length
-          ? env['LLXPRT_DEFAULT_MODEL']
-          : 'gpt-4o-mini';
-
-      const ephemeralEntries: Array<[string, unknown]> = [];
-      if (env['OPENAI_BASE_URL'] && env['OPENAI_BASE_URL'].trim().length > 0) {
-        ephemeralEntries.push(['base-url', env['OPENAI_BASE_URL']]);
-      }
-      if (env['OPENAI_API_KEY'] && env['OPENAI_API_KEY'].trim().length > 0) {
-        ephemeralEntries.push(['auth-key', env['OPENAI_API_KEY']]);
-      }
-      if (env['LLXPRT_TEST_PROFILE_KEYFILE']) {
-        ephemeralEntries.push([
-          'auth-keyfile',
-          env['LLXPRT_TEST_PROFILE_KEYFILE'],
-        ]);
-      }
-      if (env['LLXPRT_CONTEXT_LIMIT']) {
-        const parsedLimit = Number(env['LLXPRT_CONTEXT_LIMIT']);
-        if (Number.isFinite(parsedLimit) && parsedLimit > 0) {
-          ephemeralEntries.push(['context-limit', parsedLimit]);
-        }
-      }
-
-      const profile = {
-        version: 1,
-        provider: profileProvider,
-        model: profileModel,
-        modelParams: {},
-        ephemeralSettings: Object.fromEntries(
-          ephemeralEntries.filter(([, value]) => value !== undefined),
-        ),
-      };
-
-      writeFileSync(
-        join(profilesDir, `${profileName}.json`),
-        JSON.stringify(profile, null, 2),
-      );
-    }
+    writeSettingsFile(testDir, __dirname, options.settings);
+    writeProfileFile(testDir);
   }
 
-  createFile(fileName: string, content: string) {
-    const filePath = join(this.testDir!, fileName);
+  createFile(fileName: string, content: string): string {
+    const filePath = join(this.testDir as string, fileName);
     writeFileSync(filePath, content);
     return filePath;
   }
 
   mkdir(dir: string) {
-    mkdirSync(join(this.testDir!, dir), { recursive: true });
+    mkdirSync(join(this.testDir as string, dir), { recursive: true });
   }
 
   sync() {
-    // ensure file system is done before spawning
-    // 'sync' is Unix-specific, skip on Windows
+    // 'sync' is Unix-specific, skip on Windows.
     if (process.platform !== 'win32') {
-      execSync('sync', { cwd: this.testDir! });
+      execSync('sync', { cwd: this.testDir as string });
     }
   }
 
   /**
-   * The command and args to use to invoke LLxprt CLI. Allows us to switch
-   * between using the bundled llxprt.js (the default) and using the installed
-   * 'llxprt' (used to verify npm bundles).
+   * The command and args to use to invoke LLxprt CLI. Allows switching between
+   * the bundled llxprt.js and the installed 'llxprt'.
    */
   private _getCommandAndArgs(extraInitialArgs: string[] = []): {
     command: string;
     initialArgs: string[];
   } {
-    const isNpmReleaseTest =
-      env['INTEGRATION_TEST_USE_INSTALLED_LLXPRT'] === 'true';
-    const command = isNpmReleaseTest ? 'llxprt' : 'node';
-    const initialArgs = isNpmReleaseTest
-      ? extraInitialArgs
-      : [BUNDLE_PATH, ...extraInitialArgs];
-    return { command, initialArgs };
+    return getCommandAndArgs(BUNDLE_PATH, extraInitialArgs);
   }
 
-  run(options: {
-    args?: string | string[];
-    stdin?: string;
-    stdinDoesNotEnd?: boolean;
-    yolo?: boolean;
-  }): Promise<string> {
-    // Add provider and model flags from environment - FAIL FAST if not configured
-    const provider = env['LLXPRT_DEFAULT_PROVIDER'];
-    const model = env['LLXPRT_DEFAULT_MODEL'];
-    const baseUrl = env['OPENAI_BASE_URL'];
-    const apiKey = env['OPENAI_API_KEY'];
-    const keyFile =
-      env['OPENAI_API_KEYFILE'] ?? env['LLXPRT_TEST_PROFILE_KEYFILE'];
-
-    // Fail fast if required configuration is missing (unless using fake responses)
-    if (!this.fakeResponsesPath) {
-      if (!provider) {
-        throw new Error(
-          'LLXPRT_DEFAULT_PROVIDER environment variable is required but not set',
-        );
-      }
-      if (!model) {
-        throw new Error(
-          'LLXPRT_DEFAULT_MODEL environment variable is required but not set',
-        );
-      }
-      if (!apiKey && !keyFile) {
-        throw new Error(
-          'Either OPENAI_API_KEY or OPENAI_API_KEYFILE/LLXPRT_TEST_PROFILE_KEYFILE environment variable is required but not set',
-        );
-      }
-    }
+  async run(options: RunMethodOptions): Promise<string> {
+    assertProviderConfig(this.fakeResponsesPath);
 
     const yolo = options.yolo !== false;
-    const extraArgs: string[] = [
-      ...(yolo ? ['--yolo'] : []),
-      '--ide-mode',
-      'disable',
-    ];
-
-    // When using fake responses, FakeProvider is activated via LLXPRT_FAKE_RESPONSES
-    // env var in the child process. Pass --provider fake so the bootstrap's
-    // switchActiveProvider('fake') is a no-op (provider already active).
-    // No --key is needed since FakeProvider doesn't require authentication.
-    if (this.fakeResponsesPath) {
-      extraArgs.push('--provider', 'fake', '--model', 'fake-model');
-    } else {
-      extraArgs.push('--provider', provider!);
-      extraArgs.push('--model', model!);
-
-      // Add baseurl if using openai provider
-      if (provider === 'openai' && baseUrl) {
-        extraArgs.push('--baseurl', baseUrl);
-      }
-
-      // Add API key if available
-      if (apiKey) {
-        extraArgs.push('--key', apiKey);
-      } else if (keyFile) {
-        extraArgs.push('--keyfile', keyFile);
-      }
-    }
-
+    const extraArgs = buildExtraArgs(this.fakeResponsesPath, yolo);
     const { command, initialArgs } = this._getCommandAndArgs(extraArgs);
     const commandArgs = [...initialArgs];
 
-    // Filter out TERM_PROGRAM to prevent IDE detection
-    const filteredEnv = Object.entries(process.env).reduce(
-      (acc, [key, value]) => {
-        if (key !== 'TERM_PROGRAM' && key !== 'TERM_PROGRAM_VERSION') {
-          acc[key] = value;
-        }
-        return acc;
-      },
-      {} as NodeJS.ProcessEnv,
-    );
+    appendUserArgs(commandArgs, options.args);
+    appendProfileFlag(commandArgs);
 
-    const execOptions: {
-      cwd: string;
-      encoding: 'utf-8';
-      input?: string;
-      env: NodeJS.ProcessEnv;
-    } = {
-      cwd: this.testDir!,
-      encoding: 'utf-8',
-      env: {
-        ...filteredEnv,
-        // Ensure browser launch is suppressed in tests
-        NO_BROWSER: 'true',
-        LLXPRT_NO_BROWSER_AUTH: 'true',
-        CI: 'true',
-        LLXPRT_SANDBOX: 'false',
-        LLXPRT_CODE_WELCOME_CONFIG_PATH: join(
-          this.testDir!,
-          WELCOME_CONFIG_FILENAME,
-        ),
-        // When fakeResponsesPath is set, tell CLI to use FakeProvider
-        ...(this.fakeResponsesPath
-          ? { LLXPRT_FAKE_RESPONSES: this.fakeResponsesPath }
-          : {}),
-      },
+    const childEnv = buildChildEnv(
+      this.testDir as string,
+      this.fakeResponsesPath,
+    );
+    const isJsonOutput =
+      commandArgs.includes('--output-format') && commandArgs.includes('json');
+
+    const ctx: RunContext = {
+      command,
+      commandArgs,
+      testDir: this.testDir as string,
+      childEnv,
     };
 
-    if (options.args) {
-      if (Array.isArray(options.args)) {
-        commandArgs.push(...options.args);
-      } else {
-        commandArgs.push('--prompt', options.args);
+    const transform = (stdout: string): string => {
+      this._lastRunStdout = stdout;
+      if (env['LLXPRT_SANDBOX'] === 'podman') {
+        return stripTelemetryFromStdout(stdout);
       }
-    }
+      return stdout;
+    };
 
-    if (options.stdin) {
-      execOptions.input = options.stdin;
-    }
-
-    if (env['LLXPRT_TEST_PROFILE']?.trim()) {
-      const profileName = env['LLXPRT_TEST_PROFILE'].trim();
-      // Insert profile-load flags after the initial args (node, bundle path)
-      commandArgs.splice(2, 0, '--profile-load', profileName);
-    }
-
-    const child = spawn(command, commandArgs, {
-      cwd: this.testDir!,
-      stdio: 'pipe',
-      env: execOptions.env,
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    // Handle stdin if provided
-    if (execOptions.input) {
-      child.stdin!.write(execOptions.input);
-    }
-
-    if (!options.stdinDoesNotEnd) {
-      child.stdin!.end();
-    }
-
-    child.stdout!.on('data', (data: Buffer) => {
-      stdout += data;
-      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
-        process.stdout.write(data);
-      }
-    });
-
-    child.stderr!.on('data', (data: Buffer) => {
-      stderr += data;
-      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
-        process.stderr.write(data);
-      }
-    });
-
-    const processPromise = new Promise<string>((resolve, reject) => {
-      child.on('close', (code: number) => {
-        if (code === 0) {
-          // Store the raw stdout for Podman telemetry parsing
-          this._lastRunStdout = stdout;
-
-          // Filter out telemetry output when running with Podman
-          // Podman seems to output telemetry to stdout even when writing to file
-          let result = stdout;
-          if (env['LLXPRT_SANDBOX'] === 'podman') {
-            // Remove telemetry JSON objects from output
-            // They are multi-line JSON objects that start with { and contain telemetry fields
-            const lines = result.split(os.EOL);
-            const filteredLines = [];
-            let inTelemetryObject = false;
-            let braceDepth = 0;
-
-            for (const line of lines) {
-              if (!inTelemetryObject && line.trim() === '{') {
-                // Check if this might be start of telemetry object
-                inTelemetryObject = true;
-                braceDepth = 1;
-              } else if (inTelemetryObject) {
-                // Count braces to track nesting
-                for (const char of line) {
-                  if (char === '{') braceDepth++;
-                  else if (char === '}') braceDepth--;
-                }
-
-                // Check if we've closed all braces
-                if (braceDepth === 0) {
-                  inTelemetryObject = false;
-                  // Skip this line (the closing brace)
-                  continue;
-                }
-              } else {
-                // Not in telemetry object, keep the line
-                filteredLines.push(line);
-              }
-            }
-
-            result = filteredLines.join('\n');
-          }
-
-          // Check if this is a JSON output test - if so, don't include stderr
-          // as it would corrupt the JSON
-          const isJsonOutput =
-            commandArgs.includes('--output-format') &&
-            commandArgs.includes('json');
-
-          // If we have stderr output and it's not a JSON test, include that also
-          if (stderr && !isJsonOutput) {
-            result += `\n\nStdErr:\n${stderr}`;
-          }
-
-          resolve(result);
-        } else {
-          reject(new Error(`Process exited with code ${code}:\n${stderr}`));
-        }
-      });
-    });
-
-    const timeoutMs = getDefaultTimeout() * 4;
-    const timeoutPromise = new Promise<never>((_resolve, reject) => {
-      setTimeout(() => {
-        child.kill('SIGTERM');
-        reject(new Error(`TestRig.run() timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-    });
-
-    return Promise.race([processPromise, timeoutPromise]);
+    return spawnRunWithTimeout(
+      ctx,
+      options,
+      isJsonOutput,
+      transform,
+      getDefaultTimeout() * 4,
+    );
   }
 
-  runCommand(
+  async runCommand(
     args: string[],
     options: { stdin?: string } = {},
   ): Promise<string> {
     const { command, initialArgs } = this._getCommandAndArgs();
     const commandArgs = [...initialArgs, ...args];
 
-    const child = spawn(command, commandArgs, {
-      cwd: this.testDir!,
-      stdio: 'pipe',
+    const ctx: RunContext = {
+      command,
+      commandArgs,
+      testDir: this.testDir as string,
+    };
+
+    return spawnRun(ctx, { stdin: options.stdin }, false, (stdout) => {
+      this._lastRunStdout = stdout;
+      return stdout;
     });
-
-    let stdout = '';
-    let stderr = '';
-
-    if (options.stdin) {
-      child.stdin!.write(options.stdin);
-      child.stdin!.end();
-    }
-
-    child.stdout!.on('data', (data: Buffer) => {
-      stdout += data;
-      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
-        process.stdout.write(data);
-      }
-    });
-
-    child.stderr!.on('data', (data: Buffer) => {
-      stderr += data;
-      if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
-        process.stderr.write(data);
-      }
-    });
-
-    const promise = new Promise<string>((resolve, reject) => {
-      child.on('close', (code: number) => {
-        if (code === 0) {
-          this._lastRunStdout = stdout;
-          let result = stdout;
-          if (stderr) {
-            result += `\n\nStdErr:\n${stderr}`;
-          }
-          resolve(result);
-        } else {
-          reject(new Error(`Process exited with code ${code}:\n${stderr}`));
-        }
-      });
-    });
-
-    return promise;
   }
 
-  readFile(fileName: string) {
-    const filePath = join(this.testDir!, fileName);
+  readFile(fileName: string): string {
+    const filePath = join(this.testDir as string, fileName);
     const content = readFileSync(filePath, 'utf-8');
     if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
-      console.log(`--- FILE: ${filePath} ---`);
-      console.log(content);
-      console.log(`--- END FILE: ${filePath} ---`);
+      this._diagnostics.dump(`FILE: ${filePath}`, content);
     }
     return content;
   }
 
   async cleanup() {
-    // Kill any interactive runs that are still active
-    for (const run of this._interactiveRuns) {
-      if (!run['_exited']) {
-        try {
-          await run.kill();
-        } catch (error) {
-          if (env['VERBOSE'] === 'true') {
-            console.warn(
-              'Failed to kill interactive run during cleanup:',
-              error,
-            );
-          }
-        }
-      }
-    }
+    await killInteractiveRuns(this._interactiveRuns, this._diagnostics);
     this._interactiveRuns = [];
 
     if (
       process.env['REGENERATE_MODEL_GOLDENS'] === 'true' &&
-      this.fakeResponsesPath
+      this.fakeResponsesPath !== undefined &&
+      this.originalFakeResponsesPath !== undefined
     ) {
-      fs.copyFileSync(this.fakeResponsesPath, this.originalFakeResponsesPath!);
+      fs.copyFileSync(this.fakeResponsesPath, this.originalFakeResponsesPath);
     }
-    // Clean up test directory
-    if (this.testDir && !env['KEEP_OUTPUT']) {
+    if (this.testDir !== null && env['KEEP_OUTPUT'] === undefined) {
       try {
         fs.rmSync(this.testDir, { recursive: true, force: true });
       } catch (error) {
-        // Ignore cleanup errors
-        if (env['VERBOSE'] === 'true') {
-          console.warn('Cleanup warning:', (error as Error).message);
-        }
+        this._diagnostics.warn('Cleanup warning:', (error as Error).message);
       }
     }
   }
 
   async waitForTelemetryReady() {
-    // Telemetry is always written to the test directory
-    const logFilePath = join(this.testDir!, 'telemetry.log');
+    const logFilePath = join(this.testDir as string, 'telemetry.log');
 
-    if (!logFilePath) return;
-
-    // Wait for telemetry file to exist and have content
     await poll(
       () => {
-        if (!fs.existsSync(logFilePath)) return false;
+        if (!fs.existsSync(logFilePath)) {
+          return false;
+        }
         try {
           const content = readFileSync(logFilePath, 'utf-8');
-          // Check if file has meaningful content (at least one complete JSON object)
           return content.includes('"scopeMetrics"');
         } catch {
           return false;
         }
       },
-      2000, // 2 seconds max - reduced since telemetry should flush on exit now
-      100, // check every 100ms
+      2000,
+      100,
     );
   }
 
   async waitForTelemetryEvent(eventName: string, timeout?: number) {
-    if (!timeout) {
-      timeout = getDefaultTimeout();
-    }
-
+    const effectiveTimeout = timeout ?? getDefaultTimeout();
     await this.waitForTelemetryReady();
 
     return poll(
@@ -1123,11 +273,11 @@ export class TestRig {
         const logs = this._readAndParseTelemetryLog();
         return logs.some(
           (logData) =>
-            logData.attributes &&
+            logData.attributes !== undefined &&
             logData.attributes['event.name'] === `llxprt_code.${eventName}`,
         );
       },
-      timeout,
+      effectiveTimeout,
       100,
     );
   }
@@ -1137,12 +287,7 @@ export class TestRig {
     timeout?: number,
     matchArgs?: (args: string) => boolean,
   ) {
-    // Use environment-specific timeout
-    if (!timeout) {
-      timeout = getDefaultTimeout();
-    }
-
-    // Wait for telemetry to be ready before polling for tool calls
+    const effectiveTimeout = timeout ?? getDefaultTimeout();
     await this.waitForTelemetryReady();
 
     return poll(
@@ -1154,7 +299,7 @@ export class TestRig {
             (matchArgs?.call(this, log.toolRequest.args) ?? true),
         );
       },
-      timeout,
+      effectiveTimeout,
       100,
     );
   }
@@ -1164,12 +309,7 @@ export class TestRig {
     timeout?: number,
     matchArgs?: (args: string) => boolean,
   ) {
-    // Use environment-specific timeout
-    if (!timeout) {
-      timeout = getDefaultTimeout();
-    }
-
-    // Wait for telemetry to be ready before polling for tool calls
+    const effectiveTimeout = timeout ?? getDefaultTimeout();
     await this.waitForTelemetryReady();
 
     const success = await poll(
@@ -1184,23 +324,20 @@ export class TestRig {
           ),
         );
       },
-      timeout,
+      effectiveTimeout,
       100,
     );
 
-    expect(
-      success,
-      `Expected to find successful toolCalls for ${JSON.stringify(toolNames)}`,
-    ).toBe(true);
+    expect(success).toBe(true);
+    if (!success) {
+      throw new Error(
+        `Expected to find successful toolCalls for ${JSON.stringify(toolNames)}`,
+      );
+    }
   }
 
   async waitForAnyToolCall(toolNames: string[], timeout?: number) {
-    // Use environment-specific timeout
-    if (!timeout) {
-      timeout = getDefaultTimeout();
-    }
-
-    // Wait for telemetry to be ready before polling for tool calls
+    const effectiveTimeout = timeout ?? getDefaultTimeout();
     await this.waitForTelemetryReady();
 
     return poll(
@@ -1210,309 +347,46 @@ export class TestRig {
           toolLogs.some((log) => log.toolRequest.name === name),
         );
       },
-      timeout,
+      effectiveTimeout,
       100,
     );
   }
 
   _parseToolLogsFromStdout(stdout: string) {
-    const logs: {
-      timestamp: number;
-      toolRequest: {
-        name: string;
-        args: string;
-        success: boolean;
-        duration_ms: number;
-      };
-    }[] = [];
-
-    // The console output from Podman is JavaScript object notation, not JSON.
-    // Parse line-by-line to avoid broad regexes on uncontrolled data (CodeQL CWE-1333).
-    const lines = stdout.split(os.EOL);
-
-    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-      const line = lines[lineIndex];
-      const bodyMarker = "body: 'Tool call:";
-      const bodyStartIndex = line.indexOf(bodyMarker);
-
-      if (bodyStartIndex < 0) {
-        continue;
-      }
-
-      const bodyEndIndex = line.lastIndexOf("'");
-      if (bodyEndIndex <= bodyStartIndex + bodyMarker.length) {
-        continue;
-      }
-
-      const bodyText = line
-        .slice(bodyStartIndex + "body: '".length, bodyEndIndex)
-        .trim();
-      const toolPrefix = 'Tool call:';
-      if (!bodyText.startsWith(toolPrefix)) {
-        continue;
-      }
-
-      const dotAfterToolName = bodyText.indexOf('.', toolPrefix.length);
-      if (dotAfterToolName < 0) {
-        continue;
-      }
-
-      const extractedToolName = bodyText
-        .slice(toolPrefix.length, dotAfterToolName)
-        .trim();
-      if (!extractedToolName) {
-        continue;
-      }
-
-      const successLabel = 'Success:';
-      const durationLabel = 'Duration:';
-      const successLabelIndex = bodyText.indexOf(
-        successLabel,
-        dotAfterToolName,
-      );
-      const durationLabelIndex = bodyText.indexOf(
-        durationLabel,
-        dotAfterToolName,
-      );
-      if (successLabelIndex < 0 || durationLabelIndex < 0) {
-        continue;
-      }
-
-      const successText = bodyText
-        .slice(successLabelIndex + successLabel.length, durationLabelIndex)
-        .replace(/\./g, '')
-        .trim()
-        .toLowerCase();
-      const success = successText === 'true';
-
-      const durationValueStart = durationLabelIndex + durationLabel.length;
-      const durationMsSuffix = bodyText.indexOf('ms', durationValueStart);
-      if (durationMsSuffix < 0) {
-        continue;
-      }
-      const durationText = bodyText
-        .slice(durationValueStart, durationMsSuffix)
-        .replace(/\./g, '')
-        .trim();
-      const duration = Number.parseInt(durationText, 10);
-      if (Number.isNaN(duration)) {
-        continue;
-      }
-
-      // Capture nearby lines for function attributes.
-      const contextStart = Math.max(0, lineIndex - 10);
-      const contextEnd = Math.min(lines.length, lineIndex + 10);
-      const context = lines.slice(contextStart, contextEnd).join('\n');
-
-      let args = '{}';
-      const argsMatch = context.match(/function_args:\s*'([^']+)'/);
-      if (argsMatch) {
-        args = argsMatch[1];
-      }
-
-      const nameMatch = context.match(/function_name:\s*'([\w-]+)'/);
-      const actualToolName = nameMatch ? nameMatch[1] : extractedToolName;
-
-      logs.push({
-        timestamp: Date.now(),
-        toolRequest: {
-          name: actualToolName,
-          args,
-          success,
-          duration_ms: duration,
-        },
-      });
-    }
-
-    // If no matches found with the simple parsing, try the JSON parsing approach
-    // in case the format changes
-    if (logs.length === 0) {
-      const lines = stdout.split(os.EOL);
-      let currentObject = '';
-      let inObject = false;
-      let braceDepth = 0;
-
-      for (const line of lines) {
-        if (!inObject && line.trim() === '{') {
-          inObject = true;
-          braceDepth = 1;
-          currentObject = line + '\n';
-        } else if (inObject) {
-          currentObject += line + '\n';
-
-          // Count braces
-          for (const char of line) {
-            if (char === '{') braceDepth++;
-            else if (char === '}') braceDepth--;
-          }
-
-          // If we've closed all braces, try to parse the object
-          if (braceDepth === 0) {
-            inObject = false;
-            try {
-              const obj = JSON.parse(currentObject);
-
-              // Check for tool call in different formats
-              if (
-                obj.body &&
-                obj.body.includes('Tool call:') &&
-                obj.attributes
-              ) {
-                const bodyMatch = obj.body.match(/Tool call: (\w+)\./);
-                if (bodyMatch) {
-                  logs.push({
-                    timestamp: obj.timestamp || Date.now(),
-                    toolRequest: {
-                      name: bodyMatch[1],
-                      args: obj.attributes.function_args || '{}',
-                      success: obj.attributes.success !== false,
-                      duration_ms: obj.attributes.duration_ms || 0,
-                    },
-                  });
-                }
-              } else if (
-                obj.attributes &&
-                obj.attributes['event.name'] === 'llxprt_code.tool_call'
-              ) {
-                logs.push({
-                  timestamp: obj.attributes['event.timestamp'],
-                  toolRequest: {
-                    name: obj.attributes.function_name,
-                    args: obj.attributes.function_args,
-                    success: obj.attributes.success,
-                    duration_ms: obj.attributes.duration_ms,
-                  },
-                });
-              }
-            } catch {
-              // Not valid JSON
-            }
-            currentObject = '';
-          }
-        }
-      }
-    }
-
-    return logs;
+    return parseToolLogsFromStdout(stdout);
   }
 
   private _readAndParseTelemetryLog(): ParsedLog[] {
-    // Telemetry is always written to the test directory
-    const logFilePath = join(this.testDir!, 'telemetry.log');
-
-    if (!logFilePath || !fs.existsSync(logFilePath)) {
+    if (this.testDir === null) {
       return [];
     }
-
-    const content = readFileSync(logFilePath, 'utf-8');
-
-    // Split the content into individual JSON objects
-    // They are separated by "}\n{"
-    const jsonObjects = content
-      .split(/}\n{/)
-      .map((obj, index, array) => {
-        // Add back the braces we removed during split
-        if (index > 0) obj = '{' + obj;
-        if (index < array.length - 1) obj = obj + '}';
-        return obj.trim();
-      })
-      .filter((obj) => obj);
-
-    const logs: ParsedLog[] = [];
-
-    for (const jsonStr of jsonObjects) {
-      try {
-        const logData = JSON.parse(jsonStr);
-        logs.push(logData);
-      } catch (e) {
-        // Skip objects that aren't valid JSON
-        if (env['VERBOSE'] === 'true') {
-          console.error('Failed to parse telemetry object:', e);
-        }
-      }
-    }
-
-    return logs;
+    return readAndParseTelemetryLog(this.testDir, this._diagnostics);
   }
 
   readToolLogs() {
-    // For Podman, first check if telemetry file exists and has content
-    // If not, fall back to parsing from stdout
     if (env['LLXPRT_SANDBOX'] === 'podman') {
-      // Try reading from file first
-      const logFilePath = join(this.testDir!, 'telemetry.log');
-
-      if (fs.existsSync(logFilePath)) {
-        try {
-          const content = readFileSync(logFilePath, 'utf-8');
-          if (content && content.includes('"event.name"')) {
-            // File has content, use normal file parsing
-            // Continue to the normal file parsing logic below
-          } else if (this._lastRunStdout) {
-            // File exists but is empty or doesn't have events, parse from stdout
-            return this._parseToolLogsFromStdout(this._lastRunStdout);
-          }
-        } catch {
-          // Error reading file, fall back to stdout
-          if (this._lastRunStdout) {
-            return this._parseToolLogsFromStdout(this._lastRunStdout);
-          }
-        }
-      } else if (this._lastRunStdout) {
-        // No file exists, parse from stdout
-        return this._parseToolLogsFromStdout(this._lastRunStdout);
+      const fromStdout = tryReadPodmanToolLogs(
+        this.testDir as string,
+        this._lastRunStdout,
+      );
+      if (fromStdout !== undefined) {
+        return fromStdout;
       }
     }
 
     const parsedLogs = this._readAndParseTelemetryLog();
-    const logs: {
-      toolRequest: {
-        name: string;
-        args: string;
-        success: boolean;
-        duration_ms: number;
-      };
-    }[] = [];
-
-    for (const logData of parsedLogs) {
-      // Look for tool call logs
-      if (
-        logData.attributes &&
-        logData.attributes['event.name'] === 'llxprt_code.tool_call'
-      ) {
-        const toolName = logData.attributes.function_name!;
-        logs.push({
-          toolRequest: {
-            name: toolName,
-            args: logData.attributes.function_args ?? '{}',
-            success: logData.attributes.success ?? false,
-            duration_ms: logData.attributes.duration_ms ?? 0,
-          },
-        });
-      }
-    }
-
-    return logs;
+    return extractToolLogsFromTelemetry(parsedLogs);
   }
 
   readAllApiRequest(): ParsedLog[] {
     const logs = this._readAndParseTelemetryLog();
-    const apiRequests = logs.filter(
-      (logData) =>
-        logData.attributes &&
-        logData.attributes['event.name'] === 'llxprt_code.api_request',
-    );
-    return apiRequests;
+    return extractApiRequests(logs);
   }
 
   readLastApiRequest(): ParsedLog | null {
     const logs = this._readAndParseTelemetryLog();
-    const apiRequests = logs.filter(
-      (logData) =>
-        logData.attributes &&
-        logData.attributes['event.name'] === 'llxprt_code.api_request',
-    );
-    return apiRequests.pop() || null;
+    const apiRequests = extractApiRequests(logs);
+    return apiRequests.pop() ?? null;
   }
 
   async waitForMetric(metricName: string, timeout?: number) {
@@ -1523,224 +397,58 @@ export class TestRig {
       : `llxprt_code.${metricName}`;
 
     return poll(
-      () => {
-        const logs = this._readAndParseTelemetryLog();
-        for (const logData of logs) {
-          if (logData.scopeMetrics) {
-            for (const scopeMetric of logData.scopeMetrics) {
-              for (const metric of scopeMetric.metrics) {
-                if (metric.descriptor.name === fullName) {
-                  return true;
-                }
-              }
-            }
-          }
-        }
-        return false;
-      },
+      () => findMetric(this._readAndParseTelemetryLog(), fullName) !== null,
       timeout ?? getDefaultTimeout(),
       100,
     );
   }
 
   readMetric(metricName: string): Record<string, unknown> | null {
-    const logs = this._readAndParseTelemetryLog();
-    for (const logData of logs) {
-      if (logData.scopeMetrics) {
-        for (const scopeMetric of logData.scopeMetrics) {
-          for (const metric of scopeMetric.metrics) {
-            if (metric.descriptor.name === `llxprt_code.${metricName}`) {
-              return metric;
-            }
-          }
-        }
-      }
-    }
-    return null;
+    return findMetric(
+      this._readAndParseTelemetryLog(),
+      `llxprt_code.${metricName}`,
+    );
   }
 
   async runInteractive(options?: {
     args?: string | string[];
     yolo?: boolean;
   }): Promise<InteractiveRun> {
-    const provider = env['LLXPRT_DEFAULT_PROVIDER'];
-    const model = env['LLXPRT_DEFAULT_MODEL'];
-    const baseUrl = env['OPENAI_BASE_URL'];
-    const apiKey = env['OPENAI_API_KEY'];
-    const keyFile =
-      env['OPENAI_API_KEYFILE'] ?? env['LLXPRT_TEST_PROFILE_KEYFILE'];
-
-    // Fail fast if required configuration is missing (unless using fake responses)
-    if (!this.fakeResponsesPath) {
-      if (!provider) {
-        throw new Error(
-          'LLXPRT_DEFAULT_PROVIDER environment variable is required but not set',
-        );
-      }
-      if (!model) {
-        throw new Error(
-          'LLXPRT_DEFAULT_MODEL environment variable is required but not set',
-        );
-      }
-      if (!apiKey && !keyFile) {
-        throw new Error(
-          'Either OPENAI_API_KEY or OPENAI_API_KEYFILE/LLXPRT_TEST_PROFILE_KEYFILE environment variable is required but not set',
-        );
-      }
-    }
+    assertProviderConfig(this.fakeResponsesPath);
 
     const yolo = options?.yolo !== false;
-    const extraArgs: string[] = [
-      ...(yolo ? ['--yolo'] : []),
-      '--ide-mode',
-      'disable',
-    ];
-
-    // When using fake responses, FakeProvider is activated via LLXPRT_FAKE_RESPONSES
-    // env var in the child process. Pass --provider fake so the bootstrap's
-    // switchActiveProvider('fake') is a no-op (provider already active).
-    // No --key is needed since FakeProvider doesn't require authentication.
-    if (this.fakeResponsesPath) {
-      extraArgs.push('--provider', 'fake', '--model', 'fake-model');
-    } else {
-      extraArgs.push('--provider', provider!);
-      extraArgs.push('--model', model!);
-
-      // Add baseurl if using openai provider
-      if (provider === 'openai' && baseUrl) {
-        extraArgs.push('--baseurl', baseUrl);
-      }
-
-      // Add API key if available
-      if (apiKey) {
-        extraArgs.push('--key', apiKey);
-      } else if (keyFile) {
-        extraArgs.push('--keyfile', keyFile);
-      }
-    }
-
+    const extraArgs = buildExtraArgs(this.fakeResponsesPath, yolo);
     const { command, initialArgs } = this._getCommandAndArgs(extraArgs);
     const commandArgs = [...initialArgs];
 
-    if (options?.args) {
-      if (Array.isArray(options.args)) {
-        commandArgs.push(...options.args);
-      } else {
-        commandArgs.push(options.args);
-      }
-    }
+    appendInteractiveArgs(commandArgs, options?.args);
+    appendProfileFlag(commandArgs);
 
-    // Filter out TERM_PROGRAM to prevent IDE detection
-    const filteredEnv = Object.entries(process.env).reduce(
-      (acc, [key, value]) => {
-        if (
-          value !== undefined &&
-          key !== 'TERM_PROGRAM' &&
-          key !== 'TERM_PROGRAM_VERSION'
-        ) {
-          acc[key] = value;
-        }
-        return acc;
-      },
-      {} as Record<string, string>,
+    const childEnv = buildChildEnv(
+      this.testDir as string,
+      this.fakeResponsesPath,
     );
 
     const ptyOptions: pty.IPtyForkOptions = {
       name: 'xterm-color',
       cols: 80,
       rows: 80,
-      cwd: this.testDir!,
-      env: {
-        ...filteredEnv,
-        // Ensure browser launch is suppressed in tests
-        NO_BROWSER: 'true',
-        LLXPRT_NO_BROWSER_AUTH: 'true',
-        CI: 'true',
-        LLXPRT_SANDBOX: 'false',
-        LLXPRT_CODE_WELCOME_CONFIG_PATH: join(
-          this.testDir!,
-          WELCOME_CONFIG_FILENAME,
-        ),
-        // When fakeResponsesPath is set, tell CLI to use FakeProvider
-        ...(this.fakeResponsesPath
-          ? { LLXPRT_FAKE_RESPONSES: this.fakeResponsesPath }
-          : {}),
-      },
+      cwd: this.testDir as string,
+      env: childEnv,
     };
 
     const executable = command === 'node' ? process.execPath : command;
     const ptyProcess = pty.spawn(executable, commandArgs, ptyOptions);
 
-    const run = new InteractiveRun(ptyProcess);
+    const run = new InteractiveRun(ptyProcess, this._diagnostics);
     this._interactiveRuns.push(run);
 
-    const promptReadyText = '  Type your message or @path/to/file';
-    const tipsReadyText = 'Tips for getting started:';
-
-    // Wait for the app to be ready. In some CI PTY/render paths the composer
-    // placeholder may not be emitted immediately even though the interactive
-    // session has already reached the main screen.
-    const isReady = await poll(
-      () => {
-        const normalizedOutput = stripAnsi(run.output).toLowerCase();
-        return (
-          normalizedOutput.includes(promptReadyText.toLowerCase()) ||
-          normalizedOutput.includes(tipsReadyText.toLowerCase())
-        );
-      },
-      30000,
-      200,
-    );
-
-    expect(
-      isReady,
-      `Expected interactive startup output to contain either "${promptReadyText}" or "${tipsReadyText}".`,
-    ).toBe(true);
-
-    return run;
+    return waitForInteractiveReady(run);
   }
 
   readHookLogs() {
     const parsedLogs = this._readAndParseTelemetryLog();
-    const logs: {
-      hookCall: {
-        hook_event_name: string;
-        hook_name: string;
-        hook_input: Record<string, unknown>;
-        hook_output: Record<string, unknown>;
-        exit_code: number;
-        stdout: string;
-        stderr: string;
-        duration_ms: number;
-        success: boolean;
-        error: string;
-      };
-    }[] = [];
-
-    for (const logData of parsedLogs) {
-      // Look for tool call logs
-      if (
-        logData.attributes &&
-        logData.attributes['event.name'] === 'llxprt_code.hook_call'
-      ) {
-        logs.push({
-          hookCall: {
-            hook_event_name: logData.attributes.hook_event_name ?? '',
-            hook_name: logData.attributes.hook_name ?? '',
-            hook_input: logData.attributes.hook_input ?? {},
-            hook_output: logData.attributes.hook_output ?? {},
-            exit_code: logData.attributes.exit_code ?? 0,
-            stdout: logData.attributes.stdout ?? '',
-            stderr: logData.attributes.stderr ?? '',
-            duration_ms: logData.attributes.duration_ms ?? 0,
-            success: logData.attributes.success ?? false,
-            error: logData.attributes.error ?? '',
-          },
-        });
-      }
-    }
-
-    return logs;
+    return extractHookLogs(parsedLogs);
   }
 
   async pollCommand(
@@ -1752,7 +460,6 @@ export class TestRig {
     const startTime = Date.now();
     while (Date.now() - startTime < timeout) {
       await commandFn();
-      // Give it a moment to process
       await new Promise((resolve) => setTimeout(resolve, 500));
       if (predicateFn()) {
         return;
@@ -1761,4 +468,124 @@ export class TestRig {
     }
     throw new Error(`pollCommand timed out after ${timeout}ms`);
   }
+}
+
+/**
+ * Append user-supplied args (string prompt or arg array) to the command list.
+ */
+function appendUserArgs(
+  commandArgs: string[],
+  args: RunMethodOptions['args'],
+): void {
+  if (args === undefined) {
+    return;
+  }
+  if (Array.isArray(args)) {
+    commandArgs.push(...args);
+  } else {
+    commandArgs.push('--prompt', args);
+  }
+}
+
+/**
+ * Append the `--profile-load` flag when a test profile is configured.
+ */
+function appendProfileFlag(commandArgs: string[]): void {
+  const profileName = getProfileName();
+  if (profileName === undefined) {
+    return;
+  }
+  const ideFlagIndex = commandArgs.indexOf('--ide-mode');
+  const insertionIndex = ideFlagIndex >= 0 ? ideFlagIndex : commandArgs.length;
+  commandArgs.splice(insertionIndex, 0, '--profile-load', profileName);
+}
+
+/**
+ * Append args for the interactive (non-prompt) run path.
+ */
+function appendInteractiveArgs(
+  commandArgs: string[],
+  args: string | string[] | undefined,
+): void {
+  if (args === undefined) {
+    return;
+  }
+  if (Array.isArray(args)) {
+    commandArgs.push(...args);
+  } else {
+    commandArgs.push(args);
+  }
+}
+
+/**
+ * Kill any still-running interactive sessions, logging failures.
+ */
+async function killInteractiveRuns(
+  runs: InteractiveRun[],
+  diagnostics: ReturnType<typeof createDiagnosticsSink>,
+): Promise<void> {
+  for (const run of runs) {
+    if (!run.exited) {
+      try {
+        await run.kill();
+      } catch (error) {
+        diagnostics.warn(
+          'Failed to kill interactive run during cleanup:',
+          error,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Wait for the interactive session to reach its main screen.
+ */
+async function waitForInteractiveReady(
+  run: InteractiveRun,
+): Promise<InteractiveRun> {
+  const promptReadyText = '  Type your message or @path/to/file';
+  const tipsReadyText = 'Tips for getting started:';
+
+  const isReady = await poll(
+    () => {
+      const normalizedOutput = stripAnsi(run.output).toLowerCase();
+      return (
+        normalizedOutput.includes(promptReadyText.toLowerCase()) ||
+        normalizedOutput.includes(tipsReadyText.toLowerCase())
+      );
+    },
+    30000,
+    200,
+  );
+
+  expect(isReady).toBe(true);
+  return run;
+}
+
+/**
+ * Try to read tool logs from Podman stdout, returning undefined to signal that
+ * the caller should fall back to the telemetry file.
+ */
+function tryReadPodmanToolLogs(
+  testDir: string,
+  lastRunStdout: string | undefined,
+): ReturnType<typeof parseToolLogsFromStdout> | undefined {
+  const logFilePath = join(testDir, 'telemetry.log');
+
+  if (fs.existsSync(logFilePath)) {
+    try {
+      const content = readFileSync(logFilePath, 'utf-8');
+      if (content.length > 0 && content.includes('"event.name"')) {
+        return undefined; // Use normal file parsing.
+      }
+    } catch {
+      // Fall through to stdout parsing.
+    }
+  }
+
+  if (lastRunStdout !== undefined) {
+    return parseToolLogsFromStdout(lastRunStdout);
+  }
+  return undefined;
 }

--- a/packages/test-utils/src/tool-log-parsing.test.ts
+++ b/packages/test-utils/src/tool-log-parsing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  extractHookLogs,
+  parseToolLogsFromStdout,
+} from './tool-log-parsing.js';
+import type { ParsedLog } from './types.js';
+
+describe('tool and hook log parsing helpers', () => {
+  it('parses body-marker tool logs from CRLF stdout', () => {
+    const stdout = [
+      "function_name: 'write_file'",
+      'function_args: \'{"path":"file.txt"}\'',
+      "body: 'Tool call: write_file. Success: true. Duration: 17ms'",
+    ].join('\r\n');
+
+    const logs = parseToolLogsFromStdout(stdout);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.toolRequest).toStrictEqual({
+      name: 'write_file',
+      args: '{"path":"file.txt"}',
+      success: true,
+      duration_ms: 17,
+    });
+  });
+
+  it('parses fallback JSON tool logs while ignoring braces inside strings', () => {
+    const stdout = JSON.stringify(
+      {
+        timestamp: 123,
+        body: 'Tool call: read_file. Message with { braces } inside text',
+        attributes: {
+          function_args: '{"path":"file.txt"}',
+          success: true,
+          duration_ms: 5,
+        },
+      },
+      null,
+      2,
+    );
+
+    const logs = parseToolLogsFromStdout(stdout);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.timestamp).toBe(123);
+    expect(logs[0]?.toolRequest).toStrictEqual({
+      name: 'read_file',
+      args: '{"path":"file.txt"}',
+      success: true,
+      duration_ms: 5,
+    });
+  });
+
+  it('extracts normalized hook-call logs from telemetry entries', () => {
+    const parsedLogs: ParsedLog[] = [
+      {
+        attributes: {
+          'event.name': 'llxprt_code.hook_call',
+          hook_event_name: 'BeforeTool',
+          hook_name: 'node hook.cjs',
+          hook_input: { tool: 'write_file' },
+          hook_output: { decision: 'allow' },
+          exit_code: 0,
+          stdout: 'hook output',
+          stderr: '',
+          duration_ms: 10,
+          success: true,
+          error: '',
+        },
+      },
+    ];
+
+    expect(extractHookLogs(parsedLogs)).toStrictEqual([
+      {
+        hookCall: {
+          hook_event_name: 'BeforeTool',
+          hook_name: 'node hook.cjs',
+          hook_input: { tool: 'write_file' },
+          hook_output: { decision: 'allow' },
+          exit_code: 0,
+          stdout: 'hook output',
+          stderr: '',
+          duration_ms: 10,
+          success: true,
+          error: '',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/test-utils/src/tool-log-parsing.ts
+++ b/packages/test-utils/src/tool-log-parsing.ts
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { HookLogEntry, ParsedLog, ToolLogEntry } from './types.js';
+
+const BODY_MARKER = "body: 'Tool call:";
+const TOOL_PREFIX = 'Tool call:';
+const SUCCESS_LABEL = 'Success:';
+const DURATION_LABEL = 'Duration:';
+const LINE_BREAK_PATTERN = /\r?\n/;
+
+/**
+ * Parse a single Podman stdout line containing a "Tool call:" body marker.
+ * Returns null when the line does not yield a usable tool entry.
+ */
+function parseToolCallLine(line: string): {
+  extractedToolName: string;
+  success: boolean;
+  duration: number;
+} | null {
+  const bodyStartIndex = line.indexOf(BODY_MARKER);
+  if (bodyStartIndex < 0) {
+    return null;
+  }
+
+  const bodyEndIndex = line.lastIndexOf("'");
+  if (bodyEndIndex <= bodyStartIndex + BODY_MARKER.length) {
+    return null;
+  }
+
+  const bodyText = line
+    .slice(bodyStartIndex + "body: '".length, bodyEndIndex)
+    .trim();
+  if (!bodyText.startsWith(TOOL_PREFIX)) {
+    return null;
+  }
+
+  const dotAfterToolName = bodyText.indexOf('.', TOOL_PREFIX.length);
+  if (dotAfterToolName < 0) {
+    return null;
+  }
+
+  const extractedToolName = bodyText
+    .slice(TOOL_PREFIX.length, dotAfterToolName)
+    .trim();
+  if (extractedToolName.length === 0) {
+    return null;
+  }
+
+  const successLabelIndex = bodyText.indexOf(SUCCESS_LABEL, dotAfterToolName);
+  const durationLabelIndex = bodyText.indexOf(DURATION_LABEL, dotAfterToolName);
+  if (successLabelIndex < 0 || durationLabelIndex < 0) {
+    return null;
+  }
+
+  const successText = bodyText
+    .slice(successLabelIndex + SUCCESS_LABEL.length, durationLabelIndex)
+    .replace(/\./g, '')
+    .trim()
+    .toLowerCase();
+  const success = successText === 'true';
+
+  const durationValueStart = durationLabelIndex + DURATION_LABEL.length;
+  const durationMsSuffix = bodyText.indexOf('ms', durationValueStart);
+  if (durationMsSuffix < 0) {
+    return null;
+  }
+  const durationText = bodyText
+    .slice(durationValueStart, durationMsSuffix)
+    .replace(/\./g, '')
+    .trim();
+  const duration = Number.parseInt(durationText, 10);
+  if (Number.isNaN(duration)) {
+    return null;
+  }
+
+  return { extractedToolName, success, duration };
+}
+
+/**
+ * Parse the "body-marker" format from Podman stdout into tool entries.
+ */
+function parseBodyMarkerFormat(stdout: string): ToolLogEntry[] {
+  const logs: ToolLogEntry[] = [];
+  const lines = stdout.split(LINE_BREAK_PATTERN);
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    const parsed = parseToolCallLine(line);
+    if (parsed === null) {
+      continue;
+    }
+
+    const contextStart = Math.max(0, lineIndex - 10);
+    const contextEnd = Math.min(lines.length, lineIndex + 10);
+    const context = lines.slice(contextStart, contextEnd).join('\n');
+
+    const argsMatch = context.match(/function_args:\s*'([^']+)'/);
+    const args = argsMatch !== null ? argsMatch[1] : '{}';
+
+    const nameMatch = context.match(/function_name:\s*'([\w-]+)'/);
+    const actualToolName =
+      nameMatch !== null ? nameMatch[1] : parsed.extractedToolName;
+
+    logs.push({
+      timestamp: Date.now(),
+      toolRequest: {
+        name: actualToolName,
+        args,
+        success: parsed.success,
+        duration_ms: parsed.duration,
+      },
+    });
+  }
+
+  return logs;
+}
+
+/**
+ * A parsed fallback JSON object containing a tool call.
+ */
+interface FallbackObject {
+  readonly timestamp?: number;
+  readonly body?: string;
+  readonly attributes?: Record<string, unknown>;
+}
+
+/**
+ * Convert a fallback JSON object into a tool entry when applicable.
+ */
+function fallbackObjectToEntry(obj: FallbackObject): ToolLogEntry | null {
+  const attributes = obj.attributes;
+  if (
+    obj.body !== undefined &&
+    obj.body.includes('Tool call:') &&
+    attributes !== undefined
+  ) {
+    const bodyMatch = obj.body.match(/Tool call: (\w+)\./);
+    if (bodyMatch !== null) {
+      return {
+        timestamp: obj.timestamp ?? Date.now(),
+        toolRequest: {
+          name: bodyMatch[1],
+          args: readStringAttr(attributes, 'function_args') ?? '{}',
+          success: readBooleanAttr(attributes, 'success', true),
+          duration_ms: readNumberAttr(attributes, 'duration_ms') ?? 0,
+        },
+      };
+    }
+  }
+
+  if (
+    attributes !== undefined &&
+    readStringAttr(attributes, 'event.name') === 'llxprt_code.tool_call'
+  ) {
+    return {
+      timestamp: readNumberAttr(attributes, 'event.timestamp') ?? Date.now(),
+      toolRequest: {
+        name: readStringAttr(attributes, 'function_name') ?? '',
+        args: readStringAttr(attributes, 'function_args') ?? '{}',
+        success: readBooleanAttr(attributes, 'success', false),
+        duration_ms: readNumberAttr(attributes, 'duration_ms') ?? 0,
+      },
+    };
+  }
+
+  return null;
+}
+
+function readStringAttr(
+  attributes: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = attributes[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readNumberAttr(
+  attributes: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = attributes[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function readBooleanAttr(
+  attributes: Record<string, unknown>,
+  key: string,
+  defaultValue: boolean,
+): boolean {
+  const value = attributes[key];
+  return typeof value === 'boolean' ? value : defaultValue;
+}
+
+/**
+ * Parse the JSON-object-array fallback format from Podman stdout.
+ */
+function parseFallbackJsonFormat(stdout: string): ToolLogEntry[] {
+  const logs: ToolLogEntry[] = [];
+  const lines = stdout.split(LINE_BREAK_PATTERN);
+  let currentObject = '';
+  let inObject = false;
+  let braceDepth = 0;
+
+  for (const line of lines) {
+    const startNewObject = !inObject && line.trim() === '{';
+    if (startNewObject) {
+      inObject = true;
+      braceDepth = 1;
+      currentObject = line + '\n';
+    } else if (inObject) {
+      currentObject += line + '\n';
+      braceDepth += countBraceDelta(line);
+      if (braceDepth === 0) {
+        inObject = false;
+        finalizeFallbackObject(currentObject, logs);
+        currentObject = '';
+      }
+    }
+  }
+
+  return logs;
+}
+
+/**
+ * Count the net change in brace depth for a line.
+ */
+function countBraceDelta(line: string): number {
+  let delta = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const char of line) {
+    const state = readBraceParserState(char, inString, escaped);
+    inString = state.inString;
+    escaped = state.escaped;
+    delta += state.delta;
+  }
+  return delta;
+}
+
+function readBraceParserState(
+  char: string,
+  inString: boolean,
+  escaped: boolean,
+): { inString: boolean; escaped: boolean; delta: number } {
+  if (escaped) {
+    return { inString, escaped: false, delta: 0 };
+  }
+
+  if (char === '\\') {
+    return { inString, escaped: inString, delta: 0 };
+  }
+
+  if (char === '"') {
+    return { inString: !inString, escaped: false, delta: 0 };
+  }
+
+  if (inString) {
+    return { inString, escaped: false, delta: 0 };
+  }
+
+  if (char === '{') {
+    return { inString, escaped: false, delta: 1 };
+  }
+
+  if (char === '}') {
+    return { inString, escaped: false, delta: -1 };
+  }
+
+  return { inString, escaped: false, delta: 0 };
+}
+
+/**
+ * Parse an accumulated JSON object string and append any tool entry it yields.
+ */
+function finalizeFallbackObject(
+  currentObject: string,
+  logs: ToolLogEntry[],
+): void {
+  try {
+    const obj = JSON.parse(currentObject) as FallbackObject;
+    const entry = fallbackObjectToEntry(obj);
+    if (entry !== null) {
+      logs.push(entry);
+    }
+  } catch {
+    // Not valid JSON.
+  }
+}
+
+/**
+ * Parse tool-call logs from Podman stdout. Tries the body-marker format first,
+ * then falls back to a JSON-object-array format.
+ */
+export function parseToolLogsFromStdout(stdout: string): ToolLogEntry[] {
+  const bodyMarkerLogs = parseBodyMarkerFormat(stdout);
+  if (bodyMarkerLogs.length > 0) {
+    return bodyMarkerLogs;
+  }
+  return parseFallbackJsonFormat(stdout);
+}
+
+/**
+ * Extract hook-call entries from parsed telemetry logs.
+ */
+export function extractHookLogs(
+  parsedLogs: readonly ParsedLog[],
+): HookLogEntry[] {
+  const logs: HookLogEntry[] = [];
+
+  for (const logData of parsedLogs) {
+    const attributes = logData.attributes;
+    if (
+      attributes !== undefined &&
+      attributes['event.name'] === 'llxprt_code.hook_call'
+    ) {
+      logs.push({
+        hookCall: {
+          hook_event_name: attributes.hook_event_name ?? '',
+          hook_name: attributes.hook_name ?? '',
+          hook_input: attributes.hook_input ?? {},
+          hook_output: attributes.hook_output ?? {},
+          exit_code: attributes.exit_code ?? 0,
+          stdout: attributes.stdout ?? '',
+          stderr: attributes.stderr ?? '',
+          duration_ms: attributes.duration_ms ?? 0,
+          success: attributes.success ?? false,
+          error: attributes.error ?? '',
+        },
+      });
+    }
+  }
+
+  return logs;
+}

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Options for running a command with timeout support.
+ */
+export interface InteractiveRunOptions {
+  /** Maximum time to wait for the command to complete (default: 30000ms) */
+  timeout?: number;
+  /** Time to wait after SIGTERM before sending SIGKILL (default: 5000ms) */
+  gracefulKillTimeout?: number;
+}
+
+/**
+ * Result of running a command.
+ */
+export interface InteractiveRunResult {
+  /** The exit code of the process, or null if it was killed */
+  exitCode: number | null;
+  /** Standard output from the process */
+  stdout: string;
+  /** Standard error from the process */
+  stderr: string;
+  /** Whether the process timed out */
+  timedOut: boolean;
+  /** Whether the process was killed */
+  killed: boolean;
+}
+
+/**
+ * Attributes recorded on a telemetry log entry.
+ */
+export interface TelemetryAttributes {
+  readonly 'event.name'?: string;
+  readonly function_name?: string;
+  readonly function_args?: string;
+  readonly success?: boolean;
+  readonly duration_ms?: number;
+  readonly request_text?: string;
+  readonly hook_event_name?: string;
+  readonly hook_name?: string;
+  readonly hook_input?: Record<string, unknown>;
+  readonly hook_output?: Record<string, unknown>;
+  readonly exit_code?: number;
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly error?: string;
+  readonly 'event.timestamp'?: number;
+}
+
+/**
+ * A single parsed telemetry object as emitted to telemetry.log.
+ */
+export interface ParsedLog {
+  attributes?: TelemetryAttributes;
+  scopeMetrics?: Array<{
+    metrics: Array<{
+      descriptor: {
+        name: string;
+      };
+    }>;
+  }>;
+  body?: string;
+  timestamp?: number;
+}
+
+/**
+ * A normalized tool-call record extracted from telemetry or stdout.
+ */
+export interface ToolLogEntry {
+  timestamp: number;
+  toolRequest: {
+    name: string;
+    args: string;
+    success: boolean;
+    duration_ms: number;
+  };
+}
+
+/**
+ * A normalized hook-call record extracted from telemetry.
+ */
+export interface HookLogEntry {
+  hookCall: {
+    hook_event_name: string;
+    hook_name: string;
+    hook_input: Record<string, unknown>;
+    hook_output: Record<string, unknown>;
+    exit_code: number;
+    stdout: string;
+    stderr: string;
+    duration_ms: number;
+    success: boolean;
+    error: string;
+  };
+}

--- a/packages/test-utils/src/util.ts
+++ b/packages/test-utils/src/util.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { env } from 'node:process';
+import { logVerbose } from './diagnostics.js';
+import type { TestRig } from './test-rig.js';
+
+/**
+ * Get the default test timeout based on the execution environment.
+ */
+export function getDefaultTimeout(): number {
+  if (env['CI']) {
+    return 60000;
+  }
+  if (env['LLXPRT_SANDBOX']) {
+    return 30000;
+  }
+  return 15000;
+}
+
+/**
+ * Poll a predicate until it returns true or the timeout elapses.
+ */
+export async function poll(
+  predicate: () => boolean,
+  timeout: number,
+  interval: number,
+): Promise<boolean> {
+  const startTime = Date.now();
+  let attempts = 0;
+  while (Date.now() - startTime < timeout) {
+    attempts++;
+    const result = predicate();
+    if (env['VERBOSE'] === 'true' && attempts % 5 === 0) {
+      logVerbose(
+        `Poll attempt ${attempts}: ${result ? 'success' : 'waiting...'}`,
+      );
+    }
+    if (result) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  if (env['VERBOSE'] === 'true') {
+    logVerbose(`Poll timed out after ${attempts} attempts`);
+  }
+  return false;
+}
+
+/**
+ * Convert an arbitrary test name into a filesystem-safe slug.
+ */
+export function sanitizeTestName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-+/g, '-');
+}
+
+/**
+ * Build a detailed error message describing expected vs found tool calls.
+ */
+export function createToolCallErrorMessage(
+  expectedTools: string | string[],
+  foundTools: string[],
+  result: string,
+): string {
+  const expectedStr = Array.isArray(expectedTools)
+    ? expectedTools.join(' or ')
+    : expectedTools;
+  return (
+    `Expected to find ${expectedStr} tool call(s). ` +
+    `Found: ${foundTools.length > 0 ? foundTools.join(', ') : 'none'}. ` +
+    `Output preview: ${formatOutputPreview(result)}`
+  );
+}
+
+function formatOutputPreview(result: string): string {
+  if (result.length === 0) {
+    return 'no output';
+  }
+  if (result.length <= 200) {
+    return result;
+  }
+  return `${result.substring(0, 200)}...`;
+}
+
+/**
+ * Print debug information for a failing test. Returns the parsed tool logs.
+ */
+export function printDebugInfo(
+  rig: TestRig,
+  result: string,
+  context: Record<string, unknown> = {},
+) {
+  const contextEntries = Object.entries(context)
+    .map(([key, value]) => `${key}: ${String(value)}`)
+    .join('\n');
+  const preview = result.substring(0, 500);
+  const tail = result.substring(result.length - 500);
+  const allTools = rig.readToolLogs();
+
+  const dump =
+    `Test failed - Debug info:\n` +
+    `Result length: ${result.length}\n` +
+    `Result (first 500 chars): ${preview}\n` +
+    `Result (last 500 chars): ${tail}\n` +
+    `${contextEntries.length > 0 ? contextEntries + '\n' : ''}` +
+    `All tool calls found: ${allTools.map((t) => t.toolRequest.name).join(', ')}\n`;
+
+  rig.dumpDiagnostic('printDebugInfo', dump);
+  return allTools;
+}
+function formatExpectedContent(content: string | RegExp): string {
+  return content instanceof RegExp ? content.toString() : content;
+}
+
+type ExpectedContent = string | Array<string | RegExp>;
+
+/**
+ * Validate model output and warn about unexpected content. Returns whether all
+ * expected content was present.
+ */
+export function validateModelOutput(
+  result: string,
+  expectedContent: ExpectedContent | null = null,
+  testName = '',
+): boolean {
+  if (result.length === 0 || result.trim().length === 0) {
+    throw new Error('Expected LLM to return some output');
+  }
+
+  if (expectedContent === null) {
+    return true;
+  }
+
+  const contents = Array.isArray(expectedContent)
+    ? expectedContent
+    : [expectedContent];
+  const missingContent = contents.filter((content) => {
+    if (content instanceof RegExp) {
+      return !content.test(result);
+    }
+    return !result.toLowerCase().includes(content.toLowerCase());
+  });
+
+  if (missingContent.length > 0) {
+    const missingDisplay = missingContent.map(formatExpectedContent).join(', ');
+    const warning =
+      `Warning: LLM did not include expected content in response: ${missingDisplay}.\n` +
+      'This is not ideal but not a test failure.\n' +
+      'The tool was called successfully, which is the main requirement.\n' +
+      `Expected content: ${String(expectedContent)}\n` +
+      `Actual output: ${result}`;
+    logVerbose(warning);
+    return false;
+  }
+
+  if (env['VERBOSE'] === 'true') {
+    logVerbose(`${testName}: Model output validated successfully.`);
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- brings packages/test-utils under normal ESLint coverage by removing the root ignore and adding a package lint script
- splits the large TestRig harness into focused typed modules for args/env handling, process execution, interactive PTY runs, diagnostics, telemetry parsing, tool log parsing, setup, and utilities
- routes test harness diagnostics through a local diagnostics sink/log file path instead of scattered bare console calls
- preserves package-root exports for both file-system helpers and TestRig APIs
- fixes a contradictory profile precedence fixture that expected a missing explicit profile while requesting an existing one

## Verification
- npm run format
- npm run lint:eslint-guard
- npm run lint:ci
- npm run typecheck
- npm run build
- npm run test
- npm run lint
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
- OCR review --audience agent --timeout 20; recovered findings from session log after empty stdout and addressed actionable findings

fixes #2246
