### PR TITLE
Fix todo_pause continuation break (Fixes #2287)

### DIFF
--- a/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
@@ -1,0 +1,405 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for MessageStreamOrchestrator pause-tool handling.
+ *
+ * Issue #2287 requirements:
+ * 1. A successful pause-tool result must immediately break the retry/
+ *    continuation loop, even though the pause was issued as a tool call
+ *    (which otherwise routes through the generic tool-call finish path).
+ * 2. Only SUCCESSFUL pause responses break the loop. A pause
+ *    response carrying an error (invalid schema, empty/overlong reason,
+ *    filtered reason) must NOT break the loop.
+ * 3. The orchestrator must rely on the authoritative in-memory
+ *    isSuccessfulTodoPauseResponse signal, not persisted pause-state timing.
+ *
+ * The observable that DISTINGUISHES the explicit pause branch
+ * (_evaluateTodoContinuation with todoPauseSeen) from the generic
+ * tool-call finish (_finishWithToolCalls) is the AfterAgent-hook
+ * continuation: _finishWithToolCalls forwards a blocking AfterAgent hook
+ * decision into sendMessageStream (a new continuation turn), whereas the
+ * pause branch returns done immediately and never calls sendMessageStream.
+ * Asserting on sendMessageStream is asserting on the hook's public
+ * observable effect (a follow-up model turn), not on a private method.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PartListUnion } from '@google/genai';
+import type {
+  ServerGeminiStreamEvent,
+  ToolCallResponseInfo,
+  ToolCallRequestInfo,
+} from './turn.js';
+import { GeminiEventType } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
+import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
+import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
+import type { Todo } from '@vybestack/llxprt-code-tools';
+
+const mockTurnRun = vi.fn();
+
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
+  tokenLimit: vi.fn(
+    (_model: string, userContextLimit?: number) =>
+      userContextLimit ?? 1_000_000,
+  ),
+}));
+
+vi.mock('./turn.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./turn.js')>();
+  class MockTurn {
+    pendingToolCalls: unknown[] = [];
+    run = mockTurnRun;
+  }
+  return {
+    ...actual,
+    Turn: MockTurn as unknown as typeof actual.Turn,
+  };
+});
+
+import {
+  MessageStreamOrchestrator,
+  type MessageStreamDeps,
+} from './MessageStreamOrchestrator.js';
+
+function makePauseRequest(): ToolCallRequestInfo {
+  return {
+    name: 'todo_pause',
+    args: { reason: 'blocked' },
+    callId: 'pause-call-1',
+  } as unknown as ToolCallRequestInfo;
+}
+
+function makePauseResponse(success: boolean): ToolCallResponseInfo {
+  const base = {
+    callId: 'pause-call-1',
+    responseParts: [
+      {
+        functionResponse: {
+          name: 'todo_pause',
+          id: 'pause-call-1',
+          response: success ? { ok: true } : {},
+        },
+      },
+    ],
+    resultDisplay: undefined,
+  };
+  if (success) {
+    return {
+      ...base,
+      error: undefined,
+      errorType: undefined,
+    } as unknown as ToolCallResponseInfo;
+  }
+  return {
+    ...base,
+    error: new Error('reason exceeds maximum length of 500 characters'),
+    errorType: 'EXECUTION_ERROR',
+  } as unknown as ToolCallResponseInfo;
+}
+
+interface BuildOptions {
+  turnStream?: AsyncGenerator<ServerGeminiStreamEvent>;
+  activeTodos?: Todo[];
+  blockingAfterHook?: boolean;
+  isSuccessfulTodoPauseResponse?: (
+    response: ToolCallResponseInfo | undefined,
+  ) => boolean;
+}
+
+function buildOrchestrator(options: BuildOptions = {}): {
+  orchestrator: InstanceType<typeof MessageStreamOrchestrator>;
+  deps: MessageStreamDeps;
+} {
+  const mockChat = {
+    getLastPromptTokenCount: vi.fn().mockReturnValue(100),
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+  };
+
+  const providerManager = {
+    getActiveProviderName: vi.fn(() => 'openai'),
+    getActiveProvider: vi.fn(() => ({
+      name: 'openai',
+      getCurrentModel: vi.fn(() => ''),
+      getDefaultModel: vi.fn(() => ''),
+    })),
+  };
+
+  const config = {
+    getContentGeneratorConfig: vi.fn(() => ({
+      providerManager,
+      model: 'gpt-4',
+    })),
+    getMaxSessionTurns: vi.fn(() => 0),
+    getIdeMode: vi.fn(() => false),
+    getModel: vi.fn(() => 'gpt-4'),
+    getEphemeralSetting: vi.fn(() => undefined),
+    getSettingsService: vi.fn(() => ({
+      getCurrentProfileName: vi.fn(() => null),
+      get: vi.fn(() => undefined),
+    })),
+  } as unknown as Config;
+
+  const activeTodos = options.activeTodos ?? [
+    { id: 'todo-1', content: 'Active task', status: 'in_progress' },
+  ];
+
+  const stream =
+    options.turnStream ??
+    (async function* (): AsyncGenerator<ServerGeminiStreamEvent> {
+      yield { type: GeminiEventType.Content, value: 'hello' };
+      yield {
+        type: GeminiEventType.Finished,
+        value: { outcome: { hadVisibleOutput: true } },
+      };
+    })();
+
+  mockTurnRun.mockReturnValue(stream);
+
+  // A blocking AfterAgent hook is the observable distinguisher:
+  // _finishWithToolCalls forwards its reason into sendMessageStream, but the
+  // pause branch returns done immediately and never calls sendMessageStream.
+  const blockingAfterHookOutput =
+    options.blockingAfterHook === true
+      ? ({
+          isBlockingDecision: () => true,
+          shouldStopExecution: () => false,
+          getEffectiveReason: () => 'hook-says-continue',
+          shouldClearContext: () => false,
+        } as unknown as ReturnType<
+          MessageStreamDeps['agentHookManager']['fireAfterAgentHookSafe']
+        >)
+      : undefined;
+
+  const todoContinuationService = {
+    clearPausedState: vi.fn().mockResolvedValue(undefined),
+    toolActivityCount: 0,
+    toolCallReminderLevel: 'none',
+    consecutiveComplexTurns: 0,
+    lastTodoSnapshot: [],
+    recordModelActivity: vi.fn(),
+    isSuccessfulTodoPauseResponse:
+      options.isSuccessfulTodoPauseResponse ?? vi.fn().mockReturnValue(false),
+    isTodoToolCall: vi.fn().mockReturnValue(false),
+    applyPendingReminder: vi.fn((r: PartListUnion) => Promise.resolve(r)),
+    getTodoReminderForCurrentState: vi.fn().mockResolvedValue({
+      todos: activeTodos,
+      activeTodos,
+      reminder: 'Please continue working on the following task...',
+    }),
+    areTodoSnapshotsEqual: vi.fn().mockReturnValue(true),
+    processComplexityAnalysis: vi.fn().mockReturnValue(undefined),
+    appendTodoSuffixToRequest: vi.fn(),
+    appendSystemReminderToRequest: vi.fn(),
+    updateTodoToolAvailabilityFromDeclarations: vi.fn(),
+    setLastTodoToolTurn: vi.fn(),
+    shouldDeferStreamEvent: vi.fn().mockReturnValue(false),
+  } as unknown as MessageStreamDeps['todoContinuationService'];
+
+  const deps: MessageStreamDeps = {
+    config,
+    getChat: () => mockChat as unknown as ChatSession,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    } as unknown as DebugLogger,
+    loopDetector: {
+      reset: vi.fn(),
+      turnStarted: vi.fn().mockResolvedValue(false),
+      addAndCheck: vi.fn().mockReturnValue(false),
+    } as unknown as LoopDetectionService,
+    todoContinuationService,
+    ideContextTracker: {
+      getContextParts: vi.fn().mockReturnValue({
+        contextParts: [],
+        newIdeContext: undefined,
+      }),
+      recordSentContext: vi.fn(),
+    } as unknown as MessageStreamDeps['ideContextTracker'],
+    agentHookManager: {
+      cleanupOldHookState: vi.fn(),
+      fireBeforeAgentHookSafe: vi.fn().mockResolvedValue(undefined),
+      fireAfterAgentHookSafe: vi
+        .fn()
+        .mockResolvedValue(blockingAfterHookOutput),
+    } as unknown as MessageStreamDeps['agentHookManager'],
+    getEffectiveModel: () => 'gpt-4',
+    getHistory: vi.fn().mockResolvedValue([]),
+    getSessionTurnCount: vi.fn().mockReturnValue(1),
+    incrementSessionTurnCount: vi.fn(),
+    lazyInitialize: vi.fn().mockResolvedValue(undefined),
+    startChat: vi.fn().mockResolvedValue(mockChat),
+    getPreviousHistory: vi.fn().mockReturnValue(undefined),
+    setChat: vi.fn(),
+    hasChat: vi.fn().mockReturnValue(true),
+    complexityAnalyzer: {
+      analyzeComplexity: vi.fn().mockReturnValue({
+        complexityScore: 0.2,
+        isComplex: false,
+        detectedTasks: [],
+        sequentialIndicators: [],
+        questionCount: 0,
+        shouldSuggestTodos: false,
+      }),
+    } as unknown as ComplexityAnalyzer,
+    getLastPromptId: () => undefined,
+    setLastPromptId: vi.fn(),
+    resetCurrentSequenceModel: vi.fn(),
+    updateTelemetryTokenCount: vi.fn(),
+    sendMessageStream: vi.fn(
+      async function* (): AsyncGenerator<ServerGeminiStreamEvent> {
+        // Empty — only its invocation (via _finishWithToolCalls) matters.
+      },
+    ),
+  };
+
+  return {
+    orchestrator: new MessageStreamOrchestrator(deps),
+    deps,
+  };
+}
+
+async function collectEvents(
+  orchestrator: InstanceType<typeof MessageStreamOrchestrator>,
+): Promise<ServerGeminiStreamEvent[]> {
+  const events: ServerGeminiStreamEvent[] = [];
+  for await (const event of orchestrator.execute(
+    [{ text: 'test' }] as PartListUnion,
+    new AbortController().signal,
+    'prompt-1',
+    1,
+    false,
+  )) {
+    events.push(event);
+  }
+  return events;
+}
+
+function toolCallTurnStream(
+  response: ToolCallResponseInfo,
+): AsyncGenerator<ServerGeminiStreamEvent> {
+  return (async function* (): AsyncGenerator<ServerGeminiStreamEvent> {
+    yield {
+      type: GeminiEventType.ToolCallRequest,
+      value: makePauseRequest(),
+    };
+    yield {
+      type: GeminiEventType.ToolCallResponse,
+      value: response,
+    };
+    yield {
+      type: GeminiEventType.Finished,
+      value: { outcome: { hadVisibleOutput: true } },
+    };
+  })();
+}
+
+function pauseTurnStream(
+  success: boolean,
+): AsyncGenerator<ServerGeminiStreamEvent> {
+  return toolCallTurnStream(makePauseResponse(success));
+}
+
+function expectPauseToolEvents(events: ServerGeminiStreamEvent[]): void {
+  expect(
+    events.some((event) => event.type === GeminiEventType.ToolCallRequest),
+  ).toBe(true);
+  expect(
+    events.some((event) => event.type === GeminiEventType.ToolCallResponse),
+  ).toBe(true);
+}
+
+describe('MessageStreamOrchestrator — todo_pause loop break (issue #2287)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(tokenLimit).mockImplementation(
+      (_model: string, userContextLimit?: number) =>
+        userContextLimit ?? 1_000_000,
+    );
+  });
+
+  describe('successful pause breaks the loop via the explicit pause branch', () => {
+    it('suppresses the AfterAgent-hook continuation that the generic tool-call finish would fire', async () => {
+      // If todoPauseSeen is not evaluated before hadToolCallsThisTurn,
+      // _finishWithToolCalls runs and forwards the blocking hook reason into
+      // sendMessageStream. The pause branch must not.
+      const { orchestrator, deps } = buildOrchestrator({
+        turnStream: pauseTurnStream(true),
+        blockingAfterHook: true,
+        isSuccessfulTodoPauseResponse: vi.fn().mockReturnValue(true),
+      });
+
+      const events = await collectEvents(orchestrator);
+
+      expect(deps.sendMessageStream).not.toHaveBeenCalled();
+      expectPauseToolEvents(events);
+    });
+
+    it('breaks without depending on an AfterAgent-hook continuation', async () => {
+      const { orchestrator, deps } = buildOrchestrator({
+        turnStream: pauseTurnStream(true),
+        isSuccessfulTodoPauseResponse: vi.fn().mockReturnValue(true),
+      });
+
+      const events = await collectEvents(orchestrator);
+
+      expect(deps.sendMessageStream).not.toHaveBeenCalled();
+      expectPauseToolEvents(events);
+    });
+  });
+
+  describe('invalid/error pause does NOT trigger the authoritative pause branch', () => {
+    it('routes through the generic tool-call finish, forwarding the blocking hook into a continuation', async () => {
+      // An invalid pause must NOT set todoPauseSeen, so _finishWithToolCalls
+      // runs and forwards the blocking hook into sendMessageStream.
+      const { orchestrator, deps } = buildOrchestrator({
+        turnStream: pauseTurnStream(false),
+        blockingAfterHook: true,
+        isSuccessfulTodoPauseResponse: vi.fn().mockReturnValue(false),
+      });
+
+      await collectEvents(orchestrator);
+
+      expect(deps.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the raw pause response to the success classifier without short-circuiting', async () => {
+      const errorResponse = {
+        callId: 'pause-call-1',
+        responseParts: [
+          {
+            functionResponse: {
+              name: 'todo_pause',
+              id: 'pause-call-1',
+              response: {},
+            },
+          },
+        ],
+        resultDisplay: undefined,
+        error: new Error('filtered'),
+        errorType: 'EXECUTION_ERROR',
+      } as unknown as ToolCallResponseInfo;
+      const classifier = vi.fn().mockReturnValue(false);
+      const { orchestrator, deps } = buildOrchestrator({
+        turnStream: toolCallTurnStream(errorResponse),
+        blockingAfterHook: true,
+        isSuccessfulTodoPauseResponse: classifier,
+      });
+
+      await collectEvents(orchestrator);
+
+      expect(classifier).toHaveBeenCalledWith(errorResponse);
+      expect(deps.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -455,7 +455,7 @@ export class MessageStreamOrchestrator {
         hadToolCallsThisTurn = true;
       if (
         event.type === GeminiEventType.ToolCallResponse &&
-        todoContinuationService.isTodoPauseResponse(event.value)
+        todoContinuationService.isSuccessfulTodoPauseResponse(event.value)
       )
         todoPauseSeen = true;
       if (event.type === GeminiEventType.Thought) hadThinking = true;
@@ -519,6 +519,15 @@ export class MessageStreamOrchestrator {
     retryCount: number,
     ctx: StreamContext,
   ): AsyncGenerator<ServerGeminiStreamEvent, PostTurnResult> {
+    if (iter.todoPauseSeen) {
+      return yield* this._evaluateTodoContinuation(
+        iter,
+        baseRequest,
+        retryCount,
+        ctx,
+      );
+    }
+
     if (iter.hadToolCallsThisTurn) {
       return yield* this._finishWithToolCalls(iter.deferredEvents, ctx);
     }

--- a/packages/agents/src/core/TodoContinuationService.postturn.test.ts
+++ b/packages/agents/src/core/TodoContinuationService.postturn.test.ts
@@ -10,10 +10,10 @@ import {
   PostTurnAction,
   type PostTurnContext,
 } from './TodoContinuationService.js';
-import { GeminiEventType } from './turn.js';
+import { GeminiEventType, type ToolCallResponseInfo } from './turn.js';
 import { TodoReminderService } from '@vybestack/llxprt-code-core/services/todo-reminder-service.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
-import type { Todo } from '@vybestack/llxprt-code-tools';
+import { ToolErrorType, type Todo } from '@vybestack/llxprt-code-tools';
 
 // Mock TodoStore so persisted todo state doesn't hit the filesystem
 const {
@@ -97,6 +97,33 @@ const pendingTodo: Todo = {
   content: 'Do the thing',
   status: 'pending',
 };
+
+function functionResponsePart(
+  name: string,
+  id = 'pause-1',
+  response: Record<string, unknown> = {},
+): ToolCallResponseInfo['responseParts'][number] {
+  return {
+    functionResponse: {
+      name,
+      id,
+      response,
+    },
+  } as ToolCallResponseInfo['responseParts'][number];
+}
+
+function makeToolResponse(
+  overrides: Partial<ToolCallResponseInfo> = {},
+): ToolCallResponseInfo {
+  return {
+    callId: 'pause-1',
+    responseParts: [functionResponsePart('todo_pause')],
+    resultDisplay: undefined,
+    error: undefined,
+    errorType: undefined,
+    ...overrides,
+  };
+}
 
 describe('TodoContinuationService', () => {
   let service: TodoContinuationService;
@@ -193,45 +220,81 @@ describe('TodoContinuationService', () => {
 
   describe('isTodoPauseResponse', () => {
     it('returns true when response contains todo_pause function response', () => {
-      const response = {
-        callId: 'pause-1',
+      expect(service.isTodoPauseResponse(makeToolResponse())).toBe(true);
+    });
+
+    it('matches pause responses case-insensitively when the pause part is not first', () => {
+      const response = makeToolResponse({
         responseParts: [
-          {
-            functionResponse: {
-              name: 'todo_pause',
-              id: 'pause-1',
-              response: {},
-            },
-          },
+          functionResponsePart('read_file', 'tool-1', { content: 'data' }),
+          functionResponsePart('TODO_PAUSE'),
         ],
-        resultDisplay: undefined,
-        error: undefined,
-        errorType: undefined,
-      };
+      });
       expect(service.isTodoPauseResponse(response)).toBe(true);
     });
 
+    it('returns false for empty response parts', () => {
+      expect(
+        service.isTodoPauseResponse(makeToolResponse({ responseParts: [] })),
+      ).toBe(false);
+    });
+
     it('returns false for non-pause responses', () => {
-      const response = {
+      const response = makeToolResponse({
         callId: 'tool-1',
         responseParts: [
-          {
-            functionResponse: {
-              name: 'read_file',
-              id: 'tool-1',
-              response: { content: 'data' },
-            },
-          },
+          functionResponsePart('read_file', 'tool-1', { content: 'data' }),
         ],
-        resultDisplay: undefined,
-        error: undefined,
-        errorType: undefined,
-      };
+      });
       expect(service.isTodoPauseResponse(response)).toBe(false);
     });
 
     it('returns false for undefined response', () => {
       expect(service.isTodoPauseResponse(undefined)).toBe(false);
+    });
+  });
+
+  describe('isSuccessfulTodoPauseResponse', () => {
+    it('returns true for a todo_pause response with no error or errorType', () => {
+      expect(service.isSuccessfulTodoPauseResponse(makeToolResponse())).toBe(
+        true,
+      );
+    });
+
+    it('returns false for a todo_pause response carrying an error', () => {
+      const response = makeToolResponse({
+        error: new Error('reason exceeds maximum length of 500 characters'),
+        errorType: ToolErrorType.EXECUTION_FAILED,
+      });
+      expect(service.isSuccessfulTodoPauseResponse(response)).toBe(false);
+    });
+
+    it('returns false for a todo_pause response carrying only an error', () => {
+      const response = makeToolResponse({
+        error: new Error('something went wrong'),
+      });
+      expect(service.isSuccessfulTodoPauseResponse(response)).toBe(false);
+    });
+
+    it('returns false for a todo_pause response carrying only an errorType', () => {
+      const response = makeToolResponse({
+        errorType: ToolErrorType.INVALID_TOOL_PARAMS,
+      });
+      expect(service.isSuccessfulTodoPauseResponse(response)).toBe(false);
+    });
+
+    it('returns false for non-pause tool responses', () => {
+      const response = makeToolResponse({
+        callId: 'tool-1',
+        responseParts: [
+          functionResponsePart('read_file', 'tool-1', { content: 'data' }),
+        ],
+      });
+      expect(service.isSuccessfulTodoPauseResponse(response)).toBe(false);
+    });
+
+    it('returns false for undefined response', () => {
+      expect(service.isSuccessfulTodoPauseResponse(undefined)).toBe(false);
     });
   });
 

--- a/packages/agents/src/core/TodoContinuationService.ts
+++ b/packages/agents/src/core/TodoContinuationService.ts
@@ -368,6 +368,22 @@ export class TodoContinuationService {
     });
   }
 
+  /**
+   * Authoritative pause signal: a pause-tool response is only treated as a
+   * successful pause when the tool completed without an error or errorType.
+   * Invalid input (schema/validation failure, empty/overlong reason, or a
+   * reason rejected by filtering) surfaces as an error and must NOT break the
+   * continuation loop.
+   */
+  isSuccessfulTodoPauseResponse(
+    response: ToolCallResponseInfo | undefined,
+  ): boolean {
+    if (response === undefined || !this.isTodoPauseResponse(response)) {
+      return false;
+    }
+    return response.error === undefined && response.errorType === undefined;
+  }
+
   classifyPostTurnAction(context: PostTurnContext): PostTurnAction {
     const {
       hadToolCalls,

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.todoPause.test.tsx
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useAgenticLoop.todoPause.test.tsx
@@ -1,0 +1,414 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FinishReason } from '@google/genai';
+import { act } from 'react';
+import { renderHook } from '../../../../test-utils/render.js';
+import { useAgenticLoop } from '../useAgenticLoop.js';
+import { MockTool } from '@vybestack/llxprt-code-core/test-utils/mock-tool.js';
+import {
+  getOrCreateScheduler,
+  disposeScheduler,
+  clearAllSchedulers,
+} from '@vybestack/llxprt-code-core/config/schedulerSingleton.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { PolicyEngine } from '@vybestack/llxprt-code-core/policy/policy-engine.js';
+import { PolicyDecision } from '@vybestack/llxprt-code-core/policy/types.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { CoreToolScheduler } from '@vybestack/llxprt-code-agents';
+import {
+  GeminiEventType,
+  DEFAULT_AGENT_ID,
+  type ToolCallRequestInfo,
+  type ServerGeminiStreamEvent,
+  type AgentClientContract,
+  type Config,
+} from '@vybestack/llxprt-code-core';
+import type { PartListUnion, Content, Part } from '@google/genai';
+import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
+
+function toParts(req: PartListUnion): Part[] {
+  if (typeof req === 'string') return [{ text: req }];
+  if (Array.isArray(req)) {
+    return req.map((p) => (typeof p === 'string' ? { text: p } : p));
+  }
+  return [req];
+}
+
+function createScriptedAgentClient(
+  scripts: ServerGeminiStreamEvent[][],
+): AgentClientContract {
+  const scriptQueue = [...scripts];
+  const history: Content[] = [];
+  return {
+    async initialize() {},
+    isInitialized: () => true,
+    hasChatInitialized: () => true,
+    async getHistory() {
+      return history;
+    },
+    getChat: () =>
+      ({
+        recordCompletedToolCalls: vi.fn(),
+      }) as unknown as ReturnType<AgentClientContract['getChat']>,
+    getHistoryService: () => null,
+    storeHistoryServiceForReuse: () => {},
+    storeHistoryForLaterUse: (h: Content[]) => history.push(...h),
+    dispose: () => {},
+    setTools: async () => {},
+    clearTools: () => {},
+    updateSystemInstruction: async () => {},
+    addHistory: async (content: Content) => {
+      history.push(content);
+    },
+    resetChat: async () => {},
+    resumeChat: async () => {},
+    setHistory: async () => {},
+    restoreHistory: async () => {},
+    addDirectoryContext: async () => {},
+    getContentGenerator: () => {
+      throw new Error('not used by AgenticLoop');
+    },
+    startChat: async () => {
+      throw new Error('not used');
+    },
+    generateDirectMessage: () => {
+      throw new Error('not used');
+    },
+    generateJson: async () => ({}),
+    generateContent: () => {
+      throw new Error('not used');
+    },
+    generateEmbedding: async () => [],
+    async *sendMessageStream(
+      req: PartListUnion,
+      signal: AbortSignal,
+      _promptId: string,
+    ): AsyncGenerator<ServerGeminiStreamEvent> {
+      history.push({ role: 'user', parts: toParts(req) });
+      const script = scriptQueue.shift();
+      if (!script) return;
+      for (const event of script) {
+        if (signal.aborted) return;
+        yield event;
+      }
+    },
+    getUserTier: () => undefined,
+    getCurrentSequenceModel: () => 'test-model',
+  };
+}
+
+function toolCallRequestEvent(
+  name: string,
+  callId: string,
+  agentId = DEFAULT_AGENT_ID,
+  reason = 'blocked',
+): ServerGeminiStreamEvent {
+  const value: ToolCallRequestInfo = {
+    callId,
+    name,
+    args: { reason },
+    isClientInitiated: false,
+    prompt_id: callId,
+    agentId,
+  };
+  return { type: GeminiEventType.ToolCallRequest, value };
+}
+
+function finishedEvent(): ServerGeminiStreamEvent {
+  return {
+    type: GeminiEventType.Finished,
+    value: { reason: FinishReason.STOP },
+  };
+}
+
+function createAllowPolicyEngine(): PolicyEngine {
+  return new PolicyEngine({
+    rules: [],
+    defaultDecision: PolicyDecision.ALLOW,
+    nonInteractive: false,
+  });
+}
+
+function createToolRegistryForTest(tools: MockTool[]): ToolRegistry {
+  const toolMap = new Map<string, MockTool>();
+  for (const tool of tools) toolMap.set(tool.name, tool);
+  const fixture = {
+    getToolByName: (name: string) => toolMap.get(name) ?? null,
+    getTool: (name: string) => toolMap.get(name) ?? null,
+    getFunctionDeclarations: () => [],
+    getTools: () => tools,
+    discoverTools: async () => {},
+    getAllTools: () => tools,
+    getAllToolNames: () => tools.map((t) => t.name),
+    getToolsByServer: () => [],
+    registerTool: () => {},
+    getToolByDisplayName: () => null,
+    tools: toolMap,
+    discovery: {},
+  };
+  return fixture as unknown as ToolRegistry;
+}
+
+function createTestConfig(options: {
+  messageBus: MessageBus;
+  toolRegistry: ToolRegistry;
+  policyEngine: PolicyEngine;
+}): Config {
+  const { messageBus, toolRegistry, policyEngine } = options;
+  const fixture = {
+    getSessionId: () => 'agentic-loop-pause-test-session',
+    getUsageStatisticsEnabled: () => false,
+    getDebugMode: () => false,
+    getApprovalMode: () => ApprovalMode.YOLO,
+    getEphemeralSettings: () => ({}),
+    getEphemeralSetting: () => undefined,
+    getAllowedTools: (): string[] => [],
+    getExcludeTools: (): string[] => [],
+    getContentGeneratorConfig: () => ({ model: 'test-model' }),
+    getToolRegistry: () => toolRegistry,
+    getMessageBus: () => messageBus,
+    getPolicyEngine: () => policyEngine,
+    getTelemetryLogPromptsEnabled: () => false,
+    isInteractive: () => true,
+    getNonInteractive: () => false,
+    getModel: () => 'test-model',
+    getToolSchedulerFactory:
+      () =>
+      (
+        opts: ConstructorParameters<typeof CoreToolScheduler>[0],
+      ): CoreToolScheduler =>
+        new CoreToolScheduler(opts),
+    getOrCreateScheduler: (
+      sessionId: string,
+      callbacks: Parameters<Config['getOrCreateScheduler']>[1],
+      schedulerOptions: Parameters<Config['getOrCreateScheduler']>[2],
+      deps: Parameters<Config['getOrCreateScheduler']>[3],
+    ) =>
+      getOrCreateScheduler(
+        fixture as unknown as Config,
+        sessionId,
+        callbacks,
+        schedulerOptions,
+        {
+          messageBus: deps?.messageBus ?? messageBus,
+          toolRegistry: deps?.toolRegistry ?? toolRegistry,
+        },
+      ),
+    disposeScheduler: (sessionId: string) => disposeScheduler(sessionId),
+  };
+  return fixture as unknown as Config;
+}
+
+describe('useAgenticLoop pause completion routing', () => {
+  let messageBus: MessageBus;
+  let toolRegistry: ToolRegistry;
+  let config: Config;
+
+  beforeEach(() => {
+    clearAllSchedulers();
+    const pauseTool = new MockTool({ name: 'todo_pause' });
+    pauseTool.executeFn.mockResolvedValue({
+      llmContent: 'AI execution paused due to: blocked',
+      returnDisplay: 'AI paused: blocked',
+    });
+    const otherTool = new MockTool({ name: 'record_tool' });
+    otherTool.executeFn.mockResolvedValue({
+      llmContent: 'recorded-ok',
+      returnDisplay: 'recorded-ok',
+    });
+    toolRegistry = createToolRegistryForTest([pauseTool, otherTool]);
+    messageBus = new MessageBus(createAllowPolicyEngine(), false);
+    config = createTestConfig({
+      messageBus,
+      toolRegistry,
+      policyEngine: createAllowPolicyEngine(),
+    });
+  });
+
+  afterEach(() => {
+    clearAllSchedulers();
+  });
+
+  function renderWithPauseCounter(client: AgentClientContract): {
+    runLoop: (input: string, promptId: string) => Promise<void>;
+    getPauseCallCount: () => number;
+  } {
+    let pauseCallCount = 0;
+    const { result } = renderHook(() =>
+      useAgenticLoop({
+        config,
+        agentClient: client,
+        messageBus,
+        interactiveMode: true,
+        addItem: vi.fn(),
+        onToolCallsUpdate: () => {},
+        outputUpdateHandler: () => {},
+        getPreferredEditor: () => undefined,
+        onEditorOpen: () => {},
+        onEditorClose: () => {},
+        onTodoPause: () => {
+          pauseCallCount += 1;
+        },
+        processStreamEventRef: { current: () => {} },
+        flushPendingHistoryItem: () => {},
+        clearPendingHistoryItem: () => {},
+        performMemoryRefresh: async () => {},
+      }),
+    );
+    return {
+      runLoop: async (input: string, promptId: string) => {
+        const controller = new AbortController();
+        try {
+          await result.current.runLoop(input, controller.signal, promptId);
+        } finally {
+          controller.abort();
+        }
+      },
+      getPauseCallCount: () => pauseCallCount,
+    };
+  }
+
+  it('fires onTodoPause exactly once when a pause tool call succeeds', async () => {
+    const client = createScriptedAgentClient([
+      [toolCallRequestEvent('todo_pause', 'pause-ok'), finishedEvent()],
+      [finishedEvent()],
+    ]);
+    const { runLoop, getPauseCallCount } = renderWithPauseCounter(client);
+
+    await act(async () => {
+      await runLoop('go', 'p1');
+    });
+
+    const pauseTool = toolRegistry.getTool('todo_pause') as MockTool;
+    expect(pauseTool.executeFn).toHaveBeenCalledTimes(1);
+    expect(getPauseCallCount()).toBe(1);
+  });
+
+  it('fires onTodoPause once when multiple pause tool calls succeed in one batch', async () => {
+    const client = createScriptedAgentClient([
+      [
+        toolCallRequestEvent('todo_pause', 'pause-ok-1'),
+        toolCallRequestEvent('todo_pause', 'pause-ok-2'),
+        finishedEvent(),
+      ],
+      [finishedEvent()],
+    ]);
+    const { runLoop, getPauseCallCount } = renderWithPauseCounter(client);
+
+    await act(async () => {
+      await runLoop('go', 'p1');
+    });
+
+    const pauseTool = toolRegistry.getTool('todo_pause') as MockTool;
+    expect(pauseTool.executeFn).toHaveBeenCalledTimes(2);
+    expect(getPauseCallCount()).toBe(1);
+  });
+
+  it('fires onTodoPause once when one pause succeeds and another fails in one batch', async () => {
+    const pauseTool = toolRegistry.getTool('todo_pause') as MockTool;
+    pauseTool.executeFn.mockImplementation(async (params) => {
+      if (params.reason === 'blocked') {
+        return {
+          llmContent: 'AI execution paused due to: blocked',
+          returnDisplay: 'AI paused: blocked',
+        };
+      }
+      return {
+        llmContent: 'reason exceeds maximum length of 500 characters',
+        returnDisplay: 'reason exceeds maximum length of 500 characters',
+        error: {
+          message: 'reason exceeds maximum length of 500 characters',
+        },
+      };
+    });
+    const client = createScriptedAgentClient([
+      [
+        toolCallRequestEvent(
+          'todo_pause',
+          'pause-ok',
+          DEFAULT_AGENT_ID,
+          'blocked',
+        ),
+        toolCallRequestEvent(
+          'todo_pause',
+          'pause-err',
+          DEFAULT_AGENT_ID,
+          'too-long',
+        ),
+        finishedEvent(),
+      ],
+      [finishedEvent()],
+    ]);
+    const { runLoop, getPauseCallCount } = renderWithPauseCounter(client);
+
+    await act(async () => {
+      await runLoop('go', 'p1');
+    });
+
+    expect(pauseTool.executeFn).toHaveBeenCalledTimes(2);
+    expect(getPauseCallCount()).toBe(1);
+  });
+
+  it('does not fire onTodoPause when a pause tool call fails', async () => {
+    const pauseTool = toolRegistry.getTool('todo_pause') as MockTool;
+    pauseTool.executeFn.mockResolvedValue({
+      llmContent: 'reason exceeds maximum length of 500 characters',
+      returnDisplay: 'reason exceeds maximum length of 500 characters',
+      error: {
+        message: 'reason exceeds maximum length of 500 characters',
+      },
+    });
+    const client = createScriptedAgentClient([
+      [toolCallRequestEvent('todo_pause', 'pause-err'), finishedEvent()],
+      [finishedEvent()],
+    ]);
+    const { runLoop, getPauseCallCount } = renderWithPauseCounter(client);
+
+    await act(async () => {
+      await runLoop('go', 'p1');
+    });
+
+    expect(pauseTool.executeFn).toHaveBeenCalledTimes(1);
+    expect(getPauseCallCount()).toBe(0);
+  });
+
+  it('does not fire onTodoPause for a different successful tool call', async () => {
+    const client = createScriptedAgentClient([
+      [toolCallRequestEvent('record_tool', 'call-1'), finishedEvent()],
+      [finishedEvent()],
+    ]);
+    const { runLoop, getPauseCallCount } = renderWithPauseCounter(client);
+
+    await act(async () => {
+      await runLoop('go', 'p1');
+    });
+
+    const otherTool = toolRegistry.getTool('record_tool') as MockTool;
+    expect(otherTool.executeFn).toHaveBeenCalledTimes(1);
+    expect(getPauseCallCount()).toBe(0);
+  });
+
+  it('does not fire onTodoPause for an external agent pause tool call', async () => {
+    const client = createScriptedAgentClient([
+      [
+        toolCallRequestEvent('todo_pause', 'pause-subagent', 'subagent-1'),
+        finishedEvent(),
+      ],
+      [finishedEvent()],
+    ]);
+    const { runLoop, getPauseCallCount } = renderWithPauseCounter(client);
+
+    await act(async () => {
+      await runLoop('go', 'p1');
+    });
+
+    const pauseTool = toolRegistry.getTool('todo_pause') as MockTool;
+    expect(pauseTool.executeFn).toHaveBeenCalledTimes(1);
+    expect(getPauseCallCount()).toBe(0);
+  });
+});

--- a/packages/tools/src/__tests__/todo-tools.test.ts
+++ b/packages/tools/src/__tests__/todo-tools.test.ts
@@ -132,6 +132,49 @@ describe('Todo Tool Group Behavioral Tests @plan:PLAN-20260608-ISSUE1585.P10', (
     });
   });
 
+  describe('TodoPause schema and description disclose the 500-character reason cap (issue #2287)', () => {
+    it('main tool description states reason is capped at 500 characters', () => {
+      const tool = new TodoPauseTool(createFakeTodoService());
+      const description: string = tool.description;
+      expect(description.toLowerCase()).toContain('500');
+      expect(description.toLowerCase()).toMatch(/character/);
+    });
+
+    it('reason schema description states the 500-character limit and instructs streaming longer text separately', () => {
+      const tool = new TodoPauseTool(createFakeTodoService());
+      const schema = tool.schema as unknown as {
+        parametersJsonSchema?: {
+          properties?: {
+            reason?: { description?: string; maxLength?: number };
+          };
+        };
+      };
+      const reasonSchema = schema.parametersJsonSchema?.properties?.reason;
+      expect(reasonSchema).toBeDefined();
+      expect(reasonSchema?.maxLength).toBe(500);
+      const reasonDescription = (reasonSchema?.description ?? '').toLowerCase();
+      expect(reasonDescription).toContain('500');
+      // The model must be told to stream any longer explanation as normal
+      // response text, not stuff it into the tool argument.
+      expect(reasonDescription).toMatch(/stream|response text|separately/);
+    });
+
+    it('rejects a reason longer than 500 characters with the explicit length guard', () => {
+      const tool = new TodoPauseTool(createFakeTodoService());
+      const longReason = 'a'.repeat(501);
+      const error = tool.validateToolParams({ reason: longReason });
+      expect(error).not.toBeNull();
+      expect(error?.message.toLowerCase()).toContain('500');
+    });
+
+    it('accepts a reason of exactly 500 characters', () => {
+      const tool = new TodoPauseTool(createFakeTodoService());
+      const boundaryReason = 'a'.repeat(500);
+      const error = tool.validateToolParams({ reason: boundaryReason });
+      expect(error).toBeNull();
+    });
+  });
+
   describe('TodoRead reads items with ToolResult.llmContent containing structured output', () => {
     it('todos appear as structured content in ToolResult', async () => {
       const service = createFakeTodoService([

--- a/packages/tools/src/tools/todo-pause.ts
+++ b/packages/tools/src/tools/todo-pause.ts
@@ -6,7 +6,6 @@
 
 import { Type } from '@google/genai';
 import { BaseTool, type ToolResult, Kind } from './tools.js';
-import { SchemaValidator } from '../utils/schemaValidator.js';
 import type { ITodoService } from '../interfaces/ITodoService.js';
 import type { IToolHost } from '../interfaces/IToolHost.js';
 import { EmojiFilter, isEmojiFilterMode } from '../utils/EmojiFilter.js';
@@ -34,7 +33,9 @@ export class TodoPause extends BaseTool<TodoPauseParams, ToolResult> {
         'dependencies are blocking completion, or unexpected errors occur that require human intervention. ' +
         'DO NOT use this tool for normal task completion (use todo_write to update status instead), ' +
         'requesting clarification (continue with your best understanding), or minor issues that can be worked around. ' +
-        'The reason should clearly explain what specific issue is preventing progress.',
+        'The reason is limited to 500 characters and should clearly explain what specific issue is preventing progress. ' +
+        'Stream any longer user-facing explanation as normal response text before or after calling this tool; ' +
+        'do not place text longer than 500 characters in the reason argument.',
       Kind.Think,
       {
         type: Type.OBJECT,
@@ -42,7 +43,8 @@ export class TodoPause extends BaseTool<TodoPauseParams, ToolResult> {
           reason: {
             type: Type.STRING,
             description:
-              'Explanation of why the task needs to be paused (e.g., missing file, configuration error, blocked dependency)',
+              'Concise explanation of why the task needs to be paused (e.g., missing file, configuration error, blocked dependency). ' +
+              'Limited to a maximum of 500 characters; any longer user-facing explanation must be streamed as normal response text separately, not placed in this argument.',
             minLength: 1,
             maxLength: 500,
           },
@@ -61,19 +63,6 @@ export class TodoPause extends BaseTool<TodoPauseParams, ToolResult> {
   override validateToolParams(
     params: unknown,
   ): (string & { message: string }) | null {
-    // First validate against schema
-    const schemaError = SchemaValidator.validate(
-      this.schema.parameters,
-      params,
-    );
-    if (schemaError) {
-      const errorString = new String(schemaError) as string & {
-        message: string;
-      };
-      errorString.message = schemaError;
-      return errorString;
-    }
-
     // Type guard to ensure params has the expected structure
     if (params == null || typeof params !== 'object') {
       const errorString = new String('params must be an object') as string & {


### PR DESCRIPTION
## TLDR

Fixes todo_pause so only successful pause tool results immediately stop todo continuation/retry loops, while failed or invalid pause attempts remain ordinary tool failures and do not suppress continuation.

## Dive Deeper

This PR makes the pause signal explicit and success-gated:

- MessageStreamOrchestrator now detects successful todo_pause responses and evaluates the pause branch before the generic tool-call finish path.
- TodoContinuationService exposes isSuccessfulTodoPauseResponse, which requires a todo_pause response with no error and no errorType.
- The CLI agentic loop has focused coverage proving onTodoPause fires once for successful primary pause batches, does not fire for failed pauses, non-pause tools, or external-agent pause completions, and handles mixed success/failure batches.
- TodoPause tool docs/schema now clearly state the 500-character reason cap and instruct the model to stream longer user-facing explanation separately.

## Reviewer Test Plan

Suggested validation:

1. Run the test and verification commands listed below.
2. Exercise an agent flow with an active todo, then call todo_pause with a short valid reason; the continuation loop should stop immediately.
3. Exercise invalid pause attempts, such as a reason longer than 500 characters; the failure should not be treated as an authoritative pause signal.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS:

- npm run typecheck
- npm run lint
- npm run test
- npm run build
- node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"
- ocr review --audience agent --timeout 20 HEAD detached: final run reported 0 comments

## Linked issues / bugs

Fixes #2287
