### PR TITLE
Replace fs.watch with fs.watchFile for branch name polling (Fixes #2370)

### DIFF
--- a/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
@@ -25,11 +25,50 @@ vi.mock('node:fs/promises');
 const CWD = process.platform === 'win32' ? '\\test\\project' : '/test/project';
 const GIT_LOGS_HEAD_PATH = path.join(CWD, '.git', 'logs', 'HEAD');
 
+type WatchFileCallback = (curr: fs.Stats, prev: fs.Stats) => void;
+
+function createWatchFileCapture() {
+  let callback: WatchFileCallback | null = null;
+  const spy = vi.mocked(fs.watchFile).mockImplementation(((
+    _filename: fs.PathLike,
+    optionsOrListener: unknown,
+    maybeListener?: WatchFileCallback,
+  ): fs.StatWatcher => {
+    const listener =
+      typeof optionsOrListener === 'function'
+        ? (optionsOrListener as WatchFileCallback)
+        : maybeListener;
+    if (listener) {
+      callback = listener;
+    }
+    return {} as unknown as fs.StatWatcher;
+  }) as typeof fs.watchFile);
+  return {
+    spy,
+    getCallback: (): WatchFileCallback => {
+      if (!callback) throw new Error('watchFile callback not captured yet');
+      return callback;
+    },
+    getListener: (): WatchFileCallback | null => callback,
+  };
+}
+
+function mockExecReturn(...values: string[]) {
+  let callCount = 0;
+  (mockExec as MockedFunction<typeof mockExec>).mockImplementation(
+    (_command, _options, callback) => {
+      const value = values[Math.min(callCount, values.length - 1)];
+      callCount++;
+      callback?.(null, value, '');
+      return new EventEmitter() as ChildProcess;
+    },
+  );
+  return () => callCount;
+}
+
 describe('useGitBranchName', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    // Mock fsPromises.access to always succeed
     vi.mocked(fsPromises.access).mockResolvedValue(undefined);
   });
 
@@ -38,17 +77,12 @@ describe('useGitBranchName', () => {
   });
 
   it('should return branch name', async () => {
-    (mockExec as MockedFunction<typeof mockExec>).mockImplementation(
-      (_command, _options, callback) => {
-        callback?.(null, 'main\n', '');
-        return new EventEmitter() as ChildProcess;
-      },
-    );
+    mockExecReturn('main\n');
 
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
 
     await act(async () => {
-      rerender(); // Rerender to get the updated state
+      rerender();
     });
 
     expect(result.current).toBe('main');
@@ -109,33 +143,9 @@ describe('useGitBranchName', () => {
     expect(result.current).toBeUndefined();
   });
 
-  it('should update branch name when .git/HEAD changes', async () => {
-    // Create a mock watcher
-    const mockWatcher = {
-      close: vi.fn(),
-    };
-
-    let watchCallback: ((eventType: string) => void) | null = null;
-    const watchSpy = vi
-      .mocked(fs.watch)
-      .mockImplementation((path, callback) => {
-        watchCallback = callback as (eventType: string) => void;
-        return mockWatcher as unknown as fs.FSWatcher;
-      });
-
-    let callCount = 0;
-    // Mock exec to return different values on each call
-    (mockExec as MockedFunction<typeof mockExec>).mockImplementation(
-      (_command, _options, callback) => {
-        if (callCount === 0) {
-          callCount++;
-          callback?.(null, 'main\n', '');
-        } else {
-          callback?.(null, 'develop\n', '');
-        }
-        return new EventEmitter() as ChildProcess;
-      },
-    );
+  it('should update branch name when .git/logs/HEAD changes', async () => {
+    const capture = createWatchFileCapture();
+    mockExecReturn('main\n', 'develop\n');
 
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
 
@@ -144,34 +154,29 @@ describe('useGitBranchName', () => {
     });
     expect(result.current).toBe('main');
 
-    // Wait for watcher to be set up
     await waitFor(() => {
-      expect(watchSpy).toHaveBeenCalled();
+      expect(capture.spy).toHaveBeenCalled();
     });
 
-    // Simulate file change event
     await act(async () => {
-      watchCallback!('change');
+      capture.getCallback()(
+        { mtimeMs: 2000 } as fs.Stats,
+        { mtimeMs: 1000 } as fs.Stats,
+      );
       rerender();
     });
 
     expect(result.current).toBe('develop');
-    expect(fs.watch).toHaveBeenCalledWith(
+    expect(fs.watchFile).toHaveBeenCalledWith(
       GIT_LOGS_HEAD_PATH,
+      { interval: 3000 },
       expect.any(Function),
     );
   });
 
   it('should handle watcher setup error silently', async () => {
-    // Make fsPromises.access reject to simulate file not existing
     vi.mocked(fsPromises.access).mockRejectedValue(new Error('ENOENT'));
-
-    (mockExec as MockedFunction<typeof mockExec>).mockImplementation(
-      (_command, _options, callback) => {
-        callback?.(null, 'main\n', '');
-        return new EventEmitter() as ChildProcess;
-      },
-    );
+    mockExecReturn('main\n');
 
     const { result, rerender } = renderHook(() => useGitBranchName(CWD));
 
@@ -179,30 +184,13 @@ describe('useGitBranchName', () => {
       rerender();
     });
 
-    expect(result.current).toBe('main'); // Branch name should still be fetched initially
-
-    // Verify that fs.watch was never called since access check failed
-    expect(fs.watch).not.toHaveBeenCalled();
+    expect(result.current).toBe('main');
+    expect(fs.watchFile).not.toHaveBeenCalled();
   });
 
-  it('should cleanup watcher on unmount', async () => {
-    const closeMock = vi.fn();
-    const watcherEmitter = new EventEmitter();
-    const mockWatcher = {
-      close: closeMock,
-      ...watcherEmitter,
-    };
-
-    const watchMock = vi
-      .mocked(fs.watch)
-      .mockReturnValue(mockWatcher as unknown as fs.FSWatcher);
-
-    (mockExec as MockedFunction<typeof mockExec>).mockImplementation(
-      (_command, _options, callback) => {
-        callback?.(null, 'main\n', '');
-        return new EventEmitter() as ChildProcess;
-      },
-    );
+  it('should cleanup watcher on unmount with the same listener reference', async () => {
+    const capture = createWatchFileCapture();
+    mockExecReturn('main\n');
 
     const { unmount, rerender } = renderHook(() => useGitBranchName(CWD));
 
@@ -210,15 +198,126 @@ describe('useGitBranchName', () => {
       rerender();
     });
 
-    // Wait for watcher to be set up BEFORE unmounting
     await waitFor(() => {
-      expect(watchMock).toHaveBeenCalledWith(
+      expect(capture.spy).toHaveBeenCalledWith(
         GIT_LOGS_HEAD_PATH,
+        { interval: 3000 },
         expect.any(Function),
       );
     });
 
     unmount();
-    expect(closeMock).toHaveBeenCalled();
+
+    expect(fs.unwatchFile).toHaveBeenCalledWith(
+      GIT_LOGS_HEAD_PATH,
+      capture.getListener(),
+    );
+  });
+
+  it('should not refetch when mtimeMs and size are unchanged', async () => {
+    const capture = createWatchFileCapture();
+    const getCallCount = mockExecReturn('main\n');
+
+    const { result, rerender } = renderHook(() => useGitBranchName(CWD));
+
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toBe('main');
+
+    await waitFor(() => {
+      expect(capture.spy).toHaveBeenCalled();
+    });
+
+    const callsBeforePoll = getCallCount();
+
+    await act(async () => {
+      capture.getCallback()(
+        { mtimeMs: 1000, size: 42 } as fs.Stats,
+        { mtimeMs: 1000, size: 42 } as fs.Stats,
+      );
+      rerender();
+    });
+
+    expect(getCallCount()).toBe(callsBeforePoll);
+    expect(result.current).toBe('main');
+  });
+
+  it('should refetch when only size changes', async () => {
+    const capture = createWatchFileCapture();
+    mockExecReturn('main\n', 'develop\n');
+
+    const { result, rerender } = renderHook(() => useGitBranchName(CWD));
+
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toBe('main');
+
+    await waitFor(() => {
+      expect(capture.spy).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      capture.getCallback()(
+        { mtimeMs: 1000, size: 99 } as fs.Stats,
+        { mtimeMs: 1000, size: 42 } as fs.Stats,
+      );
+      rerender();
+    });
+
+    expect(result.current).toBe('develop');
+  });
+
+  it('should refetch when only mtimeMs changes', async () => {
+    const capture = createWatchFileCapture();
+    mockExecReturn('main\n', 'develop\n');
+
+    const { result, rerender } = renderHook(() => useGitBranchName(CWD));
+
+    await act(async () => {
+      rerender();
+    });
+    expect(result.current).toBe('main');
+
+    await waitFor(() => {
+      expect(capture.spy).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      capture.getCallback()(
+        { mtimeMs: 2000, size: 42 } as fs.Stats,
+        { mtimeMs: 1000, size: 42 } as fs.Stats,
+      );
+      rerender();
+    });
+
+    expect(result.current).toBe('develop');
+  });
+
+  it('should not register watchFile if unmounted before access resolves', async () => {
+    let resolveAccess: () => void = () => {};
+    vi.mocked(fsPromises.access).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAccess = resolve;
+        }),
+    );
+
+    mockExecReturn('main\n');
+
+    const { unmount, rerender } = renderHook(() => useGitBranchName(CWD));
+
+    await act(async () => {
+      rerender();
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveAccess();
+    });
+
+    expect(fs.watchFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -48,21 +48,24 @@ export function useGitBranchName(cwd: string): string | undefined {
     fetchBranchName(); // Initial fetch
 
     const gitLogsHeadPath = path.join(cwd, '.git', 'logs', 'HEAD');
-    let watcher: fs.FSWatcher | undefined;
     let cancelled = false;
+
+    const onGitLogsHeadChange = (curr: fs.Stats, prev: fs.Stats) => {
+      if (cancelled) return;
+      if (curr.mtimeMs !== prev.mtimeMs || curr.size !== prev.size) {
+        fetchBranchName();
+      }
+    };
 
     const setupWatcher = async () => {
       try {
         // Check if .git/logs/HEAD exists, as it might not in a new repo or orphaned head
         await fsPromises.access(gitLogsHeadPath, fs.constants.F_OK);
         if (cancelled) return;
-        watcher = fs.watch(gitLogsHeadPath, (eventType: string) => {
-          // Changes to .git/logs/HEAD (appends) indicate HEAD has likely changed
-          if (eventType === 'change' || eventType === 'rename') {
-            // Handle rename just in case
-            fetchBranchName();
-          }
-        });
+        // fs.watchFile (stat-polling) is used instead of fs.watch because Bun has
+        // confirmed-open bugs where fs.watch does not reliably deliver change events
+        // when a process writes to the watched file (e.g. git appending to the reflog).
+        fs.watchFile(gitLogsHeadPath, { interval: 3000 }, onGitLogsHeadChange);
       } catch {
         // Silently ignore watcher errors (e.g. permissions or file not existing),
         // similar to how exec errors are handled.
@@ -74,7 +77,7 @@ export function useGitBranchName(cwd: string): string | undefined {
 
     return () => {
       cancelled = true;
-      watcher?.close();
+      fs.unwatchFile(gitLogsHeadPath, onGitLogsHeadChange);
     };
   }, [cwd, fetchBranchName]);
 


### PR DESCRIPTION
## Summary

After the Bun runtime migration, the git branch name displayed in the CLI status bar stopped updating when the agent switches branches. The initial branch is shown correctly on startup, but subsequent branch changes (e.g., `git checkout`) are never reflected.

## Root Cause

The `useGitBranchName` hook relied on `fs.watch` from `node:fs` to detect changes to `.git/logs/HEAD`. Bun has confirmed-open bugs in `fs.watch` on macOS where change events are not reliably delivered when a process writes to a watched file (https://github.com/oven-sh/bun/issues/14568, https://github.com/oven-sh/bun/issues/15085, https://github.com/oven-sh/bun/issues/24875). Git appends a reflog entry to `.git/logs/HEAD` during branch checkout, but the watcher never fires under Bun.

## Fix

Replace `fs.watch` (event-based) with `fs.watchFile` (stat-polling at 3s interval), which is reliable across both Node.js and Bun runtimes. The polling interval is negligible for a status bar display element.

Key implementation details:
- The `watchFile` listener is extracted to a named function (`onGitLogsHeadChange`) so it can be passed to `fs.unwatchFile` for precise per-listener cleanup (avoids removing unrelated watchers)
- The listener checks `curr.mtimeMs !== prev.mtimeMs || curr.size !== prev.size` for robust change detection
- A `cancelled` flag guards the listener callback to prevent state updates after unmount
- The async `setupWatcher` race condition (unmount before `access` resolves) is handled by checking `cancelled` before registering the watcher

## Test Coverage

11 tests covering:
- Initial branch name fetch (normal, error, detached HEAD, detached HEAD error)
- Branch name update on `.git/logs/HEAD` change (mtime change)
- No refetch when mtimeMs AND size are unchanged
- Refetch when only size changes (OR condition coverage)
- Refetch when only mtimeMs changes (OR condition coverage)
- Watcher setup error handled silently (access fails)
- Cleanup passes same listener reference to `unwatchFile`
- No watchFile registered if unmounted before async setup completes

Closes #2370