### PR TITLE
feat(ui): extend profile-qualified model identity to response prefix and status fallback (Fixes #2263)

### DIFF
--- a/packages/cli/src/nonInteractiveCli.profilePrefix.test.ts
+++ b/packages/cli/src/nonInteractiveCli.profilePrefix.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for createProfileNameWriter's profile-qualified prefix
+ * (issue #2263).
+ *
+ * The writer must emit [profileName:modelName] on the first event of a turn,
+ * suppress it on subsequent events (firstEventInTurn guard), and suppress it
+ * entirely when JSON output is enabled.
+ */
+
+import { type Config, StreamJsonFormatter } from '@vybestack/llxprt-code-core';
+import {
+  vi,
+  type MockInstance,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { createProfileNameWriter } from './nonInteractiveCli.js';
+
+function createMockConfig(): Config {
+  return {
+    getModel: () => 'test-model',
+  } as unknown as Config;
+}
+
+describe('createProfileNameWriter profile-qualified prefix (issue #2263)', () => {
+  let processStdoutSpy: MockInstance;
+
+  beforeEach(() => {
+    processStdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    processStdoutSpy.mockRestore();
+  });
+
+  it('writes [profileName:modelName] on the first call of a turn', () => {
+    const writer = createProfileNameWriter(
+      createMockConfig(),
+      false,
+      null,
+      () => 'work:gpt-4',
+    );
+
+    writer();
+
+    expect(processStdoutSpy).toHaveBeenCalledWith('[work:gpt-4]\n');
+  });
+
+  it('does not write on the second call (firstEventInTurn guard)', () => {
+    const writer = createProfileNameWriter(
+      createMockConfig(),
+      false,
+      null,
+      () => 'work:gpt-4',
+    );
+
+    writer();
+    processStdoutSpy.mockClear();
+    writer();
+
+    expect(processStdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not write when jsonOutput is true', () => {
+    const writer = createProfileNameWriter(
+      createMockConfig(),
+      true,
+      null,
+      () => 'work:gpt-4',
+    );
+
+    writer();
+
+    expect(processStdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not write when the identity resolves to null', () => {
+    const writer = createProfileNameWriter(
+      createMockConfig(),
+      false,
+      null,
+      () => null,
+    );
+
+    writer();
+
+    expect(processStdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not write when a stream formatter is present', () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const writer = createProfileNameWriter(
+      createMockConfig(),
+      false,
+      streamFormatter,
+      () => 'work:gpt-4',
+    );
+
+    writer();
+
+    expect(processStdoutSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -39,6 +39,10 @@ import {
   getErrorFallbackModel,
 } from './utils/apiErrorFormatting.js';
 import { firstNonEmptyString } from './utils/coalesce.js';
+import {
+  resolveContentPrefixIdentity,
+  createCliModelIdentityRuntime,
+} from './ui/utils/modelIdentity.js';
 
 interface RunNonInteractiveParams {
   config: Config;
@@ -49,24 +53,40 @@ interface RunNonInteractiveParams {
   deferTelemetryShutdown?: boolean;
 }
 
-function createProfileNameWriter(
+export function createProfileNameWriter(
   config: Config,
   jsonOutput: boolean,
   streamFormatter: StreamJsonFormatter | null,
+  getIdentity: (() => string | null) | null = null,
 ): () => void {
+  const resolveIdentity =
+    getIdentity ??
+    (() => {
+      try {
+        return resolveContentPrefixIdentity(createCliModelIdentityRuntime());
+      } catch (error) {
+        // Degraded path: fall back to the bare profile name (no model suffix)
+        // so the prefix is still shown. Log so the format divergence is
+        // observable to operators.
+        debugLogger.debug(
+          () =>
+            `[nonInteractiveCli] resolveContentPrefixIdentity failed; using bare profile name: ${error}`,
+        );
+        const settingsService = config.getSettingsService() as Omit<
+          ReturnType<Config['getSettingsService']>,
+          'getCurrentProfileName'
+        > & {
+          getCurrentProfileName?: () => string | null;
+        };
+        return settingsService.getCurrentProfileName?.() ?? null;
+      }
+    });
   let firstEventInTurn = true;
   return () => {
     if (firstEventInTurn && !jsonOutput && !streamFormatter) {
-      const settingsService = config.getSettingsService() as Omit<
-        ReturnType<Config['getSettingsService']>,
-        'getCurrentProfileName'
-      > & {
-        getCurrentProfileName?: () => string | null;
-      };
-      const activeProfileName = settingsService.getCurrentProfileName?.();
-      if (activeProfileName) {
-        process.stdout.write(`[${activeProfileName}]
-`);
+      const identity = resolveIdentity();
+      if (identity) {
+        process.stdout.write(`[${identity}]\n`);
       }
     }
     firstEventInTurn = false;

--- a/packages/cli/src/ui/containers/SessionController.tsx
+++ b/packages/cli/src/ui/containers/SessionController.tsx
@@ -27,6 +27,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { loadHierarchicalLlxprtMemory } from '../../config/environmentLoader.js';
 import { loadSettings } from '../../config/settings.js';
+import { resolveModelIdentity } from '../utils/modelIdentity.js';
 import {
   SessionStateProvider,
   useSessionState,
@@ -79,10 +80,7 @@ export const SessionController: React.FC<SessionControllerProps> = ({
   const statusSnapshot = runtime.getActiveProviderStatus();
 
   const initialState: SessionState = {
-    currentModel:
-      statusSnapshot.providerName && statusSnapshot.modelName
-        ? `${statusSnapshot.providerName}:${statusSnapshot.modelName}`
-        : (statusSnapshot.modelName ?? config.getModel()),
+    currentModel: resolveModelIdentity(runtime, config.getModel()),
     isPaidMode: statusSnapshot.isPaidMode,
     lastProvider: statusSnapshot.providerName ?? undefined,
     userTier: undefined,
@@ -243,10 +241,7 @@ function useModelChangeWatcher(
     const checkModelChange = () => {
       const runtime = getRuntimeApi();
       const status = runtime.getActiveProviderStatus();
-      const displayModel =
-        status.providerName && status.modelName
-          ? `${status.providerName}:${status.modelName}`
-          : (status.modelName ?? config.getModel());
+      const displayModel = resolveModelIdentity(runtime, config.getModel());
       if (displayModel !== sessionState.currentModel) {
         dispatch({ type: 'SET_CURRENT_MODEL', payload: displayModel });
       }

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/contentEventProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/contentEventProcessor.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for processContentEvent's content-prefix identity threading
+ * (issue #2263).
+ *
+ * The content-prefix identity (profileName:modelName) must be threaded from the
+ * `getContentPrefixIdentity` dep into the gemini history item's `profileName`
+ * field, which is display-only (consumed by GeminiMessage.tsx's [profileName]
+ * prefix rendering).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type React from 'react';
+import type { ThinkingBlock } from '@vybestack/llxprt-code-core';
+import type { HistoryItemWithoutId } from '../../../types.js';
+import {
+  processContentEvent,
+  type ContentEventDeps,
+} from '../contentEventProcessor.js';
+
+function createDeps(
+  getContentPrefixIdentity: () => string | null,
+  overrides: Partial<ContentEventDeps> = {},
+): ContentEventDeps {
+  return {
+    addItem: vi.fn(),
+    sanitizeContent: (text: string) => ({ text, blocked: false }),
+    flushPendingHistoryItem: vi.fn(),
+    pendingHistoryItemRef: {
+      current: null,
+    } as React.MutableRefObject<HistoryItemWithoutId | null>,
+    thinkingBlocksRef: {
+      current: [],
+    } as React.MutableRefObject<ThinkingBlock[]>,
+    turnCancelledRef: { current: false },
+    setPendingHistoryItem: vi.fn(),
+    getContentPrefixIdentity,
+    ...overrides,
+  };
+}
+
+describe('processContentEvent content-prefix identity (issue #2263)', () => {
+  it('threads profileName:modelName into the pending gemini item', () => {
+    const setPendingHistoryItem = vi.fn();
+    const deps = createDeps(() => 'work:gpt-4', { setPendingHistoryItem });
+
+    processContentEvent('hello world', '', Date.now(), deps);
+
+    // ensureGeminiPendingItem creates the new pending item via the first call
+    // (object form). Later calls use the callback form for content updates.
+    const firstCall = setPendingHistoryItem.mock.calls[0][0];
+    expect(firstCall.profileName).toBe('work:gpt-4');
+
+    // Verify profileName survives the callback-form content update path
+    // (buildFullSplitItem), which produces the final rendered item.
+    const callbackCalls = setPendingHistoryItem.mock.calls.filter(
+      (call) => typeof call[0] === 'function',
+    );
+    expect(callbackCalls.length).toBeGreaterThan(0);
+    const updatedItem = (callbackCalls[0][0] as (item: unknown) => unknown)(
+      firstCall,
+    );
+    expect((updatedItem as { profileName?: string }).profileName).toBe(
+      'work:gpt-4',
+    );
+  });
+
+  it('omits profileName when getContentPrefixIdentity returns null', () => {
+    const setPendingHistoryItem = vi.fn();
+    const deps = createDeps(() => null, { setPendingHistoryItem });
+
+    processContentEvent('hello world', '', Date.now(), deps);
+
+    const firstCall = setPendingHistoryItem.mock.calls[0][0];
+    expect(firstCall.profileName).toBeUndefined();
+  });
+
+  it('treats empty string as absent (the production resolver never returns empty)', () => {
+    const setPendingHistoryItem = vi.fn();
+    const deps = createDeps(() => '', { setPendingHistoryItem });
+
+    processContentEvent('hello world', '', Date.now(), deps);
+
+    const firstCall = setPendingHistoryItem.mock.calls[0][0];
+    expect(firstCall.profileName).toBeUndefined();
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/thoughtState.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/thoughtState.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for applyThoughtToState's content-prefix identity threading
+ * (issue #2263).
+ *
+ * When a Thought event arrives before content, the thinking block is appended to
+ * the same pending gemini item that carries the response prefix. The
+ * `profileName` field must hold the full `profileName:modelName` identity — not
+ * just the bare profile name — so the prefix shown above thinking blocks is
+ * consistent with the content prefix.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type React from 'react';
+import type { ThinkingBlock } from '@vybestack/llxprt-code-core';
+import type {
+  HistoryItemGemini,
+  HistoryItemWithoutId,
+} from '../../../types.js';
+import { applyThoughtToState } from '../thoughtState.js';
+
+function createArgs(overrides: {
+  getContentPrefixIdentity: () => string | null;
+}) {
+  return {
+    thoughtSummary: { subject: 'Analyzing', description: 'the request' },
+    sanitizeContent: (text: string) => ({ text, blocked: false }),
+    getContentPrefixIdentity: overrides.getContentPrefixIdentity,
+    thinkingBlocksRef: {
+      current: [],
+    } as React.MutableRefObject<ThinkingBlock[]>,
+    setLastGeminiActivityTime: vi.fn(),
+    setThought: vi.fn(),
+    setPendingHistoryItem: vi.fn(),
+  };
+}
+
+describe('applyThoughtToState content-prefix identity (issue #2263)', () => {
+  it('threads profileName:modelName into the pending gemini item', () => {
+    const args = createArgs({
+      getContentPrefixIdentity: () => 'work:gpt-4',
+    });
+
+    applyThoughtToState(
+      args.thoughtSummary,
+      args.sanitizeContent,
+      args.getContentPrefixIdentity,
+      args.thinkingBlocksRef,
+      args.setLastGeminiActivityTime,
+      args.setThought,
+      args.setPendingHistoryItem,
+    );
+
+    expect(args.setPendingHistoryItem).toHaveBeenCalledTimes(1);
+    const updater = args.setPendingHistoryItem.mock.calls[0][0] as (
+      item: HistoryItemWithoutId | null,
+    ) => HistoryItemWithoutId | null;
+    const result = updater(null) as HistoryItemGemini | null;
+    expect(result?.type).toBe('gemini');
+    expect(result?.profileName).toBe('work:gpt-4');
+  });
+
+  it('omits profileName when getContentPrefixIdentity returns null', () => {
+    const args = createArgs({
+      getContentPrefixIdentity: () => null,
+    });
+
+    applyThoughtToState(
+      args.thoughtSummary,
+      args.sanitizeContent,
+      args.getContentPrefixIdentity,
+      args.thinkingBlocksRef,
+      args.setLastGeminiActivityTime,
+      args.setThought,
+      args.setPendingHistoryItem,
+    );
+
+    const updater = args.setPendingHistoryItem.mock.calls[0][0] as (
+      item: HistoryItemWithoutId | null,
+    ) => HistoryItemWithoutId | null;
+    const result = updater(null) as HistoryItemGemini | null;
+    expect(result?.profileName).toBeUndefined();
+  });
+
+  it('preserves an existing identity when getContentPrefixIdentity returns null', () => {
+    const args = createArgs({
+      getContentPrefixIdentity: () => null,
+    });
+
+    applyThoughtToState(
+      args.thoughtSummary,
+      args.sanitizeContent,
+      args.getContentPrefixIdentity,
+      args.thinkingBlocksRef,
+      args.setLastGeminiActivityTime,
+      args.setThought,
+      args.setPendingHistoryItem,
+    );
+
+    const updater = args.setPendingHistoryItem.mock.calls[0][0] as (
+      item: HistoryItemWithoutId | null,
+    ) => HistoryItemWithoutId | null;
+    // Simulate an existing pending item that already has the identity.
+    const result = updater({
+      type: 'gemini',
+      text: 'partial',
+      profileName: 'work:gpt-4',
+    }) as HistoryItemGemini | null;
+    expect(result?.profileName).toBe('work:gpt-4');
+  });
+
+  it('prefers live identity over existing profileName on the pending item', () => {
+    const args = createArgs({
+      getContentPrefixIdentity: () => 'new:claude-3',
+    });
+
+    applyThoughtToState(
+      args.thoughtSummary,
+      args.sanitizeContent,
+      args.getContentPrefixIdentity,
+      args.thinkingBlocksRef,
+      args.setLastGeminiActivityTime,
+      args.setThought,
+      args.setPendingHistoryItem,
+    );
+
+    const updater = args.setPendingHistoryItem.mock.calls[0][0] as (
+      item: HistoryItemWithoutId | null,
+    ) => HistoryItemWithoutId | null;
+    const result = updater({
+      type: 'gemini',
+      text: 'partial',
+      profileName: 'old:gpt-4',
+    }) as HistoryItemGemini | null;
+    expect(result?.profileName).toBe('new:claude-3');
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/contentEventProcessor.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/contentEventProcessor.ts
@@ -12,7 +12,6 @@
 
 import type React from 'react';
 import {
-  type Config,
   type ServerGeminiContentEvent as ContentEvent,
   type ThinkingBlock,
 } from '@vybestack/llxprt-code-core';
@@ -23,14 +22,9 @@ import {
   MessageType,
 } from '../../types.js';
 import { type UseHistoryManagerReturn } from '../useHistoryManager.js';
-import {
-  getCurrentProfileName,
-  buildSplitContent,
-  buildFullSplitItem,
-} from './streamUtils.js';
+import { buildSplitContent, buildFullSplitItem } from './streamUtils.js';
 
 export interface ContentEventDeps {
-  config: Config;
   addItem: UseHistoryManagerReturn['addItem'];
   sanitizeContent: (text: string) => {
     text: string;
@@ -44,6 +38,7 @@ export interface ContentEventDeps {
   setPendingHistoryItem: React.Dispatch<
     React.SetStateAction<HistoryItemWithoutId | null>
   >;
+  getContentPrefixIdentity: () => string | null;
 }
 
 function ensureGeminiPendingItem(
@@ -135,7 +130,11 @@ export function processContentEvent(
     return '';
   }
 
-  const liveProfileName = getCurrentProfileName(deps.config);
+  // Normalize empty/whitespace to null so downstream `!= null` checks treat
+  // it as absent — consistent with resolveContentPrefixIdentity's cleaned()
+  // behavior (issue #2263).
+  const rawIdentity = deps.getContentPrefixIdentity();
+  const liveProfileIdentity = rawIdentity === '' ? null : rawIdentity;
   const pendingType = getPendingGeminiType(deps.pendingHistoryItemRef.current);
   const combined = currentGeminiMessageBuffer + eventValue;
   const {
@@ -167,7 +166,7 @@ export function processContentEvent(
     deps.pendingHistoryItemRef,
     deps.setPendingHistoryItem,
     deps.flushPendingHistoryItem,
-    liveProfileName,
+    liveProfileIdentity,
     deps.thinkingBlocksRef,
     userMessageTimestamp,
   );
@@ -180,7 +179,7 @@ export function processContentEvent(
   )?.profileName;
   const { splitPoint, beforeText, afterItem } = buildSplitContent(
     sanitizedCombined,
-    liveProfileName,
+    liveProfileIdentity,
     existingProfileName ?? null,
     deps.thinkingBlocksRef.current,
     pendingType,
@@ -191,7 +190,7 @@ export function processContentEvent(
       buildFullSplitItem(
         item,
         sanitizedCombined,
-        liveProfileName,
+        liveProfileIdentity,
         deps.thinkingBlocksRef.current,
       ),
     );
@@ -201,7 +200,7 @@ export function processContentEvent(
   return applySplitResult(
     beforeText,
     pendingType,
-    liveProfileName,
+    liveProfileIdentity,
     deps.thinkingBlocksRef,
     deps.setPendingHistoryItem,
     deps.addItem,

--- a/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.test.ts
@@ -19,7 +19,6 @@ type GeminiEvent = ServerGeminiStreamEvent;
 
 function createDeps(overrides: Partial<StreamEventDeps> = {}): StreamEventDeps {
   return {
-    config: { getModel: () => 'test-model' } as never,
     addItem: vi.fn(),
     sanitizeContent: (text: string) => ({ text, blocked: false }),
     flushPendingHistoryItem: vi.fn(),
@@ -40,6 +39,7 @@ function createDeps(overrides: Partial<StreamEventDeps> = {}): StreamEventDeps {
     setPendingHistoryItem: vi.fn(),
     setLastGeminiActivityTime: vi.fn(),
     setThought: vi.fn(),
+    getContentPrefixIdentity: vi.fn(() => null),
     handleContentEvent: vi.fn((_value, buffer) => buffer),
     handleUserCancelledEvent: vi.fn(),
     handleErrorEvent: vi.fn(),

--- a/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamEventDispatcher.ts
@@ -19,7 +19,6 @@ import {
   type ServerGeminiFinishedEvent,
   type ServerGeminiErrorEvent as ErrorEvent,
   type ToolCallRequestInfo,
-  type Config,
   type ThoughtSummary,
   type ThinkingBlock,
   type ModelInfo,
@@ -32,7 +31,6 @@ import { applyThoughtToState } from './thoughtState.js';
 import { firstNonEmptyString } from '../../../utils/coalesce.js';
 
 export interface StreamEventDeps {
-  config: Config;
   addItem: (item: HistoryItemWithoutId, timestamp: number) => void;
   sanitizeContent: (text: string) => {
     text: string;
@@ -56,6 +54,11 @@ export interface StreamEventDeps {
   >;
   setLastGeminiActivityTime: React.Dispatch<React.SetStateAction<number>>;
   setThought: React.Dispatch<React.SetStateAction<ThoughtSummary | null>>;
+  /**
+   * Resolves the content-prefix identity (profileName:modelName) for the
+   * current session. Returns null when no profile is active (issue #2263).
+   */
+  getContentPrefixIdentity: () => string | null;
   handleContentEvent: (
     eventValue: ContentEvent['value'],
     currentBuffer: string,
@@ -393,7 +396,7 @@ function handleContentLikeStreamEvent(
       applyThoughtToState(
         event.value,
         deps.sanitizeContent,
-        deps.config,
+        deps.getContentPrefixIdentity,
         deps.thinkingBlocksRef,
         deps.setLastGeminiActivityTime,
         deps.setThought,

--- a/packages/cli/src/ui/hooks/geminiStream/thoughtState.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/thoughtState.ts
@@ -6,7 +6,6 @@
 
 import type React from 'react';
 import {
-  type Config,
   type ThinkingBlock,
   type ThoughtSummary,
 } from '@vybestack/llxprt-code-core';
@@ -15,7 +14,6 @@ import {
   type HistoryItemGeminiContent,
   type HistoryItemWithoutId,
 } from '../../types.js';
-import { getCurrentProfileName } from './streamUtils.js';
 
 export function applyThoughtToState(
   thoughtSummary: ThoughtSummary,
@@ -24,7 +22,7 @@ export function applyThoughtToState(
     blocked: boolean;
     feedback?: string;
   },
-  config: Config,
+  getContentPrefixIdentity: () => string | null,
   thinkingBlocksRef: React.MutableRefObject<ThinkingBlock[]>,
   setLastGeminiActivityTime: (t: number) => void,
   setThought: (t: ThoughtSummary | null) => void,
@@ -45,7 +43,8 @@ export function applyThoughtToState(
   );
   if (thinkingBlock) {
     thinkingBlocksRef.current.push(thinkingBlock);
-    const liveProfileName = getCurrentProfileName(config);
+    const rawIdentity = getContentPrefixIdentity();
+    const liveProfileName = rawIdentity === '' ? null : rawIdentity;
     setPendingHistoryItem((item) => {
       const existingProfileName = (
         item as HistoryItemGemini | HistoryItemGeminiContent | undefined

--- a/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
@@ -48,6 +48,24 @@ import {
   getErrorFallbackModel,
 } from '../../../utils/apiErrorFormatting.js';
 import {
+  resolveContentPrefixIdentity,
+  createCliModelIdentityRuntime,
+} from '../../utils/modelIdentity.js';
+
+/**
+ * Shared content-prefix identity resolver. Reads fresh runtime state at call
+ * time (no dependencies on component state/props), so a single stable reference
+ * can be reused by both ContentEventDeps and StreamEventDeps without risk of
+ * staleness (issue #2263).
+ */
+function defaultGetContentPrefixIdentity(): string | null {
+  try {
+    return resolveContentPrefixIdentity(createCliModelIdentityRuntime());
+  } catch {
+    return null;
+  }
+}
+import {
   processContentEvent,
   type ContentEventDeps,
 } from './contentEventProcessor.js';
@@ -477,7 +495,6 @@ function usePrepareQueryForGemini(deps: StreamEventHandlerDeps) {
 function useContentEventDeps(deps: StreamEventHandlerDeps): ContentEventDeps {
   return useMemo(
     () => ({
-      config: deps.config,
       addItem: deps.addItem,
       sanitizeContent: deps.sanitizeContent,
       flushPendingHistoryItem: deps.flushPendingHistoryItem,
@@ -485,9 +502,9 @@ function useContentEventDeps(deps: StreamEventHandlerDeps): ContentEventDeps {
       thinkingBlocksRef: deps.thinkingBlocksRef,
       turnCancelledRef: deps.turnCancelledRef,
       setPendingHistoryItem: deps.setPendingHistoryItem,
+      getContentPrefixIdentity: defaultGetContentPrefixIdentity,
     }),
     [
-      deps.config,
       deps.addItem,
       deps.sanitizeContent,
       deps.flushPendingHistoryItem,
@@ -571,7 +588,6 @@ function useProcessStreamEvent(
       const result = dispatchStreamEvent(
         event,
         {
-          config: deps.config,
           addItem: deps.addItem,
           sanitizeContent: deps.sanitizeContent,
           flushPendingHistoryItem: deps.flushPendingHistoryItem,
@@ -584,6 +600,7 @@ function useProcessStreamEvent(
           setPendingHistoryItem: deps.setPendingHistoryItem,
           setLastGeminiActivityTime: deps.setLastGeminiActivityTime,
           setThought: deps.setThought,
+          getContentPrefixIdentity: defaultGetContentPrefixIdentity,
           ...handlers,
           scheduleToolCalls: deps.scheduleToolCalls,
         },

--- a/packages/cli/src/ui/utils/modelIdentity.test.ts
+++ b/packages/cli/src/ui/utils/modelIdentity.test.ts
@@ -9,6 +9,7 @@ import {
   formatModelIdentity,
   formatLoadBalancerIdentity,
   resolveModelIdentity,
+  resolveContentPrefixIdentity,
   LB_PENDING_PLACEHOLDER,
   type ModelIdentityRuntime,
 } from './modelIdentity.js';
@@ -309,5 +310,141 @@ describe('resolveModelIdentity', () => {
       profileName: null,
     });
     expect(resolveModelIdentity(runtime, 'prev-label')).toBe('prev-label');
+  });
+});
+
+describe('resolveContentPrefixIdentity', () => {
+  it('returns profileName:modelName for a standard profile session', () => {
+    const runtime = makeRuntime({
+      providerName: 'openai',
+      modelName: 'gpt-4',
+      profileName: 'work',
+    });
+    expect(resolveContentPrefixIdentity(runtime)).toBe('work:gpt-4');
+  });
+
+  it('returns just the profile name when no model is available', () => {
+    const runtime = makeRuntime({
+      providerName: 'openai',
+      modelName: null,
+      profileName: 'work',
+    });
+    expect(resolveContentPrefixIdentity(runtime)).toBe('work');
+  });
+
+  it('returns profileName:activeModel for a load-balancer session after selection', () => {
+    const runtime = makeRuntime({
+      providerName: 'load-balancer',
+      modelName: 'my-lb',
+      profileName: 'my-lb',
+      lbStats: {
+        profileName: 'my-lb',
+        lastSelected: 'fast-sub',
+        lastSelectedModel: 'gpt-4o-mini',
+      },
+    });
+    expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb:gpt-4o-mini');
+  });
+
+  it('falls back to status.modelName for a load-balancer session before selection', () => {
+    const runtime = makeRuntime({
+      providerName: 'load-balancer',
+      modelName: 'my-lb',
+      profileName: 'my-lb',
+      lbStats: {
+        profileName: 'my-lb',
+        lastSelected: null,
+        lastSelectedModel: null,
+      },
+    });
+    expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb:my-lb');
+  });
+
+  it('returns just the profile name for a load-balancer session when no model is known', () => {
+    const runtime = makeRuntime({
+      providerName: 'load-balancer',
+      modelName: null,
+      profileName: 'my-lb',
+      lbStats: {
+        profileName: 'my-lb',
+        lastSelected: null,
+        lastSelectedModel: null,
+      },
+    });
+    expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb');
+  });
+
+  it('returns null when no profile is active (direct provider)', () => {
+    const runtime = makeRuntime({
+      providerName: 'gemini',
+      modelName: 'gemini-2.5-pro',
+      profileName: null,
+    });
+    expect(resolveContentPrefixIdentity(runtime)).toBeNull();
+  });
+
+  it('returns null when nothing is active at all', () => {
+    const runtime = makeRuntime({
+      providerName: null,
+      modelName: null,
+      profileName: null,
+    });
+    expect(resolveContentPrefixIdentity(runtime)).toBeNull();
+  });
+
+  describe('load-balancer error/edge degradation', () => {
+    it('uses the LB sub-profile model when getStats succeeds', () => {
+      const runtime = makeRuntime({
+        providerName: 'load-balancer',
+        modelName: 'my-lb',
+        profileName: 'my-lb',
+        lbStats: {
+          profileName: 'my-lb',
+          lastSelected: 'fast-sub',
+          lastSelectedModel: 'gpt-4o-mini',
+        },
+      });
+      expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb:gpt-4o-mini');
+    });
+
+    it('falls back to the LB provider model when getStats returns null', () => {
+      const runtime = makeRuntime({
+        providerName: 'load-balancer',
+        modelName: 'my-lb',
+        profileName: 'my-lb',
+        getStatsReturnsNull: true,
+      });
+      expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb:my-lb');
+    });
+
+    it('falls back to the LB provider model when the provider is missing', () => {
+      const runtime = makeRuntime({
+        providerName: 'load-balancer',
+        modelName: 'my-lb',
+        profileName: 'my-lb',
+        providerMissing: true,
+      });
+      expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb:my-lb');
+    });
+
+    it('falls back to the LB provider model when getStats throws', () => {
+      const runtime = makeRuntime({
+        providerName: 'load-balancer',
+        modelName: 'my-lb',
+        profileName: 'my-lb',
+        lbStatsThrows: true,
+      });
+      expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb:my-lb');
+    });
+
+    it('falls back to the LB provider model when the provider manager is null', () => {
+      const runtime = makeRuntime({
+        providerName: 'load-balancer',
+        modelName: 'my-lb',
+        profileName: 'my-lb',
+        providerManagerNull: true,
+      });
+      expect(resolveContentPrefixIdentity(runtime)).toBe('my-lb:my-lb');
+    });
   });
 });

--- a/packages/cli/src/ui/utils/modelIdentity.ts
+++ b/packages/cli/src/ui/utils/modelIdentity.ts
@@ -5,6 +5,11 @@
  */
 
 import { debugLogger } from '@vybestack/llxprt-code-core';
+import {
+  getActiveProviderStatus,
+  getActiveProfileName,
+  getCliProviderManager,
+} from '@vybestack/llxprt-code-providers/runtime/runtimeSettings.js';
 
 /**
  * Placeholder shown for a load-balancer sub-profile or model that has not yet
@@ -173,4 +178,48 @@ export function resolveModelIdentity(
     modelName: status.modelName,
     fallback,
   });
+}
+
+/**
+ * Build a {@link ModelIdentityRuntime} from the standalone CLI provider
+ * accessors. The standalone `getActiveProviderStatus()` returns extra fields
+ * (displayLabel, isPaidMode, baseURL) that are not needed for identity
+ * resolution, so only the minimal shape is projected out.
+ */
+export function createCliModelIdentityRuntime(): ModelIdentityRuntime {
+  return {
+    getActiveProviderStatus: () => {
+      const status = getActiveProviderStatus();
+      return {
+        providerName: status.providerName,
+        modelName: status.modelName,
+      };
+    },
+    getActiveProfileName: () => getActiveProfileName(),
+    getCliProviderManager: () => getCliProviderManager(),
+  };
+}
+
+/**
+ * Resolve the content-prefix identity for a response: `profileName:modelName`
+ * (NO load-balancer quad). Returns `null` when no profile is active so callers
+ * can omit the prefix entirely. For load-balancer profiles, the active
+ * sub-profile model is used (falling back to the LB provider's model name).
+ */
+export function resolveContentPrefixIdentity(
+  runtime: ModelIdentityRuntime,
+): string | null {
+  const status = runtime.getActiveProviderStatus();
+  const profileName = cleaned(runtime.getActiveProfileName());
+  if (!profileName) {
+    return null;
+  }
+  let model: string | null;
+  if (status.providerName === LOAD_BALANCER_PROVIDER_NAME) {
+    const stats = readLoadBalancerStats(runtime);
+    model = cleaned(stats?.lastSelectedModel) ?? cleaned(status.modelName);
+  } else {
+    model = cleaned(status.modelName);
+  }
+  return joinPrimaryAndModel(profileName, model);
 }


### PR DESCRIPTION
## Summary

Follow-up to #2193. The profile-qualified identity (`profileName:modelName`) was only applied to the reactive status-bar label, leaving three user-facing surfaces inconsistent with the rest of the UI. This PR extends the same identity to all three:

1. **Interactive response content prefix** — the `[profileName]` bracket above each model response now shows `[profileName:modelName]`.
2. **Non-interactive response prefix** — the per-turn writer (`createProfileNameWriter`) now emits `[profileName:modelName]`.
3. **Non-LB status-bar fallback** — `SessionController`'s `currentModel` initial value and `SET_CURRENT_MODEL` updater now use `resolveModelIdentity()` (`profileName:modelName` for standard profiles) instead of the raw `providerName:modelName` computation.

For load-balancer profiles, the content prefix shows `lbProfileName:activeModel` (the loaded profile name + active sub-profile model), **not** the full `lb:profile:subProfile:model` quad used in the status bar — per the issue spec.

### Bonus fix discovered during implementation

Thought-block streaming (`thoughtState.ts`) was using the bare `getCurrentProfileName()` while the content processor used the full identity, causing the prefix above thinking blocks to be inconsistent with the content prefix. Both now use the same `getContentPrefixIdentity()` dependency-injected resolver.

## Changes

### Source (5 files)

- **`modelIdentity.ts`** — Added `resolveContentPrefixIdentity(runtime)` (returns `profileName:modelName` or `null` when no profile is active; for LB uses active sub-profile model). Added `createCliModelIdentityRuntime()` factory to build a `ModelIdentityRuntime` from standalone CLI provider accessors for non-React callers.
- **`contentEventProcessor.ts`** — `ContentEventDeps` now takes `getContentPrefixIdentity` (DI). Replaced `getCurrentProfileName(config)` with the identity resolver. Removed dead `config` field. Normalizes empty strings to null.
- **`thoughtState.ts`** — `applyThoughtToState` now takes `getContentPrefixIdentity` instead of `config`. Uses the identity resolver instead of `getCurrentProfileName`.
- **`useStreamEventHandlers.ts`** — Provides `getContentPrefixIdentity` to both `ContentEventDeps` and `StreamEventDeps` via a shared module-level `defaultGetContentPrefixIdentity()` constant (DRY — avoids duplication).
- **`streamEventDispatcher.ts`** — Added `getContentPrefixIdentity` to `StreamEventDeps`. Passes it to `applyThoughtToState`. Removed dead `config` field and import.
- **`SessionController.tsx`** — `initialState.currentModel` and `useModelChangeWatcher`'s `displayModel` now use `resolveModelIdentity(runtime, config.getModel())`.
- **`nonInteractiveCli.ts`** — `createProfileNameWriter` now exported. Accepts optional `getIdentity` param. Default resolver calls `resolveContentPrefixIdentity()` with try/catch fallback + debug log.

### Tests (5 files, all behavioral — no mock theater)

- **`modelIdentity.test.ts`** — 13 new tests for `resolveContentPrefixIdentity` (standard profile, LB after selection, LB before selection, LB no model, direct provider → null, nothing → null, 5 LB degradation edge cases).
- **`contentEventProcessor.test.ts`** — 3 tests: threads `profileName:modelName` into pending item + verifies it survives the callback-form update path, null → omitted, empty string → treated as absent.
- **`thoughtState.test.ts`** — 4 tests: threads identity into pending item, null → omitted, preserves existing identity when null, live identity overwrites existing (precedence).
- **`nonInteractiveCli.profilePrefix.test.ts`** — 5 tests: writes `[profileName:modelName]`, firstEventInTurn guard, jsonOutput/streamFormatter suppression, null identity suppression.
- **`streamEventDispatcher.test.ts`** — Updated mock factory for interface change.

## Verification

- `npm run typecheck` ✅
- ESLint on all changed files ✅ (0 errors)
- `node scripts/check-eslint-guard.js` ✅
- `npx prettier --check` ✅
- `npm run build` ✅
- Targeted tests: 70 tests pass (5 test files)
- Broader hook/UI tests: 931 tests pass (90 test files)
- Smoke test: `[ollamakimi:kimi-k2.5]` ✅
- Open Code Review (ocr): 7 findings — all addressed (dead code removal, DRY refactor, debug log, 6 new test cases)

## Acceptance criteria

- [x] Interactive response prefix shows `profileName:modelName` for standard profiles.
- [x] Non-interactive response prefix shows `profileName:modelName` for standard profiles.
- [x] For a load-balancer profile, the response prefix shows `lbProfileName:activeModel` (no sub-profile).
- [x] Non-LB status bar consistently shows `profileName:modelName`, including the `SessionController` fallback, with `providerName:modelName` only when no profile is active.
- [x] No regression to the #2193 load-balancer status-bar identity or the direct-provider fallback.
- [x] Behavioral tests cover standard-profile, direct-provider, and load-balancer prefix cases plus the status-bar fallback.

Fixes #2263