### PR TITLE
Isolate tmux harness from nested sessions (Fixes #2469)

### DIFF
--- a/scripts/tests/tmux-harness-io.test.js
+++ b/scripts/tests/tmux-harness-io.test.js
@@ -1,0 +1,423 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for issue #2469: tmux harness isolation.
+ *
+ * scripts/tmux-harness-io.mjs must invoke every tmux command through a
+ * dedicated private socket (-S <path>) and must scrub the inherited tmux
+ * client environment variables (TMUX, TMUX_PANE, TMUX_TMPDIR) from the
+ * subprocess environment so harness commands can never attach to / mutate an
+ * outer tmux server that llxprt happens to be running inside.
+ *
+ * These tests mock node:child_process spawnSync and never start a real tmux
+ * server.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Capture spawnSync calls. The module under test imports `spawnSync` from
+// `node:child_process`, so we mock that specifier.
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args) => spawnSyncMock(...args),
+}));
+
+// Re-import fresh after the mock is registered so the module binds to the
+// mocked spawnSync.
+const {
+  runTmux,
+  tryTmux,
+  buildTmuxSocketArgs,
+  getTmuxSocketPath,
+  cleanupTmuxSocketDir,
+  TMUX_ENV_KEYS,
+} = await import('../tmux-harness-io.mjs');
+
+/**
+ * Default successful spawnSync return value (utf8 encoding => stdout is a
+ * string).
+ */
+function okReturn(stdout = '') {
+  return {
+    stdout,
+    stderr: '',
+    status: 0,
+    error: undefined,
+  };
+}
+
+function expectKillServerCall() {
+  const killServerCall = spawnSyncMock.mock.calls.find(([, args]) =>
+    args.includes('kill-server'),
+  );
+  expect(killServerCall).toBeDefined();
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+  spawnSyncMock.mockReturnValue(okReturn(''));
+  cleanupTmuxSocketDir();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  spawnSyncMock.mockReset();
+  spawnSyncMock.mockReturnValue(okReturn(''));
+  // Remove the lazily-created socket temp directory if any test created one.
+  cleanupTmuxSocketDir();
+});
+
+describe('issue #2469: cleanupTmuxSocketDir', () => {
+  it('is a safe no-op when nothing was created', () => {
+    expect(() => cleanupTmuxSocketDir()).not.toThrow();
+    expect(() => cleanupTmuxSocketDir()).not.toThrow();
+  });
+
+  it('exports the expected tmux environment keys', () => {
+    expect(TMUX_ENV_KEYS).toEqual(['TMUX', 'TMUX_PANE', 'TMUX_TMPDIR']);
+  });
+
+  it('keeps the cached socket path when cleanup fails', () => {
+    const socketPath = getTmuxSocketPath();
+    const rmSyncSpy = vi.spyOn(fs, 'rmSync').mockImplementation(() => {
+      throw new Error('EBUSY');
+    });
+
+    try {
+      expect(() => cleanupTmuxSocketDir()).not.toThrow();
+      expectKillServerCall();
+      expect(getTmuxSocketPath()).toBe(socketPath);
+    } finally {
+      rmSyncSpy.mockRestore();
+    }
+    cleanupTmuxSocketDir();
+  });
+
+  it('keeps the cached socket path when kill-server fails', () => {
+    const socketPath = getTmuxSocketPath();
+    spawnSyncMock.mockReturnValue({
+      stdout: '',
+      stderr: 'kill failed',
+      status: 1,
+      error: undefined,
+    });
+
+    expect(() => cleanupTmuxSocketDir()).not.toThrow();
+    expectKillServerCall();
+    expect(getTmuxSocketPath()).toBe(socketPath);
+    expect(fs.existsSync(path.dirname(socketPath))).toBe(true);
+  });
+
+  it('removes the socket directory when kill-server reports no server running', () => {
+    const socketPath = getTmuxSocketPath();
+    const dir = path.dirname(socketPath);
+    spawnSyncMock.mockReturnValue({
+      stdout: '',
+      stderr: 'no server running',
+      status: 1,
+      error: undefined,
+    });
+
+    expect(() => cleanupTmuxSocketDir()).not.toThrow();
+    expectKillServerCall();
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('keeps the cached socket path when kill-server has a spawn error', () => {
+    const socketPath = getTmuxSocketPath();
+    spawnSyncMock.mockReturnValue({
+      stdout: '',
+      stderr: '',
+      status: null,
+      error: new Error('spawn tmux ENOENT'),
+    });
+
+    expect(() => cleanupTmuxSocketDir()).not.toThrow();
+    expectKillServerCall();
+    expect(getTmuxSocketPath()).toBe(socketPath);
+    expect(fs.existsSync(path.dirname(socketPath))).toBe(true);
+  });
+
+  it('keeps the cached socket path when kill-server throws synchronously', () => {
+    const socketPath = getTmuxSocketPath();
+    spawnSyncMock.mockImplementation(() => {
+      throw new Error('sync throw in kill-server');
+    });
+
+    expect(() => cleanupTmuxSocketDir()).not.toThrow();
+    expectKillServerCall();
+    expect(getTmuxSocketPath()).toBe(socketPath);
+    expect(fs.existsSync(path.dirname(socketPath))).toBe(true);
+  });
+});
+
+describe('issue #2469: lazy socket temp directory', () => {
+  it('does not create a temp directory until getTmuxSocketPath is called', () => {
+    // After cleanupTmuxSocketDir, the socket path is null. Simply importing
+    // the module must not create any temp directory. Calling getTmuxSocketPath
+    // lazily creates one.
+    cleanupTmuxSocketDir();
+
+    const socketPath = getTmuxSocketPath();
+    const dir = path.dirname(socketPath);
+    expect(dir).toMatch(/llxprt-tmux-harness-/);
+    expect(fs.existsSync(dir)).toBe(true);
+
+    cleanupTmuxSocketDir();
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+});
+
+describe('issue #2469: tmux socket isolation', () => {
+  it('exposes a stable private socket path in a unique temp directory', () => {
+    const socketPath = getTmuxSocketPath();
+    expect(typeof socketPath).toBe('string');
+    expect(socketPath.length).toBeGreaterThan(0);
+    // Must be a -S style socket path (a filesystem path), not a fixed -L name.
+    expect(socketPath).toMatch(/llxprt-tmux-harness-[^/]+\/tmux\.sock$/);
+    expect(getTmuxSocketPath()).toBe(socketPath);
+  });
+
+  it('creates a new directory after cleanup and re-access', () => {
+    const first = getTmuxSocketPath();
+    const firstDir = path.dirname(first);
+
+    cleanupTmuxSocketDir();
+
+    const second = getTmuxSocketPath();
+    const secondDir = path.dirname(second);
+    expect(second).not.toBe(first);
+    expect(fs.existsSync(firstDir)).toBe(false);
+    expect(fs.existsSync(secondDir)).toBe(true);
+  });
+
+  it('prefixes tmux args with -S <private socket path>', () => {
+    runTmux(['list-sessions']);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const [command, args] = spawnSyncMock.mock.calls[0];
+    const socketPath = getTmuxSocketPath();
+    expect(command).toBe('tmux');
+    expect(args[0]).toBe('-S');
+    expect(args[1]).toBe(socketPath);
+    // The caller-provided args follow the socket flag.
+    expect(args.slice(2)).toEqual(['list-sessions']);
+  });
+
+  it('uses the dedicated socket flag rather than a fixed -L name', () => {
+    runTmux(['kill-session', '-t', 'foo']);
+    const [, args] = spawnSyncMock.mock.calls[0];
+    // -S (socket path) is the isolation mechanism, not -L (named local socket).
+    expect(args[0]).toBe('-S');
+    expect(args[1]).toBe(getTmuxSocketPath());
+    expect(args).not.toContain('-L');
+  });
+
+  it('lazily creates the socket path on the first runTmux call', () => {
+    cleanupTmuxSocketDir();
+
+    runTmux(['list-sessions']);
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnSyncMock.mock.calls[0];
+    expect(args[0]).toBe('-S');
+    expect(args[1]).toMatch(/llxprt-tmux-harness-[^/]+\/tmux\.sock$/);
+    expect(fs.existsSync(path.dirname(args[1]))).toBe(true);
+  });
+});
+
+describe('issue #2469: scrub inherited tmux client env vars', () => {
+  it('does not pass TMUX/TMUX_PANE/TMUX_TMPDIR through even when set in process.env', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1234,0');
+    vi.stubEnv('TMUX_PANE', '%1');
+    vi.stubEnv('TMUX_TMPDIR', '/tmp/tmux-1000');
+
+    runTmux(['list-sessions']);
+
+    const [, , options] = spawnSyncMock.mock.calls[0];
+    for (const key of TMUX_ENV_KEYS) {
+      expect(options.env).not.toHaveProperty(key);
+    }
+  });
+
+  it('scrubs tmux env vars when caller passes options.env explicitly', () => {
+    vi.stubEnv('MY_PROCESS_VAR', 'survives-merge');
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,9999,0');
+    vi.stubEnv('TMUX_PANE', '%99');
+    vi.stubEnv('TMUX_TMPDIR', '/tmp/tmux-1000');
+    runTmux(['list-sessions'], {
+      env: {
+        TMUX: '/tmp/tmux-1000/default,1234,0',
+        TMUX_PANE: '%2',
+        TMUX_TMPDIR: '/tmp/tmux-1000',
+        MY_VAR: 'keep-me',
+      },
+    });
+
+    const [, , options] = spawnSyncMock.mock.calls[0];
+    for (const key of TMUX_ENV_KEYS) {
+      expect(options.env).not.toHaveProperty(key);
+    }
+    // The merge of process.env plus caller env is covered: a process.env var
+    // survives alongside the caller-provided var.
+    expect(options.env.MY_PROCESS_VAR).toBe('survives-merge');
+    expect(options.env.MY_VAR).toBe('keep-me');
+  });
+
+  it('preserves non-tmux env vars from process.env', () => {
+    vi.stubEnv('MY_PROCESS_VAR', 'process-value');
+    runTmux(['list-sessions']);
+    const [, , options] = spawnSyncMock.mock.calls[0];
+    expect(options.env.MY_PROCESS_VAR).toBe('process-value');
+  });
+
+  it('preserves non-tmux env vars and other options from caller options.env', () => {
+    runTmux(['list-sessions'], {
+      cwd: '/some/cwd',
+      env: {
+        MY_VAR: 'keep-me',
+        PATH: '/usr/bin:/bin',
+      },
+    });
+
+    const [, , options] = spawnSyncMock.mock.calls[0];
+    expect(options.env.MY_VAR).toBe('keep-me');
+    expect(options.env.PATH).toBe('/usr/bin:/bin');
+    expect(options.cwd).toBe('/some/cwd');
+    // encoding default preserved.
+    expect(options.encoding).toBe('utf8');
+  });
+
+  it('handles options without an env property gracefully', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1234,0');
+    runTmux(['list-sessions'], { cwd: '/some/cwd' });
+
+    const [, , options] = spawnSyncMock.mock.calls[0];
+    expect(options.cwd).toBe('/some/cwd');
+    expect(options.encoding).toBe('utf8');
+    for (const key of TMUX_ENV_KEYS) {
+      expect(options.env).not.toHaveProperty(key);
+    }
+  });
+
+  it('forces utf8 encoding even when caller attempts to override it', () => {
+    runTmux(['list-sessions'], {
+      encoding: 'buffer',
+      env: {},
+    });
+
+    const [, , options] = spawnSyncMock.mock.calls[0];
+    expect(options.encoding).toBe('utf8');
+  });
+});
+
+describe('issue #2469: error messages include socket flag', () => {
+  it('throws an error whose message includes the -S socket flag on failure', () => {
+    spawnSyncMock.mockReturnValue({
+      stdout: '',
+      stderr: 'no server running',
+      status: 1,
+      error: undefined,
+    });
+
+    // Capture the thrown error so the message assertions are guaranteed to
+    // run (a bare try/catch after a separate toThrow can be silently skipped).
+    let thrown = null;
+    try {
+      runTmux(['list-sessions']);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).not.toBeNull();
+    expect(thrown.message).toContain('-S');
+    // Should include the private socket path verbatim.
+    expect(thrown.message).toContain(getTmuxSocketPath());
+  });
+
+  it('tryTmux swallows failures from isolated tmux invocations', () => {
+    spawnSyncMock.mockReturnValue({
+      stdout: '',
+      stderr: 'boom',
+      status: 1,
+      error: undefined,
+    });
+    // tryTmux must invoke tmux through the isolated socket even though it
+    // swallows failures, so assert the spawn args start with -S <socket>.
+    expect(tryTmux(['list-sessions'])).toBeNull();
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnSyncMock.mock.calls[0];
+    expect(args[0]).toBe('-S');
+    expect(args[1]).toBe(getTmuxSocketPath());
+  });
+
+  it('tryTmux also scrubs inherited tmux env vars', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1234,0');
+    vi.stubEnv('TMUX_PANE', '%1');
+    vi.stubEnv('TMUX_TMPDIR', '/tmp/tmux-1000');
+
+    expect(tryTmux(['list-sessions'])).toBe('');
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const [, , options] = spawnSyncMock.mock.calls[0];
+    for (const key of TMUX_ENV_KEYS) {
+      expect(options.env).not.toHaveProperty(key);
+    }
+  });
+
+  it('tryTmux returns stdout content on success', () => {
+    spawnSyncMock.mockReturnValue(okReturn('session1\nsession2'));
+
+    expect(tryTmux(['list-sessions'])).toBe('session1\nsession2');
+  });
+
+  it('throws the raw spawn error when spawnSync returns an error property', () => {
+    const spawnError = new Error('spawn tmux ENOENT');
+    spawnSyncMock.mockReturnValue({
+      stdout: '',
+      stderr: '',
+      status: null,
+      error: spawnError,
+    });
+
+    expect(() => runTmux(['list-sessions'])).toThrow(spawnError);
+  });
+
+  it('propagates a synchronous spawn throw through runTmux', () => {
+    const spawnError = new Error('sync throw');
+    spawnSyncMock.mockImplementation(() => {
+      throw spawnError;
+    });
+
+    expect(() => runTmux(['list-sessions'])).toThrow(spawnError);
+  });
+
+  it('swallows a synchronous spawn throw through tryTmux', () => {
+    spawnSyncMock.mockImplementation(() => {
+      throw new Error('sync throw');
+    });
+
+    expect(tryTmux(['list-sessions'])).toBeNull();
+  });
+});
+
+describe('buildTmuxSocketArgs pure helper', () => {
+  it('prepends -S <socket path> to the provided args', () => {
+    const result = buildTmuxSocketArgs(['list-sessions']);
+    expect(result[0]).toBe('-S');
+    expect(result[1]).toBe(getTmuxSocketPath());
+    expect(result.slice(2)).toEqual(['list-sessions']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = ['list-sessions'];
+    buildTmuxSocketArgs(input);
+    expect(input).toEqual(['list-sessions']);
+  });
+});

--- a/scripts/tmux-harness-io.mjs
+++ b/scripts/tmux-harness-io.mjs
@@ -17,6 +17,7 @@
 import { spawnSync } from 'node:child_process';
 import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
 import {
@@ -25,11 +26,121 @@ import {
   sanitizeLabel,
 } from './tmux-harness-helpers.mjs';
 
+/**
+ * Tmux client environment variables that, when inherited, can cause harness
+ * tmux commands to attach to and mutate an outer tmux server that llxprt is
+ * running inside. These must always be scrubbed from the subprocess env.
+ */
+export const TMUX_ENV_KEYS = ['TMUX', 'TMUX_PANE', 'TMUX_TMPDIR'];
+
+/**
+ * Lazily-created private tmux socket path. Using -S with a socket inside a
+ * unique temp directory guarantees concurrent harness runs each get their own
+ * tmux server and can never collide with or attach to an outer server.
+ *
+ * The temp directory and socket path are created on first access rather than
+ * at module load so that importing this module has no filesystem side effect
+ * and cannot crash on import. The created directory can later be cleaned up
+ * via {@link cleanupTmuxSocketDir}.
+ */
+let tmuxSocketPath = null;
+let tmuxSocketDir = null;
+
+export function getTmuxSocketPath() {
+  if (tmuxSocketPath === null) {
+    tmuxSocketDir = fsSync.mkdtempSync(
+      path.join(os.tmpdir(), 'llxprt-tmux-harness-'),
+    );
+    tmuxSocketPath = path.join(tmuxSocketDir, 'tmux.sock');
+  }
+  return tmuxSocketPath;
+}
+
+function killedOrMissingTmuxServer(result) {
+  if (result.status === 0) {
+    return true;
+  }
+  if (result.status === null) {
+    return false;
+  }
+  const stderr = (result.stderr ?? '').toString();
+  return stderr.includes('no server running');
+}
+
+/**
+ * Remove the lazily-created tmux socket temp directory, if one was created.
+ * After successful cleanup, subsequent calls are no-ops. Ambiguous kill-server
+ * failures preserve the socket directory and cached paths so callers can retry
+ * cleanup without orphaning a live server by deleting its only socket.
+ * Callers that intentionally keep the tmux session/server alive
+ * (e.g. --keep-session) must NOT call this, as the socket path is required to
+ * access the kept server.
+ */
+export function cleanupTmuxSocketDir() {
+  if (tmuxSocketDir === null) {
+    return;
+  }
+  if (tmuxSocketPath !== null) {
+    try {
+      const killResult = spawnSync(
+        'tmux',
+        ['-S', tmuxSocketPath, 'kill-server'],
+        buildTmuxOptions(),
+      );
+      if (killResult.error || !killedOrMissingTmuxServer(killResult)) {
+        return;
+      }
+    } catch {
+      return;
+    }
+  }
+  try {
+    fsSync.rmSync(tmuxSocketDir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup; keep cached paths so callers can retry later.
+    return;
+  }
+  tmuxSocketDir = null;
+  tmuxSocketPath = null;
+}
+
+/**
+ * Build the tmux argument vector with the dedicated private socket flag
+ * prepended. Does not mutate the input, but may lazily create the private
+ * socket directory on first call.
+ *
+ * @param {string[]} args - caller-supplied tmux arguments
+ * @returns {string[]} full argument vector beginning with the socket flag
+ */
+export function buildTmuxSocketArgs(args) {
+  return ['-S', getTmuxSocketPath(), ...args];
+}
+
+/**
+ * Build the spawn options for tmux, scrubbing inherited tmux client env vars
+ * so commands cannot attach to an outer tmux server. Caller-provided env
+ * entries (other than tmux keys) and other spawn options are preserved.
+ * Encoding is always forced to utf8 because downstream screen and matcher logic
+ * expects string output.
+ *
+ * @param {object} [options] - caller spawn options
+ * @returns {object} scrubbed spawn options safe for tmux invocation
+ */
+function buildTmuxOptions(options = {}) {
+  const { env: callerEnv, encoding: _ignoredEncoding, ...rest } = options;
+  const env = { ...process.env, ...(callerEnv ?? {}) };
+  for (const key of TMUX_ENV_KEYS) {
+    delete env[key];
+  }
+  // Force utf8 so callers cannot accidentally switch to Buffer output, which
+  // would break all downstream string-based screen/matcher logic.
+  return { ...rest, encoding: 'utf8', env };
+}
+
 export function runTmux(args, options = {}) {
-  const result = spawnSync('tmux', args, {
-    encoding: 'utf8',
-    ...options,
-  });
+  const fullArgs = buildTmuxSocketArgs(args);
+  const spawnOptions = buildTmuxOptions(options);
+  const result = spawnSync('tmux', fullArgs, spawnOptions);
 
   if (result.error) {
     throw result.error;
@@ -38,7 +149,7 @@ export function runTmux(args, options = {}) {
   if (result.status !== 0) {
     const stderr = (result.stderr ?? '').toString().trim();
     const message = stderr.length > 0 ? stderr : 'tmux command failed';
-    const err = new Error(`${message}: tmux ${args.join(' ')}`);
+    const err = new Error(`${message}: tmux ${fullArgs.join(' ')}`);
     err.code = result.status;
     throw err;
   }

--- a/scripts/tmux-harness.js
+++ b/scripts/tmux-harness.js
@@ -33,6 +33,10 @@ import {
 import {
   runTmux,
   tryTmux,
+  TMUX_ENV_KEYS,
+  getTmuxSocketPath,
+  cleanupTmuxSocketDir,
+  buildTmuxSocketArgs,
   sleep,
   isPrimaryPaneDead,
   waitForPaneDead,
@@ -66,6 +70,10 @@ export {
 export {
   runTmux,
   tryTmux,
+  TMUX_ENV_KEYS,
+  getTmuxSocketPath,
+  cleanupTmuxSocketDir,
+  buildTmuxSocketArgs,
   sleep,
   isPrimaryPaneDead,
   waitForPaneDead,
@@ -594,6 +602,7 @@ async function handleScenarioError({
   console.error(
     [
       `tmux session: ${sessionName}`,
+      ...(options.keepSession ? [`tmux socket: ${getTmuxSocketPath()}`] : []),
       `artifacts: ${outDir}`,
       `scenario: ${script?.steps ? 'script' : scenario}`,
     ].join('\n'),
@@ -680,8 +689,7 @@ async function assertScrollbackResults({
   return null;
 }
 
-async function main() {
-  const options = parseArgs(process.argv.slice(2));
+async function runMain(options) {
   const sessionName = `llxprt_tmux_${Date.now().toString(16)}`;
   const outDir = options.outDir
     ? path.resolve(process.cwd(), options.outDir)
@@ -762,6 +770,7 @@ async function main() {
 
   const summary = [
     `tmux session: ${sessionName}`,
+    ...(options.keepSession ? [`tmux socket: ${getTmuxSocketPath()}`] : []),
     `exited: ${exited ? 'yes' : 'no (killed session)'}`,
     `artifacts: ${outDir}`,
     `scenario: ${script?.steps ? 'script' : scenario}`,
@@ -770,6 +779,17 @@ async function main() {
 
   if (assertionError) {
     throw assertionError;
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  try {
+    await runMain(options);
+  } finally {
+    if (!options.keepSession) {
+      cleanupTmuxSocketDir();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #2469.

This hardens the tmux harness so it cannot attach to or mutate an ambient tmux server inherited from a parent orchestrator.

Changes:
- Route every harness tmux invocation through a private -S socket in a lazily created temp directory.
- Scrub TMUX, TMUX_PANE, and TMUX_TMPDIR from tmux subprocess environments while preserving other caller environment and spawn options.
- Clean up the private tmux server and socket directory on normal harness exit, while preserving the socket for keep-session and for ambiguous cleanup failures so the private server remains reachable.
- Add mocked regression coverage for socket isolation, env scrubbing, error handling, and cleanup behavior without starting real tmux.

## Verification

- Focused mocked harness suite: passed, 93 tests total.
- Full npm run test with scrubbed ambient credential and tmux variables: passed on second full run after transient unrelated direct reruns passed.
- npm run lint: passed.
- npm run typecheck: passed.
- npm run format: passed.
- npm run build: passed.
- OCR: clean, no comments in final run.
- Smoke: explicit equivalent ollamakimi settings passed with kimi-k2.5 against the ollama base URL. The bare profile-load smoke attempted gpt-5.5 in this environment and failed before network success; that appears unrelated to these tmux harness changes.
