### PR TITLE
fix: prevent stale turn from clobbering newer turn isResponding state (Fixes #2259)

### DIFF
--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useSubmitQuery.doublecancel.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useSubmitQuery.doublecancel.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression test for issue #2259: "double cancellation still an issue."
+ *
+ * When a user cancels a turn (ESC) and then submits a new prompt, the
+ * cancelled turn's stale `runSubmitQueryCore` finally block must NOT call
+ * `setIsResponding(false)` — that would clobber the new turn's
+ * `isResponding(true)` state, making the new turn appear cancelled.
+ *
+ * The fix: `runSubmitQueryCore`'s finally and `executeStream`'s post-runLoop
+ * logic compare the turn's AbortSignal against the current
+ * `abortControllerRef.current?.signal`. If they differ, a newer turn has
+ * superseded this one and the stale turn must not mutate shared React state.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { act, type Dispatch, type SetStateAction } from 'react';
+import { renderHook, waitFor } from '../../../../test-utils/render.js';
+import { useSubmitQuery } from '../useSubmitQuery.js';
+import { StreamingState } from '../../../types.js';
+import {
+  type Config,
+  type AgentClientContract,
+} from '@vybestack/llxprt-code-core';
+
+// ─── Module mocks ───────────────────────────────────────────────────────────
+// useSubmitQuery internally calls useStreamEventHandlers and useSessionStats.
+// We stub them so the test can isolate the turn-lifecycle / finally logic.
+
+vi.mock('../useStreamEventHandlers.js', () => ({
+  useStreamEventHandlers: () => ({
+    processStreamEvent: vi.fn(),
+    displayUserMessage: vi.fn(),
+    prepareQueryForGemini: vi
+      .fn()
+      .mockResolvedValue({ queryToSend: 'test-query', shouldProceed: true }),
+    handleLoopDetectedEvent: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../contexts/SessionContext.js', () => ({
+  useSessionStats: () => ({
+    startNewPrompt: vi.fn(),
+    getPromptCount: () => 0,
+  }),
+}));
+
+vi.mock('../useGeminiStream.js', () => ({
+  prepareTurnForQuery: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function createMockConfig(): Config {
+  return {
+    getSessionId: () => 'test-session',
+    getModel: () => 'test-model',
+    getMcpClientManager: () => undefined,
+    getMcpServers: () => ({}),
+    getContentGeneratorConfig: () => ({ model: 'test-model' }),
+    setupAsyncTaskAutoTrigger: () => () => {},
+  } as unknown as Config;
+}
+
+function createMockAgentClient(): AgentClientContract {
+  return {
+    getCurrentSequenceModel: () => 'test-model',
+    getChat: () =>
+      ({
+        recordCompletedToolCalls: vi.fn(),
+      }) as never,
+  } as unknown as AgentClientContract;
+}
+
+function createMockSetState(
+  calls: boolean[],
+): Dispatch<SetStateAction<boolean>> {
+  return vi.fn((value: SetStateAction<boolean>) => {
+    if (typeof value === 'boolean') calls.push(value);
+  }) as unknown as Dispatch<SetStateAction<boolean>>;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('useSubmitQuery — double-cancel guard (issue #2259)', () => {
+  it("does not call setIsResponding(false) from a superseded turn's finally", async () => {
+    // Two deferred runLoop promises so we control exactly when each turn's
+    // executeStream settles.
+    const turn1Deferred = createDeferred<void>();
+    const turn2Deferred = createDeferred<void>();
+
+    const setIsRespondingCalls: boolean[] = [];
+    const setIsResponding = createMockSetState(setIsRespondingCalls);
+
+    const abortControllerRef = {
+      current: null as AbortController | null,
+    };
+
+    // The mock runLoop returns turn1's deferred on the first call and turn2's
+    // deferred on the second, matching the two submitQuery calls below.
+    const runLoopRef = {
+      current: vi
+        .fn()
+        .mockReturnValueOnce(turn1Deferred.promise)
+        .mockReturnValueOnce(turn2Deferred.promise),
+    };
+
+    const { result } = renderHook(() =>
+      useSubmitQuery({
+        config: createMockConfig(),
+        agentClient: createMockAgentClient(),
+        addItem: vi.fn().mockReturnValue(1),
+        settings: {} as never,
+        onDebugMessage: vi.fn(),
+        onCancelSubmit: vi.fn(),
+        onAuthError: vi.fn(),
+        sanitizeContent: (text: string) => ({ text, blocked: false }),
+        flushPendingHistoryItem: vi.fn(),
+        pendingHistoryItemRef: { current: null },
+        thinkingBlocksRef: { current: [] },
+        turnCancelledRef: { current: false },
+        queuedSubmissionsRef: { current: [] },
+        setPendingHistoryItem: vi.fn(),
+        setIsResponding,
+        setInitError: vi.fn(),
+        setThought: vi.fn(),
+        setLastGeminiActivityTime: vi.fn(),
+        scheduleToolCalls: vi.fn(),
+        abortActiveStream: vi.fn(),
+        handleShellCommand: vi.fn().mockReturnValue(false),
+        handleSlashCommand: vi.fn().mockResolvedValue(false),
+        logger: null,
+        shellModeActive: false,
+        loopDetectedRef: { current: false },
+        lastProfileNameRef: { current: undefined },
+        lastModelInfoRef: { current: null },
+        lastModelIdentityRef: { current: null },
+        abortControllerRef,
+        runLoopRef,
+        submitQueryRef: { current: null },
+        isResponding: false,
+        streamingState: StreamingState.Idle,
+        recordingIntegration: undefined,
+      }),
+    );
+
+    // ── Turn 1: starts, setIsResponding(true) ──────────────────────────────
+    let turn1Promise!: Promise<void>;
+    await act(async () => {
+      turn1Promise = result.current.submitQuery('turn-1');
+    });
+
+    await waitFor(() => {
+      expect(setIsRespondingCalls).toStrictEqual([true]);
+    });
+
+    // ── Turn 2: starts while Turn 1's runLoop is still pending ─────────────
+    // initTurn replaces abortControllerRef.current with a NEW AbortController,
+    // so Turn 1's signal no longer matches the current one.
+    let turn2Promise!: Promise<void>;
+    await act(async () => {
+      turn2Promise = result.current.submitQuery('turn-2');
+    });
+
+    await waitFor(() => {
+      expect(setIsRespondingCalls).toStrictEqual([true, true]);
+    });
+
+    // ── Turn 1's runLoop settles ───────────────────────────────────────────
+    // Turn 1's finally must NOT call setIsResponding(false) because Turn 2
+    // has superseded it (different AbortController).
+    await act(async () => {
+      turn1Deferred.resolve();
+    });
+
+    // With the fix: no extra false call. Without the fix: [true, true, false].
+    await waitFor(() => {
+      expect(setIsRespondingCalls).toStrictEqual([true, true]);
+    });
+
+    // ── Turn 2's runLoop settles ───────────────────────────────────────────
+    // Turn 2 IS the current turn, so its finally correctly calls
+    // setIsResponding(false).
+    await act(async () => {
+      turn2Deferred.resolve();
+    });
+
+    await waitFor(() => {
+      expect(setIsRespondingCalls).toStrictEqual([true, true, false]);
+    });
+
+    // Clean up: ensure both promises resolve without unhandled rejections.
+    await act(async () => {
+      await turn1Promise.catch(() => {});
+      await turn2Promise.catch(() => {});
+    });
+  });
+
+  it('calls setIsResponding(false) from the finally when the turn is still current', async () => {
+    // Single turn that runs to completion: setIsResponding should go
+    // true → false normally. This proves the guard does not break the
+    // normal (non-superseded) path.
+    const runDeferred = createDeferred<void>();
+
+    const setIsRespondingCalls: boolean[] = [];
+    const setIsResponding = createMockSetState(setIsRespondingCalls);
+
+    const abortControllerRef = {
+      current: null as AbortController | null,
+    };
+
+    const runLoopRef = {
+      current: vi.fn().mockReturnValueOnce(runDeferred.promise),
+    };
+
+    const { result } = renderHook(() =>
+      useSubmitQuery({
+        config: createMockConfig(),
+        agentClient: createMockAgentClient(),
+        addItem: vi.fn().mockReturnValue(1),
+        settings: {} as never,
+        onDebugMessage: vi.fn(),
+        onCancelSubmit: vi.fn(),
+        onAuthError: vi.fn(),
+        sanitizeContent: (text: string) => ({ text, blocked: false }),
+        flushPendingHistoryItem: vi.fn(),
+        pendingHistoryItemRef: { current: null },
+        thinkingBlocksRef: { current: [] },
+        turnCancelledRef: { current: false },
+        queuedSubmissionsRef: { current: [] },
+        setPendingHistoryItem: vi.fn(),
+        setIsResponding,
+        setInitError: vi.fn(),
+        setThought: vi.fn(),
+        setLastGeminiActivityTime: vi.fn(),
+        scheduleToolCalls: vi.fn(),
+        abortActiveStream: vi.fn(),
+        handleShellCommand: vi.fn().mockReturnValue(false),
+        handleSlashCommand: vi.fn().mockResolvedValue(false),
+        logger: null,
+        shellModeActive: false,
+        loopDetectedRef: { current: false },
+        lastProfileNameRef: { current: undefined },
+        lastModelInfoRef: { current: null },
+        lastModelIdentityRef: { current: null },
+        abortControllerRef,
+        runLoopRef,
+        submitQueryRef: { current: null },
+        isResponding: false,
+        streamingState: StreamingState.Idle,
+        recordingIntegration: undefined,
+      }),
+    );
+
+    let turnPromise!: Promise<void>;
+    await act(async () => {
+      turnPromise = result.current.submitQuery('single-turn');
+    });
+
+    await waitFor(() => {
+      expect(setIsRespondingCalls).toStrictEqual([true]);
+    });
+
+    await act(async () => {
+      runDeferred.resolve();
+    });
+
+    await waitFor(() => {
+      expect(setIsRespondingCalls).toStrictEqual([true, false]);
+    });
+
+    await act(async () => {
+      await turnPromise.catch(() => {});
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useSubmitQuery.doublecancel.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useSubmitQuery.doublecancel.test.tsx
@@ -5,27 +5,29 @@
  */
 
 /**
- * Regression test for issue #2259: "double cancellation still an issue."
+ * Regression tests for issue #2259: "double cancellation still an issue."
  *
  * When a user cancels a turn (ESC) and then submits a new prompt, the
  * cancelled turn's stale `runSubmitQueryCore` finally block must NOT call
  * `setIsResponding(false)` — that would clobber the new turn's
  * `isResponding(true)` state, making the new turn appear cancelled.
  *
- * The fix: `runSubmitQueryCore`'s finally and `executeStream`'s post-runLoop
- * logic compare the turn's AbortSignal against the current
- * `abortControllerRef.current?.signal`. If they differ, a newer turn has
- * superseded this one and the stale turn must not mutate shared React state.
+ * The fix: `runSubmitQueryCore`'s finally, catch, recordingIntegration, and
+ * `executeStream`'s post-runLoop logic all compare the turn's AbortSignal
+ * against the current `abortControllerRef.current?.signal`. If they differ,
+ * a newer turn has superseded this one and the stale turn must not mutate
+ * shared React state.
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { act, type Dispatch, type SetStateAction } from 'react';
 import { renderHook, waitFor } from '../../../../test-utils/render.js';
 import { useSubmitQuery } from '../useSubmitQuery.js';
-import { StreamingState } from '../../../types.js';
+import { StreamingState, type HistoryItemWithoutId } from '../../../types.js';
 import {
   type Config,
   type AgentClientContract,
+  type RecordingIntegration,
 } from '@vybestack/llxprt-code-core';
 
 // ─── Module mocks ───────────────────────────────────────────────────────────
@@ -54,17 +56,27 @@ vi.mock('../useGeminiStream.js', () => ({
   prepareTurnForQuery: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mock streamUtils so we can assert whether handleSubmissionError is called.
+const handleSubmissionErrorMock = vi.hoisted(() => vi.fn());
+vi.mock('../streamUtils.js', () => ({
+  handleSubmissionError: handleSubmissionErrorMock,
+  processSlashCommandResult: vi.fn(),
+}));
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function createDeferred<T = void>(): {
   promise: Promise<T>;
   resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
 } {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function createMockConfig(): Config {
@@ -96,194 +108,592 @@ function createMockSetState(
   }) as unknown as Dispatch<SetStateAction<boolean>>;
 }
 
+interface DoubleCancelDeps {
+  setIsRespondingCalls: boolean[];
+  setIsResponding: Dispatch<SetStateAction<boolean>>;
+  abortControllerRef: React.MutableRefObject<AbortController | null>;
+  runLoopRef: React.MutableRefObject<
+    | ((
+        message: unknown,
+        signal: AbortSignal,
+        promptId: string,
+      ) => Promise<void>)
+    | null
+  >;
+  loopDetectedRef: React.MutableRefObject<boolean>;
+  handleLoopDetectedEvent: ReturnType<typeof vi.fn>;
+  flushAtTurnBoundarySpy: ReturnType<typeof vi.fn>;
+  pendingHistoryItemRef: React.MutableRefObject<HistoryItemWithoutId | null>;
+  flushPendingHistoryItem: ReturnType<typeof vi.fn>;
+  setPendingHistoryItem: ReturnType<typeof vi.fn>;
+}
+
+function createDeps(
+  options?: Partial<
+    DoubleCancelDeps & { recordingIntegration: RecordingIntegration }
+  >,
+): DoubleCancelDeps {
+  const setIsRespondingCalls: boolean[] = [];
+  const deps: DoubleCancelDeps = {
+    setIsRespondingCalls,
+    setIsResponding:
+      options?.setIsResponding ?? createMockSetState(setIsRespondingCalls),
+    abortControllerRef:
+      options?.abortControllerRef ??
+      ({ current: null as AbortController | null } as never),
+    runLoopRef: options?.runLoopRef ?? ({ current: null } as never),
+    loopDetectedRef: options?.loopDetectedRef ?? ({ current: false } as never),
+    handleLoopDetectedEvent: options?.handleLoopDetectedEvent ?? vi.fn(),
+    flushAtTurnBoundarySpy: vi.fn(),
+    pendingHistoryItemRef:
+      options?.pendingHistoryItemRef ??
+      ({
+        current: null,
+      } as React.MutableRefObject<HistoryItemWithoutId | null>),
+    flushPendingHistoryItem: options?.flushPendingHistoryItem ?? vi.fn(),
+    setPendingHistoryItem: options?.setPendingHistoryItem ?? vi.fn(),
+  };
+  return deps;
+}
+
+/**
+ * Renders `useSubmitQuery` with stubbed deps. All shared mutable state (refs,
+ * setIsResponding spy) is returned so individual tests can drive the lifecycle.
+ */
+function renderUseSubmitQuery(
+  deps: DoubleCancelDeps,
+  overrides?: {
+    streamingState?: StreamingState;
+    recordingIntegration?: RecordingIntegration;
+  },
+) {
+  return renderHook(() =>
+    useSubmitQuery({
+      config: createMockConfig(),
+      agentClient: createMockAgentClient(),
+      addItem: vi.fn().mockReturnValue(1),
+      settings: {} as never,
+      onDebugMessage: vi.fn(),
+      onCancelSubmit: vi.fn(),
+      onAuthError: vi.fn(),
+      sanitizeContent: (text: string) => ({ text, blocked: false }),
+      flushPendingHistoryItem: deps.flushPendingHistoryItem,
+      pendingHistoryItemRef: deps.pendingHistoryItemRef,
+      thinkingBlocksRef: { current: [] },
+      turnCancelledRef: { current: false },
+      queuedSubmissionsRef: { current: [] },
+      setPendingHistoryItem: deps.setPendingHistoryItem,
+      setIsResponding: deps.setIsResponding,
+      setInitError: vi.fn(),
+      setThought: vi.fn(),
+      setLastGeminiActivityTime: vi.fn(),
+      scheduleToolCalls: vi.fn(),
+      abortActiveStream: vi.fn(),
+      handleShellCommand: vi.fn().mockReturnValue(false),
+      handleSlashCommand: vi.fn().mockResolvedValue(false),
+      logger: null,
+      shellModeActive: false,
+      loopDetectedRef: deps.loopDetectedRef,
+      lastProfileNameRef: { current: undefined },
+      lastModelInfoRef: { current: null },
+      lastModelIdentityRef: { current: null },
+      abortControllerRef: deps.abortControllerRef,
+      runLoopRef: deps.runLoopRef,
+      submitQueryRef: { current: null },
+      isResponding: false,
+      streamingState: overrides?.streamingState ?? StreamingState.Idle,
+      recordingIntegration:
+        overrides?.recordingIntegration ??
+        ({
+          flushAtTurnBoundary: deps.flushAtTurnBoundarySpy,
+        } as unknown as RecordingIntegration),
+    }),
+  );
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('useSubmitQuery — double-cancel guard (issue #2259)', () => {
   it("does not call setIsResponding(false) from a superseded turn's finally", async () => {
-    // Two deferred runLoop promises so we control exactly when each turn's
-    // executeStream settles.
     const turn1Deferred = createDeferred<void>();
     const turn2Deferred = createDeferred<void>();
 
-    const setIsRespondingCalls: boolean[] = [];
-    const setIsResponding = createMockSetState(setIsRespondingCalls);
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi
+          .fn()
+          .mockReturnValueOnce(turn1Deferred.promise)
+          .mockReturnValueOnce(turn2Deferred.promise),
+      } as never,
+    });
 
-    const abortControllerRef = {
-      current: null as AbortController | null,
-    };
+    const { result } = renderUseSubmitQuery(deps);
 
-    // The mock runLoop returns turn1's deferred on the first call and turn2's
-    // deferred on the second, matching the two submitQuery calls below.
-    const runLoopRef = {
-      current: vi
-        .fn()
-        .mockReturnValueOnce(turn1Deferred.promise)
-        .mockReturnValueOnce(turn2Deferred.promise),
-    };
-
-    const { result } = renderHook(() =>
-      useSubmitQuery({
-        config: createMockConfig(),
-        agentClient: createMockAgentClient(),
-        addItem: vi.fn().mockReturnValue(1),
-        settings: {} as never,
-        onDebugMessage: vi.fn(),
-        onCancelSubmit: vi.fn(),
-        onAuthError: vi.fn(),
-        sanitizeContent: (text: string) => ({ text, blocked: false }),
-        flushPendingHistoryItem: vi.fn(),
-        pendingHistoryItemRef: { current: null },
-        thinkingBlocksRef: { current: [] },
-        turnCancelledRef: { current: false },
-        queuedSubmissionsRef: { current: [] },
-        setPendingHistoryItem: vi.fn(),
-        setIsResponding,
-        setInitError: vi.fn(),
-        setThought: vi.fn(),
-        setLastGeminiActivityTime: vi.fn(),
-        scheduleToolCalls: vi.fn(),
-        abortActiveStream: vi.fn(),
-        handleShellCommand: vi.fn().mockReturnValue(false),
-        handleSlashCommand: vi.fn().mockResolvedValue(false),
-        logger: null,
-        shellModeActive: false,
-        loopDetectedRef: { current: false },
-        lastProfileNameRef: { current: undefined },
-        lastModelInfoRef: { current: null },
-        lastModelIdentityRef: { current: null },
-        abortControllerRef,
-        runLoopRef,
-        submitQueryRef: { current: null },
-        isResponding: false,
-        streamingState: StreamingState.Idle,
-        recordingIntegration: undefined,
-      }),
-    );
-
-    // ── Turn 1: starts, setIsResponding(true) ──────────────────────────────
     let turn1Promise!: Promise<void>;
     await act(async () => {
       turn1Promise = result.current.submitQuery('turn-1');
     });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true]),
+    );
 
-    await waitFor(() => {
-      expect(setIsRespondingCalls).toStrictEqual([true]);
-    });
-
-    // ── Turn 2: starts while Turn 1's runLoop is still pending ─────────────
-    // initTurn replaces abortControllerRef.current with a NEW AbortController,
-    // so Turn 1's signal no longer matches the current one.
     let turn2Promise!: Promise<void>;
     await act(async () => {
       turn2Promise = result.current.submitQuery('turn-2');
     });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true, true]),
+    );
 
-    await waitFor(() => {
-      expect(setIsRespondingCalls).toStrictEqual([true, true]);
-    });
-
-    // ── Turn 1's runLoop settles ───────────────────────────────────────────
-    // Turn 1's finally must NOT call setIsResponding(false) because Turn 2
-    // has superseded it (different AbortController).
+    // Turn 1 settles — finally must NOT clobber Turn 2.
     await act(async () => {
       turn1Deferred.resolve();
     });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true, true]),
+    );
 
-    // With the fix: no extra false call. Without the fix: [true, true, false].
-    await waitFor(() => {
-      expect(setIsRespondingCalls).toStrictEqual([true, true]);
-    });
-
-    // ── Turn 2's runLoop settles ───────────────────────────────────────────
-    // Turn 2 IS the current turn, so its finally correctly calls
-    // setIsResponding(false).
+    // Turn 2 settles — finally correctly resets.
     await act(async () => {
       turn2Deferred.resolve();
     });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true, true, false]),
+    );
 
-    await waitFor(() => {
-      expect(setIsRespondingCalls).toStrictEqual([true, true, false]);
-    });
-
-    // Clean up: ensure both promises resolve without unhandled rejections.
     await act(async () => {
       await turn1Promise.catch(() => {});
       await turn2Promise.catch(() => {});
     });
   });
 
+  it('does not call flushPendingHistoryItem or setPendingHistoryItem from a superseded turn', async () => {
+    const turn1Deferred = createDeferred<void>();
+    const turn2Deferred = createDeferred<void>();
+
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi
+          .fn()
+          .mockReturnValueOnce(turn1Deferred.promise)
+          .mockReturnValueOnce(turn2Deferred.promise),
+      } as never,
+    });
+    // Make Turn 1 appear to have a pending history item so the post-runLoop
+    // flush path is reached if the guard is missing.
+    deps.pendingHistoryItemRef.current = { type: 'info', text: 'pending' };
+
+    const { result } = renderUseSubmitQuery(deps);
+
+    let turn1Promise!: Promise<void>;
+    await act(async () => {
+      turn1Promise = result.current.submitQuery('turn-1');
+    });
+
+    let turn2Promise!: Promise<void>;
+    await act(async () => {
+      turn2Promise = result.current.submitQuery('turn-2');
+    });
+
+    await act(async () => {
+      turn1Deferred.resolve();
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true, true]),
+    );
+
+    // Turn 1 was superseded: flushPendingHistoryItem must NOT have been called
+    // for its timestamp. Turn 2 hasn't settled yet so no flush for it either.
+    expect(deps.flushPendingHistoryItem).not.toHaveBeenCalled();
+    expect(deps.setPendingHistoryItem).not.toHaveBeenCalledWith(null);
+
+    await act(async () => {
+      turn2Deferred.resolve();
+    });
+    await act(async () => {
+      await turn1Promise.catch(() => {});
+      await turn2Promise.catch(() => {});
+    });
+  });
+
+  it('clears stale loopDetectedRef on supersession without firing handleLoopDetectedEvent', async () => {
+    const turn1Deferred = createDeferred<void>();
+    const turn2Deferred = createDeferred<void>();
+
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi
+          .fn()
+          .mockReturnValueOnce(turn1Deferred.promise)
+          .mockReturnValueOnce(turn2Deferred.promise),
+      } as never,
+    });
+
+    const { result } = renderUseSubmitQuery(deps);
+
+    let turn1Promise!: Promise<void>;
+    await act(async () => {
+      turn1Promise = result.current.submitQuery('turn-1');
+    });
+
+    // Simulate the loop-detected flag being set during Turn 1's run.
+    deps.loopDetectedRef.current = true;
+
+    let turn2Promise!: Promise<void>;
+    await act(async () => {
+      turn2Promise = result.current.submitQuery('turn-2');
+    });
+
+    await act(async () => {
+      turn1Deferred.resolve();
+    });
+
+    // The stale flag must be cleared silently so it does not leak into Turn 2,
+    // but handleLoopDetectedEvent must NOT fire for the superseded turn.
+    await waitFor(() => {
+      expect(deps.loopDetectedRef.current).toBe(false);
+    });
+    expect(deps.handleLoopDetectedEvent).not.toHaveBeenCalled();
+
+    await act(async () => {
+      turn2Deferred.resolve();
+    });
+    await act(async () => {
+      await turn1Promise.catch(() => {});
+      await turn2Promise.catch(() => {});
+    });
+  });
+
+  it('does not call handleSubmissionError from a superseded turn', async () => {
+    const turn1Deferred = createDeferred<void>();
+    const turn2Deferred = createDeferred<void>();
+
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi
+          .fn()
+          .mockReturnValueOnce(turn1Deferred.promise)
+          .mockReturnValueOnce(turn2Deferred.promise),
+      } as never,
+    });
+
+    const { result } = renderUseSubmitQuery(deps);
+
+    let turn1Promise!: Promise<void>;
+    await act(async () => {
+      turn1Promise = result.current.submitQuery('turn-1');
+    });
+
+    let turn2Promise!: Promise<void>;
+    await act(async () => {
+      turn2Promise = result.current.submitQuery('turn-2');
+    });
+
+    // Reject Turn 1's runLoop — this simulates an error (e.g. AbortError)
+    // from a cancelled turn. The catch guard must suppress it.
+    handleSubmissionErrorMock.mockClear();
+    const turn1Error = new Error('Turn 1 aborted');
+    await act(async () => {
+      turn1Deferred.reject(turn1Error);
+    });
+
+    // Turn 1 was superseded: the catch guard must prevent
+    // handleSubmissionError from being called, so the error does not surface
+    // as a user-facing message.
+    expect(handleSubmissionErrorMock).not.toHaveBeenCalled();
+    expect(deps.setIsRespondingCalls).toStrictEqual([true, true]);
+
+    await act(async () => {
+      turn2Deferred.resolve();
+    });
+    await act(async () => {
+      await turn1Promise.catch(() => {});
+      await turn2Promise.catch(() => {});
+    });
+  });
+
+  it('does not call recordingIntegration.flushAtTurnBoundary from a superseded turn', async () => {
+    const turn1Deferred = createDeferred<void>();
+    const turn2Deferred = createDeferred<void>();
+
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi
+          .fn()
+          .mockReturnValueOnce(turn1Deferred.promise)
+          .mockReturnValueOnce(turn2Deferred.promise),
+      } as never,
+    });
+
+    const { result } = renderUseSubmitQuery(deps);
+
+    let turn1Promise!: Promise<void>;
+    await act(async () => {
+      turn1Promise = result.current.submitQuery('turn-1');
+    });
+
+    let turn2Promise!: Promise<void>;
+    await act(async () => {
+      turn2Promise = result.current.submitQuery('turn-2');
+    });
+
+    await act(async () => {
+      turn1Deferred.resolve();
+    });
+
+    // Turn 1 was superseded: its finally must not flush the recording boundary.
+    expect(deps.flushAtTurnBoundarySpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      turn2Deferred.resolve();
+    });
+
+    // Turn 2 IS current: its finally should flush.
+    await waitFor(() =>
+      expect(deps.flushAtTurnBoundarySpy).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      await turn1Promise.catch(() => {});
+      await turn2Promise.catch(() => {});
+    });
+  });
+
+  it('simulates ESC cancel then new prompt: superseded turn does not clobber the new turn', async () => {
+    // This test mirrors the real user flow from issue #2259:
+    // 1. Start Turn 1 (runLoop blocks)
+    // 2. User hits ESC → cancelOngoingRequest aborts Turn 1's controller
+    //    and calls setIsResponding(false)
+    // 3. User submits Turn 2 → initTurn creates a fresh controller
+    // 4. Turn 1's runLoop settles (async cleanup finishes)
+    // 5. Turn 1's finally must NOT call setIsResponding(false)
+    const turn1Deferred = createDeferred<void>();
+    const turn2Deferred = createDeferred<void>();
+
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi
+          .fn()
+          .mockReturnValueOnce(turn1Deferred.promise)
+          .mockReturnValueOnce(turn2Deferred.promise),
+      } as never,
+    });
+
+    const { result } = renderUseSubmitQuery(deps);
+
+    // ── Step 1: Turn 1 starts ──────────────────────────────────────────────
+    let turn1Promise!: Promise<void>;
+    await act(async () => {
+      turn1Promise = result.current.submitQuery('turn-1');
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true]),
+    );
+
+    const turn1Controller = deps.abortControllerRef.current;
+    expect(turn1Controller).not.toBeNull();
+
+    // ── Step 2: User hits ESC ──────────────────────────────────────────────
+    // cancelOngoingRequest (in useGeminiStreamLifecycle) would:
+    //   - abort the controller
+    //   - setIsResponding(false)
+    //   - set turnCancelledRef.current = true
+    await act(async () => {
+      turn1Controller!.abort();
+      deps.setIsResponding(false);
+    });
+    expect(deps.setIsRespondingCalls).toStrictEqual([true, false]);
+
+    // ── Step 3: User submits Turn 2 ────────────────────────────────────────
+    // initTurn creates a NEW AbortController and resets turnCancelledRef.
+    let turn2Promise!: Promise<void>;
+    await act(async () => {
+      turn2Promise = result.current.submitQuery('turn-2');
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true, false, true]),
+    );
+
+    // The current AbortController is now Turn 2's, not Turn 1's.
+    expect(deps.abortControllerRef.current).not.toBe(turn1Controller);
+
+    // ── Step 4: Turn 1's async cleanup settles ─────────────────────────────
+    await act(async () => {
+      turn1Deferred.resolve();
+    });
+
+    // Turn 1's finally must NOT call setIsResponding(false) — that would
+    // cancel the new turn (issue #2259).
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true, false, true]),
+    );
+
+    // ── Step 5: Turn 2 finishes ────────────────────────────────────────────
+    await act(async () => {
+      turn2Deferred.resolve();
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([
+        true,
+        false,
+        true,
+        false,
+      ]),
+    );
+
+    await act(async () => {
+      await turn1Promise.catch(() => {});
+      await turn2Promise.catch(() => {});
+    });
+  });
+
+  it('queues the second prompt when streamingState is Responding, then drains after cancel', async () => {
+    // This test exercises the production isQueueable gate:
+    // When streamingState is Responding, submitQuery pushes the query to
+    // queuedSubmissionsRef instead of starting immediately. After the first
+    // turn settles and streamingState returns to Idle, the idle-queue-drain
+    // effect fires the queued submission.
+    const turn1Deferred = createDeferred<void>();
+    const turn2Deferred = createDeferred<void>();
+
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi
+          .fn()
+          .mockReturnValueOnce(turn1Deferred.promise)
+          .mockReturnValueOnce(turn2Deferred.promise),
+      } as never,
+    });
+
+    const queuedSubmissionsRef = {
+      current: [] as Array<{
+        query: string;
+        options?: { isContinuation: boolean };
+        promptId?: string;
+      }>,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ streamingState }: { streamingState: StreamingState }) =>
+        useSubmitQuery({
+          config: createMockConfig(),
+          agentClient: createMockAgentClient(),
+          addItem: vi.fn().mockReturnValue(1),
+          settings: {} as never,
+          onDebugMessage: vi.fn(),
+          onCancelSubmit: vi.fn(),
+          onAuthError: vi.fn(),
+          sanitizeContent: (text: string) => ({ text, blocked: false }),
+          flushPendingHistoryItem: deps.flushPendingHistoryItem,
+          pendingHistoryItemRef: deps.pendingHistoryItemRef,
+          thinkingBlocksRef: { current: [] },
+          turnCancelledRef: { current: false },
+          queuedSubmissionsRef,
+          setPendingHistoryItem: deps.setPendingHistoryItem,
+          setIsResponding: deps.setIsResponding,
+          setInitError: vi.fn(),
+          setThought: vi.fn(),
+          setLastGeminiActivityTime: vi.fn(),
+          scheduleToolCalls: vi.fn(),
+          abortActiveStream: vi.fn(),
+          handleShellCommand: vi.fn().mockReturnValue(false),
+          handleSlashCommand: vi.fn().mockResolvedValue(false),
+          logger: null,
+          shellModeActive: false,
+          loopDetectedRef: deps.loopDetectedRef,
+          lastProfileNameRef: { current: undefined },
+          lastModelInfoRef: { current: null },
+          lastModelIdentityRef: { current: null },
+          abortControllerRef: deps.abortControllerRef,
+          runLoopRef: deps.runLoopRef,
+          submitQueryRef: { current: null },
+          isResponding: false,
+          streamingState,
+          recordingIntegration: {
+            flushAtTurnBoundary: deps.flushAtTurnBoundarySpy,
+          } as unknown as RecordingIntegration,
+        }),
+      { initialProps: { streamingState: StreamingState.Idle } },
+    );
+
+    // ── Turn 1 starts (streamingState transitions to Responding) ───────────
+    let turn1Promise!: Promise<void>;
+    await act(async () => {
+      turn1Promise = result.current.submitQuery('turn-1');
+    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true]),
+    );
+
+    // Simulate streamingState becoming Responding (as it would when the
+    // turn starts). The submitQueryRef is now populated.
+    rerender({ streamingState: StreamingState.Responding });
+
+    // ── Turn 2 is submitted while Responding → queued ──────────────────────
+    await act(async () => {
+      await result.current.submitQuery('turn-2');
+    });
+    expect(queuedSubmissionsRef.current).toHaveLength(1);
+    expect(queuedSubmissionsRef.current[0].query).toBe('turn-2');
+
+    // ── Turn 1 is cancelled and settles ────────────────────────────────────
+    const turn1Controller = deps.abortControllerRef.current;
+    await act(async () => {
+      turn1Controller!.abort();
+    });
+    await act(async () => {
+      turn1Deferred.resolve();
+    });
+
+    // Simulate streamingState returning to Idle (cancel → setIsResponding(false)).
+    rerender({ streamingState: StreamingState.Idle });
+
+    // The idle-queue-drain effect fires, shifting and calling submitQuery
+    // for Turn 2. Turn 2 starts with a fresh AbortController.
+    await waitFor(() => {
+      expect(queuedSubmissionsRef.current).toHaveLength(0);
+    });
+
+    // Turn 2's controller is different from Turn 1's (initTurn replaces it).
+    await waitFor(() => {
+      expect(deps.abortControllerRef.current).not.toBe(turn1Controller);
+    });
+
+    // ── Turn 2 finishes ────────────────────────────────────────────────────
+    await act(async () => {
+      turn2Deferred.resolve();
+    });
+
+    await act(async () => {
+      await turn1Promise.catch(() => {});
+    });
+  });
+
   it('calls setIsResponding(false) from the finally when the turn is still current', async () => {
-    // Single turn that runs to completion: setIsResponding should go
-    // true → false normally. This proves the guard does not break the
-    // normal (non-superseded) path.
     const runDeferred = createDeferred<void>();
 
-    const setIsRespondingCalls: boolean[] = [];
-    const setIsResponding = createMockSetState(setIsRespondingCalls);
+    const deps = createDeps({
+      runLoopRef: {
+        current: vi.fn().mockReturnValueOnce(runDeferred.promise),
+      } as never,
+    });
 
-    const abortControllerRef = {
-      current: null as AbortController | null,
-    };
-
-    const runLoopRef = {
-      current: vi.fn().mockReturnValueOnce(runDeferred.promise),
-    };
-
-    const { result } = renderHook(() =>
-      useSubmitQuery({
-        config: createMockConfig(),
-        agentClient: createMockAgentClient(),
-        addItem: vi.fn().mockReturnValue(1),
-        settings: {} as never,
-        onDebugMessage: vi.fn(),
-        onCancelSubmit: vi.fn(),
-        onAuthError: vi.fn(),
-        sanitizeContent: (text: string) => ({ text, blocked: false }),
-        flushPendingHistoryItem: vi.fn(),
-        pendingHistoryItemRef: { current: null },
-        thinkingBlocksRef: { current: [] },
-        turnCancelledRef: { current: false },
-        queuedSubmissionsRef: { current: [] },
-        setPendingHistoryItem: vi.fn(),
-        setIsResponding,
-        setInitError: vi.fn(),
-        setThought: vi.fn(),
-        setLastGeminiActivityTime: vi.fn(),
-        scheduleToolCalls: vi.fn(),
-        abortActiveStream: vi.fn(),
-        handleShellCommand: vi.fn().mockReturnValue(false),
-        handleSlashCommand: vi.fn().mockResolvedValue(false),
-        logger: null,
-        shellModeActive: false,
-        loopDetectedRef: { current: false },
-        lastProfileNameRef: { current: undefined },
-        lastModelInfoRef: { current: null },
-        lastModelIdentityRef: { current: null },
-        abortControllerRef,
-        runLoopRef,
-        submitQueryRef: { current: null },
-        isResponding: false,
-        streamingState: StreamingState.Idle,
-        recordingIntegration: undefined,
-      }),
-    );
+    const { result } = renderUseSubmitQuery(deps);
 
     let turnPromise!: Promise<void>;
     await act(async () => {
       turnPromise = result.current.submitQuery('single-turn');
     });
-
-    await waitFor(() => {
-      expect(setIsRespondingCalls).toStrictEqual([true]);
-    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true]),
+    );
 
     await act(async () => {
       runDeferred.resolve();
     });
-
-    await waitFor(() => {
-      expect(setIsRespondingCalls).toStrictEqual([true, false]);
-    });
+    await waitFor(() =>
+      expect(deps.setIsRespondingCalls).toStrictEqual([true, false]),
+    );
 
     await act(async () => {
       await turnPromise.catch(() => {});

--- a/packages/cli/src/ui/hooks/geminiStream/useSubmitQuery.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useSubmitQuery.ts
@@ -336,13 +336,18 @@ async function runSubmitQueryCore(
   try {
     await executeStream(cbd, cbd.handleLoopDetectedEvent, queryToSend, turn);
   } catch (error: unknown) {
-    handleSubmissionError(
-      error,
-      cbd.addItem,
-      cbd.config,
-      cbd.onAuthError,
-      turn.userMessageTimestamp,
-    );
+    // Only surface errors for the active turn. A superseded turn's stale
+    // errors (e.g. AbortError or auth failures from a cancelled request)
+    // must not leak into the newer turn (issue #2259).
+    if (isCurrentTurn(cbd, turn)) {
+      handleSubmissionError(
+        error,
+        cbd.addItem,
+        cbd.config,
+        cbd.onAuthError,
+        turn.userMessageTimestamp,
+      );
+    }
   } finally {
     // Only clear isResponding when this turn is still the active one. When a
     // newer turn supersedes this one it replaces abortControllerRef.current
@@ -352,10 +357,12 @@ async function runSubmitQueryCore(
     if (isCurrentTurn(cbd, turn)) {
       cbd.setIsResponding(false);
     }
-    try {
-      await cbd.recordingIntegration?.flushAtTurnBoundary();
-    } catch {
-      /* non-fatal */
+    if (isCurrentTurn(cbd, turn)) {
+      try {
+        await cbd.recordingIntegration?.flushAtTurnBoundary();
+      } catch {
+        /* non-fatal */
+      }
     }
   }
 }
@@ -436,8 +443,13 @@ async function executeStream(
   // A newer turn may have started while runLoop was settling (e.g. the user
   // cancelled this turn and submitted a new prompt). If the current
   // AbortController no longer belongs to this turn, skip post-stream cleanup
-  // so it does not clobber the newer turn's state (issue #2259).
-  if (!isCurrentTurn(deps, turn)) return;
+  // so it does not clobber the newer turn's state. Clear loopDetectedRef
+  // silently to prevent a stale detection from leaking into the new turn
+  // (issue #2259).
+  if (!isCurrentTurn(deps, turn)) {
+    deps.loopDetectedRef.current = false;
+    return;
+  }
 
   if (deps.pendingHistoryItemRef.current) {
     deps.flushPendingHistoryItem(turn.userMessageTimestamp);
@@ -452,8 +464,8 @@ async function executeStream(
 /**
  * Returns true when `turn` is still the active turn. When a newer turn starts
  * (via initTurn) it replaces abortControllerRef.current with a fresh
- * AbortController; comparing signals is the precise check for whether this
- * turn has been superseded (issue #2259).
+ * AbortController; comparing signals proves this turn owns the current
+ * AbortController (issue #2259).
  */
 function isCurrentTurn(deps: UseSubmitQueryDeps, turn: TurnInit): boolean {
   return deps.abortControllerRef.current?.signal === turn.abortSignal;

--- a/packages/cli/src/ui/hooks/geminiStream/useSubmitQuery.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useSubmitQuery.ts
@@ -344,7 +344,14 @@ async function runSubmitQueryCore(
       turn.userMessageTimestamp,
     );
   } finally {
-    cbd.setIsResponding(false);
+    // Only clear isResponding when this turn is still the active one. When a
+    // newer turn supersedes this one it replaces abortControllerRef.current
+    // with a fresh AbortController; if the signals differ, the newer turn
+    // already set isResponding(true) and clearing it here would cancel the
+    // new turn (issue #2259).
+    if (isCurrentTurn(cbd, turn)) {
+      cbd.setIsResponding(false);
+    }
     try {
       await cbd.recordingIntegration?.flushAtTurnBoundary();
     } catch {
@@ -426,6 +433,12 @@ async function executeStream(
   // send → stream → schedule → execute → feed-back → repeat.
   await runLoop(queryToSend, turn.abortSignal, turn.promptId);
 
+  // A newer turn may have started while runLoop was settling (e.g. the user
+  // cancelled this turn and submitted a new prompt). If the current
+  // AbortController no longer belongs to this turn, skip post-stream cleanup
+  // so it does not clobber the newer turn's state (issue #2259).
+  if (!isCurrentTurn(deps, turn)) return;
+
   if (deps.pendingHistoryItemRef.current) {
     deps.flushPendingHistoryItem(turn.userMessageTimestamp);
     deps.setPendingHistoryItem(null);
@@ -434,4 +447,14 @@ async function executeStream(
     deps.loopDetectedRef.current = false;
     handleLoopDetectedEvent();
   }
+}
+
+/**
+ * Returns true when `turn` is still the active turn. When a newer turn starts
+ * (via initTurn) it replaces abortControllerRef.current with a fresh
+ * AbortController; comparing signals is the precise check for whether this
+ * turn has been superseded (issue #2259).
+ */
+function isCurrentTurn(deps: UseSubmitQueryDeps, turn: TurnInit): boolean {
+  return deps.abortControllerRef.current?.signal === turn.abortSignal;
 }


### PR DESCRIPTION
## Summary

Fixes the "double cancellation" bug from issue #2259: when a user cancels a turn (ESC) and then submits a new prompt, the cancelled turn's stale `runSubmitQueryCore` finally block would call `setIsResponding(false)` AFTER the newer turn had already called `setIsResponding(true)`, making the new turn appear cancelled.

Issue #2136 fixed the stale `UserCancelled` message leak but did not fix this state-clobbering race — the symptom changed from a visible "User cancelled the request." message to a silent cancellation of the new prompt.

## Root Cause

When a user cancels a turn and submits a new prompt:

1. **Turn 1** starts: `initTurn` creates `AbortController` A1, `setIsResponding(true)`, `executeStream` awaits `runLoop(...)` which serializes via `inflightRunRef`.
2. **Cancel (ESC)**: `cancelOngoingRequest` aborts A1, calls `setIsResponding(false)`, clears the queue.
3. **Turn 2** starts: `initTurn` creates a **new** `AbortController` A2 (replacing A1 in `abortControllerRef`), `setIsResponding(true)`, `executeStream` awaits `runLoop(...)` which serializes on Turn 1's still-settling `inflightRunRef`.
4. **Turn 1's `runLoop` settles**: Turn 1's `runSubmitQueryCore` finally block runs **AFTER** Turn 2's `setIsResponding(true)`, calling `setIsResponding(false)` — clobbering Turn 2's responding state.

The UI then shows the prompt as ready for input even though Turn 2 is still processing, making the new prompt appear cancelled.

## Fix

Added an `isCurrentTurn()` guard that compares the turn's `AbortSignal` against `abortControllerRef.current?.signal`. When a newer turn supersedes this one (via `initTurn` creating a fresh `AbortController`), the stale turn's:

- **`runSubmitQueryCore` finally** — skips `setIsResponding(false)` (the newer turn owns the responding state)
- **`executeStream` post-`runLoop`** — skips `flushPendingHistoryItem`, `setPendingHistoryItem`, and `loopDetectedRef` cleanup (these belong to the newer turn)

This is a minimal, surgical fix: the signal comparison is the precise indicator of whether a specific turn has been superseded, since `initTurn` is the only place that replaces `abortControllerRef.current`.

## Test Coverage

Two behavioral tests in `useSubmitQuery.doublecancel.test.tsx`:

1. **Superseded turn guard**: Two turns with deferred `runLoop` promises. Turn 1's `runLoop` settles while Turn 2 is still in-flight. Asserts Turn 1's finally does NOT call `setIsResponding(false)` — verified the test FAILS without the fix and PASSES with it.
2. **Normal single-turn path**: A single turn that runs to completion. Asserts `setIsResponding` goes true then false normally, proving the guard does not break the non-superseded path.

Both tests use `waitFor` polling (per OCR review) rather than hardcoded microtask tick counts, and the mock config includes `setupAsyncTaskAutoTrigger` (per OCR review).

Closes #2259
