### PR TITLE
Preflight OCR LLM connectivity diagnostics (Fixes #2442)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -312,6 +312,49 @@ jobs:
             exit 0
           fi
 
+      - name: Validate OCR LLM connectivity
+        shell: bash
+        env:
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_MODEL: ${{ vars.OCR_LLM_MODEL }}
+          OCR_USE_ANTHROPIC: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+        run: |
+          set -euo pipefail
+          if [ -s ocr-exit-code.txt ]; then
+            echo "::warning::Skipping OCR LLM connectivity check because an earlier OCR setup/configuration failure was recorded."
+            exit 0
+          fi
+          echo "llm-preflight" > ocr-phase.txt
+          if ! . ./ocr-workflow-helpers.sh; then
+            echo "::warning::Could not load OCR workflow helper script."
+            echo "127" > ocr-exit-code.txt
+            echo "phase=llm-preflight; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            exit 0
+          fi
+          if ! command -v ocr >/dev/null 2>&1; then
+            echo "::warning::OpenCodeReview command is unavailable before LLM connectivity check."
+            echo "OpenCodeReview command is unavailable before LLM connectivity check." >> ocr-stderr.log
+            echo "127" > ocr-exit-code.txt
+            mark_infrastructure_failure "llm-preflight" "OpenCodeReview command is unavailable before LLM connectivity check"
+            exit 0
+          fi
+          set +e
+          timeout 120s ocr llm test >> ocr-stderr.log 2>&1
+          preflight_status=$?
+          set -e
+          if [ "$preflight_status" -ne 0 ]; then
+            if [ "$preflight_status" -eq 124 ]; then
+              echo "::warning::OCR LLM connectivity check timed out after 120s. Verify provider availability and network latency."
+              mark_infrastructure_failure "llm-preflight" "OCR LLM connectivity check timed out"
+            else
+              echo "::warning::OCR LLM connectivity check failed. Verify OCR_LLM_URL, OCR_LLM_AUTH_TOKEN, OCR_LLM_MODEL, and provider availability."
+              mark_infrastructure_failure "llm-preflight" "OCR LLM connectivity check failed"
+            fi
+            echo "$preflight_status" > ocr-exit-code.txt
+            exit 0
+          fi
+
       - name: Verify review scope includes changed tests
         shell: bash
         env:
@@ -473,7 +516,11 @@ jobs:
           fi
           echo "$status" > ocr-exit-code.txt
           if [ "$status" -ne 0 ]; then
-            mark_infrastructure_failure "review" "OCR review command failed"
+            if grep -Eqi "all [0-9]+ file review(\(s\)|s)? failed" ocr-stderr.log; then
+              mark_infrastructure_failure "review" "all OCR per-file reviews failed; likely LLM provider/config/auth failure"
+            else
+              mark_infrastructure_failure "review" "OCR review command failed"
+            fi
           fi
           exit 0
 

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -247,6 +247,9 @@ describe('.github/workflows/ocr-review.yml', () => {
     const validateRun = commandText(
       stepNamed(codeReviewJob, 'Validate OCR configuration'),
     );
+    const preflightRun = commandText(
+      stepNamed(codeReviewJob, 'Validate OCR LLM connectivity'),
+    );
     const previewRun = commandText(
       stepNamed(codeReviewJob, 'Verify review scope includes changed tests'),
     );
@@ -257,7 +260,13 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(
       workflowYml.match(/mark_infrastructure_failure\(\)/g) ?? [],
     ).toHaveLength(1);
-    for (const run of [installRun, validateRun, previewRun, reviewRun]) {
+    for (const run of [
+      installRun,
+      validateRun,
+      preflightRun,
+      previewRun,
+      reviewRun,
+    ]) {
       expect(run).toContain('. ./ocr-workflow-helpers.sh');
     }
 
@@ -274,6 +283,16 @@ describe('.github/workflows/ocr-review.yml', () => {
       'echo "78" > ocr-exit-code.txt',
       'mark_infrastructure_failure "validate" "OCR configuration is missing required variables or secrets"',
       'exit 0',
+    ]);
+    expectContainsAll(preflightRun, [
+      'if [ -s ocr-exit-code.txt ]; then',
+      'Skipping OCR LLM connectivity check because an earlier OCR setup/configuration failure was recorded.',
+      'echo "llm-preflight" > ocr-phase.txt',
+      'timeout 120s ocr llm test >> ocr-stderr.log 2>&1',
+      'if [ "$preflight_status" -eq 124 ]; then',
+      'mark_infrastructure_failure "llm-preflight" "OCR LLM connectivity check timed out"',
+      'mark_infrastructure_failure "llm-preflight" "OCR LLM connectivity check failed"',
+      'echo "$preflight_status" > ocr-exit-code.txt',
     ]);
     expectContainsAll(previewRun, [
       'if [ -s ocr-exit-code.txt ]; then',
@@ -296,6 +315,9 @@ describe('.github/workflows/ocr-review.yml', () => {
       'if ! cp ocr-stdout.raw ocr-result.json; then',
       ': > ocr-result.json',
       'echo "$status" > ocr-exit-code.txt',
+      'if grep -Eqi "all [0-9]+ file review(\\(s\\)|s)? failed" ocr-stderr.log; then',
+      'mark_infrastructure_failure "review" "all OCR per-file reviews failed; likely LLM provider/config/auth failure"',
+      'else',
       'mark_infrastructure_failure "review" "OCR review command failed"',
       'exit 0',
     ]);


### PR DESCRIPTION
## Summary
- Add an OCR LLM connectivity preflight step before preview/review execution.
- Classify full per-file OCR review failures as likely provider/config/auth failures instead of only reporting a generic review failure.
- Strengthen workflow tests for the new preflight path and review failure classification.

## Verification
- npm run test:scripts -- scripts/tests/ocr-review-workflow.test.js
- npx eslint scripts/tests/ocr-review-workflow.test.js scripts/tests/ocr-review-workflow-helpers.js
- npx prettier --check .github/workflows/ocr-review.yml scripts/tests/ocr-review-workflow.test.js
- npm run typecheck
- npm run format
- npm run build
- npm run lint:eslint-guard
- Detached OpenCodeReview run completed; actionable findings addressed.

## Known local verification failures reproduced outside this change
- npm run test fails in providers proactive-renewal tests; focused providers repro fails the same way.
- npm run lint OOMs locally at 8GB heap under Node 25 and under Node 24 via npx.
- bun scripts/start.ts --profile-load ollamakimi "write me a haiku and nothing else" fails because runtime calls OpenAI model gpt-5.5 and receives 404.

Fixes #2442
