### PR TITLE
Migrate core ContentConverters off Google genai types (Fixes #2397)

### DIFF
--- a/dev-docs/genai-import-baseline.md
+++ b/dev-docs/genai-import-baseline.md
@@ -4,13 +4,12 @@
 
 Every tracked TypeScript file under `packages/**` that imports `@google/genai`, classified to the downstream issue that removes the import (or to the permanent Gemini `enclave`). This file is the baseline the #2352 enforcement ratchet compares against — the count may only ever decrease as migration issues land.
 
-**Total importers:** 152
+**Total importers:** 151
 
 **Per-owner breakdown:**
 
 - `enclave`: 25
-- `#2348`: 2
-- `#2349`: 100
+- `#2349`: 101
 - `#2351`: 25
 
 | File                                                                             | Owner   |
@@ -76,6 +75,7 @@ Every tracked TypeScript file under `packages/**` that imports `@google/genai`, 
 | `packages/agents/src/core/client.methods.test.ts`                                | #2349   |
 | `packages/agents/src/core/client.model-profile.test.ts`                          | #2349   |
 | `packages/agents/src/core/client.sendMessageStream-errors.test.ts`               | #2349   |
+| `packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts` | #2349   |
 | `packages/agents/src/core/client.sendMessageStream-overflow.test.ts`             | #2349   |
 | `packages/agents/src/core/client.sendMessageStream-thinking.test.ts`             | #2349   |
 | `packages/agents/src/core/client.sendMessageStream.test.ts`                      | #2349   |
@@ -123,8 +123,6 @@ Every tracked TypeScript file under `packages/**` that imports `@google/genai`, 
 | `packages/core/src/code_assist/googleGenAIWrapper.test.ts`                       | enclave |
 | `packages/core/src/code_assist/googleGenAIWrapper.ts`                            | enclave |
 | `packages/core/src/code_assist/server.ts`                                        | enclave |
-| `packages/core/src/core/contentGenerator.test.ts`                                | #2348   |
-| `packages/core/src/services/history/ContentConverters.ts`                        | #2348   |
 | `packages/mcp/src/client/mcp-callable-tool.ts`                                   | #2351   |
 | `packages/mcp/src/client/mcp-client.discovery.test.ts`                           | #2351   |
 | `packages/mcp/src/client/mcp-client.lifecycle.test.ts`                           | #2351   |

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -9,12 +9,33 @@ import {
   createContentGenerator,
   createContentGeneratorConfig,
 } from './contentGenerator.js';
-import { GoogleGenAIWrapper } from '../code_assist/googleGenAIWrapper.js';
 import type { Config } from '../config/config.js';
 
-vi.mock('@google/genai', () => ({
-  GoogleGenAI: vi.fn().mockImplementation(() => ({
-    models: {},
+const mockGoogleGenAIWrapperConstructor = vi.hoisted(() => vi.fn());
+const mockGoogleGenAIWrapperInstance = vi.hoisted(() => ({
+  generateContent: async (): Promise<unknown> => ({}),
+  generateContentStream: async (): Promise<AsyncGenerator<unknown>> => {
+    async function* emptyStream(): AsyncGenerator<unknown> {
+      yield* [];
+    }
+    return emptyStream();
+  },
+  countTokens: async (): Promise<unknown> => ({}),
+  embedContent: async (): Promise<unknown> => ({}),
+}));
+
+vi.mock('../code_assist/googleGenAIWrapper.js', () => ({
+  GoogleGenAIWrapper: vi
+    .fn()
+    .mockImplementation((config: unknown, requestOptions: unknown) => {
+      mockGoogleGenAIWrapperConstructor(config, requestOptions);
+      return mockGoogleGenAIWrapperInstance;
+    }),
+}));
+
+vi.mock('../utils/installationManager.js', () => ({
+  InstallationManager: vi.fn().mockImplementation(() => ({
+    getInstallationId: () => 'test-installation-id',
   })),
 }));
 
@@ -23,7 +44,11 @@ const mockConfig = {
 } as unknown as Config;
 
 describe('createContentGenerator', () => {
-  it('should create a GoogleGenAIWrapper content generator with API key', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a GoogleGenAIWrapper content generator', async () => {
     const generator = await createContentGenerator(
       {
         model: 'test-model',
@@ -31,13 +56,34 @@ describe('createContentGenerator', () => {
       },
       mockConfig,
     );
-    // We expect a GoogleGenAIWrapper instance wrapping the mocked GoogleGenAI
-    // from the code_assist enclave.
-    expect(generator).toBeInstanceOf(GoogleGenAIWrapper);
-    expect(generator).toHaveProperty('generateContent');
-    expect(generator).toHaveProperty('generateContentStream');
-    expect(generator).toHaveProperty('countTokens');
-    expect(generator).toHaveProperty('embedContent');
+    expect(generator).toBe(mockGoogleGenAIWrapperInstance);
+    expect(mockGoogleGenAIWrapperConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'test-model', apiKey: 'test-api-key' }),
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it('should add usage-statistics header when enabled', async () => {
+    const statsConfig = {
+      getUsageStatisticsEnabled: vi.fn().mockReturnValue(true),
+    } as unknown as Config;
+
+    await createContentGenerator(
+      {
+        model: 'test-model',
+        apiKey: 'test-api-key',
+      },
+      statsConfig,
+    );
+
+    expect(mockGoogleGenAIWrapperConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'test-model', apiKey: 'test-api-key' }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-gemini-api-privileged-user-id': 'test-installation-id',
+        }),
+      }),
+    );
   });
 
   it('should create a GoogleGenAIWrapper content generator with Vertex AI', async () => {
@@ -48,9 +94,11 @@ describe('createContentGenerator', () => {
       },
       mockConfig,
     );
-    expect(generator).toBeInstanceOf(GoogleGenAIWrapper);
-    expect(generator).toHaveProperty('generateContent');
-    expect(generator).toHaveProperty('generateContentStream');
+    expect(generator).toBe(mockGoogleGenAIWrapperInstance);
+    expect(mockGoogleGenAIWrapperConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'test-model', vertexai: true }),
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
   });
 
   it('should throw an error when no authentication is provided', async () => {

--- a/packages/core/src/llm-types/geminiContent.ts
+++ b/packages/core/src/llm-types/geminiContent.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Neutral structural shapes for the Gemini-style content/part wire format.
+ *
+ * These types model only the fields that core's history conversion layer
+ * references. They are structurally compatible with (but do not import)
+ * {@link @google/genai} `Part` / `Content`, so providers that pass concrete
+ * SDK objects continue to work via TypeScript structural assignability.
+ */
+
+/**
+ * Structural equivalent of {@link @google/genai} `FunctionCall`.
+ */
+export interface GeminiFunctionCall {
+  id?: string;
+  name?: string;
+  args?: Record<string, unknown>;
+}
+
+/**
+ * Structural equivalent of {@link @google/genai} `FunctionResponse`.
+ */
+export interface GeminiFunctionResponse {
+  id?: string;
+  name?: string;
+  response?: Record<string, unknown>;
+}
+
+/**
+ * Structural equivalent of {@link @google/genai} `Blob`.
+ */
+export interface GeminiInlineData {
+  mimeType?: string;
+  data?: string;
+  displayName?: string;
+}
+
+/**
+ * Provider-extension key stamped on thinking parts so the original
+ * source field name survives a Gemini round-trip.
+ */
+export interface GeminiPartExtension {
+  llxprtSourceField?:
+    | 'reasoning_content'
+    | 'thinking'
+    | 'thought'
+    | 'think_tags';
+}
+
+/**
+ * Neutral structural shape of a single Gemini content part.
+ *
+ * Only the fields consumed by core's history conversion are modeled.
+ * Concrete SDK `Part` objects are structurally assignable to this type.
+ */
+export interface GeminiContentPart extends GeminiPartExtension {
+  text?: string;
+  thought?: boolean;
+  thoughtSignature?: string;
+  functionCall?: GeminiFunctionCall;
+  functionResponse?: GeminiFunctionResponse;
+  inlineData?: GeminiInlineData;
+}
+
+/**
+ * Neutral structural shape of a Gemini `Content` message.
+ *
+ * Concrete SDK `Content` objects are structurally assignable to this type.
+ */
+export interface GeminiContent {
+  role?: string;
+  parts?: GeminiContentPart[];
+}

--- a/packages/core/src/llm-types/index.ts
+++ b/packages/core/src/llm-types/index.ts
@@ -35,6 +35,7 @@ export * from './modelRequest.js';
 export * from './providerApiError.js';
 export * from './tokensAndEmbeddings.js';
 export * from './grounding.js';
+export * from './geminiContent.js';
 
 /**
  * Neutral tool-call/tool-response ID canonicalization contract.

--- a/packages/core/src/services/history/ContentConverters.test.ts
+++ b/packages/core/src/services/history/ContentConverters.test.ts
@@ -5,13 +5,14 @@ import type {
   ToolResponseBlock,
   ThinkingBlock,
 } from './IContent';
+import type { GeminiContent } from '../../llm-types/geminiContent.js';
 import { describe, it, expect } from 'vitest';
 
 /**
  * Structural shape matching Google's Content for test fixtures.
  * The bridge (ContentConverters.ts) accepts structurally-compatible objects;
- * tests build them with this local type to avoid importing @google/genai
- * outside the sanctioned bridge file.
+ * tests build them with this local type to keep fixtures decoupled from the
+ * SDK.
  */
 interface TestContent {
   role: string;
@@ -434,5 +435,130 @@ describe('ContentConverters - History ID Conversion for Gemini', () => {
       expect(geminiContent.parts[1].functionCall?.name).toBe('second_tool');
       expect(geminiContent.parts[2].functionCall?.name).toBe('third_tool');
     });
+  });
+});
+
+describe('ContentConverters - neutral type I/O (#2397)', () => {
+  it('toGeminiContent returns a value assignable to the neutral GeminiContent type', () => {
+    const iContent: IContent = {
+      speaker: 'ai',
+      blocks: [
+        { type: 'text', text: 'hello' },
+        {
+          type: 'tool_call',
+          id: 'hist_tool_1_1',
+          name: 'search',
+          parameters: { q: 'cats' },
+        },
+      ],
+    };
+
+    const result = ContentConverters.toGeminiContent(iContent);
+
+    // Compile-time proof: the return value is structurally assignable to
+    // the neutral GeminiContent type (not @google/genai).
+    const neutral: GeminiContent = result;
+    expect(neutral).toMatchObject({
+      role: 'model',
+      parts: [
+        { text: 'hello' },
+        {
+          functionCall: {
+            name: 'search',
+            args: { q: 'cats' },
+            id: 'hist_tool_1_1',
+          },
+        },
+      ],
+    });
+  });
+
+  it('toIContent accepts a neutral GeminiContent input', () => {
+    const geminiInput: GeminiContent = {
+      role: 'model',
+      parts: [
+        { text: 'response text' },
+        {
+          functionCall: { name: 'run_tool', args: {}, id: 'call_1' },
+        },
+      ],
+    };
+
+    // Compile-time proof: neutral GeminiContent is accepted as input.
+    const result = ContentConverters.toIContent(
+      geminiInput,
+      undefined,
+      undefined,
+      'turn-neutral',
+    );
+
+    expect(result.speaker).toBe('ai');
+    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks[0].type).toBe('text');
+    expect(result.blocks[1]).toMatchObject({
+      type: 'tool_call',
+      id: expect.stringMatching(CANONICAL_ID_PATTERN),
+      name: 'run_tool',
+      parameters: {},
+    });
+  });
+
+  it('toGeminiContents / toIContents round-trip through neutral types', () => {
+    const original: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'hi' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'hello back' }],
+      },
+    ];
+
+    const geminiContents: GeminiContent[] =
+      ContentConverters.toGeminiContents(original);
+    expect(geminiContents).toHaveLength(2);
+
+    const roundTripped: IContent[] =
+      ContentConverters.toIContents(geminiContents);
+    expect(roundTripped).toHaveLength(2);
+    expect(roundTripped[0].speaker).toBe('human');
+    expect(roundTripped[0].blocks[0]).toStrictEqual({
+      type: 'text',
+      text: 'hi',
+    });
+    expect(roundTripped[1].speaker).toBe('ai');
+    expect(roundTripped[1].blocks[0]).toStrictEqual({
+      type: 'text',
+      text: 'hello back',
+    });
+  });
+
+  it('preserves llxprtSourceField through a Gemini round-trip via neutral types', () => {
+    const thinking: IContent = {
+      speaker: 'ai',
+      blocks: [
+        {
+          type: 'thinking',
+          thought: 'reasoning here',
+          sourceField: 'thinking',
+          signature: 'sig-abc',
+        } as ThinkingBlock,
+      ],
+    };
+
+    const gemini: GeminiContent = ContentConverters.toGeminiContent(thinking);
+    const back: IContent = ContentConverters.toIContent(
+      gemini,
+      undefined,
+      undefined,
+      'turn-rt',
+    );
+
+    const block = back.blocks[0] as ThinkingBlock;
+    expect(block.type).toBe('thinking');
+    expect(block.sourceField).toBe('thinking');
+    expect(block.signature).toBe('sig-abc');
+    expect(block.thought).toBe('reasoning here');
   });
 });

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -15,7 +15,10 @@
  */
 
 import { randomUUID } from 'crypto';
-import { type Content, type Part } from '@google/genai';
+import type {
+  GeminiContent,
+  GeminiContentPart,
+} from '../../llm-types/geminiContent.js';
 import type { IContent, ContentBlock, ThinkingBlock } from './IContent.js';
 import { DebugLogger } from '../../debug/index.js';
 import {
@@ -57,7 +60,7 @@ export class ContentConverters {
   }
 
   /** Convert a single IContent block to a Gemini Part. */
-  private static blockToPart(block: ContentBlock): Part | null {
+  private static blockToPart(block: ContentBlock): GeminiContentPart | null {
     switch (block.type) {
       case 'text': {
         const textBlock = block;
@@ -105,7 +108,7 @@ export class ContentConverters {
       }
       case 'thinking': {
         const thinkingBlock = block;
-        const thinkingPart: Part = {
+        const thinkingPart: GeminiContentPart = {
           thought: true,
           text: thinkingBlock.thought,
         };
@@ -113,11 +116,7 @@ export class ContentConverters {
           thinkingPart.thoughtSignature = thinkingBlock.signature;
         }
         if (ContentConverters.hasLegacyTruthyValue(thinkingBlock.sourceField)) {
-          (
-            thinkingPart as Part & {
-              llxprtSourceField?: ThinkingBlock['sourceField'];
-            }
-          ).llxprtSourceField = thinkingBlock.sourceField;
+          thinkingPart.llxprtSourceField = thinkingBlock.sourceField;
         }
         return thinkingPart;
       }
@@ -139,7 +138,7 @@ export class ContentConverters {
   /**
    * Convert IContent to Gemini Content format
    */
-  static toGeminiContent(iContent: IContent): Content {
+  static toGeminiContent(iContent: IContent): GeminiContent {
     const blocksForDebug = ContentConverters.blocksOrEmpty(iContent);
     this.logger.debug('Converting IContent to Gemini Content:', {
       speaker: iContent.speaker,
@@ -154,7 +153,7 @@ export class ContentConverters {
     });
 
     const role = this.resolveRole(iContent.speaker);
-    const parts: Part[] = [];
+    const parts: GeminiContentPart[] = [];
 
     for (const block of iContent.blocks) {
       const part = this.blockToPart(block);
@@ -189,11 +188,8 @@ export class ContentConverters {
   }
 
   /** Convert a thinking/thought Part into a ThinkingBlock. */
-  private static partToThinkingBlock(part: Part): ThinkingBlock {
-    const partWithMetadata = part as Part & {
-      llxprtSourceField?: ThinkingBlock['sourceField'];
-    };
-    const sourceField = partWithMetadata.llxprtSourceField ?? 'thought';
+  private static partToThinkingBlock(part: GeminiContentPart): ThinkingBlock {
+    const sourceField = part.llxprtSourceField ?? 'thought';
     const thinkingBlock: ThinkingBlock = {
       type: 'thinking',
       thought: part.text ?? '',
@@ -284,7 +280,7 @@ export class ContentConverters {
 
   /** Convert a functionCall Part into tool_call ContentBlock(s). */
   private static processFunctionCallPart(
-    part: Part,
+    part: GeminiContentPart,
     context: {
       turnKey: string;
       providerName: string;
@@ -327,7 +323,7 @@ export class ContentConverters {
 
   /** Convert a functionResponse Part into tool_response ContentBlock(s). */
   private static processFunctionResponsePart(
-    part: Part,
+    part: GeminiContentPart,
     context: {
       turnKey: string;
       providerName: string;
@@ -381,7 +377,7 @@ export class ContentConverters {
   }
 
   /** Convert a text-or-thought Part into a ContentBlock. */
-  private static textPartToBlock(part: Part): ContentBlock {
+  private static textPartToBlock(part: GeminiContentPart): ContentBlock {
     if (
       'thought' in part &&
       ContentConverters.hasLegacyTruthyValue(part.thought)
@@ -393,7 +389,7 @@ export class ContentConverters {
 
   /** Convert a single Gemini Part into ContentBlocks, returning any tool-call index counters. */
   private static processPartToBlocks(
-    part: Part,
+    part: GeminiContentPart,
     context: {
       turnKey: string;
       providerName: string;
@@ -435,7 +431,7 @@ export class ContentConverters {
    * Convert Gemini Content to IContent format
    */
   static toIContent(
-    content: Content,
+    content: GeminiContent,
     generateIdCb?: () => string,
     getNextUnmatchedToolCall?: () => { historyId: string; toolName?: string },
     turnKeyOverride?: string,
@@ -525,7 +521,7 @@ export class ContentConverters {
   /**
    * Convert array of IContent to array of Gemini Content
    */
-  static toGeminiContents(iContents: IContent[]): Content[] {
+  static toGeminiContents(iContents: IContent[]): GeminiContent[] {
     this.logger.debug('Converting IContent array to Gemini Contents:', {
       count: iContents.length,
       speakers: iContents.map((ic) => ic.speaker),
@@ -554,7 +550,7 @@ export class ContentConverters {
   /**
    * Convert array of Gemini Content to array of IContent
    */
-  static toIContents(contents: Content[]): IContent[] {
+  static toIContents(contents: GeminiContent[]): IContent[] {
     this.logger.debug('Converting Gemini Contents array to IContent:', {
       count: contents.length,
       roles: contents.map((c) => c.role),

--- a/packages/providers/src/gemini/neutralConverters.test.ts
+++ b/packages/providers/src/gemini/neutralConverters.test.ts
@@ -24,6 +24,7 @@ import {
   ApiError,
   Outcome,
   Language,
+  type Content,
   type Part,
   type GenerateContentResponseUsageMetadata,
   type GroundingMetadata,
@@ -47,6 +48,8 @@ import {
   type UsageStats,
   type GroundingInfo,
   type UrlAccessInfo,
+  type GeminiContent,
+  type GeminiContentPart,
 } from '@vybestack/llxprt-code-core/llm-types/index.js';
 
 // ---------------------------------------------------------------------------
@@ -60,6 +63,21 @@ function makeApiError(status: number, message: string): ApiError {
 function roundTrip(part: Part): Part {
   return blocksToGeminiParts(geminiPartsToBlocks([part]))[0];
 }
+
+describe('core Gemini content neutral type compatibility', () => {
+  it('stays structurally compatible with Google SDK content types', () => {
+    const sdkPart: Part = { text: 'hello' };
+    const neutralPart: GeminiContentPart = sdkPart;
+    const sdkContent: Content = { role: 'model', parts: [neutralPart] };
+    const neutralContent: GeminiContent = sdkContent;
+
+    expect(neutralPart.text).toBe('hello');
+    expect(neutralContent).toMatchObject({
+      role: 'model',
+      parts: [{ text: 'hello' }],
+    });
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Round-trip invariance (REQ-010.2) — all 10 supported Part shapes


### PR DESCRIPTION
## Summary

- Adds neutral core Gemini content and part structural types for the history conversion boundary.
- Migrates core ContentConverters and non-code_assist core tests away from direct Google genai imports or mocks.
- Regenerates the genai import baseline so owner 2348 is removed and only sanctioned enclaves remain in core.
- Adds provider Gemini enclave compatibility coverage for the neutral core shapes against SDK content values.

Fixes #2397

## Verification

Passed after rebasing onto latest main:
- npm run format
- changed-file ESLint for modified TypeScript files
- npm run test --workspace @vybestack/llxprt-code-core -- ContentConverters contentGenerator
- npm run test --workspace @vybestack/llxprt-code-providers -- neutralConverters
- bun scripts/genai-import-inventory.ts --check
- git diff --check
- npm run lint:eslint-guard
- npm run build
- npm run typecheck
- env -u LLXPRT_CREDENTIAL_SOCKET npm run test
- Open Code Review, final successful run: 6 files reviewed, 0 comments

Local caveats:
- npm run lint exits with Node heap out of memory under the package script 8GB heap on local Node 25.2.1. The changed-file ESLint run and eslint guard pass.
- The prescribed smoke command exits with API 404 model gpt-5.5 not found from the local ollamakimi profile, which appears to be an environment/profile issue rather than this code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when converting chat/history content, helping preserve message structure, tool calls, and special metadata during round-trips.
  * Increased reliability of AI content handling across different Gemini-based formats.
* **Tests**
  * Expanded coverage for content conversion behavior and provider compatibility.
  * Strengthened test setup for model initialization and request option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->