### PR TITLE
Cancel obsolete PR workflow runs (Fixes #2445)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
   workflow_dispatch:
     # Manual trigger - no inputs needed, uses repository variables
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   checks: 'write'
   contents: 'read'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -124,6 +124,10 @@ jobs:
     needs:
       - e2e_doc_change_filter
       - skip_check
+    concurrency:
+      group: >-
+        ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.branch_ref || github.ref }}-${{ matrix.sandbox }}
+      cancel-in-progress: true
     if: |
       (
         github.event_name == 'push' ||
@@ -246,6 +250,10 @@ jobs:
     needs:
       - e2e_doc_change_filter
       - skip_check
+    concurrency:
+      group: >-
+        ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.branch_ref || github.ref }}-macos
+      cancel-in-progress: true
     if: |
       (
         github.event_name == 'merge_group' ||

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -77,11 +77,11 @@ jobs:
         startsWith(toJSON(github.event.comment.body), '"/open-code-review\t')))
     # Job-level concurrency is evaluated only for runs that pass this job if filter,
     # so ordinary, unauthorized, and non-PR issue comments cannot cancel OCR.
-    # All authorized OCR triggers for the same PR share one group so the latest
-    # run owns the sticky summary and inline-comment posting.
+    # All authorized OCR triggers for the same PR share one workflow-scoped group
+    # so the latest run owns the sticky summary and inline-comment posting.
     concurrency:
       group: >-
-        ocr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+        ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
       cancel-in-progress: true
     steps:
       - name: Resolve PR context

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -90,9 +90,11 @@ describe('.github/workflows/ocr-review.yml', () => {
       '${{ steps.ocr-classification.outputs.policy_failure }}',
     );
     expect(codeReviewJob.concurrency?.['cancel-in-progress']).toBe(true);
+    expect(normalizedGroup).toContain(normalize('${{ github.workflow }}'));
     expect(group).toContain(
       'github.event.pull_request.number || github.event.issue.number || inputs.pr_number',
     );
+    expect(group).not.toContain('ocr-review-');
     expect(group).not.toContain("github.event_name == 'issue_comment'");
     expect(group).not.toContain("'command'");
     expect(group).not.toContain("'automatic'");
@@ -112,7 +114,7 @@ describe('.github/workflows/ocr-review.yml', () => {
       'Job-level concurrency is evaluated only for runs that pass this job if filter',
     );
     expect(workflowYml).toContain(
-      'All authorized OCR triggers for the same PR share one group',
+      'All authorized OCR triggers for the same PR share one workflow-scoped group',
     );
     expect(workflowYml).toContain(
       'run owns the sticky summary and inline-comment posting',

--- a/scripts/tests/pr-workflow-concurrency.test.js
+++ b/scripts/tests/pr-workflow-concurrency.test.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import { normalize, readRootFile } from './ocr-review-workflow-helpers.js';
+
+function loadWorkflow(path) {
+  const source = readRootFile(path);
+  try {
+    const parsed = yaml.load(source);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error(`${path} did not parse to a YAML object`);
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`Failed to parse ${path}: ${error.message}`, {
+      cause: error,
+    });
+  }
+}
+
+function expectConcurrencyGroup(concurrency, expectedFragments) {
+  expect(concurrency?.['cancel-in-progress']).toBe(true);
+  const group = normalize(concurrency?.group);
+  for (const fragment of expectedFragments) {
+    expect(group).toContain(normalize(fragment));
+  }
+}
+
+describe('PR workflow concurrency cancellation', () => {
+  it('scopes CI cancellation by workflow and PR number or ref', () => {
+    const workflow = loadWorkflow('.github/workflows/ci.yml');
+
+    expectConcurrencyGroup(workflow.concurrency, [
+      '${{ github.workflow }}',
+      'github.event.pull_request.number || github.ref',
+    ]);
+    expect(normalize(workflow.concurrency?.group)).toBe(
+      '${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}',
+    );
+  });
+
+  it('uses E2E job-level concurrency for only the jobs that run E2E work', () => {
+    const workflow = loadWorkflow('.github/workflows/e2e.yml');
+    const linuxJob = workflow.jobs?.e2e_linux;
+    const macJob = workflow.jobs?.e2e_mac;
+
+    expect(workflow.concurrency).toBeUndefined();
+    expect(linuxJob, 'workflow should contain e2e_linux').toBeTruthy();
+    expect(macJob, 'workflow should contain e2e_mac').toBeTruthy();
+    expectConcurrencyGroup(linuxJob.concurrency, [
+      '${{ github.workflow }}',
+      'github.event.pull_request.number || inputs.branch_ref || github.ref',
+      '${{ matrix.sandbox }}',
+    ]);
+    expectConcurrencyGroup(macJob.concurrency, [
+      '${{ github.workflow }}',
+      'github.event.pull_request.number || inputs.branch_ref || github.ref',
+      '-macos',
+    ]);
+    expect(workflow.jobs?.skip_check?.concurrency).toBeUndefined();
+    expect(workflow.jobs?.e2e_doc_change_filter?.concurrency).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## TLDR

Cancel obsolete PR workflow runs by adding PR/ref-scoped concurrency to CI, E2E, and OCR, without allowing unrelated PRs or unrelated workflow jobs to cancel each other.

## Dive Deeper

- CI uses workflow-level concurrency keyed by workflow name plus PR number or ref.
- E2E uses job-level concurrency on the actual E2E jobs only, keyed by workflow name, PR number or manual branch ref or Git ref, and the Linux sandbox matrix leg or macOS suffix.
- OCR keeps job-level concurrency so unauthorized or non-command issue comments cannot cancel OCR, while switching the group to the same workflow-scoped pattern.
- Added workflow contract tests for CI and E2E concurrency and updated the OCR workflow test for the new workflow-scoped OCR group.

## Reviewer Test Plan

Review the changed workflow YAML and script tests:

- Confirm CI cancellation scope is workflow plus PR number or ref.
- Confirm E2E cancellation scope is job-level and distinguishes Linux sandbox legs from macOS.
- Confirm OCR cancellation remains job-level and still scopes to the target PR from pull request, issue comment, or workflow dispatch input.
- Run the focused workflow tests and workflow lint commands listed below.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | CI  |
| npx      | ✅  | ❓  | CI  |
| Docker   | -   | -   | CI  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Local verification performed:

- npx prettier --check .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/ocr-review.yml
- npx actionlint -ignore 'SC2129:' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/ocr-review.yml
- npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/pr-workflow-concurrency.test.js scripts/tests/ocr-review-workflow.test.js
- npx eslint scripts/tests/pr-workflow-concurrency.test.js scripts/tests/ocr-review-workflow.test.js
- npm run test:scripts
- git diff --check
- npm run typecheck
- npm run format
- npm run build
- npx eslint . and npx eslint integration-tests under Node 24 with NODE_OPTIONS=--max-old-space-size=16384
- Open Code Review on changed workflow/test files

Notes:

- npm run lint hit local V8 heap exhaustion at the repository script's 8192 MB heap cap; the same ESLint targets passed directly under Node 24 with a larger heap cap.
- The local smoke command selected model gpt-5.5 and the configured endpoint returned it as not found; this appears local-profile/environment related and unrelated to these workflow YAML/test changes.

## Linked issues / bugs

Fixes #2445
