### PR TITLE
fix(test): stabilize flaky DebugLogger perf tests on CI (Fixes #2275)

### DIFF
--- a/packages/core/src/debug/DebugLogger.test.ts
+++ b/packages/core/src/debug/DebugLogger.test.ts
@@ -127,19 +127,26 @@ describe('DebugLogger', () => {
    * @scenario Zero overhead when disabled
    * @given logger disabled
    * @when log called 1000 times
-   * @then Execution time < 1ms
+   * @then No work is performed (no write, no string formatting) and wall-clock stays within budget
    */
   it('should have zero overhead when disabled @plan:PLAN-20250120-DEBUGLOGGING.P04', () => {
     const logger = new DebugLogger('llxprt:test');
     logger.enabled = false;
 
+    // Behavioral guarantee: the disabled path must be a pure no-op.
+    // This is deterministic and is the real "zero overhead" contract.
+    const writeSpy = vi.spyOn(logger.fileOutput, 'write');
+
+    // Secondary timing check: generous budget for CI runner variance.
+    // The previous 3 ms bound was routinely exceeded on shared GitHub runners.
     const start = performance.now();
     for (let i = 0; i < 1000; i++) {
       logger.log('test message');
     }
     const duration = performance.now() - start;
 
-    expect(duration).toBeLessThan(3);
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(duration).toBeLessThan(10);
   });
 
   /**

--- a/packages/telemetry/src/debug/DebugLogger.test.ts
+++ b/packages/telemetry/src/debug/DebugLogger.test.ts
@@ -98,19 +98,26 @@ describe('DebugLogger', () => {
    * @scenario Zero overhead when disabled
    * @given logger disabled
    * @when log called 1000 times
-   * @then Execution time < 1ms
+   * @then No work is performed (no write, no string formatting) and wall-clock stays within budget
    */
   it('should have zero overhead when disabled @plan:PLAN-20250120-DEBUGLOGGING.P04', () => {
     const logger = new DebugLogger('llxprt:test');
     logger.enabled = false;
 
+    // Behavioral guarantee: the disabled path must be a pure no-op.
+    // This is deterministic and is the real "zero overhead" contract.
+    const writeSpy = vi.spyOn(logger.fileOutput, 'write');
+
+    // Secondary timing check: generous budget for CI runner variance.
+    // The previous 3 ms bound was routinely exceeded on shared GitHub runners.
     const start = performance.now();
     for (let i = 0; i < 1000; i++) {
       logger.log('test message');
     }
     const duration = performance.now() - start;
 
-    expect(duration).toBeLessThan(3);
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(duration).toBeLessThan(10);
   });
 
   /**


### PR DESCRIPTION
## Problem

The nightly release `v0.10.0-nightly.260630` failed at the **"Run Preflight Checks"** step (`node scripts/preflight-ci.js`). A single flaky timing-based test in `DebugLogger.test.ts` failed:

- **Test:** `DebugLogger > should have zero overhead when disabled`
- **Assertion:** `expect(duration).toBeLessThan(3)` — 1000 calls to `logger.log()` while disabled must complete in under 3ms wall-clock
- **CI actual:** measured 3.18ms → `AssertionError`
- The disabled code path is just a boolean guard (`if (!this._enabled) return;`), but 3ms was too tight for shared GitHub runners.

Closes #2275

## Fix

Two changes applied to both copies (`packages/telemetry` + `packages/core`):

1. **Deterministic behavioral assertion** — Added `expect(writeSpy).not.toHaveBeenCalled()` so the "zero overhead" guarantee is verified deterministically, not via wall-clock timing. The disabled path must be a pure no-op: no formatting, no timestamping, no file I/O.

2. **Loosened timing budget (3ms → 10ms)** — The secondary timing check now has ~3x headroom over the observed CI worst case (3.18ms). The timer stays `performance.now()`; swapping to `process.hrtime.bigint()` would not help since both measure wall-clock time — the budget increase is what stops the flake.

### Design decision

An earlier version of this PR swapped to `process.hrtime.bigint()` and cited `regression-guards.test.ts` as precedent. That was wrong: `regression-guards.test.ts` still uses `performance.now()`, and `hrtime` doesn't solve CI variance any better. The timer was reverted to `performance.now()`.
