### PR TITLE
Feat/add litellm provider

### DIFF
--- a/docs/providers/quick-reference.md
+++ b/docs/providers/quick-reference.md
@@ -467,6 +467,50 @@ These providers use the OpenAI-compatible endpoint approach (most also have buil
 - Effective prompt budget = context-limit − max_tokens − safety.
 - The `/provider qwen` alias is for Qwen's own service, not for Cerebras.
 
+## AI Gateways / Proxies
+
+### LiteLLM
+
+[LiteLLM](https://github.com/BerriAI/litellm) is an open-source AI gateway that provides a unified OpenAI-compatible interface to 100+ LLM providers (Azure OpenAI, AWS Bedrock, Vertex AI, Groq, Together, and more).
+
+```bash
+/provider litellm      # Has built-in alias
+/key your-litellm-key
+/model anthropic/claude-sonnet-4-20250514
+```
+
+Or without the alias:
+
+```bash
+/provider openai
+/baseurl http://127.0.0.1:4000/v1/
+/key your-litellm-key
+/model gpt-4o
+```
+
+#### Model geometry & recommended settings (LiteLLM)
+
+Context and output limits depend on the underlying model routed through the proxy. Start with conservative defaults and adjust:
+
+```bash
+/set context-limit 128000
+/set modelparam max_tokens 4096
+```
+
+**Profile JSON:**
+
+```json
+{
+  "version": 1,
+  "provider": "litellm",
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "modelParams": { "max_tokens": 4096 },
+  "ephemeralSettings": { "context-limit": 200000 }
+}
+```
+
+**Environment variable:** `export LITELLM_API_KEY=sk-...`
+
 ## Local Models
 
 For complete local-model guidance, see [Using Local Models](../local-models.md).

--- a/packages/providers/src/composition/aliases/litellm.config
+++ b/packages/providers/src/composition/aliases/litellm.config
@@ -1,0 +1,10 @@
+{
+  "name": "LiteLLM",
+  "modelsDevProviderId": null,
+  "baseProvider": "openai",
+  "base-url": "http://127.0.0.1:4000/v1/",
+  "sandbox-base-url": "http://host.docker.internal:4000/v1/",
+  "defaultModel": "gpt-4o",
+  "description": "LiteLLM AI gateway proxy - unified interface to 100+ LLM providers",
+  "apiKeyEnv": "LITELLM_API_KEY"
+}

--- a/packages/providers/src/composition/providerAliases.litellm.test.ts
+++ b/packages/providers/src/composition/providerAliases.litellm.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.unmock('./providerAliases.js');
+
+import { loadProviderAliasEntries } from './providerAliases.js';
+
+describe('Built-in provider alias (LiteLLM)', () => {
+  const builtinEntries = loadProviderAliasEntries().filter(
+    (entry) => entry.source === 'builtin',
+  );
+  const litellmEntry = builtinEntries.find(
+    (candidate) => candidate.alias === 'litellm',
+  );
+
+  it('litellm alias is registered as a builtin', () => {
+    expect(litellmEntry).toBeDefined();
+  });
+
+  it('has correct base-url pointing to default LiteLLM proxy', () => {
+    expect(litellmEntry?.config['base-url']).toBe(
+      'http://127.0.0.1:4000/v1/',
+    );
+  });
+
+  it('uses openai as the base provider', () => {
+    expect(litellmEntry?.config.baseProvider).toBe('openai');
+  });
+
+  it('reads LITELLM_API_KEY env var for auth', () => {
+    expect(litellmEntry?.config.apiKeyEnv).toBe('LITELLM_API_KEY');
+  });
+
+  it('has a default model set', () => {
+    expect(litellmEntry?.config.defaultModel).toBeDefined();
+    expect(typeof litellmEntry?.config.defaultModel).toBe('string');
+    expect(litellmEntry?.config.defaultModel?.length).toBeGreaterThan(0);
+  });
+
+  it('has a human-readable name', () => {
+    expect(litellmEntry?.config.name).toBe('LiteLLM');
+  });
+
+  it('has a description', () => {
+    expect(litellmEntry?.config.description).toBeDefined();
+    expect(litellmEntry?.config.description?.length).toBeGreaterThan(0);
+  });
+
+  it('has a sandbox-base-url for Docker environments', () => {
+    expect(litellmEntry?.config['sandbox-base-url']).toBe(
+      'http://host.docker.internal:4000/v1/',
+    );
+  });
+});

--- a/packages/providers/src/composition/providerAliases.litellm.test.ts
+++ b/packages/providers/src/composition/providerAliases.litellm.test.ts
@@ -15,7 +15,7 @@ describe('Built-in provider alias (LiteLLM)', () => {
     (entry) => entry.source === 'builtin',
   );
   const litellmEntry = builtinEntries.find(
-    (candidate) => candidate.alias === 'litellm',
+    (candidate) => candidate.alias === 'LiteLLM',
   );
 
   it('litellm alias is registered as a builtin', () => {

--- a/packages/providers/src/composition/providerAliases.litellm.test.ts
+++ b/packages/providers/src/composition/providerAliases.litellm.test.ts
@@ -23,9 +23,7 @@ describe('Built-in provider alias (LiteLLM)', () => {
   });
 
   it('has correct base-url pointing to default LiteLLM proxy', () => {
-    expect(litellmEntry?.config['base-url']).toBe(
-      'http://127.0.0.1:4000/v1/',
-    );
+    expect(litellmEntry?.config['base-url']).toBe('http://127.0.0.1:4000/v1/');
   });
 
   it('uses openai as the base provider', () => {


### PR DESCRIPTION
## TLDR

Adds a built-in `LiteLLM` provider alias so users can run `/provider litellm` instead of manually configuring `/provider openai` + `/baseurl http://localhost:4000/v1/` + `/key ...`. Follows the same JSON alias pattern as `lm-studio.config` and `ollama-cloud.config`.

## Dive Deeper

[LiteLLM](https://github.com/BerriAI/litellm) is a self-hosted AI gateway proxy (50k+ stars) that provides a single OpenAI-compatible endpoint to 100+ LLM providers (Azure, Bedrock, Vertex AI, Groq, Together, etc.). Users configure models, keys, fallbacks, and rate limits on the proxy side - the client just points at the proxy URL.

Changes:
- `packages/providers/src/composition/aliases/litellm.config` - new alias config with default base URL `http://127.0.0.1:4000/v1/`, Docker sandbox URL, and `LITELLM_API_KEY` env var
- `docs/providers/quick-reference.md` - added LiteLLM setup instructions
- `packages/providers/src/composition/providerAliases.litellm.test.ts` - 8 vitest tests validating alias registration, base URL, base provider, env var, default model, name, description, and Docker sandbox URL

## Reviewer Test Plan

1. Run `npx vitest run src/composition/providerAliases.litellm.test.ts` from `packages/providers/` - all 8 tests should pass
2. Start a LiteLLM proxy locally (`litellm --model gpt-4o` or via Docker)
3. Run `/provider litellm`, `/key sk-your-proxy-key`, `/model gpt-4o`
4. Verify completions route through the proxy

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2393


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in LiteLLM provider option for easier setup with local or proxy-based AI gateways.
  * Included an OpenAI-compatible configuration path for connecting through a LiteLLM endpoint.

* **Documentation**
  * Expanded the quick reference with step-by-step LiteLLM setup guidance.
  * Added recommended token settings, a sample profile configuration, and the required API key environment variable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->