### PR TITLE
Eliminate inverted core→tools dependency and barrel over-import chain (Fixes #2417)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -261,6 +261,7 @@
         "@vybestack/llxprt-code-settings": "file:../settings",
         "@vybestack/llxprt-code-storage": "file:../storage",
         "@vybestack/llxprt-code-telemetry": "file:../telemetry",
+        "@vybestack/llxprt-code-tools": "file:../tools",
         "ansi-regex": "^6.2.2",
         "bun": "1.3.14",
         "chalk": "^5.3.0",
@@ -3549,6 +3550,8 @@
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@google/genai": "1.30.0", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^2.1.35", "node-fetch": "^3.3.2", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-a2a-server/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
 
     "@vybestack/llxprt-code-a2a-server/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
@@ -3562,6 +3565,8 @@
     "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-settings": ["@vybestack/llxprt-code-settings@file:packages/settings", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage", "zod": "^3.25.76" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@google/genai": "1.30.0", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^2.1.35", "node-fetch": "^3.3.2", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-agents/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
@@ -3581,6 +3586,8 @@
 
     "@vybestack/llxprt-code-core/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@google/genai": "1.30.0", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^2.1.35", "node-fetch": "^3.3.2", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-core/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "@vybestack/llxprt-code-core/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -3593,6 +3600,8 @@
 
     "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
 
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@google/genai": "1.30.0", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^2.1.35", "node-fetch": "^3.3.2", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
     "@vybestack/llxprt-code-mcp/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "@vybestack/llxprt-code-policy/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
@@ -3604,6 +3613,8 @@
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", { "dependencies": { "env-paths": "^4.0.0", "ignore": "^7.0.0" }, "devDependencies": { "@types/node": "^24.2.1", "typescript": "^5.3.3", "vitest": "^3.2.6" }, "optionalDependencies": { "@napi-rs/keyring": "^1.2.0" } }],
 
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", { "dependencies": { "@vybestack/llxprt-code-storage": "file:../storage" }, "devDependencies": { "@lydell/node-pty": "1.1.0", "strip-ansi": "^7.1.0", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-tools": ["@vybestack/llxprt-code-tools@file:packages/tools", { "dependencies": { "@ast-grep/lang-c": "^0.0.5", "@ast-grep/lang-cpp": "^0.0.5", "@ast-grep/lang-go": "^0.0.5", "@ast-grep/lang-java": "^0.0.6", "@ast-grep/lang-json": "^0.0.6", "@ast-grep/lang-python": "^0.0.5", "@ast-grep/lang-ruby": "^0.0.6", "@ast-grep/lang-rust": "^0.0.6", "@ast-grep/napi": "^0.40.5", "@google/genai": "1.30.0", "@lvce-editor/ripgrep": "^1.6.0", "ajv": "^8.17.1", "cheerio": "^1.1.2", "diff": "^8.0.3", "fast-glob": "^3.3.3", "glob": "^12.0.0", "html-to-text": "^9.0.5", "mime-types": "^2.1.35", "node-fetch": "^3.3.2", "shell-quote": "^1.8.4", "turndown": "^7.2.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1" }, "devDependencies": { "@types/mime-types": "^3.0.1", "@types/node": "^24.2.1", "@vybestack/llxprt-code-test-utils": "file:../test-utils", "typescript": "^5.3.3", "vitest": "^3.2.6" } }],
 
     "@vybestack/llxprt-code-providers/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
@@ -4001,6 +4012,10 @@
 
     "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
 
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-tools/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "@vybestack/llxprt-code-agents/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "@vybestack/llxprt-code-auth/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
@@ -4011,6 +4026,8 @@
 
     "@vybestack/llxprt-code-core/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
 
+    "@vybestack/llxprt-code-core/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
     "@vybestack/llxprt-code-core/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "@vybestack/llxprt-code-core/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
@@ -4019,6 +4036,10 @@
 
     "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
 
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-tools/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "@vybestack/llxprt-code-mcp/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "@vybestack/llxprt-code-policy/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
@@ -4026,6 +4047,10 @@
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-settings/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
 
     "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-tools/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "@vybestack/llxprt-code-providers/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
@@ -4046,6 +4071,10 @@
     "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-test-utils/@vybestack/llxprt-code-storage": ["@vybestack/llxprt-code-storage@file:packages/storage", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-tools/@vybestack/llxprt-code-test-utils": ["@vybestack/llxprt-code-test-utils@file:packages/test-utils", {}],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-tools/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -4281,11 +4310,19 @@
 
     "@vscode/vsce/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "@vybestack/llxprt-code-agents/@vybestack/llxprt-code-tools/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@vybestack/llxprt-code-mcp/@vybestack/llxprt-code-tools/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@vybestack/llxprt-code-providers/@vybestack/llxprt-code-tools/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "@vybestack/llxprt-code/@vybestack/llxprt-code-auth/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-ide-integration/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "@vybestack/llxprt-code/@vybestack/llxprt-code-telemetry/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
+
+    "@vybestack/llxprt-code/@vybestack/llxprt-code-tools/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23812,6 +23812,7 @@
         "@vybestack/llxprt-code-settings": "file:../settings",
         "@vybestack/llxprt-code-storage": "file:../storage",
         "@vybestack/llxprt-code-telemetry": "file:../telemetry",
+        "@vybestack/llxprt-code-tools": "file:../tools",
         "ansi-regex": "^6.2.2",
         "bun": "1.3.14",
         "chalk": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,6 +58,7 @@
     "@vybestack/llxprt-code-agents": "file:../agents",
     "@vybestack/llxprt-code-settings": "file:../settings",
     "@vybestack/llxprt-code-telemetry": "file:../telemetry",
+    "@vybestack/llxprt-code-tools": "file:../tools",
     "ansi-regex": "^6.2.2",
     "bun": "1.3.14",
     "chalk": "^5.3.0",

--- a/packages/cli/src/config/configBuilder.ts
+++ b/packages/cli/src/config/configBuilder.ts
@@ -17,6 +17,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { createAgentRuntimeFactoryBindings } from '@vybestack/llxprt-code-agents';
 import { registerAgentRuntimeFactories } from '@vybestack/llxprt-code-providers/runtime.js';
+import { ActivateSkillTool } from '@vybestack/llxprt-code-tools/tools/activate-skill.js';
 import { getEnableHooks, getEnableHooksUI } from './settingsSchema.js';
 import { loadSettings } from './settings.js';
 import { appEvents } from '../utils/events.js';
@@ -348,6 +349,16 @@ export function buildConfig(input: ConfigBuildInput): Config {
     agentClientFactory: agentRuntimeFactoryBindings.agentClientFactory,
     toolSchedulerFactory: agentRuntimeFactoryBindings.toolSchedulerFactory,
     taskToolRegistration: agentRuntimeFactoryBindings.taskToolRegistration(),
+    postSkillDiscoveryToolRegistrar: (
+      toolRegistry,
+      skillService,
+      messageBus,
+    ) => {
+      toolRegistry.unregisterTool(ActivateSkillTool.Name);
+      toolRegistry.registerTool(
+        new ActivateSkillTool(skillService, messageBus),
+      );
+    },
   });
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,11 @@
       "bun": "./index.ts",
       "import": "./dist/index.js"
     },
+    "./auth-factories.js": {
+      "types": "./dist/src/auth-factories.d.ts",
+      "bun": "./src/auth-factories.ts",
+      "import": "./dist/src/auth-factories.js"
+    },
     "./code_assist/codeAssist.js": {
       "bun": "./src/code_assist/codeAssist.ts",
       "import": "./dist/src/code_assist/codeAssist.js"

--- a/packages/core/src/config/__tests__/import-boundary.test.ts
+++ b/packages/core/src/config/__tests__/import-boundary.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #2417: Boundary guard tests ensuring the inverted core->tools
+ * dependency does not regress.
+ *
+ * These tests read source files directly and assert on import patterns,
+ * following the convention established in packages/tools/src/__tests__/forbidden-imports.test.ts.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const configTsPath = join(__dirname, '..', 'config.ts');
+const providerRegistryPath = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'packages',
+  'providers',
+  'src',
+  'auth',
+  'provider-registry.ts',
+);
+
+describe('import boundary guards @issue:2417', () => {
+  describe('config.ts', () => {
+    const source = readFileSync(configTsPath, 'utf-8');
+
+    it('does not have a value import from @vybestack/llxprt-code-tools', () => {
+      // Match import statements that are NOT type-only and import from
+      // @vybestack/llxprt-code-tools (but NOT deep paths like .../tools/activate-skill.js)
+      const lines = source.split('\n');
+      const valueImportLines = lines.filter(
+        (line) =>
+          line.includes("@vybestack/llxprt-code-tools'") &&
+          line.trim().startsWith('import') &&
+          !line.trim().startsWith('import type'),
+      );
+
+      expect(valueImportLines).toHaveLength(0);
+    });
+
+    it('does not reference ActivateSkillTool', () => {
+      // The word ActivateSkillTool should not appear in any import or
+      // constructor call — only in comments is acceptable.
+      const codeLines = source
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('//'));
+
+      const referencingLines = codeLines.filter((line) =>
+        line.includes('ActivateSkillTool'),
+      );
+
+      expect(referencingLines).toHaveLength(0);
+    });
+
+    it('allows type-only imports from @vybestack/llxprt-code-tools', () => {
+      // type-only imports are fine — they are elided at runtime.
+      const lines = source.split('\n');
+      const typeImportLines = lines.filter(
+        (line) =>
+          line.includes("@vybestack/llxprt-code-tools'") &&
+          line.trim().startsWith('import type'),
+      );
+
+      // There should be at least one (ToolRegistry)
+      expect(typeImportLines.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('provider-registry.ts', () => {
+    const source = readFileSync(providerRegistryPath, 'utf-8');
+
+    it('imports DebugLogger from a deep path, not the core barrel', () => {
+      // Must import from @vybestack/llxprt-code-core/debug/...
+      const deepImportRegex =
+        /from\s+['"]@vybestack\/llxprt-code-core\/debug\/DebugLogger\.js['"]/;
+
+      expect(deepImportRegex.test(source)).toBe(true);
+    });
+
+    it('does not import from the core barrel', () => {
+      // Must NOT import from bare @vybestack/llxprt-code-core'
+      const barrelImportRegex = /from\s+['"]@vybestack\/llxprt-code-core['"]/;
+
+      expect(barrelImportRegex.test(source)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -9,7 +9,6 @@ import path from 'node:path';
 import { PromptRegistry } from '../prompts/prompt-registry.js';
 import { ResourceRegistry } from '../resources/resource-registry.js';
 import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
-import { ActivateSkillTool } from '@vybestack/llxprt-code-tools/tools/activate-skill.js';
 import { Storage } from '@vybestack/llxprt-code-settings';
 import { CoreSkillServiceAdapter } from '../tools-adapters/CoreSkillServiceAdapter.js';
 import { DebugLogger } from '../debug/DebugLogger.js';
@@ -167,15 +166,17 @@ export class Config extends ConfigBase {
       );
       this.getSkillManager().setDisabledSkills(this.disabledSkills);
 
-      // Re-register ActivateSkillTool to update its schema with the discovered enabled skill enums
+      // Re-register ActivateSkillTool via the injected registrar hook
+      // (eliminates the inverted core->tools dependency — issue #2417)
       if (this.getSkillManager().getSkills().length > 0) {
-        this.getToolRegistry().unregisterTool(ActivateSkillTool.Name);
-        this.getToolRegistry().registerTool(
-          new ActivateSkillTool(
+        const registrar = this.getPostSkillDiscoveryToolRegistrar();
+        if (registrar) {
+          registrar(
+            this.getToolRegistry(),
             new CoreSkillServiceAdapter(this),
             initializationMessageBus,
-          ),
-        );
+          );
+        }
       }
     }
 

--- a/packages/core/src/config/configBaseCore.ts
+++ b/packages/core/src/config/configBaseCore.ts
@@ -22,6 +22,7 @@ import type {
 } from '../core/clientContract.js';
 import type { ToolSchedulerFactory } from '../core/toolSchedulerContract.js';
 import type { TaskToolRegistration } from './toolRegistryFactory.js';
+import type { PostSkillDiscoveryToolRegistrar } from './configTypes.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import type { ResourceRegistry } from '../resources/resource-registry.js';
 import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
@@ -291,6 +292,9 @@ export abstract class ConfigBaseCore {
    * @requirement REQ-INV-003
    */
   protected taskToolRegistration: TaskToolRegistration | undefined;
+  protected postSkillDiscoveryToolRegistrar:
+    | PostSkillDiscoveryToolRegistrar
+    | undefined;
   protected initialized = false;
 
   // ---- Simple field accessors ----
@@ -765,6 +769,11 @@ export abstract class ConfigBaseCore {
    */
   getTaskToolRegistration(): TaskToolRegistration | undefined {
     return this.taskToolRegistration;
+  }
+  getPostSkillDiscoveryToolRegistrar():
+    | PostSkillDiscoveryToolRegistrar
+    | undefined {
+    return this.postSkillDiscoveryToolRegistrar;
   }
   getEnableHooksUI(): boolean {
     return this.enableHooksUI;

--- a/packages/core/src/config/configBaseCore.ts
+++ b/packages/core/src/config/configBaseCore.ts
@@ -775,6 +775,11 @@ export abstract class ConfigBaseCore {
     | undefined {
     return this.postSkillDiscoveryToolRegistrar;
   }
+  setPostSkillDiscoveryToolRegistrar(
+    registrar: PostSkillDiscoveryToolRegistrar | undefined,
+  ): void {
+    this.postSkillDiscoveryToolRegistrar = registrar;
+  }
   getEnableHooksUI(): boolean {
     return this.enableHooksUI;
   }

--- a/packages/core/src/config/configConstructor.ts
+++ b/packages/core/src/config/configConstructor.ts
@@ -73,6 +73,7 @@ import type { Config } from './config.js';
 import type { AgentClientFactory } from '../core/clientContract.js';
 import type { ToolSchedulerFactory } from '../core/toolSchedulerContract.js';
 import type { TaskToolRegistration } from './toolRegistryFactory.js';
+import type { PostSkillDiscoveryToolRegistrar } from './configTypes.js';
 
 /**
  * Typed target interface for applyConfigParams — lists every field
@@ -219,6 +220,7 @@ export interface ConfigConstructorTarget {
    * @requirement REQ-INV-003
    */
   taskToolRegistration: TaskToolRegistration | undefined;
+  postSkillDiscoveryToolRegistrar: PostSkillDiscoveryToolRegistrar | undefined;
 
   // Called at end of applyConfigParams
   getProxy(): string | undefined;
@@ -474,6 +476,8 @@ function applyPolicyAndLifecycle(
   config.agentClientFactory = params.agentClientFactory;
   config.toolSchedulerFactory = params.toolSchedulerFactory;
   config.taskToolRegistration = params.taskToolRegistration;
+  config.postSkillDiscoveryToolRegistrar =
+    params.postSkillDiscoveryToolRegistrar;
 
   if (params.contextFileName !== undefined && params.contextFileName !== '') {
     setLlxprtMdFilename(params.contextFileName);

--- a/packages/core/src/config/configTypes.ts
+++ b/packages/core/src/config/configTypes.ts
@@ -31,14 +31,32 @@ import type { PolicyEngineConfig } from '../policy/types.js';
 import type { SettingsService } from '@vybestack/llxprt-code-settings';
 import type { RuntimeProviderManager } from '../runtime/contracts/RuntimeProviderManager.js';
 import type { IdeClient } from '@vybestack/llxprt-code-ide-integration';
-import type { AnyToolInvocation } from '@vybestack/llxprt-code-tools';
+import type {
+  AnyToolInvocation,
+  ISkillService,
+  ToolRegistry,
+} from '@vybestack/llxprt-code-tools';
 import { TelemetryTarget } from '../telemetry/index.js';
 import type { LspConfig } from '@vybestack/llxprt-code-ide-integration';
 import type { AgentClientFactory } from '../core/clientContract.js';
 import type { ToolSchedulerFactory } from '../core/toolSchedulerContract.js';
 import type { TaskToolRegistration } from './toolRegistryFactory.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
 
 export type { MCPOAuthConfig, AnyToolInvocation, SkillDefinition };
+
+/**
+ * Registration hook for post-skill-discovery tool registration.
+ * Core calls this during initialize() after skill discovery, passing
+ * core-owned dependencies. The composition root (CLI) supplies a
+ * callback that constructs and registers the concrete ActivateSkillTool
+ * from the tools package, eliminating the inverted core->tools dependency.
+ */
+export type PostSkillDiscoveryToolRegistrar = (
+  toolRegistry: ToolRegistry,
+  skillService: ISkillService,
+  messageBus: MessageBus,
+) => void;
 export { TelemetryTarget };
 
 export interface RedactionConfig {
@@ -477,6 +495,14 @@ export interface ConfigParameters {
    * During P01-P02, core-local default registration is used when not provided.
    */
   taskToolRegistration?: TaskToolRegistration;
+
+  /**
+   * Registration hook for post-skill-discovery tool registration.
+   * Injected by composition roots. Eliminates the inverted core->tools
+   * dependency by letting the CLI register ActivateSkillTool without
+   * core importing from the tools package.
+   */
+  postSkillDiscoveryToolRegistrar?: PostSkillDiscoveryToolRegistrar;
 
   jitContextEnabled?: boolean;
   adminSkillsEnabled?: boolean;

--- a/packages/providers/src/__tests__/auth-migration-p16.integration.test.ts
+++ b/packages/providers/src/__tests__/auth-migration-p16.integration.test.ts
@@ -66,37 +66,48 @@ function collectTsFiles(dir: string, excludeTests = true): string[] {
 
 /**
  * Check if a line contains a forbidden old core/auth import.
- * A line is forbidden if it imports from core/auth subpath,
- * unless it imports from the allowed deep path core/auth-factories.js.
- * (Note: core/auth-factories.js does NOT contain /auth/ as a subpath,
- * it contains /auth-factories.js as a sibling, so the prefix check below
- * correctly distinguishes them.)
+ * Uses regex matching against the full file content to correctly handle
+ * multi-line import statements (e.g. `import {\n  foo\n} from "..."`).
+ * A specifier is forbidden if it starts with the forbidden prefix,
+ * unless it exactly matches the allowed deep import path.
+ * (Note: auth-factories.js does not match the forbidden prefix because
+ * exact string matching distinguishes "auth-factories.js" from "auth/")
  */
-function isForbiddenAuthImport(line: string): boolean {
-  const trimmed = line.trim();
-  if (
-    trimmed.startsWith('//') ||
-    trimmed.startsWith('*') ||
-    trimmed.startsWith('/*')
-  ) {
-    return false;
-  }
-  if (!trimmed.startsWith('import')) {
-    return false;
-  }
-  // Extract the module specifier from the import line
-  const match = /from\s+['"]([^'"]+)['"]/.exec(trimmed);
-  if (!match) return false;
-  const specifier = match[1];
-  // Allow the new deep import path for auth factories
-  if (specifier === ALLOWED_AUTH_DEEP_IMPORT) return false;
-  // Forbid any import that starts with the forbidden prefix
-  // This matches both core/auth' and core/auth/anything
-  // But does NOT match core/auth-factories.js (different string)
-  return (
-    specifier === FORBIDDEN_OLD_AUTH_PREFIX ||
-    specifier.startsWith(FORBIDDEN_OLD_AUTH_PREFIX + '/')
+function findForbiddenAuthImports(content: string, relPath: string): string[] {
+  const violations: string[] = [];
+  // Match all from-import specifiers that start with the forbidden prefix.
+  // This correctly handles multi-line imports because we match the `from`
+  // clause directly rather than the `import` keyword start.
+  const escapedPrefix = FORBIDDEN_OLD_AUTH_PREFIX.replace(
+    /[.*+?^${}()|[\]\\/]/g,
+    '\\$&',
   );
+  const importRegex = new RegExp(
+    `from\\s+['"](${escapedPrefix}[^'"]*)['"]`,
+    'g',
+  );
+  let match: RegExpExecArray | null;
+  while ((match = importRegex.exec(content)) !== null) {
+    const specifier = match[1];
+    // Allow the new deep import path for auth factories
+    if (specifier === ALLOWED_AUTH_DEEP_IMPORT) continue;
+    // Find the line number for this match
+    const lineNum = content.slice(0, match.index).split('\n').length;
+    violations.push(`${relPath}:${lineNum}: ${specifier}`);
+  }
+  return violations;
+}
+
+/**
+ * Scan a single file for forbidden core/auth imports.
+ */
+function scanFileForForbiddenImports(
+  filePath: string,
+  baseDir: string,
+): string[] {
+  const relPath = path.relative(baseDir, filePath);
+  const content = fs.readFileSync(filePath, 'utf-8');
+  return findForbiddenAuthImports(content, relPath);
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -111,14 +122,9 @@ describe('Providers auth migration: no old core/auth imports', () => {
 
     const violations: string[] = [];
     for (const filePath of prodFiles) {
-      const relPath = path.relative(PROVIDERS_SRC_DIR, filePath);
-      const content = fs.readFileSync(filePath, 'utf-8');
-      const lines = content.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        if (isForbiddenAuthImport(lines[i])) {
-          violations.push(`${relPath}:${i + 1}: ${lines[i].trim()}`);
-        }
-      }
+      violations.push(
+        ...scanFileForForbiddenImports(filePath, PROVIDERS_SRC_DIR),
+      );
     }
 
     expect(
@@ -134,14 +140,9 @@ describe('Providers auth migration: no old core/auth imports', () => {
 
     const violations: string[] = [];
     for (const filePath of testFiles) {
-      const relPath = path.relative(PROVIDERS_SRC_DIR, filePath);
-      const content = fs.readFileSync(filePath, 'utf-8');
-      const lines = content.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        if (isForbiddenAuthImport(lines[i])) {
-          violations.push(`${relPath}:${i + 1}: ${lines[i].trim()}`);
-        }
-      }
+      violations.push(
+        ...scanFileForForbiddenImports(filePath, PROVIDERS_SRC_DIR),
+      );
     }
 
     expect(

--- a/packages/providers/src/__tests__/auth-migration-p16.integration.test.ts
+++ b/packages/providers/src/__tests__/auth-migration-p16.integration.test.ts
@@ -36,10 +36,9 @@ import { SettingsService } from '@vybestack/llxprt-code-settings';
 const PROVIDERS_SRC_DIR = path.resolve(__dirname, '..');
 
 /** Canonical import specifiers forbidden in providers source. */
-const FORBIDDEN_OLD_AUTH_IMPORTS = [
-  /from\s+['"]@vybestack\/llxprt-code-core\/auth/u,
-  /from\s+['"]@vybestack\/llxprt-code-core\/auth\//u,
-];
+const FORBIDDEN_OLD_AUTH_PREFIX = '@vybestack/llxprt-code-core/auth';
+const ALLOWED_AUTH_DEEP_IMPORT =
+  '@vybestack/llxprt-code-core/auth-factories.js';
 
 /**
  * Recursively collect .ts files, optionally excluding tests.
@@ -66,30 +65,38 @@ function collectTsFiles(dir: string, excludeTests = true): string[] {
 }
 
 /**
- * Find lines matching a pattern, skipping comments.
+ * Check if a line contains a forbidden old core/auth import.
+ * A line is forbidden if it imports from core/auth subpath,
+ * unless it imports from the allowed deep path core/auth-factories.js.
+ * (Note: core/auth-factories.js does NOT contain /auth/ as a subpath,
+ * it contains /auth-factories.js as a sibling, so the prefix check below
+ * correctly distinguishes them.)
  */
-function findViolatingLines(
-  filePath: string,
-  pattern: RegExp,
-  relPath: string,
-): string[] {
-  const content = fs.readFileSync(filePath, 'utf-8');
-  const lines = content.split('\n');
-  const violations: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (
-      trimmed.startsWith('//') ||
-      trimmed.startsWith('*') ||
-      trimmed.startsWith('/*')
-    ) {
-      continue;
-    }
-    if (pattern.test(lines[i])) {
-      violations.push(`${relPath}:${i + 1}: ${lines[i].trim()}`);
-    }
+function isForbiddenAuthImport(line: string): boolean {
+  const trimmed = line.trim();
+  if (
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('*') ||
+    trimmed.startsWith('/*')
+  ) {
+    return false;
   }
-  return violations;
+  if (!trimmed.startsWith('import')) {
+    return false;
+  }
+  // Extract the module specifier from the import line
+  const match = /from\s+['"]([^'"]+)['"]/.exec(trimmed);
+  if (!match) return false;
+  const specifier = match[1];
+  // Allow the new deep import path for auth factories
+  if (specifier === ALLOWED_AUTH_DEEP_IMPORT) return false;
+  // Forbid any import that starts with the forbidden prefix
+  // This matches both core/auth' and core/auth/anything
+  // But does NOT match core/auth-factories.js (different string)
+  return (
+    specifier === FORBIDDEN_OLD_AUTH_PREFIX ||
+    specifier.startsWith(FORBIDDEN_OLD_AUTH_PREFIX + '/')
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -105,8 +112,12 @@ describe('Providers auth migration: no old core/auth imports', () => {
     const violations: string[] = [];
     for (const filePath of prodFiles) {
       const relPath = path.relative(PROVIDERS_SRC_DIR, filePath);
-      for (const pattern of FORBIDDEN_OLD_AUTH_IMPORTS) {
-        violations.push(...findViolatingLines(filePath, pattern, relPath));
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (isForbiddenAuthImport(lines[i])) {
+          violations.push(`${relPath}:${i + 1}: ${lines[i].trim()}`);
+        }
       }
     }
 
@@ -124,8 +135,12 @@ describe('Providers auth migration: no old core/auth imports', () => {
     const violations: string[] = [];
     for (const filePath of testFiles) {
       const relPath = path.relative(PROVIDERS_SRC_DIR, filePath);
-      for (const pattern of FORBIDDEN_OLD_AUTH_IMPORTS) {
-        violations.push(...findViolatingLines(filePath, pattern, relPath));
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (isForbiddenAuthImport(lines[i])) {
+          violations.push(`${relPath}:${i + 1}: ${lines[i].trim()}`);
+        }
       }
     }
 

--- a/packages/providers/src/auth/BucketFailoverHandlerImpl.ts
+++ b/packages/providers/src/auth/BucketFailoverHandlerImpl.ts
@@ -11,14 +11,16 @@
  */
 
 import {
-  type BucketFailoverHandler,
-  DebugLogger,
   flushRuntimeAuthScope,
-  type FailoverContext,
-  type BucketFailureReason,
   type OAuthToken,
   type OAuthTokenRequestMetadata,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type {
+  BucketFailoverHandler,
+  FailoverContext,
+} from '@vybestack/llxprt-code-core/config/configTypes.js';
+import type { BucketFailureReason } from '@vybestack/llxprt-code-core/runtime/contracts/index.js';
 import type { BucketFailoverOAuthManagerLike } from './types.js';
 
 const logger = new DebugLogger('llxprt:bucket:failover:handler');

--- a/packages/providers/src/auth/MultiBucketAuthenticator.ts
+++ b/packages/providers/src/auth/MultiBucketAuthenticator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DebugLogger } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 
 const logger = new DebugLogger('llxprt:auth:multi-bucket');
 

--- a/packages/providers/src/auth/OnAuthErrorHandlerImpl.ts
+++ b/packages/providers/src/auth/OnAuthErrorHandlerImpl.ts
@@ -11,10 +11,8 @@
  * 2. Using TOCTOU pattern to handle race conditions with other processes
  */
 
-import {
-  type OnAuthErrorHandler,
-  DebugLogger,
-} from '@vybestack/llxprt-code-core';
+import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { createHash } from 'node:crypto';
 import type { BucketFailoverOAuthManagerLike } from './types.js';
 

--- a/packages/providers/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
+++ b/packages/providers/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
@@ -6,19 +6,17 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
+vi.mock('@vybestack/llxprt-code-auth', async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
+    await importOriginal<typeof import('@vybestack/llxprt-code-auth')>();
   return {
     ...actual,
     flushRuntimeAuthScope: vi.fn(),
   };
 });
 
-import {
-  flushRuntimeAuthScope,
-  type OAuthTokenRequestMetadata,
-} from '@vybestack/llxprt-code-core';
+import { flushRuntimeAuthScope } from '@vybestack/llxprt-code-auth';
+import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-auth';
 import { BucketFailoverHandlerImpl } from '../BucketFailoverHandlerImpl.js';
 import type { BucketFailoverOAuthManagerLike } from '../types.js';
 

--- a/packages/providers/src/auth/__tests__/anthropic-oauth-provider.fallback.spec.ts
+++ b/packages/providers/src/auth/__tests__/anthropic-oauth-provider.fallback.spec.ts
@@ -10,12 +10,14 @@ vi.mock('../local-oauth-callback.js', () => ({
   startLocalOAuthCallback: vi.fn(),
 }));
 
-import * as coreModule from '@vybestack/llxprt-code-core';
+import { AnthropicDeviceFlow } from '@vybestack/llxprt-code-auth';
 import type {
   DeviceCodeResponse,
   OAuthToken,
   TokenStore,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-auth';
+import * as secureBrowserModule from '@vybestack/llxprt-code-core/utils/secure-browser-launcher.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { AnthropicOAuthProvider } from '../anthropic-oauth-provider.js';
 import { startLocalOAuthCallback } from '../local-oauth-callback.js';
 
@@ -33,7 +35,7 @@ const openBrowserArgs: string[] = [];
 describe('AnthropicOAuthProvider fallback behavior', () => {
   let provider: AnthropicOAuthProvider;
   let tokenStore: TokenStore;
-  let deviceFlow: coreModule.AnthropicDeviceFlow;
+  let deviceFlow: AnthropicDeviceFlow;
   const DEVICE_CODE_URL =
     'https://claude.ai/oauth/authorize?redirect_uri=https%3A%2F%2Fconsole.anthropic.com%2Foauth%2Fcode';
 
@@ -61,7 +63,7 @@ describe('AnthropicOAuthProvider fallback behavior', () => {
     provider = new AnthropicOAuthProvider(tokenStore);
     deviceFlow = (
       provider as unknown as {
-        deviceFlow: coreModule.AnthropicDeviceFlow;
+        deviceFlow: AnthropicDeviceFlow;
       }
     ).deviceFlow;
 
@@ -102,12 +104,12 @@ describe('AnthropicOAuthProvider fallback behavior', () => {
       expiry: Math.floor(Date.now() / 1000) + 3600,
       scope: null,
     }));
-    vi.spyOn(coreModule, 'openBrowserSecurely').mockImplementation(
+    vi.spyOn(secureBrowserModule, 'openBrowserSecurely').mockImplementation(
       async (url: string) => {
         openBrowserArgs.push(url);
       },
     );
-    vi.spyOn(coreModule, 'shouldLaunchBrowser').mockReturnValue(true);
+    vi.spyOn(secureBrowserModule, 'shouldLaunchBrowser').mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -130,7 +132,6 @@ describe('AnthropicOAuthProvider fallback behavior', () => {
       });
 
       const debugLogs: string[] = [];
-      const { DebugLogger } = await import('@vybestack/llxprt-code-core');
       vi.spyOn(DebugLogger.prototype, 'log').mockImplementation(
         (...args: unknown[]) => {
           debugLogs.push(args.map(String).join(' '));

--- a/packages/providers/src/auth/__tests__/auth-import-isolation.test.ts
+++ b/packages/providers/src/auth/__tests__/auth-import-isolation.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #2417: Importing the providers auth entry point must NOT transitively
+ * load any tool implementation modules from @vybestack/llxprt-code-tools.
+ *
+ * Before the fix, the import chain was:
+ *   auth.js -> provider-registry.ts -> @vybestack/llxprt-code-core (barrel)
+ *   -> config.ts -> ActivateSkillTool -> ast-grep native addons
+ *
+ * After the fix, provider-registry.ts imports DebugLogger from a deep path
+ * (@vybestack/llxprt-code-core/debug/DebugLogger.js), and config.ts no longer
+ * imports ActivateSkillTool (the registration is inverted via a hook).
+ *
+ * This test verifies the isolation by mocking the specific tool implementation
+ * modules with factories that track whether they were loaded, then dynamically
+ * importing the auth index. If any tool implementation is transitively loaded,
+ * the corresponding spy will have been called.
+ *
+ * Note: we intentionally do NOT mock the tools barrel itself, because the auth
+ * import graph legitimately reaches utility functions (e.g.
+ * canonicalizeToolName) that are exported from the barrel but do not load any
+ * tool implementations or native addons. The acceptance criteria is "loads
+ * zero tool implementations," not "zero contact with the tools package."
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('auth import isolation @issue:2417', () => {
+  afterEach(() => {
+    vi.doUnmock('@vybestack/llxprt-code-tools/tools/activate-skill.js');
+    vi.doUnmock('@ast-grep/napi');
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('importing auth index does not load ActivateSkillTool or ast-grep native modules', async () => {
+    const activateSkillSpy = vi.fn(() => {
+      throw new Error(
+        'ActivateSkillTool module was loaded during auth import — import isolation broken (#2417)',
+      );
+    });
+    vi.doMock(
+      '@vybestack/llxprt-code-tools/tools/activate-skill.js',
+      activateSkillSpy,
+    );
+
+    const napiSpy = vi.fn(() => {
+      throw new Error(
+        '@ast-grep/napi was loaded during auth import — import isolation broken (#2417)',
+      );
+    });
+    vi.doMock('@ast-grep/napi', napiSpy);
+
+    vi.resetModules();
+
+    // Dynamically import the auth entry from source (not dist) to verify
+    // the source-level import graph does not reach tool implementations.
+    const authModule = await import('../index.js');
+
+    // Sanity: the auth module actually loaded.
+    expect(authModule).toBeDefined();
+    expect(typeof authModule.ProviderRegistry).toBe('function');
+
+    expect(activateSkillSpy).not.toHaveBeenCalled();
+    expect(napiSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/providers/src/auth/__tests__/auth-status-service.spec.ts
+++ b/packages/providers/src/auth/__tests__/auth-status-service.spec.ts
@@ -23,10 +23,10 @@ const { flushMockRef, providerManagerRef, providerRef } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@vybestack/llxprt-code-core', async () => {
+vi.mock('@vybestack/llxprt-code-auth', async () => {
   const actual = await vi.importActual<
-    typeof import('@vybestack/llxprt-code-core')
-  >('@vybestack/llxprt-code-core');
+    typeof import('@vybestack/llxprt-code-auth')
+  >('@vybestack/llxprt-code-auth');
   const flushMock = vi.fn(() => ({
     runtimeId: 'test-runtime',
     revokedTokens: [],
@@ -42,7 +42,7 @@ import { oauthRuntimeBridge } from '../runtime-accessor-bridge.js';
 
 import { AuthStatusService } from '../auth-status-service.js';
 import type { OAuthProvider } from '../types.js';
-import type { TokenStore, OAuthToken } from '@vybestack/llxprt-code-core';
+import type { TokenStore, OAuthToken } from '@vybestack/llxprt-code-auth';
 import type { ProviderRegistry } from '../provider-registry.js';
 import type { ProactiveRenewalManager } from '../proactive-renewal-manager.js';
 import type { OAuthBucketManager } from '../OAuthBucketManager.js';

--- a/packages/providers/src/auth/__tests__/behavioral/subagent-isolation.behavioral.spec.ts
+++ b/packages/providers/src/auth/__tests__/behavioral/subagent-isolation.behavioral.spec.ts
@@ -12,7 +12,7 @@ import {
   createTestOAuthManager,
   createBucketFailoverHandler,
 } from './test-utils.js';
-import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-core';
+import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-auth';
 
 const PROVIDER = 'anthropic';
 

--- a/packages/providers/src/auth/__tests__/behavioral/test-utils.ts
+++ b/packages/providers/src/auth/__tests__/behavioral/test-utils.ts
@@ -7,7 +7,7 @@
 import { OAuthManager } from '../../oauth-manager.js';
 import { BucketFailoverHandlerImpl } from '../../BucketFailoverHandlerImpl.js';
 import type { OAuthProvider, OAuthToken, TokenStore } from '../../types.js';
-import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-core';
+import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-auth';
 
 export class MemoryTokenStore implements TokenStore {
   private tokens = new Map<string, OAuthToken>();

--- a/packages/providers/src/auth/__tests__/codex-oauth-provider.fallback.spec.ts
+++ b/packages/providers/src/auth/__tests__/codex-oauth-provider.fallback.spec.ts
@@ -10,8 +10,8 @@ vi.mock('../local-oauth-callback.js', () => ({
   startLocalOAuthCallback: vi.fn(),
 }));
 
-import * as coreModule from '@vybestack/llxprt-code-core';
-import type { TokenStore } from '@vybestack/llxprt-code-core';
+import * as secureBrowserModule from '@vybestack/llxprt-code-core/utils/secure-browser-launcher.js';
+import type { TokenStore } from '@vybestack/llxprt-code-auth';
 import { CodexOAuthProvider } from '../codex-oauth-provider.js';
 import { startLocalOAuthCallback } from '../local-oauth-callback.js';
 
@@ -48,8 +48,10 @@ describe('CodexOAuthProvider fallback behavior', () => {
     provider = new CodexOAuthProvider(mockTokenStore);
 
     // Mock shouldLaunchBrowser to return true (interactive mode)
-    vi.spyOn(coreModule, 'shouldLaunchBrowser').mockReturnValue(true);
-    vi.spyOn(coreModule, 'openBrowserSecurely').mockResolvedValue(undefined);
+    vi.spyOn(secureBrowserModule, 'shouldLaunchBrowser').mockReturnValue(true);
+    vi.spyOn(secureBrowserModule, 'openBrowserSecurely').mockResolvedValue(
+      undefined,
+    );
   });
 
   afterEach(() => {

--- a/packages/providers/src/auth/anthropic-oauth-provider.local-flow.spec.ts
+++ b/packages/providers/src/auth/anthropic-oauth-provider.local-flow.spec.ts
@@ -12,13 +12,13 @@ vi.mock('./local-oauth-callback.js', () => ({
   startLocalOAuthCallback: vi.fn(),
 }));
 
-import * as coreModule from '@vybestack/llxprt-code-core';
+import * as secureBrowserModule from '@vybestack/llxprt-code-core/utils/secure-browser-launcher.js';
 import { OAuthError, OAuthErrorType } from '@vybestack/llxprt-code-auth';
 import type {
   DeviceCodeResponse,
   OAuthToken,
   TokenStore,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-auth';
 import { AnthropicOAuthProvider } from './anthropic-oauth-provider.js';
 import type { LocalOAuthCallbackServer } from './local-oauth-callback.js';
 import { startLocalOAuthCallback } from './local-oauth-callback.js';
@@ -98,13 +98,13 @@ describe('AnthropicOAuthProvider local callback flow', () => {
       expiry: Math.floor(Date.now() / 1000) + 3600,
       scope: null,
     }));
-    vi.spyOn(coreModule, 'openBrowserSecurely').mockImplementation(
+    vi.spyOn(secureBrowserModule, 'openBrowserSecurely').mockImplementation(
       async (url: string) => {
         openBrowserArgs.push(url);
       },
     );
     shouldLaunchBrowserSpy = vi
-      .spyOn(coreModule, 'shouldLaunchBrowser')
+      .spyOn(secureBrowserModule, 'shouldLaunchBrowser')
       .mockReturnValue(true);
   });
 

--- a/packages/providers/src/auth/anthropic-oauth-provider.test.ts
+++ b/packages/providers/src/auth/anthropic-oauth-provider.test.ts
@@ -22,16 +22,21 @@ import { ClipboardService } from './ClipboardService.js';
 import { oauthRuntimeBridge } from './runtime-accessor-bridge.js';
 
 // Mock the device flow implementation
-vi.mock('@vybestack/llxprt-code-core', async () => {
-  const actual = await vi.importActual('@vybestack/llxprt-code-core');
-  return {
-    ...actual,
-    // Mock shouldLaunchBrowser to return true for tests
-    shouldLaunchBrowser: vi.fn().mockReturnValue(true),
-    // Mock openBrowserSecurely to prevent actual browser opening
-    openBrowserSecurely: vi.fn().mockResolvedValue(undefined),
-  };
-});
+vi.mock(
+  '@vybestack/llxprt-code-core/utils/secure-browser-launcher.js',
+  async () => {
+    const actual = await vi.importActual(
+      '@vybestack/llxprt-code-core/utils/secure-browser-launcher.js',
+    );
+    return {
+      ...actual,
+      // Mock shouldLaunchBrowser to return true for tests
+      shouldLaunchBrowser: vi.fn().mockReturnValue(true),
+      // Mock openBrowserSecurely to prevent actual browser opening
+      openBrowserSecurely: vi.fn().mockResolvedValue(undefined),
+    };
+  },
+);
 
 vi.mock('@vybestack/llxprt-code-auth', async () => {
   const actual = await vi.importActual('@vybestack/llxprt-code-auth');

--- a/packages/providers/src/auth/anthropic-oauth-provider.ts
+++ b/packages/providers/src/auth/anthropic-oauth-provider.ts
@@ -24,9 +24,9 @@ import {
 import {
   openBrowserSecurely,
   shouldLaunchBrowser,
-  DebugLogger,
-  debugLogger,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-core/utils/secure-browser-launcher.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
 import { ClipboardService } from './ClipboardService.js';
 import type { LocalOAuthCallbackServer } from './local-oauth-callback.js';
 import { startLocalOAuthCallback } from './local-oauth-callback.js';

--- a/packages/providers/src/auth/auth-flow-orchestrator.ts
+++ b/packages/providers/src/auth/auth-flow-orchestrator.ts
@@ -16,14 +16,14 @@
  */
 
 import {
-  DebugLogger,
   mergeRefreshedToken,
-  type Config,
-  type MessageBus,
   type OAuthTokenRequestMetadata,
   type OAuthTokenWithExtras,
-  debugLogger,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type {
   AuthenticatorInterface,
   BucketFailoverOAuthManagerLike,

--- a/packages/providers/src/auth/auth-status-service.ts
+++ b/packages/providers/src/auth/auth-status-service.ts
@@ -19,10 +19,8 @@
  *        independent try/catch per call (no provider-name branching).
  */
 
-import {
-  DebugLogger,
-  flushRuntimeAuthScope,
-} from '@vybestack/llxprt-code-core';
+import { flushRuntimeAuthScope } from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import type { AuthStatus, TokenStore } from './types.js';
 import type { ProviderRegistry } from './provider-registry.js';
 import type { ProactiveRenewalManager } from './proactive-renewal-manager.js';

--- a/packages/providers/src/auth/codex-oauth-provider.ts
+++ b/packages/providers/src/auth/codex-oauth-provider.ts
@@ -16,12 +16,12 @@ import type {
   OAuthToken,
   TokenStore,
 } from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
 import {
-  DebugLogger,
   openBrowserSecurely,
   shouldLaunchBrowser,
-  debugLogger,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-core/utils/secure-browser-launcher.js';
 import { CODEX_CONFIG } from '@vybestack/llxprt-code-auth';
 import type { OAuthProvider } from './types.js';
 import { startLocalOAuthCallback } from './local-oauth-callback.js';

--- a/packages/providers/src/auth/migration.ts
+++ b/packages/providers/src/auth/migration.ts
@@ -14,8 +14,8 @@
  */
 
 import type { OAuthProvider } from './types.js';
-import type { TokenStore } from '@vybestack/llxprt-code-core';
-import { debugLogger } from '@vybestack/llxprt-code-core';
+import type { TokenStore } from '@vybestack/llxprt-code-auth';
+import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
 
 /**
  * Migrate any in-memory tokens to persistent storage

--- a/packages/providers/src/auth/oauth-manager.logout.spec.ts
+++ b/packages/providers/src/auth/oauth-manager.logout.spec.ts
@@ -20,10 +20,10 @@ const { flushMockRef, providerManagerRef, providerRef } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@vybestack/llxprt-code-core', async () => {
+vi.mock('@vybestack/llxprt-code-auth', async () => {
   const actual = await vi.importActual<
-    typeof import('@vybestack/llxprt-code-core')
-  >('@vybestack/llxprt-code-core');
+    typeof import('@vybestack/llxprt-code-auth')
+  >('@vybestack/llxprt-code-auth');
   const flushMock = vi.fn(() => ({
     runtimeId: 'test-runtime',
     revokedTokens: [],
@@ -39,7 +39,7 @@ import { oauthRuntimeBridge } from './runtime-accessor-bridge.js';
 
 import { OAuthManager } from './oauth-manager.js';
 import type { OAuthProvider } from './types.js';
-import type { TokenStore } from '@vybestack/llxprt-code-core';
+import type { TokenStore } from '@vybestack/llxprt-code-auth';
 
 describe('OAuthManager.logout runtime cache handling', () => {
   beforeEach(() => {

--- a/packages/providers/src/auth/oauth-manager.ts
+++ b/packages/providers/src/auth/oauth-manager.ts
@@ -16,7 +16,8 @@ import {
 } from './types.js';
 import type { IOAuthSettingsProvider } from '@vybestack/llxprt-code-auth';
 import { ProviderRegistry } from './provider-registry.js';
-import { type MessageBus, type Config } from '@vybestack/llxprt-code-core';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import type {
   OAuthManager as AuthOAuthManagerInterface,
   OAuthTokenRequestMetadata as AuthOAuthTokenRequestMetadata,

--- a/packages/providers/src/auth/proactive-renewal-manager.ts
+++ b/packages/providers/src/auth/proactive-renewal-manager.ts
@@ -11,10 +11,10 @@
  */
 
 import {
-  DebugLogger,
   mergeRefreshedToken,
   type OAuthTokenWithExtras,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import type { OAuthToken, TokenStore, OAuthProvider } from './types.js';
 import {
   createProfileManager,

--- a/packages/providers/src/auth/provider-registry.ts
+++ b/packages/providers/src/auth/provider-registry.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DebugLogger } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import type { IOAuthSettingsProvider } from '@vybestack/llxprt-code-auth';
 import type { OAuthProvider } from './types.js';
 

--- a/packages/providers/src/auth/provider-usage-info.ts
+++ b/packages/providers/src/auth/provider-usage-info.ts
@@ -16,7 +16,8 @@
  * with no coupling to OAuthManager internals.
  */
 
-import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { getRuntimeSettingsService } from '@vybestack/llxprt-code-core/runtime/settingsRuntimeAdapter.js';
 import type { IOAuthSettingsProvider } from '@vybestack/llxprt-code-auth';
 import type { TokenStore } from './types.js';

--- a/packages/providers/src/auth/proxy/credential-store-factory.ts
+++ b/packages/providers/src/auth/proxy/credential-store-factory.ts
@@ -28,7 +28,7 @@ import {
   ProxySocketClient,
   ProxyTokenStore,
 } from '@vybestack/llxprt-code-auth';
-import { createKeyringTokenStore } from '@vybestack/llxprt-code-core';
+import { createKeyringTokenStore } from '@vybestack/llxprt-code-core/auth-factories.js';
 // ProviderKeyStorage now lives in the storage package
 import type {
   ProviderKeyStorage,

--- a/packages/providers/src/auth/proxy/proactive-scheduler.ts
+++ b/packages/providers/src/auth/proxy/proactive-scheduler.ts
@@ -1,4 +1,4 @@
-import { debugLogger } from '@vybestack/llxprt-code-core';
+import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
 /**
  * @license
  * Copyright 2025 Vybestack LLC

--- a/packages/providers/src/auth/proxy/sandbox-proxy-lifecycle.ts
+++ b/packages/providers/src/auth/proxy/sandbox-proxy-lifecycle.ts
@@ -24,7 +24,7 @@ import {
   CodexDeviceFlow,
   type OAuthToken,
 } from '@vybestack/llxprt-code-auth';
-import { createKeyringTokenStore } from '@vybestack/llxprt-code-core';
+import { createKeyringTokenStore } from '@vybestack/llxprt-code-core/auth-factories.js';
 import { getProviderKeyStorage } from '@vybestack/llxprt-code-storage';
 import path from 'node:path';
 import {

--- a/packages/providers/src/auth/token-access-coordinator.ts
+++ b/packages/providers/src/auth/token-access-coordinator.ts
@@ -12,11 +12,9 @@
  * via the injected AuthenticatorInterface to avoid a circular import cycle.
  */
 
-import {
-  DebugLogger,
-  type Config,
-  type OAuthTokenRequestMetadata,
-} from '@vybestack/llxprt-code-core';
+import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type {
   OAuthToken,
   TokenStore,

--- a/packages/providers/src/auth/token-bucket-failover-helper.ts
+++ b/packages/providers/src/auth/token-bucket-failover-helper.ts
@@ -11,11 +11,9 @@
  * BucketFailoverHandlerImpl for multi-bucket OAuth profiles.
  */
 
-import {
-  DebugLogger,
-  type Config,
-  type OAuthTokenRequestMetadata,
-} from '@vybestack/llxprt-code-core';
+import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { hasRequestMetadata } from './auth-utils.js';
 import { BucketFailoverHandlerImpl } from './BucketFailoverHandlerImpl.js';
 import { OnAuthErrorHandlerImpl } from './OnAuthErrorHandlerImpl.js';

--- a/packages/providers/src/auth/token-force-refresh-helper.ts
+++ b/packages/providers/src/auth/token-force-refresh-helper.ts
@@ -16,10 +16,10 @@
  */
 
 import {
-  DebugLogger,
   mergeRefreshedToken,
   type OAuthTokenWithExtras,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { invalidateProviderRuntimeCache } from '@vybestack/llxprt-code-auth';
 import type { OAuthToken, TokenStore } from './types.js';
 import type { ProviderRegistry } from './provider-registry.js';

--- a/packages/providers/src/auth/token-profile-resolver.ts
+++ b/packages/providers/src/auth/token-profile-resolver.ts
@@ -13,10 +13,8 @@
  * without instantiating the full coordinator.
  */
 
-import {
-  DebugLogger,
-  type OAuthTokenRequestMetadata,
-} from '@vybestack/llxprt-code-core';
+import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { createProfileManager } from './profile-utils.js';
 import { oauthRuntimeBridge } from './runtime-accessor-bridge.js';
 

--- a/packages/providers/src/auth/token-refresh-helper.ts
+++ b/packages/providers/src/auth/token-refresh-helper.ts
@@ -13,10 +13,10 @@
  */
 
 import {
-  DebugLogger,
   mergeRefreshedToken,
   type OAuthTokenWithExtras,
-} from '@vybestack/llxprt-code-core';
+} from '@vybestack/llxprt-code-auth';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import type { OAuthToken, TokenStore } from './types.js';
 import type { ProviderRegistry } from './provider-registry.js';
 import type { ProactiveRenewalManager } from './proactive-renewal-manager.js';

--- a/packages/providers/src/auth/types.ts
+++ b/packages/providers/src/auth/types.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { MessageBus, Config } from '@vybestack/llxprt-code-core';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 
 // @plan:PLAN-20260608-ISSUE1586.P15
 // @requirement:REQ-API-001.2


### PR DESCRIPTION
## Summary

Fixes the inverted `core → tools` dependency and barrel over-import chain that caused importing `@vybestack/llxprt-code-providers/auth.js` to transitively load all tool implementations including ast-grep native grammar addons — the root cause of the Windows Smart App Control crash (#2399).

### Three architectural changes:

**Phase 1 — Deep imports for auth graph:**
- All 21 production source files under `packages/providers/src/auth/` now import from deep core paths (`debug/DebugLogger.js`, `utils/debugLogger.js`, `utils/secure-browser-launcher.js`, `auth-factories.js`, `config/config.js`, `config/configTypes.js`, `confirmation-bus/message-bus.js`, `runtime/contracts/index.js`) instead of the `@vybestack/llxprt-code-core` barrel
- Value symbols re-exported through core from the auth package (`mergeRefreshedToken`, `flushRuntimeAuthScope`) now imported directly from `@vybestack/llxprt-code-auth`
- Added `./auth-factories.js` deep export to `packages/core/package.json`

**Phase 2 — Inverted core→tools dependency via registration hook:**
- Defined `PostSkillDiscoveryToolRegistrar` callback type in `configTypes.ts`
- Wired through `ConfigParameters`, `ConfigBaseCore`, `ConfigConstructor`
- `config.ts` `initialize()` now calls the injected registrar hook instead of directly importing and constructing `ActivateSkillTool`
- CLI `configBuilder.ts` provides the callback that imports `ActivateSkillTool` from the tools package and registers it
- Added `@vybestack/llxprt-code-tools` as explicit dependency in `packages/cli/package.json`

**Phase 3 — Tests and boundary guards:**
- `auth-import-isolation.test.ts`: verifies importing auth index loads zero tool implementations or ast-grep native modules
- `import-boundary.test.ts`: source-level guard asserting `config.ts` has no VALUE import from tools and `provider-registry.ts` uses deep paths
- Updated `auth-migration-p16.integration.test.ts` to allow the new `auth-factories.js` deep import while still forbidding old `core/auth` imports
- Updated affected test files that mocked the core barrel for spy interception to use deep module paths instead

## Verification

- `npm run typecheck` — PASS
- `npm run lint` — PASS
- `npm run format` — PASS
- `npm run build` — PASS
- `npm run test` — all non-pre-existing failures pass (proactive-renewal tests fail identically on main)
- `bun scripts/start.ts --profile-load ollamakimi "write me a haiku"` — PASS
- Open Code Review (ocr) — 1 low finding addressed (test cleanup ordering)

Closes #2417