### PR TITLE
Make build:packages generate its own prerequisites to fix release build (Fixes #2392)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build-and-start": "npm run build && npm run start",
     "build:vscode": "bun scripts/build_vscode_companion.ts",
     "build:all": "npm run build && npm run build:sandbox && npm run build:vscode",
-    "build:packages": "npm run build --workspaces",
+    "build:packages": "npm run generate && npm run build --workspaces",
     "build:sandbox": "bun scripts/build_sandbox.ts --skip-npm-install-build",
     "bundle": "npm run generate && bun scripts/bun-build.config.mjs",
     "test": "npm run test --workspaces --if-present",

--- a/scripts/tests/publish-integrity.test.ts
+++ b/scripts/tests/publish-integrity.test.ts
@@ -505,6 +505,70 @@ describe('published package no-compile runtime contract (S6)', () => {
   }, 15000);
 });
 
+describe('release build self-contained generate contract (issue #2392)', () => {
+  // Regression guard for the release failure in
+  // https://github.com/vybestack/llxprt-code/actions/runs/28798881603
+  //
+  // packages/cli/src/generated/git-commit.ts is gitignored and only exists once
+  // `npm run generate` has run. The CLI workspace `build` script invokes tsc
+  // directly and imports GIT_COMMIT_INFO from that generated module, so tsc
+  // fails with TS2307 if the file was never generated. The release workflow
+  // builds via `npm run build:packages`, and it must NOT rely on an earlier
+  // step (e.g. Preflight) having generated the file as a side effect — when a
+  // dispatch sets force_skip_tests=true, Preflight is skipped and the build
+  // breaks. `build:packages` must therefore generate its own prerequisites.
+  it('runs generate before building workspaces in build:packages', () => {
+    const rootPackage = JSON.parse(
+      readFileSync(join(repoRoot, 'package.json'), 'utf-8'),
+    ) as PackageScripts;
+    const scripts = rootPackage.scripts ?? {};
+    const buildPackages = scripts['build:packages'] ?? '';
+
+    expect(
+      buildPackages,
+      'root "build:packages" script is missing from package.json',
+    ).not.toBe('');
+
+    const generateIndex = buildPackages.indexOf('npm run generate');
+    const buildWorkspacesIndex = buildPackages.indexOf(
+      'npm run build --workspaces',
+    );
+
+    expect(
+      generateIndex,
+      '"build:packages" must run "npm run generate" so it produces its own ' +
+        'gitignored prerequisites (packages/cli/src/generated/git-commit.ts) ' +
+        'instead of depending on an earlier workflow step. See issue #2392.',
+    ).toBeGreaterThanOrEqual(0);
+
+    expect(
+      buildWorkspacesIndex,
+      '"build:packages" must build the workspaces via ' +
+        '"npm run build --workspaces".',
+    ).toBeGreaterThanOrEqual(0);
+
+    expect(
+      generateIndex,
+      '"build:packages" must run "npm run generate" BEFORE ' +
+        '"npm run build --workspaces", otherwise the CLI workspace tsc build ' +
+        'fails with TS2307 on the not-yet-generated git-commit module.',
+    ).toBeLessThan(buildWorkspacesIndex);
+  });
+
+  it('keeps the generate script wired to the git-commit generator', () => {
+    const rootPackage = JSON.parse(
+      readFileSync(join(repoRoot, 'package.json'), 'utf-8'),
+    ) as PackageScripts;
+    const scripts = rootPackage.scripts ?? {};
+    const generate = scripts['generate'] ?? '';
+
+    // The whole point of running generate in build:packages is to create
+    // git-commit.ts. If the generate script stops invoking that generator,
+    // build:packages no longer satisfies the CLI build's import.
+    expect(generate).toContain('scripts/generate-git-commit-info.ts');
+  });
+});
+
 describe('findRelativeDependencySpecifiers (tarball-walker regex coverage)', () => {
   it('captures every supported static relative-reference form', () => {
     // Each line below is a distinct syntactic form the published lifecycle


### PR DESCRIPTION
## Summary

Fixes #2392.

The nightly/release **Release** workflow failed (run [28798881603](https://github.com/vybestack/llxprt-code/actions/runs/28798881603)) at the **Build and Prepare Packages** step with:

    src/ui/commands/bugCommand.ts(15,33): error TS2307: Cannot find module '../../generated/git-commit.js'
    src/ui/components/AboutBox.tsx(10,33): error TS2307: Cannot find module '../../generated/git-commit.js'

## Root cause

- packages/cli/src/generated/git-commit.ts is **gitignored** (.gitignore: packages/cli/src/generated/) and regenerated per build by scripts/generate-git-commit-info.ts. On a fresh CI checkout it does not exist.
- Two shipped CLI source files import GIT_COMMIT_INFO from that generated module (AboutBox.tsx, bugCommand.ts), so the CLI workspace tsc build requires it to exist.
- The release workflow builds via `npm run build:packages` (= `npm run build --workspaces`), and the CLI workspace `build` script runs `tsc` **directly, without running `generate`**.
- It only ever worked because the earlier **Run Preflight Checks** step runs the top-level `npm run build` (scripts/build.ts), which runs `npm run generate` first as a side effect, incidentally creating git-commit.ts.
- This particular run was a manual dispatch with **force_skip_tests=true**, so the quota-check, Preflight, and integration-test steps were **skipped**. Nothing generated git-commit.ts, and the CLI build failed with TS2307.

In short: `build:packages` had an **implicit, undeclared dependency** on the `generate` step being run by some unrelated earlier step. Any path that skips Preflight breaks the build.

## Fix

Make `build:packages` self-contained so it always produces its own prerequisites, eliminating the entire class of failure regardless of which caller invokes it:

    "build:packages": "npm run generate && npm run build --workspaces",

This mirrors the proven ordering already used by the top-level scripts/build.ts (generate, then build workspaces). Because git-commit.ts is written into **source** (not dist), it survives the per-package `tsc --build --clean` (which only cleans dist).

### Why not switch to a runtime git lookup?

A runtime `git rev-parse` would be semantically wrong for a **published** package — it would read the end user's current working directory repo, not the commit llxprt was built from. The baked-at-build-time file is the correct design; the real defect was build-order fragility, so that is what this PR fixes. (The old startup staleness warning that once consumed this value is already gone; GIT_COMMIT_INFO now only feeds the About box and bug-report template, which still benefit for stable releases whose version string does not embed a sha.)

## Tests

Added regression tests in scripts/tests/publish-integrity.test.ts:

- Asserts `build:packages` runs `npm run generate` **before** `npm run build --workspaces`.
- Asserts `generate` stays wired to scripts/generate-git-commit-info.ts (so build:packages keeps satisfying the CLI build's import).

## Verification

- Reproduced the original failure locally: removed git-commit.ts and confirmed the previous `build:packages` failed with the same TS2307; confirmed the new `build:packages` regenerates and builds cleanly.
- npm run format — clean (no unrelated files touched)
- npm run typecheck — pass
- npm run lint:eslint-guard — pass; eslint on the changed test file — clean
- npm run build (full clean build after npm ci) — pass, git-commit generated correctly
- npm run test:scripts — 871 passed (incl. new regression tests)
- Smoke test (bun scripts/start.ts --profile-load ollamakimi) — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the package build flow so required generated files are created before workspace builds run, reducing the chance of build failures.
  * Improved release build reliability by ensuring the generation step stays connected to the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->