### PR TITLE
fix(compression): preflight guard attempts compression before bailing (Fixes #2402)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -360,7 +360,7 @@ export class CompressionHandler {
    * Compute the baseline prompt token count for hard-limit projection.
    * Prefer API-observed prompt tokens when available (includes cache read/write).
    */
-  private getProjectedPromptBaseline(): number {
+  getProjectedPromptBaseline(): number {
     return this.lastPromptTokenCount !== null && this.lastPromptTokenCount > 0
       ? this.lastPromptTokenCount
       : this.getEffectiveTokenCount();

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -26,6 +26,7 @@ import {
   extractPromptText,
 } from './clientHelpers.js';
 import { getTokenLimitForConfiguredContext } from './contextLimitResolver.js';
+import { resolvePreflightOverflow } from './preflightRecovery.js';
 import type { Todo } from '@vybestack/llxprt-code-tools';
 import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
 import { handleTerminalEvent } from './MessageStreamTerminalHandler.js';
@@ -299,21 +300,26 @@ export class MessageStreamOrchestrator {
             .catch(() => fallback)
         : fallback;
 
-    if (estimatedRequestTokenCount > remainingTokenCount * 0.95) {
-      yield {
-        type: AgentEventType.ContextWindowWillOverflow,
-        value: { estimatedRequestTokenCount, remainingTokenCount },
-      };
-      yield* this._fireAfterHookAndEmitClearContext(ctx);
-      return new Turn(
-        getChat(),
-        ctx.prompt_id,
-        DEFAULT_AGENT_ID,
-        this._getProviderName(),
-      );
-    }
-
-    return undefined;
+    // Overflow guard: attempt automatic compression before bailing (issue
+    // #2402), matching manual /compress, the load-balancer guard (#2207),
+    // and the provider content enforcer (#2299).
+    const proceed = await resolvePreflightOverflow(this.deps, {
+      promptId: ctx.prompt_id,
+      estimatedRequestTokenCount,
+      remainingTokenCount,
+    });
+    if (proceed) return undefined;
+    yield {
+      type: AgentEventType.ContextWindowWillOverflow,
+      value: { estimatedRequestTokenCount, remainingTokenCount },
+    };
+    yield* this._fireAfterHookAndEmitClearContext(ctx);
+    return new Turn(
+      getChat(),
+      ctx.prompt_id,
+      DEFAULT_AGENT_ID,
+      this._getProviderName(),
+    );
   }
 
   private async _injectIdeContext(): Promise<void> {

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -521,7 +521,7 @@ export class ChatSession {
 
   async performCompression(
     prompt_id: string,
-    options?: { bypassCooldown?: boolean },
+    options?: { bypassCooldown?: boolean; trigger?: 'manual' | 'auto' },
   ): Promise<PerformCompressionResult> {
     return this.compressionHandler.performCompression(prompt_id, options);
   }
@@ -532,6 +532,17 @@ export class ChatSession {
 
   getLastPromptTokenCount(): number {
     return this.compressionHandler.lastPromptTokenCount ?? 0;
+  }
+
+  /**
+   * Baseline prompt tokens for projection: prefer the API-observed count,
+   * falling back to the history-derived estimate. Mirrors
+   * CompressionHandler.getProjectedPromptBaseline() so callers that re-check
+   * capacity right after compression (which nulls lastPromptTokenCount) get an
+   * accurate baseline instead of 0.
+   */
+  getProjectedPromptBaseline(): number {
+    return this.compressionHandler.getProjectedPromptBaseline();
   }
 
   recordCompletedToolCalls(

--- a/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
@@ -177,6 +177,75 @@ vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   },
 }));
 
+// All scenarios share the same token geometry: a 1000-token limit with a
+// 900-token preflight baseline, leaving 100 tokens of capacity. A 400-char
+// request estimates to ~100 tokens (100 > 100 * 0.95 = 95 → overflow).
+const MOCKED_TOKEN_LIMIT = 1000;
+const PREFLIGHT_BASELINE = 900;
+const OVERFLOW_REQUEST_CHARS = 400;
+
+interface OverflowScenario {
+  /** Post-compression projected baseline; omit when recovery never rechecks. */
+  projectedBaseline?: number;
+  /** Compression outcome: a result enum value, or an Error to reject with. */
+  compressionResult: PerformCompressionResult | Error;
+  /** Whether the turn should proceed (sets up a content stream on Turn.run). */
+  proceeds: boolean;
+}
+
+interface OverflowScenarioHandle {
+  mockChat: Partial<ChatSession>;
+  request: Part[];
+  estimatedRequestTokenCount: number;
+  remainingTokenCount: number;
+}
+
+/** Builds the shared mockChat/generator/request scaffolding for one scenario. */
+function buildOverflowScenario(
+  client: AgentClient,
+  scenario: OverflowScenario,
+): OverflowScenarioHandle {
+  vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+  vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+    PREFLIGHT_BASELINE,
+  );
+
+  const mockChat: Partial<ChatSession> = {
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    getLastPromptTokenCount: vi.fn().mockReturnValue(PREFLIGHT_BASELINE),
+    performCompression:
+      scenario.compressionResult instanceof Error
+        ? vi.fn().mockRejectedValue(scenario.compressionResult)
+        : vi.fn().mockResolvedValue(scenario.compressionResult),
+  };
+  if (scenario.projectedBaseline !== undefined) {
+    mockChat.getProjectedPromptBaseline = vi
+      .fn()
+      .mockReturnValue(scenario.projectedBaseline);
+  }
+  client['chat'] = mockChat as ChatSession;
+  client['contentGenerator'] = {
+    countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+  } as Partial<ContentGenerator> as ContentGenerator;
+
+  if (scenario.proceeds) {
+    mockTurnRunFn.mockReturnValue(
+      (async function* () {
+        yield { type: AgentEventType.Content, value: 'ok' };
+      })(),
+    );
+  }
+
+  const longText = 'a'.repeat(OVERFLOW_REQUEST_CHARS);
+  return {
+    mockChat,
+    request: [{ text: longText }],
+    estimatedRequestTokenCount: Math.floor(longText.length / 4),
+    remainingTokenCount: MOCKED_TOKEN_LIMIT - PREFLIGHT_BASELINE,
+  };
+}
+
 describe('Gemini Client — preflight compression recovery (issue 2402)', () => {
   let client: AgentClient;
 
@@ -213,46 +282,21 @@ describe('Gemini Client — preflight compression recovery (issue 2402)', () => 
     });
 
     it('should recover via automatic compression and proceed instead of bailing on a small overflow (issue 2402)', async () => {
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      // Initial preflight baseline (900) overflows; the post-compression
+      // projected baseline (100) fits, so the turn proceeds.
+      const { mockChat, request } = buildOverflowScenario(client, {
+        projectedBaseline: 100,
+        compressionResult: PerformCompressionResult.COMPRESSED,
+        proceeds: true,
+      });
 
-      const lastPromptTokenCount = 900;
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        lastPromptTokenCount,
+      const events = await fromAsync(
+        client.sendMessageStream(
+          request,
+          new AbortController().signal,
+          'prompt-id-overflow-recovered',
+        ),
       );
-
-      // Initial preflight baseline (900) is over the limit → triggers
-      // recovery; the post-compression projected baseline (100) fits.
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(900),
-        getProjectedPromptBaseline: vi.fn().mockReturnValue(100),
-        performCompression: vi
-          .fn()
-          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
-      };
-      client['chat'] = mockChat as ChatSession;
-
-      const mockGenerator: Partial<ContentGenerator> = {
-        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
-      };
-      client['contentGenerator'] = mockGenerator as ContentGenerator;
-
-      const longText = 'a'.repeat(400);
-      const request: Part[] = [{ text: longText }];
-
-      const mockStream = (async function* () {
-        yield { type: AgentEventType.Content, value: 'ok' };
-      })();
-      mockTurnRunFn.mockReturnValue(mockStream);
-
-      const stream = client.sendMessageStream(
-        request,
-        new AbortController().signal,
-        'prompt-id-overflow-recovered',
-      );
-      const events = await fromAsync(stream);
 
       expect(events).not.toContainEqual(
         expect.objectContaining({
@@ -260,8 +304,8 @@ describe('Gemini Client — preflight compression recovery (issue 2402)', () => 
         }),
       );
       expect(mockTurnRunFn).toHaveBeenCalled();
-      // The recovery is an automatic compression, so it must be reported as
-      // 'auto' (matching the downstream hard-limit paths), not 'manual'.
+      // The recovery is an automatic compression, reported as 'auto' (matching
+      // the downstream hard-limit paths), not 'manual'.
       expect(mockChat.performCompression).toHaveBeenCalledWith(
         'prompt-id-overflow-recovered',
         { bypassCooldown: true, trigger: 'auto' },
@@ -269,238 +313,125 @@ describe('Gemini Client — preflight compression recovery (issue 2402)', () => 
     });
 
     it('should bail with ContextWindowWillOverflow when compression fails (issue 2402)', async () => {
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      const handle = buildOverflowScenario(client, {
+        compressionResult: PerformCompressionResult.FAILED,
+        proceeds: false,
+      });
 
-      const lastPromptTokenCount = 900;
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        lastPromptTokenCount,
+      const events = await fromAsync(
+        client.sendMessageStream(
+          handle.request,
+          new AbortController().signal,
+          'prompt-id-overflow-compression-failed',
+        ),
       );
-
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
-        performCompression: vi
-          .fn()
-          .mockResolvedValue(PerformCompressionResult.FAILED),
-      };
-      client['chat'] = mockChat as ChatSession;
-
-      const mockGenerator: Partial<ContentGenerator> = {
-        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
-      };
-      client['contentGenerator'] = mockGenerator as ContentGenerator;
-
-      const longText = 'a'.repeat(400);
-      const request: Part[] = [{ text: longText }];
-      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
-      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
-
-      const stream = client.sendMessageStream(
-        request,
-        new AbortController().signal,
-        'prompt-id-overflow-compression-failed',
-      );
-      const events = await fromAsync(stream);
 
       expect(events).toContainEqual({
         type: AgentEventType.ContextWindowWillOverflow,
         value: {
-          estimatedRequestTokenCount,
-          remainingTokenCount,
+          estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
+          remainingTokenCount: handle.remainingTokenCount,
         },
       });
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
     it('should still bail when compression does not reduce enough (issue 2402)', async () => {
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      // Partial reduction (900 → 950) but not enough: newRemaining = 50,
+      // estimated 100 > 50 * 0.95 → still overflows → bail.
+      const handle = buildOverflowScenario(client, {
+        projectedBaseline: 950,
+        compressionResult: PerformCompressionResult.COMPRESSED,
+        proceeds: false,
+      });
 
-      const lastPromptTokenCount = 900;
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        lastPromptTokenCount,
+      const events = await fromAsync(
+        client.sendMessageStream(
+          handle.request,
+          new AbortController().signal,
+          'prompt-id-overflow-compression-insufficient',
+        ),
       );
-
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
-        // Partial reduction (900 → 950) but not enough: newRemaining = 50,
-        // estimated 100 > 50 * 0.95 → still overflows → bail.
-        getProjectedPromptBaseline: vi.fn().mockReturnValue(950),
-        performCompression: vi
-          .fn()
-          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
-      };
-      client['chat'] = mockChat as ChatSession;
-
-      const mockGenerator: Partial<ContentGenerator> = {
-        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
-      };
-      client['contentGenerator'] = mockGenerator as ContentGenerator;
-
-      const longText = 'a'.repeat(400);
-      const request: Part[] = [{ text: longText }];
-      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
-      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
-
-      const stream = client.sendMessageStream(
-        request,
-        new AbortController().signal,
-        'prompt-id-overflow-compression-insufficient',
-      );
-      const events = await fromAsync(stream);
 
       expect(events).toContainEqual({
         type: AgentEventType.ContextWindowWillOverflow,
         value: {
-          estimatedRequestTokenCount,
-          remainingTokenCount,
+          estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
+          remainingTokenCount: handle.remainingTokenCount,
         },
       });
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
     it('should bail when performCompression throws during recovery (issue 2402)', async () => {
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      const handle = buildOverflowScenario(client, {
+        compressionResult: new Error('boom'),
+        proceeds: false,
+      });
 
-      const lastPromptTokenCount = 900;
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        lastPromptTokenCount,
+      const events = await fromAsync(
+        client.sendMessageStream(
+          handle.request,
+          new AbortController().signal,
+          'prompt-id-overflow-compression-throws',
+        ),
       );
-
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
-        performCompression: vi.fn().mockRejectedValue(new Error('boom')),
-      };
-      client['chat'] = mockChat as ChatSession;
-
-      const mockGenerator: Partial<ContentGenerator> = {
-        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
-      };
-      client['contentGenerator'] = mockGenerator as ContentGenerator;
-
-      const longText = 'a'.repeat(400);
-      const request: Part[] = [{ text: longText }];
-      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
-      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
-
-      const stream = client.sendMessageStream(
-        request,
-        new AbortController().signal,
-        'prompt-id-overflow-compression-throws',
-      );
-      const events = await fromAsync(stream);
 
       expect(events).toContainEqual({
         type: AgentEventType.ContextWindowWillOverflow,
         value: {
-          estimatedRequestTokenCount,
-          remainingTokenCount,
+          estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
+          remainingTokenCount: handle.remainingTokenCount,
         },
       });
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
     it('should bail when compression is skipped because history is empty (issue 2402)', async () => {
-      // SKIPPED_EMPTY: there is nothing to compress, so the baseline is
-      // unchanged and the request still overflows. Must not falsely recover.
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      // SKIPPED_EMPTY: nothing to compress → baseline unchanged → still
+      // overflows. Must not falsely recover.
+      const handle = buildOverflowScenario(client, {
+        projectedBaseline: PREFLIGHT_BASELINE,
+        compressionResult: PerformCompressionResult.SKIPPED_EMPTY,
+        proceeds: false,
+      });
 
-      const lastPromptTokenCount = 900;
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        lastPromptTokenCount,
+      const events = await fromAsync(
+        client.sendMessageStream(
+          handle.request,
+          new AbortController().signal,
+          'prompt-id-overflow-skipped-empty',
+        ),
       );
-
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
-        // Nothing compressed → baseline unchanged → still overflows → bail.
-        getProjectedPromptBaseline: vi
-          .fn()
-          .mockReturnValue(lastPromptTokenCount),
-        performCompression: vi
-          .fn()
-          .mockResolvedValue(PerformCompressionResult.SKIPPED_EMPTY),
-      };
-      client['chat'] = mockChat as ChatSession;
-
-      const mockGenerator: Partial<ContentGenerator> = {
-        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
-      };
-      client['contentGenerator'] = mockGenerator as ContentGenerator;
-
-      const longText = 'a'.repeat(400);
-      const request: Part[] = [{ text: longText }];
-      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
-      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
-
-      const stream = client.sendMessageStream(
-        request,
-        new AbortController().signal,
-        'prompt-id-overflow-skipped-empty',
-      );
-      const events = await fromAsync(stream);
 
       expect(events).toContainEqual({
         type: AgentEventType.ContextWindowWillOverflow,
-        value: { estimatedRequestTokenCount, remainingTokenCount },
+        value: {
+          estimatedRequestTokenCount: handle.estimatedRequestTokenCount,
+          remainingTokenCount: handle.remainingTokenCount,
+        },
       });
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
     it('should proceed when compression drives remaining capacity non-positive, deferring to the downstream path (issue 2402)', async () => {
-      // After compression the baseline exceeds the limit (newRemaining <= 0).
-      // Recovery returns true so the normal send/enforcement path resolves it,
+      // After compression the projected baseline (1005) exceeds the 1000-token
+      // limit, making remaining capacity negative → defer to downstream,
       // mirroring the negative-remaining guard (issue #2139).
-      const MOCKED_TOKEN_LIMIT = 1000;
-      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+      buildOverflowScenario(client, {
+        projectedBaseline: 1005,
+        compressionResult: PerformCompressionResult.COMPRESSED,
+        proceeds: true,
+      });
+      const request: Part[] = [{ text: 'a'.repeat(OVERFLOW_REQUEST_CHARS) }];
 
-      const lastPromptTokenCount = 900;
-      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
-        lastPromptTokenCount,
+      const events = await fromAsync(
+        client.sendMessageStream(
+          request,
+          new AbortController().signal,
+          'prompt-id-overflow-defer',
+        ),
       );
-
-      // Initial preflight baseline (900) overflows; the post-compression
-      // projected baseline (1005) exceeds the 1000-token limit, making
-      // remaining capacity negative → defer to downstream (issue #2139).
-      const mockChat: Partial<ChatSession> = {
-        addHistory: vi.fn(),
-        getHistory: vi.fn().mockReturnValue([]),
-        getLastPromptTokenCount: vi.fn().mockReturnValue(900),
-        getProjectedPromptBaseline: vi.fn().mockReturnValue(1005),
-        performCompression: vi
-          .fn()
-          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
-      };
-      client['chat'] = mockChat as ChatSession;
-
-      const mockGenerator: Partial<ContentGenerator> = {
-        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
-      };
-      client['contentGenerator'] = mockGenerator as ContentGenerator;
-
-      const longText = 'a'.repeat(400);
-      const request: Part[] = [{ text: longText }];
-
-      const mockStream = (async function* () {
-        yield { type: AgentEventType.Content, value: 'ok' };
-      })();
-      mockTurnRunFn.mockReturnValue(mockStream);
-
-      const stream = client.sendMessageStream(
-        request,
-        new AbortController().signal,
-        'prompt-id-overflow-defer',
-      );
-      const events = await fromAsync(stream);
 
       expect(events).not.toContainEqual(
         expect.objectContaining({

--- a/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
@@ -1,0 +1,513 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * sendMessageStream tests: automatic compression recovery for preflight
+ * context-overflow (issue #2402).
+ * Sibling to client.sendMessageStream-overflow.test.ts (split to avoid
+ * file-level max-lines).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Part } from '@google/genai';
+import { AgentClient } from './client.js';
+import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import type { ChatSession } from './chatSession.js';
+import { AgentEventType, PerformCompressionResult } from './turn.js';
+import { uiTelemetryService } from '@vybestack/llxprt-code-core/telemetry/uiTelemetry.js';
+import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
+import { fromAsync, setupGeminiClient } from './client-test-helpers.js';
+
+// Mock prompts module before imports
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn(() =>
+    Promise.resolve('Test system instruction'),
+  ),
+  getCoreSystemPrompt: vi.fn(() => 'Test system instruction'),
+  getCompressionPrompt: vi.fn(() => 'Test compression prompt'),
+  initializePromptSystem: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+// Mock clientToolGovernance module so tests can control tool name/governance returns
+vi.mock('./clientToolGovernance.js', () => ({
+  getToolGovernanceEphemerals: vi.fn(() => undefined),
+  readToolList: vi.fn((v: unknown) =>
+    Array.isArray(v)
+      ? (v as unknown[]).filter(
+          (e): e is string => typeof e === 'string' && e.trim().length > 0,
+        )
+      : [],
+  ),
+  buildToolDeclarationsFromView: vi.fn(() => []),
+  getEnabledToolNamesForPrompt: vi.fn(() => []),
+  shouldIncludeSubagentDelegationForConfig: vi.fn(() => Promise.resolve(false)),
+}));
+
+// --- Mocks (hoisted so vi.mock factories can reference them) ---
+const {
+  mockChatCreateFn,
+  mockGenerateContentFn,
+  mockEmbedContentFn,
+  mockTurnRunFn,
+} = vi.hoisted(() => ({
+  mockChatCreateFn: vi.fn(),
+  mockGenerateContentFn: vi.fn(),
+  mockEmbedContentFn: vi.fn(),
+  mockTurnRunFn: vi.fn(),
+}));
+
+const {
+  todoStoreReadMock,
+  todoStoreReadPausedMock,
+  todoStoreWritePausedMock,
+  mockTodoStoreConstructor,
+} = vi.hoisted(() => {
+  const readMock = vi.fn();
+  const readPausedMock = vi.fn();
+  const writePausedMock = vi.fn();
+  const constructorMock = vi.fn().mockImplementation(() => ({
+    readTodos: readMock,
+    readPausedState: readPausedMock,
+    writePausedState: writePausedMock,
+  }));
+  return {
+    todoStoreReadMock: readMock,
+    todoStoreReadPausedMock: readPausedMock,
+    todoStoreWritePausedMock: writePausedMock,
+    mockTodoStoreConstructor: constructorMock,
+  };
+});
+
+vi.mock('@google/genai');
+vi.mock('@vybestack/llxprt-code-core/services/complexity-analyzer.js', () => ({
+  ComplexityAnalyzer: vi.fn().mockImplementation(() => ({
+    analyzeComplexity: vi.fn().mockReturnValue({
+      complexityScore: 0.2,
+      isComplex: false,
+      detectedTasks: [],
+      sequentialIndicators: [],
+      questionCount: 0,
+      shouldSuggestTodos: false,
+    }),
+  })),
+}));
+
+vi.mock(
+  '@vybestack/llxprt-code-core/services/todo-reminder-service.js',
+  () => ({
+    TodoReminderService: vi.fn().mockImplementation(() => ({
+      getComplexTaskSuggestion: vi.fn(),
+      getEscalatedComplexTaskSuggestion: vi.fn(),
+      getCreateListReminder: vi.fn(),
+      getUpdateActiveTodoReminder: vi.fn(),
+    })),
+  }),
+);
+vi.mock('@vybestack/llxprt-code-tools', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-tools')>();
+  return {
+    ...actual,
+    LocalTodoStore: mockTodoStoreConstructor,
+  };
+});
+vi.mock('./turn', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./turn.js')>();
+  class MockTurn {
+    pendingToolCalls = [];
+    run = mockTurnRunFn;
+    constructor() {}
+  }
+  return {
+    ...actual,
+    Turn: MockTurn,
+  };
+});
+
+vi.mock('@vybestack/llxprt-code-core/config/config.js');
+vi.mock('@vybestack/llxprt-code-core/utils/getFolderStructure.js', () => ({
+  getFolderStructure: vi.fn().mockResolvedValue('Mock Folder Structure'),
+}));
+vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn(),
+}));
+vi.mock(
+  '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js',
+  () => ({
+    getResponseText: (result: GenerateContentResponse) =>
+      result.candidates?.[0]?.content?.parts
+        ?.map((part) => part.text)
+        .join('') ?? undefined,
+  }),
+);
+vi.mock('@vybestack/llxprt-code-core/telemetry/index.js', () => ({
+  logApiRequest: vi.fn(),
+  logApiResponse: vi.fn(),
+  logApiError: vi.fn(),
+}));
+vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  retryWithBackoff: vi.fn((apiCall) => apiCall()),
+}));
+vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@vybestack/llxprt-code-ide-integration')
+    >();
+  return {
+    ...actual,
+    ideContext: {
+      ...actual.ideContext,
+      getIdeContext: vi.fn(),
+      subscribeToIdeContext: vi.fn(),
+      setIdeContext: vi.fn(),
+      clearIdeContext: vi.fn(),
+    },
+  };
+});
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
+  tokenLimit: vi.fn(),
+}));
+vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
+  uiTelemetryService: {
+    setLastPromptTokenCount: vi.fn(),
+    getLastPromptTokenCount: vi.fn(),
+  },
+}));
+
+describe('Gemini Client — preflight compression recovery (issue 2402)', () => {
+  let client: AgentClient;
+
+  beforeEach(async () => {
+    const ctx = await setupGeminiClient({
+      mockChatCreateFn,
+      mockGenerateContentFn,
+      mockEmbedContentFn,
+    });
+    client = ctx.client;
+
+    mockTodoStoreConstructor.mockImplementation(() => ({
+      readTodos: todoStoreReadMock,
+      readPausedState: todoStoreReadPausedMock,
+      writePausedState: todoStoreWritePausedMock,
+    }));
+    todoStoreReadMock.mockResolvedValue([]);
+    todoStoreReadPausedMock.mockResolvedValue(false);
+    todoStoreWritePausedMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    client.dispose();
+    vi.restoreAllMocks();
+  });
+
+  describe('sendMessageStream', () => {
+    beforeEach(() => {
+      (
+        client as unknown as {
+          todoContinuationService: { todoToolsAvailable: boolean };
+        }
+      ).todoContinuationService.todoToolsAvailable = true;
+    });
+
+    it('should recover via automatic compression and proceed instead of bailing on a small overflow (issue 2402)', async () => {
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const lastPromptTokenCount = 900;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      // Initial preflight baseline (900) is over the limit → triggers
+      // recovery; the post-compression projected baseline (100) fits.
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(900),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(100),
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const longText = 'a'.repeat(400);
+      const request: Part[] = [{ text: longText }];
+
+      const mockStream = (async function* () {
+        yield { type: AgentEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-overflow-recovered',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: AgentEventType.ContextWindowWillOverflow,
+        }),
+      );
+      expect(mockTurnRunFn).toHaveBeenCalled();
+      // The recovery is an automatic compression, so it must be reported as
+      // 'auto' (matching the downstream hard-limit paths), not 'manual'.
+      expect(mockChat.performCompression).toHaveBeenCalledWith(
+        'prompt-id-overflow-recovered',
+        { bypassCooldown: true, trigger: 'auto' },
+      );
+    });
+
+    it('should bail with ContextWindowWillOverflow when compression fails (issue 2402)', async () => {
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const lastPromptTokenCount = 900;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.FAILED),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const longText = 'a'.repeat(400);
+      const request: Part[] = [{ text: longText }];
+      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
+      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
+
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-overflow-compression-failed',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).toContainEqual({
+        type: AgentEventType.ContextWindowWillOverflow,
+        value: {
+          estimatedRequestTokenCount,
+          remainingTokenCount,
+        },
+      });
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
+    it('should still bail when compression does not reduce enough (issue 2402)', async () => {
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const lastPromptTokenCount = 900;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        // Partial reduction (900 → 950) but not enough: newRemaining = 50,
+        // estimated 100 > 50 * 0.95 → still overflows → bail.
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(950),
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const longText = 'a'.repeat(400);
+      const request: Part[] = [{ text: longText }];
+      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
+      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
+
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-overflow-compression-insufficient',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).toContainEqual({
+        type: AgentEventType.ContextWindowWillOverflow,
+        value: {
+          estimatedRequestTokenCount,
+          remainingTokenCount,
+        },
+      });
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
+    it('should bail when performCompression throws during recovery (issue 2402)', async () => {
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const lastPromptTokenCount = 900;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        performCompression: vi.fn().mockRejectedValue(new Error('boom')),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const longText = 'a'.repeat(400);
+      const request: Part[] = [{ text: longText }];
+      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
+      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
+
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-overflow-compression-throws',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).toContainEqual({
+        type: AgentEventType.ContextWindowWillOverflow,
+        value: {
+          estimatedRequestTokenCount,
+          remainingTokenCount,
+        },
+      });
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
+    it('should bail when compression is skipped because history is empty (issue 2402)', async () => {
+      // SKIPPED_EMPTY: there is nothing to compress, so the baseline is
+      // unchanged and the request still overflows. Must not falsely recover.
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const lastPromptTokenCount = 900;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        // Nothing compressed → baseline unchanged → still overflows → bail.
+        getProjectedPromptBaseline: vi
+          .fn()
+          .mockReturnValue(lastPromptTokenCount),
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.SKIPPED_EMPTY),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const longText = 'a'.repeat(400);
+      const request: Part[] = [{ text: longText }];
+      const estimatedRequestTokenCount = Math.floor(longText.length / 4);
+      const remainingTokenCount = MOCKED_TOKEN_LIMIT - lastPromptTokenCount;
+
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-overflow-skipped-empty',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).toContainEqual({
+        type: AgentEventType.ContextWindowWillOverflow,
+        value: { estimatedRequestTokenCount, remainingTokenCount },
+      });
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
+    it('should proceed when compression drives remaining capacity non-positive, deferring to the downstream path (issue 2402)', async () => {
+      // After compression the baseline exceeds the limit (newRemaining <= 0).
+      // Recovery returns true so the normal send/enforcement path resolves it,
+      // mirroring the negative-remaining guard (issue #2139).
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const lastPromptTokenCount = 900;
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        lastPromptTokenCount,
+      );
+
+      // Initial preflight baseline (900) overflows; the post-compression
+      // projected baseline (1005) exceeds the 1000-token limit, making
+      // remaining capacity negative → defer to downstream (issue #2139).
+      const mockChat: Partial<ChatSession> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(900),
+        getProjectedPromptBaseline: vi.fn().mockReturnValue(1005),
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.COMPRESSED),
+      };
+      client['chat'] = mockChat as ChatSession;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      const longText = 'a'.repeat(400);
+      const request: Part[] = [{ text: longText }];
+
+      const mockStream = (async function* () {
+        yield { type: AgentEventType.Content, value: 'ok' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const stream = client.sendMessageStream(
+        request,
+        new AbortController().signal,
+        'prompt-id-overflow-defer',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: AgentEventType.ContextWindowWillOverflow,
+        }),
+      );
+      expect(mockTurnRunFn).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
@@ -14,7 +14,7 @@ import type { Part, PartListUnion } from '@google/genai';
 import { AgentClient } from './client.js';
 import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
 import type { ChatSession } from './chatSession.js';
-import { AgentEventType } from './turn.js';
+import { AgentEventType, PerformCompressionResult } from './turn.js';
 import { uiTelemetryService } from '@vybestack/llxprt-code-core/telemetry/uiTelemetry.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import { fromAsync, setupGeminiClient } from './client-test-helpers.js';
@@ -226,6 +226,9 @@ describe('Gemini Client (client.ts)', () => {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
         getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        performCompression: vi
+          .fn()
+          .mockResolvedValue(PerformCompressionResult.FAILED),
       };
       client['chat'] = mockChat as ChatSession;
 
@@ -262,6 +265,11 @@ describe('Gemini Client (client.ts)', () => {
       });
       // Ensure turn.run is not called
       expect(mockTurnRunFn).not.toHaveBeenCalled();
+      // Recovery must have attempted (auto) compression before bailing (#2402).
+      expect(mockChat.performCompression).toHaveBeenCalledWith(
+        'prompt-id-overflow',
+        { bypassCooldown: true, trigger: 'auto' },
+      );
     });
 
     it('should NOT emit ContextWindowWillOverflow when remaining capacity is already negative (issue 2139)', async () => {

--- a/packages/agents/src/core/preflightRecovery.ts
+++ b/packages/agents/src/core/preflightRecovery.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ChatSession } from './chatSession.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { PerformCompressionResult } from './turn.js';
+import { getTokenLimitForConfiguredContext } from './contextLimitResolver.js';
+
+/**
+ * Shared overflow threshold: the guard trips when the estimated request
+ * exceeds this fraction of remaining capacity. Defined once so the initial
+ * check and the post-compression recheck always agree.
+ */
+const CONTEXT_OVERFLOW_THRESHOLD = 0.95;
+
+export interface PreflightOverflowDeps {
+  getChat: () => ChatSession;
+  getEffectiveModel: () => string;
+  config: Config;
+  logger: DebugLogger;
+}
+
+export interface PreflightOverflowContext {
+  promptId: string;
+  estimatedRequestTokenCount: number;
+  remainingTokenCount: number;
+}
+
+/**
+ * Decides whether the preflight context-overflow guard should proceed or bail.
+ * Returns true to proceed (the request fits, or automatic compression
+ * recovered it). Returns false to bail with ContextWindowWillOverflow
+ * (compression failed or the request still exceeds the limit).
+ *
+ * When overflow is detected, attempts automatic compression before bailing
+ * (issue #2402) — the same recovery manual /compress, the load-balancer guard
+ * (#2207), and the provider content enforcer (#2299) already perform.
+ */
+export async function resolvePreflightOverflow(
+  deps: PreflightOverflowDeps,
+  ctx: PreflightOverflowContext,
+): Promise<boolean> {
+  // No overflow: the request fits within the safety threshold. Keep the same
+  // comparison sense as the original guard (overflow is `estimated >
+  // remaining * threshold`) so a non-numeric remaining capacity (NaN, from
+  // un-mocked limits in callers) falls through to "proceed" exactly as before.
+  const overflows =
+    ctx.estimatedRequestTokenCount >
+    ctx.remainingTokenCount * CONTEXT_OVERFLOW_THRESHOLD;
+  if (!overflows) {
+    return true;
+  }
+
+  const { getChat, getEffectiveModel, config, logger } = deps;
+  const chat = getChat();
+  try {
+    const result = await chat.performCompression(ctx.promptId, {
+      bypassCooldown: true,
+      trigger: 'auto',
+    });
+    if (result === PerformCompressionResult.FAILED) {
+      logger.warn(
+        () =>
+          '[preflight] automatic compression failed during context-overflow recovery',
+      );
+      return false;
+    }
+    // Recompute remaining capacity from the (possibly reduced) baseline. Use
+    // the projected baseline (API-observed count, or the history-derived
+    // estimate when compression just nulled lastPromptTokenCount) — NOT
+    // getLastPromptTokenCount(), which returns 0 right after compression.
+    const newRemaining =
+      getTokenLimitForConfiguredContext(getEffectiveModel(), config) -
+      chat.getProjectedPromptBaseline();
+    if (newRemaining <= 0) {
+      return true;
+    }
+    return (
+      ctx.estimatedRequestTokenCount <=
+      newRemaining * CONTEXT_OVERFLOW_THRESHOLD
+    );
+  } catch (error) {
+    logger.warn(
+      () =>
+        '[preflight] compression attempt threw during context-overflow recovery',
+      error,
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the recurring "Sending this message (N tokens) might exceed the remaining context window limit" guard that bails the turn without ever trying automatic compression. Closes #2402.

The preflight context-overflow guard (`_checkSessionLimits` in `MessageStreamOrchestrator`) detected that a request would overflow the remaining context window and immediately emitted `ContextWindowWillOverflow` + cancelled the turn — telling the user to run `/compress` manually — **without ever attempting compression itself**, even for tiny, trivially-recoverable overflows (e.g. 716 vs 498 tokens).

## Root cause

There are three disconnected context-overflow enforcement layers, and every prior fix targeted a *different* one — none taught the preflight itself to compress before bailing:

| Layer | File | Compresses before throw? | Reached for this scenario? |
|-------|------|--------------------------|----------------------------|
| 1. Preflight (`_checkSessionLimits`) | `MessageStreamOrchestrator.ts` | **No — bails + warns** | **Yes — this is what fired** |
| 2. `PendingContextWindowEnforcer` | `pendingContextWindowEnforcement.ts` | Yes (density → compress → retry → truncate) | No — orphaned, only called from tests |
| 3. `ProviderContentEnforcer` | `providerContentEnforcement.ts` | Yes (fixed by #2299) | No — downstream of the preflight |

- #2139 added a negative-remaining escape hatch (history already over limit after a model switch).
- #2207 taught the **load-balancer** guard to compress before throwing.
- #2299 taught the **provider content enforcer** (layer 3) to compress on unsafe extraction.
- #2251/#2262 fixed token accounting (1M → real backend limit).

The preflight short-circuited before any of those could run, so the "might exceed" warning persisted.

## The fix

All changes are in `packages/agents` (the agentic loop) — no CLI/UI compression logic, keeping the architectural separation intact.

1. **`preflightRecovery.ts` (new module):** `resolvePreflightOverflow(deps, ctx)` — when the preflight detects overflow, runs `performCompression({ bypassCooldown: true, trigger: 'auto' })` (matching the downstream hard-limit paths). Recomputes remaining capacity and only returns `false` (bail) if compression fails (`FAILED`/throws) or the request still exceeds the limit. The shared `0.95` overflow threshold lives here so the initial check and the post-compression recheck can't diverge.

2. **`MessageStreamOrchestrator.ts`:** the overflow branch now calls `resolvePreflightOverflow`; the `ContextWindowWillOverflow` event is only yielded when recovery genuinely fails. The `#2139` negative-remaining guard is preserved.

3. **Correctness fix (from Open Code Review):** post-compression capacity is recomputed via `getProjectedPromptBaseline()` — **not** `getLastPromptTokenCount()`. `CompressionHandler.performCompression` nulls `lastPromptTokenCount` after applying the compressed history (it's only repopulated from the next API response), so `getLastPromptTokenCount()` returns `0`, which would make `newRemaining = tokenLimit` (the full window) and falsely report recovery success. `getProjectedPromptBaseline` mirrors the downstream path (`getProjectedPromptBaseline` → falls back to `getEffectiveTokenCount()` when `lastPromptTokenCount` is null).

4. **`ChatSession` / `CompressionHandler`:** widened `performCompression` options to forward `trigger` (so the recovery is reported as `'auto'` to PreCompress hooks/telemetry, not `'manual'`), and made `getProjectedPromptBaseline()` public + exposed it via `ChatSession` (single source of truth, no duplication).

## Tests

Behavioral tests (per `dev-docs/RULES.md`) in a new sibling file `client.sendMessageStream-overflow-compression.test.ts` (split to respect file-level `max-lines`):

- Small overflow + compression succeeds → **no** `ContextWindowWillOverflow`, turn proceeds, `performCompression` called with `{ bypassCooldown: true, trigger: 'auto' }`.
- Compression `FAILED` → existing bail behavior preserved.
- Compression succeeds but insufficient reduction → bail (genuine partial-reduction baseline).
- `performCompression` throws → bail.
- `SKIPPED_EMPTY` (nothing to compress) → bail (baseline unchanged).
- Post-compression baseline exceeds limit (`newRemaining <= 0`) → proceed, deferring to the downstream send/enforcement path (mirrors #2139).

The existing `client.sendMessageStream-overflow.test.ts` "overflows" test now explicitly mocks `performCompression` as `FAILED` and asserts the recovery was attempted (auto, bypassing cooldown) before bailing.

## Verification

- `npm run lint` — clean (no eslint-disable / ts-ignore / threshold changes; orchestrator within `max-lines`).
- `npm run typecheck` — clean (only the pre-existing `CoreToolHostAdapter` error remains).
- Full agents suite: 2704 passed (247 files).
- `npm run build` — passes.
- Smoke (`bun scripts/start.ts --profile-load ollamakimi ...`) — pre-existing 404 on model "gpt-5.5 not found" (environment/profile issue, unrelated; fails in the send path, not the preflight).
- Open Code Review (ocr, `--timeout 20`): 6 findings — 1 blocker (the token-baseline bug above, fixed), 1 DRY (shared threshold, fixed), 4 test-quality (addressed).

## Notes

- `PendingContextWindowEnforcer` (layer 2) remains orphaned (only called from tests). Wiring it into the production send path is a separate, larger refactor out of scope here; this PR addresses the preflight directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app can now automatically try to reduce message context before a send is blocked by token limits.
  * Compression can be triggered automatically or manually, and the system now tracks a prompt baseline after compression.

* **Bug Fixes**
  * Improved handling of near-overflow requests so some messages can continue instead of being stopped immediately.
  * When recovery fails, the app now falls back to the existing overflow warning and stop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->