### PR TITLE
fix(launcher): add self-exit guards to prevent orphaned shim processes on terminal/PTY death (Fixes #2468)

### DIFF
--- a/packages/cli/bin/llxprt.cjs
+++ b/packages/cli/bin/llxprt.cjs
@@ -7,6 +7,8 @@ const { basename, dirname, join } = require('node:path');
 
 const BUN_RELAUNCH_ENV = 'LLXPRT_BUN_RELAUNCHED';
 const FORWARDED_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK'];
+const SIGHUP_SELF_EXIT_DELAY_MS = 5_000;
+const ORPHAN_CHECK_INTERVAL_MS = 10_000;
 const SIGNAL_EXIT_CODES = {
   SIGHUP: 129,
   SIGINT: 130,
@@ -164,6 +166,10 @@ function describeError(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function bunLaunchErrorMessage(bunPath, error) {
+  return `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`;
+}
+
 function fatalExit(exit, message) {
   process.stderr.write(`${message}\n`);
   exit(43);
@@ -237,25 +243,54 @@ async function runCliBin(options = {}) {
       shell: isWindowsCmdShim(bunPath),
     });
   } catch (error) {
-    fatalExit(
-      exit,
-      `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
-    );
+    fatalExit(exit, bunLaunchErrorMessage(bunPath, error));
     return;
   }
 
-  attachChildHandlers(child, bunPath, exit);
+  attachChildHandlers(child, bunPath, exit, {
+    getPpid: options.getPpid,
+    selfExitDelayMs: options.selfExitDelayMs,
+    orphanCheckIntervalMs: options.orphanCheckIntervalMs,
+  });
 }
 
-function attachChildHandlers(child, bunPath, exit) {
+function attachChildHandlers(child, bunPath, exit, options = {}) {
   let settled = false;
+  let childExited = false;
+  let hangupExitTimer = null;
+  let orphanCheckTimer = null;
+
+  const getPpid = options.getPpid ?? (() => process.ppid);
+  const selfExitDelayMs = options.selfExitDelayMs ?? SIGHUP_SELF_EXIT_DELAY_MS;
+  const orphanCheckIntervalMs =
+    options.orphanCheckIntervalMs ?? ORPHAN_CHECK_INTERVAL_MS;
 
   const cleanupListeners = () => {
     child.off('close', onClose);
     child.off('error', onError);
+    child.off('exit', onChildExit);
     for (const signal of FORWARDED_SIGNALS) {
       process.off(signal, forwardSignal);
     }
+    process.off('beforeExit', onBeforeExit);
+    if (hangupExitTimer !== null) {
+      clearTimeout(hangupExitTimer);
+      hangupExitTimer = null;
+    }
+    if (orphanCheckTimer !== null) {
+      clearInterval(orphanCheckTimer);
+      orphanCheckTimer = null;
+    }
+  };
+
+  const settle = (exitCode) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanupListeners();
+    child.on('error', () => {});
+    exit(exitCode);
   };
 
   const forwardSignal = (signal) => {
@@ -267,41 +302,70 @@ function attachChildHandlers(child, bunPath, exit) {
     } catch {
       // Child may have already exited before the signal handler fired.
     }
+    // SIGHUP indicates the controlling terminal is gone. After forwarding,
+    // schedule a fallback self-exit so the shim cannot become an immortal
+    // husk if the child's close event never fires (e.g. child already
+    // reaped externally, or event loop stalled).
+    if (signal === 'SIGHUP' && hangupExitTimer === null) {
+      hangupExitTimer = setTimeout(() => {
+        settle(SIGNAL_EXIT_CODES['SIGHUP']);
+      }, selfExitDelayMs);
+      hangupExitTimer.unref();
+    }
   };
 
   const onClose = (code, signal) => {
-    if (settled) {
-      return;
-    }
-    settled = true;
-    cleanupListeners();
-    child.on('error', () => {});
+    let exitCode;
     if (code !== null) {
-      exit(code);
+      exitCode = code;
     } else if (signal !== null) {
-      exit(SIGNAL_EXIT_CODES[signal] ?? 1);
+      exitCode = SIGNAL_EXIT_CODES[signal] ?? 1;
     } else {
-      exit(1);
+      exitCode = 1;
     }
+    settle(exitCode);
   };
 
   const onError = (error) => {
     if (settled) {
       return;
     }
-    settled = true;
-    cleanupListeners();
-    child.on('error', () => {});
-    // Best-effort kill the child before reporting the fatal spawn error.
     try {
       child.kill('SIGTERM');
     } catch {
       // Child may have already exited before the async spawn error surfaced.
     }
-    fatalExit(
-      exit,
-      `Failed to launch Bun at "${bunPath}" (${describeError(error)}). Reinstall dependencies with "npm install" to restore the bundled Bun, or ensure a working Bun is executable and on your PATH (see https://bun.sh).`,
-    );
+    process.stderr.write(`${bunLaunchErrorMessage(bunPath, error)}
+`);
+    settle(43);
+  };
+
+  const onChildExit = () => {
+    childExited = true;
+  };
+
+  const onBeforeExit = () => {
+    if (settled) {
+      return;
+    }
+    // Last-resort guard: if the event loop is draining and the child has
+    // already exited (but 'close' never fired, e.g. inherited stdio with
+    // a dead terminal), exit now rather than hanging forever.
+    if (childExited) {
+      settle(1);
+    }
+  };
+
+  const checkOrphaned = () => {
+    if (settled) {
+      return;
+    }
+    // If the shim has been reparented to init (ppid === 1) and the child
+    // has already exited, the terminal is gone and no signal will arrive.
+    // Force exit to avoid becoming an immortal husk.
+    if (getPpid() === 1 && childExited) {
+      settle(1);
+    }
   };
 
   for (const signal of FORWARDED_SIGNALS) {
@@ -309,6 +373,10 @@ function attachChildHandlers(child, bunPath, exit) {
   }
   child.on('error', onError);
   child.on('close', onClose);
+  child.on('exit', onChildExit);
+  process.on('beforeExit', onBeforeExit);
+  orphanCheckTimer = setInterval(checkOrphaned, orphanCheckIntervalMs);
+  orphanCheckTimer.unref();
 }
 
 module.exports = { runCliBin };

--- a/packages/cli/bin/llxprt.cjs
+++ b/packages/cli/bin/llxprt.cjs
@@ -256,7 +256,7 @@ async function runCliBin(options = {}) {
 
 function attachChildHandlers(child, bunPath, exit, options = {}) {
   let settled = false;
-  let childExited = false;
+  let childExitInfo = null;
   let hangupExitTimer = null;
   let orphanCheckTimer = null;
 
@@ -283,14 +283,31 @@ function attachChildHandlers(child, bunPath, exit, options = {}) {
     }
   };
 
-  const settle = (exitCode) => {
+  const prepareSettle = () => {
     if (settled) {
-      return;
+      return false;
     }
     settled = true;
     cleanupListeners();
     child.on('error', () => {});
+    return true;
+  };
+
+  const settle = (exitCode) => {
+    if (!prepareSettle()) {
+      return;
+    }
     exit(exitCode);
+  };
+
+  const exitCodeFromChild = (code, signal) => {
+    if (code !== null) {
+      return code;
+    }
+    if (signal !== null) {
+      return SIGNAL_EXIT_CODES[signal] ?? 1;
+    }
+    return 1;
   };
 
   const forwardSignal = (signal) => {
@@ -315,19 +332,11 @@ function attachChildHandlers(child, bunPath, exit, options = {}) {
   };
 
   const onClose = (code, signal) => {
-    let exitCode;
-    if (code !== null) {
-      exitCode = code;
-    } else if (signal !== null) {
-      exitCode = SIGNAL_EXIT_CODES[signal] ?? 1;
-    } else {
-      exitCode = 1;
-    }
-    settle(exitCode);
+    settle(exitCodeFromChild(code, signal));
   };
 
   const onError = (error) => {
-    if (settled) {
+    if (!prepareSettle()) {
       return;
     }
     try {
@@ -337,34 +346,38 @@ function attachChildHandlers(child, bunPath, exit, options = {}) {
     }
     process.stderr.write(`${bunLaunchErrorMessage(bunPath, error)}
 `);
-    settle(43);
+    exit(43);
   };
 
-  const onChildExit = () => {
-    childExited = true;
+  const onChildExit = (code, signal) => {
+    childExitInfo = { code, signal };
   };
 
   const onBeforeExit = () => {
-    if (settled) {
+    if (settled || childExitInfo === null) {
       return;
     }
     // Last-resort guard: if the event loop is draining and the child has
     // already exited (but 'close' never fired, e.g. inherited stdio with
     // a dead terminal), exit now rather than hanging forever.
-    if (childExited) {
-      settle(1);
-    }
+    settle(exitCodeFromChild(childExitInfo.code, childExitInfo.signal));
   };
 
   const checkOrphaned = () => {
-    if (settled) {
+    if (settled || childExitInfo === null) {
       return;
     }
     // If the shim has been reparented to init (ppid === 1) and the child
     // has already exited, the terminal is gone and no signal will arrive.
     // Force exit to avoid becoming an immortal husk.
-    if (getPpid() === 1 && childExited) {
-      settle(1);
+    let orphaned;
+    try {
+      orphaned = getPpid() === 1;
+    } catch {
+      return;
+    }
+    if (orphaned) {
+      settle(exitCodeFromChild(childExitInfo.code, childExitInfo.signal));
     }
   };
 

--- a/packages/cli/src/launcher/cli-bin.test.ts
+++ b/packages/cli/src/launcher/cli-bin.test.ts
@@ -296,7 +296,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
 
     child.emit('exit', null, 'SIGTERM');
 
-    await vi.waitFor(() => expect(exitCalls).toStrictEqual([1]));
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([143]));
   });
 
   it('does not exit from orphan check when the child is still alive', async () => {
@@ -339,7 +339,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     expect(exitCalls).toStrictEqual([]);
 
     process.emit('beforeExit', 0);
-    expect(exitCalls).toStrictEqual([1]);
+    expect(exitCalls).toStrictEqual([0]);
   });
 
   it('does not exit via beforeExit when the child is still alive', async () => {

--- a/packages/cli/src/launcher/cli-bin.test.ts
+++ b/packages/cli/src/launcher/cli-bin.test.ts
@@ -20,6 +20,9 @@ interface RunCliBinOptions {
   spawn?: typeof spawnType;
   resolveBun?: () => string | null;
   resolveEntry?: () => string | null;
+  getPpid?: () => number;
+  selfExitDelayMs?: number;
+  orphanCheckIntervalMs?: number;
 }
 
 type ExitFn = (code?: number) => never;
@@ -103,9 +106,12 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
     vi.restoreAllMocks();
   });
 
-  async function runLauncher(overrides: RunCliBinOptions = {}) {
+  async function runLauncher(
+    overrides: RunCliBinOptions & { autoClose?: boolean } = {},
+  ) {
+    const { autoClose = true, ...cliBinOptions } = overrides;
     const exitCalls: number[] = [];
-    const child = createChildProcess();
+    const child = createChildProcess({ autoClose });
     const spawnFn = vi.fn(() => child);
 
     await runCliBin({
@@ -113,7 +119,7 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
       spawn: spawnFn as unknown as typeof spawnType,
       resolveBun: () => '/path/to/bun',
       resolveEntry: () => '/entry.ts',
-      ...overrides,
+      ...cliBinOptions,
     });
 
     return { child, exitCalls, spawnFn };
@@ -252,5 +258,99 @@ describe('cli bin (packages/cli/bin/llxprt.cjs)', () => {
   it('exposes runCliBin as a function without executing the launcher on import', () => {
     const bin = loadCliBin();
     expect(typeof bin.runCliBin).toBe('function');
+  });
+
+  it('schedules a self-exit on SIGHUP when the child does not close', async () => {
+    const { child, exitCalls } = await runLauncher({
+      autoClose: false,
+      selfExitDelayMs: 50,
+    });
+
+    process.emit('SIGHUP', 'SIGHUP');
+    expect(child.kill).toHaveBeenCalledWith('SIGHUP');
+
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([129]));
+  });
+
+  it('cancels the SIGHUP self-exit when the child closes before the grace period', async () => {
+    const { child, exitCalls } = await runLauncher({
+      autoClose: false,
+      selfExitDelayMs: 50,
+    });
+
+    process.emit('SIGHUP', 'SIGHUP');
+    child.emit('close', 0, null);
+
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(exitCalls).toStrictEqual([0]);
+  });
+
+  it('exits when orphaned (ppid=1) after child exit', async () => {
+    const { child, exitCalls } = await runLauncher({
+      autoClose: false,
+      getPpid: () => 1,
+      orphanCheckIntervalMs: 50,
+    });
+
+    child.emit('exit', null, 'SIGTERM');
+
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([1]));
+  });
+
+  it('does not exit from orphan check when the child is still alive', async () => {
+    const { child, exitCalls } = await runLauncher({
+      autoClose: false,
+      getPpid: () => 1,
+      orphanCheckIntervalMs: 50,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(exitCalls).toStrictEqual([]);
+
+    child.emit('close', 0, null);
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+  });
+
+  it('does not exit from orphan check when not orphaned (ppid!=1)', async () => {
+    const { child, exitCalls } = await runLauncher({
+      autoClose: false,
+      getPpid: () => 12345,
+      orphanCheckIntervalMs: 50,
+    });
+
+    child.emit('exit', 0, null);
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(exitCalls).toStrictEqual([]);
+
+    child.emit('close', 0, null);
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
+  });
+
+  it('exits via beforeExit guard when the child has exited but close never fires', async () => {
+    const { child, exitCalls } = await runLauncher({
+      autoClose: false,
+      getPpid: () => 12345,
+    });
+
+    child.emit('exit', 0, null);
+    expect(exitCalls).toStrictEqual([]);
+
+    process.emit('beforeExit', 0);
+    expect(exitCalls).toStrictEqual([1]);
+  });
+
+  it('does not exit via beforeExit when the child is still alive', async () => {
+    const { child, exitCalls } = await runLauncher({
+      autoClose: false,
+    });
+
+    process.emit('beforeExit', 0);
+    expect(exitCalls).toStrictEqual([]);
+
+    child.emit('close', 0, null);
+    await vi.waitFor(() => expect(exitCalls).toStrictEqual([0]));
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2468.

The `llxprt` launcher shim (`bin/llxprt.cjs`) forwarded SIGHUP to the Bun child but never scheduled its own exit, relying entirely on the child's `close` event to drive shutdown. When the controlling terminal died and the child was reaped externally (e.g. tmux server death), the `close` event might never fire, leaving the `node` shim as an immortal ppid=1 `Ss+` husk — sometimes still owning a zombie credential-proxy child.

### Root cause

The `forwardSignal` handler forwarded signals to the child and returned without scheduling any self-exit. The `child.on('close', onClose)` handler was the only shutdown path. If the child was killed by something other than the shim's signal forwarding (e.g. tmux tearing down the pane's process tree), and the `close` event didn't fire in the reparented state, the shim sat forever.

### Fix: three last-resort self-exit mechanisms

1. **SIGHUP fallback timer**: After forwarding SIGHUP, schedule a delayed self-exit (5s default). If the child closes normally before the timer fires, the timer is cancelled via `cleanupListeners()`. Otherwise the shim exits with SIGHUP's exit code (129).

2. **Orphan detection (ppid===1 check)**: A periodic unref'd interval (10s default) detects when the shim has been reparented to init (`ppid===1`) and the child has already exited (tracked via `child.on('exit')`). This catches the case where the terminal died without delivering SIGHUP (process group already torn down).

3. **beforeExit guard**: If the event loop drains (no more timers/I/O) and the child has exited but `close` never fired (e.g. inherited stdio with a dead terminal), exit immediately rather than hanging forever.

### Refactoring

- Extracted a shared `settle(exitCode)` function in `attachChildHandlers` to eliminate the duplicated settled/cleanup/exit pattern across `onClose`, `onError`, and the new fallback handlers.
- Extracted `bunLaunchErrorMessage(bunPath, error)` to eliminate duplicated error text between the sync spawn catch block and the async `onError` handler.

## Test plan

- [x] New unit tests: SIGHUP self-exit when child doesn't close, SIGHUP timer cancellation when child closes normally, orphan detection (ppid=1) after child exit, no-op when child still alive, no-op when not orphaned, beforeExit guard when child exited, no-op beforeExit when child alive
- [x] All 106 existing launcher tests pass (unit + e2e)
- [x] ESLint, Prettier, TypeScript, eslint-guard all pass
- [x] Build passes
- [x] OCR (Open Code Review) — 3 findings addressed (error message DRY, test listener leak, test helper consistency)

## Notes

- The credential-proxy-host.cjs sidecar was already removed by PR #2426, so the zombie credential-proxy child scenario from the issue is no longer possible from the launcher itself. This PR ensures the launcher shim cannot become an orphaned husk regardless.
- The new timers/intervals are all `.unref()`ed so they don't keep the event loop alive during normal operation.
- Configurable delays (`selfExitDelayMs`, `orphanCheckIntervalMs`, `getPpid`) are exposed as test seams via `runCliBin` options, defaulting to production values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launcher shutdown behavior so it exits more reliably when a child process hangs, disconnects, or never finishes closing.
  * Added safer handling for terminal hangups and orphaned processes to avoid leaving the app running unexpectedly.
  * Standardized launch error messages for clearer failure output.

* **Tests**
  * Added coverage for hangup, orphan detection, and fallback exit paths to verify the launcher behaves correctly in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->