### PR TITLE
Zed ACP: upgrade @agentclientprotocol/sdk 0.14.1 -> 1.2.1 (Fixes #2496)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@vybestack/llxprt-code",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.14.1",
+        "@agentclientprotocol/sdk": "^1.2.1",
         "@ai-sdk/openai": "^2.0.74",
         "@ai-sdk/provider-utils": "^2.0.6",
         "@anthropic-ai/sdk": "^0.55.1",
@@ -247,7 +247,7 @@
         "llxprt": "bin/llxprt.cjs",
       },
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.14.1",
+        "@agentclientprotocol/sdk": "^1.2.1",
         "@anthropic-ai/sdk": "^0.55.1",
         "@dqbd/tiktoken": "^1.0.21",
         "@iarna/toml": "^2.2.5",
@@ -706,7 +706,7 @@
 
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
 
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.14.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.109", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.28", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-jvTQnfmcKD/bc8fbp2bbaO8QvqSPaj7lv5rj9kj/GLHUfTGpjQV3pH7GdO4fDi1SX2PdHpPQY0y6rxJ05Xo5cg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "packages/vscode-ide-companion"
       ],
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.14.1",
+        "@agentclientprotocol/sdk": "^1.2.1",
         "@ai-sdk/openai": "^2.0.74",
         "@ai-sdk/provider-utils": "^2.0.6",
         "@anthropic-ai/sdk": "^0.55.1",
@@ -234,9 +234,9 @@
       "license": "MIT"
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.14.1.tgz",
-      "integrity": "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.2.1.tgz",
+      "integrity": "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -23798,7 +23798,7 @@
       "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.14.1",
+        "@agentclientprotocol/sdk": "^1.2.1",
         "@anthropic-ai/sdk": "^0.55.1",
         "@dqbd/tiktoken": "^1.0.21",
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "vitest": "^3.2.6"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.14.1",
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@ai-sdk/openai": "^2.0.74",
     "@ai-sdk/provider-utils": "^2.0.6",
     "@anthropic-ai/sdk": "^0.55.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@vybestack/llxprt-code-storage": "file:../storage",
-    "@agentclientprotocol/sdk": "^0.14.1",
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@anthropic-ai/sdk": "^0.55.1",
     "@dqbd/tiktoken": "^1.0.21",
     "@iarna/toml": "^2.2.5",

--- a/packages/cli/src/zed-integration/fileSystemService.ts
+++ b/packages/cli/src/zed-integration/fileSystemService.ts
@@ -14,7 +14,7 @@ export class AcpFileSystemService implements FileSystemService {
   constructor(
     private readonly connection: acp.AgentSideConnection,
     private readonly sessionId: string,
-    private readonly capabilities: acp.FileSystemCapability,
+    private readonly capabilities: acp.FileSystemCapabilities,
     private readonly fallback: FileSystemService,
   ) {}
 


### PR DESCRIPTION
## Summary

Upgrades `@agentclientprotocol/sdk` from `^0.14.1` to `^1.2.1` as the prerequisite for the #1603 ACP umbrella. ACP hit **v1.0 GA on 2026-06-24**; every subsequent sub-issue (#1604, #1606, #1608, #1609, #1610, #1611) builds on the v1 surface.

Fixes #2496. Part of #1603. **Targets the `issue1603` umbrella branch, not main.**

## Changes

- `package.json` + `packages/cli/package.json`: SDK `^0.14.1` -> `^1.2.1`
- `package-lock.json` + `bun.lock`: regenerated (plain `bun install`, not frozen, per repo convention)
- `packages/cli/src/zed-integration/fileSystemService.ts`: `acp.FileSystemCapability` -> `acp.FileSystemCapabilities` (the only source break in the entire upgrade)

## Why so small

Our current ACP usage (initialize, authenticate, newSession, prompt, cancel, session updates, permissions, fs, modes) sits on the stable core that survived 0.14 -> 1.0 unchanged. Verified against the published v1 schema:

- `PROTOCOL_VERSION` remains integer `1` -- negotiation unaffected
- `usage_update` requires `used`/`size` -- we send both
- plan entries require `content`/`priority`/`status` -- we send all three
- `tool_call`/`tool_call_update` required fields unchanged

The v1 additions (stabilized `listSessions`/`resumeSession`, new `deleteSession`/`session/close`, removed `unstable_setSessionModel`, new `plan_update`/`plan_removed` variants, MCP-over-ACP) are all optional Agent-interface methods and don't affect compilation. They're the subject of the follow-up sub-issues.

## Verification

- `npm run test` -- all workspaces green (5000+ CLI, 3900 core, all others pass)
- `npm run lint` / `npm run typecheck` / `npm run format` / `npm run build` -- clean
- Smoke test (`bun scripts/start.ts --profile-load fable5 "write me a haiku..."`) -- passes (note: ollamakimi profile currently blocked by an ollama.com account quota, unrelated to this change; verified via direct curl)
- **acplint 0.2.0** (ACP-v1-aligned linter) against the built CLI over stdio with a live provider: **Full Conformance** on streaming, tool_calls, and schema_validation categories -- all 30 checks PASS including strict Pydantic schema validation of every notification
- ocr review: no findings (diff is version bumps + one type rename)

## acplint baseline (for the umbrella)

Full run (all 14 categories) reports Partial Conformance today, entirely expected:
- authentication "failures" are acplint probing every advertised auth method (our profiles) without credentials in the sandbox -- environmental, not protocol issues
- streaming failures in the no-provider run disappear when a working provider profile is loaded (Full Conformance above)
- loadSession/list/fork/resume/terminals/config options correctly report as not advertised -- that's precisely the #1603 work this branch stack will deliver
