### PR TITLE
Fix nightly release preflight: build before lint:ci for type-aware ESLint (Fixes #2339)

### DIFF
--- a/scripts/preflight-ci.js
+++ b/scripts/preflight-ci.js
@@ -17,6 +17,14 @@ import { resolve } from 'node:path';
 /**
  * The ordered preflight step sequence.
  *
+ * `build` must run before `lint:ci` because the type-aware ESLint rules
+ * (typescript-eslint `projectService` / tsserver) require compiled `dist/*.d.ts`
+ * declarations on disk to resolve cross-workspace imports. Without them, every
+ * cross-package import silently resolves to `any`, producing hundreds of
+ * phantom `strict-boolean-expressions` and `no-unnecessary-type-assertion`
+ * errors. This mirrors the build-before-lint ordering in ci.yml. See issue
+ * #2339.
+ *
  * `lint:agents-api-surface` must run before `test:ci` because the agents
  * package API-surface guard test fails closed when the surface report
  * (`node_modules/.cache/agents-api-surface/report.json`) is absent. `clean`
@@ -28,8 +36,8 @@ import { resolve } from 'node:path';
 export function preflightSteps() {
   return [
     { command: 'npm run format' },
-    { command: 'npm run lint:ci' },
     { command: 'npm run build' },
+    { command: 'npm run lint:ci' },
     { command: 'npm run typecheck' },
     { command: 'npm run lint:agents-api-surface' },
     { command: 'npm run test:ci' },

--- a/scripts/tests/preflight-ci.test.js
+++ b/scripts/tests/preflight-ci.test.js
@@ -47,6 +47,21 @@ describe('Issue #2323: preflight-ci step ordering', () => {
     expect(typecheckIndex).toBeGreaterThan(buildIndex);
     expect(testIndex).toBeGreaterThan(typecheckIndex);
   });
+
+  /**
+   * Issue #2339: Build must precede lint:ci so type-aware ESLint rules can
+   * resolve cross-workspace imports against compiled dist/*.d.ts declarations.
+   * Before this fix, postinstall.cjs (rewritten in #2305 to be symlink-only)
+   * no longer built dist/ during npm ci, so lint:ci ran against unbuilt source
+   * and emitted 317 phantom "unexpected any" errors, failing the nightly
+   * release.
+   */
+  it('runs build before lint:ci for type-aware ESLint resolution (issue #2339)', () => {
+    const buildIndex = commands.indexOf('npm run build');
+    const lintIndex = commands.indexOf('npm run lint:ci');
+    expect(buildIndex).toBeGreaterThan(-1);
+    expect(lintIndex).toBeGreaterThan(buildIndex);
+  });
 });
 
 describe('Issue #2323: root package.json preflight script', () => {
@@ -170,10 +185,12 @@ describe('Issue #2323: runPreflight aborts on failure', () => {
 
     // Verify steps before build ran before the failure
     expect(executedCommands).toContain('npm run format');
-    expect(executedCommands).toContain('npm run lint:ci');
 
+    // lint:ci, typecheck, lint:agents-api-surface, and test:ci all run after
+    // build and must not execute when build fails (issue #2339 ordering).
     const commandsAfterBuild = executedCommands.slice(buildIndex + 1);
     const notAfterFailure = [
+      'npm run lint:ci',
       'npm run typecheck',
       'npm run lint:agents-api-surface',
       'npm run test:ci',


### PR DESCRIPTION
## Summary

The nightly release for v0.10.0-nightly.260703 failed because preflight-ci.js ran `lint:ci` before `build`, causing type-aware ESLint rules to emit 317 phantom errors when compiled `dist/*.d.ts` declarations were missing.

## Root Cause

The type-aware ESLint rules (typescript-eslint `projectService`/tsserver) require compiled `dist/*.d.ts` on disk to resolve cross-workspace imports. Without them, every cross-package import silently resolves to `any`, producing hundreds of spurious `strict-boolean-expressions` and `no-unnecessary-type-assertion` errors.

This ordering was historically safe because `postinstall.cjs` built `dist/` during `npm ci`. PR #2305 rewrote `postinstall.cjs` to be symlink-only (Bun migration S5/S7), removing the implicit build that had protected the wrong step order. The nightly was the first execution of `preflight-ci.js` in a world where `npm ci` no longer produces `dist/`.

Full analysis is documented in [issue #2339](https://github.com/vybestack/llxprt-code/issues/2339#issuecomment-4883390429).

## Changes

1. **`scripts/preflight-ci.js`**: Reordered `preflightSteps()` so `npm run build` runs **before** `npm run lint:ci`, mirroring the documented build-before-lint requirement in `ci.yml`. Added explanatory comment referencing issue #2339.

2. **`scripts/tests/preflight-ci.test.js`**:
   - Added regression test asserting `build` precedes `lint:ci` in the step sequence (issue #2339).
   - Updated the build-failure test to reflect that `lint:ci` now runs after `build` (so it should NOT execute when build fails).

## Verification

- `npm run format` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (16,000+ tests, 0 failures)
- `npm run test:scripts` ✅ (825 tests, including preflight-ci.test.js)
- Smoke test (`bun scripts/start.ts --profile-load ollamakimi`) ✅
- OCR (Open Code Review): 0 findings

## Why not convert preflight-ci.js to Bun TypeScript?

This was considered (issue #2242 Bun migration S5 covers scripts/\*.js → scripts/\*.ts). However:
- The preflight orchestrator is a thin runner; converting it adds no functional value.
- ESLint itself must stay on Node (confirmed Bun blocker: type-aware ESLint degrades under Bun hoisted node_modules).
- Converting `preflight-ci.js` is out of scope for this fix — it should be handled in the S5/S7 migration subissues that own release-pipeline conversion.

Closes #2339