### PR TITLE
feat(test): add Bun-backed root test orchestration entry point (Fixes #2463)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,11 +608,13 @@ jobs:
           bun install
           git checkout -- bun.lock
 
-      - name: 'Run test orchestrator behavioral tests'
+      - name: 'Run test orchestrator on a single workspace'
+        # Runs the orchestrator against one workspace with no actual test
+        # execution (--skip-scripts --skip-pretest). The only failure modes
+        # are bugs in the orchestrator itself (discovery, parsing, routing),
+        # which is exactly what this smoke check should surface.
         run: |-
-          bun scripts/test.ts --workspace test-utils --skip-scripts --skip-pretest || true
-        # The above is a smoke that the script runs and discovers workspaces;
-        # it may fail if test-utils has no tests or deps, so || true for now.
+          bun scripts/test.ts --workspace test-utils --skip-scripts --skip-pretest
 
       - name: 'Run script harness tests for the orchestrator'
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,6 +574,51 @@ jobs:
         run: 'node "$RUNNER_TEMP/llxprt-consumer/node_modules/.bin/llxprt" --version'
 
   #
+  # Bun-backed test orchestration smoke (issue #2463)
+  #
+  # Verifies that `bun scripts/test.ts` (the `test:bun` entry point) can
+  # discover all 16 workspaces, parse their test/pretest scripts, and produce
+  # a summary — using a dry-run mode that does not actually execute the
+  # workspace test suites. This catches regressions in the orchestrator itself
+  # without the cost of a full test matrix. The actual workspace tests still
+  # run under Vitest via the existing `test` job; this job only validates the
+  # Bun-backed orchestration script.
+  bun_test_orchestrator_smoke:
+    name: 'Bun Test Orchestrator Smoke'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    needs:
+      - 'skip_check'
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    permissions:
+      contents: 'read'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: 'Setup Bun'
+        uses: 'oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76' # ratchet:oven-sh/setup-bun@v2
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: 'Install dependencies'
+        run: |-
+          bun install
+          git checkout -- bun.lock
+
+      - name: 'Run test orchestrator behavioral tests'
+        run: |-
+          bun scripts/test.ts --workspace test-utils --skip-scripts --skip-pretest || true
+        # The above is a smoke that the script runs and discovers workspaces;
+        # it may fail if test-utils has no tests or deps, so || true for now.
+
+      - name: 'Run script harness tests for the orchestrator'
+        run: |-
+          bunx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/test-orchestrator.test.ts
+
+  #
   # Test: Node (Linux and macOS - always run)
   #
   # Stays on npm (not Bun) for S6 (#2243): Bun's hoisted linker non-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,12 +609,14 @@ jobs:
           git checkout -- bun.lock
 
       - name: 'Run test orchestrator on a single workspace'
-        # Runs the orchestrator against one workspace with no actual test
-        # execution (--skip-scripts --skip-pretest). The only failure modes
-        # are bugs in the orchestrator itself (discovery, parsing, routing),
-        # which is exactly what this smoke check should surface.
+        # Runs the orchestrator against one workspace. --skip-pretest skips
+        # pretest hooks (like the agents API-surface guard) to keep the smoke
+        # fast. The workspace's test phase still runs (vitest run), but
+        # test-utils has a tiny test suite. --skip-scripts skips the root
+        # script harness tests. The only failure modes that matter here are
+        # bugs in the orchestrator itself (discovery, parsing, routing).
         run: |-
-          bun scripts/test.ts --workspace test-utils --skip-scripts --skip-pretest
+          bun scripts/test.ts --workspace test-utils --skip-scripts
 
       - name: 'Run script harness tests for the orchestrator'
         run: |-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,39 @@ Type checking uses `tsc --noEmit`:
 bun run typecheck
 ```
 
+#### Bun-backed Test Orchestration
+
+The project also provides a Bun-backed root test entry point that preserves
+the same coverage and setup guarantees as `npm run test` (issue #2463):
+
+```bash
+bun run test:bun
+```
+
+This script (`scripts/test.ts`) orchestrates testing across all workspace
+packages using Bun as the runtime. Each workspace's tests still run under
+Vitest — not Bun's native test runner — so all Vitest-specific APIs
+(`vi.stubEnv`, `vi.unstubAllEnvs`, `vi.mocked`, `vi.setSystemTime`,
+`it.runIf`, etc.) and per-package `vitest.config.ts` configuration remain
+fully available.
+
+The script explicitly runs each workspace's `pretest` lifecycle hook before
+its test phase (npm does this automatically; Bun does not), so the agents
+API-surface guard and other pretest checks are preserved. It also runs the
+script harness tests (`scripts/tests/`) by default.
+
+Supported flags:
+
+```bash
+bun run test:bun -- --workspace core   # run only one workspace
+bun run test:bun -- --skip-scripts     # skip script harness tests
+bun run test:bun -- --skip-pretest     # skip pretest hooks
+bun run test:bun -- --continue-on-error # run all even if some fail
+```
+
+The `--workspace` flag accepts a package directory name (`core`), a relative
+path (`packages/core`), or a package name (`@vybestack/llxprt-code-core`).
+
 #### Integration Tests
 
 The integration tests are designed to validate the end-to-end functionality of LLxprt Code. They are not run as part of the default `bun run test` command.

--- a/dev-docs/bun.md
+++ b/dev-docs/bun.md
@@ -441,3 +441,70 @@ npm install
 
 Both commands produce a working, hoisted `node_modules` tree for all 16
 workspaces.
+
+## Bun-backed Test Orchestration (issue #2463)
+
+### Why `bun test` does not work as a root test entry point
+
+`bun test` invokes Bun's **native test runner**, which provides `bun:test`
+APIs (`describe`, `test`, `expect` from Bun). The repository's tests are
+written for **Vitest** and use Vitest-specific helper APIs that have no Bun
+equivalent:
+
+- `vi.stubEnv` / `vi.unstubAllEnvs` — environment-variable stubbing
+- `vi.mocked` — typed mock introspection
+- `vi.setSystemTime` — fake clock control
+- `it.runIf` — conditional test execution
+
+Additionally, Bun's `bun run <script>` does **not** invoke npm lifecycle
+hooks (`pretest` / `posttest`) the way `npm run <script>` does. The agents
+package uses a `pretest` hook to run its API-surface guard
+(`scripts/check-agents-api-surface.mjs`); running tests via `bun run test`
+would silently skip it.
+
+### The `test:bun` entry point
+
+The root `package.json` defines `test:bun`:
+
+```json
+"test:bun": "bun scripts/test.ts"
+```
+
+This script is a Bun-backed orchestrator that mirrors `npm run test
+--workspaces --if-present` (plus `test:scripts`). It:
+
+1. **Discovers all 16 workspaces** from the root `package.json` `workspaces`
+   array, reading each workspace's `package.json` to determine its `test`
+   and `pretest` scripts.
+
+2. **Runs `pretest` before `test`** for each workspace that declares one
+   (currently only `packages/agents`). This preserves the agents
+   API-surface guard and any future pretest hooks.
+
+3. **Runs each workspace's `test` script** (typically `vitest run`) in the
+   workspace directory with `node_modules/.bin` on `PATH`. Tests still run
+   under **Vitest**, not Bun's native test runner, so all Vitest APIs and
+   per-package `vitest.config.ts` configuration remain fully available.
+
+4. **Runs the script harness tests** (`scripts/tests/`) after workspace
+   tests, matching the root `test:scripts` script.
+
+### CLI flags
+
+| Flag                  | Shorthand | Description                                 |
+| --------------------- | --------- | ------------------------------------------- |
+| `--workspace <name>`  | `-w`      | Run only the matching workspace             |
+| `--skip-scripts`      |           | Skip the script harness tests               |
+| `--skip-pretest`      |           | Skip pretest lifecycle hooks                |
+| `--continue-on-error` | `-c`      | Continue after failures instead of stopping |
+
+The `--workspace` flag matches by directory name (`core`), relative path
+(`packages/core`), or package name (`@vybestack/llxprt-code-core`).
+
+### Relationship to `npm run test`
+
+Both paths run the same workspace Vitest suites and preserve the same
+pretest guards. The npm path (`npm run test`) remains the primary CI
+verification path; `test:bun` is the supported Bun-backed alternative. The
+npm path is not removed until the Bun-backed path is proven equivalent
+across all CI matrix legs.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "build:sandbox": "bun scripts/build_sandbox.ts --skip-npm-install-build",
     "bundle": "npm run generate && bun scripts/bun-build.config.mjs",
     "test": "npm run test --workspaces --if-present",
+    "test:bun": "bun scripts/test.ts",
     "test:ci": "cross-env NODE_OPTIONS=--max-old-space-size=6144 npm run test:ci --workspaces --if-present && npm run test:scripts",
     "test:scripts": "vitest run --config ./scripts/tests/vitest.config.ts",
     "test:interactive-ui": "cross-env LLXPRT_E2E_TMUX=1 vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/interactive-ui.test.ts --reporter=verbose",

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -265,10 +265,11 @@ export function orchestrateTests(
     ? allWorkspaces.filter((ws) => matchesFilter(ws, options.workspaceFilter!))
     : allWorkspaces;
 
-  const stopping = new Set<string>();
+  const failedWorkspaces = new Set<string>();
+  let skippedCount = 0;
 
   for (const workspace of workspaces) {
-    if (stopping.size > 0) {
+    if (failedWorkspaces.size > 0) {
       break;
     }
 
@@ -284,7 +285,8 @@ export function orchestrateTests(
     const shouldRunTest = workspace.hasTest && !skipTest;
 
     if (skipTest && !options.continueOnError) {
-      stopping.add(workspace.name);
+      failedWorkspaces.add(workspace.name);
+      skippedCount++;
     }
 
     if (shouldRunTest) {
@@ -298,16 +300,21 @@ export function orchestrateTests(
       results.push(testResult);
 
       if (!testResult.success && !options.continueOnError) {
-        stopping.add(workspace.name);
+        failedWorkspaces.add(workspace.name);
       }
     }
   }
 
-  if (stopping.size === 0) {
+  if (failedWorkspaces.size === 0) {
     runScriptTests(rootDir, options, runner, results);
   }
 
-  return buildSummary(results, workspaces.length, Date.now() - startTime);
+  return buildSummary(
+    results,
+    workspaces.length,
+    Date.now() - startTime,
+    skippedCount,
+  );
 }
 
 function runPretestPhase(
@@ -357,6 +364,7 @@ function buildSummary(
   results: TestPhaseResult[],
   totalWorkspaces: number,
   durationMs: number,
+  skipped: number,
 ): TestSummary {
   const passed = results.filter((r) => r.success).length;
   const failed = results.filter((r) => !r.success).length;
@@ -366,7 +374,7 @@ function buildSummary(
     totalWorkspaces,
     passed,
     failed,
-    skipped: 0,
+    skipped,
     durationMs,
   };
 }

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -394,8 +394,30 @@ function buildSummary(
   durationMs: number,
   skippedWorkspaces: string[],
 ): TestSummary {
-  const passed = results.filter((r) => r.success).length;
-  const failed = results.filter((r) => !r.success).length;
+  // Compute workspace-level outcomes so the summary counts are consistent
+  // with totalWorkspaces. Each workspace can produce multiple phase results
+  // (pretest + test); a workspace passes only if ALL its phases pass.
+  const workspaceOutcomes = new Map<string, boolean>();
+  for (const result of results) {
+    if (result.phase === 'scripts') {
+      continue;
+    }
+    const current = workspaceOutcomes.get(result.workspace);
+    workspaceOutcomes.set(
+      result.workspace,
+      (current ?? true) && result.success,
+    );
+  }
+
+  let passed = 0;
+  let failed = 0;
+  for (const success of workspaceOutcomes.values()) {
+    if (success) {
+      passed++;
+    } else {
+      failed++;
+    }
+  }
 
   return {
     results,

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -86,6 +86,7 @@ export interface TestSummary {
   passed: number;
   failed: number;
   skipped: number;
+  skippedWorkspaces: string[];
   durationMs: number;
 }
 
@@ -100,8 +101,25 @@ interface PackageJson {
 }
 
 function readPackageJson(filePath: string): PackageJson {
-  const raw = readFileSync(filePath, 'utf8');
-  return JSON.parse(raw) as PackageJson;
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `Failed to read package.json at ${filePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  try {
+    return JSON.parse(raw) as PackageJson;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse package.json at ${filePath} (invalid JSON): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }
 
 export function discoverWorkspaces(rootDir: string): WorkspaceInfo[] {
@@ -165,8 +183,9 @@ export function parseArgs(argv: readonly string[]): TestOptions {
       options.skipPretest = true;
     } else if (arg === '--continue-on-error' || arg === '-c') {
       options.continueOnError = true;
+    } else {
+      console.warn(`Warning: unknown argument "${arg}" — ignoring`);
     }
-    // Unknown arguments are silently ignored
 
     i++;
   }
@@ -266,11 +285,14 @@ export function orchestrateTests(
     : allWorkspaces;
 
   const failedWorkspaces = new Set<string>();
-  let skippedCount = 0;
+  const skippedWorkspaces: string[] = [];
 
   for (const workspace of workspaces) {
     if (failedWorkspaces.size > 0) {
-      break;
+      // A prior workspace failed in fail-fast mode; record this workspace
+      // as skipped so it appears in the summary output.
+      skippedWorkspaces.push(workspace.name);
+      continue;
     }
 
     const shouldRunPretest = workspace.hasPretest && !options.skipPretest;
@@ -286,7 +308,7 @@ export function orchestrateTests(
 
     if (skipTest && !options.continueOnError) {
       failedWorkspaces.add(workspace.name);
-      skippedCount++;
+      skippedWorkspaces.push(workspace.name);
     }
 
     if (shouldRunTest) {
@@ -313,7 +335,7 @@ export function orchestrateTests(
     results,
     workspaces.length,
     Date.now() - startTime,
-    skippedCount,
+    skippedWorkspaces,
   );
 }
 
@@ -364,7 +386,7 @@ function buildSummary(
   results: TestPhaseResult[],
   totalWorkspaces: number,
   durationMs: number,
-  skipped: number,
+  skippedWorkspaces: string[],
 ): TestSummary {
   const passed = results.filter((r) => r.success).length;
   const failed = results.filter((r) => !r.success).length;
@@ -374,7 +396,8 @@ function buildSummary(
     totalWorkspaces,
     passed,
     failed,
-    skipped,
+    skipped: skippedWorkspaces.length,
+    skippedWorkspaces,
     durationMs,
   };
 }
@@ -401,10 +424,18 @@ export function formatSummary(summary: TestSummary): string {
     );
   }
 
+  if (summary.skippedWorkspaces.length > 0) {
+    lines.push('  Skipped:');
+    for (const name of summary.skippedWorkspaces) {
+      lines.push(`    - ${name}`);
+    }
+  }
+
   lines.push('─────────────────────────────────────────────');
   lines.push(
     `  Workspaces: ${summary.totalWorkspaces}  ` +
       `Passed: ${summary.passed}  Failed: ${summary.failed}  ` +
+      `Skipped: ${summary.skipped}  ` +
       `Duration: ${durationLabel}`,
   );
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -280,8 +280,9 @@ export function orchestrateTests(
 
   const allWorkspaces = discoverWorkspaces(rootDir);
 
-  const workspaces = options.workspaceFilter
-    ? allWorkspaces.filter((ws) => matchesFilter(ws, options.workspaceFilter!))
+  const { workspaceFilter } = options;
+  const workspaces = workspaceFilter
+    ? allWorkspaces.filter((ws) => matchesFilter(ws, workspaceFilter))
     : allWorkspaces;
 
   const failedWorkspaces = new Set<string>();
@@ -307,8 +308,9 @@ export function orchestrateTests(
     const shouldRunTest = workspace.hasTest && !skipTest;
 
     if (skipTest && !options.continueOnError) {
+      // Pretest failed in fail-fast mode: the workspace has failed
+      // (recorded via its pretest TestPhaseResult), not skipped.
       failedWorkspaces.add(workspace.name);
-      skippedWorkspaces.push(workspace.name);
     }
 
     if (shouldRunTest) {
@@ -327,7 +329,11 @@ export function orchestrateTests(
     }
   }
 
-  if (failedWorkspaces.size === 0) {
+  // Skip script tests if any workspace phase failed, regardless of
+  // continue-on-error mode. Checking results (not failedWorkspaces)
+  // catches failures in both fail-fast and continue-on-error modes.
+  const anyPhaseFailed = results.some((r) => !r.success);
+  if (!anyPhaseFailed) {
     runScriptTests(rootDir, options, runner, results);
   }
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -197,6 +197,9 @@ export function parseArgs(argv: readonly string[]): TestOptions {
 // Command execution
 // ---------------------------------------------------------------------------
 
+// Mirrors `npm run` semantics: commands from package.json scripts are
+// executed through a shell. This relies on repository trust — package.json
+// files are part of the trusted source tree, just as they are for npm.
 export const defaultRunner: CommandRunner = (
   command,
   cwd,
@@ -258,7 +261,16 @@ function runPhase(
   runner: CommandRunner,
 ): TestPhaseResult {
   const start = Date.now();
-  const result = runner(command, cwd);
+  let result: { success: boolean; exitCode: number };
+  try {
+    result = runner(command, cwd);
+  } catch (error) {
+    result = {
+      success: false,
+      exitCode:
+        (propertyValue(error, 'status') as number | undefined) ?? 1,
+    };
+  }
   const durationMs = Date.now() - start;
 
   return {
@@ -326,6 +338,11 @@ export function orchestrateTests(
       if (!testResult.success && !options.continueOnError) {
         failedWorkspaces.add(workspace.name);
       }
+    } else if (!shouldRunPretest) {
+      // Workspace has neither a test nor a pretest script — nothing to run.
+      // Record it as skipped so passed + failed + skipped stays consistent
+      // with totalWorkspaces.
+      skippedWorkspaces.push(workspace.name);
     }
   }
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -267,8 +267,7 @@ function runPhase(
   } catch (error) {
     result = {
       success: false,
-      exitCode:
-        (propertyValue(error, 'status') as number | undefined) ?? 1,
+      exitCode: (propertyValue(error, 'status') as number | undefined) ?? 1,
     };
   }
   const durationMs = Date.now() - start;

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -156,6 +156,8 @@ export function parseArgs(argv: readonly string[]): TestOptions {
       i++;
       if (i < argv.length) {
         options.workspaceFilter = argv[i];
+      } else {
+        throw new Error('--workspace requires a value');
       }
     } else if (arg === '--skip-scripts') {
       options.skipScripts = true;
@@ -221,7 +223,8 @@ function matchesFilter(workspace: WorkspaceInfo, filter: string): boolean {
     return true;
   }
 
-  if (workspace.name.endsWith(filter)) {
+  const nameLastSegment = workspace.name.split('/').pop() ?? workspace.name;
+  if (nameLastSegment === filter) {
     return true;
   }
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -197,6 +197,10 @@ export function parseArgs(argv: readonly string[]): TestOptions {
 // Command execution
 // ---------------------------------------------------------------------------
 
+function extractExitCode(error: unknown): number {
+  return (propertyValue(error, 'status') as number | undefined) ?? 1;
+}
+
 // Mirrors `npm run` semantics: commands from package.json scripts are
 // executed through a shell. This relies on repository trust — package.json
 // files are part of the trusted source tree, just as they are for npm.
@@ -213,15 +217,17 @@ export const defaultRunner: CommandRunner = (
     });
     return { success: true, exitCode: 0 };
   } catch (error) {
-    const exitCode =
-      (propertyValue(error, 'status') as number | undefined) ?? 1;
-    return { success: false, exitCode };
+    return { success: false, exitCode: extractExitCode(error) };
   }
 };
 
 function createRunnerWithPATH(rootDir: string): CommandRunner {
   const nodeModulesBin = join(rootDir, 'node_modules', '.bin');
-  const pathEnv = `${nodeModulesBin}${delimiter}${process.env.PATH ?? ''}`;
+  const existingPath = process.env.PATH;
+  // Avoid trailing delimiter when PATH is unset (trailing ':' adds CWD on Unix)
+  const pathEnv = existingPath
+    ? `${nodeModulesBin}${delimiter}${existingPath}`
+    : nodeModulesBin;
 
   return (command, cwd, env = process.env) =>
     defaultRunner(command, cwd, { ...env, PATH: pathEnv });
@@ -265,10 +271,7 @@ function runPhase(
   try {
     result = runner(command, cwd);
   } catch (error) {
-    result = {
-      success: false,
-      exitCode: (propertyValue(error, 'status') as number | undefined) ?? 1,
-    };
+    result = { success: false, exitCode: extractExitCode(error) };
   }
   const durationMs = Date.now() - start;
 
@@ -507,25 +510,32 @@ function formatDuration(ms: number): string {
 // ---------------------------------------------------------------------------
 
 function main(): void {
-  const rootDir = resolve(__dirname, '..');
-  const options = parseArgs(process.argv.slice(2));
+  try {
+    const rootDir = resolve(__dirname, '..');
+    const options = parseArgs(process.argv.slice(2));
 
-  console.log('Running Bun-backed test orchestration...');
-  if (options.workspaceFilter) {
-    console.log(`  Filter: ${options.workspaceFilter}`);
-  }
-  if (options.skipScripts) {
-    console.log('  Skipping script harness tests');
-  }
-  if (options.skipPretest) {
-    console.log('  Skipping pretest hooks');
-  }
-  console.log('');
+    console.log('Running Bun-backed test orchestration...');
+    if (options.workspaceFilter) {
+      console.log(`  Filter: ${options.workspaceFilter}`);
+    }
+    if (options.skipScripts) {
+      console.log('  Skipping script harness tests');
+    }
+    if (options.skipPretest) {
+      console.log('  Skipping pretest hooks');
+    }
+    console.log('');
 
-  const summary = orchestrateTests(rootDir, options);
-  console.log(formatSummary(summary));
+    const summary = orchestrateTests(rootDir, options);
+    console.log(formatSummary(summary));
 
-  if (summary.failed > 0) {
+    if (summary.failed > 0) {
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error(
+      `Fatal error: ${error instanceof Error ? error.message : String(error)}`,
+    );
     process.exit(1);
   }
 }

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,0 +1,454 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Bun-backed root test orchestration script.
+ *
+ * Mirrors `npm run test --workspaces --if-present` (plus `test:scripts`)
+ * using Bun as the orchestration runtime. Each workspace's tests still run
+ * under Vitest — not Bun's native test runner — preserving per-package
+ * vitest.config.ts, setup files, coverage, and reporters.
+ *
+ * Why this exists (issue #2463):
+ *   `bun test` (Bun's native test runner) cannot run these tests because they
+ *   rely on Vitest-specific APIs (vi.stubEnv, vi.unstubAllEnvs, vi.mocked,
+ *   vi.setSystemTime, it.runIf, etc.) and per-package vitest configuration.
+ *   Additionally, Bun's `bun run <script>` does not invoke npm lifecycle
+ *   hooks (pretest/posttest) the way `npm run <script>` does, so the agents
+ *   API-surface guard would be silently skipped.
+ *
+ *   This script addresses both failure modes by design:
+ *   - Tests run under Vitest (the "compatibility setup" acceptance criterion),
+ *     so all Vitest helper APIs are available.
+ *   - Pretest hooks are run explicitly before each workspace's test phase.
+ *
+ * Usage:
+ *   bun scripts/test.ts                    # run all workspace + script tests
+ *   bun scripts/test.ts --workspace core   # run only the core workspace
+ *   bun scripts/test.ts --skip-scripts     # skip script harness tests
+ *   bun scripts/test.ts --skip-pretest     # skip pretest hooks
+ *   bun scripts/test.ts --continue-on-error # don't stop on first failure
+ *
+ * Or via package.json:
+ *   npm run test:bun
+ *   bun run test:bun
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { delimiter, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { propertyValue } from './utils/error-guards.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceInfo {
+  name: string;
+  relativePath: string;
+  absolutePath: string;
+  hasTest: boolean;
+  hasPretest: boolean;
+  testScript: string | undefined;
+  pretestScript: string | undefined;
+}
+
+export interface TestOptions {
+  workspaceFilter: string | undefined;
+  skipScripts: boolean;
+  skipPretest: boolean;
+  continueOnError: boolean;
+}
+
+export type CommandRunner = (
+  command: string,
+  cwd: string,
+  env?: NodeJS.ProcessEnv,
+) => { success: boolean; exitCode: number };
+
+export interface TestPhaseResult {
+  workspace: string;
+  phase: 'pretest' | 'test' | 'scripts';
+  success: boolean;
+  exitCode: number;
+  durationMs: number;
+}
+
+export interface TestSummary {
+  results: TestPhaseResult[];
+  totalWorkspaces: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Workspace discovery
+// ---------------------------------------------------------------------------
+
+interface PackageJson {
+  name?: string;
+  workspaces?: string[];
+  scripts?: Record<string, string>;
+}
+
+function readPackageJson(filePath: string): PackageJson {
+  const raw = readFileSync(filePath, 'utf8');
+  return JSON.parse(raw) as PackageJson;
+}
+
+export function discoverWorkspaces(rootDir: string): WorkspaceInfo[] {
+  const rootPkg = readPackageJson(join(rootDir, 'package.json'));
+  const workspaceGlobs = rootPkg.workspaces ?? [];
+
+  const results: WorkspaceInfo[] = [];
+
+  for (const glob of workspaceGlobs) {
+    const relativePath = glob;
+    const absolutePath = resolve(rootDir, relativePath);
+    const pkgJsonPath = join(absolutePath, 'package.json');
+
+    if (!existsSync(pkgJsonPath)) {
+      continue;
+    }
+
+    const pkg = readPackageJson(pkgJsonPath);
+    const scripts = pkg.scripts ?? {};
+
+    results.push({
+      name: pkg.name ?? relativePath,
+      relativePath,
+      absolutePath,
+      hasTest: 'test' in scripts,
+      hasPretest: 'pretest' in scripts,
+      testScript: scripts.test,
+      pretestScript: scripts.pretest,
+    });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+export function parseArgs(argv: readonly string[]): TestOptions {
+  const options: TestOptions = {
+    workspaceFilter: undefined,
+    skipScripts: false,
+    skipPretest: false,
+    continueOnError: false,
+  };
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+
+    if (arg === '--workspace' || arg === '-w') {
+      i++;
+      if (i < argv.length) {
+        options.workspaceFilter = argv[i];
+      }
+    } else if (arg === '--skip-scripts') {
+      options.skipScripts = true;
+    } else if (arg === '--skip-pretest') {
+      options.skipPretest = true;
+    } else if (arg === '--continue-on-error' || arg === '-c') {
+      options.continueOnError = true;
+    }
+    // Unknown arguments are silently ignored
+
+    i++;
+  }
+
+  return options;
+}
+
+// ---------------------------------------------------------------------------
+// Command execution
+// ---------------------------------------------------------------------------
+
+export const defaultRunner: CommandRunner = (
+  command,
+  cwd,
+  env = process.env,
+) => {
+  try {
+    execSync(command, {
+      cwd,
+      stdio: 'inherit',
+      env,
+    });
+    return { success: true, exitCode: 0 };
+  } catch (error) {
+    const exitCode =
+      (propertyValue(error, 'status') as number | undefined) ?? 1;
+    return { success: false, exitCode };
+  }
+};
+
+function createRunnerWithPATH(rootDir: string): CommandRunner {
+  const nodeModulesBin = join(rootDir, 'node_modules', '.bin');
+  const pathEnv = `${nodeModulesBin}${delimiter}${process.env.PATH ?? ''}`;
+
+  return (command, cwd, env = process.env) =>
+    defaultRunner(command, cwd, { ...env, PATH: pathEnv });
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+const SCRIPTS_TEST_COMMAND =
+  'vitest run --config ./scripts/tests/vitest.config.ts';
+const SCRIPTS_TEST_CONFIG = 'scripts/tests/vitest.config.ts';
+
+function matchesFilter(workspace: WorkspaceInfo, filter: string): boolean {
+  if (workspace.relativePath === filter || workspace.name === filter) {
+    return true;
+  }
+
+  const lastSegment = workspace.relativePath.split('/').pop() ?? '';
+  if (lastSegment === filter) {
+    return true;
+  }
+
+  if (workspace.name.endsWith(filter)) {
+    return true;
+  }
+
+  return false;
+}
+
+function runPhase(
+  workspaceName: string,
+  phase: 'pretest' | 'test' | 'scripts',
+  command: string,
+  cwd: string,
+  runner: CommandRunner,
+): TestPhaseResult {
+  const start = Date.now();
+  const result = runner(command, cwd);
+  const durationMs = Date.now() - start;
+
+  return {
+    workspace: workspaceName,
+    phase,
+    success: result.success,
+    exitCode: result.exitCode,
+    durationMs,
+  };
+}
+
+export function orchestrateTests(
+  rootDir: string,
+  options: TestOptions,
+  runner: CommandRunner = createRunnerWithPATH(rootDir),
+): TestSummary {
+  const results: TestPhaseResult[] = [];
+  const startTime = Date.now();
+
+  const allWorkspaces = discoverWorkspaces(rootDir);
+
+  const workspaces = options.workspaceFilter
+    ? allWorkspaces.filter((ws) => matchesFilter(ws, options.workspaceFilter!))
+    : allWorkspaces;
+
+  const stopping = new Set<string>();
+
+  for (const workspace of workspaces) {
+    if (stopping.size > 0) {
+      break;
+    }
+
+    const shouldRunPretest = workspace.hasPretest && !options.skipPretest;
+    const pretestPassed = runPretestPhase(
+      workspace,
+      shouldRunPretest,
+      runner,
+      results,
+    );
+
+    const skipTest = shouldRunPretest && !pretestPassed;
+    const shouldRunTest = workspace.hasTest && !skipTest;
+
+    if (skipTest && !options.continueOnError) {
+      stopping.add(workspace.name);
+    }
+
+    if (shouldRunTest) {
+      const testResult = runPhase(
+        workspace.name,
+        'test',
+        workspace.testScript!,
+        workspace.absolutePath,
+        runner,
+      );
+      results.push(testResult);
+
+      if (!testResult.success && !options.continueOnError) {
+        stopping.add(workspace.name);
+      }
+    }
+  }
+
+  if (stopping.size === 0) {
+    runScriptTests(rootDir, options, runner, results);
+  }
+
+  return buildSummary(results, workspaces.length, Date.now() - startTime);
+}
+
+function runPretestPhase(
+  workspace: WorkspaceInfo,
+  shouldRun: boolean,
+  runner: CommandRunner,
+  results: TestPhaseResult[],
+): boolean {
+  if (!shouldRun) {
+    return true;
+  }
+  const pretestResult = runPhase(
+    workspace.name,
+    'pretest',
+    workspace.pretestScript!,
+    workspace.absolutePath,
+    runner,
+  );
+  results.push(pretestResult);
+  return pretestResult.success;
+}
+
+function runScriptTests(
+  rootDir: string,
+  options: TestOptions,
+  runner: CommandRunner,
+  results: TestPhaseResult[],
+): void {
+  if (options.skipScripts) {
+    return;
+  }
+  const scriptConfigPath = join(rootDir, SCRIPTS_TEST_CONFIG);
+  if (!existsSync(scriptConfigPath)) {
+    return;
+  }
+  const scriptResult = runPhase(
+    'scripts',
+    'scripts',
+    SCRIPTS_TEST_COMMAND,
+    rootDir,
+    runner,
+  );
+  results.push(scriptResult);
+}
+
+function buildSummary(
+  results: TestPhaseResult[],
+  totalWorkspaces: number,
+  durationMs: number,
+): TestSummary {
+  const passed = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  return {
+    results,
+    totalWorkspaces,
+    passed,
+    failed,
+    skipped: 0,
+    durationMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Summary formatting
+// ---------------------------------------------------------------------------
+
+export function formatSummary(summary: TestSummary): string {
+  const lines: string[] = [];
+  const durationLabel = formatDuration(summary.durationMs);
+
+  lines.push('');
+  lines.push('─────────────────────────────────────────────');
+  lines.push('  Test Orchestration Summary');
+  lines.push('─────────────────────────────────────────────');
+
+  for (const result of summary.results) {
+    const status = result.success ? 'PASS' : 'FAIL';
+    const duration = formatDuration(result.durationMs);
+    const phaseLabel = result.phase.padEnd(8);
+    lines.push(
+      `  ${status}  ${phaseLabel}  ${result.workspace}  (${duration})`,
+    );
+  }
+
+  lines.push('─────────────────────────────────────────────');
+  lines.push(
+    `  Workspaces: ${summary.totalWorkspaces}  ` +
+      `Passed: ${summary.passed}  Failed: ${summary.failed}  ` +
+      `Duration: ${durationLabel}`,
+  );
+
+  if (summary.failed > 0) {
+    lines.push('  Result: FAILED');
+  } else {
+    lines.push('  Result: PASSED');
+  }
+
+  lines.push('─────────────────────────────────────────────');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const rootDir = resolve(__dirname, '..');
+  const options = parseArgs(process.argv.slice(2));
+
+  console.log('Running Bun-backed test orchestration...');
+  if (options.workspaceFilter) {
+    console.log(`  Filter: ${options.workspaceFilter}`);
+  }
+  if (options.skipScripts) {
+    console.log('  Skipping script harness tests');
+  }
+  if (options.skipPretest) {
+    console.log('  Skipping pretest hooks');
+  }
+  console.log('');
+
+  const summary = orchestrateTests(rootDir, options);
+  console.log(formatSummary(summary));
+
+  if (summary.failed > 0) {
+    process.exit(1);
+  }
+}
+
+// Run main when executed directly (not when imported)
+const isDirectRun =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  main();
+}

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -616,7 +616,7 @@ describe('dummy', () => { it('passes', () => { expect(1).toBe(1); }); });`,
     );
     // Pretest-only workspace runs its pretest and is counted as passed
     expect(commands.some((c) => c.command === 'echo pretest')).toBe(true);
-    expect(summary.passed).toBeGreaterThanOrEqual(1);
+    expect(summary.passed).toBe(2);
     // Summary counts must be consistent: passed + failed + skipped = total
     expect(summary.passed + summary.failed + summary.skipped).toBe(
       summary.totalWorkspaces,

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -9,6 +9,7 @@ import {
   existsSync,
   mkdtempSync,
   rmSync,
+  readFileSync,
   writeFileSync,
   mkdirSync,
 } from 'node:fs';
@@ -29,7 +30,11 @@ const fixtures: string[] = [];
 afterEach(() => {
   while (fixtures.length > 0) {
     const dir = fixtures.pop()!;
-    rmSync(dir, { recursive: true, force: true });
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (err) {
+      console.warn(`Failed to clean up temp dir ${dir}:`, err);
+    }
   }
 });
 
@@ -94,9 +99,15 @@ function createFixtureRepo(
 }
 
 describe('discoverWorkspaces', () => {
-  it('finds all 16 declared workspaces from the real repo root', () => {
+  it('finds all declared workspaces from the real repo root', () => {
     const workspaces = discoverWorkspaces(repoRoot);
-    expect(workspaces).toHaveLength(16);
+    const rootPkg = JSON.parse(
+      readFileSync(join(repoRoot, 'package.json'), 'utf-8'),
+    ) as { workspaces?: string[] };
+    const expectedCount = (rootPkg.workspaces ?? []).filter((g) =>
+      existsSync(join(repoRoot, g, 'package.json')),
+    ).length;
+    expect(workspaces).toHaveLength(expectedCount);
   });
 
   it('detects the pretest script in the agents package', () => {
@@ -197,6 +208,16 @@ describe('parseArgs', () => {
   it('ignores unknown arguments', () => {
     const opts = parseArgs(['--unknown-flag', '--workspace', 'tools']);
     expect(opts.workspaceFilter).toBe('tools');
+  });
+
+  it('throws when --workspace has no value', () => {
+    expect(() => parseArgs(['--workspace'])).toThrow(
+      '--workspace requires a value',
+    );
+  });
+
+  it('throws when -w shorthand has no value', () => {
+    expect(() => parseArgs(['-w'])).toThrow('--workspace requires a value');
   });
 });
 

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -592,6 +592,36 @@ describe('dummy', () => { it('passes', () => { expect(1).toBe(1); }); });`,
     expect(summary.failed).toBe(0);
     expect(summary.durationMs).toBeGreaterThanOrEqual(0);
   });
+
+  it('handles workspace with pretest but no test script', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/pretest-only',
+        name: 'pkg-pretest-only',
+        scripts: { pretest: 'echo pretest' },
+      },
+      {
+        dir: 'packages/normal',
+        name: 'pkg-normal',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      runner,
+    );
+    // Pretest-only workspace runs its pretest and is counted as passed
+    expect(commands.some((c) => c.command === 'echo pretest')).toBe(true);
+    expect(summary.passed).toBeGreaterThanOrEqual(1);
+    // Summary counts must be consistent: passed + failed + skipped = total
+    expect(summary.passed + summary.failed + summary.skipped).toBe(
+      summary.totalWorkspaces,
+    );
+  });
 });
 
 describe('formatSummary', () => {

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -259,10 +259,13 @@ describe('parseArgs', () => {
 
   it('warns on unknown arguments but still parses known ones', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    const opts = parseArgs(['--unknown-flag', '--workspace', 'tools']);
-    expect(opts.workspaceFilter).toBe('tools');
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
+    try {
+      const opts = parseArgs(['--unknown-flag', '--workspace', 'tools']);
+      expect(opts.workspaceFilter).toBe('tools');
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('throws when --workspace has no value', () => {
@@ -563,9 +566,17 @@ describe('dummy', () => { it('passes', () => { expect(1).toBe(1); }); });`,
       },
     ]);
 
-    orchestrateTests(root, parseArgs(['--skip-scripts']), failingPretest);
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      failingPretest,
+    );
     const testRan = commands.some((c) => c.command === 'vitest run');
     expect(testRan).toBe(false);
+    expect(summary.failed).toBeGreaterThan(0);
+    const pretestResult = summary.results.find((r) => r.phase === 'pretest');
+    expect(pretestResult).toBeDefined();
+    expect(pretestResult!.success).toBe(false);
   });
 
   it('returns a summary with total counts', () => {
@@ -618,6 +629,35 @@ describe('dummy', () => { it('passes', () => { expect(1).toBe(1); }); });`,
     expect(commands.some((c) => c.command === 'echo pretest')).toBe(true);
     expect(summary.passed).toBe(2);
     // Summary counts must be consistent: passed + failed + skipped = total
+    expect(summary.passed + summary.failed + summary.skipped).toBe(
+      summary.totalWorkspaces,
+    );
+  });
+
+  it('skips workspace with neither pretest nor test script', () => {
+    const { runner } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/no-scripts',
+        name: 'pkg-no-scripts',
+        scripts: { build: 'echo build' },
+      },
+      {
+        dir: 'packages/normal',
+        name: 'pkg-normal',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      runner,
+    );
+    // No-scripts workspace is skipped; normal workspace passes
+    expect(summary.passed).toBe(1);
+    expect(summary.skipped).toBe(1);
     expect(summary.passed + summary.failed + summary.skipped).toBe(
       summary.totalWorkspaces,
     );

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   existsSync,
   mkdtempSync,
@@ -110,14 +110,36 @@ describe('discoverWorkspaces', () => {
     expect(workspaces).toHaveLength(expectedCount);
   });
 
-  it('detects the pretest script in the agents package', () => {
-    const workspaces = discoverWorkspaces(repoRoot);
-    const agents = workspaces.find(
-      (w) => w.name === '@vybestack/llxprt-code-agents',
+  it('detects a pretest script via fixture repo', () => {
+    const fixtureRoot = createFixtureRepo([
+      {
+        dir: 'packages/with-pretest',
+        name: 'fixture-pretest-pkg',
+        scripts: {
+          pretest: 'echo running pretest',
+          test: 'vitest run',
+        },
+      },
+      {
+        dir: 'packages/no-pretest',
+        name: 'fixture-no-pretest-pkg',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const workspaces = discoverWorkspaces(fixtureRoot);
+    const withPretest = workspaces.find(
+      (w) => w.name === 'fixture-pretest-pkg',
     );
-    expect(agents).toBeDefined();
-    expect(agents!.hasPretest).toBe(true);
-    expect(agents!.pretestScript).toContain('check-agents-api-surface');
+    expect(withPretest).toBeDefined();
+    expect(withPretest!.hasPretest).toBe(true);
+    expect(withPretest!.pretestScript).toContain('pretest');
+
+    const withoutPretest = workspaces.find(
+      (w) => w.name === 'fixture-no-pretest-pkg',
+    );
+    expect(withoutPretest).toBeDefined();
+    expect(withoutPretest!.hasPretest).toBe(false);
   });
 
   it('detects test scripts in all workspaces', () => {
@@ -145,12 +167,24 @@ describe('discoverWorkspaces', () => {
     }
   });
 
-  it('reads workspace names from package.json', () => {
-    const workspaces = discoverWorkspaces(repoRoot);
+  it('reads workspace names from a fixture repo', () => {
+    const fixtureRoot = createFixtureRepo([
+      {
+        dir: 'packages/alpha',
+        name: 'fixture-alpha',
+        scripts: { test: 'vitest run' },
+      },
+      {
+        dir: 'packages/beta',
+        name: 'fixture-beta',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const workspaces = discoverWorkspaces(fixtureRoot);
     const names = workspaces.map((w) => w.name);
-    expect(names).toContain('@vybestack/llxprt-code-core');
-    expect(names).toContain('@vybestack/llxprt-code-agents');
-    expect(names).toContain('@vybestack/llxprt-code-tools');
+    expect(names).toContain('fixture-alpha');
+    expect(names).toContain('fixture-beta');
   });
 });
 
@@ -206,8 +240,11 @@ describe('parseArgs', () => {
   });
 
   it('warns on unknown arguments but still parses known ones', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const opts = parseArgs(['--unknown-flag', '--workspace', 'tools']);
     expect(opts.workspaceFilter).toBe('tools');
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it('throws when --workspace has no value', () => {

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -290,7 +290,7 @@ describe('orchestrateTests', () => {
       },
     ]);
 
-    const opts: TestOptions = { skipPretest: true };
+    const opts: TestOptions = { ...parseArgs([]), skipPretest: true };
     orchestrateTests(root, opts, runner);
     expect(commands).toHaveLength(1);
     expect(commands[0].command).toBe('vitest run');
@@ -360,7 +360,7 @@ describe('orchestrateTests', () => {
       },
     ]);
 
-    const opts: TestOptions = { continueOnError: true };
+    const opts: TestOptions = { ...parseArgs([]), continueOnError: true };
     const summary = orchestrateTests(root, opts, failingForA);
     expect(summary.failed).toBe(1);
     expect(summary.passed).toBeGreaterThanOrEqual(1);
@@ -384,7 +384,10 @@ describe('orchestrateTests', () => {
       },
     ]);
 
-    const opts: TestOptions = { workspaceFilter: 'packages/b' };
+    const opts: TestOptions = {
+      ...parseArgs([]),
+      workspaceFilter: 'packages/b',
+    };
     const summary = orchestrateTests(root, opts, runner);
     expect(summary.totalWorkspaces).toBe(1);
     expect(commands).toHaveLength(1);
@@ -407,7 +410,7 @@ describe('orchestrateTests', () => {
       },
     ]);
 
-    const opts: TestOptions = { workspaceFilter: 'pkg-a' };
+    const opts: TestOptions = { ...parseArgs([]), workspaceFilter: 'pkg-a' };
     const summary = orchestrateTests(root, opts, runner);
     expect(summary.totalWorkspaces).toBe(1);
     expect(commands).toHaveLength(1);
@@ -451,7 +454,7 @@ describe('orchestrateTests', () => {
 
     mkdirSync(join(root, 'scripts', 'tests'), { recursive: true });
 
-    const opts: TestOptions = { skipScripts: true };
+    const opts: TestOptions = { ...parseArgs([]), skipScripts: true };
     orchestrateTests(root, opts, runner);
     const scriptTest = commands.find((c) => c.command.includes('scripts'));
     expect(scriptTest).toBeUndefined();

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -205,19 +205,17 @@ describe('parseArgs', () => {
     expect(opts.continueOnError).toBe(true);
   });
 
-  it('ignores unknown arguments', () => {
+  it('warns on unknown arguments but still parses known ones', () => {
     const opts = parseArgs(['--unknown-flag', '--workspace', 'tools']);
     expect(opts.workspaceFilter).toBe('tools');
   });
 
   it('throws when --workspace has no value', () => {
-    expect(() => parseArgs(['--workspace'])).toThrow(
-      '--workspace requires a value',
-    );
+    expect(() => parseArgs(['--workspace'])).toThrow(/requires a value/u);
   });
 
   it('throws when -w shorthand has no value', () => {
-    expect(() => parseArgs(['-w'])).toThrow('--workspace requires a value');
+    expect(() => parseArgs(['-w'])).toThrow(/requires a value/u);
   });
 });
 
@@ -432,6 +430,11 @@ describe('orchestrateTests', () => {
     writeFileSync(
       join(root, 'scripts', 'tests', 'vitest.config.ts'),
       'export default {};',
+    );
+    writeFileSync(
+      join(root, 'scripts', 'tests', 'dummy.test.ts'),
+      `import { describe, it, expect } from 'vitest';
+describe('dummy', () => { it('passes', () => { expect(1).toBe(1); }); });`,
     );
 
     orchestrateTests(root, parseArgs([]), runner);

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -142,11 +142,30 @@ describe('discoverWorkspaces', () => {
     expect(withoutPretest!.hasPretest).toBe(false);
   });
 
-  it('detects test scripts in all workspaces', () => {
-    const workspaces = discoverWorkspaces(repoRoot);
-    for (const ws of workspaces) {
-      expect(ws.hasTest, `${ws.name} should have a test script`).toBe(true);
-    }
+  it('detects test scripts via fixture repo', () => {
+    const fixtureRoot = createFixtureRepo([
+      {
+        dir: 'packages/with-test',
+        name: 'fixture-with-test',
+        scripts: { test: 'vitest run' },
+      },
+      {
+        dir: 'packages/without-test',
+        name: 'fixture-without-test',
+        scripts: { build: 'echo build' },
+      },
+    ]);
+
+    const workspaces = discoverWorkspaces(fixtureRoot);
+    const withTest = workspaces.find((w) => w.name === 'fixture-with-test');
+    expect(withTest).toBeDefined();
+    expect(withTest!.hasTest).toBe(true);
+
+    const withoutTest = workspaces.find(
+      (w) => w.name === 'fixture-without-test',
+    );
+    expect(withoutTest).toBeDefined();
+    expect(withoutTest!.hasTest).toBe(false);
   });
 
   it('returns absolute paths that actually exist', () => {
@@ -162,7 +181,9 @@ describe('discoverWorkspaces', () => {
   it('returns relative paths relative to root', () => {
     const workspaces = discoverWorkspaces(repoRoot);
     for (const ws of workspaces) {
-      expect(ws.relativePath).toMatch(/^packages\//);
+      // relativePath must be genuinely relative (not absolute)
+      expect(ws.relativePath).not.toMatch(/^\//u);
+      // and must resolve to the same absolute path
       expect(resolve(repoRoot, ws.relativePath)).toBe(ws.absolutePath);
     }
   });

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -20,6 +20,7 @@ import {
   parseArgs,
   type CommandRunner,
   type TestOptions,
+  type TestSummary,
   orchestrateTests,
   formatSummary,
 } from '../test.ts';
@@ -61,10 +62,6 @@ function writePackageJson(
 
 function succeedingRunner(): CommandRunner {
   return () => ({ success: true, exitCode: 0 });
-}
-
-function failingRunner(): CommandRunner {
-  return () => ({ success: false, exitCode: 1 });
 }
 
 function createFixtureRepo(
@@ -598,54 +595,59 @@ describe('dummy', () => { it('passes', () => { expect(1).toBe(1); }); });`,
 });
 
 describe('formatSummary', () => {
+  function makeSummary(overrides: Partial<TestSummary> = {}): TestSummary {
+    return {
+      results: [],
+      totalWorkspaces: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      skippedWorkspaces: [],
+      durationMs: 100,
+      ...overrides,
+    };
+  }
+
   it('formats a passing summary', () => {
-    const summary = orchestrateTests(
-      createFixtureRepo([
+    const summary = makeSummary({
+      results: [
         {
-          dir: 'packages/a',
-          name: 'pkg-a',
-          scripts: { test: 'vitest run' },
+          workspace: 'pkg-a',
+          phase: 'test',
+          success: true,
+          exitCode: 0,
+          durationMs: 50,
         },
-      ]),
-      parseArgs(['--skip-scripts']),
-      succeedingRunner(),
-    );
+      ],
+      totalWorkspaces: 1,
+      passed: 1,
+    });
     const output = formatSummary(summary);
     expect(output).toContain('PASS');
     expect(output).toContain('pkg-a');
   });
 
   it('formats a failing summary', () => {
-    const root = createFixtureRepo([
-      {
-        dir: 'packages/a',
-        name: 'pkg-a',
-        scripts: { test: 'vitest run' },
-      },
-    ]);
-    const summary = orchestrateTests(
-      root,
-      parseArgs(['--skip-scripts']),
-      failingRunner(),
-    );
+    const summary = makeSummary({
+      results: [
+        {
+          workspace: 'pkg-a',
+          phase: 'test',
+          success: false,
+          exitCode: 1,
+          durationMs: 50,
+        },
+      ],
+      totalWorkspaces: 1,
+      failed: 1,
+    });
     const output = formatSummary(summary);
     expect(output).toContain('FAIL');
     expect(output).toContain('pkg-a');
   });
 
   it('includes duration information', () => {
-    const root = createFixtureRepo([
-      {
-        dir: 'packages/a',
-        name: 'pkg-a',
-        scripts: { test: 'vitest run' },
-      },
-    ]);
-    const summary = orchestrateTests(
-      root,
-      parseArgs(['--skip-scripts']),
-      succeedingRunner(),
-    );
+    const summary = makeSummary({ durationMs: 100 });
     const output = formatSummary(summary);
     expect(output).toMatch(/Duration:.*(?:ms|s)/u);
     expect(output).toMatch(/[0-9]/u);

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -1,0 +1,567 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  discoverWorkspaces,
+  parseArgs,
+  type CommandRunner,
+  type TestOptions,
+  orchestrateTests,
+  formatSummary,
+} from '../test.ts';
+
+const repoRoot = resolve(__dirname, '..', '..');
+const fixtures: string[] = [];
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'test-orch-'));
+  fixtures.push(dir);
+  return dir;
+}
+
+function writePackageJson(
+  dir: string,
+  scripts: Record<string, string>,
+  name = 'fixture-pkg',
+): void {
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify(
+      { name, version: '0.0.0', type: 'module', scripts },
+      null,
+      2,
+    ),
+  );
+}
+
+function succeedingRunner(): CommandRunner {
+  return () => ({ success: true, exitCode: 0 });
+}
+
+function failingRunner(): CommandRunner {
+  return () => ({ success: false, exitCode: 1 });
+}
+
+function createFixtureRepo(
+  workspaces: Array<{
+    dir: string;
+    name: string;
+    scripts: Record<string, string>;
+  }>,
+): string {
+  const root = createFixture();
+  const wsPaths: string[] = [];
+  for (const ws of workspaces) {
+    const wsDir = join(root, ws.dir);
+    mkdirSync(wsDir, { recursive: true });
+    writePackageJson(wsDir, ws.scripts, ws.name);
+    wsPaths.push(ws.dir);
+  }
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'fixture-root',
+        version: '0.0.0',
+        private: true,
+        workspaces: wsPaths,
+      },
+      null,
+      2,
+    ),
+  );
+  return root;
+}
+
+describe('discoverWorkspaces', () => {
+  it('finds all 16 declared workspaces from the real repo root', () => {
+    const workspaces = discoverWorkspaces(repoRoot);
+    expect(workspaces).toHaveLength(16);
+  });
+
+  it('detects the pretest script in the agents package', () => {
+    const workspaces = discoverWorkspaces(repoRoot);
+    const agents = workspaces.find(
+      (w) => w.name === '@vybestack/llxprt-code-agents',
+    );
+    expect(agents).toBeDefined();
+    expect(agents!.hasPretest).toBe(true);
+    expect(agents!.pretestScript).toContain('check-agents-api-surface');
+  });
+
+  it('detects test scripts in all workspaces', () => {
+    const workspaces = discoverWorkspaces(repoRoot);
+    for (const ws of workspaces) {
+      expect(ws.hasTest, `${ws.name} should have a test script`).toBe(true);
+    }
+  });
+
+  it('returns absolute paths that actually exist', () => {
+    const workspaces = discoverWorkspaces(repoRoot);
+    for (const ws of workspaces) {
+      expect(
+        existsSync(ws.absolutePath),
+        `${ws.absolutePath} should exist`,
+      ).toBe(true);
+    }
+  });
+
+  it('returns relative paths relative to root', () => {
+    const workspaces = discoverWorkspaces(repoRoot);
+    for (const ws of workspaces) {
+      expect(ws.relativePath).toMatch(/^packages\//);
+      expect(resolve(repoRoot, ws.relativePath)).toBe(ws.absolutePath);
+    }
+  });
+
+  it('reads workspace names from package.json', () => {
+    const workspaces = discoverWorkspaces(repoRoot);
+    const names = workspaces.map((w) => w.name);
+    expect(names).toContain('@vybestack/llxprt-code-core');
+    expect(names).toContain('@vybestack/llxprt-code-agents');
+    expect(names).toContain('@vybestack/llxprt-code-tools');
+  });
+});
+
+describe('parseArgs', () => {
+  it('returns defaults with no arguments', () => {
+    const opts = parseArgs([]);
+    expect(opts.workspaceFilter).toBeUndefined();
+    expect(opts.skipScripts).toBe(false);
+    expect(opts.skipPretest).toBe(false);
+    expect(opts.continueOnError).toBe(false);
+  });
+
+  it('parses --workspace with a value', () => {
+    const opts = parseArgs(['--workspace', 'core']);
+    expect(opts.workspaceFilter).toBe('core');
+  });
+
+  it('parses -w shorthand for --workspace', () => {
+    const opts = parseArgs(['-w', 'agents']);
+    expect(opts.workspaceFilter).toBe('agents');
+  });
+
+  it('parses --skip-scripts', () => {
+    const opts = parseArgs(['--skip-scripts']);
+    expect(opts.skipScripts).toBe(true);
+  });
+
+  it('parses --skip-pretest', () => {
+    const opts = parseArgs(['--skip-pretest']);
+    expect(opts.skipPretest).toBe(true);
+  });
+
+  it('parses --continue-on-error', () => {
+    const opts = parseArgs(['--continue-on-error']);
+    expect(opts.continueOnError).toBe(true);
+  });
+
+  it('parses -c shorthand for --continue-on-error', () => {
+    const opts = parseArgs(['-c']);
+    expect(opts.continueOnError).toBe(true);
+  });
+
+  it('parses multiple flags together', () => {
+    const opts = parseArgs([
+      '-w',
+      'core',
+      '--skip-scripts',
+      '--continue-on-error',
+    ]);
+    expect(opts.workspaceFilter).toBe('core');
+    expect(opts.skipScripts).toBe(true);
+    expect(opts.continueOnError).toBe(true);
+  });
+
+  it('ignores unknown arguments', () => {
+    const opts = parseArgs(['--unknown-flag', '--workspace', 'tools']);
+    expect(opts.workspaceFilter).toBe('tools');
+  });
+});
+
+describe('orchestrateTests', () => {
+  function createRecordingRunner(): {
+    runner: CommandRunner;
+    commands: Array<{ command: string; cwd: string }>;
+  } {
+    const commands: Array<{ command: string; cwd: string }> = [];
+    const runner: CommandRunner = (command, cwd) => {
+      commands.push({ command, cwd });
+      return { success: true, exitCode: 0 };
+    };
+    return { runner, commands };
+  }
+
+  function createFailingForRunner(
+    failCommand: string,
+    failCwdSuffix: string,
+  ): {
+    runner: CommandRunner;
+    commands: Array<{ command: string; cwd: string }>;
+  } {
+    const commands: Array<{ command: string; cwd: string }> = [];
+    const runner: CommandRunner = (command, cwd) => {
+      commands.push({ command, cwd });
+      if (command === failCommand && cwd.endsWith(failCwdSuffix)) {
+        return { success: false, exitCode: 1 };
+      }
+      return { success: true, exitCode: 0 };
+    };
+    return { runner, commands };
+  }
+
+  it('runs pretest before test for workspaces that have pretest', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: {
+          pretest: 'echo pretest',
+          test: 'vitest run',
+        },
+      },
+    ]);
+
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      runner,
+    );
+    expect(summary.passed).toBe(2);
+    expect(commands[0].command).toBe('echo pretest');
+    expect(commands[1].command).toBe('vitest run');
+  });
+
+  it('skips pretest when --skip-pretest is set', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: {
+          pretest: 'echo pretest',
+          test: 'vitest run',
+        },
+      },
+    ]);
+
+    const opts: TestOptions = { skipPretest: true };
+    orchestrateTests(root, opts, runner);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].command).toBe('vitest run');
+  });
+
+  it('runs only test (no pretest) for workspaces without pretest', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    orchestrateTests(root, parseArgs(['--skip-scripts']), runner);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].command).toBe('vitest run');
+  });
+
+  it('fails fast by default when a test fails', () => {
+    const { runner: failingForA, commands } = createFailingForRunner(
+      'vitest run',
+      'packages/a',
+    );
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+      {
+        dir: 'packages/b',
+        name: 'pkg-b',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      failingForA,
+    );
+    expect(summary.failed).toBeGreaterThan(0);
+    const ranB = commands.some((c) => c.cwd.endsWith('packages/b'));
+    expect(ranB).toBe(false);
+  });
+
+  it('continues on error when --continue-on-error is set', () => {
+    const { runner: failingForA, commands } = createFailingForRunner(
+      'vitest run',
+      'packages/a',
+    );
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+      {
+        dir: 'packages/b',
+        name: 'pkg-b',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const opts: TestOptions = { continueOnError: true };
+    const summary = orchestrateTests(root, opts, failingForA);
+    expect(summary.failed).toBe(1);
+    expect(summary.passed).toBeGreaterThanOrEqual(1);
+    const ranB = commands.some((c) => c.cwd.endsWith('packages/b'));
+    expect(ranB).toBe(true);
+  });
+
+  it('filters to a specific workspace by directory name', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+      {
+        dir: 'packages/b',
+        name: 'pkg-b',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const opts: TestOptions = { workspaceFilter: 'packages/b' };
+    const summary = orchestrateTests(root, opts, runner);
+    expect(summary.totalWorkspaces).toBe(1);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].cwd.endsWith('packages/b')).toBe(true);
+  });
+
+  it('filters by workspace package name', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+      {
+        dir: 'packages/b',
+        name: 'pkg-b',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const opts: TestOptions = { workspaceFilter: 'pkg-a' };
+    const summary = orchestrateTests(root, opts, runner);
+    expect(summary.totalWorkspaces).toBe(1);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].cwd.endsWith('packages/a')).toBe(true);
+  });
+
+  it('runs script tests by default', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    mkdirSync(join(root, 'scripts', 'tests'), { recursive: true });
+    writeFileSync(
+      join(root, 'scripts', 'tests', 'vitest.config.ts'),
+      'export default {};',
+    );
+
+    orchestrateTests(root, parseArgs([]), runner);
+    const scriptTest = commands.find(
+      (c) => c.command.includes('vitest') && c.command.includes('scripts'),
+    );
+    expect(scriptTest).toBeDefined();
+  });
+
+  it('skips script tests when --skip-scripts is set', () => {
+    const { runner, commands } = createRecordingRunner();
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    mkdirSync(join(root, 'scripts', 'tests'), { recursive: true });
+
+    const opts: TestOptions = { skipScripts: true };
+    orchestrateTests(root, opts, runner);
+    const scriptTest = commands.find((c) => c.command.includes('scripts'));
+    expect(scriptTest).toBeUndefined();
+  });
+
+  it('reports pretest failure as a separate phase', () => {
+    const { runner: failingPretest } = createFailingForRunner(
+      'echo pretest',
+      'packages/a',
+    );
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: {
+          pretest: 'echo pretest',
+          test: 'vitest run',
+        },
+      },
+    ]);
+
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      failingPretest,
+    );
+    const pretestResult = summary.results.find((r) => r.phase === 'pretest');
+    expect(pretestResult).toBeDefined();
+    expect(pretestResult!.success).toBe(false);
+  });
+
+  it('skips test phase when pretest fails (fail-fast)', () => {
+    const { runner: failingPretest, commands } = createFailingForRunner(
+      'echo pretest',
+      'packages/a',
+    );
+
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: {
+          pretest: 'echo pretest',
+          test: 'vitest run',
+        },
+      },
+    ]);
+
+    orchestrateTests(root, parseArgs(['--skip-scripts']), failingPretest);
+    const testRan = commands.some((c) => c.command === 'vitest run');
+    expect(testRan).toBe(false);
+  });
+
+  it('returns a summary with total counts', () => {
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+      {
+        dir: 'packages/b',
+        name: 'pkg-b',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      succeedingRunner(),
+    );
+    expect(summary.totalWorkspaces).toBe(2);
+    expect(summary.passed).toBe(2);
+    expect(summary.failed).toBe(0);
+    expect(summary.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('formatSummary', () => {
+  it('formats a passing summary', () => {
+    const summary = orchestrateTests(
+      createFixtureRepo([
+        {
+          dir: 'packages/a',
+          name: 'pkg-a',
+          scripts: { test: 'vitest run' },
+        },
+      ]),
+      parseArgs(['--skip-scripts']),
+      succeedingRunner(),
+    );
+    const output = formatSummary(summary);
+    expect(output).toContain('PASS');
+    expect(output).toContain('pkg-a');
+  });
+
+  it('formats a failing summary', () => {
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      failingRunner(),
+    );
+    const output = formatSummary(summary);
+    expect(output).toContain('FAIL');
+    expect(output).toContain('pkg-a');
+  });
+
+  it('includes duration information', () => {
+    const root = createFixtureRepo([
+      {
+        dir: 'packages/a',
+        name: 'pkg-a',
+        scripts: { test: 'vitest run' },
+      },
+    ]);
+    const summary = orchestrateTests(
+      root,
+      parseArgs(['--skip-scripts']),
+      succeedingRunner(),
+    );
+    const output = formatSummary(summary);
+    expect(output).toMatch(/Duration:.*(?:ms|s)/u);
+    expect(output).toMatch(/[0-9]/u);
+  });
+});

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -327,7 +327,8 @@ describe('orchestrateTests', () => {
       parseArgs(['--skip-scripts']),
       runner,
     );
-    expect(summary.passed).toBe(2);
+    // 1 workspace with pretest + test both passing = 1 workspace passed
+    expect(summary.passed).toBe(1);
     expect(commands[0].command).toBe('echo pretest');
     expect(commands[1].command).toBe('vitest run');
   });


### PR DESCRIPTION
## Summary

Addresses GitHub issue #2463: Support Bun-backed root test verification.

`bun test` (Bun's native test runner) cannot run this repository's tests because they rely on Vitest-specific APIs (`vi.stubEnv`, `vi.unstubAllEnvs`, `vi.mocked`, `vi.setSystemTime`, `it.runIf`, etc.) and per-package `vitest.config.ts` configuration. Additionally, `bun run <script>` does not invoke npm lifecycle hooks (`pretest`), so the agents API-surface guard would be silently skipped.

This PR provides an equivalent Bun-backed top-level script (`test:bun`) that preserves the same coverage and setup guarantees as the current project scripts.

## Changes

### `scripts/test.ts` — Bun-backed test orchestrator
- Discovers all 16 workspaces from the root `package.json` `workspaces` array
- Reads each workspace's `package.json` to determine `test` and `pretest` scripts
- Runs `pretest` before `test` for each workspace that declares one (currently `packages/agents`)
- Each workspace's tests still run under **Vitest** (not Bun's native test runner), preserving all Vitest APIs and per-package config
- Runs the script harness tests (`scripts/tests/`) after workspace tests
- Supports `--workspace`, `--skip-scripts`, `--skip-pretest`, `--continue-on-error` flags
- Exports `discoverWorkspaces`, `parseArgs`, `orchestrateTests`, `formatSummary` for testing

### `scripts/tests/test-orchestrator.test.ts` — Behavioral tests (30 tests)
- `discoverWorkspaces`: finds all 16 workspaces, detects pretest in agents, detects test scripts in all workspaces, validates absolute/relative paths
- `parseArgs`: all flags, shorthands, defaults, unknown args
- `orchestrateTests`: pretest-before-test ordering, skip-pretest, fail-fast vs continue-on-error, workspace filtering by dir name and package name, script tests inclusion/skipping, pretest failure reporting, summary counts
- `formatSummary`: passing/failing summary formatting, duration info
- Uses fixture-based temp repos and recording runners (no real test execution in tests)

### `package.json`
- Adds `"test:bun": "bun scripts/test.ts"` script

### `.github/workflows/ci.yml`
- Adds additive `Bun Test Orchestrator Smoke` CI job that validates the orchestrator behavioral tests

### `CONTRIBUTING.md`
- Documents the `test:bun` entry point, flags, and relationship to `npm run test`

### `dev-docs/bun.md`
- Documents why `bun test` does not work as a root test entry point
- Documents the `test:bun` script, its behavior, CLI flags, and relationship to the npm path

## Acceptance criteria checklist

- [x] Root-level Bun-backed test entry point runs all intended workspace tests with package-specific setup and pretest guards preserved
- [x] Vitest-oriented helper usage is supported through compatibility (tests run under Vitest, not Bun's native runner)
- [x] The agents API-surface guard and other package pretest checks are still executed
- [x] CI documents and uses the supported Bun-backed entry point where appropriate
- [x] The previous project-script verification remains available (npm path unchanged)
- [x] Direct-run failure modes from the observed run are addressed by design

Fixes #2463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Bun-backed test command (`test:bun`) to orchestrate workspace tests with options for selecting workspaces and controlling failure behavior.
  * Expanded CI with a fast Bun-backed smoke job that verifies the test orchestrator using a targeted Vitest run.

* **Documentation**
  * Documented “Bun-backed Test Orchestration,” including the new command and supported CLI flags.

* **Tests**
  * Added a comprehensive Vitest suite for workspace discovery, CLI parsing, orchestration flow, and summary formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->