### PR TITLE
Cap CodeRabbit incremental reviews at 3 per PR instead of disabling them

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,8 +29,10 @@ reviews:
     # Draft PRs are skipped (this is the default, stated here because the
     # recommended workflow relies on it: open as draft, mark ready when green).
     drafts: false
-    # Review once when the PR is opened/marked ready, not on every push.
-    # Multi-commit PRs (e.g. #2334 had 10 commits) otherwise consume one
-    # incremental review per push. Trigger follow-up reviews on demand by
-    # commenting `@coderabbitai review` after pushing fixes.
-    auto_incremental_review: false
+    # Keep automatic incremental reviews, but pause after 3 reviewed commits
+    # per PR (resume with `@coderabbitai resume`, or trigger a single review
+    # with `@coderabbitai review`). This caps quota use on multi-commit PRs
+    # without silently skipping later pushes: with incremental reviews fully
+    # disabled, follow-up commits merged unreviewed (e.g. #2394, #2384).
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 3


### PR DESCRIPTION
## What changed

Follow-up to #2363. One targeted tweak to `.coderabbit.yaml`:

```yaml
auto_review:
  auto_incremental_review: true          # was: false
  auto_pause_after_reviewed_commits: 3   # new
```

## Why

The rate-limit fix worked — since #2363 merged, **0 of 13 PRs** hit the "Review limit reached" banner, versus 9 of 19 in the days before, at a comparable PR cadence. But `auto_incremental_review: false` turned out to be too blunt, and it's quietly costing you review coverage:

- **#2394 merged with no review at all** — pushes after the PR opened were skipped, and no one triggered a manual review.
- **#2384's last day of commits merged unreviewed** — final commit July 6 06:02 UTC, but the last review ran July 5 22:07 UTC.
- 9 of the 13 post-merge PRs show *"Review skipped — Auto incremental reviews are disabled on this repository."*

In other words: the code that merges is often not the code that was reviewed. The manual `@coderabbitai review` escape hatch only got used once across those PRs, which is understandable at this PR volume — remembering to trigger reviews by hand doesn't scale.

## Why this version keeps the rate-limit win

`auto_pause_after_reviewed_commits: 3` reviews the PR when it opens plus the first 3 pushed commits — enough to cover the normal review → fix → re-review cycle automatically — then pauses with a visible message. Resuming is one comment (`@coderabbitai resume`), or `@coderabbitai review` for a single fresh pass. So it flips the failure mode from *silent skipped coverage* to *explicit opt-in throttling*.

Quota-wise this stays bounded: reviews are capped at ~4 per PR (versus unlimited before #2363, when roughly half of PRs hit the limit), and the path filters — which cut 20–55% of files per review on sampled PRs — are unchanged. Config validates against `schema.v2.json`.

Worth a re-check a few days after this lands; if limits ever reappear, dropping the pause threshold to 2 is the next dial.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic incremental reviews for PR updates.
  * Added a limit to pause review automation after 3 reviewed commits per PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->