### PR TITLE
chore(github): stop creating/applying phantom bug and triage labels in CI and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a bug to help us improve LLxprt Code
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug to help us improve LLxprt Code
-labels: ['kind/bug', 'status/need-triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for this project
-labels: ['kind/enhancement']
+type: Feature
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for this project
-labels: ['kind/enhancement', 'status/need-triage']
+labels: ['kind/enhancement']
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -362,11 +362,6 @@ jobs:
           else
             echo "Warning: continuing without ci/cd label" >&2
           fi
-          if ensure_label "bug" "d73a4a" "Something is not working"; then
-            LABEL_ARGS+=(--label "bug")
-          else
-            echo "Warning: continuing without bug label" >&2
-          fi
 
           FAILED_JOBS=()
           [[ "${WINDOWS_CI_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("windows_ci=${WINDOWS_CI_RESULT}")

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -56,5 +56,4 @@ jobs:
         run: |
           gh issue create \
             --title "Smoke test failed on ${REF} @ $(date +'%Y-%m-%d')" \
-            --body "Smoke test failed. See the full run for details: ${DETAILS_URL}" \
-            --label 'kind/bug,priority/p0'
+            --body "Smoke test failed. See the full run for details: ${DETAILS_URL}"

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -347,7 +347,9 @@ function buildNonInteractiveActivationIntent(
   const bootstrapArgs = readBootstrapArgs(params.config);
   return {
     provider:
-      params.config.getProvider() ?? bootstrapArgs?.providerOverride ?? undefined,
+      params.config.getProvider() ??
+      bootstrapArgs?.providerOverride ??
+      undefined,
     defaultProvider: 'gemini',
     authMode: useExternalAuth ? 'none' : 'auto',
     ...(bootstrapArgs?.modelOverride !== null &&
@@ -427,7 +429,6 @@ async function resolveAndStream(
     }
   }
 }
-
 
 export async function runNonInteractive(
   params: RunNonInteractiveParams,

--- a/scripts/tests/release-process.test.js
+++ b/scripts/tests/release-process.test.js
@@ -676,7 +676,7 @@ describe('scripts/bind-release-deps.ts', () => {
  * nightly workflow lacked a failure-notification step. These tests lock the
  * nightly workflow contract: report generation precedes tests, the failure
  * notification job has issues:write permission, and it opens or updates a gh
- * issue with ci/cd and bug labels linking to the workflow run.
+ * issue with the ci/cd label linking to the workflow run.
  */
 describe('.github/workflows/nightly.yml', () => {
   let nightlyWorkflow;
@@ -768,14 +768,17 @@ describe('.github/workflows/nightly.yml', () => {
     expect(notifyFailureRun).toContain('set -euo pipefail');
   });
 
-  it('creates a failure issue with ci/cd and bug labels linking to the workflow run', () => {
+  it('creates a failure issue with the ci/cd label linking to the workflow run', () => {
     const notifyFailureStep = failureNotificationStep();
     const normalizedRun = failureNotificationRun().replace(/\s+/g, ' ').trim();
     expect(notifyFailureStep.env?.RUN_URL).toBe(
       '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
     );
     expect(normalizedRun).toContain('ensure_label "ci/cd"');
-    expect(normalizedRun).toContain('ensure_label "bug"');
+    // The plain "bug" label was removed: it was recreated on every failed
+    // nightly and is not part of this repo's label taxonomy. Guard against it
+    // being reintroduced here.
+    expect(normalizedRun).not.toContain('ensure_label "bug"');
     expect(notifyFailureStep.env?.WINDOWS_CI_RESULT).toBe(
       '${{ needs.windows_ci.result }}',
     );
@@ -786,7 +789,7 @@ describe('.github/workflows/nightly.yml', () => {
       '${{ needs.behavioral_evals.result }}',
     );
     expect(normalizedRun).toContain('LABEL_ARGS+=(--label "ci/cd")');
-    expect(normalizedRun).toContain('LABEL_ARGS+=(--label "bug")');
+    expect(normalizedRun).not.toContain('LABEL_ARGS+=(--label "bug")');
     expect(normalizedRun).toContain('windows_ci=${WINDOWS_CI_RESULT}');
     expect(normalizedRun).toContain('e2e_full=${E2E_FULL_RESULT}');
     expect(normalizedRun).toContain(


### PR DESCRIPTION
## TLDR

Stops CI automation and issue templates from creating/applying labels that either shouldn't exist (`bug`) or were never created in this repo (`kind/bug`, `status/need-triage`, `kind/enhancement`). The issue-form templates now set the org-level **Issue Type** via the native `type:` key instead of phantom `kind/*` labels, so filed bugs/features get proper categorization with zero label cruft.

## Dive Deeper

Context: investigating a Windows startup failure led to filing two issues; removing the `bug` label from one and then deleting it repo-wide revealed that the label is machine-applied and would resurrect. Findings and fixes:

- **`nightly.yml` recreated and re-applied `bug`.** The "Nightly workflow failed" issues are auto-created by the nightly workflow, whose `ensure_label "bug" …` call creates the label if missing and tags the issue. Deleting the label alone was insufficient — the next failed nightly would recreate it. This PR removes the `bug` ensure/apply block; release-failure issues keep the real `ci/cd` label.
- **Phantom labels never existed in this repo.** `gh label list` confirms `kind/bug`, `status/need-triage`, `priority/p0`, and `kind/enhancement` are all absent, and 0 issues use `kind/bug` or `status/need-triage`. They are leftovers from the upstream gemini-cli label taxonomy.
- **Issue templates now set Issue Type, not labels.** GitHub issue forms support a top-level `type:` key that assigns an org-level Issue Type (the org has `Bug`, `Task`, `Feature`). Using it is the correct "type is a property, not a label" model:
  - `bug_report.yml`: `type: Bug` (was `labels: ['kind/bug', 'status/need-triage']`)
  - `feature_request.yml`: `type: Feature` (was `labels: ['kind/enhancement', 'status/need-triage']`)
- **`smoke-test.yml` would fail on label creation.** Its failure-issue step used `--label 'kind/bug,priority/p0'`; because `gh issue create --label X` errors when `X` does not exist, that step would fail before creating the issue. `gh issue create` has no `--type` flag (verified on gh 2.83.2), so setting a type there would require a raw GraphQL mutation — out of scope. The `--label` flag is removed so the issue can be created label-free.
- **Nightly-contract test updated.** `scripts/tests/release-process.test.js` pinned `ensure_label "bug"` / `LABEL_ARGS+=(--label "bug")` in the nightly script. Updated to assert the `bug` label is **absent** (negative assertions) so its reintroduction is caught. Full suite passes (33/33).
- **Pre-existing formatter break fixed.** The "Lint (Javascript)" check runs `npm run format` + `git diff --exit-code`; `main` is currently red on it because `packages/cli/src/nonInteractiveCli.ts` was left unformatted by `0d32733` (#2390). A mechanical `prettier --write` (formatting-only, no behavior change) is included to unblock; last green `ci.yml` on main was `6acf50f`.

Scope guards:
- Vendored upstream copies under `research/gemini-cli/**` and historical notes under `project-plans/**` also mention these labels; intentionally left untouched.
- Net effect: `bug`, `kind/bug`, and `status/need-triage` are no longer created or requested by any active workflow or template, so they stay gone.

## Reviewer Test Plan

- Inspect the diff: confirm no active workflow or template references `bug`, `kind/bug`, `status/need-triage`, or `kind/enhancement`, and that both issue forms carry a valid `type:` matching an enabled org Issue Type.
- Run `npx vitest run scripts/tests/release-process.test.js` → 33/33 pass, including the negative `bug`-label guards.
- Run `npm run format:check` → clean.
- Grep check: `grep -rniE "kind/bug|status/need-triage|ensure_label \"bug\"" .github/` returns no active-automation matches.
- Optional: open the Bug Report / Feature Request forms in the GitHub UI and confirm the Type is prefilled (Bug / Feature) and no phantom labels are attached.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | -   | -   | -   |
| npx      | -   | -   | -   |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

CI/metadata change (GitHub workflows, issue-form templates, a workflow-contract test, and a formatting-only source touch); no runtime code paths are affected, so the runtime matrix is not applicable.

## Linked issues / bugs

Related to the Windows startup investigation that surfaced this (issues #2399 and #2403). No close keyword — this is a standalone GitHub-metadata cleanup.
