### PR TITLE
Reset exhausted load-balancer failover rotations (Fixes #2492)

### DIFF
--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -728,6 +728,11 @@ export class LoadBalancingProvider implements IProvider {
     const numProfiles = this.config.subProfiles.length;
     const contextLimitErrors: Array<{ profile: string; error: Error }> = [];
 
+    this.logger.debug(
+      () =>
+        `[LB:failover] Starting failover rotation from index ${this.currentFailoverIndex} (${this.config.subProfiles[this.currentFailoverIndex]?.name ?? 'unknown'}) with ${numProfiles} backends`,
+    );
+
     // Check if all backends are unhealthy (circuit breakers open)
     this.validateNotAllUnhealthy(settings, numProfiles);
 
@@ -745,6 +750,11 @@ export class LoadBalancingProvider implements IProvider {
         continue;
       }
 
+      this.logger.debug(
+        () =>
+          `[LB:failover] Attempting backend at index ${currentIndex}: ${subProfile.name}`,
+      );
+
       const succeeded = yield* this.tryBackendWithRetries(
         subProfile,
         options,
@@ -761,6 +771,8 @@ export class LoadBalancingProvider implements IProvider {
       // Move to next backend (circular iteration)
       currentIndex = (currentIndex + 1) % numProfiles;
     }
+
+    this.currentFailoverIndex = 0;
 
     if (errors.length === 0 && contextLimitErrors.length > 0) {
       throw new LoadBalancerAllContextLimitsExceededError({

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -47,6 +47,7 @@ import {
 } from './loadBalancing/subProfileHelpers.js';
 import type { TokenAccountingDiagnostics } from './loadBalancing/tokenAccountingDiagnostics.js';
 import { validateLoadBalancerConfig } from './loadBalancing/configValidation.js';
+import { FailoverState } from './loadBalancing/failoverState.js';
 import {
   isResolvedSubProfile,
   type BackendMetrics,
@@ -86,7 +87,7 @@ export class LoadBalancingProvider implements IProvider {
   private circuitBreakerStates: Map<string, CircuitBreakerState> = new Map();
   private tpmBuckets: Map<number, Map<string, number>> = new Map();
   private backendMetrics: Map<string, BackendMetrics> = new Map();
-  private currentFailoverIndex = 0;
+  private readonly failoverState = new FailoverState();
   private compressionCallback: CompressionCallback | null = null;
   private accountingSource: string | null = null;
   private lastEstimatedTokens: number | null = null;
@@ -385,7 +386,7 @@ export class LoadBalancingProvider implements IProvider {
         chunks.push(chunk);
         yield chunk;
       }
-      const tokensUsed = this.extractTokenCount(chunks);
+      const tokensUsed = BackendMetricsCollector.extractTokenCount(chunks);
       if (tokensUsed > 0) {
         this.updateTPM(subProfile.name, tokensUsed);
       }
@@ -524,7 +525,7 @@ export class LoadBalancingProvider implements IProvider {
       this.circuitBreakerStates,
       this.backendMetrics,
       this.config.subProfiles,
-      (name) => this.calculateTPM(name),
+      (name) => this.tpmTracker.calculateTPM(name),
     );
   }
 
@@ -577,7 +578,7 @@ export class LoadBalancingProvider implements IProvider {
    * @plan PLAN-20251217issue902 - Sticky failover behavior
    */
   getCurrentFailoverIndex(): number {
-    return this.currentFailoverIndex;
+    return this.failoverState.getIndex();
   }
 
   /**
@@ -585,7 +586,7 @@ export class LoadBalancingProvider implements IProvider {
    * @plan PLAN-20251217issue902 - Sticky failover behavior
    */
   resetFailoverIndex(): void {
-    this.currentFailoverIndex = 0;
+    this.failoverState.reset();
   }
 
   /**
@@ -618,34 +619,10 @@ export class LoadBalancingProvider implements IProvider {
     return this.buildDelegateResolvedOptions(subProfile, options);
   }
 
-  /**
-   * Initialize circuit breaker state for a backend
-   * @plan PLAN-20251212issue489 - Phase 2
-   */
-
   private readonly circuitBreaker: CircuitBreakerManager;
   private readonly tpmTracker: TPMTracker;
   private readonly metricsCollector: BackendMetricsCollector;
 
-  private isBackendHealthy(profileName: string): boolean {
-    return this.circuitBreaker.isBackendHealthy(profileName);
-  }
-
-  private canAttemptBackend(profileName: string): boolean {
-    return this.circuitBreaker.canAttemptBackend(profileName);
-  }
-  private recordBackendSuccess(profileName: string): void {
-    this.circuitBreaker.recordBackendSuccess(profileName);
-  }
-
-  private recordBackendFailure(profileName: string, error: Error): void {
-    this.circuitBreaker.recordBackendFailure(profileName, error);
-  }
-
-  /**
-   * Wrap iterator with timeout for first chunk
-   * @plan PLAN-20251212issue489 - Phase 3
-   */
   private async *wrapWithTimeout(
     iterator: AsyncIterableIterator<IContent>,
     timeoutMs: number | undefined,
@@ -659,31 +636,8 @@ export class LoadBalancingProvider implements IProvider {
     );
   }
 
-  private isTimeoutError(error: unknown): boolean {
-    return isTimeoutError(error);
-  }
-
-  /**
-   * Update TPM tracking with new tokens
-   * @plan PLAN-20251212issue489 - Phase 4
-   */
   private updateTPM(profileName: string, tokensUsed: number): void {
     this.tpmTracker.updateTPM(profileName, tokensUsed);
-  }
-
-  private calculateTPM(profileName: string): number {
-    return this.tpmTracker.calculateTPM(profileName);
-  }
-
-  private shouldSkipOnTPM(
-    profileName: string,
-    tpmThreshold: number | undefined,
-  ): boolean {
-    return this.tpmTracker.shouldSkipOnTPM(profileName, tpmThreshold);
-  }
-
-  private extractTokenCount(chunks: IContent[]): number {
-    return BackendMetricsCollector.extractTokenCount(chunks);
   }
 
   private recordRequestStart(profileName: string): number {
@@ -710,7 +664,7 @@ export class LoadBalancingProvider implements IProvider {
     this.metricsCollector.recordRequestFailure(
       profileName,
       startTime,
-      this.isTimeoutError(error),
+      isTimeoutError(error),
     );
   }
 
@@ -723,6 +677,7 @@ export class LoadBalancingProvider implements IProvider {
   private async *executeWithFailover(
     options: GenerateChatOptions,
   ): AsyncGenerator<IContent> {
+    const { owner: requestOwner, startIndex } = this.failoverState.claim();
     const settings = this.extractFailoverSettings();
     const errors: Array<{ profile: string; error: Error }> = [];
     const numProfiles = this.config.subProfiles.length;
@@ -730,7 +685,7 @@ export class LoadBalancingProvider implements IProvider {
 
     this.logger.debug(
       () =>
-        `[LB:failover] Starting failover rotation from index ${this.currentFailoverIndex} (${this.config.subProfiles[this.currentFailoverIndex]?.name ?? 'unknown'}) with ${numProfiles} backends`,
+        `[LB:failover] Starting failover rotation from index ${startIndex} (${this.config.subProfiles[startIndex]?.name ?? 'unknown'}) with ${numProfiles} backends`,
     );
 
     // Check if all backends are unhealthy (circuit breakers open)
@@ -738,7 +693,7 @@ export class LoadBalancingProvider implements IProvider {
 
     // Start from currentFailoverIndex and iterate through all backends (Issue #902)
     let visitedCount = 0;
-    let currentIndex = this.currentFailoverIndex;
+    let currentIndex = startIndex;
 
     while (visitedCount < numProfiles) {
       const subProfile = this.config.subProfiles[currentIndex];
@@ -763,6 +718,7 @@ export class LoadBalancingProvider implements IProvider {
         contextLimitErrors,
         currentIndex,
         numProfiles,
+        requestOwner,
       );
       if (succeeded) {
         return;
@@ -772,7 +728,7 @@ export class LoadBalancingProvider implements IProvider {
       currentIndex = (currentIndex + 1) % numProfiles;
     }
 
-    this.currentFailoverIndex = 0;
+    this.failoverState.setIfOwner(requestOwner, 0);
 
     if (errors.length === 0 && contextLimitErrors.length > 0) {
       throw new LoadBalancerAllContextLimitsExceededError({
@@ -794,7 +750,7 @@ export class LoadBalancingProvider implements IProvider {
     profileName: string,
     settings: FailoverSettings,
   ): boolean {
-    if (!this.isBackendHealthy(profileName)) {
+    if (!this.circuitBreaker.isBackendHealthy(profileName)) {
       this.logger.debug(
         () =>
           `[LB:failover] Skipping unhealthy backend: ${profileName} (circuit breaker open)`,
@@ -802,7 +758,7 @@ export class LoadBalancingProvider implements IProvider {
       return true;
     }
 
-    if (this.shouldSkipOnTPM(profileName, settings.tpmThreshold)) {
+    if (this.tpmTracker.shouldSkipOnTPM(profileName, settings.tpmThreshold)) {
       this.logger.debug(
         () =>
           `[LB:failover] Skipping backend: ${profileName} (TPM below threshold)`,
@@ -813,9 +769,6 @@ export class LoadBalancingProvider implements IProvider {
     return false;
   }
 
-  /**
-   * Validate that not all backends are unhealthy (circuit breakers open).
-   */
   private validateNotAllUnhealthy(
     settings: FailoverSettings,
     numProfiles: number,
@@ -823,7 +776,7 @@ export class LoadBalancingProvider implements IProvider {
     if (settings.circuitBreakerEnabled) {
       const allUnhealthy = this.config.subProfiles
         .slice(0, numProfiles)
-        .every((sp) => !this.canAttemptBackend(sp.name));
+        .every((sp) => !this.circuitBreaker.canAttemptBackend(sp.name));
       if (allUnhealthy) {
         throw new Error(
           'All backends are currently unhealthy (circuit breakers open). Please wait for recovery or check backend configurations.',
@@ -832,10 +785,6 @@ export class LoadBalancingProvider implements IProvider {
     }
   }
 
-  /**
-   * Try a single backend with retry logic, yielding chunks on success.
-   * Handles immediate failover errors and retryable errors.
-   */
   private async *tryBackendWithRetries(
     subProfile: ResolvedSubProfile | LoadBalancerSubProfile,
     options: GenerateChatOptions,
@@ -844,10 +793,10 @@ export class LoadBalancingProvider implements IProvider {
     contextLimitErrors: Array<{ profile: string; error: Error }>,
     currentIndex: number,
     numProfiles: number,
+    requestOwner: symbol,
   ): AsyncGenerator<IContent, boolean> {
     let attempts = 0;
     const maxAttempts = Math.max(1, settings.retryCount);
-
     while (attempts < maxAttempts) {
       attempts++;
       let startTime = 0;
@@ -867,7 +816,7 @@ export class LoadBalancingProvider implements IProvider {
           startTime,
           chunksYielded,
         );
-        this.currentFailoverIndex = currentIndex;
+        this.failoverState.setIfOwner(requestOwner, currentIndex);
         return true;
       } catch (error) {
         if (
@@ -875,16 +824,22 @@ export class LoadBalancingProvider implements IProvider {
           error instanceof LoadBalancerContextLimitError
         ) {
           contextLimitErrors.push({ profile: subProfile.name, error });
-          this.currentFailoverIndex = (currentIndex + 1) % numProfiles;
-          return false;
+          return this.failoverState.advanceFrom(
+            requestOwner,
+            currentIndex,
+            numProfiles,
+          );
         }
         if (!requestStarted) {
           errors.push({
             profile: subProfile.name,
             error: error instanceof Error ? error : new Error(String(error)),
           });
-          this.currentFailoverIndex = (currentIndex + 1) % numProfiles;
-          return false;
+          return this.failoverState.advanceFrom(
+            requestOwner,
+            currentIndex,
+            numProfiles,
+          );
         }
         const handled = this.handleFailoverError(
           error,
@@ -897,18 +852,10 @@ export class LoadBalancingProvider implements IProvider {
           chunksYielded.value,
           currentIndex,
           numProfiles,
+          requestOwner,
         );
-        if (handled === 'immediate-throw') {
-          throw error;
-        }
-        if (handled === 'break') {
-          // Exit the retry while-loop. This generator returns,
-          // causing the outer executeWithFailover while-loop's
-          // yield* to complete normally. Control then continues
-          // with the next backend in the outer loop.
-          break;
-        }
-        // 'retry' — apply delay then loop
+        if (handled === 'immediate-throw') throw error;
+        if (handled === 'break') break;
         if (settings.retryDelayMs > 0) {
           await new Promise((resolve) =>
             setTimeout(resolve, settings.retryDelayMs),
@@ -919,9 +866,6 @@ export class LoadBalancingProvider implements IProvider {
     return false;
   }
 
-  /**
-   * Execute a single request attempt against a backend, yielding chunks.
-   */
   private async *attemptBackendRequest(
     subProfile: ResolvedSubProfile | LoadBalancerSubProfile,
     options: GenerateChatOptions,
@@ -963,25 +907,19 @@ export class LoadBalancingProvider implements IProvider {
       yield chunk;
     }
 
-    const tokensUsed = this.extractTokenCount(chunks);
+    const tokensUsed = BackendMetricsCollector.extractTokenCount(chunks);
     if (tokensUsed > 0) {
       this.updateTPM(subProfile.name, tokensUsed);
     }
 
     this.recordRequestSuccess(subProfile.name, startTime, tokensUsed);
     this.incrementStats(subProfile.name);
-    this.recordBackendSuccess(subProfile.name);
+    this.circuitBreaker.recordBackendSuccess(subProfile.name);
     this.logger.debug(
       () => `[LB:failover] Success on backend: ${subProfile.name}`,
     );
   }
 
-  /**
-   * Handle error during failover attempt. Returns action:
-   * - 'immediate-throw': re-throw the error (chunks already yielded or abort)
-   * - 'break': stop retrying this backend, move to next
-   * - 'retry': continue the retry loop
-   */
   private handleFailoverError(
     error: unknown,
     subProfile: ResolvedSubProfile | LoadBalancerSubProfile,
@@ -993,6 +931,7 @@ export class LoadBalancingProvider implements IProvider {
     chunksYielded: boolean,
     currentIndex: number,
     numProfiles: number,
+    requestOwner: symbol,
   ): 'immediate-throw' | 'break' | 'retry' {
     if (this.isImmediateFailoverError(error)) {
       if (chunksYielded) {
@@ -1001,7 +940,10 @@ export class LoadBalancingProvider implements IProvider {
             `[LB:failover] ${subProfile.name} returned immediate failover error after yielding chunks, aborting stream`,
         );
         this.recordRequestFailure(subProfile.name, startTime, error as Error);
-        this.recordBackendFailure(subProfile.name, error as Error);
+        this.circuitBreaker.recordBackendFailure(
+          subProfile.name,
+          error as Error,
+        );
         return 'immediate-throw';
       }
 
@@ -1010,9 +952,9 @@ export class LoadBalancingProvider implements IProvider {
           `[LB:failover] ${subProfile.name} returned immediate failover error (${getErrorStatus(error)}), skipping retries`,
       );
       this.recordRequestFailure(subProfile.name, startTime, error as Error);
-      this.recordBackendFailure(subProfile.name, error as Error);
+      this.circuitBreaker.recordBackendFailure(subProfile.name, error as Error);
       errors.push({ profile: subProfile.name, error: error as Error });
-      this.currentFailoverIndex = (currentIndex + 1) % numProfiles;
+      this.failoverState.advanceFrom(requestOwner, currentIndex, numProfiles);
       return 'break';
     }
 
@@ -1034,9 +976,9 @@ export class LoadBalancingProvider implements IProvider {
         `[LB:failover] ${subProfile.name} failed after ${attempts} attempts: ${(error as Error).message}`,
     );
     this.recordRequestFailure(subProfile.name, startTime, error as Error);
-    this.recordBackendFailure(subProfile.name, error as Error);
+    this.circuitBreaker.recordBackendFailure(subProfile.name, error as Error);
     errors.push({ profile: subProfile.name, error: error as Error });
-    this.currentFailoverIndex = (currentIndex + 1) % numProfiles;
+    this.failoverState.advanceFrom(requestOwner, currentIndex, numProfiles);
     return 'break';
   }
 

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.stickyIndex.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.stickyIndex.test.ts
@@ -1,0 +1,395 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  LoadBalancingProvider,
+  type LoadBalancingProviderConfig,
+} from '../LoadBalancingProvider.js';
+import { LoadBalancerFailoverError } from '../errors.js';
+import type { IProvider } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions } from '../GenerateChatOptions.js';
+
+describe('LoadBalancingProvider - Failover Sticky Index (Issue #2492)', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let providerManager: ProviderManager;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = createRuntimeConfigStub(settingsService);
+    providerManager = new ProviderManager({ settingsService, config });
+  });
+
+  it('should failover from sticky index 2 to healthy index 0', async () => {
+    const callLog: string[] = [];
+
+    const mockProvider: IProvider = {
+      name: 'test-provider',
+      async *generateChatCompletion(
+        options: GenerateChatOptions,
+      ): AsyncGenerator<IContent> {
+        const model = options.resolved?.model ?? '';
+        callLog.push(model);
+        if (model === 'model-a') {
+          throw new Error('backend-a error');
+        }
+        if (model === 'model-b') {
+          throw new Error('backend-b error');
+        }
+        yield { type: 'text' as const, content: 'success' };
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => ({ content: [] }),
+    };
+
+    providerManager.registerProvider(mockProvider);
+
+    const lbConfig: LoadBalancingProviderConfig = {
+      profileName: 'test-sticky-wraparound',
+      strategy: 'failover',
+      subProfiles: [
+        {
+          name: 'backend-a',
+          providerName: 'test-provider',
+          modelId: 'model-a',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-a',
+        },
+        {
+          name: 'backend-b',
+          providerName: 'test-provider',
+          modelId: 'model-b',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-b',
+        },
+        {
+          name: 'backend-c',
+          providerName: 'test-provider',
+          modelId: 'model-c',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-c',
+        },
+      ],
+    };
+
+    const provider = new LoadBalancingProvider(lbConfig, providerManager);
+    const options: GenerateChatOptions = {
+      prompt: 'test prompt',
+      messages: [{ role: 'user' as const, content: 'test' }],
+    };
+
+    callLog.length = 0;
+    for await (const _chunk of provider.generateChatCompletion(options)) {
+      // consume
+    }
+
+    expect(provider.getCurrentFailoverIndex()).toBe(2);
+
+    callLog.length = 0;
+    mockProvider.generateChatCompletion = async function* (
+      options: GenerateChatOptions,
+    ): AsyncGenerator<IContent> {
+      const model = options.resolved?.model ?? '';
+      callLog.push(model);
+      if (model === 'model-c') {
+        const error = new Error('Rate limited') as Error & {
+          status: number;
+        };
+        error.status = 429;
+        throw error;
+      }
+      if (model === 'model-a') {
+        yield { type: 'text' as const, content: 'success from a' };
+      }
+      if (model === 'model-b') {
+        throw new Error('backend-b error');
+      }
+    };
+
+    const results: IContent[] = [];
+    for await (const chunk of provider.generateChatCompletion(options)) {
+      results.push(chunk);
+    }
+
+    expect(results[0]).toStrictEqual({
+      type: 'text',
+      content: 'success from a',
+    });
+    expect(provider.getCurrentFailoverIndex()).toBe(0);
+    expect(callLog).toStrictEqual(['model-c', 'model-a']);
+  });
+
+  it('should reset sticky index to 0 after all backends fail', async () => {
+    let phase: 'first' | 'second' = 'first';
+    const callLog: string[] = [];
+
+    const mockProvider: IProvider = {
+      name: 'test-provider',
+      async *generateChatCompletion(
+        options: GenerateChatOptions,
+      ): AsyncGenerator<IContent> {
+        const model = options.resolved?.model ?? '';
+        callLog.push(model);
+        if (phase === 'first') {
+          if (model === 'model-a') {
+            throw new Error('backend-a error');
+          }
+          if (model === 'model-b') {
+            throw new Error('backend-b error');
+          }
+          yield { type: 'text' as const, content: 'success from c' };
+        } else {
+          throw new Error('all backends failed');
+        }
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => ({ content: [] }),
+    };
+
+    providerManager.registerProvider(mockProvider);
+
+    const lbConfig: LoadBalancingProviderConfig = {
+      profileName: 'test-reset-on-all-fail',
+      strategy: 'failover',
+      subProfiles: [
+        {
+          name: 'backend-a',
+          providerName: 'test-provider',
+          modelId: 'model-a',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-a',
+        },
+        {
+          name: 'backend-b',
+          providerName: 'test-provider',
+          modelId: 'model-b',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-b',
+        },
+        {
+          name: 'backend-c',
+          providerName: 'test-provider',
+          modelId: 'model-c',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-c',
+        },
+      ],
+    };
+
+    const provider = new LoadBalancingProvider(lbConfig, providerManager);
+    const options: GenerateChatOptions = {
+      prompt: 'test prompt',
+      messages: [{ role: 'user' as const, content: 'test' }],
+    };
+
+    for await (const _chunk of provider.generateChatCompletion(options)) {
+      // consume
+    }
+
+    expect(provider.getCurrentFailoverIndex()).toBe(2);
+    expect(callLog).toStrictEqual(['model-a', 'model-b', 'model-c']);
+
+    phase = 'second';
+    callLog.length = 0;
+
+    await expect(async () => {
+      for await (const _chunk of provider.generateChatCompletion(options)) {
+        // consume
+      }
+    }).rejects.toThrow(LoadBalancerFailoverError);
+
+    expect(provider.getCurrentFailoverIndex()).toBe(0);
+    expect(callLog).toStrictEqual(['model-c', 'model-a', 'model-b']);
+  });
+
+  it('should attempt all backends in order and reset index to 0 when a full rotation from sticky index 0 fails', async () => {
+    const callLog: string[] = [];
+
+    const mockProvider: IProvider = {
+      name: 'test-provider',
+      async *generateChatCompletion(
+        options: GenerateChatOptions,
+      ): AsyncGenerator<IContent> {
+        const model = options.resolved?.model ?? 'unknown';
+        callLog.push(model);
+        const chunks: IContent[] = [];
+        yield* chunks;
+        throw new Error(`backend failed for ${model}`);
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => ({ content: [] }),
+    };
+
+    providerManager.registerProvider(mockProvider);
+
+    const lbConfig: LoadBalancingProviderConfig = {
+      profileName: 'test-full-rotation-from-zero',
+      strategy: 'failover',
+      subProfiles: [
+        {
+          name: 'backend-a',
+          providerName: 'test-provider',
+          modelId: 'model-a',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-a',
+        },
+        {
+          name: 'backend-b',
+          providerName: 'test-provider',
+          modelId: 'model-b',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-b',
+        },
+        {
+          name: 'backend-c',
+          providerName: 'test-provider',
+          modelId: 'model-c',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-c',
+        },
+      ],
+    };
+
+    const provider = new LoadBalancingProvider(lbConfig, providerManager);
+    const options: GenerateChatOptions = {
+      prompt: 'test prompt',
+      messages: [{ role: 'user' as const, content: 'test' }],
+    };
+
+    expect(provider.getCurrentFailoverIndex()).toBe(0);
+
+    await expect(async () => {
+      for await (const _chunk of provider.generateChatCompletion(options)) {
+        // consume
+      }
+    }).rejects.toThrow(LoadBalancerFailoverError);
+
+    expect(callLog).toStrictEqual(['model-a', 'model-b', 'model-c']);
+    expect(provider.getCurrentFailoverIndex()).toBe(0);
+  });
+
+  it('should not be pegged to exhausted backend across multiple requests', async () => {
+    const callLog: string[] = [];
+
+    let phase: 1 | 2 | 3 = 1;
+
+    const mockProvider: IProvider = {
+      name: 'test-provider',
+      async *generateChatCompletion(
+        options: GenerateChatOptions,
+      ): AsyncGenerator<IContent> {
+        const model = options.resolved?.model ?? '';
+        callLog.push(`phase${phase}:${model}`);
+
+        if (phase === 1) {
+          if (model === 'zai-model') {
+            throw new Error('zai error');
+          }
+          if (model === 'makora-model') {
+            throw new Error('makora error');
+          }
+          yield { type: 'text' as const, content: 'ollama success' };
+        } else if (phase === 2) {
+          if (model === 'ollama-model') {
+            const error = new Error('Rate limited') as Error & {
+              status: number;
+            };
+            error.status = 429;
+            throw error;
+          }
+          yield { type: 'text' as const, content: 'zai success' };
+        } else {
+          yield { type: 'text' as const, content: 'zai success again' };
+        }
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => ({ content: [] }),
+    };
+
+    providerManager.registerProvider(mockProvider);
+
+    const lbConfig: LoadBalancingProviderConfig = {
+      profileName: 'test-not-pegged',
+      strategy: 'failover',
+      subProfiles: [
+        {
+          name: 'zai',
+          providerName: 'test-provider',
+          modelId: 'zai-model',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-zai',
+        },
+        {
+          name: 'makora',
+          providerName: 'test-provider',
+          modelId: 'makora-model',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-makora',
+        },
+        {
+          name: 'ollama',
+          providerName: 'test-provider',
+          modelId: 'ollama-model',
+          baseURL: 'https://api.test.com',
+          authToken: 'test-token-ollama',
+        },
+      ],
+    };
+
+    const provider = new LoadBalancingProvider(lbConfig, providerManager);
+    const options: GenerateChatOptions = {
+      prompt: 'test prompt',
+      messages: [{ role: 'user' as const, content: 'test' }],
+    };
+
+    const phase1Calls: string[] = [];
+    for await (const _chunk of provider.generateChatCompletion(options)) {
+      // consume
+    }
+    phase1Calls.push(...callLog.splice(0));
+    expect(provider.getCurrentFailoverIndex()).toBe(2);
+    expect(phase1Calls).toStrictEqual([
+      'phase1:zai-model',
+      'phase1:makora-model',
+      'phase1:ollama-model',
+    ]);
+
+    phase = 2;
+    const phase2Calls: string[] = [];
+    for await (const _chunk of provider.generateChatCompletion(options)) {
+      // consume
+    }
+    phase2Calls.push(...callLog.splice(0));
+    expect(provider.getCurrentFailoverIndex()).toBe(0);
+    expect(phase2Calls).toStrictEqual([
+      'phase2:ollama-model',
+      'phase2:zai-model',
+    ]);
+
+    phase = 3;
+    const phase3Calls: string[] = [];
+    for await (const _chunk of provider.generateChatCompletion(options)) {
+      // consume
+    }
+    phase3Calls.push(...callLog.splice(0));
+    expect(provider.getCurrentFailoverIndex()).toBe(0);
+    expect(phase3Calls).toStrictEqual(['phase3:zai-model']);
+  });
+});

--- a/packages/providers/src/loadBalancing/failoverState.test.ts
+++ b/packages/providers/src/loadBalancing/failoverState.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { FailoverState } from './failoverState.js';
+
+describe('FailoverState', () => {
+  it('ignores an exhausted rotation reset after a newer request succeeds', () => {
+    const state = new FailoverState();
+    const olderRequest = state.claim();
+    const newerRequest = state.claim();
+
+    state.setIfOwner(newerRequest.owner, 2);
+    state.setIfOwner(olderRequest.owner, 0);
+
+    expect(state.getIndex()).toBe(2);
+  });
+
+  it('ignores an older success after a newer request succeeds', () => {
+    const state = new FailoverState();
+    const olderRequest = state.claim();
+    const newerRequest = state.claim();
+
+    state.setIfOwner(newerRequest.owner, 1);
+    state.setIfOwner(olderRequest.owner, 2);
+
+    expect(state.getIndex()).toBe(1);
+  });
+
+  it('ignores an older failure advance after a newer request succeeds', () => {
+    const state = new FailoverState();
+    const olderRequest = state.claim();
+    const newerRequest = state.claim();
+
+    state.setIfOwner(newerRequest.owner, 2);
+    state.advanceFrom(olderRequest.owner, 0, 3);
+    const followingRequest = state.claim();
+
+    expect(followingRequest.startIndex).toBe(2);
+  });
+});

--- a/packages/providers/src/loadBalancing/failoverState.ts
+++ b/packages/providers/src/loadBalancing/failoverState.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export class FailoverState {
+  private index = 0;
+  private owner = Symbol();
+
+  getIndex(): number {
+    return this.index;
+  }
+
+  reset(): void {
+    this.index = 0;
+  }
+
+  claim(): { owner: symbol; startIndex: number } {
+    this.owner = Symbol();
+    return { owner: this.owner, startIndex: this.index };
+  }
+
+  setIfOwner(owner: symbol, index: number): void {
+    if (owner === this.owner) {
+      this.index = index;
+    }
+  }
+
+  advanceFrom(
+    owner: symbol,
+    currentIndex: number,
+    profileCount: number,
+  ): false {
+    this.setIfOwner(owner, (currentIndex + 1) % profileCount);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- reset a failover load balancer's sticky index to the preferred first backend after an exhausted full rotation
- preserve sticky selection when a backend succeeds, including circular failover from a non-zero index
- add failover diagnostics that identify the starting index and each attempted backend index
- add behavioral coverage for non-zero wraparound, all-backend failures from non-zero and zero indexes, and subsequent requests after an exhausted backend

## Why

When an upstream retry followed a fully failed load-balancer rotation that started at a sticky non-zero backend, the sticky index wrapped back to that same backend. A quota-exhausted Ollama member could therefore be retried first on every aggregate retry even when Z.AI was the preferred member.

The load balancer now resets to index 0 only after every eligible backend in the rotation has failed. Successful failover remains sticky on the backend that served the request, and existing partial-stream abort behavior is unchanged.

## Verification

- all failover tests: 56 passed before review remediation
- focused sticky-index and streaming tests: 13 passed after remediation
- full npm test suite: passed
- npm lint: passed
- npm format: passed
- npm build: passed
- providers TypeScript check: passed
- root TypeScript check remains blocked by the pre-existing main-branch error in packages/agents/src/core/ChatSessionFactory.ts for reasoning.fieldName missing from ReadonlySettingsSnapshot
- smoke entrypoint node scripts/start.js is absent; bun scripts/start.ts with the ollamakimi profile remained running without output and was terminated
- deepthinker review: pass, no blockers
- Open Code Review: clean final review, 2 files reviewed, 0 comments

Fixes #2492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider failover behavior by continuing backend rotation from the most recent position.
  * Prevented repeated attempts against an exhausted backend across consecutive requests.
  * Reset failover rotation after all available backends fail, enabling subsequent requests to retry from a clean starting point.
* **Diagnostics**
  * Added additional debug details to help monitor failover rotation and backend attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->