### PR TITLE
fix(ci): pin Node 24 in smoke-test workflow to match lockfile npm version (Fixes #2418)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 1
+      - name: 'Set up Node.js'
+        # The runner's default Node 22 ships npm 10.x, which resolves
+        # nested lockfile entries (e.g. yaml@2.9.0 under
+        # @opentelemetry/configuration) differently than the npm 11.6.2
+        # that generated package-lock.json, causing `npm ci` to fail with
+        # "Missing: yaml@2.9.0 from lock file". Pinning Node 24 (from
+        # .nvmrc) brings npm 11.x and matches every other workflow.
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # ratchet:actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: 'Setup Bun'
         # Must run BEFORE `npm ci`: in a fresh checkout without bundle/llxprt.js,
         # scripts/postinstall.cjs can run `npm run build` and `npm run bundle`,


### PR DESCRIPTION
## Summary

The smoke test workflow (`.github/workflows/smoke-test.yml`) was failing on every push to main with:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: yaml@2.9.0 from lock file
```

This was caused by the smoke-test workflow being the **only** workflow in the repo without an explicit `actions/setup-node` step. It ran on the GitHub runner's default Node 22 (npm 10.9.8), while `package-lock.json` was generated with npm 11.6.2 (Node 24, per `.nvmrc`). npm 10.x resolves nested lockfile entries differently — specifically, `yaml@2.9.0` under `@opentelemetry/configuration` and `patch-package` is not found by npm 10.x's lockfile verifier, causing `npm ci` to reject the lockfile.

## Root Cause

- `package.json` declares `"engines": { "node": ">=24" }` and `"packageManager": "npm@11.6.2"`
- `package-lock.json` was generated with npm 11.6.2 (lockfileVersion 3)
- The smoke-test workflow had no `setup-node` step, so it used the runner default Node 22 / npm 10.9.8
- npm 10.x's `npm ci` lockfile verification rejects the lockfile because it resolves nested dependency trees differently than npm 11.x
- Every other workflow (ci.yml, nightly.yml, e2e.yml, evals-nightly.yml, interactive-ui.yml, etc.) already pins Node via `setup-node` with `node-version-file: '.nvmrc'`

## Fix

Add a `setup-node` step to the smoke-test workflow that:
1. Pins Node to the version in `.nvmrc` (Node 24), bringing npm 11.x
2. Enables `cache: 'npm'` for dependency cache (matches ci.yml and other workflows)

This brings the smoke-test workflow in line with all other workflows in the repo.

## Verification

- `npx prettier --check` passes
- `npm run lint` passes
- `node ./packages/cli/bin/llxprt.cjs --version` returns `0.10.0`
- ocr (Open Code Review) passed with one suggestion (add `cache: 'npm'`), which was addressed

Closes #2418