### PR TITLE
feat(providers): support configurable reasoning field name for Ollama streaming (Fixes #2488)

### DIFF
--- a/packages/agents/src/core/ChatSessionFactory.ts
+++ b/packages/agents/src/core/ChatSessionFactory.ts
@@ -85,6 +85,9 @@ export function buildSettingsSnapshot(
     'reasoning.stripFromContext': config.getEphemeralSetting(
       'reasoning.stripFromContext',
     ) as 'all' | 'allButLast' | 'none' | undefined,
+    'reasoning.fieldName': config.getEphemeralSetting('reasoning.fieldName') as
+      | string
+      | undefined,
     'reasoning.effort': config.getEphemeralSetting('reasoning.effort') as
       | 'minimal'
       | 'low'

--- a/packages/core/src/llm-types/geminiContent.ts
+++ b/packages/core/src/llm-types/geminiContent.ts
@@ -55,11 +55,12 @@ export interface GeminiInlineData {
  * source field name survives a Gemini round-trip.
  */
 export interface GeminiPartExtension {
-  llxprtSourceField?:
-    | 'reasoning_content'
-    | 'thinking'
-    | 'thought'
-    | 'think_tags';
+  /**
+   * Source field name for round-trip serialization.
+   * Known values: 'reasoning_content', 'reasoning', 'thinking', 'thought', 'think_tags'.
+   * May also contain arbitrary user-configured field names (issue #2488).
+   */
+  llxprtSourceField?: string;
 }
 
 /**

--- a/packages/core/src/runtime/AgentRuntimeContext.ts
+++ b/packages/core/src/runtime/AgentRuntimeContext.ts
@@ -46,6 +46,8 @@ export interface ReadonlySettingsSnapshot {
   'reasoning.format'?: 'native' | 'field';
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.5 */
   'reasoning.stripFromContext'?: 'all' | 'allButLast' | 'none';
+  /** Configurable reasoning field name for streaming delta capture (issue #2488) */
+  'reasoning.fieldName'?: string;
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.6 */
   'reasoning.effort'?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.7 */
@@ -246,6 +248,7 @@ export interface AgentRuntimeContext {
       effort(): 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | undefined;
       maxTokens(): number | undefined;
       adaptiveThinking(): boolean | undefined;
+      fieldName(): string;
     };
   };
 

--- a/packages/core/src/runtime/createAgentRuntimeContext.test.ts
+++ b/packages/core/src/runtime/createAgentRuntimeContext.test.ts
@@ -423,6 +423,22 @@ describe('createAgentRuntimeContext', () => {
       const context = createAgentRuntimeContext(options);
       expect(context.ephemerals.reasoning.stripFromContext()).toBe('none');
     });
+
+    it('should default reasoning.fieldName to "reasoning_content" when not set', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: {},
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.reasoning.fieldName()).toBe(
+        'reasoning_content',
+      );
+    });
   });
 
   describe('context immutability', () => {

--- a/packages/core/src/runtime/createAgentRuntimeContext.ts
+++ b/packages/core/src/runtime/createAgentRuntimeContext.ts
@@ -35,6 +35,7 @@ const EPHEMERAL_DEFAULTS = {
     includeInResponse: true, // REQ-THINK-006.3
     format: 'field' as const, // REQ-THINK-006.4
     stripFromContext: 'none' as const, // REQ-THINK-006.5
+    fieldName: 'reasoning_content' as const, // issue #2488
   },
 } as const;
 
@@ -292,6 +293,11 @@ function buildReasoningEphemerals(
         'reasoning.stripFromContext',
         options.settings['reasoning.stripFromContext'],
       ) ?? EPHEMERAL_DEFAULTS.reasoning.stripFromContext,
+    fieldName: (): string =>
+      getLiveSetting(
+        'reasoning.fieldName',
+        options.settings['reasoning.fieldName'],
+      ) ?? EPHEMERAL_DEFAULTS.reasoning.fieldName,
     effort: (): 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | undefined =>
       getLiveSetting('reasoning.effort', options.settings['reasoning.effort']),
     maxTokens: (): number | undefined => {

--- a/packages/core/src/services/history/IContent.ts
+++ b/packages/core/src/services/history/IContent.ts
@@ -234,8 +234,12 @@ export interface ThinkingBlock {
   /** Whether this thinking should be hidden from the user */
   isHidden?: boolean;
 
-  /** Source field name for round-trip serialization */
-  sourceField?: 'reasoning_content' | 'thinking' | 'thought' | 'think_tags';
+  /**
+   * Source field name for round-trip serialization.
+   * Known values: 'reasoning_content', 'reasoning', 'thinking', 'thought', 'think_tags'.
+   * May also contain arbitrary user-configured field names (issue #2488).
+   */
+  sourceField?: string;
 
   /** Signature for Anthropic extended thinking */
   signature?: string;

--- a/packages/providers/src/openai-vercel/OpenAIVercelProvider.ts
+++ b/packages/providers/src/openai-vercel/OpenAIVercelProvider.ts
@@ -190,7 +190,10 @@ export class OpenAIVercelProvider extends BaseProvider implements IProvider {
 
     const aiTools = buildVercelTools(formattedTools);
     const params = resolveModelCallParams(options, metadata, this);
-    const captureBuffer: CaptureBuffer = createCaptureBuffer();
+    const rawFieldName = options.settings.get('reasoning.fieldName') as
+      | string
+      | undefined;
+    const captureBuffer: CaptureBuffer = createCaptureBuffer(rawFieldName);
     const { model } = await createConfiguredModel(
       options,
       this.getClientConfig(options),

--- a/packages/providers/src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts
+++ b/packages/providers/src/openai-vercel/__tests__/vercelReasoningCapture.fieldName.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @issue #2488 — Configurable reasoning field name for Ollama (delta.reasoning)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import {
+  createCaptureBuffer,
+  parseReasoningFromSseStream,
+} from '../vercelReasoningCapture.js';
+
+const logger = new DebugLogger('llxprt:test:reasoning-capture');
+
+function createSseStream(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const data = lines.join('\n\n') + '\n\n';
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(data));
+      controller.close();
+    },
+  });
+}
+
+describe('parseReasoningFromSseStream — configurable field name (#2488)', () => {
+  it('captures reasoning_content with default fieldName', async () => {
+    const captureBuffer = createCaptureBuffer();
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning_content":"hello world"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual(['hello world']);
+  });
+
+  it('auto-fallbacks to reasoning field with default fieldName (Ollama)', async () => {
+    const captureBuffer = createCaptureBuffer();
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning":"ollama thinking"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual(['ollama thinking']);
+    expect(captureBuffer.actualFieldName).toBe('reasoning');
+  });
+
+  it('records actualFieldName as reasoning_content for standard field', async () => {
+    const captureBuffer = createCaptureBuffer();
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning_content":"standard"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.actualFieldName).toBe('reasoning_content');
+  });
+
+  it('captures reasoning only when fieldName is explicitly "reasoning"', async () => {
+    const captureBuffer = createCaptureBuffer('reasoning');
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning":"explicit field"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual(['explicit field']);
+  });
+
+  it('does NOT capture reasoning_content when fieldName is explicitly "reasoning"', async () => {
+    const captureBuffer = createCaptureBuffer('reasoning');
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning_content":"should be ignored"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual([]);
+  });
+
+  it('does NOT auto-fallback when fieldName is explicitly "reasoning_content"', async () => {
+    const captureBuffer = createCaptureBuffer('reasoning_content');
+    const sseData = [
+      'data: {"choices":[{"delta":{"reasoning":"should be ignored"}}]}',
+    ];
+    const stream = createSseStream(sseData);
+
+    await parseReasoningFromSseStream(
+      stream.getReader(),
+      captureBuffer,
+      logger,
+    );
+
+    expect(captureBuffer.reasoningChunks).toStrictEqual([]);
+  });
+});

--- a/packages/providers/src/openai-vercel/vercelNonStreamingResponse.ts
+++ b/packages/providers/src/openai-vercel/vercelNonStreamingResponse.ts
@@ -162,7 +162,7 @@ export function buildThinkingBlock(
     return {
       type: 'thinking',
       thought: cleanedThinking,
-      sourceField: 'reasoning_content',
+      sourceField: rs.fieldName,
       isHidden: false,
     } as ThinkingBlock;
   }

--- a/packages/providers/src/openai-vercel/vercelReasoningCapture.ts
+++ b/packages/providers/src/openai-vercel/vercelReasoningCapture.ts
@@ -25,14 +25,17 @@ export interface CaptureBuffer {
   finalized: boolean;
   headers?: Headers;
   parsePromise?: Promise<void>;
+  fieldName?: string;
+  actualFieldName?: string;
 }
 
-export function createCaptureBuffer(): CaptureBuffer {
+export function createCaptureBuffer(fieldName?: string): CaptureBuffer {
   return {
     reasoningChunks: [],
     finalized: false,
     headers: undefined,
     parsePromise: undefined,
+    fieldName,
   };
 }
 
@@ -45,7 +48,7 @@ function captureReasoningFromJson(
   logger: DebugLogger,
 ): void {
   let parsed: {
-    choices?: Array<{ delta?: { reasoning_content?: string } }>;
+    choices?: Array<{ delta?: Record<string, unknown> }>;
   };
   try {
     parsed = JSON.parse(jsonStr) as typeof parsed;
@@ -57,12 +60,29 @@ function captureReasoningFromJson(
   if (parsed.choices === undefined || parsed.choices.length === 0) {
     return;
   }
-  const reasoningContent = parsed.choices[0]?.delta?.reasoning_content;
-  if (reasoningContent && typeof reasoningContent === 'string') {
+  const delta = parsed.choices[0]?.delta;
+  if (delta === undefined) return;
+
+  const fieldName = captureBuffer.fieldName ?? 'reasoning_content';
+  let actualFieldName = fieldName;
+  let reasoningContent: unknown = delta[fieldName];
+
+  // Auto-fallback: when fieldName was not explicitly set (undefined), also
+  // check 'reasoning' for Ollama compatibility (issue #2488)
+  if (
+    (reasoningContent === undefined || reasoningContent === null) &&
+    captureBuffer.fieldName === undefined
+  ) {
+    reasoningContent = delta['reasoning'];
+    actualFieldName = 'reasoning';
+  }
+
+  if (typeof reasoningContent === 'string' && reasoningContent !== '') {
     captureBuffer.reasoningChunks.push(reasoningContent);
+    captureBuffer.actualFieldName = actualFieldName;
     logger.debug(
       () =>
-        `[ReasoningCaptureFetch] Captured reasoning_content chunk: ${reasoningContent.length} chars`,
+        `[ReasoningCaptureFetch] Captured ${actualFieldName} chunk: ${reasoningContent.length} chars`,
     );
   }
 }

--- a/packages/providers/src/openai-vercel/vercelReasoningCapture.ts
+++ b/packages/providers/src/openai-vercel/vercelReasoningCapture.ts
@@ -17,8 +17,11 @@
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 
 /**
- * Buffer that accumulates reasoning_content chunks captured from the
+ * Buffer that accumulates reasoning chunks captured from the
  * raw SSE stream while Vercel AI SDK processes its own copy.
+ *
+ * The delta field name is configurable via captureBuffer.fieldName
+ * (default: reasoning_content; auto-fallback to reasoning for Ollama).
  */
 export interface CaptureBuffer {
   reasoningChunks: string[];
@@ -40,7 +43,8 @@ export function createCaptureBuffer(fieldName?: string): CaptureBuffer {
 }
 
 /**
- * Parses a single SSE `data:` JSON line and extracts reasoning_content.
+ * Parses a single SSE `data:` JSON line and extracts reasoning from
+ * the configured delta field (default: reasoning_content).
  */
 function captureReasoningFromJson(
   jsonStr: string,
@@ -88,8 +92,9 @@ function captureReasoningFromJson(
 }
 
 /**
- * Parses an SSE stream reader to extract reasoning_content from chunks.
- * Runs in the background while the SDK processes the other tee'd stream.
+ * Parses an SSE stream reader to extract reasoning from chunks using the
+ * configured field name. Runs in the background while the SDK processes
+ * the other tee'd stream.
  */
 export async function parseReasoningFromSseStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
@@ -137,11 +142,11 @@ export async function parseReasoningFromSseStream(
 
 /**
  * Creates a custom fetch function that intercepts streaming responses
- * and extracts reasoning_content from SSE chunks.
+ * and extracts reasoning from SSE chunks using the configured field name.
  *
- * This is necessary because Vercel AI SDK doesn't expose reasoning_content
- * from the OpenAI-compatible API response. Kimi K2 and similar models
- * send reasoning via this field.
+ * This is necessary because Vercel AI SDK doesn't expose reasoning
+ * from the OpenAI-compatible API response. Models like Kimi K2 send
+ * reasoning via the reasoning_content field; Ollama uses reasoning.
  */
 export function createReasoningCaptureFetch(
   captureBuffer: CaptureBuffer,

--- a/packages/providers/src/openai-vercel/vercelRequestParams.ts
+++ b/packages/providers/src/openai-vercel/vercelRequestParams.ts
@@ -78,6 +78,9 @@ export function resolveReasoningSettings(
         | 'native'
         | 'field'
         | undefined) ?? 'field',
+    fieldName:
+      (options.settings.get('reasoning.fieldName') as string | undefined) ??
+      'reasoning_content',
   };
 }
 

--- a/packages/providers/src/openai-vercel/vercelStreamProcessor.ts
+++ b/packages/providers/src/openai-vercel/vercelStreamProcessor.ts
@@ -198,7 +198,7 @@ export function handleStreamReasoning(
           {
             type: 'thinking',
             thought: cleaned,
-            sourceField: 'reasoning_content',
+            sourceField: rs.fieldName,
             isHidden: false,
           } as ThinkingBlock,
         ],
@@ -244,7 +244,7 @@ export function emitRemainingStreamThinking(
         {
           type: 'thinking',
           thought: cleanedThought,
-          sourceField: 'reasoning_content',
+          sourceField: rs.fieldName,
           isHidden: false,
         } as ThinkingBlock,
       ],
@@ -264,13 +264,14 @@ export function emitRemainingStreamThinking(
     const capturedReasoning = captureBuffer.reasoningChunks.join('');
     const cleanedReasoning = cleanKimiTokensFromThinking(capturedReasoning);
     if (cleanedReasoning.length > 0) {
+      const capturedFieldName = captureBuffer.actualFieldName ?? rs.fieldName;
       items.push({
         speaker: 'ai',
         blocks: [
           {
             type: 'thinking',
             thought: cleanedReasoning,
-            sourceField: 'reasoning_content',
+            sourceField: capturedFieldName,
             isHidden: false,
           } as ThinkingBlock,
         ],
@@ -278,7 +279,7 @@ export function emitRemainingStreamThinking(
       state.hasEmittedThinking = true;
       logger.debug(
         () =>
-          `[OpenAIVercelProvider] Emitted captured reasoning_content: ${cleanedReasoning.length} chars from ${captureBuffer.reasoningChunks.length} chunks`,
+          `[OpenAIVercelProvider] Emitted captured reasoning (${capturedFieldName}): ${cleanedReasoning.length} chars from ${captureBuffer.reasoningChunks.length} chunks`,
       );
     }
   }

--- a/packages/providers/src/openai-vercel/vercelStreamTypes.ts
+++ b/packages/providers/src/openai-vercel/vercelStreamTypes.ts
@@ -24,6 +24,7 @@ export interface ReasoningSettings {
   includeInContext: boolean;
   stripFromContext: StripPolicy;
   format: 'native' | 'field';
+  fieldName: string;
 }
 
 export interface ModelCallParams {

--- a/packages/providers/src/runtime/profileApplication.ts
+++ b/packages/providers/src/runtime/profileApplication.ts
@@ -643,6 +643,7 @@ const PRESERVED_PROFILE_EPHEMERALS = [
   'reasoning.budgetTokens',
   'reasoning.stripFromContext',
   'reasoning.includeInContext',
+  'reasoning.fieldName',
   'task-default-timeout-seconds',
   'task-max-timeout-seconds',
   'shell-default-timeout-seconds',

--- a/packages/providers/src/runtime/runtimeSettings.reasoningSummary.test.ts
+++ b/packages/providers/src/runtime/runtimeSettings.reasoningSummary.test.ts
@@ -31,4 +31,8 @@ describe('reasoning.summary profile save/load @issue:922', () => {
     // text.verbosity is for OpenAI Responses API response verbosity control
     expect(PROFILE_EPHEMERAL_KEYS).toContain('text.verbosity');
   });
+
+  it('should include reasoning.fieldName in PROFILE_EPHEMERAL_KEYS', () => {
+    expect(PROFILE_EPHEMERAL_KEYS).toContain('reasoning.fieldName');
+  });
 });

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -399,6 +399,7 @@ export class ProfileManager {
       'reasoning.stripFromContext',
       'reasoning.effort',
       'reasoning.maxTokens',
+      'reasoning.fieldName',
     ] as const;
 
     for (const key of reasoningKeys) {

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -123,6 +123,7 @@ export interface EphemeralSettings {
   'reasoning.includeInContext'?: boolean;
   'reasoning.stripFromContext'?: 'all' | 'allButLast' | 'none';
   'reasoning.format'?: 'native' | 'field';
+  'reasoning.fieldName'?: string;
   'compression.strategy'?: string;
   'compression.profile'?: string;
   'compression.density.readWritePruning'?: boolean;

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -195,6 +195,14 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     persistToProfile: true,
   },
   {
+    key: 'reasoning.fieldName',
+    category: 'cli-behavior',
+    description:
+      'Reasoning field name in streaming delta (reasoning_content for OpenAI/vLLM, reasoning for Ollama)',
+    type: 'string',
+    persistToProfile: true,
+  },
+  {
     key: 'reasoning.summary',
     category: 'model-behavior',
     description:


### PR DESCRIPTION
## Summary

Ollama's OpenAI-compatible endpoint emits reasoning under `delta.reasoning` instead of `delta.reasoning_content`. This caused reasoning tokens from Ollama models to be silently dropped in the streaming path, even though the model was reasoning correctly.

This PR adds a new `reasoning.fieldName` ephemeral setting (default: `reasoning_content`) that controls which delta field the SSE reasoning capture reads. When the setting is unset, auto-fallback checks both `reasoning_content` and `reasoning` fields so Ollama works out of the box without configuration. When explicitly set, only the configured field is checked.

## Problem

The streaming SSE capture in `vercelReasoningCapture.ts` hardcoded reading from `delta.reasoning_content`. Ollama uses `delta.reasoning`, so its reasoning was silently dropped. The non-streaming path already worked because it reads `result.reasoning` from the AI SDK.

Field name by backend:

| Backend | Reasoning field in delta |
|---|---|
| OpenAI / LM Studio / vLLM / DeepSeek | reasoning_content |
| Ollama | reasoning |

## Solution

1. **New setting**: `reasoning.fieldName` (default: `reasoning_content`) added to settings registry, types, ProfileManager, AgentRuntimeContext, and ChatSessionFactory
2. **Capture logic**: `vercelReasoningCapture.ts` reads the configured field name from SSE deltas, with auto-fallback to `reasoning` when the setting is unset (for Ollama compatibility)
3. **Provenance tracking**: The actual field name used during capture is tracked in `CaptureBuffer.actualFieldName` and propagated to `ThinkingBlock.sourceField` metadata, ensuring accurate provenance even when auto-fallback is taken
4. **Type safety**: `ThinkingBlock.sourceField` widened from a closed union to `string` since the field name is user-configurable
5. **Consistency**: Both streaming and non-streaming paths use `rs.fieldName` for `sourceField`

## Auto-fallback behavior

- **Setting unset (default)**: Captures from `reasoning_content` first, then falls back to `reasoning`. Both standard providers and Ollama work out of the box.
- **Setting set to `reasoning`**: Only captures from `reasoning` field (for explicit Ollama configuration).
- **Setting set to `reasoning_content`**: Only captures from `reasoning_content` (disables auto-fallback).

## Files changed

**Settings layer:**
- `packages/settings/src/profiles/types.ts` — new type
- `packages/settings/src/settings/registry/registry-entries-1.ts` — registry entry
- `packages/settings/src/profiles/ProfileManager.ts` — reasoning keys

**Runtime context:**
- `packages/core/src/runtime/AgentRuntimeContext.ts` — ephemeral type + accessor
- `packages/core/src/runtime/createAgentRuntimeContext.ts` — default + builder

**Provider layer:**
- `packages/providers/src/openai-vercel/vercelReasoningCapture.ts` — configurable capture with auto-fallback
- `packages/providers/src/openai-vercel/vercelStreamProcessor.ts` — sourceField from actual captured field
- `packages/providers/src/openai-vercel/vercelNonStreamingResponse.ts` — sourceField from rs.fieldName
- `packages/providers/src/openai-vercel/vercelRequestParams.ts` — resolveReasoningSettings
- `packages/providers/src/openai-vercel/OpenAIVercelProvider.ts` — pass raw setting to capture buffer
- `packages/providers/src/openai-vercel/vercelStreamTypes.ts` — fieldName in ReasoningSettings
- `packages/providers/src/runtime/profileApplication.ts` — preserved ephemerals

**Core types:**
- `packages/core/src/services/history/IContent.ts` — sourceField widened to string
- `packages/core/src/llm-types/geminiContent.ts` — llxprtSourceField widened to string

**Other:**
- `packages/agents/src/core/ChatSessionFactory.ts` — reasoning.fieldName passthrough

## Tests

- `vercelReasoningCapture.fieldName.test.ts`: 6 tests covering default capture, auto-fallback, explicit field names, and actualFieldName tracking
- `runtimeSettings.reasoningSummary.test.ts`: PROFILE_EPHEMERAL_KEYS includes reasoning.fieldName
- `createAgentRuntimeContext.test.ts`: reasoning.fieldName defaults to reasoning_content

## Acceptance criteria

- [x] A provider alias can set the reasoning field name (default unchanged: reasoning_content)
- [x] With the field set to reasoning, a reasoning model served via Ollama surfaces its thinking in streaming output
- [x] Existing providers (LM Studio, vLLM, OpenAI) are unaffected when the setting is left at default
- [x] Streaming and non-streaming paths behave consistently

Closes #2488