### PR TITLE
Make LB failover aggregate retryable so all-429 doesn't fatally drop to prompt (Fixes #2450)

### DIFF
--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { HttpError } from './retry.js';
-import { retryWithBackoff, isOverloadError } from './retry.js';
+import {
+  retryWithBackoff,
+  isOverloadError,
+  isRetryableError,
+} from './retry.js';
 import { setSimulate429 } from './testUtils.js';
 
 // Helper to create a mock function that fails a certain number of times
@@ -965,5 +969,101 @@ describe('isOverloadError', () => {
 
   it('returns false for a string error', () => {
     expect(isOverloadError('some string')).toBe(false);
+  });
+});
+
+describe('isRetryableError - self-classifying aggregate marker (issue #2450)', () => {
+  /**
+   * Build an object shaped like the load balancer aggregate error: a `failures`
+   * array plus a precomputed boolean `isRetryable`. `message` is included so we
+   * can prove the aggregate decision overrides message-based heuristics.
+   */
+  function makeAggregate(isRetryable: boolean, message: string) {
+    return {
+      name: 'LoadBalancerFailoverError',
+      message,
+      failures: [{ profile: 'a', error: new Error('inner') }],
+      isRetryable,
+    };
+  }
+
+  it('returns true for an aggregate whose isRetryable === true', () => {
+    expect(isRetryableError(makeAggregate(true, 'all backends 429'))).toBe(
+      true,
+    );
+  });
+
+  it('returns false for an aggregate whose isRetryable === false', () => {
+    expect(
+      isRetryableError(makeAggregate(false, 'mixed backend failures')),
+    ).toBe(false);
+  });
+
+  it('aggregate isRetryable === false is AUTHORITATIVE even when its flattened message contains a network-transient phrase', () => {
+    // Regression guard (issue #2450): the aggregate message flattens child
+    // messages. A mixed aggregate (one network-transient backend + one
+    // permanent failure) is correctly non-retryable, and must NOT be rescued
+    // by the message-based network-transient heuristic seeing the sibling's
+    // "socket hang up" text.
+    const error = makeAggregate(
+      false,
+      'zai: socket hang up; makoraglm51: bad request (status: 400)',
+    );
+    // Sanity: that same phrase WOULD trip the network-transient heuristic on a
+    // non-aggregate error.
+    expect(isRetryableError(new Error('socket hang up'))).toBe(true);
+    // But the aggregate's own decision wins.
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  it('aggregate isRetryable === true is honored even without any status or transient phrase', () => {
+    expect(
+      isRetryableError(makeAggregate(true, 'all backends rate limited')),
+    ).toBe(true);
+  });
+
+  it('a bare isRetryable marker WITHOUT a failures array is NOT treated as an aggregate', () => {
+    // The marker is intentionally specific to aggregates. A plain error that
+    // merely carries isRetryable (no failures array) is classified by the
+    // normal precedence, so a stray true marker does not make it retryable.
+    const error = new Error('client error') as Error & { isRetryable: boolean };
+    error.isRetryable = true;
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  it('returns false for a plain Error with no status and no marker', () => {
+    expect(isRetryableError(new Error('something broke'))).toBe(false);
+  });
+
+  it('honors the aggregate marker even for an empty failures array (structural edge case)', () => {
+    // A directly-constructed aggregate with empty failures and isRetryable=true
+    // (bypassing the constructor, which would compute false) is still honored
+    // by the PRIORITY 0 structural check. This documents that isRetryableError
+    // trusts the self-classifying marker regardless of array length — the
+    // constructor's computeAggregateRetryable is the guard, not isRetryableError.
+    const aggregate = {
+      name: 'LoadBalancerFailoverError',
+      message: 'no backends attempted',
+      failures: [] as unknown[],
+      isRetryable: true,
+    };
+    expect(isRetryableError(aggregate)).toBe(true);
+  });
+
+  it('still classifies status-bearing errors correctly (429 → retryable)', () => {
+    const error: HttpError = new Error('rate limited');
+    error.status = 429;
+    expect(isRetryableError(error)).toBe(true);
+  });
+
+  it('still classifies status-bearing errors correctly (400 → not retryable) even with a stray marker', () => {
+    // A 400 with a stray isRetryable marker but no failures array must still be
+    // non-retryable via status-based classification.
+    const error = new Error('bad request') as HttpError & {
+      isRetryable: boolean;
+    };
+    error.status = 400;
+    error.isRetryable = true;
+    expect(isRetryableError(error)).toBe(false);
   });
 });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -9,6 +9,11 @@ import { DebugLogger } from '../debug/index.js';
 import { delay, createAbortError } from './delay.js';
 import { RetryableQuotaError } from './googleQuotaErrors.js';
 
+// Re-exported so downstream packages (e.g. providers) can import it from the
+// public `utils/retry.js` entry point, since `googleQuotaErrors.js` is not in
+// the package export map. (issue #2450)
+export { RetryableQuotaError };
+
 export interface HttpError extends Error {
   status?: number;
 }
@@ -224,6 +229,9 @@ export function isNetworkTransientError(error: unknown): boolean {
  * @requirement REQ-R13-002 isRetryableError exported for reuse
  *
  * Decision precedence (CRITICAL - do not reorder):
+ * 0. Self-classifying aggregate errors (a `failures` array plus a boolean
+ *    `isRetryable`, e.g. the load balancer LoadBalancerFailoverError) →
+ *    authoritative, honored FIRST in both directions
  * 1. Network transient conditions (ETIMEDOUT, ECONNRESET, "fetch failed", etc.) → ALWAYS retry
  *    (centralized in isNetworkTransientError)
  * 2. RetryableQuotaError → retry
@@ -235,6 +243,25 @@ export function isNetworkTransientError(error: unknown): boolean {
  * @returns True if the error is retryable, false otherwise.
  */
 export function isRetryableError(error: Error | unknown): boolean {
+  // PRIORITY 0: Self-classifying aggregate errors (e.g. the load balancer
+  // LoadBalancerFailoverError). An aggregate-of-failures has already computed
+  // its own retryability from EACH underlying backend failure, so it is
+  // authoritative. Its human-readable message flattens the child messages,
+  // which means the message-based heuristics below (network-transient, overload)
+  // would otherwise re-interpret a sibling backend's text and override the
+  // precise per-child decision (e.g. a mixed "socket hang up" + HTTP 400
+  // aggregate must NOT be retried). Identified structurally — a `failures`
+  // array plus a boolean `isRetryable` — so core does not import from
+  // providers. (issue #2450)
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    Array.isArray((error as { failures?: unknown }).failures) &&
+    typeof (error as { isRetryable?: unknown }).isRetryable === 'boolean'
+  ) {
+    return (error as { isRetryable: boolean }).isRetryable;
+  }
+
   // PRIORITY 1: Network error codes are ALWAYS retryable (transient infrastructure failures)
   if (isNetworkTransientError(error)) {
     return true;

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -1,0 +1,463 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for issue #2450: a load-balancer `failover` profile whose
+ * backends all transiently 429 in a single pass must surface an aggregate
+ * error that the upstream retry layer classifies as retryable, rather than
+ * fatally dropping the agent back to the prompt.
+ *
+ * These tests assert OBSERVABLE outcomes on the thrown aggregate error using
+ * the real `LoadBalancingProvider`, a real `ProviderManager`, and fake
+ * delegate providers (the unit under test is never mocked).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  LoadBalancingProvider,
+  type LoadBalancingProviderConfig,
+} from '../LoadBalancingProvider.js';
+import { LoadBalancerFailoverError } from '../errors.js';
+import {
+  LoadBalancerAllContextLimitsExceededError,
+  LoadBalancerContextLimitError,
+} from '../loadBalancing/contextLimitError.js';
+import type { IProvider } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions } from '../GenerateChatOptions.js';
+import {
+  isRetryableError,
+  getErrorStatus,
+  RetryableQuotaError,
+} from '@vybestack/llxprt-code-core/utils/retry.js';
+
+/** Build a fake delegate provider that records each invocation. */
+function makeFakeProvider(
+  generator: (attempt: number) => AsyncGenerator<IContent>,
+): { provider: IProvider; counter: { value: number } } {
+  const counter = { value: 0 };
+  const provider: IProvider = {
+    name: 'test-provider',
+    async *generateChatCompletion(): AsyncGenerator<IContent> {
+      counter.value++;
+      yield* generator(counter.value);
+    },
+    getModels: async () => [],
+    getDefaultModel: () => 'test-model',
+    getServerTools: () => [],
+    invokeServerTool: async () => ({ content: [] }),
+  };
+  return { provider, counter };
+}
+
+/** Create a status-bearing error like the ones real providers throw. */
+function statusError(message: string, status: number): Error {
+  const error = new Error(message) as Error & { status: number };
+  error.status = status;
+  return error;
+}
+
+/**
+ * Create an Anthropic-style body-level overload error (no HTTP status). These
+ * carry a `type` field like `overloaded_error` / `rate_limit_error` and are
+ * classified transient by isOverloadError.
+ */
+function overloadError(type: string): Error {
+  const error = new Error(type) as Error & { type: string };
+  error.type = type;
+  return error;
+}
+
+function makeOptions(): GenerateChatOptions {
+  return {
+    prompt: 'test prompt',
+    messages: [{ role: 'user' as const, content: 'test' }],
+  };
+}
+
+function makeFailoverConfig(profileName: string): LoadBalancingProviderConfig {
+  return {
+    profileName,
+    strategy: 'failover',
+    subProfiles: [
+      {
+        name: 'zai',
+        providerName: 'test-provider',
+        modelId: 'model1',
+        baseURL: 'https://api.test.com',
+        authToken: 'token-1',
+      },
+      {
+        name: 'makoraglm51',
+        providerName: 'test-provider',
+        modelId: 'model2',
+        baseURL: 'https://api.test.com',
+        authToken: 'token-2',
+      },
+      {
+        name: 'ollamaglm51',
+        providerName: 'test-provider',
+        modelId: 'model3',
+        baseURL: 'https://api.test.com',
+        authToken: 'token-3',
+      },
+    ],
+  };
+}
+
+describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let providerManager: ProviderManager;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = createRuntimeConfigStub(settingsService);
+    providerManager = new ProviderManager({ settingsService, config });
+  });
+
+  /**
+   * Drive a failover profile to exhaustion and capture the aggregate error.
+   * Registers a fake delegate whose per-invocation behavior is supplied by
+   * `generator`, runs a real LoadBalancingProvider to completion, and asserts
+   * that the thrown value is a LoadBalancerFailoverError. Returns the aggregate
+   * plus the invocation counter so callers can assert on retryability and the
+   * number of backend attempts.
+   */
+  async function captureFailoverError(
+    generator: (attempt: number) => AsyncGenerator<IContent>,
+    profileName: string,
+  ): Promise<{ error: LoadBalancerFailoverError; counter: { value: number } }> {
+    const { provider, counter } = makeFakeProvider(generator);
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeFailoverConfig(profileName),
+      providerManager,
+    );
+
+    let thrown: unknown;
+    try {
+      for await (const _chunk of lb.generateChatCompletion(makeOptions())) {
+        // consume
+      }
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(LoadBalancerFailoverError);
+    return { error: thrown as LoadBalancerFailoverError, counter };
+  }
+
+  it('classifies an all-429 aggregate as retryable and does not masquerade as an HTTP 429', async () => {
+    const { error, counter } = await captureFailoverError(
+      function* (): AsyncGenerator<IContent> {
+        throw statusError('rate limited', 429);
+        yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+      },
+      'glm-all-429',
+    );
+
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
+    expect(counter.value).toBe(3);
+  });
+
+  /**
+   * Regression guard (issue #2450): an aggregate-of-failures is NOT itself an
+   * HTTP 429 response, so it must deliberately expose NO HTTP status. This
+   * prevents the aggregate from being mis-routed into the bucket-failover /
+   * `onPersistent429` path in retryWithBackoff, which would either throw it
+   * fatally before the isRetryable marker is consulted or bind its retry count
+   * to bucket state. Recovery is driven solely by the isRetryable marker via
+   * normal bounded retry.
+   */
+  it('does not expose an HTTP status on an all-429 aggregate (getErrorStatus === undefined)', () => {
+    const error = new LoadBalancerFailoverError('glm', [
+      { profile: 'zai', error: statusError('rate limited', 429) },
+      { profile: 'makoraglm51', error: statusError('rate limited', 429) },
+      { profile: 'ollamaglm51', error: statusError('rate limited', 429) },
+    ]);
+    expect(getErrorStatus(error)).toBeUndefined();
+  });
+
+  it('classifies an all-5xx aggregate as retryable', async () => {
+    const { error, counter } = await captureFailoverError(
+      function* (): AsyncGenerator<IContent> {
+        throw statusError('service unavailable', 503);
+        yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+      },
+      'glm-all-5xx',
+    );
+
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
+    expect(counter.value).toBe(3);
+  });
+
+  it('classifies a mixed (429 + 400) aggregate as NON-retryable', async () => {
+    const { error, counter } = await captureFailoverError(function* (
+      attempt: number,
+    ): AsyncGenerator<IContent> {
+      if (attempt <= 2) {
+        throw statusError('rate limited', 429);
+      }
+      throw statusError('bad request', 400);
+      yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+    }, 'glm-mixed');
+
+    expect(error.isRetryable).toBe(false);
+    expect(isRetryableError(error)).toBe(false);
+    expect(counter.value).toBe(3);
+  });
+
+  it('classifies a mixed (429 + 401 auth) aggregate as NON-retryable', async () => {
+    const { error, counter } = await captureFailoverError(function* (
+      attempt: number,
+    ): AsyncGenerator<IContent> {
+      if (attempt <= 2) {
+        throw statusError('rate limited', 429);
+      }
+      throw statusError('unauthorized', 401);
+      yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+    }, 'glm-mixed-auth');
+
+    // A 401 is an auth/config problem, not transient load, so the whole
+    // aggregate is non-retryable.
+    expect(error.isRetryable).toBe(false);
+    expect(isRetryableError(error)).toBe(false);
+    expect(counter.value).toBe(3);
+  });
+
+  it('classifies an all-overload (Anthropic body-level "overloaded_error", no HTTP status) aggregate as retryable', async () => {
+    const { error, counter } = await captureFailoverError(
+      function* (): AsyncGenerator<IContent> {
+        throw overloadError('overloaded_error');
+        yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+      },
+      'glm-all-overload',
+    );
+
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
+    expect(counter.value).toBe(3);
+  });
+
+  it('classifies an all-overload (Anthropic body-level "rate_limit_error", no HTTP status) aggregate as retryable', async () => {
+    const { error, counter } = await captureFailoverError(
+      function* (): AsyncGenerator<IContent> {
+        throw overloadError('rate_limit_error');
+        yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+      },
+      'glm-all-rate-limit',
+    );
+
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
+    expect(counter.value).toBe(3);
+  });
+
+  /**
+   * Regression guard (issue #2450 OCR finding): `RetryableQuotaError` (a Google
+   * quota-limit error) carries NO HTTP `.status` — only `cause.code: 429` and
+   * `retryDelayMs`. Core's `isRetryableError` handles it via `instanceof` at
+   * PRIORITY 2, but `getErrorStatus` does NOT traverse `.cause.code`. If the
+   * LB-level classifier forgot this category (as it initially did), an
+   * all-quota aggregate would be non-retryable — the same #2450 fatal-drop bug
+   * for Google providers.
+   */
+  it('classifies an all-RetryableQuotaError aggregate as retryable (Google quota, no HTTP status)', async () => {
+    const quotaError = new RetryableQuotaError(
+      'quota exceeded',
+      { code: 429, message: 'Rate limit exceeded' },
+      1,
+    );
+    const { error, counter } = await captureFailoverError(
+      function* (): AsyncGenerator<IContent> {
+        throw quotaError;
+        yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+      },
+      'glm-all-quota',
+    );
+
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
+    expect(counter.value).toBe(3);
+  });
+
+  /**
+   * Blocking regression guard (issue #2450): a MIXED aggregate where one
+   * backend fails transiently at the NETWORK layer (e.g. "socket hang up") and
+   * another fails permanently (HTTP 400). Because the aggregate flattens each
+   * child message into its own `.message`, a naive classifier that scans the
+   * message for network-transient phrases BEFORE consulting the aggregate's own
+   * decision would wrongly retry it. The aggregate is correctly non-retryable,
+   * and `isRetryableError` must honor that despite the leaked "socket hang up"
+   * text.
+   */
+  it('classifies a mixed (network-transient + 400) aggregate as NON-retryable despite the transient phrase leaking into the message', async () => {
+    const { error, counter } = await captureFailoverError(function* (
+      attempt: number,
+    ): AsyncGenerator<IContent> {
+      if (attempt <= 2) {
+        // A network-transient failure whose message trips the phrase heuristic.
+        throw new Error('socket hang up');
+      }
+      throw statusError('bad request', 400);
+      yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+    }, 'glm-mixed-network-transient');
+
+    // The flattened aggregate message really does contain the transient phrase.
+    expect(error.message).toContain('socket hang up');
+    // Sanity: that phrase in isolation IS classified network-transient. This
+    // assertion is coupled to isNetworkTransientError's phrase heuristic; if
+    // that heuristic changes, update the phrase here accordingly.
+    expect(isRetryableError(new Error('socket hang up'))).toBe(true);
+    // But the mixed aggregate is authoritatively non-retryable.
+    expect(error.isRetryable).toBe(false);
+    expect(isRetryableError(error)).toBe(false);
+    expect(counter.value).toBe(3);
+  });
+
+  it('classifies an all-network-transient aggregate as retryable', async () => {
+    const { error, counter } = await captureFailoverError(
+      function* (): AsyncGenerator<IContent> {
+        throw new Error('socket hang up');
+        yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+      },
+      'glm-all-network-transient',
+    );
+
+    expect(error.isRetryable).toBe(true);
+    expect(isRetryableError(error)).toBe(true);
+    expect(counter.value).toBe(3);
+  });
+
+  it('classifies an all-plain-Error (no status) aggregate as NON-retryable', async () => {
+    const { error, counter } = await captureFailoverError(
+      function* (): AsyncGenerator<IContent> {
+        throw new Error('backend failed');
+        yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+      },
+      'glm-plain',
+    );
+
+    expect(error.isRetryable).toBe(false);
+    expect(isRetryableError(error)).toBe(false);
+    expect(counter.value).toBe(3);
+  });
+
+  it('preserves immediate failover-to-next-backend behavior on a single 429 (issue #902 regression guard)', async () => {
+    const { provider, counter } = makeFakeProvider(function* (
+      attempt: number,
+    ): AsyncGenerator<IContent> {
+      if (attempt === 1) {
+        throw statusError('rate limited', 429);
+      }
+      yield { type: 'text' as const, content: 'ok' } as unknown as IContent;
+    });
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeFailoverConfig('glm-one-429'),
+      providerManager,
+    );
+
+    const chunks: IContent[] = [];
+    for await (const chunk of lb.generateChatCompletion(makeOptions())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(counter.value).toBe(2);
+  });
+
+  /**
+   * Streaming edge case (issue #2450 regression guard): when an immediate
+   * failover error (e.g. 429) occurs AFTER the backend has already yielded
+   * chunks to the consumer, the load balancer abandons the failover path and
+   * re-throws the RAW backend error rather than wrapping it in a
+   * LoadBalancerFailoverError. A partial stream cannot be silently retried
+   * against another backend, so the consumer must see the underlying status
+   * error, not the aggregate. This documents and guards that distinct path.
+   *
+   * The second backend's error is deliberately a distinct 500 (not a 429) so
+   * that `getErrorStatus(thrown) === 429` can only pass if the FIRST backend's
+   * error is the one re-thrown — not any 429 from any backend.
+   */
+  it('re-throws the raw backend error (not an aggregate) when a 429 occurs mid-stream after chunks were yielded', async () => {
+    const { provider, counter } = makeFakeProvider(function* (
+      attempt: number,
+    ): AsyncGenerator<IContent> {
+      if (attempt === 1) {
+        yield {
+          type: 'text' as const,
+          content: 'partial',
+        } as unknown as IContent;
+        throw statusError('rate limited', 429);
+      }
+      // A second backend must never be reached; use a distinct error so the
+      // 429 assertion can only pass via the FIRST backend's error.
+      throw statusError('second backend should not be reached', 500);
+      yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+    });
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeFailoverConfig('glm-midstream-429'),
+      providerManager,
+    );
+
+    const received: IContent[] = [];
+    let thrown: unknown;
+    try {
+      for await (const chunk of lb.generateChatCompletion(makeOptions())) {
+        received.push(chunk);
+      }
+    } catch (e) {
+      thrown = e;
+    }
+
+    // The partial chunk was delivered before the failure.
+    expect(received).toHaveLength(1);
+    // Because chunks were already yielded, the raw backend error is re-thrown
+    // instead of being collected into an aggregate.
+    expect(thrown).not.toBeInstanceOf(LoadBalancerFailoverError);
+    expect(getErrorStatus(thrown)).toBe(429);
+    // Only the first backend was ever invoked; no silent cross-backend retry.
+    expect(counter.value).toBe(1);
+  });
+
+  it('LoadBalancerAllContextLimitsExceededError is NON-retryable', () => {
+    const contextLimitError = new LoadBalancerContextLimitError({
+      profileName: 'glm',
+      subProfileName: 'zai',
+      tokens: 500000,
+      contextLimit: 128000,
+    });
+    const error = new LoadBalancerAllContextLimitsExceededError({
+      profileName: 'glm',
+      failures: [{ profile: 'zai', error: contextLimitError }],
+    });
+
+    expect(error.isRetryable).toBe(false);
+    expect(isRetryableError(error)).toBe(false);
+  });
+
+  describe('LoadBalancerFailoverError unit tests (isRetryable)', () => {
+    it('isRetryable is false for an empty failures array', () => {
+      const error = new LoadBalancerFailoverError('glm', []);
+      expect(error.isRetryable).toBe(false);
+      // The empty-array boundary must still produce a well-formed, status-less
+      // error (message construction must not depend on there being failures).
+      expect(getErrorStatus(error)).toBeUndefined();
+      expect(error.message).toBeTruthy();
+      expect(error.failures).toHaveLength(0);
+    });
+  });
+});

--- a/packages/providers/src/__tests__/LoadBalancingProvider.retryBoundary.integration.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.retryBoundary.integration.test.ts
@@ -1,0 +1,266 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * End-to-end integration tests for issue #2450: proving the Loopbreaker is
+ * actually fixed through the REAL retry boundary. A load-balancer `failover`
+ * profile whose backends all transiently 429 in a single rotation must be
+ * re-attempted as a whole rotation by the upstream `retryWithBackoff` layer
+ * (driven solely by the aggregate's `isRetryable` marker), NOT thrown fatally
+ * via the bucket-failover / `onPersistent429` path.
+ *
+ * These tests use the REAL `retryWithBackoff` from core wrapping a REAL
+ * `LoadBalancingProvider` (real `ProviderManager`, fake delegate providers).
+ * No mock theater — the unit under test is never mocked.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  LoadBalancingProvider,
+  type LoadBalancingProviderConfig,
+} from '../LoadBalancingProvider.js';
+import { LoadBalancerFailoverError } from '../errors.js';
+import type { IProvider } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions } from '../GenerateChatOptions.js';
+import {
+  retryWithBackoff,
+  isRetryableError,
+} from '@vybestack/llxprt-code-core/utils/retry.js';
+
+/** A mutable handle onto the fake delegate's behavior. */
+interface FakeBehavior {
+  /**
+   * Called with the 1-based global invocation count. Return a generator that
+   * either throws (per-backend failure) or yields a success chunk.
+   */
+  respond: (invocation: number) => AsyncGenerator<IContent>;
+}
+
+/** Build a fake delegate provider that records each invocation. */
+function makeFakeProvider(behavior: FakeBehavior): {
+  provider: IProvider;
+  counter: { value: number };
+} {
+  const counter = { value: 0 };
+  const provider: IProvider = {
+    name: 'test-provider',
+    async *generateChatCompletion(): AsyncGenerator<IContent> {
+      counter.value++;
+      yield* behavior.respond(counter.value);
+    },
+    getModels: async () => [],
+    getDefaultModel: () => 'test-model',
+    getServerTools: () => [],
+    invokeServerTool: async () => ({ content: [] }),
+  };
+  return { provider, counter };
+}
+
+/** Create a status-bearing error like the ones real providers throw. */
+function statusError(message: string, status: number): Error {
+  const error = new Error(message) as Error & { status: number };
+  error.status = status;
+  return error;
+}
+
+function makeOptions(): GenerateChatOptions {
+  return {
+    prompt: 'test prompt',
+    messages: [{ role: 'user' as const, content: 'test' }],
+  };
+}
+
+function makeFailoverConfig(profileName: string): LoadBalancingProviderConfig {
+  return {
+    profileName,
+    strategy: 'failover',
+    subProfiles: [
+      {
+        name: 'zai',
+        providerName: 'test-provider',
+        modelId: 'model1',
+        baseURL: 'https://api.test.com',
+        authToken: 'token-1',
+      },
+      {
+        name: 'makoraglm51',
+        providerName: 'test-provider',
+        modelId: 'model2',
+        baseURL: 'https://api.test.com',
+        authToken: 'token-2',
+      },
+      {
+        name: 'ollamaglm51',
+        providerName: 'test-provider',
+        modelId: 'model3',
+        baseURL: 'https://api.test.com',
+        authToken: 'token-3',
+      },
+    ],
+  };
+}
+
+const NUM_BACKENDS = 3;
+
+/** A generator that always throws a 429. */
+function* always429(): AsyncGenerator<IContent> {
+  throw statusError('rate limited', 429);
+  yield undefined as unknown as IContent; // eslint require-yield; unreachable after throw
+}
+
+/** A generator that yields a single success chunk. */
+function* successChunk(): AsyncGenerator<IContent> {
+  yield { type: 'text' as const, content: 'ok' } as unknown as IContent;
+}
+
+/**
+ * Because the LB throws lazily on the first pull, the retried `fn` must pull
+ * the first chunk itself (mirroring StreamProcessor._consumeFirstChunkAndReturn).
+ * On success it returns the first chunk so the caller can assert on it; on
+ * failure the LB aggregate error propagates out to retryWithBackoff.
+ */
+async function pullFirstChunk(
+  lb: LoadBalancingProvider,
+  options: GenerateChatOptions,
+): Promise<IContent> {
+  const it = lb.generateChatCompletion(options);
+  const first = await it.next();
+  if (first.done === true) {
+    throw new Error('stream ended immediately');
+  }
+  return first.value;
+}
+
+describe('LoadBalancingProvider retry boundary integration (issue #2450)', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let providerManager: ProviderManager;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = createRuntimeConfigStub(settingsService);
+    providerManager = new ProviderManager({ settingsService, config });
+  });
+
+  /**
+   * Scenario A (the core proof): fake delegates 429 on the ENTIRE first
+   * rotation (all 3 backends), then SUCCEED on the next rotation. The call
+   * must ultimately SUCCEED, proving the aggregate isRetryable marker drives
+   * a whole-rotation retry through normal bounded backoff.
+   *
+   * This test FAILS if isRetryable isn't honored (the aggregate is fatal) or
+   * if the aggregate is mis-classified as non-retryable.
+   */
+  it('Scenario A: retries a full failed all-429 rotation and succeeds on the next rotation', async () => {
+    const behavior: FakeBehavior = {
+      respond(invocation: number): AsyncGenerator<IContent> {
+        // First full rotation (invocations 1..NUM_BACKENDS) all 429, then
+        // succeed.
+        if (invocation <= NUM_BACKENDS) {
+          return always429();
+        }
+        return successChunk();
+      },
+    };
+    const { provider, counter } = makeFakeProvider(behavior);
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeFailoverConfig('glm-retry-then-success'),
+      providerManager,
+    );
+
+    const firstChunk = await retryWithBackoff(
+      () => pullFirstChunk(lb, makeOptions()),
+      {
+        shouldRetryOnError: (e) => isRetryableError(e),
+        maxAttempts: 3,
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+      },
+    );
+
+    expect(firstChunk).toStrictEqual({ type: 'text', content: 'ok' });
+    // First rotation failed (3 invocations), then the second rotation's first
+    // backend succeeded (1 more invocation).
+    expect(counter.value).toBe(NUM_BACKENDS + 1);
+  });
+
+  /**
+   * Scenario B (bounded + bucket-failover-path guard): ALL rotations always
+   * 429. The call must:
+   *   - reject with LoadBalancerFailoverError (the underlying aggregate), and
+   *   - do so after EXACTLY `maxAttempts` full rotations
+   *     (= maxAttempts × NUM_BACKENDS delegate invocations).
+   *
+   * Why the aggregate must NOT expose an HTTP `status` (the actual fix), and
+   * what this test guards:
+   *
+   * Inside retryWithBackoff, `classifyError` derives `is429` purely from the
+   * error's HTTP status (or an Anthropic overload body). The fixed aggregate
+   * has NO status, so `is429` is false, `attemptFailover` returns 'proceed'
+   * WITHOUT ever invoking `onPersistent429`, and recovery is driven solely by
+   * `isRetryableError` (the structural marker) under normal bounded retry —
+   * hence exactly maxAttempts × NUM_BACKENDS invocations.
+   *
+   * We deliberately wire `onPersistent429: async () => false` as a SAFETY NET
+   * to prove the negative: even with a bucket-failover callback present, the
+   * status-less aggregate never routes into it. Under the REJECTED `status =
+   * 429` design the aggregate WOULD reach `onPersistent429`; a `false` return
+   * there throws it fatally on attempt 1 (only NUM_BACKENDS invocations),
+   * whereas a `true` return decrements the attempt counter and loops
+   * unbounded. Asserting exactly maxAttempts × NUM_BACKENDS therefore fails
+   * under that design in both directions and passes only for the status-less
+   * fix. The callback is asserted to have been NEVER called to make the
+   * "bucket failover is not on the active path" guarantee explicit.
+   */
+  it('Scenario B: bounded by maxAttempts and never routes a status-less aggregate into bucket failover', async () => {
+    const behavior: FakeBehavior = {
+      respond(): AsyncGenerator<IContent> {
+        return always429();
+      },
+    };
+    const { provider, counter } = makeFakeProvider(behavior);
+    providerManager.registerProvider(provider);
+
+    const lb = new LoadBalancingProvider(
+      makeFailoverConfig('glm-always-429'),
+      providerManager,
+    );
+
+    const maxAttempts = 3;
+    let onPersistent429Calls = 0;
+    const failoverCallback = async (): Promise<boolean> => {
+      onPersistent429Calls++;
+      return false;
+    };
+
+    let thrown: unknown;
+    try {
+      await retryWithBackoff(() => pullFirstChunk(lb, makeOptions()), {
+        shouldRetryOnError: (e) => isRetryableError(e),
+        maxAttempts,
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        onPersistent429: failoverCallback,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(LoadBalancerFailoverError);
+    // Exactly maxAttempts full rotations × NUM_BACKENDS invocations. Not 1
+    // rotation (which a status-bearing aggregate would produce by routing into
+    // onPersistent429), and not unbounded.
+    expect(counter.value).toBe(maxAttempts * NUM_BACKENDS);
+    // The status-less aggregate is never classified as a 429, so the
+    // bucket-failover callback is never reached.
+    expect(onPersistent429Calls).toBe(0);
+  });
+});

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -10,7 +10,10 @@
  * @pseudocode consumer-migration.md lines 10-15
  */
 
-import { getErrorStatus } from '@vybestack/llxprt-code-core/utils/retry.js';
+import {
+  getErrorStatus,
+  isRetryableError,
+} from '@vybestack/llxprt-code-core/utils/retry.js';
 
 /**
  * Error thrown when authentication is required but not available
@@ -188,6 +191,21 @@ export class LoadBalancerFailoverError extends Error {
     readonly profile: string;
     readonly error: Error;
   }>;
+  /**
+   * Whether the aggregate failure is retryable by the upstream backoff layer.
+   * True only when EVERY recorded failure is transient/retryable (429, 5xx,
+   * network-transient, or overload). Mixed or client-error failures → false.
+   * (issue #2450)
+   *
+   * Note: the aggregate deliberately does NOT expose an HTTP `status`. An
+   * aggregate-of-failures is not itself an HTTP 429 response, and exposing a
+   * status would cause `retryWithBackoff` to mis-route the aggregate into the
+   * bucket-failover / `onPersistent429` path (which either throws it fatally
+   * before this marker is consulted, or binds its retry count to bucket
+   * state). Recovery is driven SOLELY by this `isRetryable` marker via normal
+   * bounded retry.
+   */
+  readonly isRetryable: boolean;
 
   constructor(
     profileName: string,
@@ -201,7 +219,43 @@ export class LoadBalancerFailoverError extends Error {
     this.name = 'LoadBalancerFailoverError';
     this.profileName = profileName;
     this.failures = failures;
+    this.isRetryable = computeAggregateRetryable(failures);
   }
+}
+
+/**
+ * Determine whether a single backend failure is transient/retryable for the
+ * purpose of LB-level aggregate classification. (issue #2450)
+ *
+ * Delegates to core's `isRetryableError` for all transient categories
+ * (network-transient, RetryableQuotaError, overload, 429, 5xx), then
+ * explicitly overrides 401/403 to NON-retryable because they indicate
+ * auth/config problems, not transient load. This avoids hand-syncing a
+ * duplicate precedence list — any new transient category added to
+ * `isRetryableError` is automatically honored here.
+ *
+ * Safe against recursion: this is called only on individual backend errors
+ * (`failures[].error`), never on a `LoadBalancerFailoverError` aggregate.
+ */
+function isTransientBackendFailure(error: Error): boolean {
+  if (!isRetryableError(error)) {
+    return false;
+  }
+  // Override: 401/403 are auth/config problems, not transient load.
+  const status = getErrorStatus(error);
+  if (status === 401 || status === 403) {
+    return false;
+  }
+  return true;
+}
+
+function computeAggregateRetryable(
+  failures: ReadonlyArray<{ readonly error: Error }>,
+): boolean {
+  if (failures.length === 0) {
+    return false;
+  }
+  return failures.every((f) => isTransientBackendFailure(f.error));
 }
 
 /**

--- a/packages/providers/src/loadBalancing/failoverSettings.ts
+++ b/packages/providers/src/loadBalancing/failoverSettings.ts
@@ -93,8 +93,15 @@ export function shouldFailover(
 /**
  * Check if an error should trigger immediate failover (no retry).
  *
+ * "Immediate failover" means: skip same-backend retry and move to the NEXT
+ * backend in THIS rotation. It does NOT mean the overall request is fatal or
+ * non-retryable. When all backends fail in a single pass the aggregate
+ * {@link LoadBalancerFailoverError} carries its own retryability metadata
+ * (issue #2450), allowing the upstream backoff layer to re-attempt a whole
+ * rotation rather than dropping the agent.
+ *
  * These status codes indicate the backend cannot serve requests
- * and retrying would be futile:
+ * and retrying the SAME backend would be futile:
  * - 429: Rate limited
  * - 401: Unauthorized (per Issue #902 spec; OAuth bucket failover has
  *        separate auto-renew logic that doesn't apply to load balancer)


### PR DESCRIPTION
## TLDR

A load-balancer `failover` profile whose backends all transiently return HTTP 429 in a single rotation was fatally dropping the agent back to the prompt ("Loopbreaker") instead of backing off and retrying the whole rotation. The root cause: `LoadBalancerFailoverError` carried no retryable metadata, so the upstream `retryWithBackoff` layer classified it as non-retryable and never re-attempted.

Fixes #2450

## Dive Deeper

### Root cause

When a `failover` LB profile exhausts all backends in one rotation (every backend returns 429), it throws `LoadBalancerFailoverError` — an aggregate of all per-backend failures. This error extended plain `Error` with no retryable metadata. Core's `isRetryableError()` checks for HTTP status, network-transient phrases, overload body types, and `RetryableQuotaError` — none of which the aggregate carried. So the upstream `retryWithBackoff` boundary (the ONLY backoff layer, since `RetryOrchestrator.shouldBypassRetry` intentionally bypasses the LB) classified the aggregate as non-retryable and fatally propagated it.

The user's experience: instead of seeing "rate limited, retrying..." with a backoff, the agent immediately drops to the prompt with a fatal error — even though all backends were only transiently rate-limited.

### The fix

**The aggregate self-classifies via a readonly `isRetryable` boolean marker.** Core's `isRetryableError` honors it via a **PRIORITY 0 structural check** (`Array.isArray(error.failures) && typeof error.isRetryable === 'boolean'`) — checked FIRST, before all heuristics. This is duck-typed so `packages/core` does NOT import from `packages/providers`.

The marker is `true` iff `failures.length > 0` AND every failure is transient. `isTransientBackendFailure` delegates to core's own `isRetryableError` for all transient categories (network-transient, RetryableQuotaError, overload, 429, 5xx), then overrides 401/403 to non-retryable (auth/config problems, not transient load). This eliminates hand-syncing a duplicate precedence list.

**The aggregate deliberately exposes NO HTTP `status`.** An aggregate-of-failures is not itself an HTTP 429 response. Exposing `status=429` would cause `classifyError` to mark `is429=true`, triggering `runRetryGuards → attemptFailover → onPersistent429 / _handleBucketFailover` BEFORE `shouldRetryOnError` is consulted. If bucket failover returns false → fatal throw on attempt 1 (Loopbreaker NOT fixed). If true → `state.attempt--` → unbounded retry loop. The status-less design routes recovery solely through the `isRetryable` marker under normal bounded retry.

### Why not fix the LB itself?

The LB already does one zero-delay rotation (429 = immediate failover to next backend via `isImmediateFailoverError`). The correct place for backoff-and-re-rotate is the upstream `retryWithBackoff` boundary. `StreamProcessor._consumeFirstChunkAndReturn` (issue #1750) eagerly pulls the first chunk INSIDE that boundary, so the lazily-thrown aggregate surfaces within `retryWithBackoff` — exactly where bounded backoff should handle it.

### How the StreamProcessor boundary works

`RetryOrchestrator.shouldBypassRetry` intentionally bypasses the LB (the LB has its own internal failover), so `StreamProcessor`'s `retryWithBackoff` is the ONLY backoff layer. Before this fix, if the aggregate was non-retryable, `retryWithBackoff` would not retry it — fatal. After this fix, the `isRetryable` marker drives a whole-rotation retry through normal bounded backoff.

## Reviewer Test Plan

1. Review `packages/providers/src/errors.ts` — the `isRetryable` field, `isTransientBackendFailure` (delegates to `isRetryableError` + 401/403 override), and `computeAggregateRetryable`.
2. Review `packages/core/src/utils/retry.ts` — the PRIORITY 0 structural marker block (lines ~241-254).
3. Run the targeted tests: `npx vitest run packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts packages/providers/src/__tests__/LoadBalancingProvider.retryBoundary.integration.test.ts`
4. Key assertions to verify:
   - All-429 aggregate → `isRetryable=true`, `isRetryableError(aggregate)=true`, `getErrorStatus(aggregate)=undefined`
   - Mixed (429 + 400) → `isRetryable=false`
   - All-RetryableQuotaError (Google quota, no HTTP status) → `isRetryable=true`
   - Scenario A: retry-then-success recovers after exactly NUM_BACKENDS+1 invocations
   - Scenario B: always-429 rejects after exactly maxAttempts × NUM_BACKENDS invocations (bounded, `onPersistent429` never called)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | CI  |
| npx      | ✅  | ❓  | CI  |
| Docker   | -   | -   | CI  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Local verification:

- `npm run typecheck` — 0 errors
- `npm run format` (prettier) — clean
- `npm run build --workspace @vybestack/llxprt-code-core` — clean
- eslint on all 6 changed files — exit 0
- `lint:eslint-guard` — passed (no suppressions, no threshold changes)
- Targeted vitest: 87 passed (53 core/retry + 15 retryable + 2 integration + 9 streaming + 8 errors)
- Open Code Review: 6 rounds, final round 0 comments (clean)

Notes:

- Full `eslint .` at the repository script's 8GB heap cap OOMs locally on Node 25; the same targets pass directly under Node 24 with 16GB heap. This is a known pre-existing local environment issue.
- Smoke test (`bun scripts/start.ts --profile-load ollamakimi "write me a haiku and nothing else"`) fails locally with `gpt-5.5 404 model not found` — a known local profile/settings model-resolution issue. The CLI boots end-to-end and reaches the API call.
- ~28 providers tests in `src/auth/__tests__/` (proactive-renewal fake-timer OAuth) fail locally — proven pre-existing via `git stash` + clean-branch run.

## Linked issues / bugs

Fixes #2450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved failover handling so retry decisions better reflect backend error conditions, including aggregate failures.
  * Added support for distinguishing retryable backend failures from permanent authorization-related failures.

* **Bug Fixes**
  * Fixed cases where mixed backend errors could be misclassified, improving retry behavior for 429, 5xx, quota, and transient network failures.
  * Preserved correct error details during streaming and failover, reducing incorrect fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->