### PR TITLE
Make MCP server discovery non-blocking at startup (Fixes #2325)

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -780,7 +780,12 @@ export class Config extends ConfigBase {
       client.dispose();
     }
     if (this.mcpDiscoveryPromise !== undefined) {
-      await this.mcpDiscoveryPromise;
+      try {
+        await this.mcpDiscoveryPromise;
+      } catch {
+        // Discovery may reject due to refreshMcpContext errors; swallow
+        // so that stop() cleanup still runs and no server processes leak.
+      }
     }
     if (this.mcpClientManager !== undefined) {
       await this.mcpClientManager.stop();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -13,6 +13,7 @@ import { ActivateSkillTool } from '@vybestack/llxprt-code-tools/tools/activate-s
 import { Storage } from '@vybestack/llxprt-code-settings';
 import { CoreSkillServiceAdapter } from '../tools-adapters/CoreSkillServiceAdapter.js';
 import { DebugLogger } from '../debug/DebugLogger.js';
+import { getErrorMessage } from '../utils/errors.js';
 
 import type { AgentClientContract } from '../core/clientContract.js';
 import { HookSystem } from '../hooks/hookSystem.js';
@@ -109,6 +110,8 @@ import type { ShellExecutionConfig } from '../services/shellExecutionService.js'
 import type { ToolSchedulerContract } from '../core/toolSchedulerContract.js';
 
 export class Config extends ConfigBase {
+  private static readonly logger = new DebugLogger('llxprt:config');
+
   constructor(params: ConfigParameters) {
     super();
     applyConfigParams(this as unknown as ConfigConstructorTarget, params);
@@ -782,12 +785,17 @@ export class Config extends ConfigBase {
     if (this.mcpDiscoveryPromise !== undefined) {
       try {
         await this.mcpDiscoveryPromise;
-      } catch {
-        // Discovery may reject due to refreshMcpContext errors; swallow
-        // so that stop() cleanup still runs and no server processes leak.
+      } catch (error) {
+        Config.logger.warn(
+          `MCP discovery rejected during dispose: ${getErrorMessage(error)}`,
+        );
       }
     }
+    // Issue #2325: Extension server discoveries fired by startExtension are
+    // tracked by whenDiscoverySettled(). Await it to avoid tearing down
+    // clients mid-connection.
     if (this.mcpClientManager !== undefined) {
+      await this.mcpClientManager.whenDiscoverySettled();
       await this.mcpClientManager.stop();
     }
   }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -114,6 +114,11 @@ export class Config extends ConfigBase {
     applyConfigParams(this as unknown as ConfigConstructorTarget, params);
   }
 
+  // Issue #2325: Background MCP discovery promise started in initialize() so
+  // startup is not blocked. Awaited in dispose() to avoid tearing down servers
+  // mid-discovery.
+  private mcpDiscoveryPromise: Promise<void> | undefined;
+
   /**
    * Must only be called once, throws if called again.
    */
@@ -143,10 +148,11 @@ export class Config extends ConfigBase {
       this,
       this.eventEmitter,
     );
-    await Promise.all([
-      this.mcpClientManager.startConfiguredMcpServers(),
-      this.getExtensionLoader().start(this),
-    ]);
+    // Issue #2325: Fire MCP discovery in the background — don't block startup.
+    // Tools are gated before model turns via McpClientManager.whenDiscoverySettled().
+    this.mcpDiscoveryPromise =
+      this.mcpClientManager.startConfiguredMcpServers();
+    await this.getExtensionLoader().start(this);
 
     await initializeLsp(this._lspState, this);
 
@@ -772,6 +778,9 @@ export class Config extends ConfigBase {
     const client = this.agentClient as AgentClientContract | undefined;
     if (client !== undefined) {
       client.dispose();
+    }
+    if (this.mcpDiscoveryPromise !== undefined) {
+      await this.mcpDiscoveryPromise;
     }
     if (this.mcpClientManager !== undefined) {
       await this.mcpClientManager.stop();

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -581,8 +581,11 @@ describe('McpClientManager', () => {
       // connect was called but the deferred promise hasn't resolved yet
       expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
 
-      // Now resolve the connect promise — discovery completes in background
+      // Now resolve the connect promise — discovery completes in background.
+      // Use a timeout guard so the test doesn't hang if resolveConnect is lost.
+      const timeout = setTimeout(() => resolveConnect(), 5000);
       resolveConnect();
+      clearTimeout(timeout);
       await manager.whenDiscoverySettled();
     });
 

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -559,7 +559,7 @@ describe('McpClientManager', () => {
       }) as unknown as LlxprtExtension;
 
     it('should not block startExtension on MCP server discovery (issue #2325)', async () => {
-      let resolveConnect: () => void = () => {};
+      let resolveConnect: () => void;
       const connectPromise = new Promise<void>((resolve) => {
         resolveConnect = resolve;
       });

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -13,6 +13,7 @@ import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
 import type { PromptRegistry } from '@vybestack/llxprt-code-core/prompts/prompt-registry.js';
 import type { ResourceRegistry } from '@vybestack/llxprt-code-core/resources/resource-registry.js';
 import type { WorkspaceContext } from '@vybestack/llxprt-code-core/utils/workspaceContext.js';
+import type { LlxprtExtension } from '@vybestack/llxprt-code-core/config/configTypes.js';
 import { EventEmitter } from 'node:events';
 import { CoreEvent } from '@vybestack/llxprt-code-core/utils/events.js';
 
@@ -512,6 +513,100 @@ describe('McpClientManager', () => {
       // Untrusted folder means startConfiguredMcpServers returns early
       // without touching discovery state — stays NOT_STARTED
       expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.NOT_STARTED);
+    });
+  });
+
+  describe('startExtension background discovery (issue #2325)', () => {
+    const createExtensionManager = (
+      mockedMcpClient: Record<string, ReturnType<typeof vi.fn>>,
+    ) => {
+      vi.mocked(McpClient).mockReturnValue(
+        mockedMcpClient as unknown as McpClient,
+      );
+      const mockConfig = {
+        isTrustedFolder: () => true,
+        getMcpServers: () => ({}),
+        getMcpServerCommand: () => '',
+        getPromptRegistry: () => ({}) as PromptRegistry,
+        getResourceRegistry: () => ({}) as ResourceRegistry,
+        getDebugMode: () => false,
+        getWorkspaceContext: () => ({}) as WorkspaceContext,
+        getEnableExtensionReloading: () => false,
+        getExtensionEvents: () => undefined,
+        getAllowedMcpServers: () => undefined,
+        getBlockedMcpServers: () => undefined,
+        getAgentClient: () => ({
+          isInitialized: () => false,
+        }),
+        refreshMcpContext: vi.fn(),
+      } as unknown as Config;
+      const manager = new McpClientManager(
+        '0.0.1',
+        {} as ToolRegistry,
+        mockConfig,
+      );
+      return { manager, mockConfig };
+    };
+
+    it('should not block startExtension on MCP server discovery (issue #2325)', async () => {
+      let resolveConnect: () => void = () => {};
+      const connectPromise = new Promise<void>((resolve) => {
+        resolveConnect = resolve;
+      });
+      const mockedMcpClient = {
+        connect: vi.fn().mockReturnValue(connectPromise),
+        discover: vi.fn(),
+        disconnect: vi.fn(),
+        getStatus: vi.fn(),
+        getServerConfig: vi.fn().mockReturnValue({ extension: undefined }),
+      };
+      const { manager } = createExtensionManager(mockedMcpClient);
+
+      const extension = {
+        name: 'test-ext',
+        version: '1.0.0',
+        isActive: true,
+        path: '/path/to/ext',
+        contextFiles: [],
+        mcpServers: { 'ext-server': {} },
+      } as unknown as LlxprtExtension;
+
+      // startExtension should resolve immediately without waiting for connect
+      await manager.startExtension(extension);
+
+      // connect was called but the deferred promise hasn't resolved yet
+      expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
+
+      // Now resolve the connect promise — discovery completes in background
+      resolveConnect();
+      await manager.whenDiscoverySettled();
+    });
+
+    it('whenDiscoverySettled should resolve after background discovery from startExtension', async () => {
+      const mockedMcpClient = {
+        connect: vi.fn(),
+        discover: vi.fn(),
+        disconnect: vi.fn(),
+        getStatus: vi.fn(),
+        getServerConfig: vi.fn().mockReturnValue({ extension: undefined }),
+      };
+      const { manager } = createExtensionManager(mockedMcpClient);
+
+      const extension = {
+        name: 'test-ext',
+        version: '1.0.0',
+        isActive: true,
+        path: '/path/to/ext',
+        contextFiles: [],
+        mcpServers: { 'ext-server': {} },
+      } as unknown as LlxprtExtension;
+
+      await manager.startExtension(extension);
+      // Discovery should be in progress or completed
+      await manager.whenDiscoverySettled();
+      // After settling, the client should be connected
+      expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
+      expect(mockedMcpClient.discover).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, afterEach } from 'vitest';
 import { McpClientManager } from './mcp-client-manager.js';
 import { McpClient } from './mcp-client.js';
 import { MCPDiscoveryState } from './mcp-client.js';
@@ -28,6 +28,9 @@ vi.mock('./mcp-client.js', () => ({
 }));
 
 describe('McpClientManager', () => {
+  afterEach(() => {
+    vi.mocked(McpClient).mockReset();
+  });
   it('should discover tools from all configured servers', async () => {
     const mockedMcpClient = {
       connect: vi.fn(),
@@ -582,10 +585,7 @@ describe('McpClientManager', () => {
       expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
 
       // Now resolve the connect promise — discovery completes in background.
-      // Use a timeout guard so the test doesn't hang if resolveConnect is lost.
-      const timeout = setTimeout(() => resolveConnect(), 5000);
       resolveConnect();
-      clearTimeout(timeout);
       await manager.whenDiscoverySettled();
     });
 

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -616,6 +616,10 @@ describe('McpClientManager', () => {
         manager.startExtension(makeTestExtension()),
       ).resolves.toBeUndefined();
       await expect(manager.whenDiscoverySettled()).resolves.toBeUndefined();
+      // connect was attempted but discover was never reached
+      expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
+      expect(mockedMcpClient.discover).not.toHaveBeenCalled();
+      expect(manager.getDiscoveryState()).toBe(MCPDiscoveryState.COMPLETED);
     });
   });
 });

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -548,6 +548,16 @@ describe('McpClientManager', () => {
       return { manager, mockConfig };
     };
 
+    const makeTestExtension = (): LlxprtExtension =>
+      ({
+        name: 'test-ext',
+        version: '1.0.0',
+        isActive: true,
+        path: '/path/to/ext',
+        contextFiles: [],
+        mcpServers: { 'ext-server': {} },
+      }) as unknown as LlxprtExtension;
+
     it('should not block startExtension on MCP server discovery (issue #2325)', async () => {
       let resolveConnect: () => void = () => {};
       const connectPromise = new Promise<void>((resolve) => {
@@ -555,24 +565,15 @@ describe('McpClientManager', () => {
       });
       const mockedMcpClient = {
         connect: vi.fn().mockReturnValue(connectPromise),
-        discover: vi.fn(),
-        disconnect: vi.fn(),
+        discover: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
         getStatus: vi.fn(),
         getServerConfig: vi.fn().mockReturnValue({ extension: undefined }),
       };
       const { manager } = createExtensionManager(mockedMcpClient);
 
-      const extension = {
-        name: 'test-ext',
-        version: '1.0.0',
-        isActive: true,
-        path: '/path/to/ext',
-        contextFiles: [],
-        mcpServers: { 'ext-server': {} },
-      } as unknown as LlxprtExtension;
-
       // startExtension should resolve immediately without waiting for connect
-      await manager.startExtension(extension);
+      await manager.startExtension(makeTestExtension());
 
       // connect was called but the deferred promise hasn't resolved yet
       expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
@@ -584,29 +585,34 @@ describe('McpClientManager', () => {
 
     it('whenDiscoverySettled should resolve after background discovery from startExtension', async () => {
       const mockedMcpClient = {
-        connect: vi.fn(),
-        discover: vi.fn(),
-        disconnect: vi.fn(),
+        connect: vi.fn().mockResolvedValue(undefined),
+        discover: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
         getStatus: vi.fn(),
         getServerConfig: vi.fn().mockReturnValue({ extension: undefined }),
       };
       const { manager } = createExtensionManager(mockedMcpClient);
 
-      const extension = {
-        name: 'test-ext',
-        version: '1.0.0',
-        isActive: true,
-        path: '/path/to/ext',
-        contextFiles: [],
-        mcpServers: { 'ext-server': {} },
-      } as unknown as LlxprtExtension;
-
-      await manager.startExtension(extension);
-      // Discovery should be in progress or completed
+      await manager.startExtension(makeTestExtension());
       await manager.whenDiscoverySettled();
-      // After settling, the client should be connected
       expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
       expect(mockedMcpClient.discover).toHaveBeenCalledOnce();
+    });
+
+    it('should not throw and whenDiscoverySettled should resolve when connect rejects', async () => {
+      const mockedMcpClient = {
+        connect: vi.fn().mockRejectedValue(new Error('connection refused')),
+        discover: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        getStatus: vi.fn(),
+        getServerConfig: vi.fn().mockReturnValue({ extension: undefined }),
+      };
+      const { manager } = createExtensionManager(mockedMcpClient);
+
+      await expect(
+        manager.startExtension(makeTestExtension()),
+      ).resolves.toBeUndefined();
+      await expect(manager.whenDiscoverySettled()).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -548,6 +548,9 @@ describe('McpClientManager', () => {
       return { manager, mockConfig };
     };
 
+    // Partial mock — only fields relevant to MCP discovery are populated.
+    // LlxprtExtension has many internal fields (hooks, commands, etc.) that
+    // are not exercised by startExtension, so a full stub is unnecessary.
     const makeTestExtension = (): LlxprtExtension =>
       ({
         name: 'test-ext',

--- a/packages/mcp/src/client/mcp-client-manager.test.ts
+++ b/packages/mcp/src/client/mcp-client-manager.test.ts
@@ -583,10 +583,14 @@ describe('McpClientManager', () => {
 
       // connect was called but the deferred promise hasn't resolved yet
       expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
+      // discover should NOT have been called yet — it runs after connect
+      expect(mockedMcpClient.discover).not.toHaveBeenCalled();
 
       // Now resolve the connect promise — discovery completes in background.
       resolveConnect();
       await manager.whenDiscoverySettled();
+      // After settling, discover should have been called
+      expect(mockedMcpClient.discover).toHaveBeenCalledOnce();
     });
 
     it('whenDiscoverySettled should resolve after background discovery from startExtension', async () => {

--- a/packages/mcp/src/client/mcp-client-manager.ts
+++ b/packages/mcp/src/client/mcp-client-manager.ts
@@ -104,14 +104,11 @@ export class McpClientManager {
    */
   async startExtension(extension: LlxprtExtension) {
     logger.log(`Loading extension: ${extension.name}`);
-    await Promise.all(
-      Object.entries(extension.mcpServers ?? {}).map(([name, config]) =>
-        this.maybeDiscoverMcpServer(name, {
-          ...config,
-          extension,
-        }),
-      ),
-    );
+    // Issue #2325: Fire MCP discovery without blocking — discovery completes
+    // in the background and is tracked by whenDiscoverySettled().
+    for (const [name, config] of Object.entries(extension.mcpServers ?? {})) {
+      void this.maybeDiscoverMcpServer(name, { ...config, extension });
+    }
     await this.cliConfig.refreshMcpContext();
   }
 

--- a/packages/mcp/src/client/mcp-client-manager.ts
+++ b/packages/mcp/src/client/mcp-client-manager.ts
@@ -107,7 +107,13 @@ export class McpClientManager {
     // Issue #2325: Fire MCP discovery without blocking — discovery completes
     // in the background and is tracked by whenDiscoverySettled().
     for (const [name, config] of Object.entries(extension.mcpServers ?? {})) {
-      void this.maybeDiscoverMcpServer(name, { ...config, extension });
+      try {
+        void this.maybeDiscoverMcpServer(name, { ...config, extension });
+      } catch (error) {
+        logger.warn(
+          `Error dispatching MCP discovery for server '${name}': ${getErrorMessage(error)}`,
+        );
+      }
     }
     // refreshMcpContext here sees pre-discovery tool state, but connectAndDiscover
     // emits McpClientUpdate + calls scheduleMcpContextRefresh once each server

--- a/packages/mcp/src/client/mcp-client-manager.ts
+++ b/packages/mcp/src/client/mcp-client-manager.ts
@@ -109,6 +109,9 @@ export class McpClientManager {
     for (const [name, config] of Object.entries(extension.mcpServers ?? {})) {
       void this.maybeDiscoverMcpServer(name, { ...config, extension });
     }
+    // refreshMcpContext here sees pre-discovery tool state, but connectAndDiscover
+    // emits McpClientUpdate + calls scheduleMcpContextRefresh once each server
+    // connects, so the context converges as servers come online.
     await this.cliConfig.refreshMcpContext();
   }
 


### PR DESCRIPTION
## Summary

Fixes #2325

MCP server discovery at startup no longer blocks the CLI initialization, eliminating the "blackscreen" that occurred while waiting for MCP servers to connect (especially during OAuth flows).

## Changes

### `packages/core/src/config/config.ts`
- `Config.initialize()` now fires `startConfiguredMcpServers()` in the background instead of `await`ing it alongside the extension loader. The rest of initialization (LSP, skills, subagents, AgentClient creation) proceeds immediately.
- `Config.dispose()` awaits the background discovery promise (wrapped in try/catch) before stopping MCP clients to avoid tearing down servers mid-discovery.

### `packages/mcp/src/client/mcp-client-manager.ts`
- `McpClientManager.startExtension()` now fires `maybeDiscoverMcpServer()` without awaiting each server's discovery, allowing extension loading (subagent registration, context refresh) to proceed immediately.

## Why This Is Safe

The existing infrastructure already handles deferred tool availability:

1. **`McpClientManager.whenDiscoverySettled()`** resolves once all in-flight discovery completes
2. **`agentImpl.ts` `awaitMcpDiscoveryGate()`** calls `whenDiscoverySettled()` before each model turn, ensuring MCP tools are available when the model needs them
3. **`useMcpStatus` hook** tracks discovery state via `CoreEvent.McpClientUpdate` events, so the UI shows loading status
4. **`scheduleMcpContextRefresh()`** is called by `connectAndDiscover()` as each server comes online, debounced to coalesce rapid updates

## Tests

- **`startExtension` does not block**: `startExtension()` resolves before the MCP client's `connect()` promise resolves (verified with a deferred promise)
- **`whenDiscoverySettled` resolves after background discovery**: Discovery from `startExtension` completes and settles correctly
- **Rejection resilience**: When `connect()` rejects, `startExtension` doesn't throw and `whenDiscoverySettled` still resolves
- All 573 existing tests across 44 files still pass
- ESLint guard passes — no rules loosened

## Verification

```
npm run format ✓
npm run typecheck ✓
npx eslint ✓
npx vitest run (573 tests) ✓
npm run build ✓
bun scripts/start.ts (smoke) ✓
ocr review — 5 findings addressed ✓
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App startup is now faster because MCP server discovery runs in the background instead of blocking initialization.
  * MCP-related context updates now continue to settle automatically as servers connect.

* **Bug Fixes**
  * Shutdown now waits for ongoing MCP discovery to finish, helping prevent lingering server processes.
  * Startup and discovery now complete more reliably even if one MCP connection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->