### PR TITLE
Proxy credentials for no-compile Bun launcher (Fixes #2369)

### DIFF
--- a/packages/cli/bin/credential-proxy-host.cjs
+++ b/packages/cli/bin/credential-proxy-host.cjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+'use strict';
+
+const { existsSync, readFileSync } = require('node:fs');
+const { mkdtemp, rm } = require('node:fs/promises');
+const { registerHooks, stripTypeScriptTypes } = require('node:module');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { fileURLToPath } = require('node:url');
+
+const PROXY_SOCKET_PREFIX = 'lxcp-';
+
+function shouldTransformTypeScriptUrl(url) {
+  return (
+    url.startsWith('file:') &&
+    !url.endsWith('.d.ts') &&
+    !url.endsWith('.d.mts') &&
+    !url.endsWith('.d.cts') &&
+    (url.endsWith('.ts') || url.endsWith('.mts') || url.endsWith('.cts'))
+  );
+}
+
+function getTypeScriptModuleFormat(url, context) {
+  if (url.endsWith('.cts') || context.format === 'commonjs') {
+    return 'commonjs';
+  }
+  return 'module';
+}
+
+function registerTypeScriptSourceResolver() {
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      const shouldUseBunCondition = specifier.startsWith('@vybestack/');
+      const conditions =
+        context.conditions?.includes('bun') || !shouldUseBunCondition
+          ? context.conditions
+          : [...(context.conditions ?? []), 'bun'];
+      try {
+        return nextResolve(specifier, { ...context, conditions });
+      } catch (error) {
+        const isNotFound =
+          error?.code === 'ERR_MODULE_NOT_FOUND' ||
+          error?.code === 'MODULE_NOT_FOUND';
+        if (
+          isNotFound &&
+          specifier.endsWith('.js') &&
+          context.parentURL?.startsWith('file:')
+        ) {
+          const tsUrl = new URL(
+            specifier.replace(/\.js$/, '.ts'),
+            context.parentURL,
+          );
+          if (existsSync(fileURLToPath(tsUrl))) {
+            return { url: tsUrl.href, shortCircuit: true };
+          }
+        }
+        throw error;
+      }
+    },
+    load(url, context, nextLoad) {
+      if (shouldTransformTypeScriptUrl(url)) {
+        const source = readFileSync(fileURLToPath(url), 'utf8');
+        return {
+          format: getTypeScriptModuleFormat(url, context),
+          shortCircuit: true,
+          source: stripTypeScriptTypes(source, { mode: 'transform' }),
+        };
+      }
+      return nextLoad(url, context);
+    },
+  });
+}
+
+function describeError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function main() {
+  registerTypeScriptSourceResolver();
+  const { createAndStartProxy, getProxySocketPath, stopProxy } = await import(
+    '@vybestack/llxprt-code-providers/auth.js'
+  );
+
+  const socketDir = await mkdtemp(join(tmpdir(), PROXY_SOCKET_PREFIX));
+  let handle;
+  let stopping = false;
+  let shuttingDown = false;
+
+  async function stop() {
+    if (stopping) {
+      return;
+    }
+    stopping = true;
+    try {
+      await handle?.stop();
+    } catch (error) {
+      process.stderr.write(`${describeError(error)}\n`);
+    } finally {
+      await rm(socketDir, { force: true, recursive: true }).catch(() => {});
+    }
+  }
+
+  function shutdown(exitCode) {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    void stop().finally(() => process.exit(exitCode));
+  }
+
+  let pendingSignalExitCode;
+  const requestShutdown = (exitCode) => {
+    if (handle === undefined) {
+      pendingSignalExitCode ??= exitCode;
+      return;
+    }
+    shutdown(exitCode);
+  };
+
+  process.once('SIGTERM', () => requestShutdown(0));
+  process.once('SIGINT', () => requestShutdown(130));
+  process.once('SIGHUP', () => requestShutdown(129));
+
+  try {
+    handle = await createAndStartProxy({ socketPath: socketDir });
+    const socketPath = getProxySocketPath();
+    if (socketPath === undefined) {
+      throw new Error('proxy socket path was not reported');
+    }
+    if (pendingSignalExitCode !== undefined) {
+      shutdown(pendingSignalExitCode);
+      return;
+    }
+
+    process.stdout.write(`${JSON.stringify({ socketPath })}\n`);
+    process.stdin.once('end', () => shutdown(0));
+    process.stdin.once('close', () => shutdown(0));
+    process.stdin.resume();
+  } catch (error) {
+    if (handle === undefined) {
+      await stopProxy().catch(() => {});
+    }
+    await stop().catch(() => {});
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${describeError(error)}\n`);
+  process.exit(1);
+});

--- a/packages/cli/bin/credential-proxy-host.cjs
+++ b/packages/cli/bin/credential-proxy-host.cjs
@@ -7,8 +7,7 @@ const { registerHooks, stripTypeScriptTypes } = require('node:module');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const { fileURLToPath } = require('node:url');
-
-const PROXY_SOCKET_PREFIX = 'lxcp-';
+const { PROXY_SOCKET_PREFIX } = require('./launcher-credential-env.cjs');
 
 function shouldTransformTypeScriptUrl(url) {
   return (
@@ -38,9 +37,7 @@ function registerTypeScriptSourceResolver() {
       try {
         return nextResolve(specifier, { ...context, conditions });
       } catch (error) {
-        const isNotFound =
-          error?.code === 'ERR_MODULE_NOT_FOUND' ||
-          error?.code === 'MODULE_NOT_FOUND';
+        const isNotFound = isModuleNotFound(error);
         if (
           isNotFound &&
           specifier.endsWith('.js') &&
@@ -75,12 +72,119 @@ function describeError(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
-async function main() {
-  registerTypeScriptSourceResolver();
-  const { createAndStartProxy, getProxySocketPath, stopProxy } = await import(
-    '@vybestack/llxprt-code-providers/auth.js'
-  );
+const PROVIDER_AUTH_SPECIFIER = '@vybestack/llxprt-code-providers/auth.js';
+// Node's ESM resolver truncates a missing-package error to the bare package
+// name (e.g. "Cannot find package '@scope/name' imported from ..."), so match
+// that form too, not just the full subpath specifier. For a scoped package the
+// root is the first two segments (@scope/name); for an unscoped package it is
+// the first segment.
+const PROVIDER_AUTH_PACKAGE = (() => {
+  const segments = PROVIDER_AUTH_SPECIFIER.split('/');
+  const rootSegmentCount = PROVIDER_AUTH_SPECIFIER.startsWith('@') ? 2 : 1;
+  return segments.slice(0, rootSegmentCount).join('/');
+})();
 
+function isModuleNotFound(error) {
+  return (
+    error?.code === 'ERR_MODULE_NOT_FOUND' || error?.code === 'MODULE_NOT_FOUND'
+  );
+}
+
+// Returns the first single- or double-quoted token in the string, or undefined.
+// Node module-not-found messages quote the unresolvable specifier first (before
+// any "imported from"/require-stack trailer), so this isolates it for matching.
+// The backreference enforces matching opening/closing quotes.
+function extractFirstQuotedToken(message) {
+  const match = /(['"])([^'"]+)\1/.exec(message);
+  return match ? match[2] : undefined;
+}
+
+// True when packageName appears in token as a whole path segment (bounded by a
+// path separator or the start/end of the string), so a sibling whose name only
+// STARTS WITH packageName (e.g. "@scope/name-utils") is not a false match.
+// Checks every occurrence, not just the first, so a non-segment-bounded earlier
+// match does not hide a valid later one.
+function tokenContainsPackageSegment(token, packageName) {
+  let index = token.indexOf(packageName);
+  while (index !== -1) {
+    const prefixOk = index === 0 || token[index - 1] === '/';
+    const suffixEnd = index + packageName.length;
+    const suffixOk = suffixEnd === token.length || token[suffixEnd] === '/';
+    if (prefixOk && suffixOk) {
+      return true;
+    }
+    index = token.indexOf(packageName, index + 1);
+  }
+  return false;
+}
+
+function isProviderAuthModuleNotFound(error) {
+  if (!isModuleNotFound(error)) {
+    return false;
+  }
+  // Only treat this as "the provider auth module itself is missing" when the
+  // error names it. A MODULE_NOT_FOUND from a transitive dependency inside the
+  // module must propagate so the real root cause is not masked by the
+  // TypeScript-stripping fallback (which cannot fix a missing transitive dep).
+  const message =
+    error instanceof Error && typeof error.message === 'string'
+      ? error.message
+      : '';
+  // Node quotes the UNRESOLVABLE specifier first in the message. Depending on
+  // how the provider auth entry is resolved, that quoted token is either the
+  // bare specifier ("@scope/name/auth.js"), the package name for an ESM missing
+  // package ("@scope/name"), or the absolute resolved path when a subpath
+  // export points at a missing built file (".../@scope/name/dist/.../index.js").
+  // All three contain the package name. A missing TRANSITIVE dependency instead
+  // quotes that dependency's own specifier (e.g. "some-dep"), which does NOT
+  // contain the package name — so it correctly propagates. Extract the first
+  // quoted token and test it against the package name.
+  const quoted = extractFirstQuotedToken(message);
+  return (
+    quoted !== undefined &&
+    tokenContainsPackageSegment(quoted, PROVIDER_AUTH_PACKAGE)
+  );
+}
+
+async function loadProviderAuth() {
+  let firstError;
+  try {
+    return await import(PROVIDER_AUTH_SPECIFIER);
+  } catch (error) {
+    if (!isProviderAuthModuleNotFound(error)) {
+      throw error;
+    }
+    firstError = error;
+    // Preserve the first failure's detail before falling through to the
+    // TypeScript-stripping resolver. The parent launcher captures this
+    // sidecar's stderr, so if the fallback import also fails the original root
+    // cause remains visible for debugging.
+    process.stderr.write(
+      `provider auth module not resolved as built JS, retrying with TypeScript stripping: ${describeError(error)}\n`,
+    );
+  }
+  try {
+    registerTypeScriptSourceResolver();
+    return await import(PROVIDER_AUTH_SPECIFIER);
+  } catch (fallbackError) {
+    // Link the original failure via the standard cause chain so the root cause
+    // is correlatable even if the fallback (resolver registration or import)
+    // fails for a different reason.
+    if (firstError !== undefined && fallbackError instanceof Error) {
+      fallbackError.cause ??= firstError;
+    }
+    throw fallbackError;
+  }
+}
+
+async function main() {
+  const { createAndStartProxy, getProxySocketPath, stopProxy } =
+    await loadProviderAuth();
+
+  // This sidecar owns the socket directory it creates and removes it during a
+  // graceful shutdown. The directory is also reported to the parent launcher so
+  // it can take over cleanup only if it must escalate to SIGKILL (where this
+  // process is terminated before its own cleanup can run).
   const socketDir = await mkdtemp(join(tmpdir(), PROXY_SOCKET_PREFIX));
   let handle;
   let stopping = false;
@@ -132,7 +236,7 @@ async function main() {
       return;
     }
 
-    process.stdout.write(`${JSON.stringify({ socketPath })}\n`);
+    process.stdout.write(`${JSON.stringify({ socketDir, socketPath })}\n`);
     process.stdin.once('end', () => shutdown(0));
     process.stdin.once('close', () => shutdown(0));
     process.stdin.resume();
@@ -145,7 +249,18 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  process.stderr.write(`${describeError(error)}\n`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${describeError(error)}\n`);
+    process.exit(1);
+  });
+}
+
+// Exposed for unit testing the module-not-found matching logic without
+// executing the sidecar. main() only runs when invoked as the entry point.
+module.exports = {
+  isModuleNotFound,
+  isProviderAuthModuleNotFound,
+  PROVIDER_AUTH_SPECIFIER,
+  PROVIDER_AUTH_PACKAGE,
+};

--- a/packages/cli/bin/launcher-credential-env.cjs
+++ b/packages/cli/bin/launcher-credential-env.cjs
@@ -1,0 +1,41 @@
+'use strict';
+
+const BUN_RELAUNCH_ENV = 'LLXPRT_BUN_RELAUNCHED';
+const CREDENTIAL_SOCKET_ENV = 'LLXPRT_CREDENTIAL_SOCKET';
+// Prefix for the sidecar's per-launch socket directory (created via
+// mkdtemp(join(tmpdir(), PROXY_SOCKET_PREFIX))). Shared here so the sidecar and
+// the parent launcher agree on the directory-ownership check without drift.
+const PROXY_SOCKET_PREFIX = 'lxcp-';
+
+function hasUsableCredentialSocket(env = process.env) {
+  const socketPath = env[CREDENTIAL_SOCKET_ENV];
+  return typeof socketPath === 'string' && socketPath.length > 0;
+}
+
+function createLauncherChildEnv({
+  env = process.env,
+  credentialSocketPath = null,
+}) {
+  const childEnv = {
+    ...env,
+    [BUN_RELAUNCH_ENV]: 'true',
+  };
+  // Only forward a non-empty socket path. An empty string would set an unusable
+  // CREDENTIAL_SOCKET_ENV on the child, so treat it the same as "no socket",
+  // consistent with hasUsableCredentialSocket().
+  if (
+    typeof credentialSocketPath === 'string' &&
+    credentialSocketPath.length > 0
+  ) {
+    childEnv[CREDENTIAL_SOCKET_ENV] = credentialSocketPath;
+  }
+  return childEnv;
+}
+
+module.exports = {
+  BUN_RELAUNCH_ENV,
+  CREDENTIAL_SOCKET_ENV,
+  PROXY_SOCKET_PREFIX,
+  createLauncherChildEnv,
+  hasUsableCredentialSocket,
+};

--- a/packages/cli/bin/llxprt.cjs
+++ b/packages/cli/bin/llxprt.cjs
@@ -2,11 +2,22 @@
 'use strict';
 
 const { spawn, spawnSync } = require('node:child_process');
-const { accessSync, constants, readFileSync, statSync } = require('node:fs');
-const { basename, dirname, join } = require('node:path');
-
-const RELAUNCH_ENV = 'LLXPRT_BUN_RELAUNCHED';
-const CREDENTIAL_SOCKET_ENV = 'LLXPRT_CREDENTIAL_SOCKET';
+const {
+  accessSync,
+  constants,
+  readFileSync,
+  realpathSync,
+  statSync,
+} = require('node:fs');
+const { rm } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const { basename, dirname, isAbsolute, join, normalize } = require('node:path');
+const {
+  CREDENTIAL_SOCKET_ENV,
+  PROXY_SOCKET_PREFIX,
+  createLauncherChildEnv,
+  hasUsableCredentialSocket,
+} = require('./launcher-credential-env.cjs');
 const FORWARDED_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK'];
 const SIGNAL_EXIT_CODES = {
   SIGHUP: 129,
@@ -33,6 +44,15 @@ const PROXY_HOST_NODE_ARGS = [
 ];
 const PROXY_HOST_STARTUP_TIMEOUT_MS = 15_000;
 const PROXY_HOST_SHUTDOWN_TIMEOUT_MS = 1_000;
+// Shorter, distinct window to wait for the kernel to reap the process after
+// SIGKILL, so a child stuck in uninterruptible I/O does not double the total
+// shutdown latency.
+const POST_SIGKILL_REAP_TIMEOUT_MS = 250;
+// rm() error codes that indicate a transient lock (notably on Windows) and are
+// worth retrying before giving up on removing the socket directory.
+const RETRYABLE_RM_CODES = new Set(['EBUSY', 'EPERM', 'ENOTEMPTY']);
+// Backoff between socket-directory removal retries.
+const RM_RETRY_DELAY_MS = 50;
 
 function ancestors(startDir) {
   const dirs = [];
@@ -183,32 +203,175 @@ function stopCredentialProxy(proxy) {
   return proxy.stop().catch(() => {});
 }
 
-function stopProxyHost(child) {
-  return new Promise((resolve) => {
-    if (child.exitCode !== null || child.signalCode !== null || child.killed) {
+async function stopProxyHost(child, socketDir = '') {
+  let forcedKill = false;
+  await new Promise((resolve) => {
+    // Only short-circuit when the child has ACTUALLY exited. child.killed is
+    // deliberately excluded: it is set as soon as any kill() is called (even a
+    // graceful SIGTERM the sidecar is still handling), so treating it as
+    // "already done" here would resolve before the process exits and skip the
+    // forced-kill cleanup accounting below.
+    if (child.exitCode !== null || child.signalCode !== null) {
+      // The child already exited/was signaled before we could send SIGTERM. If
+      // it died from a signal or a non-zero exit rather than exiting gracefully
+      // with code 0, the sidecar never ran its own cleanup, so the parent must
+      // remove the socket directory.
+      if (
+        child.signalCode !== null ||
+        (child.exitCode !== null && child.exitCode !== 0)
+      ) {
+        forcedKill = true;
+      }
       resolve();
       return;
     }
     const finish = () => {
       clearTimeout(timer);
+      child.off('close', finish);
       resolve();
     };
     const timer = setTimeout(() => {
+      // Only treat this as a forced kill if the child actually survived past the
+      // SIGTERM deadline. If it already exited gracefully (racing the timer), the
+      // sidecar cleaned up its own socket dir, so the parent must not attempt
+      // cleanup — keeping forcedKill accurate to its stated intent.
+      if (child.exitCode === null && child.signalCode === null) {
+        forcedKill = true;
+      }
+      // Wait for the kernel to reap the process before proceeding so the
+      // socket-directory cleanup below does not race with a lingering process
+      // still holding the directory (notably on Windows). Fall back to a short
+      // secondary deadline in case the close event never arrives.
+      let resolvedAfterKill = false;
+      const resolveOnce = () => {
+        if (resolvedAfterKill) {
+          return;
+        }
+        resolvedAfterKill = true;
+        clearTimeout(reapTimer);
+        child.off('close', resolveOnce);
+        resolve();
+      };
+      const reapTimer = setTimeout(resolveOnce, POST_SIGKILL_REAP_TIMEOUT_MS);
+      // Attach resolveOnce BEFORE removing finish so a 'close' emitted during
+      // the SIGKILL cannot slip through the gap between off() and once().
+      child.once('close', resolveOnce);
       child.off('close', finish);
       try {
         child.kill('SIGKILL');
       } catch {
         // Process may have already exited before the close event was delivered.
       }
-      resolve();
     }, PROXY_HOST_SHUTDOWN_TIMEOUT_MS);
     child.once('close', finish);
     try {
       child.kill('SIGTERM');
     } catch {
+      // If SIGTERM delivery failed and the child is still alive, it will not run
+      // its own cleanup, so the parent must take over socket-dir removal.
+      if (child.exitCode === null && child.signalCode === null) {
+        forcedKill = true;
+      }
       finish();
     }
   });
+  // The sidecar owns and removes its own socket directory during a graceful
+  // (SIGTERM) shutdown. Only when we escalate to SIGKILL — where the sidecar is
+  // terminated before it can run its own cleanup — does the parent take over
+  // removing the reported directory so it is not leaked.
+  if (forcedKill && socketDir.length > 0) {
+    await removeSocketDirWithRetry(socketDir);
+  }
+}
+
+// On Windows the kernel may still hold a lock on the socket file for a short
+// window after the process exits, so a single rm() can fail with EBUSY/EPERM/
+// ENOTEMPTY. Retry a few times before giving up, and surface a warning rather
+// than silently leaking the directory.
+async function removeSocketDirWithRetry(socketDir) {
+  // Operate only on the already-validated string form (a direct lxcp- child of
+  // tmpdir()). Deliberately do NOT realpath here: resolving a symlink before
+  // rm() would let a post-validation symlink swap redirect the recursive delete
+  // to an arbitrary target. rm() itself does not follow a top-level symlink, so
+  // the worst a swapped-in symlink can cause is removal of the link entry.
+  const maxAttempts = 3;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      await rm(socketDir, { force: true, recursive: true });
+      return;
+    } catch (error) {
+      const code =
+        error && typeof error === 'object' && typeof error.code === 'string'
+          ? error.code
+          : undefined;
+      if (!RETRYABLE_RM_CODES.has(code) || attempt === maxAttempts - 1) {
+        process.stderr.write(
+          `warning: failed to remove proxy socket dir ${socketDir}: ${describeError(error)}\n`,
+        );
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, RM_RETRY_DELAY_MS));
+    }
+  }
+}
+
+// '/' and '\' (backslash, code point 92) path separators. Backslash is only a
+// real separator on Windows; on POSIX it is a valid filename character, but
+// since mkdtemp never generates trailing separators, stripping it on all
+// platforms is a safe conservative normalization.
+const PATH_SEPARATORS = new Set(['/', String.fromCharCode(92)]);
+
+function stripTrailingSeparators(value) {
+  let end = value.length;
+  while (end > 0 && PATH_SEPARATORS.has(value[end - 1])) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+// The socket directory is later handed to a recursive rm() on the force-kill
+// cleanup path, and the sidecar's stdout is a process boundary that a buggy,
+// compromised, or tampered producer could abuse to report an arbitrary path
+// (e.g. '/' or '/tmp'). Constrain ANY directory we accept — whether explicitly
+// reported by the sidecar or derived from socketPath — to an absolute path that
+// lives directly under the OS temp directory and carries the sidecar's socket
+// prefix (matching mkdtemp(join(tmpdir(), PROXY_SOCKET_PREFIX))). This bounds
+// what rm() can ever target.
+function safeRealpath(targetPath) {
+  try {
+    return realpathSync(targetPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function isSafeProxySocketDir(candidateDir) {
+  // Strip trailing separators so a reported path like '/tmp/lxcp-abc/' still
+  // yields a usable basename.
+  const normalized = stripTrailingSeparators(candidateDir);
+  if (
+    !isAbsolute(normalized) ||
+    !basename(normalized).startsWith(PROXY_SOCKET_PREFIX)
+  ) {
+    return false;
+  }
+  // The parent must be the OS temp directory. Compare against BOTH the
+  // unresolved and realpath-resolved forms of tmpdir() and of the candidate's
+  // parent, so a symlinked temp root (e.g. macOS /var -> /private/var, which
+  // mkdtemp itself may return) is accepted whether or not the parent currently
+  // resolves on disk. If the parent does not exist (e.g. a fabricated payload)
+  // its unresolved form still will not match tmpdir(), so it is rejected.
+  const parent = dirname(normalized);
+  const acceptedParents = new Set([tmpdir()]);
+  const resolvedTmp = safeRealpath(tmpdir());
+  if (resolvedTmp !== undefined) {
+    acceptedParents.add(resolvedTmp);
+  }
+  const resolvedParent = safeRealpath(parent);
+  return (
+    acceptedParents.has(parent) ||
+    (resolvedParent !== undefined && acceptedParents.has(resolvedParent))
+  );
 }
 
 function parseProxyHostLine(line) {
@@ -221,7 +384,34 @@ function parseProxyHostLine(line) {
   ) {
     throw new Error('proxy host did not report a socket path');
   }
-  return parsed.socketPath;
+  // Prefer the explicitly reported socketDir; fall back to deriving it from
+  // socketPath for backward compatibility with older payloads. Either way the
+  // result must pass the same safety validation before it can reach rm().
+  const reportedDir =
+    typeof parsed.socketDir === 'string' && parsed.socketDir.length > 0
+      ? parsed.socketDir
+      : dirname(parsed.socketPath);
+  if (!isSafeProxySocketDir(reportedDir)) {
+    throw new Error('proxy host did not report a usable socket directory');
+  }
+  // Normalize to the trailing-separator-stripped form that isSafeProxySocketDir
+  // validated, so the containment comparison below uses exactly what was
+  // checked (dirname() never emits trailing separators).
+  const safeSocketDir = stripTrailingSeparators(reportedDir);
+  // The socketPath is forwarded to the Bun child as its credential socket, so a
+  // tampered producer must not be able to pair a safe-looking socketDir with a
+  // socketPath pointing elsewhere. Require the socket to live directly inside
+  // the validated directory. Normalize both sides so a legitimate payload that
+  // mixes '/' and '\' separators (possible on Windows) does not cause a
+  // spurious mismatch. Note: this comparison is case-sensitive; it is safe
+  // because both socketDir and socketPath originate from the same sidecar's
+  // single mkdtemp()+join() call and are therefore consistently cased.
+  if (normalize(dirname(parsed.socketPath)) !== normalize(safeSocketDir)) {
+    throw new Error(
+      'proxy host reported a socket path outside its socket directory',
+    );
+  }
+  return { socketPath: parsed.socketPath, socketDir: safeSocketDir };
 }
 
 function createCredentialProxyDefault(options = {}) {
@@ -286,11 +476,12 @@ function createCredentialProxyDefault(options = {}) {
 
     const proxyHostHandle = {
       socketPath: '',
+      socketDir: '',
       stop: async () => {
         stopping = true;
         child.off('close', onPostStartupClose);
         child.off('error', absorbLateChildError);
-        await stopProxyHost(child);
+        await stopProxyHost(child, proxyHostHandle.socketDir);
       },
     };
     onProxyCreated(proxyHostHandle);
@@ -301,7 +492,7 @@ function createCredentialProxyDefault(options = {}) {
       }
       settled = true;
       cleanup();
-      await stopProxyHost(child).catch(() => {});
+      await stopProxyHost(child, proxyHostHandle.socketDir).catch(() => {});
       reject(error);
     };
 
@@ -340,8 +531,9 @@ function createCredentialProxyDefault(options = {}) {
       }
       const line = stdout.slice(0, newline).trim();
       try {
-        const socketPath = parseProxyHostLine(line);
-        proxyHostHandle.socketPath = socketPath;
+        const proxyInfo = parseProxyHostLine(line);
+        proxyHostHandle.socketPath = proxyInfo.socketPath;
+        proxyHostHandle.socketDir = proxyInfo.socketDir;
         settled = true;
         cleanupAfterStartup();
         resolve(proxyHostHandle);
@@ -362,10 +554,9 @@ async function createChildEnv(
   onUnexpectedExit,
   onProxyCreated,
 ) {
-  const existingSocket = process.env[CREDENTIAL_SOCKET_ENV];
-  if (existingSocket !== undefined && existingSocket.length > 0) {
+  if (hasUsableCredentialSocket()) {
     return {
-      childEnv: { ...process.env, [RELAUNCH_ENV]: 'true' },
+      childEnv: createLauncherChildEnv({}),
       credentialProxy: null,
     };
   }
@@ -374,11 +565,9 @@ async function createChildEnv(
     onProxyCreated,
   });
   return {
-    childEnv: {
-      ...process.env,
-      [RELAUNCH_ENV]: 'true',
-      [CREDENTIAL_SOCKET_ENV]: credentialProxy.socketPath,
-    },
+    childEnv: createLauncherChildEnv({
+      credentialSocketPath: credentialProxy.socketPath,
+    }),
     credentialProxy,
   };
 }

--- a/packages/cli/bin/llxprt.cjs
+++ b/packages/cli/bin/llxprt.cjs
@@ -6,6 +6,7 @@ const { accessSync, constants, readFileSync, statSync } = require('node:fs');
 const { basename, dirname, join } = require('node:path');
 
 const RELAUNCH_ENV = 'LLXPRT_BUN_RELAUNCHED';
+const CREDENTIAL_SOCKET_ENV = 'LLXPRT_CREDENTIAL_SOCKET';
 const FORWARDED_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK'];
 const SIGNAL_EXIT_CODES = {
   SIGHUP: 129,
@@ -25,6 +26,13 @@ const SIGNAL_EXIT_CODES = {
   SIGTERM: 143,
   SIGBREAK: 149,
 };
+const PROXY_HOST_PATH = join(__dirname, 'credential-proxy-host.cjs');
+const PROXY_HOST_NODE_ARGS = [
+  '--disable-warning=ExperimentalWarning',
+  PROXY_HOST_PATH,
+];
+const PROXY_HOST_STARTUP_TIMEOUT_MS = 15_000;
+const PROXY_HOST_SHUTDOWN_TIMEOUT_MS = 1_000;
 
 function ancestors(startDir) {
   const dirs = [];
@@ -160,82 +168,371 @@ function isWindowsCmdShim(path) {
   );
 }
 
-function fatal(message) {
-  process.stderr.write(`${message}\n`);
-  process.exit(43);
-}
-
 function describeError(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
-// Note: LLXPRT_BUN_RELAUNCHED may already be set when a Bun-hosted LLxprt
-// process re-invokes this bin (e.g. nested tooling). That is safe: we always
-// spawn Bun directly on the TypeScript entry, never this launcher, so no
-// relaunch loop is possible and nested invocations must keep working.
-const bunPath = resolveBun();
-if (bunPath === null) {
-  fatal(
-    'Bun runtime was not found. Install it with "npm install" (it is bundled as the "bun" dependency) or install Bun directly from https://bun.sh and ensure it is on your PATH.',
-  );
+function fatalCredentialProxyMessage(error) {
+  return `Failed to start the credential proxy needed for Bun runtime access to saved provider credentials (${describeError(error)}). Reinstall dependencies with "npm install" and try again.`;
 }
 
-const entry = resolveEntry();
-if (entry === null) {
-  fatal(
-    'Could not locate the LLxprt Code TypeScript entry point (packages/cli/index.ts). Your installation may be corrupt; reinstall @vybestack/llxprt-code.',
-  );
+function stopCredentialProxy(proxy) {
+  if (proxy === null) {
+    return Promise.resolve();
+  }
+  return proxy.stop().catch(() => {});
 }
 
-const args = [entry, ...process.argv.slice(2)];
-if (isWindowsCmdShim(bunPath) && args.some(hasWindowsCmdMetaCharacter)) {
-  fatal(
-    'Cannot safely forward arguments containing Windows command-shell metacharacters through the bundled bun.cmd shim. Install Bun directly so bun.exe is on PATH, or remove shell metacharacters from the CLI arguments.',
-  );
+function readFlagValue(args, index, flag) {
+  const arg = args[index];
+  if (arg === flag) {
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith('-')) {
+      return '';
+    }
+    return value;
+  }
+  const prefix = `${flag}=`;
+  if (arg.startsWith(prefix)) {
+    return arg.slice(prefix.length);
+  }
+  return null;
 }
 
-let child;
-try {
-  child = spawn(bunPath, args, {
-    stdio: 'inherit',
-    env: { ...process.env, [RELAUNCH_ENV]: 'true' },
-    shell: isWindowsCmdShim(bunPath),
-  });
-} catch (error) {
-  fatal(
-    `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
-  );
+function hasDirectCredentialOverride(args) {
+  for (let index = 1; index < args.length; index++) {
+    const key = readFlagValue(args, index, '--key');
+    if (key !== null && key.length > 0) {
+      return true;
+    }
+    const keyfile = readFlagValue(args, index, '--keyfile');
+    if (keyfile !== null && keyfile.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
-let settled = false;
-for (const signal of FORWARDED_SIGNALS) {
-  process.on(signal, () => {
-    if (!settled) {
-      child.kill(signal);
+function stopProxyHost(child) {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null || child.killed) {
+      resolve();
+      return;
+    }
+    const finish = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      child.off('close', finish);
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Process may have already exited before the close event was delivered.
+      }
+      resolve();
+    }, PROXY_HOST_SHUTDOWN_TIMEOUT_MS);
+    child.once('close', finish);
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      finish();
     }
   });
 }
 
-child.on('error', (error) => {
-  if (settled) {
-    return;
+function parseProxyHostLine(line) {
+  const parsed = JSON.parse(line);
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof parsed.socketPath !== 'string' ||
+    parsed.socketPath.length === 0
+  ) {
+    throw new Error('proxy host did not report a socket path');
   }
-  settled = true;
-  fatal(
-    `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
-  );
-});
+  return parsed.socketPath;
+}
 
-child.on('close', (code, signal) => {
-  if (settled) {
+function createCredentialProxyDefault(options = {}) {
+  const spawnFn = options.spawn ?? spawn;
+  const env = { ...process.env };
+  delete env[CREDENTIAL_SOCKET_ENV];
+
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawnFn(process.execPath, PROXY_HOST_NODE_ARGS, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env,
+      });
+    } catch (error) {
+      reject(new Error(fatalCredentialProxyMessage(error)));
+      return;
+    }
+
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const startupTimer = setTimeout(() => {
+      void fail(
+        new Error(
+          fatalCredentialProxyMessage(
+            'proxy host did not report a socket path within the startup timeout',
+          ),
+        ),
+      );
+    }, PROXY_HOST_STARTUP_TIMEOUT_MS);
+
+    const absorbLateChildError = () => {};
+
+    const cleanup = () => {
+      clearTimeout(startupTimer);
+      child.off('error', onError);
+      child.off('close', onClose);
+      child.stdout?.off('data', onStdout);
+      child.stderr?.off('data', onStderr);
+    };
+
+    const cleanupAfterStartup = () => {
+      cleanup();
+      child.on('error', absorbLateChildError);
+    };
+
+    const fail = async (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      await stopProxyHost(child).catch(() => {});
+      reject(error);
+    };
+
+    const onError = (error) => {
+      void fail(new Error(fatalCredentialProxyMessage(error)));
+    };
+
+    const onClose = (code, signal) => {
+      const reason =
+        stderr.trim() ||
+        `proxy host exited before reporting a socket path (code=${code}, signal=${signal})`;
+      void fail(new Error(fatalCredentialProxyMessage(reason)));
+    };
+
+    const onStderr = (chunk) => {
+      stderr += chunk.toString('utf8');
+      if (stderr.length > 4096) {
+        stderr = stderr.slice(-4096);
+      }
+    };
+
+    const onStdout = (chunk) => {
+      stdout += chunk.toString('utf8');
+      const newline = stdout.indexOf('\n');
+      if (newline === -1) {
+        if (stdout.length > 8192) {
+          void fail(
+            new Error(
+              fatalCredentialProxyMessage(
+                'proxy host stdout exceeded 8192 bytes before reporting a socket path',
+              ),
+            ),
+          );
+        }
+        return;
+      }
+      const line = stdout.slice(0, newline).trim();
+      try {
+        const socketPath = parseProxyHostLine(line);
+        settled = true;
+        cleanupAfterStartup();
+        resolve({
+          socketPath,
+          stop: () => stopProxyHost(child),
+        });
+      } catch (error) {
+        void fail(new Error(fatalCredentialProxyMessage(error)));
+      }
+    };
+
+    child.once('error', onError);
+    child.once('close', onClose);
+    child.stdout?.on('data', onStdout);
+    child.stderr?.on('data', onStderr);
+  });
+}
+
+async function createChildEnv(startCredentialProxy, args) {
+  if (process.env[CREDENTIAL_SOCKET_ENV] || hasDirectCredentialOverride(args)) {
+    return {
+      childEnv: { ...process.env, [RELAUNCH_ENV]: 'true' },
+      credentialProxy: null,
+    };
+  }
+  const credentialProxy = await startCredentialProxy();
+  return {
+    childEnv: {
+      ...process.env,
+      [RELAUNCH_ENV]: 'true',
+      [CREDENTIAL_SOCKET_ENV]: credentialProxy.socketPath,
+    },
+    credentialProxy,
+  };
+}
+
+async function runCliBin(options = {}) {
+  const exit = options.exit ?? process.exit;
+  const spawnFn = options.spawn ?? spawn;
+  const startCredentialProxy =
+    options.startCredentialProxy ?? (() => createCredentialProxyDefault());
+
+  function fatalExit(message) {
+    process.stderr.write(`${message}\n`);
+    exit(43);
+  }
+
+  const bunPath =
+    options.resolveBun === undefined ? resolveBun() : options.resolveBun();
+  if (bunPath === null) {
+    fatalExit(
+      'Bun runtime was not found. Install it with "npm install" (it is bundled as the "bun" dependency) or install Bun directly from https://bun.sh and ensure it is on your PATH.',
+    );
     return;
   }
-  settled = true;
-  if (code !== null) {
-    process.exit(code);
+
+  const entry =
+    options.resolveEntry === undefined
+      ? resolveEntry()
+      : options.resolveEntry();
+  if (entry === null) {
+    fatalExit(
+      'Could not locate the LLxprt Code TypeScript entry point (packages/cli/index.ts). Your installation may be corrupt; reinstall @vybestack/llxprt-code.',
+    );
+    return;
   }
-  if (signal !== null) {
-    process.exit(SIGNAL_EXIT_CODES[signal] ?? 1);
+
+  const args = [entry, ...process.argv.slice(2)];
+  if (isWindowsCmdShim(bunPath) && args.some(hasWindowsCmdMetaCharacter)) {
+    fatalExit(
+      'Cannot safely forward arguments containing Windows command-shell metacharacters through the bundled bun.cmd shim. Install Bun directly so bun.exe is on PATH, or remove shell metacharacters from the CLI arguments.',
+    );
+    return;
   }
-  process.exit(1);
-});
+
+  let credentialProxy = null;
+  let childEnv;
+  try {
+    const envResult = await createChildEnv(startCredentialProxy, args);
+    credentialProxy = envResult.credentialProxy;
+    childEnv = envResult.childEnv;
+  } catch (error) {
+    fatalExit(describeError(error));
+    return;
+  }
+
+  let child;
+  try {
+    child = spawnFn(bunPath, args, {
+      stdio: 'inherit',
+      env: childEnv,
+      shell: isWindowsCmdShim(bunPath),
+    });
+  } catch (error) {
+    await stopCredentialProxy(credentialProxy);
+    fatalExit(
+      `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
+    );
+    return;
+  }
+
+  let settled = false;
+  const forwardSignal = (signal) => {
+    if (!settled) {
+      child.kill(signal);
+    }
+  };
+  const cleanupListeners = () => {
+    child.off('close', onClose);
+    child.off('error', onError);
+    for (const signal of FORWARDED_SIGNALS) {
+      process.off(signal, forwardSignal);
+    }
+  };
+  const settle = async (callback) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanupListeners();
+    child.on('error', () => {});
+    let callbackCalled = false;
+    const finish = () => {
+      if (callbackCalled) {
+        return;
+      }
+      callbackCalled = true;
+      callback();
+    };
+    const fastExit = (signal) => {
+      try {
+        child.kill(signal);
+      } catch {
+        // Child may have already exited before the second signal arrived.
+      }
+      finish();
+    };
+    for (const signal of FORWARDED_SIGNALS) {
+      process.once(signal, fastExit);
+    }
+    try {
+      await stopCredentialProxy(credentialProxy);
+    } finally {
+      for (const signal of FORWARDED_SIGNALS) {
+        process.off(signal, fastExit);
+      }
+    }
+    finish();
+  };
+  const onError = (error) => {
+    void settle(() => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // Child may have already exited before the async spawn error surfaced.
+      }
+      fatalExit(
+        `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
+      );
+    }).catch(() => {});
+  };
+  const onClose = (code, signal) => {
+    void settle(() => {
+      if (code !== null) {
+        exit(code);
+        return;
+      }
+      if (signal !== null) {
+        exit(SIGNAL_EXIT_CODES[signal] ?? 1);
+        return;
+      }
+      exit(1);
+    }).catch(() => {});
+  };
+
+  for (const signal of FORWARDED_SIGNALS) {
+    process.on(signal, forwardSignal);
+  }
+  child.on('error', onError);
+  child.on('close', onClose);
+}
+
+module.exports = { runCliBin, createCredentialProxyDefault };
+
+if (require.main === module) {
+  runCliBin().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/cli/bin/llxprt.cjs
+++ b/packages/cli/bin/llxprt.cjs
@@ -183,36 +183,6 @@ function stopCredentialProxy(proxy) {
   return proxy.stop().catch(() => {});
 }
 
-function readFlagValue(args, index, flag) {
-  const arg = args[index];
-  if (arg === flag) {
-    const value = args[index + 1];
-    if (value === undefined || value.startsWith('-')) {
-      return '';
-    }
-    return value;
-  }
-  const prefix = `${flag}=`;
-  if (arg.startsWith(prefix)) {
-    return arg.slice(prefix.length);
-  }
-  return null;
-}
-
-function hasDirectCredentialOverride(args) {
-  for (let index = 1; index < args.length; index++) {
-    const key = readFlagValue(args, index, '--key');
-    if (key !== null && key.length > 0) {
-      return true;
-    }
-    const keyfile = readFlagValue(args, index, '--keyfile');
-    if (keyfile !== null && keyfile.length > 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function stopProxyHost(child) {
   return new Promise((resolve) => {
     if (child.exitCode !== null || child.signalCode !== null || child.killed) {
@@ -256,6 +226,8 @@ function parseProxyHostLine(line) {
 
 function createCredentialProxyDefault(options = {}) {
   const spawnFn = options.spawn ?? spawn;
+  const onUnexpectedExit = options.onUnexpectedExit ?? (() => {});
+  const onProxyCreated = options.onProxyCreated ?? (() => {});
   const env = { ...process.env };
   delete env[CREDENTIAL_SOCKET_ENV];
 
@@ -272,6 +244,7 @@ function createCredentialProxyDefault(options = {}) {
     }
 
     let settled = false;
+    let stopping = false;
     let stdout = '';
     let stderr = '';
     const startupTimer = setTimeout(() => {
@@ -286,6 +259,13 @@ function createCredentialProxyDefault(options = {}) {
 
     const absorbLateChildError = () => {};
 
+    const onPostStartupClose = (code, signal) => {
+      if (stopping) {
+        return;
+      }
+      onUnexpectedExit({ code, signal });
+    };
+
     const cleanup = () => {
       clearTimeout(startupTimer);
       child.off('error', onError);
@@ -295,9 +275,25 @@ function createCredentialProxyDefault(options = {}) {
     };
 
     const cleanupAfterStartup = () => {
-      cleanup();
+      clearTimeout(startupTimer);
       child.on('error', absorbLateChildError);
+      child.on('close', onPostStartupClose);
+      child.off('error', onError);
+      child.off('close', onClose);
+      child.stdout?.off('data', onStdout);
+      child.stderr?.off('data', onStderr);
     };
+
+    const proxyHostHandle = {
+      socketPath: '',
+      stop: async () => {
+        stopping = true;
+        child.off('close', onPostStartupClose);
+        child.off('error', absorbLateChildError);
+        await stopProxyHost(child);
+      },
+    };
+    onProxyCreated(proxyHostHandle);
 
     const fail = async (error) => {
       if (settled) {
@@ -345,12 +341,10 @@ function createCredentialProxyDefault(options = {}) {
       const line = stdout.slice(0, newline).trim();
       try {
         const socketPath = parseProxyHostLine(line);
+        proxyHostHandle.socketPath = socketPath;
         settled = true;
         cleanupAfterStartup();
-        resolve({
-          socketPath,
-          stop: () => stopProxyHost(child),
-        });
+        resolve(proxyHostHandle);
       } catch (error) {
         void fail(new Error(fatalCredentialProxyMessage(error)));
       }
@@ -363,14 +357,22 @@ function createCredentialProxyDefault(options = {}) {
   });
 }
 
-async function createChildEnv(startCredentialProxy, args) {
-  if (process.env[CREDENTIAL_SOCKET_ENV] || hasDirectCredentialOverride(args)) {
+async function createChildEnv(
+  startCredentialProxy,
+  onUnexpectedExit,
+  onProxyCreated,
+) {
+  const existingSocket = process.env[CREDENTIAL_SOCKET_ENV];
+  if (existingSocket !== undefined && existingSocket.length > 0) {
     return {
       childEnv: { ...process.env, [RELAUNCH_ENV]: 'true' },
       credentialProxy: null,
     };
   }
-  const credentialProxy = await startCredentialProxy();
+  const credentialProxy = await startCredentialProxy({
+    onUnexpectedExit,
+    onProxyCreated,
+  });
   return {
     childEnv: {
       ...process.env,
@@ -385,7 +387,8 @@ async function runCliBin(options = {}) {
   const exit = options.exit ?? process.exit;
   const spawnFn = options.spawn ?? spawn;
   const startCredentialProxy =
-    options.startCredentialProxy ?? (() => createCredentialProxyDefault());
+    options.startCredentialProxy ??
+    ((proxyOptions) => createCredentialProxyDefault(proxyOptions));
 
   function fatalExit(message) {
     process.stderr.write(`${message}\n`);
@@ -420,41 +423,30 @@ async function runCliBin(options = {}) {
     return;
   }
 
+  let child;
   let credentialProxy = null;
   let childEnv;
-  try {
-    const envResult = await createChildEnv(startCredentialProxy, args);
-    credentialProxy = envResult.credentialProxy;
-    childEnv = envResult.childEnv;
-  } catch (error) {
-    fatalExit(describeError(error));
-    return;
-  }
-
-  let child;
-  try {
-    child = spawnFn(bunPath, args, {
-      stdio: 'inherit',
-      env: childEnv,
-      shell: isWindowsCmdShim(bunPath),
-    });
-  } catch (error) {
-    await stopCredentialProxy(credentialProxy);
-    fatalExit(
-      `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
-    );
-    return;
-  }
-
   let settled = false;
+
   const forwardSignal = (signal) => {
-    if (!settled) {
-      child.kill(signal);
+    if (settled) {
+      return;
     }
+    if (child !== undefined) {
+      child.kill(signal);
+      return;
+    }
+    settled = true;
+    cleanupListeners();
+    void stopCredentialProxy(credentialProxy).finally(() => {
+      exit(SIGNAL_EXIT_CODES[signal] ?? 1);
+    });
   };
   const cleanupListeners = () => {
-    child.off('close', onClose);
-    child.off('error', onError);
+    if (child !== undefined) {
+      child.off('close', onClose);
+      child.off('error', onError);
+    }
     for (const signal of FORWARDED_SIGNALS) {
       process.off(signal, forwardSignal);
     }
@@ -465,7 +457,7 @@ async function runCliBin(options = {}) {
     }
     settled = true;
     cleanupListeners();
-    child.on('error', () => {});
+    child?.on('error', () => {});
     let callbackCalled = false;
     const finish = () => {
       if (callbackCalled) {
@@ -476,7 +468,7 @@ async function runCliBin(options = {}) {
     };
     const fastExit = (signal) => {
       try {
-        child.kill(signal);
+        child?.kill(signal);
       } catch {
         // Child may have already exited before the second signal arrived.
       }
@@ -497,7 +489,7 @@ async function runCliBin(options = {}) {
   const onError = (error) => {
     void settle(() => {
       try {
-        child.kill('SIGTERM');
+        child?.kill('SIGTERM');
       } catch {
         // Child may have already exited before the async spawn error surfaced.
       }
@@ -519,10 +511,60 @@ async function runCliBin(options = {}) {
       exit(1);
     }).catch(() => {});
   };
+  const onProxyUnexpectedExit = ({ code, signal }) => {
+    void settle(() => {
+      try {
+        child?.kill('SIGTERM');
+      } catch {
+        // Bun child may have already exited before the proxy died.
+      }
+      fatalExit(
+        fatalCredentialProxyMessage(
+          `credential proxy host exited unexpectedly while Bun was running (code=${code}, signal=${signal})`,
+        ),
+      );
+    }).catch(() => {});
+  };
 
   for (const signal of FORWARDED_SIGNALS) {
     process.on(signal, forwardSignal);
   }
+
+  try {
+    const envResult = await createChildEnv(
+      startCredentialProxy,
+      onProxyUnexpectedExit,
+      (proxy) => {
+        credentialProxy = proxy;
+      },
+    );
+    credentialProxy = envResult.credentialProxy;
+    childEnv = envResult.childEnv;
+  } catch (error) {
+    if (settled) {
+      return;
+    }
+    cleanupListeners();
+    fatalExit(describeError(error));
+    return;
+  }
+  if (settled) {
+    return;
+  }
+  try {
+    child = spawnFn(bunPath, args, {
+      stdio: 'inherit',
+      env: childEnv,
+      shell: isWindowsCmdShim(bunPath),
+    });
+  } catch (error) {
+    await stopCredentialProxy(credentialProxy);
+    fatalExit(
+      `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
+    );
+    return;
+  }
+
   child.on('error', onError);
   child.on('close', onClose);
 }

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -246,7 +246,7 @@ describe('extension tests', () => {
         extensions,
         tempWorkspaceDir,
         manager,
-      ).filter((e) => e.isActive === true);
+      ).filter((e) => e.isActive);
       expect(activeExtensions).toHaveLength(1);
       expect(activeExtensions[0].name).toBe('enabled-extension');
     });

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -246,7 +246,7 @@ describe('extension tests', () => {
         extensions,
         tempWorkspaceDir,
         manager,
-      ).filter((e) => e.isActive);
+      ).filter((e) => e.isActive === true);
       expect(activeExtensions).toHaveLength(1);
       expect(activeExtensions[0].name).toBe('enabled-extension');
     });

--- a/packages/cli/src/launcher/bun-launcher.test.ts
+++ b/packages/cli/src/launcher/bun-launcher.test.ts
@@ -376,6 +376,40 @@ describe('relaunchUnderBunIfNeeded', () => {
     expect(createCredentialProxy).not.toHaveBeenCalled();
   });
 
+  it('treats an empty credential socket as missing and starts a proxy', async () => {
+    process.env.LLXPRT_CREDENTIAL_SOCKET = '';
+    let capturedChild: EventEmitter | null = null;
+    const stopProxy = vi.fn(async () => {});
+    const createCredentialProxy = vi.fn(async () => ({
+      socketPath: '/tmp/new.sock',
+      stop: stopProxy,
+    }));
+    const spawnFn = vi.fn(
+      (_cmd: string, _args: string[], _options: { env: NodeJS.ProcessEnv }) => {
+        capturedChild = new EventEmitter();
+        return capturedChild;
+      },
+    );
+
+    const promise = relaunchUnderBunIfNeeded({
+      isRunningUnderBun: () => false,
+      envGuardSet: () => false,
+      resolveBun: vi.fn(async () => '/path/to/bun'),
+      resolveEntry: vi.fn(async () => '/entry.ts'),
+      spawn: spawnFn as unknown as typeof import('node:child_process').spawn,
+      createCredentialProxy,
+    });
+
+    await vi.waitFor(() => expect(capturedChild).not.toBeNull());
+    capturedChild!.emit('close', 0);
+    await promise;
+
+    const spawnEnv = spawnFn.mock.calls[0][2].env as Record<string, string>;
+    expect(spawnEnv.LLXPRT_CREDENTIAL_SOCKET).toBe('/tmp/new.sock');
+    expect(createCredentialProxy).toHaveBeenCalledTimes(1);
+    expect(stopProxy).toHaveBeenCalledTimes(1);
+  });
+
   it('restores process credential socket mutations from the default proxy lifecycle', async () => {
     delete process.env.LLXPRT_CREDENTIAL_SOCKET;
     process.argv = ['/node', '/script.js'];

--- a/packages/cli/src/launcher/bun-launcher.ts
+++ b/packages/cli/src/launcher/bun-launcher.ts
@@ -7,13 +7,127 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
+import { createRequire } from 'node:module';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { FatalError } from '@vybestack/llxprt-code-core';
 import { resolveBunPath } from './bun-path-resolver.js';
 import { resolveBunEntry } from './bun-entry-resolver.js';
 
-export const BUN_RELAUNCH_ENV = 'LLXPRT_BUN_RELAUNCHED';
-const CREDENTIAL_SOCKET_ENV = 'LLXPRT_CREDENTIAL_SOCKET';
+const NEWLINE = '\n';
+
+interface LauncherCredentialEnvModule {
+  readonly BUN_RELAUNCH_ENV: string;
+  readonly CREDENTIAL_SOCKET_ENV: string;
+  readonly PROXY_SOCKET_PREFIX: string;
+  readonly createLauncherChildEnv: (options: {
+    readonly env?: NodeJS.ProcessEnv;
+    readonly credentialSocketPath?: string | null;
+  }) => NodeJS.ProcessEnv;
+  readonly hasUsableCredentialSocket: (env?: NodeJS.ProcessEnv) => boolean;
+}
+
+function isModuleNotFoundError(error: unknown, targetModule: string): boolean {
+  if (
+    !(
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'MODULE_NOT_FOUND'
+    )
+  ) {
+    return false;
+  }
+  // Only treat this as "the candidate helper itself is missing" when the error
+  // names the candidate module. A MODULE_NOT_FOUND about a transitive
+  // dependency inside the helper must propagate so the real root cause is not
+  // masked by the path-probing fallback.
+  const message =
+    error instanceof Error && typeof error.message === 'string'
+      ? error.message
+      : '';
+  // A MODULE_NOT_FOUND from Node's require() always carries a descriptive
+  // message naming the failed specifier. If no message is present, the error did
+  // not originate from the standard resolution pipeline, so propagate it (return
+  // false) rather than risk masking a real transitive failure by falling back.
+  if (message.length === 0) {
+    return false;
+  }
+  // Inspect only the failed-specifier portion (the first line, before any
+  // "Require stack:" trailer). When a transitive dependency inside the helper
+  // is missing, the require stack lists this helper as the importer, so matching
+  // against the whole message would wrongly swallow that error and mask the real
+  // root cause. Node.js quotes the resolved absolute path in the message, so
+  // only the basename is meaningful for the relative candidate specifiers.
+  const [firstLine = ''] = message.split(NEWLINE, 1);
+  return firstLine.includes(basename(targetModule));
+}
+
+const loadCommonJsModule = createRequire(import.meta.url);
+
+function loadLauncherCredentialEnv(): LauncherCredentialEnvModule {
+  // Resolve the shared helper relative to this module across the layouts this
+  // file can run from:
+  //   - source/dev tree: packages/cli/src/launcher -> ../../bin
+  //   - compiled output: packages/cli/dist/src/launcher -> ../../../bin
+  //   - flattened/packed: packages/cli/dist/launcher -> ../../bin (covered by
+  //     the first entry) or a shallower layout -> ../bin
+  const candidatePaths = [
+    '../../bin/launcher-credential-env.cjs',
+    '../../../bin/launcher-credential-env.cjs',
+    '../bin/launcher-credential-env.cjs',
+  ];
+  for (const candidatePath of candidatePaths) {
+    try {
+      const loaded: unknown = loadCommonJsModule(candidatePath);
+      if (!isLauncherCredentialEnvModule(loaded)) {
+        throw new FatalError(
+          `Launcher credential-env helper at ${candidatePath} is corrupt or incomplete. Your installation may be corrupt; reinstall @vybestack/llxprt-code and try again.`,
+          43,
+        );
+      }
+      return loaded;
+    } catch (error) {
+      if (!isModuleNotFoundError(error, candidatePath)) {
+        throw error;
+      }
+    }
+  }
+  throw new FatalError(
+    'Unable to locate the launcher credential-env helper (bin/launcher-credential-env.cjs). Your installation may be corrupt; reinstall @vybestack/llxprt-code and try again.',
+    43,
+  );
+}
+
+function isLauncherCredentialEnvModule(
+  value: unknown,
+): value is LauncherCredentialEnvModule {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  const stringKeys = [
+    'BUN_RELAUNCH_ENV',
+    'CREDENTIAL_SOCKET_ENV',
+    'PROXY_SOCKET_PREFIX',
+  ];
+  const functionKeys = ['createLauncherChildEnv', 'hasUsableCredentialSocket'];
+  return (
+    stringKeys.every((key) => typeof candidate[key] === 'string') &&
+    functionKeys.every((key) => typeof candidate[key] === 'function')
+  );
+}
+
+// The helper is loaded lazily on first use rather than at module-evaluation
+// time. If the helper cannot be resolved (a corrupt install), the resulting
+// FatalError then surfaces inside relaunchUnderBunIfNeeded/runBunLauncherIfNeeded
+// where index.ts's top-level catch translates it into the correct exit code and
+// user-facing message, instead of crashing as an unhandled import-time throw.
+let launcherCredentialEnvCache: LauncherCredentialEnvModule | undefined;
+
+function getLauncherCredentialEnv(): LauncherCredentialEnvModule {
+  launcherCredentialEnvCache ??= loadLauncherCredentialEnv();
+  return launcherCredentialEnvCache;
+}
 
 export type ExitFn = (code?: number) => never;
 
@@ -48,15 +162,23 @@ function isRunningUnderBunDefault(): boolean {
 }
 
 function envGuardSetDefault(): boolean {
+  const { BUN_RELAUNCH_ENV } = getLauncherCredentialEnv();
   return process.env[BUN_RELAUNCH_ENV] === 'true';
 }
 
-function restoreCredentialSocket(originalSocket: string | undefined): void {
-  if (originalSocket === undefined) {
-    delete process.env[CREDENTIAL_SOCKET_ENV];
+function restoreCredentialSocket(
+  credentialSocketEnv: string,
+  originalSocket: string | undefined,
+): void {
+  // Treat an empty original value the same as "absent" so the restored
+  // environment matches how hasUsableCredentialSocket() interprets it — an
+  // empty-but-present socket var would otherwise mislead any consumer that
+  // checks for mere presence.
+  if (originalSocket === undefined || originalSocket.length === 0) {
+    delete process.env[credentialSocketEnv];
     return;
   }
-  process.env[CREDENTIAL_SOCKET_ENV] = originalSocket;
+  process.env[credentialSocketEnv] = originalSocket;
 }
 
 function toCredentialProxyFatalError(error: unknown): FatalError {
@@ -68,8 +190,13 @@ function toCredentialProxyFatalError(error: unknown): FatalError {
 }
 
 async function createCredentialProxyDefault(): Promise<CredentialProxyHandle | null> {
+  // Resolve the helper constants once up-front. If the helper is corrupt, the
+  // FatalError surfaces here (before any side effects), never inside the
+  // cleanup paths below where it would mask the original failure.
+  const { CREDENTIAL_SOCKET_ENV, PROXY_SOCKET_PREFIX } =
+    getLauncherCredentialEnv();
   const originalSocket = process.env[CREDENTIAL_SOCKET_ENV];
-  const socketDir = await mkdtemp(join(tmpdir(), 'lxcp-'));
+  const socketDir = await mkdtemp(join(tmpdir(), PROXY_SOCKET_PREFIX));
   let handle: { stop: () => Promise<void> } | undefined;
   try {
     const { createAndStartProxy, getProxySocketPath } = await import(
@@ -83,7 +210,7 @@ async function createCredentialProxyDefault(): Promise<CredentialProxyHandle | n
     // Provider proxy startup exposes its socket through module state but also
     // mutates process.env. Restore immediately so only the Bun child receives
     // the proxy socket in its environment.
-    restoreCredentialSocket(originalSocket);
+    restoreCredentialSocket(CREDENTIAL_SOCKET_ENV, originalSocket);
 
     const startedHandle = handle;
     return {
@@ -93,7 +220,7 @@ async function createCredentialProxyDefault(): Promise<CredentialProxyHandle | n
         try {
           await Promise.allSettled([startedHandle.stop(), removeSocketDir]);
         } finally {
-          restoreCredentialSocket(originalSocket);
+          restoreCredentialSocket(CREDENTIAL_SOCKET_ENV, originalSocket);
         }
       },
     };
@@ -101,7 +228,7 @@ async function createCredentialProxyDefault(): Promise<CredentialProxyHandle | n
     if (handle !== undefined) {
       await handle.stop().catch(() => {});
     }
-    restoreCredentialSocket(originalSocket);
+    restoreCredentialSocket(CREDENTIAL_SOCKET_ENV, originalSocket);
     await rm(socketDir, { force: true, recursive: true });
     throw toCredentialProxyFatalError(error);
   }
@@ -170,23 +297,14 @@ async function createChildEnv(
   readonly childEnv: NodeJS.ProcessEnv;
   readonly credentialProxy: CredentialProxyHandle | null;
 }> {
-  // Only start a credential proxy when the parent does not already have one.
-  // If a socket is already set in the environment, the spread below forwards it
-  // to the child unchanged.
-  const credentialProxy =
-    process.env[CREDENTIAL_SOCKET_ENV] !== undefined
-      ? null
-      : await createCredentialProxy();
-  // The relaunch guard is deliberately applied only to the Bun child. The Node
-  // parent waits for that child and exits, while repeated calls in tests can use
-  // the injectable envGuardSet option to model an already-relaunched process.
-  const childEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    [BUN_RELAUNCH_ENV]: 'true',
-  };
-  if (credentialProxy !== null) {
-    childEnv[CREDENTIAL_SOCKET_ENV] = credentialProxy.socketPath;
-  }
+  const { createLauncherChildEnv, hasUsableCredentialSocket } =
+    getLauncherCredentialEnv();
+  const credentialProxy = hasUsableCredentialSocket()
+    ? null
+    : await createCredentialProxy();
+  const childEnv = createLauncherChildEnv({
+    credentialSocketPath: credentialProxy?.socketPath ?? null,
+  });
   return { childEnv, credentialProxy };
 }
 

--- a/packages/cli/src/launcher/cli-bin.e2e.test.ts
+++ b/packages/cli/src/launcher/cli-bin.e2e.test.ts
@@ -1,0 +1,354 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp, writeFile, rm, access } from 'node:fs/promises';
+import { accessSync, constants } from 'node:fs';
+import { createRequire } from 'node:module';
+import { basename, dirname, join, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const cliPackageRoot = resolve(__dirname, '..', '..');
+const credentialSocketEnv = 'LLXPRT_CREDENTIAL_SOCKET';
+const loadCommonJsModule = createRequire(import.meta.url);
+
+// The single source of truth for the sidecar socket-directory prefix, loaded
+// from the shared helper so these tests never hardcode a magic string that can
+// drift from production.
+const { PROXY_SOCKET_PREFIX } = loadCommonJsModule(
+  resolve(cliPackageRoot, 'bin', 'launcher-credential-env.cjs'),
+) as { PROXY_SOCKET_PREFIX: string };
+
+interface SubprocessResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+// Grace window to wait for a killed subprocess to emit 'close' before forcing
+// the timeout rejection (in case SIGKILL never produces a close event).
+const POST_KILL_GRACE_MS = 2_000;
+
+function runSubprocess(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 15_000,
+): Promise<SubprocessResult> {
+  return new Promise((resolveSubprocess, reject) => {
+    // Spawn in its own process group (detached) so the timeout handler can kill
+    // the whole tree — the Node wrapper AND the Bun grandchild it spawns —
+    // since SIGKILL is not propagated to descendants by default.
+    const child = spawn(command, [...args], {
+      cwd: cliPackageRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+    });
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    // A stdio stream with no 'error' listener throws an uncaught exception when
+    // it errors (e.g. EPIPE/ECONNRESET during a kill), which would crash the
+    // whole test process. Swallow stream errors here and rely on the child's
+    // 'error'/'close' events for the promise's resolution.
+    child.stdout.on('error', () => {});
+    child.stderr.on('error', () => {});
+    const killTree = () => {
+      if (typeof child.pid === 'number') {
+        if (process.platform === 'win32') {
+          // SIGKILL only reaps the Node wrapper, not the Bun grandchild, so use
+          // taskkill /T to terminate the whole process tree on Windows.
+          try {
+            spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+              stdio: 'ignore',
+            });
+            return;
+          } catch {
+            // Fall through to killing just the direct child.
+          }
+        } else {
+          try {
+            process.kill(-child.pid, 'SIGKILL');
+            return;
+          } catch {
+            // Fall through to killing just the direct child.
+          }
+        }
+      }
+      child.kill('SIGKILL');
+    };
+    // Guard against a hung child (e.g. one that never exits): kill the whole
+    // process tree, then reject after a fixed grace window. The grace timer is
+    // the single rejection source — relying on a newly-attached 'close'
+    // listener would be fragile because the pre-registered close handler
+    // consumes the event first, and this also covers the case where SIGKILL
+    // never produces a close event (defunct/zombie child).
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      killTree();
+      setTimeout(() => {
+        reject(
+          new Error(
+            [
+              `Subprocess timed out after ${timeoutMs}ms`,
+              `stdout: ${stdout}`,
+              `stderr: ${stderr}`,
+            ].join(String.fromCharCode(10)),
+          ),
+        );
+      }, POST_KILL_GRACE_MS).unref();
+    }, timeoutMs);
+    timer.unref();
+    child.once('error', (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolveSubprocess({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+describe('cli bin end-to-end credential routing', () => {
+  it.each([
+    // The launcher must treat an empty-string socket env the same as a missing
+    // one — both should route the child through a freshly started proxy.
+    ['empty string', ''] as const,
+    ['absent', undefined] as const,
+  ])(
+    'routes no-compile launcher children through proxy-backed credential factories (socket env: %s)',
+    async (_label, socketEnvValue) => {
+      const binPath = resolve(cliPackageRoot, 'bin', 'llxprt.cjs');
+      // This e2e test drives the real CJS launcher, so it needs a concrete Bun
+      // binary path. The bundled Bun is a direct dependency installed at the
+      // monorepo root, so resolve it there. This is intentionally a fixed path
+      // (rather than the production resolveBunPath walker) to keep the test
+      // hermetic; if the monorepo layout changes, update this path.
+      const bunPath = resolve(
+        cliPackageRoot,
+        '..',
+        '..',
+        'node_modules',
+        '.bin',
+        process.platform === 'win32' ? 'bun.cmd' : 'bun',
+      );
+      // Fail fast with an actionable message if the monorepo layout has
+      // shifted, rather than surfacing an opaque ENOENT from inside the spawned
+      // subprocess. Do this BEFORE creating the temp dir so a stale path can
+      // never leave an orphaned directory behind.
+      try {
+        accessSync(bunPath, constants.X_OK);
+      } catch (error) {
+        throw new Error(
+          `Bun binary not found at ${bunPath}. The monorepo layout may have ` +
+            `changed; update the bunPath resolution in this test.`,
+          { cause: error },
+        );
+      }
+
+      // Create the temp dir inside the cli package so Bun's node_modules
+      // resolution walks up into the monorepo workspace to find provider
+      // packages; a dir under the OS tmpdir cannot reach them. The `temp-`
+      // prefix is covered by the root .gitignore `temp-*` rule, so an orphaned
+      // directory (e.g. if the process is SIGKILLed before the finally block
+      // runs) never pollutes the working tree.
+      const tempDir = await mkdtemp(join(cliPackageRoot, 'temp-e2e-launcher-'));
+      const childEntry = join(tempDir, 'child.ts');
+      const launcherWrapper = join(tempDir, 'launcher-wrapper.cjs');
+
+      try {
+        await writeFile(
+          childEntry,
+          [
+            "import { createProviderKeyStorage } from '@vybestack/llxprt-code-providers/auth.js';",
+            'const storage = createProviderKeyStorage();',
+            '// The proxy-backed storage keeps an open socket handle, so the event',
+            '// loop never drains on its own; exit explicitly. Exit from inside the',
+            '// write callback, which fires only after the payload has flushed to',
+            '// the pipe, so the parent never sees a truncated write.',
+            'process.stdout.write(',
+            '  JSON.stringify({',
+            '    socket: process.env.LLXPRT_CREDENTIAL_SOCKET ?? null,',
+            '    storageType: storage.constructor.name,',
+            '  }) + "\\n",',
+            '  () => process.exit(0),',
+            ');',
+          ].join('\n'),
+        );
+        await writeFile(
+          launcherWrapper,
+          [
+            `'use strict';`,
+            `const { runCliBin } = require(${JSON.stringify(binPath)});`,
+            `runCliBin({`,
+            `  resolveBun: () => ${JSON.stringify(bunPath)},`,
+            `  resolveEntry: () => ${JSON.stringify(childEntry)},`,
+            `  exit: (code) => process.exit(code ?? 0),`,
+            `}).catch((error) => {`,
+            `  process.stderr.write(String(error instanceof Error ? error.stack : error));`,
+            `  process.exit(1);`,
+            `});`,
+          ].join('\n'),
+        );
+
+        const childEnv = { ...process.env };
+        // Ensure a clean relaunch state so the launcher exercises its full
+        // proxy-routing path regardless of env leakage from other tests in the
+        // same worker.
+        delete childEnv['LLXPRT_BUN_RELAUNCHED'];
+        if (socketEnvValue === undefined) {
+          delete childEnv[credentialSocketEnv];
+        } else {
+          childEnv[credentialSocketEnv] = socketEnvValue;
+        }
+        const result = await runSubprocess(
+          process.execPath,
+          [launcherWrapper, '--key', 'sk-test'],
+          childEnv,
+        );
+
+        expect(result.code).toBe(0);
+        expect(result.signal).toBeNull();
+        // Parse stdout before the stderr assertion so a garbled/non-JSON
+        // payload surfaces a clear diagnostic (including stderr) rather than
+        // being masked by that assertion below.
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(result.stdout.trim());
+        } catch (error) {
+          throw new Error(
+            `Failed to parse child stdout as JSON: ${String(error)}\n` +
+              `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
+            { cause: error },
+          );
+        }
+        // The happy path must not surface a real uncaught exception / error
+        // header from the runtime. Anchor to the start of a line and require the
+        // specific runtime error formats (with trailing content) so benign
+        // warnings (e.g. ExperimentalWarning), deprecation notices, or stack
+        // frames that merely mention these words do not cause spurious failures.
+        // Exit code is the primary success signal (asserted above); this is a
+        // secondary guard against silent runtime errors.
+        expect(result.stderr).not.toMatch(/^(Uncaught .+|Error: .+)/m);
+        const routed = parsed as {
+          socket: string | null;
+          storageType: string;
+        };
+        // The sidecar creates its socket inside <tmpdir>/<prefix><id>/, so assert
+        // on the directory portion rather than a bare substring match — that
+        // mirrors the production contract in isSafeProxySocketDir (basename of the
+        // socket directory starts with the shared prefix).
+        const { socket } = routed;
+        if (socket === null) {
+          throw new Error('Expected child to report a non-null socket path');
+        }
+        // Assert on the socket's parent directory basename using string ops
+        // (rather than a dynamically built regex) so the shared prefix needs no
+        // regex escaping: it must start with the prefix and contain a generated
+        // suffix.
+        const socketParentDir = dirname(socket);
+        const socketDirName = basename(socketParentDir);
+        expect(socketDirName.startsWith(PROXY_SOCKET_PREFIX)).toBe(true);
+        expect(socketDirName.length).toBeGreaterThan(
+          PROXY_SOCKET_PREFIX.length,
+        );
+        expect(routed.storageType).toBe('ProxyProviderKeyStorage');
+
+        // The launcher child has fully exited (runSubprocess awaited its close),
+        // so the credential proxy sidecar must have terminated gracefully and
+        // removed its own socket directory. Poll to allow for async cleanup (OS
+        // file-handle release can lag, especially under CI load). A lingering
+        // directory would signal a leaked sidecar process.
+        await vi.waitFor(
+          async () => {
+            expect(await pathExists(socketParentDir)).toBe(false);
+          },
+          { timeout: 5_000, interval: 100 },
+        );
+      } finally {
+        // Cleanup must never mask the real assertion failure with a transient
+        // rm error (EBUSY/EPERM on Windows while subprocess handles release).
+        // The `temp-*` gitignore rule guarantees an orphan never pollutes the
+        // working tree even if this removal is skipped.
+        await rm(tempDir, { force: true, recursive: true }).catch(() => {});
+      }
+    },
+    20_000,
+  );
+
+  it('creates the sidecar socket directory using the shared prefix', async () => {
+    // Behavioral drift guard: the shared helper is the single source of truth
+    // for the socket-directory prefix, and the real sidecar must create its
+    // directory with that exact prefix. This proves launcher and sidecar agree
+    // at runtime without asserting on source text.
+    expect(typeof PROXY_SOCKET_PREFIX).toBe('string');
+    expect(PROXY_SOCKET_PREFIX.length).toBeGreaterThan(0);
+
+    const bin = loadCommonJsModule(
+      resolve(cliPackageRoot, 'bin', 'llxprt.cjs'),
+    ) as {
+      createCredentialProxyDefault: () => Promise<{
+        socketPath: string;
+        socketDir: string;
+        stop: () => Promise<void>;
+      }>;
+    };
+
+    // Use vi.stubEnv for automatic, lifecycle-integrated cleanup (matching the
+    // codebase convention). An empty string is treated as missing by
+    // hasUsableCredentialSocket(), so the launcher starts a fresh proxy.
+    vi.stubEnv(credentialSocketEnv, '');
+    let proxy:
+      | Awaited<ReturnType<typeof bin.createCredentialProxyDefault>>
+      | undefined;
+    try {
+      proxy = await bin.createCredentialProxyDefault();
+      expect(basename(proxy.socketDir).startsWith(PROXY_SOCKET_PREFIX)).toBe(
+        true,
+      );
+      expect(dirname(proxy.socketPath)).toBe(proxy.socketDir);
+    } finally {
+      await proxy?.stop().catch((error) => {
+        process.stderr.write(
+          `warning: credential proxy stop failed: ${String(error)}
+`,
+        );
+      });
+      vi.unstubAllEnvs();
+    }
+  }, 20_000);
+});

--- a/packages/cli/src/launcher/cli-bin.e2e.test.ts
+++ b/packages/cli/src/launcher/cli-bin.e2e.test.ts
@@ -209,14 +209,24 @@ describe('cli bin end-to-end credential routing', () => {
             ');',
           ].join('\n'),
         );
+        // The wrapper source is fully static: the launcher bin path, the Bun
+        // binary path, and the child entry are passed in through the
+        // environment and read at runtime with process.env, rather than
+        // interpolated into the generated source. This keeps test-controlled
+        // filesystem paths out of the code-construction sink entirely (no
+        // JSON.stringify-into-source, which is not a safe JS escaper for values
+        // like U+2028/U+2029).
         await writeFile(
           launcherWrapper,
           [
             `'use strict';`,
-            `const { runCliBin } = require(${JSON.stringify(binPath)});`,
+            `const binPath = process.env.LLXPRT_E2E_BIN_PATH;`,
+            `const bunPath = process.env.LLXPRT_E2E_BUN_PATH;`,
+            `const childEntry = process.env.LLXPRT_E2E_CHILD_ENTRY;`,
+            `const { runCliBin } = require(binPath);`,
             `runCliBin({`,
-            `  resolveBun: () => ${JSON.stringify(bunPath)},`,
-            `  resolveEntry: () => ${JSON.stringify(childEntry)},`,
+            `  resolveBun: () => bunPath,`,
+            `  resolveEntry: () => childEntry,`,
             `  exit: (code) => process.exit(code ?? 0),`,
             `}).catch((error) => {`,
             `  process.stderr.write(String(error instanceof Error ? error.stack : error));`,
@@ -226,6 +236,11 @@ describe('cli bin end-to-end credential routing', () => {
         );
 
         const childEnv = { ...process.env };
+        // Hand the launcher wrapper its filesystem paths through the
+        // environment so the generated source above stays static.
+        childEnv['LLXPRT_E2E_BIN_PATH'] = binPath;
+        childEnv['LLXPRT_E2E_BUN_PATH'] = bunPath;
+        childEnv['LLXPRT_E2E_CHILD_ENTRY'] = childEntry;
         // Ensure a clean relaunch state so the launcher exercises its full
         // proxy-routing path regardless of env leakage from other tests in the
         // same worker.

--- a/packages/cli/src/launcher/cli-bin.test.ts
+++ b/packages/cli/src/launcher/cli-bin.test.ts
@@ -5,7 +5,9 @@
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { resolve } from 'node:path';
+import { mkdtemp, rm, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { createRequire } from 'node:module';
 import { EventEmitter } from 'node:events';
 import type { spawn as spawnType } from 'node:child_process';
@@ -15,8 +17,22 @@ const binPath = resolve(cliPackageRoot, 'bin', 'llxprt.cjs');
 const loadCommonJsModule = createRequire(import.meta.url);
 const credentialSocketEnv = 'LLXPRT_CREDENTIAL_SOCKET';
 
+// The launcher only accepts a sidecar socket directory that is a direct
+// lxcp-prefixed child of the OS temp dir, so fixtures must be built from the
+// real tmpdir() (which is not '/tmp' on macOS). These are parse-only fixtures:
+// the mock child process emits them as stdout text but never materializes them
+// on disk, so no mkdtemp/cleanup is needed.
+const fixtureSocketDir = join(tmpdir(), 'lxcp-fixture');
+const fixtureSocketPath = join(fixtureSocketDir, 'llxprt-credential.sock');
+const proxyStartupLine = `${JSON.stringify({
+  socketDir: fixtureSocketDir,
+  socketPath: fixtureSocketPath,
+})}
+`;
+
 interface CredentialProxyHandle {
   socketPath: string;
+  socketDir?: string;
   stop: () => Promise<void>;
 }
 
@@ -91,6 +107,15 @@ function loadCliBin(): CliBinModule {
     throw new Error('cli bin module did not expose expected test seams');
   }
   return module;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function createChildProcess({
@@ -510,11 +535,17 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     });
 
     expect(createdProxy?.socketPath).toBe('');
-    proxyHost.stdout.emit('data', Buffer.from('{"socket'));
+    // Split the startup JSON across two chunks to exercise the buffered parser.
+    const startupJson = JSON.stringify({
+      socketDir: fixtureSocketDir,
+      socketPath: fixtureSocketPath,
+    });
+    const splitAt = startupJson.indexOf('socketDir');
+    proxyHost.stdout.emit('data', Buffer.from(startupJson.slice(0, splitAt)));
 
     proxyHost.stdout.emit(
       'data',
-      Buffer.from('Path":"/tmp/llxprt-credential.sock"}\nignored\n'),
+      Buffer.from(`${startupJson.slice(splitAt)}\nignored\n`),
     );
     const proxy = await proxyPromise;
 
@@ -532,7 +563,8 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
       }),
     );
     expect(proxy).toBe(createdProxy);
-    expect(proxy.socketPath).toBe('/tmp/llxprt-credential.sock');
+    expect(proxy.socketPath).toBe(fixtureSocketPath);
+    expect(proxy.socketDir).toBe(fixtureSocketDir);
 
     const stopPromise = proxy.stop();
     proxyHost.emit('close', 0, null);
@@ -548,10 +580,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
       spawn: spawnFn as unknown as typeof spawnType,
     });
 
-    proxyHost.stdout.emit(
-      'data',
-      Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
-    );
+    proxyHost.stdout.emit('data', Buffer.from(proxyStartupLine));
     const proxy = await proxyPromise;
     proxyHost.exitCode = 0;
 
@@ -569,10 +598,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
       onUnexpectedExit,
     });
 
-    proxyHost.stdout.emit(
-      'data',
-      Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
-    );
+    proxyHost.stdout.emit('data', Buffer.from(proxyStartupLine));
     await proxyPromise;
 
     expect(onUnexpectedExit).not.toHaveBeenCalled();
@@ -593,10 +619,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
       onUnexpectedExit,
     });
 
-    proxyHost.stdout.emit(
-      'data',
-      Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
-    );
+    proxyHost.stdout.emit('data', Buffer.from(proxyStartupLine));
     const proxy = await proxyPromise;
 
     const stopPromise = proxy.stop();
@@ -668,19 +691,91 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
         spawn: spawnFn as unknown as typeof spawnType,
       });
 
-      proxyHost.stdout.emit(
-        'data',
-        Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
-      );
+      proxyHost.stdout.emit('data', Buffer.from(proxyStartupLine));
       const proxy = await proxyPromise;
       const stopPromise = proxy.stop();
 
       expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
-      await vi.advanceTimersByTimeAsync(1000);
+      // Advance past the SIGTERM deadline (SIGKILL) plus the secondary
+      // post-SIGKILL reap deadline before the stop promise settles.
+      await vi.advanceTimersByTimeAsync(2000);
       await stopPromise;
       expect(proxyHost.kill).toHaveBeenCalledWith('SIGKILL');
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it('removes the sidecar-reported socket dir when forced shutdown escalates to SIGKILL', async () => {
+    vi.useFakeTimers();
+    const socketDir = await mkdtemp(join(tmpdir(), 'lxcp-test-'));
+    try {
+      const proxyHost = createChildProcess({ autoClose: false });
+      const spawnFn = vi.fn(() => proxyHost);
+      const proxyPromise = createCredentialProxyDefault({
+        spawn: spawnFn as unknown as typeof spawnType,
+      });
+
+      expect(await pathExists(socketDir)).toBe(true);
+
+      proxyHost.stdout.emit(
+        'data',
+        Buffer.from(
+          `${JSON.stringify({
+            socketDir,
+            socketPath: join(socketDir, 'credential.sock'),
+          })}\n`,
+        ),
+      );
+      const proxy = await proxyPromise;
+
+      const stopPromise = proxy.stop();
+      // Advance past the SIGTERM deadline (SIGKILL), the secondary post-SIGKILL
+      // reap deadline, and the full removeSocketDirWithRetry backoff window
+      // (2 inter-attempt delays x 50ms = 100ms) so a retryable rm() error on a
+      // slow/flaky filesystem cannot leave the stop promise hanging under fake
+      // timers.
+      await vi.advanceTimersByTimeAsync(3000);
+      await stopPromise;
+
+      expect(proxyHost.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(await pathExists(socketDir)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      await rm(socketDir, { force: true, recursive: true });
+    }
+  });
+
+  it('leaves the sidecar-reported socket dir intact on a graceful stop', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'lxcp-test-'));
+    try {
+      const proxyHost = createChildProcess();
+      const spawnFn = vi.fn(() => proxyHost);
+      const proxyPromise = createCredentialProxyDefault({
+        spawn: spawnFn as unknown as typeof spawnType,
+      });
+
+      proxyHost.stdout.emit(
+        'data',
+        Buffer.from(
+          `${JSON.stringify({
+            socketDir,
+            socketPath: join(socketDir, 'credential.sock'),
+          })}\n`,
+        ),
+      );
+      const proxy = await proxyPromise;
+
+      const stopPromise = proxy.stop();
+      proxyHost.emit('close', 0, null);
+      await stopPromise;
+
+      // A graceful SIGTERM shutdown lets the sidecar remove its own directory;
+      // the parent must not delete it (there is no forced SIGKILL here).
+      expect(proxyHost.kill).not.toHaveBeenCalledWith('SIGKILL');
+      expect(await pathExists(socketDir)).toBe(true);
+    } finally {
+      await rm(socketDir, { force: true, recursive: true });
     }
   });
 
@@ -696,7 +791,8 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
 
       await vi.advanceTimersByTimeAsync(15_000);
       expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
-      await vi.advanceTimersByTimeAsync(1000);
+      // SIGKILL deadline plus the secondary post-SIGKILL reap deadline.
+      await vi.advanceTimersByTimeAsync(2000);
       const error = await rejection;
       expect(error).toBeInstanceOf(Error);
       expect(String(error)).toContain('credential proxy');
@@ -744,6 +840,83 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
 
     await expect(proxyPromise).rejects.toThrow(/credential proxy/);
     expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it.each([
+    // A bare filename: dirname() === '.', which must be rejected so force-kill
+    // cleanup can never target the launcher's working directory.
+    ['proxy.sock'],
+    // A file directly under the OS temp dir: dirname() yields tmpdir() itself,
+    // whose basename (e.g. 'tmp') does not carry the lxcp- prefix, so it is
+    // rejected at the basename guard before the parent === tmpdir() check.
+    [join(tmpdir(), 'proxy.sock')],
+    // The filesystem root: dirname('/proxy.sock') === '/'.
+    ['/proxy.sock'],
+    // An absolute path outside the OS temp dir.
+    ['/var/data/lxcp-abc/proxy.sock'],
+    // A socket file whose directory is a direct tmpdir child lacking the lxcp-
+    // prefix. This exercises the basename prefix guard specifically: the derived
+    // dir <tmpdir>/notlxcp-dir is rejected by the prefix check before the
+    // parent === tmpdir() check is evaluated.
+    [join(tmpdir(), 'notlxcp-dir', 'proxy.sock')],
+  ])(
+    'rejects a startup line whose derived socket dir is unsafe: %j',
+    async (socketPath) => {
+      const proxyHost = createChildProcess();
+      const spawnFn = vi.fn(() => proxyHost);
+      const proxyPromise = createCredentialProxyDefault({
+        spawn: spawnFn as unknown as typeof spawnType,
+      });
+
+      proxyHost.stdout.emit(
+        'data',
+        Buffer.from(`${JSON.stringify({ socketPath })}\n`),
+      );
+
+      await expect(proxyPromise).rejects.toThrow(/credential proxy/);
+      expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+    },
+  );
+
+  it('rejects an explicitly reported socketDir that is an unsafe path', async () => {
+    // The explicit socketDir branch must be validated too: a tampered/buggy
+    // sidecar could report '/' and trigger a catastrophic recursive rm().
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+    });
+
+    proxyHost.stdout.emit(
+      'data',
+      Buffer.from(
+        `${JSON.stringify({ socketDir: '/', socketPath: '/proxy.sock' })}\n`,
+      ),
+    );
+
+    await expect(proxyPromise).rejects.toThrow(/credential proxy/);
+    expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('accepts a fallback socket dir that is a direct lxcp- child of the OS temp dir', async () => {
+    // Parse-only: verifies validation of the reported path; the launcher never
+    // materializes this directory on disk, so no mkdtemp/cleanup is needed.
+    const socketDir = join(tmpdir(), 'lxcp-abc');
+    const socketPath = join(socketDir, 'proxy.sock');
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+    });
+
+    proxyHost.stdout.emit(
+      'data',
+      Buffer.from(`${JSON.stringify({ socketPath })}\n`),
+    );
+    const proxy = await proxyPromise;
+
+    expect(proxy.socketPath).toBe(socketPath);
+    expect(proxy.socketDir).toBe(socketDir);
   });
 
   it('exposes runCliBin as a function without executing the launcher on import', () => {

--- a/packages/cli/src/launcher/cli-bin.test.ts
+++ b/packages/cli/src/launcher/cli-bin.test.ts
@@ -1,0 +1,594 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { EventEmitter } from 'node:events';
+import type { spawn as spawnType } from 'node:child_process';
+
+const cliPackageRoot = resolve(__dirname, '..', '..');
+const binPath = resolve(cliPackageRoot, 'bin', 'llxprt.cjs');
+const loadCommonJsModule = createRequire(import.meta.url);
+const credentialSocketEnv = 'LLXPRT_CREDENTIAL_SOCKET';
+
+interface CredentialProxyHandle {
+  socketPath: string;
+  stop: () => Promise<void>;
+}
+
+interface RunCliBinOptions {
+  exit?: ExitFn;
+  spawn?: typeof spawnType;
+  resolveBun?: () => string | null;
+  resolveEntry?: () => string | null;
+  startCredentialProxy?: () => Promise<CredentialProxyHandle>;
+}
+
+type ExitFn = (code?: number) => never;
+type RunCliBin = (options?: RunCliBinOptions) => Promise<void>;
+type CreateCredentialProxyDefault = (options?: {
+  spawn?: typeof spawnType;
+}) => Promise<CredentialProxyHandle>;
+
+interface CliBinModule {
+  runCliBin: RunCliBin;
+  createCredentialProxyDefault: CreateCredentialProxyDefault;
+}
+
+interface TestChildProcess extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+}
+
+function recordingExit(sink: number[]): ExitFn {
+  const exit: ExitFn = (code?: number) => {
+    sink.push(code ?? 0);
+    return undefined as never;
+  };
+  return exit;
+}
+
+function isCliBinModule(module: unknown): module is CliBinModule {
+  if (typeof module !== 'object' || module === null) {
+    return false;
+  }
+  const { runCliBin, createCredentialProxyDefault } = module as {
+    runCliBin?: unknown;
+    createCredentialProxyDefault?: unknown;
+  };
+  return (
+    typeof runCliBin === 'function' &&
+    typeof createCredentialProxyDefault === 'function'
+  );
+}
+
+function loadCliBin(): CliBinModule {
+  const module = loadCommonJsModule(binPath);
+  if (!isCliBinModule(module)) {
+    throw new Error('cli bin module did not expose expected test seams');
+  }
+  return module;
+}
+
+function createChildProcess({
+  autoClose = true,
+}: { autoClose?: boolean } = {}): TestChildProcess {
+  const child = new EventEmitter() as TestChildProcess;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.kill = vi.fn((signal?: NodeJS.Signals | 'SIGKILL') => {
+    child.killed = true;
+    if (autoClose) {
+      process.nextTick(() => child.emit('close', null, signal ?? null));
+    }
+    return true;
+  });
+  child.killed = false;
+  child.exitCode = null;
+  child.signalCode = null;
+  return child;
+}
+
+describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalArgv: string[];
+  let runCliBin: RunCliBin;
+  let createCredentialProxyDefault: CreateCredentialProxyDefault;
+
+  beforeEach(() => {
+    originalEnv = process.env;
+    originalArgv = process.argv;
+    process.env = { ...process.env };
+    process.argv = ['/node', '/llxprt.cjs'];
+    const bin = loadCliBin();
+    runCliBin = bin.runCliBin;
+    createCredentialProxyDefault = bin.createCredentialProxyDefault;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+  });
+
+  async function runLauncher(overrides: RunCliBinOptions = {}) {
+    const exitCalls: number[] = [];
+    const child = createChildProcess();
+    const proxyStop = vi.fn(async () => {});
+    const spawnFn = vi.fn(() => child);
+    const startCredentialProxy = vi.fn(async () => ({
+      socketPath: '/tmp/llxprt-credential.sock',
+      stop: proxyStop,
+    }));
+
+    await runCliBin({
+      exit: recordingExit(exitCalls),
+      spawn: spawnFn as unknown as typeof spawnType,
+      resolveBun: () => '/path/to/bun',
+      resolveEntry: () => '/entry.ts',
+      startCredentialProxy,
+      ...overrides,
+    });
+
+    return {
+      child,
+      exitCalls,
+      proxyStop,
+      spawnFn,
+      startCredentialProxy,
+    };
+  }
+
+  it('starts a Node-owned credential proxy and passes its socket to the Bun child', async () => {
+    delete process.env[credentialSocketEnv];
+    process.argv = ['/node', '/llxprt.cjs', '--profile-load', 'dev'];
+    const exitCalls: number[] = [];
+    const proxyStop = vi.fn(async () => {});
+    const child = createChildProcess();
+    const spawnFn = vi.fn(() => child);
+    const startCredentialProxy = vi.fn(async () => ({
+      socketPath: '/tmp/llxprt-credential.sock',
+      stop: proxyStop,
+    }));
+
+    await runCliBin({
+      exit: recordingExit(exitCalls),
+      spawn: spawnFn as unknown as typeof spawnType,
+      resolveBun: () => '/path/to/bun',
+      resolveEntry: () => '/entry.ts',
+      startCredentialProxy,
+    });
+
+    expect(startCredentialProxy).toHaveBeenCalledTimes(1);
+    expect(spawnFn).toHaveBeenCalledWith(
+      '/path/to/bun',
+      ['/entry.ts', '--profile-load', 'dev'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          LLXPRT_BUN_RELAUNCHED: 'true',
+          [credentialSocketEnv]: '/tmp/llxprt-credential.sock',
+        }),
+      }),
+    );
+    child.emit('close', 0, null);
+    await vi.waitFor(() => {
+      expect(proxyStop).toHaveBeenCalledTimes(1);
+      expect(exitCalls).toStrictEqual([0]);
+    });
+  });
+
+  it('forwards an existing credential socket unchanged without nesting a proxy', async () => {
+    process.env[credentialSocketEnv] = '/tmp/existing.sock';
+    const exitCalls: number[] = [];
+    const child = createChildProcess();
+    const spawnFn = vi.fn(() => child);
+    const startCredentialProxy = vi.fn(async () => ({
+      socketPath: '/tmp/new.sock',
+      stop: vi.fn(async () => {}),
+    }));
+
+    await runCliBin({
+      exit: recordingExit(exitCalls),
+      spawn: spawnFn as unknown as typeof spawnType,
+      resolveBun: () => '/path/to/bun',
+      resolveEntry: () => '/entry.ts',
+      startCredentialProxy,
+    });
+
+    expect(startCredentialProxy).not.toHaveBeenCalled();
+    expect(spawnFn.mock.calls[0][2]).toStrictEqual(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          LLXPRT_BUN_RELAUNCHED: 'true',
+          [credentialSocketEnv]: '/tmp/existing.sock',
+        }),
+      }),
+    );
+    child.emit('close', 0, null);
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+  });
+
+  it.each([
+    [['--provider', 'openai', '--key', 'sk-test']],
+    [['--provider', 'openai', '--key=sk-test']],
+    [['--provider', 'openai', '--keyfile', '/tmp/provider-key.txt']],
+    [['--provider', 'openai', '--keyfile=/tmp/provider-key.txt']],
+  ] satisfies string[][][])(
+    'skips the credential proxy when direct credential override is supplied: %j',
+    async (args) => {
+      delete process.env[credentialSocketEnv];
+      process.argv = ['/node', '/llxprt.cjs', ...args];
+      const { child, exitCalls, spawnFn, startCredentialProxy } =
+        await runLauncher();
+
+      expect(startCredentialProxy).not.toHaveBeenCalled();
+      expect(spawnFn).toHaveBeenCalledWith(
+        '/path/to/bun',
+        ['/entry.ts', ...args],
+        expect.objectContaining({
+          env: expect.not.objectContaining({
+            [credentialSocketEnv]: expect.anything(),
+          }),
+        }),
+      );
+      child.emit('close', 0, null);
+      await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+    },
+  );
+
+  it.each([
+    [['--key']],
+    [['--key=']],
+    [['--key', '--provider']],
+    [['--keyfile']],
+    [['--keyfile=']],
+    [['--keyfile', '--model']],
+  ] satisfies string[][][])(
+    'starts the credential proxy when direct credential flag has no value: %j',
+    async (args) => {
+      delete process.env[credentialSocketEnv];
+      process.argv = ['/node', '/llxprt.cjs', ...args];
+      const { child, exitCalls, spawnFn, startCredentialProxy } =
+        await runLauncher();
+
+      expect(startCredentialProxy).toHaveBeenCalledTimes(1);
+      expect(spawnFn.mock.calls[0][2]).toStrictEqual(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            [credentialSocketEnv]: '/tmp/llxprt-credential.sock',
+          }),
+        }),
+      );
+      child.emit('close', 0, null);
+      await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+    },
+  );
+
+  it('still starts the credential proxy for named saved credentials', async () => {
+    delete process.env[credentialSocketEnv];
+    process.argv = ['/node', '/llxprt.cjs', '--key-name', 'work'];
+    const { child, exitCalls, startCredentialProxy, spawnFn } =
+      await runLauncher();
+
+    expect(startCredentialProxy).toHaveBeenCalledTimes(1);
+    expect(spawnFn.mock.calls[0][2]).toStrictEqual(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          [credentialSocketEnv]: '/tmp/llxprt-credential.sock',
+        }),
+      }),
+    );
+    child.emit('close', 0, null);
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+  });
+
+  it('treats an empty credential socket as missing and starts a proxy', async () => {
+    process.env[credentialSocketEnv] = '';
+    const exitCalls: number[] = [];
+    const child = createChildProcess();
+    const spawnFn = vi.fn(() => child);
+    const startCredentialProxy = vi.fn(async () => ({
+      socketPath: '/tmp/new.sock',
+      stop: vi.fn(async () => {}),
+    }));
+
+    await runCliBin({
+      exit: recordingExit(exitCalls),
+      spawn: spawnFn as unknown as typeof spawnType,
+      resolveBun: () => '/path/to/bun',
+      resolveEntry: () => '/entry.ts',
+      startCredentialProxy,
+    });
+
+    expect(startCredentialProxy).toHaveBeenCalledTimes(1);
+    expect(spawnFn.mock.calls[0][2]).toStrictEqual(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          [credentialSocketEnv]: '/tmp/new.sock',
+        }),
+      }),
+    );
+    child.emit('close', 0, null);
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+  });
+
+  it('stops the credential proxy when Bun emits an async spawn error', async () => {
+    delete process.env[credentialSocketEnv];
+    const { child, exitCalls, proxyStop } = await runLauncher();
+
+    child.emit('error', new Error('spawn failed'));
+
+    await vi.waitFor(() => {
+      expect(proxyStop).toHaveBeenCalledTimes(1);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(exitCalls).toStrictEqual([43]);
+    });
+  });
+
+  it('exits after Bun closes even when credential proxy cleanup rejects', async () => {
+    delete process.env[credentialSocketEnv];
+    const proxyStop = vi.fn(async () => {
+      throw new Error('stop failed');
+    });
+    const { child, exitCalls } = await runLauncher({
+      startCredentialProxy: vi.fn(async () => ({
+        socketPath: '/tmp/llxprt-credential.sock',
+        stop: proxyStop,
+      })),
+    });
+
+    child.emit('close', 0, null);
+
+    await vi.waitFor(() => {
+      expect(proxyStop).toHaveBeenCalledTimes(1);
+      expect(exitCalls).toStrictEqual([0]);
+    });
+  });
+
+  it('stops the credential proxy when Bun spawn throws synchronously', async () => {
+    delete process.env[credentialSocketEnv];
+    const proxyStop = vi.fn(async () => {});
+
+    const { exitCalls } = await runLauncher({
+      spawn: vi.fn(() => {
+        throw new Error('sync spawn failed');
+      }) as unknown as typeof spawnType,
+      startCredentialProxy: vi.fn(async () => ({
+        socketPath: '/tmp/llxprt-credential.sock',
+        stop: proxyStop,
+      })),
+    });
+
+    expect(proxyStop).toHaveBeenCalledTimes(1);
+    expect(exitCalls).toStrictEqual([43]);
+  });
+
+  it.each([
+    ['SIGINT', 130],
+    ['SIGTERM', 143],
+    ['SIGHUP', 129],
+    ['SIGBREAK', 149],
+  ] satisfies Array<[NodeJS.Signals, number]>)(
+    'forwards %s to the Bun child until close',
+    async (signal, exitCode) => {
+      delete process.env[credentialSocketEnv];
+      const { child, exitCalls } = await runLauncher();
+
+      process.emit(signal, signal);
+      child.emit('close', null, signal);
+      await vi.waitFor(() => expect(exitCalls).toStrictEqual([exitCode]));
+
+      expect(child.kill).toHaveBeenCalledWith(signal);
+    },
+  );
+
+  it('exits with code 1 when the Bun child closes without code or signal', async () => {
+    delete process.env[credentialSocketEnv];
+    const { child, exitCalls } = await runLauncher();
+
+    child.emit('close', null, null);
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([1]));
+  });
+
+  it('exits before starting a proxy when Bun cannot be resolved', async () => {
+    const { exitCalls, startCredentialProxy } = await runLauncher({
+      resolveBun: () => null,
+    });
+
+    expect(startCredentialProxy).not.toHaveBeenCalled();
+    expect(exitCalls).toStrictEqual([43]);
+  });
+
+  it('exits before starting a proxy when the CLI entry cannot be resolved', async () => {
+    const { exitCalls, startCredentialProxy } = await runLauncher({
+      resolveEntry: () => null,
+    });
+
+    expect(startCredentialProxy).not.toHaveBeenCalled();
+    expect(exitCalls).toStrictEqual([43]);
+  });
+
+  it('fails closed when credential proxy startup fails', async () => {
+    delete process.env[credentialSocketEnv];
+    const spawnFn = vi.fn(() => createChildProcess());
+    const { exitCalls } = await runLauncher({
+      spawn: spawnFn as unknown as typeof spawnType,
+      startCredentialProxy: vi.fn(async () => {
+        throw new Error('proxy failed');
+      }),
+    });
+
+    expect(spawnFn).not.toHaveBeenCalled();
+    expect(exitCalls).toStrictEqual([43]);
+  });
+
+  it('rejects when the proxy host spawn throws synchronously', async () => {
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: vi.fn(() => {
+        throw new Error('proxy spawn failed');
+      }) as unknown as typeof spawnType,
+    });
+
+    await expect(proxyPromise).rejects.toThrow(
+      /Failed to start the credential proxy needed for Bun runtime access to saved provider credentials/,
+    );
+  });
+
+  it('starts the no-compile Node proxy host with parent socket stripped', async () => {
+    const proxyHost = createChildProcess();
+    process.env[credentialSocketEnv] = '/tmp/parent.sock';
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+    });
+
+    proxyHost.stdout.emit('data', Buffer.from('{"socket'));
+
+    proxyHost.stdout.emit(
+      'data',
+      Buffer.from('Path":"/tmp/llxprt-credential.sock"}\nignored\n'),
+    );
+    const proxy = await proxyPromise;
+
+    expect(spawnFn).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining([
+        '--disable-warning=ExperimentalWarning',
+        expect.stringContaining('credential-proxy-host.cjs'),
+      ]),
+      expect.objectContaining({
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: expect.not.objectContaining({
+          [credentialSocketEnv]: expect.anything(),
+        }),
+      }),
+    );
+    expect(proxy.socketPath).toBe('/tmp/llxprt-credential.sock');
+
+    const stopPromise = proxy.stop();
+    proxyHost.emit('close', 0, null);
+    await stopPromise;
+    expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+    delete process.env[credentialSocketEnv];
+  });
+
+  it('resolves proxy stop without killing when proxy host already exited', async () => {
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+    });
+
+    proxyHost.stdout.emit(
+      'data',
+      Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
+    );
+    const proxy = await proxyPromise;
+    proxyHost.exitCode = 0;
+
+    await proxy.stop();
+
+    expect(proxyHost.kill).not.toHaveBeenCalled();
+  });
+  it('escalates proxy host shutdown to SIGKILL when close never arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      const proxyHost = createChildProcess({ autoClose: false });
+      const spawnFn = vi.fn(() => proxyHost);
+      const proxyPromise = createCredentialProxyDefault({
+        spawn: spawnFn as unknown as typeof spawnType,
+      });
+
+      proxyHost.stdout.emit(
+        'data',
+        Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
+      );
+      const proxy = await proxyPromise;
+      const stopPromise = proxy.stop();
+
+      expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+      await vi.advanceTimersByTimeAsync(1000);
+      await stopPromise;
+      expect(proxyHost.kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects and stops the proxy host when startup never reports a socket', async () => {
+    vi.useFakeTimers();
+    try {
+      const proxyHost = createChildProcess({ autoClose: false });
+      const spawnFn = vi.fn(() => proxyHost);
+      const proxyPromise = createCredentialProxyDefault({
+        spawn: spawnFn as unknown as typeof spawnType,
+      });
+      const rejection = proxyPromise.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+      await vi.advanceTimersByTimeAsync(1000);
+      const error = await rejection;
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain('credential proxy');
+      expect(proxyHost.kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects and stops the proxy host when stdout contains malformed JSON', async () => {
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+    });
+
+    proxyHost.stdout.emit('data', Buffer.from('{"not valid json\n'));
+
+    await expect(proxyPromise).rejects.toThrow(/credential proxy/);
+    expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('rejects and stops the proxy host when stdout exceeds the socket line limit', async () => {
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+    });
+
+    proxyHost.stdout.emit('data', Buffer.from('x'.repeat(8193)));
+
+    await expect(proxyPromise).rejects.toThrow(/credential proxy/);
+    expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('rejects when the no-compile proxy host exits before reporting a socket', async () => {
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+    });
+
+    proxyHost.stderr.emit('data', Buffer.from('proxy init failed\n'));
+    proxyHost.emit('close', 1, null);
+
+    await expect(proxyPromise).rejects.toThrow(/credential proxy/);
+    expect(proxyHost.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('exposes runCliBin as a function without executing the launcher on import', () => {
+    const bin = loadCliBin();
+    expect(typeof bin.runCliBin).toBe('function');
+  });
+});

--- a/packages/cli/src/launcher/cli-bin.test.ts
+++ b/packages/cli/src/launcher/cli-bin.test.ts
@@ -20,18 +20,32 @@ interface CredentialProxyHandle {
   stop: () => Promise<void>;
 }
 
+interface ProxyExitInfo {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+interface CredentialProxyStartOptions {
+  onUnexpectedExit?: (info: ProxyExitInfo) => void;
+  onProxyCreated?: (proxy: CredentialProxyHandle) => void;
+}
+
 interface RunCliBinOptions {
   exit?: ExitFn;
   spawn?: typeof spawnType;
   resolveBun?: () => string | null;
   resolveEntry?: () => string | null;
-  startCredentialProxy?: () => Promise<CredentialProxyHandle>;
+  startCredentialProxy?: (
+    options?: CredentialProxyStartOptions,
+  ) => Promise<CredentialProxyHandle>;
 }
 
 type ExitFn = (code?: number) => never;
 type RunCliBin = (options?: RunCliBinOptions) => Promise<void>;
 type CreateCredentialProxyDefault = (options?: {
   spawn?: typeof spawnType;
+  onUnexpectedExit?: (info: ProxyExitInfo) => void;
+  onProxyCreated?: (proxy: CredentialProxyHandle) => void;
 }) => Promise<CredentialProxyHandle>;
 
 interface CliBinModule {
@@ -126,10 +140,13 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     const child = createChildProcess();
     const proxyStop = vi.fn(async () => {});
     const spawnFn = vi.fn(() => child);
-    const startCredentialProxy = vi.fn(async () => ({
-      socketPath: '/tmp/llxprt-credential.sock',
-      stop: proxyStop,
-    }));
+    let receivedOnUnexpectedExit: ((info: ProxyExitInfo) => void) | undefined;
+    const startCredentialProxy = vi.fn(
+      async (proxyOptions?: CredentialProxyStartOptions) => {
+        receivedOnUnexpectedExit = proxyOptions?.onUnexpectedExit;
+        return { socketPath: '/tmp/llxprt-credential.sock', stop: proxyStop };
+      },
+    );
 
     await runCliBin({
       exit: recordingExit(exitCalls),
@@ -146,6 +163,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
       proxyStop,
       spawnFn,
       startCredentialProxy,
+      receivedOnUnexpectedExit: () => receivedOnUnexpectedExit,
     };
   }
 
@@ -224,20 +242,20 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     [['--provider', 'openai', '--keyfile', '/tmp/provider-key.txt']],
     [['--provider', 'openai', '--keyfile=/tmp/provider-key.txt']],
   ] satisfies string[][][])(
-    'skips the credential proxy when direct credential override is supplied: %j',
+    'still starts the credential proxy and forwards the socket for --key/--keyfile: %j',
     async (args) => {
       delete process.env[credentialSocketEnv];
       process.argv = ['/node', '/llxprt.cjs', ...args];
       const { child, exitCalls, spawnFn, startCredentialProxy } =
         await runLauncher();
 
-      expect(startCredentialProxy).not.toHaveBeenCalled();
+      expect(startCredentialProxy).toHaveBeenCalledTimes(1);
       expect(spawnFn).toHaveBeenCalledWith(
         '/path/to/bun',
         ['/entry.ts', ...args],
         expect.objectContaining({
-          env: expect.not.objectContaining({
-            [credentialSocketEnv]: expect.anything(),
+          env: expect.objectContaining({
+            [credentialSocketEnv]: '/tmp/llxprt-credential.sock',
           }),
         }),
       );
@@ -392,6 +410,41 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     },
   );
 
+  it('exits directly when a signal arrives before Bun starts', async () => {
+    delete process.env[credentialSocketEnv];
+    const exitCalls: number[] = [];
+    const proxyStop = vi.fn(async () => {});
+    const child = createChildProcess();
+    const spawnFn = vi.fn(() => child);
+    const startCredentialProxy = vi.fn(
+      async (proxyOptions?: CredentialProxyStartOptions) => {
+        const proxy = {
+          socketPath: '',
+          stop: proxyStop,
+        };
+        proxyOptions?.onProxyCreated?.(proxy);
+        process.nextTick(() => process.emit('SIGINT', 'SIGINT'));
+        await new Promise((resolve) => setImmediate(resolve));
+        proxy.socketPath = '/tmp/llxprt-credential.sock';
+        return proxy;
+      },
+    );
+
+    await runCliBin({
+      exit: recordingExit(exitCalls),
+      spawn: spawnFn as unknown as typeof spawnType,
+      resolveBun: () => '/path/to/bun',
+      resolveEntry: () => '/entry.ts',
+      startCredentialProxy,
+    });
+
+    expect(spawnFn).not.toHaveBeenCalled();
+    expect(proxyStop).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(exitCalls).toStrictEqual([130]);
+    });
+  });
+
   it('exits with code 1 when the Bun child closes without code or signal', async () => {
     delete process.env[credentialSocketEnv];
     const { child, exitCalls } = await runLauncher();
@@ -448,10 +501,15 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     const proxyHost = createChildProcess();
     process.env[credentialSocketEnv] = '/tmp/parent.sock';
     const spawnFn = vi.fn(() => proxyHost);
+    let createdProxy: CredentialProxyHandle | undefined;
     const proxyPromise = createCredentialProxyDefault({
       spawn: spawnFn as unknown as typeof spawnType,
+      onProxyCreated: (proxy) => {
+        createdProxy = proxy;
+      },
     });
 
+    expect(createdProxy?.socketPath).toBe('');
     proxyHost.stdout.emit('data', Buffer.from('{"socket'));
 
     proxyHost.stdout.emit(
@@ -473,6 +531,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
         }),
       }),
     );
+    expect(proxy).toBe(createdProxy);
     expect(proxy.socketPath).toBe('/tmp/llxprt-credential.sock');
 
     const stopPromise = proxy.stop();
@@ -500,6 +559,106 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
 
     expect(proxyHost.kill).not.toHaveBeenCalled();
   });
+
+  it('invokes onUnexpectedExit when the proxy host dies after startup', async () => {
+    const onUnexpectedExit = vi.fn();
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+      onUnexpectedExit,
+    });
+
+    proxyHost.stdout.emit(
+      'data',
+      Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
+    );
+    await proxyPromise;
+
+    expect(onUnexpectedExit).not.toHaveBeenCalled();
+
+    proxyHost.exitCode = 1;
+    proxyHost.emit('close', 1, null);
+
+    expect(onUnexpectedExit).toHaveBeenCalledTimes(1);
+    expect(onUnexpectedExit).toHaveBeenCalledWith({ code: 1, signal: null });
+  });
+
+  it('does not invoke onUnexpectedExit when the proxy host exits during an intentional stop', async () => {
+    const onUnexpectedExit = vi.fn();
+    const proxyHost = createChildProcess();
+    const spawnFn = vi.fn(() => proxyHost);
+    const proxyPromise = createCredentialProxyDefault({
+      spawn: spawnFn as unknown as typeof spawnType,
+      onUnexpectedExit,
+    });
+
+    proxyHost.stdout.emit(
+      'data',
+      Buffer.from('{"socketPath":"/tmp/llxprt-credential.sock"}\n'),
+    );
+    const proxy = await proxyPromise;
+
+    const stopPromise = proxy.stop();
+    proxyHost.emit('close', 0, null);
+    await stopPromise;
+
+    expect(onUnexpectedExit).not.toHaveBeenCalled();
+  });
+
+  it('kills the Bun child and exits fatally when the proxy host dies after startup', async () => {
+    delete process.env[credentialSocketEnv];
+    const { child, exitCalls, receivedOnUnexpectedExit } = await runLauncher();
+
+    const callback = receivedOnUnexpectedExit();
+    expect(callback).toBeDefined();
+    callback?.({ code: 1, signal: null });
+
+    await vi.waitFor(() => {
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(exitCalls).toStrictEqual([43]);
+    });
+  });
+
+  it('exits without spawning Bun when the proxy host dies before Bun starts', async () => {
+    delete process.env[credentialSocketEnv];
+    const exitCalls: number[] = [];
+    const child = createChildProcess();
+    const spawnFn = vi.fn(() => child);
+    const proxyStop = vi.fn(async () => {});
+    const startCredentialProxy = vi.fn(
+      async (proxyOptions?: CredentialProxyStartOptions) => {
+        const proxy = {
+          socketPath: '',
+          stop: proxyStop,
+        };
+        proxyOptions?.onProxyCreated?.(proxy);
+        await new Promise<void>((resolve) => {
+          process.nextTick(() => {
+            proxyOptions?.onUnexpectedExit?.({ code: 1, signal: null });
+            resolve();
+          });
+        });
+        proxy.socketPath = '/tmp/llxprt-credential.sock';
+        return proxy;
+      },
+    );
+
+    await runCliBin({
+      exit: recordingExit(exitCalls),
+      spawn: spawnFn as unknown as typeof spawnType,
+      resolveBun: () => '/path/to/bun',
+      resolveEntry: () => '/entry.ts',
+      startCredentialProxy,
+    });
+
+    expect(spawnFn).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(proxyStop).toHaveBeenCalledTimes(1);
+      expect(exitCalls).toStrictEqual([43]);
+    });
+  });
+
   it('escalates proxy host shutdown to SIGKILL when close never arrives', async () => {
     vi.useFakeTimers();
     try {
@@ -591,4 +750,32 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     const bin = loadCliBin();
     expect(typeof bin.runCliBin).toBe('function');
   });
+
+  it('real sidecar reports a socket usable by ProxySocketClient handshake', async () => {
+    delete process.env[credentialSocketEnv];
+    const proxy = await createCredentialProxyDefault();
+
+    try {
+      expect(typeof proxy.socketPath).toBe('string');
+      expect(proxy.socketPath.length).toBeGreaterThan(0);
+
+      const { ProxySocketClient } = await import('@vybestack/llxprt-code-core');
+      const client = new ProxySocketClient(proxy.socketPath);
+      try {
+        await expect(client.ensureConnected()).resolves.toBeUndefined();
+      } finally {
+        try {
+          client.close();
+        } catch {
+          // Preserve the original connection assertion failure if close also fails.
+        }
+      }
+    } finally {
+      try {
+        await proxy.stop();
+      } catch {
+        // Preserve the original test failure if cleanup also fails.
+      }
+    }
+  }, 20_000);
 });

--- a/packages/cli/src/launcher/credential-proxy-host.test.ts
+++ b/packages/cli/src/launcher/credential-proxy-host.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const cliPackageRoot = resolve(__dirname, '..', '..');
+const loadCommonJsModule = createRequire(import.meta.url);
+
+interface ProxyHostTestExports {
+  isModuleNotFound: (error: unknown) => boolean;
+  isProviderAuthModuleNotFound: (error: unknown) => boolean;
+  PROVIDER_AUTH_SPECIFIER: string;
+  PROVIDER_AUTH_PACKAGE: string;
+}
+
+function loadProxyHost(): ProxyHostTestExports {
+  const mod = loadCommonJsModule(
+    resolve(cliPackageRoot, 'bin', 'credential-proxy-host.cjs'),
+  ) as Record<string, unknown>;
+  // Fail loudly at setup if the CJS module's exports drift from this test's
+  // expectations, rather than letting the unsafe cast mask a mismatch.
+  if (
+    typeof mod.isModuleNotFound !== 'function' ||
+    typeof mod.isProviderAuthModuleNotFound !== 'function' ||
+    typeof mod.PROVIDER_AUTH_SPECIFIER !== 'string' ||
+    typeof mod.PROVIDER_AUTH_PACKAGE !== 'string'
+  ) {
+    throw new Error(
+      'credential-proxy-host.cjs exports do not match ProxyHostTestExports',
+    );
+  }
+  return mod as unknown as ProxyHostTestExports;
+}
+
+function moduleNotFoundError(message: string): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = 'MODULE_NOT_FOUND';
+  return error;
+}
+
+function esmModuleNotFoundError(message: string): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = 'ERR_MODULE_NOT_FOUND';
+  return error;
+}
+
+describe('credential-proxy-host module-not-found matching', () => {
+  let host: ProxyHostTestExports;
+
+  beforeAll(() => {
+    host = loadProxyHost();
+  });
+
+  it('derives the package root from the full specifier', () => {
+    expect(host.PROVIDER_AUTH_SPECIFIER).toBe(
+      '@vybestack/llxprt-code-providers/auth.js',
+    );
+    expect(host.PROVIDER_AUTH_PACKAGE).toBe('@vybestack/llxprt-code-providers');
+  });
+
+  it.each(["'", '"'])(
+    'matches when the provider auth module itself is missing (quote=%s)',
+    (quote) => {
+      expect(
+        host.isProviderAuthModuleNotFound(
+          moduleNotFoundError(
+            `Cannot find module ${quote}${host.PROVIDER_AUTH_SPECIFIER}${quote}`,
+          ),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["'", '"'])(
+    'matches the ESM missing-package error format with bare package name (quote=%s)',
+    (quote) => {
+      expect(
+        host.isProviderAuthModuleNotFound(
+          esmModuleNotFoundError(
+            `Cannot find package ${quote}${host.PROVIDER_AUTH_PACKAGE}${quote} imported from /somewhere`,
+          ),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["'", '"'])(
+    'matches the resolved-absolute-path error format when a subpath export target is missing (quote=%s)',
+    (quote) => {
+      // A consumer install resolves the "./auth.js" export to an absolute
+      // dist/.../index.js path; when that built file is absent, ESM quotes the
+      // resolved path (which contains the package name), not the specifier.
+      expect(
+        host.isProviderAuthModuleNotFound(
+          esmModuleNotFoundError(
+            `Cannot find module ${quote}/root/node_modules/${host.PROVIDER_AUTH_PACKAGE}/dist/src/auth/index.js${quote} imported from /root/packages/cli/bin/credential-proxy-host.cjs`,
+          ),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('does NOT match when a transitive dependency inside the module is missing', () => {
+    // The importer path (in the require stack) names the provider auth module,
+    // but the first quoted token is the missing transitive dependency's own
+    // specifier — this must propagate, not fall back.
+    expect(
+      host.isProviderAuthModuleNotFound(
+        moduleNotFoundError(
+          `Cannot find module 'some-transitive-dep'\nRequire stack:\n- /path/to/${host.PROVIDER_AUTH_SPECIFIER}`,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT match a sibling package whose name merely starts with the provider auth package', () => {
+    // A missing transitive dependency named "<package>-utils" must not be
+    // misclassified as the provider auth module itself being missing.
+    expect(
+      host.isProviderAuthModuleNotFound(
+        esmModuleNotFoundError(
+          `Cannot find package '${host.PROVIDER_AUTH_PACKAGE}-utils' imported from /somewhere`,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not treat non-module-not-found errors as such', () => {
+    const syntaxError = new Error('Unexpected token');
+    expect(host.isModuleNotFound(syntaxError)).toBe(false);
+    expect(host.isProviderAuthModuleNotFound(syntaxError)).toBe(false);
+  });
+
+  it('recognizes both MODULE_NOT_FOUND and ERR_MODULE_NOT_FOUND codes', () => {
+    expect(host.isModuleNotFound(moduleNotFoundError('x'))).toBe(true);
+    expect(host.isModuleNotFound(esmModuleNotFoundError('x'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Starts a Node-owned credential proxy sidecar from the CommonJS no-compile launcher when no credential socket is already present.
- Forwards an existing LLXPRT_CREDENTIAL_SOCKET unchanged and avoids nested proxies.
- Passes the proxy socket to the Bun child while preserving signal forwarding, exit-code behavior, and cleanup on spawn/error/close paths.
- Adds regression tests for CJS launcher proxy startup, existing and empty socket handling, sidecar stdout parsing, cleanup failures, signal forwarding, startup timeout, and stop escalation.

Fixes #2369

## Verification

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- npm run start -- --profile-load ollamakimi "write me a haiku and nothing else"
- node --disable-warning=ExperimentalWarning --experimental-transform-types packages/cli/bin/credential-proxy-host.cjs < /dev/null
- cd packages/cli && npx vitest run src/launcher/cli-bin.test.ts src/launcher/bun-launcher.test.ts
- OCR review completed with exit code 0 after fixes; remaining Node flag note is informational because unsupported flags cause immediate proxy-host close with stderr, while the timeout only covers a live host that never reports a socket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the CLI launcher to start more reliably and pass connection details through automatically when needed.
  * Added graceful shutdown handling for interrupts and process exit events.

* **Bug Fixes**
  * Fixed cases where the CLI could fail to launch when socket-related environment values were missing or empty.
  * Improved error handling during startup and shutdown so failures now exit cleanly with clearer feedback.
  * Added safer cleanup of temporary files and proxy processes after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->