### PR TITLE
Add CodeRabbit configuration to reduce review rate-limit hits

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# Recommended CodeRabbit config for vybestack/llxprt-code
+# Goal: keep full review quality on real code (packages/**, scripts/** source,
+# .github/workflows/**) while cutting review volume that counts against
+# per-developer rate limits.
+# Save as `.coderabbit.yaml` in the repository root.
+
+reviews:
+  profile: chill
+
+  # Diagrams add per-review work; walkthrough + summary already cover the changes.
+  sequence_diagrams: false
+
+  # Biggest lever: don't spend review capacity on planning notes, fixtures,
+  # and lockfiles. On PR #2317 this excludes 75 of 141 files (53%); on
+  # PR #2336, 24 of 111. Nothing under packages/ is affected.
+  path_filters:
+    - "!project-plans/**"          # planning/tracking notes, not shipped code
+    - "!dev-docs/**"               # internal runbooks
+    - "!**/*.lock"                 # bun.lock
+    - "!package-lock.json"
+    - "!scripts/tmux-script.*.json" # recorded tmux test fixtures
+    - "!junit-integration.xml"     # checked-in CI artifact
+    - "!**/__snapshots__/**"       # test snapshots
+
+  auto_review:
+    enabled: true
+    # Draft PRs are skipped (this is the default, stated here because the
+    # recommended workflow relies on it: open as draft, mark ready when green).
+    drafts: false
+    # Review once when the PR is opened/marked ready, not on every push.
+    # Multi-commit PRs (e.g. #2334 had 10 commits) otherwise consume one
+    # incremental review per push. Trigger follow-up reviews on demand by
+    # commenting `@coderabbitai review` after pushing fixes.
+    auto_incremental_review: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,13 +16,13 @@ reviews:
   # and lockfiles. On PR #2317 this excludes 75 of 141 files (53%); on
   # PR #2336, 24 of 111. Nothing under packages/ is affected.
   path_filters:
-    - "!project-plans/**"          # planning/tracking notes, not shipped code
-    - "!dev-docs/**"               # internal runbooks
-    - "!**/*.lock"                 # bun.lock
-    - "!package-lock.json"
-    - "!scripts/tmux-script.*.json" # recorded tmux test fixtures
-    - "!junit-integration.xml"     # checked-in CI artifact
-    - "!**/__snapshots__/**"       # test snapshots
+    - '!project-plans/**' # planning/tracking notes, not shipped code
+    - '!dev-docs/**' # internal runbooks
+    - '!**/*.lock' # bun.lock
+    - '!package-lock.json'
+    - '!scripts/tmux-script.*.json' # recorded tmux test fixtures
+    - '!junit-integration.xml' # checked-in CI artifact
+    - '!**/__snapshots__/**' # test snapshots
 
   auto_review:
     enabled: true


### PR DESCRIPTION
## Why

Recent PRs (#2337, #2336, #2317, #2313) all show CodeRabbit's "Review limit reached" banner, with waits of 2–38 minutes before the next included review. The repo currently has no `.coderabbit.yaml`, so reviews run on pure defaults: every file, on every push. A few things compound into the limit:

- **Rate limits are per developer**, and nearly all recent PRs (~60 in the last week) come from one author, so the whole repo's volume lands on one quota.
- **Every push consumes an incremental review.** PRs like #2334 landed with 10 separately-pushed commits — each push after the first review triggers another one.
- **Low-signal files inflate every review.** `project-plans/**` planning notes made up 75 of the 141 files in #2317; #2336 carried 17 recorded `scripts/tmux-script.*.json` fixtures plus `bun.lock` / `package-lock.json`.

## What this PR does

Adds a `.coderabbit.yaml` with three targeted changes:

| Setting | Effect |
|---|---|
| `path_filters` excluding plans, fixtures, and lockfiles | Verified against real PRs: removes 53% of files from #2317 and 22% from #2336, with **zero files under `packages/` affected**. Review capacity goes to code that ships. |
| `auto_review.auto_incremental_review: false` | One review when a PR opens (or is marked ready) instead of one per push. When you want a fresh look after pushing fixes, comment `@coderabbitai review`. A 10-commit PR goes from up to ~10 reviews to 1–2. |
| `sequence_diagrams: false` | Trims per-review generation work; the walkthrough and summary already describe the change. |

If dropping automatic incremental reviews feels too aggressive, a gentler alternative is `auto_review.auto_pause_after_reviewed_commits: 3` (default 5), which pauses auto-review on a PR after 3 reviewed commits until resumed.

The config validates against CodeRabbit's official schema (`schema.v2.json`).

## Workflow ideas that stack with this

- **Open PRs as drafts, mark ready when CI is green** — drafts are skipped by default, so WIP pushes are free and marking ready triggers one review of the final state.
- **`@coderabbitai pause` / `@coderabbitai resume`** on a PR under heavy iteration.
- **Usage-based reviews** (Billing → Usage) remove the wait entirely — only reviews past the plan's limits are billed, per file, and the path filters here directly cut that file count too.

## Expected impact

Roughly 50–80% fewer review events on multi-commit PRs, and 20–55% fewer files per review on the planning/fixture-heavy PRs sampled — while everything under `packages/`, `scripts/` source, and `.github/workflows/` keeps getting fully reviewed.
