### PR TITLE
fix(ui): accumulate subagent streaming text instead of replacing each token (Fixes #2008)

### DIFF
--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.display-callbacks.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.display-callbacks.test.ts
@@ -487,4 +487,68 @@ describe('AgenticLoop with caller display callbacks', () => {
       });
     expect(streamContents).toContain('survived-async');
   });
+
+  it('accumulates string output chunks into liveOutput instead of replacing (fixes #2008)', async () => {
+    const tool = new MockTool({
+      name: 'delta_streaming_tool',
+      canUpdateOutput: true,
+    });
+    tool.executeFn.mockImplementation(
+      async (
+        _params: Record<string, unknown>,
+        _signal: AbortSignal,
+        updateOutput?: (output: string) => void,
+      ) => {
+        updateOutput?.('Hello ');
+        updateOutput?.('world');
+        updateOutput?.('!');
+        return { llmContent: 'done', returnDisplay: 'done' };
+      },
+    );
+
+    const toolRegistry = createToolRegistryForTest([tool]);
+    const messageBus = new MessageBus(createAllowPolicyEngine(), false);
+    const config = createTestConfig({
+      messageBus,
+      toolRegistry,
+      policyEngine: createAllowPolicyEngine(),
+      interactive: false,
+      approvalMode: ApprovalMode.YOLO,
+    });
+
+    const toolUpdatesByStatus: ToolCall[] = [];
+
+    const { client } = createScriptedAgentClient([
+      [
+        toolCallRequestEvent('delta_streaming_tool', 'call-acc', { x: 1 }),
+        finishedEvent(),
+      ],
+      [contentEvent('final'), finishedEvent()],
+    ]);
+
+    const loop = new AgenticLoop({
+      agentClient: client,
+      config,
+      messageBus,
+      displayCallbacks: {
+        onToolCallsUpdate: (toolCalls) => {
+          toolUpdatesByStatus.push(...toolCalls);
+        },
+        getPreferredEditor: () => undefined,
+      },
+    });
+
+    await collectEvents(loop, 'go', new AbortController().signal);
+
+    const executingUpdates = toolUpdatesByStatus.filter(
+      (tc) => tc.request.callId === 'call-acc' && tc.status === 'executing',
+    );
+    expect(executingUpdates.length).toBeGreaterThanOrEqual(1);
+
+    // The last executing update (after all three chunks) must contain the
+    // full accumulated string, proving deltas are appended not replaced.
+    expect(executingUpdates[executingUpdates.length - 1]).toMatchObject({
+      liveOutput: 'Hello world!',
+    });
+  });
 });

--- a/packages/agents/src/core/coreToolScheduler.ts
+++ b/packages/agents/src/core/coreToolScheduler.ts
@@ -50,6 +50,7 @@ import type {
   AllToolCallsCompleteHandler,
   ToolCallsUpdateHandler,
 } from '@vybestack/llxprt-code-core/scheduler/types.js';
+import { accumulateLiveOutput } from '@vybestack/llxprt-code-core/scheduler/liveOutput.js';
 import { setToolContext } from '../scheduler/utils.js';
 import {
   applyTransition,
@@ -608,7 +609,10 @@ export class CoreToolScheduler implements ToolSchedulerContract {
               }
               this.toolCalls = this.toolCalls.map((tc) =>
                 tc.request.callId === id && tc.status === 'executing'
-                  ? { ...tc, liveOutput: chunk }
+                  ? {
+                      ...tc,
+                      liveOutput: accumulateLiveOutput(tc.liveOutput, chunk),
+                    }
                   : tc,
               );
               this.notifyToolCallsUpdate();

--- a/packages/agents/src/tools/task.issues.test.ts
+++ b/packages/agents/src/tools/task.issues.test.ts
@@ -82,8 +82,8 @@ describe('TaskTool', () => {
       );
 
       // Verify messages are sent without [agentId] prefix
-      expect(updateOutput).toHaveBeenNthCalledWith(2, 'First message\n');
-      expect(updateOutput).toHaveBeenNthCalledWith(3, 'Second message\n');
+      expect(updateOutput).toHaveBeenNthCalledWith(2, 'First message');
+      expect(updateOutput).toHaveBeenNthCalledWith(3, 'Second message');
 
       // Verify closing tag is sent last
       expect(updateOutput).toHaveBeenLastCalledWith(
@@ -140,7 +140,7 @@ describe('TaskTool', () => {
         1,
         '<subagent name="interactive-agent" id="agent-xml-002">\n',
       );
-      expect(updateOutput).toHaveBeenNthCalledWith(2, 'Interactive message\n');
+      expect(updateOutput).toHaveBeenNthCalledWith(2, 'Interactive message');
       expect(updateOutput).toHaveBeenLastCalledWith(
         '</subagent name="interactive-agent" id="agent-xml-002">\n',
       );
@@ -290,6 +290,133 @@ describe('TaskTool', () => {
       expect(updateOutput).toHaveBeenLastCalledWith(
         '</subagent name="async-helper" id="async-xml-agent">\n',
       );
+    });
+  });
+
+  describe('Issue #2008: subagent streaming text should flow, not one word per line', () => {
+    it('accumulates word-by-word tokens as flowing text without forced newlines', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const updateOutput = vi.fn();
+      const scope: {
+        output: {
+          emitted_vars: Record<string, string>;
+          terminate_reason: SubagentTerminateMode;
+        };
+        runInteractive: ReturnType<typeof vi.fn>;
+        runNonInteractive: ReturnType<typeof vi.fn>;
+        onMessage?: (message: string) => void;
+      } = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn(),
+        runNonInteractive: vi
+          .fn()
+          .mockImplementation(async (_ctx: ContextState) => {
+            const tokens = [
+              'The',
+              ' project',
+              ' combines',
+              ' Ink',
+              ' rendering',
+              ' with',
+              ' a',
+              ' modular',
+              ' architecture.',
+            ];
+            for (const token of tokens) {
+              scope.onMessage?.(token);
+            }
+          }),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-stream-001',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => false,
+      });
+      const invocation = tool.build({
+        subagent_name: 'streaming-agent',
+        goal_prompt: 'Do work',
+      });
+
+      await invocation.execute(new AbortController().signal, updateOutput);
+
+      const calls = updateOutput.mock.calls.map((c) => c[0] as string);
+      // Slice off opening tag (first) and closing tag (last)
+      const textChunks = calls.slice(1, -1);
+      const accumulated = textChunks.join('');
+
+      // Should be flowing prose, not a vertical column of single words
+      expect(accumulated).toBe(
+        'The project combines Ink rendering with a modular architecture.',
+      );
+      expect(accumulated).not.toContain('\n');
+    });
+
+    it('preserves newlines the LLM includes in its own tokens', async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const updateOutput = vi.fn();
+      const scope: {
+        output: {
+          emitted_vars: Record<string, string>;
+          terminate_reason: SubagentTerminateMode;
+        };
+        runInteractive: ReturnType<typeof vi.fn>;
+        runNonInteractive: ReturnType<typeof vi.fn>;
+        onMessage?: (message: string) => void;
+      } = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn(),
+        runNonInteractive: vi
+          .fn()
+          .mockImplementation(async (_ctx: ContextState) => {
+            scope.onMessage?.('First paragraph.');
+            scope.onMessage?.('\nSecond ');
+            scope.onMessage?.('paragraph.');
+          }),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-stream-002',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
+      const tool = new TaskTool(config, {
+        orchestratorFactory: () => orchestrator,
+        isInteractiveEnvironment: () => false,
+      });
+      const invocation = tool.build({
+        subagent_name: 'streaming-agent',
+        goal_prompt: 'Do work',
+      });
+
+      await invocation.execute(new AbortController().signal, updateOutput);
+
+      const calls = updateOutput.mock.calls.map((c) => c[0] as string);
+      const textChunks = calls.slice(1, -1);
+      const accumulated = textChunks.join('');
+
+      // LLM's own \n is preserved; no extra \n added to bare tokens
+      expect(accumulated).toBe('First paragraph.\nSecond paragraph.');
     });
   });
 

--- a/packages/agents/src/tools/task.max-turns.test.ts
+++ b/packages/agents/src/tools/task.max-turns.test.ts
@@ -352,11 +352,13 @@ describe('TaskTool', () => {
     await invocation.execute(new AbortController().signal, updateOutput);
 
     // Verify XML wrapping - opening tag, messages without agent prefix, closing tag
+    // Only fragments that already carry \r or \n get a trailing newline via
+    // carriage-return normalization; bare fragments flow together.
     expect(updateOutput).toHaveBeenNthCalledWith(
       1,
       '<subagent name="helper" id="agent-42">\n',
     );
-    expect(updateOutput).toHaveBeenNthCalledWith(2, 'first chunk\n');
+    expect(updateOutput).toHaveBeenNthCalledWith(2, 'first chunk');
     expect(updateOutput).toHaveBeenNthCalledWith(3, 'second chunk\n');
     expect(updateOutput).toHaveBeenNthCalledWith(4, 'third chunk\n');
     expect(updateOutput).toHaveBeenNthCalledWith(5, 'fourth chunk\n');
@@ -420,7 +422,7 @@ describe('TaskTool', () => {
       1,
       '<subagent name="helper" id="agent-42">\n',
     );
-    expect(updateOutput).toHaveBeenNthCalledWith(2, 'actual message\n');
+    expect(updateOutput).toHaveBeenNthCalledWith(2, 'actual message');
     expect(updateOutput).toHaveBeenNthCalledWith(
       3,
       '</subagent name="helper" id="agent-42">\n',

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -131,7 +131,7 @@ describe('TaskTool', () => {
       1,
       '<subagent name="helper" id="agent-42">\n',
     );
-    expect(updateOutput).toHaveBeenNthCalledWith(2, 'progress update\n');
+    expect(updateOutput).toHaveBeenNthCalledWith(2, 'progress update');
     expect(updateOutput).toHaveBeenNthCalledWith(
       3,
       '</subagent name="helper" id="agent-42">\n',

--- a/packages/agents/src/tools/taskAsyncExecution.ts
+++ b/packages/agents/src/tools/taskAsyncExecution.ts
@@ -51,13 +51,18 @@ export interface AsyncTaskCollaborators {
   buildContextState: () => ContextState;
 }
 
-/** Normalizes a streaming text fragment to a single trailing newline. */
+/**
+ * Normalizes line endings in a streaming text fragment without forcing a
+ * trailing newline. Earlier versions appended '\n' to every fragment, but
+ * that broke LLM token streaming — each word landed on its own line. The
+ * LLM's own whitespace and newlines are authoritative; we only normalize
+ * carriage-return variants to '\n'.
+ */
 export function normalizeSubagentStreamingText(text: string): string {
   if (!text) {
     return '';
   }
-  const lf = text.replace(/\r\n?/g, '\n');
-  return lf.endsWith('\n') ? lf : lf + '\n';
+  return text.replace(/\r\n?/g, '\n');
 }
 
 /**

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -16,6 +16,7 @@ import {
   type EditorType,
   type AnsiOutput,
   type MessageBus,
+  accumulateLiveOutput,
 } from '@vybestack/llxprt-code-core';
 import { useCallback, useState, useMemo, useEffect, useRef } from 'react';
 
@@ -111,7 +112,13 @@ function updatePendingItemWithOutput(
     tools: prevItem.tools.map((toolDisplay) =>
       toolDisplay.callId === toolCallId &&
       toolDisplay.status === ToolCallStatus.Executing
-        ? { ...toolDisplay, resultDisplay: outputChunk }
+        ? {
+            ...toolDisplay,
+            resultDisplay: accumulateLiveOutput(
+              toolDisplay.resultDisplay,
+              outputChunk,
+            ),
+          }
         : toolDisplay,
     ),
   };
@@ -145,7 +152,10 @@ function updateCallsWithLiveOutput(
 ): TrackedToolCall[] {
   return prevCalls.map((call) =>
     call.request.callId === toolCallId && call.status === 'executing'
-      ? { ...call, liveOutput: outputChunk }
+      ? {
+          ...call,
+          liveOutput: accumulateLiveOutput(call.liveOutput, outputChunk),
+        }
       : call,
   );
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -327,6 +327,10 @@
       "bun": "./src/scheduler/types.ts",
       "import": "./dist/src/scheduler/types.js"
     },
+    "./scheduler/liveOutput.js": {
+      "bun": "./src/scheduler/liveOutput.ts",
+      "import": "./dist/src/scheduler/liveOutput.js"
+    },
     "./code_assist/types.js": {
       "bun": "./src/code_assist/types.ts",
       "import": "./dist/src/code_assist/types.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,7 @@ export type {
   ValidatingToolCall,
   WaitingToolCall,
 } from './scheduler/types.js';
+export { accumulateLiveOutput } from './scheduler/liveOutput.js';
 
 export * from './core/contentGenerator.js';
 export * from './core/logger.js';

--- a/packages/core/src/scheduler/liveOutput.test.ts
+++ b/packages/core/src/scheduler/liveOutput.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { accumulateLiveOutput } from './liveOutput.js';
+import type { AnsiOutput, AnsiToken } from '../utils/terminalSerializer.js';
+
+function makeToken(text: string): AnsiToken {
+  return {
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    dim: false,
+    inverse: false,
+    fg: '',
+    bg: '',
+  };
+}
+
+const ansiSnapshot: AnsiOutput = [[makeToken('full')]];
+
+describe('accumulateLiveOutput', () => {
+  it('appends a string delta to an existing string', () => {
+    expect(accumulateLiveOutput('Hello ', 'world')).toBe('Hello world');
+  });
+
+  it('returns the chunk when existing is undefined', () => {
+    expect(accumulateLiveOutput(undefined, 'first')).toBe('first');
+  });
+
+  it('accumulates multiple string deltas in sequence', () => {
+    let acc: string | AnsiOutput | undefined = undefined;
+    acc = accumulateLiveOutput(acc, 'one ');
+    acc = accumulateLiveOutput(acc, 'two ');
+    acc = accumulateLiveOutput(acc, 'three');
+    expect(acc).toBe('one two three');
+  });
+
+  it('replaces with the latest AnsiOutput snapshot', () => {
+    const first: AnsiOutput = [[makeToken('snap-1')]];
+    const second: AnsiOutput = [[makeToken('snap-2')]];
+    expect(accumulateLiveOutput(first, second)).toBe(second);
+  });
+
+  it('does not append when the chunk is AnsiOutput even if existing is a string', () => {
+    expect(accumulateLiveOutput('partial', ansiSnapshot)).toBe(ansiSnapshot);
+  });
+
+  it('does not append when the existing is AnsiOutput even if the chunk is a string', () => {
+    expect(accumulateLiveOutput(ansiSnapshot, 'delta')).toBe('delta');
+  });
+});

--- a/packages/core/src/scheduler/liveOutput.test.ts
+++ b/packages/core/src/scheduler/liveOutput.test.ts
@@ -33,6 +33,15 @@ describe('accumulateLiveOutput', () => {
     expect(accumulateLiveOutput(undefined, 'first')).toBe('first');
   });
 
+  it('returns the chunk when existing is null or other non-string type', () => {
+    expect(accumulateLiveOutput(null, 'delta')).toBe('delta');
+    expect(accumulateLiveOutput(42, 'delta')).toBe('delta');
+  });
+
+  it('preserves existing output when the delta is an empty string', () => {
+    expect(accumulateLiveOutput('Hello ', '')).toBe('Hello ');
+  });
+
   it('accumulates multiple string deltas in sequence', () => {
     let acc: string | AnsiOutput | undefined = undefined;
     acc = accumulateLiveOutput(acc, 'one ');

--- a/packages/core/src/scheduler/liveOutput.test.ts
+++ b/packages/core/src/scheduler/liveOutput.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import { accumulateLiveOutput } from './liveOutput.js';
 import type { AnsiOutput, AnsiToken } from '../utils/terminalSerializer.js';
 
+/** Builds a minimal valid AnsiToken for test fixtures. */
 function makeToken(text: string): AnsiToken {
   return {
     text,

--- a/packages/core/src/scheduler/liveOutput.ts
+++ b/packages/core/src/scheduler/liveOutput.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AnsiOutput } from '../utils/terminalSerializer.js';
+
+/**
+ * Accumulates a live-output chunk onto an existing value.
+ *
+ * Tools that stream via `canUpdateOutput` deliver chunks in one of two
+ * semantics:
+ *
+ * - **`AnsiOutput`** (e.g. the shell tool) — a full terminal-buffer snapshot.
+ *   Each chunk supersedes the previous one, so the latest snapshot replaces
+ *   the old value.
+ * - **`string`** (e.g. the task tool streaming subagent text) — an incremental
+ *   delta.  Each chunk must be appended to the existing text so the display
+ *   grows rather than showing only the latest token.
+ *
+ * The `existing` parameter is typed `unknown` because callers may pass values
+ * drawn from a broader display union (e.g. `ToolResultDisplay`, which also
+ * includes `FileDiff` / `FileRead`).  The function only ever appends when both
+ * values are strings; any other combination replaces with the incoming chunk.
+ */
+export function accumulateLiveOutput(
+  existing: unknown,
+  chunk: string | AnsiOutput,
+): string | AnsiOutput {
+  return typeof chunk === 'string' && typeof existing === 'string'
+    ? existing + chunk
+    : chunk;
+}

--- a/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
+++ b/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
@@ -173,12 +173,15 @@ export function formatSuccessContent(
   return JSON.stringify(payload, null, 2);
 }
 
+/**
+ * Normalizes line endings in a streaming text fragment without forcing a
+ * trailing newline. See taskAsyncExecution.ts for rationale.
+ */
 export function normalizeSubagentStreamingText(text: string): string {
   if (!text) {
     return '';
   }
-  const lf = text.replace(/\r\n?/g, '\n');
-  return lf.endsWith('\n') ? lf : lf + '\n';
+  return text.replace(/\r\n?/g, '\n');
 }
 
 export function resolveTimeoutSeconds(


### PR DESCRIPTION
## TLDR

Subagent text streamed word-by-word and overwrote previous output, leaving only the last token visible. Two bugs were fixed:

1. **Overwrite bug**: Both the CoreToolScheduler and React UI hooks **replaced** liveOutput with each incoming chunk. For string deltas (the task/subagent tool), only the last token was ever visible.
2. **One-word-per-line bug**: normalizeSubagentStreamingText appended a trailing newline to every streaming fragment, so each LLM token landed on its own line.

## Dive Deeper

### Bug 1: Overwrite (liveOutput replacement)

Two output-chunk semantics flow through the same live-output pipeline, but the code treated them identically:

1. **AnsiOutput** (shell tool) — a full terminal-buffer snapshot. Each chunk supersedes the previous one, so REPLACE is correct.
2. **string** (task/subagent tool streaming LLM text) — an incremental delta. Each chunk must be APPENDED to the existing text.

Both the scheduler (CoreToolScheduler.onLiveOutput) and the UI hooks (useReactToolScheduler) replaced liveOutput on every chunk, wiping the accumulated text.

**Why the scheduler fix is critical:** The scheduler's onLiveOutput fires two paths synchronously per chunk:
- **outputUpdateHandler** updates UI's toolCallsByScheduler AND pendingHistoryItem
- **notifyToolCallsUpdate** REPLACES all toolCallsByScheduler with the scheduler's calls

React batches these; notifyToolCallsUpdate fires AFTER outputUpdateHandler and wins. So fixing only the UI hooks would have no effect — the scheduler's REPLACE-based calls override any UI-level accumulation.

**Fix:** Introduce accumulateLiveOutput() in packages/core/src/scheduler/liveOutput.ts — appends string deltas, replaces AnsiOutput snapshots. Applied in three places: CoreToolScheduler.onLiveOutput (authoritative source), and both UI functions (defense-in-depth).

### Bug 2: One-word-per-line (forced trailing newline)

normalizeSubagentStreamingText() appended \n to every onMessage fragment. During LLM streaming, each token (word) triggered a separate onMessage call, so every word landed on its own line.

**Fix:** Removed the forced trailing newline. Only \r variants are normalized to \n; the LLM's own whitespace and newlines are authoritative. Both copies updated: taskAsyncExecution.ts and coreSubagentServiceHelpers.ts.

## Reviewer Test Plan

1. Run a subagent (e.g. deepthinker) and watch the task tool's live output box
2. Before fix: only the last word/token is visible, each overwriting the previous, and each on its own line
3. After fix: the full accumulated text grows inside the box as the subagent streams, flowing naturally as prose
4. Shell tool output should still work as before (AnsiOutput snapshots replace, not append)
5. Run unit tests:
   - cd packages/core && npx vitest run src/scheduler/liveOutput.test.ts
   - cd packages/agents && npx vitest run src/tools/task.issues.test.ts src/tools/task.max-turns.test.ts

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

Fixes #2008