### PR TITLE
fix(compression): attempt compression when extraction is unsafe instead of throwing (Fixes #2299)

### DIFF
--- a/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
@@ -1,0 +1,332 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for ProviderContentEnforcer unsafe-extraction handling
+ * (issue #2299). When the pending contents cannot be cleanly extracted
+ * (safeToRecompose: false) and the payload exceeds the limit, the enforcer
+ * must still attempt compression and truncation before throwing.
+ *
+ * These tests follow dev-docs/RULES.md: they assert observable behavior
+ * (returned contents, error messages, pending preservation) and NEVER assert
+ * that mock functions were called.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import {
+  makeUserMessage,
+  makeAiToolCall,
+  makeToolResponse,
+  buildRuntimeContext,
+} from '../../core/__tests__/chatSession-density-helpers.js';
+import {
+  ProviderContentEnforcer,
+  type ProviderContentEnforcementDeps,
+} from '../providerContentEnforcement.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+
+function makeLogger(): DebugLogger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as DebugLogger;
+}
+
+interface EnforcerHarness {
+  enforcer: ProviderContentEnforcer;
+  deps: ProviderContentEnforcementDeps;
+  historyService: HistoryService;
+}
+
+/**
+ * Build a ProviderContentEnforcer wired to a real HistoryService with
+ * infrastructure-level mocks (token estimation, compression execution).
+ * The enforcer itself is real — only its dependencies are mocked.
+ */
+function buildEnforcerHarness(
+  historyService: HistoryService,
+  runtimeContext: AgentRuntimeContext,
+  overrides: Partial<ProviderContentEnforcementDeps> = {},
+): EnforcerHarness {
+  const performCompression = vi.fn();
+  const performFallbackCompression = vi.fn().mockResolvedValue(false);
+  const ensureDensityOptimized = vi.fn().mockResolvedValue(undefined);
+  const deps: ProviderContentEnforcementDeps = {
+    historyService,
+    runtimeContext,
+    generationConfig: {},
+    providerRuntimeNullable: undefined,
+    logger: makeLogger(),
+    ensureDensityOptimized,
+    performCompression,
+    performFallbackCompression,
+    ...overrides,
+  };
+  return { enforcer: new ProviderContentEnforcer(deps), deps, historyService };
+}
+
+/**
+ * Build contents whose prefix does NOT deep-equal the baseline, so
+ * extractPendingContents falls through to the unsafe-extraction branch
+ * (safeToRecompose: false). This is achieved by mutating the timestamp
+ * metadata on the first entry, which defeats both the prefix-match and the
+ * recomposition-identity checks.
+ */
+function buildUnsafeExtractionContents(
+  baselinePrefix: IContent[],
+  pending: IContent,
+): IContent[] {
+  const mutatedPrefix: IContent[] = baselinePrefix.map((content, index) => {
+    if (index === 0) {
+      return {
+        ...content,
+        metadata: { ...content.metadata, timestamp: -1 },
+      };
+    }
+    return content;
+  });
+  return [...mutatedPrefix, pending];
+}
+
+/**
+ * Token estimate that puts the initial projection above both the compression
+ * threshold and the margin-adjusted limit, forcing the enforcer into the
+ * overflow/compression path.
+ *
+ * With contextLimit=200_000 and the default completion budget (65_536):
+ *   compressionThreshold = min(199_000, 0.8 * 134_464 + 65_536) = 172_107
+ *   marginAdjustedLimit   = 199_000
+ *   initialProjected      = OVERFLOW_TOKENS + 65_536 = 199_536 > 199_000
+ */
+const OVERFLOW_TOKENS = 134_000;
+
+describe('ProviderContentEnforcer unsafe-extraction compression (issue #2299)', () => {
+  let historyService: HistoryService;
+  let runtimeContext: AgentRuntimeContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    historyService = new HistoryService();
+    runtimeContext = buildRuntimeContext(historyService, {
+      contextLimit: 200_000,
+      compressionThreshold: 0.8,
+    });
+  });
+
+  it('succeeds (does not throw "reduced 0 tokens") when extraction is unsafe and compression resolves the overflow', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const baseline = historyService.getCuratedForProvider();
+    const pending = makeUserMessage('new pending request');
+    const contents = buildUnsafeExtractionContents(baseline, pending);
+
+    const harness = buildEnforcerHarness(historyService, runtimeContext);
+    const estimateSpy = vi
+      .spyOn(historyService, 'estimateTokensForContents')
+      .mockResolvedValue(OVERFLOW_TOKENS);
+
+    // The real CompressionHandler clears and re-adds compressed entries.
+    // Simulate that here so recomposeProviderContents observes a changed
+    // history — this is the observable effect of compression, not a mock call.
+    harness.deps.performCompression.mockImplementation(async () => {
+      historyService.clear();
+      historyService.add(makeUserMessage('compressed summary'));
+      estimateSpy.mockResolvedValue(1_000);
+      return PerformCompressionResult.COMPRESSED;
+    });
+
+    // Before the fix, this threw "reduced 0 tokens". Now it must succeed.
+    const result = await harness.enforcer.enforce(contents, 'test-prompt');
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('preserves the pending content in the returned contents when extraction is unsafe', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const baseline = historyService.getCuratedForProvider();
+    const pending = makeUserMessage('new pending request');
+    const contents = buildUnsafeExtractionContents(baseline, pending);
+
+    const harness = buildEnforcerHarness(historyService, runtimeContext);
+    const estimateSpy = vi
+      .spyOn(historyService, 'estimateTokensForContents')
+      .mockResolvedValue(OVERFLOW_TOKENS);
+
+    harness.deps.performCompression.mockImplementation(async () => {
+      historyService.clear();
+      historyService.add(makeUserMessage('compressed summary'));
+      estimateSpy.mockResolvedValue(1_000);
+      return PerformCompressionResult.COMPRESSED;
+    });
+
+    const result = await harness.enforcer.enforce(contents, 'test-prompt');
+
+    expect(result).toContainEqual(pending);
+  });
+
+  it('reports a non-zero token reduction in the error when compression succeeds but the payload still exceeds the limit', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const baseline = historyService.getCuratedForProvider();
+    const pending = makeUserMessage('new pending request');
+    const contents = buildUnsafeExtractionContents(baseline, pending);
+
+    const harness = buildEnforcerHarness(historyService, runtimeContext);
+    const estimateSpy = vi
+      .spyOn(historyService, 'estimateTokensForContents')
+      .mockResolvedValue(140_000);
+
+    // Compression "happens" (updates history) and genuinely lowers the token
+    // estimate, but it still exceeds the margin-adjusted limit. The fallback
+    // also fails to bring it down.
+    harness.deps.performCompression.mockImplementation(async () => {
+      historyService.clear();
+      historyService.add(
+        makeUserMessage('compressed summary that is still large'),
+      );
+      // Lower than 140_000 but 136_000 + 65_536 = 201_536 > 199_000 (still over).
+      estimateSpy.mockResolvedValue(136_000);
+      return PerformCompressionResult.COMPRESSED;
+    });
+
+    let thrownError: Error | undefined;
+    try {
+      await harness.enforcer.enforce(contents, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    const message = thrownError!.message;
+    // The error must mention a reduction happened (the bug was "reduced 0 tokens").
+    expect(message).toContain('reduced');
+    // It must NOT say "reduced 0 tokens" — that is the regression signature.
+    expect(message).not.toContain('reduced 0 tokens');
+  });
+
+  it('applies fallback truncation history via the callback and reports a non-zero reduction when the payload still exceeds the limit', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const baseline = historyService.getCuratedForProvider();
+    const pending = makeUserMessage('new pending request');
+    const contents = buildUnsafeExtractionContents(baseline, pending);
+
+    const harness = buildEnforcerHarness(historyService, runtimeContext);
+    const estimateSpy = vi
+      .spyOn(historyService, 'estimateTokensForContents')
+      .mockResolvedValue(140_000);
+
+    harness.deps.performCompression.mockImplementation(async () => {
+      historyService.clear();
+      historyService.add(
+        makeUserMessage('compressed summary that is still large'),
+      );
+      // Lower than 140_000 but 136_000 + 65_536 = 201_536 > 199_000 (still over).
+      estimateSpy.mockResolvedValue(136_000);
+      return PerformCompressionResult.COMPRESSED;
+    });
+
+    // The fallback callback applies a truncated history to the real history
+    // service, mirroring what the real CompressionHandler does. The estimate
+    // stays above the limit so the enforcer must throw with a non-zero
+    // reduction (the behavioral outcome of having attempted fallback).
+    harness.deps.performFallbackCompression.mockImplementation(
+      async (_promptId, applyResult) => {
+        applyResult([makeUserMessage('truncated history')]);
+        return true;
+      },
+    );
+
+    const error = await harness.enforcer
+      .enforce(contents, 'test-prompt')
+      .catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('reduced');
+    expect((error as Error).message).not.toContain('reduced 0 tokens');
+  });
+
+  it('compressAndRecompose returns recomposed contents reflecting compressed history, not the original unchanged payload', async () => {
+    historyService.add(makeUserMessage('established history before pending'));
+    const baseline = historyService.getCuratedForProvider();
+    const pending = makeUserMessage('new pending request');
+    const contents = buildUnsafeExtractionContents(baseline, pending);
+
+    const harness = buildEnforcerHarness(historyService, runtimeContext);
+    vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+      10_000,
+    );
+
+    // Compression replaces the history with different content.
+    harness.deps.performCompression.mockImplementation(async () => {
+      historyService.clear();
+      historyService.add(makeUserMessage('compressed summary'));
+      return PerformCompressionResult.COMPRESSED;
+    });
+
+    const result = await harness.enforcer.compressAndRecompose(
+      contents,
+      'test-prompt',
+    );
+
+    // The returned contents must reflect the recomposed (compressed) history,
+    // meaning the original established-history text must be gone and replaced
+    // by the compressed summary. If the implementation ignored compression,
+    // 'established history before pending' would still be present.
+    const allText = result
+      .map((c) =>
+        c.blocks
+          .filter((b) => b.type === 'text')
+          .map((b) => (b as { text: string }).text)
+          .join(' '),
+      )
+      .join(' ');
+    expect(allText).toContain('compressed summary');
+    expect(allText).not.toContain('established history before pending');
+    // The pending content must be preserved.
+    expect(result).toContainEqual(pending);
+  });
+
+  it('preserves pending content after enforcement when buildProviderContent normalizes tool-call/tool-response structure into a different-length prefix (issue #2299 normalization shift)', async () => {
+    // Build curated history with a tool-call/tool-response structure that
+    // buildProviderContent normalizes (e.g., adds synthetic responses for
+    // orphaned calls, reorders, or splits). This makes the provider-space
+    // length differ from the raw curated length.
+    const readCall = makeAiToolCall('read_file', {
+      file_path: '/tmp/data.txt',
+    });
+    historyService.add(readCall.entry);
+    historyService.add(
+      makeToolResponse(readCall.callId, 'read_file', 'file contents'),
+    );
+    historyService.add(makeUserMessage('established user turn'));
+
+    const baseline = historyService.getCuratedForProvider();
+    const pending = makeUserMessage('new pending request after normalization');
+    const contents = buildUnsafeExtractionContents(baseline, pending);
+
+    const harness = buildEnforcerHarness(historyService, runtimeContext);
+    const estimateSpy = vi
+      .spyOn(historyService, 'estimateTokensForContents')
+      .mockResolvedValue(OVERFLOW_TOKENS);
+
+    harness.deps.performCompression.mockImplementation(async () => {
+      historyService.clear();
+      historyService.add(makeUserMessage('compressed summary'));
+      estimateSpy.mockResolvedValue(1_000);
+      return PerformCompressionResult.COMPRESSED;
+    });
+
+    const result = await harness.enforcer.enforce(contents, 'test-prompt');
+
+    // After enforcement, the pending content must survive the
+    // normalization-shift fallback path and remain the last entry.
+    expect(result.at(-1)).toStrictEqual(pending);
+  });
+});

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -149,10 +149,10 @@ export class ProviderContentEnforcer {
     contents: IContent[],
     promptId: string,
   ): Promise<IContent[]> {
-    const extraction = this.extractPendingContents(contents);
-    if (!extraction.safeToRecompose) {
+    if (contents.length === 0) {
       return contents;
     }
+    const extraction = this.extractPendingContents(contents);
     return this.runCompressionAndRecompose(
       promptId,
       extraction.pendingContents,
@@ -171,12 +171,7 @@ export class ProviderContentEnforcer {
     if (initialProjected <= limits.marginAdjustedLimit) {
       return contents;
     }
-    this.throwUnsafeExtractionOverflow(
-      limits.limit,
-      initialProjected,
-      limits.marginAdjustedLimit,
-      limits.completionBudget,
-    );
+    return undefined;
   }
 
   private async returnSafeContents(
@@ -252,9 +247,16 @@ export class ProviderContentEnforcer {
 
     this.deps.logger.warn(
       () =>
-        '[CompressionHandler] Could not extract pending contents via prefix match or recomposition; preserving provider contents unchanged',
+        '[CompressionHandler] Could not extract pending contents via prefix match or recomposition; falling back to curated-length delta heuristic',
     );
-    return { pendingContents: [], safeToRecompose: false };
+    const targetStart = Math.min(
+      this.deps.historyService.getCuratedForProvider().length,
+      contents.length,
+    );
+    return {
+      pendingContents: contents.slice(targetStart),
+      safeToRecompose: false,
+    };
   }
 
   private extractPendingContentsByRecomposition(
@@ -288,21 +290,6 @@ export class ProviderContentEnforcer {
       prefix = index + 1;
     }
     return prefix;
-  }
-
-  private throwUnsafeExtractionOverflow(
-    limit: number,
-    projected: number,
-    marginAdjustedLimit: number,
-    completionBudget: number,
-  ): never {
-    throw this.buildContextOverflowError(
-      limit,
-      projected,
-      projected,
-      marginAdjustedLimit,
-      completionBudget,
-    );
   }
 
   private contentsEqual(left: IContent[], right: IContent[]): boolean {


### PR DESCRIPTION
## Summary

When the context window overflows during a turn, `ProviderContentEnforcer.enforce()` threw without ever trying compression — even though manual `/compress` immediately afterward would succeed on the same history. The user saw `Density optimization and compression reduced 0 tokens` and a hard failure.

This PR fixes the short-circuit bug so the full density → compression → truncation pipeline runs even when pending-content extraction fails.

## Root Cause

In `providerContentEnforcement.ts`, when `extractPendingContents()` could not cleanly separate the new tool result from existing history (`safeToRecompose: false`):

1. `returnUnsafeExtractionContentsIfSafe()` called `throwUnsafeExtractionOverflow()` which threw immediately — compression was never attempted
2. `throwUnsafeExtractionOverflow()` passed the same value as both initial and final projection, so `totalReduction = 0` → "reduced 0 tokens"
3. `extractPendingContents()` returned `pendingContents: []`, which would lose the new tool result during recomposition
4. `compressAndRecompose()` (provider callback path) early-returned when `!safeToRecompose`, silently skipping compression

## Changes

### Production code (`providerContentEnforcement.ts`)

- **`returnUnsafeExtractionContentsIfSafe()`**: When `safeToRecompose: false` and payload exceeds limit, now returns `undefined` (fall through to the full pipeline) instead of calling `throwUnsafeExtractionOverflow()`
- **`throwUnsafeExtractionOverflow()`**: Removed entirely (no callers remain)
- **`extractPendingContents()` fallback**: Returns the curated-length delta slice using provider-normalized coordinates (`getCuratedForProvider().length`) instead of empty array — preserves the new tool result
- **`compressAndRecompose()`**: Removed the `!safeToRecompose` early-return gate; now only early-returns for empty input. The provider callback path now compresses regardless of extraction safety
- Updated warning log message to reflect the new heuristic fallback behavior

### Tests (`compression-unsafe-extraction.test.ts`)

6 new behavioral tests following `dev-docs/RULES.md` (no mock theater):
1. `enforce()` succeeds (does not throw "reduced 0 tokens") when extraction is unsafe and compression resolves the overflow
2. Pending content is preserved in returned contents when extraction is unsafe
3. Error reports non-zero token reduction when compression succeeds but payload still exceeds limit (directly tests the "reduced 0 tokens" regression)
4. Fallback truncation applies via callback and reports non-zero reduction when payload still exceeds limit
5. `compressAndRecompose()` returns recomposed contents reflecting compressed history, not unchanged payload
6. Pending content preserved after normalization-shift edge case (tool-call/tool-response structure that `buildProviderContent` normalizes into a different-length prefix)

Closes #2299