### PR TITLE
ci(ocr-review): exclude deleted test files from the scope guard

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -254,8 +254,14 @@ jobs:
           # TS-monorepo scope guard: match *.test.*, *.spec.*, and any file
           # inside a __tests__/, tests/, or test/ directory. Covers
           # .ts/.tsx/.js/.jsx/.mjs/.cjs variants used throughout packages/**.
+          #
+          # --diff-filter=d excludes Deleted files: OCR reviews the content of
+          # added/modified/renamed files, but a deleted test has no post-image
+          # to review, so OCR legitimately omits it from the reviewed set.
+          # Without this filter, any PR that removes a test file would fail the
+          # scope check for a file that no longer exists.
           changed_tests="$(
-            git diff --name-only "${BASE_SHA}..${HEAD_SHA}" \
+            git diff --name-only --diff-filter=d "${BASE_SHA}..${HEAD_SHA}" \
               | grep -Ei '(^|/)(__tests__|tests?)/.*\.(ts|tsx|js|jsx|mjs|cjs)$|\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$' \
               || true
           )"


### PR DESCRIPTION
## Summary

Fixes a bug in the `OCR Review` workflow's scope guard (added in #2420) that fails **any PR which deletes a test/spec file**.

## Problem

The `Verify review scope includes changed tests` step builds the list of changed test files with:

    git diff --name-only "${BASE_SHA}..${HEAD_SHA}"

`git diff --name-only` lists **Deleted** files alongside Added/Modified/Renamed ones. OCR reviews the *post-image* (content) of a change, so it correctly omits deleted files from its "Will review" set — there is nothing to review in a file that no longer exists. The guard then treats the deleted test as "missing from the reviewed set" and fails the job with:

    ::error::OCR preview did not list changed test files in the reviewed set:
    <deleted test path>

So a PR that legitimately removes a test file fails OCR Review through no fault of the diff's actual content.

## Fix

Add `--diff-filter=d` to exclude Deleted files, so the guard only requires review for files that still have content to review (Added / Modified / Renamed / Copied) — matching OCR's own scoping. A short comment explains the rationale.

    git diff --name-only --diff-filter=d "${BASE_SHA}..${HEAD_SHA}"

No behavioral change for PRs that only add or modify tests; those files are still required to appear in the reviewed set.

## Verification

- `actionlint` passes (exit 0), including its embedded shellcheck of the `run:` script.
- YAML parses cleanly; added comment lines are well under the 120-col `.yamllint` limit with no trailing whitespace.
- Reproduced against a real deleting PR: `git diff --name-only <base>..<head>` lists the deleted `credential-proxy-host.test.ts`; adding `--diff-filter=d` drops exactly that entry while retaining the added/modified test files.

## Context

Surfaced by #2426 (Fixes #2419), which deletes `packages/cli/src/launcher/credential-proxy-host.test.ts`. That PR's OpenCodeReview job failed solely due to this guard bug; every other check (CodeQL, the full 4-way Test matrix, all E2E, all lints, smokes, and the LLxprt review) is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-scope checks so deleted test or spec files no longer cause false failures during OCR preview validation.
  * The changed-tests check now focuses only on files that still exist in the diff, making verification more reliable when tests are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->