### PR TITLE
fix(agents): forward subagent systemInstruction to all providers, gate cache_control for z.ai, harden empty content blocks

### DIFF
--- a/packages/agents/src/core/DirectMessageProcessor.ts
+++ b/packages/agents/src/core/DirectMessageProcessor.ts
@@ -505,7 +505,9 @@ export class DirectMessageProcessor {
         runtimeContext.settingsService as GenerateChatOptions['settings'],
       metadata: runtimeContext.metadata,
       userMemory: resolveUserMemory(runtimeContext.config),
-      systemInstruction: this._resolveSystemInstruction(),
+      systemInstruction: extractSystemInstructionText(
+        this.generationConfig.systemInstruction,
+      ),
     });
   }
 
@@ -513,20 +515,6 @@ export class DirectMessageProcessor {
     params: SendMessageParameters,
   ): GenerateContentConfig['tools'] {
     return params.config?.tools ?? this.generationConfig.tools;
-  }
-
-  /**
-   * Extracts the system instruction string from generationConfig.
-   *
-   * Issue #2410: subagent personas are built into generationConfig
-   * .systemInstruction by subagentRuntimeSetup.createChatObject(). Without
-   * forwarding this to the provider, the subagent's task directives never
-   * reach the model.
-   */
-  private _resolveSystemInstruction(): string | undefined {
-    return extractSystemInstructionText(
-      this.generationConfig.systemInstruction,
-    );
   }
 
   /**

--- a/packages/agents/src/core/DirectMessageProcessor.ts
+++ b/packages/agents/src/core/DirectMessageProcessor.ts
@@ -32,6 +32,7 @@ import {
 import {
   resolveUserMemory,
   applyRequestModifications,
+  extractSystemInstructionText,
 } from './streamRequestHelpers.js';
 import { isSchemaDepthError } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
 import {
@@ -504,6 +505,7 @@ export class DirectMessageProcessor {
         runtimeContext.settingsService as GenerateChatOptions['settings'],
       metadata: runtimeContext.metadata,
       userMemory: resolveUserMemory(runtimeContext.config),
+      systemInstruction: this._resolveSystemInstruction(),
     });
   }
 
@@ -511,6 +513,20 @@ export class DirectMessageProcessor {
     params: SendMessageParameters,
   ): GenerateContentConfig['tools'] {
     return params.config?.tools ?? this.generationConfig.tools;
+  }
+
+  /**
+   * Extracts the system instruction string from generationConfig.
+   *
+   * Issue #2410: subagent personas are built into generationConfig
+   * .systemInstruction by subagentRuntimeSetup.createChatObject(). Without
+   * forwarding this to the provider, the subagent's task directives never
+   * reach the model.
+   */
+  private _resolveSystemInstruction(): string | undefined {
+    return extractSystemInstructionText(
+      this.generationConfig.systemInstruction,
+    );
   }
 
   /**

--- a/packages/agents/src/core/MessageConverter.issue2410.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2410.test.ts
@@ -97,6 +97,7 @@ describe('issue #2410 – empty message arrays must not create zero-part Content
     it('still converts text parts to an AI message', () => {
       const parts = [{ text: 'hello world' }];
       const result = convertMixedPartsToIContent(parts);
+      expect(result.speaker).toBe('ai');
       expect(result.blocks).toHaveLength(1);
       expect(result.blocks[0].type).toBe('text');
     });

--- a/packages/agents/src/core/MessageConverter.issue2410.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2410.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for issue #2410:
+ * Empty `{speaker:"human", blocks:[]}` IContent items are injected into
+ * subagent conversation history, causing z.ai to return HTTP 400 error 1213
+ * ("prompt parameter not received normally").
+ *
+ * The root cause: `[].every(isFunctionResponsePart)` is vacuously true, so
+ * an empty message array creates `{role:'user', parts:[]}`. These tests verify
+ * the boundary guards in MessageConverter prevent that.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+let normalizeToolInteractionInput: typeof import('./MessageConverter.js').normalizeToolInteractionInput;
+let createUserContentWithFunctionResponseFix: typeof import('./MessageConverter.js').createUserContentWithFunctionResponseFix;
+let convertMixedPartsToIContent: typeof import('./MessageConverter.js').convertMixedPartsToIContent;
+
+describe('issue #2410 – empty message arrays must not create zero-part Content', () => {
+  beforeAll(async () => {
+    const mod = await import('./MessageConverter.js');
+    normalizeToolInteractionInput = mod.normalizeToolInteractionInput;
+    createUserContentWithFunctionResponseFix =
+      mod.createUserContentWithFunctionResponseFix;
+    convertMixedPartsToIContent = mod.convertMixedPartsToIContent;
+  });
+
+  describe('createUserContentWithFunctionResponseFix', () => {
+    it('returns a Content with zero parts for an empty array (not a fabricated user turn)', () => {
+      const result = createUserContentWithFunctionResponseFix([]);
+      expect(result.role).toBe('user');
+      expect(result.parts).toHaveLength(0);
+    });
+  });
+
+  describe('normalizeToolInteractionInput', () => {
+    it('returns an empty Content array for an empty message array', () => {
+      const result = normalizeToolInteractionInput([]);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(0);
+    });
+
+    it('still handles a non-empty function-response array correctly', () => {
+      const parts = [
+        {
+          functionResponse: {
+            id: 'call_1',
+            name: 'read_file',
+            response: { output: 'hello' },
+          },
+        },
+      ];
+      const result = normalizeToolInteractionInput(parts);
+      const content = Array.isArray(result) ? result[0] : result;
+      expect(content).toBeDefined();
+      expect(content.parts).toHaveLength(1);
+      expect(content.parts[0]).toHaveProperty('functionResponse');
+    });
+
+    it('still handles string input correctly', () => {
+      const result = normalizeToolInteractionInput('hello');
+      const content = Array.isArray(result) ? result[0] : result;
+      expect(content).toBeDefined();
+      expect(content.parts).toHaveLength(1);
+      expect(content.parts[0]).toHaveProperty('text', 'hello');
+    });
+  });
+
+  describe('convertMixedPartsToIContent', () => {
+    it('returns an IContent with zero blocks for an empty parts array', () => {
+      const result = convertMixedPartsToIContent([]);
+      expect(result.blocks).toHaveLength(0);
+      expect(result.speaker).toBe('human');
+    });
+
+    it('still converts all-function-response parts to a tool message', () => {
+      const parts = [
+        {
+          functionResponse: {
+            id: 'call_1',
+            name: 'read_file',
+            response: { output: 'hello' },
+          },
+        },
+      ];
+      const result = convertMixedPartsToIContent(parts);
+      expect(result.speaker).toBe('tool');
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks[0].type).toBe('tool_response');
+    });
+
+    it('still converts text parts to an AI message', () => {
+      const parts = [{ text: 'hello world' }];
+      const result = convertMixedPartsToIContent(parts);
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks[0].type).toBe('text');
+    });
+  });
+});

--- a/packages/agents/src/core/MessageConverter.issue2410.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2410.test.ts
@@ -36,6 +36,22 @@ describe('issue #2410 – empty message arrays must not create zero-part Content
       expect(result.role).toBe('user');
       expect(result.parts).toHaveLength(0);
     });
+
+    it('converts a non-empty function-response array into a user Content with parts', () => {
+      const parts = [
+        {
+          functionResponse: {
+            id: 'call_1',
+            name: 'read_file',
+            response: { output: 'hello' },
+          },
+        },
+      ];
+      const result = createUserContentWithFunctionResponseFix(parts);
+      expect(result.role).toBe('user');
+      expect(result.parts).toHaveLength(1);
+      expect(result.parts[0]).toHaveProperty('functionResponse');
+    });
   });
 
   describe('normalizeToolInteractionInput', () => {

--- a/packages/agents/src/core/MessageConverter.issue2410.test.ts
+++ b/packages/agents/src/core/MessageConverter.issue2410.test.ts
@@ -15,21 +15,14 @@
  * the boundary guards in MessageConverter prevent that.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
-
-let normalizeToolInteractionInput: typeof import('./MessageConverter.js').normalizeToolInteractionInput;
-let createUserContentWithFunctionResponseFix: typeof import('./MessageConverter.js').createUserContentWithFunctionResponseFix;
-let convertMixedPartsToIContent: typeof import('./MessageConverter.js').convertMixedPartsToIContent;
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeToolInteractionInput,
+  createUserContentWithFunctionResponseFix,
+  convertMixedPartsToIContent,
+} from './MessageConverter.js';
 
 describe('issue #2410 – empty message arrays must not create zero-part Content', () => {
-  beforeAll(async () => {
-    const mod = await import('./MessageConverter.js');
-    normalizeToolInteractionInput = mod.normalizeToolInteractionInput;
-    createUserContentWithFunctionResponseFix =
-      mod.createUserContentWithFunctionResponseFix;
-    convertMixedPartsToIContent = mod.convertMixedPartsToIContent;
-  });
-
   describe('createUserContentWithFunctionResponseFix', () => {
     it('returns a Content with zero parts for an empty array (not a fabricated user turn)', () => {
       const result = createUserContentWithFunctionResponseFix([]);

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -134,6 +134,12 @@ function pushMixedContentParts(
 /**
  * Custom createUserContent that properly handles function response arrays.
  * Each response must be a separate Part in the same Content, not nested arrays.
+ *
+ * Issue #2410: When `message` is an empty array, this returns a zero-part
+ * `{ role: 'user', parts: [] }`. Callers MUST check `result.parts.length`
+ * before forwarding to a provider — a zero-part Content will be rejected by
+ * strict endpoints (e.g. z.ai error 1213). `HistoryService.addInternal`
+ * already drops zero-block turns derived from this.
  */
 export function createUserContentWithFunctionResponseFix(
   message: PartListUnion,
@@ -149,9 +155,9 @@ export function createUserContentWithFunctionResponseFix(
   if (Array.isArray(message)) {
     // An empty message array must not produce a fabricated user turn with
     // function-response semantics — `[].every(...)` is vacuously true and
-    // would create `{role:'user', parts:[]}`, which providers like z.ai
-    // reject with HTTP 400 error 1213 (issue #2410). Return a zero-part
-    // user Content so callers can detect and drop it.
+    // would create spurious function-response parts. Return a zero-part
+    // user Content so callers (and HistoryService) can detect and drop it
+    // (issue #2410).
     if (message.length === 0) {
       return { role: 'user' as const, parts };
     }
@@ -371,6 +377,12 @@ export function convertPartListUnionToIContent(input: PartListUnion): IContent {
 
 /**
  * Converts mixed Parts (function calls, responses, text, thoughts) to IContent.
+ *
+ * Issue #2410: When `parts` is empty, this returns a zero-block
+ * `{ speaker: 'human', blocks: [] }`. Callers MUST check `result.blocks.length`
+ * before forwarding to a provider. `HistoryService.addInternal` already drops
+ * zero-block turns, and `ContentConverters.toIContent` logs a warning when it
+ * encounters one.
  */
 export function convertMixedPartsToIContent(parts: Part[]): IContent {
   // An empty parts array would make `[].every(isFunctionResponsePart)`

--- a/packages/agents/src/core/MessageConverter.ts
+++ b/packages/agents/src/core/MessageConverter.ts
@@ -147,6 +147,15 @@ export function createUserContentWithFunctionResponseFix(
 
   // If the message is an array, process each element
   if (Array.isArray(message)) {
+    // An empty message array must not produce a fabricated user turn with
+    // function-response semantics — `[].every(...)` is vacuously true and
+    // would create `{role:'user', parts:[]}`, which providers like z.ai
+    // reject with HTTP 400 error 1213 (issue #2410). Return a zero-part
+    // user Content so callers can detect and drop it.
+    if (message.length === 0) {
+      return { role: 'user' as const, parts };
+    }
+
     // First check if this is an array of functionResponse Parts
     // This happens when multiple tool responses are sent together
     const allFunctionResponses = message.every((item) =>
@@ -188,6 +197,15 @@ export function normalizeToolInteractionInput(
   // Handle single Part (not an array)
   if (!Array.isArray(message)) {
     return createUserContentWithFunctionResponseFix(message);
+  }
+
+  // An empty array must not be normalized into a fake user message —
+  // `[].every(...)` is vacuously true, producing `{role:'user', parts:[]}`
+  // which providers like z.ai reject with HTTP 400 error 1213 (issue #2410).
+  // Return an empty Content array so callers can skip it without inventing
+  // a zero-block turn.
+  if (message.length === 0) {
+    return [];
   }
 
   // Now we have an array of parts - check if it contains tool interactions
@@ -355,6 +373,14 @@ export function convertPartListUnionToIContent(input: PartListUnion): IContent {
  * Converts mixed Parts (function calls, responses, text, thoughts) to IContent.
  */
 export function convertMixedPartsToIContent(parts: Part[]): IContent {
+  // An empty parts array would make `[].every(isFunctionResponsePart)`
+  // vacuously true, producing a fabricated tool message from no content
+  // (issue #2410). Return a zero-block human turn so callers (and
+  // HistoryService) can detect and drop it.
+  if (parts.length === 0) {
+    return { speaker: 'human', blocks: [] };
+  }
+
   // Fast path: all function responses → tool message
   const allFunctionResponses = parts.every((part) =>
     isFunctionResponsePart(part),

--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -460,7 +460,9 @@ export class StreamProcessor {
           abortSignal: params.config?.abortSignal,
         },
         userMemory,
-        systemInstruction: this._resolveSystemInstruction(),
+        systemInstruction: extractSystemInstructionText(
+          this.generationConfig.systemInstruction,
+        ),
       } as GenerateChatOptions);
 
       return await this._consumeFirstChunkAndReturn(
@@ -515,20 +517,6 @@ export class StreamProcessor {
     params: SendMessageParameters,
   ): GenerateContentConfig['tools'] {
     return selectRequestTools(params, this.generationConfig.tools);
-  }
-
-  /**
-   * Extracts the system instruction string from generationConfig.
-   *
-   * Issue #2410: subagent personas are built into generationConfig
-   * .systemInstruction by subagentRuntimeSetup.createChatObject(). Without
-   * forwarding this to the provider, the subagent's task directives never
-   * reach the model.
-   */
-  private _resolveSystemInstruction(): string | undefined {
-    return extractSystemInstructionText(
-      this.generationConfig.systemInstruction,
-    );
   }
 
   private async _applyToolSelectionHook(

--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -60,6 +60,7 @@ import {
   applyRequestModifications,
   resolveUserMemory,
   logOutgoingRequest,
+  extractSystemInstructionText,
   type ToolGroupArray,
   type ToolSelectionHookResult,
 } from './streamRequestHelpers.js';
@@ -459,6 +460,7 @@ export class StreamProcessor {
           abortSignal: params.config?.abortSignal,
         },
         userMemory,
+        systemInstruction: this._resolveSystemInstruction(),
       } as GenerateChatOptions);
 
       return await this._consumeFirstChunkAndReturn(
@@ -513,6 +515,20 @@ export class StreamProcessor {
     params: SendMessageParameters,
   ): GenerateContentConfig['tools'] {
     return selectRequestTools(params, this.generationConfig.tools);
+  }
+
+  /**
+   * Extracts the system instruction string from generationConfig.
+   *
+   * Issue #2410: subagent personas are built into generationConfig
+   * .systemInstruction by subagentRuntimeSetup.createChatObject(). Without
+   * forwarding this to the provider, the subagent's task directives never
+   * reach the model.
+   */
+  private _resolveSystemInstruction(): string | undefined {
+    return extractSystemInstructionText(
+      this.generationConfig.systemInstruction,
+    );
   }
 
   private async _applyToolSelectionHook(

--- a/packages/agents/src/core/TurnProcessor.ts
+++ b/packages/agents/src/core/TurnProcessor.ts
@@ -54,6 +54,7 @@ import {
 } from './hookToolRestrictions.js';
 import { canonicalizeToolName } from './toolGovernance.js';
 import { shouldRetryStreamAttempt } from './turnAbortHelpers.js';
+import { extractSystemInstructionText } from './streamRequestHelpers.js';
 
 import {
   AgentExecutionStoppedError,
@@ -551,6 +552,7 @@ export class TurnProcessor {
         runtimeContext.settingsService as GenerateChatOptions['settings'],
       metadata: runtimeContext.metadata,
       userMemory: resolveUserMemory(runtimeContext.config),
+      systemInstruction: this._resolveSystemInstruction(),
     });
   }
 
@@ -627,6 +629,20 @@ export class TurnProcessor {
     params: SendMessageParameters,
   ): GenerateContentConfig['tools'] {
     return params.config?.tools ?? this.generationConfig.tools;
+  }
+
+  /**
+   * Extracts the system instruction string from generationConfig.
+   *
+   * Issue #2410: subagent personas are built into generationConfig
+   * .systemInstruction by subagentRuntimeSetup.createChatObject(). Without
+   * forwarding this to the provider, the subagent's task directives never
+   * reach the model.
+   */
+  private _resolveSystemInstruction(): string | undefined {
+    return extractSystemInstructionText(
+      this.generationConfig.systemInstruction,
+    );
   }
 
   private async _applyToolSelectionHook(

--- a/packages/agents/src/core/TurnProcessor.ts
+++ b/packages/agents/src/core/TurnProcessor.ts
@@ -552,7 +552,9 @@ export class TurnProcessor {
         runtimeContext.settingsService as GenerateChatOptions['settings'],
       metadata: runtimeContext.metadata,
       userMemory: resolveUserMemory(runtimeContext.config),
-      systemInstruction: this._resolveSystemInstruction(),
+      systemInstruction: extractSystemInstructionText(
+        this.generationConfig.systemInstruction,
+      ),
     });
   }
 
@@ -629,20 +631,6 @@ export class TurnProcessor {
     params: SendMessageParameters,
   ): GenerateContentConfig['tools'] {
     return params.config?.tools ?? this.generationConfig.tools;
-  }
-
-  /**
-   * Extracts the system instruction string from generationConfig.
-   *
-   * Issue #2410: subagent personas are built into generationConfig
-   * .systemInstruction by subagentRuntimeSetup.createChatObject(). Without
-   * forwarding this to the provider, the subagent's task directives never
-   * reach the model.
-   */
-  private _resolveSystemInstruction(): string | undefined {
-    return extractSystemInstructionText(
-      this.generationConfig.systemInstruction,
-    );
   }
 
   private async _applyToolSelectionHook(

--- a/packages/agents/src/core/streamRequestHelpers.issue2410.test.ts
+++ b/packages/agents/src/core/streamRequestHelpers.issue2410.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for extractSystemInstructionText (issue #2410).
+ *
+ * This helper normalizes the various Gemini ContentUnion shapes that
+ * generationConfig.systemInstruction can hold (string, Content, Part[],
+ * single Part) into a plain-text string for forwarding to providers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractSystemInstructionText } from './streamRequestHelpers.js';
+
+describe('issue #2410 – extractSystemInstructionText', () => {
+  it('returns undefined for undefined input', () => {
+    expect(extractSystemInstructionText(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for null input', () => {
+    expect(extractSystemInstructionText(null as never)).toBeUndefined();
+  });
+
+  it('returns trimmed string for string input', () => {
+    expect(extractSystemInstructionText('  hello world  ')).toBe('hello world');
+  });
+
+  it('returns undefined for empty/whitespace string', () => {
+    expect(extractSystemInstructionText('   ')).toBeUndefined();
+    expect(extractSystemInstructionText('')).toBeUndefined();
+  });
+
+  it('extracts text from a Content shape { role, parts }', () => {
+    const content = {
+      role: 'system',
+      parts: [{ text: 'You are a subagent.' }],
+    };
+    expect(extractSystemInstructionText(content as never)).toBe(
+      'You are a subagent.',
+    );
+  });
+
+  it('returns undefined for Content with empty parts', () => {
+    const content = { role: 'system', parts: [] };
+    expect(extractSystemInstructionText(content as never)).toBeUndefined();
+  });
+
+  it('extracts text from a Part[] shape', () => {
+    const parts = [{ text: 'part one' }, { text: 'part two' }];
+    expect(extractSystemInstructionText(parts as never)).toBe(
+      'part one\npart two',
+    );
+  });
+
+  it('trims whitespace-only parts before joining', () => {
+    const parts = [{ text: '  real content  ' }, { text: '   ' }];
+    expect(extractSystemInstructionText(parts as never)).toBe('real content');
+  });
+
+  it('extracts text from a single Part shape { text }', () => {
+    const part = { text: 'single part text' };
+    expect(extractSystemInstructionText(part as never)).toBe(
+      'single part text',
+    );
+  });
+
+  it('does not treat a Content object as a single Part', () => {
+    // A Content has 'parts' — the single Part branch must not match it.
+    const content = {
+      role: 'system',
+      parts: [{ text: 'content text' }],
+      text: 'wrong',
+    };
+    expect(extractSystemInstructionText(content as never)).toBe('content text');
+  });
+
+  it('returns undefined for unrecognized shapes', () => {
+    expect(extractSystemInstructionText(42 as never)).toBeUndefined();
+    expect(
+      extractSystemInstructionText({ foo: 'bar' } as never),
+    ).toBeUndefined();
+  });
+});

--- a/packages/agents/src/core/streamRequestHelpers.issue2410.test.ts
+++ b/packages/agents/src/core/streamRequestHelpers.issue2410.test.ts
@@ -51,7 +51,7 @@ describe('issue #2410 – extractSystemInstructionText', () => {
   it('extracts text from a Part[] shape', () => {
     const parts = [{ text: 'part one' }, { text: 'part two' }];
     expect(extractSystemInstructionText(parts as never)).toBe(
-      'part one\npart two',
+      ['part one', 'part two'].join('\n'),
     );
   });
 
@@ -82,5 +82,20 @@ describe('issue #2410 – extractSystemInstructionText', () => {
     expect(
       extractSystemInstructionText({ foo: 'bar' } as never),
     ).toBeUndefined();
+  });
+
+  it('drops non-text parts and joins only text parts in a Part[]', () => {
+    const parts = [{ inlineData: { data: 'binary' } }, { text: 'hello' }];
+    expect(extractSystemInstructionText(parts as never)).toBe('hello');
+  });
+
+  it('joins multiple text parts in a Content shape the same as Part[]', () => {
+    const content = {
+      role: 'system',
+      parts: [{ text: 'a' }, { text: 'b' }],
+    };
+    expect(extractSystemInstructionText(content as never)).toBe(
+      ['a', 'b'].join('\n'),
+    );
   });
 });

--- a/packages/agents/src/core/streamRequestHelpers.issue2410.test.ts
+++ b/packages/agents/src/core/streamRequestHelpers.issue2410.test.ts
@@ -21,7 +21,11 @@ describe('issue #2410 – extractSystemInstructionText', () => {
   });
 
   it('returns undefined for null input', () => {
-    expect(extractSystemInstructionText(null as never)).toBeUndefined();
+    expect(
+      extractSystemInstructionText(
+        null as unknown as Parameters<typeof extractSystemInstructionText>[0],
+      ),
+    ).toBeUndefined();
   });
 
   it('returns trimmed string for string input', () => {
@@ -38,33 +42,51 @@ describe('issue #2410 – extractSystemInstructionText', () => {
       role: 'system',
       parts: [{ text: 'You are a subagent.' }],
     };
-    expect(extractSystemInstructionText(content as never)).toBe(
-      'You are a subagent.',
-    );
+    expect(
+      extractSystemInstructionText(
+        content as unknown as Parameters<
+          typeof extractSystemInstructionText
+        >[0],
+      ),
+    ).toBe('You are a subagent.');
   });
 
   it('returns undefined for Content with empty parts', () => {
     const content = { role: 'system', parts: [] };
-    expect(extractSystemInstructionText(content as never)).toBeUndefined();
+    expect(
+      extractSystemInstructionText(
+        content as unknown as Parameters<
+          typeof extractSystemInstructionText
+        >[0],
+      ),
+    ).toBeUndefined();
   });
 
   it('extracts text from a Part[] shape', () => {
     const parts = [{ text: 'part one' }, { text: 'part two' }];
-    expect(extractSystemInstructionText(parts as never)).toBe(
-      ['part one', 'part two'].join('\n'),
-    );
+    expect(
+      extractSystemInstructionText(
+        parts as unknown as Parameters<typeof extractSystemInstructionText>[0],
+      ),
+    ).toBe(['part one', 'part two'].join('\n'));
   });
 
   it('trims whitespace-only parts before joining', () => {
     const parts = [{ text: '  real content  ' }, { text: '   ' }];
-    expect(extractSystemInstructionText(parts as never)).toBe('real content');
+    expect(
+      extractSystemInstructionText(
+        parts as unknown as Parameters<typeof extractSystemInstructionText>[0],
+      ),
+    ).toBe('real content');
   });
 
   it('extracts text from a single Part shape { text }', () => {
     const part = { text: 'single part text' };
-    expect(extractSystemInstructionText(part as never)).toBe(
-      'single part text',
-    );
+    expect(
+      extractSystemInstructionText(
+        part as unknown as Parameters<typeof extractSystemInstructionText>[0],
+      ),
+    ).toBe('single part text');
   });
 
   it('does not treat a Content object as a single Part', () => {
@@ -74,19 +96,35 @@ describe('issue #2410 – extractSystemInstructionText', () => {
       parts: [{ text: 'content text' }],
       text: 'wrong',
     };
-    expect(extractSystemInstructionText(content as never)).toBe('content text');
+    expect(
+      extractSystemInstructionText(
+        content as unknown as Parameters<
+          typeof extractSystemInstructionText
+        >[0],
+      ),
+    ).toBe('content text');
   });
 
   it('returns undefined for unrecognized shapes', () => {
-    expect(extractSystemInstructionText(42 as never)).toBeUndefined();
     expect(
-      extractSystemInstructionText({ foo: 'bar' } as never),
+      extractSystemInstructionText(
+        42 as unknown as Parameters<typeof extractSystemInstructionText>[0],
+      ),
+    ).toBeUndefined();
+    expect(
+      extractSystemInstructionText({ foo: 'bar' } as unknown as Parameters<
+        typeof extractSystemInstructionText
+      >[0]),
     ).toBeUndefined();
   });
 
   it('drops non-text parts and joins only text parts in a Part[]', () => {
     const parts = [{ inlineData: { data: 'binary' } }, { text: 'hello' }];
-    expect(extractSystemInstructionText(parts as never)).toBe('hello');
+    expect(
+      extractSystemInstructionText(
+        parts as unknown as Parameters<typeof extractSystemInstructionText>[0],
+      ),
+    ).toBe('hello');
   });
 
   it('joins multiple text parts in a Content shape the same as Part[]', () => {
@@ -94,8 +132,12 @@ describe('issue #2410 – extractSystemInstructionText', () => {
       role: 'system',
       parts: [{ text: 'a' }, { text: 'b' }],
     };
-    expect(extractSystemInstructionText(content as never)).toBe(
-      ['a', 'b'].join('\n'),
-    );
+    expect(
+      extractSystemInstructionText(
+        content as unknown as Parameters<
+          typeof extractSystemInstructionText
+        >[0],
+      ),
+    ).toBe(['a', 'b'].join('\n'));
   });
 });

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -332,6 +332,7 @@ export function extractSystemInstructionText(
 }
 
 function extractPartsText(parts: unknown[]): string {
+  const SEPARATOR = String.fromCharCode(10); // newline
   return parts
     .map((part) => {
       if (typeof part === 'string') return part;
@@ -345,6 +346,7 @@ function extractPartsText(parts: unknown[]): string {
       }
       return '';
     })
-    .join('')
+    .filter((text) => text.length > 0)
+    .join(SEPARATOR)
     .trim();
 }

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -27,7 +27,7 @@ import type { HistoryService } from '@vybestack/llxprt-code-core/services/histor
 import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
-import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 
 export type ToolGroupArray = Array<{
   functionDeclarations?: Array<{
@@ -334,6 +334,10 @@ export function extractSystemInstructionText(
   return undefined;
 }
 
+const systemInstructionLogger = new DebugLogger(
+  'llxprt:agents:system-instruction',
+);
+
 function extractPartsText(parts: unknown[]): string {
   return parts
     .map((part) => {
@@ -346,6 +350,12 @@ function extractPartsText(parts: unknown[]): string {
       ) {
         return part.text;
       }
+      // Unrecognized part type — warn so malformed parts in a systemInstruction
+      // (which carries the subagent persona, issue #2410) are not silently lost.
+      systemInstructionLogger.warn(
+        () =>
+          `extractPartsText: dropping unrecognized systemInstruction part (type=${part === null ? 'null' : typeof part})`,
+      );
       return '';
     })
     .filter((text) => text.length > 0)

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -352,13 +352,22 @@ function extractPartsText(parts: unknown[]): string {
       }
       // Unrecognized part type — warn so malformed parts in a systemInstruction
       // (which carries the subagent persona, issue #2410) are not silently lost.
+      const partDesc = describeUnrecognizedPart(part);
       systemInstructionLogger.warn(
         () =>
-          `extractPartsText: dropping unrecognized systemInstruction part (type=${part === null ? 'null' : typeof part})`,
+          `extractPartsText: dropping unrecognized systemInstruction part (type=${partDesc})`,
       );
       return '';
     })
     .filter((text) => text.length > 0)
     .join('\n')
     .trim();
+}
+
+function describeUnrecognizedPart(part: unknown): string {
+  if (part === null) return 'null';
+  if (typeof part === 'object') {
+    return `object(keys=${Object.keys(part).join(',')})`;
+  }
+  return typeof part;
 }

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -284,6 +284,10 @@ export function logOutgoingRequest(
   );
 }
 
+const systemInstructionLogger = new DebugLogger(
+  'llxprt:agents:system-instruction',
+);
+
 /**
  * Extracts a plain-text system instruction string from a Gemini
  * `ContentUnion` value (string, Content, Part[], or Part).
@@ -339,10 +343,6 @@ export function extractSystemInstructionText(
   );
   return undefined;
 }
-
-const systemInstructionLogger = new DebugLogger(
-  'llxprt:agents:system-instruction',
-);
 
 function extractPartsText(parts: unknown[]): string {
   return parts

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -324,8 +324,10 @@ export function extractSystemInstructionText(
     const text = extractPartsText(value);
     return text.length > 0 ? text : undefined;
   }
-  // Single Part shape: { text: string }
-  if (typeof value === 'object' && 'text' in value) {
+  // Single Part shape: { text: string } — exclude Content objects that
+  // happen to have a text property alongside parts (makes this check
+  // self-contained and order-independent).
+  if (typeof value === 'object' && 'text' in value && !('parts' in value)) {
     const text = typeof value.text === 'string' ? value.text.trim() : '';
     return text.length > 0 ? text : undefined;
   }

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -332,7 +332,6 @@ export function extractSystemInstructionText(
 }
 
 function extractPartsText(parts: unknown[]): string {
-  const SEPARATOR = String.fromCharCode(10); // newline
   return parts
     .map((part) => {
       if (typeof part === 'string') return part;
@@ -347,6 +346,6 @@ function extractPartsText(parts: unknown[]): string {
       return '';
     })
     .filter((text) => text.length > 0)
-    .join(SEPARATOR)
+    .join('\n')
     .trim();
 }

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -341,14 +341,14 @@ const systemInstructionLogger = new DebugLogger(
 function extractPartsText(parts: unknown[]): string {
   return parts
     .map((part) => {
-      if (typeof part === 'string') return part;
+      if (typeof part === 'string') return part.trim();
       if (
         part !== null &&
         typeof part === 'object' &&
         'text' in part &&
         typeof part.text === 'string'
       ) {
-        return part.text;
+        return part.text.trim();
       }
       // Unrecognized part type — warn so malformed parts in a systemInstruction
       // (which carries the subagent persona, issue #2410) are not silently lost.

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -331,6 +331,12 @@ export function extractSystemInstructionText(
     const text = typeof value.text === 'string' ? value.text.trim() : '';
     return text.length > 0 ? text : undefined;
   }
+  // Unrecognized top-level shape — warn so a malformed systemInstruction
+  // (which carries the subagent persona, issue #2410) is not silently lost.
+  systemInstructionLogger.warn(
+    () =>
+      `extractSystemInstructionText: unrecognized systemInstruction shape (keys=${Object.keys(value).join(',')})`,
+  );
   return undefined;
 }
 

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -299,8 +299,8 @@ export function extractSystemInstructionText(
 ): string | undefined {
   // The SDK types declare systemInstruction as ContentUnion | undefined, but
   // defensive null-safety is needed because 'parts' in null / 'text' in null
-  // would throw at runtime. Broadening to unknown | undefined lets the null
-  // guard pass lint without a suppression directive.
+  // would throw at runtime. Broadening to unknown lets the null guard pass
+  // lint without a suppression directive.
   const value = raw as unknown;
   if (value === undefined || value === null) {
     return undefined;

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -337,9 +337,13 @@ export function extractSystemInstructionText(
   }
   // Unrecognized top-level shape — warn so a malformed systemInstruction
   // (which carries the subagent persona, issue #2410) is not silently lost.
+  const shapeDesc =
+    typeof value === 'object'
+      ? `object(keys=${Object.keys(value).join(',')})`
+      : typeof value;
   systemInstructionLogger.warn(
     () =>
-      `extractSystemInstructionText: unrecognized systemInstruction shape (keys=${Object.keys(value).join(',')})`,
+      `extractSystemInstructionText: unrecognized systemInstruction shape (type=${shapeDesc})`,
   );
   return undefined;
 }

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -283,3 +283,68 @@ export function logOutgoingRequest(
     promptId,
   );
 }
+
+/**
+ * Extracts a plain-text system instruction string from a Gemini
+ * `ContentUnion` value (string, Content, Part[], or Part).
+ *
+ * Issue #2410: subagent personas are built into
+ * generationConfig.systemInstruction by subagentRuntimeSetup.createChatObject().
+ * This helper normalizes the various shapes the SDK allows so the instruction
+ * can be forwarded to providers as a simple string. Returns undefined when the
+ * value is absent or contains no text.
+ */
+export function extractSystemInstructionText(
+  raw: GenerateContentConfig['systemInstruction'],
+): string | undefined {
+  // The SDK types declare systemInstruction as ContentUnion | undefined, but
+  // defensive null-safety is needed because 'parts' in null / 'text' in null
+  // would throw at runtime. Broadening to unknown | undefined lets the null
+  // guard pass lint without a suppression directive.
+  const value = raw as unknown;
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0 ? value : undefined;
+  }
+  // Content shape: { role, parts: Part[] }
+  if (
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    'parts' in value &&
+    Array.isArray(value.parts)
+  ) {
+    const text = extractPartsText(value.parts);
+    return text.length > 0 ? text : undefined;
+  }
+  // Part[] shape
+  if (Array.isArray(value)) {
+    const text = extractPartsText(value);
+    return text.length > 0 ? text : undefined;
+  }
+  // Single Part shape: { text: string }
+  if (typeof value === 'object' && 'text' in value) {
+    const text = typeof value.text === 'string' ? value.text.trim() : '';
+    return text.length > 0 ? text : undefined;
+  }
+  return undefined;
+}
+
+function extractPartsText(parts: unknown[]): string {
+  return parts
+    .map((part) => {
+      if (typeof part === 'string') return part;
+      if (
+        part !== null &&
+        typeof part === 'object' &&
+        'text' in part &&
+        typeof part.text === 'string'
+      ) {
+        return part.text;
+      }
+      return '';
+    })
+    .join('')
+    .trim();
+}

--- a/packages/agents/src/core/streamRequestHelpers.ts
+++ b/packages/agents/src/core/streamRequestHelpers.ts
@@ -306,7 +306,8 @@ export function extractSystemInstructionText(
     return undefined;
   }
   if (typeof value === 'string') {
-    return value.trim().length > 0 ? value : undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
   }
   // Content shape: { role, parts: Part[] }
   if (

--- a/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
@@ -12,154 +12,41 @@
  * evaluated to `false`, so the loop continued, producing an empty user turn
  * that z.ai rejected with HTTP 400 error 1213.
  *
- * These tests verify that `dispatchNonInteractiveTurnResult` returns `[]`
- * (an empty Content[] — truthy, not null) when processFunctionCalls returns [],
- * which is the exact value that the old `!nextMessages` guard failed to catch.
+ * The loop guard was extracted into `shouldStopNonInteractiveLoop` so it can
+ * be tested directly. These tests verify the guard catches all three cases:
+ * null, undefined-coerced-to-null, and the critical empty-array case.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Content, FunctionCall } from '@google/genai';
-import type { ExecutionLoopContext } from './subagentExecution.js';
-import type { NonInteractiveRunContext } from './subagentNonInteractive.js';
-import { dispatchNonInteractiveTurnResult } from './subagentNonInteractive.js';
-import {
-  SubagentTerminateMode,
-  type OutputObject,
-  type RunConfig,
-} from '@vybestack/llxprt-code-core/core/subagentTypes.js';
-import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { describe, it, expect } from 'vitest';
+import type { Content } from '@google/genai';
+import { shouldStopNonInteractiveLoop } from './subagentNonInteractive.js';
 
-// Mock processFunctionCalls so it returns [] (simulating all-hook-restricted)
-vi.mock('./subagentToolProcessing.js', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('./subagentToolProcessing.js')>();
-  return {
-    ...actual,
-    processFunctionCalls: vi.fn().mockResolvedValue([] as Content[]),
-    resolveToolName: actual.resolveToolName,
-    finalizeOutput: actual.finalizeOutput,
-    buildTodoCompletionPrompt: vi.fn().mockResolvedValue(null),
-  };
-});
-
-// Mock subagentExecution helpers
-vi.mock('./subagentExecution.js', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('./subagentExecution.js')>();
-  return {
-    ...actual,
-    checkTerminationConditions: vi.fn().mockReturnValue({ shouldStop: false }),
-    processNonInteractiveTextResponse: actual.processNonInteractiveTextResponse,
-    handleExecutionError: actual.handleExecutionError,
-    checkGoalCompletion: vi.fn().mockResolvedValue(null),
-  };
-});
-
-// Import the mocked processFunctionCalls so we can assert on it
-const { processFunctionCalls } = await import('./subagentToolProcessing.js');
-const mockedProcessFunctionCalls = vi.mocked(processFunctionCalls);
-
-function makeExecCtx(): ExecutionLoopContext {
-  return {
-    output: { emitted_vars: {}, terminate_reason: SubagentTerminateMode.ERROR },
-    subagentId: 'test-sub',
-    runConfig: {
-      max_turns: 10,
-      max_time_minutes: 5,
-    } as RunConfig,
-    textToolParser: { parse: vi.fn().mockReturnValue({ functionCalls: [] }) },
-    toolsView: {
-      listToolNames: () => [],
-      getToolMetadata: () => undefined,
-    },
-    logger: new DebugLogger('test'),
-  };
-}
-
-function makeCtx(): NonInteractiveRunContext {
-  return {
-    output: {
-      emitted_vars: {},
-      terminate_reason: SubagentTerminateMode.ERROR,
-    } as OutputObject,
-    subagentId: 'test-sub',
-    name: 'test',
-    runtimeContext: {
-      state: { sessionId: 'test-session' },
-    } as never,
-    logger: new DebugLogger('test'),
-    config: {} as never,
-    runConfig: {
-      max_turns: 10,
-      max_time_minutes: 5,
-    } as RunConfig,
-    toolExecutorContext: {
-      getToolRegistry: () => ({}) as never,
-      getEphemeralSettings: () => ({}),
-      getEphemeralSetting: () => undefined,
-      getExcludeTools: () => [],
-      getSessionId: () => 'test-session',
-      getTelemetryLogPromptsEnabled: () => false,
-      getOrCreateScheduler: vi.fn(),
-      disposeScheduler: vi.fn(),
-    },
-  };
-}
-
-describe('issue #2410 (Layer 1) – processFunctionCalls returning [] produces empty array, not null', () => {
-  beforeEach(() => {
-    mockedProcessFunctionCalls.mockClear();
-    mockedProcessFunctionCalls.mockResolvedValue([]);
+describe('issue #2410 – shouldStopNonInteractiveLoop guard', () => {
+  it('returns true for null (no further messages)', () => {
+    expect(shouldStopNonInteractiveLoop(null)).toBe(true);
   });
 
-  it('returns an empty Content[] (truthy, not null) when processFunctionCalls returns []', async () => {
-    // This is the crux of the bug: processFunctionCalls returns [] when all
-    // calls are hook-restricted. The old `!nextMessages` guard evaluated
-    // `![]` as `false`, so the loop continued and sent an empty user turn
-    // to the provider (causing z.ai error 1213). The fix checks
-    // `nextMessages.length === 0` instead.
-    const functionCalls: FunctionCall[] = [
-      { id: 'c1', name: 'restricted_tool', args: {} },
-    ];
-    const result = await dispatchNonInteractiveTurnResult(
-      functionCalls,
-      new AbortController(),
-      'prompt-1',
-      0,
-      makeExecCtx(),
-      makeCtx(),
-    );
-
-    // processFunctionCalls was actually invoked (not skipped)
-    expect(mockedProcessFunctionCalls).toHaveBeenCalledTimes(1);
-
-    // The result is [] — an empty but truthy array. The old `!nextMessages`
-    // check would NOT catch this (because ![] === false). The fix does.
-    expect(Array.isArray(result)).toBe(true);
-    expect(result).toHaveLength(0);
-
-    // Demonstrate the old guard would have failed:
-    // `!result` is false (empty array is truthy), so `if (!nextMessages)`
-    // would NOT have stopped the loop. The fix uses `nextMessages.length === 0`.
-    expect(!result).toBe(false); // old guard: does NOT stop
-    expect(result.length === 0).toBe(true); // new guard: DOES stop
+  it('returns true for an empty array — the critical bug case', () => {
+    // This is the crux of the bug: processFunctionCalls returns [] (truthy,
+    // not null) when all calls are hook-restricted. The old `!nextMessages`
+    // guard evaluated `![]` as `false`, so the loop continued and sent an
+    // empty user turn to the provider (causing z.ai error 1213).
+    const emptyArray: Content[] = [];
+    expect(shouldStopNonInteractiveLoop(emptyArray)).toBe(true);
   });
 
-  it('processFunctionCalls is invoked when function calls are present in the turn', async () => {
-    const functionCalls: FunctionCall[] = [
-      { id: 'c1', name: 'read_file', args: { path: '/tmp/test' } },
-      { id: 'c2', name: 'write_file', args: { path: '/tmp/out' } },
-    ];
-    const result = await dispatchNonInteractiveTurnResult(
-      functionCalls,
-      new AbortController(),
-      'prompt-2',
-      1,
-      makeExecCtx(),
-      makeCtx(),
-    );
+  it('returns false for a non-empty array — loop should continue', () => {
+    const messages: Content[] = [{ role: 'user', parts: [{ text: 'result' }] }];
+    expect(shouldStopNonInteractiveLoop(messages)).toBe(false);
+  });
 
-    expect(mockedProcessFunctionCalls).toHaveBeenCalledTimes(1);
-    expect(result).toHaveLength(0);
+  it('returns true for an array with multiple empty-content items', () => {
+    // Edge case: array exists but all items are empty Content objects.
+    // While unlikely in practice, the guard should still stop.
+    const messages: Content[] = [{ role: 'user', parts: [] }];
+    // This array has length 1, so the guard says "continue" — the empty-parts
+    // filtering happens downstream in ContentConverters/HistoryService.
+    // The guard only checks whether there are ANY messages at all.
+    expect(shouldStopNonInteractiveLoop(messages)).toBe(false);
   });
 });

--- a/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for issue #2410 (Layer 1):
+ * When `processFunctionCalls` returns `[]` (an empty, truthy array) — e.g.
+ * because all function calls were hook-restricted — the non-interactive loop
+ * must STOP rather than continue with `messages: []`. Previously `![]`
+ * evaluated to `false`, so the loop continued, producing an empty user turn
+ * that z.ai rejected with HTTP 400 error 1213.
+ *
+ * These tests verify two things:
+ * 1. `dispatchNonInteractiveTurnResult` can return `[]` (an empty Content[])
+ *    when processFunctionCalls returns [].
+ * 2. `executeNonInteractiveRun` stops the loop cleanly when an iteration
+ *    produces no further messages (either null or empty array).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Content, FunctionDeclaration } from '@google/genai';
+import type { ChatSession } from './chatSession.js';
+import type { ExecutionLoopContext } from './subagentExecution.js';
+import type { NonInteractiveRunContext } from './subagentNonInteractive.js';
+import {
+  executeNonInteractiveRun,
+  dispatchNonInteractiveTurnResult,
+} from './subagentNonInteractive.js';
+import {
+  SubagentTerminateMode,
+  type OutputObject,
+  type RunConfig,
+} from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { FunctionCall } from '@google/genai';
+
+// Mock processFunctionCalls so it returns [] (simulating all-hook-restricted)
+vi.mock('./subagentToolProcessing.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./subagentToolProcessing.js')>();
+  return {
+    ...actual,
+    processFunctionCalls: vi.fn().mockResolvedValue([] as Content[]),
+    resolveToolName: actual.resolveToolName,
+    finalizeOutput: actual.finalizeOutput,
+    buildTodoCompletionPrompt: vi.fn().mockResolvedValue(null),
+  };
+});
+
+// Mock subagentExecution helpers
+vi.mock('./subagentExecution.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./subagentExecution.js')>();
+  return {
+    ...actual,
+    checkTerminationConditions: vi.fn().mockReturnValue({ shouldStop: false }),
+    processNonInteractiveTextResponse: actual.processNonInteractiveTextResponse,
+    handleExecutionError: actual.handleExecutionError,
+    checkGoalCompletion: vi.fn().mockResolvedValue(null),
+  };
+});
+
+// Import the mocked processFunctionCalls so we can assert on it
+const { processFunctionCalls } = await import('./subagentToolProcessing.js');
+const mockedProcessFunctionCalls = processFunctionCalls as unknown as {
+  mockResolvedValue: (val: Content[]) => void;
+  mockClear: () => void;
+};
+
+function makeExecCtx(): ExecutionLoopContext {
+  return {
+    output: { emitted_vars: {}, terminate_reason: SubagentTerminateMode.ERROR },
+    subagentId: 'test-sub',
+    runConfig: {
+      max_turns: 10,
+      max_time_minutes: 5,
+    } as RunConfig,
+    textToolParser: { parse: vi.fn().mockReturnValue({ functionCalls: [] }) },
+    toolsView: {
+      listToolNames: () => [],
+      getToolMetadata: () => undefined,
+    },
+    logger: new DebugLogger('test'),
+  };
+}
+
+function makeCtx(): NonInteractiveRunContext {
+  return {
+    output: {
+      emitted_vars: {},
+      terminate_reason: SubagentTerminateMode.ERROR,
+    } as OutputObject,
+    subagentId: 'test-sub',
+    name: 'test',
+    runtimeContext: {
+      state: { sessionId: 'test-session' },
+    } as never,
+    logger: new DebugLogger('test'),
+    config: {} as never,
+    runConfig: {
+      max_turns: 10,
+      max_time_minutes: 5,
+    } as RunConfig,
+    toolExecutorContext: {
+      getToolRegistry: () => ({}) as never,
+      getEphemeralSettings: () => ({}),
+      getEphemeralSetting: () => undefined,
+      getExcludeTools: () => [],
+      getSessionId: () => 'test-session',
+      getTelemetryLogPromptsEnabled: () => false,
+      getOrCreateScheduler: vi.fn(),
+      disposeScheduler: vi.fn(),
+    },
+  };
+}
+
+describe('issue #2410 (Layer 1) – empty nextMessages stops the loop', () => {
+  beforeEach(() => {
+    mockedProcessFunctionCalls.mockClear();
+    mockedProcessFunctionCalls.mockResolvedValue([]);
+  });
+
+  describe('dispatchNonInteractiveTurnResult returns [] from processFunctionCalls', () => {
+    it('returns an empty Content[] (not null) when processFunctionCalls returns []', async () => {
+      // This is the crux of the bug: the return is [] (truthy), not null.
+      const functionCalls: FunctionCall[] = [
+        { id: 'c1', name: 'restricted_tool', args: {} },
+      ];
+      const result = await dispatchNonInteractiveTurnResult(
+        functionCalls,
+        new AbortController(),
+        'prompt-1',
+        0,
+        makeExecCtx(),
+        makeCtx(),
+      );
+
+      // The result is [] — an empty but truthy array. The old `!nextMessages`
+      // check would NOT catch this (because ![] === false).
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('executeNonInteractiveRun stops on empty messages', () => {
+    it('does NOT make a second provider call when the first turn yields no messages', async () => {
+      // With an empty stream, functionCalls = []. dispatchNonInteractiveTurnResult
+      // calls checkGoalCompletion (mocked → null). The loop should stop.
+      let sendMessageCallCount = 0;
+
+      const mockChat = {
+        sendMessageStream: vi.fn(() => {
+          sendMessageCallCount += 1;
+          return {
+            async *[Symbol.asyncIterator]() {
+              // Empty stream — no events
+            },
+          };
+        }),
+      } as unknown as ChatSession;
+
+      await executeNonInteractiveRun(
+        mockChat,
+        [] as FunctionDeclaration[],
+        new AbortController(),
+        [{ role: 'user', parts: [{ text: 'do the task' }] }],
+        Date.now(),
+        makeExecCtx(),
+        makeCtx(),
+        () => {},
+      );
+
+      // Exactly one provider call — loop stopped, did not retry with []
+      expect(sendMessageCallCount).toBe(1);
+    });
+  });
+});

--- a/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
@@ -40,13 +40,11 @@ describe('issue #2410 – shouldStopNonInteractiveLoop guard', () => {
     expect(shouldStopNonInteractiveLoop(messages)).toBe(false);
   });
 
-  it('returns true for an array with multiple empty-content items', () => {
-    // Edge case: array exists but all items are empty Content objects.
-    // While unlikely in practice, the guard should still stop.
+  it('returns false for a non-empty array even if individual parts are empty', () => {
+    // The guard only checks whether there are ANY messages at all (array
+    // length). It does NOT inspect individual Content.parts — empty-parts
+    // filtering is handled downstream by ContentConverters/HistoryService.
     const messages: Content[] = [{ role: 'user', parts: [] }];
-    // This array has length 1, so the guard says "continue" — the empty-parts
-    // filtering happens downstream in ContentConverters/HistoryService.
-    // The guard only checks whether there are ANY messages at all.
     expect(shouldStopNonInteractiveLoop(messages)).toBe(false);
   });
 });

--- a/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
@@ -12,29 +12,22 @@
  * evaluated to `false`, so the loop continued, producing an empty user turn
  * that z.ai rejected with HTTP 400 error 1213.
  *
- * These tests verify two things:
- * 1. `dispatchNonInteractiveTurnResult` can return `[]` (an empty Content[])
- *    when processFunctionCalls returns [].
- * 2. `executeNonInteractiveRun` stops the loop cleanly when an iteration
- *    produces no further messages (either null or empty array).
+ * These tests verify that `dispatchNonInteractiveTurnResult` returns `[]`
+ * (an empty Content[] — truthy, not null) when processFunctionCalls returns [],
+ * which is the exact value that the old `!nextMessages` guard failed to catch.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Content, FunctionDeclaration } from '@google/genai';
-import type { ChatSession } from './chatSession.js';
+import type { Content, FunctionCall } from '@google/genai';
 import type { ExecutionLoopContext } from './subagentExecution.js';
 import type { NonInteractiveRunContext } from './subagentNonInteractive.js';
-import {
-  executeNonInteractiveRun,
-  dispatchNonInteractiveTurnResult,
-} from './subagentNonInteractive.js';
+import { dispatchNonInteractiveTurnResult } from './subagentNonInteractive.js';
 import {
   SubagentTerminateMode,
   type OutputObject,
   type RunConfig,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
-import type { FunctionCall } from '@google/genai';
 
 // Mock processFunctionCalls so it returns [] (simulating all-hook-restricted)
 vi.mock('./subagentToolProcessing.js', async (importOriginal) => {
@@ -64,10 +57,7 @@ vi.mock('./subagentExecution.js', async (importOriginal) => {
 
 // Import the mocked processFunctionCalls so we can assert on it
 const { processFunctionCalls } = await import('./subagentToolProcessing.js');
-const mockedProcessFunctionCalls = processFunctionCalls as unknown as {
-  mockResolvedValue: (val: Content[]) => void;
-  mockClear: () => void;
-};
+const mockedProcessFunctionCalls = vi.mocked(processFunctionCalls);
 
 function makeExecCtx(): ExecutionLoopContext {
   return {
@@ -116,64 +106,60 @@ function makeCtx(): NonInteractiveRunContext {
   };
 }
 
-describe('issue #2410 (Layer 1) – empty nextMessages stops the loop', () => {
+describe('issue #2410 (Layer 1) – processFunctionCalls returning [] produces empty array, not null', () => {
   beforeEach(() => {
     mockedProcessFunctionCalls.mockClear();
     mockedProcessFunctionCalls.mockResolvedValue([]);
   });
 
-  describe('dispatchNonInteractiveTurnResult returns [] from processFunctionCalls', () => {
-    it('returns an empty Content[] (not null) when processFunctionCalls returns []', async () => {
-      // This is the crux of the bug: the return is [] (truthy), not null.
-      const functionCalls: FunctionCall[] = [
-        { id: 'c1', name: 'restricted_tool', args: {} },
-      ];
-      const result = await dispatchNonInteractiveTurnResult(
-        functionCalls,
-        new AbortController(),
-        'prompt-1',
-        0,
-        makeExecCtx(),
-        makeCtx(),
-      );
+  it('returns an empty Content[] (truthy, not null) when processFunctionCalls returns []', async () => {
+    // This is the crux of the bug: processFunctionCalls returns [] when all
+    // calls are hook-restricted. The old `!nextMessages` guard evaluated
+    // `![]` as `false`, so the loop continued and sent an empty user turn
+    // to the provider (causing z.ai error 1213). The fix checks
+    // `nextMessages.length === 0` instead.
+    const functionCalls: FunctionCall[] = [
+      { id: 'c1', name: 'restricted_tool', args: {} },
+    ];
+    const result = await dispatchNonInteractiveTurnResult(
+      functionCalls,
+      new AbortController(),
+      'prompt-1',
+      0,
+      makeExecCtx(),
+      makeCtx(),
+    );
 
-      // The result is [] — an empty but truthy array. The old `!nextMessages`
-      // check would NOT catch this (because ![] === false).
-      expect(Array.isArray(result)).toBe(true);
-      expect(result).toHaveLength(0);
-    });
+    // processFunctionCalls was actually invoked (not skipped)
+    expect(mockedProcessFunctionCalls).toHaveBeenCalledTimes(1);
+
+    // The result is [] — an empty but truthy array. The old `!nextMessages`
+    // check would NOT catch this (because ![] === false). The fix does.
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+
+    // Demonstrate the old guard would have failed:
+    // `!result` is false (empty array is truthy), so `if (!nextMessages)`
+    // would NOT have stopped the loop. The fix uses `nextMessages.length === 0`.
+    expect(!result).toBe(false); // old guard: does NOT stop
+    expect(result.length === 0).toBe(true); // new guard: DOES stop
   });
 
-  describe('executeNonInteractiveRun stops on empty messages', () => {
-    it('does NOT make a second provider call when the first turn yields no messages', async () => {
-      // With an empty stream, functionCalls = []. dispatchNonInteractiveTurnResult
-      // calls checkGoalCompletion (mocked → null). The loop should stop.
-      let sendMessageCallCount = 0;
+  it('processFunctionCalls is invoked when function calls are present in the turn', async () => {
+    const functionCalls: FunctionCall[] = [
+      { id: 'c1', name: 'read_file', args: { path: '/tmp/test' } },
+      { id: 'c2', name: 'write_file', args: { path: '/tmp/out' } },
+    ];
+    const result = await dispatchNonInteractiveTurnResult(
+      functionCalls,
+      new AbortController(),
+      'prompt-2',
+      1,
+      makeExecCtx(),
+      makeCtx(),
+    );
 
-      const mockChat = {
-        sendMessageStream: vi.fn(() => {
-          sendMessageCallCount += 1;
-          return {
-            async *[Symbol.asyncIterator]() {
-              // Empty stream — no events
-            },
-          };
-        }),
-      } as unknown as ChatSession;
-
-      await executeNonInteractiveRun(
-        mockChat,
-        [] as FunctionDeclaration[],
-        new AbortController(),
-        [{ role: 'user', parts: [{ text: 'do the task' }] }],
-        Date.now(),
-        makeExecCtx(),
-        makeCtx(),
-        () => {},
-      );
-
-      // Exactly one provider call — loop stopped, did not retry with []
-      expect(sendMessageCallCount).toBe(1);
-    });
+    expect(mockedProcessFunctionCalls).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
@@ -13,8 +13,8 @@
  * that z.ai rejected with HTTP 400 error 1213.
  *
  * The loop guard was extracted into `shouldStopNonInteractiveLoop` so it can
- * be tested directly. These tests verify the guard catches all three cases:
- * null, undefined-coerced-to-null, and the critical empty-array case.
+ * be tested directly. These tests verify the guard catches null and the
+ * critical empty-array case, and allows continuation for non-empty arrays.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue2410.test.ts
@@ -12,39 +12,39 @@
  * evaluated to `false`, so the loop continued, producing an empty user turn
  * that z.ai rejected with HTTP 400 error 1213.
  *
- * The loop guard was extracted into `shouldStopNonInteractiveLoop` so it can
- * be tested directly. These tests verify the guard catches null and the
- * critical empty-array case, and allows continuation for non-empty arrays.
+ * The loop guard `hasNonInteractiveMessages` was extracted into a type guard
+ * so it can be tested directly. These tests verify it returns false for null
+ * and empty arrays (stop cases), and true for non-empty arrays (continue case).
  */
 
 import { describe, it, expect } from 'vitest';
 import type { Content } from '@google/genai';
-import { shouldStopNonInteractiveLoop } from './subagentNonInteractive.js';
+import { hasNonInteractiveMessages } from './subagentNonInteractive.js';
 
-describe('issue #2410 – shouldStopNonInteractiveLoop guard', () => {
-  it('returns true for null (no further messages)', () => {
-    expect(shouldStopNonInteractiveLoop(null)).toBe(true);
+describe('issue #2410 – hasNonInteractiveMessages type guard', () => {
+  it('returns false for null (no further messages)', () => {
+    expect(hasNonInteractiveMessages(null)).toBe(false);
   });
 
-  it('returns true for an empty array — the critical bug case', () => {
+  it('returns false for an empty array — the critical bug case', () => {
     // This is the crux of the bug: processFunctionCalls returns [] (truthy,
     // not null) when all calls are hook-restricted. The old `!nextMessages`
     // guard evaluated `![]` as `false`, so the loop continued and sent an
     // empty user turn to the provider (causing z.ai error 1213).
     const emptyArray: Content[] = [];
-    expect(shouldStopNonInteractiveLoop(emptyArray)).toBe(true);
+    expect(hasNonInteractiveMessages(emptyArray)).toBe(false);
   });
 
-  it('returns false for a non-empty array — loop should continue', () => {
+  it('returns true for a non-empty array — loop should continue', () => {
     const messages: Content[] = [{ role: 'user', parts: [{ text: 'result' }] }];
-    expect(shouldStopNonInteractiveLoop(messages)).toBe(false);
+    expect(hasNonInteractiveMessages(messages)).toBe(true);
   });
 
-  it('returns false for a non-empty array even if individual parts are empty', () => {
+  it('returns true for a non-empty array even if individual parts are empty', () => {
     // The guard only checks whether there are ANY messages at all (array
     // length). It does NOT inspect individual Content.parts — empty-parts
     // filtering is handled downstream by ContentConverters/HistoryService.
     const messages: Content[] = [{ role: 'user', parts: [] }];
-    expect(shouldStopNonInteractiveLoop(messages)).toBe(false);
+    expect(hasNonInteractiveMessages(messages)).toBe(true);
   });
 });

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -454,7 +454,7 @@ export async function dispatchNonInteractiveTurnResult(
  */
 export function shouldStopNonInteractiveLoop(
   nextMessages: Content[] | null,
-): boolean {
+): nextMessages is null {
   return nextMessages === null || nextMessages.length === 0;
 }
 
@@ -521,7 +521,7 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat an empty array the
   // same as "no further messages" and stop the loop.
-  if (shouldStopNonInteractiveLoop(nextMessages) || nextMessages === null) {
+  if (shouldStopNonInteractiveLoop(nextMessages)) {
     return { action: 'stop' };
   }
   return { action: 'continue', messages: nextMessages };

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -521,13 +521,15 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat null and empty
   // array the same as "no further messages" and stop the loop.
-  if (nextMessages === null) {
-    return { action: 'stop' };
-  }
   if (shouldStopNonInteractiveLoop(nextMessages)) {
     return { action: 'stop' };
   }
-  return { action: 'continue', messages: nextMessages };
+  // shouldStopNonInteractiveLoop returned false, so nextMessages is
+  // non-null and non-empty — safe to forward.
+  return {
+    action: 'continue',
+    messages: nextMessages as Content[],
+  };
 }
 
 /**

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -532,15 +532,10 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat null and empty
   // array the same as "no further messages" and stop the loop.
-  if (shouldStopNonInteractiveLoop(nextMessages)) {
+  if (!hasNonInteractiveMessages(nextMessages)) {
     return { action: 'stop' };
   }
-  // hasNonInteractiveMessages narrows nextMessages to Content[] (it must
-  // be true here since shouldStopNonInteractiveLoop returned false).
-  if (hasNonInteractiveMessages(nextMessages)) {
-    return { action: 'continue', messages: nextMessages };
-  }
-  return { action: 'stop' };
+  return { action: 'continue', messages: nextMessages };
 }
 
 /**

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -454,7 +454,7 @@ export async function dispatchNonInteractiveTurnResult(
  */
 export function shouldStopNonInteractiveLoop(
   nextMessages: Content[] | null,
-): nextMessages is null {
+): boolean {
   return nextMessages === null || nextMessages.length === 0;
 }
 
@@ -521,7 +521,7 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat an empty array the
   // same as "no further messages" and stop the loop.
-  if (shouldStopNonInteractiveLoop(nextMessages)) {
+  if (nextMessages === null || shouldStopNonInteractiveLoop(nextMessages)) {
     return { action: 'stop' };
   }
   return { action: 'continue', messages: nextMessages };

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -519,9 +519,12 @@ async function runNonInteractiveLoopIteration(
   // `processFunctionCalls` returns `[]` (an empty, truthy array) when no
   // tool calls were executed. `!nextMessages` only catches null/undefined,
   // so an empty array would slip through and propagate a zero-part user
-  // message into provider history (issue #2410). Treat an empty array the
-  // same as "no further messages" and stop the loop.
-  if (nextMessages === null || shouldStopNonInteractiveLoop(nextMessages)) {
+  // message into provider history (issue #2410). Treat null and empty
+  // array the same as "no further messages" and stop the loop.
+  if (nextMessages === null) {
+    return { action: 'stop' };
+  }
+  if (shouldStopNonInteractiveLoop(nextMessages)) {
     return { action: 'stop' };
   }
   return { action: 'continue', messages: nextMessages };

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -442,6 +442,23 @@ export async function dispatchNonInteractiveTurnResult(
 // ---------------------------------------------------------------------------
 
 /**
+ * Determines whether the non-interactive loop should stop based on the
+ * next-messages result from `dispatchNonInteractiveTurnResult`.
+ *
+ * Issue #2410: `processFunctionCalls` can return `[]` (an empty, truthy
+ * array) when all tool calls are hook-restricted. The old guard
+ * `!nextMessages` only caught `null`/`undefined` — an empty array slipped
+ * through (`![] === false`) and propagated a zero-part user message into
+ * provider history. This helper centralizes the corrected guard so it can
+ * be unit-tested in isolation.
+ */
+export function shouldStopNonInteractiveLoop(
+  nextMessages: Content[] | null,
+): boolean {
+  return nextMessages === null || nextMessages.length === 0;
+}
+
+/**
  * Run one iteration of the non-interactive loop body. Returns a
  * discriminated result so the caller loop has a single control branch.
  */
@@ -504,10 +521,10 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat an empty array the
   // same as "no further messages" and stop the loop.
-  if (nextMessages === null || nextMessages.length === 0) {
+  if (shouldStopNonInteractiveLoop(nextMessages)) {
     return { action: 'stop' };
   }
-  return { action: 'continue', messages: nextMessages };
+  return { action: 'continue', messages: nextMessages ?? [] };
 }
 
 /**

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -521,10 +521,10 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat an empty array the
   // same as "no further messages" and stop the loop.
-  if (shouldStopNonInteractiveLoop(nextMessages)) {
+  if (shouldStopNonInteractiveLoop(nextMessages) || nextMessages === null) {
     return { action: 'stop' };
   }
-  return { action: 'continue', messages: nextMessages ?? [] };
+  return { action: 'continue', messages: nextMessages };
 }
 
 /**

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -499,7 +499,14 @@ async function runNonInteractiveLoopIteration(
     execCtx,
     ctx,
   );
-  if (!nextMessages) return { action: 'stop' };
+  // `processFunctionCalls` returns `[]` (an empty, truthy array) when no
+  // tool calls were executed. `!nextMessages` only catches null/undefined,
+  // so an empty array would slip through and propagate a zero-part user
+  // message into provider history (issue #2410). Treat an empty array the
+  // same as "no further messages" and stop the loop.
+  if (nextMessages === null || nextMessages.length === 0) {
+    return { action: 'stop' };
+  }
   return { action: 'continue', messages: nextMessages };
 }
 

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -532,10 +532,15 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat null and empty
   // array the same as "no further messages" and stop the loop.
-  if (!hasNonInteractiveMessages(nextMessages)) {
+  if (shouldStopNonInteractiveLoop(nextMessages)) {
     return { action: 'stop' };
   }
-  return { action: 'continue', messages: nextMessages };
+  // hasNonInteractiveMessages narrows nextMessages to Content[] (it must
+  // be true here since shouldStopNonInteractiveLoop returned false).
+  if (hasNonInteractiveMessages(nextMessages)) {
+    return { action: 'continue', messages: nextMessages };
+  }
+  return { action: 'stop' };
 }
 
 /**

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -442,23 +442,14 @@ export async function dispatchNonInteractiveTurnResult(
 // ---------------------------------------------------------------------------
 
 /**
- * Determines whether the non-interactive loop should stop based on the
- * next-messages result from `dispatchNonInteractiveTurnResult`.
+ * Type guard: returns true when nextMessages is non-null AND non-empty.
  *
  * Issue #2410: `processFunctionCalls` can return `[]` (an empty, truthy
  * array) when all tool calls are hook-restricted. The old guard
  * `!nextMessages` only caught `null`/`undefined` — an empty array slipped
  * through (`![] === false`) and propagated a zero-part user message into
- * provider history. This helper centralizes the corrected guard so it can
- * be unit-tested in isolation.
- */
-/**
- * Type guard: returns true when nextMessages is non-null AND non-empty.
- * Issue #2410: `processFunctionCalls` can return `[]` (an empty, truthy
- * array) when all tool calls are hook-restricted. The old guard
- * `!nextMessages` only caught `null`/`undefined` — an empty array slipped
- * through (`![] === false`) and propagated a zero-part user message into
- * provider history. This type guard centralizes the corrected check.
+ * provider history. This type guard centralizes the corrected check so it
+ * can be unit-tested in isolation.
  */
 export function hasNonInteractiveMessages(
   nextMessages: Content[] | null,

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -452,16 +452,13 @@ export async function dispatchNonInteractiveTurnResult(
  * provider history. This helper centralizes the corrected guard so it can
  * be unit-tested in isolation.
  */
-export function shouldStopNonInteractiveLoop(
-  nextMessages: Content[] | null,
-): boolean {
-  return nextMessages === null || nextMessages.length === 0;
-}
-
 /**
  * Type guard: returns true when nextMessages is non-null AND non-empty.
- * Issue #2410: the inverse of shouldStopNonInteractiveLoop, but as a proper
- * type guard so the caller gets TS narrowing to Content[] without a cast.
+ * Issue #2410: `processFunctionCalls` can return `[]` (an empty, truthy
+ * array) when all tool calls are hook-restricted. The old guard
+ * `!nextMessages` only caught `null`/`undefined` — an empty array slipped
+ * through (`![] === false`) and propagated a zero-part user message into
+ * provider history. This type guard centralizes the corrected check.
  */
 export function hasNonInteractiveMessages(
   nextMessages: Content[] | null,

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -459,6 +459,17 @@ export function shouldStopNonInteractiveLoop(
 }
 
 /**
+ * Type guard: returns true when nextMessages is non-null AND non-empty.
+ * Issue #2410: the inverse of shouldStopNonInteractiveLoop, but as a proper
+ * type guard so the caller gets TS narrowing to Content[] without a cast.
+ */
+export function hasNonInteractiveMessages(
+  nextMessages: Content[] | null,
+): nextMessages is Content[] {
+  return nextMessages !== null && nextMessages.length > 0;
+}
+
+/**
  * Run one iteration of the non-interactive loop body. Returns a
  * discriminated result so the caller loop has a single control branch.
  */
@@ -521,15 +532,10 @@ async function runNonInteractiveLoopIteration(
   // so an empty array would slip through and propagate a zero-part user
   // message into provider history (issue #2410). Treat null and empty
   // array the same as "no further messages" and stop the loop.
-  if (shouldStopNonInteractiveLoop(nextMessages)) {
+  if (!hasNonInteractiveMessages(nextMessages)) {
     return { action: 'stop' };
   }
-  // shouldStopNonInteractiveLoop returned false, so nextMessages is
-  // non-null and non-empty — safe to forward.
-  return {
-    action: 'continue',
-    messages: nextMessages as Content[],
-  };
+  return { action: 'continue', messages: nextMessages };
 }
 
 /**

--- a/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
+++ b/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
@@ -64,4 +64,12 @@ export interface RuntimeGenerateChatOptions {
     streaming?: boolean;
   };
   userMemory?: unknown;
+  /**
+   * Caller-supplied system instruction (e.g. a subagent persona/task prompt).
+   * When present, providers SHOULD merge this into their system prompt so the
+   * agent's directives reach the model. Without this field, subagent personas
+   * built in generationConfig.systemInstruction are silently dropped because
+   * the provider rebuilds its own core prompt.
+   */
+  systemInstruction?: string;
 }

--- a/packages/core/src/services/history/ContentConverters.test.ts
+++ b/packages/core/src/services/history/ContentConverters.test.ts
@@ -562,3 +562,41 @@ describe('ContentConverters - neutral type I/O (#2397)', () => {
     expect(block.thought).toBe('reasoning here');
   });
 });
+
+describe('issue #2410 – toIContent zero-block guard', () => {
+  it('produces zero blocks when input has no parts (not a fabricated turn)', () => {
+    const emptyContent: TestContent = {
+      role: 'user',
+      parts: [],
+    };
+
+    const result = ContentConverters.toIContent(
+      emptyContent,
+      undefined,
+      undefined,
+      'turn-empty',
+    );
+
+    // The converter does not fabricate content — it produces zero blocks
+    // so downstream history services can detect and drop the empty turn.
+    expect(result.blocks).toHaveLength(0);
+    expect(result.speaker).toBe('human');
+  });
+
+  it('produces zero blocks when input parts is undefined', () => {
+    const noPartsContent: TestContent = {
+      role: 'model',
+      parts: undefined as unknown as TestContent['parts'],
+    };
+
+    const result = ContentConverters.toIContent(
+      noPartsContent,
+      undefined,
+      undefined,
+      'turn-noparts',
+    );
+
+    expect(result.blocks).toHaveLength(0);
+    expect(result.speaker).toBe('ai');
+  });
+});

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -481,7 +481,11 @@ export class ContentConverters {
       this.logger.warn(
         () =>
           `[ContentConverters] toIContent produced zero blocks (issue #2410) — this turn will be dropped by history`,
-        { role: content.role, partCount: content.parts?.length ?? 0 },
+        {
+          role: content.role,
+          partCount: content.parts?.length ?? 0,
+          partTypes: content.parts?.map((p) => Object.keys(p)) ?? [],
+        },
       );
     }
 

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -39,6 +39,7 @@ function classifyPartType(part: GeminiContentPart): string {
   if ('text' in part) return 'text';
   if ('functionCall' in part) return 'functionCall';
   if ('functionResponse' in part) return 'functionResponse';
+  if ('inlineData' in part) return 'inlineData';
   if ('thought' in part) return 'thought';
   return 'other';
 }
@@ -489,6 +490,7 @@ export class ContentConverters {
         () =>
           `[ContentConverters] toIContent produced zero blocks (issue #2410) — this turn will be dropped by history`,
         {
+          turnKey,
           role: content.role,
           partCount: content.parts?.length ?? 0,
           partTypes: content.parts?.map(classifyPartType) ?? [],

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -31,6 +31,19 @@ function generateTurnKey(): string {
 }
 
 /**
+ * Maps a Gemini Content part to a human-readable type label for logging.
+ * Used by both `logToIContentInput` and the zero-block warning so they
+ * produce consistent output for cross-referencing during debugging.
+ */
+function classifyPartType(part: GeminiContentPart): string {
+  if ('text' in part) return 'text';
+  if ('functionCall' in part) return 'functionCall';
+  if ('functionResponse' in part) return 'functionResponse';
+  if ('thought' in part) return 'thought';
+  return 'other';
+}
+
+/**
  * Converts between Gemini Content format and IContent format
  */
 export class ContentConverters {
@@ -166,13 +179,7 @@ export class ContentConverters {
     this.logger.debug('Converted to Gemini Content:', {
       role,
       partCount: parts.length,
-      partTypes: parts.map((p) => {
-        if ('text' in p) return 'text';
-        if ('functionCall' in p) return 'functionCall';
-        if ('functionResponse' in p) return 'functionResponse';
-        if ('thought' in p) return 'thought';
-        return 'other';
-      }),
+      partTypes: parts.map(classifyPartType),
       functionCallIds: parts
         .filter((p) => 'functionCall' in p)
         .map((p) => (p as { functionCall?: { id?: string } }).functionCall?.id),
@@ -484,7 +491,7 @@ export class ContentConverters {
         {
           role: content.role,
           partCount: content.parts?.length ?? 0,
-          partTypes: content.parts?.map((p) => Object.keys(p)) ?? [],
+          partTypes: content.parts?.map(classifyPartType) ?? [],
         },
       );
     }
@@ -513,14 +520,7 @@ export class ContentConverters {
     this.logger.debug('Converting Gemini Content to IContent:', {
       role: content.role,
       partCount: content.parts?.length ?? 0,
-      partTypes:
-        content.parts?.map((p) => {
-          if ('text' in p) return 'text';
-          if ('functionCall' in p) return 'functionCall';
-          if ('functionResponse' in p) return 'functionResponse';
-          if ('thought' in p) return 'thought';
-          return 'other';
-        }) ?? [],
+      partTypes: content.parts?.map(classifyPartType) ?? [],
       functionCallIds:
         content.parts
           ?.filter((p) => 'functionCall' in p)

--- a/packages/core/src/services/history/ContentConverters.ts
+++ b/packages/core/src/services/history/ContentConverters.ts
@@ -436,32 +436,7 @@ export class ContentConverters {
     getNextUnmatchedToolCall?: () => { historyId: string; toolName?: string },
     turnKeyOverride?: string,
   ): IContent {
-    this.logger.debug('Converting Gemini Content to IContent:', {
-      role: content.role,
-      partCount: content.parts?.length ?? 0,
-      partTypes:
-        content.parts?.map((p) => {
-          if ('text' in p) return 'text';
-          if ('functionCall' in p) return 'functionCall';
-          if ('functionResponse' in p) return 'functionResponse';
-          if ('thought' in p) return 'thought';
-          return 'other';
-        }) ?? [],
-      functionCallIds:
-        content.parts
-          ?.filter((p) => 'functionCall' in p)
-          .map(
-            (p) => (p as { functionCall?: { id?: string } }).functionCall?.id,
-          ) ?? [],
-      functionResponseIds:
-        content.parts
-          ?.filter((p) => 'functionResponse' in p)
-          .map(
-            (p) =>
-              (p as { functionResponse?: { id?: string } }).functionResponse
-                ?.id,
-          ) ?? [],
-    });
+    this.logToIContentInput(content);
 
     const speaker = content.role === 'user' ? 'human' : 'ai';
     const blocks: ContentBlock[] = [];
@@ -502,6 +477,14 @@ export class ContentConverters {
       metadata,
     };
 
+    if (blocks.length === 0) {
+      this.logger.warn(
+        () =>
+          `[ContentConverters] toIContent produced zero blocks (issue #2410) — this turn will be dropped by history`,
+        { role: content.role, partCount: content.parts?.length ?? 0 },
+      );
+    }
+
     this.logger.debug('Converted to IContent:', {
       originalRole: content.role,
       finalSpeaker,
@@ -516,6 +499,39 @@ export class ContentConverters {
     });
 
     return result;
+  }
+
+  /**
+   * Log raw Gemini Content details before conversion to IContent.
+   * Extracted from toIContent to keep that method within complexity limits.
+   */
+  private static logToIContentInput(content: GeminiContent): void {
+    this.logger.debug('Converting Gemini Content to IContent:', {
+      role: content.role,
+      partCount: content.parts?.length ?? 0,
+      partTypes:
+        content.parts?.map((p) => {
+          if ('text' in p) return 'text';
+          if ('functionCall' in p) return 'functionCall';
+          if ('functionResponse' in p) return 'functionResponse';
+          if ('thought' in p) return 'thought';
+          return 'other';
+        }) ?? [],
+      functionCallIds:
+        content.parts
+          ?.filter((p) => 'functionCall' in p)
+          .map(
+            (p) => (p as { functionCall?: { id?: string } }).functionCall?.id,
+          ) ?? [],
+      functionResponseIds:
+        content.parts
+          ?.filter((p) => 'functionResponse' in p)
+          .map(
+            (p) =>
+              (p as { functionResponse?: { id?: string } }).functionResponse
+                ?.id,
+          ) ?? [],
+    });
   }
 
   /**

--- a/packages/core/src/services/history/HistoryService.issue2410.test.ts
+++ b/packages/core/src/services/history/HistoryService.issue2410.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for issue #2410:
+ * HistoryService.addInternal must refuse to store an IContent with zero
+ * blocks — the systemic safety net against empty turns in provider-facing
+ * history (z.ai rejects these with HTTP 400 error 1213).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { HistoryService } from './HistoryService.js';
+import type { IContent } from './IContent.js';
+
+describe('issue #2410 – HistoryService rejects zero-block turns', () => {
+  let service: HistoryService;
+
+  beforeEach(() => {
+    service = new HistoryService();
+  });
+
+  it('refuses to store a zero-block human turn', () => {
+    const emptyHuman: IContent = {
+      speaker: 'human',
+      blocks: [],
+    };
+    service.add(emptyHuman);
+    expect(service.getAll()).toHaveLength(0);
+  });
+
+  it('refuses to store a zero-block AI turn', () => {
+    const emptyAI: IContent = {
+      speaker: 'ai',
+      blocks: [],
+    };
+    service.add(emptyAI);
+    expect(service.getAll()).toHaveLength(0);
+  });
+
+  it('refuses to store a zero-block tool turn', () => {
+    const emptyTool: IContent = {
+      speaker: 'tool',
+      blocks: [],
+    };
+    service.add(emptyTool);
+    expect(service.getAll()).toHaveLength(0);
+  });
+
+  it('still stores a valid human message with one block', () => {
+    const validHuman: IContent = {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'hello' }],
+    };
+    service.add(validHuman);
+    expect(service.getAll()).toHaveLength(1);
+  });
+
+  it('still stores a valid AI message with one block', () => {
+    const validAI: IContent = {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'response' }],
+    };
+    service.add(validAI);
+    expect(service.getAll()).toHaveLength(1);
+  });
+
+  it('does not emit contentAdded for rejected zero-block content', () => {
+    let emitted = false;
+    service.on('contentAdded', () => {
+      emitted = true;
+    });
+    const emptyHuman: IContent = {
+      speaker: 'human',
+      blocks: [],
+    };
+    service.add(emptyHuman);
+    expect(emitted).toBe(false);
+  });
+
+  it('still rejects invalid speaker (pre-existing behavior)', () => {
+    const badSpeaker: IContent = {
+      speaker: 'invalid' as IContent['speaker'],
+      blocks: [{ type: 'text', text: 'hello' }],
+    };
+    service.add(badSpeaker);
+    expect(service.getAll()).toHaveLength(0);
+  });
+});

--- a/packages/core/src/services/history/HistoryService.issue2410.test.ts
+++ b/packages/core/src/services/history/HistoryService.issue2410.test.ts
@@ -90,6 +90,18 @@ describe('issue #2410 – HistoryService rejects zero-block turns', () => {
     expect(emitted).toBe(false);
   });
 
+  it('emits contentAdded for valid content', () => {
+    let emitted = false;
+    service.on('contentAdded', () => {
+      emitted = true;
+    });
+    service.add({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'hello' }],
+    });
+    expect(emitted).toBe(true);
+  });
+
   it('still rejects invalid speaker (pre-existing behavior)', () => {
     const badSpeaker: IContent = {
       speaker: 'invalid' as IContent['speaker'],

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -273,9 +273,10 @@ export class HistoryService
   }
 
   /**
-   * Add content to the history
-   * Note: We accept all content including empty responses for comprehensive history.
-   * Filtering happens only when getting curated history.
+   * Add content to the history.
+   * Zero-block turns are rejected at insertion (issue #2410): they corrupt
+   * provider-facing history (z.ai rejects empty human turns with HTTP 400
+   * error 1213). All other content with a valid speaker is accepted.
    */
   add(content: IContent, modelName?: string): void {
     // If compression is active, queue this operation
@@ -295,8 +296,15 @@ export class HistoryService
   private addInternal(content: IContent, modelName?: string): void {
     logContentAdded(this.logger, content, modelName);
 
-    // Only do basic validation - must have valid speaker
-    if (['human', 'ai', 'tool'].includes(content.speaker)) {
+    // Reject zero-block turns: a Content with no blocks corrupts provider-
+    // facing history (notably z.ai rejects empty human turns with HTTP 400
+    // error 1213, issue #2410). This is a systemic safety net — earlier
+    // layers should prevent these from reaching history, but we enforce the
+    // invariant here as the last line of defense.
+    const hasValidSpeaker = ['human', 'ai', 'tool'].includes(content.speaker);
+    const hasBlocks =
+      Array.isArray(content.blocks) && content.blocks.length > 0;
+    if (hasValidSpeaker && hasBlocks) {
       this.history.push(content);
 
       this.logger.debug(
@@ -308,6 +316,11 @@ export class HistoryService
 
       // Update token count asynchronously but atomically
       void this.updateTokenCount(content, modelName);
+    } else if (!hasBlocks) {
+      this.logger.debug(
+        'Content rejected - zero blocks (issue #2410):',
+        content.speaker,
+      );
     } else {
       this.logger.debug('Content rejected - invalid speaker:', content.speaker);
     }

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -316,13 +316,13 @@ export class HistoryService
 
       // Update token count asynchronously but atomically
       void this.updateTokenCount(content, modelName);
-    } else if (!hasBlocks) {
+    } else if (!hasValidSpeaker) {
+      this.logger.debug('Content rejected - invalid speaker:', content.speaker);
+    } else {
       this.logger.debug(
         'Content rejected - zero blocks (issue #2410):',
         content.speaker,
       );
-    } else {
-      this.logger.debug('Content rejected - invalid speaker:', content.speaker);
     }
   }
 

--- a/packages/providers/src/IProvider.ts
+++ b/packages/providers/src/IProvider.ts
@@ -63,6 +63,14 @@ export interface GenerateChatOptions {
     streaming?: boolean;
   };
   userMemory?: UserMemoryInput;
+  /**
+   * Caller-supplied system instruction (e.g. a subagent persona/task prompt).
+   * When present, providers SHOULD merge this into their system prompt so the
+   * agent's directives reach the model. Issue #2410: without this field the
+   * subagent persona built in generationConfig.systemInstruction never reaches
+   * the provider, because the provider rebuilds its own generic core prompt.
+   */
+  systemInstruction?: string;
 }
 
 /**

--- a/packages/providers/src/anthropic/AnthropicEndpointUtils.ts
+++ b/packages/providers/src/anthropic/AnthropicEndpointUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Determines whether a base URL points to the native Anthropic API
+ * (api.anthropic.com or a subdomain thereof).
+ *
+ * Returns `true` for an undefined/empty base URL (the default endpoint is
+ * Anthropic). Returns `false` for third-party Anthropic-compatible endpoints
+ * such as z.ai, suffix-spoofing hosts, and malformed URLs.
+ *
+ * Used by OAuth eligibility gating (#2411) and prompt-cache format gating
+ * (#2410): third-party endpoints reject the Anthropic cache_control array
+ * format and must not receive OAuth handshakes.
+ */
+export function isAnthropicOAuthBaseURL(baseURL?: string): boolean {
+  if (baseURL === undefined || baseURL.trim() === '') {
+    return true;
+  }
+  try {
+    const host = new URL(baseURL).hostname.toLowerCase();
+    return host === 'anthropic.com' || host.endsWith('.anthropic.com');
+  } catch {
+    return false;
+  }
+}

--- a/packages/providers/src/anthropic/AnthropicEndpointUtils.ts
+++ b/packages/providers/src/anthropic/AnthropicEndpointUtils.ts
@@ -6,11 +6,15 @@
 
 /**
  * Determines whether a base URL points to the native Anthropic API
- * (api.anthropic.com or a subdomain thereof).
+ * (anthropic.com or a subdomain thereof, e.g. api.anthropic.com).
  *
  * Returns `true` for an undefined/empty base URL (the default endpoint is
  * Anthropic). Returns `false` for third-party Anthropic-compatible endpoints
  * such as z.ai, suffix-spoofing hosts, and malformed URLs.
+ *
+ * Note: the bare apex domain `anthropic.com` (the marketing site) also
+ * matches. This is intentional for backwards compatibility — OAuth
+ * credentials are scoped to the Anthropic account, not a specific subdomain.
  *
  * Used by OAuth eligibility gating (#2411) and prompt-cache format gating
  * (#2410): third-party endpoints reject the Anthropic cache_control array

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -38,6 +38,7 @@ import {
   getLatestClaudeModel as getLatestClaudeModelFn,
 } from './AnthropicModelData.js';
 import { prepareAnthropicRequest } from './AnthropicRequestPreparation.js';
+import { isAnthropicOAuthBaseURL } from './AnthropicEndpointUtils.js';
 import { firstTruthyString } from '../utils/falsyFallback.js';
 import {
   buildAnthropicCustomHeaders,
@@ -738,23 +739,10 @@ export class AnthropicProvider extends BaseProvider {
   }
 }
 
-/**
- * True when the given base URL is Anthropic's own API host (or unset), meaning
- * OAuth against api.anthropic.com is a valid credential path. For any
- * third-party gateway (e.g. https://api.z.ai/api/anthropic) this returns false
- * so we never attempt an Anthropic OAuth handshake against the wrong endpoint.
- */
-export function isAnthropicOAuthBaseURL(baseURL?: string): boolean {
-  if (baseURL === undefined || baseURL.trim() === '') {
-    return true;
-  }
-  try {
-    const host = new URL(baseURL).hostname.toLowerCase();
-    return host === 'anthropic.com' || host.endsWith('.anthropic.com');
-  } catch {
-    return false;
-  }
-}
+// Re-exported from AnthropicEndpointUtils for backwards compatibility.
+// Issue #2410: extracted to a standalone module to avoid a circular import
+// between AnthropicProvider and AnthropicRequestPreparation.
+export { isAnthropicOAuthBaseURL } from './AnthropicEndpointUtils.js';
 
 function isRuntimeAuthTokenProvider(
   value: unknown,

--- a/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
+++ b/packages/providers/src/anthropic/AnthropicRequestPreparation.ts
@@ -29,9 +29,11 @@ import {
   sortObjectKeys,
 } from './AnthropicRequestBuilder.js';
 import { getRetryConfig } from './AnthropicRateLimitHandler.js';
+import { isAnthropicOAuthBaseURL } from './AnthropicEndpointUtils.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { shouldIncludeSubagentDelegation } from '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js';
 import { resolveUserMemory } from '../utils/userMemory.js';
+import { mergeSystemInstruction as mergeSystemInstructionShared } from '../utils/systemInstructionMerge.js';
 
 /**
  * Request preparation context returned to caller
@@ -257,6 +259,7 @@ async function buildOAuthSystemContext(params: {
   wantCaching: boolean;
   ttl: '5m' | '1h';
   cacheLogger: { debug: (fn: () => string) => void };
+  systemInstruction: string | undefined;
 }): Promise<SystemContextResult> {
   const {
     currentModel,
@@ -269,6 +272,7 @@ async function buildOAuthSystemContext(params: {
     wantCaching,
     ttl,
     cacheLogger,
+    systemInstruction,
   } = params;
 
   const messages = [...anthropicMessages];
@@ -281,7 +285,15 @@ async function buildOAuthSystemContext(params: {
     interactionMode,
   });
 
-  if (corePrompt) {
+  // Issue #2410: Merge the caller-supplied system instruction (e.g. a
+  // subagent persona/task prompt) with the core prompt before wrapping it in
+  // the <system> tag so task directives reach the OAuth endpoint.
+  const systemMessage = mergeSystemInstructionShared(
+    corePrompt,
+    systemInstruction,
+  );
+
+  if (systemMessage) {
     if (wantCaching) {
       messages.unshift({
         role: 'user',
@@ -289,7 +301,7 @@ async function buildOAuthSystemContext(params: {
           {
             type: 'text',
             text: `<system>
-${corePrompt}
+${systemMessage}
 </system>
 
 User provided conversation begins here:`,
@@ -306,7 +318,7 @@ User provided conversation begins here:`,
       messages.unshift({
         role: 'user',
         content: `<system>
-${corePrompt}
+${systemMessage}
 </system>
 
 User provided conversation begins here:`,
@@ -333,6 +345,7 @@ async function buildNonOAuthSystemContext(params: {
   anthropicMessages: readonly AnthropicMessage[];
   wantCaching: boolean;
   ttl: '5m' | '1h';
+  systemInstruction: string | undefined;
 }): Promise<SystemContextResult> {
   const {
     currentModel,
@@ -344,6 +357,7 @@ async function buildNonOAuthSystemContext(params: {
     anthropicMessages,
     wantCaching,
     ttl,
+    systemInstruction,
   } = params;
 
   const systemPrompt = await getCoreSystemPromptAsync({
@@ -355,8 +369,17 @@ async function buildNonOAuthSystemContext(params: {
     interactionMode,
   });
 
+  // Issue #2410: Merge the caller-supplied system instruction (e.g. a
+  // subagent persona/task prompt) with the core system prompt. The
+  // caller instruction is appended after the core prompt so the model
+  // sees both the base behavior directives and the agent-specific task.
+  const mergedPrompt = mergeSystemInstructionShared(
+    systemPrompt,
+    systemInstruction,
+  );
+
   const systemFieldValue = buildAnthropicSystemPrompt({
-    corePromptText: systemPrompt,
+    corePromptText: mergedPrompt,
     isOAuth: false,
     wantCaching,
     ttl,
@@ -380,6 +403,7 @@ async function buildSystemContext(params: {
   wantCaching: boolean;
   ttl: '5m' | '1h';
   cacheLogger: { debug: (fn: () => string) => void };
+  systemInstruction: string | undefined;
 }): Promise<SystemContextResult> {
   if (params.isOAuth) {
     return buildOAuthSystemContext(params);
@@ -660,6 +684,7 @@ function buildRequestContext(params: {
   cacheLogger: { debug: (fn: () => string) => void };
   toolsLogger: DebugLogger;
   logger: DebugLogger;
+  wantCaching: boolean;
 }): AnthropicRequestContext {
   const {
     reasoningSettings,
@@ -671,9 +696,13 @@ function buildRequestContext(params: {
     cacheLogger,
     toolsLogger,
     logger,
+    wantCaching,
   } = params;
 
-  if (requestSettings.wantCaching) {
+  // Issue #2410: use the effective caching flag (already gated on whether the
+  // base URL is a native Anthropic endpoint) for both system-field and
+  // message-level cache_control injection.
+  if (wantCaching) {
     attachPromptCaching(
       systemContext.messages,
       requestSettings.ttl,
@@ -711,7 +740,7 @@ function buildRequestContext(params: {
     requestBody,
     anthropicMessages: systemContext.messages,
     streamingEnabled: requestSettings.streamingEnabled,
-    wantCaching: requestSettings.wantCaching,
+    wantCaching,
     ttl: requestSettings.ttl,
     configEphemerals: requestSettings.configEphemerals,
     maxAttempts,
@@ -752,7 +781,23 @@ export async function prepareAnthropicRequest(
     params.providerName,
   );
 
-  if (requestSettings.wantCaching) {
+  // Issue #2410: z.ai and other third-party Anthropic-compatible endpoints
+  // reject the prompt-cache `system` array format
+  // ([{type:'text', text:'...', cache_control:{...}}]). Only emit cache_control
+  // when the request targets the native Anthropic API. Reusing the OAuth
+  // eligibility helper avoids duplicating the hostname check.
+  const effectiveWantCaching =
+    requestSettings.wantCaching &&
+    isAnthropicOAuthBaseURL(params.options.resolved.baseURL);
+
+  if (!effectiveWantCaching && requestSettings.wantCaching) {
+    params.cacheLogger.debug(
+      () =>
+        `Prompt caching disabled: base URL (${params.options.resolved.baseURL ?? '<unset>'}) is not a native Anthropic endpoint`,
+    );
+  }
+
+  if (effectiveWantCaching) {
     params.cacheLogger.debug(
       () => `Prompt caching enabled with TTL: ${requestSettings.ttl}`,
     );
@@ -778,9 +823,10 @@ export async function prepareAnthropicRequest(
     includeSubagentDelegation,
     interactionMode,
     anthropicMessages,
-    wantCaching: requestSettings.wantCaching,
+    wantCaching: effectiveWantCaching,
     ttl: requestSettings.ttl,
     cacheLogger: params.cacheLogger,
+    systemInstruction: params.options.systemInstruction,
   });
 
   return buildRequestContext({
@@ -793,5 +839,6 @@ export async function prepareAnthropicRequest(
     cacheLogger: params.cacheLogger,
     toolsLogger: params.toolsLogger,
     logger: params.logger,
+    wantCaching: effectiveWantCaching,
   });
 }

--- a/packages/providers/src/gemini/geminiGenerationExecution.ts
+++ b/packages/providers/src/gemini/geminiGenerationExecution.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/dumpSDKContext.js';
 import { type ResponseToChunksMapper } from './geminiResponseMapper.js';
 import { buildSystemInstruction } from './geminiRequestBuilding.js';
+import { mergeSystemInstruction } from '../utils/systemInstructionMerge.js';
 
 /** Result of a generation execution path. */
 export interface GeminiGenerationResult {
@@ -125,11 +126,17 @@ export async function executeNonOAuthGeneration(
   baseURL: string | undefined,
 ): Promise<GeminiGenerationResult> {
   const contentGenerator = await createContentGenerator();
-  const systemInstruction = await buildSystemInstruction(
+  const coreSystemInstruction = await buildSystemInstruction(
     options,
     globalConfig,
     toolNamesForPrompt,
     currentModel,
+  );
+  // Issue #2410: Merge caller-supplied system instruction (e.g. subagent
+  // persona) with the core system prompt so task directives reach the model.
+  const systemInstruction = mergeSystemInstruction(
+    coreSystemInstruction,
+    options.systemInstruction,
   );
   const apiRequest: GenerateContentParameters & { systemInstruction: string } =
     {

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -27,6 +27,7 @@ import { convertToolsToOpenAIResponses } from './schemaConverter.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { shouldIncludeSubagentDelegation } from '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js';
 import { resolveUserMemory } from '../utils/userMemory.js';
+import { mergeSystemInstruction } from '../utils/systemInstructionMerge.js';
 import { resolveRuntimeAuthToken } from '../utils/authToken.js';
 import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
@@ -172,7 +173,7 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
       toolNames ?? [],
       () => configWithManagers?.getSubagentManager?.(),
     );
-    return getCoreSystemPromptAsync({
+    const corePrompt = await getCoreSystemPromptAsync({
       userMemory,
       mcpInstructions,
       model: options.resolved.model || this.getDefaultModel(),
@@ -183,6 +184,10 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
           ? 'interactive'
           : 'non-interactive',
     });
+    // Issue #2410: Merge the caller-supplied system instruction (e.g. a
+    // subagent persona/task prompt) with the core system prompt so the
+    // instruction reaches the Responses/Codex API via request.instructions.
+    return mergeSystemInstruction(corePrompt, options.systemInstruction);
   }
 
   private getToolNamesForPrompt(

--- a/packages/providers/src/openai/OpenAIRequestPreparation.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.ts
@@ -21,6 +21,7 @@ import { convertToolsToOpenAI, type OpenAITool } from './schemaConverter.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { shouldIncludeSubagentDelegation } from '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js';
 import { resolveUserMemory } from '../utils/userMemory.js';
+import { mergeSystemInstruction } from '../utils/systemInstructionMerge.js';
 import { resolveToolFormat } from '../utils/toolFormatDetection.js';
 import { buildMessagesWithReasoning } from './OpenAIRequestBuilder.js';
 import { extractModelParamsFromOptions } from './OpenAIClientFactory.js';
@@ -115,7 +116,7 @@ async function resolveSystemPrompt(
         ? config.getSubagentManager()
         : undefined,
   );
-  return getCoreSystemPromptAsync({
+  const corePrompt = await getCoreSystemPromptAsync({
     userMemory,
     mcpInstructions,
     model,
@@ -128,6 +129,10 @@ async function resolveSystemPrompt(
         ? 'interactive'
         : 'non-interactive',
   });
+  // Issue #2410: Merge the caller-supplied system instruction (e.g. a
+  // subagent persona/task prompt) with the core system prompt so the
+  // instruction reaches the Chat Completions API as the system message.
+  return mergeSystemInstruction(corePrompt, options.systemInstruction);
 }
 
 type OpenAIInvocationRuntime = {

--- a/packages/providers/src/utils/systemInstructionMerge.ts
+++ b/packages/providers/src/utils/systemInstructionMerge.ts
@@ -5,7 +5,7 @@
  * The instruction is appended after the core prompt, separated by a blank
  * line, so the model sees both the base behavior directives and the
  * agent-specific task. Returns:
- *  - the core prompt unchanged when the instruction is absent or empty;
+ *  - the trimmed core prompt when the instruction is absent or empty;
  *  - the instruction alone when the core prompt is empty;
  *  - both joined by a blank line when both are present.
  *

--- a/packages/providers/src/utils/systemInstructionMerge.ts
+++ b/packages/providers/src/utils/systemInstructionMerge.ts
@@ -1,0 +1,30 @@
+/**
+ * Merges a caller-supplied system instruction (e.g. subagent persona/task
+ * prompt) into the core system prompt built from getCoreSystemPromptAsync.
+ *
+ * The instruction is appended after the core prompt, separated by a blank
+ * line, so the model sees both the base behavior directives and the
+ * agent-specific task. Returns:
+ *  - the core prompt unchanged when the instruction is absent or empty;
+ *  - the instruction alone when the core prompt is empty;
+ *  - both joined by a blank line when both are present.
+ *
+ * Issue #2410: Without this merge, subagent task directives set on
+ * options.systemInstruction never reach the model for several providers.
+ */
+export function mergeSystemInstruction(
+  corePrompt: string | undefined,
+  systemInstruction: string | undefined,
+): string {
+  const coreText = typeof corePrompt === 'string' ? corePrompt.trim() : '';
+  const instructionText =
+    typeof systemInstruction === 'string' ? systemInstruction.trim() : '';
+
+  if (instructionText.length === 0) {
+    return coreText;
+  }
+  if (coreText.length === 0) {
+    return instructionText;
+  }
+  return `${coreText}\n\n${instructionText}`;
+}

--- a/scripts/tmux-script.subagent-haiku.json
+++ b/scripts/tmux-script.subagent-haiku.json
@@ -1,0 +1,58 @@
+{
+  "tmux": {
+    "cols": 140,
+    "rows": 48,
+    "historyLimit": 100000,
+    "scrollbackLines": 40000,
+    "initialWaitMs": 10000
+  },
+  "startCommand": [
+    "bun",
+    "scripts/start.ts",
+    "--profile-load",
+    "zai",
+    "--yolo"
+  ],
+  "yolo": true,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 60000
+    },
+    { "type": "capture", "label": "00-startup", "scope": "screen" },
+
+    {
+      "type": "line",
+      "text": "Have the codeanalyzer and deepthinker subagents read the docs/ directory. Each should pick whatever they found most interesting from that directory and compose a haiku based on it. Run them as parallel synchronous subagents. Once both finish, print each haiku and note which subagent wrote which.",
+      "submitKeys": ["Enter"]
+    },
+    {
+      "type": "waitFor",
+      "scope": "scrollback",
+      "contains": "esc to cancel",
+      "timeoutMs": 120000
+    },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "esc to cancel",
+      "timeoutMs": 600000
+    },
+    { "type": "wait", "ms": 3000 },
+    {
+      "type": "capture",
+      "label": "01-subagent-result-screen",
+      "scope": "screen"
+    },
+    {
+      "type": "capture",
+      "label": "01-subagent-result-scrollback",
+      "scope": "scrollback"
+    },
+
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 30000 }
+  ]
+}


### PR DESCRIPTION
## Summary

Subagent personas built into `generationConfig.systemInstruction` by `subagentRuntimeSetup.createChatObject()` were silently dropped — the streaming, non-streaming, and direct message paths never forwarded the instruction to the provider. Each provider rebuilt its own generic core prompt, so the subagent's task directives never reached the model.

This PR complements #2410 (which fixes the primary provider-activation leak). While #2410 ensures subagents activate the correct provider, this PR ensures the subagent's persona/task system prompt actually reaches the model once the provider is active.

## Changes

### systemInstruction forwarding (primary fix)

- **`GenerateChatOptions` / `RuntimeGenerateChatOptions`**: Added `systemInstruction?: string` field to the provider-facing chat options contract
- **`streamRequestHelpers.ts`**: New `extractSystemInstructionText()` helper that normalizes the Gemini `ContentUnion` systemInstruction shape (string, Content, Part[], Part) into a plain string
- **`StreamProcessor`, `TurnProcessor`, `DirectMessageProcessor`**: Each now reads `generationConfig.systemInstruction` and forwards it via `GenerateChatOptions.systemInstruction`
- **Provider merge**: All five provider paths now merge the caller instruction into their system prompt:
  - Anthropic non-OAuth (z.ai) — `AnthropicRequestPreparation.buildNonOAuthSystemContext()`
  - Anthropic OAuth — `buildOAuthSystemContext()`
  - Gemini — `geminiGenerationExecution.executeNonOAuthGeneration()`
  - OpenAI Chat — `OpenAIRequestPreparation.resolveSystemPrompt()`
  - OpenAI Responses/Codex — `OpenAIResponsesProviderCore.buildSystemPrompt()`
- **`systemInstructionMerge.ts`**: Shared merge helper used by all providers (core prompt first, caller instruction appended after blank line; handles empty core, empty instruction, and both-empty edge cases)

### cache_control gating for z.ai

- **`AnthropicRequestPreparation.ts`**: `effectiveWantCaching` now gates on `isAnthropicOAuthBaseURL(baseURL)` — third-party Anthropic-compatible endpoints (z.ai) reject the `system` array-with-cache_control format
- **`AnthropicEndpointUtils.ts`**: Extracted `isAnthropicOAuthBaseURL()` to standalone module to avoid circular import between AnthropicProvider and AnthropicRequestPreparation

### Defense-in-depth: empty content block guards

Empty `{speaker:"human", blocks:[]}` IContent items were injected into subagent conversation history because `processFunctionCalls()` returns `[]` (truthy empty array) and the loop guard `!nextMessages` didn't catch it. Three layers of guards:

- **Layer 1** (`subagentNonInteractive.ts`): `if (nextMessages === null || nextMessages.length === 0)` instead of `if (!nextMessages)`
- **Layer 2** (`MessageConverter.ts`): Empty-array guards in `createUserContentWithFunctionResponseFix`, `normalizeToolInteractionInput`, `convertMixedPartsToIContent`
- **Layer 3** (`ContentConverters.ts` + `HistoryService.ts`): Warning log on zero blocks, `addInternal` rejects zero-block turns

### Tests

- `MessageConverter.issue2410.test.ts` — empty array guard tests (7 tests)
- `subagentNonInteractive.issue2410.test.ts` — empty nextMessages loop stop tests
- `HistoryService.issue2410.test.ts` — zero-block rejection tests (7 tests)
- `ContentConverters.test.ts` — zero-block guard tests added

### Investigation artifacts

- `scripts/tmux-script.subagent-haiku.json` — tmux harness script for reproducing/verifying subagent behavior

## Verification

- typecheck: pass
- lint: pass
- test: pass (only pre-existing OAuth proactive-renewal failures remain)
- format: pass
- build: pass
- ocr: clean (0 comments)

## Relationship to #2410

PR #2415 fixes the primary root cause (subagent providers not activated in isolated runtime). This PR fixes the secondary issue (system instruction dropped even when the provider is active) and adds defense-in-depth against empty content blocks. Both fixes are complementary and non-overlapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `systemInstruction` support, now preserved and merged into providers’ system prompts (including streaming and non-streaming paths).
  * Added normalization to safely extract usable instruction text.
  * Updated Anthropic request handling to conditionally apply prompt caching based on endpoint eligibility.
* **Bug Fixes**
  * Prevented empty inputs (including empty function/tool mixes and empty parts) from being treated as valid turns.
  * Stopped non-interactive loops when no new messages are produced.
  * Prevented zero-block messages from being stored in chat history.
* **Tests**
  * Added regression coverage for issue `#2410` across message conversion, content conversion, history validation, and non-interactive loop stopping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->