### PR TITLE
Surface Claude Fable 5 classifier refusals as a user-visible notice (Fixes #2329)

### DIFF
--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -763,6 +763,12 @@ variants, discriminated by `type`. See
 | `error`             | `error: StructuredError`                            | No (precedes done) |
 | `done`              | `reason: DoneReason`, `finished?`, `stop?`          | **Yes**            |
 
+`finished` is a `FinishedValue` carrying `reason: string` (the mapped
+`FinishReason`), optional `usageMetadata`, and an optional `stopReason?: string`
+— the raw provider stop reason (e.g. Anthropic `stop_reason: 'refusal'`,
+`'end_turn'`). When `stopReason` is `'refusal'`, the done's `reason` is
+`'refusal'` (see below).
+
 > Several non-terminal events _signal_ an upcoming termination by setting the
 > pending done reason (e.g. `error` → `done{reason:'error'}`, `loop-detected`
 > → `done{reason:'loop-detected'}`, `context-warning` →
@@ -779,11 +785,12 @@ export type DoneReason =
   | 'context-overflow'
   | 'loop-detected'
   | 'error'
-  | 'hook-stopped';
+  | 'hook-stopped'
+  | 'refusal';
 ```
 
 **Invariant:** every `stream()`/`chat()` turn yields/returns **exactly one**
-terminal `AgentDoneEvent` carrying one of these seven reasons. Errors surface as
+terminal `AgentDoneEvent` carrying one of these reasons. Errors surface as
 an `AgentErrorEvent` **followed by exactly one** `done{reason:'error'}` — the
 error event is informational; the `done` is the terminator.
 
@@ -792,6 +799,11 @@ error event is informational; the `done` is the terminator.
 
 - `aborted` — the turn was cancelled (e.g. via an `AbortSignal`).
 - `error` — the turn failed.
+- `refusal` — the model's safety classifier declined the request (Anthropic
+  `stop_reason: 'refusal'`, e.g. Claude Fable 5). The `finished` payload
+  carries `stopReason: 'refusal'` (the raw provider stop reason). The turn
+  completed (HTTP 200) but produced no actionable answer; surface a
+  user-visible notice rather than treating it as a hard error.
 
 > **Idle-timeout is terminal.** A stream idle-timeout emits an `idle-timeout`
 > event and then terminates the turn with `done{reason:'error'}`.

--- a/packages/a2a-server/src/agent/task.test.ts
+++ b/packages/a2a-server/src/agent/task.test.ts
@@ -17,7 +17,9 @@ import {
   type WaitingToolCall,
   type AnyDeclarativeTool,
   type AnyToolInvocation,
+  REFUSAL_NOTICE_MESSAGE,
 } from '@vybestack/llxprt-code-core';
+import { FinishReason } from '@google/genai';
 import { createMockConfig } from '../utils/testing_utils.js';
 import { CoderAgentEvent } from '../types.js';
 import type { ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server';
@@ -218,6 +220,99 @@ describe('Task', () => {
         undefined,
         undefined,
       );
+    });
+  });
+
+  describe('acceptAgentMessage refusal surfacing @issue:2329', () => {
+    it('publishes the refusal notice text when Finished has stopReason "refusal"', async () => {
+      const mockConfig = createMockConfig();
+      const mockEventBus = createMockEventBus();
+
+      const task = await Task.create(
+        'task-id',
+        'context-id',
+        mockConfig as Config,
+        mockEventBus,
+      );
+      // Spy on the same text-content path used for ordinary Content events.
+      const sendTextSpy = vi.spyOn(task, '_sendTextContent');
+
+      await task.acceptAgentMessage({
+        type: GeminiEventType.Finished,
+        value: {
+          reason: FinishReason.STOP,
+          stopReason: 'refusal',
+        },
+      });
+
+      // The exact notice (with its safety-notice prefix) must reach the client.
+      expect(sendTextSpy).toHaveBeenCalledWith(
+        `\n\n[safety notice] ${REFUSAL_NOTICE_MESSAGE}`,
+      );
+      // ...and it must be published onto the event bus as agent text content.
+      expect(mockEventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'status-update',
+          taskId: 'task-id',
+          contextId: 'context-id',
+          status: expect.objectContaining({
+            message: expect.objectContaining({
+              role: 'agent',
+              parts: [
+                expect.objectContaining({
+                  kind: 'text',
+                  text: `\n\n[safety notice] ${REFUSAL_NOTICE_MESSAGE}`,
+                }),
+              ],
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('does not publish a refusal notice when Finished has no stopReason', async () => {
+      const mockConfig = createMockConfig();
+      const mockEventBus = createMockEventBus();
+
+      const task = await Task.create(
+        'task-id',
+        'context-id',
+        mockConfig as Config,
+        mockEventBus,
+      );
+      const sendTextSpy = vi.spyOn(task, '_sendTextContent');
+
+      await task.acceptAgentMessage({
+        type: GeminiEventType.Finished,
+        value: {
+          reason: FinishReason.STOP,
+        },
+      });
+
+      expect(sendTextSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not publish a refusal notice when stopReason is "end_turn"', async () => {
+      const mockConfig = createMockConfig();
+      const mockEventBus = createMockEventBus();
+
+      const task = await Task.create(
+        'task-id',
+        'context-id',
+        mockConfig as Config,
+        mockEventBus,
+      );
+      const sendTextSpy = vi.spyOn(task, '_sendTextContent');
+
+      await task.acceptAgentMessage({
+        type: GeminiEventType.Finished,
+        value: {
+          reason: FinishReason.STOP,
+          stopReason: 'end_turn',
+        },
+      });
+
+      expect(sendTextSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -6,6 +6,7 @@
 
 import {
   GeminiEventType,
+  REFUSAL_NOTICE_MESSAGE,
   ToolConfirmationOutcome,
   ApprovalMode,
   createAgentRuntimeState,
@@ -526,6 +527,21 @@ export class Task {
       const type = event.type;
       if (getLogWarnTypes().has(type) || getLogInfoTypes().has(type)) {
         logInformationalEvent(type, event, this.id);
+      }
+      // @issue:2329 — a Finished event whose raw provider stop reason is
+      // 'refusal' indicates the model's safety classifier declined the request.
+      // The Finished event is informational (logged above), but the a2a client
+      // would otherwise see only the (possibly empty) answer text with no
+      // indication that a refusal occurred. Surface an explicit notice to the
+      // client using the same text-content path as ordinary Content events.
+      // Type narrowing is supplied by InformationalGeminiStreamEvent (which
+      // includes the Finished variant with its value.stopReason field), so no
+      // assertion is required.
+      if (
+        event.type === GeminiEventType.Finished &&
+        event.value.stopReason === 'refusal'
+      ) {
+        this._sendTextContent(`\n\n[safety notice] ${REFUSAL_NOTICE_MESSAGE}`);
       }
       // Silent types (ChatCompressed, UsageMetadata, Citation) require no action
       return;

--- a/packages/agents/src/api/__tests__/event-characterization.spec.ts
+++ b/packages/agents/src/api/__tests__/event-characterization.spec.ts
@@ -19,6 +19,7 @@ import * as fc from 'fast-check';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import { FinishReason } from '@google/genai';
 import {
   runAdapterStatic,
   wrapStream,
@@ -225,6 +226,27 @@ describe('Event characterization — adapter-characterization @plan:PLAN-2026061
     const done = doneEvents(events);
     expect(done).toHaveLength(1);
     expect(done[0].reason).toBe('stop');
+  });
+
+  it('Finished with stopReason refusal → done{refusal} preserving finished.stopReason @issue:2329', async () => {
+    const events = await runAdapterStatic([
+      wrapStream(streamFinished(FinishReason.SAFETY, 'refusal')),
+    ]);
+    const done = doneEvents(events);
+    expect(done).toHaveLength(1);
+    expect(done[0].reason).toBe('refusal');
+    expect(done[0].finished?.stopReason).toBe('refusal');
+    expect(done[0].finished?.reason).toBe(FinishReason.SAFETY);
+  });
+
+  it('Finished with a non-refusal stopReason → done{stop} @issue:2329', async () => {
+    const events = await runAdapterStatic([
+      wrapStream(streamFinished(FinishReason.STOP, 'end_turn')),
+    ]);
+    const done = doneEvents(events);
+    expect(done).toHaveLength(1);
+    expect(done[0].reason).toBe('stop');
+    expect(done[0].finished?.stopReason).toBe('end_turn');
   });
 });
 

--- a/packages/agents/src/api/__tests__/event-characterization.spec.ts
+++ b/packages/agents/src/api/__tests__/event-characterization.spec.ts
@@ -230,13 +230,13 @@ describe('Event characterization — adapter-characterization @plan:PLAN-2026061
 
   it('Finished with stopReason refusal → done{refusal} preserving finished.stopReason @issue:2329', async () => {
     const events = await runAdapterStatic([
-      wrapStream(streamFinished(FinishReason.SAFETY, 'refusal')),
+      wrapStream(streamFinished(FinishReason.STOP, 'refusal')),
     ]);
     const done = doneEvents(events);
     expect(done).toHaveLength(1);
     expect(done[0].reason).toBe('refusal');
     expect(done[0].finished?.stopReason).toBe('refusal');
-    expect(done[0].finished?.reason).toBe(FinishReason.SAFETY);
+    expect(done[0].finished?.reason).toBe(FinishReason.STOP);
   });
 
   it('Finished with a non-refusal stopReason → done{stop} @issue:2329', async () => {

--- a/packages/agents/src/api/__tests__/event-schema.spec.ts
+++ b/packages/agents/src/api/__tests__/event-schema.spec.ts
@@ -265,13 +265,13 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
   it('parses a done event preserving finished.stopReason @issue:2329', () => {
     const parsed = AgentEventSchema.parse({
       type: 'done',
-      reason: 'stop',
+      reason: 'refusal',
       finished: { reason: 'SAFETY', stopReason: 'refusal' },
     });
     expect(parsed.type).toBe('done');
     expect(parsed).toStrictEqual({
       type: 'done',
-      reason: 'stop',
+      reason: 'refusal',
       finished: { reason: 'SAFETY', stopReason: 'refusal' },
     });
   });
@@ -320,6 +320,7 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
       'loop-detected',
       'error',
       'hook-stopped',
+      'refusal',
     ]) {
       expect(DoneReasonSchema.parse(reason)).toBe(reason);
     }
@@ -486,6 +487,7 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
     'loop-detected',
     'error',
     'hook-stopped',
+    'refusal',
   ]);
 
   // The complete set of known AgentEvent discriminator tags (19 variants).
@@ -513,7 +515,7 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
 
   it('property: DoneReasonSchema parses an arbitrary string IFF it is a canonical reason (completeness + soundness) @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {
     // Soundness: for ANY generated string, parse success must agree exactly
-    // with membership in the canonical 7-reason set — no extra reason is
+    // with membership in the canonical reason set — no extra reason is
     // accepted, no canonical reason is rejected.
     fc.assert(
       fc.property(fc.string(), (s) => {

--- a/packages/agents/src/api/__tests__/event-schema.spec.ts
+++ b/packages/agents/src/api/__tests__/event-schema.spec.ts
@@ -266,13 +266,13 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
     const parsed = AgentEventSchema.parse({
       type: 'done',
       reason: 'refusal',
-      finished: { reason: 'SAFETY', stopReason: 'refusal' },
+      finished: { reason: 'STOP', stopReason: 'refusal' },
     });
     expect(parsed.type).toBe('done');
     expect(parsed).toStrictEqual({
       type: 'done',
       reason: 'refusal',
-      finished: { reason: 'SAFETY', stopReason: 'refusal' },
+      finished: { reason: 'STOP', stopReason: 'refusal' },
     });
   });
 
@@ -462,11 +462,11 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
 
   it('FinishedValueSchema accepts and preserves stopReason @issue:2329', () => {
     const parsed = FinishedValueSchema.parse({
-      reason: 'SAFETY',
+      reason: 'STOP',
       stopReason: 'refusal',
     });
     expect(parsed).toStrictEqual({
-      reason: 'SAFETY',
+      reason: 'STOP',
       stopReason: 'refusal',
     });
   });

--- a/packages/agents/src/api/__tests__/event-schema.spec.ts
+++ b/packages/agents/src/api/__tests__/event-schema.spec.ts
@@ -262,6 +262,20 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
     });
   });
 
+  it('parses a done event preserving finished.stopReason @issue:2329', () => {
+    const parsed = AgentEventSchema.parse({
+      type: 'done',
+      reason: 'stop',
+      finished: { reason: 'SAFETY', stopReason: 'refusal' },
+    });
+    expect(parsed.type).toBe('done');
+    expect(parsed).toStrictEqual({
+      type: 'done',
+      reason: 'stop',
+      finished: { reason: 'SAFETY', stopReason: 'refusal' },
+    });
+  });
+
   it('parses a minimal done event (reason only) @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {
     const parsed = AgentEventSchema.parse({ type: 'done', reason: 'aborted' });
     expect(parsed).toStrictEqual({ type: 'done', reason: 'aborted' });
@@ -443,6 +457,22 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
       reason: 'done',
     });
     expect(FinishedValueSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('FinishedValueSchema accepts and preserves stopReason @issue:2329', () => {
+    const parsed = FinishedValueSchema.parse({
+      reason: 'SAFETY',
+      stopReason: 'refusal',
+    });
+    expect(parsed).toStrictEqual({
+      reason: 'SAFETY',
+      stopReason: 'refusal',
+    });
+  });
+
+  it('FinishedValueSchema stopReason is optional @issue:2329', () => {
+    const parsed = FinishedValueSchema.parse({ reason: 'done' });
+    expect(parsed).not.toHaveProperty('stopReason');
   });
 
   // ─── property-based invariants ───────────────────────────────────────────

--- a/packages/agents/src/api/__tests__/helpers/agentHarness.ts
+++ b/packages/agents/src/api/__tests__/helpers/agentHarness.ts
@@ -361,6 +361,7 @@ export const DONE_REASONS: readonly DoneReason[] = [
   'loop-detected',
   'error',
   'hook-stopped',
+  'refusal',
 ];
 
 // ─── HistoryService identity (T4d/T4e) ──────────────────────────────────────

--- a/packages/agents/src/api/__tests__/helpers/eventHarness.ts
+++ b/packages/agents/src/api/__tests__/helpers/eventHarness.ts
@@ -163,8 +163,12 @@ export function streamMaxTurns(): ServerGeminiStreamEvent {
 
 export function streamFinished(
   reason: FinishReason = FinishReason.STOP,
+  stopReason?: string,
 ): ServerGeminiStreamEvent {
-  return { type: GeminiEventType.Finished, value: { reason } };
+  return {
+    type: GeminiEventType.Finished,
+    value: { reason, ...(stopReason !== undefined ? { stopReason } : {}) },
+  };
 }
 
 export function streamUserCancelled(): ServerGeminiStreamEvent {

--- a/packages/agents/src/api/event-schema.ts
+++ b/packages/agents/src/api/event-schema.ts
@@ -35,6 +35,9 @@ export const UsageMetadataValueSchema = z.object({
 export const FinishedValueSchema = z.object({
   reason: z.string(),
   usageMetadata: UsageMetadataValueSchema.optional(),
+  // @issue:2329 — the raw provider stop reason (e.g. 'refusal') so consumers
+  // can surface a refusal-specific notice distinct from a normal completion.
+  stopReason: z.string().optional(),
 });
 
 export const AgentStopInfoSchema = z.object({

--- a/packages/agents/src/api/event-schema.ts
+++ b/packages/agents/src/api/event-schema.ts
@@ -13,6 +13,8 @@ export const DoneReasonSchema = z.enum([
   'loop-detected',
   'error',
   'hook-stopped',
+  // @issue:2329 — safety-classifier refusal (Anthropic stop_reason: 'refusal').
+  'refusal',
 ]);
 
 export const StructuredErrorSchema = z.object({

--- a/packages/agents/src/api/event-types.ts
+++ b/packages/agents/src/api/event-types.ts
@@ -36,6 +36,9 @@ export type UsageMetadataValue = Readonly<{
 export type FinishedValue = Readonly<{
   reason: string;
   usageMetadata?: UsageMetadataValue;
+  // @issue:2329 — the raw provider stop reason (e.g. 'refusal') so consumers
+  // can surface a refusal-specific notice distinct from a normal completion.
+  stopReason?: string;
 }>;
 
 export type AgentStopInfo = Readonly<{

--- a/packages/agents/src/api/event-types.ts
+++ b/packages/agents/src/api/event-types.ts
@@ -24,7 +24,10 @@ export type DoneReason =
   | 'context-overflow'
   | 'loop-detected'
   | 'error'
-  | 'hook-stopped';
+  | 'hook-stopped'
+  // @issue:2329 — emitted when the model's safety classifier declines the
+  // request (Anthropic stop_reason: 'refusal', e.g. Claude Fable 5).
+  | 'refusal';
 
 export type UsageMetadataValue = Readonly<{
   promptTokenCount?: number;

--- a/packages/agents/src/api/eventAdapter.ts
+++ b/packages/agents/src/api/eventAdapter.ts
@@ -311,7 +311,7 @@ function* mapValueEvent(
     }
     // @pseudocode event-adapter.md steps 243-244: Finished
     case GeminiEventType.Finished: {
-      const v = e.value as { reason: string };
+      const v = e.value as { reason: string; stopReason?: string };
       state.lastFinished = v;
       yield makeDone(state, mapFinishReason(v.reason));
       state.emittedDone = true;

--- a/packages/agents/src/api/eventAdapter.ts
+++ b/packages/agents/src/api/eventAdapter.ts
@@ -209,12 +209,17 @@ function toStopInfo(e: StopEvent): AgentStopInfo {
 }
 
 /**
- * Maps a Finished reason to the public DoneReason. A Finished event represents
- * normal completion; other terminal causes arrive via their own variants.
+ * Maps a Finished value to the public DoneReason. A Finished event represents
+ * normal completion; other terminal causes arrive via their own variants. When
+ * the raw provider stop reason is `'refusal'` (the model's safety classifier
+ * declined the request, e.g. Anthropic Claude Fable 5), the done carries
+ * `reason: 'refusal'` so consumers can surface a refusal-specific notice;
+ * otherwise the done is a normal `'stop'`.
  * @pseudocode event-adapter.md step 244: mapFinishReason
+ * @issue:2329
  */
-function mapFinishReason(_reason: string): DoneReason {
-  return 'stop';
+function mapFinishReason(stopReason: string | undefined): DoneReason {
+  return stopReason === 'refusal' ? 'refusal' : 'stop';
 }
 
 /**
@@ -313,7 +318,7 @@ function* mapValueEvent(
     case GeminiEventType.Finished: {
       const v = e.value as { reason: string; stopReason?: string };
       state.lastFinished = v;
-      yield makeDone(state, mapFinishReason(v.reason));
+      yield makeDone(state, mapFinishReason(v.stopReason));
       state.emittedDone = true;
       return;
     }

--- a/packages/agents/src/api/eventAdapter.ts
+++ b/packages/agents/src/api/eventAdapter.ts
@@ -416,7 +416,12 @@ export async function* mapLoopStream(
     !state.emittedDone &&
     (state.sawActivity || state.pendingDoneReason !== null)
   ) {
-    const reason: DoneReason = state.pendingDoneReason ?? 'stop';
+    // A stronger pending terminal reason wins; otherwise derive the reason
+    // from any stored Finished value so a preserved refusal stopReason is
+    // honored even on the synthesized-completion path (@issue:2329).
+    const reason: DoneReason =
+      state.pendingDoneReason ??
+      mapFinishReason(state.lastFinished?.stopReason);
     yield makeDone(state, reason);
   }
 }

--- a/packages/agents/src/core/MessageConverter.issue2329.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2329.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #2329: surface Claude Fable 5 safety-classifier
+ * refusals as a distinguishable finish reason.
+ *
+ * Tests through the public convertIContentToResponse() entry point — no mock
+ * theater. A refusal IContent must produce a response with finishReason SAFETY
+ * and the raw provider stop reason preserved on candidate.finishMessage.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FinishReason } from '@google/genai';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { convertIContentToResponse } from './MessageConverter.js';
+
+describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
+  it('maps refusal metadata.stopReason to FinishReason.SAFETY', () => {
+    const icontent: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'I cannot help with that.' }],
+      metadata: { stopReason: 'refusal' },
+    };
+
+    const response = convertIContentToResponse(icontent);
+
+    expect(response.candidates).toBeDefined();
+    expect(response.candidates).toHaveLength(1);
+    expect(response.candidates[0].finishReason).toBe(FinishReason.SAFETY);
+  });
+
+  it('preserves the raw provider stop reason on candidate.finishMessage for refusal', () => {
+    const icontent: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'declined' }],
+      metadata: { stopReason: 'refusal' },
+    };
+
+    const response = convertIContentToResponse(icontent);
+
+    expect(response.candidates[0].finishMessage).toBe('refusal');
+  });
+
+  it('maps a normal end_turn to STOP and preserves finishMessage end_turn', () => {
+    const icontent: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'Here is the answer.' }],
+      metadata: { stopReason: 'end_turn' },
+    };
+
+    const response = convertIContentToResponse(icontent);
+
+    expect(response.candidates[0].finishReason).toBe(FinishReason.STOP);
+    expect(response.candidates[0].finishMessage).toBe('end_turn');
+  });
+
+  it('maps max_tokens to MAX_TOKENS and preserves finishMessage', () => {
+    const icontent: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'truncated' }],
+      metadata: { stopReason: 'max_tokens' },
+    };
+
+    const response = convertIContentToResponse(icontent);
+
+    expect(response.candidates[0].finishReason).toBe(FinishReason.MAX_TOKENS);
+    expect(response.candidates[0].finishMessage).toBe('max_tokens');
+  });
+
+  it('does not set finishMessage when no termination reason is present', () => {
+    const icontent: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'text' }],
+      metadata: {},
+    };
+
+    const response = convertIContentToResponse(icontent);
+
+    expect(response.candidates[0].finishReason).toBeUndefined();
+    expect(response.candidates[0].finishMessage).toBeUndefined();
+  });
+});

--- a/packages/agents/src/core/MessageConverter.issue2329.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2329.test.ts
@@ -84,7 +84,7 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     expect(response.candidates[0].finishMessage).toBeUndefined();
   });
 
-  it('leaves finishReason and finishMessage unset for an unknown stopReason', () => {
+  it('preserves finishMessage but leaves finishReason unset for an unknown stopReason', () => {
     const icontent: IContent = {
       speaker: 'ai',
       blocks: [{ type: 'text', text: 'text' }],
@@ -94,6 +94,6 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     const response = convertIContentToResponse(icontent);
 
     expect(response.candidates[0].finishReason).toBeUndefined();
-    expect(response.candidates[0].finishMessage).toBeUndefined();
+    expect(response.candidates[0].finishMessage).toBe('some_future_reason');
   });
 });

--- a/packages/agents/src/core/MessageConverter.issue2329.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2329.test.ts
@@ -9,7 +9,7 @@
  * refusals as a distinguishable finish reason.
  *
  * Tests through the public convertIContentToResponse() entry point — no mock
- * theater. A refusal IContent must produce a response with finishReason SAFETY
+ * theater. A refusal IContent must produce a response with finishReason STOP
  * and the raw provider stop reason preserved on candidate.finishMessage.
  */
 
@@ -19,7 +19,7 @@ import type { IContent } from '@vybestack/llxprt-code-core/services/history/ICon
 import { convertIContentToResponse } from './MessageConverter.js';
 
 describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
-  it('maps refusal metadata.stopReason to FinishReason.SAFETY', () => {
+  it('maps refusal metadata.stopReason to FinishReason.STOP', () => {
     const icontent: IContent = {
       speaker: 'ai',
       blocks: [{ type: 'text', text: 'I cannot help with that.' }],
@@ -30,7 +30,7 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
 
     expect(response.candidates).toBeDefined();
     expect(response.candidates).toHaveLength(1);
-    expect(response.candidates[0].finishReason).toBe(FinishReason.SAFETY);
+    expect(response.candidates[0].finishReason).toBe(FinishReason.STOP);
   });
 
   it('preserves the raw provider stop reason on candidate.finishMessage for refusal', () => {

--- a/packages/agents/src/core/MessageConverter.issue2329.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2329.test.ts
@@ -83,4 +83,17 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     expect(response.candidates[0].finishReason).toBeUndefined();
     expect(response.candidates[0].finishMessage).toBeUndefined();
   });
+
+  it('leaves finishReason and finishMessage unset for an unknown stopReason', () => {
+    const icontent: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'text' }],
+      metadata: { stopReason: 'some_future_reason' },
+    };
+
+    const response = convertIContentToResponse(icontent);
+
+    expect(response.candidates[0].finishReason).toBeUndefined();
+    expect(response.candidates[0].finishMessage).toBeUndefined();
+  });
 });

--- a/packages/agents/src/core/MessageConverter.issue2329.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2329.test.ts
@@ -10,13 +10,15 @@
  *
  * Tests through the public convertIContentToResponse() entry point — no mock
  * theater. A refusal IContent must produce a response with finishReason STOP
- * and the raw provider stop reason preserved on candidate.finishMessage.
+ * and the raw provider stop reason preserved on the repo-owned
+ * providerStopReason carrier (not the SDK's finishMessage field).
  */
 
 import { describe, it, expect } from 'vitest';
 import { FinishReason } from '@google/genai';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { convertIContentToResponse } from './MessageConverter.js';
+import { getProviderStopReason } from './providerStopReason.js';
 
 describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
   it('maps refusal metadata.stopReason to FinishReason.STOP', () => {
@@ -33,7 +35,7 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     expect(response.candidates[0].finishReason).toBe(FinishReason.STOP);
   });
 
-  it('preserves the raw provider stop reason on candidate.finishMessage for refusal', () => {
+  it('preserves the raw provider stop reason on providerStopReason for refusal', () => {
     const icontent: IContent = {
       speaker: 'ai',
       blocks: [{ type: 'text', text: 'declined' }],
@@ -42,10 +44,22 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
 
     const response = convertIContentToResponse(icontent);
 
-    expect(response.candidates[0].finishMessage).toBe('refusal');
+    expect(getProviderStopReason(response.candidates[0])).toBe('refusal');
   });
 
-  it('maps a normal end_turn to STOP and preserves finishMessage end_turn', () => {
+  it('does not overload the SDK finishMessage field with the stop reason', () => {
+    const icontent: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'declined' }],
+      metadata: { stopReason: 'refusal' },
+    };
+
+    const response = convertIContentToResponse(icontent);
+
+    expect(response.candidates[0].finishMessage).toBeUndefined();
+  });
+
+  it('maps a normal end_turn to STOP and preserves providerStopReason end_turn', () => {
     const icontent: IContent = {
       speaker: 'ai',
       blocks: [{ type: 'text', text: 'Here is the answer.' }],
@@ -55,10 +69,10 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     const response = convertIContentToResponse(icontent);
 
     expect(response.candidates[0].finishReason).toBe(FinishReason.STOP);
-    expect(response.candidates[0].finishMessage).toBe('end_turn');
+    expect(getProviderStopReason(response.candidates[0])).toBe('end_turn');
   });
 
-  it('maps max_tokens to MAX_TOKENS and preserves finishMessage', () => {
+  it('maps max_tokens to MAX_TOKENS and preserves providerStopReason', () => {
     const icontent: IContent = {
       speaker: 'ai',
       blocks: [{ type: 'text', text: 'truncated' }],
@@ -68,10 +82,10 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     const response = convertIContentToResponse(icontent);
 
     expect(response.candidates[0].finishReason).toBe(FinishReason.MAX_TOKENS);
-    expect(response.candidates[0].finishMessage).toBe('max_tokens');
+    expect(getProviderStopReason(response.candidates[0])).toBe('max_tokens');
   });
 
-  it('does not set finishMessage when no termination reason is present', () => {
+  it('does not set providerStopReason when no termination reason is present', () => {
     const icontent: IContent = {
       speaker: 'ai',
       blocks: [{ type: 'text', text: 'text' }],
@@ -81,10 +95,10 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     const response = convertIContentToResponse(icontent);
 
     expect(response.candidates[0].finishReason).toBeUndefined();
-    expect(response.candidates[0].finishMessage).toBeUndefined();
+    expect(getProviderStopReason(response.candidates[0])).toBeUndefined();
   });
 
-  it('preserves finishMessage but leaves finishReason unset for an unknown stopReason', () => {
+  it('preserves providerStopReason but leaves finishReason unset for an unknown stopReason', () => {
     const icontent: IContent = {
       speaker: 'ai',
       blocks: [{ type: 'text', text: 'text' }],
@@ -94,6 +108,8 @@ describe('Issue 2329: refusal finish-reason mapping @issue:2329', () => {
     const response = convertIContentToResponse(icontent);
 
     expect(response.candidates[0].finishReason).toBeUndefined();
-    expect(response.candidates[0].finishMessage).toBe('some_future_reason');
+    expect(getProviderStopReason(response.candidates[0])).toBe(
+      'some_future_reason',
+    );
   });
 });

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -559,7 +559,9 @@ function applyFinishReasonMapping(
       stop_sequence: FinishReason.STOP,
       tool_use: FinishReason.STOP,
       pause_turn: FinishReason.STOP,
-      refusal: FinishReason.STOP,
+      // @issue:2329 — refusal maps to SAFETY so downstream consumers can
+      // distinguish a safety-classifier refusal from a normal completion.
+      refusal: FinishReason.SAFETY,
       model_context_window_exceeded: FinishReason.MAX_TOKENS,
       // OpenAI Chat Completions-style values
       stop: FinishReason.STOP,
@@ -579,6 +581,10 @@ function applyFinishReasonMapping(
     if (hasMapping) {
       const mappedReason = finishReasonByTerminationReason[terminationReason];
       response.candidates[0].finishReason = mappedReason;
+      // @issue:2329 — preserve the raw provider stop reason on the candidate
+      // so downstream consumers (agent loop, CLI) can distinguish e.g. a
+      // safety-classifier refusal from a generic SAFETY stop.
+      response.candidates[0].finishMessage = terminationReason;
       logger.debug(
         () => `[stream:message-converter] applied terminal metadata`,
         {

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -576,13 +576,14 @@ function applyFinishReasonMapping(
       finishReasonByTerminationReason,
       terminationReason,
     );
+    // @issue:2329 — always preserve the raw provider stop reason on the
+    // candidate (even when it has no coarse FinishReason mapping) so
+    // downstream consumers (agent loop, CLI) can distinguish e.g. a
+    // safety-classifier refusal from a generic stop.
+    response.candidates[0].finishMessage = terminationReason;
     if (hasMapping) {
       const mappedReason = finishReasonByTerminationReason[terminationReason];
       response.candidates[0].finishReason = mappedReason;
-      // @issue:2329 — preserve the raw provider stop reason on the candidate
-      // so downstream consumers (agent loop, CLI) can distinguish e.g. a
-      // safety-classifier refusal from a generic SAFETY stop.
-      response.candidates[0].finishMessage = terminationReason;
       logger.debug(
         () => `[stream:message-converter] applied terminal metadata`,
         {

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -31,6 +31,7 @@ import {
   type UsageMetadataWithCache,
 } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
 import { getResponseTextFromParts } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
+import { setProviderStopReason } from './providerStopReason.js';
 
 const logger = new DebugLogger('llxprt:core:message-converter');
 
@@ -579,8 +580,10 @@ function applyFinishReasonMapping(
     // @issue:2329 — always preserve the raw provider stop reason on the
     // candidate (even when it has no coarse FinishReason mapping) so
     // downstream consumers (agent loop, CLI) can distinguish e.g. a
-    // safety-classifier refusal from a generic stop.
-    response.candidates[0].finishMessage = terminationReason;
+    // safety-classifier refusal from a generic stop. Stored on the
+    // repo-owned providerStopReason field — NOT the SDK's finishMessage,
+    // which is a human-readable description that native responses may set.
+    setProviderStopReason(response.candidates[0], terminationReason);
     if (hasMapping) {
       const mappedReason = finishReasonByTerminationReason[terminationReason];
       response.candidates[0].finishReason = mappedReason;

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -559,9 +559,7 @@ function applyFinishReasonMapping(
       stop_sequence: FinishReason.STOP,
       tool_use: FinishReason.STOP,
       pause_turn: FinishReason.STOP,
-      // @issue:2329 — refusal maps to SAFETY so downstream consumers can
-      // distinguish a safety-classifier refusal from a normal completion.
-      refusal: FinishReason.SAFETY,
+      refusal: FinishReason.STOP,
       model_context_window_exceeded: FinishReason.MAX_TOKENS,
       // OpenAI Chat Completions-style values
       stop: FinishReason.STOP,

--- a/packages/agents/src/core/chatSession.directRefusal.issue2329.test.ts
+++ b/packages/agents/src/core/chatSession.directRefusal.issue2329.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #2329 on the direct (non-streaming consumer)
+ * path: generateDirectMessage must preserve BOTH the visible refusal text and
+ * the raw provider stop reason when a streaming provider emits the realistic
+ * Anthropic shape — a text chunk first, then a trailing metadata-only chunk
+ * carrying stopReason 'refusal'.
+ *
+ * Drives the public ChatSession.generateDirectMessage API with a stub
+ * provider — no mock theater.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FinishReason } from '@google/genai';
+import { ChatSession } from './chatSession.js';
+import { getProviderStopReason } from './providerStopReason.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import { TestRuntimeProviderManager } from '../test-utils/runtimeProviderManager.js';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  createProviderRuntimeContext,
+  type ProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import {
+  createProviderAdapterFromManager,
+  createTelemetryAdapterFromConfig,
+  createToolRegistryViewFromRegistry,
+} from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
+import { createConfigParams } from './chatSession-runtime-helpers.js';
+
+vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  retryWithBackoff: vi.fn((fn: () => unknown) => fn()),
+}));
+
+describe('Issue 2329: direct-path refusal preservation @issue:2329', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let manager: TestRuntimeProviderManager;
+  let providerRuntime: ProviderRuntimeContext;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = new Config(createConfigParams(settingsService));
+
+    settingsService.set('providers.stub.base-url', 'https://stub.example.com');
+    settingsService.set('providers.stub.auth-key', 'stub-api-key');
+    settingsService.set('providers.stub.model', 'stub-model');
+
+    providerRuntime = createProviderRuntimeContext({
+      settingsService,
+      config,
+      runtimeId: 'test.runtime',
+      metadata: { source: 'chatSession.directRefusal.issue2329.test' },
+    });
+
+    manager = new TestRuntimeProviderManager(providerRuntime);
+    manager.setConfig(config);
+    config.setProviderManager(manager);
+  });
+
+  function buildChatSession(provider: IProvider): ChatSession {
+    manager.registerProvider(provider);
+    const runtimeState = createAgentRuntimeState({
+      runtimeId: 'runtime-test',
+      provider: provider.name,
+      model: config.getModel(),
+      sessionId: config.getSessionId(),
+    });
+    const view = createAgentRuntimeContext({
+      state: runtimeState,
+      history: new HistoryService(),
+      settings: {
+        compressionThreshold: 0.8,
+        contextLimit: 128000,
+        preserveThreshold: 0.2,
+        telemetry: {
+          enabled: true,
+          target: null,
+        },
+        'reasoning.includeInContext': true,
+      },
+      provider: createProviderAdapterFromManager(config.getProviderManager()),
+      telemetry: createTelemetryAdapterFromConfig(config),
+      tools: createToolRegistryViewFromRegistry(config.getToolRegistry()),
+      providerRuntime: { ...providerRuntime },
+    });
+    return new ChatSession(view, {} as unknown as ContentGenerator, {}, []);
+  }
+
+  it('preserves refusal text AND raw stop reason when the refusal arrives on a trailing metadata-only chunk', async () => {
+    const generateChatCompletionMock = vi.fn(async function* () {
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'I cannot help with that request.' }],
+      };
+      yield {
+        speaker: 'ai',
+        blocks: [],
+        metadata: { stopReason: 'refusal' },
+      };
+    });
+
+    const provider: IProvider = {
+      name: 'stub',
+      isDefault: true,
+      getModels: vi.fn(async () => []),
+      getDefaultModel: () => 'stub-model',
+      generateChatCompletion: generateChatCompletionMock,
+      getServerTools: () => [],
+      invokeServerTool: vi.fn(),
+      getAuthToken: vi.fn(async () => 'stub-auth-token'),
+    };
+
+    const chat = buildChatSession(provider);
+    const response = await chat.generateDirectMessage(
+      { message: 'risky request' },
+      'prompt-direct-refusal',
+    );
+
+    expect(response.text).toBe('I cannot help with that request.');
+    expect(response.candidates?.[0]?.finishReason).toBe(FinishReason.STOP);
+    expect(getProviderStopReason(response.candidates?.[0])).toBe('refusal');
+  });
+
+  it('preserves text and stop reason when a single chunk carries both', async () => {
+    const generateChatCompletionMock = vi.fn(async function* () {
+      yield {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Declined.' }],
+        metadata: { stopReason: 'refusal' },
+      };
+    });
+
+    const provider: IProvider = {
+      name: 'stub',
+      isDefault: true,
+      getModels: vi.fn(async () => []),
+      getDefaultModel: () => 'stub-model',
+      generateChatCompletion: generateChatCompletionMock,
+      getServerTools: () => [],
+      invokeServerTool: vi.fn(),
+      getAuthToken: vi.fn(async () => 'stub-auth-token'),
+    };
+
+    const chat = buildChatSession(provider);
+    const response = await chat.generateDirectMessage(
+      { message: 'risky request' },
+      'prompt-direct-refusal-single',
+    );
+
+    expect(response.text).toBe('Declined.');
+    expect(getProviderStopReason(response.candidates?.[0])).toBe('refusal');
+  });
+});

--- a/packages/agents/src/core/chatSession.directRefusal.issue2329.test.ts
+++ b/packages/agents/src/core/chatSession.directRefusal.issue2329.test.ts
@@ -159,6 +159,7 @@ describe('Issue 2329: direct-path refusal preservation @issue:2329', () => {
     );
 
     expect(response.text).toBe('Declined.');
+    expect(response.candidates?.[0]?.finishReason).toBe(FinishReason.STOP);
     expect(getProviderStopReason(response.candidates?.[0])).toBe('refusal');
   });
 });

--- a/packages/agents/src/core/chatSession.issue1729.test.ts
+++ b/packages/agents/src/core/chatSession.issue1729.test.ts
@@ -244,7 +244,10 @@ describe('Issue 1729: Claude stopping after thinking block', () => {
       expect(response.candidates[0].finishReason).toBe('STOP');
     });
 
-    it('should map refusal to STOP', () => {
+    // @issue:2329 — refusal now maps to SAFETY so consumers can distinguish a
+    // safety-classifier refusal from a normal completion, and the raw provider
+    // stop reason is preserved on candidate.finishMessage.
+    it('should map refusal to SAFETY @issue:2329', () => {
       const icontent: IContent = {
         speaker: 'ai',
         blocks: [{ type: 'text', text: 'refused' }],
@@ -252,7 +255,8 @@ describe('Issue 1729: Claude stopping after thinking block', () => {
       };
 
       const response = chatSession.convertIContentToResponse(icontent);
-      expect(response.candidates[0].finishReason).toBe('STOP');
+      expect(response.candidates[0].finishReason).toBe('SAFETY');
+      expect(response.candidates[0].finishMessage).toBe('refusal');
     });
 
     it('should not set finishReason for unknown stop reasons', () => {

--- a/packages/agents/src/core/chatSession.issue1729.test.ts
+++ b/packages/agents/src/core/chatSession.issue1729.test.ts
@@ -244,10 +244,10 @@ describe('Issue 1729: Claude stopping after thinking block', () => {
       expect(response.candidates[0].finishReason).toBe('STOP');
     });
 
-    // @issue:2329 — refusal now maps to SAFETY so consumers can distinguish a
-    // safety-classifier refusal from a normal completion, and the raw provider
-    // stop reason is preserved on candidate.finishMessage.
-    it('should map refusal to SAFETY @issue:2329', () => {
+    // @issue:2329 — refusal maps to STOP (coarse reason unchanged); the raw
+    // provider stop reason is preserved on candidate.finishMessage so consumers
+    // can distinguish a safety-classifier refusal from a normal completion.
+    it('should map refusal to STOP and preserve finishMessage @issue:2329', () => {
       const icontent: IContent = {
         speaker: 'ai',
         blocks: [{ type: 'text', text: 'refused' }],
@@ -255,7 +255,7 @@ describe('Issue 1729: Claude stopping after thinking block', () => {
       };
 
       const response = chatSession.convertIContentToResponse(icontent);
-      expect(response.candidates[0].finishReason).toBe('SAFETY');
+      expect(response.candidates[0].finishReason).toBe('STOP');
       expect(response.candidates[0].finishMessage).toBe('refusal');
     });
 

--- a/packages/agents/src/core/chatSession.issue1729.test.ts
+++ b/packages/agents/src/core/chatSession.issue1729.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ThinkingBlock } from '@vybestack/llxprt-code-core/services/history/blocks/ThinkingBlock.js';
 import { ChatSession } from './chatSession.js';
+import { getProviderStopReason } from './providerStopReason.js';
 import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
@@ -245,9 +246,10 @@ describe('Issue 1729: Claude stopping after thinking block', () => {
     });
 
     // @issue:2329 — refusal maps to STOP (coarse reason unchanged); the raw
-    // provider stop reason is preserved on candidate.finishMessage so consumers
-    // can distinguish a safety-classifier refusal from a normal completion.
-    it('should map refusal to STOP and preserve finishMessage @issue:2329', () => {
+    // provider stop reason is preserved on the repo-owned providerStopReason
+    // carrier so consumers can distinguish a safety-classifier refusal from a
+    // normal completion.
+    it('should map refusal to STOP and preserve providerStopReason @issue:2329', () => {
       const icontent: IContent = {
         speaker: 'ai',
         blocks: [{ type: 'text', text: 'refused' }],
@@ -256,7 +258,7 @@ describe('Issue 1729: Claude stopping after thinking block', () => {
 
       const response = chatSession.convertIContentToResponse(icontent);
       expect(response.candidates[0].finishReason).toBe('STOP');
-      expect(response.candidates[0].finishMessage).toBe('refusal');
+      expect(getProviderStopReason(response.candidates[0])).toBe('refusal');
     });
 
     it('should not set finishReason for unknown stop reasons', () => {

--- a/packages/agents/src/core/providerStopReason.ts
+++ b/packages/agents/src/core/providerStopReason.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Candidate } from '@google/genai';
+
+/**
+ * Repo-owned carrier for the raw provider stop reason (e.g. Anthropic
+ * `stop_reason: 'refusal'`, `'end_turn'`) on a response candidate.
+ *
+ * WHY a custom field: the raw provider stop reason must travel from
+ * MessageConverter (which sees IContent metadata) to Turn (which sees only
+ * GenerateContentResponse). Piggy-backing on the SDK's own
+ * `candidate.finishMessage` field was rejected because that field's
+ * documented purpose is a human-readable finish description — a native
+ * Gemini response could legitimately populate it with descriptive text that
+ * would then be misinterpreted as a machine stop-reason signal. The SDK will
+ * never populate `providerStopReason`, so collisions are impossible.
+ *
+ * @issue:2329
+ */
+export interface CandidateWithProviderStopReason extends Candidate {
+  providerStopReason?: string;
+}
+
+/**
+ * Records the raw provider stop reason on a candidate. This is the single
+ * controlled widening point for the repo-owned field; all writers must go
+ * through this helper.
+ */
+export function setProviderStopReason(
+  candidate: Candidate,
+  stopReason: string,
+): void {
+  (candidate as CandidateWithProviderStopReason).providerStopReason =
+    stopReason;
+}
+
+/**
+ * Reads the raw provider stop reason from a candidate, returning undefined
+ * when absent or not a string (e.g. on native SDK responses that never
+ * carry the field).
+ */
+export function getProviderStopReason(
+  candidate: Candidate | undefined,
+): string | undefined {
+  if (candidate === undefined) {
+    return undefined;
+  }
+  const value = (candidate as CandidateWithProviderStopReason)
+    .providerStopReason;
+  return typeof value === 'string' ? value : undefined;
+}

--- a/packages/agents/src/core/turn.issue2329.test.ts
+++ b/packages/agents/src/core/turn.issue2329.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #2329: the agents Turn must thread the raw
+ * provider stop reason (candidate.finishMessage) into the Finished event as
+ * `value.stopReason` so the CLI can show a refusal-specific notice.
+ *
+ * Follows the patterns in turn.test.ts: drives the Turn class with fake stream
+ * events (StreamEventType.CHUNK with a GenerateContentResponse) and collects
+ * emitted ServerGeminiStreamEvent values.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { GenerateContentResponse, Part } from '@google/genai';
+import { Turn, GeminiEventType, DEFAULT_AGENT_ID } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import { StreamEventType } from './chatSession.js';
+import {
+  findFinishedEvent,
+  type MockedChatInstance,
+} from './turn-test-helpers.js';
+
+const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
+  mockSendMessageStream: vi.fn(),
+  mockGetHistory: vi.fn(),
+}));
+
+vi.mock('@google/genai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@google/genai')>();
+  const MockChat = vi.fn().mockImplementation(() => ({
+    sendMessageStream: mockSendMessageStream,
+    getHistory: mockGetHistory,
+  }));
+  return {
+    ...actual,
+    Chat: MockChat,
+  };
+});
+
+vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn(),
+}));
+
+vi.mock(
+  '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js',
+  () => ({
+    getResponseText: (resp: GenerateContentResponse) =>
+      resp.candidates?.[0]?.content?.parts
+        ?.filter((part) => (part as { thought?: boolean }).thought !== true)
+        .map((part) => part.text)
+        .join('') ?? undefined,
+    getFunctionCalls: (resp: GenerateContentResponse) =>
+      resp.functionCalls ?? [],
+    getFunctionCallsFromParts: (parts: Part[]) => {
+      const functionCalls = parts
+        .filter((part) => part.functionCall !== undefined)
+        .map((part) => part.functionCall!);
+      return functionCalls.length > 0 ? functionCalls : undefined;
+    },
+    analyzeResponseOutcome: (parts: Part[]) => {
+      let hasVisibleText = false;
+      let hasThinking = false;
+      let hasToolCalls = false;
+      for (const part of parts) {
+        const isThinking = (part as { thought?: boolean }).thought === true;
+        if (isThinking) hasThinking = true;
+        if (part.functionCall !== undefined) hasToolCalls = true;
+        if (
+          !isThinking &&
+          typeof part.text === 'string' &&
+          part.text.trim() !== ''
+        )
+          hasVisibleText = true;
+      }
+      return {
+        hasVisibleText,
+        hasThinking,
+        hasToolCalls,
+        isActionable: hasVisibleText || hasToolCalls,
+      };
+    },
+  }),
+);
+
+describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => {
+  let turn: Turn;
+  let mockChatInstance: MockedChatInstance;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockChatInstance = {
+      sendMessageStream: mockSendMessageStream,
+      getHistory: mockGetHistory,
+      getConfig: () => undefined,
+    };
+    turn = new Turn(
+      mockChatInstance as unknown as ChatSession,
+      'prompt-id-2329',
+      DEFAULT_AGENT_ID,
+      'test',
+    );
+    mockGetHistory.mockReturnValue([]);
+    mockSendMessageStream.mockResolvedValue((async function* () {})());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('threads finishMessage "refusal" into Finished.value.stopReason', async () => {
+    const mockResponseStream = (async function* () {
+      yield {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'I decline to answer.' }] },
+              finishReason: 'SAFETY',
+              finishMessage: 'refusal',
+            },
+          ],
+        } as GenerateContentResponse,
+      };
+    })();
+    mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+    const events = [];
+    const reqParts: Part[] = [{ text: 'risky request' }];
+    for await (const event of turn.run(
+      reqParts,
+      new AbortController().signal,
+    )) {
+      events.push(event);
+    }
+
+    const finished = findFinishedEvent(events);
+    expect(finished).toBeDefined();
+    expect(finished?.type).toBe(GeminiEventType.Finished);
+    expect(finished?.value.reason).toBe('SAFETY');
+    expect(finished?.value.stopReason).toBe('refusal');
+  });
+
+  it('threads finishMessage "end_turn" into Finished.value.stopReason for normal completions', async () => {
+    const mockResponseStream = (async function* () {
+      yield {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'Normal answer.' }] },
+              finishReason: 'STOP',
+              finishMessage: 'end_turn',
+            },
+          ],
+        } as GenerateContentResponse,
+      };
+    })();
+    mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+    const events = [];
+    for await (const event of turn.run(
+      [{ text: 'hi' }],
+      new AbortController().signal,
+    )) {
+      events.push(event);
+    }
+
+    const finished = findFinishedEvent(events);
+    expect(finished).toBeDefined();
+    expect(finished?.value.reason).toBe('STOP');
+    expect(finished?.value.stopReason).toBe('end_turn');
+  });
+
+  it('omits stopReason from Finished when candidate has no finishMessage', async () => {
+    const mockResponseStream = (async function* () {
+      yield {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'answer' }] },
+              finishReason: 'STOP',
+            },
+          ],
+        } as GenerateContentResponse,
+      };
+    })();
+    mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+    const events = [];
+    for await (const event of turn.run(
+      [{ text: 'hi' }],
+      new AbortController().signal,
+    )) {
+      events.push(event);
+    }
+
+    const finished = findFinishedEvent(events);
+    expect(finished).toBeDefined();
+    expect(finished?.value.stopReason).toBeUndefined();
+  });
+});

--- a/packages/agents/src/core/turn.issue2329.test.ts
+++ b/packages/agents/src/core/turn.issue2329.test.ts
@@ -119,7 +119,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
           candidates: [
             {
               content: { parts: [{ text: 'I decline to answer.' }] },
-              finishReason: 'SAFETY',
+              finishReason: 'STOP',
               finishMessage: 'refusal',
             },
           ],
@@ -140,7 +140,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     const finished = findFinishedEvent(events);
     expect(finished).toBeDefined();
     expect(finished?.type).toBe(GeminiEventType.Finished);
-    expect(finished?.value.reason).toBe('SAFETY');
+    expect(finished?.value.reason).toBe('STOP');
     expect(finished?.value.stopReason).toBe('refusal');
   });
 

--- a/packages/agents/src/core/turn.issue2329.test.ts
+++ b/packages/agents/src/core/turn.issue2329.test.ts
@@ -45,6 +45,12 @@ vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
   reportError: vi.fn(),
 }));
 
+// Inline duplicate of generateContentResponseUtilitiesMock() from
+// turn-test-helpers.ts. The shared helper cannot be referenced here because
+// vi.mock factories are hoisted above ES imports, and turn-test-helpers.ts
+// imports from ./turn.js (which itself imports this mocked module), creating
+// a load-time circular dependency that deadlocks the dynamic import. This
+// matches the same inline pattern used by turn.test.ts.
 vi.mock(
   '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js',
   () => ({
@@ -232,5 +238,52 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     const finished = findFinishedEvent(events);
     expect(finished).toBeDefined();
     expect(finished?.value).not.toHaveProperty('stopReason');
+  });
+
+  it('threads finishMessage "refusal" from a content-less trailing metadata chunk', async () => {
+    // Models the real streaming shape: Anthropic delivers visible text on an
+    // initial chunk with no finishReason, then emits a SEPARATE trailing
+    // metadata-only chunk carrying the terminal stop reason/message
+    // (content-less, parts: []). The Turn must surface the refusal from that
+    // final chunk.
+    const mockResponseStream = (async function* () {
+      yield {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'I decline to answer.' }] },
+            },
+          ],
+        } as GenerateContentResponse,
+      };
+      yield {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: { parts: [] },
+              finishReason: 'STOP',
+              finishMessage: 'refusal',
+            },
+          ],
+        } as GenerateContentResponse,
+      };
+    })();
+    mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+    const events = [];
+    for await (const event of turn.run(
+      [{ text: 'risky request' }],
+      new AbortController().signal,
+    )) {
+      events.push(event);
+    }
+
+    const finished = findFinishedEvent(events);
+    expect(finished).toBeDefined();
+    expect(finished?.type).toBe(GeminiEventType.Finished);
+    expect(finished?.value.reason).toBe('STOP');
+    expect(finished?.value.stopReason).toBe('refusal');
   });
 });

--- a/packages/agents/src/core/turn.issue2329.test.ts
+++ b/packages/agents/src/core/turn.issue2329.test.ts
@@ -6,7 +6,7 @@
 
 /**
  * Behavioral tests for issue #2329: the agents Turn must thread the raw
- * provider stop reason (candidate.finishMessage) into the Finished event as
+ * provider stop reason (repo-owned candidate providerStopReason carrier) into the Finished event as
  * `value.stopReason` so the CLI can show a refusal-specific notice.
  *
  * Follows the patterns in turn.test.ts: drives the Turn class with fake stream
@@ -117,7 +117,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     vi.restoreAllMocks();
   });
 
-  it('threads finishMessage "refusal" into Finished.value.stopReason', async () => {
+  it('threads providerStopReason "refusal" into Finished.value.stopReason', async () => {
     const mockResponseStream = (async function* () {
       yield {
         type: StreamEventType.CHUNK,
@@ -126,7 +126,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
             {
               content: { parts: [{ text: 'I decline to answer.' }] },
               finishReason: 'STOP',
-              finishMessage: 'refusal',
+              providerStopReason: 'refusal',
             },
           ],
         } as GenerateContentResponse,
@@ -150,7 +150,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     expect(finished?.value.stopReason).toBe('refusal');
   });
 
-  it('threads finishMessage "end_turn" into Finished.value.stopReason for normal completions', async () => {
+  it('threads providerStopReason "end_turn" into Finished.value.stopReason for normal completions', async () => {
     const mockResponseStream = (async function* () {
       yield {
         type: StreamEventType.CHUNK,
@@ -159,7 +159,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
             {
               content: { parts: [{ text: 'Normal answer.' }] },
               finishReason: 'STOP',
-              finishMessage: 'end_turn',
+              providerStopReason: 'end_turn',
             },
           ],
         } as GenerateContentResponse,
@@ -181,7 +181,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     expect(finished?.value.stopReason).toBe('end_turn');
   });
 
-  it('omits stopReason from Finished when candidate has no finishMessage', async () => {
+  it('omits stopReason from Finished when candidate has no providerStopReason', async () => {
     const mockResponseStream = (async function* () {
       yield {
         type: StreamEventType.CHUNK,
@@ -210,7 +210,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     expect(finished?.value.stopReason).toBeUndefined();
   });
 
-  it('omits stopReason from Finished when finishMessage is an empty string', async () => {
+  it('omits stopReason from Finished when providerStopReason is an empty string', async () => {
     const mockResponseStream = (async function* () {
       yield {
         type: StreamEventType.CHUNK,
@@ -219,7 +219,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
             {
               content: { parts: [{ text: 'answer' }] },
               finishReason: 'STOP',
-              finishMessage: '',
+              providerStopReason: '',
             },
           ],
         } as GenerateContentResponse,
@@ -240,7 +240,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     expect(finished?.value).not.toHaveProperty('stopReason');
   });
 
-  it('threads finishMessage "refusal" from a content-less trailing metadata chunk', async () => {
+  it('threads providerStopReason "refusal" from a content-less trailing metadata chunk', async () => {
     // Models the real streaming shape: Anthropic delivers visible text on an
     // initial chunk with no finishReason, then emits a SEPARATE trailing
     // metadata-only chunk carrying the terminal stop reason/message
@@ -264,7 +264,7 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
             {
               content: { parts: [] },
               finishReason: 'STOP',
-              finishMessage: 'refusal',
+              providerStopReason: 'refusal',
             },
           ],
         } as GenerateContentResponse,
@@ -285,5 +285,40 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     expect(finished?.type).toBe(GeminiEventType.Finished);
     expect(finished?.value.reason).toBe('STOP');
     expect(finished?.value.stopReason).toBe('refusal');
+  });
+
+  it('does not leak the SDK finishMessage description into Finished.value.stopReason', async () => {
+    // The SDK's native Candidate.finishMessage is a human-readable finish
+    // description. A native Gemini response may populate it with descriptive
+    // text; that text must never be misinterpreted as a machine stop-reason
+    // signal. Only the repo-owned providerStopReason carrier feeds stopReason.
+    const mockResponseStream = (async function* () {
+      yield {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'A normal answer.' }] },
+              finishReason: 'STOP',
+              finishMessage: 'The model completed successfully.',
+            },
+          ],
+        } as GenerateContentResponse,
+      };
+    })();
+    mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+    const events = [];
+    for await (const event of turn.run(
+      [{ text: 'hi' }],
+      new AbortController().signal,
+    )) {
+      events.push(event);
+    }
+
+    const finished = findFinishedEvent(events);
+    expect(finished).toBeDefined();
+    expect(finished?.value.reason).toBe('STOP');
+    expect(finished?.value).not.toHaveProperty('stopReason');
   });
 });

--- a/packages/agents/src/core/turn.issue2329.test.ts
+++ b/packages/agents/src/core/turn.issue2329.test.ts
@@ -203,4 +203,34 @@ describe('Issue 2329: Finished event carries raw stopReason @issue:2329', () => 
     expect(finished).toBeDefined();
     expect(finished?.value.stopReason).toBeUndefined();
   });
+
+  it('omits stopReason from Finished when finishMessage is an empty string', async () => {
+    const mockResponseStream = (async function* () {
+      yield {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'answer' }] },
+              finishReason: 'STOP',
+              finishMessage: '',
+            },
+          ],
+        } as GenerateContentResponse,
+      };
+    })();
+    mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+    const events = [];
+    for await (const event of turn.run(
+      [{ text: 'hi' }],
+      new AbortController().signal,
+    )) {
+      events.push(event);
+    }
+
+    const finished = findFinishedEvent(events);
+    expect(finished).toBeDefined();
+    expect(finished?.value).not.toHaveProperty('stopReason');
+  });
 });

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -70,6 +70,23 @@ export const TURN_STREAM_IDLE_TIMEOUT_MS = DEFAULT_STREAM_IDLE_TIMEOUT_MS;
 
 const TURN_STREAM_IDLE_TIMEOUT_ERROR_MESSAGE =
   'Stream idle timeout: no response received within the allowed time.';
+
+/**
+ * Options object for {@link Turn.emitFinishReason}. Encapsulates the data
+ * needed to emit a Finished event, including the raw provider stop reason
+ * (@issue:2329) so it can be surfaced to consumers.
+ */
+interface EmitFinishReasonOptions {
+  finishReason: FinishReason;
+  allParts: Part[];
+  functionCalls: FunctionCall[];
+  text: string | undefined;
+  usageMetadata: GenerateContentResponseUsageMetadata | undefined;
+  traceId: string | undefined;
+  cumulativeOutcome: ResponseOutcome;
+  stopReason: string | undefined;
+}
+
 /**
  * Safely checks if an AbortSignal (or runtime-nullish value) has been aborted.
  * Runtime payloads can pass null/undefined despite declared types.
@@ -221,15 +238,18 @@ export class Turn {
     };
   }
   private *emitFinishReason(
-    finishReason: FinishReason,
-    allParts: Part[],
-    functionCalls: FunctionCall[],
-    text: string | undefined,
-    usageMetadata: GenerateContentResponseUsageMetadata | undefined,
-    traceId: string | undefined,
-    cumulativeOutcome: ResponseOutcome,
+    opts: EmitFinishReasonOptions,
   ): Generator<ServerGeminiStreamEvent> {
-    const outcome = cumulativeOutcome;
+    const {
+      finishReason,
+      allParts,
+      functionCalls,
+      text,
+      usageMetadata,
+      traceId,
+      cumulativeOutcome: outcome,
+      stopReason,
+    } = opts;
     this.logger.debug(() => `[stream:turn] emitting Finished event`, {
       finishReason,
       traceId,
@@ -237,6 +257,7 @@ export class Turn {
       toolCallCount: functionCalls.length,
       textLength: text?.length ?? 0,
       hasUsageMetadata: Boolean(usageMetadata),
+      stopReason,
       outcome,
     });
     this.finishReason = finishReason;
@@ -250,6 +271,9 @@ export class Turn {
           hadThinking: outcome.hasThinking,
           hadToolCalls: outcome.hasToolCalls,
         },
+        // @issue:2329 — only include stopReason when defined, matching
+        // existing optional-field style so consumers can detect refusals.
+        ...(stopReason !== undefined ? { stopReason } : {}),
       },
     };
   }
@@ -323,6 +347,10 @@ export class Turn {
     }
 
     const finishReason = resp.candidates?.[0]?.finishReason;
+    // @issue:2329 — thread the raw provider stop reason from the candidate's
+    // finishMessage into the Finished event so consumers can surface a
+    // refusal-specific notice.
+    const finishMessage = resp.candidates?.[0]?.finishMessage;
     const text = allowedParts
       .filter((part) => !isThoughtPart(part))
       .map((part) => part.text)
@@ -363,15 +391,16 @@ export class Turn {
     // This is the key change: Only yield 'Finished' if there is a finishReason.
     // Pass only allowed function calls so logging/outcome reflect executable calls.
     if (finishReason != null) {
-      yield* this.emitFinishReason(
+      yield* this.emitFinishReason({
         finishReason,
-        allowedParts,
+        allParts: allowedParts,
         functionCalls,
         text,
-        resp.usageMetadata,
+        usageMetadata: resp.usageMetadata,
         traceId,
         cumulativeOutcome,
-      );
+        stopReason: finishMessage,
+      });
     } else {
       this.logNoFinishReason(
         allowedParts,

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -271,9 +271,12 @@ export class Turn {
           hadThinking: outcome.hasThinking,
           hadToolCalls: outcome.hasToolCalls,
         },
-        // @issue:2329 — only include stopReason when defined, matching
-        // existing optional-field style so consumers can detect refusals.
-        ...(stopReason !== undefined ? { stopReason } : {}),
+        // @issue:2329 — only include stopReason when it carries a value,
+        // matching existing optional-field style so consumers can detect
+        // refusals without receiving a vacuous empty field.
+        ...(stopReason !== undefined && stopReason !== ''
+          ? { stopReason }
+          : {}),
       },
     };
   }

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -34,6 +34,7 @@ import {
   getHookRestrictedAllowedToolsForFunctionCall,
   mergeHookRestrictedFunctionCalls,
 } from './hookToolRestrictions.js';
+import { getProviderStopReason } from './providerStopReason.js';
 import { reportError } from '@vybestack/llxprt-code-core/utils/errorReporting.js';
 import {
   getErrorMessage,
@@ -350,10 +351,12 @@ export class Turn {
     }
 
     const finishReason = resp.candidates?.[0]?.finishReason;
-    // @issue:2329 — thread the raw provider stop reason from the candidate's
-    // finishMessage into the Finished event so consumers can surface a
-    // refusal-specific notice.
-    const finishMessage = resp.candidates?.[0]?.finishMessage;
+    // @issue:2329 — thread the raw provider stop reason (repo-owned
+    // providerStopReason field, set by MessageConverter) into the Finished
+    // event so consumers can surface a refusal-specific notice. Native SDK
+    // responses never carry this field, so descriptive finishMessage text
+    // can never leak into the stop-reason signal.
+    const providerStopReason = getProviderStopReason(resp.candidates?.[0]);
     const text = allowedParts
       .filter((part) => !isThoughtPart(part))
       .map((part) => part.text)
@@ -402,7 +405,7 @@ export class Turn {
         usageMetadata: resp.usageMetadata,
         traceId,
         cumulativeOutcome,
-        stopReason: finishMessage,
+        stopReason: providerStopReason,
       });
     } else {
       this.logNoFinishReason(

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -15,7 +15,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
 import { processAgentStream } from './nonInteractiveCliSupport.js';
-import { REFUSAL_NOTICE_MESSAGE } from './ui/hooks/geminiStream/streamUtils.js';
+import { REFUSAL_NOTICE_MESSAGE } from './utils/refusalNotice.js';
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -486,7 +486,7 @@ describe('processAgentStream', () => {
       {
         type: 'done',
         reason: 'refusal',
-        finished: { reason: 'SAFETY', stopReason: 'refusal' },
+        finished: { reason: 'STOP', stopReason: 'refusal' },
       },
     ];
 
@@ -512,7 +512,7 @@ describe('processAgentStream', () => {
       {
         type: 'done',
         reason: 'refusal',
-        finished: { reason: 'SAFETY', stopReason: 'refusal' },
+        finished: { reason: 'STOP', stopReason: 'refusal' },
       },
     ];
 
@@ -545,7 +545,7 @@ describe('processAgentStream', () => {
       {
         type: 'done',
         reason: 'refusal',
-        finished: { reason: 'SAFETY', stopReason: 'refusal' },
+        finished: { reason: 'STOP', stopReason: 'refusal' },
       },
     ];
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
 import { processAgentStream } from './nonInteractiveCliSupport.js';
+import { REFUSAL_NOTICE_MESSAGE } from './ui/hooks/geminiStream/streamUtils.js';
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
@@ -498,7 +499,7 @@ describe('processAgentStream', () => {
     );
 
     expect(processStderrSpy).toHaveBeenCalledWith(
-      'WARNING: Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.\n',
+      `WARNING: ${REFUSAL_NOTICE_MESSAGE}\n`,
     );
     expect(processStdoutSpy).toHaveBeenCalledWith('partial response');
     expect(processStdoutSpy).toHaveBeenCalledWith('\n');
@@ -529,9 +530,7 @@ describe('processAgentStream', () => {
         event.type === JsonStreamEventType.ERROR &&
         event.severity === 'warning',
     );
-    expect(warning?.message).toBe(
-      'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.',
-    );
+    expect(warning?.message).toBe(REFUSAL_NOTICE_MESSAGE);
     const result = jsonEvents.find(
       (event) => event.type === JsonStreamEventType.RESULT,
     );

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -536,6 +536,11 @@ describe('processAgentStream', () => {
       (event) => event.type === JsonStreamEventType.RESULT,
     );
     expect(result).toBeDefined();
+    // Stream-json mode relies on the structured warning event, not raw stderr.
+    const stderrWrites = processStderrSpy.mock.calls
+      .map(([value]) => String(value))
+      .join('');
+    expect(stderrWrites).not.toContain('WARNING:');
   });
 
   it('includes finish_reason:"refusal" in plain jsonOutput on done{refusal} @issue:2329', async () => {
@@ -568,6 +573,11 @@ describe('processAgentStream', () => {
     expect(parsed).toHaveProperty('response', 'partial response');
     expect(parsed).toHaveProperty('stats');
     expect(parsed).toHaveProperty('finish_reason', 'refusal');
+    // Plain-JSON mode carries the signal via finish_reason; no raw stderr.
+    const stderrWrites = processStderrSpy.mock.calls
+      .map(([value]) => String(value))
+      .join('');
+    expect(stderrWrites).not.toContain('WARNING:');
   });
 
   it('does not include finish_reason in plain jsonOutput on a normal done{stop} @issue:2329', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -480,6 +480,64 @@ describe('processAgentStream', () => {
     expect(result).toBeDefined();
   });
 
+  it('writes a refusal warning to stderr and still emits the final text on done{refusal} @issue:2329', async () => {
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'partial response' },
+      {
+        type: 'done',
+        reason: 'refusal',
+        finished: { reason: 'SAFETY', stopReason: 'refusal' },
+      },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext(),
+      Date.now(),
+      () => uiTelemetryService.getMetrics(),
+    );
+
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      'WARNING: Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.\n',
+    );
+    expect(processStdoutSpy).toHaveBeenCalledWith('partial response');
+    expect(processStdoutSpy).toHaveBeenCalledWith('\n');
+  });
+
+  it('emits a stream-json warning and RESULT on done{refusal} @issue:2329', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const metrics = uiTelemetryService.getMetrics();
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'partial' },
+      {
+        type: 'done',
+        reason: 'refusal',
+        finished: { reason: 'SAFETY', stopReason: 'refusal' },
+      },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({ streamFormatter }),
+      1000,
+      () => metrics,
+    );
+
+    const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
+    const warning = jsonEvents.find(
+      (event) =>
+        event.type === JsonStreamEventType.ERROR &&
+        event.severity === 'warning',
+    );
+    expect(warning?.message).toBe(
+      'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.',
+    );
+    const result = jsonEvents.find(
+      (event) => event.type === JsonStreamEventType.RESULT,
+    );
+    expect(result).toBeDefined();
+  });
+
   it('writes a warning to stderr and continues on a hook-blocked event', async () => {
     const events: AgentEvent[] = [
       { type: 'text', text: 'partial' },

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -538,6 +538,66 @@ describe('processAgentStream', () => {
     expect(result).toBeDefined();
   });
 
+  it('includes finish_reason:"refusal" in plain jsonOutput on done{refusal} @issue:2329', async () => {
+    const metrics = uiTelemetryService.getMetrics();
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'partial response' },
+      {
+        type: 'done',
+        reason: 'refusal',
+        finished: { reason: 'SAFETY', stopReason: 'refusal' },
+      },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({
+        jsonOutput: true,
+        config: createMockConfig({ sessionId: 'refusal-session' }),
+      }),
+      Date.now(),
+      () => metrics,
+    );
+
+    const jsonLine = processStdoutSpy.mock.calls
+      .map(([value]) => String(value).trimEnd())
+      .filter((value) => value.startsWith('{'))
+      .join('');
+    const parsed = JSON.parse(jsonLine) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('session_id', 'refusal-session');
+    expect(parsed).toHaveProperty('response', 'partial response');
+    expect(parsed).toHaveProperty('stats');
+    expect(parsed).toHaveProperty('finish_reason', 'refusal');
+  });
+
+  it('does not include finish_reason in plain jsonOutput on a normal done{stop} @issue:2329', async () => {
+    const metrics = uiTelemetryService.getMetrics();
+    const events: AgentEvent[] = [
+      { type: 'text', text: 'The capital is Paris.' },
+      { type: 'done', reason: 'stop' },
+    ];
+
+    await processAgentStream(
+      streamFromEvents(events),
+      createContext({
+        jsonOutput: true,
+        config: createMockConfig({ sessionId: 'normal-session' }),
+      }),
+      Date.now(),
+      () => metrics,
+    );
+
+    const jsonLine = processStdoutSpy.mock.calls
+      .map(([value]) => String(value).trimEnd())
+      .filter((value) => value.startsWith('{'))
+      .join('');
+    const parsed = JSON.parse(jsonLine) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('session_id', 'normal-session');
+    expect(parsed).toHaveProperty('response', 'The capital is Paris.');
+    expect(parsed).toHaveProperty('stats');
+    expect(parsed).not.toHaveProperty('finish_reason');
+  });
+
   it('writes a warning to stderr and continues on a hook-blocked event', async () => {
     const events: AgentEvent[] = [
       { type: 'text', text: 'partial' },

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -19,6 +19,7 @@ import type {
   StructuredError,
 } from '@vybestack/llxprt-code-agents';
 import { MAX_TURNS_MESSAGE } from './utils/errors.js';
+import { buildRefusalNoticeMessage } from './ui/hooks/geminiStream/streamUtils.js';
 
 type StreamConsumerContext = {
   config: Config;
@@ -290,6 +291,22 @@ function handleDone(
     case 'context-overflow':
       emitFinalResult(context, jsonResponseText, startTime, getMetrics());
       return;
+    case 'refusal': {
+      // @issue:2329 — surface the safety-classifier refusal as a user-visible
+      // warning while still emitting the final result so stdout/json output
+      // is preserved. The notice text is shared with the interactive CLI via
+      // buildRefusalNoticeMessage so both surfaces stay in sync; the
+      // 'refusal'-case fallback is guaranteed to return a string.
+      const notice =
+        buildRefusalNoticeMessage(event.finished?.stopReason) ??
+        buildRefusalNoticeMessage('refusal');
+      if (notice !== undefined) {
+        process.stderr.write(`WARNING: ${notice}\n`);
+        emitStreamError(context.streamFormatter, 'warning', notice);
+      }
+      emitFinalResult(context, jsonResponseText, startTime, getMetrics());
+      return;
+    }
     case 'hook-stopped': {
       const stop = event.stop;
       const stopMessage = `Agent execution stopped: ${

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -6,6 +6,7 @@
 
 import {
   type Config,
+  type JsonOutput,
   JsonStreamEventType,
   type StreamJsonFormatter,
   type EmojiFilter,
@@ -249,12 +250,7 @@ function emitFinalResult(
       ),
     });
   } else if (context.jsonOutput) {
-    const payload: {
-      session_id: string;
-      response: string;
-      stats: SessionMetrics;
-      finish_reason?: 'refusal';
-    } = {
+    const payload: JsonOutput = {
       session_id: context.config.getSessionId(),
       response: jsonResponseText.trimEnd(),
       stats: metrics,
@@ -300,8 +296,15 @@ function handleDone(
       // warning while still emitting the final result so stdout/json output
       // is preserved. DoneReason is authoritative here, so the shared notice
       // constant is used directly. Plain-JSON consumers get a finish_reason
-      // field; stream-json already carried the warning event above.
-      process.stderr.write(`WARNING: ${REFUSAL_NOTICE_MESSAGE}\n`);
+      // field; stream-json already carried the warning event below.
+      //
+      // The unstructured stderr warning is emitted only in pure text mode
+      // (no streamFormatter and no jsonOutput). In stream-json mode the
+      // structured warning event carries the signal; in plain-JSON mode the
+      // finish_reason field carries it.
+      if (!context.jsonOutput && context.streamFormatter === null) {
+        process.stderr.write(`WARNING: ${REFUSAL_NOTICE_MESSAGE}\n`);
+      }
       emitStreamError(
         context.streamFormatter,
         'warning',

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -19,7 +19,7 @@ import type {
   StructuredError,
 } from '@vybestack/llxprt-code-agents';
 import { MAX_TURNS_MESSAGE } from './utils/errors.js';
-import { buildRefusalNoticeMessage } from './ui/hooks/geminiStream/streamUtils.js';
+import { REFUSAL_NOTICE_MESSAGE } from './ui/hooks/geminiStream/streamUtils.js';
 
 type StreamConsumerContext = {
   config: Config;
@@ -236,6 +236,7 @@ function emitFinalResult(
   jsonResponseText: string,
   startTime: number,
   metrics: SessionMetrics,
+  finishReason?: 'refusal',
 ): void {
   if (context.streamFormatter) {
     context.streamFormatter.emitEvent({
@@ -248,17 +249,20 @@ function emitFinalResult(
       ),
     });
   } else if (context.jsonOutput) {
-    process.stdout.write(
-      `${JSON.stringify(
-        {
-          session_id: context.config.getSessionId(),
-          response: jsonResponseText.trimEnd(),
-          stats: metrics,
-        },
-        null,
-        2,
-      )}\n`,
-    );
+    const payload: {
+      session_id: string;
+      response: string;
+      stats: SessionMetrics;
+      finish_reason?: 'refusal';
+    } = {
+      session_id: context.config.getSessionId(),
+      response: jsonResponseText.trimEnd(),
+      stats: metrics,
+    };
+    if (finishReason !== undefined) {
+      payload.finish_reason = finishReason;
+    }
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else {
     process.stdout.write('\n');
   }
@@ -294,17 +298,22 @@ function handleDone(
     case 'refusal': {
       // @issue:2329 — surface the safety-classifier refusal as a user-visible
       // warning while still emitting the final result so stdout/json output
-      // is preserved. The notice text is shared with the interactive CLI via
-      // buildRefusalNoticeMessage so both surfaces stay in sync; the
-      // 'refusal'-case fallback is guaranteed to return a string.
-      const notice =
-        buildRefusalNoticeMessage(event.finished?.stopReason) ??
-        buildRefusalNoticeMessage('refusal');
-      if (notice !== undefined) {
-        process.stderr.write(`WARNING: ${notice}\n`);
-        emitStreamError(context.streamFormatter, 'warning', notice);
-      }
-      emitFinalResult(context, jsonResponseText, startTime, getMetrics());
+      // is preserved. DoneReason is authoritative here, so the shared notice
+      // constant is used directly. Plain-JSON consumers get a finish_reason
+      // field; stream-json already carried the warning event above.
+      process.stderr.write(`WARNING: ${REFUSAL_NOTICE_MESSAGE}\n`);
+      emitStreamError(
+        context.streamFormatter,
+        'warning',
+        REFUSAL_NOTICE_MESSAGE,
+      );
+      emitFinalResult(
+        context,
+        jsonResponseText,
+        startTime,
+        getMetrics(),
+        'refusal',
+      );
       return;
     }
     case 'hook-stopped': {

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -20,7 +20,7 @@ import type {
   StructuredError,
 } from '@vybestack/llxprt-code-agents';
 import { MAX_TURNS_MESSAGE } from './utils/errors.js';
-import { REFUSAL_NOTICE_MESSAGE } from './ui/hooks/geminiStream/streamUtils.js';
+import { REFUSAL_NOTICE_MESSAGE } from './utils/refusalNotice.js';
 
 type StreamConsumerContext = {
   config: Config;

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/streamUtils.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/streamUtils.test.ts
@@ -24,6 +24,7 @@ import {
   mergePendingToolGroupsForDisplay,
   collectGeminiTools,
   buildFinishReasonMessage,
+  buildRefusalNoticeMessage,
   deduplicateToolCallRequests,
   buildThinkingBlock,
   buildSplitContent,
@@ -283,6 +284,35 @@ describe('buildFinishReasonMessage', () => {
     expect(
       buildFinishReasonMessage(FinishReason.MALFORMED_FUNCTION_CALL),
     ).toBeDefined();
+  });
+});
+
+// ─── buildRefusalNoticeMessage ────────────────────────────────────────────────
+
+describe('buildRefusalNoticeMessage @issue:2329', () => {
+  it('returns the refusal notice when stopReason is "refusal"', () => {
+    const message = buildRefusalNoticeMessage('refusal');
+    expect(message).toBeDefined();
+    expect(message).toMatch(/safety classifier refused/i);
+    expect(message).toMatch(/rephrasing/i);
+    expect(message).toMatch(/switch to a different model/i);
+  });
+
+  it('returns undefined when stopReason is a normal completion reason', () => {
+    expect(buildRefusalNoticeMessage('end_turn')).toBeUndefined();
+    expect(buildRefusalNoticeMessage('stop_sequence')).toBeUndefined();
+    expect(buildRefusalNoticeMessage('max_tokens')).toBeUndefined();
+    expect(buildRefusalNoticeMessage('tool_use')).toBeUndefined();
+  });
+
+  it('returns undefined when stopReason is undefined', () => {
+    expect(buildRefusalNoticeMessage(undefined)).toBeUndefined();
+  });
+
+  it('uses the exact required message text for refusal', () => {
+    expect(buildRefusalNoticeMessage('refusal')).toBe(
+      'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.',
+    );
   });
 });
 

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useFinishedEventHandler.refusal.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useFinishedEventHandler.refusal.test.ts
@@ -146,4 +146,15 @@ describe('useFinishedEventHandler — refusal notice (issue #2329)', () => {
 
     expect(mockAddItem).not.toHaveBeenCalled();
   });
+
+  it('adds no item for a STOP completion without any stopReason', () => {
+    const result = renderHandlers();
+
+    result.current.handleFinishedEvent(
+      makeFinishedEvent(FinishReason.STOP),
+      4000,
+    );
+
+    expect(mockAddItem).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useFinishedEventHandler.refusal.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useFinishedEventHandler.refusal.test.ts
@@ -98,7 +98,7 @@ describe('useFinishedEventHandler — refusal notice (issue #2329)', () => {
     const result = renderHandlers();
 
     result.current.handleFinishedEvent(
-      makeFinishedEvent(FinishReason.SAFETY, 'refusal'),
+      makeFinishedEvent(FinishReason.STOP, 'refusal'),
       1000,
     );
 

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useFinishedEventHandler.refusal.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useFinishedEventHandler.refusal.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for issue #2329: the Finished-event handler must surface a
+ * refusal-specific notice when the raw provider stop reason is 'refusal'
+ * (Claude Fable 5 safety-classifier refusals arrive as HTTP 200 with
+ * stop_reason 'refusal'), and must stay silent for normal completions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type React from 'react';
+import { FinishReason } from '@google/genai';
+import type {
+  Config,
+  ServerGeminiFinishedEvent,
+  GeminiEventType,
+} from '@vybestack/llxprt-code-core';
+import { renderHook } from '../../../../test-utils/render.js';
+import { useStreamEventHandlers } from '../useStreamEventHandlers.js';
+import type { LoadedSettings } from '../../../../config/settings.js';
+import type { HistoryItemWithoutId } from '../../../types.js';
+import type { QueuedSubmission } from '../types.js';
+
+describe('useFinishedEventHandler — refusal notice (issue #2329)', () => {
+  const mockConfig = {
+    getModel: vi.fn(() => 'claude-fable-5'),
+    getMaxSessionTurns: vi.fn(() => 42),
+    getEphemeralSetting: vi.fn(() => undefined),
+    getSettingsService: vi.fn(() => ({
+      get: vi.fn(() => null),
+      getCurrentProfileName: vi.fn(() => null),
+    })),
+  } as unknown as Config;
+
+  const mockSettings = {
+    merged: { ui: {} },
+  } as unknown as LoadedSettings;
+
+  let mockAddItem: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockAddItem = vi.fn();
+  });
+
+  function renderHandlers() {
+    const { result } = renderHook(() =>
+      useStreamEventHandlers({
+        config: mockConfig,
+        settings: mockSettings,
+        addItem: mockAddItem,
+        onDebugMessage: vi.fn(),
+        onCancelSubmit: vi.fn(),
+        sanitizeContent: (text: string) => ({ text, blocked: false }),
+        flushPendingHistoryItem: vi.fn(),
+        pendingHistoryItemRef: {
+          current: null,
+        } as React.MutableRefObject<HistoryItemWithoutId | null>,
+        thinkingBlocksRef: { current: [] },
+        turnCancelledRef: { current: false },
+        queuedSubmissionsRef: { current: [] as QueuedSubmission[] },
+        setPendingHistoryItem: vi.fn(),
+        setIsResponding: vi.fn(),
+        setThought: vi.fn(),
+        setLastGeminiActivityTime: vi.fn(),
+        scheduleToolCalls: vi.fn().mockResolvedValue(undefined),
+        abortActiveStream: vi.fn(),
+        handleShellCommand: vi.fn(() => false),
+        handleSlashCommand: vi.fn().mockResolvedValue(false),
+        logger: null,
+        shellModeActive: false,
+        loopDetectedRef: { current: false },
+        lastProfileNameRef: { current: undefined },
+        lastModelInfoRef: { current: null },
+        lastModelIdentityRef: { current: null },
+      }),
+    );
+    return result;
+  }
+
+  function makeFinishedEvent(
+    reason: FinishReason,
+    stopReason?: string,
+  ): ServerGeminiFinishedEvent {
+    return {
+      type: 'finished' as GeminiEventType.Finished,
+      value: {
+        reason,
+        ...(stopReason !== undefined ? { stopReason } : {}),
+      },
+    };
+  }
+
+  it('adds a refusal notice info item when stopReason is "refusal"', () => {
+    const result = renderHandlers();
+
+    result.current.handleFinishedEvent(
+      makeFinishedEvent(FinishReason.SAFETY, 'refusal'),
+      1000,
+    );
+
+    expect(mockAddItem).toHaveBeenCalledTimes(1);
+    const [item, timestamp] = mockAddItem.mock.calls[0];
+    expect(item.type).toBe('info');
+    expect(item.text).toContain('safety classifier refused');
+    expect(item.text).toContain('Try rephrasing');
+    expect(timestamp).toBe(1000);
+  });
+
+  it('prefers the refusal notice over the generic SAFETY message', () => {
+    const result = renderHandlers();
+
+    result.current.handleFinishedEvent(
+      makeFinishedEvent(FinishReason.SAFETY, 'refusal'),
+      1000,
+    );
+
+    const [item] = mockAddItem.mock.calls[0];
+    expect(item.text).not.toContain('Response stopped due to safety reasons');
+  });
+
+  it('falls back to the generic message for SAFETY without a refusal stopReason', () => {
+    const result = renderHandlers();
+
+    result.current.handleFinishedEvent(
+      makeFinishedEvent(FinishReason.SAFETY),
+      2000,
+    );
+
+    expect(mockAddItem).toHaveBeenCalledTimes(1);
+    const [item] = mockAddItem.mock.calls[0];
+    expect(item.type).toBe('info');
+    expect(item.text).toContain('Response stopped due to safety reasons');
+  });
+
+  it('adds no item for a normal STOP completion', () => {
+    const result = renderHandlers();
+
+    result.current.handleFinishedEvent(
+      makeFinishedEvent(FinishReason.STOP, 'end_turn'),
+      3000,
+    );
+
+    expect(mockAddItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
@@ -46,17 +46,18 @@ import {
   getActiveProviderNameForApiError,
   getErrorFallbackModel,
 } from '../../../utils/apiErrorFormatting.js';
+import { REFUSAL_NOTICE_MESSAGE } from '../../../utils/refusalNotice.js';
 
 // ─── Re-exported constant ────────────────────────────────────────────────────
 
 export const SYSTEM_NOTICE_EVENT = 'system_notice' as const;
 
 /**
- * @issue:2329 — Single source of truth for the safety-classifier refusal
- * notice text shared by the interactive and non-interactive CLI surfaces.
+ * @issue:2329 — Re-export of the shared safety-classifier refusal notice text.
+ * Kept for back-compat with existing imports (e.g. test files). The canonical
+ * definition lives in utils/refusalNotice.ts (sourced from core).
  */
-export const REFUSAL_NOTICE_MESSAGE =
-  'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.';
+export { REFUSAL_NOTICE_MESSAGE } from '../../../utils/refusalNotice.js';
 
 // ─── Pure utility functions ───────────────────────────────────────────────────
 

--- a/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
@@ -51,6 +51,13 @@ import {
 
 export const SYSTEM_NOTICE_EVENT = 'system_notice' as const;
 
+/**
+ * @issue:2329 — Single source of truth for the safety-classifier refusal
+ * notice text shared by the interactive and non-interactive CLI surfaces.
+ */
+export const REFUSAL_NOTICE_MESSAGE =
+  'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.';
+
 // ─── Pure utility functions ───────────────────────────────────────────────────
 
 /**
@@ -200,7 +207,7 @@ export function buildRefusalNoticeMessage(
   stopReason: string | undefined,
 ): string | undefined {
   if (stopReason === 'refusal') {
-    return 'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.';
+    return REFUSAL_NOTICE_MESSAGE;
   }
   return undefined;
 }

--- a/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/streamUtils.ts
@@ -191,6 +191,21 @@ export function buildFinishReasonMessage(
 }
 
 /**
+ * @issue:2329 — Returns a refusal-specific notice when the raw provider stop
+ * reason indicates the model's safety classifier refused the request.
+ * Returns undefined for all other stop reasons, allowing callers to fall back
+ * to the generic {@link buildFinishReasonMessage}.
+ */
+export function buildRefusalNoticeMessage(
+  stopReason: string | undefined,
+): string | undefined {
+  if (stopReason === 'refusal') {
+    return 'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.';
+  }
+  return undefined;
+}
+
+/**
  * Deduplicates ToolCallRequestInfo[] by callId, preserving insertion order.
  * Addresses issue #1040 where duplicate ToolCallRequest events cause the same
  * command to execute twice.

--- a/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useStreamEventHandlers.ts
@@ -41,6 +41,7 @@ import {
   showCitations,
   getCurrentProfileName,
   buildFinishReasonMessage,
+  buildRefusalNoticeMessage,
 } from './streamUtils.js';
 import {
   getActiveProviderNameForApiError,
@@ -383,7 +384,12 @@ function useFinishedEventHandler(deps: StreamEventHandlerDeps) {
   const { addItem } = deps;
   return useCallback(
     (event: ServerGeminiFinishedEvent, userMessageTimestamp: number) => {
-      const message = buildFinishReasonMessage(event.value.reason);
+      // @issue:2329 — prefer a refusal-specific notice when the raw provider
+      // stop reason indicates a safety-classifier refusal; otherwise fall back
+      // to the generic finish-reason message.
+      const message =
+        buildRefusalNoticeMessage(event.value.stopReason) ??
+        buildFinishReasonMessage(event.value.reason);
       if (message)
         addItem(
           { type: 'info', text: `WARNING:  ${message}` },

--- a/packages/cli/src/ui/hooks/useGeminiStream.finished.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.finished.test.tsx
@@ -305,6 +305,75 @@ describe('useGeminiStream', () => {
         );
       });
     });
+    it('should add refusal notice for Finished with stopReason "refusal" @issue:2329', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'I cannot help with that.',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: {
+              reason: 'SAFETY',
+              stopReason: 'refusal',
+              usageMetadata: undefined,
+            },
+          };
+        })(),
+      );
+
+      const { result } = renderHookWithDefaults();
+
+      await act(async () => {
+        await result.current.submitQuery('risky request');
+      });
+
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          {
+            type: 'info',
+            text: expect.stringContaining('safety classifier refused'),
+          },
+          expect.any(Number),
+        );
+      });
+    });
+
+    it('should not add refusal notice for a normal STOP without stopReason @issue:2329', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Here is the answer.',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderHookWithDefaults();
+
+      await act(async () => {
+        await result.current.submitQuery('normal request');
+      });
+
+      await waitFor(() => {
+        expect(result.current.streamingState).toBe(StreamingState.Idle);
+      });
+
+      const refusalInfoMessages = mockAddItem.mock.calls.filter((call) => {
+        const item = call[0] as { type?: string; text?: unknown };
+        return (
+          item.type === 'info' &&
+          typeof item.text === 'string' &&
+          item.text.includes('safety classifier refused')
+        );
+      });
+      expect(refusalInfoMessages).toHaveLength(0);
+    });
 
     describe('ContextWindowWillOverflow event', () => {
       beforeEach(() => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.finished.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.finished.test.tsx
@@ -315,7 +315,7 @@ describe('useGeminiStream', () => {
           yield {
             type: ServerGeminiEventType.Finished,
             value: {
-              reason: 'SAFETY',
+              reason: 'STOP',
               stopReason: 'refusal',
               usageMetadata: undefined,
             },

--- a/packages/cli/src/ui/hooks/useGeminiStream.finished.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.finished.test.tsx
@@ -299,7 +299,7 @@ describe('useGeminiStream', () => {
         expect(mockAddItem).toHaveBeenCalledWith(
           {
             type: 'info',
-            text: '⚠️  Response truncated due to token limits.',
+            text: 'WARNING:  Response truncated due to token limits.',
           },
           expect.any(Number),
         );
@@ -488,44 +488,44 @@ describe('useGeminiStream', () => {
       },
       {
         reason: 'SAFETY',
-        message: '⚠️  Response stopped due to safety reasons.',
+        message: 'WARNING:  Response stopped due to safety reasons.',
       },
       {
         reason: 'RECITATION',
-        message: '⚠️  Response stopped due to recitation policy.',
+        message: 'WARNING:  Response stopped due to recitation policy.',
       },
       {
         reason: 'LANGUAGE',
-        message: '⚠️  Response stopped due to unsupported language.',
+        message: 'WARNING:  Response stopped due to unsupported language.',
       },
       {
         reason: 'BLOCKLIST',
-        message: '⚠️  Response stopped due to forbidden terms.',
+        message: 'WARNING:  Response stopped due to forbidden terms.',
       },
       {
         reason: 'PROHIBITED_CONTENT',
-        message: '⚠️  Response stopped due to prohibited content.',
+        message: 'WARNING:  Response stopped due to prohibited content.',
       },
       {
         reason: 'SPII',
         message:
-          '⚠️  Response stopped due to sensitive personally identifiable information.',
+          'WARNING:  Response stopped due to sensitive personally identifiable information.',
       },
       {
         reason: 'OTHER',
-        message: '⚠️  Response stopped for other reasons.',
+        message: 'WARNING:  Response stopped for other reasons.',
       },
       {
         reason: 'MALFORMED_FUNCTION_CALL',
-        message: '⚠️  Response stopped due to malformed function call.',
+        message: 'WARNING:  Response stopped due to malformed function call.',
       },
       {
         reason: 'IMAGE_SAFETY',
-        message: '⚠️  Response stopped due to image safety violations.',
+        message: 'WARNING:  Response stopped due to image safety violations.',
       },
       {
         reason: 'UNEXPECTED_TOOL_CALL',
-        message: '⚠️  Response stopped due to unexpected tool call.',
+        message: 'WARNING:  Response stopped due to unexpected tool call.',
       },
     ])(
       'should handle $reason finish reason correctly',

--- a/packages/cli/src/utils/refusalNotice.ts
+++ b/packages/cli/src/utils/refusalNotice.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue:2329 — CLI-side access to the shared safety-classifier refusal
+ * notice. Re-exported from core so there is a single source of truth for the
+ * notice text across the CLI, the headless CLI, and the a2a-server.
+ */
+export { REFUSAL_NOTICE_MESSAGE } from '@vybestack/llxprt-code-core';

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -248,8 +248,9 @@ export type ServerGeminiFinishedEvent = {
     usageMetadata?: GenerateContentResponseUsageMetadata;
     outcome?: ServerGeminiFinishedOutcome;
     // @issue:2329 — the raw provider stop reason (e.g. 'refusal', 'end_turn')
-    // threaded from candidate.finishMessage, so consumers can surface a
-    // refusal-specific notice distinct from a normal completion.
+    // threaded from the repo-owned candidate providerStopReason carrier, so
+    // consumers can surface a refusal-specific notice distinct from a normal
+    // completion.
     stopReason?: string;
   };
 };

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -247,6 +247,10 @@ export type ServerGeminiFinishedEvent = {
     reason: FinishReason;
     usageMetadata?: GenerateContentResponseUsageMetadata;
     outcome?: ServerGeminiFinishedOutcome;
+    // @issue:2329 — the raw provider stop reason (e.g. 'refusal', 'end_turn')
+    // threaded from candidate.finishMessage, so consumers can surface a
+    // refusal-specific notice distinct from a normal completion.
+    stopReason?: string;
   };
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,7 @@ export * from './utils/errors.js';
 export * from './utils/checkpointUtils.js';
 export * from './utils/output-format.js';
 export * from './utils/exitCodes.js';
+export * from './utils/refusalNotice.js';
 export * from './utils/getFolderStructure.js';
 export * from './utils/memoryDiscovery.js';
 export * from './utils/gitIgnoreParser.js';

--- a/packages/core/src/utils/output-format.ts
+++ b/packages/core/src/utils/output-format.ts
@@ -26,6 +26,11 @@ export interface JsonOutput {
   response?: string;
   stats?: SessionMetrics;
   error?: JsonError;
+  /**
+   * Present only when the model's safety classifier declined the request
+   * (issue #2329). Omitted on normal completion.
+   */
+  finish_reason?: 'refusal';
 }
 
 // Streaming JSON event types

--- a/packages/core/src/utils/refusalNotice.ts
+++ b/packages/core/src/utils/refusalNotice.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue:2329 — Single source of truth for the safety-classifier refusal
+ * notice text. Shared by the interactive CLI, the non-interactive (headless)
+ * CLI, and the a2a-server so all surfaces present an identical notice when the
+ * model's safety classifier refuses a request.
+ */
+export const REFUSAL_NOTICE_MESSAGE =
+  'Request declined: the model\u2019s safety classifier refused to answer this request. Try rephrasing, or switch to a different model.';

--- a/packages/providers/src/anthropic/AnthropicProvider.issue2329.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue2329.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for issue #2329: Claude Fable 5 returns safety-classifier
+ * refusals as a successful HTTP 200 with stop_reason: 'refusal'. The streaming
+ * path (message_delta.stop_reason === 'refusal') must propagate the raw value
+ * into IContent metadata.stopReason so downstream consumers can surface a
+ * refusal-specific notice. The non-streaming path is covered in
+ * AnthropicResponseParser.issue1844.test.ts.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { clearActiveProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  setupAnthropicProvider,
+  type AnthropicTestSetup,
+} from './test-utils/anthropicProviderTestSetup.js';
+
+const mockMessagesCreate = vi.hoisted(() => vi.fn());
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn(
+    async () => "You are Claude Code, Anthropic's official CLI for Claude.",
+  ),
+}));
+
+vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  getErrorStatus: vi.fn(() => undefined),
+  isNetworkTransientError: vi.fn(() => false),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: { create: mockMessagesCreate },
+  })),
+}));
+
+describe('AnthropicProvider issue #2329 – streaming refusal propagation', () => {
+  let provider: AnthropicTestSetup['provider'];
+  let buildCallOptions: AnthropicTestSetup['buildCallOptions'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const setup = setupAnthropicProvider();
+    provider = setup.provider;
+    buildCallOptions = setup.buildCallOptions;
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  it('should propagate stopReason "refusal" from message_delta @issue:2329', async () => {
+    const mockStream = {
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'I cannot help with that.' },
+        };
+        yield {
+          type: 'message_delta',
+          delta: { stop_reason: 'refusal' },
+        };
+      },
+    };
+
+    mockMessagesCreate.mockResolvedValue(mockStream);
+
+    const messages: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'risky request' }],
+      },
+    ];
+    const generator = provider.generateChatCompletion(
+      buildCallOptions(messages),
+    );
+
+    const chunks = [];
+    for await (const chunk of generator) {
+      chunks.push(chunk);
+    }
+
+    const refusalChunk = chunks.find(
+      (c) => c.metadata?.stopReason === 'refusal',
+    );
+    expect(refusalChunk).toBeDefined();
+    expect(refusalChunk?.metadata?.stopReason).toBe('refusal');
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicProvider.issue2329.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue2329.test.ts
@@ -54,15 +54,46 @@ describe('AnthropicProvider issue #2329 – streaming refusal propagation', () =
   });
 
   it('should propagate stopReason "refusal" from message_delta @issue:2329', async () => {
+    // Realistic full Anthropic SSE event sequence, matching the shapes
+    // AnthropicStreamProcessor consumes (see AnthropicStreamProcessor.ts):
+    // message_start → content_block_start → content_block_delta →
+    // message_delta (with stop_reason) → message_stop.
     const mockStream = {
       async *[Symbol.asyncIterator]() {
         yield {
+          type: 'message_start',
+          message: {
+            id: 'msg_refusal_2329',
+            type: 'message',
+            role: 'assistant',
+            content: [],
+            model: 'claude-fable-5-20250929',
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 12, output_tokens: 0 },
+          },
+        };
+        yield {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'text', text: '' },
+        };
+        yield {
           type: 'content_block_delta',
+          index: 0,
           delta: { type: 'text_delta', text: 'I cannot help with that.' },
         };
         yield {
+          type: 'content_block_stop',
+          index: 0,
+        };
+        yield {
           type: 'message_delta',
-          delta: { stop_reason: 'refusal' },
+          delta: { stop_reason: 'refusal', stop_sequence: null },
+          usage: { output_tokens: 8 },
+        };
+        yield {
+          type: 'message_stop',
         };
       },
     };
@@ -84,6 +115,16 @@ describe('AnthropicProvider issue #2329 – streaming refusal propagation', () =
       chunks.push(chunk);
     }
 
+    // The visible text content must be yielded from the content_block_delta.
+    const textChunk = chunks.find(
+      (c) =>
+        c.blocks.length > 0 &&
+        c.blocks[0].type === 'text' &&
+        (c.blocks[0] as { text: string }).text === 'I cannot help with that.',
+    );
+    expect(textChunk).toBeDefined();
+
+    // The terminal metadata (stop_reason === 'refusal') must be propagated.
     const refusalChunk = chunks.find(
       (c) => c.metadata?.stopReason === 'refusal',
     );


### PR DESCRIPTION
## Summary

Fixes #2329

Claude Fable 5 returns safety-classifier refusals as **successful HTTP 200 responses with `stop_reason: 'refusal'`** (not an error), with the refusal text delivered as ordinary assistant content. Before this PR, `MessageConverter` mapped `refusal` to a plain `STOP`, so a refusal was indistinguishable from a normal completion — the user saw the refusal text as if it were a normal answer with no indication the model declined the request.

This PR threads the raw provider stop reason end-to-end and surfaces refusals distinctly on every consumer surface.

## How it works

The raw provider stop reason now flows through the whole pipeline:

    AnthropicResponseParser / AnthropicStreamProcessor   (metadata.stopReason: 'refusal' — pre-existing from #2328)
      -> MessageConverter                                 (candidate.finishMessage = raw stop reason; coarse FinishReason mapping for 'refusal' stays STOP)
      -> agents Turn                                      (Finished event gains value.stopReason)
      -> agents public API eventAdapter                   (done{ reason: 'refusal' } + finished.stopReason)
      -> CLI (interactive + non-interactive)              (user-visible notice / structured JSON marker)

### Per-layer changes

- **`packages/agents/src/core/MessageConverter.ts`** — when a termination reason maps, the raw provider stop reason is preserved on `candidate.finishMessage` (a standard optional `@google/genai` `Candidate` field, previously unused in this repo). The coarse mapping `refusal -> FinishReason.STOP` is intentionally unchanged from main: the raw `stopReason` is the authoritative refusal signal, and remapping the coarse reason would risk conflating refusals with generic provider safety stops (e.g. OpenAI `content_filter -> SAFETY`).
- **`packages/core/src/core/turn.ts` / `packages/agents/src/core/turn.ts`** — `ServerGeminiFinishedEvent.value` gains optional `stopReason?: string`; the Turn threads `candidate.finishMessage` into it (`emitFinishReason` refactored to an options object; empty-string values are excluded so no vacuous field leaks to consumers).
- **agents public API** (`event-types.ts`, `event-schema.ts`, `eventAdapter.ts`) — `DoneReason` gains `'refusal'`; the adapter maps `Finished.value.stopReason === 'refusal'` to `done{ reason: 'refusal' }` and `FinishedValue` preserves `stopReason`. Documented in `docs/agent-api.md`.
- **Interactive CLI** (`streamUtils.ts`, `useStreamEventHandlers.ts`) — a refusal-specific notice is shown: *"Request declined: the model's safety classifier refused to answer this request. Try rephrasing, or switch to a different model."* Falls back to the existing generic finish-reason messages otherwise. `REFUSAL_NOTICE_MESSAGE` is the single source of truth shared with the non-interactive surface.
- **Non-interactive CLI** (`nonInteractiveCliSupport.ts`, `output-format.ts`) — mode-appropriate structured signaling:
  - plain text: `WARNING: <notice>` on stderr, final text preserved on stdout
  - `--output-format json`: the final JSON object includes `"finish_reason": "refusal"` (field absent on normal completions so existing consumers see byte-identical output); exported `JsonOutput` interface updated to match
  - `--output-format stream-json`: a `severity: 'warning'` error event precedes the RESULT event
  - the unstructured stderr warning fires only in pure text mode, matching the existing `ConsolePatcher` `stderr: !jsonOutput` convention

## Scope decisions

- The issue lists a client-side auto-fallback to another model as **optional**; it is intentionally not implemented. The notice suggests rephrasing or switching models instead.
- Other stop reasons (`pause_turn`, `content_filter`, etc.) are behaviorally unchanged.

## Acceptance criteria coverage

- ✅ A Fable 5 refusal is distinguishable to consumers: `done{ reason: 'refusal' }` + `finished.stopReason` on the agents API, `Finished.value.stopReason` internally, `finish_reason` in JSON output.
- ✅ The user sees an explicit indication the request was declined by a safety classifier (interactive notice, non-interactive stderr warning / structured markers).
- ✅ Behavioral tests cover both non-streaming and streaming (`message_delta.stop_reason === 'refusal'`) paths.

## Tests (all behavioral, no mock theater)

- `packages/providers/src/anthropic/AnthropicProvider.issue2329.test.ts` — streaming `message_delta` refusal propagation (non-streaming already locked by `AnthropicResponseParser.issue1844.test.ts`)
- `packages/agents/src/core/MessageConverter.issue2329.test.ts` — refusal/end_turn/max_tokens/unknown/absent stopReason -> finishReason + finishMessage
- `packages/agents/src/core/turn.issue2329.test.ts` — Finished event carries `stopReason`; omitted when absent or empty
- `packages/agents/src/api/__tests__/event-characterization.spec.ts` — refusal -> `done{refusal}`; `end_turn` -> `done{stop}` (proves DoneReason derives from stopReason, not the coarse reason)
- `packages/agents/src/api/__tests__/event-schema.spec.ts` — schema round-trips `finished.stopReason`; canonical DoneReason set includes `refusal`
- `packages/cli/src/ui/hooks/geminiStream/__tests__/useFinishedEventHandler.refusal.test.ts` — notice precedence and silence for normal completions (with and without stopReason)
- `packages/cli/src/nonInteractiveCli.test.ts` — text/stderr, stream-json warning + RESULT, plain-JSON `finish_reason` present on refusal and absent on normal stop, stderr suppressed in JSON modes
- `packages/cli/src/ui/hooks/geminiStream/__tests__/streamUtils.test.ts` — `buildRefusalNoticeMessage` unit coverage

## Verification

- `npm run test` — all green (~1,500 test files across workspaces)
- `npm run typecheck`, `npm run format`, `npm run build`, `npm run lint:eslint-guard` — clean
- eslint on all changed files — clean (no suppressions added anywhere)
- Smoke test `node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else"` — passes
- Reviewed pre-push by deepthinker (approved) and Open Code Review (2 findings, both remediated: empty-string stopReason exclusion; SDK type verification for `finishMessage`, which is a declared optional field on `Candidate`)

## Sources

- Anthropic Docs — Refusals and fallback: https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback
- Anthropic Docs — Introducing Claude Fable 5 and Claude Mythos 5: https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
