### PR TITLE
fix(compression): stop masked empty-summary errors from aborting turns (Fixes #2333)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -21,7 +21,7 @@ import type {
 } from '@vybestack/llxprt-code-core/core/compression/types.js';
 import {
   shouldRetryCompressionError,
-  isTransientCompressionError,
+  isFallbackEligibleCompressionError,
 } from '@vybestack/llxprt-code-core/core/compression/types.js';
 import {
   getCompressionStrategy,
@@ -765,13 +765,15 @@ export class CompressionHandler {
       primaryError = err;
     }
 
-    // Permanent errors are rethrown immediately — no fallback
-    if (!isTransientCompressionError(primaryError)) {
+    // Permanent errors that are not fallback-eligible are rethrown immediately.
+    // Transient errors (already retried) and EmptySummaryError fall back to
+    // truncation instead of aborting the turn. (Issue #2333)
+    if (!isFallbackEligibleCompressionError(primaryError)) {
       throw primaryError;
     }
 
     this.logger.warn(
-      'Primary compression strategy failed after retries (transient), attempting fallback',
+      'Primary compression strategy failed after retries, attempting fallback truncation',
       primaryError,
     );
     return this.performFallbackCompression(context, primaryError, applyResult);

--- a/packages/agents/src/compression/MiddleOutStrategy-error.test.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy-error.test.ts
@@ -27,22 +27,22 @@ import {
   testProviderRuntime,
 } from './MiddleOutStrategy-test-helpers.js';
 
-describe('MiddleOutStrategy empty summary handling', () => {
-  /**
-   * Helper: runs compress and returns the thrown error, asserting it throws.
-   */
-  async function captureCompressError(
-    ctx: Parameters<MiddleOutStrategy['compress']>[0],
-  ): Promise<unknown> {
-    const strategy = new MiddleOutStrategy();
-    try {
-      await strategy.compress(ctx);
-      throw new Error('Expected compress() to throw but it did not');
-    } catch (error) {
-      return error;
-    }
+/**
+ * Helper: runs compress and returns the thrown error, asserting it throws.
+ */
+async function captureCompressError(
+  ctx: Parameters<MiddleOutStrategy['compress']>[0],
+): Promise<unknown> {
+  const strategy = new MiddleOutStrategy();
+  try {
+    await strategy.compress(ctx);
+    throw new Error('Expected compress() to throw but it did not');
+  } catch (error) {
+    return error;
   }
+}
 
+describe('MiddleOutStrategy empty summary handling', () => {
   it('throws EmptySummaryError when LLM returns empty summary', async () => {
     const emptyProvider = createFakeProvider('empty-provider', '');
     const history = generateHistory(20);
@@ -126,14 +126,7 @@ describe('MiddleOutStrategy enriched EmptySummaryError diagnostics (issue #2333)
       }),
     });
 
-    const strategy = new MiddleOutStrategy();
-    let thrownError: unknown;
-    try {
-      await strategy.compress(ctx);
-      throw new Error('Expected compress() to throw but it did not');
-    } catch (error) {
-      thrownError = error;
-    }
+    const thrownError = await captureCompressError(ctx);
 
     expect(thrownError).toBeInstanceOf(EmptySummaryError);
     const emptyError = thrownError as EmptySummaryError;

--- a/packages/agents/src/compression/MiddleOutStrategy-error.test.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy-error.test.ts
@@ -6,12 +6,15 @@
 
 /**
  * @plan PLAN-20260211-COMPRESSION.P05
+ * @plan PLAN-20260218-COMPRESSION-RETRY.P01
  *
  * Error-handling behavioral tests for MiddleOutStrategy: empty summary
- * handling and transient error classification.
+ * handling, transient error classification, and enriched diagnostics
+ * (issue #2333 — reasoning model burns budget on thinking, returns no text).
  */
 
 import { describe, it, expect } from 'vitest';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import {
   EmptySummaryError,
   isTransientCompressionError,
@@ -72,6 +75,88 @@ describe('MiddleOutStrategy empty summary handling', () => {
 
     const error = await captureCompressError(ctx);
     expect(error).toBeInstanceOf(EmptySummaryError);
+    expect(isTransientCompressionError(error)).toBe(false);
+  });
+});
+
+describe('MiddleOutStrategy enriched EmptySummaryError diagnostics (issue #2333)', () => {
+  /**
+   * Issue #2333 scenario: a reasoning model (e.g. gpt-5.5) burns its entire
+   * output-token budget on thinking blocks and produces zero text. The stream
+   * yields only thinking blocks with finishReason=incomplete. The strategy
+   * must throw EmptySummaryError carrying diagnostics that reveal the root
+   * cause (finishReason: incomplete, thinking block count > 0).
+   */
+  it('includes finishReason and thinkingBlockCount when provider yields only thinking blocks', async () => {
+    const thinkingOnlyProvider: IProvider = {
+      name: 'thinking-only-provider',
+      getModels: async () => [],
+      getDefaultModel: () => 'gpt-5.5',
+      getServerTools: () => [],
+      invokeServerTool: async () => ({}),
+      async *generateChatCompletion() {
+        yield {
+          speaker: 'ai' as const,
+          blocks: [
+            {
+              type: 'thinking' as const,
+              thought: 'Let me analyze the conversation history deeply...',
+              sourceField: 'reasoning_content',
+              isHidden: false,
+            },
+          ],
+        };
+        yield {
+          speaker: 'ai' as const,
+          blocks: [],
+          metadata: {
+            finishReason: 'incomplete',
+            stopReason: 'max_tokens',
+          },
+        };
+      },
+    } as unknown as IProvider;
+
+    const history = generateHistory(20);
+    const ctx = buildContext({
+      history,
+      resolveProvider: () => ({
+        provider: thinkingOnlyProvider,
+        runtime: testProviderRuntime,
+      }),
+    });
+
+    const strategy = new MiddleOutStrategy();
+    let thrownError: unknown;
+    try {
+      await strategy.compress(ctx);
+      throw new Error('Expected compress() to throw but it did not');
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(EmptySummaryError);
+    const emptyError = thrownError as EmptySummaryError;
+    expect(emptyError.finishReason).toBe('incomplete');
+    expect(emptyError.stopReason).toBe('max_tokens');
+    expect(emptyError.thinkingBlockCount).toBeGreaterThan(0);
+    expect(emptyError.blockTypeCounts?.['thinking']).toBeGreaterThan(0);
+    expect(isTransientCompressionError(thrownError)).toBe(false);
+    expect(emptyError.message).toContain('finishReason: incomplete');
+    expect(emptyError.message).toContain('thinking:');
+  });
+
+  /**
+   * Backward compatibility: EmptySummaryError without diagnostics still works
+   * and has the original message format.
+   */
+  it('EmptySummaryError without diagnostics has backward-compatible message', () => {
+    const error = new EmptySummaryError('middle-out');
+    expect(error.message).toBe(
+      'Compression strategy "middle-out" produced an empty summary',
+    );
+    expect(error.finishReason).toBeUndefined();
+    expect(error.blockTypeCounts).toBeUndefined();
     expect(isTransientCompressionError(error)).toBe(false);
   });
 });

--- a/packages/agents/src/compression/MiddleOutStrategy.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy.ts
@@ -346,6 +346,15 @@ export class MiddleOutStrategy implements CompressionStrategy {
     };
   }> {
     const providerRuntime = resolvedRuntime;
+    // Declared above the try block so partial diagnostics are available
+    // to the catch handler when a mid-stream error interrupts the loop.
+    let summary = '';
+    let lastBlockWasNonText = false;
+    let capturedUsage: UsageStats | undefined;
+    let finishReason: string | undefined;
+    let stopReason: string | undefined;
+    const blockTypeCounts: Record<string, number> = {};
+
     try {
       const stream = provider.generateChatCompletion({
         contents: request,
@@ -362,13 +371,6 @@ export class MiddleOutStrategy implements CompressionStrategy {
           source: 'MiddleOutStrategy.callProvider',
         },
       });
-
-      let summary = '';
-      let lastBlockWasNonText = false;
-      let capturedUsage: UsageStats | undefined;
-      let finishReason: string | undefined;
-      let stopReason: string | undefined;
-      const blockTypeCounts: Record<string, number> = {};
 
       for await (const chunk of stream) {
         for (const block of chunk.blocks) {
@@ -398,9 +400,13 @@ export class MiddleOutStrategy implements CompressionStrategy {
         diagnostics: { finishReason, stopReason, blockTypeCounts },
       };
     } catch (error) {
+      const blocksSummary =
+        Object.entries(blockTypeCounts)
+          .map(([type, count]) => `${type}:${count}`)
+          .join(',') || 'none';
       throw new CompressionExecutionError(
         'middle-out',
-        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)}`,
+        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)} [partial diagnostics: finishReason=${finishReason ?? 'none'}, blocks=${blocksSummary}]`,
         { isTransient: isTransientCompressionError(error) },
       );
     }

--- a/packages/agents/src/compression/MiddleOutStrategy.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy.ts
@@ -117,13 +117,7 @@ export class MiddleOutStrategy implements CompressionStrategy {
 
     const compressionProfile =
       context.runtimeContext.ephemerals.compressionProfile();
-    const {
-      provider,
-      resolvedRuntime,
-      resolvedConfig,
-      resolvedOptions,
-      invocation,
-    } = destructureProviderResult(
+    const providerResult = destructureProviderResult(
       await context.resolveProvider(compressionProfile),
     );
 
@@ -133,28 +127,10 @@ export class MiddleOutStrategy implements CompressionStrategy {
       largeLastPromptInjection,
     );
 
-    const { text: summary, usage: capturedUsage } = await this.callProvider(
-      provider,
+    const { finalSummary, capturedUsage } = await this.compressAndVerify(
+      context,
       compressionRequest,
-      context,
-      resolvedRuntime,
-      resolvedConfig,
-      resolvedOptions,
-      invocation,
-    );
-
-    if (!summary.trim()) {
-      throw new EmptySummaryError('middle-out');
-    }
-
-    const finalSummary = await this.maybeVerifySummary(
-      context,
-      provider,
-      summary,
-      resolvedRuntime,
-      resolvedConfig,
-      resolvedOptions,
-      invocation,
+      providerResult,
     );
 
     const newHistory = this.assembleHistory(
@@ -304,6 +280,54 @@ export class MiddleOutStrategy implements CompressionStrategy {
     return fallback;
   }
 
+  /**
+   * Calls the provider, throws EmptySummaryError with diagnostics if the
+   * summary is empty, then runs the optional verification pass.
+   */
+  private async compressAndVerify(
+    context: CompressionContext,
+    request: IContent[],
+    providerResult: ReturnType<typeof destructureProviderResult>,
+  ): Promise<{ finalSummary: string; capturedUsage: UsageStats | undefined }> {
+    const {
+      provider,
+      resolvedRuntime,
+      resolvedConfig,
+      resolvedOptions,
+      invocation,
+    } = providerResult;
+
+    const {
+      text: summary,
+      usage: capturedUsage,
+      diagnostics,
+    } = await this.callProvider(
+      provider,
+      request,
+      context,
+      resolvedRuntime,
+      resolvedConfig,
+      resolvedOptions,
+      invocation,
+    );
+
+    if (!summary.trim()) {
+      throw new EmptySummaryError('middle-out', diagnostics);
+    }
+
+    const finalSummary = await this.maybeVerifySummary(
+      context,
+      provider,
+      summary,
+      resolvedRuntime,
+      resolvedConfig,
+      resolvedOptions,
+      invocation,
+    );
+
+    return { finalSummary, capturedUsage };
+  }
+
   private async callProvider(
     provider: IProvider,
     request: IContent[],
@@ -312,7 +336,15 @@ export class MiddleOutStrategy implements CompressionStrategy {
     resolvedConfig: Config | undefined,
     resolvedOptions: RuntimeGenerateChatOptions['resolved'] | undefined,
     invocation: RuntimeGenerateChatOptions['invocation'] | undefined,
-  ): Promise<{ text: string; usage?: UsageStats }> {
+  ): Promise<{
+    text: string;
+    usage?: UsageStats;
+    diagnostics: {
+      finishReason?: string;
+      stopReason?: string;
+      blockTypeCounts?: Record<string, number>;
+    };
+  }> {
     const providerRuntime = resolvedRuntime;
     try {
       const stream = provider.generateChatCompletion({
@@ -334,8 +366,14 @@ export class MiddleOutStrategy implements CompressionStrategy {
       let summary = '';
       let lastBlockWasNonText = false;
       let capturedUsage: UsageStats | undefined;
+      let finishReason: string | undefined;
+      let stopReason: string | undefined;
+      const blockTypeCounts: Record<string, number> = {};
 
       for await (const chunk of stream) {
+        for (const block of chunk.blocks) {
+          blockTypeCounts[block.type] = (blockTypeCounts[block.type] ?? 0) + 1;
+        }
         const result = aggregateTextFromBlocks(
           chunk.blocks,
           summary,
@@ -346,9 +384,19 @@ export class MiddleOutStrategy implements CompressionStrategy {
         if (chunk.metadata?.usage) {
           capturedUsage = chunk.metadata.usage;
         }
+        if (chunk.metadata?.finishReason) {
+          finishReason = chunk.metadata.finishReason;
+        }
+        if (chunk.metadata?.stopReason) {
+          stopReason = chunk.metadata.stopReason;
+        }
       }
 
-      return { text: summary, usage: capturedUsage };
+      return {
+        text: summary,
+        usage: capturedUsage,
+        diagnostics: { finishReason, stopReason, blockTypeCounts },
+      };
     } catch (error) {
       throw new CompressionExecutionError(
         'middle-out',

--- a/packages/agents/src/compression/MiddleOutStrategy.ts
+++ b/packages/agents/src/compression/MiddleOutStrategy.ts
@@ -406,7 +406,7 @@ export class MiddleOutStrategy implements CompressionStrategy {
           .join(',') || 'none';
       throw new CompressionExecutionError(
         'middle-out',
-        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)} [partial diagnostics: finishReason=${finishReason ?? 'none'}, blocks=${blocksSummary}]`,
+        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)} [partial diagnostics: finishReason=${finishReason ?? 'none'}, stopReason=${stopReason ?? 'none'}, blocks=${blocksSummary}]`,
         { isTransient: isTransientCompressionError(error) },
       );
     }

--- a/packages/agents/src/compression/OneShotStrategy.ts
+++ b/packages/agents/src/compression/OneShotStrategy.ts
@@ -304,6 +304,15 @@ export class OneShotStrategy implements CompressionStrategy {
     };
   }> {
     const providerRuntime = resolvedRuntime;
+    // Declared above the try block so partial diagnostics are available
+    // to the catch handler when a mid-stream error interrupts the loop.
+    let summary = '';
+    let lastBlockWasNonText = false;
+    let capturedUsage: UsageStats | undefined;
+    let finishReason: string | undefined;
+    let stopReason: string | undefined;
+    const blockTypeCounts: Record<string, number> = {};
+
     try {
       const stream = provider.generateChatCompletion({
         contents: request,
@@ -320,13 +329,6 @@ export class OneShotStrategy implements CompressionStrategy {
           source: 'OneShotStrategy.callProvider',
         },
       });
-
-      let summary = '';
-      let lastBlockWasNonText = false;
-      let capturedUsage: UsageStats | undefined;
-      let finishReason: string | undefined;
-      let stopReason: string | undefined;
-      const blockTypeCounts: Record<string, number> = {};
 
       for await (const chunk of stream) {
         for (const block of chunk.blocks) {
@@ -356,9 +358,13 @@ export class OneShotStrategy implements CompressionStrategy {
         diagnostics: { finishReason, stopReason, blockTypeCounts },
       };
     } catch (error) {
+      const blocksSummary =
+        Object.entries(blockTypeCounts)
+          .map(([type, count]) => `${type}:${count}`)
+          .join(',') || 'none';
       throw new CompressionExecutionError(
         'one-shot',
-        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)}`,
+        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)} [partial diagnostics: finishReason=${finishReason ?? 'none'}, blocks=${blocksSummary}]`,
         { isTransient: isTransientCompressionError(error) },
       );
     }

--- a/packages/agents/src/compression/OneShotStrategy.ts
+++ b/packages/agents/src/compression/OneShotStrategy.ts
@@ -364,7 +364,7 @@ export class OneShotStrategy implements CompressionStrategy {
           .join(',') || 'none';
       throw new CompressionExecutionError(
         'one-shot',
-        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)} [partial diagnostics: finishReason=${finishReason ?? 'none'}, blocks=${blocksSummary}]`,
+        `LLM provider call failed: ${error instanceof Error ? error.message : String(error)} [partial diagnostics: finishReason=${finishReason ?? 'none'}, stopReason=${stopReason ?? 'none'}, blocks=${blocksSummary}]`,
         { isTransient: isTransientCompressionError(error) },
       );
     }

--- a/packages/agents/src/compression/OneShotStrategy.ts
+++ b/packages/agents/src/compression/OneShotStrategy.ts
@@ -113,7 +113,11 @@ export class OneShotStrategy implements CompressionStrategy {
       toCompress,
     );
 
-    const { text: summary, usage: capturedUsage } = await this.callProvider(
+    const {
+      text: summary,
+      usage: capturedUsage,
+      diagnostics,
+    } = await this.callProvider(
       provider,
       compressionRequest,
       context,
@@ -124,7 +128,7 @@ export class OneShotStrategy implements CompressionStrategy {
     );
 
     if (!summary.trim()) {
-      throw new EmptySummaryError('one-shot');
+      throw new EmptySummaryError('one-shot', diagnostics);
     }
 
     const finalSummary = await this.maybeVerifySummary(
@@ -290,7 +294,15 @@ export class OneShotStrategy implements CompressionStrategy {
     resolvedConfig: Config | undefined,
     resolvedOptions: RuntimeGenerateChatOptions['resolved'] | undefined,
     invocation: RuntimeGenerateChatOptions['invocation'] | undefined,
-  ): Promise<{ text: string; usage?: UsageStats }> {
+  ): Promise<{
+    text: string;
+    usage?: UsageStats;
+    diagnostics: {
+      finishReason?: string;
+      stopReason?: string;
+      blockTypeCounts?: Record<string, number>;
+    };
+  }> {
     const providerRuntime = resolvedRuntime;
     try {
       const stream = provider.generateChatCompletion({
@@ -312,8 +324,14 @@ export class OneShotStrategy implements CompressionStrategy {
       let summary = '';
       let lastBlockWasNonText = false;
       let capturedUsage: UsageStats | undefined;
+      let finishReason: string | undefined;
+      let stopReason: string | undefined;
+      const blockTypeCounts: Record<string, number> = {};
 
       for await (const chunk of stream) {
+        for (const block of chunk.blocks) {
+          blockTypeCounts[block.type] = (blockTypeCounts[block.type] ?? 0) + 1;
+        }
         const result = aggregateTextFromBlocks(
           chunk.blocks,
           summary,
@@ -324,9 +342,19 @@ export class OneShotStrategy implements CompressionStrategy {
         if (chunk.metadata?.usage) {
           capturedUsage = chunk.metadata.usage;
         }
+        if (chunk.metadata?.finishReason) {
+          finishReason = chunk.metadata.finishReason;
+        }
+        if (chunk.metadata?.stopReason) {
+          stopReason = chunk.metadata.stopReason;
+        }
       }
 
-      return { text: summary, usage: capturedUsage };
+      return {
+        text: summary,
+        usage: capturedUsage,
+        diagnostics: { finishReason, stopReason, blockTypeCounts },
+      };
     } catch (error) {
       throw new CompressionExecutionError(
         'one-shot',

--- a/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
@@ -43,20 +43,21 @@ vi.mock('@vybestack/llxprt-code-core/utils/delay.js', () => ({
 
 // ---- Shared setup/assertion helpers for the Issue #2333 fallback tests ----
 
+let restoreStrategyFactory: (() => void) | undefined;
+
 interface EmptySummaryFallbackSetup {
   chat: ChatSession;
   historyService: HistoryService;
   addSpy: MockInstance<HistoryService['add']>;
   getFallbackCalled: () => boolean;
   getPrimaryCallCount: () => number;
+  restore: () => void;
 }
 
-interface EmptySummaryFallbackAssertions {
-  historyService: HistoryService;
-  addSpy: MockInstance<HistoryService['add']>;
-  getFallbackCalled: () => boolean;
-  getPrimaryCallCount: () => number;
-}
+type EmptySummaryFallbackAssertions = Omit<
+  EmptySummaryFallbackSetup,
+  'chat' | 'restore'
+>;
 
 /**
  * Installs the empty-summary fallback factory mock and builds a ChatSession
@@ -68,7 +69,7 @@ function setupEmptySummaryFallback(
   runtimeSetup: ReturnType<typeof createChatSessionRuntime>,
   providerRuntimeSnapshot: ProviderRuntimeContext,
 ): EmptySummaryFallbackSetup {
-  const { getFallbackCalled, getPrimaryCallCount } =
+  const { getFallbackCalled, getPrimaryCallCount, restore } =
     mockStrategyFactoryWithEmptySummaryFallback();
 
   const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
@@ -83,6 +84,7 @@ function setupEmptySummaryFallback(
     addSpy,
     getFallbackCalled,
     getPrimaryCallCount,
+    restore,
   };
 }
 
@@ -297,6 +299,8 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
   });
 
   afterEach(() => {
+    restoreStrategyFactory?.();
+    restoreStrategyFactory = undefined;
     vi.restoreAllMocks();
   });
 
@@ -386,7 +390,9 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
       addSpy,
       getFallbackCalled,
       getPrimaryCallCount,
+      restore,
     } = setupEmptySummaryFallback(runtimeSetup, providerRuntimeSnapshot);
+    restoreStrategyFactory = restore;
 
     // performCompression should resolve (COMPRESSED) via fallback, not reject
     await expect(chat.performCompression('test-prompt')).resolves.toBe(
@@ -419,7 +425,9 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
       addSpy,
       getFallbackCalled,
       getPrimaryCallCount,
+      restore,
     } = setupEmptySummaryFallback(runtimeSetup, providerRuntimeSnapshot);
+    restoreStrategyFactory = restore;
 
     // The threshold-triggered auto-compression path must resolve (not reject)
     // and apply the truncation fallback.

--- a/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
@@ -14,10 +14,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  CompressionExecutionError,
-  EmptySummaryError,
-} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import { CompressionExecutionError } from '@vybestack/llxprt-code-core/core/compression/types.js';
 import { PerformCompressionResult } from '../../core/turn.js';
 import * as compressionFactory from '../compressionStrategyFactory.js';
 import { ChatSession } from '../../core/chatSession.js';
@@ -29,6 +26,7 @@ import {
   makeAnthropicOverloadError,
   makeAnthropicSdkWrappedError,
   makeChatSession,
+  mockStrategyFactoryWithEmptySummaryFallback,
 } from './compression-retry-helpers.js';
 
 // Mock the delay utility so retryWithBackoff doesn't actually wait in tests
@@ -309,49 +307,16 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
   it('falls back to truncation when primary strategy returns an empty summary', async () => {
     const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
 
-    let fallbackCalled = false;
-    let primaryCallCount = 0;
-
-    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
-      (name) => {
-        if (name === 'top-down-truncation') {
-          return {
-            name: 'top-down-truncation' as const,
-            requiresLLM: false,
-            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
-            compress: vi.fn().mockImplementation(async () => {
-              fallbackCalled = true;
-              return {
-                newHistory: [],
-                metadata: {
-                  originalMessageCount: 10,
-                  compressedMessageCount: 5,
-                  strategyUsed: 'top-down-truncation' as const,
-                  llmCallMade: false,
-                },
-              };
-            }),
-          };
-        }
-        return {
-          name: 'middle-out' as const,
-          requiresLLM: true,
-          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
-          compress: vi.fn().mockImplementation(async () => {
-            primaryCallCount++;
-            throw new EmptySummaryError('middle-out');
-          }),
-        };
-      },
-    );
+    const { getFallbackCalled, getPrimaryCallCount } =
+      mockStrategyFactoryWithEmptySummaryFallback();
 
     // performCompression should resolve (COMPRESSED) via fallback, not reject
     await expect(chat.performCompression('test-prompt')).resolves.toBe(
       PerformCompressionResult.COMPRESSED,
     );
-    expect(fallbackCalled).toBe(true);
+    expect(getFallbackCalled()).toBe(true);
     // Empty summary is non-retryable — primary must be called exactly once
-    expect(primaryCallCount).toBe(1);
+    expect(getPrimaryCallCount()).toBe(1);
   });
 
   /**
@@ -368,49 +333,16 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
   it('ensureCompressionBeforeSend does not reject on EmptySummaryError and applies the truncation fallback', async () => {
     const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
 
-    let fallbackCalled = false;
-    let primaryCallCount = 0;
-
-    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
-      (name) => {
-        if (name === 'top-down-truncation') {
-          return {
-            name: 'top-down-truncation' as const,
-            requiresLLM: false,
-            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
-            compress: vi.fn().mockImplementation(async () => {
-              fallbackCalled = true;
-              return {
-                newHistory: [],
-                metadata: {
-                  originalMessageCount: 10,
-                  compressedMessageCount: 5,
-                  strategyUsed: 'top-down-truncation' as const,
-                  llmCallMade: false,
-                },
-              };
-            }),
-          };
-        }
-        return {
-          name: 'middle-out' as const,
-          requiresLLM: true,
-          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
-          compress: vi.fn().mockImplementation(async () => {
-            primaryCallCount++;
-            throw new EmptySummaryError('middle-out');
-          }),
-        };
-      },
-    );
+    const { getFallbackCalled, getPrimaryCallCount } =
+      mockStrategyFactoryWithEmptySummaryFallback();
 
     // The threshold-triggered auto-compression path must resolve (not reject)
     // and apply the truncation fallback.
     await expect(
       chat.ensureCompressionBeforeSend('test-prompt', 0, 'send'),
     ).resolves.toBeUndefined();
-    expect(fallbackCalled).toBe(true);
+    expect(getFallbackCalled()).toBe(true);
     // Empty summary is non-retryable — primary must be called exactly once
-    expect(primaryCallCount).toBe(1);
+    expect(getPrimaryCallCount()).toBe(1);
   });
 });

--- a/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
@@ -14,7 +14,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { CompressionExecutionError } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { PerformCompressionResult } from '../../core/turn.js';
 import * as compressionFactory from '../compressionStrategyFactory.js';
 import { ChatSession } from '../../core/chatSession.js';
@@ -38,6 +40,79 @@ vi.mock('@vybestack/llxprt-code-core/utils/delay.js', () => ({
     return err;
   },
 }));
+
+// ---- Shared setup/assertion helpers for the Issue #2333 fallback tests ----
+
+interface EmptySummaryFallbackSetup {
+  chat: ChatSession;
+  historyService: HistoryService;
+  addSpy: MockInstance<HistoryService['add']>;
+  getFallbackCalled: () => boolean;
+  getPrimaryCallCount: () => number;
+}
+
+interface EmptySummaryFallbackAssertions {
+  historyService: HistoryService;
+  addSpy: MockInstance<HistoryService['add']>;
+  getFallbackCalled: () => boolean;
+  getPrimaryCallCount: () => number;
+}
+
+/**
+ * Installs the empty-summary fallback factory mock and builds a ChatSession
+ * with the shared historyService.add spy wired up, returning all the handles
+ * the two Issue #2333 tests need. The distinct act step (performCompression
+ * vs ensureCompressionBeforeSend) stays inline in each test.
+ */
+function setupEmptySummaryFallback(
+  runtimeSetup: ReturnType<typeof createChatSessionRuntime>,
+  providerRuntimeSnapshot: ProviderRuntimeContext,
+): EmptySummaryFallbackSetup {
+  const { getFallbackCalled, getPrimaryCallCount } =
+    mockStrategyFactoryWithEmptySummaryFallback();
+
+  const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
+  const historyService = chat.getHistoryService();
+  // ChatSession's constructor re-wraps historyService.add with a density
+  // tracker, so spy on it here to observe calls applied during compression.
+  const addSpy = vi.spyOn(historyService, 'add');
+
+  return {
+    chat,
+    historyService,
+    addSpy,
+    getFallbackCalled,
+    getPrimaryCallCount,
+  };
+}
+
+/**
+ * The four shared assertions for the Issue #2333 fallback path: the
+ * truncation fallback was used, the primary strategy was called exactly once
+ * (empty summary is non-retryable), and the fallback summary was applied to
+ * the session history (clear + add).
+ */
+function expectEmptySummaryFallbackApplied({
+  historyService,
+  addSpy,
+  getFallbackCalled,
+  getPrimaryCallCount,
+}: EmptySummaryFallbackAssertions): void {
+  expect(getFallbackCalled()).toBe(true);
+  // Empty summary is non-retryable — primary must be called exactly once
+  expect(getPrimaryCallCount()).toBe(1);
+
+  // The fallback's truncated summary must actually be applied to the session
+  // history (clear + add), not just returned by the mock.
+  expect(historyService.clear).toHaveBeenCalledTimes(1);
+  expect(addSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'mock truncated summary' }],
+    }),
+    expect.any(String),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Phase 2: Retry behavior in performCompression
@@ -305,33 +380,25 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
    * the empty summary.
    */
   it('falls back to truncation when primary strategy returns an empty summary', async () => {
-    const { getFallbackCalled, getPrimaryCallCount } =
-      mockStrategyFactoryWithEmptySummaryFallback();
-
-    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
-    const historyService = chat.getHistoryService();
-    // ChatSession's constructor re-wraps historyService.add with a density
-    // tracker, so spy on it here to observe calls applied during compression.
-    const addSpy = vi.spyOn(historyService, 'add');
+    const {
+      chat,
+      historyService,
+      addSpy,
+      getFallbackCalled,
+      getPrimaryCallCount,
+    } = setupEmptySummaryFallback(runtimeSetup, providerRuntimeSnapshot);
 
     // performCompression should resolve (COMPRESSED) via fallback, not reject
     await expect(chat.performCompression('test-prompt')).resolves.toBe(
       PerformCompressionResult.COMPRESSED,
     );
-    expect(getFallbackCalled()).toBe(true);
-    // Empty summary is non-retryable — primary must be called exactly once
-    expect(getPrimaryCallCount()).toBe(1);
 
-    // The fallback's truncated summary must actually be applied to the session
-    // history (clear + add), not just returned by the mock.
-    expect(historyService.clear).toHaveBeenCalledTimes(1);
-    expect(addSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        speaker: 'human',
-        blocks: [{ type: 'text', text: 'mock truncated summary' }],
-      }),
-      expect.any(String),
-    );
+    expectEmptySummaryFallbackApplied({
+      historyService,
+      addSpy,
+      getFallbackCalled,
+      getPrimaryCallCount,
+    });
   });
 
   /**
@@ -346,33 +413,25 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
    * top-down-truncation fallback without retrying the empty summary.
    */
   it('ensureCompressionBeforeSend does not reject on EmptySummaryError and applies the truncation fallback', async () => {
-    const { getFallbackCalled, getPrimaryCallCount } =
-      mockStrategyFactoryWithEmptySummaryFallback();
-
-    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
-    const historyService = chat.getHistoryService();
-    // ChatSession's constructor re-wraps historyService.add with a density
-    // tracker, so spy on it here to observe calls applied during compression.
-    const addSpy = vi.spyOn(historyService, 'add');
+    const {
+      chat,
+      historyService,
+      addSpy,
+      getFallbackCalled,
+      getPrimaryCallCount,
+    } = setupEmptySummaryFallback(runtimeSetup, providerRuntimeSnapshot);
 
     // The threshold-triggered auto-compression path must resolve (not reject)
     // and apply the truncation fallback.
     await expect(
       chat.ensureCompressionBeforeSend('test-prompt', 0, 'send'),
     ).resolves.toBeUndefined();
-    expect(getFallbackCalled()).toBe(true);
-    // Empty summary is non-retryable — primary must be called exactly once
-    expect(getPrimaryCallCount()).toBe(1);
 
-    // The fallback's truncated summary must actually be applied to the session
-    // history (clear + add), not just returned by the mock.
-    expect(historyService.clear).toHaveBeenCalledTimes(1);
-    expect(addSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        speaker: 'human',
-        blocks: [{ type: 'text', text: 'mock truncated summary' }],
-      }),
-      expect.any(String),
-    );
+    expectEmptySummaryFallbackApplied({
+      historyService,
+      addSpy,
+      getFallbackCalled,
+      getPrimaryCallCount,
+    });
   });
 });

--- a/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
@@ -14,7 +14,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { CompressionExecutionError } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import {
+  CompressionExecutionError,
+  EmptySummaryError,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
 import { PerformCompressionResult } from '../../core/turn.js';
 import * as compressionFactory from '../compressionStrategyFactory.js';
 import { ChatSession } from '../../core/chatSession.js';
@@ -294,5 +297,120 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
     await expect(chat.performCompression('test-prompt')).resolves.toBe(
       PerformCompressionResult.FAILED,
     );
+  });
+
+  /**
+   * @requirement REQ-CR-004
+   * Issue #2333: When the primary strategy deterministically returns an empty
+   * summary (EmptySummaryError), the turn must not abort. Instead it should
+   * fall back to the non-LLM top-down-truncation strategy without retrying
+   * the empty summary.
+   */
+  it('falls back to truncation when primary strategy returns an empty summary', async () => {
+    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
+
+    let fallbackCalled = false;
+    let primaryCallCount = 0;
+
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      (name) => {
+        if (name === 'top-down-truncation') {
+          return {
+            name: 'top-down-truncation' as const,
+            requiresLLM: false,
+            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+            compress: vi.fn().mockImplementation(async () => {
+              fallbackCalled = true;
+              return {
+                newHistory: [],
+                metadata: {
+                  originalMessageCount: 10,
+                  compressedMessageCount: 5,
+                  strategyUsed: 'top-down-truncation' as const,
+                  llmCallMade: false,
+                },
+              };
+            }),
+          };
+        }
+        return {
+          name: 'middle-out' as const,
+          requiresLLM: true,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi.fn().mockImplementation(async () => {
+            primaryCallCount++;
+            throw new EmptySummaryError('middle-out');
+          }),
+        };
+      },
+    );
+
+    // performCompression should resolve (COMPRESSED) via fallback, not reject
+    await expect(chat.performCompression('test-prompt')).resolves.toBe(
+      PerformCompressionResult.COMPRESSED,
+    );
+    expect(fallbackCalled).toBe(true);
+    // Empty summary is non-retryable — primary must be called exactly once
+    expect(primaryCallCount).toBe(1);
+  });
+
+  /**
+   * @requirement REQ-CR-004
+   * Issue #2333: The threshold-triggered auto-compression path exercised at
+   * send time — `ChatSession.ensureCompressionBeforeSend(...)` — must not
+   * reject when the primary (middle-out) strategy throws an
+   * EmptySummaryError. This is the exact user-facing failure mode from the
+   * issue: an empty summary from the primary strategy aborted the turn with a
+   * surfaced "[API Error: Compression strategy "middle-out" produced an empty
+   * summary]" message. Instead the turn should complete via the non-LLM
+   * top-down-truncation fallback without retrying the empty summary.
+   */
+  it('ensureCompressionBeforeSend does not reject on EmptySummaryError and applies the truncation fallback', async () => {
+    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
+
+    let fallbackCalled = false;
+    let primaryCallCount = 0;
+
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+      (name) => {
+        if (name === 'top-down-truncation') {
+          return {
+            name: 'top-down-truncation' as const,
+            requiresLLM: false,
+            trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+            compress: vi.fn().mockImplementation(async () => {
+              fallbackCalled = true;
+              return {
+                newHistory: [],
+                metadata: {
+                  originalMessageCount: 10,
+                  compressedMessageCount: 5,
+                  strategyUsed: 'top-down-truncation' as const,
+                  llmCallMade: false,
+                },
+              };
+            }),
+          };
+        }
+        return {
+          name: 'middle-out' as const,
+          requiresLLM: true,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi.fn().mockImplementation(async () => {
+            primaryCallCount++;
+            throw new EmptySummaryError('middle-out');
+          }),
+        };
+      },
+    );
+
+    // The threshold-triggered auto-compression path must resolve (not reject)
+    // and apply the truncation fallback.
+    await expect(
+      chat.ensureCompressionBeforeSend('test-prompt', 0, 'send'),
+    ).resolves.toBeUndefined();
+    expect(fallbackCalled).toBe(true);
+    // Empty summary is non-retryable — primary must be called exactly once
+    expect(primaryCallCount).toBe(1);
   });
 });

--- a/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
@@ -305,10 +305,10 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
    * the empty summary.
    */
   it('falls back to truncation when primary strategy returns an empty summary', async () => {
-    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
-
     const { getFallbackCalled, getPrimaryCallCount } =
       mockStrategyFactoryWithEmptySummaryFallback();
+
+    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
 
     // performCompression should resolve (COMPRESSED) via fallback, not reject
     await expect(chat.performCompression('test-prompt')).resolves.toBe(
@@ -331,10 +331,10 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
    * top-down-truncation fallback without retrying the empty summary.
    */
   it('ensureCompressionBeforeSend does not reject on EmptySummaryError and applies the truncation fallback', async () => {
-    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
-
     const { getFallbackCalled, getPrimaryCallCount } =
       mockStrategyFactoryWithEmptySummaryFallback();
+
+    const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
 
     // The threshold-triggered auto-compression path must resolve (not reject)
     // and apply the truncation fallback.

--- a/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-behavior.test.ts
@@ -309,6 +309,10 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
       mockStrategyFactoryWithEmptySummaryFallback();
 
     const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
+    const historyService = chat.getHistoryService();
+    // ChatSession's constructor re-wraps historyService.add with a density
+    // tracker, so spy on it here to observe calls applied during compression.
+    const addSpy = vi.spyOn(historyService, 'add');
 
     // performCompression should resolve (COMPRESSED) via fallback, not reject
     await expect(chat.performCompression('test-prompt')).resolves.toBe(
@@ -317,6 +321,17 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
     expect(getFallbackCalled()).toBe(true);
     // Empty summary is non-retryable — primary must be called exactly once
     expect(getPrimaryCallCount()).toBe(1);
+
+    // The fallback's truncated summary must actually be applied to the session
+    // history (clear + add), not just returned by the mock.
+    expect(historyService.clear).toHaveBeenCalledTimes(1);
+    expect(addSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'mock truncated summary' }],
+      }),
+      expect.any(String),
+    );
   });
 
   /**
@@ -335,6 +350,10 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
       mockStrategyFactoryWithEmptySummaryFallback();
 
     const chat = makeChatSession(runtimeSetup, providerRuntimeSnapshot);
+    const historyService = chat.getHistoryService();
+    // ChatSession's constructor re-wraps historyService.add with a density
+    // tracker, so spy on it here to observe calls applied during compression.
+    const addSpy = vi.spyOn(historyService, 'add');
 
     // The threshold-triggered auto-compression path must resolve (not reject)
     // and apply the truncation fallback.
@@ -344,5 +363,16 @@ describe('ChatSession compression fallback @plan PLAN-20260218-COMPRESSION-RETRY
     expect(getFallbackCalled()).toBe(true);
     // Empty summary is non-retryable — primary must be called exactly once
     expect(getPrimaryCallCount()).toBe(1);
+
+    // The fallback's truncated summary must actually be applied to the session
+    // history (clear + add), not just returned by the mock.
+    expect(historyService.clear).toHaveBeenCalledTimes(1);
+    expect(addSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'mock truncated summary' }],
+      }),
+      expect.any(String),
+    );
   });
 });

--- a/packages/agents/src/compression/__tests__/compression-retry-classification.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-classification.test.ts
@@ -415,6 +415,14 @@ describe('isFallbackEligibleCompressionError @plan PLAN-20260218-COMPRESSION-RET
     ).toBe(true);
   });
 
+  it('returns true for Anthropic SDK-wrapped overloaded_error (issue #2053 shape)', () => {
+    expect(
+      isFallbackEligibleCompressionError(
+        makeAnthropicSdkWrappedError('overloaded_error'),
+      ),
+    ).toBe(true);
+  });
+
   it('returns false for CompressionExecutionError default (non-transient)', () => {
     expect(
       isFallbackEligibleCompressionError(

--- a/packages/agents/src/compression/__tests__/compression-retry-classification.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-classification.test.ts
@@ -18,10 +18,12 @@ import * as fc from 'fast-check';
 import {
   isTransientCompressionError,
   shouldRetryCompressionError,
+  isFallbackEligibleCompressionError,
   CompressionExecutionError,
   CompressionStrategyError,
   UnknownStrategyError,
   PromptResolutionError,
+  EmptySummaryError,
 } from '@vybestack/llxprt-code-core/core/compression/types.js';
 import {
   makeHttpError,
@@ -372,6 +374,119 @@ describe('Property-based: error classification @plan PLAN-20260218-COMPRESSION-R
         },
       ),
       { numRuns: 50 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFallbackEligibleCompressionError (Issue #2333)
+// ---------------------------------------------------------------------------
+
+describe('isFallbackEligibleCompressionError @plan PLAN-20260218-COMPRESSION-RETRY.P01', () => {
+  /**
+   * Issue #2333: EmptySummaryError is fallback-eligible so that an empty
+   * LLM summary degrades gracefully to truncation instead of aborting the turn.
+   */
+  it('returns true for EmptySummaryError', () => {
+    expect(
+      isFallbackEligibleCompressionError(new EmptySummaryError('middle-out')),
+    ).toBe(true);
+  });
+
+  it('returns true for HTTP 429 rate limit error', () => {
+    expect(isFallbackEligibleCompressionError(makeHttpError(429))).toBe(true);
+  });
+
+  it('returns true for HTTP 500 server error', () => {
+    expect(isFallbackEligibleCompressionError(makeHttpError(500))).toBe(true);
+  });
+
+  it('returns true for ECONNRESET network error', () => {
+    expect(
+      isFallbackEligibleCompressionError(makeNetworkError('ECONNRESET')),
+    ).toBe(true);
+  });
+
+  it('returns true for Anthropic overloaded_error', () => {
+    expect(
+      isFallbackEligibleCompressionError(
+        makeAnthropicOverloadError('overloaded_error'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for CompressionExecutionError default (non-transient)', () => {
+    expect(
+      isFallbackEligibleCompressionError(
+        new CompressionExecutionError('middle-out', 'permanent failure'),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for PromptResolutionError', () => {
+    expect(
+      isFallbackEligibleCompressionError(
+        new PromptResolutionError('prompt-id'),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for UnknownStrategyError', () => {
+    expect(
+      isFallbackEligibleCompressionError(
+        new UnknownStrategyError('bad-strategy'),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for plain CompressionStrategyError', () => {
+    expect(
+      isFallbackEligibleCompressionError(
+        new CompressionStrategyError('msg', 'EXECUTION_FAILED'),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for CompressionExecutionError with isTransient: true', () => {
+    const err = new CompressionExecutionError('middle-out', 'rate limited', {
+      isTransient: true,
+    });
+    expect(isFallbackEligibleCompressionError(err)).toBe(true);
+  });
+
+  it('returns false for HTTP 400', () => {
+    expect(isFallbackEligibleCompressionError(makeHttpError(400))).toBe(false);
+  });
+
+  it('returns false for HTTP 401', () => {
+    expect(isFallbackEligibleCompressionError(makeHttpError(401))).toBe(false);
+  });
+
+  /**
+   * Verify EmptySummaryError transience classification is unchanged — it must
+   * stay non-transient / non-retryable; only fallback-eligibility changes.
+   */
+  it('EmptySummaryError remains non-transient (shouldRetry is false)', () => {
+    expect(
+      isTransientCompressionError(new EmptySummaryError('middle-out')),
+    ).toBe(false);
+    expect(
+      shouldRetryCompressionError(new EmptySummaryError('middle-out')),
+    ).toBe(false);
+  });
+
+  /**
+   * Property: fallback-eligibility mirrors transience for HTTP errors.
+   */
+  it('isFallbackEligibleCompressionError matches isTransientCompressionError for all HTTP statuses', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 400, max: 599 }), (status) => {
+        const err = makeHttpError(status);
+        expect(isFallbackEligibleCompressionError(err)).toBe(
+          isTransientCompressionError(err),
+        );
+      }),
+      { numRuns: 200 },
     );
   });
 });

--- a/packages/agents/src/compression/__tests__/compression-retry-classification.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-classification.test.ts
@@ -470,6 +470,21 @@ describe('isFallbackEligibleCompressionError @plan PLAN-20260218-COMPRESSION-RET
     expect(isFallbackEligibleCompressionError(makeHttpError(401))).toBe(false);
   });
 
+  it('returns false for generic programming error (permanent)', () => {
+    const err = new TypeError('Cannot read property of undefined');
+    expect(isFallbackEligibleCompressionError(err)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isFallbackEligibleCompressionError(null)).toBe(false);
+  });
+
+  it('returns false for string error', () => {
+    expect(isFallbackEligibleCompressionError('some error message')).toBe(
+      false,
+    );
+  });
+
   /**
    * Verify EmptySummaryError transience classification is unchanged — it must
    * stay non-transient / non-retryable; only fallback-eligibility changes.

--- a/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
@@ -176,12 +176,14 @@ export function makeChatSession(
 export function mockStrategyFactoryWithEmptySummaryFallback(): {
   getFallbackCalled: () => boolean;
   getPrimaryCallCount: () => number;
+  restore: () => void;
 } {
   let fallbackCalled = false;
   let primaryCallCount = 0;
 
-  vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
-    (name) => {
+  const spy = vi
+    .spyOn(compressionFactory, 'getCompressionStrategy')
+    .mockImplementation((name) => {
       if (name === 'top-down-truncation') {
         return {
           name: 'top-down-truncation' as const,
@@ -218,11 +220,11 @@ export function mockStrategyFactoryWithEmptySummaryFallback(): {
           throw new EmptySummaryError('middle-out');
         }),
       };
-    },
-  );
+    });
 
   return {
     getFallbackCalled: () => fallbackCalled,
     getPrimaryCallCount: () => primaryCallCount,
+    restore: () => spy.mockRestore(),
   };
 }

--- a/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
@@ -191,7 +191,12 @@ export function mockStrategyFactoryWithEmptySummaryFallback(): {
             .fn()
             .mockImplementation(async (context: CompressionContext) => {
               fallbackCalled = true;
-              const newHistory: IContent[] = [];
+              const newHistory: IContent[] = [
+                {
+                  speaker: 'human',
+                  blocks: [{ type: 'text', text: 'mock truncated summary' }],
+                },
+              ];
               return {
                 newHistory,
                 metadata: {

--- a/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
@@ -14,7 +14,11 @@
  */
 
 import { vi } from 'vitest';
-import { EmptySummaryError } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import {
+  EmptySummaryError,
+  type CompressionContext,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import * as compressionFactory from '../compressionStrategyFactory.js';
 import { ChatSession } from '../../core/chatSession.js';
 import type { createChatSessionRuntime } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
@@ -183,18 +187,21 @@ export function mockStrategyFactoryWithEmptySummaryFallback(): {
           name: 'top-down-truncation' as const,
           requiresLLM: false,
           trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
-          compress: vi.fn().mockImplementation(async () => {
-            fallbackCalled = true;
-            return {
-              newHistory: [],
-              metadata: {
-                originalMessageCount: 10,
-                compressedMessageCount: 5,
-                strategyUsed: 'top-down-truncation' as const,
-                llmCallMade: false,
-              },
-            };
-          }),
+          compress: vi
+            .fn()
+            .mockImplementation(async (context: CompressionContext) => {
+              fallbackCalled = true;
+              const newHistory: IContent[] = [];
+              return {
+                newHistory,
+                metadata: {
+                  originalMessageCount: context.history.length,
+                  compressedMessageCount: newHistory.length,
+                  strategyUsed: 'top-down-truncation' as const,
+                  llmCallMade: false,
+                },
+              };
+            }),
         };
       }
       return {

--- a/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-helpers.ts
@@ -14,6 +14,8 @@
  */
 
 import { vi } from 'vitest';
+import { EmptySummaryError } from '@vybestack/llxprt-code-core/core/compression/types.js';
+import * as compressionFactory from '../compressionStrategyFactory.js';
 import { ChatSession } from '../../core/chatSession.js';
 import type { createChatSessionRuntime } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
 import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
@@ -151,4 +153,64 @@ export function makeChatSession(
   };
 
   return new ChatSession(view, mockContentGenerator, {}, []);
+}
+
+// ---------------------------------------------------------------------------
+// Strategy factory mocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Installs a `vi.spyOn` mock on {@link compressionFactory.getCompressionStrategy}
+ * that returns a deterministic primary (middle-out) strategy throwing
+ * {@link EmptySummaryError} and a non-LLM top-down-truncation fallback
+ * strategy that succeeds. This is the shared mock for the two Issue #2333
+ * tests (performCompression and ensureCompressionBeforeSend).
+ *
+ * @plan PLAN-20260218-COMPRESSION-RETRY.P01
+ * @requirement REQ-CR-004
+ */
+export function mockStrategyFactoryWithEmptySummaryFallback(): {
+  getFallbackCalled: () => boolean;
+  getPrimaryCallCount: () => number;
+} {
+  let fallbackCalled = false;
+  let primaryCallCount = 0;
+
+  vi.spyOn(compressionFactory, 'getCompressionStrategy').mockImplementation(
+    (name) => {
+      if (name === 'top-down-truncation') {
+        return {
+          name: 'top-down-truncation' as const,
+          requiresLLM: false,
+          trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+          compress: vi.fn().mockImplementation(async () => {
+            fallbackCalled = true;
+            return {
+              newHistory: [],
+              metadata: {
+                originalMessageCount: 10,
+                compressedMessageCount: 5,
+                strategyUsed: 'top-down-truncation' as const,
+                llmCallMade: false,
+              },
+            };
+          }),
+        };
+      }
+      return {
+        name: 'middle-out' as const,
+        requiresLLM: true,
+        trigger: { mode: 'threshold' as const, defaultThreshold: 0.8 },
+        compress: vi.fn().mockImplementation(async () => {
+          primaryCallCount++;
+          throw new EmptySummaryError('middle-out');
+        }),
+      };
+    },
+  );
+
+  return {
+    getFallbackCalled: () => fallbackCalled,
+    getPrimaryCallCount: () => primaryCallCount,
+  };
 }

--- a/packages/core/src/core/compression/types.ts
+++ b/packages/core/src/core/compression/types.ts
@@ -387,3 +387,18 @@ export function isTransientCompressionError(error: unknown): boolean {
 export function shouldRetryCompressionError(error: unknown): boolean {
   return isTransientCompressionError(error);
 }
+
+/**
+ * Returns true if a failed primary compression attempt should fall back
+ * to the non-LLM truncation strategy instead of aborting the turn.
+ * Transient errors (already retried) and empty-summary failures are
+ * fallback-eligible; configuration/logic errors (unknown strategy,
+ * prompt resolution, permanent execution errors) are not.
+ *
+ * (Issue #2333: EmptySummaryError is intentionally non-transient so it is not
+ * retried, but it IS fallback-eligible so the turn degrades gracefully.)
+ */
+export function isFallbackEligibleCompressionError(error: unknown): boolean {
+  if (error instanceof EmptySummaryError) return true;
+  return isTransientCompressionError(error);
+}

--- a/packages/core/src/core/compression/types.ts
+++ b/packages/core/src/core/compression/types.ts
@@ -285,16 +285,48 @@ export class CompressionExecutionError extends CompressionStrategyError {
  * This is always a permanent (non-retryable) failure — the model returned
  * nothing deterministically; retrying is unlikely to succeed.
  *
+ * Carries optional diagnostics (finishReason, stopReason, blockTypeCounts)
+ * so the caller can distinguish a genuinely empty model response from a
+ * masked provider failure (e.g. reasoning model that burns its entire
+ * output-token budget on thinking and produces no text — issue #2333).
+ *
  * @plan PLAN-20260211-COMPRESSION.P14
  */
 export class EmptySummaryError extends CompressionStrategyError {
-  constructor(strategy: string) {
-    super(
+  readonly finishReason?: string;
+  readonly stopReason?: string;
+  readonly blockTypeCounts?: Readonly<Record<string, number>>;
+  readonly thinkingBlockCount?: number;
+
+  constructor(
+    strategy: string,
+    diagnostics?: {
+      finishReason?: string;
+      stopReason?: string;
+      blockTypeCounts?: Readonly<Record<string, number>>;
+    },
+  ) {
+    const parts: string[] = [
       `Compression strategy "${strategy}" produced an empty summary`,
-      COMPRESSION_ERROR_CODES.EMPTY_SUMMARY,
-      { strategy },
-    );
+    ];
+    if (diagnostics?.finishReason) {
+      parts.push(`(finishReason: ${diagnostics.finishReason}`);
+      if (diagnostics.stopReason)
+        parts.push(`, stopReason: ${diagnostics.stopReason}`);
+      parts.push(`)`);
+    }
+    if (diagnostics?.blockTypeCounts) {
+      const summary = Object.entries(diagnostics.blockTypeCounts)
+        .map(([type, count]) => `${type}:${count}`)
+        .join(', ');
+      parts.push(`[blocks received: ${summary}]`);
+    }
+    super(parts.join(' '), COMPRESSION_ERROR_CODES.EMPTY_SUMMARY, { strategy });
     this.name = 'EmptySummaryError';
+    this.finishReason = diagnostics?.finishReason;
+    this.stopReason = diagnostics?.stopReason;
+    this.blockTypeCounts = diagnostics?.blockTypeCounts;
+    this.thinkingBlockCount = diagnostics?.blockTypeCounts?.['thinking'];
   }
 }
 

--- a/packages/core/src/services/history/IContent.ts
+++ b/packages/core/src/services/history/IContent.ts
@@ -78,6 +78,9 @@ export interface ContentMetadata {
 
   /** Finish reason from OpenAI-style providers (e.g., stop, length, tool_calls) */
   finishReason?: string;
+
+  /** Reason the response was incomplete (e.g., max_output_tokens) */
+  incompleteReason?: string;
 }
 
 export interface UsageStats {

--- a/packages/providers/src/openai/parseResponsesStream.test.ts
+++ b/packages/providers/src/openai/parseResponsesStream.test.ts
@@ -332,6 +332,26 @@ describe('parseResponsesStream terminal events (issue #2333)', () => {
   });
 
   /**
+   * response.failed events without an error object must still throw using
+   * the fallback message.
+   */
+  it('throws fallback message on response.failed event with no error payload', async () => {
+    const chunks = [
+      'data: {"type":"response.failed","response":{"id":"r1","object":"response","model":"gpt-4o","status":"failed"}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const stream = createSSEStream(chunks);
+    const iterator = parseResponsesStream(stream);
+
+    await expect(async () => {
+      for await (const _message of iterator) {
+        // drain
+      }
+    }).rejects.toThrow('OpenAI Responses API stream failed');
+  });
+
+  /**
    * response.incomplete events should NOT throw — partial content may be
    * useful. Instead, terminal metadata (usage, stopReason) is yielded.
    * The `incomplete` status maps to `max_tokens` stopReason.
@@ -354,5 +374,31 @@ describe('parseResponsesStream terminal events (issue #2333)', () => {
     expect(usageMessage).toBeDefined();
     expect(usageMessage?.metadata?.stopReason).toBe('max_tokens');
     expect(usageMessage?.metadata?.finishReason).toBe('incomplete');
+  });
+
+  /**
+   * response.incomplete without usage should NOT throw and should complete
+   * normally, yielding the text delta but no usage metadata message.
+   */
+  it('completes normally for response.incomplete with no usage object', async () => {
+    const chunks = [
+      'data: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+      'data: {"type":"response.incomplete","response":{"id":"r1","object":"response","model":"gpt-4o","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const stream = createSSEStream(chunks);
+    const messages: IContent[] = [];
+
+    for await (const message of parseResponsesStream(stream)) {
+      messages.push(message);
+    }
+
+    // The text delta was yielded; no usage metadata message is present.
+    expect(messages).toHaveLength(1);
+    expect(messages[0].blocks).toStrictEqual([
+      { type: 'text', text: 'partial' },
+    ]);
+    expect(messages.find((m) => m.metadata?.usage)).toBeUndefined();
   });
 });

--- a/packages/providers/src/openai/parseResponsesStream.test.ts
+++ b/packages/providers/src/openai/parseResponsesStream.test.ts
@@ -290,3 +290,69 @@ describe('parseErrorResponse', () => {
     });
   });
 });
+
+describe('parseResponsesStream terminal events (issue #2333)', () => {
+  /**
+   * response.failed events must throw so server-side failures propagate
+   * instead of being silently swallowed (root cause of masked empty summaries).
+   */
+  it('throws on response.failed event with provider error message', async () => {
+    const chunks = [
+      'data: {"type":"response.failed","response":{"id":"r1","object":"response","model":"gpt-4o","status":"failed","error":{"message":"Internal server error","type":"server_error"}}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const stream = createSSEStream(chunks);
+    const iterator = parseResponsesStream(stream);
+
+    await expect(async () => {
+      for await (const _message of iterator) {
+        // drain
+      }
+    }).rejects.toThrow('Internal server error');
+  });
+
+  /**
+   * Top-level error events (e.g. rate limit) must also throw.
+   */
+  it('throws on top-level error event with error message', async () => {
+    const chunks = [
+      'data: {"type":"error","error":{"message":"rate limit exceeded","type":"rate_limit_error"}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const stream = createSSEStream(chunks);
+    const iterator = parseResponsesStream(stream);
+
+    await expect(async () => {
+      for await (const _message of iterator) {
+        // drain
+      }
+    }).rejects.toThrow('rate limit exceeded');
+  });
+
+  /**
+   * response.incomplete events should NOT throw — partial content may be
+   * useful. Instead, terminal metadata (usage, stopReason) is yielded.
+   * The `incomplete` status maps to `max_tokens` stopReason.
+   */
+  it('yields metadata for response.incomplete with stopReason max_tokens', async () => {
+    const chunks = [
+      'data: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+      'data: {"type":"response.incomplete","response":{"id":"r1","object":"response","model":"gpt-4o","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":10,"output_tokens":5000,"total_tokens":5010}}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const stream = createSSEStream(chunks);
+    const messages: IContent[] = [];
+
+    for await (const message of parseResponsesStream(stream)) {
+      messages.push(message);
+    }
+
+    const usageMessage = messages.find((m) => m.metadata?.usage);
+    expect(usageMessage).toBeDefined();
+    expect(usageMessage?.metadata?.stopReason).toBe('max_tokens');
+    expect(usageMessage?.metadata?.finishReason).toBe('incomplete');
+  });
+});

--- a/packages/providers/src/openai/parseResponsesStream.ts
+++ b/packages/providers/src/openai/parseResponsesStream.ts
@@ -357,9 +357,10 @@ function* handleFunctionCallDone(
 }
 
 /**
- * Build and throw a stream-interruption error for terminal `response.failed`
+ * Build a stream-interruption error for terminal `response.failed`
  * or top-level `error` events. Uses createStreamInterruptionError so the error
  * is classified as transient/retryable (server-side failures should be retried).
+ * Callers are responsible for throwing the returned Error.
  */
 function createTerminalStreamError(
   errorPayload: ResponsesApiError | undefined,

--- a/packages/providers/src/openai/parseResponsesStream.ts
+++ b/packages/providers/src/openai/parseResponsesStream.ts
@@ -361,12 +361,12 @@ function* handleFunctionCallDone(
  * or top-level `error` events. Uses createStreamInterruptionError so the error
  * is classified as transient/retryable (server-side failures should be retried).
  */
-function throwTerminalStreamError(
+function createTerminalStreamError(
   errorPayload: ResponsesApiError | undefined,
   responseStatus?: string | number,
-): never {
+): Error {
   const message = errorPayload?.message ?? 'OpenAI Responses API stream failed';
-  throw createStreamInterruptionError(message, {
+  return createStreamInterruptionError(message, {
     providerError: errorPayload,
     responseStatus,
   });
@@ -424,11 +424,18 @@ function* handleResponseCompleted(
 
   // Usage data
   const terminalReason = event.response?.status ?? 'completed';
+  const incompleteReason =
+    terminalReason === 'incomplete'
+      ? event.response?.incomplete_details?.reason
+      : undefined;
 
   // Defensive: some implementations send failure via response.completed with
   // status "failed" rather than a standalone response.failed event.
   if (terminalReason === 'failed') {
-    throwTerminalStreamError(event.response?.error, event.response?.status);
+    throw createTerminalStreamError(
+      event.response?.error,
+      event.response?.status,
+    );
   }
 
   if (event.response?.usage) {
@@ -445,6 +452,7 @@ function* handleResponseCompleted(
         },
         stopReason: mapFinishReasonToStopReason(terminalReason),
         finishReason: terminalReason,
+        ...(incompleteReason ? { incompleteReason } : {}),
       },
     };
   }
@@ -648,14 +656,12 @@ function* dispatchEventCases(
       );
       break;
     case 'response.failed':
-      throwTerminalStreamError(
+      throw createTerminalStreamError(
         event.response?.error ?? event.error,
         event.response?.status,
       );
-      break;
     case 'error':
-      throwTerminalStreamError(event.error);
-      break;
+      throw createTerminalStreamError(event.error);
     default:
       break;
   }

--- a/packages/providers/src/openai/parseResponsesStream.ts
+++ b/packages/providers/src/openai/parseResponsesStream.ts
@@ -16,6 +16,12 @@ import { mapFinishReasonToStopReason } from './finishReasonMapping.js';
 
 const logger = new DebugLogger('llxprt:providers:openai-responses:sse');
 
+interface ResponsesApiError {
+  message?: string;
+  type?: string;
+  code?: string;
+}
+
 // Types for Responses API events
 interface ResponsesEvent {
   type: string;
@@ -38,11 +44,17 @@ interface ResponsesEvent {
   };
   item_id?: string;
   arguments?: string;
+  /** Top-level error payload (for `error` event type). */
+  error?: ResponsesApiError;
   response?: {
     id: string;
     object: string;
     model: string;
     status: string;
+    /** Error payload for `response.failed` events. */
+    error?: ResponsesApiError;
+    /** Reason metadata for `response.incomplete` events. */
+    incomplete_details?: { reason?: string };
     usage?: {
       input_tokens: number;
       output_tokens: number;
@@ -345,7 +357,23 @@ function* handleFunctionCallDone(
 }
 
 /**
- * Handle response.completed / response.done events.
+ * Build and throw a stream-interruption error for terminal `response.failed`
+ * or top-level `error` events. Uses createStreamInterruptionError so the error
+ * is classified as transient/retryable (server-side failures should be retried).
+ */
+function throwTerminalStreamError(
+  errorPayload: ResponsesApiError | undefined,
+  responseStatus?: string | number,
+): never {
+  const message = errorPayload?.message ?? 'OpenAI Responses API stream failed';
+  throw createStreamInterruptionError(message, {
+    providerError: errorPayload,
+    responseStatus,
+  });
+}
+
+/**
+ * Handle response.completed / response.done / response.incomplete events.
  */
 function* handleResponseCompleted(
   event: ResponsesEvent,
@@ -396,6 +424,13 @@ function* handleResponseCompleted(
 
   // Usage data
   const terminalReason = event.response?.status ?? 'completed';
+
+  // Defensive: some implementations send failure via response.completed with
+  // status "failed" rather than a standalone response.failed event.
+  if (terminalReason === 'failed') {
+    throwTerminalStreamError(event.response?.error, event.response?.status);
+  }
+
   if (event.response?.usage) {
     yield {
       speaker: 'ai',
@@ -604,12 +639,22 @@ function* dispatchEventCases(
       break;
     case 'response.completed':
     case 'response.done':
+    case 'response.incomplete':
       state = yield* handleCompletedEvent(
         event,
         state,
         includeThinkingInResponse,
         emittedThoughts,
       );
+      break;
+    case 'response.failed':
+      throwTerminalStreamError(
+        event.response?.error ?? event.error,
+        event.response?.status,
+      );
+      break;
+    case 'error':
+      throwTerminalStreamError(event.error);
       break;
     default:
       break;


### PR DESCRIPTION
## Summary

Fixes #2333 — compression strategy "middle-out" produced an empty summary and aborted the agent turn with a user-facing API Error.

Investigation revealed the empty summary was very likely a **masked provider failure**. The OpenAI Responses API stream parser (`parseResponsesStream.ts`) silently dropped `response.failed`, `response.incomplete`, and `error` SSE events (they hit `default: break;`). A server-side failure or reasoning-model budget exhaustion (e.g., gpt-5.5 burning its entire output budget on thinking blocks) produced an empty stream that was misdiagnosed as "model deterministically returned nothing."

## Three-layer fix

### Layer 1: Root cause — `parseResponsesStream.ts`
- `response.failed` events now **throw** (`createStreamInterruptionError`, classified transient/retryable) instead of being silently swallowed
- `error` events (e.g., rate limit) now **throw** the same way
- `response.incomplete` events are now **handled** (routed through `handleResponseCompleted`) and yield terminal metadata including `incompleteReason` from `incomplete_details` — partial content remains useful in the agent loop
- Defensive check: if `response.completed` arrives with `status: "failed"`, throws rather than treating it as success

### Layer 2: Diagnostics — `EmptySummaryError` enrichment
- `EmptySummaryError` now carries optional diagnostics: `finishReason`, `stopReason`, `blockTypeCounts`, `thinkingBlockCount`
- `MiddleOutStrategy` and `OneShotStrategy` `callProvider` capture block type counts, finish/stop reasons from the stream and pass them through
- Mid-stream errors enrich the `CompressionExecutionError` message with partial diagnostics
- Distinguishes a genuine "model returned nothing" from a masked failure (e.g., `finishReason: incomplete, thinking:12, text:0`)

### Layer 3: Graceful degradation — `CompressionHandler`
- New `isFallbackEligibleCompressionError` predicate: `EmptySummaryError` is fallback-eligible (but still non-transient/non-retryable — retrying the LLM call is pointless)
- `runCompressionWithRetryAndFallback` now falls back to `top-down-truncation` instead of rethrowing — the turn degrades gracefully instead of aborting
- The warn log now carries the enriched diagnostics instead of masking the root cause

## Test plan
- `parseResponsesStream.test.ts`: 5 new tests (response.failed throws, error throws, response.incomplete yields metadata, response.failed without error payload, response.incomplete without usage)
- `MiddleOutStrategy-error.test.ts`: 2 new tests (thinking-only diagnostics with finishReason/blockTypeCounts, backward-compatible message format)
- `compression-retry-classification.test.ts`: 14 new tests for `isFallbackEligibleCompressionError` classification
- `compression-retry-behavior.test.ts`: 2 new tests (EmptySummaryError fallback via performCompression and via ensureCompressionBeforeSend)

## Verification
All passing: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, smoke test (`node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"`).

closes #2333