### PR TITLE
Add claude-fable-5 to the Anthropic OAuth (Claude Code) model list (Fixes #2328)

### DIFF
--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -95,6 +95,21 @@ describe('tokenLimit', () => {
       expect(tokenLimit('claude-sonnet-5-20260630')).toBe(200_000);
     });
 
+    // Claude Fable 5 defaults to the Claude Code / subscription 200K context
+    // window. The advertised 1M window is API-only and plan-gated; override
+    // via /set or a profile (context-limit).
+    it('should return 200K (auth default) limit for claude-fable-5', () => {
+      expect(tokenLimit('claude-fable-5')).toBe(200_000);
+    });
+
+    it('should return 200K limit for the claude-fable-5-latest alias', () => {
+      expect(tokenLimit('claude-fable-5-latest')).toBe(200_000);
+    });
+
+    it('should return 200K limit for a claude-fable-5 dated snapshot', () => {
+      expect(tokenLimit('claude-fable-5-20260701')).toBe(200_000);
+    });
+
     it('honors a user-supplied context limit override (e.g. /set or profile)', () => {
       expect(tokenLimit('claude-opus-4-8', 1_000_000)).toBe(1_000_000);
     });

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -56,6 +56,11 @@ const EXACT_LIMITS: Record<string, TokenCount> = {
   // /set or a profile (context-limit).
   'claude-sonnet-5': 200_000,
   'claude-sonnet-5-latest': 200_000,
+  // Claude Fable 5 defaults to the Claude Code / subscription 200K context
+  // window. The advertised 1M window is API-only and plan-gated; override via
+  // /set or a profile (context-limit). Mirrors getContextWindowForModel.
+  'claude-fable-5': 200_000,
+  'claude-fable-5-latest': 200_000,
   'claude-3-7-opus-20250115': 300_000,
   'claude-3-7-sonnet-20250115': 300_000,
   'claude-3-opus-20240229': 200_000,
@@ -137,6 +142,12 @@ export function tokenLimit(
   // subscription-safe 200K default as the bare alias and -latest. Mirrors
   // getContextWindowForModel in the anthropic package.
   if (modelWithoutPrefix.toLowerCase().includes('claude-sonnet-5')) {
+    return 200_000;
+  }
+
+  // Claude Fable 5 dated snapshot variants (e.g. claude-fable-5-YYYYMMDD)
+  // resolve to the same subscription-safe 200K default.
+  if (modelWithoutPrefix.toLowerCase().includes('claude-fable-5')) {
     return 200_000;
   }
 

--- a/packages/providers/src/anthropic/AnthropicModelData.test.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_MODELS,
   isOpus46Plus,
   isSonnet5,
+  isFable5,
   supportsAdaptiveThinking,
   getLatestClaudeModel,
   getMaxTokensForModel,
@@ -182,6 +183,83 @@ describe('AnthropicModelData Claude Sonnet 5 @issue:2289', () => {
 
     it('returns the Opus latest alias for the opus tier', () => {
       expect(getLatestClaudeModel('opus')).toBe('claude-opus-4-latest');
+    });
+  });
+});
+
+describe('AnthropicModelData Claude Fable 5 @issue:2328', () => {
+  describe('catalog entries', () => {
+    // Context window reflects the Claude Code / subscription (auth) 200K
+    // default; the advertised 1M window is API-only/plan-gated. Max output
+    // defaults to 40K (a 128K cap is not realistic at a 200K context window).
+    it('includes claude-fable-5 with 200K context / 40K output in OAUTH_MODELS', () => {
+      const model = OAUTH_MODELS.find((m) => m.id === 'claude-fable-5');
+      expect(model).toBeDefined();
+      expect(model?.name).toBe('Claude Fable 5');
+      expect(model?.contextWindow).toBe(200000);
+      expect(model?.maxOutputTokens).toBe(40000);
+    });
+
+    it('places claude-fable-5 at the top of OAUTH_MODELS', () => {
+      expect(OAUTH_MODELS[0].id).toBe('claude-fable-5');
+    });
+
+    it('does NOT include claude-fable-5 in DEFAULT_MODELS (OAuth-only)', () => {
+      expect(DEFAULT_MODELS.some((m) => m.id === 'claude-fable-5')).toBe(false);
+    });
+  });
+
+  describe('isFable5', () => {
+    it('returns true for claude-fable-5 and dated snapshot variants', () => {
+      expect(isFable5('claude-fable-5')).toBe(true);
+      expect(isFable5('claude-fable-5-20260701')).toBe(true);
+      expect(isFable5('claude-fable-5-latest')).toBe(true);
+    });
+
+    it('returns false for opus, sonnet, and non-claude models', () => {
+      expect(isFable5('claude-opus-4-8')).toBe(false);
+      expect(isFable5('claude-sonnet-5')).toBe(false);
+      expect(isFable5('gpt-5.5')).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isFable5('Claude-Fable-5')).toBe(true);
+    });
+  });
+
+  describe('supportsAdaptiveThinking', () => {
+    it('returns true for claude-fable-5 and dated variants', () => {
+      expect(supportsAdaptiveThinking('claude-fable-5')).toBe(true);
+      expect(supportsAdaptiveThinking('claude-fable-5-20260701')).toBe(true);
+    });
+
+    it('returns false for models without adaptive thinking', () => {
+      expect(supportsAdaptiveThinking('claude-opus-4-5')).toBe(false);
+      expect(supportsAdaptiveThinking('claude-haiku-4-5')).toBe(false);
+    });
+  });
+
+  describe('getMaxTokensForModel', () => {
+    it('returns 40000 for claude-fable-5, the -latest alias, and dated variants', () => {
+      expect(getMaxTokensForModel('claude-fable-5')).toBe(40000);
+      expect(getMaxTokensForModel('claude-fable-5-latest')).toBe(40000);
+      expect(getMaxTokensForModel('claude-fable-5-20260701')).toBe(40000);
+    });
+
+    it('is case-insensitive (routes through isFable5)', () => {
+      expect(getMaxTokensForModel('Claude-Fable-5')).toBe(40000);
+    });
+  });
+
+  describe('getContextWindowForModel', () => {
+    it('returns 200000 (auth default) for claude-fable-5, the -latest alias, and dated variants', () => {
+      expect(getContextWindowForModel('claude-fable-5')).toBe(200000);
+      expect(getContextWindowForModel('claude-fable-5-latest')).toBe(200000);
+      expect(getContextWindowForModel('claude-fable-5-20260701')).toBe(200000);
+    });
+
+    it('is case-insensitive (routes through isFable5)', () => {
+      expect(getContextWindowForModel('Claude-Fable-5')).toBe(200000);
     });
   });
 });

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -62,6 +62,17 @@ function stripTrailingDateSegment(modelId: string): string {
  */
 export const OAUTH_MODELS: Array<Omit<IModel, 'provider'>> = [
   {
+    id: 'claude-fable-5',
+    name: 'Claude Fable 5',
+    supportedToolFormats: ['anthropic'],
+    // Claude Code / subscription (auth) 200K context window; the advertised
+    // 1M window is API-only and plan-gated (raise via /set or a profile
+    // context-limit). Output defaults to 40K — a 128K cap is not realistic at
+    // a 200K context window (raise via /set or a profile maxOutputTokens).
+    contextWindow: 200000,
+    maxOutputTokens: 40000,
+  },
+  {
     id: 'claude-opus-4-8',
     name: 'Claude Opus 4.8',
     supportedToolFormats: ['anthropic'],
@@ -284,11 +295,20 @@ export function isSonnet5(modelId: string): boolean {
 }
 
 /**
+ * Whether the model is Claude Fable 5 (adaptive thinking is always on and
+ * cannot be disabled; control depth via the `effort` parameter). Matches the
+ * bare alias and dated snapshot variants (e.g. claude-fable-5-YYYYMMDD).
+ */
+export function isFable5(modelId: string): boolean {
+  return modelId.toLowerCase().includes('claude-fable-5');
+}
+
+/**
  * Whether the model supports adaptive thinking (the Anthropic `effort`
- * parameter). Currently Opus 4.6+ and Sonnet 5.
+ * parameter). Currently Opus 4.6+, Sonnet 5, and Fable 5.
  */
 export function supportsAdaptiveThinking(modelId: string): boolean {
-  return isOpus46Plus(modelId) || isSonnet5(modelId);
+  return isOpus46Plus(modelId) || isSonnet5(modelId) || isFable5(modelId);
 }
 
 /**
@@ -311,6 +331,13 @@ export function getMaxTokensForModel(modelId: string): number {
   // alias and dated snapshot IDs like claude-sonnet-5-YYYYMMDD).
   if (isSonnet5(modelId)) {
     return 128000;
+  }
+  // Claude Fable 5 defaults to 40K max output on the Claude Code /
+  // subscription tier (a 128K cap is not realistic at a 200K context window;
+  // raise via /set or a profile). Fable IDs contain no opus/sonnet/haiku, so
+  // without this explicit branch they fall through to the 4096 default.
+  if (isFable5(modelId)) {
+    return 40000;
   }
 
   const normalizedModelId = stripTrailingDateSegment(modelId.toLowerCase());
@@ -348,6 +375,13 @@ export function getContextWindowForModel(modelId: string): number {
   // via /set or a profile (context-limit). Matches the -latest alias and
   // dated snapshots too.
   if (isSonnet5(modelId)) {
+    return 200000;
+  }
+  // Claude Fable 5 defaults to the Claude Code / subscription 200K context
+  // window. The advertised 1M window is API-only and plan-gated; raise it
+  // via /set or a profile (context-limit). Matches the -latest alias and
+  // dated snapshots too.
+  if (isFable5(modelId)) {
     return 200000;
   }
   if (modelId.includes('claude-sonnet-4')) {

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -295,12 +295,19 @@ export function isSonnet5(modelId: string): boolean {
 }
 
 /**
- * Whether the model is Claude Fable 5 (adaptive thinking is always on and
- * cannot be disabled; control depth via the `effort` parameter). Matches the
- * bare alias and dated snapshot variants (e.g. claude-fable-5-YYYYMMDD).
+ * Anchored Fable 5 identifier: matches the bare `claude-fable-5` alias, the
+ * `claude-fable-5-latest` pointer, and dated snapshots
+ * (`claude-fable-5-YYYYMMDD`), but NOT a future `claude-fable-50`. An anchored
+ * regex is used instead of a substring test so version boundaries are exact.
+ */
+const FABLE_5_PATTERN = /^claude-fable-5(-latest|-\d{8})?$/i;
+
+/**
+ * Whether the model is Claude Fable 5. Adaptive thinking is always on and
+ * cannot be disabled (control depth via the `effort` parameter).
  */
 export function isFable5(modelId: string): boolean {
-  return modelId.toLowerCase().includes('claude-fable-5');
+  return FABLE_5_PATTERN.test(modelId);
 }
 
 /**

--- a/packages/providers/src/anthropic/AnthropicProvider.fable5.thinking.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.fable5.thinking.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tests for AnthropicProvider extended thinking specific to Claude Fable 5
+ * (adaptive thinking is always on and cannot be disabled). Split from
+ * AnthropicProvider.thinking.config.test.ts for max-lines compliance.
+ * @issue #2328
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { AnthropicRequestBody } from './test-utils/anthropicTestUtils.js';
+import {
+  mockMessagesCreate,
+  setupThinkingProvider,
+  type ThinkingTestSetup,
+} from './test-utils/anthropicThinkingTestSetup.js';
+import { clearActiveProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+
+describe('AnthropicProvider Fable 5 Extended Thinking @issue:2328', () => {
+  let provider: ThinkingTestSetup['provider'];
+  let settingsService: ThinkingTestSetup['settingsService'];
+  let buildCallOptions: ThinkingTestSetup['buildCallOptions'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const setup = setupThinkingProvider();
+    provider = setup.provider;
+    settingsService = setup.settingsService;
+    buildCallOptions = setup.buildCallOptions;
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  // Shared harness: pin Fable 5, apply reasoning settings, run one turn, and
+  // return the captured request body. Collapses the per-test boilerplate.
+  async function generateFable5Request(
+    settings: Array<[string, unknown]>,
+  ): Promise<AnthropicRequestBody> {
+    for (const [key, value] of settings) {
+      settingsService.set(key, value);
+    }
+
+    mockMessagesCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'response' }],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+
+    const messages: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'Hello' }] },
+    ];
+
+    const generator = provider.generateChatCompletion(
+      buildCallOptions(messages, {
+        settingsOverrides: { global: { model: 'claude-fable-5' } },
+      }),
+    );
+    await generator.next();
+
+    return mockMessagesCreate.mock.calls[0][0] as AnthropicRequestBody;
+  }
+
+  it('should use adaptive thinking for Claude Fable 5 @issue:2328', async () => {
+    const request = await generateFable5Request([['reasoning.enabled', true]]);
+    // Fable 5 is adaptive-capable: adaptive thinking is always on.
+    expect(request.thinking).toBeDefined();
+    expect(request.thinking?.type).toBe('adaptive');
+    expect(request.thinking?.budget_tokens).toBeUndefined();
+    // Fable 5 defaults to 40K max output (not the API-only 128K ceiling).
+    expect(request.max_tokens).toBe(40000);
+  });
+
+  it('should keep adaptive thinking for Claude Fable 5 even when a reasoning budget is configured @issue:2328', async () => {
+    const request = await generateFable5Request([
+      ['reasoning.enabled', true],
+      ['reasoning.budgetTokens', 8000],
+    ]);
+    // Fable 5 is adaptive-only: a configured budget must not downgrade it to
+    // legacy budgeted 'enabled' thinking.
+    expect(request.thinking?.type).toBe('adaptive');
+    expect(request.thinking?.budget_tokens).toBeUndefined();
+  });
+
+  it('should keep adaptive thinking for Claude Fable 5 even when adaptiveThinking is disabled @issue:2328', async () => {
+    const request = await generateFable5Request([
+      ['reasoning.enabled', true],
+      ['reasoning.adaptiveThinking', false],
+    ]);
+    // Fable 5 cannot disable thinking; an adaptiveThinking:false override
+    // must still produce adaptive thinking.
+    expect(request.thinking?.type).toBe('adaptive');
+    expect(request.thinking?.budget_tokens).toBeUndefined();
+  });
+
+  it('should place effort in output_config for Claude Fable 5 @issue:2328', async () => {
+    const request = await generateFable5Request([
+      ['reasoning.enabled', true],
+      ['reasoning.effort', 'medium'],
+    ]);
+    expect(request.thinking).toBeDefined();
+    expect(request.thinking?.type).toBe('adaptive');
+    expect(request.output_config).toBeDefined();
+    expect(request.output_config?.effort).toBe('medium');
+  });
+
+  it('should omit the thinking field for Claude Fable 5 when reasoning is disabled @issue:2328', async () => {
+    const request = await generateFable5Request([['reasoning.enabled', false]]);
+    // Fable 5 cannot disable adaptive thinking. With reasoning disabled we
+    // omit the thinking field entirely (never send the unsupported 'disabled'
+    // type); the API then applies its adaptive default.
+    expect(request.thinking).toBeUndefined();
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicProvider.fable5.thinking.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.fable5.thinking.test.ts
@@ -70,6 +70,9 @@ describe('AnthropicProvider Fable 5 Extended Thinking @issue:2328', () => {
     expect(request.thinking).toBeDefined();
     expect(request.thinking?.type).toBe('adaptive');
     expect(request.thinking?.budget_tokens).toBeUndefined();
+    // Fable 5 never returns raw chain-of-thought; request 'summarized' so
+    // thinking blocks carry readable summaries instead of empty fields.
+    expect(request.thinking?.display).toBe('summarized');
     // Fable 5 defaults to 40K max output (not the API-only 128K ceiling).
     expect(request.max_tokens).toBe(40000);
   });
@@ -113,5 +116,14 @@ describe('AnthropicProvider Fable 5 Extended Thinking @issue:2328', () => {
     // omit the thinking field entirely (never send the unsupported 'disabled'
     // type); the API then applies its adaptive default.
     expect(request.thinking).toBeUndefined();
+  });
+
+  it('does not carry a zero-data-retention/privacy directive for Claude Fable 5 @issue:2328', async () => {
+    const request = await generateFable5Request([['reasoning.enabled', true]]);
+    // Fable 5 is a designated Covered Model: it requires 30-day data retention
+    // and is NOT available under zero-data-retention. A privacy/ZDR directive
+    // would be rejected by the API, so the request body must never include one.
+    expect(request).not.toHaveProperty('privacy');
+    expect(request).not.toHaveProperty('zero_data_retention');
   });
 });

--- a/packages/providers/src/anthropic/AnthropicProvider.getModels.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.getModels.test.ts
@@ -255,6 +255,46 @@ describe('AnthropicProvider', () => {
       expect(opus48?.maxOutputTokens).toBe(32000);
     });
 
+    it('should include Claude Fable 5 model in OAuth model list @issue:2328', async () => {
+      const oauthProvider = new AnthropicProvider(
+        'sk-ant-oat01-fable-test-token',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      vi.spyOn(oauthProvider, 'getAuthToken').mockResolvedValue(
+        'sk-ant-oat01-fable-test-token',
+      );
+
+      const models = await oauthProvider.getModels();
+      const modelIds = models.map((m) => m.id);
+
+      expect(modelIds).toContain('claude-fable-5');
+
+      const fable5 = models.find((m) => m.id === 'claude-fable-5');
+      expect(fable5).toBeDefined();
+      expect(fable5?.name).toBe('Claude Fable 5');
+      expect(fable5?.provider).toBe('anthropic');
+      expect(fable5?.supportedToolFormats).toContain('anthropic');
+      expect(fable5?.contextWindow).toBe(200000);
+      expect(fable5?.maxOutputTokens).toBe(40000);
+    });
+
+    it('should NOT include Claude Fable 5 in default list when auth is unavailable @issue:2328', async () => {
+      const noAuthProvider = new AnthropicProvider(
+        undefined,
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      vi.spyOn(noAuthProvider, 'getAuthToken').mockResolvedValue(undefined);
+
+      const models = await noAuthProvider.getModels();
+      const modelIds = models.map((m) => m.id);
+
+      expect(modelIds).not.toContain('claude-fable-5');
+    });
+
     it('should include Claude Opus 4.6 model in default list when auth is unavailable', async () => {
       const noAuthProvider = new AnthropicProvider(
         undefined,

--- a/packages/providers/src/anthropic/AnthropicProvider.getModels.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.getModels.test.ts
@@ -280,6 +280,37 @@ describe('AnthropicProvider', () => {
       expect(fable5?.maxOutputTokens).toBe(40000);
     });
 
+    it('returns OAUTH_MODELS (incl. Fable 5) for an OAuth-enabled provider without resolving a live token @issue:2328', async () => {
+      // Mirrors the real OAuth-only runtime: OAuth is the configured auth and
+      // getAuthToken() resolves with includeOAuth: false -> '' (no API key).
+      // The static OAuth list must be returned without a live token, otherwise
+      // OAuth accounts fall through to DEFAULT_MODELS and Fable is hidden.
+      const oauthManager = {
+        isOAuthEnabled: (provider: string) => provider === 'anthropic',
+      } as unknown as ConstructorParameters<typeof AnthropicProvider>[3];
+      const oauthProvider = new AnthropicProvider(
+        undefined,
+        undefined,
+        TEST_PROVIDER_CONFIG,
+        oauthManager,
+      );
+
+      // No OAuth token resolves at model-list time for OAuth-only accounts.
+      const getAuthTokenSpy = vi.spyOn(oauthProvider, 'getAuthToken');
+      getAuthTokenSpy.mockResolvedValue('');
+
+      const models = await oauthProvider.getModels();
+      const modelIds = models.map((m) => m.id);
+
+      // Fable surfaces without resolving a token.
+      expect(modelIds).toContain('claude-fable-5');
+      // The curated OAuth list is returned, not DEFAULT_MODELS: the bare alias
+      // claude-opus-4-5 exists only in OAUTH_MODELS.
+      expect(modelIds).toContain('claude-opus-4-5');
+      // No live token was resolved (no unwanted OAuth refresh at list time).
+      expect(getAuthTokenSpy).not.toHaveBeenCalled();
+    });
+
     it('should NOT include Claude Fable 5 in default list when auth is unavailable @issue:2328', async () => {
       const noAuthProvider = new AnthropicProvider(
         undefined,

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -229,6 +229,21 @@ export class AnthropicProvider extends BaseProvider {
   }
 
   override async getModels(): Promise<IModel[]> {
+    // The OAuth model list is static, so return it directly when OAuth is the
+    // configured auth for this provider. We deliberately do NOT resolve a live
+    // token here: model listing is a config-time operation and OAuth token
+    // refresh is reserved for prompt sends (BaseProvider.getAuthToken resolves
+    // with includeOAuth: false, yielding '' for OAuth-only accounts). Resolving
+    // a token merely to pick a static list would either trigger an unwanted
+    // refresh or — for OAuth-only accounts with no API key — fall through to
+    // getDefaultModels() (DEFAULT_MODELS), hiding the curated OAuth list.
+    if (this.isOAuthEnabled()) {
+      this.getAuthLogger().debug(
+        () => 'Using hardcoded model list for OAuth authentication',
+      );
+      return OAUTH_MODELS.map((m) => ({ ...m, provider: this.name }));
+    }
+
     const authToken = await this.getAuthToken();
     if (!authToken) {
       this.getAuthLogger().debug(
@@ -239,7 +254,9 @@ export class AnthropicProvider extends BaseProvider {
       return this.getDefaultModels();
     }
 
-    // Check if using OAuth - the models.list endpoint doesn't work with OAuth tokens
+    // API-key path: the models.list endpoint does not work with OAuth tokens.
+    // classifyOAuthToken is kept as a defensive fallback for the rare case
+    // where an OAuth token is resolved despite isOAuthEnabled() being false.
     const isOAuthToken = this.classifyOAuthToken(authToken);
 
     if (isOAuthToken) {

--- a/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
@@ -216,6 +216,28 @@ export function attachPromptCaching(
   }
 }
 
+type AnthropicThinkingConfig = {
+  thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
+  output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
+};
+
+/**
+ * Build the adaptive-thinking config shared by Fable 5 and other
+ * adaptive-capable models. Centralizes the `{ type: 'adaptive' }` literal and
+ * the `effort` mapping so future thinking-field changes have one source.
+ */
+function buildAdaptiveConfig(
+  thinkingEffort?: 'low' | 'medium' | 'high' | 'max',
+): AnthropicThinkingConfig {
+  const config: AnthropicThinkingConfig = {
+    thinking: { type: 'adaptive' as const },
+  };
+  if (thinkingEffort) {
+    config.output_config = { effort: thinkingEffort };
+  }
+  return config;
+}
+
 /**
  * Build thinking configuration for Anthropic API
  * @issue #1307: Correct adaptive thinking support for Opus 4.6
@@ -228,10 +250,7 @@ export function buildThinkingConfig(options: {
   adaptiveThinking?: boolean;
   thinkingEffort?: 'low' | 'medium' | 'high' | 'max';
   model: string;
-}): {
-  thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
-  output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
-} {
+}): AnthropicThinkingConfig {
   if (!options.reasoningEnabled) {
     return {};
   }
@@ -241,18 +260,7 @@ export function buildThinkingConfig(options: {
   // Depth is controlled exclusively via `effort`, so ignore any
   // reasoningBudgetTokens / adaptiveThinking override for Fable 5.
   if (isFable5(options.model)) {
-    const config: {
-      thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
-      output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
-    } = {
-      thinking: { type: 'adaptive' as const },
-    };
-
-    if (options.thinkingEffort) {
-      config.output_config = { effort: options.thinkingEffort };
-    }
-
-    return config;
+    return buildAdaptiveConfig(options.thinkingEffort);
   }
 
   const adaptiveCapable = supportsAdaptiveThinking(options.model);
@@ -262,24 +270,10 @@ export function buildThinkingConfig(options: {
     options.reasoningBudgetTokens == null &&
     options.adaptiveThinking !== false
   ) {
-    const config: {
-      thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
-      output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
-    } = {
-      thinking: { type: 'adaptive' as const },
-    };
-
-    if (options.thinkingEffort) {
-      config.output_config = { effort: options.thinkingEffort };
-    }
-
-    return config;
+    return buildAdaptiveConfig(options.thinkingEffort);
   }
 
-  const config: {
-    thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
-    output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
-  } = {
+  const config: AnthropicThinkingConfig = {
     thinking: {
       type: 'enabled' as const,
       budget_tokens: options.reasoningBudgetTokens ?? 10000,

--- a/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
@@ -217,7 +217,11 @@ export function attachPromptCaching(
 }
 
 type AnthropicThinkingConfig = {
-  thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
+  thinking?: {
+    type: 'adaptive' | 'enabled';
+    budget_tokens?: number;
+    display?: 'summarized' | 'omitted';
+  };
   output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
 };
 
@@ -225,13 +229,21 @@ type AnthropicThinkingConfig = {
  * Build the adaptive-thinking config shared by Fable 5 and other
  * adaptive-capable models. Centralizes the `{ type: 'adaptive' }` literal and
  * the `effort` mapping so future thinking-field changes have one source.
+ *
+ * `display` is only relevant to Fable 5, which never returns raw
+ * chain-of-thought; other adaptive models pass nothing and keep API defaults.
  */
 function buildAdaptiveConfig(
   thinkingEffort?: 'low' | 'medium' | 'high' | 'max',
+  display?: 'summarized' | 'omitted',
 ): AnthropicThinkingConfig {
-  const config: AnthropicThinkingConfig = {
-    thinking: { type: 'adaptive' as const },
+  const thinking: NonNullable<AnthropicThinkingConfig['thinking']> = {
+    type: 'adaptive' as const,
   };
+  if (display) {
+    thinking.display = display;
+  }
+  const config: AnthropicThinkingConfig = { thinking };
   if (thinkingEffort) {
     config.output_config = { effort: thinkingEffort };
   }
@@ -258,9 +270,11 @@ export function buildThinkingConfig(options: {
   // Claude Fable 5: adaptive thinking is the only mode and is always on — it
   // cannot be disabled or switched to legacy budgeted 'enabled' thinking.
   // Depth is controlled exclusively via `effort`, so ignore any
-  // reasoningBudgetTokens / adaptiveThinking override for Fable 5.
+  // reasoningBudgetTokens / adaptiveThinking override for Fable 5. Fable 5
+  // never returns raw thinking, so request `display: 'summarized'` to get
+  // readable summaries instead of empty thinking blocks.
   if (isFable5(options.model)) {
-    return buildAdaptiveConfig(options.thinkingEffort);
+    return buildAdaptiveConfig(options.thinkingEffort, 'summarized');
   }
 
   const adaptiveCapable = supportsAdaptiveThinking(options.model);
@@ -316,7 +330,11 @@ export function buildAnthropicRequestBody(options: {
   maxTokens: number;
   streamingEnabled: boolean;
   modelParams: Record<string, unknown>;
-  thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
+  thinking?: {
+    type: 'adaptive' | 'enabled';
+    budget_tokens?: number;
+    display?: 'summarized' | 'omitted';
+  };
   outputConfig?: { effort: 'low' | 'medium' | 'high' | 'max' };
 }): Record<string, unknown> {
   const requestBody: Record<string, unknown> = {

--- a/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestBuilder.ts
@@ -15,7 +15,7 @@ import type {
   AnthropicMessage,
   AnthropicMessageBlock,
 } from './AnthropicMessageNormalizer.js';
-import { supportsAdaptiveThinking } from './AnthropicModelData.js';
+import { isFable5, supportsAdaptiveThinking } from './AnthropicModelData.js';
 
 /**
  * A content block with cache_control attached.
@@ -220,6 +220,7 @@ export function attachPromptCaching(
  * Build thinking configuration for Anthropic API
  * @issue #1307: Correct adaptive thinking support for Opus 4.6
  * @issue #2289: Extended to Sonnet 5 (also supports adaptive thinking)
+ * @issue #2328: Fable 5 is adaptive-only (never budgeted 'enabled' or 'disabled')
  */
 export function buildThinkingConfig(options: {
   reasoningEnabled: boolean;
@@ -233,6 +234,25 @@ export function buildThinkingConfig(options: {
 } {
   if (!options.reasoningEnabled) {
     return {};
+  }
+
+  // Claude Fable 5: adaptive thinking is the only mode and is always on — it
+  // cannot be disabled or switched to legacy budgeted 'enabled' thinking.
+  // Depth is controlled exclusively via `effort`, so ignore any
+  // reasoningBudgetTokens / adaptiveThinking override for Fable 5.
+  if (isFable5(options.model)) {
+    const config: {
+      thinking?: { type: 'adaptive' | 'enabled'; budget_tokens?: number };
+      output_config?: { effort: 'low' | 'medium' | 'high' | 'max' };
+    } = {
+      thinking: { type: 'adaptive' as const },
+    };
+
+    if (options.thinkingEffort) {
+      config.output_config = { effort: options.thinkingEffort };
+    }
+
+    return config;
   }
 
   const adaptiveCapable = supportsAdaptiveThinking(options.model);

--- a/packages/providers/src/anthropic/AnthropicResponseParser.issue1844.test.ts
+++ b/packages/providers/src/anthropic/AnthropicResponseParser.issue1844.test.ts
@@ -114,4 +114,23 @@ describe('issue #1844 – Anthropic non-streaming stopReason propagation', () =>
     expect(result.metadata!.usage!.completionTokens).toBe(5);
     expect(result.metadata!.stopReason).toBe('end_turn');
   });
+
+  // Fable 5 returns refusals as successful HTTP 200 with stop_reason:
+  // 'refusal' (not an error). The parser must propagate the value without
+  // throwing so callers can surface a user-visible notice.
+  it('should propagate stopReason "refusal" without throwing @issue:2328', () => {
+    const message = createMockMessage('refusal');
+    const options = {
+      isOAuth: false,
+      tools: undefined,
+      unprefixToolName: (name: string) => name,
+      findToolSchema: () => undefined,
+      cacheLogger: { debug: () => {} },
+    };
+
+    const result = parseAnthropicResponse(message, options);
+
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.stopReason).toBe('refusal');
+  });
 });

--- a/packages/providers/src/anthropic/AnthropicResponseParser.issue1844.test.ts
+++ b/packages/providers/src/anthropic/AnthropicResponseParser.issue1844.test.ts
@@ -115,10 +115,12 @@ describe('issue #1844 – Anthropic non-streaming stopReason propagation', () =>
     expect(result.metadata!.stopReason).toBe('end_turn');
   });
 
-  // Fable 5 returns refusals as successful HTTP 200 with stop_reason:
-  // 'refusal' (not an error). The parser must propagate the value without
-  // throwing so callers can surface a user-visible notice.
-  it('should propagate stopReason "refusal" without throwing @issue:2328', () => {
+  // Fable 5 returns refusals as a successful HTTP 200 with stop_reason:
+  // 'refusal' (not an error). This only verifies the parser propagates the
+  // value into metadata.stopReason without throwing — it does NOT verify any
+  // user-visible refusal notice. Surfacing a notice (and optional fallback) is
+  // tracked separately in #2329.
+  it('should propagate stopReason "refusal" without throwing @issue:2329', () => {
     const message = createMockMessage('refusal');
     const options = {
       isOAuth: false,

--- a/packages/providers/src/composition/aliases/anthropic.config
+++ b/packages/providers/src/composition/aliases/anthropic.config
@@ -11,7 +11,7 @@
   },
   "modelDefaults": [
     {
-      "pattern": "claude-(opus|sonnet|haiku)",
+      "pattern": "claude-(opus|sonnet|haiku|fable)",
       "ephemeralSettings": {
         "reasoning.enabled": true,
         "reasoning.adaptiveThinking": true,
@@ -20,6 +20,13 @@
     },
     {
       "pattern": "claude-opus-4-8",
+      "ephemeralSettings": {
+        "reasoning.effort": "high",
+        "context-limit": 200000
+      }
+    },
+    {
+      "pattern": "claude-fable-5",
       "ephemeralSettings": {
         "reasoning.effort": "high",
         "context-limit": 200000

--- a/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
+++ b/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
@@ -572,6 +572,35 @@ describe('anthropic.config modelDefaults (Phase 02)', () => {
     expect(defaults['context-limit']).toBe(200000);
   });
 
+  // Claude Fable 5: the broad Claude pattern includes `fable` and a
+  // fable-specific rule sets effort + context-limit. Guards the config-regex
+  // gap where fable previously matched no rule.
+  it('claude-fable-5 matches the broad Claude rule (reasoning defaults) @issue:2328', () => {
+    const entry = getAnthropicEntry();
+    const defaults = computeMatchedDefaults(
+      'claude-fable-5',
+      entry.config.modelDefaults!,
+    );
+    expect(defaults['reasoning.enabled']).toBe(true);
+    expect(defaults['reasoning.adaptiveThinking']).toBe(true);
+    expect(defaults['reasoning.includeInContext']).toBe(true);
+  });
+
+  it('rules merge in order — claude-fable-5 gets broad + fable-specific settings @issue:2328', () => {
+    const entry = getAnthropicEntry();
+    const defaults = computeMatchedDefaults(
+      'claude-fable-5',
+      entry.config.modelDefaults!,
+    );
+    // From the broad "claude-(opus|sonnet|haiku|fable)" rule
+    expect(defaults['reasoning.enabled']).toBe(true);
+    expect(defaults['reasoning.adaptiveThinking']).toBe(true);
+    expect(defaults['reasoning.includeInContext']).toBe(true);
+    // From the specific "claude-fable-5" rule (merged on top)
+    expect(defaults['reasoning.effort']).toBe('high');
+    expect(defaults['context-limit']).toBe(200000);
+  });
+
   it('user anthropic.config with different modelDefaults shadows the builtin', async () => {
     const { Storage } = await import('@vybestack/llxprt-code-settings');
     const fakeLlxprtDir = path.join(tmpDir, '.llxprt');


### PR DESCRIPTION
## Summary

Adds `claude-fable-5` to the Anthropic **OAuth (Claude Code / subscription) model list** (`OAUTH_MODELS`) with correct subscription-tier settings, wires it end-to-end through the reasoning defaults, token-limit math, and adaptive-thinking routing so the runtime behavior — not just the catalog metadata — is correct. Closes #2328.

Claude Fable 5 was suspended globally on 2026-06-12 under a US export-control directive and **re-deployed on 2026-07-01** across Claude Platform, Claude.ai, Claude Code, and Claude Cowork. This makes it selectable again for users authenticating with a Claude Code / Max / Pro OAuth token (`sk-ant-oat01-*`).

## What changed

**Catalog + capabilities** (`packages/providers/src/anthropic/AnthropicModelData.ts`):

- New `OAUTH_MODELS` entry for `claude-fable-5` (200K context / 40K max output — see Rationale).
- `isFable5(modelId)` predicate, anchored to `/^claude-fable-5(-latest|-\d{8})?$/i` so it matches the bare alias, `-latest`, and dated snapshots (`claude-fable-5-YYYYMMDD`) but **not** a future `claude-fable-50`.
- `supportsAdaptiveThinking()`, `getMaxTokensForModel()` (→ `40000`), and `getContextWindowForModel()` (→ `200000`) all recognize Fable 5.

**OAuth model listing** (`AnthropicProvider.ts`):

- `getModels()` now returns the static `OAUTH_MODELS` list directly when `isOAuthEnabled()`, **without resolving a live token**. Model listing is a config-time operation; `BaseProvider.getAuthToken` resolves with `includeOAuth: false` and yields `''` for OAuth-only accounts. Without this, an OAuth-only account (no API key) falls through to `DEFAULT_MODELS` and Fable 5 (plus the rest of the curated OAuth list) is hidden from the menu.

**Reasoning defaults** (`composition/aliases/anthropic.config`):

- Broadened the base Claude reasoning rule from `claude-(opus|sonnet|haiku)` to include `fable`, and added a fable-specific rule (`effort: high`, `context-limit: 200000`). Without this, Fable matched **no** rule and got no adaptive-thinking defaults unless the user manually set `reasoning.enabled` — so adaptive thinking was silently off at runtime.

**Token-limit math** (`packages/core/src/core/tokenLimits.ts`):

- Added exact `200_000` entries for `claude-fable-5` / `claude-fable-5-latest` plus a dated-snapshot fallback, mirroring `getContextWindowForModel`. Previously Fable fell through to the ~1M `DEFAULT_TOKEN_LIMIT`, inflating context math and under-triggering compression ~5×.

**Adaptive-thinking routing** (`AnthropicRequestBuilder.ts`):

- `buildThinkingConfig()` special-cases Fable 5: it **always** returns `{ type: 'adaptive' }` (+ `effort` via `output_config`), ignoring `reasoningBudgetTokens` and `adaptiveThinking: false` overrides, so it never emits the unsupported `{ type: 'disabled' }` config. When reasoning is disabled entirely, the thinking field is omitted so the API applies its adaptive default.
- Requests `display: 'summarized'` for Fable 5 (type widened with an optional `display` field, threaded through the shared `buildAdaptiveConfig` helper). Fable 5 never returns raw chain-of-thought, so without this the thinking blocks come back empty; `summarized` yields readable summaries. Only Fable passes a `display`; other adaptive models keep API defaults.

## Tests

- OAuth model-list membership (positive for OAuth token, negative for API key / `DEFAULT_MODELS`), plus a new test that the OAuth list (incl. Fable 5) is returned for an OAuth-enabled provider **without** resolving a live token.
- `isFable5` + helper coverage (alias / case-insensitive / dated variants / negatives).
- Reasoning defaults for `claude-fable-5` asserted from the merged config **without** pre-forcing `reasoning.enabled` (guards the config-regex gap that previously produced a false green).
- `tokenLimit('claude-fable-5' / '-latest' / dated)` === 200K.
- Adaptive-thinking routing including budget-override, adaptive-disabled, and reasoning-disabled paths; `thinking.display === 'summarized'`; `max_tokens === 40000`.
- ZDR/privacy guard: Fable 5 is a Covered Model, so the request body must carry no `privacy` / `zero_data_retention` directive.
- Refusal `stop_reason` propagation without throwing (parser layer; tagged `@issue:2329`).

Fable-5 thinking tests live in a dedicated file (`AnthropicProvider.fable5.thinking.test.ts`), split from `AnthropicProvider.thinking.config.test.ts` for `max-lines` compliance.

## Settings rationale (subscription / OAuth tier)

- **`id: 'claude-fable-5'`** — dateless, pinned snapshot ID (same as API / Claude Code).
- **`contextWindow: 200000`** — the docs advertise 1M, but 1M is API-only and plan-gated. Matches the existing convention in this file for the subscription tier (Sonnet 5 and Opus 4.6/4.7/4.8 all default to 200K here; raisable via `/set` or a profile `context-limit`).
- **`maxOutputTokens: 40000`** — the API ceiling is 128K, but per maintainer decision a 128K cap is not realistic at a 200K context window on the subscription tier. 40K is the default and is overridable.

## Why OAuth-only

The OAuth path returns a hardcoded model list because Anthropic's `models.list` endpoint does not work with OAuth tokens. We spoof the Claude Code client there (system prompt, `llxprt_` tool-name prefixing, `oauth-2025-04-20` beta header). This PR scopes the addition to `OAUTH_MODELS`; the API-key path (`DEFAULT_MODELS` / `models.list`) can be a follow-up.

## Deferred (tracked separately)

- **#2329 — user-visible refusal surfacing.** Fable 5 returns safety-classifier refusals as HTTP 200 with `stop_reason: 'refusal'`. This PR locks the safety behavior (the refusal stop reason propagates as `metadata.stopReason === 'refusal'` without crashing), but the user-visible refusal notice (and optional client-side fallback to Opus 4.8) is a cross-layer change (agents `MessageConverter` + UI) tracked in #2329.
- **#2335 — cross-model thinking-signature 400.** Switching Claude models mid-session (e.g. opus → fable → opus) triggers `400 Invalid signature in thinking block`. This is pre-existing on `main` (not caused by this PR) but surfaces more often now that Fable 5 is selectable; the fix (drop cross-model thinking blocks) is tracked in #2335.

## Verification

- Providers test suite: 3552 passed | 18 skipped | 0 failed.
- `core` tokenLimits tests: 38 passed.
- `tsc --noEmit`: clean across all packages.
- `eslint` on all changed files + `lint:eslint-guard` + `prettier`: clean (no lint-guardrail loosening).
- `npm run build`: clean.
- Smoke: `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"`: OK.

## Sources

- Anthropic — Redeploying Claude Fable 5: https://www.anthropic.com/news/redeploying-fable-5
- Anthropic Docs — Introducing Claude Fable 5 and Claude Mythos 5: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
