### PR TITLE
Fail loudly on unavailable profile provider; never save LB runtime as a standard profile (Fixes #2479, Fixes #2478)

### DIFF
--- a/packages/cli/src/integration-tests/profile-system.integration.test.ts
+++ b/packages/cli/src/integration-tests/profile-system.integration.test.ts
@@ -19,27 +19,38 @@ describe('Profile Save/Load Cycle Integration Tests', () => {
   let tempDir: string;
   let profileManager: ProfileManager;
   let originalHome: string | undefined;
+  let originalConfigHome: string | undefined;
 
   beforeEach(async () => {
-    // Store original HOME environment variable
+    // Store original env vars
     originalHome = process.env.HOME;
+    originalConfigHome = process.env.LLXPRT_CONFIG_HOME;
 
     // Create a temporary directory for our test
     tempDir = await createTempDirectory();
 
-    // Set HOME to our temp directory so ProfileManager uses it
+    // Point the storage config root at our temp directory so ProfileManager
+    // uses it. ProfileManager resolves Storage.getGlobalConfigDir()/profiles,
+    // which honors LLXPRT_CONFIG_HOME (setting HOME alone is NOT enough and
+    // previously made these tests write into the real user profiles dir).
     process.env.HOME = tempDir;
+    process.env.LLXPRT_CONFIG_HOME = path.join(tempDir, '.llxprt');
 
-    // Create a new ProfileManager instance (will use our temp HOME)
+    // Create a new ProfileManager instance (will use our temp config root)
     profileManager = new ProfileManager();
   });
 
   afterEach(async () => {
-    // Restore original HOME
+    // Restore original env vars
     if (originalHome !== undefined) {
       process.env.HOME = originalHome;
     } else {
       delete process.env.HOME;
+    }
+    if (originalConfigHome !== undefined) {
+      process.env.LLXPRT_CONFIG_HOME = originalConfigHome;
+    } else {
+      delete process.env.LLXPRT_CONFIG_HOME;
     }
 
     // Clean up temp directory

--- a/packages/cli/src/ui/commands/providerCommand.test.ts
+++ b/packages/cli/src/ui/commands/providerCommand.test.ts
@@ -72,11 +72,13 @@ describe('providerCommand /provider save', () => {
   let originalHome: string | undefined;
   let originalUserProfile: string | undefined;
   let originalConfigHome: string | undefined;
+  let originalDataHome: string | undefined;
 
   beforeAll(() => {
     originalHome = process.env.HOME;
     originalUserProfile = process.env.USERPROFILE;
     originalConfigHome = process.env['LLXPRT_CONFIG_HOME'];
+    originalDataHome = process.env['LLXPRT_DATA_HOME'];
   });
 
   beforeEach(() => {
@@ -85,6 +87,10 @@ describe('providerCommand /provider save', () => {
     process.env.HOME = tempDir;
     process.env.USERPROFILE = tempDir;
     process.env['LLXPRT_CONFIG_HOME'] = path.join(tempDir, '.llxprt');
+    // Alias configs are written to <dataDir>/providers; the global
+    // test-storage isolation sets LLXPRT_DATA_HOME, so redirect it to this
+    // test's own root for the existsSync assertion below.
+    process.env['LLXPRT_DATA_HOME'] = path.join(tempDir, '.llxprt');
   });
 
   afterEach(() => {
@@ -106,6 +112,11 @@ describe('providerCommand /provider save', () => {
       delete process.env['LLXPRT_CONFIG_HOME'];
     } else {
       process.env['LLXPRT_CONFIG_HOME'] = originalConfigHome;
+    }
+    if (originalDataHome === undefined) {
+      delete process.env['LLXPRT_DATA_HOME'];
+    } else {
+      process.env['LLXPRT_DATA_HOME'] = originalDataHome;
     }
   });
 

--- a/packages/cli/test-setup-storage-isolation.ts
+++ b/packages/cli/test-setup-storage-isolation.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Isolates ALL storage roots to a per-run temp directory so tests can never
+ * write into the real user config/data dirs (profiles, settings, secure
+ * store). Integration tests previously leaked artifacts such as
+ * test-profile.json into ~/Library/Preferences/llxprt-code/profiles because
+ * ProfileManager defaults to Storage.getGlobalConfigDir().
+ *
+ * Storage.getGlobal*Dir() reads these env vars at call time, and CLI
+ * subprocesses spawned by integration tests inherit process.env, so setting
+ * them here covers both in-process and subprocess writes.
+ */
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+
+if (!process.env.LLXPRT_CONFIG_HOME) {
+  const testStorageRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'llxprt-cli-test-storage-'),
+  );
+  process.env.LLXPRT_CONFIG_HOME = path.join(testStorageRoot, 'config');
+  process.env.LLXPRT_DATA_HOME = path.join(testStorageRoot, 'data');
+  process.env.LLXPRT_CACHE_HOME = path.join(testStorageRoot, 'cache');
+}

--- a/packages/cli/test-setup-storage-isolation.ts
+++ b/packages/cli/test-setup-storage-isolation.ts
@@ -19,11 +19,16 @@ import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
 
-if (!process.env.LLXPRT_CONFIG_HOME) {
+// Guard on a dedicated marker (NOT on LLXPRT_CONFIG_HOME): a developer or CI
+// shell may legitimately export LLXPRT_CONFIG_HOME for CLI usage, and reusing
+// it as the guard would silently skip isolation and let tests write into that
+// real directory. The marker only dedupes isolation within this process tree.
+if (!process.env.LLXPRT_TEST_STORAGE_ISOLATED) {
   const testStorageRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), 'llxprt-cli-test-storage-'),
   );
   process.env.LLXPRT_CONFIG_HOME = path.join(testStorageRoot, 'config');
   process.env.LLXPRT_DATA_HOME = path.join(testStorageRoot, 'data');
   process.env.LLXPRT_CACHE_HOME = path.join(testStorageRoot, 'cache');
+  process.env.LLXPRT_TEST_STORAGE_ISOLATED = '1';
 }

--- a/packages/cli/test-setup.ts
+++ b/packages/cli/test-setup.ts
@@ -7,6 +7,10 @@
 // Set NODE_ENV to test if not already set
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
+// Isolate storage roots (profiles/settings/secure-store) to a temp dir so
+// tests never write into the real user config/data dirs.
+import './test-setup-storage-isolation.js';
+
 // Unset NO_COLOR environment variable to ensure consistent theme behavior between local and CI test runs
 if (process.env.NO_COLOR !== undefined) {
   delete process.env.NO_COLOR;

--- a/packages/cli/test/providers/providerAliases.test.ts
+++ b/packages/cli/test/providers/providerAliases.test.ts
@@ -31,6 +31,7 @@ describe('Provider alias integration', () => {
   let originalHome: string | undefined;
   let originalUserProfile: string | undefined;
   let originalConfigHome: string | undefined;
+  let originalDataHome: string | undefined;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-alias-test-'));
@@ -64,9 +65,14 @@ describe('Provider alias integration', () => {
     originalHome = process.env.HOME;
     originalUserProfile = process.env.USERPROFILE;
     originalConfigHome = process.env['LLXPRT_CONFIG_HOME'];
+    originalDataHome = process.env['LLXPRT_DATA_HOME'];
     process.env.HOME = tempDir;
     process.env.USERPROFILE = tempDir;
     process.env['LLXPRT_CONFIG_HOME'] = llxprtDir;
+    // User alias configs are read from <dataDir>/providers; the global
+    // test-storage isolation sets LLXPRT_DATA_HOME, so point it at this
+    // test's own root too.
+    process.env['LLXPRT_DATA_HOME'] = llxprtDir;
 
     resetProviderManager();
     setFileSystem(new NodeFileSystem());
@@ -98,6 +104,11 @@ describe('Provider alias integration', () => {
       delete process.env['LLXPRT_CONFIG_HOME'];
     } else {
       process.env['LLXPRT_CONFIG_HOME'] = originalConfigHome;
+    }
+    if (originalDataHome === undefined) {
+      delete process.env['LLXPRT_DATA_HOME'];
+    } else {
+      process.env['LLXPRT_DATA_HOME'] = originalDataHome;
     }
 
     resetProviderManager();

--- a/packages/cli/vitest.cli-integration.config.ts
+++ b/packages/cli/vitest.cli-integration.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     include: ['src/integration-tests/**/*.integration.test.ts'],
     environment: 'node',
     globals: true,
+    setupFiles: ['./test-setup-storage-isolation.ts'],
     reporters: ['default', 'junit'],
     silent: false,
     outputFile: {

--- a/packages/cli/vitest.config.integration.ts
+++ b/packages/cli/vitest.config.integration.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     include: ['src/providers/integration/**/*.test.ts'],
     environment: 'node',
     globals: true,
+    setupFiles: ['./test-setup-storage-isolation.ts'],
     reporters: ['default', 'junit'],
     silent: true,
     outputFile: {

--- a/packages/cli/vitest.integration.config.ts
+++ b/packages/cli/vitest.integration.config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
     },
     globals: true,
     reporters: ['default'],
+    setupFiles: ['./test-setup-storage-isolation.ts'],
     testTimeout: 30000, // Longer timeout for integration tests
     poolOptions: {
       threads: {

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -528,6 +528,19 @@ export class LoadBalancingProvider implements IProvider {
     );
   }
 
+  /**
+   * Exposes the load-balancer configuration so profile persistence can
+   * serialize the ACTIVE load balancer back into a genuine
+   * type:'loadbalancer' profile. Without this, saving a profile while a
+   * load balancer is active snapshots the virtual provider name
+   * ('load-balancer') into a standard profile — a corrupt file that can
+   * never be re-applied because 'load-balancer' is not a registered
+   * provider at load time (issue #2479).
+   */
+  getLoadBalancerConfig(): Readonly<LoadBalancingProviderConfig> {
+    return this.config;
+  }
+
   resetStats(): void {
     this.stats.clear();
     this.lastSelected = null;

--- a/packages/providers/src/LoggingProviderWrapper.ts
+++ b/packages/providers/src/LoggingProviderWrapper.ts
@@ -64,6 +64,10 @@ import {
   accumulateTokenUsage,
   resolveLoggingConfig,
 } from './logging/tokenAccumulator.js';
+import {
+  delegateGetStats,
+  delegateGetLoadBalancerConfig,
+} from './loadBalancing/wrappedProviderDelegation.js';
 
 export type { ConversationDataRedactor };
 
@@ -970,17 +974,13 @@ export class LoggingProviderWrapper implements IProvider {
     return this.performanceTracker.getLatestMetrics();
   }
 
-  /**
-   * Delegate getStats() to wrapped provider if it supports it (e.g., LoadBalancingProvider)
-   * @returns Stats from the underlying provider, or undefined if not supported
-   */
+  /** Delegate getStats() to the wrapped provider (e.g., LoadBalancingProvider). */
   getStats(): unknown {
-    if (
-      'getStats' in this.wrapped &&
-      typeof this.wrapped.getStats === 'function'
-    ) {
-      return (this.wrapped as { getStats: () => unknown }).getStats();
-    }
-    return undefined;
+    return delegateGetStats(this.wrapped);
+  }
+
+  /** Delegate getLoadBalancerConfig() down the wrapper chain (issue #2479). */
+  getLoadBalancerConfig(): unknown {
+    return delegateGetLoadBalancerConfig(this.wrapped);
   }
 }

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -46,6 +46,10 @@ import {
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { AllBucketsExhaustedError } from './errors.js';
 import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import {
+  delegateGetStats,
+  delegateGetLoadBalancerConfig,
+} from './loadBalancing/wrappedProviderDelegation.js';
 
 /**
  * Internal shape used to carry an AbortSignal through retry orchestration when
@@ -241,13 +245,16 @@ export class RetryOrchestrator implements IProvider {
    * underlying provider.
    */
   getStats(): unknown {
-    const candidate = this.wrappedProvider as {
-      getStats?: () => unknown;
-    };
-    if (typeof candidate.getStats === 'function') {
-      return candidate.getStats();
-    }
-    return undefined;
+    return delegateGetStats(this.wrappedProvider);
+  }
+
+  /**
+   * Delegate getLoadBalancerConfig() to the wrapped provider when supported
+   * (LoadBalancingProvider), so profile persistence can serialize the active
+   * load balancer through the wrapper chain (issue #2479).
+   */
+  getLoadBalancerConfig(): unknown {
+    return delegateGetLoadBalancerConfig(this.wrappedProvider);
   }
 
   /**

--- a/packages/providers/src/loadBalancing/wrappedProviderDelegation.ts
+++ b/packages/providers/src/loadBalancing/wrappedProviderDelegation.ts
@@ -14,18 +14,19 @@
  * a corrupt standard profile with provider:'load-balancer' (issue #2479).
  */
 
-export function delegateGetStats(wrapped: unknown): unknown {
-  const candidate = wrapped as { getStats?: () => unknown };
-  if (typeof candidate.getStats === 'function') {
-    return candidate.getStats();
+function delegateMethod(wrapped: unknown, methodName: string): unknown {
+  const candidate = wrapped as Record<string, unknown>;
+  const method = candidate[methodName];
+  if (typeof method === 'function') {
+    return (method as (this: unknown) => unknown).call(wrapped);
   }
   return undefined;
 }
 
+export function delegateGetStats(wrapped: unknown): unknown {
+  return delegateMethod(wrapped, 'getStats');
+}
+
 export function delegateGetLoadBalancerConfig(wrapped: unknown): unknown {
-  const candidate = wrapped as { getLoadBalancerConfig?: () => unknown };
-  if (typeof candidate.getLoadBalancerConfig === 'function') {
-    return candidate.getLoadBalancerConfig();
-  }
-  return undefined;
+  return delegateMethod(wrapped, 'getLoadBalancerConfig');
 }

--- a/packages/providers/src/loadBalancing/wrappedProviderDelegation.ts
+++ b/packages/providers/src/loadBalancing/wrappedProviderDelegation.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Delegation helpers for provider wrappers (LoggingProviderWrapper,
+ * RetryOrchestrator). Wrappers sit between callers and the underlying
+ * provider (e.g. LoadBalancingProvider), so optional capabilities like
+ * getStats()/getLoadBalancerConfig() must be forwarded down the chain.
+ * getLoadBalancerConfig() lets profile persistence serialize the ACTIVE
+ * load balancer back into a genuine type:'loadbalancer' profile instead of
+ * a corrupt standard profile with provider:'load-balancer' (issue #2479).
+ */
+
+export function delegateGetStats(wrapped: unknown): unknown {
+  const candidate = wrapped as { getStats?: () => unknown };
+  if (typeof candidate.getStats === 'function') {
+    return candidate.getStats();
+  }
+  return undefined;
+}
+
+export function delegateGetLoadBalancerConfig(wrapped: unknown): unknown {
+  const candidate = wrapped as { getLoadBalancerConfig?: () => unknown };
+  if (typeof candidate.getLoadBalancerConfig === 'function') {
+    return candidate.getLoadBalancerConfig();
+  }
+  return undefined;
+}

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -526,6 +526,17 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
       '1h';
     if (promptCachingSetting === 'off') return;
 
+    // An explicit prompt_cache_key from modelParams/request overrides (already
+    // sanitized at translateRequestOverrides) takes precedence over the
+    // runtimeId-derived default.
+    if (
+      typeof request.prompt_cache_key === 'string' &&
+      request.prompt_cache_key.trim() !== ''
+    ) {
+      if (!isCodex) request.prompt_cache_retention = '24h';
+      return;
+    }
+
     const cacheKey =
       (options.invocation as { runtimeId?: string } | undefined)?.runtimeId ??
       options.runtime?.runtimeId;

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -288,6 +288,11 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
           () =>
             `Skipping reasoning object in modelParams - handled via model-behavior settings`,
         );
+      } else if (key === 'prompt_cache_key' && typeof value === 'string') {
+        // OpenAI rejects prompt_cache_key longer than 64 chars (issue #2135);
+        // clamp at egress so overlong keys injected via modelParams never
+        // reach the API.
+        requestOverrides[key] = sanitizePromptCacheKey(value);
       } else {
         requestOverrides[key] = value;
       }

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -288,11 +288,21 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
           () =>
             `Skipping reasoning object in modelParams - handled via model-behavior settings`,
         );
-      } else if (key === 'prompt_cache_key' && typeof value === 'string') {
+      } else if (key === 'prompt_cache_key') {
         // OpenAI rejects prompt_cache_key longer than 64 chars (issue #2135);
         // clamp at egress so overlong keys injected via modelParams never
-        // reach the API.
-        requestOverrides[key] = sanitizePromptCacheKey(value);
+        // reach the API. Non-string or empty values are dropped entirely
+        // rather than forwarded as invalid request fields.
+        const sanitized =
+          typeof value === 'string' ? sanitizePromptCacheKey(value) : '';
+        if (sanitized !== '') {
+          requestOverrides[key] = sanitized;
+        } else {
+          this.logger.debug(
+            () =>
+              `Dropping invalid prompt_cache_key from modelParams (type=${typeof value})`,
+          );
+        }
       } else {
         requestOverrides[key] = value;
       }

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
@@ -635,4 +635,76 @@ describe('OpenAIResponsesProvider prompt-caching @issue:1145', () => {
     expect(cacheKey.length).toBeLessThanOrEqual(64);
     expect(cacheKey).not.toBe(overlongKey);
   });
+
+  it('should drop a non-string prompt_cache_key injected via modelParams instead of forwarding it', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+
+    let capturedBody: string | undefined;
+    mockFetch.mockImplementation(
+      async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        if (init?.body != null) {
+          capturedBody =
+            typeof init.body === 'string'
+              ? init.body
+              : await new Response(init.body).text();
+        }
+        return createMockStreamingResponse();
+      },
+    );
+
+    const settings = new SettingsService();
+    settings.set('activeProvider', provider.name);
+    settings.setProviderSetting(provider.name, 'model', 'o3-mini');
+
+    const config = createRuntimeConfigStub(settings);
+    const runtime = createProviderRuntimeContext({
+      settingsService: settings,
+      runtimeId: 'short-runtime-id',
+      config,
+    });
+
+    const invocation = createRuntimeInvocationContext({
+      runtime,
+      settings,
+      providerName: provider.name,
+      ephemeralsSnapshot: {
+        'prompt-caching': '1h',
+        prompt_cache_key: 12345,
+      },
+    });
+
+    const options = createProviderCallOptions({
+      settings,
+      config,
+      runtime,
+      invocation,
+      providerName: provider.name,
+      contents: [
+        { speaker: 'human', blocks: [{ type: 'text', text: 'test message' }] },
+      ],
+      ephemeralSettings: { 'prompt-caching': '1h' },
+    });
+
+    const generator = provider.generateChatCompletion(options);
+    for await (const _content of generator) {
+      // drain
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(capturedBody).toBeDefined();
+    const requestBody = JSON.parse(capturedBody!);
+
+    // The invalid non-string override must not survive; the provider's own
+    // runtimeId-derived key (a valid string) is applied instead.
+    const cacheKey = requestBody.prompt_cache_key as string;
+    expect(typeof cacheKey).toBe('string');
+    expect(cacheKey).not.toBe(12345 as unknown as string);
+    expect(cacheKey.length).toBeLessThanOrEqual(64);
+  });
 });

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { OpenAIResponsesProvider } from '../OpenAIResponsesProvider.js';
+import { sanitizePromptCacheKey } from '../sanitizePromptCacheKey.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import {
   createProviderRuntimeContext,
@@ -703,8 +704,6 @@ describe('OpenAIResponsesProvider prompt-caching @issue:1145', () => {
     // The invalid non-string override must not survive; the provider's own
     // runtimeId-derived key (a valid string) is applied instead.
     const cacheKey = requestBody.prompt_cache_key as string;
-    expect(typeof cacheKey).toBe('string');
-    expect(cacheKey).not.toBe(12345 as unknown as string);
-    expect(cacheKey.length).toBeLessThanOrEqual(64);
+    expect(cacheKey).toBe(sanitizePromptCacheKey('short-runtime-id'));
   });
 });

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
@@ -558,4 +558,81 @@ describe('OpenAIResponsesProvider prompt-caching @issue:1145', () => {
     // non-Codex still gets retention
     expect(requestBody.prompt_cache_retention).toBe('24h');
   });
+
+  it('should clamp an over-long prompt_cache_key injected via modelParams (issue #2135)', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+
+    let capturedBody: string | undefined;
+    mockFetch.mockImplementation(
+      async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        if (init?.body != null) {
+          capturedBody =
+            typeof init.body === 'string'
+              ? init.body
+              : await new Response(init.body).text();
+        }
+        return createMockStreamingResponse();
+      },
+    );
+
+    // Mirrors a subagent runtimeId: <uuid>#<subagent-name>#<8-char id> (69 chars)
+    const overlongKey =
+      '0d4429a9-79b0-4b64-a63e-d5d7a45f1878#fallbacktypescriptcoder#a1b2c3d4';
+    expect(overlongKey.length).toBeGreaterThan(64);
+
+    const settings = new SettingsService();
+    settings.set('activeProvider', provider.name);
+    settings.setProviderSetting(provider.name, 'model', 'o3-mini');
+
+    const config = createRuntimeConfigStub(settings);
+    const runtime = createProviderRuntimeContext({
+      settingsService: settings,
+      runtimeId: 'short-runtime-id',
+      config,
+    });
+
+    // Unknown ephemeral settings pass through separateSettings() as
+    // modelParams, which translateRequestOverrides() copies onto the request.
+    const invocation = createRuntimeInvocationContext({
+      runtime,
+      settings,
+      providerName: provider.name,
+      ephemeralsSnapshot: {
+        'prompt-caching': '1h',
+        prompt_cache_key: overlongKey,
+      },
+    });
+
+    const options = createProviderCallOptions({
+      settings,
+      config,
+      runtime,
+      invocation,
+      providerName: provider.name,
+      contents: [
+        { speaker: 'human', blocks: [{ type: 'text', text: 'test message' }] },
+      ],
+      ephemeralSettings: { 'prompt-caching': '1h' },
+    });
+
+    const generator = provider.generateChatCompletion(options);
+    for await (const _content of generator) {
+      // drain
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(capturedBody).toBeDefined();
+    const requestBody = JSON.parse(capturedBody!);
+
+    const cacheKey = requestBody.prompt_cache_key as string;
+    expect(typeof cacheKey).toBe('string');
+    expect(cacheKey.length).toBeLessThanOrEqual(64);
+    expect(cacheKey).not.toBe(overlongKey);
+  });
 });

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.promptCacheKey.test.ts
@@ -635,6 +635,11 @@ describe('OpenAIResponsesProvider prompt-caching @issue:1145', () => {
     expect(typeof cacheKey).toBe('string');
     expect(cacheKey.length).toBeLessThanOrEqual(64);
     expect(cacheKey).not.toBe(overlongKey);
+    // The explicitly injected (sanitized) modelParams key wins over the
+    // runtimeId-derived default, proving the translateRequestOverrides path
+    // was exercised rather than applyPromptCaching overwriting it.
+    expect(cacheKey).toBe(sanitizePromptCacheKey(overlongKey));
+    expect(cacheKey).not.toBe(sanitizePromptCacheKey('short-runtime-id'));
   });
 
   it('should drop a non-string prompt_cache_key injected via modelParams instead of forwarding it', async () => {

--- a/packages/providers/src/openai/openaiRequestParams.test.ts
+++ b/packages/providers/src/openai/openaiRequestParams.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { filterOpenAIRequestParams } from './openaiRequestParams.js';
+import { MAX_PROMPT_CACHE_KEY_LENGTH } from '../openai-responses/sanitizePromptCacheKey.js';
 
 describe('filterOpenAIRequestParams', () => {
   it('keeps supported OpenAI parameters and normalizes aliases', () => {
@@ -50,5 +51,44 @@ describe('filterOpenAIRequestParams', () => {
         effort: 'xhigh',
       },
     });
+  });
+
+  it('passes short prompt_cache_key values through unchanged', () => {
+    const filtered = filterOpenAIRequestParams({
+      prompt_cache_key: 'session-abc123',
+    });
+
+    expect(filtered).toStrictEqual({
+      prompt_cache_key: 'session-abc123',
+    });
+  });
+
+  it('clamps prompt_cache_key values longer than 64 chars (issue #2135)', () => {
+    // Mirrors a real subagent runtimeId: <uuid>#<subagent-name>#<8-char id>
+    const overlongKey =
+      '0d4429a9-79b0-4b64-a63e-d5d7a45f1878#fallbacktypescriptcoder#a1b2c3d4';
+    expect(overlongKey.length).toBeGreaterThan(MAX_PROMPT_CACHE_KEY_LENGTH);
+
+    const filtered = filterOpenAIRequestParams({
+      prompt_cache_key: overlongKey,
+    });
+
+    const clamped = filtered?.prompt_cache_key as string;
+    expect(clamped.length).toBeLessThanOrEqual(MAX_PROMPT_CACHE_KEY_LENGTH);
+    expect(clamped.startsWith('rk:')).toBe(true);
+
+    // Deterministic: the same overlong key maps to the same clamped key
+    const filteredAgain = filterOpenAIRequestParams({
+      prompt_cache_key: overlongKey,
+    });
+    expect(filteredAgain?.prompt_cache_key).toBe(clamped);
+  });
+
+  it('still drops empty prompt_cache_key values', () => {
+    const filtered = filterOpenAIRequestParams({
+      prompt_cache_key: '   ',
+    });
+
+    expect(filtered).toBeUndefined();
   });
 });

--- a/packages/providers/src/openai/openaiRequestParams.test.ts
+++ b/packages/providers/src/openai/openaiRequestParams.test.ts
@@ -91,4 +91,13 @@ describe('filterOpenAIRequestParams', () => {
 
     expect(filtered).toBeUndefined();
   });
+
+  it('drops non-string prompt_cache_key values instead of forwarding them', () => {
+    const filtered = filterOpenAIRequestParams({
+      prompt_cache_key: 12345,
+      temperature: 0.5,
+    });
+
+    expect(filtered).toStrictEqual({ temperature: 0.5 });
+  });
 });

--- a/packages/providers/src/openai/openaiRequestParams.ts
+++ b/packages/providers/src/openai/openaiRequestParams.ts
@@ -5,6 +5,8 @@
  * must never be forwarded to the API.
  */
 
+import { sanitizePromptCacheKey } from '../openai-responses/sanitizePromptCacheKey.js';
+
 const OPENAI_ALLOWED_PARAM_KEYS = new Set<string>([
   'temperature',
   'top_p',
@@ -109,12 +111,14 @@ function processParamEntry(
     }
     return { key: normalizedKey, value: sanitized };
   }
-  if (
-    normalizedKey === 'prompt_cache_key' &&
-    typeof value === 'string' &&
-    value.trim() === ''
-  ) {
-    return undefined;
+  if (normalizedKey === 'prompt_cache_key' && typeof value === 'string') {
+    if (value.trim() === '') {
+      return undefined;
+    }
+    // OpenAI rejects prompt_cache_key longer than 64 chars (issue #2135);
+    // clamp at egress so overlong runtime/session-derived keys never reach
+    // the API regardless of which layer injected them.
+    return { key: normalizedKey, value: sanitizePromptCacheKey(value) };
   }
   return { key: normalizedKey, value };
 }

--- a/packages/providers/src/openai/openaiRequestParams.ts
+++ b/packages/providers/src/openai/openaiRequestParams.ts
@@ -111,13 +111,14 @@ function processParamEntry(
     }
     return { key: normalizedKey, value: sanitized };
   }
-  if (normalizedKey === 'prompt_cache_key' && typeof value === 'string') {
-    if (value.trim() === '') {
-      return undefined;
-    }
+  if (normalizedKey === 'prompt_cache_key') {
     // OpenAI rejects prompt_cache_key longer than 64 chars (issue #2135);
     // clamp at egress so overlong runtime/session-derived keys never reach
-    // the API regardless of which layer injected them.
+    // the API regardless of which layer injected them. Non-string or empty
+    // values are dropped rather than forwarded as invalid request fields.
+    if (typeof value !== 'string' || value.trim() === '') {
+      return undefined;
+    }
     return { key: normalizedKey, value: sanitizePromptCacheKey(value) };
   }
   return { key: normalizedKey, value };

--- a/packages/providers/src/runtime/__tests__/profileApplication.unavailableProvider.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.unavailableProvider.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for issue #2479: a profile naming a provider that is not
+ * registered must FAIL LOUDLY instead of silently falling back to the first
+ * registered provider (gemini). The silent fallback produced dead sessions:
+ * the profile "loaded", the session landed on gemini without credentials,
+ * and every subsequent prompt was swallowed with no error.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Profile } from '@vybestack/llxprt-code-settings';
+import {
+  switchActiveProviderMock,
+  setActiveModelMock,
+  updateActiveProviderBaseUrlMock,
+  updateActiveProviderApiKeyMock,
+  setActiveModelParamMock,
+  clearActiveModelParamMock,
+  getActiveModelParamsMock,
+  setEphemeralSettingMock,
+  getCliRuntimeServicesMock,
+  getActiveProviderOrThrowMock,
+  isCliStatelessProviderModeEnabledMock,
+  isCliRuntimeStatelessReadyMock,
+  createProviderKeyStorageMock,
+  providerManagerStub,
+  resetProfileApplicationStubs,
+  restoreGcpEnvVars,
+} from './profileApplicationTestSetup.js';
+
+vi.mock('../runtimeSettings.js', () => ({
+  switchActiveProvider: switchActiveProviderMock,
+  setActiveModel: setActiveModelMock,
+  updateActiveProviderBaseUrl: updateActiveProviderBaseUrlMock,
+  updateActiveProviderApiKey: updateActiveProviderApiKeyMock,
+  setActiveModelParam: setActiveModelParamMock,
+  clearActiveModelParam: clearActiveModelParamMock,
+  getActiveModelParams: getActiveModelParamsMock,
+  setEphemeralSetting: setEphemeralSettingMock,
+  createProviderKeyStorage: createProviderKeyStorageMock,
+  getCliRuntimeServices: getCliRuntimeServicesMock,
+  getActiveProviderOrThrow: getActiveProviderOrThrowMock,
+  isCliStatelessProviderModeEnabled: isCliStatelessProviderModeEnabledMock,
+  isCliRuntimeStatelessReady: isCliRuntimeStatelessReadyMock,
+}));
+
+const { applyProfileWithGuards, selectAvailableProvider } = await import(
+  '../profileApplication.js'
+);
+
+describe('selectAvailableProvider (issue #2479)', () => {
+  it('throws when the requested provider is not registered', () => {
+    expect(() =>
+      selectAvailableProvider('load-balancer', ['gemini', 'openai']),
+    ).toThrow(
+      /Provider 'load-balancer' is not available \(registered providers: gemini, openai\)\. Profile not applied\./,
+    );
+  });
+
+  it('does NOT silently fall back to the first registered provider', () => {
+    expect(() => selectAvailableProvider('anthropic', ['gemini'])).toThrow(
+      /Provider 'anthropic' is not available/,
+    );
+  });
+
+  it('still selects the requested provider when it is registered', () => {
+    const result = selectAvailableProvider('anthropic', [
+      'gemini',
+      'anthropic',
+    ]);
+    expect(result.providerName).toBe('anthropic');
+    expect(result.didFallback).toBe(false);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('keeps the silent fallback for profiles with no provider at all', () => {
+    const result = selectAvailableProvider(undefined, ['gemini', 'openai']);
+    expect(result.providerName).toBe('gemini');
+    expect(result.didFallback).toBe(false);
+    expect(result.requestedProvider).toBeNull();
+  });
+
+  it('keeps the silent fallback for empty-string provider', () => {
+    const result = selectAvailableProvider('   ', ['openai']);
+    expect(result.providerName).toBe('openai');
+    expect(result.requestedProvider).toBeNull();
+  });
+
+  it('still throws when no providers are registered at all', () => {
+    expect(() => selectAvailableProvider('anthropic', [])).toThrow(
+      /No registered providers are available/,
+    );
+  });
+});
+
+describe('applyProfileWithGuards with unavailable provider (issue #2479)', () => {
+  let savedGcpProject: string | undefined;
+  let savedGcpLocation: string | undefined;
+
+  beforeEach(() => {
+    const saved = resetProfileApplicationStubs();
+    savedGcpProject = saved.savedGcpProject;
+    savedGcpLocation = saved.savedGcpLocation;
+  });
+
+  afterEach(() => {
+    restoreGcpEnvVars(savedGcpProject, savedGcpLocation);
+    vi.clearAllMocks();
+  });
+
+  it('rejects the corrupt-profile shape that caused the dead session', async () => {
+    // Exact corruption from the field: a runtime snapshot of an active
+    // load-balancer session saved as a standard profile. 'load-balancer'
+    // is a virtual provider name that is never registered at startup.
+    const corruptProfile: Profile = {
+      version: 1,
+      provider: 'load-balancer',
+      model: 'gemini-2.5-pro',
+      modelParams: {},
+      ephemeralSettings: {
+        'context-limit': 200000,
+        maxOutputTokens: 60000,
+      },
+    };
+
+    providerManagerStub.available = ['gemini', 'openai', 'anthropic'];
+    providerManagerStub.providerLookup = new Map([
+      ['gemini', { name: 'gemini' }],
+      ['openai', { name: 'openai' }],
+      ['anthropic', { name: 'anthropic' }],
+    ]);
+
+    await expect(
+      applyProfileWithGuards(corruptProfile, { profileName: 'zai' }),
+    ).rejects.toThrow(/Provider 'load-balancer' is not available/);
+
+    // The session must not have been mutated: no provider switch happened.
+    expect(switchActiveProviderMock).not.toHaveBeenCalled();
+    expect(setActiveModelMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects before mutating ephemeral settings', async () => {
+    const profile: Profile = {
+      version: 1,
+      provider: 'not-a-real-provider',
+      model: 'some-model',
+      modelParams: {},
+      ephemeralSettings: { 'base-url': 'https://example.invalid' },
+    };
+
+    providerManagerStub.available = ['gemini'];
+    providerManagerStub.providerLookup = new Map([
+      ['gemini', { name: 'gemini' }],
+    ]);
+
+    await expect(
+      applyProfileWithGuards(profile, { profileName: 'broken' }),
+    ).rejects.toThrow(/Provider 'not-a-real-provider' is not available/);
+
+    expect(setEphemeralSettingMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/providers/src/runtime/__tests__/profileApplicationTestSetup.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplicationTestSetup.ts
@@ -168,6 +168,11 @@ export const providerManagerStub = {
   },
   registerProvider(provider: { name: string }) {
     this.providerLookup.set(provider.name, provider);
+    // Mirror the real ProviderManager: listProviders() reflects every
+    // registered provider, so registration must update the available list.
+    if (!this.available.includes(provider.name)) {
+      this.available.push(provider.name);
+    }
   },
 };
 export const isCliStatelessProviderModeEnabledMock = vi

--- a/packages/providers/src/runtime/__tests__/profileSnapshot.loadBalancerSave.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileSnapshot.loadBalancerSave.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for issue #2479 (save side): saving a profile while a
+ * load balancer is the active provider must produce a genuine
+ * type:'loadbalancer' profile (or fail loudly) — never a standard profile
+ * with provider:'load-balancer'. That corrupt shape can never be re-applied
+ * because 'load-balancer' is not a registered provider at load time, and it
+ * previously produced dead sessions via the silent gemini fallback.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isLoadBalancerProfile } from '@vybestack/llxprt-code-settings';
+import type { LoadBalancerProfile } from '@vybestack/llxprt-code-settings';
+
+const saveProfileMock = vi.hoisted(() => vi.fn());
+
+const runtimeServicesState = vi.hoisted(() => ({
+  activeProviderName: 'load-balancer' as string,
+  lbConfig: null as unknown,
+  ephemerals: {} as Record<string, unknown>,
+}));
+
+vi.mock('../runtimeAccessors.js', () => ({
+  getCliRuntimeServices: vi.fn(() => ({
+    config: {
+      getEphemeralSettings: () => runtimeServicesState.ephemerals,
+      getProvider: () => runtimeServicesState.activeProviderName,
+      getModel: () => 'whatever-model',
+    },
+    settingsService: {
+      setCurrentProfileName: vi.fn(),
+      set: vi.fn(),
+      get: vi.fn(),
+    },
+    providerManager: {
+      getActiveProviderName: () => runtimeServicesState.activeProviderName,
+      getProviderByName: (name: string) =>
+        name === 'load-balancer' && runtimeServicesState.lbConfig !== null
+          ? {
+              getLoadBalancerConfig: () => runtimeServicesState.lbConfig,
+            }
+          : null,
+    },
+  })),
+  maybeGetCliOAuthManager: vi.fn(() => null),
+  getActiveModelName: vi.fn(() => 'test-model'),
+  getActiveModelParams: vi.fn(() => ({})),
+  _internal: {
+    resolveActiveProviderName: vi.fn(
+      () => runtimeServicesState.activeProviderName,
+    ),
+    getProviderSettingsSnapshot: vi.fn(() => ({})),
+    getActiveProviderOrThrow: vi.fn(),
+    extractModelParams: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('../profileApplication.js', () => ({
+  applyProfileWithGuards: vi.fn(),
+}));
+
+vi.mock('@vybestack/llxprt-code-settings', async () => {
+  const actual = await vi.importActual<
+    typeof import('@vybestack/llxprt-code-settings')
+  >('@vybestack/llxprt-code-settings');
+  return {
+    ...actual,
+    ProfileManager: vi.fn(() => ({
+      saveProfile: saveProfileMock,
+      loadProfile: vi.fn(),
+      listProfiles: vi.fn(),
+    })),
+  };
+});
+
+const { buildRuntimeProfileSnapshot, saveProfileSnapshot } = await import(
+  '../profileSnapshot.js'
+);
+
+describe('profile save while load balancer is active (issue #2479)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtimeServicesState.activeProviderName = 'load-balancer';
+    runtimeServicesState.ephemerals = {};
+    runtimeServicesState.lbConfig = {
+      profileName: 'glm',
+      strategy: 'round-robin',
+      subProfiles: [
+        { name: 'glm-a', providerName: 'anthropic', model: 'glm-5.2' },
+        { name: 'glm-b', providerName: 'anthropic', model: 'glm-5.2' },
+      ],
+      contextLimit: 200000,
+      lbProfileEphemeralSettings: { 'context-limit': 200000 },
+      lbProfileModelParams: {},
+    };
+  });
+
+  it('serializes the active load balancer as a genuine loadbalancer profile', () => {
+    const snapshot = buildRuntimeProfileSnapshot() as LoadBalancerProfile;
+
+    expect(isLoadBalancerProfile(snapshot)).toBe(true);
+    expect(snapshot.type).toBe('loadbalancer');
+    expect(snapshot.policy).toBe('roundrobin');
+    expect(snapshot.profiles).toStrictEqual(['glm-a', 'glm-b']);
+    expect(snapshot.contextLimit).toBe(200000);
+    // The corrupt field-shape from the field must never be produced:
+    expect(snapshot.provider).not.toBe('load-balancer');
+  });
+
+  it('maps failover strategy to failover policy', () => {
+    runtimeServicesState.lbConfig = {
+      ...(runtimeServicesState.lbConfig as Record<string, unknown>),
+      strategy: 'failover',
+    };
+
+    const snapshot = buildRuntimeProfileSnapshot() as LoadBalancerProfile;
+    expect(isLoadBalancerProfile(snapshot)).toBe(true);
+    expect(snapshot.policy).toBe('failover');
+  });
+
+  it('the saved loadbalancer snapshot passes isLoadBalancerProfile so reload takes the LB path', async () => {
+    const saved = await saveProfileSnapshot('glm');
+
+    expect(saveProfileMock).toHaveBeenCalledTimes(1);
+    const [, persisted] = saveProfileMock.mock.calls[0];
+    expect(isLoadBalancerProfile(persisted)).toBe(true);
+    expect(isLoadBalancerProfile(saved)).toBe(true);
+  });
+
+  it('throws instead of writing a corrupt file when the LB config is unreadable', () => {
+    runtimeServicesState.lbConfig = null;
+
+    expect(() => buildRuntimeProfileSnapshot()).toThrow(
+      /load balancer is active but its configuration could not be read/,
+    );
+  });
+
+  it('saveProfileSnapshot refuses to persist provider load-balancer as a standard profile', async () => {
+    runtimeServicesState.lbConfig = null;
+
+    await expect(saveProfileSnapshot('zai')).rejects.toThrow(
+      /could not be read|corrupt profile/,
+    );
+    expect(saveProfileMock).not.toHaveBeenCalled();
+  });
+
+  it('additionalConfig cannot strip the loadbalancer type into a corrupt standard profile', async () => {
+    await expect(
+      saveProfileSnapshot('zai', {
+        type: undefined,
+        provider: 'load-balancer',
+      } as never),
+    ).rejects.toThrow(/corrupt profile/);
+    expect(saveProfileMock).not.toHaveBeenCalled();
+  });
+
+  it('standard-provider saves are unaffected', async () => {
+    runtimeServicesState.activeProviderName = 'anthropic';
+
+    const saved = await saveProfileSnapshot('zai');
+    expect(saveProfileMock).toHaveBeenCalledTimes(1);
+    expect(saved.provider).toBe('anthropic');
+    expect(isLoadBalancerProfile(saved)).toBe(false);
+  });
+});

--- a/packages/providers/src/runtime/__tests__/profileSnapshot.loadBalancerSave.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileSnapshot.loadBalancerSave.test.ts
@@ -123,7 +123,7 @@ describe('profile save while load balancer is active (issue #2479)', () => {
     expect(snapshot.policy).toBe('failover');
   });
 
-  it('the saved loadbalancer snapshot passes isLoadBalancerProfile so reload takes the LB path', async () => {
+  it('the saved loadbalancer snapshot passes isLoadBalancerProfile validation', async () => {
     const saved = await saveProfileSnapshot('glm');
 
     expect(saveProfileMock).toHaveBeenCalledTimes(1);

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -129,18 +129,24 @@ export function selectAvailableProvider(
     );
   }
 
-  const fallbackProvider = availableProviders[0];
   if (trimmedRequested) {
-    warnings.push(
-      `Provider '${trimmedRequested}' unavailable, using '${fallbackProvider}'`,
+    // A profile that explicitly names a provider must never be silently
+    // rerouted to a different provider (issue #2479: a corrupt profile
+    // naming an unregistered provider landed the session on gemini with
+    // no error, swallowing all subsequent input). Fail loudly instead.
+    throw new Error(
+      `Provider '${trimmedRequested}' is not available (registered providers: ${availableProviders.join(
+        ', ',
+      )}). Profile not applied.`,
     );
   }
 
+  const fallbackProvider = availableProviders[0];
   return {
     providerName: fallbackProvider,
     warnings,
-    didFallback: Boolean(trimmedRequested),
-    requestedProvider: trimmedRequested || null,
+    didFallback: false,
+    requestedProvider: null,
   };
 }
 

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -38,6 +38,12 @@ import { maybeRegisterLoadBalancerProfile } from './profile-application/loadBala
 export interface ProviderSelectionResult {
   providerName: string;
   warnings: string[];
+  /**
+   * Always false since issue #2479: a named-but-unavailable provider now
+   * throws instead of silently falling back, so no success path sets this to
+   * true anymore. Retained for API stability (threaded through
+   * ProfileApplicationResult and profileSnapshot consumers).
+   */
   didFallback: boolean;
 
   requestedProvider: string | null;

--- a/packages/providers/src/runtime/profileSnapshot.ts
+++ b/packages/providers/src/runtime/profileSnapshot.ts
@@ -225,10 +225,22 @@ function buildLoadBalancerProfileSnapshot(
     );
   }
 
+  // Exhaustive over LoadBalancingProviderConfig['strategy']: adding a new
+  // strategy without a profile-policy mapping fails compilation here rather
+  // than silently saving as roundrobin.
+  const policyByStrategy: Record<
+    LoadBalancingProviderConfig['strategy'],
+    LoadBalancerProfile['policy']
+  > = {
+    failover: 'failover',
+    'round-robin': 'roundrobin',
+  };
+  const policy = policyByStrategy[lbConfig.strategy];
+
   return {
     version: 1,
     type: 'loadbalancer',
-    policy: lbConfig.strategy === 'failover' ? 'failover' : 'roundrobin',
+    policy,
     profiles: memberNames,
     ...(typeof lbConfig.contextLimit === 'number' && lbConfig.contextLimit > 0
       ? { contextLimit: lbConfig.contextLimit }

--- a/packages/providers/src/runtime/profileSnapshot.ts
+++ b/packages/providers/src/runtime/profileSnapshot.ts
@@ -29,6 +29,7 @@ import {
   _internal as runtimeAccessorsInternal,
 } from './runtimeAccessors.js';
 import { applyProfileWithGuards } from './profileApplication.js';
+import type { LoadBalancingProviderConfig } from '../loadBalancing/loadBalancerTypes.js';
 import {
   getProfileEphemeralSettings,
   getProfileModel,
@@ -206,23 +207,16 @@ function buildLoadBalancerProfileSnapshot(
 ): LoadBalancerProfile {
   const provider = snapshotProviderManager.getProviderByName?.(
     'load-balancer',
-  ) as { getLoadBalancerConfig?: () => unknown } | null | undefined;
+  ) as
+    | { getLoadBalancerConfig?: () => Readonly<LoadBalancingProviderConfig> }
+    | null
+    | undefined;
   const lbConfig =
     typeof provider?.getLoadBalancerConfig === 'function'
-      ? (provider.getLoadBalancerConfig() as {
-          strategy?: string;
-          subProfiles?: Array<{ name?: unknown }>;
-          contextLimit?: number;
-          lbProfileEphemeralSettings?: Record<string, unknown>;
-          lbProfileModelParams?: Record<string, unknown>;
-        } | null)
+      ? provider.getLoadBalancerConfig()
       : null;
 
-  const memberNames = Array.isArray(lbConfig?.subProfiles)
-    ? lbConfig.subProfiles
-        .map((sub) => sub.name)
-        .filter((name): name is string => typeof name === 'string')
-    : [];
+  const memberNames = lbConfig?.subProfiles.map((sub) => sub.name) ?? [];
 
   if (!lbConfig || memberNames.length === 0) {
     throw new Error(

--- a/packages/providers/src/runtime/profileSnapshot.ts
+++ b/packages/providers/src/runtime/profileSnapshot.ts
@@ -194,6 +194,60 @@ function isSkippableProfileKey(
   return false;
 }
 
+/**
+ * Serializes the ACTIVE LoadBalancingProvider back into a genuine
+ * type:'loadbalancer' profile. Saving while a load balancer is active used to
+ * snapshot the virtual provider name ('load-balancer') into a STANDARD
+ * profile — a corrupt file that could never be re-applied because
+ * 'load-balancer' is not a registered provider at load time (issue #2479).
+ */
+function buildLoadBalancerProfileSnapshot(
+  snapshotProviderManager: RuntimeSnapshotProviderManager,
+): LoadBalancerProfile {
+  const provider = snapshotProviderManager.getProviderByName?.(
+    'load-balancer',
+  ) as { getLoadBalancerConfig?: () => unknown } | null | undefined;
+  const lbConfig =
+    typeof provider?.getLoadBalancerConfig === 'function'
+      ? (provider.getLoadBalancerConfig() as {
+          strategy?: string;
+          subProfiles?: Array<{ name?: unknown }>;
+          contextLimit?: number;
+          lbProfileEphemeralSettings?: Record<string, unknown>;
+          lbProfileModelParams?: Record<string, unknown>;
+        } | null)
+      : null;
+
+  const memberNames = Array.isArray(lbConfig?.subProfiles)
+    ? lbConfig.subProfiles
+        .map((sub) => sub.name)
+        .filter((name): name is string => typeof name === 'string')
+    : [];
+
+  if (!lbConfig || memberNames.length === 0) {
+    throw new Error(
+      'Cannot save profile: a load balancer is active but its configuration ' +
+        'could not be read. Saving would produce a corrupt profile.',
+    );
+  }
+
+  return {
+    version: 1,
+    type: 'loadbalancer',
+    policy: lbConfig.strategy === 'failover' ? 'failover' : 'roundrobin',
+    profiles: memberNames,
+    ...(typeof lbConfig.contextLimit === 'number' && lbConfig.contextLimit > 0
+      ? { contextLimit: lbConfig.contextLimit }
+      : {}),
+    provider: '',
+    model: '',
+    modelParams: (lbConfig.lbProfileModelParams ??
+      {}) as LoadBalancerProfile['modelParams'],
+    ephemeralSettings: (lbConfig.lbProfileEphemeralSettings ??
+      {}) as LoadBalancerProfile['ephemeralSettings'],
+  };
+}
+
 export function buildRuntimeProfileSnapshot(): Profile {
   const { config, settingsService, providerManager } = getCliRuntimeServices();
   const snapshotConfig = config as RuntimeSnapshotConfig;
@@ -204,6 +258,10 @@ export function buildRuntimeProfileSnapshot(): Profile {
     snapshotProviderManager.getActiveProviderName?.() ??
     snapshotConfig.getProvider?.() ??
     'openai';
+
+  if (providerName === 'load-balancer') {
+    return buildLoadBalancerProfileSnapshot(snapshotProviderManager);
+  }
   const providerSettings = getProviderSettingsSnapshot(
     settingsService,
     providerName,
@@ -593,6 +651,21 @@ export async function saveProfileSnapshot(
   let finalProfile: Profile = snapshot;
   if (additionalConfig) {
     finalProfile = { ...snapshot, ...additionalConfig } as Profile;
+  }
+
+  // Defense in depth for issue #2479: never persist the virtual
+  // 'load-balancer' provider name as a standard profile. Such a file can
+  // never be re-applied ('load-balancer' is not a registered provider at
+  // load time) and previously produced dead sessions via silent fallback.
+  if (
+    !isLoadBalancerProfile(finalProfile) &&
+    finalProfile.provider === 'load-balancer'
+  ) {
+    throw new Error(
+      `Cannot save profile '${profileName}': the active provider is a ` +
+        'load balancer but the snapshot is not a valid loadbalancer profile. ' +
+        'Saving would produce a corrupt profile.',
+    );
   }
 
   await manager.saveProfile(profileName, finalProfile);


### PR DESCRIPTION
## Summary

Fixes the 0.10.0 "profile load lands on gemini and the session silently swallows all input" regression (#2479), documents the root-cause analysis for the installer path-splitting report (#2478), and hardens two adjacent defects discovered while diagnosing.

Fixes #2479
Fixes #2478

## Root cause (#2479)

The user's `zai.json` profile file was **corrupt**: it contained `provider: "load-balancer"` — a virtual provider name that is never registered at startup. Two compounding defects:

1. **Save side wrote the corrupt file.** Running `/profile save` while a load-balancer profile was active snapshotted the runtime's virtual provider name (`load-balancer`) into a STANDARD profile. That file can never be re-applied.
2. **Load side hid the failure.** `selectAvailableProvider()` silently substituted `availableProviders[0]` (gemini) when the profile's named provider wasn't registered. The session came up on the wrong provider with no error; because auth/wiring didn't match, submitted prompts vanished with no echo, no spinner, and no error message — a fully dead session.

## Changes

### Load side — fail loudly (packages/providers/src/runtime/profileApplication.ts)
- A profile that explicitly names an unavailable provider now throws `Provider 'X' is not available (registered providers: ...). Profile not applied.` instead of silently rerouting to gemini.
- The silent fallback survives only when the profile names no provider at all; the zero-providers case still throws.
- Interactive `/profile load` surfaces the error via its existing catch; explicit `--profile-load` fails loudly at startup.

### Save side — never write a corrupt profile (packages/providers/src/runtime/profileSnapshot.ts, LoadBalancingProvider.ts, loadBalancing/wrappedProviderDelegation.ts)
- Saving while a load balancer is active now serializes a **genuine** `type:'loadbalancer'` profile (policy, member profiles, contextLimit, LB ephemerals/modelParams) from the registered `LoadBalancingProvider` via a new `getLoadBalancerConfig()` accessor (delegated through provider wrappers).
- If the LB config cannot be read, save **throws** rather than writing a corrupt file.
- `saveProfileSnapshot` refuses to write any standard profile whose provider is `load-balancer`.

### prompt_cache_key egress clamp (packages/providers/src/openai/openaiRequestParams.ts, openai-responses/OpenAIResponsesProviderCore.ts)
- Overlong keys (e.g. 69-char subagent runtimeIds) injected via modelParams/request overrides bypassed `sanitizePromptCacheKey` and failed OpenAI requests with `string too long` (this broke subagent launches during diagnosis). Both egress paths now clamp through the shared sanitizer; non-string/empty values are dropped rather than forwarded.

### Test storage isolation (packages/cli/test-setup-storage-isolation.ts + vitest configs)
- Integration tests were writing real files (test-profile.json, legacy-profile.json, …) into `~/Library/Preferences/llxprt-code/profiles`. A global vitest setup now redirects `LLXPRT_CONFIG_HOME`/`LLXPRT_DATA_HOME`/`LLXPRT_CACHE_HOME` to a per-run temp dir (unless already set), and the alias tests set `LLXPRT_DATA_HOME` explicitly.

## #2478 (installer "Application Support" path split)

Full root-cause analysis posted on the issue (https://github.com/vybestack/llxprt-code/issues/2478#issuecomment-4931631555). Summary: the plural error message is emitted by macOS `open` receiving two args after an unquoted `~/Library/Application Support/llxprt-code/configuration` path was word-split by a raw shell. Exhaustive static search of the repo source, published nightly, bundle, and install scripts found **no** raw-shell `open` interpolation — every in-repo consumer uses argv-array spawns. The emitter is external to this package; the analysis and a diagnosis recipe are documented on the issue.

## Regression tests

- `profileApplication.unavailableProvider.test.ts` (8 tests): named-but-unavailable provider rejects loudly with no session mutation; the exact corrupt `provider:'load-balancer'` shape is rejected; empty/no-provider profiles still fall back silently; zero-provider throw preserved.
- `profileSnapshot.loadBalancerSave.test.ts` (7 tests): LB-active save produces a genuine reloadable `type:'loadbalancer'` profile (satisfies `isLoadBalancerProfile`); unreadable LB config throws; standard-profile guard refuses `provider:'load-balancer'`.
- `openaiRequestParams.test.ts` / `OpenAIResponsesProvider.promptCacheKey.test.ts`: overlong keys clamped deterministically to ≤64 chars on both egress paths; empty/non-string values dropped (responses path falls back to the runtimeId-derived key).

## Verification

- `npm run lint`, `npm run typecheck`, `npm run build`, `npm run format` — clean
- Full workspace test suites green (providers 3869+, core 4993, cli 5126+, agents 257/257 files, a2a-server 109)
- Smoke: `bun scripts/start.ts --profile-load zai "write me a haiku and nothing else"` — passes (exercises the restored profile end-to-end)
- Open Code Review (ocr) run on both commits; all findings addressed (invalid-value drop, real LB config type, strengthened test assertion)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load-balancer profiles can now be saved and restored reliably, including strategy, member profiles, context limits, and related settings.
* **Bug Fixes**
  * Unavailable explicitly requested providers no longer fall back silently during profile application.
  * Prevented invalid/virtual load-balancer provider shapes from being persisted as normal profiles.
  * Improved prompt cache key handling: invalid types are dropped and overlong keys are sanitized.
* **Tests**
  * Added storage isolation for integration tests and expanded regression coverage for load-balancer and prompt-caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->