### PR TITLE
Add Claude Sonnet 5 (claude-sonnet-5) to the model menu (Fixes #2289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - `task-max-async` setting to limit concurrent async tasks (default: 5)
 - Auto-trigger notifications when async tasks complete
 
+### Changed
+
+- The Anthropic provider's default model is now **Claude Opus 4.8** (`claude-opus-4-8`), aligning `getDefaultModel()` with the `anthropic` alias config (`anthropic.config` already declared `claude-opus-4-8` as its `defaultModel`) (#2289).
+
 ### Migration
 
 - Direct consumers constructing `AuthPrecedenceResolver` and expecting it to resolve named auth keys must pass `providerKeyStorage` in the constructor options or use core's `createAuthPrecedenceResolver()` factory. The CLI profile flow already resolves named keys to concrete provider API keys before provider construction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added **Claude Sonnet 5** (`claude-sonnet-5`) to the model menu: it is now selectable in the profile-create wizard, appears in the Anthropic provider model list (both OAuth and default paths), and resolves correct max output tokens (128K), context window (200K subscription default; 1M is API-only/plan-gated), and token limits. The "latest" sonnet alias logic now tracks Sonnet 5, and adaptive thinking / `effort` wiring covers it (#2289).
 - Async task execution: Launch subagents with `async=true` to run in background (#244)
 - `check_async_tasks` tool for model to query async task status
 - `/tasks list` command to show all async tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changed
 
 - The Anthropic provider's default model is now **Claude Opus 4.8** (`claude-opus-4-8`), aligning `getDefaultModel()` with the `anthropic` alias config (`anthropic.config` already declared `claude-opus-4-8` as its `defaultModel`) (#2289).
+- `AnthropicProvider.getLatestClaude4Model()` was renamed to `getLatestClaudeModel()` so the helper tracks the newest release of each tier (e.g. Sonnet 5) rather than a single generation. The old name is retained as a deprecated alias delegating to the new method and will be removed in a future release (#2289).
 
 ### Migration
 

--- a/docs/providers/quick-reference.md
+++ b/docs/providers/quick-reference.md
@@ -109,7 +109,7 @@ Note: OAuth is lazy — authentication happens when you first use the provider.
 
 #### Model geometry & recommended settings (Anthropic)
 
-Common models: `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`
+Common models: `claude-opus-4-8`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-haiku-4-5`
 
 Guidance:
 

--- a/packages/cli/src/ui/components/ProfileCreateWizard/constants.ts
+++ b/packages/cli/src/ui/components/ProfileCreateWizard/constants.ts
@@ -13,6 +13,7 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
     needsBaseUrl: false,
     supportsOAuth: true,
     knownModels: [
+      'claude-sonnet-5',
       'claude-sonnet-4-5-20250929',
       'claude-haiku-4-5-20251001',
       'claude-opus-4-5-20251101',

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -80,8 +80,19 @@ describe('tokenLimit', () => {
       expect(tokenLimit('claude-sonnet-4-6')).toBe(200_000);
     });
 
+    // Claude Sonnet 5 defaults to the Claude Code / subscription 200K context
+    // window. The advertised 1M window is API-only and plan-gated; override
+    // via /set or a profile (context-limit).
+    it('should return 200K (auth default) limit for claude-sonnet-5', () => {
+      expect(tokenLimit('claude-sonnet-5')).toBe(200_000);
+    });
+
     it('honors a user-supplied context limit override (e.g. /set or profile)', () => {
       expect(tokenLimit('claude-opus-4-8', 1_000_000)).toBe(1_000_000);
+    });
+
+    it('honors a user-supplied context limit override for claude-sonnet-5', () => {
+      expect(tokenLimit('claude-sonnet-5', 1_000_000)).toBe(1_000_000);
     });
   });
 

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -87,6 +87,14 @@ describe('tokenLimit', () => {
       expect(tokenLimit('claude-sonnet-5')).toBe(200_000);
     });
 
+    it('should return 200K limit for the claude-sonnet-5-latest alias', () => {
+      expect(tokenLimit('claude-sonnet-5-latest')).toBe(200_000);
+    });
+
+    it('should return 200K limit for a claude-sonnet-5 dated snapshot', () => {
+      expect(tokenLimit('claude-sonnet-5-20260630')).toBe(200_000);
+    });
+
     it('honors a user-supplied context limit override (e.g. /set or profile)', () => {
       expect(tokenLimit('claude-opus-4-8', 1_000_000)).toBe(1_000_000);
     });

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -55,6 +55,7 @@ const EXACT_LIMITS: Record<string, TokenCount> = {
   // window. The advertised 1M window is API-only and plan-gated; override via
   // /set or a profile (context-limit).
   'claude-sonnet-5': 200_000,
+  'claude-sonnet-5-latest': 200_000,
   'claude-3-7-opus-20250115': 300_000,
   'claude-3-7-sonnet-20250115': 300_000,
   'claude-3-opus-20240229': 200_000,
@@ -129,6 +130,14 @@ export function tokenLimit(
   // Check OpenAI 128K models
   if (matchesAnyPrefix(modelWithoutPrefix, OPENAI_128K_PREFIXES)) {
     return 128_000;
+  }
+
+  // Claude Sonnet 5 dated snapshot variants (e.g. claude-sonnet-5-YYYYMMDD)
+  // are not individually exact-keyed above; resolve them to the same
+  // subscription-safe 200K default as the bare alias and -latest. Mirrors
+  // getContextWindowForModel in the anthropic package.
+  if (modelWithoutPrefix.toLowerCase().includes('claude-sonnet-5')) {
+    return 200_000;
   }
 
   return DEFAULT_TOKEN_LIMIT;

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -51,6 +51,10 @@ const EXACT_LIMITS: Record<string, TokenCount> = {
   'claude-opus-4-latest': 200_000,
   'claude-sonnet-4-6': 200_000,
   'claude-sonnet-4-latest': 400_000,
+  // Claude Sonnet 5 defaults to the Claude Code / subscription 200K context
+  // window. The advertised 1M window is API-only and plan-gated; override via
+  // /set or a profile (context-limit).
+  'claude-sonnet-5': 200_000,
   'claude-3-7-opus-20250115': 300_000,
   'claude-3-7-sonnet-20250115': 300_000,
   'claude-3-opus-20240229': 200_000,

--- a/packages/providers/src/anthropic/AnthropicModelData.test.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.test.ts
@@ -9,6 +9,9 @@ import {
   OAUTH_MODELS,
   DEFAULT_MODELS,
   isOpus46Plus,
+  isSonnet5,
+  supportsAdaptiveThinking,
+  getLatestClaudeModel,
   getMaxTokensForModel,
   getContextWindowForModel,
 } from './AnthropicModelData.js';
@@ -85,6 +88,92 @@ describe('AnthropicModelData latest Opus models', () => {
 
     it('returns 200000 (auth default) for the claude-opus-4-latest alias', () => {
       expect(getContextWindowForModel('claude-opus-4-latest')).toBe(200000);
+    });
+  });
+});
+
+describe('AnthropicModelData Claude Sonnet 5 @issue:2289', () => {
+  describe('catalog entries', () => {
+    // Context window reflects the Claude Code / subscription (auth) 200K
+    // default; the advertised 1M window is API-only/plan-gated. Max output
+    // is the full 128K ceiling.
+    it('includes claude-sonnet-5 with 200K context / 128K output in OAUTH_MODELS', () => {
+      const model = OAUTH_MODELS.find((m) => m.id === 'claude-sonnet-5');
+      expect(model).toBeDefined();
+      expect(model?.name).toBe('Claude Sonnet 5');
+      expect(model?.contextWindow).toBe(200000);
+      expect(model?.maxOutputTokens).toBe(128000);
+    });
+
+    it('includes claude-sonnet-5 in DEFAULT_MODELS', () => {
+      expect(DEFAULT_MODELS.some((m) => m.id === 'claude-sonnet-5')).toBe(true);
+    });
+  });
+
+  describe('isSonnet5', () => {
+    it('returns true for claude-sonnet-5 and dated snapshot variants', () => {
+      expect(isSonnet5('claude-sonnet-5')).toBe(true);
+      expect(isSonnet5('claude-sonnet-5-20260630')).toBe(true);
+      expect(isSonnet5('claude-sonnet-5-latest')).toBe(true);
+    });
+
+    it('returns false for sonnet 4 and non-sonnet models', () => {
+      expect(isSonnet5('claude-sonnet-4-6')).toBe(false);
+      expect(isSonnet5('claude-opus-4-8')).toBe(false);
+      expect(isSonnet5('gpt-5.5')).toBe(false);
+    });
+  });
+
+  describe('supportsAdaptiveThinking', () => {
+    it('returns true for Opus 4.6+ and Sonnet 5', () => {
+      expect(supportsAdaptiveThinking('claude-opus-4-6')).toBe(true);
+      expect(supportsAdaptiveThinking('claude-opus-4-8')).toBe(true);
+      expect(supportsAdaptiveThinking('claude-sonnet-5')).toBe(true);
+      expect(supportsAdaptiveThinking('claude-sonnet-5-20260630')).toBe(true);
+    });
+
+    it('returns false for models without adaptive thinking', () => {
+      expect(supportsAdaptiveThinking('claude-sonnet-4-6')).toBe(false);
+      expect(supportsAdaptiveThinking('claude-opus-4-5')).toBe(false);
+    });
+  });
+
+  describe('getMaxTokensForModel', () => {
+    it('returns 128000 for claude-sonnet-5 and dated variants', () => {
+      expect(getMaxTokensForModel('claude-sonnet-5')).toBe(128000);
+      expect(getMaxTokensForModel('claude-sonnet-5-20260630')).toBe(128000);
+    });
+
+    it('still returns 64000 for claude-sonnet-4 models', () => {
+      expect(getMaxTokensForModel('claude-sonnet-4-6')).toBe(64000);
+      expect(getMaxTokensForModel('claude-sonnet-4-5-20250929')).toBe(64000);
+    });
+  });
+
+  describe('getContextWindowForModel', () => {
+    it('returns 200000 (auth default) for claude-sonnet-5 and dated variants', () => {
+      expect(getContextWindowForModel('claude-sonnet-5')).toBe(200000);
+      expect(getContextWindowForModel('claude-sonnet-5-20260630')).toBe(
+        200000,
+      );
+    });
+
+    it('still returns 400000 for claude-sonnet-4 models', () => {
+      expect(getContextWindowForModel('claude-sonnet-4-6')).toBe(400000);
+    });
+  });
+
+  describe('getLatestClaudeModel', () => {
+    it('returns the Sonnet 5 latest alias for the sonnet tier', () => {
+      expect(getLatestClaudeModel('sonnet')).toBe('claude-sonnet-5-latest');
+    });
+
+    it('defaults to the sonnet tier', () => {
+      expect(getLatestClaudeModel()).toBe('claude-sonnet-5-latest');
+    });
+
+    it('returns the Opus latest alias for the opus tier', () => {
+      expect(getLatestClaudeModel('opus')).toBe('claude-opus-4-latest');
     });
   });
 });

--- a/packages/providers/src/anthropic/AnthropicModelData.test.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.test.ts
@@ -153,9 +153,7 @@ describe('AnthropicModelData Claude Sonnet 5 @issue:2289', () => {
   describe('getContextWindowForModel', () => {
     it('returns 200000 (auth default) for claude-sonnet-5 and dated variants', () => {
       expect(getContextWindowForModel('claude-sonnet-5')).toBe(200000);
-      expect(getContextWindowForModel('claude-sonnet-5-20260630')).toBe(
-        200000,
-      );
+      expect(getContextWindowForModel('claude-sonnet-5-20260630')).toBe(200000);
     });
 
     it('still returns 400000 for claude-sonnet-4 models', () => {

--- a/packages/providers/src/anthropic/AnthropicModelData.test.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.test.ts
@@ -139,9 +139,14 @@ describe('AnthropicModelData Claude Sonnet 5 @issue:2289', () => {
   });
 
   describe('getMaxTokensForModel', () => {
-    it('returns 128000 for claude-sonnet-5 and dated variants', () => {
+    it('returns 128000 for claude-sonnet-5, the -latest alias, and dated variants', () => {
       expect(getMaxTokensForModel('claude-sonnet-5')).toBe(128000);
+      expect(getMaxTokensForModel('claude-sonnet-5-latest')).toBe(128000);
       expect(getMaxTokensForModel('claude-sonnet-5-20260630')).toBe(128000);
+    });
+
+    it('is case-insensitive (routes through isSonnet5)', () => {
+      expect(getMaxTokensForModel('Claude-Sonnet-5')).toBe(128000);
     });
 
     it('still returns 64000 for claude-sonnet-4 models', () => {
@@ -151,9 +156,14 @@ describe('AnthropicModelData Claude Sonnet 5 @issue:2289', () => {
   });
 
   describe('getContextWindowForModel', () => {
-    it('returns 200000 (auth default) for claude-sonnet-5 and dated variants', () => {
+    it('returns 200000 (auth default) for claude-sonnet-5, the -latest alias, and dated variants', () => {
       expect(getContextWindowForModel('claude-sonnet-5')).toBe(200000);
+      expect(getContextWindowForModel('claude-sonnet-5-latest')).toBe(200000);
       expect(getContextWindowForModel('claude-sonnet-5-20260630')).toBe(200000);
+    });
+
+    it('is case-insensitive (routes through isSonnet5)', () => {
+      expect(getContextWindowForModel('Claude-Sonnet-5')).toBe(200000);
     });
 
     it('still returns 400000 for claude-sonnet-4 models', () => {

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -307,9 +307,9 @@ export function getMaxTokensForModel(modelId: string): number {
   ) {
     return 64000;
   }
-  // Claude Sonnet 5 supports up to 128K max output (also matches dated
-  // snapshot IDs like claude-sonnet-5-YYYYMMDD).
-  if (modelId.includes('claude-sonnet-5')) {
+  // Claude Sonnet 5 supports up to 128K max output (also matches the -latest
+  // alias and dated snapshot IDs like claude-sonnet-5-YYYYMMDD).
+  if (isSonnet5(modelId)) {
     return 128000;
   }
 
@@ -345,8 +345,9 @@ export function getContextWindowForModel(modelId: string): number {
   }
   // Claude Sonnet 5 defaults to the Claude Code / subscription 200K context
   // window. The advertised 1M window is API-only and plan-gated; raise it
-  // via /set or a profile (context-limit). Matches dated snapshots too.
-  if (modelId.includes('claude-sonnet-5')) {
+  // via /set or a profile (context-limit). Matches the -latest alias and
+  // dated snapshots too.
+  if (isSonnet5(modelId)) {
     return 200000;
   }
   if (modelId.includes('claude-sonnet-4')) {

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -280,11 +280,7 @@ export function isOpus46Plus(modelId: string): boolean {
  * snapshot variants (e.g. claude-sonnet-5-YYYYMMDD).
  */
 export function isSonnet5(modelId: string): boolean {
-  const normalized = modelId.toLowerCase();
-  return (
-    normalized === 'claude-sonnet-5-latest' ||
-    normalized.includes('claude-sonnet-5')
-  );
+  return modelId.toLowerCase().includes('claude-sonnet-5');
 }
 
 /**

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -111,6 +111,16 @@ export const OAUTH_MODELS: Array<Omit<IModel, 'provider'>> = [
     maxOutputTokens: 32000,
   },
   {
+    id: 'claude-sonnet-5',
+    name: 'Claude Sonnet 5',
+    supportedToolFormats: ['anthropic'],
+    // Defaults reflect the Claude Code / subscription (auth) 200K context
+    // window. The API-only 1M window is plan-gated; raise it via /set or a
+    // profile (context-limit). Max output is the full 128K ceiling.
+    contextWindow: 200000,
+    maxOutputTokens: 128000,
+  },
+  {
     id: 'claude-sonnet-4-6',
     name: 'Claude Sonnet 4.6',
     supportedToolFormats: ['anthropic'],
@@ -201,6 +211,13 @@ export const DEFAULT_MODELS: Array<Omit<IModel, 'provider'>> = [
     maxOutputTokens: 32000,
   },
   {
+    id: 'claude-sonnet-5',
+    name: 'Claude Sonnet 5',
+    supportedToolFormats: ['anthropic'],
+    contextWindow: 200000,
+    maxOutputTokens: 128000,
+  },
+  {
     id: 'claude-sonnet-4-6',
     name: 'Claude Sonnet 4.6',
     supportedToolFormats: ['anthropic'],
@@ -224,24 +241,24 @@ export const DEFAULT_MODELS: Array<Omit<IModel, 'provider'>> = [
 ];
 
 /**
- * Helper method to get the latest Claude 4 model ID for a given tier.
+ * Helper method to get the latest Claude model ID for a given tier.
  * This can be used when you want to ensure you're using the latest model.
  * @param tier - The model tier: 'opus', 'sonnet', or 'haiku'
  * @returns The latest model ID for that tier
  */
-export function getLatestClaude4Model(
+export function getLatestClaudeModel(
   tier: 'opus' | 'sonnet' | 'haiku' = 'sonnet',
 ): string {
   switch (tier) {
     case 'opus':
       return 'claude-opus-4-latest';
     case 'sonnet':
-      return 'claude-sonnet-4-latest';
+      return 'claude-sonnet-5-latest';
     case 'haiku':
       // Haiku 4 not yet available, but future-proofed
       return 'claude-haiku-4-latest';
     default:
-      return 'claude-sonnet-4-latest';
+      return 'claude-sonnet-5-latest';
   }
 }
 
@@ -255,6 +272,27 @@ export function isOpus46Plus(modelId: string): boolean {
     modelId.includes('claude-opus-4-7') ||
     modelId.includes('claude-opus-4-8')
   );
+}
+
+/**
+ * Whether the model is Claude Sonnet 5 (supports adaptive thinking via the
+ * effort parameter, 128K max output). Matches the bare alias and dated
+ * snapshot variants (e.g. claude-sonnet-5-YYYYMMDD).
+ */
+export function isSonnet5(modelId: string): boolean {
+  const normalized = modelId.toLowerCase();
+  return (
+    normalized === 'claude-sonnet-5-latest' ||
+    normalized.includes('claude-sonnet-5')
+  );
+}
+
+/**
+ * Whether the model supports adaptive thinking (the Anthropic `effort`
+ * parameter). Currently Opus 4.6+ and Sonnet 5.
+ */
+export function supportsAdaptiveThinking(modelId: string): boolean {
+  return isOpus46Plus(modelId) || isSonnet5(modelId);
 }
 
 /**
@@ -272,6 +310,11 @@ export function getMaxTokensForModel(modelId: string): number {
     modelId.includes('claude-sonnet-4')
   ) {
     return 64000;
+  }
+  // Claude Sonnet 5 supports up to 128K max output (also matches dated
+  // snapshot IDs like claude-sonnet-5-YYYYMMDD).
+  if (modelId.includes('claude-sonnet-5')) {
+    return 128000;
   }
 
   const normalizedModelId = stripTrailingDateSegment(modelId.toLowerCase());
@@ -303,6 +346,12 @@ export function getContextWindowForModel(modelId: string): number {
   // Other Claude 4 opus models have larger context windows
   if (modelId.includes('claude-opus-4')) {
     return 500000;
+  }
+  // Claude Sonnet 5 defaults to the Claude Code / subscription 200K context
+  // window. The advertised 1M window is API-only and plan-gated; raise it
+  // via /set or a profile (context-limit). Matches dated snapshots too.
+  if (modelId.includes('claude-sonnet-5')) {
+    return 200000;
   }
   if (modelId.includes('claude-sonnet-4')) {
     return 400000;

--- a/packages/providers/src/anthropic/AnthropicProvider.chat.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.chat.test.ts
@@ -266,9 +266,9 @@ describe('AnthropicProvider', () => {
 
       expect(mockAnthropicInstance.messages.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-sonnet-4-6',
+          model: 'claude-opus-4-8',
           messages: [{ role: 'user', content: 'Say hello' }],
-          max_tokens: 64000,
+          max_tokens: 32000,
           stream: true,
           system: expect.any(String),
         }),
@@ -543,9 +543,9 @@ describe('AnthropicProvider', () => {
 
       expect(mockAnthropicInstance.messages.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-sonnet-4-6',
+          model: 'claude-opus-4-8',
           messages: [{ role: 'user', content: 'What is the weather?' }],
-          max_tokens: 64000,
+          max_tokens: 32000,
           stream: true,
           system: expect.any(String),
           tools: [

--- a/packages/providers/src/anthropic/AnthropicProvider.thinking.config.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.thinking.config.test.ts
@@ -474,6 +474,72 @@ describe('AnthropicProvider Extended Thinking @plan:PLAN-ANTHROPIC-THINKING', ()
       expect(request.thinking?.type).toBe('enabled');
       expect(request.thinking?.budget_tokens).toBe(10000);
     });
+
+    it('should use adaptive thinking for Sonnet 5 when no explicit budgetTokens @issue:2289', async () => {
+      settingsService.set('reasoning.enabled', true);
+      // Don't set budgetTokens
+
+      mockMessagesCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'response' }],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+      const messages: IContent[] = [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'Hello' }],
+        },
+      ];
+
+      const generator = provider.generateChatCompletion(
+        buildCallOptions(messages, {
+          settingsOverrides: {
+            global: {
+              model: 'claude-sonnet-5',
+            },
+          },
+        }),
+      );
+      await generator.next();
+
+      const request = mockMessagesCreate.mock
+        .calls[0][0] as AnthropicRequestBody;
+      expect(request.thinking).toBeDefined();
+      expect(request.thinking?.type).toBe('adaptive');
+      expect(request.thinking?.budget_tokens).toBeUndefined();
+    });
+
+    it('should map xhigh effort to max for Sonnet 5 @issue:2289', async () => {
+      settingsService.set('reasoning.enabled', true);
+      settingsService.set('reasoning.effort', 'xhigh');
+
+      mockMessagesCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'response' }],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+      const messages: IContent[] = [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'Hello' }],
+        },
+      ];
+
+      const generator = provider.generateChatCompletion(
+        buildCallOptions(messages, {
+          settingsOverrides: {
+            global: {
+              model: 'claude-sonnet-5',
+            },
+          },
+        }),
+      );
+      await generator.next();
+
+      const request = mockMessagesCreate.mock
+        .calls[0][0] as AnthropicRequestBody;
+      expect(request.output_config?.effort).toBe('max');
+    });
   });
 
   describe('Streaming Thinking Tests @requirement:REQ-ANTHROPIC-THINK-002', () => {

--- a/packages/providers/src/anthropic/AnthropicProvider.thinking.config.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.thinking.config.test.ts
@@ -72,7 +72,9 @@ describe('AnthropicProvider Extended Thinking @plan:PLAN-ANTHROPIC-THINKING', ()
     it('should use default budget_tokens of 10000 when not specified', async () => {
       // Use global settings (not provider-specific) for reasoning
       settingsService.set('reasoning.enabled', true);
-      // Don't set budgetTokens - should default to 10000
+      // Don't set budgetTokens - should default to 10000.
+      // Pin a non-adaptive model: the provider default is Opus 4.8 (adaptive),
+      // but this test validates the manual-mode budget default of 10000.
 
       mockMessagesCreate.mockResolvedValueOnce({
         content: [{ type: 'text', text: 'response' }],
@@ -87,7 +89,13 @@ describe('AnthropicProvider Extended Thinking @plan:PLAN-ANTHROPIC-THINKING', ()
       ];
 
       const generator = provider.generateChatCompletion(
-        buildCallOptions(messages),
+        buildCallOptions(messages, {
+          settingsOverrides: {
+            global: {
+              model: 'claude-sonnet-4-5-20250929',
+            },
+          },
+        }),
       );
       await generator.next();
 

--- a/packages/providers/src/anthropic/AnthropicProvider.thinking.multiturn.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.thinking.multiturn.test.ts
@@ -105,8 +105,16 @@ describe('AnthropicProvider Extended Thinking @plan:PLAN-ANTHROPIC-THINKING', ()
         usage: { input_tokens: 100, output_tokens: 50 },
       });
 
+      // Pin a non-adaptive model: the provider default is Opus 4.8 (adaptive),
+      // but this test asserts the manual 'enabled' thinking mode persists.
       const generator = provider.generateChatCompletion(
-        buildCallOptions(messages),
+        buildCallOptions(messages, {
+          settingsOverrides: {
+            global: {
+              model: 'claude-sonnet-4-5-20250929',
+            },
+          },
+        }),
       );
       await generator.next();
 

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -337,6 +337,16 @@ export class AnthropicProvider extends BaseProvider {
     return getLatestClaudeModelFn(tier);
   }
 
+  /**
+   * @deprecated Use {@link getLatestClaudeModel} instead. The old name was
+   * tied to the "Claude 4" generation; the helper now tracks the newest
+   * release of each tier (e.g. Sonnet 5). Kept as a thin alias for backward
+   * compatibility and will be removed in a future release.
+   */
+  getLatestClaude4Model(tier: 'opus' | 'sonnet' | 'haiku' = 'sonnet'): string {
+    return this.getLatestClaudeModel(tier);
+  }
+
   private getMaxTokensForModel(modelId: string): number {
     return getMaxTokensForModelFn(modelId);
   }

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -35,7 +35,7 @@ import {
   DEFAULT_MODELS,
   getMaxTokensForModel as getMaxTokensForModelFn,
   getContextWindowForModel as getContextWindowForModelFn,
-  getLatestClaude4Model as getLatestClaude4ModelFn,
+  getLatestClaudeModel as getLatestClaudeModelFn,
 } from './AnthropicModelData.js';
 import { prepareAnthropicRequest } from './AnthropicRequestPreparation.js';
 import { firstTruthyString } from '../utils/falsyFallback.js';
@@ -271,17 +271,23 @@ export class AnthropicProvider extends BaseProvider {
         });
       }
 
-      // Add "latest" aliases for Claude 4 tiers (opus, sonnet). We pick the newest
-      // version of each tier based on the sorted order created above.
+      // Add "latest" aliases for Claude tiers (opus, sonnet). We pick the newest
+      // version of each tier (e.g. Sonnet 5 outranks Sonnet 4) based on the
+      // sorted order created above.
       const addLatestAlias = (tier: 'opus' | 'sonnet') => {
+        // Match any major version of the tier (e.g. claude-sonnet-4-*,
+        // claude-sonnet-5, claude-sonnet-5-YYYYMMDD) so the alias tracks the
+        // newest release rather than a single hardcoded generation.
+        const tierRegex = new RegExp(`^claude-${tier}-(\\d+)`);
         const tierModels = models
-          .filter((m) => m.id.startsWith(`claude-${tier}-4-`))
+          .filter((m) => tierRegex.test(m.id))
           .sort((a, b) => b.id.localeCompare(a.id));
         if (tierModels.length > 0) {
           const latest = tierModels[0];
+          const majorVersion = tierRegex.exec(latest.id)?.[1] ?? '4';
           models.push({
             ...latest,
-            id: `claude-${tier}-4-latest`,
+            id: `claude-${tier}-${majorVersion}-latest`,
             name: latest.name.replace(/-\d{8}$/, '-latest'),
           });
         }
@@ -322,13 +328,13 @@ export class AnthropicProvider extends BaseProvider {
   }
 
   /**
-   * Helper method to get the latest Claude 4 model ID for a given tier.
+   * Helper method to get the latest Claude model ID for a given tier.
    * This can be used when you want to ensure you're using the latest model.
    * @param tier - The model tier: 'opus', 'sonnet', or 'haiku'
    * @returns The latest model ID for that tier
    */
-  getLatestClaude4Model(tier: 'opus' | 'sonnet' | 'haiku' = 'sonnet'): string {
-    return getLatestClaude4ModelFn(tier);
+  getLatestClaudeModel(tier: 'opus' | 'sonnet' | 'haiku' = 'sonnet'): string {
+    return getLatestClaudeModelFn(tier);
   }
 
   private getMaxTokensForModel(modelId: string): number {

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -317,7 +317,7 @@ export class AnthropicProvider extends BaseProvider {
 
   override getDefaultModel(): string {
     // Return hardcoded default - do NOT call getModel() to avoid circular dependency
-    return 'claude-sonnet-4-6';
+    return 'claude-opus-4-8';
   }
 
   /**

--- a/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
@@ -15,7 +15,7 @@ import type {
   AnthropicMessage,
   AnthropicMessageBlock,
 } from './AnthropicMessageNormalizer.js';
-import { isOpus46Plus } from './AnthropicModelData.js';
+import { supportsAdaptiveThinking } from './AnthropicModelData.js';
 
 /**
  * A content block with cache_control attached.
@@ -219,6 +219,7 @@ export function attachPromptCaching(
 /**
  * Build thinking configuration for Anthropic API
  * @issue #1307: Correct adaptive thinking support for Opus 4.6
+ * @issue #2289: Extended to Sonnet 5 (also supports adaptive thinking)
  */
 export function buildThinkingConfig(options: {
   reasoningEnabled: boolean;
@@ -234,10 +235,10 @@ export function buildThinkingConfig(options: {
     return {};
   }
 
-  const opus46Plus = isOpus46Plus(options.model);
+  const adaptiveCapable = supportsAdaptiveThinking(options.model);
 
   if (
-    opus46Plus &&
+    adaptiveCapable &&
     options.reasoningBudgetTokens == null &&
     options.adaptiveThinking !== false
   ) {

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -11,7 +11,7 @@
  * @issue #1572 - Decomposing AnthropicProvider (Step 5)
  */
 
-import { isOpus46Plus } from './AnthropicModelData.js';
+import { supportsAdaptiveThinking } from './AnthropicModelData.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
@@ -402,7 +402,7 @@ function mapEffortLevel(
     return undefined;
   }
 
-  const opus46Plus = isOpus46Plus(currentModel);
+  const adaptiveCapable = supportsAdaptiveThinking(currentModel);
 
   if (rawEffort === 'minimal' || rawEffort === 'low') {
     return 'low';
@@ -411,11 +411,11 @@ function mapEffortLevel(
   } else if (rawEffort === 'high') {
     return 'high';
   } else if (rawEffort === 'xhigh') {
-    return opus46Plus ? 'max' : 'high';
+    return adaptiveCapable ? 'max' : 'high';
   }
 
   // rawEffort is 'max' here
-  return opus46Plus ? 'max' : 'high';
+  return adaptiveCapable ? 'max' : 'high';
 }
 
 /**

--- a/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
+++ b/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
@@ -535,6 +535,17 @@ describe('anthropic.config modelDefaults (Phase 02)', () => {
     expect(defaults['reasoning.enabled']).toBe(true);
   });
 
+  it('claude-sonnet-5 matches the broad Claude rule (adaptive thinking) @issue:2289', () => {
+    const entry = getAnthropicEntry();
+    const defaults = computeMatchedDefaults(
+      'claude-sonnet-5',
+      entry.config.modelDefaults!,
+    );
+    expect(defaults['reasoning.enabled']).toBe(true);
+    expect(defaults['reasoning.adaptiveThinking']).toBe(true);
+    expect(defaults['reasoning.includeInContext']).toBe(true);
+  });
+
   it('non-Claude model like gpt-4o does NOT match any rule', () => {
     const entry = getAnthropicEntry();
     const defaults = computeMatchedDefaults(

--- a/project-plans/multi-provider/claude-4-model-selection.md
+++ b/project-plans/multi-provider/claude-4-model-selection.md
@@ -57,7 +57,7 @@ provider.setModel('claude-opus-4-latest'); // Use latest Opus 4
 
 ```typescript
 const provider = new AnthropicProvider(apiKey);
-const latestSonnet = provider.getLatestClaude4Model('sonnet');
+const latestSonnet = provider.getLatestClaudeModel('sonnet');
 provider.setModel(latestSonnet);
 ```
 


### PR DESCRIPTION
## Summary

Surfaces **Claude Sonnet 5** (`claude-sonnet-5`) across the model menu so it is selectable for the 0.10.0 release. The advertised 1M context window is API-only/plan-gated and remains overridable via `/set` or a profile (`context-limit`).

## Changes

### 1. Provider model catalog — `packages/providers/src/anthropic/AnthropicModelData.ts`
- Added `claude-sonnet-5` to `OAUTH_MODELS` and `DEFAULT_MODELS` (200K subscription context default, 128K max output).
- Added `isSonnet5()` and `supportsAdaptiveThinking()` helpers.
- Added explicit `getMaxTokensForModel` (128K) and `getContextWindowForModel` (200K) branches for `claude-sonnet-5` (also matches dated snapshot variants).
- Renamed `getLatestClaude4Model` → `getLatestClaudeModel` and pointed the sonnet tier at `claude-sonnet-5-latest`.

### 2. Latest-alias logic — `AnthropicProvider.ts`
- `addLatestAlias` now matches any major version (regex `^claude-{tier}-(\d+)`) so the dynamic "latest" alias tracks Sonnet 5 and future generations.

### 3. Reasoning / thinking config — `AnthropicRequestBuilder.ts` + `AnthropicRequestPreparation.ts`
- Replaced the `isOpus46Plus` gate in adaptive-thinking and effort-mapping logic with `supportsAdaptiveThinking` so Sonnet 5 gets adaptive thinking and the full `xhigh`→`max` effort mapping.

### 4. Token limits — `packages/core/src/core/tokenLimits.ts`
- Added `'claude-sonnet-5': 200_000` to `EXACT_LIMITS` (auth default), in sync with `getContextWindowForModel`.

### 5. Profile-create wizard — `ProfileCreateWizard/constants.ts`
- Added `'claude-sonnet-5'` to the anthropic `knownModels` so it appears in the model menu.

### 6. Docs & changelog
- Updated `docs/providers/quick-reference.md` model list; added a CHANGELOG entry under `[Unreleased]`.

## Decision points
- **Context window:** followed the Opus 4.6+ precedent — 200K subscription-safe default (1M is API-only/gated, overridable).
- **Max output:** full 128K ceiling per the model spec.
- **Default model:** set to `claude-opus-4-8`, aligning `getDefaultModel()` with the `anthropic.config` `defaultModel` (already `claude-opus-4-8`).

## Verification
- `AnthropicModelData.test.ts` (24), `tokenLimits.test.ts` (33), `AnthropicProvider.thinking.config.test.ts` (20), `providerAliases.modelDefaults.test.ts` (28) — all passing.
- Full `packages/providers/src/anthropic` suite (291) and `src/composition`/`src/runtime` suites (437) green.
- `packages/core/src/core` suite (176) green.
- ESLint clean on all changed files; `lint:eslint-guard` passed; `tsc --noEmit` on providers package passed.

Fixes #2289