### PR TITLE
fix(providers): use a Windows named pipe for the credential proxy transport (Fixes #2403)

### DIFF
--- a/packages/providers/src/auth/proxy/__tests__/credential-proxy-server.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/credential-proxy-server.test.ts
@@ -28,6 +28,8 @@ import type {
 } from '@vybestack/llxprt-code-core';
 import { ProxySocketClient } from '@vybestack/llxprt-code-core';
 
+const isWindows = process.platform === 'win32';
+
 // ─── In-Memory Test Double: TokenStore ───────────────────────────────────────
 
 class InMemoryTokenStore implements TokenStore {
@@ -205,15 +207,18 @@ describe('CredentialProxyServer', () => {
    * @when start() is called
    * @then A Unix socket file exists at the returned path
    */
-  it('start creates a Unix socket and returns the socket path', async () => {
-    server = createServer();
-    const socketPath = await server.start();
+  it.skipIf(isWindows)(
+    'start creates a Unix socket and returns the socket path',
+    async () => {
+      server = createServer();
+      const socketPath = await server.start();
 
-    expect(socketPath).toStrictEqual(expect.any(String));
-    expect(socketPath.endsWith('.sock')).toBe(true);
-    const stat = fs.statSync(socketPath);
-    expect(stat.isSocket()).toBe(true);
-  });
+      expect(socketPath).toStrictEqual(expect.any(String));
+      expect(socketPath.endsWith('.sock')).toBe(true);
+      const stat = fs.statSync(socketPath);
+      expect(stat.isSocket()).toBe(true);
+    },
+  );
 
   /**
    * @requirement R25.2
@@ -222,16 +227,19 @@ describe('CredentialProxyServer', () => {
    * @when stop() is called
    * @then The socket file is removed from disk
    */
-  it('stop removes the socket file and rejects new connections', async () => {
-    server = createServer();
-    const socketPath = await server.start();
+  it.skipIf(isWindows)(
+    'stop removes the socket file and rejects new connections',
+    async () => {
+      server = createServer();
+      const socketPath = await server.start();
 
-    expect(fs.existsSync(socketPath)).toBe(true);
+      expect(fs.existsSync(socketPath)).toBe(true);
 
-    await server.stop();
+      await server.stop();
 
-    expect(fs.existsSync(socketPath)).toBe(false);
-  });
+      expect(fs.existsSync(socketPath)).toBe(false);
+    },
+  );
 
   /**
    * @requirement R25.3

--- a/packages/providers/src/auth/proxy/__tests__/e2e-credential-flow.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/e2e-credential-flow.test.ts
@@ -265,7 +265,8 @@ describe('E2E Credential Flow (Phase 37)', () => {
         );
         expect(hostAfterRemove).toBeNull();
 
-        // 6. Stop proxy → verify socket removed
+        // 6. Stop proxy → verify socket removed. On Windows the pipe path is
+        //    not a filesystem entry, so existsSync is also false there.
         await server.stop();
         expect(fs.existsSync(socketPath)).toBe(false);
       } finally {

--- a/packages/providers/src/auth/proxy/__tests__/integration.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/integration.test.ts
@@ -24,6 +24,8 @@ import {
 import { CredentialProxyServer } from '../credential-proxy-server.js';
 import { createAndStartProxy, stopProxy } from '../sandbox-proxy-lifecycle.js';
 
+const isWindows = process.platform === 'win32';
+
 /** @plan:PLAN-20250214-CREDPROXY.P31 */
 
 class InMemoryTokenStore implements TokenStore {
@@ -244,29 +246,35 @@ describe('proxy integration (phase 31)', () => {
     await expect(handle.stop()).resolves.toBeUndefined();
   });
 
-  it('creates socket file on server start and removes it on server stop', async () => {
-    // @requirement R25.1
-    // @scenario Real server lifecycle should materialize then clean up Unix socket file.
-    let socketPath = '';
-    await withServer(async (started) => {
-      socketPath = started.socketPath;
-      expect(fs.existsSync(started.socketPath)).toBe(true);
-    });
-    expect(fs.existsSync(socketPath)).toBe(false);
-  });
+  it.skipIf(isWindows)(
+    'creates socket file on server start and removes it on server stop',
+    async () => {
+      // @requirement R25.1
+      // @scenario Real server lifecycle should materialize then clean up Unix socket file.
+      let socketPath = '';
+      await withServer(async (started) => {
+        socketPath = started.socketPath;
+        expect(fs.existsSync(started.socketPath)).toBe(true);
+      });
+      expect(fs.existsSync(socketPath)).toBe(false);
+    },
+  );
 
-  it('builds socket path using pid+nonce naming convention', async () => {
-    // @requirement R25.2
-    // @scenario Generated socket path should include process id and random nonce suffix.
-    await withServer(async ({ socketPath }) => {
-      const socketFile = path.basename(socketPath);
-      // Socket filename format: {pid}-{base64url nonce}.sock
-      // base64url uses [A-Za-z0-9_-], 128 bits = 22 chars
-      expect(socketFile).toMatch(
-        new RegExp(`^${process.pid}-[A-Za-z0-9_-]{22}\\.sock$`),
-      );
-    });
-  });
+  it.skipIf(isWindows)(
+    'builds socket path using pid+nonce naming convention',
+    async () => {
+      // @requirement R25.2
+      // @scenario Generated socket path should include process id and random nonce suffix.
+      await withServer(async ({ socketPath }) => {
+        const socketFile = path.basename(socketPath);
+        // Socket filename format: {pid}-{base64url nonce}.sock
+        // base64url uses [A-Za-z0-9_-], 128 bits = 22 chars
+        expect(socketFile).toMatch(
+          new RegExp(`^${process.pid}-[A-Za-z0-9_-]{22}\\.sock$`),
+        );
+      });
+    },
+  );
 
   it('returns sanitized token over proxy getToken when host token has refresh_token', async () => {
     // @requirement R10.1

--- a/packages/providers/src/auth/proxy/__tests__/platform-matrix.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/platform-matrix.test.ts
@@ -14,7 +14,7 @@
  * @requirement R4.1, R4.2, R4.3, R27.1, R27.2, R27.3
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as net from 'node:net';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -612,6 +612,134 @@ describe('Platform Matrix Tests (Phase 38)', () => {
         // Clean up
         for (const client of clients) {
           client.close();
+        }
+      },
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Windows Named Pipe Transport
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Windows named pipe transport', () => {
+    /**
+     * @requirement R3.1 (Windows)
+     * @scenario start() returns a named-pipe endpoint on win32
+     * @given A CredentialProxyServer is started on Windows
+     * @when start() is called
+     * @then The returned path is a `\\.\pipe\lxcp-...` pipe name (not a .sock file)
+     */
+    it.skipIf(!isWindows)(
+      'win32: start() returns a \\\\.\\pipe\\ endpoint with lxcp- prefix',
+      async () => {
+        const tokenStore = new InMemoryTokenStore();
+        const keyStorage = new InMemoryProviderKeyStorage();
+        server = new CredentialProxyServer({
+          tokenStore,
+          providerKeyStorage: keyStorage as unknown as ProviderKeyStorage,
+          // socketDir is intentionally passed and must be IGNORED on Windows
+          socketDir: tmpDir,
+        });
+
+        const pipePath = await server.start();
+
+        expect(pipePath.startsWith('\\\\.\\pipe\\lxcp-')).toBe(true);
+        expect(pipePath.endsWith('.sock')).toBe(false);
+      },
+    );
+
+    /**
+     * @requirement R2.1, R3.3 (Windows)
+     * @scenario ProxySocketClient round-trips a request over the named pipe
+     * @given A CredentialProxyServer on Windows with a pre-populated token
+     * @when A ProxySocketClient connects and requests the token
+     * @then The full handshake + request + response succeeds
+     */
+    it.skipIf(!isWindows)(
+      'win32: ProxySocketClient round-trips a request over the named pipe',
+      async () => {
+        const tokenStore = new InMemoryTokenStore();
+        const keyStorage = new InMemoryProviderKeyStorage();
+
+        await tokenStore.saveToken(
+          'anthropic',
+          {
+            access_token: 'win-pipe-token',
+            expiry: Math.floor(Date.now() / 1000) + 3600,
+            token_type: 'Bearer',
+          },
+          'default',
+        );
+
+        server = new CredentialProxyServer({
+          tokenStore,
+          providerKeyStorage: keyStorage as unknown as ProviderKeyStorage,
+          socketDir: tmpDir,
+        });
+
+        const pipePath = await server.start();
+        const client = new ProxySocketClient(pipePath);
+        try {
+          await client.ensureConnected();
+
+          const res = await client.request('get_token', {
+            provider: 'anthropic',
+          });
+          expect(res.ok).toBe(true);
+          expect(res.data?.access_token).toBe('win-pipe-token');
+
+          const listRes = await client.request('list_providers', {});
+          expect(listRes.ok).toBe(true);
+          expect(listRes.data?.providers).toContain('anthropic');
+        } finally {
+          client.close();
+        }
+      },
+    );
+
+    /**
+     * @requirement R3.2 (Windows)
+     * @scenario No POSIX-only fs/permission call runs for the named pipe
+     * @given A CredentialProxyServer on Windows
+     * @when start() and then stop() are called
+     * @then The POSIX-only fs calls (mkdirSync/chmodSync/unlinkSync) are never
+     *   invoked, and no file materializes at the pipe path
+     */
+    it.skipIf(!isWindows)(
+      'win32: start()/stop() invoke no mkdirSync/chmodSync/unlinkSync for the pipe',
+      async () => {
+        const tokenStore = new InMemoryTokenStore();
+        const keyStorage = new InMemoryProviderKeyStorage();
+        server = new CredentialProxyServer({
+          tokenStore,
+          providerKeyStorage: keyStorage as unknown as ProviderKeyStorage,
+          socketDir: tmpDir,
+        });
+
+        const mkdirSpy = vi.spyOn(fs, 'mkdirSync');
+        const chmodSpy = vi.spyOn(fs, 'chmodSync');
+        const unlinkSpy = vi.spyOn(fs, 'unlinkSync');
+
+        try {
+          const pipePath = await server.start();
+
+          // The spy assertions are the authoritative guard that no POSIX-only
+          // fs/permission call ran. We deliberately do not assert
+          // fs.existsSync(pipePath) while the pipe is live: on Windows an
+          // active named pipe can resolve as an existing system object, so
+          // that check is unreliable until the server is stopped.
+          expect(mkdirSpy).not.toHaveBeenCalled();
+          expect(chmodSpy).not.toHaveBeenCalled();
+
+          await server.stop();
+
+          expect(unlinkSpy).not.toHaveBeenCalled();
+          // After stop the pipe is released; no on-disk file was ever created.
+          expect(fs.existsSync(pipePath)).toBe(false);
+        } finally {
+          mkdirSpy.mockRestore();
+          chmodSpy.mockRestore();
+          unlinkSpy.mockRestore();
         }
       },
     );

--- a/packages/providers/src/auth/proxy/__tests__/platform-matrix.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/platform-matrix.test.ts
@@ -20,6 +20,17 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+// Replace the frozen `node:fs` ESM namespace with a spread copy so individual
+// methods can be spied on. `import * as fs` yields a non-configurable module
+// namespace whose properties `vi.spyOn` cannot redefine; the spread preserves
+// real behavior for every method while making them mockable. Both this file
+// and credential-proxy-server.ts resolve the same mocked module, so a spy here
+// intercepts the server's own fs calls.
+vi.mock('node:fs', async (importActual) => {
+  const actual = await importActual<typeof import('node:fs')>();
+  return { ...actual };
+});
+
 import type { OAuthToken } from '@vybestack/llxprt-code-core';
 import type { ProviderKeyStorage } from '@vybestack/llxprt-code-storage';
 import { ProxySocketClient } from '@vybestack/llxprt-code-core';
@@ -719,6 +730,13 @@ describe('Platform Matrix Tests (Phase 38)', () => {
         const mkdirSpy = vi.spyOn(fs, 'mkdirSync');
         const chmodSpy = vi.spyOn(fs, 'chmodSync');
         const unlinkSpy = vi.spyOn(fs, 'unlinkSync');
+
+        // Confirm the spies were actually installed before relying on
+        // not.toHaveBeenCalled(); otherwise a silently failed spy would make
+        // the guard assertions meaningless.
+        expect(vi.isMockFunction(fs.mkdirSync)).toBe(true);
+        expect(vi.isMockFunction(fs.chmodSync)).toBe(true);
+        expect(vi.isMockFunction(fs.unlinkSync)).toBe(true);
 
         try {
           const pipePath = await server.start();

--- a/packages/providers/src/auth/proxy/credential-proxy-server.ts
+++ b/packages/providers/src/auth/proxy/credential-proxy-server.ts
@@ -6,7 +6,8 @@
 
 /**
  * Host-side credential proxy server that listens on a Unix domain socket
- * and serves token/key operations to sandboxed inner processes.
+ * (POSIX) or a Windows named pipe (win32) and serves token/key operations
+ * to sandboxed inner processes.
  *
  * @plan PLAN-20250214-CREDPROXY.P15
  * @requirement R1, R2, R3
@@ -39,6 +40,8 @@ export type { OAuthFlowInterface } from './credential-proxy-oauth-handler.js';
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const PROTOCOL_VERSION = 1;
+
+const isWindows = process.platform === 'win32';
 
 // ─── Options ─────────────────────────────────────────────────────────────────
 
@@ -76,21 +79,35 @@ export class CredentialProxyServer {
     const socketPath = this.buildSocketPath();
     this.socketPath = socketPath;
 
-    const dir = path.dirname(socketPath);
-    fs.mkdirSync(dir, { mode: 0o700, recursive: true });
+    // Windows named pipes have no on-disk directory to create; only POSIX
+    // Unix-domain sockets live on the filesystem.
+    if (!isWindows) {
+      const dir = path.dirname(socketPath);
+      fs.mkdirSync(dir, { mode: 0o700, recursive: true });
+    }
 
     this.server = net.createServer((socket) => this.handleConnection(socket));
 
     await new Promise<void>((resolve, reject) => {
       this.server!.once('error', reject);
+      // Node accepts a `\\.\pipe\...` string here unchanged on Windows. Node/
+      // libuv create the pipe with the system default security descriptor and
+      // do NOT apply a per-user DACL, so the 128-bit nonce in the pipe name is
+      // the primary access-control barrier (the same unguessability defense the
+      // POSIX socket path relies on).
       this.server!.listen(socketPath, () => {
         this.server!.removeListener('error', reject);
         resolve();
       });
     });
 
-    // Set socket permissions to owner read/write only (0o600)
-    fs.chmodSync(socketPath, 0o600);
+    if (!isWindows) {
+      // Set socket permissions to owner read/write only (0o600).
+      // On Windows there is no on-disk file to chmod; the named pipe uses the
+      // system default security descriptor (no per-user DACL is applied by
+      // Node), so the 128-bit nonce is the sole access-control mechanism.
+      fs.chmodSync(socketPath, 0o600);
+    }
 
     return socketPath;
   }
@@ -114,7 +131,9 @@ export class CredentialProxyServer {
         });
       }
     } finally {
-      if (socketPathToClean !== null) {
+      // Windows named pipes are released when the server closes; there is no
+      // on-disk file to unlink. Only POSIX Unix-domain sockets need cleanup.
+      if (!isWindows && socketPathToClean !== null) {
         try {
           fs.unlinkSync(socketPathToClean);
         } catch {
@@ -129,11 +148,20 @@ export class CredentialProxyServer {
   }
 
   private buildSocketPath(): string {
-    const tmpdir = fs.realpathSync(os.tmpdir());
-    const uid = process.getuid?.() ?? process.pid;
     // Use 128-bit cryptographic nonce, base64url encoded for compactness
     // (macOS has ~104 char limit on Unix socket paths)
     const nonce = crypto.randomBytes(16).toString('base64url');
+
+    if (isWindows) {
+      // Windows named pipe. Use string concatenation (not path.join) so the
+      // `\\.\pipe` prefix is preserved. base64url never contains a backslash, so the
+      // nonce cannot corrupt the pipe namespace. The socketDir option is
+      // intentionally ignored — a named pipe has no directory component.
+      return `\\\\.\\pipe\\lxcp-${process.pid}-${nonce}`;
+    }
+
+    const tmpdir = fs.realpathSync(os.tmpdir());
+    const uid = process.getuid?.() ?? process.pid;
     // Use short directory name "lc-" to fit within macOS socket path limits
     const dir = this.options.socketDir ?? path.join(tmpdir, `lc-${uid}`);
     return path.join(dir, `${process.pid}-${nonce}.sock`);


### PR DESCRIPTION
## Summary

The credential proxy server bound a POSIX Unix-domain socket to a `.sock` filesystem path and applied POSIX-only permission calls. On Windows, Node's `net.Server.listen(path)` cannot bind an arbitrary NTFS temp path as an AF_UNIX socket, so it fails with `listen EACCES`. This PR platform-branches the transport: **Windows named pipe (`\\.\pipe\lxcp-<pid>-<nonce>`) on `win32`, Unix-domain socket on POSIX** — behind the unchanged `CredentialProxyServer` / `ProxySocketClient` API, so callers are untouched.

Fixes #2403.

## Important scope note (please read)

Issue #2403 was filed against an earlier architecture. **PR #2426** ("Minimal Node launcher: exec Bun directly, keychain-direct in non-sandbox, proxy only in sandbox", Fixes #2419) merged *after* the issue and:

- rewrote `packages/cli/bin/llxprt.cjs` into a minimal stub that **starts no proxy** (a bare `llxprt` no longer touches the proxy at all), and
- **deleted** `packages/cli/bin/credential-proxy-host.cjs`.

Consequently the launcher-side checklist items in the issue — `isSafeProxySocketDir`, `parseProxyHostLine`, and the launcher `removeSocketDirWithRetry` cleanup — **target code that no longer exists** and are intentionally not addressed here. The credential proxy is now a **sandbox/container-only** concern; its sole remaining production caller is `sandbox-containers.ts` → `createAndStartProxy` (`sandbox-proxy-lifecycle.ts`). The still-valid, real fix is the **server-side transport**, which is what this PR delivers.

## Changes

### Production — `packages/providers/src/auth/proxy/credential-proxy-server.ts`
- Added a module-level `const isWindows = process.platform === 'win32'`.
- `buildSocketPath()` returns `\\.\pipe\lxcp-<pid>-<nonce>` on win32 (string concatenation, not `path.join`, so the `\\.\pipe\` prefix is preserved; base64url never emits a backslash so the nonce can't corrupt the pipe namespace). `socketDir` is ignored on Windows (a pipe has no directory). POSIX behavior is byte-for-byte unchanged (realpath tmpdir, uid, `lc-<uid>` dir, `<pid>-<nonce>.sock`).
- `start()` gates the POSIX-only calls: `mkdirSync({ mode: 0o700 })` and `chmodSync(0o600)` run only on POSIX. The `net.createServer` + `listen` flow is identical on both platforms.
- `stop()` gates the socket-file `unlinkSync` to POSIX; a Windows named pipe is released automatically when the server closes.
- Class JSDoc and inline comments updated to accurately describe both transports and the Windows access-control model (see Security below).

The client side already accepts a named-pipe path unchanged via `net.createConnection`.

### Tests (behavioral, real IPC — per `dev-docs/RULES.md`, no mock theater)
- **New Windows-only coverage** in `platform-matrix.test.ts` (`it.skipIf(!isWindows)`):
  1. `start()` returns a `\\.\pipe\lxcp-` endpoint (and not a `.sock`), even when a `socketDir` is passed (proving it is ignored).
  2. A **real `ProxySocketClient`** connects over the pipe and round-trips `get_token` + `list_providers`, asserting on the **returned token/provider data**, not just `ok`.
  3. A guard test **spies on `fs.mkdirSync`/`chmodSync`/`unlinkSync`** and asserts they are **never called** on Windows (the authoritative proof that no POSIX-only fs/permission call runs on win32). It deliberately does not assert `fs.existsSync` on a *live* pipe (unreliable on Windows) and only checks it after `stop()`.
- **POSIX transport-shape assertions** (`.sock` suffix, `isSocket()`, on-disk existence, `pid+nonce` naming) are gated with `it.skipIf(isWindows)` in `credential-proxy-server.test.ts` and `integration.test.ts`, so they still run unchanged on Linux/macOS. The `0o600`/`0o700`/realpath POSIX tests are unchanged.

## Security

On Windows, Node/libuv create the named pipe with the **system default security descriptor** and do **not** apply a per-user DACL. The 128-bit cryptographic nonce in the pipe name is therefore the **primary access-control barrier** — the same unguessability defense the POSIX random-socket-filename path already relies on. Comments were corrected to state this accurately rather than implying a per-user ACL. A stronger same-user isolation model (custom security descriptor / authenticated handshake) would be a separate hardening item and is out of scope here.

## CI / where the Windows tests run

- **Gating CI** (`ci.yml`) runs the test matrix on **ubuntu + macos** only, so the new `skipIf(!isWindows)` tests are skipped there and the POSIX tests stay green.
- **Nightly** (`nightly.yml`) runs `npm run test` on **windows-latest**, so the new Windows pipe-creation + round-trip tests **actually execute there** — satisfying the issue's "wire a Windows job that does one round-trip" criterion with no new workflow.

## Verification

- `npm run typecheck` — clean.
- `npm run lint` (eslint) on changed files + `lint:eslint-guard` — clean (no eslint-disable / ts-ignore / complexity-threshold changes).
- `npm run format` (prettier) — clean.
- `npm run build` — clean.
- `providers` proxy suite — **245 passed / 6 skipped** (the platform-gated tests). Full `providers` run shows only 28 pre-existing failures in `src/auth/__tests__/` proactive-renewal/oauthManager fake-timer tests — **proven pre-existing** by re-running on a clean `git stash` of these changes (identical failures without the diff).
- Smoke test failure (`404 model gpt-5.5`) is a local profile/settings model-resolution issue, **also proven pre-existing** via clean-stash run; the CLI boots end-to-end and reaches the API call.

## Acceptance criteria mapping

- [x] On Windows, `CredentialProxyServer.start()` returns a working pipe endpoint.
- [x] Real-IPC round-trip test on Windows (server + `ProxySocketClient` over the pipe, `get_token`/`list_providers`).
- [x] POSIX behavior unchanged (socket path, `0o600`, tmpdir-child dir; existing POSIX tests still pass).
- [x] No POSIX-only fs/permission call (`chmodSync`, `mkdirSync({mode})`, `getuid`, socket-file `unlinkSync`) runs on Windows — asserted via fs spies.
- [x] `platform-matrix.test.ts` no longer skips the core transport on Windows (adds `skipIf(!isWindows)` pipe-creation + round-trip).
- [x] Windows job runs a round-trip (existing nightly windows-latest `npm test`).
- [ ] Launcher `isSafeProxySocketDir`/`parseProxyHostLine` — **N/A**: that code was removed by #2426 (see scope note).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows-compatible credential proxy transport using named pipes.
  * Socket paths are now generated appropriately for each platform, while Unix socket behavior remains unchanged.

* **Bug Fixes**
  * Improved startup and shutdown handling so socket cleanup no longer relies on Unix-only filesystem behavior on Windows.
  * Expanded test coverage to verify proxy connections and lifecycle behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->