### PR TITLE
fix(oauth): register providers on all OAuthManager creation paths and normalize case (Fixes #2291)

### DIFF
--- a/packages/cli/src/ui/commands/authCommand.test.ts
+++ b/packages/cli/src/ui/commands/authCommand.test.ts
@@ -494,6 +494,66 @@ describe('AuthCommandExecutor OAuth Support', () => {
     });
   });
 
+  describe('Case normalization', () => {
+    it('@given user enters /auth Codex enable @when provider has uppercase @then enables OAuth for codex', async () => {
+      const mockIsEnabled = vi.fn().mockReturnValue(false);
+      const mockToggleOAuth = vi.fn().mockResolvedValue(true);
+      const mockGetHigherPriority = vi.fn().mockResolvedValue(null);
+      (mockOAuthManager.isOAuthEnabled as unknown) = mockIsEnabled;
+      (mockOAuthManager.toggleOAuthEnabled as unknown) = mockToggleOAuth;
+      (mockOAuthManager.getHigherPriorityAuth as unknown) =
+        mockGetHigherPriority;
+
+      const result = await executor.execute(mockContext, 'Codex enable');
+
+      expect(mockToggleOAuth).toHaveBeenCalledWith('codex');
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'OAuth enabled for codex',
+      });
+    });
+
+    it('@given user enters /auth GEMINI @when provider is all-caps @then shows status for gemini', async () => {
+      const mockIsEnabled = vi.fn().mockReturnValue(false);
+      const mockIsAuthenticated = vi.fn().mockResolvedValue(false);
+      const mockGetHigherPriority = vi.fn().mockResolvedValue(null);
+      (mockOAuthManager.isOAuthEnabled as unknown) = mockIsEnabled;
+      (mockOAuthManager.isAuthenticated as unknown) = mockIsAuthenticated;
+      (mockOAuthManager.getHigherPriorityAuth as unknown) =
+        mockGetHigherPriority;
+
+      const result = await executor.execute(mockContext, 'GEMINI');
+
+      expect(mockIsEnabled).toHaveBeenCalledWith('gemini');
+      expect(mockIsAuthenticated).toHaveBeenCalledWith('gemini');
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'OAuth for gemini: DISABLED',
+      });
+    });
+
+    it('@given user enters /auth Gemini ENABLE @when both provider and action are mixed case @then enables OAuth for gemini', async () => {
+      const mockIsEnabled = vi.fn().mockReturnValue(false);
+      const mockToggleOAuth = vi.fn().mockResolvedValue(true);
+      const mockGetHigherPriority = vi.fn().mockResolvedValue(null);
+      (mockOAuthManager.isOAuthEnabled as unknown) = mockIsEnabled;
+      (mockOAuthManager.toggleOAuthEnabled as unknown) = mockToggleOAuth;
+      (mockOAuthManager.getHigherPriorityAuth as unknown) =
+        mockGetHigherPriority;
+
+      const result = await executor.execute(mockContext, 'Gemini ENABLE');
+
+      expect(mockToggleOAuth).toHaveBeenCalledWith('gemini');
+      expect(result).toStrictEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'OAuth enabled for gemini',
+      });
+    });
+  });
+
   describe('Command interface compliance', () => {
     it('@given auth command @when checking properties @then has correct OAuth description', async () => {
       // Import the actual command to test its properties

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -18,11 +18,9 @@ import type {
 import { CommandKind } from './types.js';
 import {
   OAuthManager,
-  GeminiOAuthProvider,
-  AnthropicOAuthProvider,
-  CodexOAuthProvider,
   createTokenStore,
 } from '@vybestack/llxprt-code-providers/auth.js';
+import { registerStandardOAuthProviders } from '@vybestack/llxprt-code-providers/composition.js';
 import { LoadedSettingsOAuthAdapter } from '../../auth/oauth-settings-adapter.js';
 import { DebugLogger, MessageBus } from '@vybestack/llxprt-code-core';
 import { getRuntimeApi } from '../contexts/RuntimeContext.js';
@@ -40,16 +38,16 @@ const logger = new DebugLogger('llxprt:ui:auth-command');
  */
 function getOAuthManager(): OAuthManager {
   const runtime = getRuntimeApi();
-  let oauthManager = runtime.getCliOAuthManager();
+  const oauthManager = runtime.getCliOAuthManager();
 
-  if (!oauthManager) {
-    const tokenStore = createTokenStore();
-    oauthManager = new OAuthManager(tokenStore);
-    oauthManager.registerProvider(new GeminiOAuthProvider());
-    oauthManager.registerProvider(new AnthropicOAuthProvider());
+  if (oauthManager) {
+    return oauthManager;
   }
 
-  return oauthManager;
+  const tokenStore = createTokenStore();
+  const fallback = new OAuthManager(tokenStore);
+  registerStandardOAuthProviders(fallback, tokenStore);
+  return fallback;
 }
 
 /**
@@ -238,15 +236,12 @@ export class AuthCommandExecutor {
   ): Promise<SlashCommandActionReturn> {
     // Parse args while preserving original parts for error messages
     const trimmedArgs = args?.trim() ?? '';
-    const parts = trimmedArgs.split(/\s+/).filter((p) => p.length > 0); // Remove empty parts
-    const provider = parts[0];
-    const action = parts[1];
+    const parts = trimmedArgs.split(/\s+/).filter((p) => p.length > 0);
+    const provider = parts[0]?.toLowerCase();
+    const action = parts[1]?.toLowerCase();
     const param = parts[2];
 
-    // For error messages, we want to show the provider as the user typed it
-    // This should be the first word from the arguments, trimmed of leading/trailing spaces
-    // but preserving any internal structure
-    const originalProvider = provider || ''; // Use the parsed provider for consistency
+    const originalProvider = parts[0] || '';
 
     // If no provider specified, show the auth dialog
     if (!provider) {
@@ -707,10 +702,7 @@ export const authCommand: SlashCommand = {
         },
       );
 
-      // Register OAuth providers
-      oauthManager.registerProvider(new GeminiOAuthProvider());
-      oauthManager.registerProvider(new AnthropicOAuthProvider());
-      oauthManager.registerProvider(new CodexOAuthProvider(tokenStore));
+      registerStandardOAuthProviders(oauthManager, tokenStore);
 
       runtime.registerCliProviderInfrastructure(providerManager, oauthManager, {
         messageBus: runtimeMessageBus,

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -10,12 +10,14 @@ import { renderWithProviders } from '../../test-utils/render.js';
 
 const mockGetAuthStatus = vi.fn();
 const mockAuthenticate = vi.fn();
+const mockToggleOAuthEnabled = vi.fn();
 
 vi.mock('../contexts/RuntimeContext.js', () => ({
   useRuntimeApi: () => ({
     getCliOAuthManager: () => ({
       authenticate: mockAuthenticate,
       getAuthStatus: mockGetAuthStatus,
+      toggleOAuthEnabled: mockToggleOAuthEnabled,
     }),
   }),
 }));
@@ -24,6 +26,7 @@ vi.mock('../../providers/providerManagerInstance.js', () => ({
   getOAuthManager: () => ({
     authenticate: mockAuthenticate,
     getAuthStatus: mockGetAuthStatus,
+    toggleOAuthEnabled: mockToggleOAuthEnabled,
   }),
 }));
 
@@ -40,8 +43,10 @@ describe('AuthDialog', () => {
     vi.clearAllMocks();
     mockGetAuthStatus.mockReset();
     mockAuthenticate.mockReset();
+    mockToggleOAuthEnabled.mockReset();
     mockGetAuthStatus.mockResolvedValue([]);
     mockAuthenticate.mockResolvedValue(undefined);
+    mockToggleOAuthEnabled.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -180,7 +185,7 @@ describe('AuthDialog', () => {
     });
   });
 
-  it('should authenticate provider when selected', async () => {
+  it('should toggle OAuth enabled when provider is selected', async () => {
     const onSelect = vi.fn();
     const settings: LoadedSettings = new LoadedSettings(
       {
@@ -210,10 +215,91 @@ describe('AuthDialog', () => {
     stdin.write('1');
     await wait();
 
-    expect(mockAuthenticate).toHaveBeenCalledWith('gemini', undefined, {
-      signalAuthCompletion: true,
-    });
-    expect(onSelect).toHaveBeenCalledWith('oauth_gemini', SettingScope.User);
+    expect(mockToggleOAuthEnabled).toHaveBeenCalledWith('gemini');
+    expect(mockAuthenticate).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should toggle OAuth OFF when toggleOAuthEnabled returns false', async () => {
+    mockToggleOAuthEnabled.mockResolvedValue(false);
+    const onSelect = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+    );
+
+    const { lastFrame, stdin, unmount } = renderWithProviders(
+      <AuthDialog onSelect={onSelect} settings={settings} />,
+    );
+    await wait();
+
+    const beforeFrame = lastFrame();
+    expect(beforeFrame).toContain('[ON]');
+
+    stdin.write('1');
+    await wait();
+
+    expect(mockToggleOAuthEnabled).toHaveBeenCalledWith('gemini');
+    expect(mockAuthenticate).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+
+    const afterFrame = lastFrame();
+    expect(afterFrame).toContain('[OFF]');
+    unmount();
+  });
+
+  it('should show error message when toggleOAuthEnabled rejects', async () => {
+    mockToggleOAuthEnabled.mockRejectedValue(new Error('Network failure'));
+    const onSelect = vi.fn();
+    const settings: LoadedSettings = new LoadedSettings(
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: {},
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      {
+        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        path: '',
+      },
+      true,
+    );
+
+    const { lastFrame, stdin, unmount } = renderWithProviders(
+      <AuthDialog onSelect={onSelect} settings={settings} />,
+    );
+    await wait();
+
+    stdin.write('1');
+    await wait();
+
+    expect(mockToggleOAuthEnabled).toHaveBeenCalledWith('gemini');
+    expect(onSelect).not.toHaveBeenCalled();
+
+    const frame = lastFrame();
+    expect(frame).toContain('Failed to toggle OAuth for gemini');
     unmount();
   });
 

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -234,7 +234,11 @@ describe('AuthDialog', () => {
         path: '',
       },
       {
-        settings: { ui: { customThemes: {} }, mcpServers: {} },
+        settings: {
+          ui: { customThemes: {} },
+          mcpServers: {},
+          oauthEnabledProviders: { gemini: true },
+        },
         path: '',
       },
       {

--- a/packages/cli/src/ui/components/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.test.tsx
@@ -207,7 +207,13 @@ describe('AuthDialog', () => {
       true,
     );
 
-    const { stdin, unmount } = renderWithProviders(
+    mockGetAuthStatus
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { provider: 'gemini', authenticated: false, oauthEnabled: true },
+      ]);
+
+    const { lastFrame, stdin, unmount } = renderWithProviders(
       <AuthDialog onSelect={onSelect} settings={settings} />,
     );
     await wait();
@@ -218,6 +224,7 @@ describe('AuthDialog', () => {
     expect(mockToggleOAuthEnabled).toHaveBeenCalledWith('gemini');
     expect(mockAuthenticate).not.toHaveBeenCalled();
     expect(onSelect).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('[ON]');
     unmount();
   });
 

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -26,6 +26,7 @@ interface AuthDialogState {
   enabledProviders: Set<string>;
   setEnabledProviders: React.Dispatch<React.SetStateAction<Set<string>>>;
   authStatuses: Map<string, AuthStatus>;
+  refreshAuthStatuses: () => Promise<void>;
 }
 
 function getEnabledProviders(
@@ -173,6 +174,21 @@ function useAuthDialogState(
     () => new Map(),
   );
 
+  const refreshAuthStatuses = useCallback(async (): Promise<void> => {
+    const oauthManager = runtime.getCliOAuthManager();
+    if (!oauthManager) return;
+    try {
+      const statuses = await oauthManager.getAuthStatus();
+      if (!mountedRef.current) return;
+      setAuthStatuses(
+        new Map(statuses.map((status) => [status.provider, status])),
+      );
+      syncEnabledProvidersFromAuthStatus(setEnabledProviders, statuses);
+    } catch {
+      if (mountedRef.current) setAuthStatuses(new Map());
+    }
+  }, [mountedRef, runtime, setEnabledProviders]);
+
   useEffect(() => {
     setEnabledProviders(
       getEnabledProviders(settings.merged.oauthEnabledProviders),
@@ -180,28 +196,14 @@ function useAuthDialogState(
   }, [settings.merged.oauthEnabledProviders]);
 
   useEffect(() => {
-    const oauthManager = runtime.getCliOAuthManager();
-    const getAuthStatus = oauthManager?.getAuthStatus;
-    if (getAuthStatus === undefined) return;
-
-    void (async () => {
-      try {
-        const statuses = await getAuthStatus.call(oauthManager);
-        if (!mountedRef.current) return;
-        setAuthStatuses(
-          new Map(statuses.map((status) => [status.provider, status])),
-        );
-        syncEnabledProvidersFromAuthStatus(setEnabledProviders, statuses);
-      } catch {
-        if (mountedRef.current) setAuthStatuses(new Map());
-      }
-    })();
-  }, [mountedRef, runtime]);
+    void refreshAuthStatuses();
+  }, [refreshAuthStatuses]);
 
   return {
     enabledProviders,
     setEnabledProviders,
     authStatuses,
+    refreshAuthStatuses,
   };
 }
 
@@ -246,8 +248,12 @@ export function AuthDialog({
   const [errorMessage, setErrorMessage] = useState<string | null>(
     firstNonEmptyString(initialErrorMessage) ?? null,
   );
-  const { enabledProviders, setEnabledProviders, authStatuses } =
-    useAuthDialogState(settings, runtime, mountedRef);
+  const {
+    enabledProviders,
+    setEnabledProviders,
+    authStatuses,
+    refreshAuthStatuses,
+  } = useAuthDialogState(settings, runtime, mountedRef);
   const items = useMemo(
     () => buildAuthItems(enabledProviders, authStatuses),
     [enabledProviders, authStatuses],
@@ -283,16 +289,19 @@ export function AuthDialog({
             }
             return next;
           });
+          await refreshAuthStatuses();
         } catch (error) {
           if (mountedRef.current) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
             setErrorMessage(
-              `Failed to toggle OAuth for ${providerName}: ${error}`,
+              `Failed to toggle OAuth for ${providerName}: ${errorMessage}`,
             );
           }
         }
       })();
     },
-    [mountedRef, onSelect, runtime, setEnabledProviders],
+    [mountedRef, onSelect, refreshAuthStatuses, runtime, setEnabledProviders],
   );
 
   useCloseAuthDialogOnEscape(onSelect);

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -26,9 +26,6 @@ interface AuthDialogState {
   enabledProviders: Set<string>;
   setEnabledProviders: React.Dispatch<React.SetStateAction<Set<string>>>;
   authStatuses: Map<string, AuthStatus>;
-  setAuthStatuses: React.Dispatch<
-    React.SetStateAction<Map<string, AuthStatus>>
-  >;
 }
 
 function getEnabledProviders(
@@ -51,7 +48,7 @@ const AuthDialogHeader: React.FC = () => (
     </Text>
     <Box marginTop={1}>
       <Text color={Colors.Foreground}>
-        Select an OAuth provider to authenticate:
+        Select an OAuth provider to toggle enable/disable:
       </Text>
     </Box>
     <Box marginTop={1}>
@@ -205,7 +202,6 @@ function useAuthDialogState(
     enabledProviders,
     setEnabledProviders,
     authStatuses,
-    setAuthStatuses,
   };
 }
 
@@ -225,24 +221,6 @@ function syncEnabledProvidersFromAuthStatus(
     }
     return next;
   });
-}
-
-function recordAuthenticatedProvider(
-  authMethod: string,
-  providerName: string,
-  setEnabledProviders: React.Dispatch<React.SetStateAction<Set<string>>>,
-  setAuthStatuses: React.Dispatch<
-    React.SetStateAction<Map<string, AuthStatus>>
-  >,
-): void {
-  setEnabledProviders((prev) => new Set([...prev, authMethod]));
-  setAuthStatuses((prev) =>
-    new Map(prev).set(providerName, {
-      provider: providerName,
-      authenticated: true,
-      oauthEnabled: true,
-    }),
-  );
 }
 
 function useCloseAuthDialogOnEscape(
@@ -268,12 +246,8 @@ export function AuthDialog({
   const [errorMessage, setErrorMessage] = useState<string | null>(
     firstNonEmptyString(initialErrorMessage) ?? null,
   );
-  const {
-    enabledProviders,
-    setEnabledProviders,
-    authStatuses,
-    setAuthStatuses,
-  } = useAuthDialogState(settings, runtime, mountedRef);
+  const { enabledProviders, setEnabledProviders, authStatuses } =
+    useAuthDialogState(settings, runtime, mountedRef);
   const items = useMemo(
     () => buildAuthItems(enabledProviders, authStatuses),
     [enabledProviders, authStatuses],
@@ -298,27 +272,27 @@ export function AuthDialog({
 
       void (async () => {
         try {
-          await oauthManager.authenticate(providerName, undefined, {
-            signalAuthCompletion: true,
-          });
+          const enabled = await oauthManager.toggleOAuthEnabled(providerName);
           if (!mountedRef.current) return;
-          recordAuthenticatedProvider(
-            authMethod,
-            providerName,
-            setEnabledProviders,
-            setAuthStatuses,
-          );
-          onSelect(authMethod, SettingScope.User);
+          setEnabledProviders((prev) => {
+            const next = new Set(prev);
+            if (enabled) {
+              next.add(authMethod);
+            } else {
+              next.delete(authMethod);
+            }
+            return next;
+          });
         } catch (error) {
           if (mountedRef.current) {
             setErrorMessage(
-              `Authentication failed for ${providerName}: ${error}`,
+              `Failed to toggle OAuth for ${providerName}: ${error}`,
             );
           }
         }
       })();
     },
-    [mountedRef, onSelect, runtime, setAuthStatuses, setEnabledProviders],
+    [mountedRef, onSelect, runtime, setEnabledProviders],
   );
 
   useCloseAuthDialogOnEscape(onSelect);

--- a/packages/providers/src/composition/index.ts
+++ b/packages/providers/src/composition/index.ts
@@ -64,6 +64,7 @@ export type { AliasAwareBaseProvider } from './aliasProviderFactory.js';
 // ─── OAuth provider registration ─────────────────────────────────────────────
 export {
   ensureOAuthProviderRegistered,
+  registerStandardOAuthProviders,
   isOAuthProviderRegistered,
   resetRegisteredProviders,
 } from './oauth-provider-registration.js';

--- a/packages/providers/src/composition/oauth-provider-registration.test.ts
+++ b/packages/providers/src/composition/oauth-provider-registration.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerStandardOAuthProviders,
+  isOAuthProviderRegistered,
+  resetRegisteredProviders,
+} from './oauth-provider-registration.js';
+import { OAuthManager, createTokenStore } from '../auth/index.js';
+import type { OAuthManager as OAuthManagerType } from '../auth/index.js';
+
+function createFreshManager(): OAuthManagerType {
+  const tokenStore = createTokenStore();
+  return new OAuthManager(tokenStore);
+}
+
+describe('registerStandardOAuthProviders', () => {
+  beforeEach(() => {
+    resetRegisteredProviders();
+  });
+
+  it('registers gemini, anthropic, and codex on a fresh manager', () => {
+    const oauthManager = createFreshManager();
+
+    expect(oauthManager.getSupportedProviders()).toStrictEqual([]);
+
+    registerStandardOAuthProviders(oauthManager, oauthManager.getTokenStore());
+
+    expect(oauthManager.getSupportedProviders().sort()).toStrictEqual([
+      'anthropic',
+      'codex',
+      'gemini',
+    ]);
+  });
+
+  it('does not duplicate providers when called twice on the same manager', () => {
+    const oauthManager = createFreshManager();
+
+    registerStandardOAuthProviders(oauthManager, oauthManager.getTokenStore());
+    registerStandardOAuthProviders(oauthManager, oauthManager.getTokenStore());
+
+    expect(oauthManager.getSupportedProviders().sort()).toStrictEqual([
+      'anthropic',
+      'codex',
+      'gemini',
+    ]);
+  });
+
+  it('registers providers when tokenStore is passed explicitly', () => {
+    const oauthManager = createFreshManager();
+    const explicitTokenStore = createTokenStore();
+
+    registerStandardOAuthProviders(oauthManager, explicitTokenStore);
+
+    expect(isOAuthProviderRegistered('gemini', oauthManager)).toBe(true);
+    expect(isOAuthProviderRegistered('anthropic', oauthManager)).toBe(true);
+    expect(isOAuthProviderRegistered('codex', oauthManager)).toBe(true);
+  });
+
+  it('registers providers using tokenStore from the oauthManager when none is passed', () => {
+    const oauthManager = createFreshManager();
+
+    registerStandardOAuthProviders(oauthManager);
+
+    expect(oauthManager.getSupportedProviders().sort()).toStrictEqual([
+      'anthropic',
+      'codex',
+      'gemini',
+    ]);
+  });
+});

--- a/packages/providers/src/composition/oauth-provider-registration.ts
+++ b/packages/providers/src/composition/oauth-provider-registration.ts
@@ -89,6 +89,22 @@ export function ensureOAuthProviderRegistered(
 }
 
 /**
+ * Register all three standard OAuth providers (gemini, anthropic, codex) on an
+ * OAuthManager instance. This is the canonical way to ensure a manager has the
+ * full provider set available, regardless of which creation path produced it.
+ * Delegates to ensureOAuthProviderRegistered for dedup and tokenStore handling.
+ */
+export function registerStandardOAuthProviders(
+  oauthManager: OAuthRegistrationManager,
+  tokenStore?: TokenStore,
+  addItem?: AddItemCallback,
+): void {
+  ensureOAuthProviderRegistered('gemini', oauthManager, tokenStore, addItem);
+  ensureOAuthProviderRegistered('anthropic', oauthManager, tokenStore, addItem);
+  ensureOAuthProviderRegistered('codex', oauthManager, tokenStore, addItem);
+}
+
+/**
  * Check if an OAuth provider has been registered
  */
 export function isOAuthProviderRegistered(

--- a/packages/providers/src/composition/providerManagerInstance.oauthRegistration.test.ts
+++ b/packages/providers/src/composition/providerManagerInstance.oauthRegistration.test.ts
@@ -57,6 +57,16 @@ function mockProviderModules(opts: {
   }));
 }
 
+function createRegisterStandardOAuthProvidersMock(
+  ensureMock: ReturnType<typeof vi.fn>,
+): (oauthManager: unknown, tokenStore?: unknown, addItem?: unknown) => void {
+  return (oauthManager, tokenStore, addItem) => {
+    for (const provider of ['gemini', 'anthropic', 'codex'] as const) {
+      ensureMock(provider, oauthManager, tokenStore, addItem);
+    }
+  };
+}
+
 describe('Anthropic OAuth registration with environment key', () => {
   let ensureOAuthProviderRegisteredMock: ReturnType<typeof vi.fn>;
   let anthropicCtor: ReturnType<typeof vi.fn>;
@@ -88,6 +98,9 @@ describe('Anthropic OAuth registration with environment key', () => {
 
     vi.doMock('./oauth-provider-registration.js', () => ({
       ensureOAuthProviderRegistered: ensureOAuthProviderRegisteredMock,
+      registerStandardOAuthProviders: createRegisterStandardOAuthProvidersMock(
+        ensureOAuthProviderRegisteredMock,
+      ),
       isOAuthProviderRegistered: vi.fn(),
       resetRegisteredProviders: vi.fn(),
     }));
@@ -136,6 +149,9 @@ describe('Anthropic OAuth registration with environment key', () => {
 
     vi.doMock('./oauth-provider-registration.js', () => ({
       ensureOAuthProviderRegistered: ensureOAuthProviderRegisteredMock,
+      registerStandardOAuthProviders: createRegisterStandardOAuthProvidersMock(
+        ensureOAuthProviderRegisteredMock,
+      ),
       isOAuthProviderRegistered: vi.fn(),
       resetRegisteredProviders: vi.fn(),
     }));
@@ -191,6 +207,9 @@ describe('Anthropic OAuth registration with environment key', () => {
   it('threads OAuth manager only into OAuth-capable alias providers', async () => {
     vi.doMock('./oauth-provider-registration.js', () => ({
       ensureOAuthProviderRegistered: ensureOAuthProviderRegisteredMock,
+      registerStandardOAuthProviders: createRegisterStandardOAuthProvidersMock(
+        ensureOAuthProviderRegisteredMock,
+      ),
       isOAuthProviderRegistered: vi.fn(),
       resetRegisteredProviders: vi.fn(),
     }));

--- a/packages/providers/src/composition/providerManagerInstance.schemaDefaults.test.ts
+++ b/packages/providers/src/composition/providerManagerInstance.schemaDefaults.test.ts
@@ -56,6 +56,7 @@ function mockProviderModules(openaiCtor: unknown): void {
   }));
   vi.doMock('./oauth-provider-registration.js', () => ({
     ensureOAuthProviderRegistered: vi.fn(),
+    registerStandardOAuthProviders: vi.fn(),
     isOAuthProviderRegistered: vi.fn(),
     resetRegisteredProviders: vi.fn(),
   }));

--- a/packages/providers/src/composition/providerManagerInstance.ts
+++ b/packages/providers/src/composition/providerManagerInstance.ts
@@ -35,7 +35,7 @@ import { Storage } from '@vybestack/llxprt-code-settings';
 import { OAuthManager, createTokenStore } from '../auth/index.js';
 import type { OAuthManagerRuntimeMessageBusDeps } from '../auth/index.js';
 import type { IOAuthSettingsProvider } from '@vybestack/llxprt-code-auth';
-import { ensureOAuthProviderRegistered } from './oauth-provider-registration.js';
+import { registerStandardOAuthProviders } from './oauth-provider-registration.js';
 import type { OAuthUICallback } from '@vybestack/llxprt-code-auth';
 
 import { type IProviderConfig } from '../types/IProviderConfig.js';
@@ -371,24 +371,7 @@ function registerOAuthProviders(
   tokenStore: ReturnType<typeof createTokenStore>,
   addItem: ProviderManagerFactoryOptions['addItem'],
 ): void {
-  void ensureOAuthProviderRegistered(
-    'gemini',
-    oauthManager,
-    tokenStore,
-    addItem,
-  );
-  void ensureOAuthProviderRegistered(
-    'anthropic',
-    oauthManager,
-    tokenStore,
-    addItem,
-  );
-  void ensureOAuthProviderRegistered(
-    'codex',
-    oauthManager,
-    tokenStore,
-    addItem,
-  );
+  registerStandardOAuthProviders(oauthManager, tokenStore, addItem);
 }
 
 /** Resolves OpenAI-specific settings from user settings and ephemeral overrides. */

--- a/packages/providers/src/runtime/runtimeContextFactory.ts
+++ b/packages/providers/src/runtime/runtimeContextFactory.ts
@@ -39,6 +39,7 @@ import type { SettingsService } from '@vybestack/llxprt-code-settings';
 import { ProviderManager } from '../ProviderManager.js';
 import { OAuthManager, createTokenStore } from '../auth/index.js';
 import { createFileOAuthSettingsProvider } from '../auth/file-oauth-settings.js';
+import { registerStandardOAuthProviders } from '../composition/oauth-provider-registration.js';
 
 const DEFAULT_MODEL = 'gemini-1.5-flash';
 const DEFAULT_DEBUG_MODE = false;
@@ -316,12 +317,15 @@ function resolveOAuthManager(
     sharedTokenStore ??
     (sharedTokenStore = createTokenStore() as KeyringTokenStore);
   const oauthSettings = createFileOAuthSettingsProvider();
-  return (
-    optionsOAuthManager ??
-    new OAuthManager(tokenStore, oauthSettings, {
-      messageBus: sessionMessageBus,
-    })
-  );
+  if (optionsOAuthManager) {
+    registerStandardOAuthProviders(optionsOAuthManager);
+    return optionsOAuthManager;
+  }
+  const oauthManager = new OAuthManager(tokenStore, oauthSettings, {
+    messageBus: sessionMessageBus,
+  });
+  registerStandardOAuthProviders(oauthManager, tokenStore);
+  return oauthManager;
 }
 
 /**

--- a/packages/providers/src/runtime/runtimeContextFactory.ts
+++ b/packages/providers/src/runtime/runtimeContextFactory.ts
@@ -316,11 +316,11 @@ function resolveOAuthManager(
   const tokenStore =
     sharedTokenStore ??
     (sharedTokenStore = createTokenStore() as KeyringTokenStore);
-  const oauthSettings = createFileOAuthSettingsProvider();
   if (optionsOAuthManager) {
     registerStandardOAuthProviders(optionsOAuthManager);
     return optionsOAuthManager;
   }
+  const oauthSettings = createFileOAuthSettingsProvider();
   const oauthManager = new OAuthManager(tokenStore, oauthSettings, {
     messageBus: sessionMessageBus,
   });


### PR DESCRIPTION
## Summary

On fresh installs, `getCliOAuthManager()` returned a provider-less OAuthManager, causing every `/auth <provider> <action>` command to fail with an empty supported providers list:

```
Unknown provider: Codex. Supported providers:
```

(no providers listed — empty array from `getSupportedProviders()`)

## Root Cause

There were **four inconsistent OAuthManager creation paths**, none of which reliably registered all three providers:

1. **Completer helper** (`getOAuthManager()` in `authCommand.ts`) — missing Codex registration, created throwaway instances not persisted to runtime
2. **Action fallback** (in `authCommand.ts`) — constructed Gemini/Anthropic without tokenStore, triggering deprecation warnings and breaking token persistence
3. **Isolated runtime factory** (`resolveOAuthManager` in `runtimeContextFactory.ts`) — created a bare OAuthManager with zero providers that could be picked up by the runtime registry via identity resolution fallback
4. **No case normalization** — `/auth Codex enable` (capital C) failed even when `codex` was registered

Additionally, the `/auth` dialog (AuthDialog) had a regression where selecting a provider with Enter triggered a login flow instead of toggling OAuth enable/disable.

## Changes

### Centralized provider registration
- Added `registerStandardOAuthProviders()` to `oauth-provider-registration.ts` as a single canonical helper that registers gemini, anthropic, and codex via the existing `ensureOAuthProviderRegistered()` dedup guard
- Exported from `composition/index.ts`
- Refactored `providerManagerInstance.ts` private `registerOAuthProviders` to delegate to it (DRY)

### Fixed all four creation paths
- **Completer helper**: now calls `registerStandardOAuthProviders` (adds missing Codex, ensures tokenStore)
- **Action fallback**: now calls `registerStandardOAuthProviders` (fixes missing tokenStore for Gemini/Anthropic)
- **Isolated runtime factory** (`resolveOAuthManager`): now registers standard providers on both bare and caller-provided OAuthManagers, ensuring no provider-less manager reaches the runtime registry

### Case normalization
- `AuthCommandExecutor.execute()` now lowercases the provider name before validation and before all downstream operations

### AuthDialog toggle behavior
- Restored the `/auth` dialog Enter behavior to toggle OAuth enable/disable instead of triggering a login flow
- Removed `setAuthStatuses` leak from the `AuthDialogState` interface

## Test Coverage

- **`oauth-provider-registration.test.ts`** (new): Tests `registerStandardOAuthProviders` registers all three providers, is idempotent, and is usable standalone
- **`authCommand.test.ts`**: Added case normalization tests (Codex/GEMINI lowercase)
- **`providerManagerInstance.oauthRegistration.test.ts`**: Extracted mock helper to eliminate DRY violation (per OCR review)
- **`AuthDialog.test.tsx`**: Updated to verify toggle behavior; added disable path and error path tests; removed redundant subset test

## Verification

- `npm run typecheck` ✅
- `npm run format` ✅
- `npx eslint <changed files>` ✅
- `npm run build` ✅
- Providers tests: 3510 passed ✅
- CLI authCommand tests: 32 passed ✅
- Smoke test: ✅

Closes #2291