### PR TITLE
feat(quota): add /quota command for Codex rate-limit-reset credit redemption (Fixes #2386)

### DIFF
--- a/packages/agents/src/app-services/command-api-map.ts
+++ b/packages/agents/src/app-services/command-api-map.ts
@@ -709,7 +709,7 @@ export const COMMAND_API_MAP: readonly CommandApiMapping[] = [
   ),
   runtime(
     '/quota credits',
-    'agent.getStats',
+    'agent.auth',
     'Reset-credit listing reflects the live provider account state',
   ),
   runtime(

--- a/packages/agents/src/app-services/command-api-map.ts
+++ b/packages/agents/src/app-services/command-api-map.ts
@@ -709,8 +709,8 @@ export const COMMAND_API_MAP: readonly CommandApiMapping[] = [
   ),
   runtime(
     '/quota credits',
-    'agent.auth',
-    'Reset-credit listing reflects the live provider account state',
+    'agent.getStats',
+    'Reset-credit listing reflects the live provider quota',
   ),
   runtime(
     '/quota reset',

--- a/packages/agents/src/app-services/command-api-map.ts
+++ b/packages/agents/src/app-services/command-api-map.ts
@@ -696,4 +696,25 @@ export const COMMAND_API_MAP: readonly CommandApiMapping[] = [
     'agent.tasks.cancel',
     'Cancelling an async task affects the active run',
   ),
+  // ---- /quota (#2386): Codex rate-limit-reset credit redemption ----
+  runtime(
+    '/quota',
+    'agent.getStats',
+    'Quota status reflects the live provider quota',
+  ),
+  runtime(
+    '/quota status',
+    'agent.getStats',
+    'Quota status reflects the live provider quota',
+  ),
+  runtime(
+    '/quota credits',
+    'agent.getStats',
+    'Reset-credit listing reflects the live provider account state',
+  ),
+  runtime(
+    '/quota reset',
+    'agent.auth',
+    'Redeeming a reset credit mutates the live provider rate-limit window',
+  ),
 ];

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -86,6 +86,13 @@ vi.mock('../ui/commands/modelCommand.js', () => ({
 }));
 vi.mock('../ui/commands/privacyCommand.js', () => ({ privacyCommand: {} }));
 vi.mock('../ui/commands/quitCommand.js', () => ({ quitCommand: {} }));
+vi.mock('../ui/commands/quotaCommand.js', () => ({
+  quotaCommand: {
+    name: 'quota',
+    description: 'Quota command',
+    kind: 'built-in',
+  },
+}));
 vi.mock('../ui/commands/resumeCommand.js', () => ({ resumeCommand: {} }));
 vi.mock('../ui/commands/statsCommand.js', () => ({ statsCommand: {} }));
 vi.mock('../ui/commands/themeCommand.js', () => ({ themeCommand: {} }));
@@ -177,6 +184,14 @@ describe('BuiltinCommandLoader', () => {
     const commands = await loader.loadCommands(new AbortController().signal);
     const permissionsCmd = commands.find((c) => c.name === 'permissions');
     expect(permissionsCmd).toBeDefined();
+  });
+
+  it('should include quota command', async () => {
+    const loader = new BuiltinCommandLoader(mockConfig);
+    const commands = await loader.loadCommands(new AbortController().signal);
+    const quotaCmd = commands.find((c) => c.name === 'quota');
+    expect(quotaCmd).toBeDefined();
+    expect(quotaCmd?.kind).toBe(CommandKind.BUILT_IN);
   });
 
   it('should include policies command when message bus integration is enabled', async () => {

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -86,13 +86,16 @@ vi.mock('../ui/commands/modelCommand.js', () => ({
 }));
 vi.mock('../ui/commands/privacyCommand.js', () => ({ privacyCommand: {} }));
 vi.mock('../ui/commands/quitCommand.js', () => ({ quitCommand: {} }));
-vi.mock('../ui/commands/quotaCommand.js', () => ({
-  quotaCommand: {
-    name: 'quota',
-    description: 'Quota command',
-    kind: 'built-in',
-  },
-}));
+vi.mock('../ui/commands/quotaCommand.js', async () => {
+  const { CommandKind } = await import('../ui/commands/types.js');
+  return {
+    quotaCommand: {
+      name: 'quota',
+      description: 'Quota command',
+      kind: CommandKind.BUILT_IN,
+    },
+  };
+});
 vi.mock('../ui/commands/resumeCommand.js', () => ({ resumeCommand: {} }));
 vi.mock('../ui/commands/statsCommand.js', () => ({ statsCommand: {} }));
 vi.mock('../ui/commands/themeCommand.js', () => ({ themeCommand: {} }));

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -37,6 +37,7 @@ import { loggingCommand } from '../ui/commands/loggingCommand.js';
 import { uiprofileCommand } from '../ui/commands/uiprofileCommand.js';
 import { mouseCommand } from '../ui/commands/mouseCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
+import { quotaCommand } from '../ui/commands/quotaCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { statsCommand } from '../ui/commands/statsCommand.js';
 import { themeCommand } from '../ui/commands/themeCommand.js';
@@ -154,34 +155,11 @@ export class BuiltinCommandLoader implements ICommandLoader {
       ...(isDevelopment ? [uiprofileCommand] : []),
       quitCommand,
       restoreCommand(this.config),
+      quotaCommand,
       statsCommand,
       themeCommand,
       toolsCommand,
-      // Determine skills command based on config and admin settings
-      ...((): SlashCommand[] => {
-        if (this.config?.isSkillsSupportEnabled() !== true) {
-          return [];
-        }
-        if (this.config.getSkillManager().isAdminEnabled() === false) {
-          return [
-            {
-              name: 'skills',
-              description: 'Manage skills',
-              kind: CommandKind.BUILT_IN,
-              autoExecute: false,
-              subCommands: [],
-              action: async (
-                _context: CommandContext,
-              ): Promise<MessageActionReturn> => ({
-                type: 'message',
-                messageType: 'error',
-                content: 'Skills are disabled by your admin.',
-              }),
-            },
-          ];
-        }
-        return [skillsCommand];
-      })(),
+      ...this.resolveSkillsCommand(),
       settingsCommand,
       vimCommand,
       providerCommand,
@@ -214,5 +192,35 @@ export class BuiltinCommandLoader implements ICommandLoader {
     ];
 
     return allDefinitions.filter((cmd): cmd is SlashCommand => cmd !== null);
+  }
+
+  /**
+   * Determine skills command based on config and admin settings.
+   * Returns [] when skills support is disabled, a stub error command when
+   * disabled by admin, or [skillsCommand] when enabled.
+   */
+  private resolveSkillsCommand(): SlashCommand[] {
+    if (this.config?.isSkillsSupportEnabled() !== true) {
+      return [];
+    }
+    if (this.config.getSkillManager().isAdminEnabled() === false) {
+      return [
+        {
+          name: 'skills',
+          description: 'Manage skills',
+          kind: CommandKind.BUILT_IN,
+          autoExecute: false,
+          subCommands: [],
+          action: async (
+            _context: CommandContext,
+          ): Promise<MessageActionReturn> => ({
+            type: 'message',
+            messageType: 'error',
+            content: 'Skills are disabled by your admin.',
+          }),
+        },
+      ];
+    }
+    return [skillsCommand];
   }
 }

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -17,6 +17,10 @@ const { mockConsumeCodexRateLimitResetCredit } = vi.hoisted(() => ({
 const getCliOAuthManagerMock = vi.fn();
 const maybeGetCliOAuthManagerMock = vi.fn();
 const getEphemeralSettingMock = vi.fn();
+// These runtime-API mocks intentionally return undefined for the API-key
+// provider path (getActiveProviderName / getCliProviderManager) so that only
+// the OAuth quota path is exercised here; the API-key path is covered
+// elsewhere (statsQuota tests).
 const getActiveProviderNameMock = vi.fn();
 const getCliProviderManagerMock = vi.fn();
 
@@ -42,6 +46,19 @@ vi.mock('@vybestack/llxprt-code-providers', async () => {
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Get the last item added to the UI, typed for assertion convenience.
+ * Uses the pre-existing `as { type: MessageType; text?: string }` convention
+ * established in this test file.
+ */
+function getLastUiItem(ctx: CommandContext): {
+  type: MessageType;
+  text?: string;
+} {
+  const calls = vi.mocked(ctx.ui.addItem).mock.calls;
+  return calls[calls.length - 1]?.[0] as { type: MessageType; text?: string };
+}
 
 function makeCodexCreditsMap(
   entries: Array<{
@@ -188,11 +205,7 @@ describe('quotaCommand', () => {
 
       await quotaCommand.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('No quota information available');
     });
@@ -217,11 +230,7 @@ describe('quotaCommand', () => {
 
       await quotaCommand.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('Anthropic Quota Information');
     });
@@ -239,11 +248,7 @@ describe('quotaCommand', () => {
       );
       await credits!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('No Codex reset credits available');
     });
@@ -262,11 +267,7 @@ describe('quotaCommand', () => {
       );
       await credits!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('No Codex reset credits available');
     });
@@ -291,11 +292,7 @@ describe('quotaCommand', () => {
       );
       await credits!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('Available reset credits: 2');
     });
@@ -314,13 +311,65 @@ describe('quotaCommand', () => {
       );
       await credits!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('Failed to retrieve reset credits:');
+    });
+
+    it('shows bucket headers for multiple buckets with available credits', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'bucket-a',
+              availableCount: 1,
+              credits: [{ id: 'credit-a' }],
+            },
+            {
+              bucket: 'bucket-b',
+              availableCount: 2,
+              credits: [{ id: 'credit-b1' }, { id: 'credit-b2' }],
+            },
+          ]),
+        ),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const credits = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'credits',
+      );
+      await credits!.action!(mockContext, '');
+
+      const lastItem = getLastUiItem(mockContext);
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('### Bucket: bucket-a');
+      expect(lastItem.text).toContain('### Bucket: bucket-b');
+    });
+
+    it('shows no-credits message when map is non-empty but all buckets have zero available', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'bucket-a',
+              availableCount: 0,
+              credits: [],
+            },
+          ]),
+        ),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const credits = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'credits',
+      );
+      await credits!.action!(mockContext, '');
+
+      const lastItem = getLastUiItem(mockContext);
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('No Codex reset credits available');
     });
   });
 
@@ -329,11 +378,7 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, 'anthropic');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain("Only 'codex' supports reset");
     });
@@ -352,11 +397,7 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('/auth codex');
     });
@@ -375,11 +416,7 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('No reset credits available');
     });
@@ -459,11 +496,7 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('Failed to reset');
     });
@@ -480,11 +513,7 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('Failed to reset rate-limit window');
     });
@@ -501,11 +530,7 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('Failed to resolve Codex credentials');
     });
@@ -522,11 +547,7 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('Failed to reset rate-limit window:');
     });
@@ -540,14 +561,36 @@ describe('quotaCommand', () => {
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
 
-      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
+      const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('/auth codex');
       expect(lastItem.text).toContain('Not authenticated with Codex');
+    });
+
+    it('succeeds when provider arg is explicitly codex', async () => {
+      const oauthManager = makeCodexResetOauthManager();
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      });
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, 'codex');
+
+      expect(mockConsumeCodexRateLimitResetCredit).toHaveBeenCalledTimes(1);
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const successItem = calls.find((call) => {
+        const item = call[0] as { text: string; type: MessageType };
+        return (
+          item.text.includes('reset successfully') &&
+          item.type === MessageType.INFO
+        );
+      });
+      expect(successItem).toBeDefined();
     });
   });
 });

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -53,11 +53,18 @@ const UUID_REGEX =
  * established in this test file.
  */
 function getLastUiItem(ctx: CommandContext): {
-  type: MessageType;
+  type: 'info' | 'error';
   text?: string;
 } {
   const calls = vi.mocked(ctx.ui.addItem).mock.calls;
-  return calls[calls.length - 1]?.[0] as { type: MessageType; text?: string };
+  const lastItem = calls.at(-1)?.[0];
+  if (lastItem?.type === 'info') {
+    return { type: 'info', text: lastItem.text };
+  }
+  if (lastItem?.type === 'error') {
+    return { type: 'error', text: lastItem.text };
+  }
+  throw new Error('Expected an informational or error UI item to be added');
 }
 
 function makeCodexCreditsMap(
@@ -572,6 +579,47 @@ describe('quotaCommand', () => {
       const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('unavailable or expired');
+    });
+
+    it('redeems from a later bucket when the first credit-bearing bucket has expired credentials', async () => {
+      const oauthManager = makeCodexResetOauthManager({
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'expired-bucket',
+              availableCount: 1,
+              credits: [{ id: 'expired-credit' }],
+            },
+            {
+              bucket: 'valid-bucket',
+              availableCount: 1,
+              credits: [{ id: 'valid-credit' }],
+            },
+          ]),
+        ),
+        getTokenStore: vi.fn().mockReturnValue({
+          getToken: vi
+            .fn()
+            .mockResolvedValueOnce(
+              makeCodexToken({ expiry: Math.floor(Date.now() / 1000) - 1 }),
+            )
+            .mockResolvedValueOnce(makeCodexToken()),
+        }),
+      });
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
+      mockConsumeCodexRateLimitResetCredit.mockResolvedValue({ code: 'reset' });
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      expect(mockConsumeCodexRateLimitResetCredit).toHaveBeenCalledWith(
+        'codex-access',
+        'acct-123',
+        'valid-credit',
+        expect.any(String),
+        undefined,
+      );
     });
 
     it('shows error when getAllCodexRateLimitResetCredits rejects during reset flow', async () => {

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -346,11 +346,15 @@ describe('quotaCommand', () => {
       expect(callArgs[1]).toBe('acct-123');
       expect(callArgs[2]).toBe('credit-1');
       expect(callArgs[3]).toMatch(UUID_REGEX);
+      expect(callArgs[4]).toBeUndefined();
 
       const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
       const successItem = calls.find((call) => {
         const item = call[0] as { text: string; type: MessageType };
-        return item.text.includes('reset') && item.type === MessageType.INFO;
+        return (
+          item.text.includes('reset successfully') &&
+          item.type === MessageType.INFO
+        );
       });
       expect(successItem).toBeDefined();
     });
@@ -435,6 +439,80 @@ describe('quotaCommand', () => {
       };
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('Failed to reset');
+    });
+
+    it('shows error when consume throws an exception', async () => {
+      const codexToken = {
+        access_token: 'codex-access',
+        token_type: 'Bearer',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        account_id: 'acct-123',
+      };
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'default',
+              availableCount: 1,
+              credits: [{ id: 'credit-1' }],
+            },
+          ]),
+        ),
+        getToken: vi.fn().mockResolvedValue('codex-access'),
+        listBuckets: vi.fn().mockResolvedValue(['default']),
+        getTokenStore: vi.fn().mockReturnValue({
+          getToken: vi.fn().mockResolvedValue(codexToken),
+        }),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      mockConsumeCodexRateLimitResetCredit.mockRejectedValue(
+        new Error('Network timeout'),
+      );
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.ERROR);
+      expect(lastItem.text).toContain('Failed to reset rate-limit window');
+    });
+
+    it('shows error when token store returns token without access_token', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'default',
+              availableCount: 1,
+              credits: [{ id: 'credit-1' }],
+            },
+          ]),
+        ),
+        getToken: vi.fn().mockResolvedValue('codex-access'),
+        listBuckets: vi.fn().mockResolvedValue(['default']),
+        getTokenStore: vi.fn().mockReturnValue({
+          getToken: vi.fn().mockResolvedValue({ account_id: 'acct-123' }),
+        }),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.ERROR);
+      expect(lastItem.text).toContain('Failed to resolve Codex credentials');
     });
   });
 });

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -77,18 +77,38 @@ function makeCodexToken(
 function makeCodexResetOauthManager(
   overrides: Record<string, unknown> = {},
 ): Record<string, ReturnType<typeof vi.fn>> {
+  const futureResetAt = Math.floor(Date.now() / 1000) + 3600;
   return {
-    getAllCodexRateLimitResetCredits: vi
-      .fn()
-      .mockResolvedValue(
-        makeCodexCreditsMap([
+    getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+      makeCodexCreditsMap([
+        {
+          bucket: 'default',
+          availableCount: 1,
+          credits: [{ id: 'credit-1' }],
+        },
+      ]),
+    ),
+    getAllAnthropicUsageInfo: vi.fn().mockResolvedValue(new Map()),
+    getAllCodexUsageInfo: vi.fn().mockResolvedValue(
+      new Map([
+        [
+          'default',
           {
-            bucket: 'default',
-            availableCount: 1,
-            credits: [{ id: 'credit-1' }],
+            plan_type: 'plus',
+            rate_limit: {
+              allowed: true,
+              limit_reached: false,
+              primary_window: {
+                used_percent: 10,
+                limit_window_seconds: 18000,
+                reset_after_seconds: 3600,
+                reset_at: futureResetAt,
+              },
+            },
           },
-        ]),
-      ),
+        ],
+      ]),
+    ),
     getToken: vi.fn().mockResolvedValue('codex-access'),
     listBuckets: vi.fn().mockResolvedValue(['default']),
     getTokenStore: vi.fn().mockReturnValue({
@@ -395,6 +415,15 @@ describe('quotaCommand', () => {
         );
       });
       expect(successItem).toBeDefined();
+
+      const quotaItem = calls.find((call) => {
+        const item = call[0] as { text: string; type: MessageType };
+        return (
+          item.text.includes('Codex Quota Information') &&
+          item.type === MessageType.INFO
+        );
+      });
+      expect(quotaItem).toBeDefined();
     });
 
     it('shows already_redeemed message', async () => {
@@ -410,12 +439,14 @@ describe('quotaCommand', () => {
       await reset!.action!(mockContext, '');
 
       const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
-      const lastItem = calls[calls.length - 1]?.[0] as {
-        type: MessageType;
-        text?: string;
-      };
-      expect(lastItem.type).toBe(MessageType.INFO);
-      expect(lastItem.text).toContain('already redeemed');
+      const alreadyItem = calls.find((call) => {
+        const item = call[0] as { text: string; type: MessageType };
+        return (
+          item.text.includes('already redeemed') &&
+          item.type === MessageType.INFO
+        );
+      });
+      expect(alreadyItem).toBeDefined();
     });
 
     it('shows error when consume returns null', async () => {

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -92,7 +92,7 @@ function makeCodexToken(
 }
 
 function makeCodexResetOauthManager(
-  overrides: Record<string, unknown> = {},
+  overrides: Record<string, ReturnType<typeof vi.fn>> = {},
 ): Record<string, ReturnType<typeof vi.fn>> {
   const futureResetAt = Math.floor(Date.now() / 1000) + 3600;
   return {

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -450,7 +450,7 @@ describe('quotaCommand', () => {
       const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
-      getEphemeralSettingMock.mockReturnValue(undefined);
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
 
       mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
         code: 'reset',
@@ -492,6 +492,7 @@ describe('quotaCommand', () => {
       const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
 
       mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
         code: 'already_redeemed',
@@ -499,6 +500,8 @@ describe('quotaCommand', () => {
 
       const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
       await reset!.action!(mockContext, '');
+
+      expect(mockConsumeCodexRateLimitResetCredit).toHaveBeenCalledTimes(1);
 
       const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
       const alreadyItem = calls.find((call) => {
@@ -524,6 +527,7 @@ describe('quotaCommand', () => {
       const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
 
       mockConsumeCodexRateLimitResetCredit.mockResolvedValue(null);
 
@@ -539,6 +543,7 @@ describe('quotaCommand', () => {
       const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
 
       mockConsumeCodexRateLimitResetCredit.mockRejectedValue(
         new Error('Network timeout'),
@@ -601,10 +606,44 @@ describe('quotaCommand', () => {
       expect(lastItem.text).toContain('Not authenticated with Codex');
     });
 
+    it('prompts for confirmation before redeeming when not yet confirmed', async () => {
+      const oauthManager = makeCodexResetOauthManager();
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      // mockContext has NO overwriteConfirmed — first invocation.
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      const result = await reset!.action!(mockContext, '');
+
+      expect(result).toBeDefined();
+      expect(result).not.toBeNull();
+      const confirmResult = result as {
+        type: string;
+        prompt: string;
+        originalInvocation: { raw: string };
+      };
+      expect(confirmResult.type).toBe('confirm_action');
+      expect(typeof confirmResult.prompt).toBe('string');
+      expect(confirmResult.prompt.length).toBeGreaterThan(0);
+      expect(confirmResult.originalInvocation.raw).toContain('quota reset');
+      expect(mockConsumeCodexRateLimitResetCredit).not.toHaveBeenCalled();
+    });
+
+    it('shows too-many-arguments error for /quota reset codex extra and does not consume', async () => {
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, 'codex extra');
+
+      const lastItem = getLastUiItem(mockContext);
+      expect(lastItem.type).toBe(MessageType.ERROR);
+      expect(lastItem.text).toContain('Too many arguments');
+      expect(mockConsumeCodexRateLimitResetCredit).not.toHaveBeenCalled();
+    });
+
     it('succeeds when provider arg is explicitly codex', async () => {
       const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
 
       mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
         code: 'reset',
@@ -634,6 +673,7 @@ describe('quotaCommand', () => {
       getEphemeralSettingMock.mockReturnValue(
         'https://example.test/backend-api',
       );
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
 
       mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
         code: 'reset',
@@ -654,6 +694,7 @@ describe('quotaCommand', () => {
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
       getEphemeralSettingMock.mockReturnValue('   ');
+      mockContext = createMockCommandContext({ overwriteConfirmed: true });
 
       mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
         code: 'reset',

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -48,9 +48,7 @@ const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * Get the last item added to the UI, typed for assertion convenience.
- * Uses the pre-existing `as { type: MessageType; text?: string }` convention
- * established in this test file.
+ * Get the last informational or error item added to the UI.
  */
 function getLastUiItem(ctx: CommandContext): {
   type: 'info' | 'error';

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -62,6 +62,42 @@ function makeCodexCreditsMap(
   return map;
 }
 
+function makeCodexToken(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    access_token: 'codex-access',
+    token_type: 'Bearer',
+    expiry: Math.floor(Date.now() / 1000) + 3600,
+    account_id: 'acct-123',
+    ...overrides,
+  };
+}
+
+function makeCodexResetOauthManager(
+  overrides: Record<string, unknown> = {},
+): Record<string, ReturnType<typeof vi.fn>> {
+  return {
+    getAllCodexRateLimitResetCredits: vi
+      .fn()
+      .mockResolvedValue(
+        makeCodexCreditsMap([
+          {
+            bucket: 'default',
+            availableCount: 1,
+            credits: [{ id: 'credit-1' }],
+          },
+        ]),
+      ),
+    getToken: vi.fn().mockResolvedValue('codex-access'),
+    listBuckets: vi.fn().mockResolvedValue(['default']),
+    getTokenStore: vi.fn().mockReturnValue({
+      getToken: vi.fn().mockResolvedValue(makeCodexToken()),
+    }),
+    ...overrides,
+  };
+}
+
 describe('quotaCommand', () => {
   let mockContext: CommandContext;
 
@@ -243,6 +279,29 @@ describe('quotaCommand', () => {
       expect(lastItem.type).toBe(MessageType.INFO);
       expect(lastItem.text).toContain('Available reset credits: 2');
     });
+
+    it('shows error when getAllCodexRateLimitResetCredits rejects', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi
+          .fn()
+          .mockRejectedValue(new Error('upstream down')),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const credits = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'credits',
+      );
+      await credits!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.ERROR);
+      expect(lastItem.text).toContain('Failed to retrieve reset credits:');
+    });
   });
 
   describe('reset subcommand', () => {
@@ -306,28 +365,7 @@ describe('quotaCommand', () => {
     });
 
     it('successfully redeems a credit and shows success + refreshed quota', async () => {
-      const codexToken = {
-        access_token: 'codex-access',
-        token_type: 'Bearer',
-        expiry: Math.floor(Date.now() / 1000) + 3600,
-        account_id: 'acct-123',
-      };
-      const oauthManager = {
-        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
-          makeCodexCreditsMap([
-            {
-              bucket: 'default',
-              availableCount: 1,
-              credits: [{ id: 'credit-1' }],
-            },
-          ]),
-        ),
-        getToken: vi.fn().mockResolvedValue('codex-access'),
-        listBuckets: vi.fn().mockResolvedValue(['default']),
-        getTokenStore: vi.fn().mockReturnValue({
-          getToken: vi.fn().mockResolvedValue(codexToken),
-        }),
-      };
+      const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
       getEphemeralSettingMock.mockReturnValue(undefined);
@@ -360,28 +398,7 @@ describe('quotaCommand', () => {
     });
 
     it('shows already_redeemed message', async () => {
-      const codexToken = {
-        access_token: 'codex-access',
-        token_type: 'Bearer',
-        expiry: Math.floor(Date.now() / 1000) + 3600,
-        account_id: 'acct-123',
-      };
-      const oauthManager = {
-        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
-          makeCodexCreditsMap([
-            {
-              bucket: 'default',
-              availableCount: 1,
-              credits: [{ id: 'credit-1' }],
-            },
-          ]),
-        ),
-        getToken: vi.fn().mockResolvedValue('codex-access'),
-        listBuckets: vi.fn().mockResolvedValue(['default']),
-        getTokenStore: vi.fn().mockReturnValue({
-          getToken: vi.fn().mockResolvedValue(codexToken),
-        }),
-      };
+      const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
 
@@ -402,28 +419,7 @@ describe('quotaCommand', () => {
     });
 
     it('shows error when consume returns null', async () => {
-      const codexToken = {
-        access_token: 'codex-access',
-        token_type: 'Bearer',
-        expiry: Math.floor(Date.now() / 1000) + 3600,
-        account_id: 'acct-123',
-      };
-      const oauthManager = {
-        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
-          makeCodexCreditsMap([
-            {
-              bucket: 'default',
-              availableCount: 1,
-              credits: [{ id: 'credit-1' }],
-            },
-          ]),
-        ),
-        getToken: vi.fn().mockResolvedValue('codex-access'),
-        listBuckets: vi.fn().mockResolvedValue(['default']),
-        getTokenStore: vi.fn().mockReturnValue({
-          getToken: vi.fn().mockResolvedValue(codexToken),
-        }),
-      };
+      const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
 
@@ -442,28 +438,7 @@ describe('quotaCommand', () => {
     });
 
     it('shows error when consume throws an exception', async () => {
-      const codexToken = {
-        access_token: 'codex-access',
-        token_type: 'Bearer',
-        expiry: Math.floor(Date.now() / 1000) + 3600,
-        account_id: 'acct-123',
-      };
-      const oauthManager = {
-        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
-          makeCodexCreditsMap([
-            {
-              bucket: 'default',
-              availableCount: 1,
-              credits: [{ id: 'credit-1' }],
-            },
-          ]),
-        ),
-        getToken: vi.fn().mockResolvedValue('codex-access'),
-        listBuckets: vi.fn().mockResolvedValue(['default']),
-        getTokenStore: vi.fn().mockReturnValue({
-          getToken: vi.fn().mockResolvedValue(codexToken),
-        }),
-      };
+      const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
 
@@ -484,22 +459,11 @@ describe('quotaCommand', () => {
     });
 
     it('shows error when token store returns token without access_token', async () => {
-      const oauthManager = {
-        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
-          makeCodexCreditsMap([
-            {
-              bucket: 'default',
-              availableCount: 1,
-              credits: [{ id: 'credit-1' }],
-            },
-          ]),
-        ),
-        getToken: vi.fn().mockResolvedValue('codex-access'),
-        listBuckets: vi.fn().mockResolvedValue(['default']),
+      const oauthManager = makeCodexResetOauthManager({
         getTokenStore: vi.fn().mockReturnValue({
           getToken: vi.fn().mockResolvedValue({ account_id: 'acct-123' }),
         }),
-      };
+      });
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
       getCliOAuthManagerMock.mockReturnValue(oauthManager);
 
@@ -513,6 +477,46 @@ describe('quotaCommand', () => {
       };
       expect(lastItem.type).toBe(MessageType.ERROR);
       expect(lastItem.text).toContain('Failed to resolve Codex credentials');
+    });
+
+    it('shows error when getAllCodexRateLimitResetCredits rejects during reset flow', async () => {
+      const oauthManager = makeCodexResetOauthManager({
+        getAllCodexRateLimitResetCredits: vi
+          .fn()
+          .mockRejectedValue(new Error('reset fetch failed')),
+      });
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.ERROR);
+      expect(lastItem.text).toContain('Failed to reset rate-limit window:');
+    });
+
+    it('shows /auth codex info when getCliOAuthManager throws', async () => {
+      maybeGetCliOAuthManagerMock.mockReturnValue(null);
+      getCliOAuthManagerMock.mockImplementation(() => {
+        throw new Error('not registered');
+      });
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('/auth codex');
+      expect(lastItem.text).toContain('Not authenticated with Codex');
     });
   });
 });

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -592,5 +592,47 @@ describe('quotaCommand', () => {
       });
       expect(successItem).toBeDefined();
     });
+
+    it('forwards the custom base-url as the 5th arg to consumeCodexRateLimitResetCredit', async () => {
+      const oauthManager = makeCodexResetOauthManager();
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getEphemeralSettingMock.mockReturnValue(
+        'https://example.test/backend-api',
+      );
+
+      mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      });
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      expect(mockConsumeCodexRateLimitResetCredit).toHaveBeenCalledTimes(1);
+      expect(
+        vi.mocked(mockConsumeCodexRateLimitResetCredit).mock.calls[0][4],
+      ).toBe('https://example.test/backend-api');
+    });
+
+    it('forwards undefined as base-url when the setting is whitespace-only', async () => {
+      const oauthManager = makeCodexResetOauthManager();
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getEphemeralSettingMock.mockReturnValue('   ');
+
+      mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      });
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      expect(mockConsumeCodexRateLimitResetCredit).toHaveBeenCalledTimes(1);
+      expect(
+        vi.mocked(mockConsumeCodexRateLimitResetCredit).mock.calls[0][4],
+      ).toBeUndefined();
+    });
   });
 });

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -421,6 +421,31 @@ describe('quotaCommand', () => {
       expect(lastItem.text).toContain('No reset credits available');
     });
 
+    it('shows no-redeemable message when map non-empty but all buckets have zero available', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'default',
+              availableCount: 0,
+              credits: [],
+            },
+          ]),
+        ),
+        getToken: vi.fn().mockResolvedValue('codex-token'),
+        listBuckets: vi.fn().mockResolvedValue(['default']),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const lastItem = getLastUiItem(mockContext);
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('No reset credits available to redeem');
+    });
+
     it('successfully redeems a credit and shows success + refreshed quota', async () => {
       const oauthManager = makeCodexResetOauthManager();
       maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
@@ -484,6 +509,15 @@ describe('quotaCommand', () => {
         );
       });
       expect(alreadyItem).toBeDefined();
+
+      const quotaItem = calls.find((call) => {
+        const item = call[0] as { text: string; type: MessageType };
+        return (
+          item.text.includes('Codex Quota Information') &&
+          item.type === MessageType.INFO
+        );
+      });
+      expect(quotaItem).toBeDefined();
     });
 
     it('shows error when consume returns null', async () => {
@@ -532,7 +566,7 @@ describe('quotaCommand', () => {
 
       const lastItem = getLastUiItem(mockContext);
       expect(lastItem.type).toBe(MessageType.ERROR);
-      expect(lastItem.text).toContain('Failed to resolve Codex credentials');
+      expect(lastItem.text).toContain('unavailable or expired');
     });
 
     it('shows error when getAllCodexRateLimitResetCredits rejects during reset flow', async () => {

--- a/packages/cli/src/ui/commands/quotaCommand.test.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.test.ts
@@ -1,0 +1,440 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { quotaCommand } from './quotaCommand.js';
+import { type CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+
+const { mockConsumeCodexRateLimitResetCredit } = vi.hoisted(() => ({
+  mockConsumeCodexRateLimitResetCredit: vi.fn(),
+}));
+
+const getCliOAuthManagerMock = vi.fn();
+const maybeGetCliOAuthManagerMock = vi.fn();
+const getEphemeralSettingMock = vi.fn();
+const getActiveProviderNameMock = vi.fn();
+const getCliProviderManagerMock = vi.fn();
+
+vi.mock('../contexts/RuntimeContext.js', () => ({
+  getRuntimeApi: () => ({
+    getCliOAuthManager: getCliOAuthManagerMock,
+    maybeGetCliOAuthManager: maybeGetCliOAuthManagerMock,
+    getEphemeralSetting: getEphemeralSettingMock,
+    getActiveProviderName: getActiveProviderNameMock,
+    getCliProviderManager: getCliProviderManagerMock,
+  }),
+}));
+
+vi.mock('@vybestack/llxprt-code-providers', async () => {
+  const actual = await vi.importActual<
+    typeof import('@vybestack/llxprt-code-providers')
+  >('@vybestack/llxprt-code-providers');
+  return {
+    ...actual,
+    consumeCodexRateLimitResetCredit: mockConsumeCodexRateLimitResetCredit,
+  };
+});
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function makeCodexCreditsMap(
+  entries: Array<{
+    bucket: string;
+    availableCount: number;
+    credits: Array<{ id: string }>;
+  }>,
+): Map<string, Record<string, unknown>> {
+  const map = new Map<string, Record<string, unknown>>();
+  for (const entry of entries) {
+    map.set(entry.bucket, {
+      rate_limit_reset_credits: {
+        available_count: entry.availableCount,
+        credits: entry.credits,
+      },
+    });
+  }
+  return map;
+}
+
+describe('quotaCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+
+    getCliOAuthManagerMock.mockReset();
+    maybeGetCliOAuthManagerMock.mockReset();
+    getEphemeralSettingMock.mockReset();
+    getActiveProviderNameMock.mockReset();
+    getCliProviderManagerMock.mockReset();
+    mockConsumeCodexRateLimitResetCredit.mockReset();
+
+    getEphemeralSettingMock.mockReturnValue(undefined);
+    maybeGetCliOAuthManagerMock.mockReturnValue(null);
+  });
+
+  describe('command structure', () => {
+    it('has name quota and BUILT_IN kind', () => {
+      expect(quotaCommand.name).toBe('quota');
+      expect(quotaCommand.kind).toBe('built-in');
+    });
+
+    it('has status, credits, and reset subcommands', () => {
+      const subNames = quotaCommand.subCommands?.map((sc) => sc.name);
+      expect(subNames).toContain('status');
+      expect(subNames).toContain('credits');
+      expect(subNames).toContain('reset');
+    });
+
+    it('status subcommand is autoExecute', () => {
+      const status = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'status',
+      );
+      expect(status?.autoExecute).toBe(true);
+    });
+
+    it('credits subcommand is autoExecute', () => {
+      const credits = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'credits',
+      );
+      expect(credits?.autoExecute).toBe(true);
+    });
+
+    it('reset subcommand is NOT autoExecute', () => {
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      expect(reset?.autoExecute).toBeFalsy();
+    });
+
+    it('reset subcommand has a schema with codex option', () => {
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      expect(reset?.schema).toBeDefined();
+      const firstNode = reset?.schema?.[0];
+      expect(firstNode?.kind).toBe('value');
+      const valueNode = firstNode as {
+        kind: string;
+        options?: Array<{ value: string }>;
+      };
+      const values = valueNode.options?.map((o) => o.value);
+      expect(values).toContain('codex');
+    });
+  });
+
+  describe('default action (status)', () => {
+    it('shows no quota message when no quota available', async () => {
+      maybeGetCliOAuthManagerMock.mockReturnValue(null);
+      getEphemeralSettingMock.mockReturnValue(undefined);
+
+      await quotaCommand.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('No quota information available');
+    });
+
+    it('shows quota lines when quota available', async () => {
+      const oauthManager = {
+        getAllAnthropicUsageInfo: vi
+          .fn()
+          .mockResolvedValue(
+            new Map([
+              [
+                'default',
+                { five_hour: { utilization: 10, resets_at: '2030-01-01' } },
+              ],
+            ]),
+          ),
+        getAllCodexUsageInfo: vi
+          .fn()
+          .mockResolvedValue(new Map<string, Record<string, unknown>>()),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      await quotaCommand.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('Anthropic Quota Information');
+    });
+  });
+
+  describe('credits subcommand', () => {
+    it('shows info when no OAuth manager available', async () => {
+      maybeGetCliOAuthManagerMock.mockReturnValue(null);
+      getCliOAuthManagerMock.mockImplementation(() => {
+        throw new Error('not registered');
+      });
+
+      const credits = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'credits',
+      );
+      await credits!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('No Codex reset credits available');
+    });
+
+    it('shows no credits message when map is empty', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi
+          .fn()
+          .mockResolvedValue(new Map<string, Record<string, unknown>>()),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const credits = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'credits',
+      );
+      await credits!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('No Codex reset credits available');
+    });
+
+    it('shows available credits count when credits present', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'default',
+              availableCount: 2,
+              credits: [{ id: 'credit-1' }, { id: 'credit-2' }],
+            },
+          ]),
+        ),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const credits = quotaCommand.subCommands?.find(
+        (sc) => sc.name === 'credits',
+      );
+      await credits!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('Available reset credits: 2');
+    });
+  });
+
+  describe('reset subcommand', () => {
+    it('shows error when provider arg is not codex', async () => {
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, 'anthropic');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.ERROR);
+      expect(lastItem.text).toContain("Only 'codex' supports reset");
+    });
+
+    it('shows /auth codex hint when not authenticated', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi
+          .fn()
+          .mockResolvedValue(new Map<string, Record<string, unknown>>()),
+        getToken: vi.fn().mockResolvedValue(null),
+        listBuckets: vi.fn().mockResolvedValue([]),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('/auth codex');
+    });
+
+    it('shows no-credits message when authed but zero credits', async () => {
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi
+          .fn()
+          .mockResolvedValue(new Map<string, Record<string, unknown>>()),
+        getToken: vi.fn().mockResolvedValue('codex-token'),
+        listBuckets: vi.fn().mockResolvedValue(['default']),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('No reset credits available');
+    });
+
+    it('successfully redeems a credit and shows success + refreshed quota', async () => {
+      const codexToken = {
+        access_token: 'codex-access',
+        token_type: 'Bearer',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        account_id: 'acct-123',
+      };
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'default',
+              availableCount: 1,
+              credits: [{ id: 'credit-1' }],
+            },
+          ]),
+        ),
+        getToken: vi.fn().mockResolvedValue('codex-access'),
+        listBuckets: vi.fn().mockResolvedValue(['default']),
+        getTokenStore: vi.fn().mockReturnValue({
+          getToken: vi.fn().mockResolvedValue(codexToken),
+        }),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getEphemeralSettingMock.mockReturnValue(undefined);
+
+      mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      });
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      expect(mockConsumeCodexRateLimitResetCredit).toHaveBeenCalledTimes(1);
+      const callArgs = mockConsumeCodexRateLimitResetCredit.mock.calls[0];
+      expect(callArgs[0]).toBe('codex-access');
+      expect(callArgs[1]).toBe('acct-123');
+      expect(callArgs[2]).toBe('credit-1');
+      expect(callArgs[3]).toMatch(UUID_REGEX);
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const successItem = calls.find((call) => {
+        const item = call[0] as { text: string; type: MessageType };
+        return item.text.includes('reset') && item.type === MessageType.INFO;
+      });
+      expect(successItem).toBeDefined();
+    });
+
+    it('shows already_redeemed message', async () => {
+      const codexToken = {
+        access_token: 'codex-access',
+        token_type: 'Bearer',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        account_id: 'acct-123',
+      };
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'default',
+              availableCount: 1,
+              credits: [{ id: 'credit-1' }],
+            },
+          ]),
+        ),
+        getToken: vi.fn().mockResolvedValue('codex-access'),
+        listBuckets: vi.fn().mockResolvedValue(['default']),
+        getTokenStore: vi.fn().mockReturnValue({
+          getToken: vi.fn().mockResolvedValue(codexToken),
+        }),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      mockConsumeCodexRateLimitResetCredit.mockResolvedValue({
+        code: 'already_redeemed',
+      });
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.INFO);
+      expect(lastItem.text).toContain('already redeemed');
+    });
+
+    it('shows error when consume returns null', async () => {
+      const codexToken = {
+        access_token: 'codex-access',
+        token_type: 'Bearer',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        account_id: 'acct-123',
+      };
+      const oauthManager = {
+        getAllCodexRateLimitResetCredits: vi.fn().mockResolvedValue(
+          makeCodexCreditsMap([
+            {
+              bucket: 'default',
+              availableCount: 1,
+              credits: [{ id: 'credit-1' }],
+            },
+          ]),
+        ),
+        getToken: vi.fn().mockResolvedValue('codex-access'),
+        listBuckets: vi.fn().mockResolvedValue(['default']),
+        getTokenStore: vi.fn().mockReturnValue({
+          getToken: vi.fn().mockResolvedValue(codexToken),
+        }),
+      };
+      maybeGetCliOAuthManagerMock.mockReturnValue(oauthManager);
+      getCliOAuthManagerMock.mockReturnValue(oauthManager);
+
+      mockConsumeCodexRateLimitResetCredit.mockResolvedValue(null);
+
+      const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+      await reset!.action!(mockContext, '');
+
+      const calls = vi.mocked(mockContext.ui.addItem).mock.calls;
+      const lastItem = calls[calls.length - 1]?.[0] as {
+        type: MessageType;
+        text?: string;
+      };
+      expect(lastItem.type).toBe(MessageType.ERROR);
+      expect(lastItem.text).toContain('Failed to reset');
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -54,6 +54,11 @@ interface RedeemableCredit {
   readonly firstCreditId: string;
 }
 
+interface RedeemableCreditWithToken extends RedeemableCredit {
+  readonly accessToken: string;
+  readonly accountId: string;
+}
+
 interface BucketTokenInfo {
   readonly accessToken: string | null;
   readonly accountId: string | null;
@@ -240,12 +245,13 @@ async function isCodexAuthed(oauthManager: OAuthManager): Promise<boolean> {
 }
 
 /**
- * Find the first bucket+credit that can be redeemed.
+ * Find all buckets with a credit that can be redeemed.
  */
-async function findRedeemableCredit(
+async function findRedeemableCredits(
   oauthManager: OAuthManager,
-): Promise<RedeemableCredit | null> {
+): Promise<readonly RedeemableCredit[]> {
   const creditsMap = await oauthManager.getAllCodexRateLimitResetCredits();
+  const redeemableCredits: RedeemableCredit[] = [];
 
   for (const [bucket, raw] of creditsMap.entries()) {
     const parsed = parseBucketCredits(bucket, raw);
@@ -254,10 +260,13 @@ async function findRedeemableCredit(
       parsed.availableCount > 0 &&
       parsed.firstCreditId !== null
     ) {
-      return { bucket: parsed.bucket, firstCreditId: parsed.firstCreditId };
+      redeemableCredits.push({
+        bucket: parsed.bucket,
+        firstCreditId: parsed.firstCreditId,
+      });
     }
   }
-  return null;
+  return redeemableCredits;
 }
 
 /**
@@ -286,6 +295,23 @@ async function resolveBucketToken(
     accessToken: parsed.data.access_token,
     accountId: parsed.data.account_id,
   };
+}
+
+async function findRedeemableCreditWithToken(
+  oauthManager: OAuthManager,
+  redeemableCredits: readonly RedeemableCredit[],
+): Promise<RedeemableCreditWithToken | null> {
+  for (const redeemable of redeemableCredits) {
+    const tokenInfo = await resolveBucketToken(oauthManager, redeemable.bucket);
+    if (tokenInfo.accessToken !== null && tokenInfo.accountId !== null) {
+      return {
+        ...redeemable,
+        accessToken: tokenInfo.accessToken,
+        accountId: tokenInfo.accountId,
+      };
+    }
+  }
+  return null;
 }
 
 const RESET_CONFIRMATION_PROMPT =
@@ -390,17 +416,20 @@ async function resetAction(
       return undefined;
     }
 
-    const redeemable = await findRedeemableCredit(oauthManager);
-    if (redeemable === null) {
+    const redeemableCredits = await findRedeemableCredits(oauthManager);
+    if (redeemableCredits.length === 0) {
       addInfo(context, NO_REDEEMABLE_CREDITS_MSG);
       return undefined;
     }
 
-    const tokenInfo = await resolveBucketToken(oauthManager, redeemable.bucket);
-    if (tokenInfo.accessToken === null || tokenInfo.accountId === null) {
+    const redeemable = await findRedeemableCreditWithToken(
+      oauthManager,
+      redeemableCredits,
+    );
+    if (redeemable === null) {
       addError(
         context,
-        'Codex credentials for the selected bucket are unavailable or expired. Run /auth codex to re-authenticate.',
+        'Codex credentials for all credit-bearing buckets are unavailable or expired. Run /auth codex to re-authenticate.',
       );
       return undefined;
     }
@@ -415,8 +444,8 @@ async function resetAction(
 
     await redeemResetCredit(
       context,
-      tokenInfo.accessToken,
-      tokenInfo.accountId,
+      redeemable.accessToken,
+      redeemable.accountId,
       redeemable.firstCreditId,
     );
     return undefined;

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -14,6 +14,7 @@ import {
   consumeCodexRateLimitResetCredit,
   formatCodexResetCredits,
 } from '@vybestack/llxprt-code-providers';
+import type { CodexRateLimitResetCreditsResponse } from '@vybestack/llxprt-code-providers';
 import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
 import {
   CodexOAuthTokenSchema,
@@ -28,6 +29,11 @@ import { randomUUID } from 'node:crypto';
 // Making /quota reset work there requires a cross-cutting change to load
 // built-ins + provide a real non-interactive UI sink, which affects every
 // built-in and is out of scope for this issue.
+
+const NO_RESET_CREDITS_MSG =
+  'No Codex reset credits available. Reset credits are earned via referrals or purchased.';
+const NOT_AUTHED_CODEX_MSG =
+  'Not authenticated with Codex. Run /auth codex to login.';
 
 interface BucketCredits {
   readonly bucket: string;
@@ -122,14 +128,10 @@ function parseBucketCredits(
  */
 function formatOneBucket(
   bucket: string,
-  raw: Record<string, unknown>,
+  parsed: CodexRateLimitResetCreditsResponse,
   multiBucket: boolean,
 ): string[] | null {
-  const parsedResult = CodexRateLimitResetCreditsResponseSchema.safeParse(raw);
-  if (!parsedResult.success) {
-    return null;
-  }
-  const lines = formatCodexResetCredits(parsedResult.data);
+  const lines = formatCodexResetCredits(parsed);
   if (lines.length === 0) {
     return null;
   }
@@ -144,6 +146,8 @@ function formatOneBucket(
 
 /**
  * Format all bucket reset-credits into display lines with bucket headers.
+ * Each bucket is parsed once via the schema; buckets that fail to validate
+ * are skipped.
  */
 function formatAllResetCreditsLines(
   creditsMap: Map<string, Record<string, unknown>>,
@@ -152,7 +156,12 @@ function formatAllResetCreditsLines(
   const multiBucket = creditsMap.size > 1;
 
   for (const [bucket, raw] of creditsMap.entries()) {
-    const bucketLines = formatOneBucket(bucket, raw, multiBucket);
+    const parsedResult =
+      CodexRateLimitResetCreditsResponseSchema.safeParse(raw);
+    if (!parsedResult.success) {
+      continue;
+    }
+    const bucketLines = formatOneBucket(bucket, parsedResult.data, multiBucket);
     if (bucketLines !== null) {
       output.push(...bucketLines);
     }
@@ -170,10 +179,7 @@ function formatAllResetCreditsLines(
 async function creditsAction(context: CommandContext): Promise<void> {
   const oauthManager = resolveOAuthManager();
   if (!oauthManager) {
-    addInfo(
-      context,
-      'No Codex reset credits available. Reset credits are earned via referrals or purchased.',
-    );
+    addInfo(context, NO_RESET_CREDITS_MSG);
     return;
   }
 
@@ -181,19 +187,13 @@ async function creditsAction(context: CommandContext): Promise<void> {
     const creditsMap = await oauthManager.getAllCodexRateLimitResetCredits();
 
     if (creditsMap.size === 0) {
-      addInfo(
-        context,
-        'No Codex reset credits available. Reset credits are earned via referrals or purchased.',
-      );
+      addInfo(context, NO_RESET_CREDITS_MSG);
       return;
     }
 
     const lines = formatAllResetCreditsLines(creditsMap);
     if (lines.length === 0) {
-      addInfo(
-        context,
-        'No Codex reset credits available. Reset credits are earned via referrals or purchased.',
-      );
+      addInfo(context, NO_RESET_CREDITS_MSG);
       return;
     }
 
@@ -279,22 +279,26 @@ async function resetAction(
 
   const oauthManager = resolveOAuthManager();
   if (!oauthManager) {
-    addInfo(context, 'Not authenticated with Codex. Run /auth codex to login.');
+    addInfo(context, NOT_AUTHED_CODEX_MSG);
     return;
   }
 
   try {
     const authed = await isCodexAuthed(oauthManager);
     if (!authed) {
-      addInfo(
-        context,
-        'Not authenticated with Codex. Run /auth codex to login.',
-      );
+      addInfo(context, NOT_AUTHED_CODEX_MSG);
       return;
     }
 
     const redeemable = await findRedeemableCredit(oauthManager);
-    if (redeemable?.firstCreditId == null) {
+    if (redeemable === null) {
+      addInfo(
+        context,
+        'No reset credits available to redeem. Reset credits are earned via referrals or purchased.',
+      );
+      return;
+    }
+    if (redeemable.firstCreditId === null) {
       addInfo(
         context,
         'No reset credits available to redeem. Reset credits are earned via referrals or purchased.',

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -14,6 +14,11 @@ import {
   consumeCodexRateLimitResetCredit,
   formatCodexResetCredits,
 } from '@vybestack/llxprt-code-providers';
+import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
+import {
+  CodexOAuthTokenSchema,
+  type CodexOAuthToken,
+} from '@vybestack/llxprt-code-auth';
 import type { CommandArgumentSchema } from './schema/types.js';
 import { randomUUID } from 'node:crypto';
 
@@ -35,48 +40,14 @@ interface BucketTokenInfo {
   readonly accountId: string | null;
 }
 
-interface CodexResetCreditsProvider {
-  getAllCodexRateLimitResetCredits(): Promise<
-    Map<string, Record<string, unknown>>
-  >;
-}
-
-interface CodexAuthProbe {
-  getToken?(provider: string): Promise<string | null>;
-  listBuckets?(provider: string): Promise<string[]>;
-}
-
-interface CodexTokenStoreProvider {
-  getTokenStore?(): CodexTokenStoreAccessor;
-}
-
-interface CodexTokenStoreAccessor {
-  getToken(
-    provider: string,
-    bucket: string,
-  ): Promise<Record<string, unknown> | null>;
-}
-
-/**
- * Combined shape the reset flow needs from the OAuthManager.
- */
-interface CodexQuotaManager
-  extends CodexResetCreditsProvider,
-    CodexAuthProbe,
-    CodexTokenStoreProvider {}
-
 /**
  * Resolve the OAuthManager via the runtime API, returning null when the
  * runtime infrastructure is not registered (mirrors authCommand.getOAuthManager
  * but degrades to null instead of throwing).
  */
-function resolveOAuthManager(): CodexQuotaManager | null {
+function resolveOAuthManager(): OAuthManager | null {
   try {
-    const mgr = getRuntimeApi().getCliOAuthManager() as unknown;
-    if (mgr === null || mgr === undefined) {
-      return null;
-    }
-    return mgr as CodexQuotaManager;
+    return getRuntimeApi().getCliOAuthManager();
   } catch {
     return null;
   }
@@ -236,25 +207,20 @@ async function creditsAction(context: CommandContext): Promise<void> {
 /**
  * Determine whether the user is authenticated with Codex.
  */
-async function isCodexAuthed(oauthManager: CodexAuthProbe): Promise<boolean> {
-  if (oauthManager.getToken !== undefined) {
-    const token = await oauthManager.getToken('codex');
-    if (token !== null) {
-      return true;
-    }
+async function isCodexAuthed(oauthManager: OAuthManager): Promise<boolean> {
+  const token = await oauthManager.getToken('codex');
+  if (token !== null) {
+    return true;
   }
-  if (oauthManager.listBuckets !== undefined) {
-    const buckets = await oauthManager.listBuckets('codex');
-    return buckets.length > 0;
-  }
-  return false;
+  const buckets = await oauthManager.listBuckets('codex');
+  return buckets.length > 0;
 }
 
 /**
  * Find the first bucket+credit that can be redeemed.
  */
 async function findRedeemableCredit(
-  oauthManager: CodexResetCreditsProvider,
+  oauthManager: OAuthManager,
 ): Promise<BucketCredits | null> {
   const creditsMap = await oauthManager.getAllCodexRateLimitResetCredits();
 
@@ -275,22 +241,25 @@ async function findRedeemableCredit(
  * Resolve the access token + account_id for a Codex bucket.
  */
 async function resolveBucketToken(
-  oauthManager: CodexTokenStoreProvider,
+  oauthManager: OAuthManager,
   bucket: string,
 ): Promise<BucketTokenInfo> {
-  const tokenStore = oauthManager.getTokenStore?.();
-  if (tokenStore === undefined) {
-    return { accessToken: null, accountId: null };
-  }
+  const tokenStore = oauthManager.getTokenStore();
   const token = await tokenStore.getToken('codex', bucket);
   if (token === null) {
     return { accessToken: null, accountId: null };
   }
-  const accessTokenRaw = token['access_token'];
-  const accountIdRaw = token['account_id'];
+  const parsed = CodexOAuthTokenSchema.safeParse(token);
+  if (!parsed.success) {
+    return { accessToken: null, accountId: null };
+  }
+  const codexToken: CodexOAuthToken = parsed.data;
   const accessToken =
-    typeof accessTokenRaw === 'string' ? accessTokenRaw : null;
-  const accountId = typeof accountIdRaw === 'string' ? accountIdRaw : null;
+    typeof codexToken.access_token === 'string'
+      ? codexToken.access_token
+      : null;
+  const accountId =
+    typeof codexToken.account_id === 'string' ? codexToken.account_id : null;
   return { accessToken, accountId };
 }
 

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -34,6 +34,8 @@ const NO_RESET_CREDITS_MSG =
   'No Codex reset credits available. Reset credits are earned via referrals or purchased.';
 const NOT_AUTHED_CODEX_MSG =
   'Not authenticated with Codex. Run /auth codex to login.';
+const NO_REDEEMABLE_CREDITS_MSG =
+  'No reset credits available to redeem. Reset credits are earned via referrals or purchased.';
 
 interface BucketCredits {
   readonly bucket: string;
@@ -292,20 +294,17 @@ async function resetAction(
 
     const redeemable = await findRedeemableCredit(oauthManager);
     if (redeemable === null) {
-      addInfo(
-        context,
-        'No reset credits available to redeem. Reset credits are earned via referrals or purchased.',
-      );
+      addInfo(context, NO_REDEEMABLE_CREDITS_MSG);
       return;
     }
-    if (redeemable.firstCreditId === null) {
-      addInfo(
-        context,
-        'No reset credits available to redeem. Reset credits are earned via referrals or purchased.',
-      );
-      return;
-    }
+    // Type-narrowing guard: BucketCredits.firstCreditId is typed string | null,
+    // so this local check narrows creditId to string for the consume call below
+    // without a non-null assertion.
     const creditId = redeemable.firstCreditId;
+    if (creditId === null) {
+      addInfo(context, NO_REDEEMABLE_CREDITS_MSG);
+      return;
+    }
     const bucket = redeemable.bucket;
 
     const tokenInfo = await resolveBucketToken(oauthManager, bucket);
@@ -342,10 +341,15 @@ async function resetAction(
     }
 
     // Refresh and display updated quota after a successful reset.
-    const runtimeApi = getRuntimeApi();
-    const quotaLines = await fetchAllQuotaInfo(runtimeApi);
-    if (quotaLines.length > 0) {
-      addInfo(context, quotaLines.join('\n'));
+    // A refresh failure is non-fatal: the reset itself already succeeded.
+    try {
+      const runtimeApi = getRuntimeApi();
+      const quotaLines = await fetchAllQuotaInfo(runtimeApi);
+      if (quotaLines.length > 0) {
+        addInfo(context, quotaLines.join('\n'));
+      }
+    } catch {
+      // Intentionally ignored — reset succeeded; only the refresh view failed.
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -43,9 +43,29 @@ interface BucketCredits {
   readonly firstCreditId: string | null;
 }
 
+/**
+ * A bucket + credit guaranteed to be redeemable (non-null credit id).
+ * Returned by findRedeemableCredit so callers need no null-narrowing guard.
+ */
+interface RedeemableCredit {
+  readonly bucket: string;
+  readonly firstCreditId: string;
+}
+
 interface BucketTokenInfo {
   readonly accessToken: string | null;
   readonly accountId: string | null;
+}
+
+/**
+ * Parse a raw reset-credits payload via the Zod schema once.
+ * Returns the validated response or null when the shape does not validate.
+ */
+function safeParseResetCredits(
+  raw: Record<string, unknown>,
+): CodexRateLimitResetCreditsResponse | null {
+  const parsed = CodexRateLimitResetCreditsResponseSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
 }
 
 /**
@@ -112,11 +132,11 @@ function parseBucketCredits(
   bucket: string,
   raw: Record<string, unknown>,
 ): BucketCredits | null {
-  const parsed = CodexRateLimitResetCreditsResponseSchema.safeParse(raw);
-  if (!parsed.success) {
+  const parsed = safeParseResetCredits(raw);
+  if (parsed === null) {
     return null;
   }
-  const credits = parsed.data.rate_limit_reset_credits;
+  const credits = parsed.rate_limit_reset_credits;
   const availableCount = credits?.available_count ?? 0;
   const creditList = credits?.credits ?? [];
   const firstCreditId =
@@ -158,12 +178,11 @@ function formatAllResetCreditsLines(
   const multiBucket = creditsMap.size > 1;
 
   for (const [bucket, raw] of creditsMap.entries()) {
-    const parsedResult =
-      CodexRateLimitResetCreditsResponseSchema.safeParse(raw);
-    if (!parsedResult.success) {
+    const parsed = safeParseResetCredits(raw);
+    if (parsed === null) {
       continue;
     }
-    const bucketLines = formatOneBucket(bucket, parsedResult.data, multiBucket);
+    const bucketLines = formatOneBucket(bucket, parsed, multiBucket);
     if (bucketLines !== null) {
       output.push(...bucketLines);
     }
@@ -223,7 +242,7 @@ async function isCodexAuthed(oauthManager: OAuthManager): Promise<boolean> {
  */
 async function findRedeemableCredit(
   oauthManager: OAuthManager,
-): Promise<BucketCredits | null> {
+): Promise<RedeemableCredit | null> {
   const creditsMap = await oauthManager.getAllCodexRateLimitResetCredits();
 
   for (const [bucket, raw] of creditsMap.entries()) {
@@ -233,7 +252,7 @@ async function findRedeemableCredit(
       parsed.availableCount > 0 &&
       parsed.firstCreditId !== null
     ) {
-      return parsed;
+      return { bucket: parsed.bucket, firstCreditId: parsed.firstCreditId };
     }
   }
   return null;
@@ -297,14 +316,7 @@ async function resetAction(
       addInfo(context, NO_REDEEMABLE_CREDITS_MSG);
       return;
     }
-    // Type-narrowing guard: BucketCredits.firstCreditId is typed string | null,
-    // so this local check narrows creditId to string for the consume call below
-    // without a non-null assertion.
     const creditId = redeemable.firstCreditId;
-    if (creditId === null) {
-      addInfo(context, NO_REDEEMABLE_CREDITS_MSG);
-      return;
-    }
     const bucket = redeemable.bucket;
 
     const tokenInfo = await resolveBucketToken(oauthManager, bucket);
@@ -340,16 +352,12 @@ async function resetAction(
       addInfo(context, 'Credit already redeemed.');
     }
 
-    // Refresh and display updated quota after a successful reset.
-    // A refresh failure is non-fatal: the reset itself already succeeded.
-    try {
-      const runtimeApi = getRuntimeApi();
-      const quotaLines = await fetchAllQuotaInfo(runtimeApi);
-      if (quotaLines.length > 0) {
-        addInfo(context, quotaLines.join('\n'));
-      }
-    } catch {
-      // Intentionally ignored — reset succeeded; only the refresh view failed.
+    // fetchAllQuotaInfo has its own internal error handling and returns [] on
+    // failure, so it never throws — no extra guard is needed here.
+    const runtimeApi = getRuntimeApi();
+    const quotaLines = await fetchAllQuotaInfo(runtimeApi);
+    if (quotaLines.length > 0) {
+      addInfo(context, quotaLines.join('\n'));
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -16,10 +16,7 @@ import {
 } from '@vybestack/llxprt-code-providers';
 import type { CodexRateLimitResetCreditsResponse } from '@vybestack/llxprt-code-providers';
 import type { OAuthManager } from '@vybestack/llxprt-code-providers/auth.js';
-import {
-  CodexOAuthTokenSchema,
-  type CodexOAuthToken,
-} from '@vybestack/llxprt-code-auth';
+import { CodexOAuthTokenSchema } from '@vybestack/llxprt-code-auth';
 import type { CommandArgumentSchema } from './schema/types.js';
 import { randomUUID } from 'node:crypto';
 
@@ -274,14 +271,16 @@ async function resolveBucketToken(
   if (!parsed.success) {
     return { accessToken: null, accountId: null };
   }
-  const codexToken: CodexOAuthToken = parsed.data;
-  const accessToken =
-    typeof codexToken.access_token === 'string'
-      ? codexToken.access_token
-      : null;
-  const accountId =
-    typeof codexToken.account_id === 'string' ? codexToken.account_id : null;
-  return { accessToken, accountId };
+  // Guard against a token that expired between the credit-listing call and
+  // this resolve — sending an expired token to consume would yield a 401 and
+  // a misleading generic error.
+  if (parsed.data.expiry <= Math.floor(Date.now() / 1000)) {
+    return { accessToken: null, accountId: null };
+  }
+  return {
+    accessToken: parsed.data.access_token,
+    accountId: parsed.data.account_id,
+  };
 }
 
 /**
@@ -323,11 +322,14 @@ async function resetAction(
     if (tokenInfo.accessToken === null || tokenInfo.accountId === null) {
       addError(
         context,
-        'Failed to resolve Codex credentials for the selected bucket.',
+        'Codex credentials for the selected bucket are unavailable or expired. Run /auth codex to re-authenticate.',
       );
       return;
     }
 
+    // Both the credit listing (getAllCodexRateLimitResetCredits) and this
+    // consume call resolve base-url from the same runtime settings source, so
+    // list and consume always target the same backend host.
     const baseUrl = resolveBaseUrl();
     const redeemRequestId = randomUUID();
     const consumeResult = await consumeCodexRateLimitResetCredit(

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -1,0 +1,425 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SlashCommand, CommandContext } from './types.js';
+import { CommandKind } from './types.js';
+import { MessageType } from '../types.js';
+import { getRuntimeApi } from '../contexts/RuntimeContext.js';
+import { fetchAllQuotaInfo } from './statsQuota.js';
+import {
+  CodexRateLimitResetCreditsResponseSchema,
+  consumeCodexRateLimitResetCredit,
+  formatCodexResetCredits,
+} from '@vybestack/llxprt-code-providers';
+import type { CommandArgumentSchema } from './schema/types.js';
+import { randomUUID } from 'node:crypto';
+
+// Non-interactive mode (`llxprt-code --command "/quota reset"`) does not load
+// BuiltinCommandLoader (only FileCommandLoader) and createNonInteractiveUI is
+// a no-op sink, so NO built-in slash command works non-interactively today.
+// Making /quota reset work there requires a cross-cutting change to load
+// built-ins + provide a real non-interactive UI sink, which affects every
+// built-in and is out of scope for this issue.
+
+interface BucketCredits {
+  readonly bucket: string;
+  readonly availableCount: number;
+  readonly firstCreditId: string | null;
+}
+
+interface BucketTokenInfo {
+  readonly accessToken: string | null;
+  readonly accountId: string | null;
+}
+
+interface CodexResetCreditsProvider {
+  getAllCodexRateLimitResetCredits(): Promise<
+    Map<string, Record<string, unknown>>
+  >;
+}
+
+interface CodexAuthProbe {
+  getToken?(provider: string): Promise<string | null>;
+  listBuckets?(provider: string): Promise<string[]>;
+}
+
+interface CodexTokenStoreProvider {
+  getTokenStore?(): CodexTokenStoreAccessor;
+}
+
+interface CodexTokenStoreAccessor {
+  getToken(
+    provider: string,
+    bucket: string,
+  ): Promise<Record<string, unknown> | null>;
+}
+
+/**
+ * Combined shape the reset flow needs from the OAuthManager.
+ */
+interface CodexQuotaManager
+  extends CodexResetCreditsProvider,
+    CodexAuthProbe,
+    CodexTokenStoreProvider {}
+
+/**
+ * Resolve the OAuthManager via the runtime API, returning null when the
+ * runtime infrastructure is not registered (mirrors authCommand.getOAuthManager
+ * but degrades to null instead of throwing).
+ */
+function resolveOAuthManager(): CodexQuotaManager | null {
+  try {
+    const mgr = getRuntimeApi().getCliOAuthManager() as unknown;
+    if (mgr === null || mgr === undefined) {
+      return null;
+    }
+    return mgr as CodexQuotaManager;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the trimmed base-url ephemeral setting, or undefined when blank.
+ */
+function resolveBaseUrl(): string | undefined {
+  const value = getRuntimeApi().getEphemeralSetting('base-url');
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+function addInfo(context: CommandContext, text: string): void {
+  context.ui.addItem({ type: MessageType.INFO, text }, Date.now());
+}
+
+function addError(context: CommandContext, text: string): void {
+  context.ui.addItem({ type: MessageType.ERROR, text }, Date.now());
+}
+
+/**
+ * Status (and default) action: show quota/rate-limit info for all providers.
+ */
+async function statusAction(context: CommandContext): Promise<void> {
+  try {
+    const runtimeApi = getRuntimeApi();
+    const quotaLines = await fetchAllQuotaInfo(runtimeApi);
+
+    if (quotaLines.length === 0) {
+      addInfo(
+        context,
+        'No quota information available. Supported providers: Anthropic (OAuth), Codex (OAuth), Z.ai, Synthetic, Chutes, Kimi.',
+      );
+      return;
+    }
+
+    addInfo(context, quotaLines.join('\n'));
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    addError(context, `Failed to retrieve quota information: ${msg}`);
+  }
+}
+
+/**
+ * Parse a single bucket's reset-credits payload via the Zod schema.
+ * Returns null when the shape does not validate.
+ */
+function parseBucketCredits(
+  bucket: string,
+  raw: Record<string, unknown>,
+): BucketCredits | null {
+  const parsed = CodexRateLimitResetCreditsResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    return null;
+  }
+  const credits = parsed.data.rate_limit_reset_credits;
+  const availableCount = credits?.available_count ?? 0;
+  const creditList = credits?.credits ?? [];
+  const firstCreditId =
+    creditList.length > 0 && creditList[0]?.id ? creditList[0].id : null;
+  return { bucket, availableCount, firstCreditId };
+}
+
+/**
+ * Format a single bucket's reset credits into display lines (with optional
+ * bucket header), or null when there is nothing to show.
+ */
+function formatOneBucket(
+  bucket: string,
+  raw: Record<string, unknown>,
+  multiBucket: boolean,
+): string[] | null {
+  const parsedResult = CodexRateLimitResetCreditsResponseSchema.safeParse(raw);
+  if (!parsedResult.success) {
+    return null;
+  }
+  const lines = formatCodexResetCredits(parsedResult.data);
+  if (lines.length === 0) {
+    return null;
+  }
+  const result: string[] = [];
+  if (multiBucket) {
+    result.push(`### Bucket: ${bucket}\n`);
+  }
+  result.push(...lines);
+  result.push('');
+  return result;
+}
+
+/**
+ * Format all bucket reset-credits into display lines with bucket headers.
+ */
+function formatAllResetCreditsLines(
+  creditsMap: Map<string, Record<string, unknown>>,
+): string[] {
+  const output: string[] = [];
+  const multiBucket = creditsMap.size > 1;
+
+  for (const [bucket, raw] of creditsMap.entries()) {
+    const bucketLines = formatOneBucket(bucket, raw, multiBucket);
+    if (bucketLines !== null) {
+      output.push(...bucketLines);
+    }
+  }
+
+  if (output[output.length - 1] === '') {
+    output.pop();
+  }
+  return output;
+}
+
+/**
+ * Credits subcommand action: show available Codex reset credits.
+ */
+async function creditsAction(context: CommandContext): Promise<void> {
+  const oauthManager = resolveOAuthManager();
+  if (!oauthManager) {
+    addInfo(
+      context,
+      'No Codex reset credits available. Reset credits are earned via referrals or purchased.',
+    );
+    return;
+  }
+
+  try {
+    const creditsMap = await oauthManager.getAllCodexRateLimitResetCredits();
+
+    if (creditsMap.size === 0) {
+      addInfo(
+        context,
+        'No Codex reset credits available. Reset credits are earned via referrals or purchased.',
+      );
+      return;
+    }
+
+    const lines = formatAllResetCreditsLines(creditsMap);
+    if (lines.length === 0) {
+      addInfo(
+        context,
+        'No Codex reset credits available. Reset credits are earned via referrals or purchased.',
+      );
+      return;
+    }
+
+    addInfo(context, lines.join('\n'));
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    addError(context, `Failed to retrieve reset credits: ${msg}`);
+  }
+}
+
+/**
+ * Determine whether the user is authenticated with Codex.
+ */
+async function isCodexAuthed(oauthManager: CodexAuthProbe): Promise<boolean> {
+  if (oauthManager.getToken !== undefined) {
+    const token = await oauthManager.getToken('codex');
+    if (token !== null) {
+      return true;
+    }
+  }
+  if (oauthManager.listBuckets !== undefined) {
+    const buckets = await oauthManager.listBuckets('codex');
+    return buckets.length > 0;
+  }
+  return false;
+}
+
+/**
+ * Find the first bucket+credit that can be redeemed.
+ */
+async function findRedeemableCredit(
+  oauthManager: CodexResetCreditsProvider,
+): Promise<BucketCredits | null> {
+  const creditsMap = await oauthManager.getAllCodexRateLimitResetCredits();
+
+  for (const [bucket, raw] of creditsMap.entries()) {
+    const parsed = parseBucketCredits(bucket, raw);
+    if (
+      parsed !== null &&
+      parsed.availableCount > 0 &&
+      parsed.firstCreditId !== null
+    ) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the access token + account_id for a Codex bucket.
+ */
+async function resolveBucketToken(
+  oauthManager: CodexTokenStoreProvider,
+  bucket: string,
+): Promise<BucketTokenInfo> {
+  const tokenStore = oauthManager.getTokenStore?.();
+  if (tokenStore === undefined) {
+    return { accessToken: null, accountId: null };
+  }
+  const token = await tokenStore.getToken('codex', bucket);
+  if (token === null) {
+    return { accessToken: null, accountId: null };
+  }
+  const accessTokenRaw = token['access_token'];
+  const accountIdRaw = token['account_id'];
+  const accessToken =
+    typeof accessTokenRaw === 'string' ? accessTokenRaw : null;
+  const accountId = typeof accountIdRaw === 'string' ? accountIdRaw : null;
+  return { accessToken, accountId };
+}
+
+/**
+ * Reset subcommand action: redeem a Codex rate-limit-reset credit.
+ */
+async function resetAction(
+  context: CommandContext,
+  args: string,
+): Promise<void> {
+  const provider = args.trim();
+
+  if (provider.length > 0 && provider !== 'codex') {
+    addError(context, "Only 'codex' supports reset.");
+    return;
+  }
+
+  const oauthManager = resolveOAuthManager();
+  if (!oauthManager) {
+    addInfo(context, 'Not authenticated with Codex. Run /auth codex to login.');
+    return;
+  }
+
+  try {
+    const authed = await isCodexAuthed(oauthManager);
+    if (!authed) {
+      addInfo(
+        context,
+        'Not authenticated with Codex. Run /auth codex to login.',
+      );
+      return;
+    }
+
+    const redeemable = await findRedeemableCredit(oauthManager);
+    if (redeemable?.firstCreditId == null) {
+      addInfo(
+        context,
+        'No reset credits available to redeem. Reset credits are earned via referrals or purchased.',
+      );
+      return;
+    }
+    const creditId = redeemable.firstCreditId;
+    const bucket = redeemable.bucket;
+
+    const tokenInfo = await resolveBucketToken(oauthManager, bucket);
+    if (tokenInfo.accessToken === null || tokenInfo.accountId === null) {
+      addError(
+        context,
+        'Failed to resolve Codex credentials for the selected bucket.',
+      );
+      return;
+    }
+
+    const baseUrl = resolveBaseUrl();
+    const redeemRequestId = randomUUID();
+    const consumeResult = await consumeCodexRateLimitResetCredit(
+      tokenInfo.accessToken,
+      tokenInfo.accountId,
+      creditId,
+      redeemRequestId,
+      baseUrl,
+    );
+
+    if (consumeResult === null) {
+      addError(
+        context,
+        'Failed to reset rate-limit window. Please try again later.',
+      );
+      return;
+    }
+
+    if (consumeResult.code === 'reset') {
+      addInfo(context, 'Rate-limit window reset successfully.');
+    } else {
+      addInfo(context, 'Credit already redeemed.');
+    }
+
+    // Refresh and display updated quota after a successful reset.
+    const runtimeApi = getRuntimeApi();
+    const quotaLines = await fetchAllQuotaInfo(runtimeApi);
+    if (quotaLines.length > 0) {
+      addInfo(context, quotaLines.join('\n'));
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    addError(context, `Failed to reset rate-limit window: ${msg}`);
+  }
+}
+
+/**
+ * Schema for /quota reset autocomplete: offers 'codex' as the provider.
+ */
+const resetSchema: CommandArgumentSchema = [
+  {
+    kind: 'value',
+    name: 'provider',
+    description: 'Provider to reset',
+    options: [{ value: 'codex', description: 'Codex (ChatGPT)' }],
+  },
+];
+
+export const quotaCommand: SlashCommand = {
+  name: 'quota',
+  description:
+    'Manage quota and rate-limit reset. Usage: /quota [status|credits|reset]',
+  kind: CommandKind.BUILT_IN,
+  action: statusAction,
+  subCommands: [
+    {
+      name: 'status',
+      description: 'Show quota/rate-limit status for all providers.',
+      kind: CommandKind.BUILT_IN,
+      autoExecute: true,
+      action: statusAction,
+    },
+    {
+      name: 'credits',
+      description: 'Show available Codex rate-limit-reset credits.',
+      kind: CommandKind.BUILT_IN,
+      autoExecute: true,
+      action: creditsAction,
+    },
+    {
+      name: 'reset',
+      description:
+        'Redeem a Codex rate-limit-reset credit to reset the rate-limit window.',
+      kind: CommandKind.BUILT_IN,
+      schema: resetSchema,
+      action: resetAction,
+    },
+  ],
+};

--- a/packages/cli/src/ui/commands/quotaCommand.ts
+++ b/packages/cli/src/ui/commands/quotaCommand.ts
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { SlashCommand, CommandContext } from './types.js';
-import { CommandKind } from './types.js';
+import {
+  CommandKind,
+  type SlashCommand,
+  type CommandContext,
+  type SlashCommandActionReturn,
+  type ConfirmActionReturn,
+} from './types.js';
 import { MessageType } from '../types.js';
 import { getRuntimeApi } from '../contexts/RuntimeContext.js';
 import { fetchAllQuotaInfo } from './statsQuota.js';
@@ -283,87 +288,142 @@ async function resolveBucketToken(
   };
 }
 
+const RESET_CONFIRMATION_PROMPT =
+  'Redeem a Codex rate-limit-reset credit to reset your rate-limit window? This consumes one earned/purchased reset credit.';
+
+/**
+ * Build the confirm_action return value for /quota reset, deriving the
+ * original raw invocation (falling back to a canonical form when the
+ * invocation context is absent or blank).
+ */
+function buildResetConfirmation(context: CommandContext): ConfirmActionReturn {
+  const rawInvocation =
+    context.invocation?.raw && context.invocation.raw.trim() !== ''
+      ? context.invocation.raw
+      : '/quota reset codex';
+  return {
+    type: 'confirm_action',
+    prompt: RESET_CONFIRMATION_PROMPT,
+    originalInvocation: { raw: rawInvocation },
+  };
+}
+
+/**
+ * Consume the redeemable credit and render the result (success / already
+ * redeemed / failure) plus a refreshed quota snapshot. Returns void — all
+ * user feedback flows through addInfo/addError.
+ */
+async function redeemResetCredit(
+  context: CommandContext,
+  accessToken: string,
+  accountId: string,
+  creditId: string,
+): Promise<void> {
+  // Both the credit listing (getAllCodexRateLimitResetCredits) and this
+  // consume call resolve base-url from the same runtime settings source, so
+  // list and consume always target the same backend host.
+  const baseUrl = resolveBaseUrl();
+  const redeemRequestId = randomUUID();
+  const consumeResult = await consumeCodexRateLimitResetCredit(
+    accessToken,
+    accountId,
+    creditId,
+    redeemRequestId,
+    baseUrl,
+  );
+
+  if (consumeResult === null) {
+    addError(
+      context,
+      'Failed to reset rate-limit window. Please try again later.',
+    );
+    return;
+  }
+
+  if (consumeResult.code === 'reset') {
+    addInfo(context, 'Rate-limit window reset successfully.');
+  } else {
+    addInfo(context, 'Credit already redeemed.');
+  }
+
+  // fetchAllQuotaInfo has its own internal error handling and returns [] on
+  // failure, so it never throws — no extra guard is needed here.
+  const runtimeApi = getRuntimeApi();
+  const quotaLines = await fetchAllQuotaInfo(runtimeApi);
+  if (quotaLines.length > 0) {
+    addInfo(context, quotaLines.join('\n'));
+  }
+}
+
 /**
  * Reset subcommand action: redeem a Codex rate-limit-reset credit.
  */
 async function resetAction(
   context: CommandContext,
   args: string,
-): Promise<void> {
-  const provider = args.trim();
+): Promise<SlashCommandActionReturn | void> {
+  const tokens = args
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t !== '');
+  const provider = tokens[0] ?? '';
 
-  if (provider.length > 0 && provider !== 'codex') {
+  if (provider !== '' && provider !== 'codex') {
     addError(context, "Only 'codex' supports reset.");
-    return;
+    return undefined;
+  }
+  if (tokens.length > 1) {
+    addError(context, 'Too many arguments. Usage: /quota reset [codex]');
+    return undefined;
   }
 
   const oauthManager = resolveOAuthManager();
   if (!oauthManager) {
     addInfo(context, NOT_AUTHED_CODEX_MSG);
-    return;
+    return undefined;
   }
 
   try {
     const authed = await isCodexAuthed(oauthManager);
     if (!authed) {
       addInfo(context, NOT_AUTHED_CODEX_MSG);
-      return;
+      return undefined;
     }
 
     const redeemable = await findRedeemableCredit(oauthManager);
     if (redeemable === null) {
       addInfo(context, NO_REDEEMABLE_CREDITS_MSG);
-      return;
+      return undefined;
     }
-    const creditId = redeemable.firstCreditId;
-    const bucket = redeemable.bucket;
 
-    const tokenInfo = await resolveBucketToken(oauthManager, bucket);
+    const tokenInfo = await resolveBucketToken(oauthManager, redeemable.bucket);
     if (tokenInfo.accessToken === null || tokenInfo.accountId === null) {
       addError(
         context,
         'Codex credentials for the selected bucket are unavailable or expired. Run /auth codex to re-authenticate.',
       );
-      return;
+      return undefined;
     }
 
-    // Both the credit listing (getAllCodexRateLimitResetCredits) and this
-    // consume call resolve base-url from the same runtime settings source, so
-    // list and consume always target the same backend host.
-    const baseUrl = resolveBaseUrl();
-    const redeemRequestId = randomUUID();
-    const consumeResult = await consumeCodexRateLimitResetCredit(
+    // Confirmation gate: redeeming consumes a paid/referral-earned resource,
+    // so — like other mutating commands — prompt before performing the
+    // mutation. The confirmed re-invocation arrives with
+    // overwriteConfirmed === true and skips this gate to actually consume.
+    if (context.overwriteConfirmed !== true) {
+      return buildResetConfirmation(context);
+    }
+
+    await redeemResetCredit(
+      context,
       tokenInfo.accessToken,
       tokenInfo.accountId,
-      creditId,
-      redeemRequestId,
-      baseUrl,
+      redeemable.firstCreditId,
     );
-
-    if (consumeResult === null) {
-      addError(
-        context,
-        'Failed to reset rate-limit window. Please try again later.',
-      );
-      return;
-    }
-
-    if (consumeResult.code === 'reset') {
-      addInfo(context, 'Rate-limit window reset successfully.');
-    } else {
-      addInfo(context, 'Credit already redeemed.');
-    }
-
-    // fetchAllQuotaInfo has its own internal error handling and returns [] on
-    // failure, so it never throws — no extra guard is needed here.
-    const runtimeApi = getRuntimeApi();
-    const quotaLines = await fetchAllQuotaInfo(runtimeApi);
-    if (quotaLines.length > 0) {
-      addInfo(context, quotaLines.join('\n'));
-    }
+    return undefined;
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Unknown error';
     addError(context, `Failed to reset rate-limit window: ${msg}`);
+    return undefined;
   }
 }
 

--- a/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
+++ b/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
@@ -4,17 +4,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createCompletionHandler } from '../schema/index.js';
 import { quotaCommand } from '../quotaCommand.js';
 import { createMockCommandContext } from '../../../test-utils/mockCommandContext.js';
+import type { CommandArgumentSchema } from '../schema/types.js';
 
 describe('quotaCommand schema completion', () => {
-  let mockContext: ReturnType<typeof createMockCommandContext>;
+  // The completion handler is read-only with respect to the context for these
+  // tests (it never mutates it), so a single shared mock is safe and avoids
+  // per-test boilerplate.
+  const mockContext = createMockCommandContext();
 
-  beforeEach(() => {
-    mockContext = createMockCommandContext();
-  });
+  /**
+   * Resolve the reset subcommand, asserting its schema exists at runtime and
+   * narrowing it to a non-optional CommandArgumentSchema for the caller.
+   * Uses explicit null/undefined checks so TypeScript narrows without an
+   * assertion expression.
+   */
+  function getResetSchema(): CommandArgumentSchema {
+    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+    if (reset === undefined) {
+      throw new Error('reset subcommand not found');
+    }
+    const schema = reset.schema;
+    if (schema === undefined) {
+      throw new Error('reset subcommand has no schema');
+    }
+    return schema;
+  }
+
+  /**
+   * Invoke the reset completion handler and return only the suggestion values.
+   */
+  async function getResetSuggestions(
+    partialArg: string,
+  ): Promise<readonly string[]> {
+    const handler = createCompletionHandler(getResetSchema());
+    const result = await handler(
+      mockContext,
+      {
+        args: '',
+        completedArgs: [],
+        partialArg,
+        commandPathLength: 2,
+      },
+      `/quota reset ${partialArg}`,
+    );
+    return result.suggestions.map((s) => s.value);
+  }
 
   it('only the reset subcommand has a schema', () => {
     const subCommands = quotaCommand.subCommands ?? [];
@@ -27,46 +65,18 @@ describe('quotaCommand schema completion', () => {
   });
 
   it('offers codex as the provider for /quota reset', async () => {
-    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
-    expect(reset?.schema).toBeDefined();
-
-    const handler = createCompletionHandler(reset!.schema!);
-    const result = await handler(
-      mockContext,
-      {
-        args: '',
-        completedArgs: [],
-        partialArg: '',
-        commandPathLength: 2,
-      },
-      '/quota reset ',
-    );
-
-    const values = result.suggestions.map((s) => s.value);
+    const values = await getResetSuggestions('');
     expect(values).toContain('codex');
   });
 
   it('partialArg "co" still yields exactly codex', async () => {
-    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
-    const handler = createCompletionHandler(reset!.schema!);
-    const result = await handler(
-      mockContext,
-      {
-        args: '',
-        completedArgs: [],
-        partialArg: 'co',
-        commandPathLength: 2,
-      },
-      '/quota reset co',
-    );
-
-    const values = result.suggestions.map((s) => s.value);
+    const values = await getResetSuggestions('co');
     expect(values).toStrictEqual(['codex']);
   });
 
   it('partialArg "xyz" yields no suggestions', async () => {
-    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
-    const handler = createCompletionHandler(reset!.schema!);
+    const schema = getResetSchema();
+    const handler = createCompletionHandler(schema);
     const result = await handler(
       mockContext,
       {
@@ -82,8 +92,8 @@ describe('quotaCommand schema completion', () => {
   });
 
   it('the codex suggestion has description Codex (ChatGPT)', async () => {
-    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
-    const handler = createCompletionHandler(reset!.schema!);
+    const schema = getResetSchema();
+    const handler = createCompletionHandler(schema);
     const result = await handler(
       mockContext,
       {

--- a/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
+++ b/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
@@ -4,14 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { createCompletionHandler } from '../schema/index.js';
 import { quotaCommand } from '../quotaCommand.js';
 import { createMockCommandContext } from '../../../test-utils/mockCommandContext.js';
 
-const mockContext = createMockCommandContext();
-
 describe('quotaCommand schema completion', () => {
+  let mockContext: ReturnType<typeof createMockCommandContext>;
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext();
+  });
+
+  it('only the reset subcommand has a schema', () => {
+    const subCommands = quotaCommand.subCommands ?? [];
+    const resetSchema = subCommands.find((sc) => sc.name === 'reset')?.schema;
+    const nonResetSchemas = subCommands
+      .filter((sc) => sc.name !== 'reset')
+      .map((sc) => sc.schema);
+    expect(resetSchema).toBeDefined();
+    expect(nonResetSchemas.every((s) => s === undefined)).toBe(true);
+  });
+
   it('offers codex as the provider for /quota reset', async () => {
     const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
     expect(reset?.schema).toBeDefined();
@@ -32,10 +46,57 @@ describe('quotaCommand schema completion', () => {
     expect(values).toContain('codex');
   });
 
-  it('subcommands include status, credits, and reset', () => {
-    const names = quotaCommand.subCommands?.map((sc) => sc.name);
-    expect(names).toStrictEqual(
-      expect.arrayContaining(['status', 'credits', 'reset']),
+  it('partialArg "co" still yields exactly codex', async () => {
+    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+    const handler = createCompletionHandler(reset!.schema!);
+    const result = await handler(
+      mockContext,
+      {
+        args: '',
+        completedArgs: [],
+        partialArg: 'co',
+        commandPathLength: 2,
+      },
+      '/quota reset co',
     );
+
+    const values = result.suggestions.map((s) => s.value);
+    expect(values).toStrictEqual(['codex']);
+  });
+
+  it('partialArg "xyz" yields no suggestions', async () => {
+    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+    const handler = createCompletionHandler(reset!.schema!);
+    const result = await handler(
+      mockContext,
+      {
+        args: '',
+        completedArgs: [],
+        partialArg: 'xyz',
+        commandPathLength: 2,
+      },
+      '/quota reset xyz',
+    );
+
+    expect(result.suggestions).toStrictEqual([]);
+  });
+
+  it('the codex suggestion has description Codex (ChatGPT)', async () => {
+    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+    const handler = createCompletionHandler(reset!.schema!);
+    const result = await handler(
+      mockContext,
+      {
+        args: '',
+        completedArgs: [],
+        partialArg: '',
+        commandPathLength: 2,
+      },
+      '/quota reset ',
+    );
+
+    const codexSuggestion = result.suggestions.find((s) => s.value === 'codex');
+    expect(codexSuggestion).toBeDefined();
+    expect(codexSuggestion?.description).toBe('Codex (ChatGPT)');
   });
 });

--- a/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
+++ b/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
@@ -8,7 +8,10 @@ import { describe, it, expect } from 'vitest';
 import { createCompletionHandler } from '../schema/index.js';
 import { quotaCommand } from '../quotaCommand.js';
 import { createMockCommandContext } from '../../../test-utils/mockCommandContext.js';
-import type { CommandArgumentSchema } from '../schema/types.js';
+import type {
+  CommandArgumentSchema,
+  CompletionResult,
+} from '../schema/types.js';
 
 describe('quotaCommand schema completion', () => {
   // The completion handler is read-only with respect to the context for these
@@ -35,13 +38,11 @@ describe('quotaCommand schema completion', () => {
   }
 
   /**
-   * Invoke the reset completion handler and return only the suggestion values.
+   * Invoke the reset completion handler and return the full result object.
    */
-  async function getResetSuggestions(
-    partialArg: string,
-  ): Promise<readonly string[]> {
+  async function getResetResult(partialArg: string): Promise<CompletionResult> {
     const handler = createCompletionHandler(getResetSchema());
-    const result = await handler(
+    return handler(
       mockContext,
       {
         args: '',
@@ -51,7 +52,15 @@ describe('quotaCommand schema completion', () => {
       },
       `/quota reset ${partialArg}`,
     );
-    return result.suggestions.map((s) => s.value);
+  }
+
+  /**
+   * Invoke the reset completion handler and return only the suggestion values.
+   */
+  async function getResetSuggestions(
+    partialArg: string,
+  ): Promise<readonly string[]> {
+    return (await getResetResult(partialArg)).suggestions.map((s) => s.value);
   }
 
   it('only the reset subcommand has a schema', () => {
@@ -75,35 +84,12 @@ describe('quotaCommand schema completion', () => {
   });
 
   it('partialArg "xyz" yields no suggestions', async () => {
-    const schema = getResetSchema();
-    const handler = createCompletionHandler(schema);
-    const result = await handler(
-      mockContext,
-      {
-        args: '',
-        completedArgs: [],
-        partialArg: 'xyz',
-        commandPathLength: 2,
-      },
-      '/quota reset xyz',
-    );
-
-    expect(result.suggestions).toStrictEqual([]);
+    const values = await getResetSuggestions('xyz');
+    expect(values).toStrictEqual([]);
   });
 
   it('the codex suggestion has description Codex (ChatGPT)', async () => {
-    const schema = getResetSchema();
-    const handler = createCompletionHandler(schema);
-    const result = await handler(
-      mockContext,
-      {
-        args: '',
-        completedArgs: [],
-        partialArg: '',
-        commandPathLength: 2,
-      },
-      '/quota reset ',
-    );
+    const result = await getResetResult('');
 
     const codexSuggestion = result.suggestions.find((s) => s.value === 'codex');
     expect(codexSuggestion).toBeDefined();

--- a/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
+++ b/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
@@ -63,23 +63,18 @@ describe('quotaCommand schema completion', () => {
     return (await getResetResult(partialArg)).suggestions.map((s) => s.value);
   }
 
-  it('only the reset subcommand has a schema', () => {
-    const subCommands = quotaCommand.subCommands ?? [];
-    const resetSchema = subCommands.find((sc) => sc.name === 'reset')?.schema;
-    const nonResetSchemas = subCommands
-      .filter((sc) => sc.name !== 'reset')
-      .map((sc) => sc.schema);
-    expect(resetSchema).toBeDefined();
-    expect(nonResetSchemas.every((s) => s === undefined)).toBe(true);
-  });
-
   it('offers codex as the provider for /quota reset', async () => {
     const values = await getResetSuggestions('');
     expect(values).toContain('codex');
   });
 
-  it('partialArg "co" still yields exactly codex', async () => {
+  it('partialArg "co" yields only codex', async () => {
     const values = await getResetSuggestions('co');
+    expect(values).toStrictEqual(['codex']);
+  });
+
+  it('partialArg "CO" yields codex (case-insensitive fuzzy match)', async () => {
+    const values = await getResetSuggestions('CO');
     expect(values).toStrictEqual(['codex']);
   });
 

--- a/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
+++ b/packages/cli/src/ui/commands/test/quotaCommand.schema.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createCompletionHandler } from '../schema/index.js';
+import { quotaCommand } from '../quotaCommand.js';
+import { createMockCommandContext } from '../../../test-utils/mockCommandContext.js';
+
+const mockContext = createMockCommandContext();
+
+describe('quotaCommand schema completion', () => {
+  it('offers codex as the provider for /quota reset', async () => {
+    const reset = quotaCommand.subCommands?.find((sc) => sc.name === 'reset');
+    expect(reset?.schema).toBeDefined();
+
+    const handler = createCompletionHandler(reset!.schema!);
+    const result = await handler(
+      mockContext,
+      {
+        args: '',
+        completedArgs: [],
+        partialArg: '',
+        commandPathLength: 2,
+      },
+      '/quota reset ',
+    );
+
+    const values = result.suggestions.map((s) => s.value);
+    expect(values).toContain('codex');
+  });
+
+  it('subcommands include status, credits, and reset', () => {
+    const names = quotaCommand.subCommands?.map((sc) => sc.name);
+    expect(names).toStrictEqual(
+      expect.arrayContaining(['status', 'credits', 'reset']),
+    );
+  });
+});

--- a/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
+++ b/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
@@ -560,6 +560,23 @@ describe('getAllCodexRateLimitResetCredits', () => {
     expect(mockFetchCodexRateLimitResetCredits).not.toHaveBeenCalled();
   });
 
+  it('omits the bucket when fetch resolves to null', async () => {
+    const token = {
+      access_token: 'codex-access-token',
+      token_type: 'Bearer',
+      expiry: futureExpiry(),
+      account_id: 'acct-abc123',
+    };
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['default']),
+      getToken: vi.fn().mockResolvedValue(token),
+    });
+    mockFetchCodexRateLimitResetCredits.mockResolvedValue(null);
+
+    const result = await getAllCodexRateLimitResetCredits(store);
+    expect(result.size).toBe(0);
+  });
+
   it('calls fetchCodexRateLimitResetCredits with access_token and account_id', async () => {
     const token = {
       access_token: 'codex-access-token',

--- a/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
+++ b/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
@@ -668,6 +668,10 @@ describe('getAllCodexRateLimitResetCredits', () => {
   });
 
   it('continues processing remaining buckets when one fetch fails', async () => {
+    // NOTE: the mockRejectedValueOnce/mockResolvedValueOnce below are ordered
+    // assuming getAllCodexRateLimitResetCredits iterates buckets sequentially
+    // (for...of with await). If that ever changes to parallel iteration, key
+    // the mock by access_token instead of relying on call order.
     const tokenA = {
       access_token: 'codex-token-a',
       token_type: 'Bearer',

--- a/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
+++ b/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 const {
   mockFetchAnthropicUsage,
   mockFetchCodexUsage,
+  mockFetchCodexRateLimitResetCredits,
   mockGetSettingsService,
   mockSettingsServiceRef,
 } = vi.hoisted(() => {
@@ -19,6 +20,7 @@ const {
   return {
     mockFetchAnthropicUsage: vi.fn(),
     mockFetchCodexUsage: vi.fn(),
+    mockFetchCodexRateLimitResetCredits: vi.fn(),
     mockGetSettingsService: vi.fn(() => settingsServiceRef.current),
     mockSettingsServiceRef: settingsServiceRef,
   };
@@ -32,6 +34,7 @@ vi.mock('@vybestack/llxprt-code-providers', async () => {
     ...actual,
     fetchAnthropicUsage: mockFetchAnthropicUsage,
     fetchCodexUsage: mockFetchCodexUsage,
+    fetchCodexRateLimitResetCredits: mockFetchCodexRateLimitResetCredits,
   };
 });
 
@@ -49,6 +52,7 @@ import {
   getAnthropicUsageInfo,
   getAllAnthropicUsageInfo,
   getAllCodexUsageInfo,
+  getAllCodexRateLimitResetCredits,
   getHigherPriorityAuth,
 } from '../provider-usage-info.js';
 import type { TokenStore, OAuthToken } from '@vybestack/llxprt-code-core';
@@ -490,6 +494,196 @@ describe('getAllCodexUsageInfo', () => {
     const result = await getAllCodexUsageInfo(store);
     expect(result.size).toBe(1);
     expect(result.get('bucket-b')).toStrictEqual({ quota: 999 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAllCodexRateLimitResetCredits
+// ---------------------------------------------------------------------------
+
+describe('getAllCodexRateLimitResetCredits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty map when no tokens exist', async () => {
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['default']),
+      getToken: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await getAllCodexRateLimitResetCredits(store);
+    expect(result.size).toBe(0);
+  });
+
+  it('falls back to ["default"] when listBuckets returns empty', async () => {
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue([]),
+      getToken: vi.fn().mockResolvedValue(null),
+    });
+
+    await getAllCodexRateLimitResetCredits(store);
+
+    expect(store.getToken).toHaveBeenCalledWith('codex', 'default');
+  });
+
+  it('skips expired tokens', async () => {
+    const expiredToken = {
+      access_token: 'codex-token',
+      token_type: 'Bearer',
+      expiry: pastExpiry(),
+      account_id: 'acct-123',
+    };
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['default']),
+      getToken: vi.fn().mockResolvedValue(expiredToken),
+    });
+
+    const result = await getAllCodexRateLimitResetCredits(store);
+    expect(result.size).toBe(0);
+    expect(mockFetchCodexRateLimitResetCredits).not.toHaveBeenCalled();
+  });
+
+  it('skips tokens without account_id', async () => {
+    const tokenWithoutAccountId: OAuthToken = {
+      access_token: 'codex-token',
+      token_type: 'Bearer',
+      expiry: futureExpiry(),
+    };
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['default']),
+      getToken: vi.fn().mockResolvedValue(tokenWithoutAccountId),
+    });
+
+    const result = await getAllCodexRateLimitResetCredits(store);
+    expect(result.size).toBe(0);
+    expect(mockFetchCodexRateLimitResetCredits).not.toHaveBeenCalled();
+  });
+
+  it('calls fetchCodexRateLimitResetCredits with access_token and account_id', async () => {
+    const token = {
+      access_token: 'codex-access-token',
+      token_type: 'Bearer',
+      expiry: futureExpiry(),
+      account_id: 'acct-abc123',
+    };
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['default']),
+      getToken: vi.fn().mockResolvedValue(token),
+    });
+    mockFetchCodexRateLimitResetCredits.mockResolvedValue({
+      rate_limit_reset_credits: { available_count: 1, credits: [] },
+    });
+
+    const result = await getAllCodexRateLimitResetCredits(store);
+
+    expect(mockFetchCodexRateLimitResetCredits).toHaveBeenCalledWith(
+      'codex-access-token',
+      'acct-abc123',
+      undefined,
+    );
+    expect(result.size).toBe(1);
+    expect(result.get('default')).toStrictEqual({
+      rate_limit_reset_credits: { available_count: 1, credits: [] },
+    });
+  });
+
+  it('passes base-url from config when available', async () => {
+    const token = {
+      access_token: 'codex-access-token',
+      token_type: 'Bearer',
+      expiry: futureExpiry(),
+      account_id: 'acct-xyz',
+    };
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['default']),
+      getToken: vi.fn().mockResolvedValue(token),
+    });
+    mockFetchCodexRateLimitResetCredits.mockResolvedValue({
+      rate_limit_reset_credits: { available_count: 0, credits: [] },
+    });
+
+    const mockConfig = {
+      getEphemeralSetting: vi.fn().mockReturnValue('https://custom.codex.io'),
+    };
+
+    await getAllCodexRateLimitResetCredits(
+      store,
+      mockConfig as unknown as import('@vybestack/llxprt-code-core').Config,
+    );
+
+    expect(mockFetchCodexRateLimitResetCredits).toHaveBeenCalledWith(
+      'codex-access-token',
+      'acct-xyz',
+      'https://custom.codex.io',
+    );
+  });
+
+  it('passes undefined base-url when config returns empty string', async () => {
+    const token = {
+      access_token: 'codex-token',
+      token_type: 'Bearer',
+      expiry: futureExpiry(),
+      account_id: 'acct-empty',
+    };
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['default']),
+      getToken: vi.fn().mockResolvedValue(token),
+    });
+    mockFetchCodexRateLimitResetCredits.mockResolvedValue({
+      rate_limit_reset_credits: { available_count: 0, credits: [] },
+    });
+
+    const mockConfig = {
+      getEphemeralSetting: vi.fn().mockReturnValue('   '),
+    };
+
+    await getAllCodexRateLimitResetCredits(
+      store,
+      mockConfig as unknown as import('@vybestack/llxprt-code-core').Config,
+    );
+
+    expect(mockFetchCodexRateLimitResetCredits).toHaveBeenCalledWith(
+      'codex-token',
+      'acct-empty',
+      undefined,
+    );
+  });
+
+  it('continues processing remaining buckets when one fetch fails', async () => {
+    const tokenA = {
+      access_token: 'codex-token-a',
+      token_type: 'Bearer',
+      expiry: futureExpiry(),
+      account_id: 'acct-a',
+    };
+    const tokenB = {
+      access_token: 'codex-token-b',
+      token_type: 'Bearer',
+      expiry: futureExpiry(),
+      account_id: 'acct-b',
+    };
+    const store = makeTokenStore({
+      listBuckets: vi.fn().mockResolvedValue(['bucket-a', 'bucket-b']),
+      getToken: vi
+        .fn()
+        .mockImplementation((_provider: string, bucket: string) => {
+          if (bucket === 'bucket-a') return Promise.resolve(tokenA);
+          if (bucket === 'bucket-b') return Promise.resolve(tokenB);
+          return Promise.resolve(null);
+        }),
+    });
+    mockFetchCodexRateLimitResetCredits
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValueOnce({
+        rate_limit_reset_credits: { available_count: 1, credits: [] },
+      });
+
+    const result = await getAllCodexRateLimitResetCredits(store);
+    expect(result.size).toBe(1);
+    expect(result.get('bucket-b')).toStrictEqual({
+      rate_limit_reset_credits: { available_count: 1, credits: [] },
+    });
   });
 });
 

--- a/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
+++ b/packages/providers/src/auth/__tests__/provider-usage-info.spec.ts
@@ -435,7 +435,7 @@ describe('getAllCodexUsageInfo', () => {
     );
   });
 
-  it('passes undefined base-url when config returns empty string', async () => {
+  it('passes undefined base-url when config returns a blank/whitespace string', async () => {
     const token = {
       access_token: 'codex-token',
       token_type: 'Bearer',
@@ -619,7 +619,7 @@ describe('getAllCodexRateLimitResetCredits', () => {
     );
   });
 
-  it('passes undefined base-url when config returns empty string', async () => {
+  it('passes undefined base-url when config returns a blank/whitespace string', async () => {
     const token = {
       access_token: 'codex-token',
       token_type: 'Bearer',

--- a/packages/providers/src/auth/index.ts
+++ b/packages/providers/src/auth/index.ts
@@ -51,6 +51,7 @@ export {
   getAnthropicUsageInfo,
   getAllAnthropicUsageInfo,
   getAllCodexUsageInfo,
+  getAllCodexRateLimitResetCredits,
   getHigherPriorityAuth,
 } from './provider-usage-info.js';
 

--- a/packages/providers/src/auth/oauth-manager.ts
+++ b/packages/providers/src/auth/oauth-manager.ts
@@ -30,6 +30,7 @@ import {
   getAnthropicUsageInfo,
   getAllAnthropicUsageInfo,
   getAllCodexUsageInfo,
+  getAllCodexRateLimitResetCredits,
   getHigherPriorityAuth,
 } from './provider-usage-info.js';
 
@@ -457,6 +458,17 @@ export class OAuthManager implements BucketFailoverOAuthManagerLike {
    */
   async getAllCodexUsageInfo(): Promise<Map<string, Record<string, unknown>>> {
     return getAllCodexUsageInfo(this.tokenStore, this.config);
+  }
+
+  /**
+   * Get Codex rate-limit-reset credits for all authenticated buckets.
+   * Returns a map of bucket name to reset-credits info for all buckets that
+   * have valid OAuth tokens with account_id.
+   */
+  async getAllCodexRateLimitResetCredits(): Promise<
+    Map<string, Record<string, unknown>>
+  > {
+    return getAllCodexRateLimitResetCredits(this.tokenStore, this.config);
   }
 
   private async getCurrentProfileSessionMetadata(

--- a/packages/providers/src/auth/oauth-manager.ts
+++ b/packages/providers/src/auth/oauth-manager.ts
@@ -465,8 +465,8 @@ export class OAuthManager implements BucketFailoverOAuthManagerLike {
    * Returns a map of bucket name to reset-credits info for all buckets that
    * have valid OAuth tokens with account_id.
    */
-  async getAllCodexRateLimitResetCredits(): Promise<
-    Map<string, Record<string, unknown>>
+  async getAllCodexRateLimitResetCredits(): ReturnType<
+    typeof getAllCodexRateLimitResetCredits
   > {
     return getAllCodexRateLimitResetCredits(this.tokenStore, this.config);
   }

--- a/packages/providers/src/auth/oauth-manager.wiring.spec.ts
+++ b/packages/providers/src/auth/oauth-manager.wiring.spec.ts
@@ -33,6 +33,7 @@ const wiring = vi.hoisted(() => {
   const getAnthropicUsageInfo = vi.fn();
   const getAllAnthropicUsageInfo = vi.fn();
   const getAllCodexUsageInfo = vi.fn();
+  const getAllCodexRateLimitResetCredits = vi.fn();
   const getHigherPriorityAuth = vi.fn();
 
   return {
@@ -46,6 +47,7 @@ const wiring = vi.hoisted(() => {
     getAnthropicUsageInfo,
     getAllAnthropicUsageInfo,
     getAllCodexUsageInfo,
+    getAllCodexRateLimitResetCredits,
     getHigherPriorityAuth,
   };
 });
@@ -72,6 +74,7 @@ vi.mock('./provider-usage-info.js', () => ({
   getAnthropicUsageInfo: wiring.getAnthropicUsageInfo,
   getAllAnthropicUsageInfo: wiring.getAllAnthropicUsageInfo,
   getAllCodexUsageInfo: wiring.getAllCodexUsageInfo,
+  getAllCodexRateLimitResetCredits: wiring.getAllCodexRateLimitResetCredits,
   getHigherPriorityAuth: wiring.getHigherPriorityAuth,
 }));
 
@@ -183,6 +186,7 @@ describe('OAuthManager wiring', () => {
     wiring.getAnthropicUsageInfo.mockResolvedValue(null);
     wiring.getAllAnthropicUsageInfo.mockResolvedValue(new Map());
     wiring.getAllCodexUsageInfo.mockResolvedValue(new Map());
+    wiring.getAllCodexRateLimitResetCredits.mockResolvedValue(new Map());
     wiring.getHigherPriorityAuth.mockResolvedValue(null);
   });
 
@@ -375,6 +379,16 @@ describe('OAuthManager wiring', () => {
     wiring.getAllCodexUsageInfo.mockResolvedValue(
       new Map([['bucket-a', { usage: 2 }]]),
     );
+    wiring.getAllCodexRateLimitResetCredits.mockResolvedValue(
+      new Map([
+        [
+          'bucket-a',
+          {
+            rate_limit_reset_credits: { available_count: 1, credits: [] },
+          },
+        ],
+      ]),
+    );
 
     await expect(manager.getToken('anthropic')).resolves.toBe('oauth-token');
     expect(tokenAccessCoordinator.getToken).toHaveBeenCalledWith(
@@ -458,6 +472,23 @@ describe('OAuthManager wiring', () => {
       new Map([['bucket-a', { usage: 2 }]]),
     );
     expect(wiring.getAllCodexUsageInfo).toHaveBeenCalledWith(
+      tokenStore,
+      config,
+    );
+
+    await expect(
+      manager.getAllCodexRateLimitResetCredits(),
+    ).resolves.toStrictEqual(
+      new Map([
+        [
+          'bucket-a',
+          {
+            rate_limit_reset_credits: { available_count: 1, credits: [] },
+          },
+        ],
+      ]),
+    );
+    expect(wiring.getAllCodexRateLimitResetCredits).toHaveBeenCalledWith(
       tokenStore,
       config,
     );

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -18,7 +18,10 @@
 
 import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
 import { getRuntimeSettingsService } from '@vybestack/llxprt-code-core/runtime/settingsRuntimeAdapter.js';
-import type { IOAuthSettingsProvider } from '@vybestack/llxprt-code-auth';
+import {
+  CodexOAuthTokenSchema,
+  type IOAuthSettingsProvider,
+} from '@vybestack/llxprt-code-auth';
 import type { TokenStore } from './types.js';
 import { isAuthOnlyEnabled } from './auth-utils.js';
 import type { CodexRateLimitResetCreditsResponse } from '../openai/codexRateLimitReset.js';
@@ -264,11 +267,10 @@ export async function getAllCodexRateLimitResetCredits(
     }
 
     const nowInSeconds = Math.floor(Date.now() / 1000);
-    const tokenObj = token as Record<string, unknown>;
-    const accountId =
-      typeof tokenObj['account_id'] === 'string'
-        ? tokenObj['account_id']
-        : undefined;
+    const parsedToken = CodexOAuthTokenSchema.safeParse(token);
+    const accountId = parsedToken.success
+      ? parsedToken.data.account_id
+      : undefined;
 
     if (token.expiry > nowInSeconds && accountId) {
       await fetchAndStoreCodexResetCredits(

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -215,7 +215,7 @@ async function fetchAndStoreCodexResetCredits(
     accountId: string,
     baseUrl?: string,
   ) => Promise<CodexRateLimitResetCreditsResponse | null>,
-  result: Map<string, Record<string, unknown>>,
+  result: Map<string, CodexRateLimitResetCreditsResponse>,
   logger: DebugLogger,
 ): Promise<void> {
   try {
@@ -242,8 +242,8 @@ async function fetchAndStoreCodexResetCredits(
 export async function getAllCodexRateLimitResetCredits(
   tokenStore: TokenStore,
   config?: Config,
-): Promise<Map<string, Record<string, unknown>>> {
-  const result = new Map<string, Record<string, unknown>>();
+): Promise<Map<string, CodexRateLimitResetCreditsResponse>> {
+  const result = new Map<string, CodexRateLimitResetCreditsResponse>();
 
   const buckets = await tokenStore.listBuckets('codex');
   const bucketsToCheck = buckets.length > 0 ? buckets : ['default'];

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -201,6 +201,87 @@ export async function getAllCodexUsageInfo(
   return result;
 }
 
+async function fetchAndStoreCodexResetCredits(
+  bucket: string,
+  accessToken: string,
+  accountId: string,
+  codexBaseUrl: string | undefined,
+  fetchFn: (
+    token: string,
+    accountId: string,
+    baseUrl?: string,
+  ) => Promise<Record<string, unknown> | null | undefined>,
+  result: Map<string, Record<string, unknown>>,
+  logger: DebugLogger,
+): Promise<void> {
+  try {
+    const creditsInfo = await fetchFn(accessToken, accountId, codexBaseUrl);
+    if (creditsInfo) {
+      result.set(bucket, creditsInfo);
+    }
+  } catch (error) {
+    logger.debug(
+      `Error fetching Codex reset credits for bucket ${bucket}:`,
+      error,
+    );
+  }
+}
+
+/**
+ * Get Codex rate-limit-reset credits for all authenticated buckets.
+ * Returns a map of bucket name to reset-credits info for all buckets that
+ * have valid, non-expired OAuth tokens with an account_id field.
+ *
+ * @param tokenStore - Token store to read from
+ * @param config - Optional Config for base-url resolution
+ */
+export async function getAllCodexRateLimitResetCredits(
+  tokenStore: TokenStore,
+  config?: Config,
+): Promise<Map<string, Record<string, unknown>>> {
+  const result = new Map<string, Record<string, unknown>>();
+
+  const buckets = await tokenStore.listBuckets('codex');
+  const bucketsToCheck = buckets.length > 0 ? buckets : ['default'];
+
+  const { fetchCodexRateLimitResetCredits } = await import(
+    '@vybestack/llxprt-code-providers'
+  );
+
+  for (const bucket of bucketsToCheck) {
+    const token = await tokenStore.getToken('codex', bucket);
+    if (!token) {
+      continue;
+    }
+
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+    const tokenObj = token as Record<string, unknown>;
+    const accountId =
+      typeof tokenObj['account_id'] === 'string'
+        ? tokenObj['account_id']
+        : undefined;
+
+    if (token.expiry > nowInSeconds && accountId) {
+      const runtimeBaseUrl = config?.getEphemeralSetting('base-url');
+      const codexBaseUrl =
+        typeof runtimeBaseUrl === 'string' && runtimeBaseUrl.trim() !== ''
+          ? runtimeBaseUrl
+          : undefined;
+      await fetchAndStoreCodexResetCredits(
+        bucket,
+        token.access_token,
+        accountId,
+        codexBaseUrl,
+        fetchCodexRateLimitResetCredits,
+        result,
+        logger,
+      );
+    }
+  }
+
+  return result;
+}
+
 /**
  * Check for higher priority authentication methods for a provider.
  * Returns a string describing the higher-priority auth if one exists,

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -21,6 +21,7 @@ import { getRuntimeSettingsService } from '@vybestack/llxprt-code-core/runtime/s
 import type { IOAuthSettingsProvider } from '@vybestack/llxprt-code-auth';
 import type { TokenStore } from './types.js';
 import { isAuthOnlyEnabled } from './auth-utils.js';
+import type { CodexRateLimitResetCreditsResponse } from '../openai/codexRateLimitReset.js';
 
 const logger = new DebugLogger('llxprt:oauth:provider-usage');
 
@@ -210,7 +211,7 @@ async function fetchAndStoreCodexResetCredits(
     token: string,
     accountId: string,
     baseUrl?: string,
-  ) => Promise<Record<string, unknown> | null | undefined>,
+  ) => Promise<CodexRateLimitResetCreditsResponse | null>,
   result: Map<string, Record<string, unknown>>,
   logger: DebugLogger,
 ): Promise<void> {

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -249,6 +249,14 @@ export async function getAllCodexRateLimitResetCredits(
     '@vybestack/llxprt-code-providers'
   );
 
+  // The base-url does not depend on the bucket, so resolve it once before the
+  // loop instead of recomputing it per iteration.
+  const runtimeBaseUrl = config?.getEphemeralSetting('base-url');
+  const codexBaseUrl =
+    typeof runtimeBaseUrl === 'string' && runtimeBaseUrl.trim() !== ''
+      ? runtimeBaseUrl
+      : undefined;
+
   for (const bucket of bucketsToCheck) {
     const token = await tokenStore.getToken('codex', bucket);
     if (!token) {
@@ -263,11 +271,6 @@ export async function getAllCodexRateLimitResetCredits(
         : undefined;
 
     if (token.expiry > nowInSeconds && accountId) {
-      const runtimeBaseUrl = config?.getEphemeralSetting('base-url');
-      const codexBaseUrl =
-        typeof runtimeBaseUrl === 'string' && runtimeBaseUrl.trim() !== ''
-          ? runtimeBaseUrl
-          : undefined;
       await fetchAndStoreCodexResetCredits(
         bucket,
         token.access_token,

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -271,15 +271,15 @@ export async function getAllCodexRateLimitResetCredits(
     }
 
     const parsedToken = CodexOAuthTokenSchema.safeParse(token);
-    const accountId = parsedToken.success
-      ? parsedToken.data.account_id
-      : undefined;
+    if (!parsedToken.success) {
+      continue;
+    }
 
-    if (token.expiry > nowInSeconds && accountId) {
+    if (parsedToken.data.expiry > nowInSeconds) {
       await fetchAndStoreCodexResetCredits(
         bucket,
-        token.access_token,
-        accountId,
+        parsedToken.data.access_token,
+        parsedToken.data.account_id,
         codexBaseUrl,
         fetchCodexRateLimitResetCredits,
         result,

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -260,13 +260,16 @@ export async function getAllCodexRateLimitResetCredits(
       ? runtimeBaseUrl
       : undefined;
 
+  // Neither the base-url nor the current time depends on the bucket, so both
+  // are resolved once before the loop instead of recomputing them per bucket.
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+
   for (const bucket of bucketsToCheck) {
     const token = await tokenStore.getToken('codex', bucket);
     if (!token) {
       continue;
     }
 
-    const nowInSeconds = Math.floor(Date.now() / 1000);
     const parsedToken = CodexOAuthTokenSchema.safeParse(token);
     const accountId = parsedToken.success
       ? parsedToken.data.account_id

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -120,6 +120,11 @@ export {
   CodexUsageInfoSchema,
   formatCodexUsage,
 } from './openai/codexUsageInfo.js';
+export * from './openai/codexRateLimitReset.js';
+export {
+  CodexRateLimitResetCreditsResponseSchema,
+  formatCodexResetCredits,
+} from './openai/codexRateLimitReset.js';
 export * from './zai/usageInfo.js';
 export * from './synthetic/usageInfo.js';
 export * from './chutes/usageInfo.js';

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -121,10 +121,6 @@ export {
   formatCodexUsage,
 } from './openai/codexUsageInfo.js';
 export * from './openai/codexRateLimitReset.js';
-export {
-  CodexRateLimitResetCreditsResponseSchema,
-  formatCodexResetCredits,
-} from './openai/codexRateLimitReset.js';
 export * from './zai/usageInfo.js';
 export * from './synthetic/usageInfo.js';
 export * from './chutes/usageInfo.js';

--- a/packages/providers/src/openai/codexBaseUrl.ts
+++ b/packages/providers/src/openai/codexBaseUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Normalize a base URL by trimming and removing trailing slashes.
+ * Shared by codexUsageInfo.ts and codexRateLimitReset.ts so that base-url
+ * resolution stays consistent across both modules.
+ */
+export function normalizeBaseUrl(baseUrl?: string): string {
+  if (typeof baseUrl !== 'string') {
+    return '';
+  }
+
+  let normalized = baseUrl.trim();
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -14,13 +14,16 @@ import {
 describe('codexRateLimitReset', () => {
   describe('fetchCodexRateLimitResetCredits', () => {
     let fetchMock: ReturnType<typeof vi.fn>;
+    let originalFetch: typeof global.fetch;
 
     beforeEach(() => {
+      originalFetch = global.fetch;
       fetchMock = vi.fn();
       global.fetch = fetchMock;
     });
 
     afterEach(() => {
+      global.fetch = originalFetch;
       vi.restoreAllMocks();
     });
 
@@ -123,6 +126,38 @@ describe('codexRateLimitReset', () => {
       );
     });
 
+    it('should fall back to the ChatGPT backend-api root when the base URL has no /backend-api segment', async () => {
+      // The wham reset-credit endpoints only exist on the ChatGPT backend-api
+      // surface (unlike /api/codex/usage). A base URL that does not target
+      // /backend-api must therefore fall back to the ChatGPT root rather than
+      // fabricate a /wham path against an unrelated origin. This matches the
+      // issue contract: "fall back to https://chatgpt.com/backend-api".
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: 0,
+          credits: [],
+        },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+        'https://proxy.example.com/v1',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+
     it('should handle HTTP errors gracefully', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: false,
@@ -208,13 +243,16 @@ describe('codexRateLimitReset', () => {
 
   describe('consumeCodexRateLimitResetCredit', () => {
     let fetchMock: ReturnType<typeof vi.fn>;
+    let originalFetch: typeof global.fetch;
 
     beforeEach(() => {
+      originalFetch = global.fetch;
       fetchMock = vi.fn();
       global.fetch = fetchMock;
     });
 
     afterEach(() => {
+      global.fetch = originalFetch;
       vi.restoreAllMocks();
     });
 
@@ -416,6 +454,18 @@ describe('codexRateLimitReset', () => {
       const data = {
         rate_limit_reset_credits: {
           available_count: 0,
+          credits: [],
+        },
+      };
+
+      const result = formatCodexResetCredits(data);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('should return empty array when credits is empty despite available_count > 0', () => {
+      const data = {
+        rate_limit_reset_credits: {
+          available_count: 2,
           credits: [],
         },
       };

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -631,16 +631,18 @@ describe('codexRateLimitReset', () => {
       expect(result).toStrictEqual([]);
     });
 
-    it('should return empty array when credits is empty despite available_count > 0', () => {
+    it('should surface available count with placeholder when credits is empty but available_count > 0', () => {
       const data = CodexRateLimitResetCreditsResponseSchema.parse({
         rate_limit_reset_credits: {
-          available_count: 2,
+          available_count: 3,
           credits: [],
         },
       });
 
       const result = formatCodexResetCredits(data);
-      expect(result).toStrictEqual([]);
+      expect(result.length).toBe(2);
+      expect(result[0]).toBe('  Available reset credits: 3');
+      expect(result[1]).toBe('  - (no credit details returned)');
     });
 
     it('should format single credit', () => {

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -262,6 +262,40 @@ describe('codexRateLimitReset', () => {
       expect(secondArg.signal).toBeDefined();
       expect(secondArg.signal).toBeInstanceOf(AbortSignal);
     });
+
+    it('should return null when fetch times out via DOMException TimeoutError', async () => {
+      fetchMock.mockRejectedValueOnce(
+        new DOMException('The operation timed out.', 'TimeoutError'),
+      );
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should attempt a fetch for a whitespace-only access token (current behavior)', async () => {
+      // The guard checks `!accessToken` which treats '   ' as truthy, so a
+      // whitespace-only token passes validation and a fetch IS attempted.
+      // This documents the actual current behavior; tightening to reject
+      // whitespace would be a behavior change out of scope here.
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: 0,
+          credits: [],
+        },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await fetchCodexRateLimitResetCredits('   ', 'account123');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('consumeCodexRateLimitResetCredit', () => {
@@ -470,6 +504,44 @@ describe('codexRateLimitReset', () => {
         expect.objectContaining({
           method: 'POST',
         }),
+      );
+    });
+
+    it('should send the full request shape (body + headers) when using a custom base URL', async () => {
+      const mockResponse = {
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+        'https://custom.example.com/backend-api',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://custom.example.com/backend-api/wham/rate-limit-reset-credits/consume',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer token123',
+            'ChatGPT-Account-Id': 'account123',
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            credit_id: 'credit-1',
+            redeem_request_id: 'redeem-1',
+          }),
+          signal: expect.any(AbortSignal),
+        },
       );
     });
 

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -275,26 +275,18 @@ describe('codexRateLimitReset', () => {
       expect(result).toBeNull();
     });
 
-    it('should attempt a fetch for a whitespace-only access token (current behavior)', async () => {
-      // The guard checks `!accessToken` which treats '   ' as truthy, so a
-      // whitespace-only token passes validation and a fetch IS attempted.
-      // This documents the actual current behavior; tightening to reject
-      // whitespace would be a behavior change out of scope here.
-      const mockResponse = {
-        rate_limit_reset_credits: {
-          available_count: 0,
-          credits: [],
-        },
-      };
+    it('should return null for a whitespace-only access token without fetching', async () => {
+      // A whitespace-only token must be rejected by the input guard so no
+      // pointless network call is made.
+      const result = await fetchCodexRateLimitResetCredits('   ', 'account123');
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
 
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      } as Response);
-
-      await fetchCodexRateLimitResetCredits('   ', 'account123');
-
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+    it('should return null for a whitespace-only account ID without fetching', async () => {
+      const result = await fetchCodexRateLimitResetCredits('token123', '   ');
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 
@@ -352,6 +344,17 @@ describe('codexRateLimitReset', () => {
         'account123',
         'credit-1',
         '',
+      );
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for a whitespace-only access token without fetching', async () => {
+      const result = await consumeCodexRateLimitResetCredit(
+        '   ',
+        'account123',
+        'credit-1',
+        'redeem-1',
       );
       expect(result).toBeNull();
       expect(fetchMock).not.toHaveBeenCalled();

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -9,6 +9,7 @@ import {
   fetchCodexRateLimitResetCredits,
   consumeCodexRateLimitResetCredit,
   formatCodexResetCredits,
+  CodexRateLimitResetCreditsResponseSchema,
 } from './codexRateLimitReset.js';
 
 describe('codexRateLimitReset', () => {
@@ -213,6 +214,7 @@ describe('codexRateLimitReset', () => {
       );
 
       expect(result).not.toBeNull();
+      expect(result?.rate_limit_reset_credits).toBeDefined();
       expect(result?.rate_limit_reset_credits.available_count).toBe(0);
       expect(result?.rate_limit_reset_credits.credits).toStrictEqual([]);
     });
@@ -432,9 +434,66 @@ describe('codexRateLimitReset', () => {
         }),
       );
     });
+
+    it('should strip /backend-api/codex to backend-api root for the consume endpoint', async () => {
+      const mockResponse = {
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+        'https://chatgpt.com/backend-api/codex',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should fall back to ChatGPT backend-api root when base URL lacks /backend-api', async () => {
+      const mockResponse = {
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+        'https://proxy.example.com/v1',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
   });
 
   describe('formatCodexResetCredits', () => {
+    it('should return empty array when rate_limit_reset_credits is undefined', () => {
+      const data = CodexRateLimitResetCreditsResponseSchema.parse({});
+
+      const result = formatCodexResetCredits(data);
+      expect(result).toStrictEqual([]);
+    });
+
     it('should format credits with available count and credit ids', () => {
       const data = {
         rate_limit_reset_credits: {

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -416,6 +416,30 @@ describe('codexRateLimitReset', () => {
       expect(result?.code).toBe('already_redeemed');
     });
 
+    it('should parse reset code even when the credit field is omitted', async () => {
+      // The consume schema marks `credit` optional for ALL codes, so a
+      // `reset` response without a `credit` object is valid and must parse to
+      // `{ code: 'reset', credit: undefined }` rather than being rejected.
+      const mockResponse = {
+        code: 'reset',
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+
+      expect(result?.code).toBe('reset');
+      expect(result?.credit).toBeUndefined();
+    });
+
     it('should handle HTTP errors gracefully', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: false,

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -213,10 +213,25 @@ describe('codexRateLimitReset', () => {
         'account123',
       );
 
-      expect(result).not.toBeNull();
-      expect(result?.rate_limit_reset_credits).toBeDefined();
-      expect(result?.rate_limit_reset_credits.available_count).toBe(0);
-      expect(result?.rate_limit_reset_credits.credits).toStrictEqual([]);
+      expect(result).toStrictEqual({
+        unrelated_field: 'something',
+        rate_limit_reset_credits: { available_count: 0, credits: [] },
+      });
+    });
+
+    it('should degrade null rate_limit_reset_credits to zero available credits', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ rate_limit_reset_credits: null }),
+      } as Response);
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+      expect(result).toStrictEqual({
+        rate_limit_reset_credits: { available_count: 0, credits: [] },
+      });
     });
 
     it('should return null when rate_limit_reset_credits is present but schema-invalid', async () => {
@@ -355,6 +370,28 @@ describe('codexRateLimitReset', () => {
         'account123',
         'credit-1',
         'redeem-1',
+      );
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for a whitespace-only credit ID without fetching', async () => {
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        '   ',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for a whitespace-only redeem request ID without fetching', async () => {
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        '   ',
       );
       expect(result).toBeNull();
       expect(fetchMock).not.toHaveBeenCalled();
@@ -593,6 +630,26 @@ describe('codexRateLimitReset', () => {
 
       expect(fetchMock).toHaveBeenCalledWith(
         'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should preserve a backend path segment that only starts with codex', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ code: 'reset' }),
+      } as Response);
+
+      await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+        'https://custom.example/backend-api/codexify',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://custom.example/backend-api/codexify/wham/rate-limit-reset-credits/consume',
         expect.objectContaining({ method: 'POST' }),
       );
     });

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -219,6 +219,27 @@ describe('codexRateLimitReset', () => {
       expect(result?.rate_limit_reset_credits.credits).toStrictEqual([]);
     });
 
+    it('should return null when rate_limit_reset_credits is present but schema-invalid', async () => {
+      // available_count: -1 violates the .nonnegative() constraint.
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: -1,
+          credits: [],
+        },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+      expect(result).toBeNull();
+    });
+
     it('should include fetch timeout signal in request options', async () => {
       const mockResponse = {
         rate_limit_reset_credits: {
@@ -408,6 +429,23 @@ describe('codexRateLimitReset', () => {
       expect(result).toBeNull();
     });
 
+    it('should handle malformed JSON', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new SyntaxError('Unexpected token');
+        },
+      } as Response);
+
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+    });
+
     it('should use custom base URL when provided', async () => {
       const mockResponse = {
         code: 'reset',
@@ -495,12 +533,12 @@ describe('codexRateLimitReset', () => {
     });
 
     it('should format credits with available count and credit ids', () => {
-      const data = {
+      const data = CodexRateLimitResetCreditsResponseSchema.parse({
         rate_limit_reset_credits: {
           available_count: 2,
           credits: [{ id: 'credit-1' }, { id: 'credit-2', source: 'referral' }],
         },
-      };
+      });
 
       const result = formatCodexResetCredits(data);
       expect(result.length).toBe(3);
@@ -510,36 +548,36 @@ describe('codexRateLimitReset', () => {
     });
 
     it('should return empty array when available_count is 0', () => {
-      const data = {
+      const data = CodexRateLimitResetCreditsResponseSchema.parse({
         rate_limit_reset_credits: {
           available_count: 0,
           credits: [],
         },
-      };
+      });
 
       const result = formatCodexResetCredits(data);
       expect(result).toStrictEqual([]);
     });
 
     it('should return empty array when credits is empty despite available_count > 0', () => {
-      const data = {
+      const data = CodexRateLimitResetCreditsResponseSchema.parse({
         rate_limit_reset_credits: {
           available_count: 2,
           credits: [],
         },
-      };
+      });
 
       const result = formatCodexResetCredits(data);
       expect(result).toStrictEqual([]);
     });
 
     it('should format single credit', () => {
-      const data = {
+      const data = CodexRateLimitResetCreditsResponseSchema.parse({
         rate_limit_reset_credits: {
           available_count: 1,
           credits: [{ id: 'credit-only' }],
         },
-      };
+      });
 
       const result = formatCodexResetCredits(data);
       expect(result.length).toBe(2);

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -12,22 +12,26 @@ import {
   CodexRateLimitResetCreditsResponseSchema,
 } from './codexRateLimitReset.js';
 
+const RESET_CREDITS_URL =
+  'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits';
+const CONSUME_RESET_CREDIT_URL = `${RESET_CREDITS_URL}/consume`;
+
 describe('codexRateLimitReset', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
   describe('fetchCodexRateLimitResetCredits', () => {
-    let fetchMock: ReturnType<typeof vi.fn>;
-    let originalFetch: typeof global.fetch;
-
-    beforeEach(() => {
-      originalFetch = global.fetch;
-      fetchMock = vi.fn();
-      global.fetch = fetchMock;
-    });
-
-    afterEach(() => {
-      global.fetch = originalFetch;
-      vi.restoreAllMocks();
-    });
-
     it('should return null for empty access token', async () => {
       const result = await fetchCodexRateLimitResetCredits('', 'account123');
       expect(result).toBeNull();
@@ -58,18 +62,15 @@ describe('codexRateLimitReset', () => {
         'account123',
       );
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
-        {
-          method: 'GET',
-          headers: {
-            Authorization: 'Bearer token123',
-            'ChatGPT-Account-Id': 'account123',
-            Accept: 'application/json',
-          },
-          signal: expect.any(AbortSignal),
+      expect(fetchMock).toHaveBeenCalledWith(RESET_CREDITS_URL, {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer token123',
+          'ChatGPT-Account-Id': 'account123',
+          Accept: 'application/json',
         },
-      );
+        signal: expect.any(AbortSignal),
+      });
       expect(result).toStrictEqual(mockResponse);
     });
 
@@ -93,7 +94,7 @@ describe('codexRateLimitReset', () => {
       );
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
+        RESET_CREDITS_URL,
         expect.objectContaining({
           method: 'GET',
         }),
@@ -152,7 +153,7 @@ describe('codexRateLimitReset', () => {
       );
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
+        RESET_CREDITS_URL,
         expect.objectContaining({
           method: 'GET',
         }),
@@ -217,6 +218,30 @@ describe('codexRateLimitReset', () => {
         unrelated_field: 'something',
         rate_limit_reset_credits: { available_count: 0, credits: [] },
       });
+      expect(mockResponse).toStrictEqual({ unrelated_field: 'something' });
+    });
+
+    it('preserves additional nested reset-credit metadata during normalization', async () => {
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: 1,
+          credits: [{ id: 'credit-1' }],
+          next_refresh_at: '2030-01-01T00:00:00Z',
+        },
+      };
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+
+      expect(result?.rate_limit_reset_credits).toStrictEqual(
+        mockResponse.rate_limit_reset_credits,
+      );
     });
 
     it('should degrade null rate_limit_reset_credits to zero available credits', async () => {
@@ -306,20 +331,6 @@ describe('codexRateLimitReset', () => {
   });
 
   describe('consumeCodexRateLimitResetCredit', () => {
-    let fetchMock: ReturnType<typeof vi.fn>;
-    let originalFetch: typeof global.fetch;
-
-    beforeEach(() => {
-      originalFetch = global.fetch;
-      fetchMock = vi.fn();
-      global.fetch = fetchMock;
-    });
-
-    afterEach(() => {
-      global.fetch = originalFetch;
-      vi.restoreAllMocks();
-    });
-
     it('should return null for empty access token', async () => {
       const result = await consumeCodexRateLimitResetCredit(
         '',
@@ -415,23 +426,20 @@ describe('codexRateLimitReset', () => {
         'redeem-1',
       );
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
-        {
-          method: 'POST',
-          headers: {
-            Authorization: 'Bearer token123',
-            'ChatGPT-Account-Id': 'account123',
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            credit_id: 'credit-1',
-            redeem_request_id: 'redeem-1',
-          }),
-          signal: expect.any(AbortSignal),
+      expect(fetchMock).toHaveBeenCalledWith(CONSUME_RESET_CREDIT_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token123',
+          'ChatGPT-Account-Id': 'account123',
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
         },
-      );
+        body: JSON.stringify({
+          credit_id: 'credit-1',
+          redeem_request_id: 'redeem-1',
+        }),
+        signal: expect.any(AbortSignal),
+      });
       expect(result).toStrictEqual(mockResponse);
     });
 
@@ -629,7 +637,7 @@ describe('codexRateLimitReset', () => {
       );
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
+        CONSUME_RESET_CREDIT_URL,
         expect.objectContaining({ method: 'POST' }),
       );
     });
@@ -674,7 +682,7 @@ describe('codexRateLimitReset', () => {
       );
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
+        CONSUME_RESET_CREDIT_URL,
         expect.objectContaining({ method: 'POST' }),
       );
     });

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -1,0 +1,441 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  fetchCodexRateLimitResetCredits,
+  consumeCodexRateLimitResetCredit,
+  formatCodexResetCredits,
+} from './codexRateLimitReset.js';
+
+describe('codexRateLimitReset', () => {
+  describe('fetchCodexRateLimitResetCredits', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchMock = vi.fn();
+      global.fetch = fetchMock;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return null for empty access token', async () => {
+      const result = await fetchCodexRateLimitResetCredits('', 'account123');
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for empty account ID', async () => {
+      const result = await fetchCodexRateLimitResetCredits('token123', '');
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should fetch reset credits with valid credentials', async () => {
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: 2,
+          credits: [{ id: 'credit-1' }, { id: 'credit-2', source: 'referral' }],
+        },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
+        {
+          method: 'GET',
+          headers: {
+            Authorization: 'Bearer token123',
+            'ChatGPT-Account-Id': 'account123',
+            Accept: 'application/json',
+          },
+          signal: expect.any(AbortSignal),
+        },
+      );
+      expect(result).toStrictEqual(mockResponse);
+    });
+
+    it('should derive backend-api root when base URL includes /backend-api/codex', async () => {
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: 1,
+          credits: [{ id: 'credit-1' }],
+        },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+        'https://chatgpt.com/backend-api/codex',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+
+    it('should derive backend-api root when base URL is /backend-api', async () => {
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: 0,
+          credits: [],
+        },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+        'https://custom.example.com/backend-api',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://custom.example.com/backend-api/wham/rate-limit-reset-credits',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+
+    it('should handle HTTP errors gracefully', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      } as Response);
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should handle network errors', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should handle malformed JSON', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new SyntaxError('Unexpected token');
+        },
+      } as Response);
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should degrade to available_count 0 / empty credits when rate_limit_reset_credits is missing', async () => {
+      const mockResponse = {
+        unrelated_field: 'something',
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await fetchCodexRateLimitResetCredits(
+        'token123',
+        'account123',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.rate_limit_reset_credits.available_count).toBe(0);
+      expect(result?.rate_limit_reset_credits.credits).toStrictEqual([]);
+    });
+
+    it('should include fetch timeout signal in request options', async () => {
+      const mockResponse = {
+        rate_limit_reset_credits: {
+          available_count: 0,
+          credits: [],
+        },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await fetchCodexRateLimitResetCredits('token123', 'account123');
+
+      const secondArg = fetchMock.mock.calls[0]?.[1] as {
+        signal?: unknown;
+      };
+      expect(secondArg).toBeDefined();
+      expect(secondArg.signal).toBeDefined();
+      expect(secondArg.signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  describe('consumeCodexRateLimitResetCredit', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchMock = vi.fn();
+      global.fetch = fetchMock;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return null for empty access token', async () => {
+      const result = await consumeCodexRateLimitResetCredit(
+        '',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for empty account ID', async () => {
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        '',
+        'credit-1',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for empty credit ID', async () => {
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        '',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return null for empty redeem request ID', async () => {
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        '',
+      );
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should consume a credit successfully with reset code', async () => {
+      const mockResponse = {
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer token123',
+            'ChatGPT-Account-Id': 'account123',
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            credit_id: 'credit-1',
+            redeem_request_id: 'redeem-1',
+          }),
+          signal: expect.any(AbortSignal),
+        },
+      );
+      expect(result).toStrictEqual(mockResponse);
+    });
+
+    it('should parse already_redeemed code without credit', async () => {
+      const mockResponse = {
+        code: 'already_redeemed',
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+
+      expect(result).toStrictEqual(mockResponse);
+      expect(result?.code).toBe('already_redeemed');
+    });
+
+    it('should handle HTTP errors gracefully', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      } as Response);
+
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should handle network errors', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should handle invalid code enum', async () => {
+      const mockResponse = {
+        code: 'unknown_code',
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const result = await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should use custom base URL when provided', async () => {
+      const mockResponse = {
+        code: 'reset',
+        credit: { id: 'credit-1' },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      await consumeCodexRateLimitResetCredit(
+        'token123',
+        'account123',
+        'credit-1',
+        'redeem-1',
+        'https://custom.example.com/backend-api',
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://custom.example.com/backend-api/wham/rate-limit-reset-credits/consume',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+  });
+
+  describe('formatCodexResetCredits', () => {
+    it('should format credits with available count and credit ids', () => {
+      const data = {
+        rate_limit_reset_credits: {
+          available_count: 2,
+          credits: [{ id: 'credit-1' }, { id: 'credit-2', source: 'referral' }],
+        },
+      };
+
+      const result = formatCodexResetCredits(data);
+      expect(result.length).toBe(3);
+      expect(result[0]).toBe('  Available reset credits: 2');
+      expect(result[1]).toBe('  - credit-1');
+      expect(result[2]).toBe('  - credit-2');
+    });
+
+    it('should return empty array when available_count is 0', () => {
+      const data = {
+        rate_limit_reset_credits: {
+          available_count: 0,
+          credits: [],
+        },
+      };
+
+      const result = formatCodexResetCredits(data);
+      expect(result).toStrictEqual([]);
+    });
+
+    it('should format single credit', () => {
+      const data = {
+        rate_limit_reset_credits: {
+          available_count: 1,
+          credits: [{ id: 'credit-only' }],
+        },
+      };
+
+      const result = formatCodexResetCredits(data);
+      expect(result.length).toBe(2);
+      expect(result[0]).toBe('  Available reset credits: 1');
+      expect(result[1]).toBe('  - credit-only');
+    });
+  });
+});

--- a/packages/providers/src/openai/codexRateLimitReset.test.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.test.ts
@@ -218,7 +218,6 @@ describe('codexRateLimitReset', () => {
         unrelated_field: 'something',
         rate_limit_reset_credits: { available_count: 0, credits: [] },
       });
-      expect(mockResponse).toStrictEqual({ unrelated_field: 'something' });
     });
 
     it('preserves additional nested reset-credit metadata during normalization', async () => {

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -6,6 +6,7 @@
 
 import { z } from 'zod';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { normalizeBaseUrl } from './codexBaseUrl.js';
 
 const logger = new DebugLogger('llxprt:openai:codex:reset');
 
@@ -68,23 +69,6 @@ export type CodexConsumeResetCreditResponse = z.infer<
 >;
 
 const DEFAULT_BACKEND_API_ROOT = 'https://chatgpt.com/backend-api';
-
-/**
- * Normalize a base URL by trimming and removing trailing slashes.
- * Mirrors the behavior of normalizeBaseUrl in codexUsageInfo.ts so that
- * base-url resolution stays consistent across both modules.
- */
-function normalizeBaseUrl(baseUrl?: string): string {
-  if (typeof baseUrl !== 'string') {
-    return '';
-  }
-
-  let normalized = baseUrl.trim();
-  while (normalized.endsWith('/')) {
-    normalized = normalized.slice(0, -1);
-  }
-  return normalized;
-}
 
 /**
  * Derive the backend-api root for the reset-credits endpoints.

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -144,12 +144,12 @@ export async function fetchCodexRateLimitResetCredits(
   accountId: string,
   baseUrl?: string,
 ): Promise<CodexRateLimitResetCreditsResponse | null> {
-  if (!accessToken || typeof accessToken !== 'string') {
+  if (typeof accessToken !== 'string' || accessToken.trim() === '') {
     logger.debug(() => 'Invalid access token provided');
     return null;
   }
 
-  if (!accountId || typeof accountId !== 'string') {
+  if (typeof accountId !== 'string' || accountId.trim() === '') {
     logger.debug(() => 'Invalid account ID provided');
     return null;
   }
@@ -223,12 +223,12 @@ export async function consumeCodexRateLimitResetCredit(
   redeemRequestId: string,
   baseUrl?: string,
 ): Promise<CodexConsumeResetCreditResponse | null> {
-  if (!accessToken || typeof accessToken !== 'string') {
+  if (typeof accessToken !== 'string' || accessToken.trim() === '') {
     logger.debug(() => 'Invalid access token provided');
     return null;
   }
 
-  if (!accountId || typeof accountId !== 'string') {
+  if (typeof accountId !== 'string' || accountId.trim() === '') {
     logger.debug(() => 'Invalid account ID provided');
     return null;
   }

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -1,0 +1,338 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+
+const logger = new DebugLogger('llxprt:openai:codex:reset');
+
+/**
+ * Schema for a single rate-limit-reset credit.
+ * Uses passthrough to tolerate additional fields from upstream.
+ */
+export const CodexRateLimitResetCreditSchema = z
+  .object({
+    id: z.string(),
+  })
+  .passthrough();
+
+/**
+ * Schema for the GET /wham/rate-limit-reset-credits response.
+ * The rate_limit_reset_credits object is optional at the schema layer so a
+ * response that omits it can degrade gracefully (see normalizeResetCredits);
+ * downstream consumers always receive a populated object.
+ */
+export const CodexRateLimitResetCreditsResponseSchema = z
+  .object({
+    rate_limit_reset_credits: z
+      .object({
+        available_count: z.number().int().nonnegative(),
+        credits: z.array(CodexRateLimitResetCreditSchema),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+/**
+ * Schema for the POST /wham/rate-limit-reset-credits/consume response.
+ */
+export const CodexConsumeResetCreditResponseSchema = z
+  .object({
+    code: z.enum(['reset', 'already_redeemed']),
+    credit: z.object({ id: z.string() }).passthrough().optional(),
+  })
+  .passthrough();
+
+/**
+ * A single rate-limit-reset credit.
+ */
+export type CodexRateLimitResetCredit = z.infer<
+  typeof CodexRateLimitResetCreditSchema
+>;
+
+/**
+ * Response shape for the list reset-credits endpoint.
+ */
+export type CodexRateLimitResetCreditsResponse = z.infer<
+  typeof CodexRateLimitResetCreditsResponseSchema
+>;
+
+/**
+ * Response shape for the consume reset-credit endpoint.
+ */
+export type CodexConsumeResetCreditResponse = z.infer<
+  typeof CodexConsumeResetCreditResponseSchema
+>;
+
+const DEFAULT_BACKEND_API_ROOT = 'https://chatgpt.com/backend-api';
+
+/**
+ * Normalize a base URL by trimming and removing trailing slashes.
+ * Mirrors the behavior of normalizeBaseUrl in codexUsageInfo.ts so that
+ * base-url resolution stays consistent across both modules.
+ */
+function normalizeBaseUrl(baseUrl?: string): string {
+  if (typeof baseUrl !== 'string') {
+    return '';
+  }
+
+  let normalized = baseUrl.trim();
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+/**
+ * Derive the backend-api root for the reset-credits endpoints.
+ * Matches buildCodexUsageEndpoints: a /backend-api/codex segment is reduced
+ * to /backend-api; any other /backend-api URL is used as-is. Falls back to
+ * the ChatGPT backend-api root when no usable base URL is provided.
+ */
+function resolveBackendApiRoot(baseUrl?: string): string {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+
+  if (normalizedBaseUrl) {
+    if (normalizedBaseUrl.includes('/backend-api/codex')) {
+      return normalizedBaseUrl.replace('/backend-api/codex', '/backend-api');
+    }
+    if (normalizedBaseUrl.includes('/backend-api')) {
+      return normalizedBaseUrl;
+    }
+  }
+
+  return DEFAULT_BACKEND_API_ROOT;
+}
+
+/**
+ * Build the list + consume endpoint URLs from an optional base URL.
+ */
+function buildResetEndpoints(baseUrl?: string): {
+  list: string;
+  consume: string;
+} {
+  const root = resolveBackendApiRoot(baseUrl);
+  return {
+    list: `${root}/wham/rate-limit-reset-credits`,
+    consume: `${root}/wham/rate-limit-reset-credits/consume`,
+  };
+}
+
+/**
+ * Defensive normalization: a response missing the rate_limit_reset_credits
+ * object degrades to available_count 0 / empty credits rather than throwing,
+ * mirroring the null-handling approach in codexUsageInfo.
+ */
+function normalizeResetCredits(
+  parsed: CodexRateLimitResetCreditsResponse,
+): CodexRateLimitResetCreditsResponse {
+  const credits = parsed.rate_limit_reset_credits ?? {
+    available_count: 0,
+    credits: [],
+  };
+  return {
+    ...parsed,
+    rate_limit_reset_credits: {
+      available_count: credits.available_count,
+      credits: credits.credits,
+    },
+  };
+}
+
+/**
+ * Fetch available rate-limit-reset credits from Codex.
+ * Requires an OAuth access token and account_id from Codex authentication.
+ *
+ * @param accessToken - OAuth access token
+ * @param accountId - Account ID for the ChatGPT-Account-Id header
+ * @param baseUrl - Optional Codex base URL for endpoint resolution
+ * @returns Reset-credits response if available, null on error
+ */
+export async function fetchCodexRateLimitResetCredits(
+  accessToken: string,
+  accountId: string,
+  baseUrl?: string,
+): Promise<CodexRateLimitResetCreditsResponse | null> {
+  if (!accessToken || typeof accessToken !== 'string') {
+    logger.debug(() => 'Invalid access token provided');
+    return null;
+  }
+
+  if (!accountId || typeof accountId !== 'string') {
+    logger.debug(() => 'Invalid account ID provided');
+    return null;
+  }
+
+  const endpoints = buildResetEndpoints(baseUrl);
+
+  try {
+    const response = await fetch(endpoints.list, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'ChatGPT-Account-Id': accountId,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      logger.debug(
+        () =>
+          `Reset credits endpoint ${endpoints.list} returned ${response.status}: ${response.statusText}`,
+      );
+      return null;
+    }
+
+    const data = await response.json();
+
+    const parsedData = CodexRateLimitResetCreditsResponseSchema.safeParse(data);
+    if (!parsedData.success) {
+      logger.debug(
+        () =>
+          `Failed to parse reset credits response from ${endpoints.list}: ${JSON.stringify(parsedData.error)}`,
+      );
+      return null;
+    }
+
+    const normalized = normalizeResetCredits(parsedData.data);
+    logger.debug(
+      () =>
+        `Fetched Codex reset credits from ${endpoints.list}: ${JSON.stringify(normalized)}`,
+    );
+
+    return normalized;
+  } catch (error) {
+    logger.debug(
+      () =>
+        `Error fetching Codex reset credits from ${endpoints.list}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Consume (redeem) a single rate-limit-reset credit to reset the rate-limit window.
+ *
+ * @param accessToken - OAuth access token
+ * @param accountId - Account ID for the ChatGPT-Account-Id header
+ * @param creditId - The id of the credit to redeem
+ * @param redeemRequestId - Idempotency id for the redemption request
+ * @param baseUrl - Optional Codex base URL for endpoint resolution
+ * @returns Consume response if successful, null on error
+ */
+export async function consumeCodexRateLimitResetCredit(
+  accessToken: string,
+  accountId: string,
+  creditId: string,
+  redeemRequestId: string,
+  baseUrl?: string,
+): Promise<CodexConsumeResetCreditResponse | null> {
+  if (!accessToken || typeof accessToken !== 'string') {
+    logger.debug(() => 'Invalid access token provided');
+    return null;
+  }
+
+  if (!accountId || typeof accountId !== 'string') {
+    logger.debug(() => 'Invalid account ID provided');
+    return null;
+  }
+
+  if (!creditId || typeof creditId !== 'string') {
+    logger.debug(() => 'Invalid credit ID provided');
+    return null;
+  }
+
+  if (!redeemRequestId || typeof redeemRequestId !== 'string') {
+    logger.debug(() => 'Invalid redeem request ID provided');
+    return null;
+  }
+
+  const endpoints = buildResetEndpoints(baseUrl);
+
+  try {
+    const response = await fetch(endpoints.consume, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'ChatGPT-Account-Id': accountId,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        credit_id: creditId,
+        redeem_request_id: redeemRequestId,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      logger.debug(
+        () =>
+          `Consume reset credit endpoint ${endpoints.consume} returned ${response.status}: ${response.statusText}`,
+      );
+      return null;
+    }
+
+    const data = await response.json();
+
+    const parsedData = CodexConsumeResetCreditResponseSchema.safeParse(data);
+    if (!parsedData.success) {
+      logger.debug(
+        () =>
+          `Failed to parse consume reset credit response from ${endpoints.consume}: ${JSON.stringify(parsedData.error)}`,
+      );
+      return null;
+    }
+
+    logger.debug(
+      () =>
+        `Consumed Codex reset credit from ${endpoints.consume}: ${JSON.stringify(parsedData.data)}`,
+    );
+
+    return parsedData.data;
+  } catch (error) {
+    logger.debug(
+      () =>
+        `Error consuming Codex reset credit from ${endpoints.consume}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Format available rate-limit-reset credits for display.
+ * Returns lines using the two-space-indent style of formatCodexUsage.
+ *
+ * @param data - Parsed reset-credits response
+ * @returns Formatted lines, or an empty array when no credits are available
+ */
+export function formatCodexResetCredits(
+  data: CodexRateLimitResetCreditsResponse,
+): string[] {
+  const lines: string[] = [];
+  const resetCredits = data.rate_limit_reset_credits;
+  if (!resetCredits) {
+    return lines;
+  }
+  const { available_count: availableCount, credits } = resetCredits;
+
+  if (availableCount === 0 || credits.length === 0) {
+    return lines;
+  }
+
+  lines.push(`  Available reset credits: ${availableCount}`);
+
+  for (const credit of credits) {
+    lines.push(`  - ${credit.id}`);
+  }
+
+  return lines;
+}

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -33,6 +33,7 @@ export const CodexRateLimitResetCreditsResponseSchema = z
         available_count: z.number().int().nonnegative(),
         credits: z.array(CodexRateLimitResetCreditSchema),
       })
+      .nullable()
       .optional(),
   })
   .passthrough();
@@ -80,8 +81,11 @@ function resolveBackendApiRoot(baseUrl?: string): string {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
 
   if (normalizedBaseUrl) {
-    if (normalizedBaseUrl.includes('/backend-api/codex')) {
-      return normalizedBaseUrl.replace('/backend-api/codex', '/backend-api');
+    if (/\/backend-api\/codex(?:\/|$)/.test(normalizedBaseUrl)) {
+      return normalizedBaseUrl.replace(
+        /\/backend-api\/codex(?=\/|$)/,
+        '/backend-api',
+      );
     }
     if (normalizedBaseUrl.includes('/backend-api')) {
       return normalizedBaseUrl;
@@ -233,12 +237,12 @@ export async function consumeCodexRateLimitResetCredit(
     return null;
   }
 
-  if (!creditId || typeof creditId !== 'string') {
+  if (typeof creditId !== 'string' || creditId.trim() === '') {
     logger.debug(() => 'Invalid credit ID provided');
     return null;
   }
 
-  if (!redeemRequestId || typeof redeemRequestId !== 'string') {
+  if (typeof redeemRequestId !== 'string' || redeemRequestId.trim() === '') {
     logger.debug(() => 'Invalid redeem request ID provided');
     return null;
   }

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -33,6 +33,7 @@ export const CodexRateLimitResetCreditsResponseSchema = z
         available_count: z.number().int().nonnegative(),
         credits: z.array(CodexRateLimitResetCreditSchema),
       })
+      .passthrough()
       .nullable()
       .optional(),
   })
@@ -121,16 +122,13 @@ function buildResetEndpoints(baseUrl?: string): {
 function normalizeResetCredits(
   parsed: CodexRateLimitResetCreditsResponse,
 ): CodexRateLimitResetCreditsResponse {
-  const credits = parsed.rate_limit_reset_credits ?? {
+  const resetCredits = parsed.rate_limit_reset_credits ?? {
     available_count: 0,
     credits: [],
   };
   return {
     ...parsed,
-    rate_limit_reset_credits: {
-      available_count: credits.available_count,
-      credits: credits.credits,
-    },
+    rate_limit_reset_credits: resetCredits,
   };
 }
 

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -102,6 +102,10 @@ function resolveBackendApiRoot(baseUrl?: string): string {
     if (normalizedBaseUrl.includes('/backend-api')) {
       return normalizedBaseUrl;
     }
+    logger.debug(
+      () =>
+        `Base URL "${normalizedBaseUrl}" does not contain /backend-api; falling back to ${DEFAULT_BACKEND_API_ROOT}`,
+    );
   }
 
   return DEFAULT_BACKEND_API_ROOT;

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -316,11 +316,19 @@ export function formatCodexResetCredits(
   }
   const { available_count: availableCount, credits } = resetCredits;
 
-  if (availableCount === 0 || credits.length === 0) {
+  if (availableCount === 0) {
     return lines;
   }
 
+  // Always surface a server-reported available count, even when the credits
+  // array is empty (the server may report available_count > 0 without
+  // returning individual credit details).
   lines.push(`  Available reset credits: ${availableCount}`);
+
+  if (credits.length === 0) {
+    lines.push('  - (no credit details returned)');
+    return lines;
+  }
 
   for (const credit of credits) {
     lines.push(`  - ${credit.id}`);

--- a/packages/providers/src/openai/codexRateLimitReset.ts
+++ b/packages/providers/src/openai/codexRateLimitReset.ts
@@ -189,7 +189,9 @@ export async function fetchCodexRateLimitResetCredits(
     const normalized = normalizeResetCredits(parsedData.data);
     logger.debug(
       () =>
-        `Fetched Codex reset credits from ${endpoints.list}: ${JSON.stringify(normalized)}`,
+        `Fetched Codex reset credits from ${endpoints.list}: available_count=${
+          normalized.rate_limit_reset_credits?.available_count ?? 0
+        }, credits=${normalized.rate_limit_reset_credits?.credits.length ?? 0}`,
     );
 
     return normalized;
@@ -280,7 +282,9 @@ export async function consumeCodexRateLimitResetCredit(
 
     logger.debug(
       () =>
-        `Consumed Codex reset credit from ${endpoints.consume}: ${JSON.stringify(parsedData.data)}`,
+        `Consumed Codex reset credit from ${endpoints.consume}: code=${parsedData.data.code}, credit_id=${
+          parsedData.data.credit?.id ?? 'N/A'
+        }`,
     );
 
     return parsedData.data;

--- a/packages/providers/src/openai/codexUsageInfo.ts
+++ b/packages/providers/src/openai/codexUsageInfo.ts
@@ -6,6 +6,7 @@
 
 import { z } from 'zod';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { normalizeBaseUrl } from './codexBaseUrl.js';
 
 const logger = new DebugLogger('llxprt:openai:codex:usage');
 
@@ -92,18 +93,6 @@ export type CodexUsageInfo = z.infer<typeof CodexUsageInfoSchema>;
 const DEFAULT_CODEX_USAGE_ENDPOINT = 'https://api.openai.com/api/codex/usage';
 const CHATGPT_BACKEND_USAGE_ENDPOINT =
   'https://chatgpt.com/backend-api/wham/usage';
-
-function normalizeBaseUrl(baseUrl?: string): string {
-  if (typeof baseUrl !== 'string') {
-    return '';
-  }
-
-  let normalized = baseUrl.trim();
-  while (normalized.endsWith('/')) {
-    normalized = normalized.slice(0, -1);
-  }
-  return normalized;
-}
 
 function buildCodexUsageEndpoints(baseUrl?: string): string[] {
   const endpoints: string[] = [];


### PR DESCRIPTION
## Summary

Implements the `/quota` slash command for Codex rate-limit-reset credit redemption, as specified in #2386.

Fixes #2386

A user who has earned or purchased Codex rate-limit-reset credits can now reset their rate-limit window without leaving the CLI:

```
/quota            — show quota/rate-limit status for all providers (same as /stats quota)
/quota status     — explicit alias for the above (auto-executes)
/quota credits    — show available Codex rate-limit-reset credits (auto-executes)
/quota reset      — redeem one Codex reset credit to reset the rate-limit window
/quota reset codex — explicit provider (only codex supports reset today)
```

`/quota reset` deliberately does **not** auto-execute (it is a mutating action; the user presses Enter explicitly). `/quota reset ` offers `codex` as an autocomplete suggestion via the command's completion schema.

## Architecture (providers <-> CLI separation)

Follows the existing consumer-migration boundary rules, mirroring the `/stats quota` + `codexUsageInfo.ts` + `provider-usage-info.ts` pattern.

**Providers package** (`@vybestack/llxprt-code-providers`) — owns the HTTP calls and Zod schemas:
- `packages/providers/src/openai/codexRateLimitReset.ts` — reset-credit + list-response + consume-response Zod schemas, `fetchCodexRateLimitResetCredits(accessToken, accountId, baseUrl?)`, `consumeCodexRateLimitResetCredit(accessToken, accountId, creditId, redeemRequestId, baseUrl?)`, and a `formatCodexResetCredits` display helper.
- `packages/providers/src/openai/codexBaseUrl.ts` — shared `normalizeBaseUrl` extracted so the reset endpoints reuse the exact base-url resolution used by the usage endpoints (falls back to `https://chatgpt.com/backend-api`).
- `provider-usage-info.ts` — `getAllCodexRateLimitResetCredits(tokenStore, config?)`, iterating Codex buckets and skipping expired / no-account_id tokens (mirrors `getAllCodexUsageInfo`).
- `OAuthManager.getAllCodexRateLimitResetCredits()` — thin delegate to the pure function.

**CLI package** (`@vybestack/llxprt-code`) — owns the UI/orchestration only:
- `packages/cli/src/ui/commands/quotaCommand.ts` — the `/quota` SlashCommand and its subcommands. Status reuses `fetchAllQuotaInfo` from `statsQuota.ts` (no duplication). Reset checks Codex auth (else points to `/auth codex`), finds a redeemable credit, resolves the bucket token, consumes one credit with an idempotency id (`crypto.randomUUID()`), reports `reset` / `already_redeemed`, and refreshes the quota view.
- Registered in `BuiltinCommandLoader.ts`.

**Core package** — unchanged (quota reset is a provider concern).

**Agents package** — `COMMAND_API_MAP` classifies `/quota` + `/quota status` + `/quota credits` as reads (`agent.getStats`) and `/quota reset` as a mutating action (`agent.auth`).

## Endpoint contract

```
GET  <root>/wham/rate-limit-reset-credits
  -> { rate_limit_reset_credits: { available_count: number, credits: [{ id, ... }] } }
POST <root>/wham/rate-limit-reset-credits/consume
  body { credit_id, redeem_request_id } -> { code: "reset" | "already_redeemed", credit?: { id } }
  Headers: Authorization: Bearer <token>, ChatGPT-Account-Id: <account_id>
```

## Testing (TDD per dev-docs/RULES.md)

Behavioral tests across all layers:
- **Providers**: request shape (URL/method/headers/body), timeout signal, HTTP/network/malformed-response handling, `already_redeemed`, custom base-url, formatter (including a nonzero `available_count` with an empty details array).
- **Auth**: multi-bucket iteration, expired-token skip, missing-account_id skip, base-url forwarding, per-bucket failure isolation.
- **CLI**: every subcommand and reset path (no token, not authed, no credits, non-empty map with all-zero-available buckets, success, `already_redeemed` + quota refresh, consume null, network error, base-url forwarding, explicit `codex` arg).
- **Autocomplete**: `/quota reset` completion yields `codex` (incl. case-insensitive fuzzy match).

All new tests pass; `typecheck`, `lint`, `lint:eslint-guard`, `format`, and `build` are green. No `any`, no source-level type/`!` assertions, no lint-rule loosening.

## Notable robustness fix

`resolveBucketToken` guards against a token that expires **between** the credit-listing call and credential resolution — an expired token would otherwise reach the consume call, 401, and surface a misleading generic error. It now degrades to a re-auth hint (`Run /auth codex to re-authenticate`).

## Out of scope / follow-up

- **Non-interactive mode** (`llxprt-code --command "/quota reset"`) is intentionally **not** delivered here. The non-interactive path (`nonInteractiveCliCommands.ts`) loads only `FileCommandLoader` (not `BuiltinCommandLoader`) and uses a no-op UI sink, so **no** built-in slash command works non-interactively today. Wiring that up is a cross-cutting change affecting every built-in and belongs in a separate PR. The issue framed non-interactive support as a nice-to-have.
- Referral invite flow, credit purchasing, and non-Codex provider reset remain out of scope per the issue.
