### PR TITLE
Zed ACP: implement session/load with continuous session recording (Fixes #1604)

### DIFF
--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -564,6 +564,13 @@ Session lifecycle: `resume(target, options?)`, `createCheckpoint(label?)`,
 `restoreCheckpoint(id)`, `listCheckpoints()`, `setRecording(state)`,
 `getRecording()`.
 
+`resume()` returns the reconstructed history
+(`Promise<readonly AgentHistoryItem[]>`) so callers can replay the restored
+conversation without a lossy `getHistory()` round-trip (previously
+`Promise<void>`; callers that ignore the return value are source-compatible).
+`setRecording({ enabled: true })` records continuously: it snapshots the
+current history and appends every subsequent turn to the session JSONL file.
+
 #### `agent.hooks` — `AgentHookControl`
 
 Lifecycle hooks: `onHookExecution(cb)`, `triggerSessionStart()`,

--- a/docs/zed-integration.md
+++ b/docs/zed-integration.md
@@ -176,6 +176,23 @@ Logs go to `~/.llxprt/debug/`. Only enable when troubleshooting — they get lar
 
 **Profile not found** — list profiles with `llxprt` then `/profile list`. Names are case-sensitive.
 
+## Extension Namespace (`llxprt/`)
+
+LLxprt reserves the `llxprt/` prefix for vendor-specific ACP extension methods and notifications. This namespace is documented for future use; no `llxprt/`-prefixed extension methods are implemented yet.
+
+When a concrete use case arrives (e.g. subagent status, memory operations, debug toggles, provider hints), the method name will be `llxprt/<feature>` and will be advertised here. Clients that do not recognize a `llxprt/` method MUST ignore it per the ACP [extensibility](https://agentclientprotocol.com/protocol/extensibility) rules (`_meta` / extension handling).
+
+## Session Metadata
+
+LLxprt emits ACP `session_info_update` notifications carrying:
+
+- **`title`** — a truncated preview of the first user prompt (derived once, consistent with the on-disk session listing).
+- **`updatedAt`** — an ISO 8601 timestamp refreshed after every turn (success, cancel, or error).
+
+This metadata also populates the `listSessions` response so Zed's session sidebar shows descriptive names and freshness without reading the recording files.
+
+When a session has both a durable on-disk recording and live in-memory metadata (e.g. the agent process is still running), `listSessions` merges them: the durable recording's title takes precedence (it is the authoritative first-user-message preview), while `updatedAt` is the newer of the two. A session with no durable recording yet shows the live title and `updatedAt` only.
+
 ## Related
 
 - [Zed External Agents Documentation](https://zed.dev/docs/ai/external-agents)

--- a/docs/zed-integration.md
+++ b/docs/zed-integration.md
@@ -193,6 +193,14 @@ This metadata also populates the `listSessions` response so Zed's session sideba
 
 When a session has both a durable on-disk recording and live in-memory metadata (e.g. the agent process is still running), `listSessions` merges them: the durable recording's title takes precedence (it is the authoritative first-user-message preview), while `updatedAt` is the newer of the two. A session with no durable recording yet shows the live title and `updatedAt` only.
 
+## Terminal Integration
+
+When the client advertises the `terminal` capability (`terminal: true` in `ClientCapabilities`), LLxprt creates an ACP terminal for each shell tool call via `connection.createTerminal`. This delegates command execution to Zed's native terminal renderer, giving the user live inline output as the command runs.
+
+The terminal is correlated to the originating tool call (by command and working directory) and embedded in the tool call's content as a `terminal` content block. The terminal is released after the tool call completes, and killed and released on cancel or session dispose.
+
+When the terminal capability is absent (or `false`), shell output is captured as text and emitted via the standard `content` content block — the same behavior as non-terminal ACP clients.
+
 ## Related
 
 - [Zed External Agents Documentation](https://zed.dev/docs/ai/external-agents)

--- a/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
@@ -52,14 +52,17 @@ function humanText(text: string): IContent {
 
 /**
  * Minimal in-memory Config projection exposing ONLY the surface SessionControl
- * touches: a fixed project root, a storage.getProjectTempDir() that drives the
- * chats-dir derivation, a workspace context, and the recording-service
+ * touches: a fixed project root, a storage whose getProjectChatsDir() drives
+ * the chats-dir derivation, a workspace context, and the recording-service
  * get/set pair. The installed recording service is observable so A2 can assert
  * Config was not left pointing at a half-installed resumed service.
  */
 interface FakeConfig {
   readonly getProjectRoot: () => string;
-  readonly storage: { readonly getProjectTempDir: () => string };
+  readonly storage: {
+    readonly getProjectTempDir: () => string;
+    readonly getProjectChatsDir: () => string;
+  };
   readonly getWorkspaceContext: () => {
     readonly getDirectories: () => readonly string[];
   };
@@ -73,7 +76,10 @@ function buildFakeConfig(projectRoot: string): FakeConfig {
   let installed: SessionRecordingServiceType | undefined;
   return {
     getProjectRoot: () => projectRoot,
-    storage: { getProjectTempDir: () => projectRoot },
+    storage: {
+      getProjectTempDir: () => projectRoot,
+      getProjectChatsDir: () => join(projectRoot, 'chats'),
+    },
     getWorkspaceContext: () => ({ getDirectories: () => [projectRoot] }),
     setSessionRecordingService: (service) => {
       installed = service;

--- a/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
@@ -1,0 +1,399 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260617-COREAPI.P20
+ * @requirement:REQ-010
+ *
+ * Concurrency / failure-atomicity / bounded-re-attach behavior for
+ * SessionControl (issue #1604 code-review FINDINGS A1/A2/A3). These drive the
+ * REAL SessionControl against a REAL on-disk recorded session (produced by the
+ * REAL SessionRecordingService + SessionLockManager) and an HONEST fake client
+ * whose HistoryService can be swapped for a throwing one — never mocks-were-
+ * called theater. Every assertion is on real observable state: on-disk lock
+ * files, the Config-installed recording service identity, and the number of
+ * live 'contentAdded' subscribers on the real HistoryService.
+ *
+ * A1 (serialized state mutation): two concurrent resume() calls settle with the
+ *     final recording/lock belonging to the LAST operation, no orphaned lock
+ *     files, both promises settle.
+ * A2 (atomic resume subscribe): when the post-restore subscribe throws, resume
+ *     rejects, Config is NOT left pointing at the resumed service, and the
+ *     adopted lock file is released (gone).
+ * A3 (bounded re-attach): a startRecording whose HistoryService was unavailable
+ *     leaves the integration unsubscribed; the NEXT operation re-attaches it so
+ *     later content events reach the recording file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  SessionRecordingService,
+  getProjectHash,
+} from '@vybestack/llxprt-code-core';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { AgentClientContract } from '@vybestack/llxprt-code-core/core/clientContract.js';
+import { SessionControl } from '../control/sessionControl.js';
+import type { SessionControlDeps } from '../control/sessionControl.js';
+
+/** Alias for the recording-service type used in the FakeConfig projection. */
+type SessionRecordingServiceType = SessionRecordingService;
+
+/** A single human text IContent turn (the neutral recorded shape). */
+function humanText(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+/**
+ * Minimal in-memory Config projection exposing ONLY the surface SessionControl
+ * touches: a fixed project root, a storage.getProjectTempDir() that drives the
+ * chats-dir derivation, a workspace context, and the recording-service
+ * get/set pair. The installed recording service is observable so A2 can assert
+ * Config was not left pointing at a half-installed resumed service.
+ */
+interface FakeConfig {
+  readonly getProjectRoot: () => string;
+  readonly storage: { readonly getProjectTempDir: () => string };
+  readonly getWorkspaceContext: () => {
+    readonly getDirectories: () => readonly string[];
+  };
+  setSessionRecordingService: (
+    service: SessionRecordingServiceType | undefined,
+  ) => void;
+  getSessionRecordingService: () => SessionRecordingServiceType | undefined;
+}
+
+function buildFakeConfig(projectRoot: string): FakeConfig {
+  let installed: SessionRecordingServiceType | undefined;
+  return {
+    getProjectRoot: () => projectRoot,
+    storage: { getProjectTempDir: () => projectRoot },
+    getWorkspaceContext: () => ({ getDirectories: () => [projectRoot] }),
+    setSessionRecordingService: (service) => {
+      installed = service;
+    },
+    getSessionRecordingService: () => installed,
+  };
+}
+
+/**
+ * Honest fake client: exposes a swappable HistoryService and records
+ * restoreHistory calls. getHistory() returns whatever seed was configured (as
+ * Gemini-ish content the ContentConverters bridge accepts). This is a genuine
+ * collaborator, not a call-spy assertion target.
+ */
+interface FakeClient {
+  contract: AgentClientContract;
+  setHistoryService: (hs: HistoryService | null) => void;
+  restoreCount: () => number;
+}
+
+function buildFakeClient(seed: readonly IContent[] = []): FakeClient {
+  let historyService: HistoryService | null = new HistoryService();
+  let restoreCalls = 0;
+  const contract = {
+    getHistory: async () => [...seed],
+    getHistoryService: () => historyService,
+    restoreHistory: async () => {
+      restoreCalls += 1;
+    },
+  } as unknown as AgentClientContract;
+  return {
+    contract,
+    setHistoryService: (hs) => {
+      historyService = hs;
+    },
+    restoreCount: () => restoreCalls,
+  };
+}
+
+function buildDeps(
+  config: FakeConfig,
+  client: AgentClientContract,
+  sessionId: string,
+): SessionControlDeps {
+  return {
+    config: config as unknown as SessionControlDeps['config'],
+    sessionId: () => sessionId,
+    resolveClient: () => client,
+    getProvider: () => 'fake',
+    getModel: () => 'fake-model',
+  };
+}
+
+/** chats dir SessionControl derives: join(projectTempDir, 'chats'). */
+function chatsDirOf(projectRoot: string): string {
+  return join(projectRoot, 'chats');
+}
+
+/**
+ * Records a REAL resumable session to disk for `sessionId`: materializes a JSONL
+ * file via the real SessionRecordingService (seeded with one content event),
+ * flushes, and disposes so the file is complete and unlocked (resumable).
+ */
+async function recordResumableSession(
+  projectRoot: string,
+  sessionId: string,
+  seed: IContent,
+): Promise<void> {
+  const service = new SessionRecordingService({
+    sessionId,
+    projectHash: getProjectHash(projectRoot),
+    chatsDir: chatsDirOf(projectRoot),
+    workspaceDirs: [projectRoot],
+    provider: 'fake',
+    model: 'fake-model',
+  });
+  service.recordContent(seed);
+  await service.flush();
+  await service.dispose();
+}
+
+/** Runs `fn` against a fresh isolated project-root temp dir, always cleaned up. */
+async function withProjectRoot(
+  fn: (projectRoot: string) => Promise<void>,
+): Promise<void> {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'llxprt-sc-conc-'));
+  try {
+    await fn(projectRoot);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+}
+
+/** Lists the on-disk .lock files remaining in the chats dir. */
+function remainingLockFiles(projectRoot: string): string[] {
+  try {
+    return readdirSync(chatsDirOf(projectRoot)).filter((n) =>
+      n.endsWith('.lock'),
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Asserts a settled result is fulfilled and returns its value (no conditional
+ * expect): throws with the rejection reason otherwise so the test fails with a
+ * useful message rather than a swallowed branch.
+ */
+function unwrapFulfilled<T>(outcome: PromiseSettledResult<T>): T {
+  if (outcome.status !== 'fulfilled') {
+    throw new Error(
+      `expected fulfilled outcome, got rejected: ${String(outcome.reason)}`,
+    );
+  }
+  return outcome.value;
+}
+
+describe('SessionControl concurrency + atomicity (issue #1604 A1/A2/A3) @plan:PLAN-20260617-COREAPI.P20 @requirement:REQ-010', () => {
+  it('A1: serializes resume() racing stopRecording so the teardown cannot dispose the resource resume is adopting — the LAST-submitted op wins with a clean, consistent final state and no orphaned lock @requirement:REQ-010', async () => {
+    await withProjectRoot(async (projectRoot) => {
+      const sessionId = 'concurrent-session-id';
+      await recordResumableSession(
+        projectRoot,
+        sessionId,
+        humanText('recorded turn alpha'),
+      );
+
+      const config = buildFakeConfig(projectRoot);
+      const client = buildFakeClient([humanText('live turn')]);
+      const control = new SessionControl(
+        buildDeps(config, client.contract, sessionId),
+      );
+
+      // Fire resume() and setRecording(false) (stopRecording) concurrently.
+      // Without the op-chain mutex the stop could read/dispose the recording +
+      // release the lock that resume is mid-way through adopting (use-after-free
+      // / a "completed" stop that nonetheless leaves recording enabled, or an
+      // orphaned lock file). With serialization the two run strictly in
+      // submission order: resume FULLY adopts the resumed recording + lock, THEN
+      // stop tears that exact resource down — a clean disabled end state.
+      const resumePromise = control.resume('latest');
+      const stopPromise = control.setRecording({ enabled: false });
+      const [resumeOutcome, stopOutcome] = await Promise.allSettled([
+        resumePromise,
+        stopPromise,
+      ]);
+
+      // Both settle without a crossed-state crash.
+      expect(stopOutcome.status).toBe('fulfilled');
+      // resume genuinely ran and adopted the recorded history (it restored a
+      // non-empty transcript through the client) — proving the stop did NOT
+      // short-circuit or corrupt the in-flight resume. Unwrap via the settled
+      // result's value without a conditional expect.
+      const resumeValue = unwrapFulfilled(resumeOutcome);
+      expect(resumeValue.length).toBeGreaterThanOrEqual(1);
+      expect(client.restoreCount()).toBe(1);
+
+      // LAST-submitted op wins: stop ran AFTER resume fully committed, so the
+      // final state is cleanly DISABLED — recording off, Config cleared, and the
+      // resumed lock released (no orphaned lock file). A non-serialized
+      // interleaving would leave recording enabled or a dangling lock here.
+      expect(control.getRecording().enabled).toBe(false);
+      expect(config.getSessionRecordingService()).toBeUndefined();
+      expect(remainingLockFiles(projectRoot)).toStrictEqual([]);
+
+      // Dispose after an already-clean teardown is a safe no-op.
+      await expect(control.dispose()).resolves.toBeUndefined();
+    });
+  });
+
+  it('A1b: serializes two concurrent resume() calls for the same latest session — both settle, no orphaned lock, exactly one lock survives with the winning recording @requirement:REQ-010', async () => {
+    await withProjectRoot(async (projectRoot) => {
+      const sessionId = 'concurrent-dual-resume';
+      await recordResumableSession(
+        projectRoot,
+        sessionId,
+        humanText('recorded turn omega'),
+      );
+
+      const config = buildFakeConfig(projectRoot);
+      const client = buildFakeClient([humanText('live turn')]);
+      const control = new SessionControl(
+        buildDeps(config, client.contract, sessionId),
+      );
+
+      // Two concurrent resume('latest') calls. The session lock is EXCLUSIVE, so
+      // exactly one can hold it at a time. Serialization makes the first fully
+      // adopt the lock, then the second observes it held (by this same process)
+      // and rejects cleanly with "in use" — WITHOUT adopting or releasing the
+      // first op's resources (no crossed state, no orphaned lock).
+      const [first, second] = await Promise.allSettled([
+        control.resume('latest'),
+        control.resume('latest'),
+      ]);
+
+      // Both settle; exactly one succeeds and one rejects with the lock reason.
+      const statuses = [first.status, second.status].sort();
+      expect(statuses).toStrictEqual(['fulfilled', 'rejected']);
+      const rejected = [first, second].find((r) => r.status === 'rejected');
+      expect((rejected as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+      expect(
+        ((rejected as PromiseRejectedResult).reason as Error).message,
+      ).toMatch(/in use/i);
+
+      // The winner's recording is active + Config-installed, and EXACTLY ONE
+      // lock file survives (the rejected op did not orphan a second lock nor
+      // release the winner's). The lock is named after the resolved session
+      // FILE (core locks the target file), so assert the COUNT, not the name.
+      expect(control.getRecording().enabled).toBe(true);
+      expect(config.getSessionRecordingService()?.isActive()).toBe(true);
+      expect(remainingLockFiles(projectRoot)).toHaveLength(1);
+
+      // Teardown releases the surviving lock (no leak past dispose).
+      await control.dispose();
+      expect(remainingLockFiles(projectRoot)).toStrictEqual([]);
+    });
+  });
+
+  it('A2: a post-restore subscribe failure rejects resume, leaves Config NOT pointing at the resumed service, and releases the adopted lock file @requirement:REQ-010', async () => {
+    await withProjectRoot(async (projectRoot) => {
+      const sessionId = 'atomic-resume-session';
+      await recordResumableSession(
+        projectRoot,
+        sessionId,
+        humanText('recorded turn beta'),
+      );
+
+      const config = buildFakeConfig(projectRoot);
+      const client = buildFakeClient([humanText('live turn')]);
+
+      // A HistoryService whose 'on' throws so the post-restore integration
+      // subscribe fails DURING resume (after the resumed recording + lock were
+      // acquired). This models a real subscribe failure, not a mocked outcome.
+      const throwingHistory = new HistoryService();
+      const originalOn = throwingHistory.on.bind(throwingHistory);
+      throwingHistory.on = ((
+        event: string,
+        listener: (...a: never[]) => void,
+      ) => {
+        if (event === 'contentAdded') {
+          throw new Error('subscribe boom');
+        }
+        return originalOn(
+          event as Parameters<typeof originalOn>[0],
+          listener as Parameters<typeof originalOn>[1],
+        );
+      }) as HistoryService['on'];
+      client.setHistoryService(throwingHistory);
+
+      const control = new SessionControl(
+        buildDeps(config, client.contract, sessionId),
+      );
+
+      // resume MUST reject with the subscribe failure (not silently half-enable).
+      await expect(control.resume('latest')).rejects.toThrow('subscribe boom');
+
+      // FINDING A2: Config was NOT left pointing at the resumed recording
+      // service — half-enabled recording (turns silently dropped) cannot occur.
+      expect(config.getSessionRecordingService()).toBeUndefined();
+
+      // getRecording reflects cleanly disabled state.
+      expect(control.getRecording().enabled).toBe(false);
+
+      // The adopted session lock was released: NO lock file remains on disk.
+      expect(remainingLockFiles(projectRoot)).toStrictEqual([]);
+
+      // Dispose is a clean no-op (nothing to release) — does not throw.
+      await expect(control.dispose()).resolves.toBeUndefined();
+    });
+  });
+
+  it('A3: an integration left unsubscribed (HistoryService unavailable at enable) is re-attached by the next operation, so later content events reach the recording @requirement:REQ-010', async () => {
+    await withProjectRoot(async (projectRoot) => {
+      const sessionId = 'reattach-session';
+      const config = buildFakeConfig(projectRoot);
+      // Enable recording while the client has NO HistoryService: the integration
+      // is committed but left unsubscribed (continuous recording dead).
+      const client = buildFakeClient([humanText('seed turn')]);
+      client.setHistoryService(null);
+      const control = new SessionControl(
+        buildDeps(config, client.contract, sessionId),
+      );
+
+      await control.setRecording({ enabled: true });
+      const recording = config.getSessionRecordingService();
+      expect(recording).toBeDefined();
+
+      // Now a HistoryService becomes available (as it would once the client's
+      // chat materializes). No listener is attached yet (enable could not
+      // subscribe), so the bounded-re-attach must wire it on the NEXT operation.
+      const liveHistory = new HistoryService();
+      expect(liveHistory.listenerCount('contentAdded')).toBe(0);
+      client.setHistoryService(liveHistory);
+
+      // A subsequent state-mutating operation runs ensureSubscribed() at its
+      // start, re-attaching the previously-dead integration. Toggling recording
+      // off would dispose it, so instead trigger a no-op-ish operation that
+      // still runs ensureSubscribed: a second setRecording(true) which, via
+      // startRecording, calls ensureSubscribed BEFORE swapping. To observe the
+      // re-attach on the ORIGINAL integration we instead emit on the history and
+      // assert the recording captured it after re-attach.
+      //
+      // Drive re-attach explicitly through resume of a nonexistent session so
+      // ensureSubscribed runs first (re-attaching the live integration) before
+      // the resume attempt fails on no-such-session — proving the re-attach
+      // happens at the START of the next operation independent of that op's
+      // outcome.
+      const beforeCount = liveHistory.listenerCount('contentAdded');
+      await expect(control.resume('does-not-exist-id')).rejects.toThrow(
+        /Failed to resume session/,
+      );
+
+      // The previously-dead integration is now subscribed to the live history:
+      // exactly one 'contentAdded' listener was attached by the re-attach.
+      expect(liveHistory.listenerCount('contentAdded')).toBe(beforeCount + 1);
+
+      await control.dispose();
+      // Dispose unsubscribed the re-attached integration (no leaked listener).
+      expect(liveHistory.listenerCount('contentAdded')).toBe(0);
+    });
+  });
+});

--- a/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
@@ -214,7 +214,7 @@ describe('SessionControl concurrency + atomicity (issue #1604 A1/A2/A3) @plan:PL
         buildDeps(config, client.contract, sessionId),
       );
 
-      // Fire resume() and setRecording(false) (stopRecording) concurrently.
+      // Fire resume() and setRecording({ enabled: false }) concurrently.
       // Without the op-chain mutex the stop could read/dispose the recording +
       // release the lock that resume is mid-way through adopting (use-after-free
       // / a "completed" stop that nonetheless leaves recording enabled, or an
@@ -375,19 +375,11 @@ describe('SessionControl concurrency + atomicity (issue #1604 A1/A2/A3) @plan:PL
       expect(liveHistory.listenerCount('contentAdded')).toBe(0);
       client.setHistoryService(liveHistory);
 
-      // A subsequent state-mutating operation runs ensureSubscribed() at its
-      // start, re-attaching the previously-dead integration. Toggling recording
-      // off would dispose it, so instead trigger a no-op-ish operation that
-      // still runs ensureSubscribed: a second setRecording(true) which, via
-      // startRecording, calls ensureSubscribed BEFORE swapping. To observe the
-      // re-attach on the ORIGINAL integration we instead emit on the history and
-      // assert the recording captured it after re-attach.
-      //
-      // Drive re-attach explicitly through resume of a nonexistent session so
-      // ensureSubscribed runs first (re-attaching the live integration) before
-      // the resume attempt fails on no-such-session — proving the re-attach
-      // happens at the START of the next operation independent of that op's
-      // outcome.
+      // Drive re-attach through resume of a nonexistent session: resume calls
+      // ensureSubscribed() FIRST, re-attaching the ORIGINAL integration, and it
+      // only replaces/disposes that integration after a successful lookup.
+      // Therefore the expected lookup failure leaves the re-attached listener
+      // available for direct observation below.
       const beforeCount = liveHistory.listenerCount('contentAdded');
       await expect(control.resume('does-not-exist-id')).rejects.toThrow(
         /Failed to resume session/,

--- a/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
@@ -225,7 +225,7 @@ describe('SessionControl continuous recording @plan:PLAN-20260617-COREAPI.P20 @r
       // fixture's raw id is not asserted — the pairing invariant is what the
       // #1604 replay's tool_call/tool_call_update matching depends on).
       const blocks = raw
-        .split(String.fromCharCode(10))
+        .split('\n')
         .filter((line) => line.trim().length > 0)
         .map((line) => JSON.parse(line) as Record<string, unknown>)
         .flatMap((entry) => {

--- a/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
@@ -83,9 +83,16 @@ async function withIsolatedAgent(
   try {
     await fn(agent);
   } finally {
-    await cleanup();
-    rmSync(workingDir, { recursive: true, force: true });
-    rmSync(storageTempDirFor(workingDir), { recursive: true, force: true });
+    // FINDING F1: a cleanup() rejection must NOT skip the temp-dir removal. Nest
+    // the cleanup() in its own try/finally so BOTH rmSync calls always run
+    // (preventing leaked working/storage dirs across a cleanup failure), while
+    // the original cleanup() error still propagates out of the finally.
+    try {
+      await cleanup();
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+      rmSync(storageTempDirFor(workingDir), { recursive: true, force: true });
+    }
   }
 }
 

--- a/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
@@ -38,6 +38,8 @@ import {
   buildAgent,
   drain,
   captureHistoryServiceIdentity,
+  respondToFirstConfirmation,
+  ToolConfirmationOutcome,
 } from './helpers/agentHarness.js';
 
 /** Builds a public AgentMessage (Content) with role + a single text part. */
@@ -179,6 +181,65 @@ describe('SessionControl continuous recording @plan:PLAN-20260617-COREAPI.P20 @r
       const raw = readFileSync(path, 'utf8');
       expect(raw).toContain('post-resume-sentinel-gamma');
       expect(raw).toContain('a plain text reply');
+    });
+  });
+
+  it('records COMPLETED TOOL CALLS (call + response) into the session JSONL for later replay (issue #1605 verification) @requirement:REQ-010', async () => {
+    await withIsolatedAgent('tool-call-then-answer.jsonl', async (agent) => {
+      // Recording is enabled BEFORE the tool turn, so the tool call and its
+      // response reach the JSONL only via the live RecordingIntegration
+      // subscription — proving the Agent API runtime records completed tool
+      // calls into session history (the #1605 acceptance bar the Zed
+      // loadSession replay depends on). The file materializes on first content
+      // (the session is unprompted at enable time), so the path is read AFTER
+      // the turn.
+      await agent.session.setRecording({ enabled: true });
+
+      const responder = respondToFirstConfirmation(
+        agent,
+        ToolConfirmationOutcome.ProceedOnce,
+      );
+      try {
+        await drain(agent.stream('run the tool'));
+      } finally {
+        responder.unsubscribe();
+      }
+
+      const path = agent.session.getRecording().path ?? '';
+      expect(path.length).toBeGreaterThan(0);
+
+      // Disable to flush + dispose so all queued writes land.
+      await agent.session.setRecording({ enabled: false });
+
+      const raw = readFileSync(path, 'utf8');
+      // The recorded transcript carries the tool CALL block for read_file …
+      expect(raw).toContain('"tool_call"');
+      expect(raw).toContain('read_file');
+      // … its RESPONSE block …
+      expect(raw).toContain('"tool_response"');
+      // … and the post-tool assistant text, i.e. the full completed exchange.
+      expect(raw).toContain('after the tool ran');
+
+      // The recorded call and response PAIR: the response's callId equals the
+      // recorded call's id (the runtime normalizes ids in history, so the
+      // fixture's raw id is not asserted — the pairing invariant is what the
+      // #1604 replay's tool_call/tool_call_update matching depends on).
+      const blocks = raw
+        .split(String.fromCharCode(10))
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .flatMap((entry) => {
+          const payload = entry['payload'] as
+            | { content?: { blocks?: ReadonlyArray<Record<string, unknown>> } }
+            | undefined;
+          return payload?.content?.blocks ?? [];
+        });
+      const callBlock = blocks.find((b) => b['type'] === 'tool_call');
+      const responseBlock = blocks.find((b) => b['type'] === 'tool_response');
+      expect(callBlock).toBeDefined();
+      expect(responseBlock).toBeDefined();
+      expect(typeof callBlock?.['id']).toBe('string');
+      expect(responseBlock?.['callId']).toBe(callBlock?.['id']);
     });
   });
 

--- a/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan:PLAN-20260617-COREAPI.P20
+ * @requirement:REQ-010
+ *
+ * Continuous session-recording + resume-returns-history behavior for the public
+ * agent.session surface (REQ-010, issue #1604). These tests drive the REAL
+ * SessionControl wired onto the core recording machinery (SessionRecordingService
+ * + RecordingIntegration + resumeSession) over a real FakeProvider, and assert
+ * real observable state on disk — never mocks-were-called theater.
+ *
+ * Covers the architectural fix that makes Zed session recording work:
+ *  (a) setRecording(true) subscribes a RecordingIntegration so a SUBSEQUENT
+ *      turn's content is appended to the JSONL file (continuous recording, not a
+ *      one-shot snapshot) — the acceptance bar from the brief.
+ *  (b) resume() returns the reconstructed IContent[] so callers can replay it.
+ *  (c) post-resume turns keep appending to the resumed JSONL file.
+ *  (d) teardown (setRecording(false)) unsubscribes the integration from the
+ *      HistoryService (no leaked 'contentAdded' listener).
+ *
+ * TEST HYGIENE mirrors session.spec.ts: every test uses a fresh isolated working
+ * dir and removes BOTH it and its derived storage temp dir in `finally`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import type { Agent, AgentMessage } from '@vybestack/llxprt-code-agents';
+import {
+  buildAgent,
+  drain,
+  captureHistoryServiceIdentity,
+} from './helpers/agentHarness.js';
+
+/** Builds a public AgentMessage (Content) with role + a single text part. */
+function textMessage(role: 'user' | 'model', text: string): AgentMessage {
+  return { role, parts: [{ text }] };
+}
+
+/**
+ * Derives the core storage temp dir for a working directory, mirroring
+ * Storage.getProjectTempDir (`~/.llxprt/tmp/<sha256(workingDir)>`). Used only
+ * for test cleanup so recording artifacts never accumulate.
+ */
+function storageTempDirFor(workingDir: string): string {
+  const hash = createHash('sha256').update(workingDir).digest('hex');
+  return join(homedir(), '.llxprt', 'tmp', hash);
+}
+
+/**
+ * Reaches the Agent's live HistoryService as an EventEmitter via the same
+ * documented internal probe the harness uses (captureHistoryServiceIdentity).
+ * HistoryService extends EventEmitter, so listenerCount is a genuine public
+ * observable for subscribe/unsubscribe assertions.
+ */
+function historyEmitter(agent: Agent): EventEmitter {
+  const hs = captureHistoryServiceIdentity(agent);
+  if (!(hs instanceof EventEmitter)) {
+    throw new Error('HistoryService not reachable as EventEmitter');
+  }
+  return hs;
+}
+
+/**
+ * Runs a scenario against a real Agent over an isolated working dir, then
+ * disposes the agent and removes both the working dir and its derived storage
+ * temp dir. Guarantees no stray recording artifacts survive.
+ */
+async function withIsolatedAgent(
+  fixture: string,
+  fn: (agent: Agent) => Promise<void>,
+): Promise<void> {
+  const workingDir = mkdtempSync(join(tmpdir(), 'llxprt-rec-spec-'));
+  const { agent, cleanup } = await buildAgent(fixture, { workingDir });
+  try {
+    await fn(agent);
+  } finally {
+    await cleanup();
+    rmSync(workingDir, { recursive: true, force: true });
+    rmSync(storageTempDirFor(workingDir), { recursive: true, force: true });
+  }
+}
+
+describe('SessionControl continuous recording @plan:PLAN-20260617-COREAPI.P20 @requirement:REQ-010', () => {
+  it('appends a turn that happens AFTER setRecording(true) to the JSONL file (continuous, not a one-shot snapshot) @requirement:REQ-010', async () => {
+    await withIsolatedAgent('multi-turn-text.jsonl', async (agent) => {
+      // Turn 1 happens BEFORE recording is enabled.
+      await drain(agent.stream('first-user-utterance'));
+
+      // Enable recording: snapshots the current history (turn 1) and subscribes
+      // a RecordingIntegration to the reused HistoryService.
+      await agent.session.setRecording({ enabled: true });
+      const path = agent.session.getRecording().path ?? '';
+      expect(path.length).toBeGreaterThan(0);
+
+      // Turn 2 happens AFTER recording is enabled. Its user + assistant content
+      // reaches the JSONL file ONLY via the subscribed integration — a one-shot
+      // snapshot taken at enable time could not contain it.
+      await drain(agent.stream('second-user-sentinel-epsilon'));
+
+      // Disable to flush + dispose the service so all queued writes land.
+      await agent.session.setRecording({ enabled: false });
+
+      const raw = readFileSync(path, 'utf8');
+      // The SECOND turn's user prompt and assistant reply are both present.
+      expect(raw).toContain('second-user-sentinel-epsilon');
+      expect(raw).toContain('turn two reply');
+    });
+  });
+
+  it('resume() returns the reconstructed IContent[] history @requirement:REQ-010', async () => {
+    await withIsolatedAgent('plain-text.jsonl', async (agent) => {
+      // Record a real session to disk: seed a known history, enable recording
+      // (materialize + snapshot + flush), then disable (flush + dispose + release
+      // the lock so the file becomes resumable).
+      const seeded = [
+        textMessage('user', 'resume-return sentinel: wombat'),
+        textMessage('model', 'acknowledged wombat'),
+      ];
+      await agent.setHistory(seeded);
+      await agent.session.setRecording({ enabled: true });
+      await agent.session.setRecording({ enabled: false });
+
+      const restored = await agent.session.resume('latest');
+
+      // The returned value is a real IContent[] carrying the recorded turns —
+      // not void, not a Gemini Content[] round-trip.
+      expect(Array.isArray(restored)).toBe(true);
+      expect(restored.length).toBeGreaterThanOrEqual(2);
+      for (const item of restored) {
+        expect(item).toHaveProperty('speaker');
+        expect(item).toHaveProperty('blocks');
+        expect(Array.isArray(item.blocks)).toBe(true);
+      }
+      const serialized = JSON.stringify(restored);
+      expect(serialized).toContain('resume-return sentinel: wombat');
+      expect(serialized).toContain('acknowledged wombat');
+    });
+  });
+
+  it('post-resume turns append to the resumed JSONL file @requirement:REQ-010', async () => {
+    await withIsolatedAgent('plain-text.jsonl', async (agent) => {
+      // Record + release a session so it can be resumed.
+      await agent.setHistory([textMessage('user', 'pre-resume base turn')]);
+      await agent.session.setRecording({ enabled: true });
+      await agent.session.setRecording({ enabled: false });
+
+      // Resume: adopts the resumed recording service and subscribes a fresh
+      // integration so post-resume turns keep appending to the SAME file.
+      await agent.session.resume('latest');
+      const path = agent.session.getRecording().path ?? '';
+      expect(path.length).toBeGreaterThan(0);
+
+      // A post-resume turn appends to the resumed file.
+      await drain(agent.stream('post-resume-sentinel-gamma'));
+
+      // Disable to flush the appended content.
+      await agent.session.setRecording({ enabled: false });
+
+      const raw = readFileSync(path, 'utf8');
+      expect(raw).toContain('post-resume-sentinel-gamma');
+      expect(raw).toContain('a plain text reply');
+    });
+  });
+
+  it('teardown unsubscribes the RecordingIntegration from the HistoryService (no leaked listener) @requirement:REQ-010', async () => {
+    await withIsolatedAgent('plain-text.jsonl', async (agent) => {
+      // Warm up so the chat + reused HistoryService are materialized and the
+      // identity probe returns a stable EventEmitter.
+      await drain(agent.stream('warm up the history service'));
+      const emitter = historyEmitter(agent);
+      const baseline = emitter.listenerCount('contentAdded');
+
+      await agent.session.setRecording({ enabled: true });
+      // Enabling subscribes exactly one additional 'contentAdded' listener.
+      expect(emitter.listenerCount('contentAdded')).toBe(baseline + 1);
+
+      await agent.session.setRecording({ enabled: false });
+      // Disabling disposes the integration, returning the listener count to the
+      // pre-enable baseline (no leaked subscription).
+      expect(emitter.listenerCount('contentAdded')).toBe(baseline);
+    });
+  });
+});

--- a/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
@@ -83,8 +83,8 @@ async function withIsolatedAgent(
   const workingDir = mkdtempSync(join(tmpdir(), 'llxprt-rec-spec-'));
   // The temp dirs must be removed on EVERY exit path, including a buildAgent
   // rejection (which would otherwise leak the just-created workingDir), a
-  // scenario failure, and — FINDING F1 — a cleanup() rejection, which must NOT
-  // skip the rmSync calls. Note that only ONE error can ultimately propagate:
+  // scenario failure, and a cleanup() rejection, which must NOT skip the rmSync
+  // calls. Note that only ONE error can ultimately propagate:
   // if fn() throws AND cleanup() then also rejects in the finally, cleanup()'s
   // error replaces fn()'s. That is the standard try/finally trade-off and
   // acceptable here — either failure fails the test loudly; the invariant this

--- a/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
@@ -79,20 +79,21 @@ async function withIsolatedAgent(
   fn: (agent: Agent) => Promise<void>,
 ): Promise<void> {
   const workingDir = mkdtempSync(join(tmpdir(), 'llxprt-rec-spec-'));
-  const { agent, cleanup } = await buildAgent(fixture, { workingDir });
+  // The temp dirs must be removed on EVERY exit path, including a buildAgent
+  // rejection (which would otherwise leak the just-created workingDir), a
+  // scenario failure, and — FINDING F1 — a cleanup() rejection, which must NOT
+  // skip the rmSync calls. cleanup() is nested in its own try/finally so both
+  // removals always run while the original error still propagates.
   try {
-    await fn(agent);
-  } finally {
-    // FINDING F1: a cleanup() rejection must NOT skip the temp-dir removal. Nest
-    // the cleanup() in its own try/finally so BOTH rmSync calls always run
-    // (preventing leaked working/storage dirs across a cleanup failure), while
-    // the original cleanup() error still propagates out of the finally.
+    const { agent, cleanup } = await buildAgent(fixture, { workingDir });
     try {
-      await cleanup();
+      await fn(agent);
     } finally {
-      rmSync(workingDir, { recursive: true, force: true });
-      rmSync(storageTempDirFor(workingDir), { recursive: true, force: true });
+      await cleanup();
     }
+  } finally {
+    rmSync(workingDir, { recursive: true, force: true });
+    rmSync(storageTempDirFor(workingDir), { recursive: true, force: true });
   }
 }
 

--- a/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.recording.behavior.test.ts
@@ -82,8 +82,11 @@ async function withIsolatedAgent(
   // The temp dirs must be removed on EVERY exit path, including a buildAgent
   // rejection (which would otherwise leak the just-created workingDir), a
   // scenario failure, and — FINDING F1 — a cleanup() rejection, which must NOT
-  // skip the rmSync calls. cleanup() is nested in its own try/finally so both
-  // removals always run while the original error still propagates.
+  // skip the rmSync calls. Note that only ONE error can ultimately propagate:
+  // if fn() throws AND cleanup() then also rejects in the finally, cleanup()'s
+  // error replaces fn()'s. That is the standard try/finally trade-off and
+  // acceptable here — either failure fails the test loudly; the invariant this
+  // helper guarantees is only that no temp dir survives.
   try {
     const { agent, cleanup } = await buildAgent(fixture, { workingDir });
     try {

--- a/packages/agents/src/api/agent.ts
+++ b/packages/agents/src/api/agent.ts
@@ -630,10 +630,22 @@ export interface AgentIdeControl {
 }
 
 export interface AgentSessionControl {
+  /**
+   * Resumes a previously recorded session (by 'latest' or a session
+   * reference/prefix) and returns the reconstructed history as IContent[] so
+   * callers can replay the restored conversation (e.g. the Zed ACP loadSession
+   * path streaming session/update notifications) without a lossy getHistory()
+   * Gemini Content[] round-trip. Callers that ignore the return value remain
+   * source-compatible. The restored history is also fed through the client
+   * restore path, and a RecordingIntegration is subscribed so post-resume turns
+   * continue appending to the resumed JSONL file.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
   resume(
     target: 'latest' | string,
     options?: { readonly prefix?: boolean },
-  ): Promise<void>;
+  ): Promise<readonly AgentHistoryItem[]>;
   createCheckpoint(label?: string): Promise<SessionCheckpoint>;
   restoreCheckpoint(id: string): Promise<void>;
   listCheckpoints(): readonly SessionCheckpoint[];

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -882,13 +882,15 @@ export class SessionControl implements AgentSessionControl {
   // ─── Path derivation ─────────────────────────────────────────────────────
 
   /**
-   * Derives the chats directory (where session recordings live) from the
-   * project storage temp dir, matching the CLI's derivation.
+   * The chats directory (where session recordings live), delegated to
+   * Storage.getProjectChatsDir() — the single source of truth every
+   * reader/prober shares, so the recording writer and the probes can never
+   * drift apart on the location.
    * @plan:PLAN-20260617-COREAPI.P20
    * @requirement:REQ-010
    */
   private chatsDir(): string {
-    return join(this.deps.config.storage.getProjectTempDir(), 'chats');
+    return this.deps.config.storage.getProjectChatsDir();
   }
 
   /**

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -47,6 +47,7 @@ import { ContentConverters } from '@vybestack/llxprt-code-core/services/history/
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { AgentClientContract } from '@vybestack/llxprt-code-core/core/clientContract.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type {
   AgentSessionControl,
   SessionCheckpoint,
@@ -56,6 +57,15 @@ import type {
 const CHECKPOINT_PREFIX = 'checkpoint-';
 const CHECKPOINT_SUFFIX = '.json';
 const RECORDING_FORMAT = 'jsonl';
+
+/**
+ * Module logger mirroring the neighboring toolControl.ts precedent
+ * (a module-scoped core DebugLogger). Used to surface an otherwise-silent
+ * recording-subscription gap so lost continuous recording is diagnosable.
+ * @plan:PLAN-20260617-COREAPI.P20
+ * @requirement:REQ-010
+ */
+const logger = new DebugLogger('llxprt:agents:session-control');
 
 /**
  * The shape of a parsed checkpoint file payload (Logger.saveCheckpoint writes
@@ -400,6 +410,16 @@ export class SessionControl implements AgentSessionControl {
     const historyService = this.deps.resolveClient().getHistoryService();
     if (historyService !== null) {
       integration.subscribeToHistory(historyService);
+    } else {
+      // No HistoryService yet: the integration is created + stored but left
+      // unsubscribed, so NO subsequent turn is appended until a later
+      // start/resume re-attempts the subscription. Left silent this is an
+      // invisible continuous-recording loss; warn so it is diagnosable.
+      logger.warn(
+        () =>
+          `subscribeIntegration: HistoryService unavailable for session ${this.deps.sessionId()}; ` +
+          `recording integration left unsubscribed (subsequent turns will not be recorded until re-subscribed)`,
+      );
     }
     this.integration = integration;
   }

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -19,10 +19,15 @@
  *   converts the loaded Content[] to IContent[] before the client restore path.
  * - Recording is backed by SessionRecordingService; setRecording(true) starts a
  *   service and seeds it with the current history so a file is materialized,
- *   setRecording(false) flushes + disposes it.
+ *   then subscribes a RecordingIntegration to the client's HistoryService so
+ *   EVERY subsequent turn's content is appended to the JSONL file (continuous
+ *   recording, not a one-shot snapshot). setRecording(false) disposes the
+ *   integration + service.
  * - resume is backed by resumeSession (CONTINUE_LATEST for 'latest'); a success
- *   feeds the reconstructed IContent history through the client restore path and
- *   adopts the returned recording service.
+ *   feeds the reconstructed IContent history through the client restore path,
+ *   adopts the returned recording service, subscribes a fresh RecordingIntegration
+ *   so post-resume turns keep appending to the resumed file, and returns the
+ *   restored IContent[] so callers (e.g. the Zed loadSession path) can replay it.
  */
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
@@ -31,6 +36,7 @@ import { join } from 'node:path';
 import {
   Logger,
   SessionRecordingService,
+  RecordingIntegration,
   resumeSession,
   CONTINUE_LATEST,
   getProjectHash,
@@ -98,6 +104,19 @@ export class SessionControl implements AgentSessionControl {
   private recording: SessionRecordingService | null = null;
 
   /**
+   * The live RecordingIntegration bridging the client's HistoryService
+   * 'contentAdded'/compression events onto the active recording service, or
+   * null when recording is disabled. This is what makes recording CONTINUOUS
+   * (every subsequent turn is appended) rather than a one-shot snapshot. It is
+   * created + subscribed by startRecording/resume and disposed (unsubscribed)
+   * by releaseRecording so no history-event listener leaks past a stop/resume/
+   * dispose.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private integration: RecordingIntegration | null = null;
+
+  /**
    * The on-disk session lock acquired by a successful resume, or null when no
    * resume holds a lock. Released (and cleared) when a new resume replaces it,
    * when recording is stopped, or when the surface is disposed.
@@ -124,13 +143,25 @@ export class SessionControl implements AgentSessionControl {
    * are released by dispose()/teardownActiveSession(), so neither the prior nor
    * the resumed resources leak on any path. On failure a clear typed Error is
    * thrown carrying the core error (never a not-implemented signal).
+   *
+   * After the resumed history is restored into the client, a fresh
+   * RecordingIntegration is subscribed to the client's HistoryService so
+   * post-resume turns keep appending to the resumed JSONL file (continuous
+   * recording across the resume boundary). The prior integration (if any) is
+   * disposed alongside the prior recording so no history-event listener leaks.
+   *
+   * Returns the reconstructed IContent[] history so callers that need to replay
+   * the restored conversation (e.g. the Zed ACP loadSession path streaming
+   * session/update notifications) can consume it directly WITHOUT a lossy
+   * getHistory() Gemini Content[] round-trip. Callers that ignore the return
+   * value remain source-compatible.
    * @plan:PLAN-20260617-COREAPI.P20
    * @requirement:REQ-010
    */
   async resume(
     target: 'latest' | string,
     _options?: { readonly prefix?: boolean },
-  ): Promise<void> {
+  ): Promise<readonly IContent[]> {
     const request: ResumeRequest = {
       continueRef: target === 'latest' ? CONTINUE_LATEST : target,
       projectHash: getProjectHash(this.deps.config.getProjectRoot()),
@@ -143,25 +174,31 @@ export class SessionControl implements AgentSessionControl {
     if (!result.ok) {
       throw new Error(`Failed to resume session: ${result.error}`);
     }
-    // Capture the prior recording service + session lock, then adopt the resumed
-    // recording + lock into the instance fields (and install the recording on
-    // Config) SYNCHRONOUSLY — before any await. Adopting before any throwable
-    // await guarantees the resumed recording service and on-disk session lock are
-    // owned by the fields on every subsequent throw path (prior-resource teardown
-    // OR restoreHistory), so dispose()/teardownActiveSession() can always release
-    // them and neither the prior nor the resumed resources can leak.
+    // Capture the prior recording service + integration + session lock, then
+    // adopt the resumed recording + lock into the instance fields (and install
+    // the recording on Config) SYNCHRONOUSLY — before any await. Adopting before
+    // any throwable await guarantees the resumed recording service and on-disk
+    // session lock are owned by the fields on every subsequent throw path
+    // (prior-resource teardown OR restoreHistory), so dispose()/
+    // teardownActiveSession() can always release them and neither the prior nor
+    // the resumed resources can leak.
     const priorRecording = this.recording;
+    const priorIntegration = this.integration;
     const priorLockHandle = this.currentLockHandle;
     this.recording = result.recording;
+    this.integration = null;
     this.deps.config.setSessionRecordingService(result.recording);
     this.currentLockHandle = result.lockHandle;
-    // Release the prior recording service + session lock now that the resumed
-    // resources are owned. The captured prior locals are disposed/released
-    // directly (NOT via releaseRecording/releaseLockHandle, which act on the
-    // fields that now hold the resumed resources). Each step is guarded so a
-    // single prior-teardown failure does not skip the other; a collected failure
+    // Release the prior integration + recording service + session lock now that
+    // the resumed resources are owned. The captured prior locals are disposed/
+    // released directly (NOT via releaseRecording/releaseLockHandle, which act on
+    // the fields that now hold the resumed resources). Each step is guarded so a
+    // single prior-teardown failure does not skip the others; a collected failure
     // is surfaced after the resumed history is restored.
     const teardownErrors: unknown[] = [];
+    if (priorIntegration !== null) {
+      this.guardSync(teardownErrors, () => priorIntegration.dispose());
+    }
     await this.guard(teardownErrors, async () => {
       if (priorRecording !== null) {
         await priorRecording.dispose();
@@ -173,9 +210,17 @@ export class SessionControl implements AgentSessionControl {
       }
     });
     await this.deps.resolveClient().restoreHistory(result.history);
+    // Subscribe a fresh integration AFTER restoreHistory so the client's chat
+    // (and thus its HistoryService) is materialized; post-resume turns now
+    // append to the resumed file. Guarded so a subscription failure does not
+    // mask a prior-teardown failure surfaced below.
+    this.guardSync(teardownErrors, () =>
+      this.subscribeIntegration(result.recording),
+    );
     if (teardownErrors.length > 0) {
       throw teardownErrors[0];
     }
+    return result.history;
   }
 
   /**
@@ -292,11 +337,24 @@ export class SessionControl implements AgentSessionControl {
 
   /**
    * Starts a fresh recording service for this session, replacing any prior one
-   * (the prior service is flushed + disposed first). The current history is
-   * recorded as content events so the file materializes and getRecording().path
-   * is defined. The freshly built service is installed on Config via
-   * setSessionRecordingService so the rest of the system (which reads the active
-   * recording via config.getSessionRecordingService) observes the swap.
+   * (the prior service + integration are flushed + disposed first). The current
+   * history is recorded as content events so the file materializes and
+   * getRecording().path is defined. The freshly built service is installed on
+   * Config via setSessionRecordingService so the rest of the system (which reads
+   * the active recording via config.getSessionRecordingService) observes the
+   * swap. A RecordingIntegration is then subscribed to the client's
+   * HistoryService so EVERY subsequent turn's 'contentAdded' event is appended
+   * to the JSONL file — this is what makes recording continuous rather than a
+   * one-shot snapshot.
+   *
+   * HistoryService availability: the agents-package client eagerly creates +
+   * stores a HistoryService at construction (storeHistoryServiceForReuse) and
+   * reuses that SAME instance across turns (createChatSessionSafe reuses the
+   * stored service), so getHistoryService() is non-null here and the single
+   * subscription established now captures all future turns. If it is
+   * nonetheless null at this moment (no client/chat), the integration is still
+   * created and Config still owns the service; subscribeIntegration is a no-op
+   * that the next startRecording/resume re-attempts.
    * @plan:PLAN-20260617-COREAPI.P20
    * @requirement:REQ-010
    */
@@ -318,6 +376,32 @@ export class SessionControl implements AgentSessionControl {
     await service.flush();
     this.recording = service;
     this.deps.config.setSessionRecordingService(service);
+    this.subscribeIntegration(service);
+  }
+
+  /**
+   * Creates a RecordingIntegration around the given service and subscribes it
+   * to the client's HistoryService so future 'contentAdded'/compression events
+   * are appended continuously. Stored in the instance field so releaseRecording
+   * can dispose it (unsubscribe) on stop/resume/dispose. When the client's
+   * HistoryService is not yet available, the integration is still created +
+   * stored but left unsubscribed; a later start/resume re-attempts the
+   * subscription. Idempotent per call: any prior integration is disposed first
+   * so no duplicate listeners accumulate.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private subscribeIntegration(service: SessionRecordingService): void {
+    if (this.integration !== null) {
+      this.integration.dispose();
+      this.integration = null;
+    }
+    const integration = new RecordingIntegration(service);
+    const historyService = this.deps.resolveClient().getHistoryService();
+    if (historyService !== null) {
+      integration.subscribeToHistory(historyService);
+    }
+    this.integration = integration;
   }
 
   /**
@@ -333,12 +417,20 @@ export class SessionControl implements AgentSessionControl {
   }
 
   /**
-   * Disposes the live recording service (if any), clears the private field, and
-   * clears it from Config. No-op when no recording is active.
+   * Disposes the live RecordingIntegration (unsubscribing its HistoryService
+   * listeners) and the live recording service (if any), clears the private
+   * fields, and clears the service from Config. The integration is disposed
+   * FIRST so no 'contentAdded' event can reach a service mid-disposal. No-op
+   * when no recording is active.
    * @plan:PLAN-20260617-COREAPI.P20
    * @requirement:REQ-010
    */
   private async releaseRecording(): Promise<void> {
+    const integration = this.integration;
+    if (integration !== null) {
+      this.integration = null;
+      integration.dispose();
+    }
     const service = this.recording;
     if (service === null) {
       return;
@@ -375,6 +467,21 @@ export class SessionControl implements AgentSessionControl {
   ): Promise<void> {
     try {
       await fn();
+    } catch (e) {
+      errors.push(e);
+    }
+  }
+
+  /**
+   * Synchronous variant of {@link guard} for non-awaitable teardown/subscription
+   * steps (integration dispose/subscribe) so a single failure is collected
+   * rather than short-circuiting the remaining steps.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private guardSync(errors: unknown[], fn: () => void): void {
+    try {
+      fn();
     } catch (e) {
       errors.push(e);
     }

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -305,7 +305,7 @@ export class SessionControl implements AgentSessionControl {
     try {
       subscribed = this.attachIntegrationToHistory(integration);
     } catch (error) {
-      integration.dispose();
+      this.disposeIntegrationQuietly(integration);
       await this.disposeServiceQuietly(result.recording);
       await this.releaseLockQuietly(result.lockHandle);
       throw error;
@@ -392,7 +392,7 @@ export class SessionControl implements AgentSessionControl {
     } catch (error) {
       this.integration = null;
       this.integrationNeedsSubscribe = false;
-      integration.dispose();
+      this.disposeIntegrationQuietly(integration);
       logger.warn(
         () =>
           `ensureSubscribed: re-attach failed for session ${this.deps.sessionId()}; ` +
@@ -400,6 +400,15 @@ export class SessionControl implements AgentSessionControl {
             error instanceof Error ? error.message : String(error)
           }`,
       );
+    }
+  }
+
+  /** Best-effort integration dispose for failure/rollback paths. */
+  private disposeIntegrationQuietly(integration: RecordingIntegration): void {
+    try {
+      integration.dispose();
+    } catch {
+      // Best-effort: the triggering error is rethrown by the caller.
     }
   }
 
@@ -612,8 +621,8 @@ export class SessionControl implements AgentSessionControl {
     try {
       subscribed = this.attachIntegrationToHistory(integration);
     } catch (error) {
-      integration.dispose();
-      await service.dispose();
+      this.disposeIntegrationQuietly(integration);
+      await this.disposeServiceQuietly(service);
       throw error;
     }
     this.recording = service;
@@ -681,18 +690,23 @@ export class SessionControl implements AgentSessionControl {
    */
   private async releaseRecording(): Promise<void> {
     const integration = this.integration;
-    if (integration !== null) {
-      this.integration = null;
-      this.integrationNeedsSubscribe = false;
-      integration.dispose();
-    }
     const service = this.recording;
-    if (service === null) {
-      return;
-    }
+    this.integration = null;
+    this.integrationNeedsSubscribe = false;
     this.recording = null;
     this.deps.config.setSessionRecordingService(undefined);
-    await service.dispose();
+    const errors: unknown[] = [];
+    if (integration !== null) {
+      this.guardSync(errors, () => integration.dispose());
+    }
+    await this.guard(errors, async () => {
+      if (service !== null) {
+        await service.dispose();
+      }
+    });
+    if (errors.length > 0) {
+      throw errors[0];
+    }
   }
 
   /**

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -193,14 +193,13 @@ export class SessionControl implements AgentSessionControl {
    * core SessionDiscovery resolves). On success the returned recording service
    * is adopted as the live recording (installed on Config as the active
    * recording, same swap semantics as setRecording) and the returned session
-   * lock is retained, both stored into the instance fields SYNCHRONOUSLY before
-   * any await. The prior recording service and session lock are then released,
-   * and the reconstructed IContent history is fed through the client restore
-   * path. Adopting the resumed recording + lock before any throwable await
-   * guarantees that if prior teardown or restoreHistory fails, the resumed
-   * recording service and on-disk session lock remain owned by the fields and
-   * are released by dispose()/teardownActiveSession(), so neither the prior nor
-   * the resumed resources leak on any path. On failure a clear typed Error is
+   * lock is retained. The resumed resources remain local while the prior
+   * recording service and session lock are released and the reconstructed
+   * IContent history is fed through the client restore path. Only after the new
+   * integration subscribes successfully are the recording and lock committed to
+   * the instance fields; every earlier failure disposes/releases the locals, so
+   * neither the prior nor the resumed resources leak on any path. On failure a
+   * clear typed Error is
    * thrown carrying the core error (never a not-implemented signal).
    *
    * After the resumed history is restored into the client, a fresh

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -32,14 +32,13 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import type { Content } from '@google/genai';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import {
   Logger,
   SessionRecordingService,
   RecordingIntegration,
   resumeSession,
   CONTINUE_LATEST,
-  getProjectHash,
   type ResumeRequest,
   type LockHandle,
 } from '@vybestack/llxprt-code-core';
@@ -267,7 +266,7 @@ export class SessionControl implements AgentSessionControl {
     this.ensureSubscribed();
     const request: ResumeRequest = {
       continueRef: target === 'latest' ? CONTINUE_LATEST : target,
-      projectHash: getProjectHash(this.deps.config.getProjectRoot()),
+      projectHash: this.persistenceProjectHash(),
       chatsDir: this.chatsDir(),
       currentProvider: this.deps.getProvider(),
       currentModel: this.deps.getModel(),
@@ -598,9 +597,10 @@ export class SessionControl implements AgentSessionControl {
     await this.stopRecording();
     const service = new SessionRecordingService({
       sessionId: this.deps.sessionId(),
-      projectHash: getProjectHash(this.deps.config.getProjectRoot()),
+      projectHash: this.persistenceProjectHash(),
       chatsDir: this.chatsDir(),
       workspaceDirs: this.workspaceDirs(),
+      cwd: this.deps.config.getProjectRoot(),
       provider: this.deps.getProvider(),
       model: this.deps.getModel(),
     });
@@ -891,6 +891,10 @@ export class SessionControl implements AgentSessionControl {
     } catch {
       return [];
     }
+  }
+
+  private persistenceProjectHash(): string {
+    return basename(this.deps.config.storage.getProjectTempDir());
   }
 
   // ─── Path derivation ─────────────────────────────────────────────────────

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -135,7 +135,56 @@ export class SessionControl implements AgentSessionControl {
    */
   private currentLockHandle: LockHandle | null = null;
 
+  /**
+   * Promise-chain mutex (FINDING A1) serializing the state-mutating public
+   * operations (resume, setRecording enable/disable, dispose) so they never
+   * interleave their multi-await recording/integration/lock swaps. Without it a
+   * concurrent resume()/setRecording()/dispose() could adopt+dispose the same
+   * recording service or session lock across each other's await points
+   * (use-after-free / orphaned lock). runExclusive chains onto this so each op
+   * runs strictly after the prior one settles; it always settles (never
+   * rejects) so a failed op cannot poison the chain for the next caller.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private opChain: Promise<void> = Promise.resolve();
+
+  /**
+   * True when {@link integration} is committed as the live integration but its
+   * subscription to the client HistoryService could not be established yet (the
+   * HistoryService was unavailable at attach time), so continuous recording is
+   * currently dead (FINDING A3). The next state-mutating operation re-attempts
+   * the subscription via {@link ensureSubscribed}; cleared once subscribed or
+   * when the integration is disposed.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private integrationNeedsSubscribe = false;
+
   constructor(private readonly deps: SessionControlDeps) {}
+
+  /**
+   * Runs `fn` under the {@link opChain} serializer (FINDING A1) so the
+   * state-mutating public operations execute strictly one-at-a-time. The chain
+   * link is made to always settle (errors swallowed for the CHAIN only) so a
+   * rejected operation does not break serialization for the next caller, while
+   * the caller of runExclusive still receives the real result/rejection of its
+   * own `fn`.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const priorSettled = this.opChain;
+    const run = (async () => {
+      await priorSettled;
+      return fn();
+    })();
+    this.opChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
 
   /**
    * Resumes a previously recorded session via the core resumeSession flow.
@@ -172,6 +221,50 @@ export class SessionControl implements AgentSessionControl {
     target: 'latest' | string,
     _options?: { readonly prefix?: boolean },
   ): Promise<readonly IContent[]> {
+    // FINDING A1: serialize through the op-chain mutex so a concurrent
+    // resume/setRecording/dispose cannot interleave their multi-await
+    // recording/integration/lock swaps (use-after-free / orphaned lock).
+    return this.runExclusive(() => this.resumeInternal(target));
+  }
+
+  /**
+   * The serialized resume body (runs inside {@link runExclusive}). Ordering is
+   * failure-safe (FINDINGS A2/A3):
+   *
+   *  1. ensureSubscribed() first re-attempts any previously-dead integration
+   *     subscription (A3) so a resume that follows a null-history enable does not
+   *     start from a silently-dead recording.
+   *  2. resumeSession() builds the resumed recording (already seeded with the
+   *     resumed history) + acquires its session lock. These are held in LOCALS,
+   *     NOT committed to the instance fields yet.
+   *  3. The PRIOR integration is disposed (unsubscribed) BEFORE restoreHistory so
+   *     the restoreHistory-driven 'contentAdded' events (HistoryService.addAll
+   *     emits one per item) are NOT double-recorded into the prior file; the
+   *     prior recording service + lock are torn down here too. A prior-teardown
+   *     failure releases the freshly-acquired resumed resources and rethrows so
+   *     nothing leaks (mirrors the old FINDING F7 surface-first ordering).
+   *  4. restoreHistory() runs with NO integration subscribed (prior disposed,
+   *     resumed not yet subscribed) so the resumed items — already in the resumed
+   *     recording file — are not re-recorded.
+   *  5. A fresh integration is built + subscribed BEFORE committing the fields /
+   *     Config (FINDING A2, mirroring the startRecording F8 ordering). Only after
+   *     a successful subscribe are this.recording / Config / this.integration /
+   *     the lock committed. On subscribe failure the resumed recording + lock are
+   *     disposed/released and the fields are left CLEANLY DISABLED (Config is NOT
+   *     left pointing at the resumed service, no lock file leaks) — half-enabled
+   *     recording (turns silently dropped) can no longer occur.
+   *
+   * Prior state cannot be "left intact" on a late failure because step 3 must
+   * tear it down early to avoid the restoreHistory double-record; the safe
+   * fallback is therefore a clean DISABLED state, never a stale reference to a
+   * disposed service/lock.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private async resumeInternal(
+    target: 'latest' | string,
+  ): Promise<readonly IContent[]> {
+    this.ensureSubscribed();
     const request: ResumeRequest = {
       continueRef: target === 'latest' ? CONTINUE_LATEST : target,
       projectHash: getProjectHash(this.deps.config.getProjectRoot()),
@@ -184,66 +277,164 @@ export class SessionControl implements AgentSessionControl {
     if (!result.ok) {
       throw new Error(`Failed to resume session: ${result.error}`);
     }
-    // Capture the prior recording service + integration + session lock, then
-    // adopt the resumed recording + lock into the instance fields (and install
-    // the recording on Config) SYNCHRONOUSLY — before any await. Adopting before
-    // any throwable await guarantees the resumed recording service and on-disk
-    // session lock are owned by the fields on every subsequent throw path
-    // (prior-resource teardown OR restoreHistory), so dispose()/
-    // teardownActiveSession() can always release them and neither the prior nor
-    // the resumed resources can leak.
+    // Tear down the prior recording/integration/lock BEFORE restoreHistory (see
+    // step 3 in the doc). On a prior-teardown failure, release the freshly
+    // acquired resumed resources (still only in locals) and rethrow so neither
+    // the prior nor the resumed resources leak, ending cleanly disabled.
+    try {
+      await this.teardownPriorBeforeResume();
+    } catch (error) {
+      await this.disposeServiceQuietly(result.recording);
+      await this.releaseLockQuietly(result.lockHandle);
+      throw error;
+    }
+    // restoreHistory with NO integration subscribed (no double-record). On
+    // failure the resumed resources are released and state stays disabled.
+    try {
+      await this.deps.resolveClient().restoreHistory(result.history);
+    } catch (error) {
+      await this.disposeServiceQuietly(result.recording);
+      await this.releaseLockQuietly(result.lockHandle);
+      throw error;
+    }
+    // FINDING A2: subscribe BEFORE committing. On subscribe failure dispose the
+    // integration + resumed recording, release the resumed lock, and rethrow —
+    // the fields/Config are never pointed at a non-integrated resumed service.
+    const integration = new RecordingIntegration(result.recording);
+    let subscribed: boolean;
+    try {
+      subscribed = this.attachIntegrationToHistory(integration);
+    } catch (error) {
+      integration.dispose();
+      await this.disposeServiceQuietly(result.recording);
+      await this.releaseLockQuietly(result.lockHandle);
+      throw error;
+    }
+    // Commit the resumed resources only now that the integration is live.
+    this.recording = result.recording;
+    this.deps.config.setSessionRecordingService(result.recording);
+    this.integration = integration;
+    this.integrationNeedsSubscribe = !subscribed;
+    this.currentLockHandle = result.lockHandle;
+    return result.history;
+  }
+
+  /**
+   * Disposes the prior integration (unsubscribing it so an imminent
+   * restoreHistory does not double-record into the prior file), then disposes
+   * the prior recording service and releases the prior session lock, clearing
+   * all three fields. Each step is guarded so a single failure does not skip the
+   * others; the first collected failure is rethrown so the caller (resumeInternal)
+   * can release the freshly acquired resumed resources and surface the failure.
+   * The fields are cleared to null up front so that even on a partial-teardown
+   * throw no field is left referencing a disposed/released resource.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private async teardownPriorBeforeResume(): Promise<void> {
     const priorRecording = this.recording;
     const priorIntegration = this.integration;
     const priorLockHandle = this.currentLockHandle;
-    this.recording = result.recording;
+    this.recording = null;
     this.integration = null;
-    this.deps.config.setSessionRecordingService(result.recording);
-    this.currentLockHandle = result.lockHandle;
-    // Release the prior integration + recording service + session lock now that
-    // the resumed resources are owned. The captured prior locals are disposed/
-    // released directly (NOT via releaseRecording/releaseLockHandle, which act on
-    // the fields that now hold the resumed resources). Each step is guarded so a
-    // single prior-teardown failure does not skip the others; a collected failure
-    // is surfaced after the resumed history is restored.
-    const teardownErrors: unknown[] = [];
+    this.integrationNeedsSubscribe = false;
+    this.currentLockHandle = null;
+    this.deps.config.setSessionRecordingService(undefined);
+    const errors: unknown[] = [];
     if (priorIntegration !== null) {
-      this.guardSync(teardownErrors, () => priorIntegration.dispose());
+      this.guardSync(errors, () => priorIntegration.dispose());
     }
-    await this.guard(teardownErrors, async () => {
+    await this.guard(errors, async () => {
       if (priorRecording !== null) {
         await priorRecording.dispose();
       }
     });
-    await this.guard(teardownErrors, async () => {
+    await this.guard(errors, async () => {
       if (priorLockHandle !== null) {
         await priorLockHandle.release();
       }
     });
-    // FINDING F7: surface any prior-teardown failure BEFORE the restoreHistory
-    // await. Previously teardownErrors were only checked AFTER restoreHistory,
-    // so a restoreHistory throw silently discarded a collected prior-teardown
-    // error (a leaked prior lock/recording that could not be released would go
-    // unreported). Surfacing teardown first is safe: the resumed recording +
-    // lock are already adopted into the instance fields, so on this throw path
-    // dispose()/teardownActiveSession() still release them (nothing leaks), and
-    // a restoreHistory failure would throw on its own anyway. The now-empty
-    // teardownErrors array is reused below for the post-restore subscribe.
-    if (teardownErrors.length > 0) {
-      throw teardownErrors[0];
+    if (errors.length > 0) {
+      throw errors[0];
     }
-    await this.deps.resolveClient().restoreHistory(result.history);
-    // Subscribe a fresh integration AFTER restoreHistory so the client's chat
-    // (and thus its HistoryService) is materialized; post-resume turns now
-    // append to the resumed file. Guarded (FINDING F8) so a subscription failure
-    // does not orphan the adopted recording/lock — the fields still own them, so
-    // teardown releases them — and the failure is surfaced after.
-    this.guardSync(teardownErrors, () =>
-      this.subscribeIntegration(result.recording),
-    );
-    if (teardownErrors.length > 0) {
-      throw teardownErrors[0];
+  }
+
+  /**
+   * Re-attempts a previously-deferred integration subscription (FINDING A3).
+   * When a prior startRecording/resume committed an integration but could not
+   * subscribe it (the client HistoryService was unavailable at attach time,
+   * leaving continuous recording dead), the next state-mutating operation calls
+   * this at its start (inside {@link runExclusive}) to re-attach it now that the
+   * HistoryService may exist. No-op when nothing is pending or the service is
+   * still unavailable (the flag is kept for a later attempt). A subscribe throw
+   * is self-healing: the dead integration is disposed + cleared and the flag
+   * reset so the operation can proceed to build a fresh subscription rather than
+   * failing permanently on a poisoned listener.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private ensureSubscribed(): void {
+    if (!this.integrationNeedsSubscribe) {
+      return;
     }
-    return result.history;
+    const integration = this.integration;
+    if (integration === null) {
+      this.integrationNeedsSubscribe = false;
+      return;
+    }
+    const historyService = this.deps.resolveClient().getHistoryService();
+    if (historyService === null) {
+      return;
+    }
+    try {
+      integration.subscribeToHistory(historyService);
+      this.integrationNeedsSubscribe = false;
+    } catch (error) {
+      this.integration = null;
+      this.integrationNeedsSubscribe = false;
+      integration.dispose();
+      logger.warn(
+        () =>
+          `ensureSubscribed: re-attach failed for session ${this.deps.sessionId()}; ` +
+          `dropped the dead integration so the operation can rebuild it: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      );
+    }
+  }
+
+  /**
+   * Best-effort dispose of a recording service on a resume failure/rollback
+   * path, swallowing any dispose error (the original failure is the one to
+   * surface). Used only for the freshly acquired resumed service that is NOT yet
+   * committed to the instance fields.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private async disposeServiceQuietly(
+    service: SessionRecordingService,
+  ): Promise<void> {
+    try {
+      await service.dispose();
+    } catch {
+      // Best-effort: the triggering error is rethrown by the caller.
+    }
+  }
+
+  /**
+   * Best-effort release of a session lock on a resume failure/rollback path,
+   * swallowing any release error. Used only for the freshly acquired resumed
+   * lock that is NOT yet committed to the instance fields, so the on-disk lock
+   * file is removed even when the resume is aborted.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private async releaseLockQuietly(handle: LockHandle): Promise<void> {
+    try {
+      await handle.release();
+    } catch {
+      // Best-effort: the triggering error is rethrown by the caller.
+    }
   }
 
   /**
@@ -331,11 +522,16 @@ export class SessionControl implements AgentSessionControl {
    * @requirement:REQ-010
    */
   async setRecording(state: SessionRecordingState): Promise<void> {
-    if (state.enabled) {
-      await this.startRecording();
-      return;
-    }
-    await this.stopRecording();
+    // FINDING A1: serialize enable/disable through the op-chain mutex so they
+    // never interleave with a concurrent resume()/dispose() (crossed
+    // recording/lock state).
+    await this.runExclusive(async () => {
+      if (state.enabled) {
+        await this.startRecording();
+        return;
+      }
+      await this.stopRecording();
+    });
   }
 
   /**
@@ -376,12 +572,20 @@ export class SessionControl implements AgentSessionControl {
    * stored service), so getHistoryService() is non-null here and the single
    * subscription established now captures all future turns. If it is
    * nonetheless null at this moment (no client/chat), the integration is still
-   * created and Config still owns the service; subscribeIntegration is a no-op
-   * that the next startRecording/resume re-attempts.
+   * created and Config still owns the service; the subscription is deferred
+   * (integrationNeedsSubscribe) and the next startRecording/resume re-attempts
+   * it via {@link ensureSubscribed} (FINDING A3).
+   *
+   * Called only from within {@link runExclusive} (via setRecording), so it is
+   * already serialized against resume/dispose.
    * @plan:PLAN-20260617-COREAPI.P20
    * @requirement:REQ-010
    */
   private async startRecording(): Promise<void> {
+    // FINDING A3: re-attach any previously-dead integration before replacing it,
+    // so a pending-subscribe flag from an earlier null-history enable does not
+    // survive across the fresh service swap.
+    this.ensureSubscribed();
     await this.stopRecording();
     const service = new SessionRecordingService({
       sessionId: this.deps.sessionId(),
@@ -404,8 +608,9 @@ export class SessionControl implements AgentSessionControl {
     // service (neither is referenced by any field yet) and rethrow; the instance
     // fields stay untouched so recording remains cleanly disabled.
     const integration = new RecordingIntegration(service);
+    let subscribed: boolean;
     try {
-      this.attachIntegrationToHistory(integration);
+      subscribed = this.attachIntegrationToHistory(integration);
     } catch (error) {
       integration.dispose();
       await service.dispose();
@@ -414,62 +619,43 @@ export class SessionControl implements AgentSessionControl {
     this.recording = service;
     this.deps.config.setSessionRecordingService(service);
     this.integration = integration;
-  }
-
-  /**
-   * Creates a RecordingIntegration around the given service and subscribes it
-   * to the client's HistoryService so future 'contentAdded'/compression events
-   * are appended continuously. Stored in the instance field so releaseRecording
-   * can dispose it (unsubscribe) on stop/resume/dispose. When the client's
-   * HistoryService is not yet available, the integration is still created +
-   * stored but left unsubscribed; a later start/resume re-attempts the
-   * subscription. Idempotent per call: any prior integration is disposed first
-   * so no duplicate listeners accumulate. Used by the resume path (guarded by
-   * the teardown-error accumulator); a subscribe throw disposes the just-built
-   * integration before propagating so no half-subscribed integration leaks.
-   * @plan:PLAN-20260617-COREAPI.P20
-   * @requirement:REQ-010
-   */
-  private subscribeIntegration(service: SessionRecordingService): void {
-    if (this.integration !== null) {
-      this.integration.dispose();
-      this.integration = null;
-    }
-    const integration = new RecordingIntegration(service);
-    try {
-      this.attachIntegrationToHistory(integration);
-    } catch (error) {
-      integration.dispose();
-      throw error;
-    }
-    this.integration = integration;
+    // FINDING A3: when the HistoryService was unavailable the integration is
+    // committed but dead; flag it so a later operation re-attaches it rather
+    // than leaving continuous recording permanently off.
+    this.integrationNeedsSubscribe = !subscribed;
   }
 
   /**
    * Subscribes `integration` to the client's HistoryService so future
    * 'contentAdded'/compression events are appended continuously; when no
    * HistoryService is available yet the integration is left unsubscribed and a
-   * warning is logged (a later start/resume re-attempts the subscription). Pure
-   * attach step shared by startRecording and subscribeIntegration; it commits NO
-   * instance state so callers control ownership/rollback.
+   * warning is logged (a later start/resume re-attempts the subscription via
+   * {@link ensureSubscribed}, FINDING A3). Pure attach step shared by
+   * startRecording and resumeInternal; it commits NO instance state so callers
+   * control ownership/rollback. Returns true when the subscription was
+   * established, false when it was deferred (no HistoryService yet) so the
+   * caller can set integrationNeedsSubscribe.
    * @plan:PLAN-20260617-COREAPI.P20
    * @requirement:REQ-010
    */
-  private attachIntegrationToHistory(integration: RecordingIntegration): void {
+  private attachIntegrationToHistory(
+    integration: RecordingIntegration,
+  ): boolean {
     const historyService = this.deps.resolveClient().getHistoryService();
     if (historyService !== null) {
       integration.subscribeToHistory(historyService);
-    } else {
-      // No HistoryService yet: the integration is left unsubscribed, so NO
-      // subsequent turn is appended until a later start/resume re-attempts the
-      // subscription. Left silent this is an invisible continuous-recording
-      // loss; warn so it is diagnosable.
-      logger.warn(
-        () =>
-          `subscribeIntegration: HistoryService unavailable for session ${this.deps.sessionId()}; ` +
-          `recording integration left unsubscribed (subsequent turns will not be recorded until re-subscribed)`,
-      );
+      return true;
     }
+    // No HistoryService yet: the integration is left unsubscribed, so NO
+    // subsequent turn is appended until a later start/resume re-attempts the
+    // subscription. Left silent this is an invisible continuous-recording
+    // loss; warn so it is diagnosable AND flag it for bounded re-attach.
+    logger.warn(
+      () =>
+        `attachIntegrationToHistory: HistoryService unavailable for session ${this.deps.sessionId()}; ` +
+        `recording integration left unsubscribed (subsequent turns will not be recorded until re-subscribed)`,
+    );
+    return false;
   }
 
   /**
@@ -497,6 +683,7 @@ export class SessionControl implements AgentSessionControl {
     const integration = this.integration;
     if (integration !== null) {
       this.integration = null;
+      this.integrationNeedsSubscribe = false;
       integration.dispose();
     }
     const service = this.recording;
@@ -566,7 +753,10 @@ export class SessionControl implements AgentSessionControl {
    * @requirement:REQ-010
    */
   async dispose(): Promise<void> {
-    await this.teardownActiveSession();
+    // FINDING A1: serialize teardown through the op-chain mutex so dispose never
+    // races a concurrent resume()/setRecording() adopting resources it is
+    // releasing (double-dispose / released-then-adopted lock).
+    await this.runExclusive(() => this.teardownActiveSession());
   }
 
   /**

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -219,11 +219,24 @@ export class SessionControl implements AgentSessionControl {
         await priorLockHandle.release();
       }
     });
+    // FINDING F7: surface any prior-teardown failure BEFORE the restoreHistory
+    // await. Previously teardownErrors were only checked AFTER restoreHistory,
+    // so a restoreHistory throw silently discarded a collected prior-teardown
+    // error (a leaked prior lock/recording that could not be released would go
+    // unreported). Surfacing teardown first is safe: the resumed recording +
+    // lock are already adopted into the instance fields, so on this throw path
+    // dispose()/teardownActiveSession() still release them (nothing leaks), and
+    // a restoreHistory failure would throw on its own anyway. The now-empty
+    // teardownErrors array is reused below for the post-restore subscribe.
+    if (teardownErrors.length > 0) {
+      throw teardownErrors[0];
+    }
     await this.deps.resolveClient().restoreHistory(result.history);
     // Subscribe a fresh integration AFTER restoreHistory so the client's chat
     // (and thus its HistoryService) is materialized; post-resume turns now
-    // append to the resumed file. Guarded so a subscription failure does not
-    // mask a prior-teardown failure surfaced below.
+    // append to the resumed file. Guarded (FINDING F8) so a subscription failure
+    // does not orphan the adopted recording/lock — the fields still own them, so
+    // teardown releases them — and the failure is surfaced after.
     this.guardSync(teardownErrors, () =>
       this.subscribeIntegration(result.recording),
     );
@@ -384,9 +397,23 @@ export class SessionControl implements AgentSessionControl {
       service.recordContent(item);
     }
     await service.flush();
+    // FINDING F8: build + subscribe the integration BEFORE committing
+    // this.recording and the Config recording service, so a subscribe failure
+    // cannot leave recording PARTIALLY enabled (fields/Config set with no live
+    // integration). On failure dispose the integration AND the freshly built
+    // service (neither is referenced by any field yet) and rethrow; the instance
+    // fields stay untouched so recording remains cleanly disabled.
+    const integration = new RecordingIntegration(service);
+    try {
+      this.attachIntegrationToHistory(integration);
+    } catch (error) {
+      integration.dispose();
+      await service.dispose();
+      throw error;
+    }
     this.recording = service;
     this.deps.config.setSessionRecordingService(service);
-    this.subscribeIntegration(service);
+    this.integration = integration;
   }
 
   /**
@@ -397,7 +424,9 @@ export class SessionControl implements AgentSessionControl {
    * HistoryService is not yet available, the integration is still created +
    * stored but left unsubscribed; a later start/resume re-attempts the
    * subscription. Idempotent per call: any prior integration is disposed first
-   * so no duplicate listeners accumulate.
+   * so no duplicate listeners accumulate. Used by the resume path (guarded by
+   * the teardown-error accumulator); a subscribe throw disposes the just-built
+   * integration before propagating so no half-subscribed integration leaks.
    * @plan:PLAN-20260617-COREAPI.P20
    * @requirement:REQ-010
    */
@@ -407,21 +436,40 @@ export class SessionControl implements AgentSessionControl {
       this.integration = null;
     }
     const integration = new RecordingIntegration(service);
+    try {
+      this.attachIntegrationToHistory(integration);
+    } catch (error) {
+      integration.dispose();
+      throw error;
+    }
+    this.integration = integration;
+  }
+
+  /**
+   * Subscribes `integration` to the client's HistoryService so future
+   * 'contentAdded'/compression events are appended continuously; when no
+   * HistoryService is available yet the integration is left unsubscribed and a
+   * warning is logged (a later start/resume re-attempts the subscription). Pure
+   * attach step shared by startRecording and subscribeIntegration; it commits NO
+   * instance state so callers control ownership/rollback.
+   * @plan:PLAN-20260617-COREAPI.P20
+   * @requirement:REQ-010
+   */
+  private attachIntegrationToHistory(integration: RecordingIntegration): void {
     const historyService = this.deps.resolveClient().getHistoryService();
     if (historyService !== null) {
       integration.subscribeToHistory(historyService);
     } else {
-      // No HistoryService yet: the integration is created + stored but left
-      // unsubscribed, so NO subsequent turn is appended until a later
-      // start/resume re-attempts the subscription. Left silent this is an
-      // invisible continuous-recording loss; warn so it is diagnosable.
+      // No HistoryService yet: the integration is left unsubscribed, so NO
+      // subsequent turn is appended until a later start/resume re-attempts the
+      // subscription. Left silent this is an invisible continuous-recording
+      // loss; warn so it is diagnosable.
       logger.warn(
         () =>
           `subscribeIntegration: HistoryService unavailable for session ${this.deps.sessionId()}; ` +
           `recording integration left unsubscribed (subsequent turns will not be recorded until re-subscribed)`,
       );
     }
-    this.integration = integration;
   }
 
   /**

--- a/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
+++ b/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
@@ -63,6 +63,17 @@ export class AcpTerminalShellHost implements IShellToolHost {
     onOutput: (event: ShellOutputEvent) => void,
     signal: AbortSignal,
   ): Promise<ShellExecutionResult> {
+    const allowed = this.delegate.isCommandAllowed(command);
+    if (!allowed.allowed) {
+      return Promise.resolve({
+        output: '',
+        exitCode: null,
+        signal: null,
+        error: new Error(allowed.reason ?? 'Command not allowed'),
+        aborted: false,
+        pid: undefined,
+      });
+    }
     return this.terminals.executeShellCommand(command, cwd, onOutput, signal);
   }
 

--- a/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
+++ b/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  IShellToolHost,
+  ShellExecutionResult,
+  ShellOutputEvent,
+} from '@vybestack/llxprt-code-tools';
+import type { TerminalManager } from './zed-terminal-manager.js';
+
+export class AcpTerminalShellHost implements IShellToolHost {
+  constructor(
+    private readonly delegate: IShellToolHost,
+    private readonly terminals: TerminalManager,
+  ) {}
+
+  getTargetDir(): string {
+    return this.delegate.getTargetDir();
+  }
+
+  getWorkspaceContext() {
+    return this.delegate.getWorkspaceContext();
+  }
+
+  isCommandAllowed(command: string) {
+    return this.delegate.isCommandAllowed(command);
+  }
+
+  isShellInvocationAllowlisted(command: string, toolName: string): boolean {
+    return this.delegate.isShellInvocationAllowlisted(command, toolName);
+  }
+
+  isInteractive(): boolean {
+    return this.delegate.isInteractive();
+  }
+
+  isYoloMode(): boolean {
+    return this.delegate.isYoloMode();
+  }
+
+  getDebugMode(): boolean {
+    return this.delegate.getDebugMode();
+  }
+
+  getShellExecutionConfig() {
+    return this.delegate.getShellExecutionConfig();
+  }
+
+  getTimeoutConfig() {
+    return this.delegate.getTimeoutConfig();
+  }
+
+  getOutputLimits() {
+    return this.delegate.getOutputLimits();
+  }
+
+  executeShellCommand(
+    command: string,
+    cwd: string,
+    onOutput: (event: ShellOutputEvent) => void,
+    signal: AbortSignal,
+  ): Promise<ShellExecutionResult> {
+    return this.terminals.executeShellCommand(command, cwd, onOutput, signal);
+  }
+
+  getCommandRoots(command: string): string[] {
+    return this.delegate.getCommandRoots(command);
+  }
+
+  stripShellWrapper(command: string): string {
+    return this.delegate.stripShellWrapper(command);
+  }
+
+  validatePathWithinWorkspace(
+    workspaceContext: ReturnType<IShellToolHost['getWorkspaceContext']>,
+    dirPath: string,
+    label: string,
+  ): string | null {
+    return this.delegate.validatePathWithinWorkspace(
+      workspaceContext,
+      dirPath,
+      label,
+    );
+  }
+
+  isPtyActive(pid: number): boolean {
+    return this.delegate.isPtyActive(pid);
+  }
+
+  formatMemoryUsage(bytes: number): string {
+    return this.delegate.formatMemoryUsage(bytes);
+  }
+
+  trySummarizeOutput(
+    content: string,
+    signal: AbortSignal,
+    tokenBudget?: number,
+  ): Promise<string> {
+    return this.delegate.trySummarizeOutput(content, signal, tokenBudget);
+  }
+
+  getSummarizeConfig() {
+    return this.delegate.getSummarizeConfig();
+  }
+
+  limitOutputTokens(content: string) {
+    return this.delegate.limitOutputTokens(content);
+  }
+}

--- a/packages/cli/src/zed-integration/acp-types.ts
+++ b/packages/cli/src/zed-integration/acp-types.ts
@@ -26,13 +26,10 @@ export interface DeleteSessionRequest {
 
 export type DeleteSessionResponse = Record<string, never>;
 
-export interface ClientCapabilitiesWithSession {
-  readonly fs?: {
-    readonly readTextFile?: boolean;
-    readonly writeTextFile?: boolean;
-  };
-  readonly terminal?: boolean;
+export type ClientCapabilitiesWithSession = NonNullable<
+  acp.InitializeRequest['clientCapabilities']
+> & {
   readonly session?: {
     readonly configOptions?: boolean;
   };
-}
+};

--- a/packages/cli/src/zed-integration/acp-types.ts
+++ b/packages/cli/src/zed-integration/acp-types.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+
+/**
+ * The pinned ACP SDK (0.14.1) does not yet export `CloseSessionRequest`,
+ * `DeleteSessionRequest`, or their responses, nor does its
+ * `ClientCapabilities` type include the `session` field used for
+ * config-option gating.  These local type aliases keep the integration
+ * strongly-typed without resorting to `any`.
+ */
+
+export interface CloseSessionRequest {
+  readonly sessionId: acp.SessionId;
+}
+
+export type CloseSessionResponse = Record<string, never>;
+
+export interface DeleteSessionRequest {
+  readonly sessionId: acp.SessionId;
+}
+
+export type DeleteSessionResponse = Record<string, never>;
+
+export interface ClientCapabilitiesWithSession {
+  readonly fs?: {
+    readonly readTextFile?: boolean;
+    readonly writeTextFile?: boolean;
+  };
+  readonly terminal?: boolean;
+  readonly session?: {
+    readonly configOptions?: boolean;
+  };
+}

--- a/packages/cli/src/zed-integration/fileSystemService.ts
+++ b/packages/cli/src/zed-integration/fileSystemService.ts
@@ -14,7 +14,7 @@ export class AcpFileSystemService implements FileSystemService {
   constructor(
     private readonly connection: acp.AgentSideConnection,
     private readonly sessionId: string,
-    private readonly capabilities: acp.FileSystemCapabilities,
+    private readonly capabilities: acp.FileSystemCapability,
     private readonly fallback: FileSystemService,
   ) {}
 

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -155,6 +155,6 @@ async function handleNotice(
   return null;
 }
 
-function assertNever(event: never): acp.StopReason | null {
+function assertNever(event: never): never {
   throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -158,6 +158,6 @@ function assertNever(event: never): never {
   const detail =
     typeof event === 'object' && 'type' in event
       ? String((event as { type: unknown }).type)
-      : JSON.stringify(event);
+      : String(event);
   throw new Error(`Unhandled agent event: ${detail}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import {
+  extractThoughtText,
+  mapDoneReasonToStopReason,
+  translateErrorEvent,
+  translateIdleTimeout,
+} from './zed-helpers.js';
+import type { StreamBatcher } from './zed-stream-batcher.js';
+import {
+  emitToolCallStart,
+  emitToolResult,
+  emitToolStatus,
+} from './zed-tool-handler.js';
+
+interface AgentEventHandlers {
+  sendUpdate(update: acp.SessionUpdate): Promise<void>;
+  sendUsage(
+    usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
+  ): Promise<void>;
+  handleConfirmation(
+    event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
+  ): Promise<void>;
+}
+
+export async function handleZedAgentEvent(
+  event: AgentEvent,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<acp.StopReason | null> {
+  switch (event.type) {
+    case 'text':
+      batcher.append(event.text, false);
+      return null;
+    case 'thinking': {
+      const thoughtText = extractThoughtText(event.thought);
+      if (thoughtText.length > 0) batcher.append(thoughtText, true);
+      return null;
+    }
+    case 'tool-call':
+      await batcher.flush();
+      await emitToolCallStart(event.call, handlers.sendUpdate);
+      return null;
+    case 'tool-status':
+      await batcher.flush();
+      await emitToolStatus(event.update, handlers.sendUpdate);
+      return null;
+    case 'tool-result':
+      await batcher.flush();
+      await emitToolResult(event.result, handlers.sendUpdate);
+      return null;
+    case 'tool-confirmation':
+      await batcher.flush();
+      await handlers.handleConfirmation(event);
+      return null;
+    case 'done':
+      await batcher.flush();
+      return mapDoneReasonToStopReason(event.reason);
+    case 'error':
+      await batcher.flush();
+      throw translateErrorEvent(event);
+    case 'idle-timeout':
+      await batcher.flush();
+      throw translateIdleTimeout(event);
+    case 'invalid-stream':
+      await batcher.flush();
+      throw new Error(
+        'Agent produced an invalid stream that could not be recovered.',
+      );
+    case 'hook-blocked':
+      await batcher.flush();
+      throw new Error(
+        event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
+      );
+    case 'loop-detected':
+      await batcher.flush();
+      return 'end_turn';
+    case 'notice':
+      await batcher.flush();
+      await handlers.sendUpdate({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: event.message },
+      });
+      return null;
+    case 'usage':
+      await batcher.flush();
+      await handlers.sendUsage(event.usage);
+      return null;
+    case 'context-warning':
+    case 'compression':
+    case 'model-info':
+    case 'retry':
+    case 'citation':
+      return null;
+    default: {
+      const exhaustive: never = event;
+      throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -155,10 +155,5 @@ async function handleNotice(
 }
 
 function assertNever(event: never): never {
-  const record = event as Record<string, unknown> | null;
-  const detail =
-    record !== null && typeof record.type === 'string'
-      ? record.type
-      : String(event);
-  throw new Error(`Unhandled agent event: ${detail}`);
+  throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -155,9 +155,10 @@ async function handleNotice(
 }
 
 function assertNever(event: never): never {
+  const record = event as Record<string, unknown> | null;
   const detail =
-    typeof event === 'object' && 'type' in event
-      ? String((event as { type: unknown }).type)
+    record !== null && typeof record.type === 'string'
+      ? record.type
       : String(event);
   throw new Error(`Unhandled agent event: ${detail}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -27,6 +27,7 @@ interface AgentEventHandlers {
   handleConfirmation(
     event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
   ): Promise<void>;
+  resolveToolKind(toolName: string): string | undefined;
 }
 
 export async function handleZedAgentEvent(
@@ -45,15 +46,27 @@ export async function handleZedAgentEvent(
     }
     case 'tool-call':
       await batcher.flush();
-      await emitToolCallStart(event.call, handlers.sendUpdate);
+      await emitToolCallStart(
+        event.call,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.call.name),
+      );
       return null;
     case 'tool-status':
       await batcher.flush();
-      await emitToolStatus(event.update, handlers.sendUpdate);
+      await emitToolStatus(
+        event.update,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.update.name),
+      );
       return null;
     case 'tool-result':
       await batcher.flush();
-      await emitToolResult(event.result, handlers.sendUpdate);
+      await emitToolResult(
+        event.result,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.result.name),
+      );
       return null;
     case 'tool-confirmation':
       await batcher.flush();

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -42,7 +42,7 @@ export async function handleZedAgentEvent(
     case 'thinking':
       return handleThinking(event, batcher);
     case 'tool-call':
-      return handleToolEvent(event, batcher, handlers, emitToolCallStart);
+      return handleToolEvent(event, batcher, handlers);
     case 'tool-status':
       return handleToolUpdate(event, batcher, handlers);
     case 'tool-result':
@@ -103,10 +103,9 @@ async function handleToolEvent(
   event: Extract<AgentEvent, { type: 'tool-call' }>,
   batcher: StreamBatcher,
   handlers: AgentEventHandlers,
-  emit: typeof emitToolCallStart,
 ): Promise<null> {
   await batcher.flush();
-  await emit(
+  await emitToolCallStart(
     event.call,
     handlers.sendUpdate,
     handlers.resolveToolKind(event.call.name),
@@ -156,5 +155,9 @@ async function handleNotice(
 }
 
 function assertNever(event: never): never {
-  throw new Error(`Unhandled agent event: ${String(event)}`);
+  const detail =
+    typeof event === 'object' && 'type' in event
+      ? String((event as { type: unknown }).type)
+      : JSON.stringify(event);
+  throw new Error(`Unhandled agent event: ${detail}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -39,35 +39,14 @@ export async function handleZedAgentEvent(
     case 'text':
       batcher.append(event.text, false);
       return null;
-    case 'thinking': {
-      const thoughtText = extractThoughtText(event.thought);
-      if (thoughtText.length > 0) batcher.append(thoughtText, true);
-      return null;
-    }
+    case 'thinking':
+      return handleThinking(event, batcher);
     case 'tool-call':
-      await batcher.flush();
-      await emitToolCallStart(
-        event.call,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.call.name),
-      );
-      return null;
+      return handleToolEvent(event, batcher, handlers, emitToolCallStart);
     case 'tool-status':
-      await batcher.flush();
-      await emitToolStatus(
-        event.update,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.update.name),
-      );
-      return null;
+      return handleToolUpdate(event, batcher, handlers);
     case 'tool-result':
-      await batcher.flush();
-      await emitToolResult(
-        event.result,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.result.name),
-      );
-      return null;
+      return handleToolResultEvent(event, batcher, handlers);
     case 'tool-confirmation':
       await batcher.flush();
       await handlers.handleConfirmation(event);
@@ -95,12 +74,7 @@ export async function handleZedAgentEvent(
       await batcher.flush();
       return 'end_turn';
     case 'notice':
-      await batcher.flush();
-      await handlers.sendUpdate({
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: event.message },
-      });
-      return null;
+      return handleNotice(event, batcher, handlers);
     case 'usage':
       await batcher.flush();
       await handlers.sendUsage(event.usage);
@@ -111,9 +85,76 @@ export async function handleZedAgentEvent(
     case 'retry':
     case 'citation':
       return null;
-    default: {
-      const exhaustive: never = event;
-      throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
-    }
+    default:
+      return assertNever(event);
   }
+}
+
+function handleThinking(
+  event: Extract<AgentEvent, { type: 'thinking' }>,
+  batcher: StreamBatcher,
+): null {
+  const thoughtText = extractThoughtText(event.thought);
+  if (thoughtText.length > 0) batcher.append(thoughtText, true);
+  return null;
+}
+
+async function handleToolEvent(
+  event: Extract<AgentEvent, { type: 'tool-call' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+  emit: typeof emitToolCallStart,
+): Promise<null> {
+  await batcher.flush();
+  await emit(
+    event.call,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.call.name),
+  );
+  return null;
+}
+
+async function handleToolUpdate(
+  event: Extract<AgentEvent, { type: 'tool-status' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await emitToolStatus(
+    event.update,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.update.name),
+  );
+  return null;
+}
+
+async function handleToolResultEvent(
+  event: Extract<AgentEvent, { type: 'tool-result' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await emitToolResult(
+    event.result,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.result.name),
+  );
+  return null;
+}
+
+async function handleNotice(
+  event: Extract<AgentEvent, { type: 'notice' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await handlers.sendUpdate({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: event.message },
+  });
+  return null;
+}
+
+function assertNever(event: never): acp.StopReason | null {
+  throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-setup.ts
+++ b/packages/cli/src/zed-integration/zed-agent-setup.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Agent } from '@vybestack/llxprt-code-agents';
+
+export async function enableZedSessionRecording(
+  agent: Agent,
+  onFailure: (error: unknown) => void,
+): Promise<void> {
+  try {
+    await agent.session.setRecording({ enabled: true });
+  } catch (error) {
+    onFailure(error);
+  }
+}
+
+export async function buildZedSession<T>(
+  agent: Agent,
+  build: () => T | Promise<T>,
+  onDisposeFailure: (error: unknown) => void,
+): Promise<T> {
+  try {
+    return await build();
+  } catch (error) {
+    try {
+      await agent.dispose();
+    } catch (disposeError) {
+      onDisposeFailure(disposeError);
+    }
+    throw error;
+  }
+}

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -49,6 +49,10 @@ describe('Zed available commands', () => {
       name: 'model',
       args: 'ignored',
     });
+    expect(parseZedCommandPrompt('/model')).toStrictEqual({
+      name: 'model',
+      args: '',
+    });
     await expect(
       executeZedCommand('/unknown', { agent: buildAgent() }),
     ).resolves.toBeNull();

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { Config } from '@vybestack/llxprt-code-core';
+import {
+  buildAvailableCommandsUpdate,
+  executeZedCommand,
+  getZedAvailableCommands,
+  parseZedCommandPrompt,
+} from './zed-command-registry.js';
+import { tryHandleZedCommand } from './zed-prompt-command.js';
+
+function buildAgent(): Agent {
+  return {
+    getModel: () => 'test-model',
+    compress: vi.fn(async () => ({ status: 'compressed' as const })),
+    tools: { list: () => [] },
+    memory: { getFilePaths: () => [] },
+    profiles: { list: () => [] },
+    tasks: { list: () => [] },
+  } as unknown as Agent;
+}
+
+const config = {} as Config;
+
+describe('Zed available commands', () => {
+  it('advertises only commands backed by honest Agent API reads/actions', () => {
+    const commands = getZedAvailableCommands();
+    expect(new Set(commands.map(({ name }) => name))).toStrictEqual(
+      new Set(['compact', 'tools', 'memory', 'profile', 'model', 'task']),
+    );
+    expect(commands.every(({ description }) => description.length > 0)).toBe(
+      true,
+    );
+    expect(buildAvailableCommandsUpdate()).toStrictEqual({
+      sessionUpdate: 'available_commands_update',
+      availableCommands: commands,
+    });
+  });
+
+  it('parses arguments and leaves unknown commands for the model', async () => {
+    expect(parseZedCommandPrompt('')).toBeNull();
+    expect(parseZedCommandPrompt('/')).toBeNull();
+    expect(parseZedCommandPrompt('   ')).toBeNull();
+    expect(parseZedCommandPrompt('/model ignored')).toStrictEqual({
+      name: 'model',
+      args: 'ignored',
+    });
+    await expect(
+      executeZedCommand('/unknown', { agent: buildAgent(), config }),
+    ).resolves.toBeNull();
+  });
+
+  it('returns a protocol-visible error when command execution fails', async () => {
+    const agent = buildAgent();
+    vi.mocked(agent.compress).mockRejectedValue(
+      new Error('compression unavailable'),
+    );
+    await expect(
+      executeZedCommand('/compact', { agent, config }),
+    ).resolves.toStrictEqual({
+      text: 'Command /compact failed: compression unavailable',
+    });
+  });
+
+  it('executes a command and emits a protocol-visible result', async () => {
+    const updates: acp.SessionUpdate[] = [];
+    const handled = await tryHandleZedCommand(
+      [{ type: 'text', text: '/model' }],
+      buildAgent(),
+      config,
+      async (update) => {
+        updates.push(update);
+      },
+    );
+
+    expect(handled).toStrictEqual({ response: { stopReason: 'end_turn' } });
+    expect(updates).toStrictEqual([
+      {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'Current model: test-model' },
+      },
+    ]);
+  });
+
+  it('does not dispatch command-looking text when another block is present', async () => {
+    const updates: acp.SessionUpdate[] = [];
+    const result = await tryHandleZedCommand(
+      [
+        { type: 'text', text: '/compact' },
+        { type: 'image', data: 'image', mimeType: 'image/png' },
+      ],
+      buildAgent(),
+      config,
+      async (update) => {
+        updates.push(update);
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(updates).toStrictEqual([]);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -7,7 +7,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import type { Config } from '@vybestack/llxprt-code-core';
 import {
   buildAvailableCommandsUpdate,
   executeZedCommand,
@@ -26,8 +25,6 @@ function buildAgent(): Agent {
     tasks: { list: () => [] },
   } as unknown as Agent;
 }
-
-const config = {} as Config;
 
 describe('Zed available commands', () => {
   it('advertises only commands backed by honest Agent API reads/actions', () => {
@@ -53,10 +50,10 @@ describe('Zed available commands', () => {
       args: 'ignored',
     });
     await expect(
-      executeZedCommand('/unknown', { agent: buildAgent(), config }),
+      executeZedCommand('/unknown', { agent: buildAgent() }),
     ).resolves.toBeNull();
     await expect(
-      executeZedCommand('/MODEL', { agent: buildAgent(), config }),
+      executeZedCommand('/MODEL', { agent: buildAgent() }),
     ).resolves.toStrictEqual({ text: 'Current model: test-model' });
   });
 
@@ -66,7 +63,7 @@ describe('Zed available commands', () => {
       new Error('compression unavailable'),
     );
     await expect(
-      executeZedCommand('/compact', { agent, config }),
+      executeZedCommand('/compact', { agent }),
     ).resolves.toStrictEqual({
       text: 'Command /compact failed.',
     });
@@ -77,7 +74,6 @@ describe('Zed available commands', () => {
     const handled = await tryHandleZedCommand(
       [{ type: 'text', text: '/model' }],
       buildAgent(),
-      config,
       async (update) => {
         updates.push(update);
       },
@@ -100,7 +96,6 @@ describe('Zed available commands', () => {
         { type: 'image', data: 'image', mimeType: 'image/png' },
       ],
       buildAgent(),
-      config,
       async (update) => {
         updates.push(update);
       },

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -55,6 +55,9 @@ describe('Zed available commands', () => {
     await expect(
       executeZedCommand('/unknown', { agent: buildAgent(), config }),
     ).resolves.toBeNull();
+    await expect(
+      executeZedCommand('/MODEL', { agent: buildAgent(), config }),
+    ).resolves.toStrictEqual({ text: 'Current model: test-model' });
   });
 
   it('returns a protocol-visible error when command execution fails', async () => {
@@ -65,7 +68,7 @@ describe('Zed available commands', () => {
     await expect(
       executeZedCommand('/compact', { agent, config }),
     ).resolves.toStrictEqual({
-      text: 'Command /compact failed: compression unavailable',
+      text: 'Command /compact failed.',
     });
   });
 

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { Config } from '@vybestack/llxprt-code-core';
+
+export interface ZedCommandContext {
+  readonly agent: Agent;
+  readonly config: Config;
+}
+
+export interface ZedCommandResult {
+  readonly text: string;
+  readonly stopReason?: acp.StopReason;
+}
+
+interface ZedCommandDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly inputHint?: string;
+  readonly handler: (
+    context: ZedCommandContext,
+    args: string,
+  ) => Promise<ZedCommandResult>;
+}
+
+export function parseZedCommandPrompt(
+  prompt: string,
+): { readonly name: string; readonly args: string } | null {
+  if (!prompt.startsWith('/')) return null;
+  const value = prompt.slice(1).trimStart();
+  if (value.length === 0) return null;
+  const boundary = value.search(/\s/);
+  return boundary === -1
+    ? { name: value, args: '' }
+    : {
+        name: value.slice(0, boundary),
+        args: value.slice(boundary + 1).trim(),
+      };
+}
+
+function formatCompression(
+  result: Awaited<ReturnType<Agent['compress']>>,
+): string {
+  const counts =
+    result.originalTokenCount === undefined ||
+    result.newTokenCount === undefined
+      ? ''
+      : ` (${result.originalTokenCount} → ${result.newTokenCount} tokens)`;
+  return `Context compression ${result.status}${counts}.`;
+}
+
+const COMMANDS: readonly ZedCommandDefinition[] = [
+  {
+    name: 'compact',
+    description: 'Compress conversation history to free context space',
+    handler: async ({ agent }) => ({
+      text: formatCompression(await agent.compress()),
+    }),
+  },
+  {
+    name: 'tools',
+    description: 'List available tools and their enabled status',
+    handler: async ({ agent }) => {
+      const tools = agent.tools.list();
+      return {
+        text:
+          tools.length === 0
+            ? 'No tools available.'
+            : `Available tools:\n${tools
+                .map((tool) => `  ${tool.enabled ? '[x]' : '[ ]'} ${tool.name}`)
+                .join('\n')}`,
+      };
+    },
+  },
+  {
+    name: 'memory',
+    description: 'Show memory files currently in use',
+    handler: async ({ agent }) => {
+      const paths = agent.memory.getFilePaths();
+      return {
+        text:
+          paths.length === 0
+            ? 'No memory files in use.'
+            : `Memory files:\n${paths.map((path) => `  ${path}`).join('\n')}`,
+      };
+    },
+  },
+  {
+    name: 'profile',
+    description: 'List saved profiles and identify the startup default',
+    handler: async ({ agent }) => {
+      const profiles = agent.profiles.list();
+      return {
+        text:
+          profiles.length === 0
+            ? 'No profiles available.'
+            : `Profiles:\n${profiles
+                .map(
+                  (profile) =>
+                    `  ${profile.name}${profile.isDefault ? ' (default)' : ''}`,
+                )
+                .join('\n')}`,
+      };
+    },
+  },
+  {
+    name: 'model',
+    description: 'Show the current model',
+    handler: async ({ agent }) => ({
+      text: `Current model: ${agent.getModel()}`,
+    }),
+  },
+  {
+    name: 'task',
+    description: 'Show active subagent tasks',
+    handler: async ({ agent }) => {
+      const tasks = agent.tasks.list();
+      return {
+        text:
+          tasks.length === 0
+            ? 'No active subagent tasks.'
+            : `Subagent tasks:\n${tasks
+                .map((task) => `  [${task.status}] ${task.goalPrompt}`)
+                .join('\n')}`,
+      };
+    },
+  },
+];
+
+const COMMAND_MAP = new Map(COMMANDS.map((command) => [command.name, command]));
+
+export function getZedAvailableCommands(): acp.AvailableCommand[] {
+  return COMMANDS.map(({ name, description, inputHint }) => ({
+    name,
+    description,
+    ...(inputHint === undefined ? {} : { input: { hint: inputHint } }),
+  }));
+}
+
+export function buildAvailableCommandsUpdate(): acp.SessionUpdate {
+  return {
+    sessionUpdate: 'available_commands_update',
+    availableCommands: getZedAvailableCommands(),
+  };
+}
+
+export async function executeZedCommand(
+  prompt: string,
+  context: ZedCommandContext,
+): Promise<ZedCommandResult | null> {
+  const parsed = parseZedCommandPrompt(prompt);
+  const command = parsed === null ? undefined : COMMAND_MAP.get(parsed.name);
+  if (command === undefined) return null;
+  try {
+    return await command.handler(context, parsed?.args ?? '');
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { text: `Command /${command.name} failed: ${detail}` };
+  }
+}

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -161,7 +161,10 @@ export async function executeZedCommand(
   try {
     return await command.handler(context, parsed.args);
   } catch (error) {
-    logger.error(() => `Command /${command.name} failed: ${String(error)}`);
+    logger.error(
+      () =>
+        `Command /${command.name} failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -154,12 +154,12 @@ export async function executeZedCommand(
   context: ZedCommandContext,
 ): Promise<ZedCommandResult | null> {
   const parsed = parseZedCommandPrompt(prompt);
-  const command = parsed === null ? undefined : COMMAND_MAP.get(parsed.name);
+  if (parsed === null) return null;
+  const command = COMMAND_MAP.get(parsed.name.toLowerCase());
   if (command === undefined) return null;
   try {
-    return await command.handler(context, parsed?.args ?? '');
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    return { text: `Command /${command.name} failed: ${detail}` };
+    return await command.handler(context, parsed.args);
+  } catch {
+    return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -6,13 +6,12 @@
 
 import type * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 
 const logger = new DebugLogger('llxprt:zed-integration:commands');
 
 export interface ZedCommandContext {
   readonly agent: Agent;
-  readonly config: Config;
 }
 
 export interface ZedCommandResult {

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -161,7 +161,7 @@ export async function executeZedCommand(
   try {
     return await command.handler(context, parsed.args);
   } catch (error) {
-    logger.debug(() => `Command /${command.name} failed: ${String(error)}`);
+    logger.error(() => `Command /${command.name} failed: ${String(error)}`);
     return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -6,7 +6,9 @@
 
 import type * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import type { Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+
+const logger = new DebugLogger('llxprt:zed-integration:commands');
 
 export interface ZedCommandContext {
   readonly agent: Agent;
@@ -159,7 +161,8 @@ export async function executeZedCommand(
   if (command === undefined) return null;
   try {
     return await command.handler(context, parsed.args);
-  } catch {
+  } catch (error) {
+    logger.debug(() => `Command /${command.name} failed: ${String(error)}`);
     return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -188,6 +188,27 @@ describe('Zed config options', () => {
     );
   });
 
+  it('wraps model switch failures as structured ACP internal errors', async () => {
+    const failure = applyZedConfigOption(
+      {
+        setModel: async () => {
+          throw new Error('provider disconnected');
+        },
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      } as unknown as Agent,
+      configFixture(),
+      'model',
+      'beta',
+    );
+
+    await expect(failure).rejects.toMatchObject({ code: -32603 });
+  });
+
   it('publishes agent-side setting changes and removes listeners on teardown', async () => {
     const sendUpdate = vi.fn(async () => undefined);
     const stop = observeZedConfigOptions(
@@ -204,11 +225,15 @@ describe('Zed config options', () => {
       vi.fn(),
     );
 
-    coreEvents.emitSettingsChanged();
-    await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
-    stop();
-    coreEvents.emitSettingsChanged();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(sendUpdate).toHaveBeenCalledOnce();
+    try {
+      coreEvents.emitSettingsChanged();
+      await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
+      stop();
+      coreEvents.emitSettingsChanged();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(sendUpdate).toHaveBeenCalledOnce();
+    } finally {
+      stop();
+    }
   });
 });

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import {
+  coreEvents,
+  type Config,
+  type RuntimeModel,
+} from '@vybestack/llxprt-code-core';
+import {
+  applyZedConfigOption,
+  buildZedConfigOptions,
+  observeZedConfigOptions,
+  setZedConfigOption,
+  zedConfigOptionsForClient,
+} from './zed-config-options.js';
+
+function configFixture(values: Record<string, unknown> = {}): Config {
+  const models: RuntimeModel[] = [
+    { id: 'alpha', name: 'Alpha', provider: 'test' },
+    { id: 'beta', name: 'Beta', provider: 'test' },
+  ];
+  return {
+    getModel: () => 'alpha',
+    getEphemeralSetting: (key: string) => values[key],
+    setEphemeralSetting: (key: string, value: unknown) => {
+      values[key] = value;
+    },
+    getProviderManager: () => ({ getAvailableModels: async () => models }),
+  } as Config;
+}
+
+describe('Zed config options', () => {
+  it('maps active-provider models and current settings to strict ACP selects', async () => {
+    const options = await buildZedConfigOptions(
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      },
+      configFixture({ 'reasoning.effort': 'high', emojifilter: 'warn' }),
+    );
+
+    expect(
+      options.map(({ id, currentValue }) => ({ id, currentValue })),
+    ).toStrictEqual([
+      { id: 'model', currentValue: 'alpha' },
+      { id: 'reasoning.effort', currentValue: 'high' },
+      { id: 'emojifilter', currentValue: 'warn' },
+    ]);
+    expect(options[0]).toMatchObject({
+      category: 'model',
+      options: [
+        { value: 'alpha', name: 'Alpha' },
+        { value: 'beta', name: 'Beta' },
+      ],
+    });
+  });
+
+  it('applies validated settings and returns the updated snapshot', async () => {
+    const values: Record<string, unknown> = {};
+    const options = await applyZedConfigOption(
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      } as Agent,
+      configFixture(values),
+      'emojifilter',
+      'error',
+    );
+
+    expect(values.emojifilter).toBe('error');
+    expect(options.find(({ id }) => id === 'emojifilter')).toMatchObject({
+      currentValue: 'error',
+    });
+  });
+
+  it('omits initial options unless the client advertises config support', async () => {
+    const config = configFixture();
+    await expect(
+      zedConfigOptionsForClient(
+        undefined,
+        {
+          getModel: () => 'alpha',
+          getProviderStatus: () => ({
+            provider: 'test',
+            model: 'alpha',
+            authStatus: 'authenticated' as const,
+          }),
+        },
+        config,
+      ),
+    ).resolves.toStrictEqual({});
+    const supported = await zedConfigOptionsForClient(
+      { session: { configOptions: {} } },
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      },
+      config,
+    );
+    expect(supported.configOptions?.map(({ id }) => id)).toStrictEqual([
+      'model',
+      'reasoning.effort',
+      'emojifilter',
+    ]);
+  });
+
+  it('switches models and strictly publishes the updated full snapshot', async () => {
+    const config = configFixture();
+    const setModel = vi.fn(async () => undefined);
+    const result = await setZedConfigOption(
+      {
+        setModel,
+        getModel: () => 'beta',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      } as unknown as Agent,
+      config,
+      'model',
+      'beta',
+    );
+
+    expect(setModel).toHaveBeenCalledWith('beta');
+    expect(result.configOptions).toHaveLength(3);
+  });
+
+  it('publishes agent-side setting changes and removes listeners on teardown', async () => {
+    const sendUpdate = vi.fn(async () => undefined);
+    const stop = observeZedConfigOptions(
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      },
+      configFixture(),
+      sendUpdate,
+      vi.fn(),
+    );
+
+    coreEvents.emitSettingsChanged();
+    await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
+    stop();
+    coreEvents.emitSettingsChanged();
+    await Promise.resolve();
+    expect(sendUpdate).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -76,7 +76,7 @@ describe('Zed config options', () => {
           model: 'alpha',
           authStatus: 'authenticated' as const,
         }),
-      } as Agent,
+      } as unknown as Agent,
       configFixture(values),
       'emojifilter',
       'error',
@@ -158,17 +158,19 @@ describe('Zed config options', () => {
           value: 'warn',
         },
       ),
-    ).toThrow('Resource not found');
+    ).toThrow('Config options not supported by client');
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it('switches models and strictly publishes the updated full snapshot', async () => {
     const config = configFixture();
-    const setModel = vi.fn(async () => undefined);
+    let currentModel = 'alpha';
     const result = await setZedConfigOption(
       {
-        setModel,
-        getModel: () => 'beta',
+        setModel: async (model: string) => {
+          currentModel = model;
+        },
+        getModel: () => currentModel,
         getProviderStatus: () => ({
           provider: 'test',
           model: 'alpha',
@@ -180,7 +182,7 @@ describe('Zed config options', () => {
       'beta',
     );
 
-    expect(setModel).toHaveBeenCalledWith('beta');
+    expect(currentModel).toBe('beta');
     expect(result.configOptions.find(({ id }) => id === 'model')).toMatchObject(
       { currentValue: 'beta' },
     );

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -103,7 +103,7 @@ describe('Zed config options', () => {
       ),
     ).resolves.toStrictEqual({});
     const supported = await zedConfigOptionsForClient(
-      { session: { configOptions: {} } },
+      { session: { configOptions: true } },
       {
         getModel: () => 'alpha',
         getProviderStatus: () => ({

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -55,7 +55,7 @@ describe('Zed config options', () => {
       { id: 'reasoning.effort', currentValue: 'high' },
       { id: 'emojifilter', currentValue: 'warn' },
     ]);
-    expect(options[0]).toMatchObject({
+    expect(options.find(({ id }) => id === 'model')).toMatchObject({
       category: 'model',
       options: [
         { value: 'alpha', name: 'Alpha' },
@@ -140,7 +140,9 @@ describe('Zed config options', () => {
     );
 
     expect(setModel).toHaveBeenCalledWith('beta');
-    expect(result.configOptions).toHaveLength(3);
+    expect(result.configOptions.find(({ id }) => id === 'model')).toMatchObject(
+      { currentValue: 'beta' },
+    );
   });
 
   it('publishes agent-side setting changes and removes listeners on teardown', async () => {

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -14,9 +14,11 @@ import {
 import {
   applyZedConfigOption,
   buildZedConfigOptions,
+  dispatchZedConfigOption,
   observeZedConfigOptions,
   setZedConfigOption,
   zedConfigOptionsForClient,
+  zedSessionConfigOptions,
 } from './zed-config-options.js';
 
 function configFixture(values: Record<string, unknown> = {}): Config {
@@ -119,6 +121,45 @@ describe('Zed config options', () => {
       'reasoning.effort',
       'emojifilter',
     ]);
+    await expect(
+      zedConfigOptionsForClient(
+        { session: { configOptions: false } },
+        {
+          getModel: () => 'alpha',
+          getProviderStatus: () => ({
+            provider: 'test',
+            model: 'alpha',
+            authStatus: 'authenticated' as const,
+          }),
+        },
+        config,
+      ),
+    ).resolves.toStrictEqual({});
+  });
+
+  it('gates loaded snapshots and mutations on explicit client support', async () => {
+    const getConfigOptions = vi.fn(async () => []);
+    await expect(
+      zedSessionConfigOptions(
+        { session: { configOptions: false } },
+        { getConfigOptions },
+      ),
+    ).resolves.toStrictEqual({});
+    expect(getConfigOptions).not.toHaveBeenCalled();
+
+    const setConfigOption = vi.fn(async () => ({ configOptions: [] }));
+    expect(() =>
+      dispatchZedConfigOption(
+        { session: { configOptions: false } },
+        new Map([['session-1', { setConfigOption }]]),
+        {
+          sessionId: 'session-1',
+          configId: 'emojifilter',
+          value: 'warn',
+        },
+      ),
+    ).toThrow('Resource not found');
+    expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it('switches models and strictly publishes the updated full snapshot', async () => {
@@ -165,7 +206,7 @@ describe('Zed config options', () => {
     await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
     stop();
     coreEvents.emitSettingsChanged();
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(sendUpdate).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -140,9 +140,9 @@ export async function zedConfigOptionsForClient(
   agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
   config: Config,
 ): Promise<Pick<acp.NewSessionResponse, 'configOptions'>> {
-  return capabilities?.session?.configOptions == null
-    ? {}
-    : { configOptions: await buildZedConfigOptions(agent, config) };
+  return capabilities?.session?.configOptions === true
+    ? { configOptions: await buildZedConfigOptions(agent, config) }
+    : {};
 }
 
 export async function setZedConfigOption(
@@ -175,7 +175,7 @@ export function dispatchZedConfigOption(
   params: acp.SetSessionConfigOptionRequest,
 ): Promise<acp.SetSessionConfigOptionResponse> {
   const session = sessions.get(params.sessionId);
-  if (session === undefined || capabilities?.session?.configOptions == null) {
+  if (session === undefined || capabilities?.session?.configOptions !== true) {
     throw acp.RequestError.resourceNotFound(params.sessionId);
   }
   return session.setConfigOption(params.configId, params.value);
@@ -216,8 +216,16 @@ export function observeZedConfigOptions(
   coreEvents.on(CoreEvent.SettingsChanged, refresh);
   return () => {
     stopped = true;
-    coreEvents.off(CoreEvent.ModelChanged, refresh);
-    coreEvents.off(CoreEvent.SettingsChanged, refresh);
+    try {
+      coreEvents.off(CoreEvent.ModelChanged, refresh);
+    } catch {
+      // Listener removal is best-effort during teardown.
+    }
+    try {
+      coreEvents.off(CoreEvent.SettingsChanged, refresh);
+    } catch {
+      // Listener removal is best-effort during teardown.
+    }
   };
 }
 
@@ -225,7 +233,7 @@ export function zedSessionConfigOptions(
   capabilities: ClientCapabilitiesWithSession | undefined,
   session: { getConfigOptions(): Promise<acp.SessionConfigOption[]> },
 ): Promise<Pick<acp.LoadSessionResponse, 'configOptions'>> {
-  return capabilities?.session?.configOptions == null
-    ? Promise.resolve({})
-    : session.getConfigOptions().then((configOptions) => ({ configOptions }));
+  return capabilities?.session?.configOptions === true
+    ? session.getConfigOptions().then((configOptions) => ({ configOptions }))
+    : Promise.resolve({});
 }

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -13,6 +13,7 @@ import {
   type RuntimeModel,
 } from '@vybestack/llxprt-code-core';
 import { parseEphemeralSettingValue } from '@vybestack/llxprt-code-providers/runtime.js';
+import type { ClientCapabilitiesWithSession } from './acp-types.js';
 
 const REASONING_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'];
 const EMOJI_VALUES = ['allowed', 'auto', 'warn', 'error'];
@@ -135,7 +136,7 @@ export async function applyZedConfigOption(
 }
 
 export async function zedConfigOptionsForClient(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
   config: Config,
 ): Promise<Pick<acp.NewSessionResponse, 'configOptions'>> {
@@ -169,7 +170,7 @@ interface ConfigurableZedSession {
 }
 
 export function dispatchZedConfigOption(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   sessions: ReadonlyMap<string, ConfigurableZedSession>,
   params: acp.SetSessionConfigOptionRequest,
 ): Promise<acp.SetSessionConfigOptionResponse> {
@@ -221,7 +222,7 @@ export function observeZedConfigOptions(
 }
 
 export function zedSessionConfigOptions(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   session: { getConfigOptions(): Promise<acp.SessionConfigOption[]> },
 ): Promise<Pick<acp.LoadSessionResponse, 'configOptions'>> {
   return capabilities?.session?.configOptions == null

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -206,23 +206,25 @@ export function observeZedConfigOptions(
     pending = true;
     if (running) return;
     running = true;
-    void (async () => {
+    void runRefreshLoop();
+  };
+
+  async function runRefreshLoop(): Promise<void> {
+    try {
       while (pending && !stopped) {
         pending = false;
-        try {
-          const configOptions = await buildZedConfigOptions(agent, config);
-          if (isStopped()) return;
-          await sendUpdate({
-            sessionUpdate: 'config_option_update',
-            configOptions,
-          });
-        } catch (error) {
-          onError(error);
-        }
+        await sendConfigOptionUpdate(
+          agent,
+          config,
+          sendUpdate,
+          isStopped,
+          onError,
+        );
       }
+    } finally {
       running = false;
-    })();
-  };
+    }
+  }
   coreEvents.on(CoreEvent.ModelChanged, refresh);
   coreEvents.on(CoreEvent.SettingsChanged, refresh);
   return () => {
@@ -247,4 +249,23 @@ export function zedSessionConfigOptions(
   return capabilities?.session?.configOptions === true
     ? session.getConfigOptions().then((configOptions) => ({ configOptions }))
     : Promise.resolve({});
+}
+
+async function sendConfigOptionUpdate(
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
+  isStopped: () => boolean,
+  onError: (error: unknown) => void,
+): Promise<void> {
+  try {
+    const configOptions = await buildZedConfigOptions(agent, config);
+    if (isStopped()) return;
+    await sendUpdate({
+      sessionUpdate: 'config_option_update',
+      configOptions,
+    });
+  } catch (error) {
+    onError(error);
+  }
 }

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -108,8 +108,9 @@ export async function applyZedConfigOption(
   if (configId === 'model') {
     const models = await availableModels(agent, config);
     if (
+      models !== undefined &&
       value !== agent.getModel() &&
-      models?.some(({ id }) => id === value) !== true
+      !models.some(({ id }) => id === value)
     ) {
       throw acp.RequestError.invalidParams({ value }, 'Unavailable model.');
     }
@@ -149,14 +150,8 @@ export async function setZedConfigOption(
   agent: Agent,
   config: Config,
   configId: string,
-  value: string | boolean,
+  value: string,
 ): Promise<acp.SetSessionConfigOptionResponse> {
-  if (typeof value !== 'string') {
-    throw acp.RequestError.invalidParams(
-      { configId },
-      'Expected select value.',
-    );
-  }
   return {
     configOptions: await applyZedConfigOption(agent, config, configId, value),
   };
@@ -165,7 +160,7 @@ export async function setZedConfigOption(
 interface ConfigurableZedSession {
   setConfigOption(
     configId: string,
-    value: string | boolean,
+    value: string,
   ): Promise<acp.SetSessionConfigOptionResponse>;
 }
 
@@ -175,8 +170,20 @@ export function dispatchZedConfigOption(
   params: acp.SetSessionConfigOptionRequest,
 ): Promise<acp.SetSessionConfigOptionResponse> {
   const session = sessions.get(params.sessionId);
-  if (session === undefined || capabilities?.session?.configOptions !== true) {
+  if (session === undefined) {
     throw acp.RequestError.resourceNotFound(params.sessionId);
+  }
+  if (capabilities?.session?.configOptions !== true) {
+    throw acp.RequestError.invalidParams(
+      { sessionId: params.sessionId },
+      'Config options not supported by client.',
+    );
+  }
+  if (typeof params.value !== 'string') {
+    throw acp.RequestError.invalidParams(
+      { configId: params.configId },
+      'Expected select value.',
+    );
   }
   return session.setConfigOption(params.configId, params.value);
 }

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -114,7 +114,11 @@ export async function applyZedConfigOption(
     ) {
       throw acp.RequestError.invalidParams({ value }, 'Unavailable model.');
     }
-    await agent.setModel(value);
+    try {
+      await agent.setModel(value);
+    } catch (error) {
+      throw acp.RequestError.internalError({ configId, error: String(error) });
+    }
     return buildZedConfigOptions(agent, config);
   }
   if (configId !== 'reasoning.effort' && configId !== 'emojifilter') {

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import {
+  coreEvents,
+  CoreEvent,
+  type Config,
+  type RuntimeModel,
+} from '@vybestack/llxprt-code-core';
+import { parseEphemeralSettingValue } from '@vybestack/llxprt-code-providers/runtime.js';
+
+const REASONING_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+const EMOJI_VALUES = ['allowed', 'auto', 'warn', 'error'];
+
+function selectOption(value: string): acp.SessionConfigSelectOption {
+  return { value, name: value };
+}
+
+function settingOption(
+  config: Config,
+  id: string,
+  name: string,
+  category: acp.SessionConfigOptionCategory,
+  values: readonly string[],
+  fallback: string,
+): acp.SessionConfigOption {
+  const current = config.getEphemeralSetting(id);
+  return {
+    type: 'select',
+    id,
+    name,
+    category,
+    currentValue: typeof current === 'string' ? current : fallback,
+    options: values.map(selectOption),
+  };
+}
+
+function modelOption(
+  currentModel: string,
+  models: readonly RuntimeModel[],
+): acp.SessionConfigOption {
+  const available = models.some(({ id }) => id === currentModel)
+    ? models
+    : [{ id: currentModel, name: currentModel, provider: '' }, ...models];
+  return {
+    type: 'select',
+    id: 'model',
+    name: 'Model',
+    category: 'model',
+    currentValue: currentModel,
+    options: available.map((model) => ({ value: model.id, name: model.name })),
+  };
+}
+
+async function availableModels(
+  agent: Pick<Agent, 'getProviderStatus'>,
+  config: Config,
+): Promise<RuntimeModel[] | undefined> {
+  try {
+    const provider = agent.getProviderStatus().provider;
+    return (
+      (await config.getProviderManager()?.getAvailableModels(provider)) ?? []
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildZedConfigOptions(
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+): Promise<acp.SessionConfigOption[]> {
+  const currentModel = agent.getModel();
+  const models = await availableModels(agent, config);
+  return [
+    ...(models === undefined ? [] : [modelOption(currentModel, models)]),
+    settingOption(
+      config,
+      'reasoning.effort',
+      'Thinking level',
+      'thought_level',
+      REASONING_VALUES,
+      'medium',
+    ),
+    settingOption(
+      config,
+      'emojifilter',
+      'Emoji filter',
+      '_display',
+      EMOJI_VALUES,
+      'auto',
+    ),
+  ];
+}
+
+export async function applyZedConfigOption(
+  agent: Agent,
+  config: Config,
+  configId: string,
+  value: string,
+): Promise<acp.SessionConfigOption[]> {
+  if (configId === 'model') {
+    const models = await availableModels(agent, config);
+    if (
+      value !== agent.getModel() &&
+      models?.some(({ id }) => id === value) !== true
+    ) {
+      throw acp.RequestError.invalidParams({ value }, 'Unavailable model.');
+    }
+    await agent.setModel(value);
+    return buildZedConfigOptions(agent, config);
+  }
+  if (configId !== 'reasoning.effort' && configId !== 'emojifilter') {
+    throw acp.RequestError.invalidParams(
+      { configId },
+      'Unknown config option.',
+    );
+  }
+  const parsed = parseEphemeralSettingValue(configId, value);
+  if (!parsed.success) {
+    throw acp.RequestError.invalidParams({ configId }, parsed.message);
+  }
+  try {
+    config.setEphemeralSetting(configId, parsed.value);
+    coreEvents.emitSettingsChanged();
+  } catch (error) {
+    throw acp.RequestError.internalError({ configId, error: String(error) });
+  }
+  return buildZedConfigOptions(agent, config);
+}
+
+export async function zedConfigOptionsForClient(
+  capabilities: acp.ClientCapabilities | undefined,
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+): Promise<Pick<acp.NewSessionResponse, 'configOptions'>> {
+  return capabilities?.session?.configOptions == null
+    ? {}
+    : { configOptions: await buildZedConfigOptions(agent, config) };
+}
+
+export async function setZedConfigOption(
+  agent: Agent,
+  config: Config,
+  configId: string,
+  value: string | boolean,
+): Promise<acp.SetSessionConfigOptionResponse> {
+  if (typeof value !== 'string') {
+    throw acp.RequestError.invalidParams(
+      { configId },
+      'Expected select value.',
+    );
+  }
+  return {
+    configOptions: await applyZedConfigOption(agent, config, configId, value),
+  };
+}
+
+interface ConfigurableZedSession {
+  setConfigOption(
+    configId: string,
+    value: string | boolean,
+  ): Promise<acp.SetSessionConfigOptionResponse>;
+}
+
+export function dispatchZedConfigOption(
+  capabilities: acp.ClientCapabilities | undefined,
+  sessions: ReadonlyMap<string, ConfigurableZedSession>,
+  params: acp.SetSessionConfigOptionRequest,
+): Promise<acp.SetSessionConfigOptionResponse> {
+  const session = sessions.get(params.sessionId);
+  if (session === undefined || capabilities?.session?.configOptions == null) {
+    throw acp.RequestError.resourceNotFound(params.sessionId);
+  }
+  return session.setConfigOption(params.configId, params.value);
+}
+
+export function observeZedConfigOptions(
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
+  onError: (error: unknown) => void,
+): () => void {
+  let stopped = false;
+  let running = false;
+  let pending = false;
+  const isStopped = () => stopped;
+  const refresh = () => {
+    pending = true;
+    if (running) return;
+    running = true;
+    void (async () => {
+      while (pending && !stopped) {
+        pending = false;
+        try {
+          const configOptions = await buildZedConfigOptions(agent, config);
+          if (isStopped()) return;
+          await sendUpdate({
+            sessionUpdate: 'config_option_update',
+            configOptions,
+          });
+        } catch (error) {
+          onError(error);
+        }
+      }
+      running = false;
+    })();
+  };
+  coreEvents.on(CoreEvent.ModelChanged, refresh);
+  coreEvents.on(CoreEvent.SettingsChanged, refresh);
+  return () => {
+    stopped = true;
+    coreEvents.off(CoreEvent.ModelChanged, refresh);
+    coreEvents.off(CoreEvent.SettingsChanged, refresh);
+  };
+}
+
+export function zedSessionConfigOptions(
+  capabilities: acp.ClientCapabilities | undefined,
+  session: { getConfigOptions(): Promise<acp.SessionConfigOption[]> },
+): Promise<Pick<acp.LoadSessionResponse, 'configOptions'>> {
+  return capabilities?.session?.configOptions == null
+    ? Promise.resolve({})
+    : session.getConfigOptions().then((configOptions) => ({ configOptions }));
+}

--- a/packages/cli/src/zed-integration/zed-content-utils.ts
+++ b/packages/cli/src/zed-integration/zed-content-utils.ts
@@ -69,7 +69,9 @@ export function extractToolResultText(
 export function extractTextFromPartList(
   llmContent: ContractPartListUnion | undefined,
 ): string | null {
-  if (llmContent === undefined) {
+  // Runtime callers can pass null (deserialized JSON); the type does not
+  // include it, so check explicitly.
+  if (llmContent === undefined || (llmContent as unknown) === null) {
     return null;
   }
 

--- a/packages/cli/src/zed-integration/zed-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-helpers.ts
@@ -279,3 +279,16 @@ export function translateIdleTimeout(
 ): Error {
   return new Error(event.error.message);
 }
+
+/**
+ * Renders the pre-delivery debug line for a session/update notification: the
+ * update kind plus the text length when the update carries text content. Pure;
+ * extracted here to keep zedIntegration.ts within its max-lines budget.
+ */
+export function describeSessionUpdateForLog(update: acp.SessionUpdate): string {
+  const chars =
+    'content' in update && update.content && 'text' in update.content
+      ? `(${(update.content as { text: string }).text.length} chars)`
+      : '';
+  return `sendUpdate: ${update.sessionUpdate} ${chars}`;
+}

--- a/packages/cli/src/zed-integration/zed-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-helpers.ts
@@ -292,3 +292,30 @@ export function describeSessionUpdateForLog(update: acp.SessionUpdate): string {
       : '';
   return `sendUpdate: ${update.sessionUpdate} ${chars}`;
 }
+
+/**
+ * Builds the usage_update session notification for a turn's usage metadata
+ * (issue #1607): `used` is the total tokens now in context (the response's
+ * cumulative totalTokenCount) and `size` is the configured context-window
+ * limit, so the client can render consumption against the real window rather
+ * than against itself. Returns null when the event carries no usable counts
+ * (nothing meaningful to report). `size` is clamped up to `used` so a
+ * mid-flight limit change can never report used > size on the wire.
+ */
+export function buildUsageUpdate(
+  usage: {
+    readonly totalTokenCount?: number;
+    readonly candidatesTokenCount?: number;
+  },
+  contextWindowSize: number,
+): acp.SessionUpdate | null {
+  const used = usage.totalTokenCount ?? usage.candidatesTokenCount ?? 0;
+  if (used === 0) {
+    return null;
+  }
+  return {
+    sessionUpdate: 'usage_update',
+    used,
+    size: Math.max(contextWindowSize, used),
+  };
+}

--- a/packages/cli/src/zed-integration/zed-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-helpers.ts
@@ -9,6 +9,11 @@ import {
   ToolConfirmationOutcome,
   ApprovalMode,
 } from '@vybestack/llxprt-code-core';
+import type {
+  AgentEvent,
+  DoneReason,
+  ThoughtSummary,
+} from '@vybestack/llxprt-code-agents';
 import type * as acp from '@agentclientprotocol/sdk';
 import { z } from 'zod';
 
@@ -20,6 +25,36 @@ export function parseZedAuthMethodId(
     throw new Error('No profiles available for selection');
   }
   return z.enum(availableProfiles as [string, ...string[]]).parse(methodId);
+}
+
+/**
+ * Maps an Agent-API {@link DoneReason} to the ACP {@link acp.StopReason} the Zed
+ * client expects. Terminal failure reasons (`error`, `hook-stopped`) have no
+ * clean stop reason and throw so the prompt path surfaces them as errors. Kept
+ * here (a pure mapper alongside the other Zed mapping helpers) so zedIntegration.ts
+ * stays within its max-lines budget.
+ */
+export function mapDoneReasonToStopReason(reason: DoneReason): acp.StopReason {
+  switch (reason) {
+    case 'stop':
+    case 'loop-detected':
+      return 'end_turn';
+    case 'aborted':
+      return 'cancelled';
+    case 'max-turns':
+      return 'max_turn_requests';
+    case 'context-overflow':
+      return 'max_tokens';
+    case 'refusal':
+      return 'refusal';
+    case 'error':
+    case 'hook-stopped':
+      throw new Error(`Agent stopped with terminal reason: ${reason}`);
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
 }
 
 /**
@@ -189,4 +224,58 @@ export function buildAvailableModes(): acp.SessionMode[] {
       description: 'Auto-approves all tools',
     },
   ];
+}
+
+/**
+ * Builds the ACP session `modes` block (available modes + the session's current
+ * mode) shared by the newSession and loadSession (disk-resume AND #1604
+ * re-attach) responses. Typed via the response's `modes` field so it stays exact
+ * without importing a possibly-renamed acp type. Centralized here so the mode
+ * advertisement is identical across all three response paths.
+ */
+export function buildSessionModes(
+  currentModeId: ApprovalMode,
+): acp.LoadSessionResponse['modes'] {
+  return {
+    availableModes: buildAvailableModes(),
+    currentModeId,
+  };
+}
+
+/**
+ * Flattens an Agent-API {@link ThoughtSummary} into the display text the Zed
+ * thought-chunk carries: the non-empty subject/description joined by a space.
+ * Pure mapper kept alongside the other Zed event mappers so zedIntegration.ts
+ * stays within its max-lines budget.
+ */
+export function extractThoughtText(thought: ThoughtSummary): string {
+  const parts = [thought.subject, thought.description].filter(
+    (v) => v.length > 0,
+  );
+  return parts.join(parts.length > 1 ? ' ' : '');
+}
+
+/**
+ * Translates an Agent `error` event into an Error for the prompt path, carrying
+ * the upstream numeric `status` (when present) so downstream 429 handling can
+ * still detect a rate-limit. Pure; extracted here to keep zedIntegration.ts thin.
+ */
+export function translateErrorEvent(
+  event: Extract<AgentEvent, { type: 'error' }>,
+): Error {
+  const error = new Error(event.error.message);
+  if (event.error.status !== undefined) {
+    Object.assign(error, { status: event.error.status });
+  }
+  return error;
+}
+
+/**
+ * Translates an Agent `idle-timeout` event into an Error carrying its message.
+ * Pure; extracted here to keep zedIntegration.ts within its max-lines budget.
+ */
+export function translateIdleTimeout(
+  event: Extract<AgentEvent, { type: 'idle-timeout' }>,
+): Error {
+  return new Error(event.error.message);
 }

--- a/packages/cli/src/zed-integration/zed-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-helpers.ts
@@ -298,8 +298,8 @@ export function describeSessionUpdateForLog(update: acp.SessionUpdate): string {
  * (issue #1607): `used` is the total tokens now in context (the response's
  * cumulative totalTokenCount) and `size` is the configured context-window
  * limit, so the client can render consumption against the real window rather
- * than against itself. Returns null when the event carries no usable counts
- * (nothing meaningful to report). `size` is clamped up to `used` so a
+ * than against itself. Returns null when the usage metadata carries no usable
+ * counts (nothing meaningful to report). `size` is clamped up to `used` so a
  * mid-flight limit change can never report used > size on the wire.
  */
 export function buildUsageUpdate(

--- a/packages/cli/src/zed-integration/zed-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-helpers.ts
@@ -298,9 +298,12 @@ export function describeSessionUpdateForLog(update: acp.SessionUpdate): string {
  * (issue #1607): `used` is the total tokens now in context (the response's
  * cumulative totalTokenCount) and `size` is the configured context-window
  * limit, so the client can render consumption against the real window rather
- * than against itself. Returns null when the usage metadata carries no usable
- * counts (nothing meaningful to report). `size` is clamped up to `used` so a
- * mid-flight limit change can never report used > size on the wire.
+ * than against itself. When a provider omits cumulative `totalTokenCount`, the
+ * candidate count is retained as a lower-bound fallback rather than suppressing
+ * usage entirely; it represents only this completion, so it may under-report
+ * context consumption but never overstates it. Returns null when the metadata
+ * carries no usable count. `size` is clamped up to `used` so a mid-flight limit
+ * change can never report used > size on the wire.
  */
 export function buildUsageUpdate(
   usage: {

--- a/packages/cli/src/zed-integration/zed-initialize.ts
+++ b/packages/cli/src/zed-integration/zed-initialize.ts
@@ -25,8 +25,6 @@ export async function initializeZedAgent(
       sessionCapabilities: {
         list: {},
         resume: {},
-        delete: {},
-        close: {},
       },
       promptCapabilities: {
         image: true,

--- a/packages/cli/src/zed-integration/zed-initialize.ts
+++ b/packages/cli/src/zed-integration/zed-initialize.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core';
+import * as acp from '@agentclientprotocol/sdk';
+import { loadProfileByName } from '@vybestack/llxprt-code-providers/runtime.js';
+import { parseZedAuthMethodId } from './zed-helpers.js';
+
+export async function initializeZedAgent(
+  config: Config,
+): Promise<acp.InitializeResponse> {
+  const profileNames = await getAvailableProfileNames(config);
+  return {
+    protocolVersion: acp.PROTOCOL_VERSION,
+    authMethods: profileNames.map((name) => ({
+      id: name,
+      name,
+      description: null,
+    })),
+    agentCapabilities: {
+      loadSession: true,
+      sessionCapabilities: {
+        list: {},
+        resume: {},
+        delete: {},
+        close: {},
+      },
+      promptCapabilities: {
+        image: true,
+        audio: true,
+        embeddedContext: true,
+      },
+    },
+  };
+}
+
+export async function authenticateZedAgent(
+  config: Config,
+  methodId: string,
+): Promise<void> {
+  await loadProfileByName(
+    parseZedAuthMethodId(methodId, await getAvailableProfileNames(config)),
+  );
+}
+
+async function getAvailableProfileNames(config: Config): Promise<string[]> {
+  return (await config.getProfileManager()?.listProfiles()) ?? [];
+}

--- a/packages/cli/src/zed-integration/zed-plan-update.ts
+++ b/packages/cli/src/zed-integration/zed-plan-update.ts
@@ -13,6 +13,7 @@ export function buildZedPlanUpdate(todos: readonly Todo[]): acp.SessionUpdate {
     entries: todos.map((todo) => ({
       content: todo.content,
       status: todo.status,
+      // ACP plan entries only support a fixed 'medium' priority.
       priority: 'medium',
     })),
   };

--- a/packages/cli/src/zed-integration/zed-plan-update.ts
+++ b/packages/cli/src/zed-integration/zed-plan-update.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Todo } from '@vybestack/llxprt-code-core';
+
+export function buildZedPlanUpdate(todos: readonly Todo[]): acp.SessionUpdate {
+  return {
+    sessionUpdate: 'plan',
+    entries: todos.map((todo) => ({
+      content: todo.content,
+      status: todo.status,
+      priority: 'medium',
+    })),
+  };
+}

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -43,7 +43,6 @@ export function extractPromptText(
  *
  * @param prompt The raw ACP content blocks from the prompt request.
  * @param agent The session's real Agent.
- * @param config The session's real Config.
  * @param sendUpdate Callback to stream an `agent_message_chunk`.
  */
 export async function tryHandleZedCommand(

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -68,7 +68,7 @@ export async function tryHandleZedCommand(
   } catch (error) {
     logger.debug(() => `Command response delivery failed: ${String(error)}`);
     throw acp.RequestError.internalError(
-      {},
+      { cause: String(error) },
       'Command response delivery failed.',
     );
   }

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as acp from '@agentclientprotocol/sdk';
+import * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
 import type { Config } from '@vybestack/llxprt-code-core';
 
@@ -61,10 +61,17 @@ export async function tryHandleZedCommand(
   if (result === null) {
     return null;
   }
-  await sendUpdate({
-    sessionUpdate: 'agent_message_chunk',
-    content: { type: 'text', text: result.text },
-  });
+  try {
+    await sendUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: result.text },
+    });
+  } catch {
+    throw acp.RequestError.internalError(
+      {},
+      'Command response delivery failed.',
+    );
+  }
   return {
     response: { stopReason: result.stopReason ?? 'end_turn' },
   };

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { Config } from '@vybestack/llxprt-code-core';
+
+import {
+  executeZedCommand,
+  type ZedCommandResult,
+} from './zed-command-registry.js';
+
+/**
+ * Extracts the first text content from an ACP prompt content-block array. A
+ * Zed slash command arrives as a single text block, so only the first text
+ * block's text is relevant for command detection.
+ *
+ * Returns `null` when the prompt has no text block (e.g. only image/audio),
+ * so the caller treats it as an ordinary (non-slash) prompt.
+ */
+export function extractPromptText(
+  prompt: readonly acp.ContentBlock[],
+): string | null {
+  if (prompt.length !== 1 || prompt[0].type !== 'text') {
+    return null;
+  }
+  return prompt[0].text;
+}
+
+/**
+ * Attempts to handle a prompt as a Zed slash command. When the prompt is a
+ * known Zed command (e.g. `/compact`, `/tools`), this executes the command,
+ * streams the result text as an `agent_message_chunk` via the provided
+ * `sendUpdate` callback, and returns the final {@link acp.PromptResponse}.
+ *
+ * Returns `null` when the prompt is NOT a slash command (or is an unknown
+ * command), so the caller continues with ordinary model-streaming.
+ *
+ * @param prompt The raw ACP content blocks from the prompt request.
+ * @param agent The session's real Agent.
+ * @param config The session's real Config.
+ * @param sendUpdate Callback to stream an `agent_message_chunk`.
+ */
+export async function tryHandleZedCommand(
+  prompt: readonly acp.ContentBlock[],
+  agent: Agent,
+  config: Config,
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
+): Promise<{ response: acp.PromptResponse } | null> {
+  const text = extractPromptText(prompt);
+  if (text === null) {
+    return null;
+  }
+  const result: ZedCommandResult | null = await executeZedCommand(text, {
+    agent,
+    config,
+  });
+  if (result === null) {
+    return null;
+  }
+  await sendUpdate({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: result.text },
+  });
+  return {
+    response: { stopReason: result.stopReason ?? 'end_turn' },
+  };
+}

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -6,7 +6,9 @@
 
 import * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import type { Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+
+const logger = new DebugLogger('llxprt:zed-integration:prompt-command');
 
 import {
   executeZedCommand,
@@ -66,7 +68,8 @@ export async function tryHandleZedCommand(
       sessionUpdate: 'agent_message_chunk',
       content: { type: 'text', text: result.text },
     });
-  } catch {
+  } catch (error) {
+    logger.debug(() => `Command response delivery failed: ${String(error)}`);
     throw acp.RequestError.internalError(
       {},
       'Command response delivery failed.',

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -6,7 +6,7 @@
 
 import * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 
 const logger = new DebugLogger('llxprt:zed-integration:prompt-command');
 
@@ -49,7 +49,6 @@ export function extractPromptText(
 export async function tryHandleZedCommand(
   prompt: readonly acp.ContentBlock[],
   agent: Agent,
-  config: Config,
   sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
 ): Promise<{ response: acp.PromptResponse } | null> {
   const text = extractPromptText(prompt);
@@ -58,7 +57,6 @@ export async function tryHandleZedCommand(
   }
   const result: ZedCommandResult | null = await executeZedCommand(text, {
     agent,
-    config,
   });
   if (result === null) {
     return null;

--- a/packages/cli/src/zed-integration/zed-session-config.ts
+++ b/packages/cli/src/zed-integration/zed-session-config.ts
@@ -19,6 +19,7 @@ import {
   type RuntimeProviderManager,
 } from '@vybestack/llxprt-code-core';
 import type { FileSystemService } from '@vybestack/llxprt-code-storage';
+import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
 
 /**
  * Resolves the effective target directory for a session from an optional
@@ -61,12 +62,16 @@ export function createSessionScopedConfig(
   config: Config,
   initialFileSystemService: FileSystemService,
   targetDir: string = config.getTargetDir(),
+  resolveToolRegistry?: () => ToolRegistry | undefined,
 ): Config {
   let fileSystemService = initialFileSystemService;
   let providerManager: RuntimeProviderManager | undefined =
     config.getProviderManager();
   return new Proxy(config, {
     get(target, property, receiver) {
+      if (property === 'getToolRegistry' && resolveToolRegistry !== undefined) {
+        return () => resolveToolRegistry() ?? config.getToolRegistry();
+      }
       if (property === 'getFileSystemService') {
         return () => fileSystemService;
       }

--- a/packages/cli/src/zed-integration/zed-session-config.ts
+++ b/packages/cli/src/zed-integration/zed-session-config.ts
@@ -18,6 +18,7 @@ import {
   isWithinRoot,
   type RuntimeProviderManager,
 } from '@vybestack/llxprt-code-core';
+import type { FileSystemService } from '@vybestack/llxprt-code-storage';
 
 /**
  * Resolves the effective target directory for a session from an optional
@@ -51,7 +52,7 @@ export function resolveSessionTargetDir(
  */
 export function createSessionScopedConfig(
   config: Config,
-  initialFileSystemService: ReturnType<Config['getFileSystemService']>,
+  initialFileSystemService: FileSystemService,
   targetDir: string = config.getTargetDir(),
 ): Config {
   let fileSystemService = initialFileSystemService;
@@ -63,7 +64,7 @@ export function createSessionScopedConfig(
         return () => fileSystemService;
       }
       if (property === 'setFileSystemService') {
-        return (nextFileSystemService: typeof fileSystemService) => {
+        return (nextFileSystemService: FileSystemService) => {
           fileSystemService = nextFileSystemService;
         };
       }

--- a/packages/cli/src/zed-integration/zed-session-config.ts
+++ b/packages/cli/src/zed-integration/zed-session-config.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Session-scoped Config construction for the Zed integration (issue #1604).
+ * Extracted from zedIntegration.ts so that near-cap file stays within its
+ * max-lines budget; the behavior is unchanged and exercised by
+ * zedIntegration.test.ts (createSessionScopedConfig) and the loadSession/prompt
+ * suites.
+ */
+
+import * as path from 'node:path';
+import {
+  type Config,
+  isWithinRoot,
+  type RuntimeProviderManager,
+} from '@vybestack/llxprt-code-core';
+
+/**
+ * Resolves the effective target directory for a session from an optional
+ * client-supplied cwd: an empty/whitespace cwd falls back to the config target
+ * dir; an absolute or config-relative cwd is accepted only when it resolves
+ * WITHIN the config target dir (otherwise the target dir is used), so a session
+ * can never escape the project root.
+ */
+export function resolveSessionTargetDir(
+  config: Config,
+  cwd: string | undefined,
+): string {
+  if (cwd === undefined || cwd.trim().length === 0) {
+    return config.getTargetDir();
+  }
+  const candidate = path.isAbsolute(cwd)
+    ? cwd
+    : path.resolve(config.getTargetDir(), cwd);
+  return isWithinRoot(candidate, config.getTargetDir())
+    ? candidate
+    : config.getTargetDir();
+}
+
+/**
+ * Builds a per-session Config proxy that overrides the file-system service,
+ * provider manager, and project/target dir for a single session WITHOUT
+ * mutating the shared base Config. getFileSystemService/getProviderManager
+ * return the session-scoped instances (swappable via their setters), and
+ * getProjectRoot/getTargetDir return the resolved session target dir; every
+ * other access falls through to the base Config.
+ */
+export function createSessionScopedConfig(
+  config: Config,
+  initialFileSystemService: ReturnType<Config['getFileSystemService']>,
+  targetDir: string = config.getTargetDir(),
+): Config {
+  let fileSystemService = initialFileSystemService;
+  let providerManager: RuntimeProviderManager | undefined =
+    config.getProviderManager();
+  return new Proxy(config, {
+    get(target, property, receiver) {
+      if (property === 'getFileSystemService') {
+        return () => fileSystemService;
+      }
+      if (property === 'setFileSystemService') {
+        return (nextFileSystemService: typeof fileSystemService) => {
+          fileSystemService = nextFileSystemService;
+        };
+      }
+      if (property === 'getProviderManager') {
+        return () => providerManager;
+      }
+      if (property === 'setProviderManager') {
+        return (nextProviderManager: RuntimeProviderManager) => {
+          providerManager = nextProviderManager;
+        };
+      }
+      if (property === 'getProjectRoot') {
+        return () => targetDir;
+      }
+      if (property === 'getTargetDir') {
+        return () => targetDir;
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}

--- a/packages/cli/src/zed-integration/zed-session-config.ts
+++ b/packages/cli/src/zed-integration/zed-session-config.ts
@@ -22,16 +22,23 @@ import type { FileSystemService } from '@vybestack/llxprt-code-storage';
 
 /**
  * Resolves the effective target directory for a session from an optional
- * client-supplied cwd: an empty/whitespace cwd falls back to the config target
- * dir; an absolute or config-relative cwd is accepted only when it resolves
- * WITHIN the config target dir (otherwise the target dir is used), so a session
- * can never escape the project root.
+ * client-supplied cwd: a missing/non-string/empty cwd falls back to the config
+ * target dir; an absolute or config-relative cwd is accepted only when it
+ * resolves WITHIN the config target dir (otherwise the target dir is used), so
+ * a session can never escape the project root via lexical traversal (`..`
+ * segments are resolved before the containment check).
+ *
+ * Trust model: the cwd comes from the ACP client (the user's own editor over
+ * stdio), which shares the local user's privileges — this guard protects
+ * against accidental misconfiguration, not a hostile client. Symlinks inside
+ * the project are deliberately NOT realpath-resolved here; a client that can
+ * plant symlinks already has direct filesystem access.
  */
 export function resolveSessionTargetDir(
   config: Config,
   cwd: string | undefined,
 ): string {
-  if (cwd === undefined || cwd.trim().length === 0) {
+  if (typeof cwd !== 'string' || cwd.trim().length === 0) {
     return config.getTargetDir();
   }
   const candidate = path.isAbsolute(cwd)

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -140,18 +140,60 @@ describe('classifyResumeFailure (issue #1604 FINDING B: corrupt vs missing)', ()
     expect(error.message).toContain(CORRUPT_ID);
   });
 
-  it('falls back to the plain not-found mapping when the probe itself REJECTS (never masks the original error)', async () => {
+  it('falls back to the plain resourceNotFound mapping when the probe rejects with ENOENT (chats dir absent → genuinely missing, FINDING B2)', async () => {
     const error = await classifyResumeFailure(
       CORRUPT_ID,
       resumeError(`Session not found for this project: ${CORRUPT_ID}`),
       async () => {
-        throw new Error('EACCES: permission denied, scandir chats');
+        const enoent = new Error(
+          'ENOENT: no such file or directory, scandir chats',
+        ) as NodeJS.ErrnoException;
+        enoent.code = 'ENOENT';
+        throw enoent;
       },
     );
-    // A directory-read failure must not become the surfaced error: the original
-    // not-found classification stands.
+    // An absent chats dir means the session genuinely does not exist on disk:
+    // the original not-found classification stands.
     expect(error.code).toBe(-32002);
     expect(error.message).toContain(CORRUPT_ID);
+  });
+
+  it('maps a NON-ENOENT probe rejection (EACCES) to internalError carrying the probe failure, NOT a misleading resourceNotFound (FINDING B2)', async () => {
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      resumeError(`Session not found for this project: ${CORRUPT_ID}`),
+      async () => {
+        const eacces = new Error(
+          'EACCES: permission denied, scandir chats',
+        ) as NodeJS.ErrnoException;
+        eacces.code = 'EACCES';
+        throw eacces;
+      },
+    );
+    // Existence is indeterminate (we could not read the dir), so reporting "not
+    // found" would be misleading: surface an internalError whose detail names
+    // the probe failure so the client sees the real, actionable reason.
+    expect(error).toBeInstanceOf(RequestError);
+    expect(error.code).toBe(-32603);
+    expect(error.message).toContain('EACCES');
+    expect(error.message.toLowerCase()).toContain('probe failed');
+    expect(error.data).toMatchObject({ sessionId: CORRUPT_ID });
+    expect((error.data as { probeError: string }).probeError).toContain(
+      'EACCES',
+    );
+  });
+
+  it('maps a NON-ENOENT probe rejection with NO errno code to internalError (indeterminate existence, FINDING B2)', async () => {
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      resumeError('No sessions found for this project'),
+      async () => {
+        throw new Error('disk exploded');
+      },
+    );
+    // A generic (no-code) probe error is also indeterminate → internalError.
+    expect(error.code).toBe(-32603);
+    expect(error.message).toContain('disk exploded');
   });
 
   it('does NOT probe (and returns internalError) for a non-not-found reason even if a file would match', async () => {

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -12,8 +12,11 @@
  * `Failed to resume session: <detail>` envelope that SessionControl.resume adds —
  * and assert the resulting JSON-RPC error code + carried detail. This guards the
  * not-found vs everything-else classification against the real core vocabulary,
- * so a wording drift on either side is caught. No mocks: pure inputs -> real
- * RequestError.
+ * so a wording drift on either side is caught. No result-shaped mocks of the
+ * code under test: the classifier runs for real over pure inputs (the injected
+ * directory listers are honest fakes returning entry names / throwing errno
+ * errors, not stand-ins for the matching logic) and produces real RequestError
+ * instances.
  */
 
 import { describe, expect, it } from 'vitest';

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -292,19 +292,28 @@ describe('findMatchingSessionFile (issue #1604: shared session-file matcher)', (
     ).toBeNull();
   });
 
-  it('does NOT match a file for a DIFFERENT id whose first 12 chars merely overlap a longer id (suffix must be the full -<first12>.jsonl token)', () => {
-    // A file recorded for the 12-char id 'abcdef123456' ends with
-    // '-abcdef123456.jsonl'. Searching for the LONGER id 'abcdef123456X7890'
-    // uses suffix '-abcdef123456.jsonl' built from ITS first 12 chars — which
-    // happens to be identical. This documents the matcher's granularity: file
-    // names embed only the first 12 id characters (see sessionFileSuffix), so
-    // ids sharing that full 12-char prefix are indistinguishable by design
-    // (session ids are UUIDs, making such a collision impractical). What the
-    // matcher MUST still guarantee: an id whose first 12 chars DIFFER never
-    // matches, even when one is a prefix of the other.
-    const shortId = 'abcdef12345'; // 11 chars — first 12 differ from ID above
-    expect(findMatchingSessionFile(shortId, [matchingFileName(ID)])).toBeNull();
-    // And the exact-prefix file IS found for the id that owns it.
+  it('documents the 12-char-prefix granularity: ids sharing the SAME first 12 chars are indistinguishable, ids differing within them never match', () => {
+    // File names embed only the FIRST 12 id characters (see sessionFileSuffix:
+    // `session-<ts>-<first12>.jsonl`), so the matcher inherits the recording
+    // service's naming granularity by design. Session ids are UUIDs, making a
+    // full 12-char prefix collision impractical — but the behavior is pinned
+    // here so a future naming change is a conscious decision.
+    //
+    // 1. GENUINE first-12 collision: a DIFFERENT id sharing ID's exact first 12
+    //    chars ('corrupt-abcd') DOES match ID's file — the documented limit.
+    const collidingId = `${ID.substring(0, 12)}-completely-different-tail`;
+    expect(collidingId).not.toBe(ID);
+    expect(findMatchingSessionFile(collidingId, [matchingFileName(ID)])).toBe(
+      matchingFileName(ID),
+    );
+    // 2. Ids that DIFFER within the first 12 chars never match, even when one
+    //    is a leading substring of the other (suffix is the full 12-char token,
+    //    not a prefix comparison).
+    const shorterId = ID.substring(0, 11); // only 11 chars → shorter suffix token
+    expect(
+      findMatchingSessionFile(shorterId, [matchingFileName(ID)]),
+    ).toBeNull();
+    // 3. And the file IS found for the id that owns it.
     expect(findMatchingSessionFile(ID, [matchingFileName(ID)])).toBe(
       matchingFileName(ID),
     );

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -199,6 +199,15 @@ describe('classifyResumeFailure (issue #1604 FINDING B: corrupt vs missing)', ()
     expect(error.message).toContain('disk exploded');
   });
 
+  it('maps a non-array probe result to internalError instead of leaking a TypeError', async () => {
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      resumeError('No sessions found for this project'),
+      async () => undefined as unknown as readonly string[],
+    );
+    expect(error.code).toBe(-32603);
+    expect(error.message).toContain('non-array');
+  });
   it('does NOT probe (and returns internalError) for a non-not-found reason even if a file would match', async () => {
     let probed = false;
     const error = await classifyResumeFailure(

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -18,7 +18,11 @@
 
 import { describe, expect, it } from 'vitest';
 import { RequestError } from '@agentclientprotocol/sdk';
-import { mapResumeError } from './zed-session-errors.js';
+import {
+  classifyResumeFailure,
+  mapResumeError,
+  wrapReplayFailure,
+} from './zed-session-errors.js';
 
 const SESSION_ID = 'sess-xyz';
 
@@ -70,5 +74,118 @@ describe('mapResumeError (issue #1604 FINDING 4)', () => {
     expect((error.data as { reason: string }).reason).toBe(
       'raw string failure',
     );
+  });
+
+  it('passes an already-constructed RequestError through UNCHANGED (no double-wrap, FINDING E guard)', () => {
+    const original = RequestError.resourceNotFound(SESSION_ID);
+    const mapped = mapResumeError(SESSION_ID, original);
+    // Same instance, not re-wrapped into a generic internalError.
+    expect(mapped).toBe(original);
+    expect(mapped.code).toBe(-32002);
+  });
+});
+
+// A recorded session file for `sessionId` is named
+// `session-<timestamp>-<first-12-of-id>.jsonl` (SessionRecordingService), so a
+// matching entry both starts with `session-` and ends with `-<first12>.jsonl`.
+function matchingFileName(sessionId: string): string {
+  return `session-2026-07-11T10-00-00-${sessionId.substring(0, 12)}.jsonl`;
+}
+
+describe('classifyResumeFailure (issue #1604 FINDING B: corrupt vs missing)', () => {
+  const CORRUPT_ID = 'corrupt-abcdef123456';
+
+  it('reports internalError (with the filename) when a not-found resume has a MATCHING session file on disk (corrupt-but-present)', async () => {
+    const fileName = matchingFileName(CORRUPT_ID);
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      resumeError(`Session not found for this project: ${CORRUPT_ID}`),
+      async () => [fileName, 'session-unrelated-000000000000.jsonl'],
+    );
+    expect(error).toBeInstanceOf(RequestError);
+    // Present-but-unreadable is NOT missing: surface as internal error so the
+    // client knows the session exists but could not be loaded.
+    expect(error.code).toBe(-32603);
+    expect(error.message).toContain('could not be read/replayed');
+    expect(error.message).toContain(fileName);
+    expect(error.data).toMatchObject({ sessionId: CORRUPT_ID, file: fileName });
+  });
+
+  it('reports genuine resourceNotFound when NO session file matches the id', async () => {
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      resumeError('No sessions found for this project'),
+      async () => ['session-something-else-999999999999.jsonl'],
+    );
+    expect(error.code).toBe(-32002);
+    expect(error.message).toContain(CORRUPT_ID);
+  });
+
+  it('falls back to the plain not-found mapping when the probe itself REJECTS (never masks the original error)', async () => {
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      resumeError(`Session not found for this project: ${CORRUPT_ID}`),
+      async () => {
+        throw new Error('EACCES: permission denied, scandir chats');
+      },
+    );
+    // A directory-read failure must not become the surfaced error: the original
+    // not-found classification stands.
+    expect(error.code).toBe(-32002);
+    expect(error.message).toContain(CORRUPT_ID);
+  });
+
+  it('does NOT probe (and returns internalError) for a non-not-found reason even if a file would match', async () => {
+    let probed = false;
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      resumeError('Session is in use by another process'),
+      async () => {
+        probed = true;
+        return [matchingFileName(CORRUPT_ID)];
+      },
+    );
+    expect(probed).toBe(false);
+    expect(error.code).toBe(-32603);
+    expect(error.message).toContain('in use');
+  });
+
+  it('passes an already-constructed RequestError through unchanged without probing', async () => {
+    let probed = false;
+    const original = RequestError.resourceNotFound(CORRUPT_ID);
+    const error = await classifyResumeFailure(
+      CORRUPT_ID,
+      original,
+      async () => {
+        probed = true;
+        return [matchingFileName(CORRUPT_ID)];
+      },
+    );
+    expect(error).toBe(original);
+    expect(probed).toBe(false);
+  });
+});
+
+describe('wrapReplayFailure (issue #1604 FINDING A: strict replay delivery)', () => {
+  it('wraps a transport failure into internalError carrying the detail and a replay phase marker', () => {
+    const error = wrapReplayFailure(
+      SESSION_ID,
+      new Error('socket hang up mid-replay'),
+    );
+    expect(error).toBeInstanceOf(RequestError);
+    expect(error.code).toBe(-32603);
+    expect(error.message).toContain('socket hang up mid-replay');
+    expect(error.data).toMatchObject({
+      sessionId: SESSION_ID,
+      phase: 'replay',
+    });
+    expect((error.data as { reason: string }).reason).toContain(
+      'socket hang up mid-replay',
+    );
+  });
+
+  it('passes an already-constructed RequestError through unchanged (no double-wrap)', () => {
+    const original = RequestError.internalError({ x: 1 }, 'inner');
+    expect(wrapReplayFailure(SESSION_ID, original)).toBe(original);
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the resume-failure -> ACP RequestError mapping used by
+ * ACP session/load (issue #1604, FINDING 4). These feed the EXACT error strings
+ * the core resume flow produces (see packages/core/src/recording/resumeSession.ts,
+ * SessionDiscovery.ts, ReplayEngine.ts) — wrapped in the
+ * `Failed to resume session: <detail>` envelope that SessionControl.resume adds —
+ * and assert the resulting JSON-RPC error code + carried detail. This guards the
+ * not-found vs everything-else classification against the real core vocabulary,
+ * so a wording drift on either side is caught. No mocks: pure inputs -> real
+ * RequestError.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { RequestError } from '@agentclientprotocol/sdk';
+import { mapResumeError } from './zed-session-errors.js';
+
+const SESSION_ID = 'sess-xyz';
+
+/** Wraps a core resume detail in the envelope SessionControl.resume throws. */
+function resumeError(detail: string): Error {
+  return new Error(`Failed to resume session: ${detail}`);
+}
+
+describe('mapResumeError (issue #1604 FINDING 4)', () => {
+  it.each([
+    'No sessions found for this project',
+    `Session not found for this project: ${SESSION_ID}`,
+    'Session index 5 out of range (1-3)',
+  ])(
+    'maps the not-found core reason %j to resourceNotFound (-32002) carrying the session id',
+    (detail) => {
+      const error = mapResumeError(SESSION_ID, resumeError(detail));
+      expect(error).toBeInstanceOf(RequestError);
+      expect(error.code).toBe(-32002);
+      expect(error.message).toContain(SESSION_ID);
+    },
+  );
+
+  it.each([
+    'Session is in use by another process',
+    'All sessions for this project are in use',
+    'Failed to replay session: Missing or corrupt session_start event',
+    'Failed to replay session: Empty file',
+    'Failed to replay session: Project hash mismatch: expected a got b',
+    "Ambiguous session prefix 'ab' matches: abc, abd",
+  ])(
+    'maps the non-not-found core reason %j to internalError (-32603) carrying the underlying detail',
+    (detail) => {
+      const error = mapResumeError(SESSION_ID, resumeError(detail));
+      expect(error).toBeInstanceOf(RequestError);
+      expect(error.code).toBe(-32603);
+      // The underlying detail is surfaced in BOTH the message and structured
+      // data so the client can show why the load actually failed.
+      expect(error.message).toContain(detail);
+      expect(error.data).toMatchObject({ sessionId: SESSION_ID });
+      expect((error.data as { reason: string }).reason).toContain(detail);
+    },
+  );
+
+  it('handles a non-Error thrown value by stringifying it (still internalError with detail)', () => {
+    const error = mapResumeError(SESSION_ID, 'raw string failure');
+    expect(error.code).toBe(-32603);
+    expect(error.message).toContain('raw string failure');
+    expect((error.data as { reason: string }).reason).toBe(
+      'raw string failure',
+    );
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -291,4 +291,22 @@ describe('findMatchingSessionFile (issue #1604: shared session-file matcher)', (
       ]),
     ).toBeNull();
   });
+
+  it('does NOT match a file for a DIFFERENT id whose first 12 chars merely overlap a longer id (suffix must be the full -<first12>.jsonl token)', () => {
+    // A file recorded for the 12-char id 'abcdef123456' ends with
+    // '-abcdef123456.jsonl'. Searching for the LONGER id 'abcdef123456X7890'
+    // uses suffix '-abcdef123456.jsonl' built from ITS first 12 chars — which
+    // happens to be identical. This documents the matcher's granularity: file
+    // names embed only the first 12 id characters (see sessionFileSuffix), so
+    // ids sharing that full 12-char prefix are indistinguishable by design
+    // (session ids are UUIDs, making such a collision impractical). What the
+    // matcher MUST still guarantee: an id whose first 12 chars DIFFER never
+    // matches, even when one is a prefix of the other.
+    const shortId = 'abcdef12345'; // 11 chars — first 12 differ from ID above
+    expect(findMatchingSessionFile(shortId, [matchingFileName(ID)])).toBeNull();
+    // And the exact-prefix file IS found for the id that owns it.
+    expect(findMatchingSessionFile(ID, [matchingFileName(ID)])).toBe(
+      matchingFileName(ID),
+    );
+  });
 });

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from 'vitest';
 import { RequestError } from '@agentclientprotocol/sdk';
 import {
   classifyResumeFailure,
+  findMatchingSessionFile,
   mapResumeError,
   wrapReplayFailure,
 } from './zed-session-errors.js';
@@ -205,5 +206,47 @@ describe('wrapReplayFailure (issue #1604 FINDING A: strict replay delivery)', ()
   it('passes an already-constructed RequestError through unchanged (no double-wrap)', () => {
     const original = RequestError.internalError({ x: 1 }, 'inner');
     expect(wrapReplayFailure(SESSION_ID, original)).toBe(original);
+  });
+});
+
+describe('findMatchingSessionFile (issue #1604: shared session-file matcher)', () => {
+  const ID = 'corrupt-abcdef123456';
+
+  it('returns the matching entry naming this session (session-<ts>-<first12>.jsonl)', () => {
+    const match = matchingFileName(ID);
+    expect(
+      findMatchingSessionFile(ID, [
+        'session-unrelated-000000000000.jsonl',
+        match,
+      ]),
+    ).toBe(match);
+  });
+
+  it('returns null when NO entry matches the id (unprompted session / different id)', () => {
+    expect(
+      findMatchingSessionFile(ID, [
+        'session-something-else-999999999999.jsonl',
+        'not-a-session.txt',
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns null for an empty directory listing', () => {
+    expect(findMatchingSessionFile(ID, [])).toBeNull();
+  });
+
+  it('requires BOTH the session- prefix and the -<first12>.jsonl suffix (no partial match)', () => {
+    // Right suffix but wrong prefix word → no match.
+    expect(
+      findMatchingSessionFile(ID, [
+        `chat-2026-07-11-${ID.substring(0, 12)}.jsonl`,
+      ]),
+    ).toBeNull();
+    // Right prefix but wrong id suffix → no match.
+    expect(
+      findMatchingSessionFile(ID, [
+        'session-2026-07-11T10-00-00-000000000000.jsonl',
+      ]),
+    ).toBeNull();
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-errors.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.test.ts
@@ -67,6 +67,24 @@ describe('mapResumeError (issue #1604 FINDING 4)', () => {
     },
   );
 
+  it.each([
+    'Failed to replay session: session content not found in cache',
+    'Failed to replay session: value out of range while decoding event',
+    'Corrupt session: header not found in file',
+  ])(
+    'maps a corrupt/replay reason %j that merely CONTAINS "not found"/"out of range" to internalError (-32603), NOT resourceNotFound (FINDING F1)',
+    (detail) => {
+      const error = mapResumeError(SESSION_ID, resumeError(detail));
+      expect(error).toBeInstanceOf(RequestError);
+      // The substring "not found"/"out of range" appears, but the message is NOT
+      // one of the EXACT core not-found sentences, so it must surface as an
+      // internal error carrying the detail rather than a misleading "not found".
+      expect(error.code).toBe(-32603);
+      expect(error.message).toContain(detail);
+      expect((error.data as { reason: string }).reason).toContain(detail);
+    },
+  );
+
   it('handles a non-Error thrown value by stringifying it (still internalError with detail)', () => {
     const error = mapResumeError(SESSION_ID, 'raw string failure');
     expect(error.code).toBe(-32603);

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -235,6 +235,13 @@ function isEnoent(error: unknown): boolean {
  * so the loadSession re-attach probe (zed-session-loader.ts) decides "does an
  * on-disk recording exist for this id?" against the EXACT same naming rule the
  * corrupt-vs-missing resume probe uses, keeping the two in lockstep.
+ *
+ * Known limitation: because the file name embeds ONLY the first 12 characters
+ * of the id, two ids sharing that 12-char prefix are indistinguishable at the
+ * file-name level — the matcher inherits the recording service's naming
+ * granularity and cannot be stricter than it. Session ids are UUIDs, so a
+ * 12-hex-char prefix collision is not a practical concern; resolving it would
+ * require the recording service to embed the full id in the file name.
  */
 export function findMatchingSessionFile(
   sessionId: string,

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -34,7 +34,12 @@
  */
 
 import * as acp from '@agentclientprotocol/sdk';
-import { DebugLogger } from '@vybestack/llxprt-code-core';
+import {
+  DebugLogger,
+  RESUME_NO_SESSIONS_FOUND,
+  RESUME_SESSION_NOT_FOUND_PREFIX,
+  RESUME_SESSION_INDEX_OUT_OF_RANGE_RE,
+} from '@vybestack/llxprt-code-core';
 
 /** JSON-RPC code ACP assigns to resourceNotFound (-32002). */
 const RESOURCE_NOT_FOUND_CODE = acp.RequestError.resourceNotFound('').code;
@@ -59,20 +64,14 @@ export const SESSION_FILE_ID_PREFIX_LENGTH = 12;
  */
 const logger = new DebugLogger('llxprt:zed-integration:session-errors');
 
-/**
- * The EXACT not-found sentences the core resume flow emits, matched verbatim so
- * an unrelated message that merely CONTAINS the words "not found" (e.g. "Replay
- * failed: session content not found in cache") is NOT misclassified as a missing
- * session (FINDING F1). Sourced from:
- *  - resumeSession.ts: `No sessions found for this project`
- *  - SessionDiscovery.resolveSessionRef: `Session not found for this project: <ref>`
- *  - SessionDiscovery.resolveSessionRef: `Session index <n> out of range (1-<m>)`
- * Each is carried inside the `Failed to resume session: <detail>` envelope that
- * SessionControl.resume adds, so a substring match against that envelope is used.
- */
-const NO_SESSIONS_FOUND = 'No sessions found for this project';
-const SESSION_NOT_FOUND_PREFIX = 'Session not found for this project:';
-const SESSION_INDEX_OUT_OF_RANGE = /Session index \d+ out of range/;
+// The EXACT not-found sentences the core resume flow emits, matched verbatim so
+// an unrelated message that merely CONTAINS the words "not found" (e.g. "Replay
+// failed: session content not found in cache") is NOT misclassified as a missing
+// session (FINDING F1). Imported from core's resumeNotFoundMessages.ts — the
+// same constants the emitting sites (resumeSession.ts / SessionDiscovery.ts)
+// use — so a core rewording can never silently desynchronize this classifier.
+// Each sentence is carried inside the `Failed to resume session: <detail>`
+// envelope SessionControl.resume adds, so substring matching is used.
 
 /**
  * Maps a resume rejection to the closest ACP {@link acp.RequestError}. A
@@ -314,8 +313,8 @@ function errorMessage(error: unknown): string {
  */
 function isNotFoundResumeReason(detail: string): boolean {
   return (
-    detail.includes(NO_SESSIONS_FOUND) ||
-    detail.includes(SESSION_NOT_FOUND_PREFIX) ||
-    SESSION_INDEX_OUT_OF_RANGE.test(detail)
+    detail.includes(RESUME_NO_SESSIONS_FOUND) ||
+    detail.includes(RESUME_SESSION_NOT_FOUND_PREFIX) ||
+    RESUME_SESSION_INDEX_OUT_OF_RANGE_RE.test(detail)
   );
 }

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -40,6 +40,18 @@ import { DebugLogger } from '@vybestack/llxprt-code-core';
 const RESOURCE_NOT_FOUND_CODE = acp.RequestError.resourceNotFound('').code;
 
 /**
+ * Length of the session-id prefix embedded in a recorded session filename
+ * (FINDING B1). SessionRecordingService.materialize (packages/core) names files
+ * `session-<timestamp>-<first-N-of-id>.jsonl` using `sessionId.substring(0, 12)`
+ * — that call is the SOURCE OF TRUTH for this contract. Core does not export the
+ * constant, so it is duplicated here (the single place the zed layer reconstructs
+ * the filename) rather than left as a bare magic `12`; if core ever changes the
+ * prefix length, update it here to keep the corrupt-vs-missing + re-attach probes
+ * matching real recorded filenames.
+ */
+export const SESSION_FILE_ID_PREFIX_LENGTH = 12;
+
+/**
  * Module logger (mirroring the zedIntegration.ts / sessionControl.ts precedent
  * of a namespaced core DebugLogger) used to surface the otherwise-silent
  * corrupt-vs-missing probe failure (FINDING F6) so a swallowed readdir error is
@@ -119,45 +131,100 @@ export async function classifyResumeFailure(
   if (mapped.code !== RESOURCE_NOT_FOUND_CODE) {
     return mapped;
   }
-  const matchingFile = await probeMatchingSessionFile(sessionId, probe);
-  if (matchingFile === null) {
-    return mapped;
+  const outcome = await probeMatchingSessionFile(sessionId, probe);
+  if (outcome.kind === 'match') {
+    const detail = `session file exists but could not be read/replayed (corrupt or incompatible): ${outcome.file}`;
+    return acp.RequestError.internalError(
+      { sessionId, reason: detail, file: outcome.file },
+      detail,
+    );
   }
-  const detail = `session file exists but could not be read/replayed (corrupt or incompatible): ${matchingFile}`;
-  return acp.RequestError.internalError(
-    { sessionId, reason: detail, file: matchingFile },
-    detail,
-  );
+  if (outcome.kind === 'probe-error') {
+    // FINDING B2: a NON-ENOENT probe failure (EACCES, disk error, ...) means we
+    // genuinely could not determine whether the session exists on disk, so
+    // reporting resourceNotFound would be MISLEADING (the session may well
+    // exist). Surface an internalError carrying the probe failure as cause
+    // detail so the client sees the real, actionable reason instead of a
+    // spurious "not found". ENOENT (chats dir absent) is NOT a probe-error — it
+    // means genuinely missing and keeps the resourceNotFound path below.
+    const detail = `could not determine whether the session exists on disk (session-file probe failed): ${outcome.message}`;
+    return acp.RequestError.internalError(
+      { sessionId, reason: detail, probeError: outcome.message },
+      detail,
+    );
+  }
+  // outcome.kind === 'no-match' (including ENOENT chats dir): genuinely missing.
+  return mapped;
 }
 
 /**
- * Returns the first chats-dir entry that matches this session's recorded
- * filename, or null when none match or the probe fails. A probe rejection is
- * swallowed (returns null) so the caller falls back to the plain mapping and the
- * original resume failure is never masked by a directory-read error.
+ * The three distinguishable outcomes of the corrupt-vs-missing session-file
+ * probe (FINDING B2): a matching file was found (corrupt-but-present), no file
+ * matched (genuinely missing — includes an ENOENT chats dir), or the probe
+ * itself failed for a NON-ENOENT reason (EACCES/disk error) so existence is
+ * indeterminate and must surface as an internalError rather than a misleading
+ * resourceNotFound.
+ */
+type ProbeOutcome =
+  | { readonly kind: 'match'; readonly file: string }
+  | { readonly kind: 'no-match' }
+  | { readonly kind: 'probe-error'; readonly message: string };
+
+/**
+ * Probes the on-disk chats-dir namespace for a recorded file matching
+ * `sessionId`, returning a {@link ProbeOutcome}. A successful listing yields
+ * `match` (with the filename) or `no-match`. A probe rejection is classified by
+ * errno: an ENOENT (the chats dir does not exist yet) is treated as `no-match`
+ * (genuinely missing, keep the resourceNotFound path); any other rejection
+ * (EACCES, EIO, ...) yields `probe-error` (existence indeterminate → the caller
+ * surfaces internalError, FINDING B2) and is logged at debug (FINDING F6) so the
+ * underlying directory-read error stays diagnosable.
  */
 async function probeMatchingSessionFile(
   sessionId: string,
   probe: () => Promise<readonly string[]>,
-): Promise<string | null> {
+): Promise<ProbeOutcome> {
   let entries: readonly string[];
   try {
     entries = await probe();
   } catch (error) {
-    // A probe (readdir) failure must NOT mask the original resume failure, so
-    // the caller falls back to the plain not-found mapping. Log at debug level
-    // (FINDING F6) so the swallowed directory-read error stays diagnosable
-    // instead of vanishing silently.
+    const message = error instanceof Error ? error.message : String(error);
+    if (isEnoent(error)) {
+      // The chats dir does not exist yet: the session is genuinely missing, not
+      // a probe failure. Keep the plain not-found mapping.
+      logger.debug(
+        () =>
+          `probeMatchingSessionFile: chats dir absent (ENOENT) for ${sessionId}; ` +
+          `treating as genuinely missing: ${message}`,
+      );
+      return { kind: 'no-match' };
+    }
+    // A NON-ENOENT probe failure (EACCES/disk error) means existence is
+    // indeterminate; the caller surfaces internalError instead of a misleading
+    // resourceNotFound (FINDING B2). Log at debug (FINDING F6) so it stays
+    // diagnosable.
     logger.debug(
       () =>
         `probeMatchingSessionFile: session-file probe failed for ${sessionId}; ` +
-        `falling back to plain mapping: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `reporting indeterminate existence: ${message}`,
     );
-    return null;
+    return { kind: 'probe-error', message };
   }
-  return findMatchingSessionFile(sessionId, entries);
+  const file = findMatchingSessionFile(sessionId, entries);
+  return file === null ? { kind: 'no-match' } : { kind: 'match', file };
+}
+
+/**
+ * True when `error` is a Node ENOENT (no-such-file/directory) rejection — used
+ * to distinguish a genuinely-absent chats dir (missing session) from a real
+ * probe failure such as EACCES (FINDING B2).
+ */
+function isEnoent(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
 }
 
 /**
@@ -188,7 +255,7 @@ export function findMatchingSessionFile(
  * with `session-` and ends with this suffix.
  */
 function sessionFileSuffix(sessionId: string): string {
-  return `-${sessionId.substring(0, 12)}.jsonl`;
+  return `-${sessionId.substring(0, SESSION_FILE_ID_PREFIX_LENGTH)}.jsonl`;
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -39,22 +39,11 @@ import {
   RESUME_NO_SESSIONS_FOUND,
   RESUME_SESSION_NOT_FOUND_PREFIX,
   RESUME_SESSION_INDEX_OUT_OF_RANGE_RE,
+  SESSION_FILE_ID_PREFIX_LENGTH,
 } from '@vybestack/llxprt-code-core';
 
 /** JSON-RPC code ACP assigns to resourceNotFound (-32002). */
 const RESOURCE_NOT_FOUND_CODE = acp.RequestError.resourceNotFound('').code;
-
-/**
- * Length of the session-id prefix embedded in a recorded session filename
- * (FINDING B1). SessionRecordingService.materialize (packages/core) names files
- * `session-<timestamp>-<first-N-of-id>.jsonl` using `sessionId.substring(0, 12)`
- * — that call is the SOURCE OF TRUTH for this contract. Core does not export the
- * constant, so it is duplicated here (the single place the zed layer reconstructs
- * the filename) rather than left as a bare magic `12`; if core ever changes the
- * prefix length, update it here to keep the corrupt-vs-missing + re-attach probes
- * matching real recorded filenames.
- */
-export const SESSION_FILE_ID_PREFIX_LENGTH = 12;
 
 /**
  * Module logger (mirroring the zedIntegration.ts / sessionControl.ts precedent

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -176,7 +176,7 @@ async function probeMatchingSessionFile(
   try {
     entries = await probe();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     if (isEnoent(error)) {
       // The chats dir does not exist yet: the session is genuinely missing, not
       // a probe failure. Keep the plain not-found mapping.

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -34,9 +34,33 @@
  */
 
 import * as acp from '@agentclientprotocol/sdk';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 
 /** JSON-RPC code ACP assigns to resourceNotFound (-32002). */
 const RESOURCE_NOT_FOUND_CODE = acp.RequestError.resourceNotFound('').code;
+
+/**
+ * Module logger (mirroring the zedIntegration.ts / sessionControl.ts precedent
+ * of a namespaced core DebugLogger) used to surface the otherwise-silent
+ * corrupt-vs-missing probe failure (FINDING F6) so a swallowed readdir error is
+ * diagnosable. Debug-level only: it never changes the fallback behavior.
+ */
+const logger = new DebugLogger('llxprt:zed-integration:session-errors');
+
+/**
+ * The EXACT not-found sentences the core resume flow emits, matched verbatim so
+ * an unrelated message that merely CONTAINS the words "not found" (e.g. "Replay
+ * failed: session content not found in cache") is NOT misclassified as a missing
+ * session (FINDING F1). Sourced from:
+ *  - resumeSession.ts: `No sessions found for this project`
+ *  - SessionDiscovery.resolveSessionRef: `Session not found for this project: <ref>`
+ *  - SessionDiscovery.resolveSessionRef: `Session index <n> out of range (1-<m>)`
+ * Each is carried inside the `Failed to resume session: <detail>` envelope that
+ * SessionControl.resume adds, so a substring match against that envelope is used.
+ */
+const NO_SESSIONS_FOUND = 'No sessions found for this project';
+const SESSION_NOT_FOUND_PREFIX = 'Session not found for this project:';
+const SESSION_INDEX_OUT_OF_RANGE = /Session index \d+ out of range/;
 
 /**
  * Maps a resume rejection to the closest ACP {@link acp.RequestError}. A
@@ -119,7 +143,18 @@ async function probeMatchingSessionFile(
   let entries: readonly string[];
   try {
     entries = await probe();
-  } catch {
+  } catch (error) {
+    // A probe (readdir) failure must NOT mask the original resume failure, so
+    // the caller falls back to the plain not-found mapping. Log at debug level
+    // (FINDING F6) so the swallowed directory-read error stays diagnosable
+    // instead of vanishing silently.
+    logger.debug(
+      () =>
+        `probeMatchingSessionFile: session-file probe failed for ${sessionId}; ` +
+        `falling back to plain mapping: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    );
     return null;
   }
   const suffix = sessionFileSuffix(sessionId);
@@ -173,17 +208,22 @@ function errorMessage(error: unknown): string {
 
 /**
  * True when the resume detail indicates the session could not be found (as
- * opposed to being locked, corrupt, or otherwise unreadable). Matches the core
- * not-found strings case-insensitively: "No sessions found for this project",
- * "Session not found for this project: <ref>", and an out-of-range index
- * reference. Lock/corrupt/replay reasons deliberately fall through to
- * internalError.
+ * opposed to being locked, corrupt, or otherwise unreadable). Matches ONLY the
+ * EXACT core not-found vocabulary (FINDING F1) — the three sentences the core
+ * discovery/resume layer emits — rather than any message that merely contains
+ * the substring "not found" or "out of range":
+ *   - "No sessions found for this project"        (resumeSession.ts)
+ *   - "Session not found for this project: <ref>" (SessionDiscovery)
+ *   - "Session index <n> out of range (1-<m>)"    (SessionDiscovery)
+ * A corrupt/replay message such as "Failed to replay session: ... content not
+ * found in cache" therefore falls through to internalError instead of being
+ * misreported as a missing session. Lock/corrupt/replay/hash reasons all fall
+ * through to internalError.
  */
 function isNotFoundResumeReason(detail: string): boolean {
-  const normalized = detail.toLowerCase();
   return (
-    normalized.includes('not found') ||
-    normalized.includes('no sessions found') ||
-    normalized.includes('out of range')
+    detail.includes(NO_SESSIONS_FOUND) ||
+    detail.includes(SESSION_NOT_FOUND_PREFIX) ||
+    SESSION_INDEX_OUT_OF_RANGE.test(detail)
   );
 }

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -217,9 +217,11 @@ async function probeMatchingSessionFile(
 /**
  * True when `error` is a Node ENOENT (no-such-file/directory) rejection — used
  * to distinguish a genuinely-absent chats dir (missing session) from a real
- * probe failure such as EACCES (FINDING B2).
+ * probe failure such as EACCES (FINDING B2). Exported so the loadSession
+ * re-attach probe (zed-session-loader.ts) classifies its probe failures with
+ * the exact same rule instead of keeping a duplicate.
  */
-function isEnoent(error: unknown): boolean {
+export function isEnoent(error: unknown): boolean {
   return (
     typeof error === 'object' &&
     error !== null &&

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -42,8 +42,8 @@ import {
   SESSION_FILE_ID_PREFIX_LENGTH,
 } from '@vybestack/llxprt-code-core';
 
-/** JSON-RPC code ACP assigns to resourceNotFound (-32002). */
-const RESOURCE_NOT_FOUND_CODE = acp.RequestError.resourceNotFound('').code;
+/** JSON-RPC code ACP assigns to resourceNotFound. */
+const RESOURCE_NOT_FOUND_CODE = -32002;
 
 /**
  * Module logger (mirroring the zedIntegration.ts / sessionControl.ts precedent

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -157,6 +157,22 @@ async function probeMatchingSessionFile(
     );
     return null;
   }
+  return findMatchingSessionFile(sessionId, entries);
+}
+
+/**
+ * Pure matcher: returns the first entry naming a recorded session file for
+ * `sessionId`, or null when none match. SessionRecordingService.materialize
+ * names files `session-<timestamp>-<first-12-of-id>.jsonl`, so a matching file
+ * both starts with `session-` and ends with `-<first-12-of-id>.jsonl`. Exported
+ * so the loadSession re-attach probe (zed-session-loader.ts) decides "does an
+ * on-disk recording exist for this id?" against the EXACT same naming rule the
+ * corrupt-vs-missing resume probe uses, keeping the two in lockstep.
+ */
+export function findMatchingSessionFile(
+  sessionId: string,
+  entries: readonly string[],
+): string | null {
   const suffix = sessionFileSuffix(sessionId);
   return (
     entries.find(

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -97,11 +97,11 @@ export function mapResumeError(
  * (`session-<timestamp>-<first-12-of-id>.jsonl`), the session exists but could
  * not be read/replayed (corrupt or incompatible) and an internalError carrying
  * the filename is returned instead of the misleading resourceNotFound. When no
- * entry matches, the genuine resourceNotFound is returned. When `probe` itself
- * rejects (e.g. a readdir error), the plain mapping is returned unchanged so the
- * original resume failure is never masked. Non-not-found mappings (and
- * already-constructed RequestErrors, via the {@link mapResumeError} passthrough)
- * are returned without probing.
+ * entry matches (including an absent chats directory), the genuine
+ * resourceNotFound is returned. A non-ENOENT probe failure makes existence
+ * indeterminate and therefore becomes internalError with the probe detail.
+ * Non-not-found mappings and already-constructed RequestErrors are returned
+ * without probing.
  */
 export async function classifyResumeFailure(
   sessionId: string,

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -175,9 +175,6 @@ async function probeMatchingSessionFile(
   let entries: readonly string[];
   try {
     entries = await probe();
-    if (!Array.isArray(entries)) {
-      throw new TypeError('session-file probe returned a non-array result');
-    }
   } catch (error) {
     const message = errorMessage(error);
     if (isEnoent(error)) {
@@ -200,6 +197,12 @@ async function probeMatchingSessionFile(
         `reporting indeterminate existence: ${message}`,
     );
     return { kind: 'probe-error', message };
+  }
+  if (!Array.isArray(entries)) {
+    return {
+      kind: 'probe-error',
+      message: 'session-file probe returned a non-array result',
+    };
   }
   const file = findMatchingSessionFile(sessionId, entries);
   return file === null ? { kind: 'no-match' } : { kind: 'match', file };

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -175,6 +175,9 @@ async function probeMatchingSessionFile(
   let entries: readonly string[];
   try {
     entries = await probe();
+    if (!Array.isArray(entries)) {
+      throw new TypeError('session-file probe returned a non-array result');
+    }
   } catch (error) {
     const message = errorMessage(error);
     if (isEnoent(error)) {

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resume-failure -> ACP RequestError mapping for ACP session/load (loadSession)
+ * (issue #1604).
+ *
+ * `agent.session.resume` (SessionControl.resume) rejects with a single
+ * `Error('Failed to resume session: <detail>')` whose <detail> is the core
+ * resume flow's distinguishable reason (see resumeSession.ts / SessionDiscovery
+ * / ReplayEngine): a missing session ("No sessions found for this project",
+ * "Session not found for this project: <ref>", "... out of range ...") versus an
+ * in-use lock, a project-hash mismatch, an empty/corrupt file, or a replay
+ * error. Collapsing every one of these into resourceNotFound (as the first cut
+ * did) misleads the client into thinking the session does not exist when it may
+ * simply be locked or corrupt. This pure mapper distinguishes the not-found
+ * family (-> resourceNotFound(sessionId)) from everything else (-> internalError
+ * carrying the underlying detail in both the message and structured data) so the
+ * Zed client receives an actionable error.
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+
+/**
+ * Maps a resume rejection to the closest ACP {@link acp.RequestError}. A
+ * not-found-style reason yields {@link acp.RequestError.resourceNotFound}
+ * (JSON-RPC -32002) carrying the session id; every other reason (locked,
+ * corrupt, replay/hash failure, or an unrecognized message) yields
+ * {@link acp.RequestError.internalError} (JSON-RPC -32603) carrying the
+ * underlying detail as both the appended message and structured `data`, so the
+ * client can surface why the load actually failed.
+ */
+export function mapResumeError(
+  sessionId: string,
+  error: unknown,
+): acp.RequestError {
+  const detail = errorMessage(error);
+  if (isNotFoundResumeReason(detail)) {
+    return acp.RequestError.resourceNotFound(sessionId);
+  }
+  return acp.RequestError.internalError({ sessionId, reason: detail }, detail);
+}
+
+/**
+ * Extracts a human-readable message from an unknown thrown value (Error.message
+ * when available, else its String() form) so the mapper can classify it.
+ */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * True when the resume detail indicates the session could not be found (as
+ * opposed to being locked, corrupt, or otherwise unreadable). Matches the core
+ * not-found strings case-insensitively: "No sessions found for this project",
+ * "Session not found for this project: <ref>", and an out-of-range index
+ * reference. Lock/corrupt/replay reasons deliberately fall through to
+ * internalError.
+ */
+function isNotFoundResumeReason(detail: string): boolean {
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes('not found') ||
+    normalized.includes('no sessions found') ||
+    normalized.includes('out of range')
+  );
+}

--- a/packages/cli/src/zed-integration/zed-session-errors.ts
+++ b/packages/cli/src/zed-integration/zed-session-errors.ts
@@ -20,9 +20,23 @@
  * family (-> resourceNotFound(sessionId)) from everything else (-> internalError
  * carrying the underlying detail in both the message and structured data) so the
  * Zed client receives an actionable error.
+ *
+ * Corrupt-vs-missing disambiguation (FINDING B): the core discovery layer
+ * silently SKIPS a session file whose header/first line is unreadable, so a
+ * corrupt-but-present session surfaces the SAME "not found" reason as a session
+ * that genuinely does not exist. `classifyResumeFailure` closes that gap in the
+ * zed layer WITHOUT touching core discovery: when the plain mapping would be
+ * resourceNotFound, it probes the on-disk session-file namespace (a readdir of
+ * the chats dir, injected for testability) and — if a file matching this
+ * session's `session-*-<first-12-of-id>.jsonl` name EXISTS — reports
+ * internalError ("session file exists but could not be read/replayed") instead,
+ * so a corrupt session is never misreported as missing.
  */
 
 import * as acp from '@agentclientprotocol/sdk';
+
+/** JSON-RPC code ACP assigns to resourceNotFound (-32002). */
+const RESOURCE_NOT_FOUND_CODE = acp.RequestError.resourceNotFound('').code;
 
 /**
  * Maps a resume rejection to the closest ACP {@link acp.RequestError}. A
@@ -32,16 +46,121 @@ import * as acp from '@agentclientprotocol/sdk';
  * {@link acp.RequestError.internalError} (JSON-RPC -32603) carrying the
  * underlying detail as both the appended message and structured `data`, so the
  * client can surface why the load actually failed.
+ *
+ * Passthrough guard: an `error` that is ALREADY an {@link acp.RequestError}
+ * (e.g. a precise error thrown by a lower layer) is returned unchanged so it is
+ * never double-wrapped into a generic internalError.
  */
 export function mapResumeError(
   sessionId: string,
   error: unknown,
 ): acp.RequestError {
+  if (error instanceof acp.RequestError) {
+    return error;
+  }
   const detail = errorMessage(error);
   if (isNotFoundResumeReason(detail)) {
     return acp.RequestError.resourceNotFound(sessionId);
   }
   return acp.RequestError.internalError({ sessionId, reason: detail }, detail);
+}
+
+/**
+ * Like {@link mapResumeError}, but disambiguates a not-found classification
+ * against the on-disk session-file namespace (FINDING B). When the plain mapping
+ * is resourceNotFound, `probe` is invoked to list the chats-dir entries; if any
+ * entry matches this session's recorded filename
+ * (`session-<timestamp>-<first-12-of-id>.jsonl`), the session exists but could
+ * not be read/replayed (corrupt or incompatible) and an internalError carrying
+ * the filename is returned instead of the misleading resourceNotFound. When no
+ * entry matches, the genuine resourceNotFound is returned. When `probe` itself
+ * rejects (e.g. a readdir error), the plain mapping is returned unchanged so the
+ * original resume failure is never masked. Non-not-found mappings (and
+ * already-constructed RequestErrors, via the {@link mapResumeError} passthrough)
+ * are returned without probing.
+ */
+export async function classifyResumeFailure(
+  sessionId: string,
+  error: unknown,
+  probe: () => Promise<readonly string[]>,
+): Promise<acp.RequestError> {
+  // An already-constructed RequestError from a lower layer is authoritative:
+  // pass it through unchanged WITHOUT probing/re-wrapping (FINDING E guard), even
+  // when it is a resourceNotFound — re-classifying it would double-wrap a precise
+  // error and could spuriously flip it based on unrelated on-disk files.
+  if (error instanceof acp.RequestError) {
+    return error;
+  }
+  const mapped = mapResumeError(sessionId, error);
+  if (mapped.code !== RESOURCE_NOT_FOUND_CODE) {
+    return mapped;
+  }
+  const matchingFile = await probeMatchingSessionFile(sessionId, probe);
+  if (matchingFile === null) {
+    return mapped;
+  }
+  const detail = `session file exists but could not be read/replayed (corrupt or incompatible): ${matchingFile}`;
+  return acp.RequestError.internalError(
+    { sessionId, reason: detail, file: matchingFile },
+    detail,
+  );
+}
+
+/**
+ * Returns the first chats-dir entry that matches this session's recorded
+ * filename, or null when none match or the probe fails. A probe rejection is
+ * swallowed (returns null) so the caller falls back to the plain mapping and the
+ * original resume failure is never masked by a directory-read error.
+ */
+async function probeMatchingSessionFile(
+  sessionId: string,
+  probe: () => Promise<readonly string[]>,
+): Promise<string | null> {
+  let entries: readonly string[];
+  try {
+    entries = await probe();
+  } catch {
+    return null;
+  }
+  const suffix = sessionFileSuffix(sessionId);
+  return (
+    entries.find(
+      (name) => name.startsWith('session-') && name.endsWith(suffix),
+    ) ?? null
+  );
+}
+
+/**
+ * The trailing `-<first-12-of-id>.jsonl` a recorded session file for `sessionId`
+ * ends with. SessionRecordingService.materialize names files
+ * `session-<timestamp>-<first-12-of-id>.jsonl`, so a matching file both starts
+ * with `session-` and ends with this suffix.
+ */
+function sessionFileSuffix(sessionId: string): string {
+  return `-${sessionId.substring(0, 12)}.jsonl`;
+}
+
+/**
+ * Wraps a history-REPLAY failure (a rejected `session/update` during
+ * streamHistory, FINDING A) into an ACP {@link acp.RequestError}. A dead/failing
+ * transport that loses the transcript must surface as an error rather than a
+ * silent success, so this yields {@link acp.RequestError.internalError} carrying
+ * the underlying detail (and a `phase: 'replay'` marker) in both the message and
+ * structured `data`. An `error` that is ALREADY a RequestError is returned
+ * unchanged (passthrough guard) so it is never double-wrapped.
+ */
+export function wrapReplayFailure(
+  sessionId: string,
+  error: unknown,
+): acp.RequestError {
+  if (error instanceof acp.RequestError) {
+    return error;
+  }
+  const detail = errorMessage(error);
+  return acp.RequestError.internalError(
+    { sessionId, reason: detail, phase: 'replay' },
+    `Failed to replay session history: ${detail}`,
+  );
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -71,7 +71,11 @@ export async function consumeAgentStream(
     return terminalStopReason;
   } finally {
     if (deps.terminals !== null) {
-      await deps.terminals.settleAll();
+      try {
+        await deps.terminals.settleAll();
+      } catch {
+        // Swallow cleanup errors so they don't mask the original error
+      }
     }
   }
 }
@@ -141,6 +145,7 @@ export async function runPromptTurn(
     (u) => deps.streamDeps.sendUpdate(u),
   );
   let terminalStopReason: acp.StopReason | null = null;
+  let thrownError: unknown = null;
   try {
     terminalStopReason = await consumeAgentStream(
       deps.streamDeps,
@@ -151,21 +156,21 @@ export async function runPromptTurn(
       batcher,
     );
   } catch (error) {
-    if (getErrorStatus(error) === 429) {
-      await safeFlush(batcher);
+    thrownError = error;
+  }
+  await safeFlush(batcher);
+  batcher.dispose();
+  if (thrownError !== null) {
+    if (getErrorStatus(thrownError) === 429) {
       throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     if (
       pendingSend.signal.aborted ||
-      (error instanceof Error && error.name === 'AbortError')
+      (thrownError instanceof Error && thrownError.name === 'AbortError')
     ) {
-      await safeFlush(batcher);
       return { stopReason: 'cancelled' };
     }
-    await safeFlush(batcher);
-    throw error;
-  } finally {
-    batcher.dispose();
+    throw thrownError;
   }
   if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
     return { stopReason: 'cancelled' };

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -98,19 +98,35 @@ async function processStreamEvent(
     handleConfirmation: deps.handleConfirmation,
     resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
   });
-  if (
-    event.type === 'tool-call' &&
-    deps.terminals !== null &&
-    TerminalManager.isShellToolCall(
-      event.call,
-      deps.agent.tools.get(event.call.name)?.kind,
-    )
-  ) {
-    await deps.terminals.observeToolCall(event.call);
-  } else if (event.type === 'tool-result' && deps.terminals !== null) {
-    deps.terminals.completeToolCall(event.result.id);
-  }
+  await trackTerminalEvent(event, deps);
   return stopReason;
+}
+
+/**
+ * Best-effort terminal bookkeeping after each event. Extracted so terminal
+ * tracking errors never mask the stop reason from `handleZedAgentEvent`.
+ * The single `deps.terminals !== null` check addresses the repeated null guard.
+ */
+async function trackTerminalEvent(
+  event: AgentEvent,
+  deps: SessionStreamDeps,
+): Promise<void> {
+  if (deps.terminals === null) return;
+  try {
+    if (
+      event.type === 'tool-call' &&
+      TerminalManager.isShellToolCall(
+        event.call,
+        deps.agent.tools.get(event.call.name)?.kind,
+      )
+    ) {
+      await deps.terminals.observeToolCall(event.call);
+    } else if (event.type === 'tool-result') {
+      deps.terminals.completeToolCall(event.result.id);
+    }
+  } catch (error) {
+    deps.logger.debug(() => `Terminal tracking failed: ${String(error)}`);
+  }
 }
 
 export interface PromptTurnDeps {
@@ -173,11 +189,11 @@ export async function runPromptTurn(
     }
     throw thrownError;
   }
-  if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
-    return { stopReason: 'cancelled' };
-  }
   if (terminalStopReason !== null) {
     return { stopReason: terminalStopReason };
+  }
+  if (pendingSend.signal.aborted) {
+    return { stopReason: 'cancelled' };
   }
   return { stopReason: 'end_turn' };
 }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -56,44 +56,63 @@ export async function consumeAgentStream(
     maxTurns: deps.maxTurns,
   });
   let terminalStopReason: acp.StopReason | null = null;
-  for await (const event of eventStream) {
-    if (deps.isPromptStale(promptGeneration, pendingSend)) {
-      if (event.type === 'done') {
-        return 'cancelled';
-      }
-      continue;
+  try {
+    for await (const event of eventStream) {
+      const result = await processStreamEvent(
+        event,
+        deps,
+        batcher,
+        promptGeneration,
+        pendingSend,
+      );
+      if (result === 'cancelled') return 'cancelled';
+      if (result !== null) terminalStopReason = result;
     }
-    if (
-      event.type === 'tool-call' &&
-      deps.terminals !== null &&
-      TerminalManager.isShellToolCall(
-        event.call,
-        deps.agent.tools.get(event.call.name)?.kind,
-      )
-    ) {
-      await deps.terminals.handleToolCall(event.call);
-    }
-    try {
-      const stopReason = await handleZedAgentEvent(event, batcher, {
-        sendUpdate: deps.sendUpdate,
-        sendUsage: deps.sendUsage,
-        handleConfirmation: deps.handleConfirmation,
-        resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-      });
-      if (event.type === 'tool-result' && deps.terminals !== null) {
-        await deps.terminals.releaseTerminal(event.result.id);
-      }
-      if (stopReason !== null) {
-        terminalStopReason = stopReason;
-      }
-    } catch (error) {
-      if (deps.terminals !== null) {
-        await deps.terminals.settleAll();
-      }
-      throw error;
+    return terminalStopReason;
+  } finally {
+    if (deps.terminals !== null) {
+      await deps.terminals.settleAll();
     }
   }
-  return terminalStopReason;
+}
+
+async function processStreamEvent(
+  event: AgentEvent,
+  deps: SessionStreamDeps,
+  batcher: StreamBatcher,
+  promptGeneration: number,
+  pendingSend: AbortController,
+): Promise<acp.StopReason | null | 'cancelled'> {
+  if (deps.isPromptStale(promptGeneration, pendingSend)) {
+    return event.type === 'done' ? 'cancelled' : null;
+  }
+  if (
+    event.type === 'tool-call' &&
+    deps.terminals !== null &&
+    TerminalManager.isShellToolCall(
+      event.call,
+      deps.agent.tools.get(event.call.name)?.kind,
+    )
+  ) {
+    await deps.terminals.handleToolCall(event.call);
+  }
+  try {
+    const stopReason = await handleZedAgentEvent(event, batcher, {
+      sendUpdate: deps.sendUpdate,
+      sendUsage: deps.sendUsage,
+      handleConfirmation: deps.handleConfirmation,
+      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+    });
+    if (event.type === 'tool-result' && deps.terminals !== null) {
+      await deps.terminals.releaseTerminal(event.result.id);
+    }
+    return stopReason;
+  } catch (error) {
+    if (deps.terminals !== null) {
+      await deps.terminals.settleAll();
+    }
+    throw error;
+  }
 }
 
 export interface PromptTurnDeps {

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import { type Agent, type AgentEvent } from '@vybestack/llxprt-code-agents';
+import {
+  EmojiFilter,
+  type ContractPart,
+  type FilterConfiguration,
+  getErrorStatus,
+} from '@vybestack/llxprt-code-core';
+import { handleZedAgentEvent } from './zed-agent-event-handler.js';
+import { StreamBatcher } from './zed-stream-batcher.js';
+import type { ZedPathResolver } from './zed-path-resolver.js';
+import { TerminalManager } from './zed-terminal-manager.js';
+
+type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+type SendUsageFn = (
+  usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
+) => Promise<void>;
+type HandleConfirmationFn = (
+  event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
+) => Promise<void>;
+
+export interface SessionStreamDeps {
+  readonly agent: Agent;
+  readonly terminals: TerminalManager | null;
+  readonly sendUpdate: SendUpdateFn;
+  readonly sendUsage: SendUsageFn;
+  readonly handleConfirmation: HandleConfirmationFn;
+  readonly isPromptStale: (
+    promptGeneration: number,
+    pendingSend: AbortController,
+  ) => boolean;
+  readonly maxTurns: number;
+}
+
+/**
+ * Consumes the agent event stream, forwarding each event to the Zed handler
+ * and managing terminal lifecycle for shell tool calls.
+ */
+export async function consumeAgentStream(
+  deps: SessionStreamDeps,
+  parts: readonly ContractPart[],
+  pendingSend: AbortController,
+  promptId: string,
+  promptGeneration: number,
+  batcher: StreamBatcher,
+): Promise<acp.StopReason | null> {
+  const eventStream = deps.agent.stream(parts, {
+    signal: pendingSend.signal,
+    promptId,
+    maxTurns: deps.maxTurns,
+  });
+  let terminalStopReason: acp.StopReason | null = null;
+  for await (const event of eventStream) {
+    if (deps.isPromptStale(promptGeneration, pendingSend)) {
+      if (event.type === 'done') {
+        return 'cancelled';
+      }
+      continue;
+    }
+    if (
+      event.type === 'tool-call' &&
+      deps.terminals !== null &&
+      TerminalManager.isShellToolCall(
+        event.call,
+        deps.agent.tools.get(event.call.name)?.kind,
+      )
+    ) {
+      await deps.terminals.handleToolCall(event.call);
+    }
+    const stopReason = await handleZedAgentEvent(event, batcher, {
+      sendUpdate: deps.sendUpdate,
+      sendUsage: deps.sendUsage,
+      handleConfirmation: deps.handleConfirmation,
+      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+    });
+    if (event.type === 'tool-result' && deps.terminals !== null) {
+      await deps.terminals.releaseTerminal(event.result.id);
+    }
+    if (stopReason !== null) {
+      terminalStopReason = stopReason;
+    }
+  }
+  return terminalStopReason;
+}
+
+export interface PromptTurnDeps {
+  readonly pathResolver: ZedPathResolver;
+  readonly emojiFilterMode: FilterConfiguration['mode'];
+  readonly streamDeps: SessionStreamDeps;
+}
+
+export async function runPromptTurn(
+  deps: PromptTurnDeps,
+  params: acp.PromptRequest,
+  pendingSend: AbortController,
+  promptId: string,
+  promptGeneration: number,
+): Promise<acp.PromptResponse> {
+  let parts: ContractPart[];
+  try {
+    parts = await deps.pathResolver.resolvePrompt(
+      params.prompt,
+      pendingSend.signal,
+    );
+  } catch (error) {
+    if (
+      pendingSend.signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return { stopReason: 'cancelled' };
+    }
+    throw error;
+  }
+  const batcher = new StreamBatcher(
+    new EmojiFilter({ mode: deps.emojiFilterMode }),
+    (u) => deps.streamDeps.sendUpdate(u),
+  );
+  let terminalStopReason: acp.StopReason | null = null;
+  try {
+    terminalStopReason = await consumeAgentStream(
+      deps.streamDeps,
+      parts,
+      pendingSend,
+      promptId,
+      promptGeneration,
+      batcher,
+    );
+  } catch (error) {
+    if (getErrorStatus(error) === 429) {
+      throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
+    }
+    if (
+      pendingSend.signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return { stopReason: 'cancelled' };
+    }
+    throw error;
+  } finally {
+    try {
+      await batcher.flush();
+    } finally {
+      batcher.dispose();
+    }
+  }
+  if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+    return { stopReason: 'cancelled' };
+  }
+  if (terminalStopReason !== null) {
+    return { stopReason: terminalStopReason };
+  }
+  return { stopReason: 'end_turn' };
+}

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -90,7 +90,7 @@ async function processStreamEvent(
   pendingSend: AbortController,
 ): Promise<acp.StopReason | null | 'cancelled'> {
   if (deps.isPromptStale(promptGeneration, pendingSend)) {
-    return event.type === 'done' ? 'cancelled' : null;
+    return 'cancelled';
   }
   const stopReason = await handleZedAgentEvent(event, batcher, {
     sendUpdate: deps.sendUpdate,

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -178,14 +178,14 @@ export async function runPromptTurn(
   await safeFlush(batcher, deps.streamDeps.logger);
   batcher.dispose();
   if (thrownError !== null) {
-    if (getErrorStatus(thrownError) === 429) {
-      throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
-    }
     if (
       pendingSend.signal.aborted ||
       (thrownError instanceof Error && thrownError.name === 'AbortError')
     ) {
       return { stopReason: 'cancelled' };
+    }
+    if (getErrorStatus(thrownError) === 429) {
+      throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     throw thrownError;
   }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -9,6 +9,7 @@ import { type Agent, type AgentEvent } from '@vybestack/llxprt-code-agents';
 import {
   EmojiFilter,
   type ContractPart,
+  type DebugLogger,
   type FilterConfiguration,
   getErrorStatus,
 } from '@vybestack/llxprt-code-core';
@@ -36,6 +37,7 @@ export interface SessionStreamDeps {
     pendingSend: AbortController,
   ) => boolean;
   readonly maxTurns: number;
+  readonly logger: Pick<DebugLogger, 'debug'>;
 }
 
 /**
@@ -73,8 +75,8 @@ export async function consumeAgentStream(
     if (deps.terminals !== null) {
       try {
         await deps.terminals.settleAll();
-      } catch {
-        // Swallow cleanup errors so they don't mask the original error
+      } catch (error) {
+        deps.logger.debug(() => `Terminal cleanup failed: ${String(error)}`);
       }
     }
   }
@@ -90,6 +92,12 @@ async function processStreamEvent(
   if (deps.isPromptStale(promptGeneration, pendingSend)) {
     return event.type === 'done' ? 'cancelled' : null;
   }
+  const stopReason = await handleZedAgentEvent(event, batcher, {
+    sendUpdate: deps.sendUpdate,
+    sendUsage: deps.sendUsage,
+    handleConfirmation: deps.handleConfirmation,
+    resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+  });
   if (
     event.type === 'tool-call' &&
     deps.terminals !== null &&
@@ -98,16 +106,9 @@ async function processStreamEvent(
       deps.agent.tools.get(event.call.name)?.kind,
     )
   ) {
-    await deps.terminals.handleToolCall(event.call);
-  }
-  const stopReason = await handleZedAgentEvent(event, batcher, {
-    sendUpdate: deps.sendUpdate,
-    sendUsage: deps.sendUsage,
-    handleConfirmation: deps.handleConfirmation,
-    resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-  });
-  if (event.type === 'tool-result' && deps.terminals !== null) {
-    await deps.terminals.releaseTerminal(event.result.id);
+    await deps.terminals.observeToolCall(event.call);
+  } else if (event.type === 'tool-result' && deps.terminals !== null) {
+    deps.terminals.completeToolCall(event.result.id);
   }
   return stopReason;
 }
@@ -158,7 +159,7 @@ export async function runPromptTurn(
   } catch (error) {
     thrownError = error;
   }
-  await safeFlush(batcher);
+  await safeFlush(batcher, deps.streamDeps.logger);
   batcher.dispose();
   if (thrownError !== null) {
     if (getErrorStatus(thrownError) === 429) {
@@ -181,11 +182,13 @@ export async function runPromptTurn(
   return { stopReason: 'end_turn' };
 }
 
-async function safeFlush(batcher: StreamBatcher): Promise<void> {
+async function safeFlush(
+  batcher: StreamBatcher,
+  logger: Pick<DebugLogger, 'debug'>,
+): Promise<void> {
   try {
     await batcher.flush();
-  } catch {
-    // Swallow flush errors so the original error from consumeAgentStream
-    // is not masked by a secondary flush failure.
+  } catch (error) {
+    logger.debug(() => `Stream flush failed: ${String(error)}`);
   }
 }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -73,17 +73,24 @@ export async function consumeAgentStream(
     ) {
       await deps.terminals.handleToolCall(event.call);
     }
-    const stopReason = await handleZedAgentEvent(event, batcher, {
-      sendUpdate: deps.sendUpdate,
-      sendUsage: deps.sendUsage,
-      handleConfirmation: deps.handleConfirmation,
-      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-    });
-    if (event.type === 'tool-result' && deps.terminals !== null) {
-      await deps.terminals.releaseTerminal(event.result.id);
-    }
-    if (stopReason !== null) {
-      terminalStopReason = stopReason;
+    try {
+      const stopReason = await handleZedAgentEvent(event, batcher, {
+        sendUpdate: deps.sendUpdate,
+        sendUsage: deps.sendUsage,
+        handleConfirmation: deps.handleConfirmation,
+        resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+      });
+      if (event.type === 'tool-result' && deps.terminals !== null) {
+        await deps.terminals.releaseTerminal(event.result.id);
+      }
+      if (stopReason !== null) {
+        terminalStopReason = stopReason;
+      }
+    } catch (error) {
+      if (deps.terminals !== null) {
+        await deps.terminals.settleAll();
+      }
+      throw error;
     }
   }
   return terminalStopReason;
@@ -133,21 +140,20 @@ export async function runPromptTurn(
     );
   } catch (error) {
     if (getErrorStatus(error) === 429) {
+      await safeFlush(batcher);
       throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     if (
       pendingSend.signal.aborted ||
       (error instanceof Error && error.name === 'AbortError')
     ) {
+      await safeFlush(batcher);
       return { stopReason: 'cancelled' };
     }
+    await safeFlush(batcher);
     throw error;
   } finally {
-    try {
-      await batcher.flush();
-    } finally {
-      batcher.dispose();
-    }
+    batcher.dispose();
   }
   if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
     return { stopReason: 'cancelled' };
@@ -156,4 +162,13 @@ export async function runPromptTurn(
     return { stopReason: terminalStopReason };
   }
   return { stopReason: 'end_turn' };
+}
+
+async function safeFlush(batcher: StreamBatcher): Promise<void> {
+  try {
+    await batcher.flush();
+  } catch {
+    // Swallow flush errors so the original error from consumeAgentStream
+    // is not masked by a secondary flush failure.
+  }
 }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -96,23 +96,16 @@ async function processStreamEvent(
   ) {
     await deps.terminals.handleToolCall(event.call);
   }
-  try {
-    const stopReason = await handleZedAgentEvent(event, batcher, {
-      sendUpdate: deps.sendUpdate,
-      sendUsage: deps.sendUsage,
-      handleConfirmation: deps.handleConfirmation,
-      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-    });
-    if (event.type === 'tool-result' && deps.terminals !== null) {
-      await deps.terminals.releaseTerminal(event.result.id);
-    }
-    return stopReason;
-  } catch (error) {
-    if (deps.terminals !== null) {
-      await deps.terminals.settleAll();
-    }
-    throw error;
+  const stopReason = await handleZedAgentEvent(event, batcher, {
+    sendUpdate: deps.sendUpdate,
+    sendUsage: deps.sendUsage,
+    handleConfirmation: deps.handleConfirmation,
+    resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+  });
+  if (event.type === 'tool-result' && deps.terminals !== null) {
+    await deps.terminals.releaseTerminal(event.result.id);
   }
+  return stopReason;
 }
 
 export interface PromptTurnDeps {

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -73,6 +73,11 @@ describe('deriveSessionTitle (issue #1611: first-prompt title)', () => {
     expect(deriveSessionTitle([])).toBeNull();
   });
 
+  it('preserves whitespace-only text without trimming to null', () => {
+    const title = deriveSessionTitle([{ type: 'text', text: '   ' }]);
+    expect(title).toBe('   ');
+  });
+
   // Finding #5: live normalization must match durable SessionDiscovery behavior
   // (extractUserMessageText: join with '', NO trim, NO newline collapse).
   it('does NOT trim leading/trailing whitespace, matching durable behavior (finding 5)', () => {
@@ -146,6 +151,14 @@ describe('deriveTitleFromHistory (issue #1611: restored-session title hydration)
       humanContent('Second human has text'),
     ];
     expect(deriveTitleFromHistory(history)).toBe('Second human has text');
+  });
+
+  it('skips human entries with an empty blocks array', () => {
+    const history: IContent[] = [
+      { speaker: 'human', blocks: [] },
+      humanContent('Next human has text'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Next human has text');
   });
 
   it('returns null for empty history', () => {
@@ -306,6 +319,7 @@ describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restore
       { type: 'text', text: 'First live prompt' },
     ]);
     expect(result.wonTitle).toBe(false);
+    expect(result.title).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -21,7 +21,10 @@
 
 import { describe, it, expect } from 'vitest';
 import type * as acp from '@agentclientprotocol/sdk';
-import type { IContent } from '@vybestack/llxprt-code-core';
+import {
+  SESSION_TITLE_MAX_LENGTH,
+  type IContent,
+} from '@vybestack/llxprt-code-core';
 import {
   deriveSessionTitle,
   deriveTitleFromHistory,
@@ -48,9 +51,8 @@ describe('deriveSessionTitle (issue #1611: first-prompt title)', () => {
   it('truncates a long prompt to the bounded length used by the listing', () => {
     const long = 'x'.repeat(500);
     const title = deriveSessionTitle([{ type: 'text', text: long }]);
-    // Consistent with SessionDiscovery.readFirstUserMessage (maxLength 120).
-    expect(title).toHaveLength(120);
-    expect(title).toBe(long.slice(0, 120));
+    expect(title).toHaveLength(SESSION_TITLE_MAX_LENGTH);
+    expect(title).toBe(long.slice(0, SESSION_TITLE_MAX_LENGTH));
   });
 
   it('ignores non-text blocks (images, resource links) and still titles from text', () => {
@@ -168,7 +170,9 @@ describe('deriveTitleFromHistory (issue #1611: restored-session title hydration)
   it('truncates long history text to the bounded length', () => {
     const long = 'y'.repeat(500);
     const history: IContent[] = [humanContent(long)];
-    expect(deriveTitleFromHistory(history)).toBe(long.slice(0, 120));
+    expect(deriveTitleFromHistory(history)).toBe(
+      long.slice(0, SESSION_TITLE_MAX_LENGTH),
+    );
   });
 
   it('does NOT trim or collapse newlines, matching durable behavior (finding 5)', () => {

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -296,17 +296,16 @@ describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restore
     expect(title).toBe('First title');
   });
 
-  it('returns undefined when history has no human text', () => {
+  it('consumes title eligibility when restored history has no human text', () => {
     const tracker = new SessionTitleTracker();
     const title = tracker.hydrateFromHistory([
       { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
     ]);
     expect(title).toBeUndefined();
-    // Eligibility NOT consumed — a later text prompt can still win the title.
     const result = tracker.consumeTitleEligibility([
       { type: 'text', text: 'First live prompt' },
     ]);
-    expect(result.wonTitle).toBe(true);
+    expect(result.wonTitle).toBe(false);
   });
 });
 

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -1,0 +1,341 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for session-info derivation (issue #1611):
+ * - The title is a truncated preview of the first user prompt, derived
+ *   consistently with SessionDiscovery.readFirstUserMessage (which feeds the
+ *   durable session listing). No LLM call.
+ * - The ACP session_info_update notification carries title and/or updatedAt
+ *   using the SDK's discriminated-union variant directly (no casts).
+ * - Title eligibility is consumed synchronously (race-safe for overlapping
+ *   prompts), even when the first prompt has no text (finding 1).
+ * - Restored sessions hydrate title from history so later prompts never retitle
+ *   them (finding 2).
+ * - Live title normalization matches durable SessionDiscovery behavior
+ *   (finding 5): no trimming, no newline collapsing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { IContent } from '@vybestack/llxprt-code-core';
+import {
+  deriveSessionTitle,
+  deriveTitleFromHistory,
+  buildSessionInfoUpdate,
+  SessionTitleTracker,
+} from './zed-session-info.js';
+
+describe('deriveSessionTitle (issue #1611: first-prompt title)', () => {
+  it('extracts text from a single text block', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'Investigate session lifecycle' },
+    ]);
+    expect(title).toBe('Investigate session lifecycle');
+  });
+
+  it('concatenates text across multiple text blocks', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'Fix the ' },
+      { type: 'text', text: 'bug in parser' },
+    ]);
+    expect(title).toBe('Fix the bug in parser');
+  });
+
+  it('truncates a long prompt to the bounded length used by the listing', () => {
+    const long = 'x'.repeat(500);
+    const title = deriveSessionTitle([{ type: 'text', text: long }]);
+    // Consistent with SessionDiscovery.readFirstUserMessage (maxLength 120).
+    expect(title).toHaveLength(120);
+    expect(title).toBe(long.slice(0, 120));
+  });
+
+  it('ignores non-text blocks (images, resource links) and still titles from text', () => {
+    const title = deriveSessionTitle([
+      { type: 'resource_link', uri: 'file:///p', name: 'p.ts' },
+      { type: 'text', text: 'Review this file' },
+    ]);
+    expect(title).toBe('Review this file');
+  });
+
+  it('returns null when the prompt has no text content (only media/resources)', () => {
+    const title = deriveSessionTitle([
+      { type: 'image', data: 'base64', mimeType: 'image/png' },
+      { type: 'resource_link', uri: 'file:///p', name: 'p.ts' },
+    ]);
+    expect(title).toBeNull();
+  });
+
+  it('returns null for an empty prompt', () => {
+    expect(deriveSessionTitle([])).toBeNull();
+  });
+
+  // Finding #5: live normalization must match durable SessionDiscovery behavior
+  // (extractUserMessageText: join with '', NO trim, NO newline collapse).
+  it('does NOT trim leading/trailing whitespace, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: '  hello world  ' },
+    ]);
+    // Durable extractUserMessageText does NOT trim — live must match.
+    expect(title).toBe('  hello world  ');
+  });
+
+  it('does NOT collapse newlines, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'line one\nline two\nline three' },
+    ]);
+    // Durable extractUserMessageText does NOT replace newlines — live must
+    // match so the durable listing title and the live title are identical.
+    expect(title).toBe('line one\nline two\nline three');
+  });
+
+  it('does NOT collapse tabs or other whitespace, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([{ type: 'text', text: 'col1\tcol2' }]);
+    expect(title).toBe('col1\tcol2');
+  });
+});
+
+describe('deriveTitleFromHistory (issue #1611: restored-session title hydration)', () => {
+  function humanContent(text: string): IContent {
+    return {
+      speaker: 'human',
+      blocks: [{ type: 'text', text }],
+    };
+  }
+
+  it('extracts the first human-speaker text from history', () => {
+    const history: IContent[] = [
+      humanContent('First user message'),
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('First user message');
+  });
+
+  it('skips ai/tool entries and uses the first human text', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'welcome' }] },
+      { speaker: 'tool', blocks: [{ type: 'text', text: 'result' }] },
+      humanContent('Actual first user message'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Actual first user message');
+  });
+
+  it('returns null when history has no human text', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ];
+    expect(deriveTitleFromHistory(history)).toBeNull();
+  });
+
+  it('skips human entries with no text blocks', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            data: 'base64',
+            mimeType: 'image/png',
+            encoding: 'base64',
+          },
+        ],
+      },
+      humanContent('Second human has text'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Second human has text');
+  });
+
+  it('returns null for empty history', () => {
+    expect(deriveTitleFromHistory([])).toBeNull();
+  });
+
+  it('truncates long history text to the bounded length', () => {
+    const long = 'y'.repeat(500);
+    const history: IContent[] = [humanContent(long)];
+    expect(deriveTitleFromHistory(history)).toBe(long.slice(0, 120));
+  });
+
+  it('does NOT trim or collapse newlines, matching durable behavior (finding 5)', () => {
+    const history: IContent[] = [humanContent('  line one\nline two  ')];
+    expect(deriveTitleFromHistory(history)).toBe('  line one\nline two  ');
+  });
+});
+
+describe('buildSessionInfoUpdate (issue #1611: ACP session_info_update)', () => {
+  it('builds a title-only update using the SDK discriminated-union variant', () => {
+    const update = buildSessionInfoUpdate({ title: 'My session' });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      title: 'My session',
+    });
+  });
+
+  it('builds an updatedAt-only update', () => {
+    const update = buildSessionInfoUpdate({
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+
+  it('builds a combined title + updatedAt update', () => {
+    const update = buildSessionInfoUpdate({
+      title: 'My session',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      title: 'My session',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+});
+
+describe('SessionTitleTracker.consumeTitleEligibility (issue #1611 finding 1: synchronous, race-safe)', () => {
+  it('wins the title on the first text-bearing prompt', () => {
+    const tracker = new SessionTitleTracker();
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First prompt here' },
+    ]);
+    expect(result.wonTitle).toBe(true);
+    expect(result.title).toBe('First prompt here');
+  });
+
+  it('consumes eligibility even when the first prompt has no text (no retitle later)', () => {
+    const tracker = new SessionTitleTracker();
+    const first = tracker.consumeTitleEligibility([
+      { type: 'image', data: 'base64', mimeType: 'image/png' },
+    ]);
+    expect(first.wonTitle).toBe(false);
+    expect(first.title).toBeUndefined();
+
+    // A LATER text-bearing prompt must NOT win — eligibility was consumed.
+    const second = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Now with text' },
+    ]);
+    expect(second.wonTitle).toBe(false);
+    expect(second.title).toBeUndefined();
+  });
+
+  it('does NOT win on the second prompt (title set once, eligibility consumed once)', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First prompt here' },
+    ]);
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Second prompt here' },
+    ]);
+    expect(result.wonTitle).toBe(false);
+    expect(result.title).toBe('First prompt here');
+  });
+
+  it('is race-safe: only the first synchronous call wins, regardless of turn completion order', () => {
+    // Simulate overlapping prompts: both call consumeTitleEligibility before
+    // either turn completes. Only the first wins.
+    const tracker = new SessionTitleTracker();
+    const promptA = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Prompt A' },
+    ]);
+    const promptB = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Prompt B' },
+    ]);
+    expect(promptA.wonTitle).toBe(true);
+    expect(promptA.title).toBe('Prompt A');
+    expect(promptB.wonTitle).toBe(false);
+    expect(promptB.title).toBe('Prompt A');
+  });
+});
+
+describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restored sessions)', () => {
+  it('sets the title from the first human text in restored history', () => {
+    const tracker = new SessionTitleTracker();
+    const title = tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored session title' }],
+      },
+    ]);
+    expect(title).toBe('Restored session title');
+    expect(tracker.getTitle()).toBe('Restored session title');
+  });
+
+  it('consumes title eligibility so a later live prompt never retitles', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored title' }],
+      },
+    ]);
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'New prompt after restore' },
+    ]);
+    expect(result.wonTitle).toBe(false);
+    expect(result.title).toBe('Restored title');
+  });
+
+  it('is idempotent: a second hydrate is a no-op', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'First title' }],
+      },
+    ]);
+    const title = tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Second title' }],
+      },
+    ]);
+    expect(title).toBe('First title');
+  });
+
+  it('returns undefined when history has no human text', () => {
+    const tracker = new SessionTitleTracker();
+    const title = tracker.hydrateFromHistory([
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ]);
+    expect(title).toBeUndefined();
+    // Eligibility NOT consumed — a later text prompt can still win the title.
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First live prompt' },
+    ]);
+    expect(result.wonTitle).toBe(true);
+  });
+});
+
+describe('SessionTitleTracker.recordTurn (issue #1611: updatedAt-per-turn)', () => {
+  it('returns an updatedAt update', () => {
+    const tracker = new SessionTitleTracker();
+    const result = tracker.recordTurn('2026-07-12T00:00:00Z');
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+
+  it('advances updatedAt on each turn', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.recordTurn('2026-07-12T00:00:00Z');
+    const result = tracker.recordTurn('2026-07-12T00:01:00Z');
+    expect(result.updates[0]).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:01:00Z',
+    });
+    expect(tracker.getUpdatedAt()).toBe('2026-07-12T00:01:00Z');
+  });
+
+  it('does not carry a title field (title is handled by consumeTitleEligibility)', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.consumeTitleEligibility([{ type: 'text', text: 'First' }]);
+    const result = tracker.recordTurn('2026-07-12T00:00:00Z');
+    expect(result.updates[0]).not.toHaveProperty('title');
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -28,14 +28,16 @@ const TITLE_MAX_LENGTH = 120;
 export function deriveSessionTitle(
   prompt: readonly acp.ContentBlock[],
 ): string | null {
-  const text = prompt
+  return extractTitleText(prompt);
+}
+
+function extractTitleText(
+  blocks: ReadonlyArray<{ readonly type: string; readonly text?: unknown }>,
+): string | null {
+  const text = blocks
     .filter(
-      (
-        block,
-      ): block is acp.ContentBlock & {
-        type: 'text';
-        text: string;
-      } => block.type === 'text',
+      (block): block is { readonly type: 'text'; readonly text: string } =>
+        block.type === 'text' && typeof block.text === 'string',
     )
     .map((block) => block.text)
     .join('');
@@ -61,17 +63,9 @@ export function deriveTitleFromHistory(
     if (item.speaker !== 'human') {
       continue;
     }
-    const text = item.blocks
-      .filter(
-        (block): block is { type: 'text'; text: string } =>
-          block.type === 'text',
-      )
-      .map((block) => block.text)
-      .join('');
-    if (text.length > 0) {
-      return text.length > TITLE_MAX_LENGTH
-        ? text.slice(0, TITLE_MAX_LENGTH)
-        : text;
+    const title = extractTitleText(item.blocks);
+    if (title !== null) {
+      return title;
     }
   }
   return null;
@@ -116,9 +110,8 @@ export interface TitleEligibilityResult {
 
 export interface SessionInfoRecordResult {
   /**
-   * The session_info_update notification to emit for this turn: always an
-   * updatedAt update (title is emitted via consumeTitleEligibility). Empty only
-   * if updatedAt is unchanged.
+   * The session_info_update notifications to emit for this turn: always an
+   * updatedAt update, optionally preceded by a pending title retry.
    */
   readonly updates: ReadonlyArray<
     acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -5,13 +5,10 @@
  */
 
 import type * as acp from '@agentclientprotocol/sdk';
-import type { IContent } from '@vybestack/llxprt-code-core';
-
-/**
- * Maximum title length, matching SessionDiscovery.readFirstUserMessage so the
- * live session_info_update title and the durable on-disk listing title agree.
- */
-const TITLE_MAX_LENGTH = 120;
+import {
+  SESSION_TITLE_MAX_LENGTH,
+  type IContent,
+} from '@vybestack/llxprt-code-core';
 
 /**
  * Derives a human-readable title from the first user prompt by concatenating
@@ -44,8 +41,8 @@ function extractTitleText(
   if (text.length === 0) {
     return null;
   }
-  return text.length > TITLE_MAX_LENGTH
-    ? text.slice(0, TITLE_MAX_LENGTH)
+  return text.length > SESSION_TITLE_MAX_LENGTH
+    ? text.slice(0, SESSION_TITLE_MAX_LENGTH)
     : text;
 }
 

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -201,11 +201,11 @@ export class SessionTitleTracker {
       return this.title;
     }
     const derived = deriveTitleFromHistory(history);
+    this.titleEligibilityConsumed = true;
     if (derived === null) {
       return undefined;
     }
     this.title = derived;
-    this.titleEligibilityConsumed = true;
     return this.title;
   }
 

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+/**
+ * Maximum title length, matching SessionDiscovery.readFirstUserMessage so the
+ * live session_info_update title and the durable on-disk listing title agree.
+ */
+const TITLE_MAX_LENGTH = 120;
+
+/**
+ * Derives a human-readable title from the first user prompt by concatenating
+ * its text blocks (ignoring media/resources) and truncating to the bounded
+ * length the session listing uses. Returns null when the prompt carries no
+ * text. No LLM call — consistent with the durable listing convention.
+ *
+ * Normalization intentionally matches the durable path
+ * (SessionDiscovery.readFirstUserMessage → extractUserMessageText): text blocks
+ * are joined with an empty separator and truncated — NO trimming or newline
+ * collapsing — so the live title is byte-identical to the on-disk listing
+ * title for the same first user message.
+ */
+export function deriveSessionTitle(
+  prompt: readonly acp.ContentBlock[],
+): string | null {
+  const text = prompt
+    .filter(
+      (
+        block,
+      ): block is acp.ContentBlock & {
+        type: 'text';
+        text: string;
+      } => block.type === 'text',
+    )
+    .map((block) => block.text)
+    .join('');
+  if (text.length === 0) {
+    return null;
+  }
+  return text.length > TITLE_MAX_LENGTH
+    ? text.slice(0, TITLE_MAX_LENGTH)
+    : text;
+}
+
+/**
+ * Extracts the first human-speaker text from a resumed history, using the SAME
+ * join + truncate normalization as {@link deriveSessionTitle} and the durable
+ * SessionDiscovery.readFirstUserMessage. Returns null when the history has no
+ * human text block, so a restored session with only ai/tool entries is not
+ * titled (matching the durable listing, which shows no title for such sessions).
+ */
+export function deriveTitleFromHistory(
+  history: readonly IContent[],
+): string | null {
+  for (const item of history) {
+    if (item.speaker !== 'human') {
+      continue;
+    }
+    const text = item.blocks
+      .filter(
+        (block): block is { type: 'text'; text: string } =>
+          block.type === 'text',
+      )
+      .map((block) => block.text)
+      .join('');
+    if (text.length > 0) {
+      return text.length > TITLE_MAX_LENGTH
+        ? text.slice(0, TITLE_MAX_LENGTH)
+        : text;
+    }
+  }
+  return null;
+}
+
+/**
+ * Builds an ACP `session_info_update` {@link acp.SessionUpdate} using the SDK's
+ * discriminated-union variant directly (no casts). Only the supplied fields are
+ * carried so partial title/updatedAt updates are emitted without nulling the
+ * other.
+ */
+export function buildSessionInfoUpdate(fields: {
+  readonly title?: string;
+  readonly updatedAt?: string;
+}): acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' } {
+  const update: acp.SessionInfoUpdate & {
+    sessionUpdate: 'session_info_update';
+  } = {
+    sessionUpdate: 'session_info_update',
+  };
+  if (fields.title !== undefined) {
+    update.title = fields.title;
+  }
+  if (fields.updatedAt !== undefined) {
+    update.updatedAt = fields.updatedAt;
+  }
+  return update;
+}
+
+export interface TitleEligibilityResult {
+  /**
+   * True when THIS call won the title — i.e. the derived title was freshly set.
+   * The caller emits a session_info_update carrying the title exactly once.
+   */
+  readonly wonTitle: boolean;
+  /**
+   * The current title (undefined until the first text-bearing prompt wins or
+   * hydration sets it from history).
+   */
+  readonly title: string | undefined;
+}
+
+export interface SessionInfoRecordResult {
+  /**
+   * The session_info_update notification to emit for this turn: always an
+   * updatedAt update (title is emitted via consumeTitleEligibility). Empty only
+   * if updatedAt is unchanged.
+   */
+  readonly updates: ReadonlyArray<
+    acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }
+  >;
+  /**
+   * The current title (undefined until the first text-bearing prompt wins or
+   * hydration sets it from history).
+   */
+  readonly title: string | undefined;
+}
+
+/**
+ * Tracks per-session title (derived once from the first text-bearing prompt)
+ * and updatedAt (refreshed every turn). Keeping this state in a cohesive
+ * helper lets zedIntegration.ts stay within its max-lines budget and makes the
+ * externally observable session_info_update semantics unit-testable in
+ * isolation.
+ *
+ * Title eligibility is consumed SYNCHRONOUSLY at prompt-acceptance time via
+ * {@link consumeTitleEligibility}, not deferred to turn completion, so
+ * overlapping prompts cannot both claim the title (race-safety, issue #1611
+ * finding 1). Restored sessions hydrate the title from history via
+ * {@link hydrateFromHistory} so later prompts never retitle them (finding 2).
+ */
+export class SessionTitleTracker {
+  private title: string | undefined;
+  private updatedAt: string | undefined;
+  /**
+   * Once consumed, no future call can win the title — even if the winning
+   * prompt had no text (so a no-text first prompt still suppresses a later
+   * retitle).
+   */
+  private titleEligibilityConsumed = false;
+  /**
+   * A title that won eligibility but whose session_info_update notification
+   * failed transport. Retried (prepended) on the next turn's metadata emission
+   * so a transient transport error doesn't permanently lose the title.
+   * Issue #1611: pending title notification retry after transport failure.
+   */
+  private pendingTitle: string | undefined;
+
+  /**
+   * Synchronously consumes title eligibility for a prompt: on the FIRST call
+   * (whether or not the prompt has text), eligibility is permanently consumed.
+   * If the prompt has text and no title is set yet, the title is derived and
+   * set. Returns whether THIS call won the title (so the caller emits the
+   * session_info_update exactly once) and the current title.
+   */
+  consumeTitleEligibility(
+    prompt: readonly acp.ContentBlock[],
+  ): TitleEligibilityResult {
+    if (this.titleEligibilityConsumed) {
+      return { wonTitle: false, title: this.title };
+    }
+    this.titleEligibilityConsumed = true;
+    if (this.title !== undefined) {
+      return { wonTitle: false, title: this.title };
+    }
+    const derived = deriveSessionTitle(prompt);
+    if (derived === null) {
+      return { wonTitle: false, title: undefined };
+    }
+    this.title = derived;
+    return { wonTitle: true, title: this.title };
+  }
+
+  hydrateFromMetadata(title: string | null): string | undefined {
+    if (this.titleEligibilityConsumed) {
+      return this.title;
+    }
+    this.titleEligibilityConsumed = true;
+    if (title !== null) {
+      this.title = title;
+    }
+    return this.title;
+  }
+
+  /**
+   * Hydrates the title from a resumed history (issue #1611 finding 2). Called
+   * after a load/resume replays the conversation, BEFORE any new prompt. If the
+   * history's first human text yields a title, it is set AND eligibility is
+   * consumed, so the next live prompt can never retitle the session. Idempotent:
+   * a no-op if a title was already set or eligibility already consumed.
+   */
+  hydrateFromHistory(history: readonly IContent[]): string | undefined {
+    if (this.title !== undefined || this.titleEligibilityConsumed) {
+      return this.title;
+    }
+    const derived = deriveTitleFromHistory(history);
+    if (derived === null) {
+      return undefined;
+    }
+    this.title = derived;
+    this.titleEligibilityConsumed = true;
+    return this.title;
+  }
+
+  /**
+   * Records a completed turn: advances updatedAt and returns the
+   * session_info_update notification the caller should push. Title is handled
+   * separately via {@link consumeTitleEligibility} at acceptance time.
+   *
+   * If a pending title exists (from a previous transport failure), it is
+   * prepended to the updates so the caller retries it this turn.
+   */
+  recordTurn(updatedAt: string): SessionInfoRecordResult {
+    this.updatedAt = updatedAt;
+    const updates: Array<
+      acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }
+    > = [];
+    if (this.pendingTitle !== undefined) {
+      updates.push(
+        buildSessionInfoUpdate({
+          title: this.pendingTitle,
+          updatedAt,
+        }),
+      );
+      this.pendingTitle = undefined;
+    }
+    updates.push(buildSessionInfoUpdate({ updatedAt }));
+    return { updates, title: this.title };
+  }
+
+  /**
+   * Marks a title as pending for retry (issue #1611). Called by the caller
+   * when the title-bearing session_info_update notification fails transport.
+   * The next {@link recordTurn} will prepend the title to its updates.
+   */
+  markPendingTitle(title: string): void {
+    this.pendingTitle = title;
+  }
+
+  /**
+   * Returns the pending title (for testing) or undefined when none is pending.
+   */
+  getPendingTitle(): string | undefined {
+    return this.pendingTitle;
+  }
+
+  getTitle(): string | undefined {
+    return this.title;
+  }
+
+  getUpdatedAt(): string | undefined {
+    return this.updatedAt;
+  }
+}

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -19,6 +19,7 @@ export interface LifecycleSessionHandle {
   getApprovalMode(): ApprovalMode;
   getLifecycleInfo(): LifecycleSession;
   dispose(): Promise<void>;
+  sendAvailableCommands(): Promise<void>;
 }
 
 interface RestoredSession {
@@ -86,6 +87,7 @@ export class SessionLifecycle {
       if (live.getLifecycleInfo().cwd !== params.cwd) {
         throw acp.RequestError.resourceNotFound(params.sessionId);
       }
+      await live.sendAvailableCommands();
       return { modes: buildSessionModes(live.getApprovalMode()) };
     }
     const listed = await this.list({ cwd: params.cwd });
@@ -93,6 +95,7 @@ export class SessionLifecycle {
       throw acp.RequestError.resourceNotFound(params.sessionId);
     }
     const { session } = await this.restore(params.sessionId, params.cwd);
+    await session.sendAvailableCommands();
     this.sessions.set(params.sessionId, session);
     return { modes: buildSessionModes(session.getApprovalMode()) };
   }

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -148,8 +148,11 @@ export class SessionLifecycle {
     if (live === undefined) {
       return false;
     }
-    await live.dispose();
-    this.sessions.delete(sessionId);
+    try {
+      await live.dispose();
+    } finally {
+      this.sessions.delete(sessionId);
+    }
     return true;
   }
 }

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import {
+  deleteSessionById,
+  getProjectHash,
+  type ApprovalMode,
+  type Config,
+} from '@vybestack/llxprt-code-core';
+import { buildSessionModes } from './zed-helpers.js';
+import { listRecordedSessions } from './zed-session-listing.js';
+import type { LifecycleSession } from './zed-session-pagination.js';
+
+export interface LifecycleSessionHandle {
+  getApprovalMode(): ApprovalMode;
+  getLifecycleInfo(): LifecycleSession;
+  dispose(): Promise<void>;
+}
+
+interface RestoredSession {
+  readonly session: LifecycleSessionHandle;
+}
+
+export class SessionLifecycle {
+  private readonly queues = new Map<string, Promise<unknown>>();
+
+  constructor(
+    private readonly config: Config,
+    private readonly sessions: Map<string, LifecycleSessionHandle>,
+    private readonly restore: (
+      sessionId: string,
+      cwd: string | undefined,
+    ) => Promise<RestoredSession>,
+  ) {}
+
+  list(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
+    const projectRoot = this.config.getProjectRoot();
+    return listRecordedSessions(
+      this.config.storage.getProjectChatsDir(),
+      getProjectHash(projectRoot),
+      projectRoot,
+      params,
+      [...this.sessions.values()].map((session) => session.getLifecycleInfo()),
+    );
+  }
+
+  resume(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
+    return this.runSerialized(params.sessionId, () =>
+      this.performResume(params),
+    );
+  }
+
+  close(params: acp.CloseSessionRequest): Promise<acp.CloseSessionResponse> {
+    return this.runSerialized(params.sessionId, async () => {
+      await this.disposeLive(params.sessionId);
+      return {};
+    });
+  }
+
+  delete(params: acp.DeleteSessionRequest): Promise<acp.DeleteSessionResponse> {
+    return this.runSerialized(params.sessionId, () =>
+      this.performDelete(params),
+    );
+  }
+
+  runSerialized<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    const prior = this.queues.get(sessionId);
+    const run = (prior ?? Promise.resolve()).then(operation, operation);
+    this.queues.set(sessionId, run);
+    return run.finally(() => {
+      if (this.queues.get(sessionId) === run) {
+        this.queues.delete(sessionId);
+      }
+    });
+  }
+
+  private async performResume(
+    params: acp.ResumeSessionRequest,
+  ): Promise<acp.ResumeSessionResponse> {
+    const live = this.sessions.get(params.sessionId);
+    if (live !== undefined) {
+      if (live.getLifecycleInfo().cwd !== params.cwd) {
+        throw acp.RequestError.resourceNotFound(params.sessionId);
+      }
+      return { modes: buildSessionModes(live.getApprovalMode()) };
+    }
+    const listed = await this.list({ cwd: params.cwd });
+    if (!listed.sessions.some((item) => item.sessionId === params.sessionId)) {
+      throw acp.RequestError.resourceNotFound(params.sessionId);
+    }
+    const { session } = await this.restore(params.sessionId, params.cwd);
+    this.sessions.set(params.sessionId, session);
+    return { modes: buildSessionModes(session.getApprovalMode()) };
+  }
+
+  private async performDelete(
+    params: acp.DeleteSessionRequest,
+  ): Promise<acp.DeleteSessionResponse> {
+    const hadLiveSession = await this.disposeLive(params.sessionId);
+    const projectRoot = this.config.getProjectRoot();
+    const result = await deleteSessionById(
+      params.sessionId,
+      this.config.storage.getProjectChatsDir(),
+      getProjectHash(projectRoot),
+    );
+    if (result.ok) {
+      return {};
+    }
+    if (result.error.startsWith('Session not found:')) {
+      if (hadLiveSession) {
+        return {};
+      }
+      throw acp.RequestError.resourceNotFound(params.sessionId);
+    }
+    throw acp.RequestError.internalError({
+      sessionId: params.sessionId,
+      reason: result.error,
+    });
+  }
+
+  private async disposeLive(sessionId: string): Promise<boolean> {
+    const live = this.sessions.get(sessionId);
+    if (live === undefined) {
+      return false;
+    }
+    await live.dispose();
+    this.sessions.delete(sessionId);
+    return true;
+  }
+}

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -20,6 +20,7 @@ export interface LifecycleSessionHandle {
   getLifecycleInfo(): LifecycleSession;
   dispose(): Promise<void>;
   sendAvailableCommands(): Promise<void>;
+  getConfigOptions(): Promise<acp.SessionConfigOption[]>;
 }
 
 interface RestoredSession {
@@ -36,6 +37,11 @@ export class SessionLifecycle {
       sessionId: string,
       cwd: string | undefined,
     ) => Promise<RestoredSession>,
+    private readonly configOptions: (
+      session: LifecycleSessionHandle,
+    ) => Promise<
+      Pick<acp.ResumeSessionResponse, 'configOptions'>
+    > = async () => ({}),
   ) {}
 
   list(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
@@ -88,7 +94,10 @@ export class SessionLifecycle {
         throw acp.RequestError.resourceNotFound(params.sessionId);
       }
       await live.sendAvailableCommands();
-      return { modes: buildSessionModes(live.getApprovalMode()) };
+      return {
+        modes: buildSessionModes(live.getApprovalMode()),
+        ...(await this.configOptions(live)),
+      };
     }
     const listed = await this.list({ cwd: params.cwd });
     if (!listed.sessions.some((item) => item.sessionId === params.sessionId)) {
@@ -97,7 +106,10 @@ export class SessionLifecycle {
     const { session } = await this.restore(params.sessionId, params.cwd);
     await session.sendAvailableCommands();
     this.sessions.set(params.sessionId, session);
-    return { modes: buildSessionModes(session.getApprovalMode()) };
+    return {
+      modes: buildSessionModes(session.getApprovalMode()),
+      ...(await this.configOptions(session)),
+    };
   }
 
   private async performDelete(

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -14,6 +14,12 @@ import {
 import { buildSessionModes } from './zed-helpers.js';
 import { listRecordedSessions } from './zed-session-listing.js';
 import type { LifecycleSession } from './zed-session-pagination.js';
+import type {
+  CloseSessionRequest,
+  CloseSessionResponse,
+  DeleteSessionRequest,
+  DeleteSessionResponse,
+} from './acp-types.js';
 
 export interface LifecycleSessionHandle {
   getApprovalMode(): ApprovalMode;
@@ -61,14 +67,14 @@ export class SessionLifecycle {
     );
   }
 
-  close(params: acp.CloseSessionRequest): Promise<acp.CloseSessionResponse> {
+  close(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     return this.runSerialized(params.sessionId, async () => {
       await this.disposeLive(params.sessionId);
       return {};
     });
   }
 
-  delete(params: acp.DeleteSessionRequest): Promise<acp.DeleteSessionResponse> {
+  delete(params: DeleteSessionRequest): Promise<DeleteSessionResponse> {
     return this.runSerialized(params.sessionId, () =>
       this.performDelete(params),
     );
@@ -113,8 +119,8 @@ export class SessionLifecycle {
   }
 
   private async performDelete(
-    params: acp.DeleteSessionRequest,
-  ): Promise<acp.DeleteSessionResponse> {
+    params: DeleteSessionRequest,
+  ): Promise<DeleteSessionResponse> {
     const hadLiveSession = await this.disposeLive(params.sessionId);
     const projectRoot = this.config.getProjectRoot();
     const result = await deleteSessionById(

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -453,6 +453,9 @@ describe('recorded ACP session listing', () => {
       const updatedAt = result.sessions[0].updatedAt;
       expect(updatedAt).toBeDefined();
       expect(new Date(updatedAt ?? '').toISOString()).toBe(updatedAt);
+      expect(new Date(updatedAt!).getTime()).toBeGreaterThan(
+        Date.now() - 10_000,
+      );
     });
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -93,4 +93,329 @@ describe('recorded ACP session listing', () => {
       false,
     );
   });
+
+  it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+
+    const liveSession = {
+      sessionId: 'live-only-session',
+      cwd: '/workspace',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+      title: 'Live session title from first prompt',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'live-only-session',
+      cwd: '/workspace',
+      title: 'Live session title from first prompt',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+    });
+  });
+
+  it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'merged-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Durable title from disk' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const liveSession = {
+      sessionId: 'merged-session',
+      cwd: '/workspace',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+      title: 'Live title that should be overridden',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Durable title wins over live title.
+    expect(result.sessions[0].title).toBe('Durable title from disk');
+  });
+
+  it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'freshness-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Some title' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const liveSession = {
+      sessionId: 'freshness-session',
+      cwd: '/workspace',
+      // Live updatedAt is newer than the durable file mtime.
+      updatedAt: '2099-01-01T00:00:00.000Z',
+      title: 'Live title',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // updatedAt should be the live (newer) value.
+    expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
+  });
+});
+describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  // The durable path (SessionDiscovery.readFirstUserMessage →
+  // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
+  // NO newline collapse. The live path (deriveSessionTitle) must match exactly
+  // so the on-disk listing title and the session_info_update title agree.
+  const cases: Array<{ name: string; text: string }> = [
+    { name: 'multiline', text: 'line one\nline two\nline three' },
+    { name: 'leading/trailing whitespace', text: '  padded title  ' },
+    { name: 'tabs', text: 'col1\tcol2' },
+    { name: 'multiple text blocks', text: 'part1part2' },
+  ];
+
+  for (const { name, text } of cases) {
+    it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
+      const { deriveSessionTitle } = await import('./zed-session-info.js');
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'consistency-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      const content: IContent = {
+        speaker: 'human',
+        blocks:
+          name === 'multiple text blocks'
+            ? [
+                { type: 'text', text: 'part1' },
+                { type: 'text', text: 'part2' },
+              ]
+            : [{ type: 'text', text }],
+      };
+      service.recordContent(content);
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+      const durableTitle = result.sessions[0].title;
+
+      const liveTitle = deriveSessionTitle(
+        name === 'multiple text blocks'
+          ? [
+              { type: 'text', text: 'part1' },
+              { type: 'text', text: 'part2' },
+            ]
+          : [{ type: 'text', text }],
+      );
+
+      expect(durableTitle).toBe(liveTitle);
+    });
+  }
+});
+
+describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it('uses the session_metadata title when present', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'metadata-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // Record a metadata title BEFORE the content event.
+    service.recordSessionMetadata('Metadata title from ACP');
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Different first human text' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // The session_metadata title wins over the first-human-text fallback.
+    expect(result.sessions[0].title).toBe('Metadata title from ACP');
+  });
+
+  it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'legacy-metadata-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // No recordSessionMetadata — legacy behavior.
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Legacy first human text' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Falls back to first-human-text for legacy sessions.
+    expect(result.sessions[0].title).toBe('Legacy first human text');
+  });
+
+  it('omits title when session_metadata is explicit null (untitled)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'untitled-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // Explicit null title.
+    service.recordSessionMetadata(null);
+    service.recordContent({
+      speaker: 'human',
+      blocks: [
+        { type: 'text', text: 'Human text that should NOT be the title' },
+      ],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Explicit null → no title surfaced (consistent with legacy no-human-text).
+    expect(result.sessions[0]).not.toHaveProperty('title');
+  });
+
+  it('includes createdAt in the listing for immutable ordering (issue #1611)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'created-at-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordSessionMetadata('Title');
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+  });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -12,6 +12,7 @@ import {
   SessionRecordingService,
   type IContent,
 } from '@vybestack/llxprt-code-core';
+import { deriveSessionTitle } from './zed-session-info.js';
 import { listRecordedSessions } from './zed-session-listing.js';
 
 const roots: string[] = [];
@@ -22,218 +23,15 @@ describe('recorded ACP session listing', () => {
       roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
     );
   });
-  it('returns persisted cwd, first human text title, and updated timestamp', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'listed-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    const content: IContent = {
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
-    };
-    service.recordContent(content);
-    await service.flush();
-    await service.dispose();
 
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'listed-session',
-      cwd: '/workspace',
-      title: 'Investigate session lifecycle',
-    });
-    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
-  });
-
-  it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'legacy-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: [],
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'ai',
-      blocks: [{ type: 'text', text: 'agent-only content' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions[0].cwd).toBe('/fallback');
-    expect(result.sessions[0]).not.toHaveProperty('title');
-    expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
-      false,
-    );
-  });
-
-  it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-
-    const liveSession = {
-      sessionId: 'live-only-session',
-      cwd: '/workspace',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-      title: 'Live session title from first prompt',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'live-only-session',
-      cwd: '/workspace',
-      title: 'Live session title from first prompt',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-    });
-  });
-
-  it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'merged-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Durable title from disk' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const liveSession = {
-      sessionId: 'merged-session',
-      cwd: '/workspace',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-      title: 'Live title that should be overridden',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Durable title wins over live title.
-    expect(result.sessions[0].title).toBe('Durable title from disk');
-  });
-
-  it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'freshness-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Some title' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const liveSession = {
-      sessionId: 'freshness-session',
-      cwd: '/workspace',
-      // Live updatedAt is newer than the durable file mtime.
-      updatedAt: '2099-01-01T00:00:00.000Z',
-      title: 'Live title',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // updatedAt should be the live (newer) value.
-    expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
-  });
-});
-describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
-  afterEach(async () => {
-    await Promise.all(
-      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-    );
-  });
-
-  // The durable path (SessionDiscovery.readFirstUserMessage →
-  // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
-  // NO newline collapse. The live path (deriveSessionTitle) must match exactly
-  // so the on-disk listing title and the session_info_update title agree.
-  const cases: Array<{ name: string; text: string }> = [
-    { name: 'multiline', text: 'line one\nline two\nline three' },
-    { name: 'leading/trailing whitespace', text: '  padded title  ' },
-    { name: 'tabs', text: 'col1\tcol2' },
-    { name: 'multiple text blocks', text: 'part1part2' },
-  ];
-
-  for (const { name, text } of cases) {
-    it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
-      const { deriveSessionTitle } = await import('./zed-session-info.js');
+  describe('listing and live merging', () => {
+    it('returns persisted cwd, first human text title, and updated timestamp', async () => {
       const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
       roots.push(root);
       const chatsDir = join(root, 'chats');
       await mkdir(chatsDir);
       const service = new SessionRecordingService({
-        sessionId: 'consistency-session',
+        sessionId: 'listed-session',
         projectHash: 'project-hash',
         chatsDir,
         workspaceDirs: ['/workspace'],
@@ -243,13 +41,7 @@ describe('durable + live title normalization consistency (issue #1611 finding 5)
       });
       const content: IContent = {
         speaker: 'human',
-        blocks:
-          name === 'multiple text blocks'
-            ? [
-                { type: 'text', text: 'part1' },
-                { type: 'text', text: 'part2' },
-              ]
-            : [{ type: 'text', text }],
+        blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
       };
       service.recordContent(content);
       await service.flush();
@@ -261,161 +53,362 @@ describe('durable + live title normalization consistency (issue #1611 finding 5)
         '/fallback',
         {},
       );
-      const durableTitle = result.sessions[0].title;
 
-      const liveTitle = deriveSessionTitle(
-        name === 'multiple text blocks'
-          ? [
-              { type: 'text', text: 'part1' },
-              { type: 'text', text: 'part2' },
-            ]
-          : [{ type: 'text', text }],
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]).toMatchObject({
+        sessionId: 'listed-session',
+        cwd: '/workspace',
+        title: 'Investigate session lifecycle',
+      });
+      expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+    });
+
+    it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'legacy-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: [],
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'agent-only content' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
       );
 
-      expect(durableTitle).toBe(liveTitle);
+      expect(result.sessions[0].cwd).toBe('/fallback');
+      expect(result.sessions[0]).not.toHaveProperty('title');
+      expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
+        false,
+      );
     });
-  }
-});
 
-describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
-  afterEach(async () => {
-    await Promise.all(
-      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-    );
+    it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+
+      const liveSession = {
+        sessionId: 'live-only-session',
+        cwd: '/workspace',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        title: 'Live session title from first prompt',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]).toMatchObject({
+        sessionId: 'live-only-session',
+        cwd: '/workspace',
+        title: 'Live session title from first prompt',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+      });
+    });
+
+    it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'merged-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Durable title from disk' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'merged-session',
+        cwd: '/workspace',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        title: 'Live title that should be overridden',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Durable title wins over live title.
+      expect(result.sessions[0].title).toBe('Durable title from disk');
+    });
+
+    it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'freshness-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Some title' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'freshness-session',
+        cwd: '/workspace',
+        // Live updatedAt is newer than the durable file mtime.
+        updatedAt: '2099-01-01T00:00:00.000Z',
+        title: 'Live title',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // updatedAt should be the live (newer) value.
+      expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
+    });
+  });
+  describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
+    // The durable path (SessionDiscovery.readFirstUserMessage →
+    // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
+    // NO newline collapse. The live path (deriveSessionTitle) must match exactly
+    // so the on-disk listing title and the session_info_update title agree.
+    const cases: Array<{ name: string; text: string }> = [
+      { name: 'multiline', text: 'line one\nline two\nline three' },
+      { name: 'leading/trailing whitespace', text: '  padded title  ' },
+      { name: 'tabs', text: 'col1\tcol2' },
+      { name: 'multiple text blocks', text: 'part1part2' },
+    ];
+
+    for (const { name, text } of cases) {
+      it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
+        const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+        roots.push(root);
+        const chatsDir = join(root, 'chats');
+        await mkdir(chatsDir);
+        const service = new SessionRecordingService({
+          sessionId: 'consistency-session',
+          projectHash: 'project-hash',
+          chatsDir,
+          workspaceDirs: ['/workspace'],
+          cwd: '/workspace',
+          provider: 'openai',
+          model: 'test-model',
+        });
+        const content: IContent = {
+          speaker: 'human',
+          blocks:
+            name === 'multiple text blocks'
+              ? [
+                  { type: 'text', text: 'part1' },
+                  { type: 'text', text: 'part2' },
+                ]
+              : [{ type: 'text', text }],
+        };
+        service.recordContent(content);
+        await service.flush();
+        await service.dispose();
+
+        const result = await listRecordedSessions(
+          chatsDir,
+          'project-hash',
+          '/fallback',
+          {},
+        );
+        const durableTitle = result.sessions[0].title;
+
+        const liveTitle = deriveSessionTitle(
+          name === 'multiple text blocks'
+            ? [
+                { type: 'text', text: 'part1' },
+                { type: 'text', text: 'part2' },
+              ]
+            : [{ type: 'text', text }],
+        );
+
+        expect(durableTitle).toBe(liveTitle);
+      });
+    }
   });
 
-  it('uses the session_metadata title when present', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'metadata-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
+  describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
+    it('uses the session_metadata title when present', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'metadata-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // Record a metadata title BEFORE the content event.
+      service.recordSessionMetadata('Metadata title from ACP');
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Different first human text' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // The session_metadata title wins over the first-human-text fallback.
+      expect(result.sessions[0].title).toBe('Metadata title from ACP');
     });
-    // Record a metadata title BEFORE the content event.
-    service.recordSessionMetadata('Metadata title from ACP');
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Different first human text' }],
+
+    it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'legacy-metadata-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // No recordSessionMetadata — legacy behavior.
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Legacy first human text' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Falls back to first-human-text for legacy sessions.
+      expect(result.sessions[0].title).toBe('Legacy first human text');
     });
-    await service.flush();
-    await service.dispose();
 
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
+    it('omits title when session_metadata is explicit null (untitled)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'untitled-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // Explicit null title.
+      service.recordSessionMetadata(null);
+      service.recordContent({
+        speaker: 'human',
+        blocks: [
+          { type: 'text', text: 'Human text that should NOT be the title' },
+        ],
+      });
+      await service.flush();
+      await service.dispose();
 
-    expect(result.sessions).toHaveLength(1);
-    // The session_metadata title wins over the first-human-text fallback.
-    expect(result.sessions[0].title).toBe('Metadata title from ACP');
-  });
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
 
-  it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'legacy-metadata-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
+      expect(result.sessions).toHaveLength(1);
+      // Explicit null → no title surfaced (consistent with legacy no-human-text).
+      expect(result.sessions[0]).not.toHaveProperty('title');
     });
-    // No recordSessionMetadata — legacy behavior.
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Legacy first human text' }],
+
+    it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'created-at-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordSessionMetadata('Title');
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      const updatedAt = result.sessions[0].updatedAt;
+      expect(updatedAt).toBeDefined();
+      expect(new Date(updatedAt ?? '').toISOString()).toBe(updatedAt);
     });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Falls back to first-human-text for legacy sessions.
-    expect(result.sessions[0].title).toBe('Legacy first human text');
-  });
-
-  it('omits title when session_metadata is explicit null (untitled)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'untitled-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    // Explicit null title.
-    service.recordSessionMetadata(null);
-    service.recordContent({
-      speaker: 'human',
-      blocks: [
-        { type: 'text', text: 'Human text that should NOT be the title' },
-      ],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Explicit null → no title surfaced (consistent with legacy no-human-text).
-    expect(result.sessions[0]).not.toHaveProperty('title');
-  });
-
-  it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'created-at-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordSessionMetadata('Title');
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -260,6 +260,16 @@ describe('recorded ACP session listing', () => {
     // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
     // NO newline collapse. The live path (deriveSessionTitle) must match exactly
     // so the on-disk listing title and the session_info_update title agree.
+
+    function buildBlocks(name: string, text: string) {
+      return name === 'multiple text blocks'
+        ? [
+            { type: 'text' as const, text: 'part1' },
+            { type: 'text' as const, text: 'part2' },
+          ]
+        : [{ type: 'text' as const, text }];
+    }
+
     const cases: Array<{ name: string; text: string }> = [
       { name: 'multiline', text: 'line one\nline two\nline three' },
       { name: 'leading/trailing whitespace', text: '  padded title  ' },
@@ -283,15 +293,10 @@ describe('recorded ACP session listing', () => {
           provider: 'openai',
           model: 'test-model',
         });
+        const blocks = buildBlocks(name, text);
         const content: IContent = {
           speaker: 'human',
-          blocks:
-            name === 'multiple text blocks'
-              ? [
-                  { type: 'text', text: 'part1' },
-                  { type: 'text', text: 'part2' },
-                ]
-              : [{ type: 'text', text }],
+          blocks,
         };
         service.recordContent(content);
         await service.flush();
@@ -305,14 +310,7 @@ describe('recorded ACP session listing', () => {
         );
         const durableTitle = result.sessions[0].title;
 
-        const liveTitle = deriveSessionTitle(
-          name === 'multiple text blocks'
-            ? [
-                { type: 'text', text: 'part1' },
-                { type: 'text', text: 'part2' },
-              ]
-            : [{ type: 'text', text }],
-        );
+        const liveTitle = deriveSessionTitle(blocks);
 
         expect(durableTitle).toBe(liveTitle);
       });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  SessionRecordingService,
+  type IContent,
+} from '@vybestack/llxprt-code-core';
+import { listRecordedSessions } from './zed-session-listing.js';
+
+const roots: string[] = [];
+
+describe('recorded ACP session listing', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+  it('returns persisted cwd, first human text title, and updated timestamp', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'listed-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
+    };
+    service.recordContent(content);
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'listed-session',
+      cwd: '/workspace',
+      title: 'Investigate session lifecycle',
+    });
+    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'legacy-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: [],
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'agent-only content' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions[0].cwd).toBe('/fallback');
+    expect(result.sessions[0]).not.toHaveProperty('title');
+    expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -390,7 +390,7 @@ describe('session_metadata title takes precedence over legacy first-human-text (
     expect(result.sessions[0]).not.toHaveProperty('title');
   });
 
-  it('includes createdAt in the listing for immutable ordering (issue #1611)', async () => {
+  it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
     const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
     roots.push(root);
     const chatsDir = join(root, 'chats');

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -209,6 +209,51 @@ describe('recorded ACP session listing', () => {
       // updatedAt should be the live (newer) value.
       expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
     });
+
+    it('preserves the durable updatedAt when it is newer than the live value', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'durable-newer-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Some title' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'durable-newer-session',
+        cwd: '/workspace',
+        // Live updatedAt is older than the durable file mtime.
+        updatedAt: '2000-01-01T00:00:00.000Z',
+        title: 'Live title',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Durable mtime is newer than the live value, so it should be preserved.
+      expect(result.sessions[0].updatedAt).not.toBe('2000-01-01T00:00:00.000Z');
+      expect(new Date(result.sessions[0].updatedAt!).getTime()).toBeGreaterThan(
+        new Date('2000-01-01T00:00:00.000Z').getTime(),
+      );
+    });
   });
   describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
     // The durable path (SessionDiscovery.readFirstUserMessage →
@@ -220,6 +265,7 @@ describe('recorded ACP session listing', () => {
       { name: 'leading/trailing whitespace', text: '  padded title  ' },
       { name: 'tabs', text: 'col1\tcol2' },
       { name: 'multiple text blocks', text: 'part1part2' },
+      { name: 'truncation (>120 chars)', text: 'z'.repeat(200) },
     ];
 
     for (const { name, text } of cases) {

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -51,6 +51,11 @@ export async function listRecordedSessions(
     }
     return {
       ...live,
+      // createdAt is immutable — durable recording wins (live sessions may not
+      // have it until the session_start is persisted). Issue #1611.
+      ...(durable.createdAt !== undefined
+        ? { createdAt: durable.createdAt }
+        : {}),
       updatedAt:
         durable.updatedAt > live.updatedAt ? durable.updatedAt : live.updatedAt,
       ...(durable.title === undefined ? {} : { title: durable.title }),
@@ -58,16 +63,33 @@ export async function listRecordedSessions(
   }
 }
 
+/**
+ * Resolves the tri-state title for a durable session.
+ *
+ * Issue #1611: a persisted `session_metadata` event is the source of truth.
+ * For legacy files without one (title === undefined), fall back to the first
+ * human message (which returns null for no-human-text sessions, omitted from
+ * the output). A null metadata title (explicit untitled) is preserved.
+ */
 async function toLifecycleSession(
   summary: SessionSummary,
   fallbackCwd: string,
 ): Promise<LifecycleSession> {
-  const title = await SessionDiscovery.readFirstUserMessage(summary.filePath);
+  const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
+    summary.filePath,
+  );
+  const resolvedTitle =
+    metadataTitle === undefined
+      ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
+      : metadataTitle;
   return {
     sessionId: summary.sessionId,
     cwd: summary.cwd ?? fallbackCwd,
     updatedAt: summary.lastModified.toISOString(),
-    ...(title === null ? {} : { title }),
+    ...(summary.createdAt !== undefined
+      ? { createdAt: summary.createdAt }
+      : {}),
+    ...(typeof resolvedTitle === 'string' ? { title: resolvedTitle } : {}),
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -13,8 +13,26 @@ import {
 } from './zed-session-pagination.js';
 
 const SESSION_PAGE_SIZE = 50;
+const LIST_CONCURRENCY_LIMIT = 8;
 
 const logger = new DebugLogger('llxprt:zed-integration:session-listing');
+
+async function mapWithConcurrencyLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let index = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (index < items.length) {
+      const current = index++;
+      results[current] = await fn(items[current]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 export async function listRecordedSessions(
   chatsDir: string,
@@ -24,8 +42,10 @@ export async function listRecordedSessions(
   liveSessions: readonly LifecycleSession[] = [],
 ): Promise<acp.ListSessionsResponse> {
   const summaries = await SessionDiscovery.listSessions(chatsDir, projectHash);
-  const records = await Promise.all(
-    summaries.map((summary) => toLifecycleSession(summary, fallbackCwd)),
+  const records = await mapWithConcurrencyLimit(
+    summaries,
+    LIST_CONCURRENCY_LIMIT,
+    (summary) => toLifecycleSession(summary, fallbackCwd),
   );
   const merged = new Map(
     records.map((session) => [session.sessionId, session] as const),

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -69,7 +69,8 @@ export async function listRecordedSessions(
  * Issue #1611: a persisted `session_metadata` event is the source of truth.
  * For legacy files without one (title === undefined), fall back to the first
  * human message (which returns null for no-human-text sessions, omitted from
- * the output). A null metadata title (explicit untitled) is preserved.
+ * the output). A null metadata title remains explicitly untitled by suppressing
+ * that legacy fallback and omitting the ACP title property.
  */
 async function toLifecycleSession(
   summary: SessionSummary,
@@ -78,7 +79,7 @@ async function toLifecycleSession(
   const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
     summary.filePath,
   );
-  const resolvedTitle =
+  const displayTitle =
     metadataTitle === undefined
       ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
       : metadataTitle;
@@ -89,7 +90,7 @@ async function toLifecycleSession(
     ...(summary.createdAt !== undefined
       ? { createdAt: summary.createdAt }
       : {}),
-    ...(typeof resolvedTitle === 'string' ? { title: resolvedTitle } : {}),
+    ...(typeof displayTitle === 'string' ? { title: displayTitle } : {}),
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SessionSummary } from '@vybestack/llxprt-code-core';
+import { SessionDiscovery } from '@vybestack/llxprt-code-core';
+import type * as acp from '@agentclientprotocol/sdk';
+import {
+  paginateSessions,
+  type LifecycleSession,
+} from './zed-session-pagination.js';
+
+const SESSION_PAGE_SIZE = 50;
+
+export async function listRecordedSessions(
+  chatsDir: string,
+  projectHash: string,
+  fallbackCwd: string,
+  request: acp.ListSessionsRequest,
+  liveSessions: readonly LifecycleSession[] = [],
+): Promise<acp.ListSessionsResponse> {
+  const summaries = await SessionDiscovery.listSessions(chatsDir, projectHash);
+  const records = await Promise.all(
+    summaries.map((summary) => toLifecycleSession(summary, fallbackCwd)),
+  );
+  const merged = new Map(
+    records.map((session) => [session.sessionId, session] as const),
+  );
+  for (const session of liveSessions) {
+    const durable = merged.get(session.sessionId);
+    merged.set(session.sessionId, mergeLifecycleSession(durable, session));
+  }
+  const page = paginateSessions(
+    [...merged.values()],
+    { cwd: request.cwd ?? null, cursor: request.cursor ?? null },
+    SESSION_PAGE_SIZE,
+  );
+  return {
+    sessions: page.sessions.map(toSessionInfo),
+    ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+  };
+
+  function mergeLifecycleSession(
+    durable: LifecycleSession | undefined,
+    live: LifecycleSession,
+  ): LifecycleSession {
+    if (durable === undefined) {
+      return live;
+    }
+    return {
+      ...live,
+      updatedAt:
+        durable.updatedAt > live.updatedAt ? durable.updatedAt : live.updatedAt,
+      ...(durable.title === undefined ? {} : { title: durable.title }),
+    };
+  }
+}
+
+async function toLifecycleSession(
+  summary: SessionSummary,
+  fallbackCwd: string,
+): Promise<LifecycleSession> {
+  const title = await SessionDiscovery.readFirstUserMessage(summary.filePath);
+  return {
+    sessionId: summary.sessionId,
+    cwd: summary.cwd ?? fallbackCwd,
+    updatedAt: summary.lastModified.toISOString(),
+    ...(title === null ? {} : { title }),
+  };
+}
+
+function toSessionInfo(session: LifecycleSession): acp.SessionInfo {
+  return {
+    sessionId: session.sessionId,
+    cwd: session.cwd,
+    updatedAt: session.updatedAt,
+    ...(session.title === undefined ? {} : { title: session.title }),
+  };
+}

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -76,12 +76,14 @@ async function toLifecycleSession(
   summary: SessionSummary,
   fallbackCwd: string,
 ): Promise<LifecycleSession> {
-  const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
-    summary.filePath,
+  const metadataTitle = await readTitleSafe(() =>
+    SessionDiscovery.readSessionMetadataTitle(summary.filePath),
   );
   const displayTitle =
     metadataTitle === undefined
-      ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
+      ? await readTitleSafe(() =>
+          SessionDiscovery.readFirstUserMessage(summary.filePath),
+        )
       : metadataTitle;
   return {
     sessionId: summary.sessionId,
@@ -92,6 +94,16 @@ async function toLifecycleSession(
       : {}),
     ...(typeof displayTitle === 'string' ? { title: displayTitle } : {}),
   };
+}
+
+async function readTitleSafe(
+  read: () => Promise<string | null | undefined>,
+): Promise<string | null | undefined> {
+  try {
+    return await read();
+  } catch {
+    return undefined;
+  }
 }
 
 function toSessionInfo(session: LifecycleSession): acp.SessionInfo {

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -5,7 +5,7 @@
  */
 
 import type { SessionSummary } from '@vybestack/llxprt-code-core';
-import { SessionDiscovery } from '@vybestack/llxprt-code-core';
+import { SessionDiscovery, DebugLogger } from '@vybestack/llxprt-code-core';
 import type * as acp from '@agentclientprotocol/sdk';
 import {
   paginateSessions,
@@ -13,6 +13,8 @@ import {
 } from './zed-session-pagination.js';
 
 const SESSION_PAGE_SIZE = 50;
+
+const logger = new DebugLogger('llxprt:zed-integration:session-listing');
 
 export async function listRecordedSessions(
   chatsDir: string,
@@ -101,7 +103,8 @@ async function readTitleSafe(
 ): Promise<string | null | undefined> {
   try {
     return await read();
-  } catch {
+  } catch (error) {
+    logger.debug(() => `Title resolution failed: ${String(error)}`);
     return undefined;
   }
 }

--- a/packages/cli/src/zed-integration/zed-session-loader.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.test.ts
@@ -28,11 +28,12 @@ import {
 const PROJECT_TEMP_DIR = '/tmp/llxprt-project-abc';
 const EXPECTED_CHATS_DIR = path.join(PROJECT_TEMP_DIR, 'chats');
 
-/** Config whose storage.getProjectTempDir drives the chats-dir derivation. */
+/** Config whose storage.getProjectChatsDir drives the chats-dir derivation. */
 function buildConfig(): Config {
   return {
     storage: {
       getProjectTempDir: () => PROJECT_TEMP_DIR,
+      getProjectChatsDir: () => EXPECTED_CHATS_DIR,
     },
   } as unknown as Config;
 }
@@ -49,7 +50,7 @@ describe('hasRecordedSessionFile (issue #1604 re-attach probe)', () => {
     vi.restoreAllMocks();
   });
 
-  it('derives the chats dir from storage.getProjectTempDir()/chats and reports true when a matching recording exists', async () => {
+  it('derives the chats dir from storage.getProjectChatsDir() and reports true when a matching recording exists', async () => {
     const sessionId = 'sess-1234567890ab';
     let listedDir: string | undefined;
     const lister: ChatSessionFileLister = async (dir) => {

--- a/packages/cli/src/zed-integration/zed-session-loader.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the loadSession loader helpers (issue #1604 re-attach):
+ * the on-disk recording probe {@link hasRecordedSessionFile} and the live
+ * in-memory history bridge {@link readAgentHistoryAsIContent}. These exercise the
+ * REAL chats-dir derivation + filename matching against an honest readdir-like
+ * lister (directory entry names, NOT a result-shaped mock of our logic) and the
+ * REAL ContentConverters bridge against a fake agent, so no internal decision
+ * logic is mocked.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import * as path from 'node:path';
+import type { Config } from '@vybestack/llxprt-code-core';
+import type { Agent, AgentMessage } from '@vybestack/llxprt-code-agents';
+import {
+  hasRecordedSessionFile,
+  readAgentHistoryAsIContent,
+  type ChatSessionFileLister,
+} from './zed-session-loader.js';
+
+const PROJECT_TEMP_DIR = '/tmp/llxprt-project-abc';
+const EXPECTED_CHATS_DIR = path.join(PROJECT_TEMP_DIR, 'chats');
+
+/** Config whose storage.getProjectTempDir drives the chats-dir derivation. */
+function buildConfig(): Config {
+  return {
+    storage: {
+      getProjectTempDir: () => PROJECT_TEMP_DIR,
+    },
+  } as unknown as Config;
+}
+
+/** The real recorded-file name shape for a session id. */
+function recordedName(sessionId: string): string {
+  return `session-2026-07-11T10-00-00-${sessionId.substring(0, 12)}.jsonl`;
+}
+
+describe('hasRecordedSessionFile (issue #1604 re-attach probe)', () => {
+  it('derives the chats dir from storage.getProjectTempDir()/chats and reports true when a matching recording exists', async () => {
+    const sessionId = 'sess-1234567890ab';
+    let listedDir: string | undefined;
+    const lister: ChatSessionFileLister = async (dir) => {
+      listedDir = dir;
+      return [recordedName(sessionId), 'session-other-000000000000.jsonl'];
+    };
+
+    const exists = await hasRecordedSessionFile(
+      buildConfig(),
+      sessionId,
+      lister,
+    );
+
+    expect(exists).toBe(true);
+    // The probe read the SAME chats dir the recording layer writes to.
+    expect(listedDir).toBe(EXPECTED_CHATS_DIR);
+  });
+
+  it('reports false (→ re-attach) when NO entry matches the session id (an unprompted session with no recording)', async () => {
+    const lister: ChatSessionFileLister = async () => [
+      'session-unrelated-999999999999.jsonl',
+      'not-a-session-file.txt',
+    ];
+
+    const exists = await hasRecordedSessionFile(
+      buildConfig(),
+      'sess-1234567890ab',
+      lister,
+    );
+
+    expect(exists).toBe(false);
+  });
+
+  it('reports false when the chats dir is empty (fresh project, no recordings yet)', async () => {
+    const lister: ChatSessionFileLister = async () => [];
+    const exists = await hasRecordedSessionFile(
+      buildConfig(),
+      'sess-1234567890ab',
+      lister,
+    );
+    expect(exists).toBe(false);
+  });
+
+  it('treats a probe failure (e.g. chats dir does not exist, ENOENT) as no recording present (→ re-attach) rather than surfacing an error', async () => {
+    const lister: ChatSessionFileLister = async () => {
+      const error = new Error(
+        'ENOENT: no such file or directory, scandir chats',
+      ) as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      throw error;
+    };
+
+    // Must resolve false (not reject): a missing directory routes to re-attach.
+    await expect(
+      hasRecordedSessionFile(buildConfig(), 'sess-1234567890ab', lister),
+    ).resolves.toBe(false);
+  });
+
+  it('matches ONLY on the session id suffix, not an unrelated file that merely starts with session-', async () => {
+    const sessionId = 'abcdef123456ffff';
+    const lister: ChatSessionFileLister = async () => [
+      // Same prefix word, DIFFERENT id suffix → must NOT match.
+      `session-2026-07-11T10-00-00-abcdef000000.jsonl`,
+    ];
+
+    const exists = await hasRecordedSessionFile(
+      buildConfig(),
+      sessionId,
+      lister,
+    );
+    expect(exists).toBe(false);
+  });
+});
+
+describe('readAgentHistoryAsIContent (issue #1604 re-attach replay bridge)', () => {
+  /** Fake agent exposing only getHistory (the sole method this helper uses). */
+  function buildAgent(history: readonly AgentMessage[]): {
+    agent: Agent;
+    getHistory: ReturnType<typeof vi.fn>;
+  } {
+    const getHistory = vi.fn(async () => history);
+    const agent = { getHistory } as unknown as Agent;
+    return { agent, getHistory };
+  }
+
+  it('converts the live Gemini history to neutral IContent[] preserving speaker + text', async () => {
+    const { agent, getHistory } = buildAgent([
+      { role: 'user', parts: [{ text: 'hello there' }] },
+      { role: 'model', parts: [{ text: 'general kenobi' }] },
+    ]);
+
+    const items = await readAgentHistoryAsIContent(agent);
+
+    expect(getHistory).toHaveBeenCalledTimes(1);
+    expect(items).toHaveLength(2);
+    expect(items[0].speaker).toBe('human');
+    expect(items[1].speaker).toBe('ai');
+    // Text survives the conversion in order.
+    const texts = items.flatMap((item) =>
+      item.blocks
+        .filter(
+          (b): b is Extract<typeof b, { type: 'text' }> => b.type === 'text',
+        )
+        .map((b) => b.text),
+    );
+    expect(texts).toStrictEqual(['hello there', 'general kenobi']);
+  });
+
+  it('returns an empty array for a fresh unprompted session (empty live history → zero replay updates)', async () => {
+    const { agent } = buildAgent([]);
+    const items = await readAgentHistoryAsIContent(agent);
+    expect(items).toStrictEqual([]);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-loader.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.test.ts
@@ -14,8 +14,9 @@
  * logic is mocked.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as path from 'node:path';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { Config } from '@vybestack/llxprt-code-core';
 import type { Agent, AgentMessage } from '@vybestack/llxprt-code-agents';
 import {
@@ -42,6 +43,12 @@ function recordedName(sessionId: string): string {
 }
 
 describe('hasRecordedSessionFile (issue #1604 re-attach probe)', () => {
+  afterEach(() => {
+    // Restore any DebugLogger.prototype.warn spy installed by the C2 tests so it
+    // does not leak into sibling tests.
+    vi.restoreAllMocks();
+  });
+
   it('derives the chats dir from storage.getProjectTempDir()/chats and reports true when a matching recording exists', async () => {
     const sessionId = 'sess-1234567890ab';
     let listedDir: string | undefined;
@@ -86,7 +93,12 @@ describe('hasRecordedSessionFile (issue #1604 re-attach probe)', () => {
     expect(exists).toBe(false);
   });
 
-  it('treats a probe failure (e.g. chats dir does not exist, ENOENT) as no recording present (→ re-attach) rather than surfacing an error', async () => {
+  it('treats an ENOENT probe failure (chats dir does not exist) as no recording present (→ re-attach) WITHOUT a warn (expected case, FINDING C2)', async () => {
+    // Spy on the DebugLogger the loader module uses so we can assert the ENOENT
+    // case stays at debug level (no warn) — the common fresh-project path.
+    const warnSpy = vi
+      .spyOn(DebugLogger.prototype, 'warn')
+      .mockImplementation(() => undefined);
     const lister: ChatSessionFileLister = async () => {
       const error = new Error(
         'ENOENT: no such file or directory, scandir chats',
@@ -99,6 +111,36 @@ describe('hasRecordedSessionFile (issue #1604 re-attach probe)', () => {
     await expect(
       hasRecordedSessionFile(buildConfig(), 'sess-1234567890ab', lister),
     ).resolves.toBe(false);
+    // ENOENT is expected → logged at debug only, NOT warn.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats a NON-ENOENT probe failure (EACCES) as no recording present (→ re-attach, fail-open) BUT logs a warn so it is diagnosable (FINDING C2)', async () => {
+    const warnSpy = vi
+      .spyOn(DebugLogger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+    const lister: ChatSessionFileLister = async () => {
+      const error = new Error(
+        'EACCES: permission denied, scandir chats',
+      ) as NodeJS.ErrnoException;
+      error.code = 'EACCES';
+      throw error;
+    };
+
+    // Still fail-open to re-attach (a load must not crash on a probe issue)...
+    await expect(
+      hasRecordedSessionFile(buildConfig(), 'sess-1234567890ab', lister),
+    ).resolves.toBe(false);
+    // ...but the unexpected failure IS surfaced at warn (not silently swallowed
+    // at the same level as the expected ENOENT case).
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const firstArg = warnSpy.mock.calls[0]?.[0];
+    const rendered =
+      typeof firstArg === 'function'
+        ? (firstArg as () => string)()
+        : String(firstArg);
+    expect(rendered).toContain('EACCES');
+    expect(rendered.toLowerCase()).toContain('non-enoent');
   });
 
   it('matches ONLY on the session id suffix, not an unrelated file that merely starts with session-', async () => {

--- a/packages/cli/src/zed-integration/zed-session-loader.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.test.ts
@@ -132,15 +132,17 @@ describe('hasRecordedSessionFile (issue #1604 re-attach probe)', () => {
       hasRecordedSessionFile(buildConfig(), 'sess-1234567890ab', lister),
     ).resolves.toBe(false);
     // ...but the unexpected failure IS surfaced at warn (not silently swallowed
-    // at the same level as the expected ENOENT case).
+    // at the same level as the expected ENOENT case). Assert the DIAGNOSTIC
+    // CONTENT (which session, which error) rather than the message's exact
+    // phrasing, so a reworded log does not break the behavioral contract.
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const firstArg = warnSpy.mock.calls[0]?.[0];
     const rendered =
       typeof firstArg === 'function'
         ? (firstArg as () => string)()
         : String(firstArg);
+    expect(rendered).toContain('sess-1234567890ab');
     expect(rendered).toContain('EACCES');
-    expect(rendered.toLowerCase()).toContain('non-enoent');
   });
 
   it('matches ONLY on the session id suffix, not an unrelated file that merely starts with session-', async () => {

--- a/packages/cli/src/zed-integration/zed-session-loader.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.ts
@@ -57,12 +57,13 @@ export async function resumeAgentHistory(
   agent: Agent,
   sessionId: string,
   sessionConfig: Config,
+  listFiles: ChatSessionFileLister = nodeChatSessionFileLister,
 ): Promise<readonly IContent[]> {
   try {
     return await agent.session.resume(sessionId);
   } catch (error) {
     throw await classifyResumeFailure(sessionId, error, () =>
-      listSessionFileNames(sessionConfig),
+      listSessionFileNames(sessionConfig, listFiles),
     );
   }
 }
@@ -70,15 +71,20 @@ export async function resumeAgentHistory(
 /**
  * Lists the chats-dir entry names for the corrupt-vs-missing probe (FINDING B),
  * deriving the directory the SAME way the recording layer does
- * (`join(storage.getProjectTempDir(), 'chats')`). A read failure propagates to
- * {@link classifyResumeFailure}, which swallows it and falls back to the plain
- * mapping so the original resume failure is never masked.
+ * (`join(storage.getProjectTempDir(), 'chats')`) and delegating the actual read
+ * to the injected {@link ChatSessionFileLister} (FINDING C1) so the resume probe
+ * and the re-attach probe ({@link hasRecordedSessionFile}) share ONE injected
+ * lister rather than one hardcoding readdir. A read failure propagates to
+ * {@link classifyResumeFailure}, which classifies it (ENOENT → genuinely
+ * missing; other → indeterminate/internalError) so the original resume failure
+ * is never silently masked.
  */
 async function listSessionFileNames(
   sessionConfig: Config,
+  listFiles: ChatSessionFileLister,
 ): Promise<readonly string[]> {
   const chatsDir = chatsDirFor(sessionConfig);
-  return readdir(chatsDir);
+  return listFiles(chatsDir);
 }
 
 /**
@@ -110,15 +116,44 @@ export async function hasRecordedSessionFile(
     const entries = await listFiles(chatsDir);
     return findMatchingSessionFile(sessionId, entries) !== null;
   } catch (error) {
-    logger.debug(
-      () =>
-        `hasRecordedSessionFile: probe failed for ${sessionId}; treating as ` +
-        `no on-disk recording (re-attach): ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-    );
+    const message = error instanceof Error ? error.message : String(error);
+    // FINDING C2: both branches fail-open to re-attach (a load must NOT crash on
+    // a probe issue), but distinguish the severity so a real problem is
+    // diagnosable rather than swallowed at the SAME level as the expected case:
+    //   - ENOENT (chats dir not created yet — the common fresh-project case) is
+    //     EXPECTED: log at debug only.
+    //   - any other error (EACCES, EIO, ...) is UNEXPECTED and means the probe
+    //     could not actually determine recording presence: log at warn so it is
+    //     visible, while still returning false (re-attach) rather than rethrowing.
+    if (isEnoentError(error)) {
+      logger.debug(
+        () =>
+          `hasRecordedSessionFile: chats dir absent (ENOENT) for ${sessionId}; ` +
+          `treating as no on-disk recording (re-attach): ${message}`,
+      );
+    } else {
+      logger.warn(
+        () =>
+          `hasRecordedSessionFile: probe failed (non-ENOENT) for ${sessionId}; ` +
+          `could not determine recording presence, failing open to re-attach: ${message}`,
+      );
+    }
     return false;
   }
+}
+
+/**
+ * True when `error` is a Node ENOENT (no-such-file/directory) rejection — used
+ * by {@link hasRecordedSessionFile} to log the expected missing-chats-dir case
+ * at debug while surfacing genuinely unexpected probe failures at warn
+ * (FINDING C2).
+ */
+function isEnoentError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
 }
 
 /**
@@ -139,8 +174,18 @@ export async function readAgentHistoryAsIContent(
 
 /**
  * Derives the chats directory (where session recordings live) from a config's
- * project storage temp dir, matching the recording layer + SessionControl
- * derivation exactly.
+ * project storage temp dir: `join(storage.getProjectTempDir(), 'chats')`.
+ *
+ * FINDING C3 — this 'chats' derivation is DUPLICATED across three call sites
+ * that MUST stay in lockstep (there is no shared exported constant because
+ * SessionControl's copy is private in packages/agents and core does not export
+ * one). If the derivation ever changes, update ALL of:
+ *   1. this function (the zed loadSession re-attach + corrupt-vs-missing probes);
+ *   2. SessionControl.chatsDir() (packages/agents/src/api/control/sessionControl.ts)
+ *      — the recording/resume path that WRITES the files;
+ *   3. the `chatsDir` passed into SessionRecordingService's config (the core
+ *      recording layer that materializes `<chatsDir>/session-*.jsonl`).
+ * A drift in any one silently breaks the probe↔recording filename match.
  */
 function chatsDirFor(config: Config): string {
   return path.join(config.storage.getProjectTempDir(), 'chats');

--- a/packages/cli/src/zed-integration/zed-session-loader.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.ts
@@ -185,7 +185,13 @@ export async function readAgentHistoryForReplay(
  * (FINDING C3).
  */
 function chatsDirFor(config: Config): string {
-  return config.storage.getProjectChatsDir();
+  const storage = (config as Record<string, unknown>).storage;
+  if (storage === undefined || storage === null) {
+    throw new Error(
+      'Cannot resolve chats directory: config.storage is not available',
+    );
+  }
+  return (storage as Config['storage']).getProjectChatsDir();
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-loader.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resume + error-classification helpers for ACP session/load (loadSession)
+ * (issue #1604). These own the I/O-touching parts of a load (the recorded-history
+ * resume and the corrupt-vs-missing session-file probe) plus the final
+ * RequestError normalization, kept OUT of zedIntegration.ts so that near-cap file
+ * stays within its max-lines budget and the load orchestration is individually
+ * testable.
+ */
+
+import { readdir } from 'node:fs/promises';
+import * as path from 'node:path';
+import * as acp from '@agentclientprotocol/sdk';
+import type { Config, IContent } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import { classifyResumeFailure } from './zed-session-errors.js';
+
+/**
+ * Resumes the agent's recorded history, mapping a resume rejection to a precise
+ * ACP RequestError via {@link classifyResumeFailure}. When the plain
+ * classification would be "not found", the on-disk session-file namespace (the
+ * same chats dir the recording writes to) is probed so a corrupt-but-present
+ * session is reported as internalError ("file exists but could not be
+ * read/replayed") rather than being misreported as resourceNotFound (FINDING B).
+ */
+export async function resumeAgentHistory(
+  agent: Agent,
+  sessionId: string,
+  sessionConfig: Config,
+): Promise<readonly IContent[]> {
+  try {
+    return await agent.session.resume(sessionId);
+  } catch (error) {
+    throw await classifyResumeFailure(sessionId, error, () =>
+      listSessionFileNames(sessionConfig),
+    );
+  }
+}
+
+/**
+ * Lists the chats-dir entry names for the corrupt-vs-missing probe (FINDING B),
+ * deriving the directory the SAME way the recording layer does
+ * (`join(storage.getProjectTempDir(), 'chats')`). A read failure propagates to
+ * {@link classifyResumeFailure}, which swallows it and falls back to the plain
+ * mapping so the original resume failure is never masked.
+ */
+async function listSessionFileNames(
+  sessionConfig: Config,
+): Promise<readonly string[]> {
+  const chatsDir = path.join(
+    sessionConfig.storage.getProjectTempDir(),
+    'chats',
+  );
+  return readdir(chatsDir);
+}
+
+/**
+ * Normalizes a post-fromConfig load failure into an ACP RequestError (FINDING E).
+ * An error that is ALREADY a RequestError (e.g. the precise error returned by
+ * {@link resumeAgentHistory}) passes through unchanged; any other throw (such as
+ * one while constructing the Session AFTER resume already adopted the recording +
+ * lock) is wrapped as internalError carrying the detail, so the caller can always
+ * dispose the fresh agent and rethrow a single, well-formed RequestError.
+ */
+export function toLoadRequestError(
+  sessionId: string,
+  error: unknown,
+): acp.RequestError {
+  if (error instanceof acp.RequestError) {
+    return error;
+  }
+  const detail = error instanceof Error ? error.message : String(error);
+  return acp.RequestError.internalError({ sessionId, reason: detail }, detail);
+}

--- a/packages/cli/src/zed-integration/zed-session-loader.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.ts
@@ -23,6 +23,7 @@ import {
   classifyResumeFailure,
   findMatchingSessionFile,
   isEnoent,
+  wrapReplayFailure,
 } from './zed-session-errors.js';
 
 /**
@@ -156,6 +157,24 @@ export async function readAgentHistoryAsIContent(
 ): Promise<readonly IContent[]> {
   const history = await agent.getHistory();
   return ContentConverters.toIContents([...history]);
+}
+
+/**
+ * {@link readAgentHistoryAsIContent} with replay-failure normalization: a
+ * getHistory()/conversion rejection is wrapped exactly like a delivery failure
+ * ({@link wrapReplayFailure} -> internalError, phase:'replay') so a re-attach
+ * load always rejects with a well-formed RequestError — consistent with the
+ * disk-resume path's error semantics.
+ */
+export async function readAgentHistoryForReplay(
+  agent: Agent,
+  sessionId: string,
+): Promise<readonly IContent[]> {
+  try {
+    return await readAgentHistoryAsIContent(agent);
+  } catch (error) {
+    throw wrapReplayFailure(sessionId, error);
+  }
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-loader.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.ts
@@ -14,7 +14,6 @@
  */
 
 import { readdir } from 'node:fs/promises';
-import * as path from 'node:path';
 import * as acp from '@agentclientprotocol/sdk';
 import type { Config, IContent } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
@@ -23,6 +22,7 @@ import type { Agent } from '@vybestack/llxprt-code-agents';
 import {
   classifyResumeFailure,
   findMatchingSessionFile,
+  isEnoent,
 } from './zed-session-errors.js';
 
 /**
@@ -71,7 +71,7 @@ export async function resumeAgentHistory(
 /**
  * Lists the chats-dir entry names for the corrupt-vs-missing probe (FINDING B),
  * deriving the directory the SAME way the recording layer does
- * (`join(storage.getProjectTempDir(), 'chats')`) and delegating the actual read
+ * (via Storage.getProjectChatsDir()) and delegating the actual read
  * to the injected {@link ChatSessionFileLister} (FINDING C1) so the resume probe
  * and the re-attach probe ({@link hasRecordedSessionFile}) share ONE injected
  * lister rather than one hardcoding readdir. A read failure propagates to
@@ -102,7 +102,7 @@ async function listSessionFileNames(
  * directory safely routes to re-attach rather than surfacing an error.
  *
  * The directory is derived the SAME way the recording layer does
- * (`join(storage.getProjectTempDir(), 'chats')`) and matched with the SAME
+ * (via Storage.getProjectChatsDir()) and matched with the SAME
  * filename rule the corrupt-vs-missing resume probe uses
  * ({@link findMatchingSessionFile}), keeping the two in lockstep.
  */
@@ -125,7 +125,7 @@ export async function hasRecordedSessionFile(
     //   - any other error (EACCES, EIO, ...) is UNEXPECTED and means the probe
     //     could not actually determine recording presence: log at warn so it is
     //     visible, while still returning false (re-attach) rather than rethrowing.
-    if (isEnoentError(error)) {
+    if (isEnoent(error)) {
       logger.debug(
         () =>
           `hasRecordedSessionFile: chats dir absent (ENOENT) for ${sessionId}; ` +
@@ -140,20 +140,6 @@ export async function hasRecordedSessionFile(
     }
     return false;
   }
-}
-
-/**
- * True when `error` is a Node ENOENT (no-such-file/directory) rejection — used
- * by {@link hasRecordedSessionFile} to log the expected missing-chats-dir case
- * at debug while surfacing genuinely unexpected probe failures at warn
- * (FINDING C2).
- */
-function isEnoentError(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    (error as NodeJS.ErrnoException).code === 'ENOENT'
-  );
 }
 
 /**
@@ -173,22 +159,14 @@ export async function readAgentHistoryAsIContent(
 }
 
 /**
- * Derives the chats directory (where session recordings live) from a config's
- * project storage temp dir: `join(storage.getProjectTempDir(), 'chats')`.
- *
- * FINDING C3 — this 'chats' derivation is DUPLICATED across three call sites
- * that MUST stay in lockstep (there is no shared exported constant because
- * SessionControl's copy is private in packages/agents and core does not export
- * one). If the derivation ever changes, update ALL of:
- *   1. this function (the zed loadSession re-attach + corrupt-vs-missing probes);
- *   2. SessionControl.chatsDir() (packages/agents/src/api/control/sessionControl.ts)
- *      — the recording/resume path that WRITES the files;
- *   3. the `chatsDir` passed into SessionRecordingService's config (the core
- *      recording layer that materializes `<chatsDir>/session-*.jsonl`).
- * A drift in any one silently breaks the probe↔recording filename match.
+ * The chats directory (where session recordings live), delegated to
+ * Storage.getProjectChatsDir() — the single source of truth shared with
+ * SessionControl.chatsDir() (the recording/resume path that WRITES the files),
+ * so the probe↔recording filename match can never drift on the location
+ * (FINDING C3).
  */
 function chatsDirFor(config: Config): string {
-  return path.join(config.storage.getProjectTempDir(), 'chats');
+  return config.storage.getProjectChatsDir();
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-loader.ts
+++ b/packages/cli/src/zed-integration/zed-session-loader.ts
@@ -7,18 +7,43 @@
 /**
  * Resume + error-classification helpers for ACP session/load (loadSession)
  * (issue #1604). These own the I/O-touching parts of a load (the recorded-history
- * resume and the corrupt-vs-missing session-file probe) plus the final
- * RequestError normalization, kept OUT of zedIntegration.ts so that near-cap file
- * stays within its max-lines budget and the load orchestration is individually
- * testable.
+ * resume, the corrupt-vs-missing session-file probe, the live-session re-attach
+ * probe, and the in-memory history bridge) plus the final RequestError
+ * normalization, kept OUT of zedIntegration.ts so that near-cap file stays within
+ * its max-lines budget and the load orchestration is individually testable.
  */
 
 import { readdir } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as acp from '@agentclientprotocol/sdk';
 import type { Config, IContent } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
+import { ContentConverters } from '@vybestack/llxprt-code-core/services/history/ContentConverters.js';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import { classifyResumeFailure } from './zed-session-errors.js';
+import {
+  classifyResumeFailure,
+  findMatchingSessionFile,
+} from './zed-session-errors.js';
+
+/**
+ * A readdir-like directory lister injected for testability (FINDING B / #1604
+ * re-attach). Production passes {@link nodeChatSessionFileLister} (a thin wrapper
+ * over `node:fs/promises` readdir); tests pass an honest fake that returns the
+ * directory entry names, NOT a result-shaped mock of our matching logic, so the
+ * real chats-dir derivation + filename matching are exercised.
+ */
+export type ChatSessionFileLister = (
+  chatsDir: string,
+) => Promise<readonly string[]>;
+
+/**
+ * Default {@link ChatSessionFileLister}: the real `node:fs/promises` readdir,
+ * wrapped so it satisfies the lister signature regardless of readdir's overloads.
+ */
+export const nodeChatSessionFileLister: ChatSessionFileLister = (chatsDir) =>
+  readdir(chatsDir);
+
+const logger = new DebugLogger('llxprt:zed-integration:session-loader');
 
 /**
  * Resumes the agent's recorded history, mapping a resume rejection to a precise
@@ -52,11 +77,73 @@ export async function resumeAgentHistory(
 async function listSessionFileNames(
   sessionConfig: Config,
 ): Promise<readonly string[]> {
-  const chatsDir = path.join(
-    sessionConfig.storage.getProjectTempDir(),
-    'chats',
-  );
+  const chatsDir = chatsDirFor(sessionConfig);
   return readdir(chatsDir);
+}
+
+/**
+ * Re-attach decision probe (#1604): true when a recorded session file for
+ * `sessionId` already exists on disk under the ZedAgent config's chats dir.
+ *
+ * A freshly created but UNPROMPTED session has no recording — SessionRecordingService
+ * only materializes the JSONL file on the FIRST content event — so this returns
+ * false for it, signalling loadSession to RE-ATTACH the live in-memory session
+ * (replaying its in-memory history) instead of destroying it and failing a disk
+ * resume that would find no file. Once the session has been prompted (a file
+ * exists), this returns true and loadSession takes the destroy-prior + disk-resume
+ * path. Any probe failure (e.g. the chats dir does not exist yet, ENOENT) is
+ * treated as "no recording present" (returns false, logged at debug) so a missing
+ * directory safely routes to re-attach rather than surfacing an error.
+ *
+ * The directory is derived the SAME way the recording layer does
+ * (`join(storage.getProjectTempDir(), 'chats')`) and matched with the SAME
+ * filename rule the corrupt-vs-missing resume probe uses
+ * ({@link findMatchingSessionFile}), keeping the two in lockstep.
+ */
+export async function hasRecordedSessionFile(
+  config: Config,
+  sessionId: string,
+  listFiles: ChatSessionFileLister,
+): Promise<boolean> {
+  try {
+    const chatsDir = chatsDirFor(config);
+    const entries = await listFiles(chatsDir);
+    return findMatchingSessionFile(sessionId, entries) !== null;
+  } catch (error) {
+    logger.debug(
+      () =>
+        `hasRecordedSessionFile: probe failed for ${sessionId}; treating as ` +
+        `no on-disk recording (re-attach): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Reads a live agent's in-memory conversation as neutral IContent[] for the
+ * re-attach replay (#1604). `agent.getHistory()` returns the Gemini-shaped
+ * history (readonly AgentMessage[]); it is converted to IContent[] via the SAME
+ * ContentConverters.toIContents bridge the recording/resume path uses (see
+ * sessionControl.ts), so the re-attach replay maps identically to a disk resume.
+ * A fresh unprompted session has empty history, yielding an empty array (zero
+ * replay updates).
+ */
+export async function readAgentHistoryAsIContent(
+  agent: Agent,
+): Promise<readonly IContent[]> {
+  const history = await agent.getHistory();
+  return ContentConverters.toIContents([...history]);
+}
+
+/**
+ * Derives the chats directory (where session recordings live) from a config's
+ * project storage temp dir, matching the recording layer + SessionControl
+ * derivation exactly.
+ */
+function chatsDirFor(config: Config): string {
+  return path.join(config.storage.getProjectTempDir(), 'chats');
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -180,4 +180,20 @@ describe('session lifecycle pagination', () => {
       'c',
     ]);
   });
+
+  it('returns empty sessions with no nextCursor for an empty list', () => {
+    const result = paginateSessions([], { cwd: null, cursor: null }, 10);
+    expect(result.sessions).toStrictEqual([]);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('returns no nextCursor when results fit exactly within pageSize', () => {
+    const exact: LifecycleSession[] = [
+      { sessionId: 'x', cwd: '/w', updatedAt: '2026-01-02T00:00:00.000Z' },
+      { sessionId: 'y', cwd: '/w', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+    const result = paginateSessions(exact, { cwd: null, cursor: null }, 2);
+    expect(result.sessions.map((s) => s.sessionId)).toStrictEqual(['x', 'y']);
+    expect(result.nextCursor).toBeUndefined();
+  });
 });

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -78,8 +78,8 @@ describe('session lifecycle pagination', () => {
   });
 
   it('updatedAt changes cannot omit sessions: immutable createdAt ordering (issue #1611)', () => {
-    // Two sessions with the SAME createdAt but different updatedAt (simulating
-    // a session that was updated mid-pagination). Ordering must be stable by
+    // Two sessions with different createdAt and updatedAt values. Ordering must
+    // remain stable when a session is updated mid-pagination because it uses
     // createdAt + sessionId, so the cursor is not invalidated.
     const stable: LifecycleSession[] = [
       {

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  paginateSessions,
+  type LifecycleSession,
+} from './zed-session-pagination.js';
+
+const sessions: readonly LifecycleSession[] = [
+  { sessionId: 'b', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
+  { sessionId: 'a', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
+  { sessionId: 'c', cwd: '/b', updatedAt: '2026-01-02T00:00:00.000Z' },
+];
+
+describe('session lifecycle pagination', () => {
+  it('orders by updatedAt then sessionId descending and continues with an opaque cursor', () => {
+    const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
+    expect(first.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'b',
+      'a',
+    ]);
+    expect(first.nextCursor).toStrictEqual(expect.any(String));
+
+    const second = paginateSessions(
+      sessions,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      2,
+    );
+    expect(second).toStrictEqual({ sessions: [sessions[2]] });
+  });
+
+  it('filters by exact cwd before pagination', () => {
+    const result = paginateSessions(sessions, { cwd: '/a', cursor: null }, 10);
+    expect(result.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'b',
+      'a',
+    ]);
+  });
+
+  it('rejects a malformed cursor', () => {
+    expect(() =>
+      paginateSessions(sessions, { cwd: null, cursor: 'not-a-cursor' }, 2),
+    ).toThrow(/cursor/i);
+  });
+
+  it('rejects a cursor created for a different cwd filter', () => {
+    const first = paginateSessions(sessions, { cwd: '/a', cursor: null }, 1);
+    expect(() =>
+      paginateSessions(
+        sessions,
+        { cwd: '/b', cursor: first.nextCursor ?? null },
+        1,
+      ),
+    ).toThrow(/cursor/i);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -142,6 +142,24 @@ describe('session lifecycle pagination', () => {
     ]);
   });
 
+  it('continues a legacy page when updatedAt is valid but not canonical', () => {
+    const legacy: LifecycleSession[] = [
+      { sessionId: 'new', cwd: '/w', updatedAt: '2026-06-01T00:00:00Z' },
+      { sessionId: 'old', cwd: '/w', updatedAt: '2026-01-01T00:00:00Z' },
+    ];
+    const first = paginateSessions(legacy, { cwd: null, cursor: null }, 1);
+
+    const second = paginateSessions(
+      legacy,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      1,
+    );
+
+    expect(second.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'old',
+    ]);
+  });
+
   it('rejects a legacy v1 cursor (version mismatch)', () => {
     const v1Cursor = Buffer.from(
       JSON.stringify({

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -10,14 +10,33 @@ import {
   type LifecycleSession,
 } from './zed-session-pagination.js';
 
+/**
+ * Issue #1611: pagination now orders by immutable createdAt + sessionId
+ * (not updatedAt, which can change and cause session omission).
+ */
 const sessions: readonly LifecycleSession[] = [
-  { sessionId: 'b', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
-  { sessionId: 'a', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
-  { sessionId: 'c', cwd: '/b', updatedAt: '2026-01-02T00:00:00.000Z' },
+  {
+    sessionId: 'b',
+    cwd: '/a',
+    updatedAt: '2026-01-03T00:00:00.000Z',
+    createdAt: '2026-01-03T00:00:00.000Z',
+  },
+  {
+    sessionId: 'a',
+    cwd: '/a',
+    updatedAt: '2026-01-03T00:00:00.000Z',
+    createdAt: '2026-01-03T00:00:00.000Z',
+  },
+  {
+    sessionId: 'c',
+    cwd: '/b',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    createdAt: '2026-01-02T00:00:00.000Z',
+  },
 ];
 
 describe('session lifecycle pagination', () => {
-  it('orders by updatedAt then sessionId descending and continues with an opaque cursor', () => {
+  it('orders by createdAt then sessionId descending and continues with an opaque cursor', () => {
     const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
     expect(first.sessions.map((session) => session.sessionId)).toStrictEqual([
       'b',
@@ -55,6 +74,85 @@ describe('session lifecycle pagination', () => {
         { cwd: '/b', cursor: first.nextCursor ?? null },
         1,
       ),
+    ).toThrow(/cursor/i);
+  });
+
+  it('updatedAt changes cannot omit sessions: immutable createdAt ordering (issue #1611)', () => {
+    // Two sessions with the SAME createdAt but different updatedAt (simulating
+    // a session that was updated mid-pagination). Ordering must be stable by
+    // createdAt + sessionId, so the cursor is not invalidated.
+    const stable: LifecycleSession[] = [
+      {
+        sessionId: 'x',
+        cwd: '/w',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        createdAt: '2026-07-10T10:00:00.000Z',
+      },
+      {
+        sessionId: 'y',
+        cwd: '/w',
+        updatedAt: '2026-07-12T13:00:00.000Z',
+        createdAt: '2026-07-10T09:00:00.000Z',
+      },
+    ];
+    const first = paginateSessions(stable, { cwd: null, cursor: null }, 1);
+    expect(first.sessions[0].sessionId).toBe('x');
+
+    // Simulate the "updatedAt changed between pages" scenario:
+    // After page 1, the first session's updatedAt changes — but createdAt
+    // is immutable, so the cursor still correctly filters.
+    const firstAfterMutation: LifecycleSession = {
+      ...stable[0],
+      updatedAt: '2026-07-12T23:59:59.000Z',
+    };
+    const secondSet = [firstAfterMutation, stable[1]];
+    const second = paginateSessions(
+      secondSet,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      10,
+    );
+    expect(second.sessions.map((s) => s.sessionId)).toStrictEqual(['y']);
+  });
+
+  it('v2 cursor is self-contained and process-independent (issue #1611)', () => {
+    // The cursor encodes the full (createdAt, sessionId) tuple so the next
+    // page can be computed without shared state.
+    const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
+    expect(first.nextCursor).toStrictEqual(expect.any(String));
+
+    // Decode the cursor to verify it's self-contained.
+    const decoded = JSON.parse(
+      Buffer.from(first.nextCursor!, 'base64url').toString('utf8'),
+    );
+    expect(decoded.v).toBe(2);
+    expect(decoded.createdAt).toBeDefined();
+    expect(decoded.sessionId).toBe('a');
+    expect(decoded.cwd).toBeNull();
+  });
+
+  it('falls back to updatedAt when createdAt is absent (legacy)', () => {
+    const legacy: LifecycleSession[] = [
+      { sessionId: 'old', cwd: '/w', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { sessionId: 'new', cwd: '/w', updatedAt: '2026-06-01T00:00:00.000Z' },
+    ];
+    const result = paginateSessions(legacy, { cwd: null, cursor: null }, 10);
+    expect(result.sessions.map((s) => s.sessionId)).toStrictEqual([
+      'new',
+      'old',
+    ]);
+  });
+
+  it('rejects a legacy v1 cursor (version mismatch)', () => {
+    const v1Cursor = Buffer.from(
+      JSON.stringify({
+        version: 1,
+        cwd: null,
+        updatedAt: '2026-01-03T00:00:00.000Z',
+        sessionId: 'b',
+      }),
+    ).toString('base64url');
+    expect(() =>
+      paginateSessions(sessions, { cwd: null, cursor: v1Cursor }, 2),
     ).toThrow(/cursor/i);
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -160,7 +160,7 @@ describe('session lifecycle pagination', () => {
     ]);
   });
 
-  it('rejects a legacy v1 cursor (version mismatch)', () => {
+  it('continues from a legacy v1 cursor using its updatedAt boundary', () => {
     const v1Cursor = Buffer.from(
       JSON.stringify({
         version: 1,
@@ -169,8 +169,15 @@ describe('session lifecycle pagination', () => {
         sessionId: 'b',
       }),
     ).toString('base64url');
-    expect(() =>
-      paginateSessions(sessions, { cwd: null, cursor: v1Cursor }, 2),
-    ).toThrow(/cursor/i);
+    const result = paginateSessions(
+      sessions,
+      { cwd: null, cursor: v1Cursor },
+      2,
+    );
+
+    expect(result.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'a',
+      'c',
+    ]);
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -85,9 +85,9 @@ export function paginateSessions(
  */
 function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
   return compareByCreatedAtAndId(
-    a.createdAt ?? a.updatedAt,
+    getCreatedAt(a),
     a.sessionId,
-    b.createdAt ?? b.updatedAt,
+    getCreatedAt(b),
     b.sessionId,
   );
 }
@@ -97,7 +97,7 @@ function compareWithCursor(
   cursor: CursorPayload,
 ): number {
   return compareByCreatedAtAndId(
-    session.createdAt ?? session.updatedAt,
+    getCreatedAt(session),
     session.sessionId,
     cursor.createdAt,
     cursor.sessionId,
@@ -121,11 +121,17 @@ function compareDescending(a: string, b: string): number {
   return a > b ? -1 : 1;
 }
 
+function getCreatedAt(session: LifecycleSession): string {
+  const value = session.createdAt ?? session.updatedAt;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : value;
+}
+
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
   const payload: CursorPayload = {
     v: 2,
     cwd,
-    createdAt: session.createdAt ?? session.updatedAt,
+    createdAt: getCreatedAt(session),
     sessionId: session.sessionId,
   };
   return Buffer.from(JSON.stringify(payload)).toString('base64url');

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -33,6 +33,13 @@ interface CursorPayload {
   readonly sessionId: string;
 }
 
+interface LegacyCursorPayload {
+  readonly version: 1;
+  readonly cwd: string | null;
+  readonly updatedAt: string;
+  readonly sessionId: string;
+}
+
 interface PaginationRequest {
   readonly cwd: string | null;
   readonly cursor: string | null;
@@ -148,10 +155,11 @@ function decodeCursor(
     const value: unknown = JSON.parse(
       Buffer.from(cursor, 'base64url').toString('utf8'),
     );
-    if (!isCursorPayload(value) || value.cwd !== cwd) {
+    const decoded = normalizeCursorPayload(value);
+    if (decoded === null || decoded.cwd !== cwd) {
       throw new Error('cursor does not match this request');
     }
-    return value;
+    return decoded;
   } catch (error) {
     const detail = error instanceof Error ? error.message : 'invalid encoding';
     throw acp.RequestError.invalidParams(
@@ -161,20 +169,51 @@ function decodeCursor(
   }
 }
 
+function normalizeCursorPayload(value: unknown): CursorPayload | null {
+  if (isCursorPayload(value)) {
+    return value;
+  }
+  if (!isLegacyCursorPayload(value)) {
+    return null;
+  }
+  return {
+    v: 2,
+    cwd: value.cwd,
+    createdAt: new Date(Date.parse(value.updatedAt)).toISOString(),
+    sessionId: value.sessionId,
+  };
+}
+
 function isCursorPayload(value: unknown): value is CursorPayload {
   if (value === null || typeof value !== 'object') {
     return false;
   }
   const record = value as Record<string, unknown>;
+  return (
+    record.v === 2 &&
+    hasValidCursorIdentity(record) &&
+    isCanonicalTimestamp(record.createdAt)
+  );
+}
+
+function isLegacyCursorPayload(value: unknown): value is LegacyCursorPayload {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.version === 1 &&
+    hasValidCursorIdentity(record) &&
+    typeof record.updatedAt === 'string' &&
+    Number.isFinite(Date.parse(record.updatedAt))
+  );
+}
+
+function hasValidCursorIdentity(record: Record<string, unknown>): boolean {
   const hasValidCwd = record.cwd === null || typeof record.cwd === 'string';
   const hasValidSessionId =
     typeof record.sessionId === 'string' && record.sessionId.length > 0;
-  return (
-    record.v === 2 &&
-    hasValidCwd &&
-    isCanonicalTimestamp(record.createdAt) &&
-    hasValidSessionId
-  );
+  return hasValidCwd && hasValidSessionId;
 }
 
 function isCanonicalTimestamp(value: unknown): value is string {

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -11,12 +11,25 @@ export interface LifecycleSession {
   readonly cwd: string;
   readonly updatedAt: string;
   readonly title?: string;
+  /**
+   * Immutable creation timestamp used for stable ordering (issue #1611).
+   * Falls back to updatedAt for legacy sessions without a persisted createdAt.
+   */
+  readonly createdAt?: string;
 }
 
+/**
+ * Self-contained, process-independent snapshot cursor (issue #1611).
+ *
+ * The cursor encodes the full (createdAt, sessionId) tuple of the last item on
+ * the previous page so the next page can be computed from the cursor alone,
+ * without any shared in-process state. The `v` field distinguishes v1 (legacy
+ * updatedAt-based, unstable) from v2 (createdAt-based, immutable).
+ */
 interface CursorPayload {
-  readonly version: 1;
+  readonly v: 2;
   readonly cwd: string | null;
-  readonly updatedAt: string;
+  readonly createdAt: string;
   readonly sessionId: string;
 }
 
@@ -60,11 +73,21 @@ export function paginateSessions(
   return { sessions: page, nextCursor: encodeCursor(last, request.cwd) };
 }
 
+/**
+ * Orders sessions by createdAt DESC then sessionId DESC.
+ *
+ * createdAt is the immutable session_start timestamp — it never changes when
+ * a session is updated (issue #1611). Falls back to updatedAt when createdAt
+ * is absent (legacy sessions recorded before this change) so they still sort
+ * deterministically. Using updatedAt as a fallback is acceptable because legacy
+ * sessions are static (no new writes), so their updatedAt is effectively
+ * immutable too.
+ */
 function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
-  return compareByUpdatedAtAndId(
-    a.updatedAt,
+  return compareByCreatedAtAndId(
+    a.createdAt ?? a.updatedAt,
     a.sessionId,
-    b.updatedAt,
+    b.createdAt ?? b.updatedAt,
     b.sessionId,
   );
 }
@@ -73,21 +96,21 @@ function compareWithCursor(
   session: LifecycleSession,
   cursor: CursorPayload,
 ): number {
-  return compareByUpdatedAtAndId(
-    session.updatedAt,
+  return compareByCreatedAtAndId(
+    session.createdAt ?? session.updatedAt,
     session.sessionId,
-    cursor.updatedAt,
+    cursor.createdAt,
     cursor.sessionId,
   );
 }
 
-function compareByUpdatedAtAndId(
-  aUpdatedAt: string,
+function compareByCreatedAtAndId(
+  aCreatedAt: string,
   aId: string,
-  bUpdatedAt: string,
+  bCreatedAt: string,
   bId: string,
 ): number {
-  const timestamp = compareDescending(aUpdatedAt, bUpdatedAt);
+  const timestamp = compareDescending(aCreatedAt, bCreatedAt);
   return timestamp === 0 ? compareDescending(aId, bId) : timestamp;
 }
 
@@ -100,9 +123,9 @@ function compareDescending(a: string, b: string): number {
 
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
   const payload: CursorPayload = {
-    version: 1,
+    v: 2,
     cwd,
-    updatedAt: session.updatedAt,
+    createdAt: session.createdAt ?? session.updatedAt,
     sessionId: session.sessionId,
   };
   return Buffer.from(JSON.stringify(payload)).toString('base64url');
@@ -138,10 +161,22 @@ function isCursorPayload(value: unknown): value is CursorPayload {
   }
   const record = value as Record<string, unknown>;
   const hasValidCwd = record.cwd === null || typeof record.cwd === 'string';
+  const hasValidSessionId =
+    typeof record.sessionId === 'string' && record.sessionId.length > 0;
   return (
-    record.version === 1 &&
+    record.v === 2 &&
     hasValidCwd &&
-    typeof record.updatedAt === 'string' &&
-    typeof record.sessionId === 'string'
+    isCanonicalTimestamp(record.createdAt) &&
+    hasValidSessionId
+  );
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false;
+  }
+  const timestamp = Date.parse(value);
+  return (
+    Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value
   );
 }

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+
+export interface LifecycleSession {
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly updatedAt: string;
+  readonly title?: string;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly cwd: string | null;
+  readonly updatedAt: string;
+  readonly sessionId: string;
+}
+
+interface PaginationRequest {
+  readonly cwd: string | null;
+  readonly cursor: string | null;
+}
+
+interface PaginationResult {
+  readonly sessions: readonly LifecycleSession[];
+  readonly nextCursor?: string;
+}
+
+export function paginateSessions(
+  sessions: readonly LifecycleSession[],
+  request: PaginationRequest,
+  pageSize: number,
+): PaginationResult {
+  if (!Number.isInteger(pageSize) || pageSize <= 0) {
+    throw acp.RequestError.invalidParams(
+      { pageSize },
+      'pageSize must be a positive integer',
+    );
+  }
+  const cursor = decodeCursor(request.cursor, request.cwd);
+  const ordered = [...sessions]
+    .filter((session) => request.cwd === null || session.cwd === request.cwd)
+    .sort(compareSessions);
+  const remaining =
+    cursor === null
+      ? ordered
+      : ordered.filter((session) => compareWithCursor(session, cursor) > 0);
+  const page = remaining.slice(0, pageSize);
+  if (remaining.length <= pageSize) {
+    return { sessions: page };
+  }
+  const last = page.at(-1);
+  if (last === undefined) {
+    return { sessions: page };
+  }
+  return { sessions: page, nextCursor: encodeCursor(last, request.cwd) };
+}
+
+function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
+  return compareByUpdatedAtAndId(
+    a.updatedAt,
+    a.sessionId,
+    b.updatedAt,
+    b.sessionId,
+  );
+}
+
+function compareWithCursor(
+  session: LifecycleSession,
+  cursor: CursorPayload,
+): number {
+  return compareByUpdatedAtAndId(
+    session.updatedAt,
+    session.sessionId,
+    cursor.updatedAt,
+    cursor.sessionId,
+  );
+}
+
+function compareByUpdatedAtAndId(
+  aUpdatedAt: string,
+  aId: string,
+  bUpdatedAt: string,
+  bId: string,
+): number {
+  const timestamp = compareDescending(aUpdatedAt, bUpdatedAt);
+  return timestamp === 0 ? compareDescending(aId, bId) : timestamp;
+}
+
+function compareDescending(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  return a > b ? -1 : 1;
+}
+
+function encodeCursor(session: LifecycleSession, cwd: string | null): string {
+  const payload: CursorPayload = {
+    version: 1,
+    cwd,
+    updatedAt: session.updatedAt,
+    sessionId: session.sessionId,
+  };
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+function decodeCursor(
+  cursor: string | null,
+  cwd: string | null,
+): CursorPayload | null {
+  if (cursor === null) {
+    return null;
+  }
+  try {
+    const value: unknown = JSON.parse(
+      Buffer.from(cursor, 'base64url').toString('utf8'),
+    );
+    if (!isCursorPayload(value) || value.cwd !== cwd) {
+      throw new Error('cursor does not match this request');
+    }
+    return value;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'invalid encoding';
+    throw acp.RequestError.invalidParams(
+      { cursor },
+      `Invalid session cursor: ${detail}`,
+    );
+  }
+}
+
+function isCursorPayload(value: unknown): value is CursorPayload {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  const hasValidCwd = record.cwd === null || typeof record.cwd === 'string';
+  return (
+    record.version === 1 &&
+    hasValidCwd &&
+    typeof record.updatedAt === 'string' &&
+    typeof record.sessionId === 'string'
+  );
+}

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -131,7 +131,13 @@ function compareDescending(a: string, b: string): number {
 function getCreatedAt(session: LifecycleSession): string {
   const value = session.createdAt ?? session.updatedAt;
   const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : value;
+  if (Number.isFinite(timestamp)) {
+    return new Date(timestamp).toISOString();
+  }
+  // Invalid or non-standard timestamp (corrupted/legacy data). Fall back to
+  // the epoch sentinel so sort order is deterministic and cursor encoding
+  // never embeds an invalid value that would break decode (issue #1611).
+  return new Date(0).toISOString();
 }
 
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
@@ -151,22 +157,26 @@ function decodeCursor(
   if (cursor === null) {
     return null;
   }
+  let detail: string;
   try {
     const value: unknown = JSON.parse(
       Buffer.from(cursor, 'base64url').toString('utf8'),
     );
     const decoded = normalizeCursorPayload(value);
-    if (decoded === null || decoded.cwd !== cwd) {
-      throw new Error('cursor does not match this request');
+    if (decoded === null) {
+      throw new Error('malformed cursor payload');
+    }
+    if (decoded.cwd !== cwd) {
+      throw new Error('cursor cwd does not match request cwd');
     }
     return decoded;
   } catch (error) {
-    const detail = error instanceof Error ? error.message : 'invalid encoding';
-    throw acp.RequestError.invalidParams(
-      { cursor },
-      `Invalid session cursor: ${detail}`,
-    );
+    detail = error instanceof Error ? error.message : 'invalid encoding';
   }
+  throw acp.RequestError.invalidParams(
+    { cursor },
+    `Invalid session cursor: ${detail}`,
+  );
 }
 
 function normalizeCursorPayload(value: unknown): CursorPayload | null {

--- a/packages/cli/src/zed-integration/zed-session-replay.edge-cases.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.edge-cases.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
+
+describe('mapHistoryToSessionUpdates (issue #1604 replay edge cases)', () => {
+  it('maps a combined { output, error } result to a FAILED tool_call_update carrying the output text (output precedence, FINDING F3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-combined',
+            name: 'run_shell_command',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-combined',
+            toolName: 'run_shell_command',
+            result: { output: 'partial output', error: 'command failed' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-combined',
+      status: 'failed',
+      kind: 'execute',
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: 'partial output' },
+        },
+      ],
+    });
+  });
+
+  it('maps a tool_response with null result to a completed tool_call_update with no content (FINDING F3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-null-result',
+            name: 'run_shell_command',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-null-result',
+            toolName: 'run_shell_command',
+            result: null,
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-null-result',
+      status: 'completed',
+      kind: 'execute',
+      content: [],
+    });
+  });
+
+  it('maps a tool_response with undefined result to a completed tool_call_update with no content (FINDING F3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-undef-result',
+            name: 'run_shell_command',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-undef-result',
+            toolName: 'run_shell_command',
+            result: undefined,
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-undef-result',
+      status: 'completed',
+      kind: 'execute',
+      content: [],
+    });
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
@@ -213,8 +213,7 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
       } as unknown as IContent,
     ];
     const [start, synthetic] = mapHistoryToSessionUpdates(history);
-    // The start carries the id as toolCallId AND as the title fallback; kind is
-    // omitted for the unknown (non-string) name.
+    // The id is also the title fallback, and an invalid name maps to other.
     expect(start).toStrictEqual({
       sessionUpdate: 'tool_call',
       toolCallId: 'call-noname',
@@ -225,7 +224,6 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
       locations: [],
       rawInput: { foo: 'bar' },
     });
-    expect(start).toHaveProperty('kind', 'other');
     // Still pending at end-of-history → the usual synthetic failed terminal.
     expect(synthetic).toStrictEqual({
       sessionUpdate: 'tool_call_update',

--- a/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
@@ -199,7 +199,7 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
     expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
   });
 
-  it('falls back the tool_call title to the id when name is missing but keeps the (valid) id (FINDING D4)', () => {
+  it("falls back the tool_call's title to the id when name is missing but keeps the (valid) id (FINDING D4)", () => {
     const history = [
       {
         speaker: 'ai',

--- a/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
@@ -55,6 +55,24 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
     expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
   });
 
+  it.each([
+    ['missing', undefined],
+    ['null', null],
+    ['a number', 42],
+    ['an unknown string', 'narrator'],
+  ])(
+    'skips an item whose speaker is %s (not human/ai/tool) instead of mapping it (FINDING D1)',
+    (_label, badSpeaker) => {
+      const history = [
+        {
+          speaker: badSpeaker,
+          blocks: [{ type: 'text', text: 'should not be replayed' }],
+        } as unknown as IContent,
+      ];
+      expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+    },
+  );
+
   it('continues replaying VALID items after skipping a malformed one (FINDING D1)', () => {
     const validItem: IContent = {
       speaker: 'human',

--- a/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Defensive-mapping tests for mapHistoryToSessionUpdates against MALFORMED
+ * persisted history (issue #1604 FINDINGS D1/D2/D3/D4). Recorded IContent read
+ * back from disk is UNTRUSTED — a truncated/corrupt JSONL line can yield a null
+ * item, an item missing its blocks, a text block whose `text` is not a string,
+ * or a tool block missing its id/name. None of these may throw and abort the
+ * WHOLE load; the mapper skips the unusable item/block and replays the rest.
+ *
+ * Split out of zed-session-replay.test.ts (which asserts the happy-path wire
+ * shapes) to keep each file within the max-lines budget. The `as unknown as
+ * IContent` / block casts here are type-honest ONLY for modelling corrupted
+ * persisted data in tests — a real disk file carries no compile-time guarantee,
+ * which the finding explicitly sanctions.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  IContent,
+  ToolCallBlock,
+  ToolResponseBlock,
+} from '@vybestack/llxprt-code-core';
+
+import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
+
+describe('mapHistoryToSessionUpdates — malformed persisted history (issue #1604 D1/D2/D3/D4)', () => {
+  it('returns [] for an empty history (boundary, FINDING D3)', () => {
+    expect(mapHistoryToSessionUpdates([])).toStrictEqual([]);
+  });
+
+  it('skips a null item without throwing (FINDING D1/D3)', () => {
+    const history = [null as unknown as IContent];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('skips an undefined item without throwing (FINDING D1/D3)', () => {
+    const history = [undefined as unknown as IContent];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('skips an item with no blocks array without throwing (FINDING D1/D3)', () => {
+    const history = [{ speaker: 'human' } as unknown as IContent];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('skips an item whose blocks is a non-array without throwing (FINDING D1/D3)', () => {
+    const history = [
+      { speaker: 'ai', blocks: 'not-an-array' } as unknown as IContent,
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('continues replaying VALID items after skipping a malformed one (FINDING D1)', () => {
+    const validItem: IContent = {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'survived' }],
+    };
+    const history: readonly IContent[] = [
+      null as unknown as IContent,
+      validItem,
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'survived' },
+      },
+    ]);
+  });
+
+  it('skips a text block whose text is not a string without throwing (FINDING D2/D3)', () => {
+    const history = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 42 as unknown as string }],
+      } as unknown as IContent,
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  // ─── FINDING D4: tool blocks missing a string id/name ─────────────────────
+
+  it('drops an ai tool_call block that has no string id (no update with an undefined id, FINDING D4)', () => {
+    const history = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            name: 'read_file',
+            parameters: { absolute_path: '/a' },
+          } as unknown as ToolCallBlock,
+        ],
+      } as unknown as IContent,
+    ];
+    // No id → the call cannot be tracked/paired → nothing is emitted (and no
+    // trailing synthetic failure, since it was never added to pending).
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('drops a tool_response block that has no string callId (cannot pair, FINDING D4)', () => {
+    const history = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            toolName: 'read_file',
+            result: { output: 'orphan' },
+          } as unknown as ToolResponseBlock,
+        ],
+      } as unknown as IContent,
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('falls back the tool_call title to the id when name is missing but keeps the (valid) id (FINDING D4)', () => {
+    const history = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-noname',
+            parameters: { foo: 'bar' },
+          } as unknown as ToolCallBlock,
+        ],
+      } as unknown as IContent,
+    ];
+    const [start, synthetic] = mapHistoryToSessionUpdates(history);
+    // The start carries the id as toolCallId AND as the title fallback; kind is
+    // omitted for the unknown (non-string) name.
+    expect(start).toStrictEqual({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-noname',
+      title: 'call-noname',
+      status: 'in_progress',
+      content: [],
+      locations: [],
+      rawInput: { foo: 'bar' },
+    });
+    expect('kind' in start).toBe(false);
+    // Still pending at end-of-history → the usual synthetic failed terminal.
+    expect(synthetic).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-noname',
+      status: 'failed',
+      content: [],
+    });
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
@@ -220,16 +220,18 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
       toolCallId: 'call-noname',
       title: 'call-noname',
       status: 'in_progress',
+      kind: 'other',
       content: [],
       locations: [],
       rawInput: { foo: 'bar' },
     });
-    expect('kind' in start).toBe(false);
+    expect(start).toHaveProperty('kind', 'other');
     // Still pending at end-of-history → the usual synthetic failed terminal.
     expect(synthetic).toStrictEqual({
       sessionUpdate: 'tool_call_update',
       toolCallId: 'call-noname',
       status: 'failed',
+      kind: 'other',
       content: [],
     });
   });

--- a/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
@@ -111,11 +111,7 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
     const history = [
       {
         speaker: 'ai',
-        blocks: [
-          null,
-          42,
-          { type: 'text', text: 'after malformed' },
-        ],
+        blocks: [null, 42, { type: 'text', text: 'after malformed' }],
       } as unknown as IContent,
     ];
     // The two malformed leading elements are skipped; the trailing valid text
@@ -148,7 +144,6 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
       },
     ]);
   });
-
 
   // ─── FINDING D4: tool blocks missing a string id/name ─────────────────────
 
@@ -220,4 +215,42 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
       content: [],
     });
   });
+
+  it.each([
+    ['missing', undefined],
+    ['null', null],
+    ['a number', 42],
+    ['an array', ['not', 'a', 'record']],
+  ])(
+    'sends rawInput as {} when the recorded parameters are %s — matching the live start path, which ALWAYS includes rawInput',
+    (_label, badParameters) => {
+      const history = [
+        {
+          speaker: 'ai',
+          blocks: [
+            {
+              type: 'tool_call',
+              id: 'call-badparams',
+              name: 'read_file',
+              parameters: badParameters,
+            } as unknown as ToolCallBlock,
+          ],
+        } as unknown as IContent,
+      ];
+      const [start] = mapHistoryToSessionUpdates(history);
+      // Live tool starts (zed-tool-handler emitToolCallStart) always carry
+      // rawInput; replay must stay wire-identical, so malformed/missing
+      // parameters degrade to an EMPTY object rather than omitting the field.
+      expect(start).toStrictEqual({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call-badparams',
+        title: 'read_file',
+        status: 'in_progress',
+        content: [],
+        locations: [],
+        kind: 'read',
+        rawInput: {},
+      });
+    },
+  );
 });

--- a/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.malformed.test.ts
@@ -81,6 +81,74 @@ describe('mapHistoryToSessionUpdates — malformed persisted history (issue #160
     ];
     expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
   });
+  // ─── FINDING D1 (block level): malformed ELEMENTS inside a narrowed blocks ──
+  // The item-level narrowing only proves `blocks` is an array; each ELEMENT is
+  // still untrusted. A null/undefined/primitive element, or an object with no
+  // string `type`, must be SKIPPED silently (no throw on `block.type`) so one
+  // corrupt element cannot abort the whole replay.
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['a string', 'x'],
+    ['an object without a type', {}],
+    ['an object whose type is not a string', { type: 42 }],
+  ])(
+    'skips a block that is %s without throwing (FINDING D1 block level)',
+    (_label, badBlock) => {
+      const history = [
+        {
+          speaker: 'ai',
+          blocks: [badBlock],
+        } as unknown as IContent,
+      ];
+      expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+    },
+  );
+
+  it('replays a VALID block that FOLLOWS a malformed one in the SAME item (FINDING D1 block level)', () => {
+    const history = [
+      {
+        speaker: 'ai',
+        blocks: [
+          null,
+          42,
+          { type: 'text', text: 'after malformed' },
+        ],
+      } as unknown as IContent,
+    ];
+    // The two malformed leading elements are skipped; the trailing valid text
+    // block still maps to its agent_message_chunk.
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'after malformed' },
+      },
+    ]);
+  });
+
+  it('replays a VALID item that FOLLOWS an item with malformed blocks (FINDING D1 block level)', () => {
+    const history = [
+      {
+        speaker: 'ai',
+        blocks: [null, { type: 42 }, 'x'],
+      } as unknown as IContent,
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'next item survives' }],
+      } as unknown as IContent,
+    ];
+    // Every element of the first item is malformed (skipped), and the whole
+    // second item still replays.
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'next item survives' },
+      },
+    ]);
+  });
+
 
   // ─── FINDING D4: tool blocks missing a string id/name ─────────────────────
 

--- a/packages/cli/src/zed-integration/zed-session-replay.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.test.ts
@@ -141,7 +141,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     });
   });
 
-  it('maps a { output } success result to a completed tool_call_update carrying the output text (FINDING 3)', () => {
+  it('maps a { output } success result to a completed tool_call_update carrying the output text (FINDING F3)', () => {
     const history: IContent[] = [
       {
         speaker: 'ai',
@@ -174,7 +174,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     });
   });
 
-  it('maps a { error } result to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
+  it('maps a { error } result to a FAILED tool_call_update carrying the error text (FINDING F3)', () => {
     const history: IContent[] = [
       {
         speaker: 'ai',
@@ -242,7 +242,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     });
   });
 
-  it('maps a tool_response whose block.error is set to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
+  it('maps a tool_response whose block.error is set to a FAILED tool_call_update carrying the error text (FINDING F3)', () => {
     const history: IContent[] = [
       {
         speaker: 'ai',

--- a/packages/cli/src/zed-integration/zed-session-replay.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.test.ts
@@ -97,6 +97,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
         toolCallId: 'call-1',
         status: 'failed',
         content: [],
+        kind: 'read',
       },
     ]);
   });
@@ -132,6 +133,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'call-1',
       status: 'completed',
+      kind: 'read',
       content: [
         {
           type: 'content',
@@ -170,6 +172,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'call-out',
       status: 'completed',
+      kind: 'execute',
       content: [{ type: 'content', content: { type: 'text', text: 'x' } }],
     });
   });
@@ -203,6 +206,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'call-err',
       status: 'failed',
+      kind: 'execute',
       content: [{ type: 'content', content: { type: 'text', text: 'y' } }],
     });
   });
@@ -238,6 +242,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'call-obj-err',
       status: 'failed',
+      kind: 'execute',
       content: [{ type: 'content', content: { type: 'text', text: 'boom' } }],
     });
   });
@@ -272,6 +277,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'call-boom',
       status: 'failed',
+      kind: 'edit',
       content: [
         {
           type: 'content',
@@ -310,6 +316,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'call-2',
       status: 'completed',
+      kind: 'other',
       content: [],
     });
   });
@@ -333,7 +340,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
   });
 
-  it('omits kind for an unknown tool name but still emits the in_progress tool_call (with no inferable locations)', () => {
+  it('maps an unknown tool name to other while still emitting the in_progress tool_call', () => {
     const history: IContent[] = [
       {
         speaker: 'ai',
@@ -353,11 +360,12 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       toolCallId: 'call-x',
       title: 'totally_unknown_tool',
       status: 'in_progress',
+      kind: 'other',
       content: [],
       locations: [],
       rawInput: { foo: 'bar' },
     });
-    expect('kind' in update).toBe(false);
+    expect(update).toHaveProperty('kind', 'other');
   });
 
   it('pairs an ai tool_call with its later tool_response: in_progress start THEN completed update, no synthetic failure (FINDING 2/3 ordered pairing)', () => {
@@ -400,6 +408,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
         sessionUpdate: 'tool_call_update',
         toolCallId: 'paired-1',
         status: 'completed',
+        kind: 'read',
         content: [
           { type: 'content', content: { type: 'text', text: 'paired body' } },
         ],
@@ -537,6 +546,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
         sessionUpdate: 'tool_call_update',
         toolCallId: 'dup-1',
         status: 'completed',
+        kind: 'read',
         content: [
           { type: 'content', content: { type: 'text', text: 'winner' } },
         ],
@@ -695,6 +705,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'mcp-1',
       status: 'completed',
+      kind: 'execute',
       content: [
         {
           type: 'content',
@@ -706,6 +717,17 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
 
   it('joins ONLY the text elements of a mixed MCP content array, skipping non-text elements (FINDING D)', () => {
     const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'mcp-mixed',
+            name: 'some_tool',
+            parameters: {},
+          },
+        ],
+      },
       {
         speaker: 'tool',
         blocks: [
@@ -724,29 +746,12 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
         ],
       },
     ];
-    // MCP content-array extraction is asserted through a PAIRED call/response:
-    // an orphan response (no matching start) would be dropped by the pending
-    // check before extraction is observable, so pairing is required to surface
-    // the extracted text on the terminal update.
-    const paired: IContent[] = [
-      {
-        speaker: 'ai',
-        blocks: [
-          {
-            type: 'tool_call',
-            id: 'mcp-mixed',
-            name: 'some_tool',
-            parameters: {},
-          },
-        ],
-      },
-      ...history,
-    ];
-    const updates = mapHistoryToSessionUpdates(paired);
+    const updates = mapHistoryToSessionUpdates(history);
     expect(updates[1]).toStrictEqual({
       sessionUpdate: 'tool_call_update',
       toolCallId: 'mcp-mixed',
       status: 'completed',
+      kind: 'other',
       content: [
         { type: 'content', content: { type: 'text', text: 'visible text' } },
       ],
@@ -796,6 +801,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call_update',
       toolCallId: 'mcp-empty',
       status: 'completed',
+      kind: 'other',
       content: [],
     });
   });

--- a/packages/cli/src/zed-integration/zed-session-replay.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.test.ts
@@ -1,0 +1,799 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the pure IContent -> ACP SessionUpdate replay mapping
+ * (mapHistoryToSessionUpdates) used by ACP session/load (issue #1604). These
+ * assert the EXACT v1 snake_case wire payload shapes for every block kind so a
+ * regression in the discriminators or field names is caught structurally, and
+ * they pin the order-aware tool-call pairing semantics (FINDING C) and the
+ * result-text extraction precedence including MCP-style content arrays
+ * (FINDING D). Pure inputs -> pure output; no mocks, no connection.
+ *
+ * The ZedAgent.loadSession ORCHESTRATION (streaming, cleanup, error mapping)
+ * lives in zedIntegration.loadSession.test.ts; the record->resume->history
+ * fidelity is proven by the agents-package behavioral tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
+
+describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
+  it('maps a human text block to a user_message_chunk', () => {
+    const history: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'hello there' }] },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'hello there' },
+      },
+    ]);
+  });
+
+  it('maps an ai text block to an agent_message_chunk', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'the answer' }] },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'the answer' },
+      },
+    ]);
+  });
+
+  it('maps an ai thinking block to an agent_thought_chunk carrying the thought text', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'thinking', thought: 'let me reason' }],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'agent_thought_chunk',
+        content: { type: 'text', text: 'let me reason' },
+      },
+    ]);
+  });
+
+  it('maps a lone ai tool_call (no recorded response) to an in_progress tool_call matching the live start shape, then a synthetic failed update (FINDING 2/3: orphaned/interrupted turn)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-1',
+            name: 'read_file',
+            parameters: { absolute_path: '/project/a.ts' },
+          },
+        ],
+      },
+    ];
+    // Live start shape (emitToolCallStart): in_progress, empty content, inferred
+    // locations + kind, rawInput. Because the call has NO paired response in the
+    // history, a terminal failed tool_call_update (empty content) is synthesized
+    // so the client does not render a perpetually-running tool.
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call-1',
+        title: 'read_file',
+        status: 'in_progress',
+        content: [],
+        locations: [{ path: '/project/a.ts' }],
+        kind: 'read',
+        rawInput: { absolute_path: '/project/a.ts' },
+      },
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-1',
+        status: 'failed',
+        content: [],
+      },
+    ]);
+  });
+
+  it('maps a tool tool_response block to a completed tool_call_update with text content', () => {
+    // Paired call so the response has a matching in_progress start (FINDING C
+    // drops orphan responses); the terminal update is asserted at index [1].
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-1',
+            name: 'read_file',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-1',
+            toolName: 'read_file',
+            result: 'file body contents',
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-1',
+      status: 'completed',
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: 'file body contents' },
+        },
+      ],
+    });
+  });
+
+  it('maps a { output } success result to a completed tool_call_update carrying the output text (FINDING 3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-out',
+            name: 'run_shell_command',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-out',
+            toolName: 'run_shell_command',
+            result: { output: 'x' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-out',
+      status: 'completed',
+      content: [{ type: 'content', content: { type: 'text', text: 'x' } }],
+    });
+  });
+
+  it('maps a { error } result to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-err',
+            name: 'run_shell_command',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-err',
+            toolName: 'run_shell_command',
+            result: { error: 'y' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-err',
+      status: 'failed',
+      content: [{ type: 'content', content: { type: 'text', text: 'y' } }],
+    });
+  });
+
+  it('maps a tool_response whose block.error is set to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-boom',
+            name: 'write_file',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-boom',
+            toolName: 'write_file',
+            result: {},
+            error: 'permission denied',
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-boom',
+      status: 'failed',
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: 'permission denied' },
+        },
+      ],
+    });
+  });
+
+  it('emits an empty content array for a tool_response with no representable text', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-2',
+            name: 'secret_tool',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-2',
+            toolName: 'secret_tool',
+            result: {},
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-2',
+      status: 'completed',
+      content: [],
+    });
+  });
+
+  it('skips whitespace-only text and skips media/code blocks (v1 replay)', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: '   ' }] },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: 'AAAA',
+            encoding: 'base64',
+          },
+          { type: 'code', code: 'const x = 1;' },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('omits kind for an unknown tool name but still emits the in_progress tool_call (with no inferable locations)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-x',
+            name: 'totally_unknown_tool',
+            parameters: { foo: 'bar' },
+          },
+        ],
+      },
+    ];
+    const [update] = mapHistoryToSessionUpdates(history);
+    expect(update).toStrictEqual({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-x',
+      title: 'totally_unknown_tool',
+      status: 'in_progress',
+      content: [],
+      locations: [],
+      rawInput: { foo: 'bar' },
+    });
+    expect('kind' in update).toBe(false);
+  });
+
+  it('pairs an ai tool_call with its later tool_response: in_progress start THEN completed update, no synthetic failure (FINDING 2/3 ordered pairing)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'paired-1',
+            name: 'read_file',
+            parameters: { absolute_path: '/project/z.ts' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'paired-1',
+            toolName: 'read_file',
+            result: { output: 'paired body' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'paired-1',
+        title: 'read_file',
+        status: 'in_progress',
+        content: [],
+        locations: [{ path: '/project/z.ts' }],
+        kind: 'read',
+        rawInput: { absolute_path: '/project/z.ts' },
+      },
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'paired-1',
+        status: 'completed',
+        content: [
+          { type: 'content', content: { type: 'text', text: 'paired body' } },
+        ],
+      },
+    ]);
+  });
+
+  it('orders pairing across a multi-tool conversation: each call starts in_progress and completes from its own response (FINDING 2/3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 't1',
+            name: 'read_file',
+            parameters: { absolute_path: '/a' },
+          },
+          {
+            type: 'tool_call',
+            id: 't2',
+            name: 'run_shell_command',
+            parameters: { command: 'ls' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 't1',
+            toolName: 'read_file',
+            result: { output: 'first' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 't2',
+            toolName: 'run_shell_command',
+            result: { error: 'boom' },
+          },
+        ],
+      },
+    ];
+    expect(
+      mapHistoryToSessionUpdates(history).map((u) => ({
+        kind: u.sessionUpdate,
+        id: (u as { toolCallId?: string }).toolCallId,
+        status: (u as { status?: string }).status,
+      })),
+    ).toStrictEqual([
+      { kind: 'tool_call', id: 't1', status: 'in_progress' },
+      { kind: 'tool_call', id: 't2', status: 'in_progress' },
+      { kind: 'tool_call_update', id: 't1', status: 'completed' },
+      { kind: 'tool_call_update', id: 't2', status: 'failed' },
+    ]);
+  });
+
+  // ─── FINDING C: order-aware tool-call pairing edge cases ──────────────────
+
+  it('DROPS an orphan tool_response that arrives before any matching tool_call (no floating terminal update, FINDING C)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'never-started',
+            toolName: 'read_file',
+            result: { output: 'ghost' },
+          },
+        ],
+      },
+    ];
+    // The response has no in_progress start to pair with; emitting a terminal
+    // update would hand the client a lifecycle it never saw begin. Dropped.
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('emits exactly ONE terminal update for a call (first response wins; duplicate responses for the same id are dropped, FINDING C)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'dup-1',
+            name: 'read_file',
+            parameters: { absolute_path: '/a' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'dup-1',
+            toolName: 'read_file',
+            result: { output: 'winner' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'dup-1',
+            toolName: 'read_file',
+            result: { output: 'loser' },
+          },
+        ],
+      },
+    ];
+    const updates = mapHistoryToSessionUpdates(history);
+    // start + exactly one completed terminal; the second response is dropped.
+    expect(updates).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'dup-1',
+        title: 'read_file',
+        status: 'in_progress',
+        content: [],
+        locations: [{ path: '/a' }],
+        kind: 'read',
+        rawInput: { absolute_path: '/a' },
+      },
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'dup-1',
+        status: 'completed',
+        content: [
+          { type: 'content', content: { type: 'text', text: 'winner' } },
+        ],
+      },
+    ]);
+  });
+
+  it('treats the SAME callId reused across turns (start, complete, start again, complete) as TWO independent lifecycles (FINDING C determinism)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'reused',
+            name: 'run_shell_command',
+            parameters: { command: 'first' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'reused',
+            toolName: 'run_shell_command',
+            result: { output: 'one' },
+          },
+        ],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'reused',
+            name: 'run_shell_command',
+            parameters: { command: 'second' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'reused',
+            toolName: 'run_shell_command',
+            result: { output: 'two' },
+          },
+        ],
+      },
+    ];
+    // Because the first response clears the pending id BEFORE the second start,
+    // the second start re-adds it as a NEW pending call: both start->complete
+    // lifecycles are emitted in order, each pairing with its own response.
+    expect(
+      mapHistoryToSessionUpdates(history).map((u) => ({
+        kind: u.sessionUpdate,
+        status: (u as { status?: string }).status,
+        text: (u as { content?: Array<{ content?: { text?: string } }> })
+          .content?.[0]?.content?.text,
+      })),
+    ).toStrictEqual([
+      { kind: 'tool_call', status: 'in_progress', text: undefined },
+      { kind: 'tool_call_update', status: 'completed', text: 'one' },
+      { kind: 'tool_call', status: 'in_progress', text: undefined },
+      { kind: 'tool_call_update', status: 'completed', text: 'two' },
+    ]);
+  });
+
+  it('synthesizes trailing failed updates for still-pending calls in original START order (FINDING C)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'pending-a',
+            name: 'read_file',
+            parameters: { absolute_path: '/a' },
+          },
+          {
+            type: 'tool_call',
+            id: 'pending-b',
+            name: 'read_file',
+            parameters: { absolute_path: '/b' },
+          },
+        ],
+      },
+      // Only the SECOND call gets a response; 'pending-a' and (after) nothing
+      // else stays pending. Interleave a response for b to prove the trailing
+      // synthetic is emitted only for the still-pending 'pending-a'.
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'pending-b',
+            toolName: 'read_file',
+            result: { output: 'b done' },
+          },
+        ],
+      },
+    ];
+    expect(
+      mapHistoryToSessionUpdates(history).map((u) => ({
+        kind: u.sessionUpdate,
+        id: (u as { toolCallId?: string }).toolCallId,
+        status: (u as { status?: string }).status,
+      })),
+    ).toStrictEqual([
+      { kind: 'tool_call', id: 'pending-a', status: 'in_progress' },
+      { kind: 'tool_call', id: 'pending-b', status: 'in_progress' },
+      { kind: 'tool_call_update', id: 'pending-b', status: 'completed' },
+      // 'pending-a' never got a response -> trailing synthetic failed update.
+      { kind: 'tool_call_update', id: 'pending-a', status: 'failed' },
+    ]);
+  });
+
+  // ─── FINDING D: MCP-style result.content array extraction ─────────────────
+
+  it('extracts joined text from an MCP-style result.content ARRAY into the completed update (FINDING D)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'mcp-1',
+            name: 'run_shell_command',
+            parameters: { command: 'x' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'mcp-1',
+            toolName: 'run_shell_command',
+            result: {
+              content: [
+                { type: 'text', text: 'part one ' },
+                { type: 'text', text: 'part two' },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const updates = mapHistoryToSessionUpdates(history);
+    expect(updates[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'mcp-1',
+      status: 'completed',
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: 'part one part two' },
+        },
+      ],
+    });
+  });
+
+  it('joins ONLY the text elements of a mixed MCP content array, skipping non-text elements (FINDING D)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'mcp-mixed',
+            toolName: 'some_tool',
+            result: {
+              content: [
+                { type: 'image', data: 'AAAA', mimeType: 'image/png' },
+                { type: 'text', text: 'visible text' },
+                { type: 'resource', uri: 'file:///x' },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    // Orphan response (no start) still exercises extraction via a direct call is
+    // not possible here; instead assert through a paired call so a terminal
+    // update is produced.
+    const paired: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'mcp-mixed',
+            name: 'some_tool',
+            parameters: {},
+          },
+        ],
+      },
+      ...history,
+    ];
+    const updates = mapHistoryToSessionUpdates(paired);
+    expect(updates[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'mcp-mixed',
+      status: 'completed',
+      content: [
+        { type: 'content', content: { type: 'text', text: 'visible text' } },
+      ],
+    });
+  });
+
+  it('emits empty content for an MCP content array with NO text elements (no crash, FINDING D)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'mcp-empty',
+            name: 'some_tool',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'mcp-empty',
+            toolName: 'some_tool',
+            result: {
+              content: [
+                { type: 'image', data: 'AAAA', mimeType: 'image/png' },
+                { type: 'resource', uri: 'file:///x' },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const updates = mapHistoryToSessionUpdates(history);
+    expect(updates[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'mcp-empty',
+      status: 'completed',
+      content: [],
+    });
+  });
+
+  it('preserves whole-conversation order across a multi-block transcript', () => {
+    const history: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'do a thing' }] },
+      {
+        speaker: 'ai',
+        blocks: [
+          { type: 'thinking', thought: 'planning' },
+          { type: 'text', text: 'working on it' },
+          {
+            type: 'tool_call',
+            id: 'c1',
+            name: 'run_shell_command',
+            parameters: { command: 'ls' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'c1',
+            toolName: 'run_shell_command',
+            result: 'a.ts b.ts',
+          },
+        ],
+      },
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'done' }] },
+    ];
+    expect(
+      mapHistoryToSessionUpdates(history).map((u) => u.sessionUpdate),
+    ).toStrictEqual([
+      'user_message_chunk',
+      'agent_thought_chunk',
+      'agent_message_chunk',
+      'tool_call',
+      'tool_call_update',
+      'agent_message_chunk',
+    ]);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-replay.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.test.ts
@@ -101,7 +101,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     ]);
   });
 
-  it('maps a tool tool_response block to a completed tool_call_update with text content', () => {
+  it('maps a tool-speaker tool_response block to a completed tool_call_update with text content', () => {
     // Paired call so the response has a matching in_progress start (FINDING C
     // drops orphan responses); the terminal update is asserted at index [1].
     const history: IContent[] = [

--- a/packages/cli/src/zed-integration/zed-session-replay.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.test.ts
@@ -207,6 +207,41 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     });
   });
 
+  it('maps an OBJECT-shaped { error: { message } } result to a FAILED tool_call_update carrying the message text (FINDING F3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-obj-err',
+            name: 'run_shell_command',
+            parameters: {},
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-obj-err',
+            toolName: 'run_shell_command',
+            result: { error: { message: 'boom' } },
+          },
+        ],
+      },
+    ];
+    // createErrorResponse can persist an object-shaped error ({ error: { message } });
+    // it must be detected as a failure AND surface the nested message text.
+    expect(mapHistoryToSessionUpdates(history)[1]).toStrictEqual({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 'call-obj-err',
+      status: 'failed',
+      content: [{ type: 'content', content: { type: 'text', text: 'boom' } }],
+    });
+  });
+
   it('maps a tool_response whose block.error is set to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
     const history: IContent[] = [
       {
@@ -717,7 +752,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     });
   });
 
-  it('emits empty content for an MCP content array with NO text elements (no crash, FINDING D)', () => {
+  it('emits empty content for an MCP content array with NO usable text: non-text elements AND whitespace-only text are BOTH skipped (no crash, FINDING D + FINDING F11)', () => {
     const history: IContent[] = [
       {
         speaker: 'ai',
@@ -739,14 +774,22 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
             toolName: 'some_tool',
             result: {
               content: [
+                // Non-text elements are skipped (FINDING D)...
                 { type: 'image', data: 'AAAA', mimeType: 'image/png' },
                 { type: 'resource', uri: 'file:///x' },
+                // ...and whitespace-only text elements are trimmed + skipped
+                // (FINDING F11), so they do NOT pass blank text through. Both
+                // spaces and a newline+tab element must be dropped.
+                { type: 'text', text: '   ' },
+                { type: 'text', text: '\n\t' },
               ],
             },
           },
         ],
       },
     ];
+    // With no usable text, the update carries an empty content array (no blank
+    // text leaks from the whitespace-only elements).
     const updates = mapHistoryToSessionUpdates(history);
     expect(updates[1]).toStrictEqual({
       sessionUpdate: 'tool_call_update',

--- a/packages/cli/src/zed-integration/zed-session-replay.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.test.ts
@@ -724,9 +724,10 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
         ],
       },
     ];
-    // Orphan response (no start) still exercises extraction via a direct call is
-    // not possible here; instead assert through a paired call so a terminal
-    // update is produced.
+    // MCP content-array extraction is asserted through a PAIRED call/response:
+    // an orphan response (no matching start) would be dropped by the pending
+    // check before extraction is observable, so pairing is required to surface
+    // the extracted text on the terminal update.
     const paired: IContent[] = [
       {
         speaker: 'ai',

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -16,6 +16,16 @@
  * the ordered list of ACP {@link acp.SessionUpdate} notifications the live
  * streaming path (StreamBatcher / zed-tool-handler.ts) would have produced.
  *
+ * Tool-call fidelity: the live path emits a tool_call (status 'in_progress',
+ * empty content, inferred locations/kind) at call time and a SEPARATE
+ * tool_call_update (completed/failed with the result text) when the response
+ * arrives. Replay mirrors that two-update shape so a reconstructed transcript is
+ * wire-indistinguishable from a live one: each recorded ai ToolCallBlock emits
+ * the in_progress tool_call, and its paired tool ToolResponseBlock emits the
+ * terminal tool_call_update. A ToolCallBlock with no recorded response (an
+ * interrupted turn) gets a synthetic 'failed' tool_call_update so the client
+ * never renders a perpetually-running tool.
+ *
  * It is kept separate from zedIntegration.ts (and free of any I/O) so the
  * mapping stays small, individually unit-testable against the v1 snake_case
  * wire discriminators, and lint-clean under the complexity guardrails.
@@ -30,63 +40,102 @@ import type {
   ToolCallBlock,
   ToolResponseBlock,
 } from '@vybestack/llxprt-code-core';
-import { inferToolKind } from './zed-tool-handler.js';
+import { buildToolLocations, inferToolKind } from './zed-tool-handler.js';
 import { extractToolResultText } from './zed-content-utils.js';
+
+/** Readonly JSON-object shape used when narrowing recorded `unknown` payloads. */
+type Dict = Readonly<Record<string, unknown>>;
 
 /**
  * Maps a full resumed history (ordered IContent[]) to the ordered ACP
  * SessionUpdate notifications that replay the conversation. Empty/whitespace
- * text chunks are skipped; unmappable blocks (media, code, empty tool text)
- * contribute no update. The output order preserves the history order and, per
- * message, the block order — matching how the live path emits chunks.
+ * text chunks are skipped; unmappable blocks (media, code) contribute no update.
+ * Each ai tool_call contributes an in_progress tool_call PLUS — when the call
+ * has no recorded response — a terminal failed tool_call_update; a recorded tool
+ * response contributes the matching completed/failed tool_call_update. The
+ * output preserves the history order and, per message, the block order.
  */
 export function mapHistoryToSessionUpdates(
   items: readonly IContent[],
 ): acp.SessionUpdate[] {
+  const respondedCallIds = collectRespondedCallIds(items);
   const updates: acp.SessionUpdate[] = [];
   for (const item of items) {
-    appendMessageUpdates(item, updates);
+    for (const block of item.blocks) {
+      appendBlockUpdates(item.speaker, block, respondedCallIds, updates);
+    }
   }
   return updates;
 }
 
 /**
- * Appends the SessionUpdates for a single IContent message, dispatching on the
- * speaker so each block is mapped by the rules for that role.
+ * Pre-scans the history for the callIds that DO have a tool ToolResponseBlock,
+ * so the block pass can tell a paired tool_call (whose response will emit the
+ * terminal update) from an orphaned one (interrupted turn) that needs a
+ * synthetic failed update. Kept as a separate pure pass so the per-block mapping
+ * stays a simple forward walk.
  */
-function appendMessageUpdates(item: IContent, out: acp.SessionUpdate[]): void {
-  for (const block of item.blocks) {
-    const update = mapBlock(item.speaker, block);
-    if (update !== null) {
-      out.push(update);
+function collectRespondedCallIds(
+  items: readonly IContent[],
+): ReadonlySet<string> {
+  const ids = new Set<string>();
+  for (const item of items) {
+    if (item.speaker !== 'tool') {
+      continue;
+    }
+    for (const block of item.blocks) {
+      if (block.type === 'tool_response') {
+        ids.add(block.callId);
+      }
     }
   }
+  return ids;
 }
 
 /**
- * Maps a single (speaker, block) pair to at most one SessionUpdate, or null when
- * the block has no faithful replay representation (empty text, media/code, a
- * human-authored non-text block, etc.).
+ * Appends the SessionUpdate(s) for a single (speaker, block) pair to `out`. Most
+ * blocks map to at most one update; an ai tool_call may append two (the
+ * in_progress tool_call and, when orphaned, a terminal failed update).
  */
-function mapBlock(
+function appendBlockUpdates(
   speaker: IContent['speaker'],
   block: ContentBlock,
-): acp.SessionUpdate | null {
+  respondedCallIds: ReadonlySet<string>,
+  out: acp.SessionUpdate[],
+): void {
   switch (block.type) {
     case 'text':
-      return mapTextBlock(speaker, block);
+      pushDefined(out, mapTextBlock(speaker, block));
+      return;
     case 'thinking':
-      return mapThinkingBlock(speaker, block);
+      pushDefined(out, mapThinkingBlock(speaker, block));
+      return;
     case 'tool_call':
-      return speaker === 'ai' ? mapToolCallBlock(block) : null;
+      if (speaker === 'ai') {
+        appendToolCallUpdates(block, respondedCallIds, out);
+      }
+      return;
     case 'tool_response':
-      return speaker === 'tool' ? mapToolResponseBlock(block) : null;
+      if (speaker === 'tool') {
+        out.push(mapToolResponseBlock(block));
+      }
+      return;
     // Media/code blocks are intentionally skipped in v1 replay: ACP has no
     // lossless chunk for a stored CodeBlock, and re-streaming base64 MediaBlock
     // payloads on every reconnect would be wasteful and is not required to
     // reconstruct the readable transcript.
     default:
-      return null;
+      return;
+  }
+}
+
+/** Pushes `update` onto `out` when it is non-null (small readability helper). */
+function pushDefined(
+  out: acp.SessionUpdate[],
+  update: acp.SessionUpdate | null,
+): void {
+  if (update !== null) {
+    out.push(update);
   }
 }
 
@@ -139,32 +188,73 @@ function mapThinkingBlock(
 }
 
 /**
- * ai tool_call -> tool_call update (status 'completed', since a stored history
- * block represents a call that already ran). Field names mirror the live start
- * path in zed-tool-handler.ts (toolCallId/title/kind/rawInput); kind is inferred
- * from the tool name via the SAME TOOL_KIND_BY_NAME table.
+ * Appends the replay updates for an ai ToolCallBlock: first the in_progress
+ * tool_call matching the live start shape, then — ONLY when the call has no
+ * recorded response — a terminal failed tool_call_update (empty content) so an
+ * interrupted turn does not leave a perpetually-running tool on the client. A
+ * call WITH a recorded response gets its terminal update from that response
+ * block (mapToolResponseBlock), preserving the live "start then complete" pair.
  */
-function mapToolCallBlock(block: ToolCallBlock): acp.SessionUpdate {
+function appendToolCallUpdates(
+  block: ToolCallBlock,
+  respondedCallIds: ReadonlySet<string>,
+  out: acp.SessionUpdate[],
+): void {
+  out.push(buildToolCallStart(block));
+  if (!respondedCallIds.has(block.id)) {
+    out.push({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: block.id,
+      status: 'failed',
+      content: [],
+    });
+  }
+}
+
+/**
+ * ai tool_call -> in_progress tool_call. Field names + shape mirror the live
+ * start path in zed-tool-handler.ts (emitToolCallStart): status 'in_progress',
+ * empty content, locations inferred from the recorded parameters via the SAME
+ * buildToolLocations helper, kind inferred via the SAME inferToolKind table, and
+ * rawInput carrying the narrowed parameters. kind is omitted (rather than sent
+ * as undefined) for unknown tools; both are wire-identical after JSON encoding.
+ */
+function buildToolCallStart(block: ToolCallBlock): acp.SessionUpdate {
   const kind = inferToolKind(block.name);
+  const rawInput = toRawInput(block.parameters);
   return {
     sessionUpdate: 'tool_call',
     toolCallId: block.id,
     title: block.name,
-    status: 'completed',
+    status: 'in_progress',
+    content: [],
+    locations: buildToolLocations(rawInput ?? {}),
     ...(kind !== undefined ? { kind } : {}),
-    rawInput: toRawInput(block.parameters),
+    ...(rawInput !== undefined ? { rawInput } : {}),
   };
 }
 
 /**
- * tool tool_response -> tool_call_update (status 'completed'). When the stored
- * result renders to non-empty text (via the SAME extractToolResultText helper
- * the live tool path uses), it is included as a single text ToolCallContent;
- * otherwise the update carries an empty content array (mirroring the live
- * suppressed-display behavior).
+ * tool tool_response -> terminal tool_call_update. Status is 'failed' when the
+ * block carries an error (ToolResponseBlock.error) OR its result is an object
+ * with a string `error` property (the { error } failure shape produced by
+ * createErrorResponse), else 'completed'. The displayed text is extracted with a
+ * precedence that mirrors how results are actually recorded: result.output
+ * (the { output } success shape), then a string result.content, then the failure
+ * error text, then the shared extractToolResultText fallback. Only non-empty
+ * text yields a content entry; otherwise the update carries an empty content
+ * array (mirroring the live suppressed-display behavior).
+ *
+ * Diff replay gap: the recorded IContent does NOT persist the display/FileDiff
+ * metadata the live path uses to emit a { type: 'diff' } ToolCallContent, so a
+ * faithful diff replay is not reconstructable from recorded history yet. It is
+ * intentionally deferred here (tracked on issue #1604); replay surfaces the
+ * textual result instead of a structured diff.
  */
 function mapToolResponseBlock(block: ToolResponseBlock): acp.SessionUpdate {
-  const text = extractToolResultText({ llmContent: block.result });
+  const record = asRecord(block.result);
+  const failed = isFailedResponse(block, record);
+  const text = extractResponseText(block, record, failed);
   const content: acp.ToolCallContent[] =
     text !== null && text.length > 0
       ? [{ type: 'content', content: { type: 'text', text } }]
@@ -172,9 +262,70 @@ function mapToolResponseBlock(block: ToolResponseBlock): acp.SessionUpdate {
   return {
     sessionUpdate: 'tool_call_update',
     toolCallId: block.callId,
-    status: 'completed',
+    status: failed ? 'failed' : 'completed',
     content,
   };
+}
+
+/**
+ * A recorded tool response is a failure when its block carries a non-empty
+ * error string OR its result object exposes a non-empty string `error` property
+ * (the { error } shape emitted by the core createErrorResponse path).
+ */
+function isFailedResponse(
+  block: ToolResponseBlock,
+  record: Dict | null,
+): boolean {
+  if (typeof block.error === 'string' && block.error.length > 0) {
+    return true;
+  }
+  return typeof record?.error === 'string' && record.error.length > 0;
+}
+
+/**
+ * Extracts the display text for a tool response with the precedence documented
+ * on mapToolResponseBlock: result.output, then string result.content, then (for
+ * failures) the error text, then the shared extractToolResultText fallback.
+ * Returns null when no non-empty text is representable.
+ */
+function extractResponseText(
+  block: ToolResponseBlock,
+  record: Dict | null,
+  failed: boolean,
+): string | null {
+  const output = record?.output;
+  if (typeof output === 'string' && output.length > 0) {
+    return output;
+  }
+  const inlineContent = record?.content;
+  if (typeof inlineContent === 'string' && inlineContent.length > 0) {
+    return inlineContent;
+  }
+  if (failed) {
+    const errorText = failureText(block, record);
+    if (errorText !== null) {
+      return errorText;
+    }
+  }
+  return extractToolResultText({ llmContent: block.result });
+}
+
+/**
+ * Returns the failure text for a failed response: the block-level error string
+ * when present, else a string result.error property, else null.
+ */
+function failureText(
+  block: ToolResponseBlock,
+  record: Dict | null,
+): string | null {
+  if (typeof block.error === 'string' && block.error.length > 0) {
+    return block.error;
+  }
+  const resultError = record?.error;
+  if (typeof resultError === 'string' && resultError.length > 0) {
+    return resultError;
+  }
+  return null;
 }
 
 /**
@@ -182,15 +333,19 @@ function mapToolResponseBlock(block: ToolResponseBlock): acp.SessionUpdate {
  * shape ACP expects: a JSON object, or undefined when the stored value is not a
  * plain object (so the wire payload never carries a non-object rawInput).
  */
-function toRawInput(
-  parameters: unknown,
-): Readonly<Record<string, unknown>> | undefined {
-  if (
-    parameters !== null &&
-    typeof parameters === 'object' &&
-    !Array.isArray(parameters)
-  ) {
-    return parameters as Readonly<Record<string, unknown>>;
+function toRawInput(parameters: unknown): Dict | undefined {
+  const record = asRecord(parameters);
+  return record ?? undefined;
+}
+
+/**
+ * Narrows an unknown value to a readonly JSON object (non-null, non-array
+ * object), or null otherwise. Local to this module so the mapping stays
+ * self-contained and pure.
+ */
+function asRecord(value: unknown): Dict | null {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Dict;
   }
-  return undefined;
+  return null;
 }

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -254,8 +254,10 @@ function buildToolCallStart(block: ToolCallBlock): acp.SessionUpdate {
 /**
  * tool tool_response -> terminal tool_call_update. Status is 'failed' when the
  * block carries an error (ToolResponseBlock.error) OR its result is an object
- * with a string `error` property (the { error } failure shape produced by
- * createErrorResponse), else 'completed'. The displayed text is extracted with a
+ * with a non-empty string `error` property OR a nested `error.message` string
+ * (the { error } and { error: { message } } failure shapes produced by
+ * createErrorResponse, FINDING F3), else 'completed'. The displayed text is
+ * extracted with a
  * precedence that mirrors how results are actually recorded: result.output
  * (the { output } success shape), then a string result.content, then an
  * MCP-style result.content array (joined text elements), then the failure error
@@ -287,8 +289,12 @@ function mapToolResponseBlock(block: ToolResponseBlock): acp.SessionUpdate {
 
 /**
  * A recorded tool response is a failure when its block carries a non-empty
- * error string OR its result object exposes a non-empty string `error` property
- * (the { error } shape emitted by the core createErrorResponse path).
+ * error string OR its result object exposes an `error` property that is either a
+ * non-empty string (the `{ error: string }` shape) OR an object with a non-empty
+ * string `message` (the `{ error: { message } }` shape the core
+ * createErrorResponse path can produce, FINDING F3). Both error shapes must mark
+ * the update 'failed' so an object-shaped error is not silently rendered as a
+ * completed call.
  */
 function isFailedResponse(
   block: ToolResponseBlock,
@@ -297,7 +303,28 @@ function isFailedResponse(
   if (typeof block.error === 'string' && block.error.length > 0) {
     return true;
   }
-  return typeof record?.error === 'string' && record.error.length > 0;
+  return resultErrorText(record) !== null;
+}
+
+/**
+ * Extracts the failure text carried by a result object's `error` property,
+ * supporting BOTH the `{ error: string }` shape and the `{ error: { message:
+ * string } }` object shape (FINDING F3). Returns the non-empty error/message
+ * string, or null when there is no representable error text.
+ */
+function resultErrorText(record: Dict | null): string | null {
+  const resultError = record?.error;
+  if (typeof resultError === 'string' && resultError.length > 0) {
+    return resultError;
+  }
+  const nested = asRecord(resultError);
+  if (nested !== null) {
+    const message = nested.message;
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+  return null;
 }
 
 /**
@@ -354,22 +381,26 @@ function extractContentArrayText(value: unknown): string | null {
 
 /**
  * Narrows a single MCP-style content-array element to its text: returns the
- * `text` string for a non-empty `{ type: 'text', text: string }` element, else
- * null (skipping images/resources and malformed entries).
+ * `text` string for a `{ type: 'text', text: string }` element whose text is
+ * non-whitespace, else null (skipping images/resources, malformed entries, and
+ * whitespace-only text elements, FINDING F11). Whitespace-only elements are
+ * dropped so a content array of only blank text yields an empty content array on
+ * the update rather than passing blank text through.
  */
 function textOfContentElement(element: unknown): string | null {
   const record = asRecord(element);
   if (record === null || record.type !== 'text') {
     return null;
   }
-  return typeof record.text === 'string' && record.text.length > 0
+  return typeof record.text === 'string' && record.text.trim().length > 0
     ? record.text
     : null;
 }
 
 /**
  * Returns the failure text for a failed response: the block-level error string
- * when present, else a string result.error property, else null.
+ * when present, else the result object's error text (string `error` OR nested
+ * `error.message`, via {@link resultErrorText}, FINDING F3), else null.
  */
 function failureText(
   block: ToolResponseBlock,
@@ -378,11 +409,7 @@ function failureText(
   if (typeof block.error === 'string' && block.error.length > 0) {
     return block.error;
   }
-  const resultError = record?.error;
-  if (typeof resultError === 'string' && resultError.length > 0) {
-    return resultError;
-  }
-  return null;
+  return resultErrorText(record);
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -72,7 +72,7 @@ type Dict = Readonly<Record<string, unknown>>;
  * tool response for a pending id emits the terminal completed/failed update and
  * clears it; unmatched responses are dropped; and any call still pending after
  * the whole history is walked yields a trailing synthetic failed update, in
- * original start order (Set iteration preserves insertion order). The output
+ * original start order (Map iteration preserves insertion order). The output
  * preserves history order and, per message, block order.
  */
 export function mapHistoryToSessionUpdates(

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -265,27 +265,33 @@ function mapThinkingBlock(
  * start path in zed-tool-handler.ts (emitToolCallStart): status 'in_progress',
  * empty content, locations inferred from the recorded parameters via the SAME
  * buildToolLocations helper, kind inferred via the SAME inferToolKind table, and
- * rawInput carrying the narrowed parameters. kind is omitted (rather than sent
- * as undefined) for unknown tools; both are wire-identical after JSON encoding.
+ * rawInput ALWAYS present ({} when parameters are missing/malformed) exactly as
+ * the live path always sends call.args. kind is omitted (rather than sent as
+ * undefined) for unknown tools; both are wire-identical after JSON encoding.
  */
 function buildToolCallStart(block: ToolCallBlock): acp.SessionUpdate {
-  const kind = inferToolKind(block.name);
-  const rawInput = toRawInput(block.parameters);
   // FINDING D4: fall back to the id for the title when `name` is missing/non-
   // string in malformed persisted data. Keeping the (already-validated string)
   // id as the title preserves identifying info on the wire rather than sending
-  // an undefined title; kind inference on a non-string name yields undefined
-  // (omitted), which is correct for an unknown tool.
-  const title = isNonEmptyString(block.name) ? block.name : block.id;
+  // an undefined title. inferToolKind is only consulted for a validated string
+  // name — its signature requires one, and a malformed block must not leak a
+  // non-string into the lookup — so an unknown/malformed name yields undefined
+  // (kind omitted), which is correct for an unknown tool.
+  const named = isNonEmptyString(block.name);
+  const kind = named ? inferToolKind(block.name) : undefined;
+  // rawInput is sent unconditionally ({} when the recorded parameters are
+  // missing/malformed) to stay wire-identical with the live start path in
+  // zed-tool-handler.ts (emitToolCallStart), which always includes rawInput.
+  const rawInput = toRawInput(block.parameters) ?? {};
   return {
     sessionUpdate: 'tool_call',
     toolCallId: block.id,
-    title,
+    title: named ? block.name : block.id,
     status: 'in_progress',
     content: [],
-    locations: buildToolLocations(rawInput ?? {}),
+    locations: buildToolLocations(rawInput),
     ...(kind !== undefined ? { kind } : {}),
-    ...(rawInput !== undefined ? { rawInput } : {}),
+    rawInput,
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -16,15 +16,27 @@
  * the ordered list of ACP {@link acp.SessionUpdate} notifications the live
  * streaming path (StreamBatcher / zed-tool-handler.ts) would have produced.
  *
- * Tool-call fidelity: the live path emits a tool_call (status 'in_progress',
- * empty content, inferred locations/kind) at call time and a SEPARATE
- * tool_call_update (completed/failed with the result text) when the response
- * arrives. Replay mirrors that two-update shape so a reconstructed transcript is
- * wire-indistinguishable from a live one: each recorded ai ToolCallBlock emits
- * the in_progress tool_call, and its paired tool ToolResponseBlock emits the
- * terminal tool_call_update. A ToolCallBlock with no recorded response (an
- * interrupted turn) gets a synthetic 'failed' tool_call_update so the client
- * never renders a perpetually-running tool.
+ * Tool-call fidelity (order-aware pairing): the live path emits a tool_call
+ * (status 'in_progress', empty content, inferred locations/kind) at call time
+ * and a SEPARATE tool_call_update (completed/failed with the result text) when
+ * the response arrives. Replay mirrors that two-update shape via a SINGLE
+ * ordered walk that tracks a `pending` set of started-but-unfinished callIds:
+ *
+ *  - an ai ToolCallBlock emits the in_progress tool_call and marks the id
+ *    pending;
+ *  - a tool ToolResponseBlock whose id IS pending emits exactly ONE terminal
+ *    tool_call_update (first response wins) and clears the id — a duplicate
+ *    response for the same id is then dropped;
+ *  - a tool ToolResponseBlock whose id is NOT pending (an orphan response before
+ *    its start, or a second response after completion) is DROPPED so replay
+ *    never emits a floating terminal update with no matching start;
+ *  - any id still pending at end-of-history (an interrupted turn) gets a
+ *    synthetic 'failed' tool_call_update, in original start order, so the client
+ *    never renders a perpetually-running tool.
+ *
+ * This ordered pairing (vs a global pre-scan of every response id) keeps the
+ * start->end status transitions correct across response-before-call, duplicate
+ * responses, and the same id reused across turns.
  *
  * It is kept separate from zedIntegration.ts (and free of any I/O) so the
  * mapping stays small, individually unit-testable against the v1 snake_case
@@ -50,57 +62,46 @@ type Dict = Readonly<Record<string, unknown>>;
  * Maps a full resumed history (ordered IContent[]) to the ordered ACP
  * SessionUpdate notifications that replay the conversation. Empty/whitespace
  * text chunks are skipped; unmappable blocks (media, code) contribute no update.
- * Each ai tool_call contributes an in_progress tool_call PLUS — when the call
- * has no recorded response — a terminal failed tool_call_update; a recorded tool
- * response contributes the matching completed/failed tool_call_update. The
- * output preserves the history order and, per message, the block order.
+ *
+ * Tool calls are paired in a single ordered pass (see the module doc): each ai
+ * tool_call emits an in_progress tool_call and is tracked as pending; the FIRST
+ * tool response for a pending id emits the terminal completed/failed update and
+ * clears it; unmatched responses are dropped; and any call still pending after
+ * the whole history is walked yields a trailing synthetic failed update, in
+ * original start order (Set iteration preserves insertion order). The output
+ * preserves history order and, per message, block order.
  */
 export function mapHistoryToSessionUpdates(
   items: readonly IContent[],
 ): acp.SessionUpdate[] {
-  const respondedCallIds = collectRespondedCallIds(items);
   const updates: acp.SessionUpdate[] = [];
+  const pending = new Set<string>();
   for (const item of items) {
     for (const block of item.blocks) {
-      appendBlockUpdates(item.speaker, block, respondedCallIds, updates);
+      appendBlockUpdates(item.speaker, block, pending, updates);
     }
+  }
+  // Every id still pending had no delivered response (an interrupted turn):
+  // synthesize its terminal failed update now, in start order, so the client
+  // does not render a perpetually-running tool. Set iteration order is the
+  // insertion (call-start) order.
+  for (const toolCallId of pending) {
+    updates.push(buildSyntheticFailedUpdate(toolCallId));
   }
   return updates;
 }
 
 /**
- * Pre-scans the history for the callIds that DO have a tool ToolResponseBlock,
- * so the block pass can tell a paired tool_call (whose response will emit the
- * terminal update) from an orphaned one (interrupted turn) that needs a
- * synthetic failed update. Kept as a separate pure pass so the per-block mapping
- * stays a simple forward walk.
- */
-function collectRespondedCallIds(
-  items: readonly IContent[],
-): ReadonlySet<string> {
-  const ids = new Set<string>();
-  for (const item of items) {
-    if (item.speaker !== 'tool') {
-      continue;
-    }
-    for (const block of item.blocks) {
-      if (block.type === 'tool_response') {
-        ids.add(block.callId);
-      }
-    }
-  }
-  return ids;
-}
-
-/**
- * Appends the SessionUpdate(s) for a single (speaker, block) pair to `out`. Most
- * blocks map to at most one update; an ai tool_call may append two (the
- * in_progress tool_call and, when orphaned, a terminal failed update).
+ * Appends the SessionUpdate(s) for a single (speaker, block) pair to `out`,
+ * mutating `pending` for tool-call lifecycle tracking. Text/thinking map to at
+ * most one update; an ai tool_call emits its in_progress start and marks the id
+ * pending; a tool tool_response emits its terminal update only when it pairs
+ * with a pending start (see appendToolResponseUpdate).
  */
 function appendBlockUpdates(
   speaker: IContent['speaker'],
   block: ContentBlock,
-  respondedCallIds: ReadonlySet<string>,
+  pending: Set<string>,
   out: acp.SessionUpdate[],
 ): void {
   switch (block.type) {
@@ -112,12 +113,13 @@ function appendBlockUpdates(
       return;
     case 'tool_call':
       if (speaker === 'ai') {
-        appendToolCallUpdates(block, respondedCallIds, out);
+        out.push(buildToolCallStart(block));
+        pending.add(block.id);
       }
       return;
     case 'tool_response':
       if (speaker === 'tool') {
-        out.push(mapToolResponseBlock(block));
+        appendToolResponseUpdate(block, pending, out);
       }
       return;
     // Media/code blocks are intentionally skipped in v1 replay: ACP has no
@@ -127,6 +129,45 @@ function appendBlockUpdates(
     default:
       return;
   }
+}
+
+/**
+ * Emits the terminal tool_call_update for a recorded tool response, order-aware
+ * against the `pending` set of started-but-unfinished calls:
+ *  - if the callId IS pending: emit exactly ONE terminal update (first response
+ *    wins) and clear the id so a later duplicate response for the same id is
+ *    dropped;
+ *  - if the callId is NOT pending (an orphan response that arrived before its
+ *    start, or a second response after the call already completed): DROP it.
+ *    Emitting a floating terminal update with no matching in_progress start
+ *    would hand the client a tool_call_update it never saw begin, corrupting the
+ *    status transition; dropping keeps replay wire-consistent with the live
+ *    start->end pairing.
+ */
+function appendToolResponseUpdate(
+  block: ToolResponseBlock,
+  pending: Set<string>,
+  out: acp.SessionUpdate[],
+): void {
+  if (!pending.has(block.callId)) {
+    return;
+  }
+  pending.delete(block.callId);
+  out.push(mapToolResponseBlock(block));
+}
+
+/**
+ * Builds the synthetic terminal update for a tool call that never received a
+ * response: a 'failed' tool_call_update with empty content, matching the live
+ * behavior of never leaving a perpetually-running tool on the client.
+ */
+function buildSyntheticFailedUpdate(toolCallId: string): acp.SessionUpdate {
+  return {
+    sessionUpdate: 'tool_call_update',
+    toolCallId,
+    status: 'failed',
+    content: [],
+  };
 }
 
 /** Pushes `update` onto `out` when it is non-null (small readability helper). */
@@ -188,30 +229,6 @@ function mapThinkingBlock(
 }
 
 /**
- * Appends the replay updates for an ai ToolCallBlock: first the in_progress
- * tool_call matching the live start shape, then — ONLY when the call has no
- * recorded response — a terminal failed tool_call_update (empty content) so an
- * interrupted turn does not leave a perpetually-running tool on the client. A
- * call WITH a recorded response gets its terminal update from that response
- * block (mapToolResponseBlock), preserving the live "start then complete" pair.
- */
-function appendToolCallUpdates(
-  block: ToolCallBlock,
-  respondedCallIds: ReadonlySet<string>,
-  out: acp.SessionUpdate[],
-): void {
-  out.push(buildToolCallStart(block));
-  if (!respondedCallIds.has(block.id)) {
-    out.push({
-      sessionUpdate: 'tool_call_update',
-      toolCallId: block.id,
-      status: 'failed',
-      content: [],
-    });
-  }
-}
-
-/**
  * ai tool_call -> in_progress tool_call. Field names + shape mirror the live
  * start path in zed-tool-handler.ts (emitToolCallStart): status 'in_progress',
  * empty content, locations inferred from the recorded parameters via the SAME
@@ -240,10 +257,11 @@ function buildToolCallStart(block: ToolCallBlock): acp.SessionUpdate {
  * with a string `error` property (the { error } failure shape produced by
  * createErrorResponse), else 'completed'. The displayed text is extracted with a
  * precedence that mirrors how results are actually recorded: result.output
- * (the { output } success shape), then a string result.content, then the failure
- * error text, then the shared extractToolResultText fallback. Only non-empty
- * text yields a content entry; otherwise the update carries an empty content
- * array (mirroring the live suppressed-display behavior).
+ * (the { output } success shape), then a string result.content, then an
+ * MCP-style result.content array (joined text elements), then the failure error
+ * text, then the shared extractToolResultText fallback. Only non-empty text
+ * yields a content entry; otherwise the update carries an empty content array
+ * (mirroring the live suppressed-display behavior).
  *
  * Diff replay gap: the recorded IContent does NOT persist the display/FileDiff
  * metadata the live path uses to emit a { type: 'diff' } ToolCallContent, so a
@@ -284,9 +302,10 @@ function isFailedResponse(
 
 /**
  * Extracts the display text for a tool response with the precedence documented
- * on mapToolResponseBlock: result.output, then string result.content, then (for
- * failures) the error text, then the shared extractToolResultText fallback.
- * Returns null when no non-empty text is representable.
+ * on mapToolResponseBlock: result.output, then string result.content, then an
+ * MCP-style result.content array, then (for failures) the error text, then the
+ * shared extractToolResultText fallback. Returns null when no non-empty text is
+ * representable.
  */
 function extractResponseText(
   block: ToolResponseBlock,
@@ -301,6 +320,10 @@ function extractResponseText(
   if (typeof inlineContent === 'string' && inlineContent.length > 0) {
     return inlineContent;
   }
+  const arrayText = extractContentArrayText(inlineContent);
+  if (arrayText !== null) {
+    return arrayText;
+  }
   if (failed) {
     const errorText = failureText(block, record);
     if (errorText !== null) {
@@ -308,6 +331,40 @@ function extractResponseText(
     }
   }
   return extractToolResultText({ llmContent: block.result });
+}
+
+/**
+ * Joins the text of an MCP-style result.content array: keeps only elements that
+ * look like `{ type: 'text', text: string }`, concatenates their `text` (no
+ * separator, matching how streamed text chunks recombine), and returns the
+ * result only when non-empty. Non-text elements (images, resources) are skipped.
+ * Returns null when the value is not an array or yields no text, so the caller
+ * falls through to the next precedence tier.
+ */
+function extractContentArrayText(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const text = value
+    .map((element) => textOfContentElement(element))
+    .filter((entry): entry is string => entry !== null)
+    .join('');
+  return text.length > 0 ? text : null;
+}
+
+/**
+ * Narrows a single MCP-style content-array element to its text: returns the
+ * `text` string for a non-empty `{ type: 'text', text: string }` element, else
+ * null (skipping images/resources and malformed entries).
+ */
+function textOfContentElement(element: unknown): string | null {
+  const record = asRecord(element);
+  if (record === null || record.type !== 'text') {
+    return null;
+  }
+  return typeof record.text === 'string' && record.text.length > 0
+    ? record.text
+    : null;
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * IContent -> ACP SessionUpdate mapping for ACP session/load (loadSession)
+ * conversation replay (issue #1604).
+ *
+ * When Zed calls `session/load`, the agent resumes a persisted session and must
+ * stream the historical conversation back to the client as `session/update`
+ * notifications BEFORE the load resolves, so the client can reconstruct the
+ * transcript. This module owns the pure, side-effect-free translation from the
+ * neutral {@link IContent} history (as returned by `agent.session.resume`) to
+ * the ordered list of ACP {@link acp.SessionUpdate} notifications the live
+ * streaming path (StreamBatcher / zed-tool-handler.ts) would have produced.
+ *
+ * It is kept separate from zedIntegration.ts (and free of any I/O) so the
+ * mapping stays small, individually unit-testable against the v1 snake_case
+ * wire discriminators, and lint-clean under the complexity guardrails.
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type {
+  IContent,
+  ContentBlock,
+  TextBlock,
+  ThinkingBlock,
+  ToolCallBlock,
+  ToolResponseBlock,
+} from '@vybestack/llxprt-code-core';
+import { inferToolKind } from './zed-tool-handler.js';
+import { extractToolResultText } from './zed-content-utils.js';
+
+/**
+ * Maps a full resumed history (ordered IContent[]) to the ordered ACP
+ * SessionUpdate notifications that replay the conversation. Empty/whitespace
+ * text chunks are skipped; unmappable blocks (media, code, empty tool text)
+ * contribute no update. The output order preserves the history order and, per
+ * message, the block order — matching how the live path emits chunks.
+ */
+export function mapHistoryToSessionUpdates(
+  items: readonly IContent[],
+): acp.SessionUpdate[] {
+  const updates: acp.SessionUpdate[] = [];
+  for (const item of items) {
+    appendMessageUpdates(item, updates);
+  }
+  return updates;
+}
+
+/**
+ * Appends the SessionUpdates for a single IContent message, dispatching on the
+ * speaker so each block is mapped by the rules for that role.
+ */
+function appendMessageUpdates(item: IContent, out: acp.SessionUpdate[]): void {
+  for (const block of item.blocks) {
+    const update = mapBlock(item.speaker, block);
+    if (update !== null) {
+      out.push(update);
+    }
+  }
+}
+
+/**
+ * Maps a single (speaker, block) pair to at most one SessionUpdate, or null when
+ * the block has no faithful replay representation (empty text, media/code, a
+ * human-authored non-text block, etc.).
+ */
+function mapBlock(
+  speaker: IContent['speaker'],
+  block: ContentBlock,
+): acp.SessionUpdate | null {
+  switch (block.type) {
+    case 'text':
+      return mapTextBlock(speaker, block);
+    case 'thinking':
+      return mapThinkingBlock(speaker, block);
+    case 'tool_call':
+      return speaker === 'ai' ? mapToolCallBlock(block) : null;
+    case 'tool_response':
+      return speaker === 'tool' ? mapToolResponseBlock(block) : null;
+    // Media/code blocks are intentionally skipped in v1 replay: ACP has no
+    // lossless chunk for a stored CodeBlock, and re-streaming base64 MediaBlock
+    // payloads on every reconnect would be wasteful and is not required to
+    // reconstruct the readable transcript.
+    default:
+      return null;
+  }
+}
+
+/**
+ * human text -> user_message_chunk; ai text -> agent_message_chunk. Tool-speaker
+ * text (rare) is skipped. Whitespace-only text is skipped.
+ */
+function mapTextBlock(
+  speaker: IContent['speaker'],
+  block: TextBlock,
+): acp.SessionUpdate | null {
+  const text = block.text;
+  if (text.trim().length === 0) {
+    return null;
+  }
+  if (speaker === 'human') {
+    return {
+      sessionUpdate: 'user_message_chunk',
+      content: { type: 'text', text },
+    };
+  }
+  if (speaker === 'ai') {
+    return {
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text },
+    };
+  }
+  return null;
+}
+
+/**
+ * ai thinking -> agent_thought_chunk (text content carrying the thought). Empty
+ * thoughts, or thinking blocks from a non-ai speaker, are skipped.
+ */
+function mapThinkingBlock(
+  speaker: IContent['speaker'],
+  block: ThinkingBlock,
+): acp.SessionUpdate | null {
+  if (speaker !== 'ai') {
+    return null;
+  }
+  const text = block.thought;
+  if (typeof text !== 'string' || text.trim().length === 0) {
+    return null;
+  }
+  return {
+    sessionUpdate: 'agent_thought_chunk',
+    content: { type: 'text', text },
+  };
+}
+
+/**
+ * ai tool_call -> tool_call update (status 'completed', since a stored history
+ * block represents a call that already ran). Field names mirror the live start
+ * path in zed-tool-handler.ts (toolCallId/title/kind/rawInput); kind is inferred
+ * from the tool name via the SAME TOOL_KIND_BY_NAME table.
+ */
+function mapToolCallBlock(block: ToolCallBlock): acp.SessionUpdate {
+  const kind = inferToolKind(block.name);
+  return {
+    sessionUpdate: 'tool_call',
+    toolCallId: block.id,
+    title: block.name,
+    status: 'completed',
+    ...(kind !== undefined ? { kind } : {}),
+    rawInput: toRawInput(block.parameters),
+  };
+}
+
+/**
+ * tool tool_response -> tool_call_update (status 'completed'). When the stored
+ * result renders to non-empty text (via the SAME extractToolResultText helper
+ * the live tool path uses), it is included as a single text ToolCallContent;
+ * otherwise the update carries an empty content array (mirroring the live
+ * suppressed-display behavior).
+ */
+function mapToolResponseBlock(block: ToolResponseBlock): acp.SessionUpdate {
+  const text = extractToolResultText({ llmContent: block.result });
+  const content: acp.ToolCallContent[] =
+    text !== null && text.length > 0
+      ? [{ type: 'content', content: { type: 'text', text } }]
+      : [];
+  return {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: block.callId,
+    status: 'completed',
+    content,
+  };
+}
+
+/**
+ * Narrows a stored ToolCallBlock.parameters (typed `unknown`) to the `rawInput`
+ * shape ACP expects: a JSON object, or undefined when the stored value is not a
+ * plain object (so the wire payload never carries a non-object rawInput).
+ */
+function toRawInput(
+  parameters: unknown,
+): Readonly<Record<string, unknown>> | undefined {
+  if (
+    parameters !== null &&
+    typeof parameters === 'object' &&
+    !Array.isArray(parameters)
+  ) {
+    return parameters as Readonly<Record<string, unknown>>;
+  }
+  return undefined;
+}

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -76,7 +76,17 @@ export function mapHistoryToSessionUpdates(
 ): acp.SessionUpdate[] {
   const updates: acp.SessionUpdate[] = [];
   const pending = new Set<string>();
-  for (const item of items) {
+  // FINDING D1: iterate as `unknown` because persisted history read back from
+  // disk is UNTRUSTED — the static `readonly IContent[]` type is a contract, not
+  // a runtime guarantee. A corrupt/truncated JSONL line can yield a null item or
+  // one whose `blocks` is missing/non-array; asRenderableContent narrows each
+  // against the real runtime shape so a malformed entry is skipped instead of
+  // throwing and aborting the WHOLE load.
+  for (const raw of items as readonly unknown[]) {
+    const item = asRenderableContent(raw);
+    if (item === null) {
+      continue;
+    }
     for (const block of item.blocks) {
       appendBlockUpdates(item.speaker, block, pending, updates);
     }
@@ -112,13 +122,19 @@ function appendBlockUpdates(
       pushDefined(out, mapThinkingBlock(speaker, block));
       return;
     case 'tool_call':
-      if (speaker === 'ai') {
+      // FINDING D4: a tool_call whose id is missing/non-string cannot be tracked
+      // (nothing could ever pair its response) and would emit an update carrying
+      // an undefined toolCallId on the wire. Skip it entirely.
+      if (speaker === 'ai' && isNonEmptyString(block.id)) {
         out.push(buildToolCallStart(block));
         pending.add(block.id);
       }
       return;
     case 'tool_response':
-      if (speaker === 'tool') {
+      // FINDING D4: a tool_response without a string callId can never pair with a
+      // started call, so it would always be dropped by the pending check anyway;
+      // guard explicitly so the intent is clear and no undefined id is handled.
+      if (speaker === 'tool' && isNonEmptyString(block.callId)) {
         appendToolResponseUpdate(block, pending, out);
       }
       return;
@@ -189,7 +205,10 @@ function mapTextBlock(
   block: TextBlock,
 ): acp.SessionUpdate | null {
   const text = block.text;
-  if (text.trim().length === 0) {
+  // FINDING D2: guard against a non-string `text` in malformed persisted data
+  // (mirrors the guard mapThinkingBlock already has for `thought`). Calling
+  // .trim() on a non-string would throw and abort the load; skip instead.
+  if (typeof text !== 'string' || text.trim().length === 0) {
     return null;
   }
   if (speaker === 'human') {
@@ -239,15 +258,55 @@ function mapThinkingBlock(
 function buildToolCallStart(block: ToolCallBlock): acp.SessionUpdate {
   const kind = inferToolKind(block.name);
   const rawInput = toRawInput(block.parameters);
+  // FINDING D4: fall back to the id for the title when `name` is missing/non-
+  // string in malformed persisted data. Keeping the (already-validated string)
+  // id as the title preserves identifying info on the wire rather than sending
+  // an undefined title; kind inference on a non-string name yields undefined
+  // (omitted), which is correct for an unknown tool.
+  const title = isNonEmptyString(block.name) ? block.name : block.id;
   return {
     sessionUpdate: 'tool_call',
     toolCallId: block.id,
-    title: block.name,
+    title,
     status: 'in_progress',
     content: [],
     locations: buildToolLocations(rawInput ?? {}),
     ...(kind !== undefined ? { kind } : {}),
     ...(rawInput !== undefined ? { rawInput } : {}),
+  };
+}
+
+/**
+ * True when `value` is a non-empty string. Used to validate persisted tool-call
+ * ids/callIds/names read back from disk (FINDING D4) before they are emitted on
+ * the wire, so a corrupt block never yields an update with an undefined id.
+ */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Narrows an UNTRUSTED persisted history entry to a renderable IContent — a
+ * non-null object whose `blocks` is an array (FINDING D1). Returns null for a
+ * null/undefined item or one whose blocks is missing/non-array (a
+ * corrupt/truncated JSONL line that still JSON-parsed), so the caller skips it
+ * rather than throwing on `item.blocks`. Individual malformed BLOCKS are handled
+ * downstream by the per-block guards (D2/D4); this only guarantees `blocks` is
+ * iterable.
+ */
+function asRenderableContent(
+  value: unknown,
+): { speaker: IContent['speaker']; blocks: readonly ContentBlock[] } | null {
+  if (value === null || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as { speaker?: unknown; blocks?: unknown };
+  if (!Array.isArray(record.blocks)) {
+    return null;
+  }
+  return {
+    speaker: record.speaker as IContent['speaker'],
+    blocks: record.blocks as readonly ContentBlock[],
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -110,7 +110,7 @@ export function mapHistoryToSessionUpdates(
   }
   // Every id still pending had no delivered response (an interrupted turn):
   // synthesize its terminal failed update now, in start order, so the client
-  // does not render a perpetually-running tool. Set iteration order is the
+  // does not render a perpetually-running tool. Map iteration preserves the
   // insertion (call-start) order.
   for (const [toolCallId, kind] of pending) {
     updates.push(buildSyntheticFailedUpdate(toolCallId, kind));

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -52,7 +52,11 @@ import type {
   ToolCallBlock,
   ToolResponseBlock,
 } from '@vybestack/llxprt-code-core';
-import { buildToolLocations, inferToolKind } from './zed-tool-handler.js';
+import {
+  buildToolLocations,
+  inferToolKind,
+  toAcpToolKind,
+} from './zed-tool-handler.js';
 import { extractToolResultText } from './zed-content-utils.js';
 
 /** Readonly JSON-object shape used when narrowing recorded `unknown` payloads. */
@@ -75,7 +79,7 @@ export function mapHistoryToSessionUpdates(
   items: readonly IContent[],
 ): acp.SessionUpdate[] {
   const updates: acp.SessionUpdate[] = [];
-  const pending = new Set<string>();
+  const pending = new Map<string, acp.ToolKind>();
   // FINDING D1: iterate as `unknown` because persisted history read back from
   // disk is UNTRUSTED — the static `readonly IContent[]` type is a contract, not
   // a runtime guarantee. A corrupt/truncated JSONL line can yield a null item or
@@ -108,8 +112,8 @@ export function mapHistoryToSessionUpdates(
   // synthesize its terminal failed update now, in start order, so the client
   // does not render a perpetually-running tool. Set iteration order is the
   // insertion (call-start) order.
-  for (const toolCallId of pending) {
-    updates.push(buildSyntheticFailedUpdate(toolCallId));
+  for (const [toolCallId, kind] of pending) {
+    updates.push(buildSyntheticFailedUpdate(toolCallId, kind));
   }
   return updates;
 }
@@ -124,7 +128,7 @@ export function mapHistoryToSessionUpdates(
 function appendBlockUpdates(
   speaker: IContent['speaker'],
   block: ContentBlock,
-  pending: Set<string>,
+  pending: Map<string, acp.ToolKind>,
   out: acp.SessionUpdate[],
 ): void {
   switch (block.type) {
@@ -139,8 +143,9 @@ function appendBlockUpdates(
       // (nothing could ever pair its response) and would emit an update carrying
       // an undefined toolCallId on the wire. Skip it entirely.
       if (speaker === 'ai' && isNonEmptyString(block.id)) {
-        out.push(buildToolCallStart(block));
-        pending.add(block.id);
+        const kind = toolKindForRecordedCall(block);
+        out.push(buildToolCallStart(block, kind));
+        pending.set(block.id, kind);
       }
       return;
     case 'tool_response':
@@ -175,14 +180,15 @@ function appendBlockUpdates(
  */
 function appendToolResponseUpdate(
   block: ToolResponseBlock,
-  pending: Set<string>,
+  pending: Map<string, acp.ToolKind>,
   out: acp.SessionUpdate[],
 ): void {
-  if (!pending.has(block.callId)) {
+  const kind = pending.get(block.callId);
+  if (kind === undefined) {
     return;
   }
   pending.delete(block.callId);
-  out.push(mapToolResponseBlock(block));
+  out.push(mapToolResponseBlock(block, kind));
 }
 
 /**
@@ -190,12 +196,16 @@ function appendToolResponseUpdate(
  * response: a 'failed' tool_call_update with empty content, matching the live
  * behavior of never leaving a perpetually-running tool on the client.
  */
-function buildSyntheticFailedUpdate(toolCallId: string): acp.SessionUpdate {
+function buildSyntheticFailedUpdate(
+  toolCallId: string,
+  kind: acp.ToolKind,
+): acp.SessionUpdate {
   return {
     sessionUpdate: 'tool_call_update',
     toolCallId,
     status: 'failed',
     content: [],
+    kind,
   };
 }
 
@@ -269,16 +279,15 @@ function mapThinkingBlock(
  * the live path always sends call.args. kind is omitted (rather than sent as
  * undefined) for unknown tools; both are wire-identical after JSON encoding.
  */
-function buildToolCallStart(block: ToolCallBlock): acp.SessionUpdate {
+function buildToolCallStart(
+  block: ToolCallBlock,
+  kind: acp.ToolKind,
+): acp.SessionUpdate {
   // FINDING D4: fall back to the id for the title when `name` is missing/non-
   // string in malformed persisted data. Keeping the (already-validated string)
   // id as the title preserves identifying info on the wire rather than sending
-  // an undefined title. inferToolKind is only consulted for a validated string
-  // name — its signature requires one, and a malformed block must not leak a
-  // non-string into the lookup — so an unknown/malformed name yields undefined
-  // (kind omitted), which is correct for an unknown tool.
+  // an undefined title.
   const named = isNonEmptyString(block.name);
-  const kind = named ? inferToolKind(block.name) : undefined;
   // rawInput is sent unconditionally ({} when the recorded parameters are
   // missing/malformed) to stay wire-identical with the live start path in
   // zed-tool-handler.ts (emitToolCallStart), which always includes rawInput.
@@ -290,9 +299,15 @@ function buildToolCallStart(block: ToolCallBlock): acp.SessionUpdate {
     status: 'in_progress',
     content: [],
     locations: buildToolLocations(rawInput),
-    ...(kind !== undefined ? { kind } : {}),
+    kind,
     rawInput,
   };
+}
+
+function toolKindForRecordedCall(block: ToolCallBlock): acp.ToolKind {
+  return toAcpToolKind(
+    isNonEmptyString(block.name) ? inferToolKind(block.name) : undefined,
+  );
 }
 
 /**
@@ -391,7 +406,10 @@ function asRenderableBlock(value: unknown): ContentBlock | null {
  * intentionally deferred here (tracked on issue #1604); replay surfaces the
  * textual result instead of a structured diff.
  */
-function mapToolResponseBlock(block: ToolResponseBlock): acp.SessionUpdate {
+function mapToolResponseBlock(
+  block: ToolResponseBlock,
+  kind: acp.ToolKind,
+): acp.SessionUpdate {
   const record = asRecord(block.result);
   const failed = isFailedResponse(block, record);
   const text = extractResponseText(block, record, failed);
@@ -404,6 +422,7 @@ function mapToolResponseBlock(block: ToolResponseBlock): acp.SessionUpdate {
     toolCallId: block.callId,
     status: failed ? 'failed' : 'completed',
     content,
+    kind,
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -118,7 +118,7 @@ export function mapHistoryToSessionUpdates(
  * Appends the SessionUpdate(s) for a single (speaker, block) pair to `out`,
  * mutating `pending` for tool-call lifecycle tracking. Text/thinking map to at
  * most one update; an ai tool_call emits its in_progress start and marks the id
- * pending; a tool tool_response emits its terminal update only when it pairs
+ * pending; a tool-speaker tool_response emits its terminal update only when it pairs
  * with a pending start (see appendToolResponseUpdate).
  */
 function appendBlockUpdates(
@@ -304,16 +304,25 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
+/** The valid IContent speaker discriminators a persisted item may carry. */
+const VALID_SPEAKERS: ReadonlySet<IContent['speaker']> = new Set([
+  'human',
+  'ai',
+  'tool',
+]);
+
 /**
  * Narrows an UNTRUSTED persisted history entry to a renderable IContent — a
- * non-null object whose `blocks` is an array (FINDING D1). Returns null for a
- * null/undefined item or one whose blocks is missing/non-array (a
+ * non-null object whose `speaker` is a valid discriminator ('human' | 'ai' |
+ * 'tool') and whose `blocks` is an array (FINDING D1). Returns null for a
+ * null/undefined item or one whose speaker/blocks is missing/invalid (a
  * corrupt/truncated JSONL line that still JSON-parsed), so the caller skips it
- * rather than throwing on `item.blocks`. The array ELEMENTS deliberately stay
- * `unknown`: the caller narrows each one with {@link asRenderableBlock} (D1 at
- * the block level) before use, and the type-specific fields are then guarded by
- * the per-block D2/D4 checks. This function only guarantees `blocks` is iterable
- * — it does NOT (and must not) pretend the raw elements are valid ContentBlocks.
+ * rather than throwing on `item.blocks` or silently mapping an unknown speaker.
+ * The array ELEMENTS deliberately stay `unknown`: the caller narrows each one
+ * with {@link asRenderableBlock} (D1 at the block level) before use, and the
+ * type-specific fields are then guarded by the per-block D2/D4 checks. This
+ * function only guarantees the speaker union and that `blocks` is iterable — it
+ * does NOT (and must not) pretend the raw elements are valid ContentBlocks.
  */
 function asRenderableContent(
   value: unknown,
@@ -322,6 +331,9 @@ function asRenderableContent(
     return null;
   }
   const record = value as { speaker?: unknown; blocks?: unknown };
+  if (!VALID_SPEAKERS.has(record.speaker as IContent['speaker'])) {
+    return null;
+  }
   if (!Array.isArray(record.blocks)) {
     return null;
   }
@@ -360,7 +372,7 @@ function asRenderableBlock(value: unknown): ContentBlock | null {
 }
 
 /**
- * tool tool_response -> terminal tool_call_update. Status is 'failed' when the
+ * tool-speaker tool_response -> terminal tool_call_update. Status is 'failed' when the
  * block carries an error (ToolResponseBlock.error) OR its result is an object
  * with a non-empty string `error` property OR a nested `error.message` string
  * (the { error } and { error: { message } } failure shapes produced by

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -87,7 +87,20 @@ export function mapHistoryToSessionUpdates(
     if (item === null) {
       continue;
     }
-    for (const block of item.blocks) {
+    // FINDING D1 (block level): each ELEMENT of a narrowed blocks array is STILL
+    // untrusted — the item-level narrowing only proved `blocks` is an array, not
+    // that its elements are objects. Persisted JSONL can carry blocks: [null],
+    // [undefined], [42], ['x'], [{}] (no type), or [{type: 42}]. asRenderableBlock
+    // narrows every element to a non-null object with a STRING `type`, so a
+    // malformed element is skipped silently (matching the malformed-ITEM skip)
+    // instead of throwing on `block.type` in appendBlockUpdates and aborting the
+    // WHOLE replay. A valid block AFTER a malformed one in the same item — and a
+    // valid item AFTER a malformed-blocks item — both still replay.
+    for (const rawBlock of item.blocks) {
+      const block = asRenderableBlock(rawBlock);
+      if (block === null) {
+        continue;
+      }
       appendBlockUpdates(item.speaker, block, pending, updates);
     }
   }
@@ -290,13 +303,15 @@ function isNonEmptyString(value: unknown): value is string {
  * non-null object whose `blocks` is an array (FINDING D1). Returns null for a
  * null/undefined item or one whose blocks is missing/non-array (a
  * corrupt/truncated JSONL line that still JSON-parsed), so the caller skips it
- * rather than throwing on `item.blocks`. Individual malformed BLOCKS are handled
- * downstream by the per-block guards (D2/D4); this only guarantees `blocks` is
- * iterable.
+ * rather than throwing on `item.blocks`. The array ELEMENTS deliberately stay
+ * `unknown`: the caller narrows each one with {@link asRenderableBlock} (D1 at
+ * the block level) before use, and the type-specific fields are then guarded by
+ * the per-block D2/D4 checks. This function only guarantees `blocks` is iterable
+ * — it does NOT (and must not) pretend the raw elements are valid ContentBlocks.
  */
 function asRenderableContent(
   value: unknown,
-): { speaker: IContent['speaker']; blocks: readonly ContentBlock[] } | null {
+): { speaker: IContent['speaker']; blocks: readonly unknown[] } | null {
   if (value === null || typeof value !== 'object') {
     return null;
   }
@@ -306,8 +321,36 @@ function asRenderableContent(
   }
   return {
     speaker: record.speaker as IContent['speaker'],
-    blocks: record.blocks as readonly ContentBlock[],
+    blocks: record.blocks as readonly unknown[],
   };
+}
+
+/**
+ * Narrows a single UNTRUSTED persisted block to a renderable {@link ContentBlock}
+ * — a non-null object carrying a STRING `type` discriminator (FINDING D1 at the
+ * block level). Returns null for a null/undefined/primitive element or an object
+ * with no string `type` (the `blocks: [null]`, `[undefined]`, `[42]`, `['x']`,
+ * `[{}]`, `[{type: 42}]` shapes a corrupt/truncated JSONL line can carry), so the
+ * caller SKIPS it silently rather than throwing on `block.type` in
+ * {@link appendBlockUpdates} and aborting the WHOLE replay.
+ *
+ * Only the `type` discriminator is validated here; the type-specific fields
+ * (text/thought/id/callId) remain guarded downstream by the per-block D2/D4
+ * checks exactly as they are for a statically-typed block, so an object with a
+ * valid `type` but a malformed payload is still handled defensively rather than
+ * throwing. The `as ContentBlock` mirrors the established narrowing idiom in this
+ * module (see {@link asRecord} / {@link asRenderableContent}): a runtime check
+ * precedes a precise assertion, never `any`.
+ */
+function asRenderableBlock(value: unknown): ContentBlock | null {
+  if (value === null || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as { type?: unknown };
+  if (typeof record.type !== 'string') {
+    return null;
+  }
+  return value as ContentBlock;
 }
 
 /**

--- a/packages/cli/src/zed-integration/zed-session-replay.ts
+++ b/packages/cli/src/zed-integration/zed-session-replay.ts
@@ -274,10 +274,9 @@ function mapThinkingBlock(
  * ai tool_call -> in_progress tool_call. Field names + shape mirror the live
  * start path in zed-tool-handler.ts (emitToolCallStart): status 'in_progress',
  * empty content, locations inferred from the recorded parameters via the SAME
- * buildToolLocations helper, kind inferred via the SAME inferToolKind table, and
- * rawInput ALWAYS present ({} when parameters are missing/malformed) exactly as
- * the live path always sends call.args. kind is omitted (rather than sent as
- * undefined) for unknown tools; both are wire-identical after JSON encoding.
+ * buildToolLocations helper, kind inferred via the SAME inferToolKind table and
+ * normalized to `other` for unknown tools, and rawInput ALWAYS present ({} when
+ * parameters are missing/malformed) exactly as the live path sends call.args.
  */
 function buildToolCallStart(
   block: ToolCallBlock,

--- a/packages/cli/src/zed-integration/zed-stream-batcher.test.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.test.ts
@@ -69,10 +69,16 @@ describe('StreamBatcher blocked-path timer handling (issue #1604 E1/E2)', () => 
 
     // 1) A normal clean chunk: emits nothing yet but ARMS the 100ms batch timer.
     batcher.append('clean text ', false);
+    // Precondition: the timer really is armed by the first append — otherwise
+    // the later no-stray-flush assertions would pass vacuously (nothing to
+    // clear) and the timer-clearing path would go unexercised.
+    expect(vi.getTimerCount()).toBe(1);
 
     // 2) A blocked chunk (carries an emoji, error mode → blocked): must clear the
     // armed timer, flush the residual, then emit the blocked error message.
     batcher.append('oops \u{1F600}', false);
+    // The armed batch timer was cleared synchronously by the blocked path.
+    expect(vi.getTimerCount()).toBe(0);
 
     // Let the blocked-path microtask chain settle.
     await vi.runAllTimersAsync();

--- a/packages/cli/src/zed-integration/zed-stream-batcher.test.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for StreamBatcher's blocked-path timer handling (issue #1604
+ * FINDING E1/E2). These drive the REAL StreamBatcher over a REAL EmojiFilter in
+ * `error` mode and a real-ish sendUpdate collector — no result-shaped mocks —
+ * with fake timers so the batch-timer race is deterministically observable.
+ *
+ * FINDING E1: a normal chunk arms the 100ms batch timer; a following blocked
+ *   chunk must CLEAR that timer (as flush() does) before building its blocked
+ *   chain. Otherwise the stale timer later fires a SECOND flush()+flushBuffer()
+ *   chain that races the blocked-path chain and re-flushes already-flushed
+ *   content after the error message. We assert both the exact emitted sequence
+ *   AND that the real EmojiFilter.flushBuffer is not called an extra time by a
+ *   stray timer after the blocked chunk settled.
+ * FINDING E2: the emitted blocked message equals the exported
+ *   STREAM_BLOCKED_MESSAGE constant (single source of truth), not a duplicated
+ *   literal.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import { EmojiFilter } from '@vybestack/llxprt-code-core';
+import { StreamBatcher, STREAM_BLOCKED_MESSAGE } from './zed-stream-batcher.js';
+
+/** Collects the text of every agent_message_chunk / agent_thought_chunk sent. */
+interface UpdateCollector {
+  readonly sendUpdate: (update: acp.SessionUpdate) => Promise<void>;
+  readonly texts: () => string[];
+}
+
+function buildCollector(): UpdateCollector {
+  const texts: string[] = [];
+  return {
+    sendUpdate: async (update: acp.SessionUpdate) => {
+      const maybe = update as { content?: { text?: string } };
+      if (typeof maybe.content?.text === 'string') {
+        texts.push(maybe.content.text);
+      }
+    },
+    texts: () => [...texts],
+  };
+}
+
+describe('StreamBatcher blocked-path timer handling (issue #1604 E1/E2)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('E1: clears the pending batch timer on a blocked chunk so no stray secondary flush fires after the blocked sequence', async () => {
+    const filter = new EmojiFilter({ mode: 'error' });
+    // Spy (pass-through) on the REAL flushBuffer so we can count how many times a
+    // flush path runs: the blocked path calls it once (residual), and flush()
+    // calls it once per flush. A stray timer firing after the blocked chunk
+    // would call it an EXTRA time — the regression this guards.
+    const flushBufferSpy = vi.spyOn(filter, 'flushBuffer');
+    const collector = buildCollector();
+    const batcher = new StreamBatcher(filter, collector.sendUpdate);
+
+    // 1) A normal clean chunk: emits nothing yet but ARMS the 100ms batch timer.
+    batcher.append('clean text ', false);
+
+    // 2) A blocked chunk (carries an emoji, error mode → blocked): must clear the
+    // armed timer, flush the residual, then emit the blocked error message.
+    batcher.append('oops \u{1F600}', false);
+
+    // Let the blocked-path microtask chain settle.
+    await vi.runAllTimersAsync();
+    const flushCountAfterBlocked = flushBufferSpy.mock.calls.length;
+    const textsAfterBlocked = collector.texts();
+
+    // Advance well past the batch interval: if the timer had NOT been cleared it
+    // would fire here, running an extra flush()+flushBuffer() chain.
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.runAllTimersAsync();
+
+    // No additional flushBuffer invocation occurred after the blocked chunk
+    // settled — the stale timer was cleared, so nothing fired late.
+    expect(flushBufferSpy.mock.calls.length).toBe(flushCountAfterBlocked);
+    // And no additional text was emitted by a stray flush.
+    expect(collector.texts()).toStrictEqual(textsAfterBlocked);
+
+    // The emitted sequence is the residual clean text THEN exactly one blocked
+    // error message — no duplicate/secondary flush of already-flushed content.
+    expect(collector.texts()).toStrictEqual([
+      'clean text ',
+      STREAM_BLOCKED_MESSAGE,
+    ]);
+    // Exactly one blocked error message overall.
+    expect(
+      collector.texts().filter((t) => t === STREAM_BLOCKED_MESSAGE),
+    ).toHaveLength(1);
+  });
+
+  it('E2: the blocked message emitted equals the exported STREAM_BLOCKED_MESSAGE constant', async () => {
+    const filter = new EmojiFilter({ mode: 'error' });
+    const collector = buildCollector();
+    const batcher = new StreamBatcher(filter, collector.sendUpdate);
+
+    batcher.append('bad \u{1F600}', false);
+    await vi.runAllTimersAsync();
+
+    expect(collector.texts()).toContain(STREAM_BLOCKED_MESSAGE);
+    // The constant is the exact wire literal (guards accidental drift).
+    expect(STREAM_BLOCKED_MESSAGE).toBe(
+      '[Error: Response blocked due to emoji detection]',
+    );
+  });
+});

--- a/packages/cli/src/zed-integration/zed-stream-batcher.test.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.test.ts
@@ -116,4 +116,23 @@ describe('StreamBatcher blocked-path timer handling (issue #1604 E1/E2)', () => 
       '[Error: Response blocked due to emoji detection]',
     );
   });
+
+  it('ignores a late append after dispose(): nothing is emitted and no timer is armed past the turn', async () => {
+    const filter = new EmojiFilter({ mode: 'allowed' });
+    const collector = buildCollector();
+    const batcher = new StreamBatcher(filter, collector.sendUpdate);
+
+    batcher.append('flushed before dispose', false);
+    await batcher.flush();
+    batcher.dispose();
+
+    // A stray chunk arriving after the owning prompt disposed the batcher must
+    // be dropped: no new batch timer, no pending chunk, no late emission.
+    batcher.append('late chunk after dispose', false);
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.runAllTimersAsync();
+    await batcher.flush();
+
+    expect(collector.texts()).toStrictEqual(['flushed before dispose']);
+  });
 });

--- a/packages/cli/src/zed-integration/zed-stream-batcher.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.ts
@@ -34,6 +34,7 @@ export class StreamBatcher {
   private pendingChunks: Array<{ kind: 'text' | 'thought'; text: string }> = [];
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
   private flushChain: Promise<void> = Promise.resolve();
+  private disposed = false;
   private readonly logger: DebugLogger;
 
   constructor(
@@ -49,6 +50,9 @@ export class StreamBatcher {
   }
 
   append(text: string, isThought: boolean): void {
+    if (this.disposed) {
+      return;
+    }
     const filterResult = isThought
       ? this.emojiFilter.filterText(text)
       : this.emojiFilter.filterStreamChunk(text);
@@ -117,11 +121,15 @@ export class StreamBatcher {
 
   /**
    * Clears any pending batch timer and drops buffered chunks so no timer fires
-   * after the owning prompt completes/aborts (FINDING F9). Idempotent and safe
-   * to call after {@link flush}; it does NOT emit, so any pending chunks must be
-   * flushed first (the prompt path flushes then disposes).
+   * after the owning prompt completes/aborts (FINDING F9), and marks the batcher
+   * disposed so a late {@link append} after the turn ends is a silent no-op
+   * (nothing new can enter the flush chain). Idempotent and safe to call after
+   * {@link flush}; it does NOT emit, so any pending chunks must be flushed first
+   * (the prompt path flushes then disposes). An in-flight flush link is left to
+   * settle naturally — it only drains the (now empty) pending queue.
    */
   dispose(): void {
+    this.disposed = true;
     if (this.batchTimer !== null) {
       clearTimeout(this.batchTimer);
       this.batchTimer = null;

--- a/packages/cli/src/zed-integration/zed-stream-batcher.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.ts
@@ -132,8 +132,8 @@ export class StreamBatcher {
    * disposed so a late {@link append} after the turn ends is a silent no-op
    * (nothing new can enter the flush chain). Idempotent and safe to call after
    * {@link flush}; it does NOT emit, so any pending chunks must be flushed first
-   * (the prompt path flushes then disposes). An in-flight flush link is left to
-   * settle naturally — it only drains the (now empty) pending queue.
+   * (the prompt path flushes then disposes). An in-flight flush is not aborted:
+   * chunks it already detached may finish sending while the chain settles.
    */
   dispose(): void {
     this.disposed = true;

--- a/packages/cli/src/zed-integration/zed-stream-batcher.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.ts
@@ -142,6 +142,10 @@ export class StreamBatcher {
       this.batchTimer = null;
     }
     this.pendingChunks = [];
+    // Drop residual streaming state without emitting after the prompt boundary.
+    // The batcher/filter are per-prompt, but draining here also makes disposal
+    // complete if that ownership model changes later.
+    this.emojiFilter.flushBuffer();
   }
 
   private async flushEmojiBuffer(): Promise<void> {

--- a/packages/cli/src/zed-integration/zed-stream-batcher.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * StreamBatcher batches live streaming text/thought chunks from the agent turn
+ * and flushes them to the ACP client as agent_message_chunk / agent_thought_chunk
+ * session/update notifications on a short interval, routing every chunk through
+ * the session's EmojiFilter (with blocked-response handling and a trailing
+ * buffer flush).
+ *
+ * Extracted from zedIntegration.ts into its own module so the integration file
+ * stays within the max-lines complexity budget; the behavior is unchanged and
+ * fully exercised by zedIntegration.prompt.test.ts.
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { EmojiFilter } from '@vybestack/llxprt-code-core';
+
+const BATCH_INTERVAL_MS = 100;
+
+export class StreamBatcher {
+  private pendingChunks: Array<{ kind: 'text' | 'thought'; text: string }> = [];
+  private batchTimer: ReturnType<typeof setTimeout> | null = null;
+  private flushChain: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly emojiFilter: EmojiFilter,
+    private readonly sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
+  ) {}
+
+  append(text: string, isThought: boolean): void {
+    const filterResult = isThought
+      ? this.emojiFilter.filterText(text)
+      : this.emojiFilter.filterStreamChunk(text);
+    if (filterResult.blocked) {
+      const pending = this.flushChain
+        .then(() => this.doFlush())
+        .then(() =>
+          this.sendUpdate({
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: '[Error: Response blocked due to emoji detection]',
+            },
+          }),
+        );
+      this.flushChain = pending.catch(() => undefined);
+      return;
+    }
+    const filteredText =
+      typeof filterResult.filtered === 'string' ? filterResult.filtered : '';
+    if (filteredText.length === 0) {
+      return;
+    }
+    this.appendPendingChunk(isThought ? 'thought' : 'text', filteredText);
+    this.batchTimer ??= setTimeout(() => {
+      this.batchTimer = null;
+      void this.flush();
+    }, BATCH_INTERVAL_MS);
+  }
+
+  async flush(): Promise<void> {
+    if (this.batchTimer !== null) {
+      clearTimeout(this.batchTimer);
+      this.batchTimer = null;
+    }
+    const pending = this.flushChain
+      .then(() => this.doFlush())
+      .then(() => this.flushEmojiBuffer());
+    this.flushChain = pending.catch(() => undefined);
+    await pending;
+  }
+
+  private async flushEmojiBuffer(): Promise<void> {
+    const remaining = this.emojiFilter.flushBuffer();
+    if (remaining.length === 0) {
+      return;
+    }
+    this.appendPendingChunk('text', remaining);
+    await this.doFlush();
+  }
+
+  private appendPendingChunk(kind: 'text' | 'thought', text: string): void {
+    const lastChunk = this.pendingChunks.at(-1);
+    if (lastChunk?.kind === kind) {
+      lastChunk.text += text;
+      return;
+    }
+    this.pendingChunks.push({ kind, text });
+  }
+
+  private async doFlush(): Promise<void> {
+    const chunks = this.pendingChunks;
+    this.pendingChunks = [];
+    for (const chunk of chunks) {
+      await this.sendUpdate({
+        sessionUpdate:
+          chunk.kind === 'thought'
+            ? 'agent_thought_chunk'
+            : 'agent_message_chunk',
+        content: { type: 'text', text: chunk.text },
+      });
+    }
+  }
+}

--- a/packages/cli/src/zed-integration/zed-stream-batcher.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.ts
@@ -17,7 +17,7 @@
  */
 
 import type * as acp from '@agentclientprotocol/sdk';
-import type { EmojiFilter } from '@vybestack/llxprt-code-core';
+import { type EmojiFilter, DebugLogger } from '@vybestack/llxprt-code-core';
 
 const BATCH_INTERVAL_MS = 100;
 
@@ -25,17 +25,38 @@ export class StreamBatcher {
   private pendingChunks: Array<{ kind: 'text' | 'thought'; text: string }> = [];
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
   private flushChain: Promise<void> = Promise.resolve();
+  private readonly logger: DebugLogger;
 
   constructor(
     private readonly emojiFilter: EmojiFilter,
     private readonly sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
-  ) {}
+    logger?: DebugLogger,
+  ) {
+    // Injectable for testability; defaults to the shared zed-integration
+    // namespace so the otherwise-silent flush-chain / per-chunk failures
+    // (FINDING F4/F17) are diagnosable.
+    this.logger =
+      logger ?? new DebugLogger('llxprt:zed-integration:stream-batcher');
+  }
 
   append(text: string, isThought: boolean): void {
     const filterResult = isThought
       ? this.emojiFilter.filterText(text)
       : this.emojiFilter.filterStreamChunk(text);
     if (filterResult.blocked) {
+      // FINDING F10: flush the EmojiFilter's residual buffer SYNCHRONOUSLY, right
+      // now — NOT later in the async flushChain. The content that triggered the
+      // block is still in the filter's internal buffer; if it is not cleared
+      // before this append() returns, the NEXT synchronous append() re-combines
+      // it with the following chunk and re-blocks the (otherwise clean) content.
+      // flushBuffer() is synchronous. Any emittable residual is queued in order
+      // ahead of the error update; in error mode (the only mode that blocks
+      // stream chunks) the offending emoji content yields no emittable text and
+      // is simply discarded, leaving the buffer clean for subsequent chunks.
+      const residual = this.emojiFilter.flushBuffer();
+      if (residual.length > 0) {
+        this.appendPendingChunk('text', residual);
+      }
       const pending = this.flushChain
         .then(() => this.doFlush())
         .then(() =>
@@ -47,7 +68,7 @@ export class StreamBatcher {
             },
           }),
         );
-      this.flushChain = pending.catch(() => undefined);
+      this.flushChain = this.settleChainLink(pending);
       return;
     }
     const filteredText =
@@ -70,8 +91,22 @@ export class StreamBatcher {
     const pending = this.flushChain
       .then(() => this.doFlush())
       .then(() => this.flushEmojiBuffer());
-    this.flushChain = pending.catch(() => undefined);
+    this.flushChain = this.settleChainLink(pending);
     await pending;
+  }
+
+  /**
+   * Clears any pending batch timer and drops buffered chunks so no timer fires
+   * after the owning prompt completes/aborts (FINDING F9). Idempotent and safe
+   * to call after {@link flush}; it does NOT emit, so any pending chunks must be
+   * flushed first (the prompt path flushes then disposes).
+   */
+  dispose(): void {
+    if (this.batchTimer !== null) {
+      clearTimeout(this.batchTimer);
+      this.batchTimer = null;
+    }
+    this.pendingChunks = [];
   }
 
   private async flushEmojiBuffer(): Promise<void> {
@@ -95,14 +130,55 @@ export class StreamBatcher {
   private async doFlush(): Promise<void> {
     const chunks = this.pendingChunks;
     this.pendingChunks = [];
+    let firstError: unknown = null;
+    let failureCount = 0;
+    // FINDING F4: iterate a detached local copy and CONTINUE past a per-chunk
+    // send failure so a single rejecting sendUpdate does not drop every later
+    // chunk. The injected sendUpdate is best-effort today (Session.sendUpdate
+    // swallows), so this cannot reject in practice — but the injected contract
+    // is not guaranteed, so no chunk is silently lost if it ever does. The first
+    // error is collected + logged (not rethrown) to keep the flushChain intact.
     for (const chunk of chunks) {
-      await this.sendUpdate({
-        sessionUpdate:
-          chunk.kind === 'thought'
-            ? 'agent_thought_chunk'
-            : 'agent_message_chunk',
-        content: { type: 'text', text: chunk.text },
-      });
+      try {
+        await this.sendUpdate({
+          sessionUpdate:
+            chunk.kind === 'thought'
+              ? 'agent_thought_chunk'
+              : 'agent_message_chunk',
+          content: { type: 'text', text: chunk.text },
+        });
+      } catch (error) {
+        failureCount += 1;
+        if (firstError === null) {
+          firstError = error;
+        }
+      }
     }
+    if (firstError !== null) {
+      this.logger.debug(
+        () =>
+          `doFlush: ${failureCount} chunk update(s) failed to send; the remaining chunks were still attempted (no chunk dropped). First error: ${
+            firstError instanceof Error
+              ? firstError.message
+              : String(firstError)
+          }`,
+      );
+    }
+  }
+
+  /**
+   * Terminates a flush-chain link so a rejection cannot poison the serialized
+   * chain for subsequent appends, while still surfacing the swallowed error via
+   * the logger (FINDING F17) instead of discarding it silently.
+   */
+  private settleChainLink(pending: Promise<void>): Promise<void> {
+    return pending.catch((error: unknown) => {
+      this.logger.debug(
+        () =>
+          `flush chain link failed (swallowed to keep the batch chain alive): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      );
+    });
   }
 }

--- a/packages/cli/src/zed-integration/zed-stream-batcher.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.ts
@@ -112,9 +112,16 @@ export class StreamBatcher {
       clearTimeout(this.batchTimer);
       this.batchTimer = null;
     }
-    const pending = this.flushChain
-      .then(() => this.doFlush())
-      .then(() => this.flushEmojiBuffer());
+    // try/finally so the trailing emoji-buffer flush runs even if a future
+    // doFlush change introduces a rejection path — the residual filter content
+    // must never be stranded behind a failed chunk send.
+    const pending = this.flushChain.then(async () => {
+      try {
+        await this.doFlush();
+      } finally {
+        await this.flushEmojiBuffer();
+      }
+    });
     this.flushChain = this.settleChainLink(pending);
     await pending;
   }
@@ -138,6 +145,13 @@ export class StreamBatcher {
   }
 
   private async flushEmojiBuffer(): Promise<void> {
+    // A dispose() that raced an in-flight chain link means the prompt is over:
+    // do not re-queue residual filter content past the turn boundary. (The
+    // standard prompt pattern — await flush() in try, dispose() in finally —
+    // never hits this: dispose only runs after the flush chain link settled.)
+    if (this.disposed) {
+      return;
+    }
     const remaining = this.emojiFilter.flushBuffer();
     if (remaining.length === 0) {
       return;

--- a/packages/cli/src/zed-integration/zed-stream-batcher.ts
+++ b/packages/cli/src/zed-integration/zed-stream-batcher.ts
@@ -21,6 +21,15 @@ import { type EmojiFilter, DebugLogger } from '@vybestack/llxprt-code-core';
 
 const BATCH_INTERVAL_MS = 100;
 
+/**
+ * The message emitted (as an agent_message_chunk) when the EmojiFilter blocks a
+ * streamed response in error mode (FINDING E2). Exported so tests reference this
+ * single source of truth instead of duplicating the literal, keeping the wire
+ * text and its assertions in lockstep.
+ */
+export const STREAM_BLOCKED_MESSAGE =
+  '[Error: Response blocked due to emoji detection]';
+
 export class StreamBatcher {
   private pendingChunks: Array<{ kind: 'text' | 'thought'; text: string }> = [];
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -57,6 +66,17 @@ export class StreamBatcher {
       if (residual.length > 0) {
         this.appendPendingChunk('text', residual);
       }
+      // FINDING E1: clear any pending batch timer BEFORE building the blocked
+      // chain (exactly as flush() does). Otherwise a timer armed by a prior
+      // normal chunk survives and later fires its own flush() — appending a
+      // SECOND doFlush()+flushEmojiBuffer chain that races the blocked-path
+      // chain, re-flushing already-flushed content after the error message. The
+      // blocked path here already flushes the residual + queued chunks, so the
+      // timer has nothing left to do.
+      if (this.batchTimer !== null) {
+        clearTimeout(this.batchTimer);
+        this.batchTimer = null;
+      }
       const pending = this.flushChain
         .then(() => this.doFlush())
         .then(() =>
@@ -64,7 +84,7 @@ export class StreamBatcher {
             sessionUpdate: 'agent_message_chunk',
             content: {
               type: 'text',
-              text: '[Error: Response blocked due to emoji detection]',
+              text: STREAM_BLOCKED_MESSAGE,
             },
           }),
         );

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -12,6 +12,10 @@ type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Manages ACP terminal lifecycle for a single Zed session.
  *
@@ -64,7 +68,9 @@ export class TerminalManager {
         sessionId: this.sessionId,
       });
     } catch (error) {
-      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      this.logger.debug(
+        () => `Failed to create ACP terminal: ${errorMessage(error)}`,
+      );
       return;
     }
     const existing = this.activeTerminals.get(call.id);
@@ -73,7 +79,9 @@ export class TerminalManager {
       try {
         await existing.release();
       } catch (error) {
-        this.logger.debug(() => `Prior terminal release failed: ${error}`);
+        this.logger.debug(
+          () => `Prior terminal release failed: ${errorMessage(error)}`,
+        );
       }
     }
     this.activeTerminals.set(call.id, handle);
@@ -89,9 +97,13 @@ export class TerminalManager {
       try {
         await handle.release();
       } catch (releaseError) {
-        this.logger.debug(() => `Terminal release failed: ${releaseError}`);
+        this.logger.debug(
+          () => `Terminal release failed: ${errorMessage(releaseError)}`,
+        );
       }
-      this.logger.debug(() => `Terminal update send failed: ${error}`);
+      this.logger.debug(
+        () => `Terminal update send failed: ${errorMessage(error)}`,
+      );
     }
   }
 
@@ -106,7 +118,9 @@ export class TerminalManager {
     try {
       await handle.release();
     } catch (error) {
-      this.logger.debug(() => `Terminal release failed: ${error}`);
+      this.logger.debug(
+        () => `Terminal release failed: ${errorMessage(error)}`,
+      );
     }
   }
 
@@ -122,12 +136,16 @@ export class TerminalManager {
         try {
           await handle.kill();
         } catch (error) {
-          this.logger.debug(() => `Terminal kill failed: ${error}`);
+          this.logger.debug(
+            () => `Terminal kill failed: ${errorMessage(error)}`,
+          );
         }
         try {
           await handle.release();
         } catch (error) {
-          this.logger.debug(() => `Terminal release failed: ${error}`);
+          this.logger.debug(
+            () => `Terminal release failed: ${errorMessage(error)}`,
+          );
         }
       }),
     );

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -144,9 +144,7 @@ export class TerminalManager {
     this.pendingCalls.splice(0);
     const terminals = [...this.activeTerminals];
     this.activeTerminals.clear();
-    for (const terminal of terminals) {
-      await this.killAndRelease(terminal);
-    }
+    await Promise.allSettled(terminals.map((t) => this.killAndRelease(t)));
   }
 
   private claimPendingCall(command: string, cwd: string): string | undefined {
@@ -189,7 +187,7 @@ export class TerminalManager {
       });
     let previousOutput = '';
     let killed = false;
-    const killDeadline = Date.now() + KILL_GRACE_PERIOD_MS;
+    let killDeadline = 0;
     let done = false;
     while (!done) {
       if (exitError !== undefined) {
@@ -197,6 +195,7 @@ export class TerminalManager {
       }
       if (signal.aborted && !killed) {
         killed = true;
+        killDeadline = Date.now() + KILL_GRACE_PERIOD_MS;
         await this.kill(active);
       }
       done = exit !== undefined || (killed && Date.now() >= killDeadline);

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -211,6 +211,20 @@ export class TerminalManager {
       }
       previousOutput = current.output;
     }
+    // Final poll after exit settles so output produced between the last poll
+    // and process exit is never lost.
+    if (exit !== undefined) {
+      try {
+        const final = await active.handle.currentOutput();
+        const finalDelta = outputDelta(previousOutput, final.output);
+        if (finalDelta !== '') {
+          onOutput({ type: 'data', chunk: finalDelta });
+        }
+        previousOutput = final.output;
+      } catch {
+        // Swallow transient poll errors after exit.
+      }
+    }
     return {
       output: previousOutput,
       exitCode: exit?.exitCode ?? null,

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -8,11 +8,7 @@ import type * as acp from '@agentclientprotocol/sdk';
 import type { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
 
-interface PendingShellCall {
-  readonly toolCallId: string;
-  readonly command: string;
-  readonly cwd: string;
-}
+type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
 
@@ -21,13 +17,12 @@ type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
  *
  * When the client advertises the `terminal` capability, shell tool-calls
  * trigger terminal creation via `connection.createTerminal`.  Each terminal
- * is correlated to its tool-call (by command/cwd matching) so that terminal
- * content can be emitted inline and terminals are cleaned up on completion,
- * cancel, and dispose.
+ * is correlated to its tool-call by `toolCallId` so that terminal content can
+ * be emitted inline and terminals are cleaned up on completion, cancel, and
+ * dispose.
  */
 export class TerminalManager {
-  private readonly activeTerminals = new Map<string, acp.TerminalHandle>();
-  private readonly pendingShellCalls: PendingShellCall[] = [];
+  private readonly activeTerminals = new Map<string, TerminalHandleLike>();
 
   constructor(
     private readonly sessionId: string,
@@ -49,9 +44,9 @@ export class TerminalManager {
   }
 
   /**
-   * Records a pending shell tool-call and creates an ACP terminal for it.
-   * Emits an early terminal-content update so the client renders the terminal
-   * inline during execution.
+   * Creates an ACP terminal for a shell tool-call and immediately correlates
+   * it by `toolCallId`.  Emits a terminal-content update so the client renders
+   * the terminal inline during execution.
    */
   async handleToolCall(call: AgentToolCall): Promise<void> {
     const command =
@@ -61,7 +56,6 @@ export class TerminalManager {
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']
         : this.targetDir;
-    this.pendingShellCalls.push({ toolCallId: call.id, command, cwd });
     try {
       const handle = await this.connection.createTerminal({
         command,
@@ -69,32 +63,16 @@ export class TerminalManager {
         sessionId: this.sessionId,
         args: ['-c', command],
       });
-      await this.registerTerminal(command, cwd, handle);
+      this.activeTerminals.set(call.id, handle);
+      await this.sendUpdate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: call.id,
+        status: 'in_progress',
+        content: [{ type: 'terminal', terminalId: handle.id }],
+      });
     } catch (error) {
       this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
     }
-  }
-
-  /**
-   * Correlates a created terminal to its tool-call by matching command/cwd,
-   * records the handle, and emits the terminal-content update.
-   */
-  async registerTerminal(
-    command: string,
-    cwd: string,
-    handle: acp.TerminalHandle,
-  ): Promise<void> {
-    const match = this.pendingShellCalls.find(
-      (entry) => entry.command === command && entry.cwd === cwd,
-    );
-    if (match === undefined) return;
-    this.activeTerminals.set(match.toolCallId, handle);
-    await this.sendUpdate({
-      sessionUpdate: 'tool_call_update',
-      toolCallId: match.toolCallId,
-      status: 'in_progress',
-      content: [{ type: 'terminal', terminalId: handle.id }],
-    });
   }
 
   /**
@@ -105,10 +83,6 @@ export class TerminalManager {
     const handle = this.activeTerminals.get(toolCallId);
     if (handle === undefined) return;
     this.activeTerminals.delete(toolCallId);
-    const idx = this.pendingShellCalls.findIndex(
-      (entry) => entry.toolCallId === toolCallId,
-    );
-    if (idx >= 0) this.pendingShellCalls.splice(idx, 1);
     try {
       await handle.release();
     } catch (error) {

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -4,29 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as path from 'node:path';
 import type * as acp from '@agentclientprotocol/sdk';
 import type { DebugLogger } from '@vybestack/llxprt-code-core';
+import { getShellConfiguration } from '@vybestack/llxprt-code-core';
 import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
+import type {
+  ShellExecutionResult,
+  ShellOutputEvent,
+} from '@vybestack/llxprt-code-tools';
 
-type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
+const OUTPUT_POLL_INTERVAL_MS = 100;
+const APPROXIMATE_BYTES_PER_TOKEN = 4;
+const KILL_GRACE_PERIOD_MS = 5000;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+
+interface PendingShellCall {
+  readonly id: string;
+  readonly command: string;
+  readonly cwd: string;
+}
+
+interface ActiveTerminal {
+  readonly handle: acp.TerminalHandle;
+  readonly command: string;
+  readonly cwd: string;
+  toolCallId: string | undefined;
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/**
- * Manages ACP terminal lifecycle for a single Zed session.
- *
- * When the client advertises the `terminal` capability, shell tool-calls
- * trigger terminal creation via `connection.createTerminal`.  Each terminal
- * is correlated to its tool-call by `toolCallId` so that terminal content can
- * be emitted inline and terminals are cleaned up on completion, cancel, and
- * dispose.
- */
 export class TerminalManager {
-  private readonly activeTerminals = new Map<string, TerminalHandleLike>();
+  private readonly pendingCalls: PendingShellCall[] = [];
+  private readonly activeTerminals = new Set<ActiveTerminal>();
 
   constructor(
     private readonly sessionId: string,
@@ -34,12 +47,9 @@ export class TerminalManager {
     private readonly targetDir: string,
     private readonly sendUpdate: SendUpdateFn,
     private readonly logger: DebugLogger,
+    private readonly maxOutputTokens?: number,
   ) {}
 
-  /**
-   * Returns `true` if the tool-call is an execute-kind shell command that
-   * should trigger terminal creation.
-   */
   static isShellToolCall(
     call: AgentToolCall,
     kind: string | undefined,
@@ -47,107 +57,235 @@ export class TerminalManager {
     return kind === 'execute' && typeof call.args['command'] === 'string';
   }
 
-  /**
-   * Creates an ACP terminal for a shell tool-call and immediately correlates
-   * it by `toolCallId`.  Emits a terminal-content update so the client renders
-   * the terminal inline during execution.
-   */
-  async handleToolCall(call: AgentToolCall): Promise<void> {
-    const command =
-      typeof call.args['command'] === 'string' ? call.args['command'] : '';
-    if (command.trim() === '') return;
-    const cwd =
-      typeof call.args['dir_path'] === 'string'
-        ? call.args['dir_path']
-        : this.targetDir;
-    let handle: TerminalHandleLike;
-    try {
-      handle = await this.connection.createTerminal({
-        command,
-        cwd,
-        sessionId: this.sessionId,
-      });
-    } catch (error) {
-      this.logger.debug(
-        () => `Failed to create ACP terminal: ${errorMessage(error)}`,
-      );
+  async observeToolCall(call: AgentToolCall): Promise<void> {
+    const command = readCommand(call);
+    if (command === null) {
       return;
     }
-    const existing = this.activeTerminals.get(call.id);
-    if (existing !== undefined) {
-      this.activeTerminals.delete(call.id);
-      try {
-        await existing.release();
-      } catch (error) {
-        this.logger.debug(
-          () => `Prior terminal release failed: ${errorMessage(error)}`,
-        );
-      }
+    const pending: PendingShellCall = {
+      id: call.id,
+      command,
+      cwd: resolveCallCwd(call, this.targetDir),
+    };
+    const active = [...this.activeTerminals].find(
+      (terminal) =>
+        terminal.toolCallId === undefined &&
+        terminal.cwd === pending.cwd &&
+        commandsMatch(terminal.command, pending.command),
+    );
+    if (active === undefined) {
+      this.pendingCalls.push(pending);
+      return;
     }
-    this.activeTerminals.set(call.id, handle);
-    try {
-      await this.sendUpdate({
-        sessionUpdate: 'tool_call_update',
-        toolCallId: call.id,
-        status: 'in_progress',
-        content: [{ type: 'terminal', terminalId: handle.id }],
-      });
-    } catch (error) {
-      this.activeTerminals.delete(call.id);
-      try {
-        await handle.release();
-      } catch (releaseError) {
-        this.logger.debug(
-          () => `Terminal release failed: ${errorMessage(releaseError)}`,
-        );
-      }
-      this.logger.debug(
-        () => `Terminal update send failed: ${errorMessage(error)}`,
-      );
+    active.toolCallId = pending.id;
+    await this.sendTerminalUpdate(active);
+  }
+
+  completeToolCall(toolCallId: string): void {
+    const pendingIndex = this.pendingCalls.findIndex(
+      (pending) => pending.id === toolCallId,
+    );
+    if (pendingIndex >= 0) {
+      this.pendingCalls.splice(pendingIndex, 1);
     }
   }
 
-  /**
-   * Releases a terminal after its tool call has completed.  Safe to call
-   * multiple times — the handle is removed on first call.
-   */
-  async releaseTerminal(toolCallId: string): Promise<void> {
-    const handle = this.activeTerminals.get(toolCallId);
-    if (handle === undefined) return;
-    this.activeTerminals.delete(toolCallId);
+  async executeShellCommand(
+    command: string,
+    cwd: string,
+    onOutput: (event: ShellOutputEvent) => void,
+    signal: AbortSignal,
+  ): Promise<ShellExecutionResult> {
+    if (signal.aborted) {
+      return abortedResult();
+    }
+    const shell = getShellConfiguration();
+    const handle = await this.connection.createTerminal({
+      command: shell.executable,
+      args: [...shell.argsPrefix, command],
+      cwd,
+      sessionId: this.sessionId,
+      ...(this.maxOutputTokens === undefined
+        ? {}
+        : {
+            outputByteLimit: this.maxOutputTokens * APPROXIMATE_BYTES_PER_TOKEN,
+          }),
+    });
+    const active: ActiveTerminal = {
+      handle,
+      command,
+      cwd,
+      toolCallId: this.claimPendingCall(command, cwd),
+    };
+    this.activeTerminals.add(active);
     try {
-      await handle.release();
+      if (active.toolCallId !== undefined) {
+        await this.sendTerminalUpdate(active);
+      }
+      return await this.waitForTerminal(active, onOutput, signal);
+    } catch (error) {
+      if (this.activeTerminals.delete(active)) {
+        await this.killAndRelease(active);
+      }
+      throw error;
+    } finally {
+      if (this.activeTerminals.delete(active)) {
+        await this.release(active);
+      }
+    }
+  }
+
+  async settleAll(): Promise<void> {
+    this.pendingCalls.splice(0);
+    const terminals = [...this.activeTerminals];
+    this.activeTerminals.clear();
+    for (const terminal of terminals) {
+      await this.killAndRelease(terminal);
+    }
+  }
+
+  private claimPendingCall(command: string, cwd: string): string | undefined {
+    const index = this.pendingCalls.findIndex(
+      (pending) =>
+        pending.cwd === cwd && commandsMatch(command, pending.command),
+    );
+    if (index < 0) {
+      return undefined;
+    }
+    return this.pendingCalls.splice(index, 1)[0]?.id;
+  }
+
+  private async sendTerminalUpdate(active: ActiveTerminal): Promise<void> {
+    if (active.toolCallId === undefined) {
+      return;
+    }
+    await this.sendUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: active.toolCallId,
+      status: 'in_progress',
+      content: [{ type: 'terminal', terminalId: active.handle.id }],
+    });
+  }
+
+  private async waitForTerminal(
+    active: ActiveTerminal,
+    onOutput: (event: ShellOutputEvent) => void,
+    signal: AbortSignal,
+  ): Promise<ShellExecutionResult> {
+    let exit: acp.WaitForTerminalExitResponse | undefined;
+    let exitError: unknown;
+    const exitPromise = active.handle
+      .waitForExit()
+      .then((result) => {
+        exit = result;
+      })
+      .catch((error: unknown) => {
+        exitError = error;
+      });
+    let previousOutput = '';
+    let killed = false;
+    const killDeadline = Date.now() + KILL_GRACE_PERIOD_MS;
+    let done = false;
+    while (!done) {
+      if (exitError !== undefined) {
+        throw exitError;
+      }
+      if (signal.aborted && !killed) {
+        killed = true;
+        await this.kill(active);
+      }
+      done = exit !== undefined || (killed && Date.now() >= killDeadline);
+      if (done) {
+        continue;
+      }
+      await Promise.race([exitPromise, delay(OUTPUT_POLL_INTERVAL_MS)]);
+      const current = await active.handle.currentOutput();
+      const chunk = outputDelta(previousOutput, current.output);
+      if (chunk !== '') {
+        onOutput({ type: 'data', chunk });
+      }
+      previousOutput = current.output;
+    }
+    return {
+      output: previousOutput,
+      exitCode: exit?.exitCode ?? null,
+      signal: exit?.signal ?? null,
+      error: null,
+      aborted: signal.aborted,
+      pid: undefined,
+    };
+  }
+
+  private async killAndRelease(active: ActiveTerminal): Promise<void> {
+    await this.kill(active);
+    await this.release(active);
+  }
+
+  private async kill(active: ActiveTerminal): Promise<void> {
+    try {
+      await active.handle.kill();
+    } catch (error) {
+      this.logger.debug(() => `Terminal kill failed: ${errorMessage(error)}`);
+    }
+  }
+
+  private async release(active: ActiveTerminal): Promise<void> {
+    try {
+      await active.handle.release();
     } catch (error) {
       this.logger.debug(
         () => `Terminal release failed: ${errorMessage(error)}`,
       );
     }
   }
+}
 
-  /**
-   * Kills and releases all active terminals.  Called on cancel and dispose
-   * so no terminal is leaked.
-   */
-  async settleAll(): Promise<void> {
-    const entries = [...this.activeTerminals.entries()];
-    this.activeTerminals.clear();
-    await Promise.allSettled(
-      entries.map(async ([, handle]) => {
-        try {
-          await handle.kill();
-        } catch (error) {
-          this.logger.debug(
-            () => `Terminal kill failed: ${errorMessage(error)}`,
-          );
-        }
-        try {
-          await handle.release();
-        } catch (error) {
-          this.logger.debug(
-            () => `Terminal release failed: ${errorMessage(error)}`,
-          );
-        }
-      }),
-    );
+function readCommand(call: AgentToolCall): string | null {
+  const command = call.args['command'];
+  return typeof command === 'string' && command.trim() !== '' ? command : null;
+}
+
+function resolveCallCwd(call: AgentToolCall, targetDir: string): string {
+  const dirPath = call.args['dir_path'];
+  const directory = call.args['directory'];
+  let value = '';
+  if (typeof dirPath === 'string') {
+    value = dirPath;
+  } else if (typeof directory === 'string') {
+    value = directory;
   }
+  if (value === '') {
+    return targetDir;
+  }
+  return path.isAbsolute(value) ? value : path.resolve(targetDir, value);
+}
+
+function commandsMatch(preparedCommand: string, rawCommand: string): boolean {
+  const trimmed = rawCommand.trim();
+  if (preparedCommand === trimmed) {
+    return true;
+  }
+  const terminated = trimmed.endsWith('&') ? trimmed : `${trimmed};`;
+  return preparedCommand.startsWith(`{ ${terminated} }; __code=$?;`);
+}
+
+function abortedResult(): ShellExecutionResult {
+  return {
+    output: '',
+    exitCode: null,
+    signal: null,
+    error: null,
+    aborted: true,
+    pid: undefined,
+  };
+}
+
+function outputDelta(previous: string, current: string): string {
+  return current.startsWith(previous)
+    ? current.slice(previous.length)
+    : current;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -78,7 +78,12 @@ export class TerminalManager {
       return;
     }
     active.toolCallId = pending.id;
-    await this.sendTerminalUpdate(active);
+    try {
+      await this.sendTerminalUpdate(active);
+    } catch (error) {
+      active.toolCallId = undefined;
+      throw error;
+    }
   }
 
   completeToolCall(toolCallId: string): void {
@@ -265,7 +270,8 @@ function commandsMatch(preparedCommand: string, rawCommand: string): boolean {
   if (preparedCommand === trimmed) {
     return true;
   }
-  const terminated = trimmed.endsWith('&') ? trimmed : `${trimmed};`;
+  const terminated =
+    trimmed.endsWith('&') || trimmed.endsWith(';') ? trimmed : `${trimmed};`;
   return preparedCommand.startsWith(`{ ${terminated} }; __code=$?;`);
 }
 

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -56,13 +56,28 @@ export class TerminalManager {
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']
         : this.targetDir;
+    let handle: TerminalHandleLike;
     try {
-      const handle = await this.connection.createTerminal({
+      handle = await this.connection.createTerminal({
         command,
         cwd,
         sessionId: this.sessionId,
       });
-      this.activeTerminals.set(call.id, handle);
+    } catch (error) {
+      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      return;
+    }
+    const existing = this.activeTerminals.get(call.id);
+    if (existing !== undefined) {
+      this.activeTerminals.delete(call.id);
+      try {
+        await existing.release();
+      } catch (error) {
+        this.logger.debug(() => `Prior terminal release failed: ${error}`);
+      }
+    }
+    this.activeTerminals.set(call.id, handle);
+    try {
       await this.sendUpdate({
         sessionUpdate: 'tool_call_update',
         toolCallId: call.id,
@@ -70,7 +85,13 @@ export class TerminalManager {
         content: [{ type: 'terminal', terminalId: handle.id }],
       });
     } catch (error) {
-      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      this.activeTerminals.delete(call.id);
+      try {
+        await handle.release();
+      } catch (releaseError) {
+        this.logger.debug(() => `Terminal release failed: ${releaseError}`);
+      }
+      this.logger.debug(() => `Terminal update send failed: ${error}`);
     }
   }
 

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -61,7 +61,6 @@ export class TerminalManager {
         command,
         cwd,
         sessionId: this.sessionId,
-        args: ['-c', command],
       });
       this.activeTerminals.set(call.id, handle);
       await this.sendUpdate({

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { DebugLogger } from '@vybestack/llxprt-code-core';
+import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
+
+interface PendingShellCall {
+  readonly toolCallId: string;
+  readonly command: string;
+  readonly cwd: string;
+}
+
+type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+
+/**
+ * Manages ACP terminal lifecycle for a single Zed session.
+ *
+ * When the client advertises the `terminal` capability, shell tool-calls
+ * trigger terminal creation via `connection.createTerminal`.  Each terminal
+ * is correlated to its tool-call (by command/cwd matching) so that terminal
+ * content can be emitted inline and terminals are cleaned up on completion,
+ * cancel, and dispose.
+ */
+export class TerminalManager {
+  private readonly activeTerminals = new Map<string, acp.TerminalHandle>();
+  private readonly pendingShellCalls: PendingShellCall[] = [];
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly connection: acp.AgentSideConnection,
+    private readonly targetDir: string,
+    private readonly sendUpdate: SendUpdateFn,
+    private readonly logger: DebugLogger,
+  ) {}
+
+  /**
+   * Returns `true` if the tool-call is an execute-kind shell command that
+   * should trigger terminal creation.
+   */
+  static isShellToolCall(
+    call: AgentToolCall,
+    kind: string | undefined,
+  ): boolean {
+    return kind === 'execute' && typeof call.args['command'] === 'string';
+  }
+
+  /**
+   * Records a pending shell tool-call and creates an ACP terminal for it.
+   * Emits an early terminal-content update so the client renders the terminal
+   * inline during execution.
+   */
+  async handleToolCall(call: AgentToolCall): Promise<void> {
+    const command =
+      typeof call.args['command'] === 'string' ? call.args['command'] : '';
+    if (command === '') return;
+    const cwd =
+      typeof call.args['dir_path'] === 'string'
+        ? call.args['dir_path']
+        : this.targetDir;
+    this.pendingShellCalls.push({ toolCallId: call.id, command, cwd });
+    try {
+      const handle = await this.connection.createTerminal({
+        command,
+        cwd,
+        sessionId: this.sessionId,
+        args: ['-c', command],
+      });
+      await this.registerTerminal(command, cwd, handle);
+    } catch (error) {
+      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+    }
+  }
+
+  /**
+   * Correlates a created terminal to its tool-call by matching command/cwd,
+   * records the handle, and emits the terminal-content update.
+   */
+  async registerTerminal(
+    command: string,
+    cwd: string,
+    handle: acp.TerminalHandle,
+  ): Promise<void> {
+    const match = this.pendingShellCalls.find(
+      (entry) => entry.command === command && entry.cwd === cwd,
+    );
+    if (match === undefined) return;
+    this.activeTerminals.set(match.toolCallId, handle);
+    await this.sendUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: match.toolCallId,
+      status: 'in_progress',
+      content: [{ type: 'terminal', terminalId: handle.id }],
+    });
+  }
+
+  /**
+   * Releases a terminal after its tool call has completed.  Safe to call
+   * multiple times — the handle is removed on first call.
+   */
+  async releaseTerminal(toolCallId: string): Promise<void> {
+    const handle = this.activeTerminals.get(toolCallId);
+    if (handle === undefined) return;
+    this.activeTerminals.delete(toolCallId);
+    const idx = this.pendingShellCalls.findIndex(
+      (entry) => entry.toolCallId === toolCallId,
+    );
+    if (idx >= 0) this.pendingShellCalls.splice(idx, 1);
+    try {
+      await handle.release();
+    } catch (error) {
+      this.logger.debug(() => `Terminal release failed: ${error}`);
+    }
+  }
+
+  /**
+   * Kills and releases all active terminals.  Called on cancel and dispose
+   * so no terminal is leaked.
+   */
+  async settleAll(): Promise<void> {
+    const entries = [...this.activeTerminals.entries()];
+    this.activeTerminals.clear();
+    await Promise.allSettled(
+      entries.map(async ([, handle]) => {
+        try {
+          await handle.kill();
+        } catch (error) {
+          this.logger.debug(() => `Terminal kill failed: ${error}`);
+        }
+        try {
+          await handle.release();
+        } catch (error) {
+          this.logger.debug(() => `Terminal release failed: ${error}`);
+        }
+      }),
+    );
+  }
+}

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -51,7 +51,7 @@ export class TerminalManager {
   async handleToolCall(call: AgentToolCall): Promise<void> {
     const command =
       typeof call.args['command'] === 'string' ? call.args['command'] : '';
-    if (command === '') return;
+    if (command.trim() === '') return;
     const cwd =
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']

--- a/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
@@ -38,7 +38,7 @@ describe('buildZedTerminalSetup', () => {
       new DebugLogger('llxprt:zed-terminal-setup-test'),
     );
 
-    expect(setup.registry.getTool('run_shell_command')).toBeUndefined();
+    expect(setup.registry.getTool(ShellTool.Name)).toBeUndefined();
   });
 
   it('registers a terminal-backed ShellTool when the base registry includes one', () => {

--- a/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+import {
+  ShellTool,
+  type IShellToolHost,
+  type ToolRegistry,
+} from '@vybestack/llxprt-code-tools';
+import { buildZedTerminalSetup } from './zed-terminal-setup.js';
+import { RecordingConnection } from './zed-test-helpers.js';
+
+function configFixture(): Config {
+  return {
+    getPolicyEngine: () => undefined,
+    getDebugMode: () => false,
+    getTargetDir: () => '/project',
+    getEphemeralSetting: () => undefined,
+  } as unknown as Config;
+}
+
+describe('buildZedTerminalSetup', () => {
+  it('does not enable a shell tool excluded from the base registry', () => {
+    const baseRegistry = {
+      getAllTools: vi.fn(() => []),
+    } as unknown as ToolRegistry;
+
+    const setup = buildZedTerminalSetup(
+      'session-1',
+      configFixture(),
+      baseRegistry,
+      new RecordingConnection() as unknown as acp.AgentSideConnection,
+      new DebugLogger('llxprt:zed-terminal-setup-test'),
+    );
+
+    expect(setup.registry.getTool('run_shell_command')).toBeUndefined();
+  });
+
+  it('registers a terminal-backed ShellTool when the base registry includes one', () => {
+    const baseShellTool = new ShellTool({} as unknown as IShellToolHost);
+    const baseRegistry = {
+      getAllTools: vi.fn(() => [baseShellTool]),
+    } as unknown as ToolRegistry;
+
+    const setup = buildZedTerminalSetup(
+      'session-1',
+      configFixture(),
+      baseRegistry,
+      new RecordingConnection() as unknown as acp.AgentSideConnection,
+      new DebugLogger('llxprt:zed-terminal-setup-test'),
+    );
+
+    const tool = setup.registry.getTool('run_shell_command');
+    expect(tool).toBeDefined();
+    expect(tool).not.toBe(baseShellTool);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-terminal-setup.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import {
+  type Config,
+  type DebugLogger,
+  MessageBus,
+} from '@vybestack/llxprt-code-core';
+import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
+import { CoreShellToolHostAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreShellToolHostAdapter.js';
+import { CoreToolRegistryHostAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreToolRegistryHostAdapter.js';
+import { ShellTool, ToolRegistry } from '@vybestack/llxprt-code-tools';
+import { AcpTerminalShellHost } from './acp-terminal-shell-host.js';
+import { TerminalManager } from './zed-terminal-manager.js';
+
+export interface ZedTerminalSetup {
+  readonly messageBus: MessageBus;
+  readonly registry: ToolRegistry;
+  readonly terminals: TerminalManager;
+}
+
+export function buildZedTerminalSetup(
+  sessionId: string,
+  config: Config,
+  baseRegistry: ToolRegistry,
+  connection: acp.AgentSideConnection,
+  logger: DebugLogger,
+): ZedTerminalSetup {
+  const messageBus = new MessageBus(
+    config.getPolicyEngine(),
+    config.getDebugMode(),
+  );
+  const outputLimit = config.getEphemeralSetting('tool-output-max-tokens');
+  const terminals = new TerminalManager(
+    sessionId,
+    connection,
+    config.getTargetDir(),
+    (update) => connection.sessionUpdate({ sessionId, update }),
+    logger,
+    typeof outputLimit === 'number' ? outputLimit : undefined,
+  );
+  const messageBusAdapter = new CoreMessageBusAdapter(messageBus);
+  const registry = new ToolRegistry(
+    new CoreToolRegistryHostAdapter(config),
+    messageBusAdapter,
+  );
+  const baseTools = baseRegistry.getAllTools();
+  let hasShellTool = false;
+  for (const tool of baseTools) {
+    if (tool.name === ShellTool.Name) {
+      hasShellTool = true;
+      continue;
+    }
+    registry.registerTool(tool);
+  }
+  if (hasShellTool) {
+    registry.registerTool(
+      new ShellTool(
+        new AcpTerminalShellHost(
+          new CoreShellToolHostAdapter(config),
+          terminals,
+        ),
+        messageBusAdapter,
+      ),
+    );
+  }
+  return { messageBus, registry, terminals };
+}

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -184,7 +184,7 @@ export class RecordingConnection {
 
   private terminalOutput = '';
   private terminalExitDelayed = false;
-  private terminalExitResolve: ((value: void) => void) | null = null;
+  private terminalExitResolves = new Map<string, () => void>();
 
   setTerminalOutput(output: string): void {
     this.terminalOutput = output;
@@ -194,13 +194,23 @@ export class RecordingConnection {
     this.terminalExitDelayed = true;
   }
 
-  resolveDelayedTerminalExit(): void {
-    if (this.terminalExitResolve !== null) {
-      const fn = this.terminalExitResolve;
-      this.terminalExitResolve = null;
-      this.terminalExitDelayed = false;
+  resolveDelayedTerminalExit(terminalId?: string): void {
+    if (terminalId !== undefined) {
+      const fn = this.terminalExitResolves.get(terminalId);
+      if (fn !== undefined) {
+        this.terminalExitResolves.delete(terminalId);
+        fn();
+      }
+      if (this.terminalExitResolves.size === 0) {
+        this.terminalExitDelayed = false;
+      }
+      return;
+    }
+    for (const fn of this.terminalExitResolves.values()) {
       fn();
     }
+    this.terminalExitResolves.clear();
+    this.terminalExitDelayed = false;
   }
 
   /**
@@ -212,16 +222,24 @@ export class RecordingConnection {
     if (this.hasTerminalContentUpdate()) return Promise.resolve();
     const deadline = Date.now() + timeoutMs;
     return new Promise<void>((resolve, reject) => {
-      const check = (): void => {
-        if (this.hasTerminalContentUpdate()) {
-          resolve();
-        } else if (Date.now() >= deadline) {
-          reject(new Error('waitForTerminalCreated timed out'));
-        } else {
-          setTimeout(check, 5);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const cleanup = (): void => {
+        if (timer !== undefined) {
+          clearTimeout(timer);
         }
       };
-      setTimeout(check, 5);
+      const check = (): void => {
+        if (this.hasTerminalContentUpdate()) {
+          cleanup();
+          resolve();
+        } else if (Date.now() >= deadline) {
+          cleanup();
+          reject(new Error('waitForTerminalCreated timed out'));
+        } else {
+          timer = setTimeout(check, 5);
+        }
+      };
+      timer = setTimeout(check, 5);
     });
   }
 
@@ -385,19 +403,19 @@ export class RecordingConnection {
       waitForExit: vi.fn(async () => {
         if (this.terminalExitDelayed) {
           await new Promise<void>((resolve) => {
-            this.terminalExitResolve = resolve;
+            this.terminalExitResolves.set(terminalId, resolve);
           });
         }
         return { exitCode: 0, signal: null };
       }),
       kill: vi.fn(async () => {
         this.killCalls += 1;
-        this.resolveDelayedTerminalExit();
+        this.resolveDelayedTerminalExit(terminalId);
         return {};
       }),
       release: vi.fn(async () => {
         this.releaseCalls += 1;
-        this.resolveDelayedTerminalExit();
+        this.resolveDelayedTerminalExit(terminalId);
         return {};
       }),
     };

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -22,7 +22,10 @@ export type ConfirmationCapture = {
   requiresUserConfirmation?: boolean;
 };
 
-export function buildScriptedAgent(nextEvents: () => readonly AgentEvent[]): {
+export function buildScriptedAgent(
+  nextEvents: () => readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
   agent: Agent;
   confirmations: ConfirmationCapture[];
 } {
@@ -37,6 +40,8 @@ export function buildScriptedAgent(nextEvents: () => readonly AgentEvent[]): {
     setApprovalMode: vi.fn(),
     dispose: vi.fn().mockResolvedValue(undefined),
     tools: {
+      get: (name: string) =>
+        Object.hasOwn(toolKinds, name) ? { kind: toolKinds[name] } : undefined,
       respondToConfirmation: (
         confirmationId: string,
         decision: ToolConfirmationOutcome,
@@ -63,11 +68,14 @@ export function buildScriptedAgent(nextEvents: () => readonly AgentEvent[]): {
   return { agent, confirmations };
 }
 
-export function buildFakeAgent(events: readonly AgentEvent[]): {
+export function buildFakeAgent(
+  events: readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
   agent: Agent;
   confirmations: ConfirmationCapture[];
 } {
-  return buildScriptedAgent(() => events);
+  return buildScriptedAgent(() => events, toolKinds);
 }
 
 export class RecordingConnection {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -404,6 +404,12 @@ export class RecordingConnection {
     return handle;
   }
 
+  /**
+   * Returns content-focused session updates, excluding infrastructure
+   * notifications (`available_commands_update` and `session_info_update`).
+   * Use {@link sessionInfoUpdates} for title/updatedAt assertions and
+   * {@link availableCommandUpdates} for command-registry assertions.
+   */
   onlySessionUpdates(): acp.SessionUpdate[] {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -209,19 +209,21 @@ export class RecordingConnection {
    * a `terminal` content block) has been recorded — i.e., the Session has
    * created and registered a terminal.
    */
-  waitForTerminalCreated(): Promise<void> {
-    return this.hasTerminalContentUpdate()
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          const check = (): void => {
-            if (this.hasTerminalContentUpdate()) {
-              resolve();
-            } else {
-              setTimeout(check, 5);
-            }
-          };
+  waitForTerminalCreated(timeoutMs = 5000): Promise<void> {
+    if (this.hasTerminalContentUpdate()) return Promise.resolve();
+    const deadline = Date.now() + timeoutMs;
+    return new Promise<void>((resolve, reject) => {
+      const check = (): void => {
+        if (this.hasTerminalContentUpdate()) {
+          resolve();
+        } else if (Date.now() >= deadline) {
+          reject(new Error('waitForTerminalCreated timed out'));
+        } else {
           setTimeout(check, 5);
-        });
+        }
+      };
+      setTimeout(check, 5);
+    });
   }
 
   private hasTerminalContentUpdate(): boolean {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -90,6 +90,7 @@ export function buildBlockingScriptedAgent(
       if (signal !== undefined && !signal.aborted) {
         await new Promise<void>((resolve) => {
           signal.addEventListener('abort', () => resolve(), { once: true });
+          if (signal.aborted) resolve();
         });
       }
     },

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -68,6 +68,63 @@ export function buildScriptedAgent(
   return { agent, confirmations };
 }
 
+/**
+ * Like {@link buildScriptedAgent} but the stream blocks after yielding all
+ * events until the abort signal fires.  Used to test cancel/dispose while a
+ * prompt turn is still in-flight.
+ */
+export function buildBlockingScriptedAgent(
+  nextEvents: () => readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
+  agent: Agent;
+  confirmations: ConfirmationCapture[];
+} {
+  const confirmations: ConfirmationCapture[] = [];
+  const agent = {
+    async *stream(_input: unknown, opts?: unknown): AsyncIterable<AgentEvent> {
+      for (const e of nextEvents()) {
+        yield e;
+      }
+      const signal = (opts as { signal?: AbortSignal } | undefined)?.signal;
+      if (signal !== undefined && !signal.aborted) {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+    },
+    getApprovalMode: (): ApprovalMode => 'default' as ApprovalMode,
+    setApprovalMode: vi.fn(),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    tools: {
+      get: (name: string) =>
+        Object.hasOwn(toolKinds, name) ? { kind: toolKinds[name] } : undefined,
+      respondToConfirmation: (
+        confirmationId: string,
+        decision: ToolConfirmationOutcome,
+        payload?: ToolConfirmationPayload,
+        requiresUserConfirmation?: boolean,
+      ) => {
+        confirmations.push({
+          confirmationId,
+          decision,
+          ...(payload === undefined ? {} : { payload }),
+          ...(requiresUserConfirmation === undefined
+            ? {}
+            : { requiresUserConfirmation }),
+        });
+      },
+      onConfirmationRequest: () => () => {},
+      onToolUpdate: () => () => {},
+      setEditorCallbacks: () => {},
+      setEnabled: vi.fn().mockResolvedValue(undefined),
+      list: () => [],
+      keys: {},
+    },
+  } as unknown as Agent;
+  return { agent, confirmations };
+}
+
 export function buildFakeAgent(
   events: readonly AgentEvent[],
   toolKinds: Readonly<Record<string, string>> = {},
@@ -76,6 +133,16 @@ export function buildFakeAgent(
   confirmations: ConfirmationCapture[];
 } {
   return buildScriptedAgent(() => events, toolKinds);
+}
+
+export function buildBlockingFakeAgent(
+  events: readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
+  agent: Agent;
+  confirmations: ConfirmationCapture[];
+} {
+  return buildBlockingScriptedAgent(() => events, toolKinds);
 }
 
 export class RecordingConnection {
@@ -95,6 +162,70 @@ export class RecordingConnection {
   private sessionUpdateFailAfter: number | null = null;
   private sessionUpdateError: Error | null = null;
   private sessionUpdateCalls = 0;
+
+  // --- Terminal test-double state ---
+
+  readonly createTerminalCalls: Array<{
+    command: string;
+    cwd?: string | null;
+    sessionId: string;
+    args?: string[];
+    env?: Array<{ name: string; value: string }>;
+    outputByteLimit?: number | null;
+  }> = [];
+
+  killCalls = 0;
+  releaseCalls = 0;
+
+  private terminalOutput = '';
+  private terminalExitDelayed = false;
+  private terminalExitResolve: ((value: void) => void) | null = null;
+
+  setTerminalOutput(output: string): void {
+    this.terminalOutput = output;
+  }
+
+  delayTerminalExit(): void {
+    this.terminalExitDelayed = true;
+  }
+
+  resolveDelayedTerminalExit(): void {
+    if (this.terminalExitResolve !== null) {
+      const fn = this.terminalExitResolve;
+      this.terminalExitResolve = null;
+      this.terminalExitDelayed = false;
+      fn();
+    }
+  }
+
+  /**
+   * Resolves once at least one terminal content update (tool_call_update with
+   * a `terminal` content block) has been recorded — i.e., the Session has
+   * created and registered a terminal.
+   */
+  waitForTerminalCreated(): Promise<void> {
+    return this.hasTerminalContentUpdate()
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          const check = (): void => {
+            if (this.hasTerminalContentUpdate()) {
+              resolve();
+            } else {
+              setTimeout(check, 5);
+            }
+          };
+          setTimeout(check, 5);
+        });
+  }
+
+  private hasTerminalContentUpdate(): boolean {
+    return this.messages.some(
+      (m) =>
+        m.kind === 'sessionUpdate' &&
+        m.update.sessionUpdate === 'tool_call_update' &&
+        (m.update.content ?? []).some((c) => c.type === 'terminal'),
+    );
+  }
 
   /**
    * Arms sessionUpdate to REJECT starting with the (0-based) `afterCount`-th
@@ -218,6 +349,58 @@ export class RecordingConnection {
     },
   );
 
+  createTerminal: Mock = vi.fn(
+    async (params: acp.CreateTerminalRequest): Promise<acp.TerminalHandle> => {
+      const call = {
+        command: params.command,
+        cwd: params.cwd,
+        sessionId: params.sessionId,
+        ...(params.args !== undefined ? { args: params.args } : {}),
+        ...(params.env !== undefined ? { env: params.env } : {}),
+        ...(params.outputByteLimit !== undefined
+          ? { outputByteLimit: params.outputByteLimit }
+          : {}),
+      };
+      this.createTerminalCalls.push(call);
+      const terminalId = `terminal-${this.createTerminalCalls.length}`;
+      return this.buildFakeTerminalHandle(terminalId);
+    },
+  );
+
+  private buildFakeTerminalHandle(terminalId: string): acp.TerminalHandle {
+    const handle = {
+      id: terminalId,
+      currentOutput: vi.fn(async () => ({
+        output: this.terminalOutput,
+        exitStatus: null,
+        truncated: false,
+      })),
+      waitForExit: vi.fn(async () => {
+        if (this.terminalExitDelayed) {
+          await new Promise<void>((resolve) => {
+            this.terminalExitResolve = resolve;
+          });
+        }
+        return { exitCode: 0, signal: null };
+      }),
+      kill: vi.fn(async () => {
+        this.killCalls += 1;
+        this.resolveDelayedTerminalExit();
+        return {};
+      }),
+      release: vi.fn(async () => {
+        this.releaseCalls += 1;
+        this.resolveDelayedTerminalExit();
+        return {};
+      }),
+      [Symbol.asyncDispose]: vi.fn(async () => {
+        this.releaseCalls += 1;
+        this.resolveDelayedTerminalExit();
+      }),
+    };
+    return handle as unknown as acp.TerminalHandle;
+  }
+
   onlySessionUpdates(): acp.SessionUpdate[] {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
@@ -291,12 +474,15 @@ export function createSession(
   agent: Agent,
   connection: RecordingConnection,
   config: Config = buildMinimalConfig(),
+  terminalEnabled = false,
 ): Session {
   return new Session(
     'test-session-id',
     agent,
     config,
     connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
   );
 }
 

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -203,7 +203,21 @@ export class RecordingConnection {
   onlySessionUpdates(): acp.SessionUpdate[] {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
-      .map((m) => (m as { update: acp.SessionUpdate }).update);
+      .map((m) => (m as { update: acp.SessionUpdate }).update)
+      .filter((update) => update.sessionUpdate !== 'available_commands_update');
+  }
+
+  availableCommandUpdates(): acp.AvailableCommandsUpdate[] {
+    return this.messages
+      .filter((m) => m.kind === 'sessionUpdate')
+      .map((m) => (m as { update: acp.SessionUpdate }).update)
+      .filter(
+        (
+          update,
+        ): update is acp.AvailableCommandsUpdate & {
+          sessionUpdate: 'available_commands_update';
+        } => update.sessionUpdate === 'available_commands_update',
+      );
   }
 
   sessionUpdateKinds(): string[] {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -145,6 +145,11 @@ export function buildBlockingFakeAgent(
   return buildBlockingScriptedAgent(() => events, toolKinds);
 }
 
+export type FakeTerminalHandle = Pick<
+  acp.TerminalHandle,
+  'id' | 'currentOutput' | 'waitForExit' | 'kill' | 'release'
+>;
+
 export class RecordingConnection {
   readonly messages: Array<
     | { kind: 'sessionUpdate'; update: acp.SessionUpdate }
@@ -350,7 +355,7 @@ export class RecordingConnection {
   );
 
   createTerminal: Mock = vi.fn(
-    async (params: acp.CreateTerminalRequest): Promise<acp.TerminalHandle> => {
+    async (params: acp.CreateTerminalRequest): Promise<FakeTerminalHandle> => {
       const call = {
         command: params.command,
         cwd: params.cwd,
@@ -367,7 +372,7 @@ export class RecordingConnection {
     },
   );
 
-  private buildFakeTerminalHandle(terminalId: string): acp.TerminalHandle {
+  private buildFakeTerminalHandle(terminalId: string): FakeTerminalHandle {
     const handle = {
       id: terminalId,
       currentOutput: vi.fn(async () => ({
@@ -393,12 +398,8 @@ export class RecordingConnection {
         this.resolveDelayedTerminalExit();
         return {};
       }),
-      [Symbol.asyncDispose]: vi.fn(async () => {
-        this.releaseCalls += 1;
-        this.resolveDelayedTerminalExit();
-      }),
     };
-    return handle as unknown as acp.TerminalHandle;
+    return handle;
   }
 
   onlySessionUpdates(): acp.SessionUpdate[] {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -84,6 +84,34 @@ export class RecordingConnection {
     optionId: ToolConfirmationOutcome.ProceedOnce,
   };
   private permissionRejection: Error | null = null;
+  private sessionUpdateFailAfter: number | null = null;
+  private sessionUpdateError: Error | null = null;
+  private sessionUpdateCalls = 0;
+
+  /**
+   * Arms sessionUpdate to REJECT starting with the (0-based) `afterCount`-th
+   * call: the first `afterCount` notifications are still recorded/delivered
+   * normally, then every subsequent call throws `error`. Used to simulate a
+   * dead/failing transport mid history-replay (issue #1604 FINDING A) so strict
+   * streamHistory delivery and loadSession cleanup can be asserted. `afterCount:
+   * 0` fails the very first update.
+   */
+  failSessionUpdateAfter(afterCount: number, error: Error): void {
+    this.sessionUpdateFailAfter = afterCount;
+    this.sessionUpdateError = error;
+  }
+
+  /**
+   * Disarms {@link failSessionUpdateAfter} and resets the call counter so a
+   * SUBSEQUENT operation on the same connection delivers normally — used to
+   * simulate a transport that has recovered before a retry load (issue #1604
+   * FINDING A partial-failure test).
+   */
+  clearSessionUpdateFailure(): void {
+    this.sessionUpdateFailAfter = null;
+    this.sessionUpdateError = null;
+    this.sessionUpdateCalls = 0;
+  }
   private gatedDeferred: {
     resolve: (o: acp.RequestPermissionOutcome) => void;
     promise: Promise<acp.RequestPermissionOutcome>;
@@ -125,6 +153,17 @@ export class RecordingConnection {
 
   sessionUpdate: Mock = vi.fn(
     async (params: acp.SessionNotification): Promise<void> => {
+      if (
+        this.sessionUpdateFailAfter !== null &&
+        this.sessionUpdateCalls >= this.sessionUpdateFailAfter
+      ) {
+        this.sessionUpdateCalls++;
+        throw (
+          this.sessionUpdateError ??
+          new Error('sessionUpdate transport failure')
+        );
+      }
+      this.sessionUpdateCalls++;
       this.messages.push({ kind: 'sessionUpdate', update: params.update });
     },
   );

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -112,6 +112,16 @@ export class RecordingConnection {
     this.sessionUpdateError = null;
     this.sessionUpdateCalls = 0;
   }
+
+  clearSessionInfoUpdates(): void {
+    const retained = this.messages.filter(
+      (message) =>
+        message.kind !== 'sessionUpdate' ||
+        message.update.sessionUpdate !== 'session_info_update',
+    );
+    this.messages.splice(0, this.messages.length, ...retained);
+  }
+
   private gatedDeferred: {
     resolve: (o: acp.RequestPermissionOutcome) => void;
     promise: Promise<acp.RequestPermissionOutcome>;

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -226,6 +226,10 @@ export function buildMinimalConfig(): Config {
     getEnableRecursiveFileSearch: () => false,
     getFileSystemService: () => ({ readTextFile: async () => '' }),
     getMaxSessionTurns: () => 50,
+    // usage_update path (issue #1607): sendUsageUpdate resolves the context
+    // window via getTokenLimitForConfiguredContext(model, config).
+    getModel: () => 'test-model',
+    getContentGeneratorConfig: () => undefined,
   } as unknown as Config;
 }
 

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -90,7 +90,6 @@ export function buildBlockingScriptedAgent(
       if (signal !== undefined && !signal.aborted) {
         await new Promise<void>((resolve) => {
           signal.addEventListener('abort', () => resolve(), { once: true });
-          if (signal.aborted) resolve();
         });
       }
     },
@@ -478,15 +477,12 @@ export function createSession(
   agent: Agent,
   connection: RecordingConnection,
   config: Config = buildMinimalConfig(),
-  terminalEnabled = false,
 ): Session {
   return new Session(
     'test-session-id',
     agent,
     config,
     connection as unknown as acp.AgentSideConnection,
-    false,
-    terminalEnabled,
   );
 }
 

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -204,7 +204,27 @@ export class RecordingConnection {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
       .map((m) => (m as { update: acp.SessionUpdate }).update)
-      .filter((update) => update.sessionUpdate !== 'available_commands_update');
+      .filter(
+        (update) =>
+          update.sessionUpdate !== 'available_commands_update' &&
+          update.sessionUpdate !== 'session_info_update',
+      );
+  }
+
+  sessionInfoUpdates(): Array<
+    Extract<acp.SessionUpdate, { sessionUpdate: 'session_info_update' }>
+  > {
+    return this.messages
+      .filter((m) => m.kind === 'sessionUpdate')
+      .map((m) => (m as { update: acp.SessionUpdate }).update)
+      .filter(
+        (
+          update,
+        ): update is Extract<
+          acp.SessionUpdate,
+          { sessionUpdate: 'session_info_update' }
+        > => update.sessionUpdate === 'session_info_update',
+      );
   }
 
   availableCommandUpdates(): acp.AvailableCommandsUpdate[] {
@@ -232,6 +252,7 @@ export function buildMinimalConfig(): Config {
     getApprovalMode: () => 'default' as ApprovalMode,
     setApprovalMode: () => {},
     getTargetDir: () => '/project',
+    getProjectRoot: () => '/project',
     getFileService: () => ({ shouldIgnoreFile: () => false }),
     getFileFilteringOptions: () => ({
       respectGitIgnore: true,
@@ -244,6 +265,7 @@ export function buildMinimalConfig(): Config {
     // window via getTokenLimitForConfiguredContext(model, config).
     getModel: () => 'test-model',
     getContentGeneratorConfig: () => undefined,
+    getSessionRecordingService: () => undefined,
   } as unknown as Config;
 }
 

--- a/packages/cli/src/zed-integration/zed-tool-handler.ts
+++ b/packages/cli/src/zed-integration/zed-tool-handler.ts
@@ -323,7 +323,7 @@ function mapToolUpdateStatus(
   }
 }
 
-const TOOL_KIND_BY_NAME = new Map<string, acp.ToolKind>([
+export const TOOL_KIND_BY_NAME: ReadonlyMap<string, acp.ToolKind> = new Map([
   ...[
     'read_file',
     'read_line_range',

--- a/packages/cli/src/zed-integration/zed-tool-handler.ts
+++ b/packages/cli/src/zed-integration/zed-tool-handler.ts
@@ -6,6 +6,7 @@
 
 import type { ToolCallConfirmationDetails } from '@vybestack/llxprt-code-core';
 import {
+  Kind,
   ToolConfirmationOutcome,
   type ToolConfirmationPayload,
 } from '@vybestack/llxprt-code-tools';
@@ -13,7 +14,9 @@ import type * as acp from '@agentclientprotocol/sdk';
 import { z } from 'zod';
 import { toPermissionOptions } from './zed-helpers.js';
 import type {
+  AgentEvent,
   AgentToolCall,
+  AgentToolControl,
   AgentToolResult,
   ToolUpdate,
 } from '@vybestack/llxprt-code-agents';
@@ -24,6 +27,7 @@ type Dict = Readonly<Record<string, unknown>>;
 export async function emitToolCallStart(
   call: AgentToolCall,
   sendUpdate: SendUpdateFn,
+  registeredKind?: string,
 ): Promise<void> {
   // rawInput carries the tool arguments for parity with the replay start shape
   // (zed-session-replay.ts buildToolCallStart) and because ACP recommends it on
@@ -35,7 +39,7 @@ export async function emitToolCallStart(
     title: call.name,
     content: [],
     locations: buildToolLocations(call.args),
-    kind: inferToolKind(call.name),
+    kind: resolveToolKind(call.name, registeredKind),
     rawInput: call.args,
   });
 }
@@ -43,6 +47,7 @@ export async function emitToolCallStart(
 export async function emitToolStatus(
   update: ToolUpdate,
   sendUpdate: SendUpdateFn,
+  registeredKind?: string,
 ): Promise<void> {
   const status = mapToolUpdateStatus(update.status);
   if (status === null) {
@@ -54,12 +59,14 @@ export async function emitToolStatus(
     toolCallId: update.id,
     status,
     content: text ? textContent(text) : [],
+    kind: resolveToolKind(update.name, registeredKind),
   });
 }
 
 export async function emitToolResult(
   result: AgentToolResult,
   sendUpdate: SendUpdateFn,
+  registeredKind?: string,
 ): Promise<void> {
   const isError = result.isError === true;
   const content = isError
@@ -70,7 +77,39 @@ export async function emitToolResult(
     toolCallId: result.id,
     status: isError ? 'failed' : 'completed',
     content,
+    kind: resolveToolKind(result.name, registeredKind),
   });
+}
+
+export async function emitAgentToolEvent(
+  event: Extract<
+    AgentEvent,
+    { type: 'tool-call' | 'tool-status' | 'tool-result' }
+  >,
+  sendUpdate: SendUpdateFn,
+  tools: Pick<AgentToolControl, 'get'>,
+): Promise<void> {
+  if (event.type === 'tool-call') {
+    await emitToolCallStart(
+      event.call,
+      sendUpdate,
+      tools.get(event.call.name)?.kind,
+    );
+    return;
+  }
+  if (event.type === 'tool-status') {
+    await emitToolStatus(
+      event.update,
+      sendUpdate,
+      tools.get(event.update.name)?.kind,
+    );
+    return;
+  }
+  await emitToolResult(
+    event.result,
+    sendUpdate,
+    tools.get(event.result.name)?.kind,
+  );
 }
 
 function buildErrorContent(result: AgentToolResult): acp.ToolCallContent[] {
@@ -89,6 +128,7 @@ export async function requestToolConfirmation(
   name: string,
   details: unknown,
   connection: acp.AgentSideConnection,
+  registeredKind?: string,
 ): Promise<PermissionRoundTripResult> {
   const confirmationDetails = coerceConfirmationDetails(details);
   const params: acp.RequestPermissionRequest = {
@@ -103,7 +143,7 @@ export async function requestToolConfirmation(
       title: confirmationDetails?.title ?? name,
       content: buildConfirmationContent(confirmationDetails),
       locations: buildConfirmationLocations(confirmationDetails),
-      kind: inferToolKind(name),
+      kind: resolveToolKind(name, registeredKind),
     },
   };
   return parsePermissionOutcome(await connection.requestPermission(params));
@@ -362,6 +402,21 @@ export const TOOL_KIND_BY_NAME: ReadonlyMap<string, acp.ToolKind> = new Map([
 
 export function inferToolKind(name: string): acp.ToolKind | undefined {
   return TOOL_KIND_BY_NAME.get(name);
+}
+
+const ACP_TOOL_KINDS: ReadonlySet<string> = new Set(Object.values(Kind));
+
+export function toAcpToolKind(kind: string | undefined): acp.ToolKind {
+  return kind !== undefined && ACP_TOOL_KINDS.has(kind)
+    ? (kind as acp.ToolKind)
+    : 'other';
+}
+
+function resolveToolKind(
+  name: string,
+  registeredKind: string | undefined,
+): acp.ToolKind {
+  return toAcpToolKind(registeredKind ?? inferToolKind(name));
 }
 
 function asRecord(value: unknown): Dict | null {

--- a/packages/cli/src/zed-integration/zed-tool-handler.ts
+++ b/packages/cli/src/zed-integration/zed-tool-handler.ts
@@ -231,7 +231,7 @@ function buildConfirmationLocations(
   return path === undefined ? [] : [buildLocation(path)];
 }
 
-function buildToolLocations(args: Dict): acp.ToolCallLocation[] {
+export function buildToolLocations(args: Dict): acp.ToolCallLocation[] {
   const paths = [
     firstString(args, [
       'absolute_path',

--- a/packages/cli/src/zed-integration/zed-tool-handler.ts
+++ b/packages/cli/src/zed-integration/zed-tool-handler.ts
@@ -350,7 +350,7 @@ const TOOL_KIND_BY_NAME = new Map<string, acp.ToolKind>([
   ),
 ]);
 
-function inferToolKind(name: string): acp.ToolKind | undefined {
+export function inferToolKind(name: string): acp.ToolKind | undefined {
   return TOOL_KIND_BY_NAME.get(name);
 }
 

--- a/packages/cli/src/zed-integration/zed-tool-handler.ts
+++ b/packages/cli/src/zed-integration/zed-tool-handler.ts
@@ -352,6 +352,12 @@ const TOOL_KIND_BY_NAME = new Map<string, acp.ToolKind>([
   ...['run_shell_command', 'execute_command', 'exec'].map(
     (name) => [name, 'execute'] as const,
   ),
+  ...['direct_web_fetch', 'exa_web_search', 'web_fetch', 'web_search'].map(
+    (name) => [name, 'fetch'] as const,
+  ),
+  ...['todo_write', 'todo_read', 'todo_pause', 'save_memory'].map(
+    (name) => [name, 'think'] as const,
+  ),
 ]);
 
 export function inferToolKind(name: string): acp.ToolKind | undefined {

--- a/packages/cli/src/zed-integration/zed-tool-handler.ts
+++ b/packages/cli/src/zed-integration/zed-tool-handler.ts
@@ -6,7 +6,6 @@
 
 import type { ToolCallConfirmationDetails } from '@vybestack/llxprt-code-core';
 import {
-  Kind,
   ToolConfirmationOutcome,
   type ToolConfirmationPayload,
 } from '@vybestack/llxprt-code-tools';
@@ -404,7 +403,18 @@ export function inferToolKind(name: string): acp.ToolKind | undefined {
   return TOOL_KIND_BY_NAME.get(name);
 }
 
-const ACP_TOOL_KINDS: ReadonlySet<string> = new Set(Object.values(Kind));
+const ACP_TOOL_KINDS: ReadonlySet<string> = new Set<acp.ToolKind>([
+  'read',
+  'edit',
+  'delete',
+  'move',
+  'search',
+  'execute',
+  'think',
+  'fetch',
+  'switch_mode',
+  'other',
+]);
 
 export function toAcpToolKind(kind: string | undefined): acp.ToolKind {
   return kind !== undefined && ACP_TOOL_KINDS.has(kind)

--- a/packages/cli/src/zed-integration/zed-tool-handler.ts
+++ b/packages/cli/src/zed-integration/zed-tool-handler.ts
@@ -25,6 +25,9 @@ export async function emitToolCallStart(
   call: AgentToolCall,
   sendUpdate: SendUpdateFn,
 ): Promise<void> {
+  // rawInput carries the tool arguments for parity with the replay start shape
+  // (zed-session-replay.ts buildToolCallStart) and because ACP recommends it on
+  // tool_call for client-side debugging (conformance tooling flags its absence).
   await sendUpdate({
     sessionUpdate: 'tool_call',
     toolCallId: call.id,
@@ -33,6 +36,7 @@ export async function emitToolCallStart(
     content: [],
     locations: buildToolLocations(call.args),
     kind: inferToolKind(call.name),
+    rawInput: call.args,
   });
 }
 

--- a/packages/cli/src/zed-integration/zed-tool-kind.test.ts
+++ b/packages/cli/src/zed-integration/zed-tool-kind.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for inferToolKind (issue #1605): every mapped internal tool
+ * name must resolve to a valid ACP ToolKind, and unknown names must yield
+ * undefined (rendered as an omitted kind — ACP's "other"-equivalent default)
+ * rather than an invalid value on the wire.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { inferToolKind } from './zed-tool-handler.js';
+
+const ACP_TOOL_KINDS = [
+  'read',
+  'edit',
+  'delete',
+  'move',
+  'search',
+  'execute',
+  'think',
+  'fetch',
+  'switch_mode',
+  'other',
+] as const;
+
+describe('inferToolKind (issue #1605: ToolKind mapping)', () => {
+  it.each([
+    ['read_file', 'read'],
+    ['read_many_files', 'read'],
+    ['list_directory', 'read'],
+    ['glob', 'read'],
+    ['search_file_content', 'read'],
+    ['write_file', 'edit'],
+    ['replace', 'edit'],
+    ['apply_patch', 'edit'],
+    ['delete_line_range', 'edit'],
+    ['run_shell_command', 'execute'],
+    ['direct_web_fetch', 'fetch'],
+    ['exa_web_search', 'fetch'],
+    ['web_fetch', 'fetch'],
+    ['todo_write', 'think'],
+    ['todo_read', 'think'],
+    ['save_memory', 'think'],
+  ])('maps %s -> %s', (name, expected) => {
+    const kind = inferToolKind(name);
+    expect(kind).toBe(expected);
+    // Whatever the table says, the value must be a REAL ACP ToolKind.
+    expect(ACP_TOOL_KINDS).toContain(kind);
+  });
+
+  it('returns undefined for an unknown tool name (kind omitted on the wire, never an invalid value)', () => {
+    expect(inferToolKind('some_mcp_server_tool')).toBeUndefined();
+    expect(inferToolKind('')).toBeUndefined();
+  });
+});

--- a/packages/cli/src/zed-integration/zed-tool-kind.test.ts
+++ b/packages/cli/src/zed-integration/zed-tool-kind.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { inferToolKind } from './zed-tool-handler.js';
+import { inferToolKind, TOOL_KIND_BY_NAME } from './zed-tool-handler.js';
 
 const ACP_TOOL_KINDS = [
   'read',
@@ -28,29 +28,16 @@ const ACP_TOOL_KINDS = [
 ] as const;
 
 describe('inferToolKind (issue #1605: ToolKind mapping)', () => {
-  it.each([
-    ['read_file', 'read'],
-    ['read_many_files', 'read'],
-    ['list_directory', 'read'],
-    ['glob', 'read'],
-    ['search_file_content', 'read'],
-    ['write_file', 'edit'],
-    ['replace', 'edit'],
-    ['apply_patch', 'edit'],
-    ['delete_line_range', 'edit'],
-    ['run_shell_command', 'execute'],
-    ['direct_web_fetch', 'fetch'],
-    ['exa_web_search', 'fetch'],
-    ['web_fetch', 'fetch'],
-    ['todo_write', 'think'],
-    ['todo_read', 'think'],
-    ['save_memory', 'think'],
-  ])('maps %s -> %s', (name, expected) => {
-    const kind = inferToolKind(name);
-    expect(kind).toBe(expected);
-    // Whatever the table says, the value must be a REAL ACP ToolKind.
-    expect(ACP_TOOL_KINDS).toContain(kind);
-  });
+  it.each([...TOOL_KIND_BY_NAME.entries()])(
+    'maps %s -> %s',
+    (name, expected) => {
+      const kind = inferToolKind(name);
+      expect(kind).toBe(expected);
+      // Every table entry — including future additions — must be a REAL ACP
+      // ToolKind, so an invalid wire value cannot hide in an untested entry.
+      expect(ACP_TOOL_KINDS).toContain(kind);
+    },
+  );
 
   it('returns undefined for an unknown tool name (kind omitted on the wire, never an invalid value)', () => {
     expect(inferToolKind('some_mcp_server_tool')).toBeUndefined();

--- a/packages/cli/src/zed-integration/zed-tool-kind.test.ts
+++ b/packages/cli/src/zed-integration/zed-tool-kind.test.ts
@@ -12,7 +12,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { inferToolKind, TOOL_KIND_BY_NAME } from './zed-tool-handler.js';
+import { Kind } from '@vybestack/llxprt-code-tools';
+import {
+  inferToolKind,
+  TOOL_KIND_BY_NAME,
+  toAcpToolKind,
+} from './zed-tool-handler.js';
 
 const ACP_TOOL_KINDS = [
   'read',
@@ -42,5 +47,19 @@ describe('inferToolKind (issue #1605: ToolKind mapping)', () => {
   it('returns undefined for an unknown tool name (kind omitted on the wire, never an invalid value)', () => {
     expect(inferToolKind('some_mcp_server_tool')).toBeUndefined();
     expect(inferToolKind('')).toBeUndefined();
+  });
+});
+
+describe('toAcpToolKind (issue #1605: registered Kind mapping)', () => {
+  it.each(Object.values(Kind))(
+    'passes through the registered %s kind',
+    (kind) => {
+      expect(toAcpToolKind(kind)).toBe(kind);
+    },
+  );
+
+  it('maps absent and future non-ACP kinds to other', () => {
+    expect(toAcpToolKind(undefined)).toBe('other');
+    expect(toAcpToolKind('communicate')).toBe('other');
   });
 });

--- a/packages/cli/src/zed-integration/zed-tool-kind.test.ts
+++ b/packages/cli/src/zed-integration/zed-tool-kind.test.ts
@@ -28,7 +28,6 @@ const ACP_TOOL_KINDS = [
   'execute',
   'think',
   'fetch',
-  'switch_mode',
   'other',
 ] as const;
 

--- a/packages/cli/src/zed-integration/zed-usage-update.test.ts
+++ b/packages/cli/src/zed-integration/zed-usage-update.test.ts
@@ -39,6 +39,17 @@ describe('buildUsageUpdate (issue #1607: usage_update size/used semantics)', () 
     });
   });
 
+  it('treats an explicit zero totalTokenCount as authoritative (no fallback to candidates)', () => {
+    // `??` intentionally distinguishes absent from zero: a provider explicitly
+    // reporting total=0 wins, even if it also supplies a candidate count.
+    expect(
+      buildUsageUpdate(
+        { totalTokenCount: 0, candidatesTokenCount: 450 },
+        64000,
+      ),
+    ).toBeNull();
+  });
+
   it('returns null when the event carries no usable token counts (nothing to report)', () => {
     expect(buildUsageUpdate({}, 128000)).toBeNull();
     expect(

--- a/packages/cli/src/zed-integration/zed-usage-update.test.ts
+++ b/packages/cli/src/zed-integration/zed-usage-update.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for buildUsageUpdate (issue #1607): the usage_update
+ * notification must report `used` = tokens now in context (the response's
+ * cumulative totalTokenCount) against `size` = the configured context-window
+ * limit — not the pre-#1607 shape where size merely mirrored used, which told
+ * the client nothing about remaining headroom.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildUsageUpdate } from './zed-helpers.js';
+
+describe('buildUsageUpdate (issue #1607: usage_update size/used semantics)', () => {
+  it('reports used = totalTokenCount against size = the context-window limit', () => {
+    expect(
+      buildUsageUpdate(
+        { totalTokenCount: 1200, candidatesTokenCount: 300 },
+        128000,
+      ),
+    ).toStrictEqual({
+      sessionUpdate: 'usage_update',
+      used: 1200,
+      size: 128000,
+    });
+  });
+
+  it('falls back to candidatesTokenCount for used when totalTokenCount is absent', () => {
+    expect(
+      buildUsageUpdate({ candidatesTokenCount: 450 }, 64000),
+    ).toStrictEqual({
+      sessionUpdate: 'usage_update',
+      used: 450,
+      size: 64000,
+    });
+  });
+
+  it('returns null when the event carries no usable token counts (nothing to report)', () => {
+    expect(buildUsageUpdate({}, 128000)).toBeNull();
+    expect(
+      buildUsageUpdate({ totalTokenCount: 0, candidatesTokenCount: 0 }, 128000),
+    ).toBeNull();
+  });
+
+  it('clamps size up to used so used can never exceed size on the wire', () => {
+    // A mid-flight context-limit reduction (or a model swap to a smaller
+    // window) must not produce used > size — the update degrades to a full
+    // window rather than an impossible ratio.
+    expect(buildUsageUpdate({ totalTokenCount: 200000 }, 128000)).toStrictEqual(
+      {
+        sessionUpdate: 'usage_update',
+        used: 200000,
+        size: 200000,
+      },
+    );
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -30,6 +30,7 @@ import type * as acp from '@agentclientprotocol/sdk';
 import { RequestError } from '@agentclientprotocol/sdk';
 import type { Config, IContent } from '@vybestack/llxprt-code-core';
 import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { LoadedSettings } from '../config/settings.js';
 
 import { RecordingConnection } from './zed-test-helpers.js';
 
@@ -103,19 +104,37 @@ function buildBaseConfig(): Config {
   } as unknown as Config;
 }
 
+/**
+ * Minimal typed LoadedSettings stub (F14): the ZedAgent constructor only stores
+ * the settings arg (it is unused by the loadSession/newSession orchestration
+ * paths under test), so a typed empty projection avoids an `as never` cast while
+ * staying honest about what the code touches.
+ */
+function buildStubSettings(): LoadedSettings {
+  return {} as LoadedSettings;
+}
+
+/** Typed InitializeRequest for a client that advertises no capabilities. */
+function buildInitializeRequest(): acp.InitializeRequest {
+  return { protocolVersion: 1, clientCapabilities: {} };
+}
+
+/**
+ * Constructs a ZedAgent over the RecordingConnection with typed stub args (no
+ * `as never`, F14) and initializes it. Shared by every orchestration test,
+ * including the initialize()-advertises-loadSession assertion (F15) so the
+ * makeZedAgent setup is not duplicated.
+ */
 async function makeZedAgent(
   connection: RecordingConnection,
 ): Promise<InstanceType<typeof import('./zedIntegration.js').ZedAgent>> {
   const mod = await import('./zedIntegration.js');
   const zedAgent = new mod.ZedAgent(
     buildBaseConfig(),
-    { debug: () => {} } as never,
+    buildStubSettings(),
     connection as unknown as acp.AgentSideConnection,
   );
-  await zedAgent.initialize({
-    protocolVersion: '1',
-    clientCapabilities: {},
-  } as never);
+  await zedAgent.initialize(buildInitializeRequest());
   return zedAgent;
 }
 
@@ -123,15 +142,14 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
   it('initialize() advertises loadSession: true', async () => {
     const connection = new RecordingConnection();
     const mod = await import('./zedIntegration.js');
+    // Reuse the shared typed constructor args (F15) rather than re-inlining the
+    // ZedAgent setup; assert the capability from a fresh initialize() call.
     const zedAgent = new mod.ZedAgent(
       buildBaseConfig(),
-      { debug: () => {} } as never,
+      buildStubSettings(),
       connection as unknown as acp.AgentSideConnection,
     );
-    const response = await zedAgent.initialize({
-      protocolVersion: '1',
-      clientCapabilities: {},
-    } as never);
+    const response = await zedAgent.initialize(buildInitializeRequest());
     expect(response.agentCapabilities?.loadSession).toBe(true);
   });
 
@@ -462,6 +480,16 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     // Full cleanup even on partial delivery: fresh agent disposed once.
     expect(failingStub.dispose).toHaveBeenCalledTimes(1);
 
+    // Pre-retry proof of cleanup (F16): prompting the failed id throws
+    // "Session not found" because the partially-replayed load removed its
+    // this.sessions entry (no stale/half-dead session survived the failure).
+    await expect(
+      zedAgent.prompt({
+        sessionId: 'partial-fail-session',
+        prompt: [{ type: 'text', text: 'still there?' }],
+      } as acp.PromptRequest),
+    ).rejects.toThrow(/Session not found/);
+
     // Transport recovers before the retry.
     connection.clearSessionUpdateFailure();
 
@@ -475,5 +503,112 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
       .map((u) => (u as { content: { text: string } }).content.text);
     // 'a1' from the failed load, then 'retry ok' from the successful retry.
     expect(agentTexts).toStrictEqual(['a1', 'retry ok']);
+  });
+
+  // ─── FINDING F5: concurrent same-id loadSession serialization ─────────────
+
+  it('serializes two CONCURRENT loadSession calls for the SAME id so exactly one live session remains and neither agent is double-disposed (FINDING F5)', async () => {
+    // The FIRST load's resume is gated so it resolves AFTER the second load has
+    // already been dispatched: without per-id serialization both loads would
+    // build agents and race to install, the later overwriting the earlier and
+    // orphaning its recording lock. With serialization the second load runs only
+    // after the first fully installs, then disposes it (replace semantics) and
+    // installs itself — leaving exactly one live session, each agent disposed at
+    // most once.
+    let releaseFirstResume!: () => void;
+    const firstResumeGate = new Promise<void>((resolve) => {
+      releaseFirstResume = resolve;
+    });
+    const firstResume = vi.fn(async () => {
+      await firstResumeGate;
+      return [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'first' }] },
+      ] as readonly IContent[];
+    });
+    const firstDispose = vi.fn(async () => undefined);
+    const firstAgent = {
+      getApprovalMode: () => 'default',
+      setApprovalMode: vi.fn(),
+      dispose: firstDispose,
+      async *stream() {},
+      session: { resume: firstResume, setRecording: vi.fn() },
+      tools: { respondToConfirmation: vi.fn() },
+    } as unknown as Agent;
+
+    const secondStub = buildStubAgent({
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'second' }] },
+      ],
+    });
+
+    // The module-level fromConfig mock accumulates calls across tests (no
+    // beforeEach reset in this file); reset it so this test's build-count
+    // assertion has a clean baseline and its two agents are returned in order.
+    mockFromConfig.mockReset();
+    mockFromConfig
+      .mockResolvedValueOnce(firstAgent)
+      .mockResolvedValueOnce(secondStub.agent);
+
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection);
+
+    const params: acp.LoadSessionRequest = {
+      sessionId: 'concurrent-session',
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest;
+
+    // Fire both loads concurrently; the second is dispatched while the first is
+    // still awaiting its gated resume.
+    const firstLoad = zedAgent.loadSession(params);
+    const secondLoad = zedAgent.loadSession(params);
+
+    // Flush to a macrotask boundary so ALL runnable microtasks settle: the first
+    // load progresses until it parks on the gated resume, and the second load
+    // parks behind the first's queue entry (serialization). A macrotask flush is
+    // robust to the exact number of intermediate awaits, unlike a single
+    // Promise.resolve() tick.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The first load built its agent and called resume (now parked on the gate);
+    // the second is serialized behind it, so it has NOT built an agent and its
+    // resume has NOT been called — proving the two same-id loads do not race.
+    expect(mockFromConfig).toHaveBeenCalledTimes(1);
+    expect(firstResume).toHaveBeenCalledTimes(1);
+    expect(secondStub.resume).toHaveBeenCalledTimes(0);
+
+    // Release the first resume; both loads now settle in order.
+    releaseFirstResume();
+    const [firstResult, secondResult] = await Promise.all([
+      firstLoad,
+      secondLoad,
+    ]);
+
+    // Both settled sanely with modes advertised.
+    expect(firstResult.modes?.currentModeId).toBe('default');
+    expect(secondResult.modes?.currentModeId).toBe('default');
+
+    // The first session was disposed exactly once (replaced by the second); the
+    // second remains live and was never disposed. No double-dispose occurred.
+    expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(secondStub.dispose).toHaveBeenCalledTimes(0);
+
+    // Exactly one live session remains: prompting the id reaches the SECOND
+    // (live) agent's stream and completes rather than throwing "Session not
+    // found".
+    await expect(
+      zedAgent.prompt({
+        sessionId: 'concurrent-session',
+        prompt: [{ type: 'text', text: 'who is live?' }],
+      } as acp.PromptRequest),
+    ).resolves.toBeDefined();
+
+    // Both transcripts streamed in order: first load's 'first', then the second
+    // load's 'second'.
+    const agentTexts = connection
+      .onlySessionUpdates()
+      .filter((u) => u.sessionUpdate === 'agent_message_chunk')
+      .map((u) => (u as { content: { text: string } }).content.text);
+    expect(agentTexts).toStrictEqual(['first', 'second']);
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -327,7 +327,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     ).rejects.toThrow(/Session not found/);
   });
 
-  it('closeSession keeps a session tracked when agent disposal fails', async () => {
+  it('closeSession succeeds and removes the session even when agent disposal fails', async () => {
     const stub = buildStubAgent({});
     stub.dispose.mockRejectedValueOnce(new Error('dispose failed'));
     mockFromConfig.mockResolvedValue(stub.agent);
@@ -342,14 +342,10 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
 
     await expect(
       zedAgent.closeSession({ sessionId: created.sessionId }),
-    ).rejects.toThrow('dispose failed');
+    ).resolves.toEqual({});
     await expect(
-      zedAgent.resumeSession({
-        sessionId: created.sessionId,
-        cwd: '/project',
-        mcpServers: [],
-      }),
-    ).resolves.toMatchObject({ modes: expect.any(Object) });
+      zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
+    ).rejects.toThrow(/Session not found/);
   });
 
   it('initialize() advertises loadSession: true', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -739,14 +739,14 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     mockFromConfig.mockResolvedValue(stub.agent);
 
     const connection = new RecordingConnection();
-    // Dead transport: the first (and only) replay update rejects.
-    connection.failSessionUpdateAfter(0, new Error('transport is dead'));
     const zedAgent = await makeZedAgent(connection, emptyChatsLister);
 
     const created = await zedAgent.newSession({
       cwd: '/project',
       mcpServers: [],
     } as acp.NewSessionRequest);
+    connection.clearSessionUpdateFailure();
+    connection.failSessionUpdateAfter(0, new Error('transport is dead'));
 
     let caught: unknown;
     try {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -780,6 +780,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     const firstAgent = {
       getApprovalMode: () => 'default',
       setApprovalMode: vi.fn(),
+      getHistory: vi.fn(async () => []),
       dispose: firstDispose,
       async *stream() {},
       session: { resume: firstResume, setRecording: vi.fn() },

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -26,13 +26,49 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import type * as acp from '@agentclientprotocol/sdk';
 import { RequestError } from '@agentclientprotocol/sdk';
 import type { Config, IContent } from '@vybestack/llxprt-code-core';
-import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { Agent, AgentMessage } from '@vybestack/llxprt-code-agents';
 import type { LoadedSettings } from '../config/settings.js';
+import type { ChatSessionFileLister } from './zed-session-loader.js';
 
 import { RecordingConnection } from './zed-test-helpers.js';
+
+/**
+ * A chats dir that never exists on disk, so the disk-resume corrupt-vs-missing
+ * probe (zed-session-loader.listSessionFileNames does a REAL readdir here) always
+ * hits ENOENT and falls back to the plain not-found mapping — keeping the
+ * resourceNotFound test deterministic. The RE-ATTACH probe (hasRecordedSessionFile)
+ * uses the INJECTED lister below instead, so this path value is irrelevant to it.
+ */
+const NONEXISTENT_CHATS_PARENT = path.join(
+  os.tmpdir(),
+  'llxprt-zed-loadsession-tests-nonexistent',
+);
+
+/**
+ * Honest readdir-like lister that reports NO on-disk recordings (empty chats
+ * dir), driving loadSession down the RE-ATTACH path when a live session exists.
+ */
+const emptyChatsLister: ChatSessionFileLister = async () => [];
+
+/**
+ * Honest readdir-like lister that reports a recorded session file on disk for
+ * each given session id, driving loadSession down the DISK-RESUME path (the file
+ * "exists"). Returns real directory ENTRY NAMES matching the
+ * `session-<timestamp>-<first-12-of-id>.jsonl` shape SessionRecordingService
+ * writes, so the production findMatchingSessionFile logic (not a result-shaped
+ * mock) decides the branch.
+ */
+function recordedFilesLister(...sessionIds: string[]): ChatSessionFileLister {
+  const names = sessionIds.map(
+    (id) => `session-2026-07-11T10-00-00-${id.substring(0, 12)}.jsonl`,
+  );
+  return async () => names;
+}
 
 const mockFromConfig = vi.hoisted(() => vi.fn());
 
@@ -58,16 +94,24 @@ interface StubAgentHandle {
   readonly resume: ReturnType<typeof vi.fn>;
   readonly setRecording: ReturnType<typeof vi.fn>;
   readonly dispose: ReturnType<typeof vi.fn>;
+  readonly getHistory: ReturnType<typeof vi.fn>;
 }
 
 /**
  * Builds a stub Agent whose session.resume returns the given fixed history (or
- * rejects with the given error). Captures the resume/setRecording/dispose spies
- * so orchestration can be asserted without a real provider bootstrap.
+ * rejects with the given error). Captures the resume/setRecording/dispose/getHistory
+ * spies so orchestration can be asserted without a real provider bootstrap.
+ *
+ * `getHistory` returns the LIVE in-memory history (Gemini AgentMessage[]) used by
+ * the #1604 re-attach replay path; it defaults to empty (a fresh unprompted
+ * session → zero replay updates). It is DISTINCT from `resumeHistory`, which is
+ * the neutral IContent[] the disk resume returns.
  */
 function buildStubAgent(options: {
   resumeHistory?: readonly IContent[];
   resumeError?: Error;
+  liveHistory?: readonly AgentMessage[];
+  streamText?: string;
 }): StubAgentHandle {
   const resume = vi.fn(async () => {
     if (options.resumeError !== undefined) {
@@ -77,15 +121,32 @@ function buildStubAgent(options: {
   });
   const setRecording = vi.fn(async () => undefined);
   const dispose = vi.fn(async () => undefined);
+  const getHistory = vi.fn(async () => options.liveHistory ?? []);
+  const streamText = options.streamText;
   const agent = {
     getApprovalMode: () => 'default',
     setApprovalMode: vi.fn(),
     dispose,
-    async *stream() {},
+    getHistory,
+    async *stream() {
+      if (streamText !== undefined) {
+        yield { type: 'text', text: streamText };
+      }
+      yield { type: 'done', reason: 'stop' };
+    },
     session: { resume, setRecording },
     tools: { respondToConfirmation: vi.fn() },
   } as unknown as Agent;
-  return { agent, resume, setRecording, dispose };
+  return { agent, resume, setRecording, dispose, getHistory };
+}
+
+/**
+ * Builds a live Gemini AgentMessage (Content) for the re-attach getHistory stub:
+ * a model turn carrying a single text part. Used to prove the re-attach path
+ * replays the live in-memory transcript (not the disk resume fixture).
+ */
+function modelMessage(text: string): AgentMessage {
+  return { role: 'model', parts: [{ text }] };
 }
 
 function buildBaseConfig(): Config {
@@ -101,6 +162,13 @@ function buildBaseConfig(): Config {
     getDebugMode: () => false,
     getTargetDir: () => '/project',
     getMaxSessionTurns: () => 50,
+    // The re-attach + corrupt-vs-missing probes derive the chats dir from
+    // storage.getProjectTempDir(); point it at a dir that never exists so the
+    // disk-resume probe's REAL readdir hits ENOENT (falling back to the plain
+    // mapping) while the injected re-attach lister decides the re-attach branch.
+    storage: {
+      getProjectTempDir: () => NONEXISTENT_CHATS_PARENT,
+    },
   } as unknown as Config;
 }
 
@@ -127,12 +195,14 @@ function buildInitializeRequest(): acp.InitializeRequest {
  */
 async function makeZedAgent(
   connection: RecordingConnection,
+  sessionFileLister?: ChatSessionFileLister,
 ): Promise<InstanceType<typeof import('./zedIntegration.js').ZedAgent>> {
   const mod = await import('./zedIntegration.js');
   const zedAgent = new mod.ZedAgent(
     buildBaseConfig(),
     buildStubSettings(),
     connection as unknown as acp.AgentSideConnection,
+    sessionFileLister,
   );
   await zedAgent.initialize(buildInitializeRequest());
   return zedAgent;
@@ -309,7 +379,13 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
       .mockResolvedValueOnce(retryStub.agent);
 
     const connection = new RecordingConnection();
-    const zedAgent = await makeZedAgent(connection);
+    // This is a RECORDED session (the reconnect exercises the disk-resume replace
+    // path), so the injected probe reports a matching on-disk file for the id —
+    // driving loadSession down the destroy-prior + resume branch, NOT re-attach.
+    const zedAgent = await makeZedAgent(
+      connection,
+      recordedFilesLister('lock-session'),
+    );
 
     const params: acp.LoadSessionRequest = {
       sessionId: 'lock-session',
@@ -356,7 +432,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     expect(agentTexts).toStrictEqual(['live session', 'retry session']);
   });
 
-  it('replaces a prior loaded session with the same id (reconnect friendliness)', async () => {
+  it('takes the DISK-RESUME path (dispose prior + fresh build/resume/replay) when a matching recording EXISTS on disk for a live same-id session (#1604 probe decides disk branch)', async () => {
     const firstStub = buildStubAgent({
       resumeHistory: [
         { speaker: 'ai', blocks: [{ type: 'text', text: 'first load' }] },
@@ -367,12 +443,22 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
         { speaker: 'ai', blocks: [{ type: 'text', text: 'second load' }] },
       ],
     });
+    // The module-level fromConfig mock accumulates calls across tests (no
+    // beforeEach reset in this file); reset it so this test's build-count
+    // assertion has a clean baseline and its two agents are returned in order.
+    mockFromConfig.mockReset();
     mockFromConfig
       .mockResolvedValueOnce(firstStub.agent)
       .mockResolvedValueOnce(secondStub.agent);
 
     const connection = new RecordingConnection();
-    const zedAgent = await makeZedAgent(connection);
+    // A recording EXISTS on disk for this id, so the second (reconnect) load must
+    // take the disk-resume replace path — NOT re-attach. The injected lister is an
+    // honest readdir fake returning the real session-*-<first12>.jsonl entry name,
+    // so production findMatchingSessionFile decides the branch.
+    const lister = recordedFilesLister('dup-session');
+    const listerSpy = vi.fn(lister);
+    const zedAgent = await makeZedAgent(connection, listerSpy);
 
     const params: acp.LoadSessionRequest = {
       sessionId: 'dup-session',
@@ -383,14 +469,168 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     await zedAgent.loadSession(params);
     await zedAgent.loadSession(params);
 
-    // The prior session's agent was disposed when the second load replaced it.
+    // The probe was consulted on the second load (a live session existed) and,
+    // finding a matching file, routed to the disk path.
+    expect(listerSpy).toHaveBeenCalledTimes(1);
+    // Disk path: a fresh agent was built + resumed for the reconnect...
+    expect(mockFromConfig).toHaveBeenCalledTimes(2);
+    expect(secondStub.resume).toHaveBeenCalledWith('dup-session');
+    // ...and the prior session's agent was disposed when the second load replaced it.
     expect(firstStub.dispose).toHaveBeenCalledTimes(1);
-    // Both loads streamed their respective transcripts.
+    // Both loads streamed their respective (disk-resumed) transcripts.
     const agentTexts = connection
       .onlySessionUpdates()
       .filter((u) => u.sessionUpdate === 'agent_message_chunk')
       .map((u) => (u as { content: { text: string } }).content.text);
     expect(agentTexts).toStrictEqual(['first load', 'second load']);
+  });
+
+  // ─── #1604: re-attach live unprompted sessions on session/load ────────────
+
+  it('RE-ATTACHES a just-created unprompted session on immediate loadSession: succeeds with modes, ZERO replay updates, original session preserved (promptable), fromConfig NOT called again, nothing disposed', async () => {
+    // A fresh session created via newSession with no prompt: empty live history
+    // (zero replay), and a stream that completes so a later prompt proves the
+    // ORIGINAL session object is still live.
+    const stub = buildStubAgent({ liveHistory: [], streamText: 'still alive' });
+    // Clean baseline for the strict fromConfig build-count assertions below (the
+    // module-level mock accumulates across tests; no beforeEach reset here).
+    mockFromConfig.mockReset();
+    mockFromConfig.mockResolvedValue(stub.agent);
+
+    const connection = new RecordingConnection();
+    // Empty chats dir → no on-disk recording for the unprompted session → the
+    // load must RE-ATTACH rather than destroy-and-resume.
+    const zedAgent = await makeZedAgent(connection, emptyChatsLister);
+
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.NewSessionRequest);
+    // newSession built exactly one agent.
+    expect(mockFromConfig).toHaveBeenCalledTimes(1);
+
+    const response = await zedAgent.loadSession({
+      sessionId: created.sessionId,
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest);
+
+    // Succeeds and advertises modes (ACP loadSession conformance on a live,
+    // never-prompted session — no resourceNotFound).
+    expect(response.modes?.currentModeId).toBe('default');
+    expect(response.modes?.availableModes.map((m) => m.id)).toContain(
+      'default',
+    );
+    // ZERO replay updates: an unprompted session has no history to replay.
+    expect(connection.sessionUpdateKinds()).toStrictEqual([]);
+    // The live in-memory history was consulted (re-attach path), and the disk
+    // resume was NOT taken.
+    expect(stub.getHistory).toHaveBeenCalledTimes(1);
+    expect(stub.resume).toHaveBeenCalledTimes(0);
+    // No SECOND agent was built — the ORIGINAL session was re-attached, not
+    // rebuilt.
+    expect(mockFromConfig).toHaveBeenCalledTimes(1);
+    // Nothing was disposed: the live session survived the load.
+    expect(stub.dispose).toHaveBeenCalledTimes(0);
+
+    // The ORIGINAL session is still live and promptable after the re-attach.
+    await expect(
+      zedAgent.prompt({
+        sessionId: created.sessionId,
+        prompt: [{ type: 'text', text: 'are you there?' }],
+      } as acp.PromptRequest),
+    ).resolves.toBeDefined();
+    // Still the SAME agent (never rebuilt/disposed) served the prompt.
+    expect(mockFromConfig).toHaveBeenCalledTimes(1);
+    expect(stub.dispose).toHaveBeenCalledTimes(0);
+  });
+
+  it('RE-ATTACH replays the live in-memory transcript (from getHistory) when an unprompted session was loaded after some in-memory turns, without a disk resume', async () => {
+    // A live session whose in-memory history has content but which has NOT yet
+    // materialized a recording file (empty chats dir): re-attach must replay the
+    // LIVE history (getHistory), not the disk resume fixture.
+    const stub = buildStubAgent({
+      liveHistory: [modelMessage('live reattach text')],
+      // resumeHistory is deliberately DIFFERENT so a wrong (disk) path is visible.
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'DISK not used' }] },
+      ],
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection, emptyChatsLister);
+
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.NewSessionRequest);
+
+    await zedAgent.loadSession({
+      sessionId: created.sessionId,
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest);
+
+    // The live transcript was replayed via getHistory; resume was NOT called.
+    expect(stub.getHistory).toHaveBeenCalledTimes(1);
+    expect(stub.resume).toHaveBeenCalledTimes(0);
+    const agentTexts = connection
+      .onlySessionUpdates()
+      .filter((u) => u.sessionUpdate === 'agent_message_chunk')
+      .map((u) => (u as { content: { text: string } }).content.text);
+    expect(agentTexts).toStrictEqual(['live reattach text']);
+    // Live session preserved (re-attach never disposes a healthy session).
+    expect(stub.dispose).toHaveBeenCalledTimes(0);
+  });
+
+  it('RE-ATTACH propagates a wrapped internalError WITHOUT disposing the healthy live session when replay delivery fails', async () => {
+    const stub = buildStubAgent({
+      liveHistory: [modelMessage('will fail to deliver')],
+    });
+    // Clean baseline for the fromConfig build-count assertion below.
+    mockFromConfig.mockReset();
+    mockFromConfig.mockResolvedValue(stub.agent);
+
+    const connection = new RecordingConnection();
+    // Dead transport: the first (and only) replay update rejects.
+    connection.failSessionUpdateAfter(0, new Error('transport is dead'));
+    const zedAgent = await makeZedAgent(connection, emptyChatsLister);
+
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.NewSessionRequest);
+
+    let caught: unknown;
+    try {
+      await zedAgent.loadSession({
+        sessionId: created.sessionId,
+        cwd: '/project',
+        mcpServers: [],
+      } as acp.LoadSessionRequest);
+    } catch (e) {
+      caught = e;
+    }
+
+    // A lost re-attach transcript surfaces as a wrapped internalError (replay
+    // phase), mirroring the disk path's strict-replay contract.
+    expect(caught).toBeInstanceOf(RequestError);
+    expect((caught as RequestError).code).toBe(-32603);
+    expect((caught as RequestError).message).toContain('replay');
+    // CRUCIAL re-attach cleanup semantics: the healthy live session is NOT
+    // disposed on a replay failure (it was never destroyed), so it is still
+    // live and promptable — unlike the disk path which disposes on replay failure.
+    expect(stub.dispose).toHaveBeenCalledTimes(0);
+    // clearing the transport, the SAME live session still serves a prompt.
+    connection.clearSessionUpdateFailure();
+    await expect(
+      zedAgent.prompt({
+        sessionId: created.sessionId,
+        prompt: [{ type: 'text', text: 'recovered?' }],
+      } as acp.PromptRequest),
+    ).resolves.toBeDefined();
+    expect(mockFromConfig).toHaveBeenCalledTimes(1);
   });
 
   // ─── FINDING A: strict history-replay delivery ────────────────────────────
@@ -550,7 +790,12 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
       .mockResolvedValueOnce(secondStub.agent);
 
     const connection = new RecordingConnection();
-    const zedAgent = await makeZedAgent(connection);
+    // Recorded session: the second (serialized) load must take the disk-resume
+    // replace path, so the injected probe reports a matching on-disk file.
+    const zedAgent = await makeZedAgent(
+      connection,
+      recordedFilesLister('concurrent-session'),
+    );
 
     const params: acp.LoadSessionRequest = {
       sessionId: 'concurrent-session',

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -25,7 +25,7 @@
  * is asserted without a provider bootstrap.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import type * as acp from '@agentclientprotocol/sdk';
@@ -209,6 +209,18 @@ async function makeZedAgent(
 }
 
 describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
+  // FINDING F2: reset the module-level fromConfig mock before EVERY test so no
+  // test inherits queued mockResolvedValueOnce implementations or accumulated
+  // call counts from a prior test. Each test then establishes its OWN
+  // resolved-value expectation (single mockResolvedValue or ordered
+  // mockResolvedValueOnce chain), so the strict build-count / call-order
+  // assertions are self-contained and order-independent. This replaces the
+  // scattered inline mockFromConfig.mockReset() calls the individual tests used
+  // to need.
+  beforeEach(() => {
+    mockFromConfig.mockReset();
+  });
+
   it('initialize() advertises loadSession: true', async () => {
     const connection = new RecordingConnection();
     const mod = await import('./zedIntegration.js');
@@ -443,10 +455,9 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
         { speaker: 'ai', blocks: [{ type: 'text', text: 'second load' }] },
       ],
     });
-    // The module-level fromConfig mock accumulates calls across tests (no
-    // beforeEach reset in this file); reset it so this test's build-count
-    // assertion has a clean baseline and its two agents are returned in order.
-    mockFromConfig.mockReset();
+    // The top-level beforeEach (FINDING F2) already reset the mock; this test
+    // just establishes its ordered two-agent resolution for the build-count
+    // assertion below.
     mockFromConfig
       .mockResolvedValueOnce(firstStub.agent)
       .mockResolvedValueOnce(secondStub.agent);
@@ -492,9 +503,8 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     // (zero replay), and a stream that completes so a later prompt proves the
     // ORIGINAL session object is still live.
     const stub = buildStubAgent({ liveHistory: [], streamText: 'still alive' });
-    // Clean baseline for the strict fromConfig build-count assertions below (the
-    // module-level mock accumulates across tests; no beforeEach reset here).
-    mockFromConfig.mockReset();
+    // The top-level beforeEach (F2) reset the mock; set this test's single
+    // resolution for the strict fromConfig build-count assertions below.
     mockFromConfig.mockResolvedValue(stub.agent);
 
     const connection = new RecordingConnection();
@@ -588,8 +598,8 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     const stub = buildStubAgent({
       liveHistory: [modelMessage('will fail to deliver')],
     });
-    // Clean baseline for the fromConfig build-count assertion below.
-    mockFromConfig.mockReset();
+    // beforeEach (F2) already reset the mock; set this test's single resolution
+    // for the fromConfig build-count assertion below.
     mockFromConfig.mockResolvedValue(stub.agent);
 
     const connection = new RecordingConnection();
@@ -781,10 +791,8 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
       ],
     });
 
-    // The module-level fromConfig mock accumulates calls across tests (no
-    // beforeEach reset in this file); reset it so this test's build-count
-    // assertion has a clean baseline and its two agents are returned in order.
-    mockFromConfig.mockReset();
+    // The top-level beforeEach (F2) already reset the mock; establish this
+    // test's ordered two-agent resolution for the build-count assertion below.
     mockFromConfig
       .mockResolvedValueOnce(firstAgent)
       .mockResolvedValueOnce(secondStub.agent);

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -5,24 +5,24 @@
  */
 
 /**
- * Behavioral tests for ACP session/load (loadSession) in the Zed integration
- * (issue #1604). Two honest layers:
+ * Behavioral tests for ACP session/load (loadSession) ORCHESTRATION in the Zed
+ * integration (issue #1604). This drives the REAL ZedAgent with a stubbed
+ * `fromConfig` whose agent.session.resume returns a fixed IContent[] (or
+ * rejects). It asserts the restored conversation is streamed to the client
+ * (RecordingConnection) as ordered session/update notifications BEFORE
+ * loadSession resolves, that the response advertises modes, that an unknown
+ * session rejects with the chosen RequestError, that a duplicate load replaces
+ * the prior session, and — for the second review round — that a failing
+ * history-replay transport fully cleans up (no stale entry / leaked lock) so a
+ * retry loads cleanly (FINDING A).
  *
- *  1. IContent -> ACP SessionUpdate mapping (mapHistoryToSessionUpdates):
- *     asserts EXACT v1 snake_case wire payload shapes for every block kind, so a
- *     regression in the discriminators or field names is caught structurally.
- *
- *  2. ZedAgent.loadSession orchestration: drives the REAL ZedAgent with a stubbed
- *     `fromConfig` whose agent.session.resume returns a fixed IContent[]. Asserts
- *     the restored conversation is streamed to the client (RecordingConnection)
- *     as ordered session/update notifications BEFORE loadSession resolves, that
- *     the response advertises modes, that an unknown session rejects with the
- *     chosen RequestError, and that a duplicate load replaces the prior session.
- *
- * The record->resume->history FIDELITY is proven separately by the agents-package
- * behavioral tests (sessionControl.recording.behavior.test.ts) against the REAL
- * recording services; here the resume return value is a fixed fixture so the
- * mapping + orchestration are asserted without a provider bootstrap.
+ * The pure IContent -> ACP SessionUpdate MAPPING (mapHistoryToSessionUpdates,
+ * exact wire shapes + ordered tool pairing + MCP extraction) is asserted
+ * separately in zed-session-replay.test.ts; the record->resume->history FIDELITY
+ * is proven by the agents-package behavioral tests
+ * (sessionControl.recording.behavior.test.ts) against the REAL recording
+ * services. Here the resume return value is a fixed fixture so the orchestration
+ * is asserted without a provider bootstrap.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -31,7 +31,6 @@ import { RequestError } from '@agentclientprotocol/sdk';
 import type { Config, IContent } from '@vybestack/llxprt-code-core';
 import type { Agent } from '@vybestack/llxprt-code-agents';
 
-import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
 import { RecordingConnection } from './zed-test-helpers.js';
 
 const mockFromConfig = vi.hoisted(() => vi.fn());
@@ -52,410 +51,6 @@ vi.mock('@vybestack/llxprt-code-providers/runtime.js', () => ({
   loadProfileByName: vi.fn(),
   setCliRuntimeContext: vi.fn(),
 }));
-
-// ─── Layer 1: pure mapping (exact v1 snake_case wire shapes) ─────────────────
-
-describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
-  it('maps a human text block to a user_message_chunk', () => {
-    const history: IContent[] = [
-      { speaker: 'human', blocks: [{ type: 'text', text: 'hello there' }] },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'user_message_chunk',
-        content: { type: 'text', text: 'hello there' },
-      },
-    ]);
-  });
-
-  it('maps an ai text block to an agent_message_chunk', () => {
-    const history: IContent[] = [
-      { speaker: 'ai', blocks: [{ type: 'text', text: 'the answer' }] },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: 'the answer' },
-      },
-    ]);
-  });
-
-  it('maps an ai thinking block to an agent_thought_chunk carrying the thought text', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'ai',
-        blocks: [{ type: 'thinking', thought: 'let me reason' }],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'agent_thought_chunk',
-        content: { type: 'text', text: 'let me reason' },
-      },
-    ]);
-  });
-
-  it('maps a lone ai tool_call (no recorded response) to an in_progress tool_call matching the live start shape, then a synthetic failed update (FINDING 2/3: orphaned/interrupted turn)', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'ai',
-        blocks: [
-          {
-            type: 'tool_call',
-            id: 'call-1',
-            name: 'read_file',
-            parameters: { absolute_path: '/project/a.ts' },
-          },
-        ],
-      },
-    ];
-    // Live start shape (emitToolCallStart): in_progress, empty content, inferred
-    // locations + kind, rawInput. Because the call has NO paired response in the
-    // history, a terminal failed tool_call_update (empty content) is synthesized
-    // so the client does not render a perpetually-running tool.
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'tool_call',
-        toolCallId: 'call-1',
-        title: 'read_file',
-        status: 'in_progress',
-        content: [],
-        locations: [{ path: '/project/a.ts' }],
-        kind: 'read',
-        rawInput: { absolute_path: '/project/a.ts' },
-      },
-      {
-        sessionUpdate: 'tool_call_update',
-        toolCallId: 'call-1',
-        status: 'failed',
-        content: [],
-      },
-    ]);
-  });
-
-  it('maps a tool tool_response block to a completed tool_call_update with text content', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 'call-1',
-            toolName: 'read_file',
-            result: 'file body contents',
-          },
-        ],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'tool_call_update',
-        toolCallId: 'call-1',
-        status: 'completed',
-        content: [
-          {
-            type: 'content',
-            content: { type: 'text', text: 'file body contents' },
-          },
-        ],
-      },
-    ]);
-  });
-
-  it('maps a { output } success result to a completed tool_call_update carrying the output text (FINDING 3)', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 'call-out',
-            toolName: 'run_shell_command',
-            result: { output: 'x' },
-          },
-        ],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'tool_call_update',
-        toolCallId: 'call-out',
-        status: 'completed',
-        content: [{ type: 'content', content: { type: 'text', text: 'x' } }],
-      },
-    ]);
-  });
-
-  it('maps a { error } result to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 'call-err',
-            toolName: 'run_shell_command',
-            result: { error: 'y' },
-          },
-        ],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'tool_call_update',
-        toolCallId: 'call-err',
-        status: 'failed',
-        content: [{ type: 'content', content: { type: 'text', text: 'y' } }],
-      },
-    ]);
-  });
-
-  it('maps a tool_response whose block.error is set to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 'call-boom',
-            toolName: 'write_file',
-            result: {},
-            error: 'permission denied',
-          },
-        ],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'tool_call_update',
-        toolCallId: 'call-boom',
-        status: 'failed',
-        content: [
-          {
-            type: 'content',
-            content: { type: 'text', text: 'permission denied' },
-          },
-        ],
-      },
-    ]);
-  });
-
-  it('emits an empty content array for a tool_response with no representable text', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 'call-2',
-            toolName: 'secret_tool',
-            result: {},
-          },
-        ],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'tool_call_update',
-        toolCallId: 'call-2',
-        status: 'completed',
-        content: [],
-      },
-    ]);
-  });
-
-  it('skips whitespace-only text and skips media/code blocks (v1 replay)', () => {
-    const history: IContent[] = [
-      { speaker: 'ai', blocks: [{ type: 'text', text: '   ' }] },
-      {
-        speaker: 'ai',
-        blocks: [
-          {
-            type: 'media',
-            mimeType: 'image/png',
-            data: 'AAAA',
-            encoding: 'base64',
-          },
-          { type: 'code', code: 'const x = 1;' },
-        ],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
-  });
-
-  it('omits kind for an unknown tool name but still emits the in_progress tool_call (with no inferable locations)', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'ai',
-        blocks: [
-          {
-            type: 'tool_call',
-            id: 'call-x',
-            name: 'totally_unknown_tool',
-            parameters: { foo: 'bar' },
-          },
-        ],
-      },
-    ];
-    const [update] = mapHistoryToSessionUpdates(history);
-    expect(update).toStrictEqual({
-      sessionUpdate: 'tool_call',
-      toolCallId: 'call-x',
-      title: 'totally_unknown_tool',
-      status: 'in_progress',
-      content: [],
-      locations: [],
-      rawInput: { foo: 'bar' },
-    });
-    expect('kind' in update).toBe(false);
-  });
-
-  it('pairs an ai tool_call with its later tool_response: in_progress start THEN completed update, no synthetic failure (FINDING 2/3 ordered pairing)', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'ai',
-        blocks: [
-          {
-            type: 'tool_call',
-            id: 'paired-1',
-            name: 'read_file',
-            parameters: { absolute_path: '/project/z.ts' },
-          },
-        ],
-      },
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 'paired-1',
-            toolName: 'read_file',
-            result: { output: 'paired body' },
-          },
-        ],
-      },
-    ];
-    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
-      {
-        sessionUpdate: 'tool_call',
-        toolCallId: 'paired-1',
-        title: 'read_file',
-        status: 'in_progress',
-        content: [],
-        locations: [{ path: '/project/z.ts' }],
-        kind: 'read',
-        rawInput: { absolute_path: '/project/z.ts' },
-      },
-      {
-        sessionUpdate: 'tool_call_update',
-        toolCallId: 'paired-1',
-        status: 'completed',
-        content: [
-          { type: 'content', content: { type: 'text', text: 'paired body' } },
-        ],
-      },
-    ]);
-  });
-
-  it('orders pairing across a multi-tool conversation: each call starts in_progress and completes from its own response (FINDING 2/3)', () => {
-    const history: IContent[] = [
-      {
-        speaker: 'ai',
-        blocks: [
-          {
-            type: 'tool_call',
-            id: 't1',
-            name: 'read_file',
-            parameters: { absolute_path: '/a' },
-          },
-          {
-            type: 'tool_call',
-            id: 't2',
-            name: 'run_shell_command',
-            parameters: { command: 'ls' },
-          },
-        ],
-      },
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 't1',
-            toolName: 'read_file',
-            result: { output: 'first' },
-          },
-        ],
-      },
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 't2',
-            toolName: 'run_shell_command',
-            result: { error: 'boom' },
-          },
-        ],
-      },
-    ];
-    expect(
-      mapHistoryToSessionUpdates(history).map((u) => ({
-        kind: u.sessionUpdate,
-        id: (u as { toolCallId?: string }).toolCallId,
-        status: (u as { status?: string }).status,
-      })),
-    ).toStrictEqual([
-      { kind: 'tool_call', id: 't1', status: 'in_progress' },
-      { kind: 'tool_call', id: 't2', status: 'in_progress' },
-      { kind: 'tool_call_update', id: 't1', status: 'completed' },
-      { kind: 'tool_call_update', id: 't2', status: 'failed' },
-    ]);
-  });
-
-  it('preserves whole-conversation order across a multi-block transcript', () => {
-    const history: IContent[] = [
-      { speaker: 'human', blocks: [{ type: 'text', text: 'do a thing' }] },
-      {
-        speaker: 'ai',
-        blocks: [
-          { type: 'thinking', thought: 'planning' },
-          { type: 'text', text: 'working on it' },
-          {
-            type: 'tool_call',
-            id: 'c1',
-            name: 'run_shell_command',
-            parameters: { command: 'ls' },
-          },
-        ],
-      },
-      {
-        speaker: 'tool',
-        blocks: [
-          {
-            type: 'tool_response',
-            callId: 'c1',
-            toolName: 'run_shell_command',
-            result: 'a.ts b.ts',
-          },
-        ],
-      },
-      { speaker: 'ai', blocks: [{ type: 'text', text: 'done' }] },
-    ];
-    expect(
-      mapHistoryToSessionUpdates(history).map((u) => u.sessionUpdate),
-    ).toStrictEqual([
-      'user_message_chunk',
-      'agent_thought_chunk',
-      'agent_message_chunk',
-      'tool_call',
-      'tool_call_update',
-      'agent_message_chunk',
-    ]);
-  });
-});
-
-// ─── Layer 2: ZedAgent.loadSession orchestration ────────────────────────────
 
 interface StubAgentHandle {
   readonly agent: Agent;
@@ -778,5 +373,107 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
       .filter((u) => u.sessionUpdate === 'agent_message_chunk')
       .map((u) => (u as { content: { text: string } }).content.text);
     expect(agentTexts).toStrictEqual(['first load', 'second load']);
+  });
+
+  // ─── FINDING A: strict history-replay delivery ────────────────────────────
+
+  it('rejects with internalError and fully cleans up when history replay delivery FAILS on the very first update (FINDING A)', async () => {
+    const stub = buildStubAgent({
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'lost transcript' }] },
+      ],
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+
+    const connection = new RecordingConnection();
+    // Dead transport: every session/update rejects, starting with the first.
+    connection.failSessionUpdateAfter(0, new Error('transport is dead'));
+    const zedAgent = await makeZedAgent(connection);
+
+    const params: acp.LoadSessionRequest = {
+      sessionId: 'replay-fail-session',
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest;
+
+    let caught: unknown;
+    try {
+      await zedAgent.loadSession(params);
+    } catch (e) {
+      caught = e;
+    }
+
+    // A lost transcript must NOT resolve as success: it is an internal error.
+    expect(caught).toBeInstanceOf(RequestError);
+    expect((caught as RequestError).code).toBe(-32603);
+    expect((caught as RequestError).message).toContain('replay');
+    // The fresh agent was disposed exactly once (releasing the recording lock).
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
+    // No transcript survived, and NO stale session entry remains: prompting the
+    // id fails with "Session not found".
+    await expect(
+      zedAgent.prompt({
+        sessionId: 'replay-fail-session',
+        prompt: [{ type: 'text', text: 'hello?' }],
+      } as acp.PromptRequest),
+    ).rejects.toThrow(/Session not found/);
+  });
+
+  it('cleans up on a PARTIAL replay failure (first N updates delivered, then a mid-stream failure) and a later retry loads cleanly (FINDING A)', async () => {
+    const history: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'q1' }] },
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'a1' }] },
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'a2-never-delivered' }] },
+    ];
+    const failingStub = buildStubAgent({ resumeHistory: history });
+    const retryStub = buildStubAgent({
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'retry ok' }] },
+      ],
+    });
+    mockFromConfig
+      .mockResolvedValueOnce(failingStub.agent)
+      .mockResolvedValueOnce(retryStub.agent);
+
+    const connection = new RecordingConnection();
+    // Deliver the first two updates, then fail the third mid-replay.
+    connection.failSessionUpdateAfter(2, new Error('socket closed mid-replay'));
+    const zedAgent = await makeZedAgent(connection);
+
+    const params: acp.LoadSessionRequest = {
+      sessionId: 'partial-fail-session',
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest;
+
+    let caught: unknown;
+    try {
+      await zedAgent.loadSession(params);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(RequestError);
+    expect((caught as RequestError).code).toBe(-32603);
+    // The two updates that DID land are recorded; the third failed the load.
+    expect(connection.sessionUpdateKinds()).toStrictEqual([
+      'user_message_chunk',
+      'agent_message_chunk',
+    ]);
+    // Full cleanup even on partial delivery: fresh agent disposed once.
+    expect(failingStub.dispose).toHaveBeenCalledTimes(1);
+
+    // Transport recovers before the retry.
+    connection.clearSessionUpdateFailure();
+
+    // A subsequent load for the SAME id (transport now healthy) succeeds and
+    // installs cleanly, proving no leaked lock / stale entry blocked the retry.
+    const response = await zedAgent.loadSession(params);
+    expect(response.modes?.currentModeId).toBe('default');
+    const agentTexts = connection
+      .onlySessionUpdates()
+      .filter((u) => u.sessionUpdate === 'agent_message_chunk')
+      .map((u) => (u as { content: { text: string } }).content.text);
+    // 'a1' from the failed load, then 'retry ok' from the successful retry.
+    expect(agentTexts).toStrictEqual(['a1', 'retry ok']);
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -163,11 +163,12 @@ function buildBaseConfig(): Config {
     getTargetDir: () => '/project',
     getMaxSessionTurns: () => 50,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
-    // storage.getProjectTempDir(); point it at a dir that never exists so the
+    // storage.getProjectChatsDir(); point it at a dir that never exists so the
     // disk-resume probe's REAL readdir hits ENOENT (falling back to the plain
     // mapping) while the injected re-attach lister decides the re-attach branch.
     storage: {
       getProjectTempDir: () => NONEXISTENT_CHATS_PARENT,
+      getProjectChatsDir: () => path.join(NONEXISTENT_CHATS_PARENT, 'chats'),
     },
   } as unknown as Config;
 }

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -95,7 +95,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     ]);
   });
 
-  it('maps an ai tool_call block to a completed tool_call with inferred kind + rawInput', () => {
+  it('maps a lone ai tool_call (no recorded response) to an in_progress tool_call matching the live start shape, then a synthetic failed update (FINDING 2/3: orphaned/interrupted turn)', () => {
     const history: IContent[] = [
       {
         speaker: 'ai',
@@ -109,14 +109,26 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
         ],
       },
     ];
+    // Live start shape (emitToolCallStart): in_progress, empty content, inferred
+    // locations + kind, rawInput. Because the call has NO paired response in the
+    // history, a terminal failed tool_call_update (empty content) is synthesized
+    // so the client does not render a perpetually-running tool.
     expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
       {
         sessionUpdate: 'tool_call',
         toolCallId: 'call-1',
         title: 'read_file',
-        status: 'completed',
+        status: 'in_progress',
+        content: [],
+        locations: [{ path: '/project/a.ts' }],
         kind: 'read',
         rawInput: { absolute_path: '/project/a.ts' },
+      },
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-1',
+        status: 'failed',
+        content: [],
       },
     ]);
   });
@@ -144,6 +156,84 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
           {
             type: 'content',
             content: { type: 'text', text: 'file body contents' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('maps a { output } success result to a completed tool_call_update carrying the output text (FINDING 3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-out',
+            toolName: 'run_shell_command',
+            result: { output: 'x' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-out',
+        status: 'completed',
+        content: [{ type: 'content', content: { type: 'text', text: 'x' } }],
+      },
+    ]);
+  });
+
+  it('maps a { error } result to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-err',
+            toolName: 'run_shell_command',
+            result: { error: 'y' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-err',
+        status: 'failed',
+        content: [{ type: 'content', content: { type: 'text', text: 'y' } }],
+      },
+    ]);
+  });
+
+  it('maps a tool_response whose block.error is set to a FAILED tool_call_update carrying the error text (FINDING 3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-boom',
+            toolName: 'write_file',
+            result: {},
+            error: 'permission denied',
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-boom',
+        status: 'failed',
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: 'permission denied' },
           },
         ],
       },
@@ -193,7 +283,7 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
     expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
   });
 
-  it('omits kind for an unknown tool name but still emits the tool_call', () => {
+  it('omits kind for an unknown tool name but still emits the in_progress tool_call (with no inferable locations)', () => {
     const history: IContent[] = [
       {
         speaker: 'ai',
@@ -212,10 +302,115 @@ describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
       sessionUpdate: 'tool_call',
       toolCallId: 'call-x',
       title: 'totally_unknown_tool',
-      status: 'completed',
+      status: 'in_progress',
+      content: [],
+      locations: [],
       rawInput: { foo: 'bar' },
     });
     expect('kind' in update).toBe(false);
+  });
+
+  it('pairs an ai tool_call with its later tool_response: in_progress start THEN completed update, no synthetic failure (FINDING 2/3 ordered pairing)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'paired-1',
+            name: 'read_file',
+            parameters: { absolute_path: '/project/z.ts' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'paired-1',
+            toolName: 'read_file',
+            result: { output: 'paired body' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'paired-1',
+        title: 'read_file',
+        status: 'in_progress',
+        content: [],
+        locations: [{ path: '/project/z.ts' }],
+        kind: 'read',
+        rawInput: { absolute_path: '/project/z.ts' },
+      },
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'paired-1',
+        status: 'completed',
+        content: [
+          { type: 'content', content: { type: 'text', text: 'paired body' } },
+        ],
+      },
+    ]);
+  });
+
+  it('orders pairing across a multi-tool conversation: each call starts in_progress and completes from its own response (FINDING 2/3)', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 't1',
+            name: 'read_file',
+            parameters: { absolute_path: '/a' },
+          },
+          {
+            type: 'tool_call',
+            id: 't2',
+            name: 'run_shell_command',
+            parameters: { command: 'ls' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 't1',
+            toolName: 'read_file',
+            result: { output: 'first' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 't2',
+            toolName: 'run_shell_command',
+            result: { error: 'boom' },
+          },
+        ],
+      },
+    ];
+    expect(
+      mapHistoryToSessionUpdates(history).map((u) => ({
+        kind: u.sessionUpdate,
+        id: (u as { toolCallId?: string }).toolCallId,
+        status: (u as { status?: string }).status,
+      })),
+    ).toStrictEqual([
+      { kind: 'tool_call', id: 't1', status: 'in_progress' },
+      { kind: 'tool_call', id: 't2', status: 'in_progress' },
+      { kind: 'tool_call_update', id: 't1', status: 'completed' },
+      { kind: 'tool_call_update', id: 't2', status: 'failed' },
+    ]);
   });
 
   it('preserves whole-conversation order across a multi-block transcript', () => {
@@ -434,6 +629,118 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     expect(stub.dispose).toHaveBeenCalledTimes(1);
     // No transcript was streamed for a failed load.
     expect(connection.sessionUpdateKinds()).toStrictEqual([]);
+  });
+
+  it('maps a non-not-found resume failure (locked/corrupt) to RequestError.internalError (code -32603) carrying the underlying detail (FINDING 4)', async () => {
+    const stub = buildStubAgent({
+      resumeError: new Error(
+        'Failed to resume session: Failed to replay session: Missing or corrupt session_start event',
+      ),
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection);
+
+    let caught: unknown;
+    try {
+      await zedAgent.loadSession({
+        sessionId: 'corrupt-session',
+        cwd: '/project',
+        mcpServers: [],
+      } as acp.LoadSessionRequest);
+    } catch (e) {
+      caught = e;
+    }
+
+    // A corrupt/locked reason is NOT resourceNotFound: it is surfaced as an
+    // internal error so the client sees the session exists but could not load.
+    expect(caught).toBeInstanceOf(RequestError);
+    expect((caught as RequestError).code).toBe(-32603);
+    // The underlying core detail is carried in the message AND the data payload
+    // so the client can show why the load failed (actionable, not "not found").
+    expect((caught as RequestError).message).toContain('corrupt');
+    expect((caught as RequestError).data).toMatchObject({
+      sessionId: 'corrupt-session',
+    });
+    expect(
+      ((caught as RequestError).data as { reason: string }).reason,
+    ).toContain('corrupt');
+    // The freshly built agent was still torn down on the failure path.
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
+    expect(connection.sessionUpdateKinds()).toStrictEqual([]);
+  });
+
+  it('does not leave a stale/half-dead session when the replacement resume fails, and a later successful load for the same id works (FINDING 1)', async () => {
+    // First load succeeds and installs a live in-memory session.
+    const firstStub = buildStubAgent({
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'live session' }] },
+      ],
+    });
+    // Second load (a reconnect) builds a fresh agent whose resume REJECTS: the
+    // prior session was already disposed to release the on-disk lock, so this
+    // must NOT leave a half-dead entry behind.
+    const failingStub = buildStubAgent({
+      resumeError: new Error('Session is in use by another process'),
+    });
+    // Third load (a retry) succeeds again and must cleanly install.
+    const retryStub = buildStubAgent({
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'retry session' }] },
+      ],
+    });
+    mockFromConfig
+      .mockResolvedValueOnce(firstStub.agent)
+      .mockResolvedValueOnce(failingStub.agent)
+      .mockResolvedValueOnce(retryStub.agent);
+
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection);
+
+    const params: acp.LoadSessionRequest = {
+      sessionId: 'lock-session',
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest;
+
+    // 1) Initial successful load installs a live session; nothing disposed yet.
+    await zedAgent.loadSession(params);
+    expect(firstStub.dispose).toHaveBeenCalledTimes(0);
+
+    // 2) Failing reload: surfaces the underlying detail, disposes the fresh
+    // (failing) agent, and leaves NO stale entry for the id.
+    let caught: unknown;
+    try {
+      await zedAgent.loadSession(params);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(RequestError);
+    // 'in use' is a lock reason (not not-found) -> internalError carrying detail.
+    expect((caught as RequestError).code).toBe(-32603);
+    expect((caught as RequestError).message).toContain('in use');
+    // The prior in-memory session was disposed FIRST (to release the on-disk
+    // lock the replacement needs), and the fresh failing agent was disposed on
+    // the failure path — each exactly once.
+    expect(firstStub.dispose).toHaveBeenCalledTimes(1);
+    expect(failingStub.dispose).toHaveBeenCalledTimes(1);
+    // Prompting the id now fails because NO stale entry survived the failed load.
+    await expect(
+      zedAgent.prompt({
+        sessionId: 'lock-session',
+        prompt: [{ type: 'text', text: 'are you there?' }],
+      } as acp.PromptRequest),
+    ).rejects.toThrow(/Session not found/);
+
+    // 3) A subsequent successful load for the SAME id works and streams again.
+    const response = await zedAgent.loadSession(params);
+    expect(response.modes?.currentModeId).toBe('default');
+    const agentTexts = connection
+      .onlySessionUpdates()
+      .filter((u) => u.sessionUpdate === 'agent_message_chunk')
+      .map((u) => (u as { content: { text: string } }).content.text);
+    expect(agentTexts).toStrictEqual(['live session', 'retry session']);
   });
 
   it('replaces a prior loaded session with the same id (reconnect friendliness)', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -163,6 +163,9 @@ function buildBaseConfig(): Config {
     getTargetDir: () => '/project',
     getProjectRoot: () => '/project',
     getMaxSessionTurns: () => 50,
+    // No recording service in loadSession tests — the session lifecycle under
+    // test does not depend on session recording (only the re-attach/resume
+    // probes and session-info hydration paths are exercised here).
     getSessionRecordingService: () => undefined,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
     // storage.getProjectChatsDir(); point it at a dir that never exists so the

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -161,6 +161,7 @@ function buildBaseConfig(): Config {
     getEphemeralSetting: () => undefined,
     getDebugMode: () => false,
     getTargetDir: () => '/project',
+    getProjectRoot: () => '/project',
     getMaxSessionTurns: () => 50,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
     // storage.getProjectChatsDir(); point it at a dir that never exists so the
@@ -222,6 +223,134 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     mockFromConfig.mockReset();
   });
 
+  it('resumeSession reattaches a live session without replaying history', async () => {
+    const stub = buildStubAgent({
+      liveHistory: [modelMessage('must not replay')],
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection, async () => []);
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    const response = await zedAgent.resumeSession({
+      sessionId: created.sessionId,
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    expect(response.modes?.currentModeId).toBe('default');
+    expect(connection.onlySessionUpdates()).toStrictEqual([]);
+    expect(stub.resume).not.toHaveBeenCalled();
+  });
+
+  it('resumeSession rejects an unknown session without replaying updates', async () => {
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection, async () => []);
+
+    await expect(
+      zedAgent.resumeSession({
+        sessionId: 'missing-session',
+        cwd: '/project',
+        mcpServers: [],
+      }),
+    ).rejects.toMatchObject({ code: -32002 });
+    expect(connection.onlySessionUpdates()).toStrictEqual([]);
+  });
+
+  it('closeSession disposes a live session and is idempotent', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.closeSession({ sessionId: created.sessionId }),
+    ).resolves.toStrictEqual({});
+    await expect(
+      zedAgent.closeSession({ sessionId: created.sessionId }),
+    ).resolves.toStrictEqual({});
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
+    await expect(
+      zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
+    ).rejects.toThrow(/Session not found/);
+  });
+
+  it('resumeSession rejects a live session when cwd does not match', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.resumeSession({
+        sessionId: created.sessionId,
+        cwd: '/project/other',
+        mcpServers: [],
+      }),
+    ).rejects.toMatchObject({ code: -32002 });
+  });
+
+  it('deleteSession succeeds for a live session before recording materializes', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.deleteSession({ sessionId: created.sessionId }),
+    ).resolves.toStrictEqual({});
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
+    await expect(
+      zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
+    ).rejects.toThrow(/Session not found/);
+  });
+
+  it('closeSession keeps a session tracked when agent disposal fails', async () => {
+    const stub = buildStubAgent({});
+    stub.dispose.mockRejectedValueOnce(new Error('dispose failed'));
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.closeSession({ sessionId: created.sessionId }),
+    ).rejects.toThrow('dispose failed');
+    await expect(
+      zedAgent.resumeSession({
+        sessionId: created.sessionId,
+        cwd: '/project',
+        mcpServers: [],
+      }),
+    ).resolves.toMatchObject({ modes: expect.any(Object) });
+  });
+
   it('initialize() advertises loadSession: true', async () => {
     const connection = new RecordingConnection();
     const mod = await import('./zedIntegration.js');
@@ -234,6 +363,12 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     );
     const response = await zedAgent.initialize(buildInitializeRequest());
     expect(response.agentCapabilities?.loadSession).toBe(true);
+    expect(response.agentCapabilities?.sessionCapabilities).toStrictEqual({
+      list: {},
+      resume: {},
+      delete: {},
+      close: {},
+    });
   });
 
   it('streams the restored conversation as ordered session/update notifications and returns modes', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -112,6 +112,7 @@ function buildStubAgent(options: {
   resumeError?: Error;
   liveHistory?: readonly AgentMessage[];
   streamText?: string;
+  recordingError?: Error;
 }): StubAgentHandle {
   const resume = vi.fn(async () => {
     if (options.resumeError !== undefined) {
@@ -119,7 +120,11 @@ function buildStubAgent(options: {
     }
     return options.resumeHistory ?? [];
   });
-  const setRecording = vi.fn(async () => undefined);
+  const setRecording = vi.fn(async () => {
+    if (options.recordingError !== undefined) {
+      throw options.recordingError;
+    }
+  });
   const dispose = vi.fn(async () => undefined);
   const getHistory = vi.fn(async () => options.liveHistory ?? []);
   const streamText = options.streamText;
@@ -225,6 +230,38 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
   // to need.
   beforeEach(() => {
     mockFromConfig.mockReset();
+  });
+
+  it('continues creating a session when optional recording setup fails', async () => {
+    const stub = buildStubAgent({
+      recordingError: new Error('recording unavailable'),
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      emptyChatsLister,
+    );
+
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    expect(created.sessionId).toStrictEqual(expect.any(String));
+    expect(stub.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes a new session when initial command advertisement fails', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const connection = new RecordingConnection();
+    connection.failSessionUpdateAfter(0, new Error('transport unavailable'));
+    const zedAgent = await makeZedAgent(connection, emptyChatsLister);
+
+    await expect(
+      zedAgent.newSession({ cwd: '/project', mcpServers: [] }),
+    ).rejects.toThrow('transport unavailable');
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
   });
 
   it('resumeSession reattaches a live session without replaying history', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -1,0 +1,475 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for ACP session/load (loadSession) in the Zed integration
+ * (issue #1604). Two honest layers:
+ *
+ *  1. IContent -> ACP SessionUpdate mapping (mapHistoryToSessionUpdates):
+ *     asserts EXACT v1 snake_case wire payload shapes for every block kind, so a
+ *     regression in the discriminators or field names is caught structurally.
+ *
+ *  2. ZedAgent.loadSession orchestration: drives the REAL ZedAgent with a stubbed
+ *     `fromConfig` whose agent.session.resume returns a fixed IContent[]. Asserts
+ *     the restored conversation is streamed to the client (RecordingConnection)
+ *     as ordered session/update notifications BEFORE loadSession resolves, that
+ *     the response advertises modes, that an unknown session rejects with the
+ *     chosen RequestError, and that a duplicate load replaces the prior session.
+ *
+ * The record->resume->history FIDELITY is proven separately by the agents-package
+ * behavioral tests (sessionControl.recording.behavior.test.ts) against the REAL
+ * recording services; here the resume return value is a fixed fixture so the
+ * mapping + orchestration are asserted without a provider bootstrap.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import { RequestError } from '@agentclientprotocol/sdk';
+import type { Config, IContent } from '@vybestack/llxprt-code-core';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+
+import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
+import { RecordingConnection } from './zed-test-helpers.js';
+
+const mockFromConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('@vybestack/llxprt-code-agents', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    fromConfig: (...args: unknown[]) => mockFromConfig(...args),
+  };
+});
+
+vi.mock('@vybestack/llxprt-code-providers/runtime.js', () => ({
+  registerAgentRuntimeFactories: vi.fn(),
+  resetAgentRuntimeFactories: vi.fn(),
+  clearActiveModelParam: vi.fn(),
+  getActiveModelParams: vi.fn(),
+  loadProfileByName: vi.fn(),
+  setCliRuntimeContext: vi.fn(),
+}));
+
+// ─── Layer 1: pure mapping (exact v1 snake_case wire shapes) ─────────────────
+
+describe('mapHistoryToSessionUpdates (issue #1604 replay mapping)', () => {
+  it('maps a human text block to a user_message_chunk', () => {
+    const history: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'hello there' }] },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'hello there' },
+      },
+    ]);
+  });
+
+  it('maps an ai text block to an agent_message_chunk', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'the answer' }] },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'the answer' },
+      },
+    ]);
+  });
+
+  it('maps an ai thinking block to an agent_thought_chunk carrying the thought text', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'thinking', thought: 'let me reason' }],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'agent_thought_chunk',
+        content: { type: 'text', text: 'let me reason' },
+      },
+    ]);
+  });
+
+  it('maps an ai tool_call block to a completed tool_call with inferred kind + rawInput', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-1',
+            name: 'read_file',
+            parameters: { absolute_path: '/project/a.ts' },
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call-1',
+        title: 'read_file',
+        status: 'completed',
+        kind: 'read',
+        rawInput: { absolute_path: '/project/a.ts' },
+      },
+    ]);
+  });
+
+  it('maps a tool tool_response block to a completed tool_call_update with text content', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-1',
+            toolName: 'read_file',
+            result: 'file body contents',
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-1',
+        status: 'completed',
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: 'file body contents' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('emits an empty content array for a tool_response with no representable text', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call-2',
+            toolName: 'secret_tool',
+            result: {},
+          },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-2',
+        status: 'completed',
+        content: [],
+      },
+    ]);
+  });
+
+  it('skips whitespace-only text and skips media/code blocks (v1 replay)', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: '   ' }] },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'media',
+            mimeType: 'image/png',
+            data: 'AAAA',
+            encoding: 'base64',
+          },
+          { type: 'code', code: 'const x = 1;' },
+        ],
+      },
+    ];
+    expect(mapHistoryToSessionUpdates(history)).toStrictEqual([]);
+  });
+
+  it('omits kind for an unknown tool name but still emits the tool_call', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'call-x',
+            name: 'totally_unknown_tool',
+            parameters: { foo: 'bar' },
+          },
+        ],
+      },
+    ];
+    const [update] = mapHistoryToSessionUpdates(history);
+    expect(update).toStrictEqual({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-x',
+      title: 'totally_unknown_tool',
+      status: 'completed',
+      rawInput: { foo: 'bar' },
+    });
+    expect('kind' in update).toBe(false);
+  });
+
+  it('preserves whole-conversation order across a multi-block transcript', () => {
+    const history: IContent[] = [
+      { speaker: 'human', blocks: [{ type: 'text', text: 'do a thing' }] },
+      {
+        speaker: 'ai',
+        blocks: [
+          { type: 'thinking', thought: 'planning' },
+          { type: 'text', text: 'working on it' },
+          {
+            type: 'tool_call',
+            id: 'c1',
+            name: 'run_shell_command',
+            parameters: { command: 'ls' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'c1',
+            toolName: 'run_shell_command',
+            result: 'a.ts b.ts',
+          },
+        ],
+      },
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'done' }] },
+    ];
+    expect(
+      mapHistoryToSessionUpdates(history).map((u) => u.sessionUpdate),
+    ).toStrictEqual([
+      'user_message_chunk',
+      'agent_thought_chunk',
+      'agent_message_chunk',
+      'tool_call',
+      'tool_call_update',
+      'agent_message_chunk',
+    ]);
+  });
+});
+
+// ─── Layer 2: ZedAgent.loadSession orchestration ────────────────────────────
+
+interface StubAgentHandle {
+  readonly agent: Agent;
+  readonly resume: ReturnType<typeof vi.fn>;
+  readonly setRecording: ReturnType<typeof vi.fn>;
+  readonly dispose: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Builds a stub Agent whose session.resume returns the given fixed history (or
+ * rejects with the given error). Captures the resume/setRecording/dispose spies
+ * so orchestration can be asserted without a real provider bootstrap.
+ */
+function buildStubAgent(options: {
+  resumeHistory?: readonly IContent[];
+  resumeError?: Error;
+}): StubAgentHandle {
+  const resume = vi.fn(async () => {
+    if (options.resumeError !== undefined) {
+      throw options.resumeError;
+    }
+    return options.resumeHistory ?? [];
+  });
+  const setRecording = vi.fn(async () => undefined);
+  const dispose = vi.fn(async () => undefined);
+  const agent = {
+    getApprovalMode: () => 'default',
+    setApprovalMode: vi.fn(),
+    dispose,
+    async *stream() {},
+    session: { resume, setRecording },
+    tools: { respondToConfirmation: vi.fn() },
+  } as unknown as Agent;
+  return { agent, resume, setRecording, dispose };
+}
+
+function buildBaseConfig(): Config {
+  return {
+    getFileSystemService: () => ({
+      readTextFile: vi.fn(async () => 'base'),
+      writeTextFile: vi.fn(async () => undefined),
+    }),
+    getProviderManager: () => ({ id: 'base' }),
+    setProviderManager: vi.fn(),
+    getProfileManager: () => undefined,
+    getEphemeralSetting: () => undefined,
+    getDebugMode: () => false,
+    getTargetDir: () => '/project',
+    getMaxSessionTurns: () => 50,
+  } as unknown as Config;
+}
+
+async function makeZedAgent(
+  connection: RecordingConnection,
+): Promise<InstanceType<typeof import('./zedIntegration.js').ZedAgent>> {
+  const mod = await import('./zedIntegration.js');
+  const zedAgent = new mod.ZedAgent(
+    buildBaseConfig(),
+    { debug: () => {} } as never,
+    connection as unknown as acp.AgentSideConnection,
+  );
+  await zedAgent.initialize({
+    protocolVersion: '1',
+    clientCapabilities: {},
+  } as never);
+  return zedAgent;
+}
+
+describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
+  it('initialize() advertises loadSession: true', async () => {
+    const connection = new RecordingConnection();
+    const mod = await import('./zedIntegration.js');
+    const zedAgent = new mod.ZedAgent(
+      buildBaseConfig(),
+      { debug: () => {} } as never,
+      connection as unknown as acp.AgentSideConnection,
+    );
+    const response = await zedAgent.initialize({
+      protocolVersion: '1',
+      clientCapabilities: {},
+    } as never);
+    expect(response.agentCapabilities?.loadSession).toBe(true);
+  });
+
+  it('streams the restored conversation as ordered session/update notifications and returns modes', async () => {
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'earlier question' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          { type: 'thinking', thought: 'recalling' },
+          { type: 'text', text: 'earlier answer' },
+          {
+            type: 'tool_call',
+            id: 'tc-1',
+            name: 'read_file',
+            parameters: { absolute_path: '/project/x.ts' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'tc-1',
+            toolName: 'read_file',
+            result: 'the file text',
+          },
+        ],
+      },
+    ];
+    const stub = buildStubAgent({ resumeHistory: history });
+    mockFromConfig.mockResolvedValue(stub.agent);
+
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection);
+
+    const response = await zedAgent.loadSession({
+      sessionId: 'session-abc',
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest);
+
+    // resume was called with the requested session id.
+    expect(stub.resume).toHaveBeenCalledWith('session-abc');
+
+    // The restored transcript was streamed in order BEFORE loadSession resolved.
+    expect(connection.sessionUpdateKinds()).toStrictEqual([
+      'user_message_chunk',
+      'agent_thought_chunk',
+      'agent_message_chunk',
+      'tool_call',
+      'tool_call_update',
+    ]);
+
+    // The response advertises the available modes + current mode.
+    expect(response.modes?.currentModeId).toBe('default');
+    expect(response.modes?.availableModes.map((m) => m.id)).toContain(
+      'default',
+    );
+  });
+
+  it('rejects an unknown session with RequestError.resourceNotFound (code -32002)', async () => {
+    const stub = buildStubAgent({
+      resumeError: new Error('No sessions found for this project'),
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection);
+
+    let caught: unknown;
+    try {
+      await zedAgent.loadSession({
+        sessionId: 'missing-session',
+        cwd: '/project',
+        mcpServers: [],
+      } as acp.LoadSessionRequest);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(RequestError);
+    expect((caught as RequestError).code).toBe(-32002);
+    expect((caught as RequestError).message).toContain('missing-session');
+    // The freshly built agent was torn down so no lock/recording leaks.
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
+    // No transcript was streamed for a failed load.
+    expect(connection.sessionUpdateKinds()).toStrictEqual([]);
+  });
+
+  it('replaces a prior loaded session with the same id (reconnect friendliness)', async () => {
+    const firstStub = buildStubAgent({
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'first load' }] },
+      ],
+    });
+    const secondStub = buildStubAgent({
+      resumeHistory: [
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'second load' }] },
+      ],
+    });
+    mockFromConfig
+      .mockResolvedValueOnce(firstStub.agent)
+      .mockResolvedValueOnce(secondStub.agent);
+
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection);
+
+    const params: acp.LoadSessionRequest = {
+      sessionId: 'dup-session',
+      cwd: '/project',
+      mcpServers: [],
+    } as acp.LoadSessionRequest;
+
+    await zedAgent.loadSession(params);
+    await zedAgent.loadSession(params);
+
+    // The prior session's agent was disposed when the second load replaced it.
+    expect(firstStub.dispose).toHaveBeenCalledTimes(1);
+    // Both loads streamed their respective transcripts.
+    const agentTexts = connection
+      .onlySessionUpdates()
+      .filter((u) => u.sessionUpdate === 'agent_message_chunk')
+      .map((u) => (u as { content: { text: string } }).content.text);
+    expect(agentTexts).toStrictEqual(['first load', 'second load']);
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -163,6 +163,7 @@ function buildBaseConfig(): Config {
     getTargetDir: () => '/project',
     getProjectRoot: () => '/project',
     getMaxSessionTurns: () => 50,
+    getSessionRecordingService: () => undefined,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
     // storage.getProjectChatsDir(); point it at a dir that never exists so the
     // disk-resume probe's REAL readdir hits ENOENT (falling back to the plain

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -342,7 +342,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
 
     await expect(
       zedAgent.closeSession({ sessionId: created.sessionId }),
-    ).resolves.toEqual({});
+    ).resolves.toStrictEqual({});
     await expect(
       zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
     ).rejects.toThrow(/Session not found/);
@@ -363,8 +363,6 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     expect(response.agentCapabilities?.sessionCapabilities).toStrictEqual({
       list: {},
       resume: {},
-      delete: {},
-      close: {},
     });
   });
 

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -25,9 +25,9 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map((session) => session.dispose()),
+  );
 }
 
 describe('Zed Session.prompt (Agent API) - streaming output', () => {
@@ -806,7 +806,7 @@ describe('Zed Session.prompt (Agent API) - session_info_update (issue #1611)', (
       sessionId: 'test-session-id',
       prompt: [{ type: 'text', text: 'First prompt here' }],
     });
-    connection.messages.length = 0;
+    const firstInfoUpdates = connection.sessionInfoUpdates();
 
     await session.prompt({
       sessionId: 'test-session-id',
@@ -814,9 +814,10 @@ describe('Zed Session.prompt (Agent API) - session_info_update (issue #1611)', (
     });
 
     const infoUpdates = connection.sessionInfoUpdates();
-    expect(infoUpdates).toHaveLength(1);
-    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
-    expect(infoUpdates[0].title).toBeUndefined();
+    expect(firstInfoUpdates).toHaveLength(1);
+    expect(infoUpdates).toHaveLength(2);
+    expect(infoUpdates[1].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[1].title).toBeUndefined();
   });
 
   it('emits updatedAt after a cancelled turn', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -212,6 +212,43 @@ describe('Zed Session.prompt (Agent API) - tool-call status progression', () => 
     expect((updates[2] as { status: string }).status).toBe('completed');
   });
 
+  it('uses the registered tool kind on every live tool notification', async () => {
+    const toolCallId = 'registry-kind';
+    const { agent } = buildFakeAgent(
+      [
+        {
+          type: 'tool-call',
+          call: { id: toolCallId, name: 'custom_lookup', args: {} },
+        },
+        {
+          type: 'tool-status',
+          update: {
+            id: toolCallId,
+            name: 'custom_lookup',
+            status: 'executing',
+          },
+        },
+        {
+          type: 'tool-result',
+          result: { id: toolCallId, name: 'custom_lookup', output: 'found' },
+        },
+        { type: 'done', reason: 'stop' },
+      ],
+      { custom_lookup: 'search' },
+    );
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await runPrompt(session);
+
+    expect(
+      connection
+        .onlySessionUpdates()
+        .map((update) => (update as { kind?: acp.ToolKind }).kind),
+    ).toStrictEqual(['search', 'search', 'search']);
+  });
+
   it('surfaces multiple path locations and known tool kinds', async () => {
     const { agent } = buildFakeAgent([
       {

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -11,6 +11,7 @@ import type { Config } from '@vybestack/llxprt-code-core';
 import { todoEvents } from '@vybestack/llxprt-code-core';
 
 import { Session } from './zedIntegration.js';
+import { STREAM_BLOCKED_MESSAGE } from './zed-stream-batcher.js';
 import {
   buildFakeAgent,
   buildScriptedAgent,
@@ -152,10 +153,7 @@ describe('Zed Session.prompt (Agent API) - streaming output', () => {
     const texts = connection
       .onlySessionUpdates()
       .map((u) => (u as { content: { text: string } }).content.text);
-    expect(texts).toStrictEqual([
-      '[Error: Response blocked due to emoji detection]',
-      'all clean now.',
-    ]);
+    expect(texts).toStrictEqual([STREAM_BLOCKED_MESSAGE, 'all clean now.']);
   });
 });
 

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -165,11 +165,18 @@ describe('Zed Session.prompt (Agent API) - tool-call status progression', () => 
     const startUpdate = updates[0] as {
       locations: acp.ToolCallLocation[];
       status: string;
+      rawInput?: Record<string, unknown>;
     };
     expect(startUpdate.status).toBe('in_progress');
     expect(startUpdate.locations).toStrictEqual([
       { path: '/project/file.txt', line: 7 },
     ]);
+    // FINDING F: the LIVE tool_call start carries rawInput (the tool args) for
+    // parity with the replay start shape and ACP debugging conformance.
+    expect(startUpdate.rawInput).toStrictEqual({
+      absolute_path: '/project/file.txt',
+      offset: 7,
+    });
     expect((updates[1] as { status: string }).status).toBe('in_progress');
     expect((updates[2] as { status: string }).status).toBe('completed');
   });

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -423,6 +423,7 @@ describe('Zed Session.prompt (Agent API) - tool permission round-trip', () => {
       'sessionUpdate',
       'requestPermission',
       'sessionUpdate',
+      'sessionUpdate',
     ]);
     expect(confirmations).toStrictEqual([
       { confirmationId, decision: ToolConfirmationOutcome.ProceedOnce },
@@ -736,5 +737,119 @@ describe('Zed Session (Agent API) - lifecycle', () => {
     });
     await new Promise((r) => setImmediate(r));
     expect(connection.sessionUpdateKinds()).not.toContain('plan');
+  });
+});
+
+describe('Zed Session.prompt (Agent API) - session_info_update (issue #1611)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('emits a session_info_update with a title derived from the first prompt', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Investigate session lifecycle' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBe('Investigate session lifecycle');
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('emits updatedAt on a subsequent prompt without regenerating the title', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'First prompt here' }],
+    });
+    connection.messages.length = 0;
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Second prompt here' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('emits updatedAt after a cancelled turn', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'aborted' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const response = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'A prompt that gets cancelled' }],
+    });
+
+    expect(response.stopReason).toBe('cancelled');
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('emits updatedAt after a failed turn (error event)', async () => {
+    const { agent } = buildFakeAgent([
+      { type: 'error', error: { message: 'kaboom' } },
+    ]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await expect(
+      session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'A prompt that errors' }],
+      }),
+    ).rejects.toThrow(/kaboom/);
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('does not emit a title when the first prompt has no text content', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('exposes the derived title and updatedAt via getLifecycleInfo for the session listing', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Listing title here' }],
+    });
+
+    const info = session.getLifecycleInfo();
+    expect(info.title).toBe('Listing title here');
+    expect(info.updatedAt).toStrictEqual(expect.any(String));
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -124,6 +124,39 @@ describe('Zed Session.prompt (Agent API) - streaming output', () => {
     };
     expect(update.content.text).toContain('blocked due to emoji detection');
   });
+
+  it('flushes the emoji buffer on a blocked chunk so a following clean chunk is emitted (not re-blocked) (FINDING F10)', async () => {
+    // Error mode: the first chunk carries an emoji and is blocked. The blocking
+    // content stays in the EmojiFilter's internal buffer; without flushing it on
+    // the blocked path, the NEXT (clean) chunk would be concatenated with the
+    // stale emoji buffer, re-detected, and blocked again — losing the clean text.
+    const { agent } = buildFakeAgent([
+      { type: 'text', text: 'blocked \u{1F600}' },
+      { type: 'text', text: 'all clean now.' },
+      { type: 'done', reason: 'stop' },
+    ]);
+    const connection = new RecordingConnection();
+    const config = {
+      ...buildMinimalConfig(),
+      getEphemeralSetting: (key: string) =>
+        key === 'emojifilter' ? 'error' : undefined,
+    } as unknown as Config;
+    const session = createSession(agent, connection, config);
+    createdSessions.push(session);
+
+    await runPrompt(session);
+
+    // Exactly ONE blocked error, THEN the clean follow-up text — proving the
+    // buffer was flushed so the clean chunk filtered cleanly instead of being
+    // re-blocked (which would produce a second error and drop 'all clean now.').
+    const texts = connection
+      .onlySessionUpdates()
+      .map((u) => (u as { content: { text: string } }).content.text);
+    expect(texts).toStrictEqual([
+      '[Error: Response blocked due to emoji detection]',
+      'all clean now.',
+    ]);
+  });
 });
 
 describe('Zed Session.prompt (Agent API) - tool-call status progression', () => {

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -126,7 +126,7 @@ describe('Zed Session.prompt (Agent API) - streaming output', () => {
     expect(update.content.text).toContain('blocked due to emoji detection');
   });
 
-  it('flushes the emoji buffer on a blocked chunk so a following clean chunk is emitted (not re-blocked) (FINDING F10)', async () => {
+  it('flushes the emoji buffer on a blocked chunk so a following clean chunk is emitted instead of re-blocked', async () => {
     // Error mode: the first chunk carries an emoji and is blocked. The blocking
     // content stays in the EmojiFilter's internal buffer; without flushing it on
     // the blocked path, the NEXT (clean) chunk would be concatenated with the
@@ -202,8 +202,7 @@ describe('Zed Session.prompt (Agent API) - tool-call status progression', () => 
     expect(startUpdate.locations).toStrictEqual([
       { path: '/project/file.txt', line: 7 },
     ]);
-    // FINDING F: the LIVE tool_call start carries rawInput (the tool args) for
-    // parity with the replay start shape and ACP debugging conformance.
+    // The live tool_call start carries rawInput for replay parity and ACP debugging.
     expect(startUpdate.rawInput).toStrictEqual({
       absolute_path: '/project/file.txt',
       offset: 7,

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -52,7 +52,7 @@ describe('Zed Session - session_info_update findings (issue #1611 remediation)',
           ];
     });
     const connection = new RecordingConnection();
-    const gate = connection.armPermissionGate();
+    const permissionGate = connection.armPermissionGate();
     const session = createSession(agent, connection);
     createdSessions.push(session);
 
@@ -60,7 +60,7 @@ describe('Zed Session - session_info_update findings (issue #1611 remediation)',
       sessionId: 'test-session-id',
       prompt: [{ type: 'text', text: 'Prompt A title' }],
     });
-    await gate.arrived;
+    await permissionGate.arrived;
     const secondPrompt = session.prompt({
       sessionId: 'test-session-id',
       prompt: [{ type: 'text', text: 'Prompt B title' }],

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -85,7 +85,7 @@ describe('Zed Session - session_info_update findings (issue #1611 remediation)',
       sessionId: 'test-session-id',
       prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
     });
-    connection.messages.length = 0;
+    connection.clearSessionInfoUpdates();
 
     await session.prompt({
       sessionId: 'test-session-id',

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -25,9 +25,9 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map((session) => session.dispose()),
+  );
 }
 
 describe('Zed Session - session_info_update findings (issue #1611 remediation)', () => {

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -13,7 +13,7 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { Session } from './zedIntegration.js';
+import type { Session } from './zedIntegration.js';
 import {
   buildFakeAgent,
   buildScriptedAgent,

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for session_info_update remediation findings (issue #1611):
+ * - Finding 1: title eligibility consumed synchronously at acceptance, race-safe.
+ * - Finding 3: slash command success/failure shares exact-once metadata finally.
+ * - Finding 4: pre-turn listing timestamp stable (initialized once).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  buildScriptedAgent,
+  RecordingConnection,
+  createSession,
+  editConfirmation,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  for (const session of createdSessions.splice(0)) {
+    await session.dispose();
+  }
+}
+
+describe('Zed Session - session_info_update findings (issue #1611 remediation)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('finding 1: the first ACCEPTED prompt wins the title even if a later overlapping prompt finishes first', async () => {
+    let promptCount = 0;
+    const { agent } = buildScriptedAgent(() => {
+      promptCount += 1;
+      return promptCount === 1
+        ? [
+            {
+              type: 'tool-call',
+              call: { id: 'race-tool', name: 'edit', args: {} },
+            },
+            editConfirmation('race-conf', 'race-tool'),
+            { type: 'done', reason: 'stop' },
+          ]
+        : [
+            { type: 'text', text: 'second response' },
+            { type: 'done', reason: 'stop' },
+          ];
+    });
+    const connection = new RecordingConnection();
+    const gate = connection.armPermissionGate();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const firstPrompt = session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Prompt A title' }],
+    });
+    await gate.arrived;
+    const secondPrompt = session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Prompt B title' }],
+    });
+    const firstResponse = await firstPrompt;
+    const secondResponse = await secondPrompt;
+
+    expect(firstResponse.stopReason).toBe('cancelled');
+    expect(secondResponse.stopReason).toBe('end_turn');
+
+    const info = session.getLifecycleInfo();
+    expect(info.title).toBe('Prompt A title');
+  });
+
+  it('finding 1: a no-text first prompt consumes eligibility so a later text prompt does not retitle', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
+    });
+    connection.messages.length = 0;
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Should not become the title' }],
+    });
+
+    expect(session.getLifecycleInfo().title).toBeUndefined();
+  });
+
+  it('finding 3: a slash command emits exact-once session_info_update metadata (updatedAt)', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: '/tools' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('finding 3: a slash command as the first text prompt still wins the title (shared finally)', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: '/help me with something' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBe('/help me with something');
+  });
+
+  it('retries a title notification after a transient transport failure without failing either prompt', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    connection.failSessionUpdateAfter(0, new Error('transport down'));
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const first = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Persistent title' }],
+    });
+    expect(first.stopReason).toBe('end_turn');
+    expect(connection.sessionInfoUpdates()).toHaveLength(0);
+
+    connection.clearSessionUpdateFailure();
+    const second = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Second prompt' }],
+    });
+    expect(second.stopReason).toBe('end_turn');
+    expect(connection.sessionInfoUpdates()).toContainEqual(
+      expect.objectContaining({ title: 'Persistent title' }),
+    );
+  });
+
+  it('finding 4: getLifecycleInfo returns a stable updatedAt before the first turn', () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const first = session.getLifecycleInfo();
+    const second = session.getLifecycleInfo();
+    expect(first.updatedAt).toBe(second.updatedAt);
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
@@ -20,9 +20,9 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map((session) => session.dispose()),
+  );
 }
 
 describe('Zed Session.prompt (Agent API) - stale prompt terminal events', () => {
@@ -79,6 +79,40 @@ describe('Zed Session.prompt (Agent API) - stale prompt terminal events', () => 
 
     expect(firstResponse.stopReason).toBe('cancelled');
     expect(secondResponse.stopReason).toBe('end_turn');
+  });
+
+  it('stops consuming a stream at the first event after a prompt becomes stale', async () => {
+    let promptCount = 0;
+    let staleEventsProduced = 0;
+    const { agent } = buildScriptedAgent(() => []);
+    agent.stream = async function* () {
+      promptCount += 1;
+      if (promptCount === 1) {
+        yield {
+          type: 'tool-call',
+          call: { id: 'stale-stop-tool', name: 'edit', args: {} },
+        } as const;
+        yield editConfirmation('stale-stop-confirmation', 'stale-stop-tool');
+        staleEventsProduced += 1;
+        yield { type: 'text', text: 'first stale event' } as const;
+        staleEventsProduced += 1;
+        yield { type: 'text', text: 'second stale event' } as const;
+        return;
+      }
+      yield { type: 'done', reason: 'stop' } as const;
+    };
+    const connection = new RecordingConnection();
+    const gate = connection.armPermissionGate();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const firstPrompt = runPrompt(session);
+    await gate.arrived;
+    const secondPrompt = runPrompt(session);
+    await firstPrompt;
+    await secondPrompt;
+
+    expect(staleEventsProduced).toBe(1);
   });
 
   it('returns cancelled (not an error) when a cancelled prompt ends with done:hook-stopped', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
@@ -27,6 +27,26 @@ async function disposeCreatedSessions(): Promise<void> {
 
 describe('Zed Session.prompt (Agent API) - stale prompt terminal events', () => {
   afterEach(disposeCreatedSessions);
+
+  it('preserves a completed turn when cancellation arrives after done', async () => {
+    const sessionRef: { current: Session | null } = { current: null };
+    const { agent } = buildFakeAgent([]);
+    agent.stream = async function* () {
+      yield { type: 'done', reason: 'stop' } as const;
+      const currentSession = sessionRef.current;
+      if (currentSession === null) throw new Error('Session not initialized');
+      await currentSession.cancelPendingPrompt();
+    };
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    sessionRef.current = session;
+    createdSessions.push(session);
+
+    const response = await runPrompt(session);
+
+    expect(response.stopReason).toBe('end_turn');
+  });
+
   it('returns cancelled (not an error) when a superseded prompt ends with done:error', async () => {
     const toolCallId = 'stale-error-tool';
     let promptCount = 0;

--- a/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for Session.streamHistory restored-session title hydration
+ * (issue #1611 finding 2). Exercises the real streamHistory orchestration that
+ * load/resume uses (not a faked restoration) to verify the title is hydrated
+ * from restored history so a later prompt never retitles the session.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  RecordingConnection,
+  createSession,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  const sessions = createdSessions.splice(0);
+  await Promise.allSettled(sessions.map((session) => session.dispose()));
+}
+
+describe('Zed Session.streamHistory - restored-session title hydration (issue #1611 finding 2)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('hydrates the title from restored history so a later prompt does not retitle', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored session title' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'prior response' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBe('Restored session title');
+
+    connection.messages.length = 0;
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'New prompt after restore' }],
+    });
+
+    expect(session.getLifecycleInfo().title).toBe('Restored session title');
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('does not set a title when restored history has no human text', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'agent-only content' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBeUndefined();
+  });
+
+  it('uses the first human text when restored history has multiple human entries', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'First restored message' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'response one' }],
+      },
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Second restored message' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBe('First restored message');
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
@@ -51,7 +51,7 @@ describe('Zed Session.streamHistory - restored-session title hydration (issue #1
 
     expect(session.getLifecycleInfo().title).toBe('Restored session title');
 
-    connection.messages.length = 0;
+    connection.clearSessionInfoUpdates();
     await session.prompt({
       sessionId: 'test-session-id',
       prompt: [{ type: 'text', text: 'New prompt after restore' }],

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -6,64 +6,34 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import type * as acp from '@agentclientprotocol/sdk';
-import type { Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
 
 import { Session } from './zedIntegration.js';
+import { TerminalManager } from './zed-terminal-manager.js';
 import {
   buildFakeAgent,
-  buildBlockingFakeAgent,
   RecordingConnection,
   buildMinimalConfig,
 } from './zed-test-helpers.js';
 
 const createdSessions: Session[] = [];
+// Mirrors the output of buildCommandToExecute('echo hello', false, '/tmp/shell.tmp')
+// from packages/tools/src/tools/shell-helpers.ts. Update together if the wrapping format changes.
+const preparedEcho =
+  '{ echo hello; }; __code=$?; pgrep -g 0 >/tmp/shell.tmp 2>&1; exit $__code;';
 
-async function disposeCreatedSessions(): Promise<void> {
-  await Promise.allSettled(
-    createdSessions.splice(0).map(async (session) => {
-      try {
-        await session.dispose();
-      } catch {
-        // Continue disposing remaining sessions even if one fails
-      }
-    }),
-  );
-}
-
-function createTerminalSession(
-  events: readonly AgentEvent[],
+function terminalManager(
   connection: RecordingConnection,
-  config: Config = buildMinimalConfig(),
-  terminalEnabled = true,
-): Session {
-  const { agent } = buildFakeAgent(events, { run_shell_command: 'execute' });
-  return new Session(
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void> = (update) =>
+    connection.sessionUpdate({ sessionId: 'test-session-id', update }),
+): TerminalManager {
+  return new TerminalManager(
     'test-session-id',
-    agent,
-    config,
     connection as unknown as acp.AgentSideConnection,
-    false,
-    terminalEnabled,
-  );
-}
-
-function createBlockingTerminalSession(
-  events: readonly AgentEvent[],
-  connection: RecordingConnection,
-  config: Config = buildMinimalConfig(),
-  terminalEnabled = true,
-): Session {
-  const { agent } = buildBlockingFakeAgent(events, {
-    run_shell_command: 'execute',
-  });
-  return new Session(
-    'test-session-id',
-    agent,
-    config,
-    connection as unknown as acp.AgentSideConnection,
-    false,
-    terminalEnabled,
+    '/project',
+    sendUpdate,
+    new DebugLogger('llxprt:zed-terminal-test'),
   );
 }
 
@@ -74,17 +44,6 @@ function shellToolCallEvent(toolCallId: string, command: string): AgentEvent {
       id: toolCallId,
       name: 'run_shell_command',
       args: { command },
-    },
-  };
-}
-
-function shellToolStatusEvent(toolCallId: string): AgentEvent {
-  return {
-    type: 'tool-status',
-    update: {
-      id: toolCallId,
-      name: 'run_shell_command',
-      status: 'executing',
     },
   };
 }
@@ -102,191 +61,179 @@ function shellToolResultEvent(toolCallId: string, output: string): AgentEvent {
 
 const doneEvent: AgentEvent = { type: 'done', reason: 'stop' };
 
-describe('Zed Session — terminal capability integration', () => {
-  afterEach(disposeCreatedSessions);
-
-  describe('terminal-enabled sessions', () => {
-    it('emits terminal content on shell tool calls when terminal capability is present', async () => {
-      const toolCallId = 'shell-1';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('hello');
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'echo hello'),
-          shellToolStatusEvent(toolCallId),
-          shellToolResultEvent(toolCallId, 'hello'),
-          doneEvent,
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'run echo' }],
-      });
-
-      const toolCallUpdates = connection
-        .onlySessionUpdates()
-        .filter(
-          (
-            u,
-          ): u is Extract<acp.SessionUpdate, { sessionUpdate: 'tool_call' }> =>
-            u.sessionUpdate === 'tool_call',
-        );
-      expect(toolCallUpdates).toHaveLength(1);
-      expect(toolCallUpdates[0].kind).toBe('execute');
-
-      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
-        if (u.sessionUpdate !== 'tool_call_update') return false;
-        const content = u.content ?? [];
-        return content.some(
-          (c): c is Extract<typeof c, { type: 'terminal' }> =>
-            c.type === 'terminal',
-        );
-      });
-      expect(hasTerminalContent).toBe(true);
-    });
-
-    it('creates a terminal via connection.createTerminal for shell commands', async () => {
-      const toolCallId = 'shell-create';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('file1\nfile2');
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'ls'),
-          shellToolResultEvent(toolCallId, 'file1\nfile2'),
-          doneEvent,
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'list files' }],
-      });
-
-      expect(connection.createTerminalCalls).toHaveLength(1);
-      const call = connection.createTerminalCalls[0];
-      expect(call.command).toBe('ls');
-      expect(call.sessionId).toBe('test-session-id');
-    });
-
-    it('releases terminals on normal completion', async () => {
-      const toolCallId = 'shell-release';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('done');
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'echo done'),
-          shellToolResultEvent(toolCallId, 'done'),
-          doneEvent,
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'echo' }],
-      });
-
-      expect(connection.releaseCalls).toBe(1);
-    });
-
-    it('kills and releases terminals on cancel', async () => {
-      const toolCallId = 'shell-cancel';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('');
-      connection.delayTerminalExit();
-      const session = createBlockingTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'sleep 999'),
-          shellToolStatusEvent(toolCallId),
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      const promptPromise = session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'sleep' }],
-      });
-
-      await connection.waitForTerminalCreated();
-      await session.cancelPendingPrompt();
-      await promptPromise;
-
-      expect(connection.killCalls).toBe(1);
-    });
-
-    it('kills and releases terminals on dispose', async () => {
-      const toolCallId = 'shell-dispose';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('');
-      connection.delayTerminalExit();
-      const session = createBlockingTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'sleep 999'),
-          shellToolStatusEvent(toolCallId),
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      const promptPromise = session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'sleep' }],
-      });
-
-      await connection.waitForTerminalCreated();
-      await session.dispose();
-      await promptPromise.catch(() => undefined);
-
-      expect(connection.killCalls).toBe(1);
-    });
+describe('Zed terminal execution', () => {
+  afterEach(async () => {
+    await Promise.allSettled(
+      createdSessions.splice(0).map((session) => session.dispose()),
+    );
   });
 
-  describe('terminal-disabled sessions (fallback)', () => {
-    it('does not create terminals and emits text content when terminal capability is absent', async () => {
-      const toolCallId = 'shell-fallback';
-      const connection = new RecordingConnection();
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'echo text-output'),
-          shellToolResultEvent(toolCallId, 'text-output'),
-          doneEvent,
-        ],
-        connection,
-        undefined,
-        false,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'echo' }],
-      });
-
-      expect(connection.createTerminalCalls).toHaveLength(0);
-
-      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
-        if (u.sessionUpdate !== 'tool_call_update') return false;
-        const content = u.content ?? [];
-        return content.some((c) => c.type === 'terminal');
-      });
-      expect(hasTerminalContent).toBe(false);
-
-      const hasTextContent = connection.onlySessionUpdates().some((u) => {
-        if (u.sessionUpdate !== 'tool_call_update') return false;
-        const content = u.content ?? [];
-        return content.some(
-          (c): c is Extract<typeof c, { type: 'content' }> =>
-            c.type === 'content',
-        );
-      });
-      expect(hasTextContent).toBe(true);
+  it('delegates shell execution to the ACP terminal exactly once', async () => {
+    const connection = new RecordingConnection();
+    connection.setTerminalOutput('hello\n');
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-1',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
     });
+    const chunks: string[] = [];
+
+    const result = await terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      (event) => {
+        if (event.type === 'data' && event.chunk !== undefined) {
+          chunks.push(event.chunk);
+        }
+      },
+      new AbortController().signal,
+    );
+
+    expect(connection.createTerminalCalls).toStrictEqual([
+      {
+        command: 'bash',
+        args: ['-c', preparedEcho],
+        cwd: '/project',
+        sessionId: 'test-session-id',
+      },
+    ]);
+    expect(result).toMatchObject({ output: 'hello\n', exitCode: 0 });
+    expect(chunks.join('')).toBe('hello\n');
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'shell-1',
+        content: [{ type: 'terminal', terminalId: 'terminal-1' }],
+      }),
+    );
+    expect(connection.releaseCalls).toBe(1);
+  });
+
+  it('does not create a terminal for an already-cancelled execution', async () => {
+    const connection = new RecordingConnection();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      terminalManager(connection).executeShellCommand(
+        preparedEcho,
+        '/project',
+        () => undefined,
+        controller.signal,
+      ),
+    ).resolves.toMatchObject({ aborted: true });
+    expect(connection.createTerminalCalls).toHaveLength(0);
+  });
+
+  it('does not mirror a shell command merely by observing its agent event', async () => {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection);
+    const { agent } = buildFakeAgent(
+      [
+        shellToolCallEvent('shell-observed', 'touch side-effect'),
+        shellToolResultEvent('shell-observed', 'locally executed'),
+        doneEvent,
+      ],
+      { run_shell_command: 'execute' },
+    );
+    const session = new Session(
+      'test-session-id',
+      agent,
+      buildMinimalConfig(),
+      connection as unknown as acp.AgentSideConnection,
+      false,
+      terminals,
+    );
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'run it once' }],
+    });
+
+    expect(connection.createTerminalCalls).toHaveLength(0);
+  });
+
+  it('kills and releases delegated execution on cancellation', async () => {
+    const connection = new RecordingConnection();
+    connection.delayTerminalExit();
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-cancel',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
+    });
+    const controller = new AbortController();
+    const execution = terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      controller.signal,
+    );
+
+    await connection.waitForTerminalCreated();
+    controller.abort();
+    await execution;
+
+    expect(connection.killCalls).toBe(1);
+    expect(connection.releaseCalls).toBe(1);
+  });
+
+  it('cleans up the client process when terminal update delivery fails', async () => {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection, async () => {
+      throw new Error('transport closed');
+    });
+    await terminals.observeToolCall({
+      id: 'shell-failure',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
+    });
+
+    await expect(
+      terminals.executeShellCommand(
+        preparedEcho,
+        '/project',
+        () => undefined,
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow('transport closed');
+    expect(connection.killCalls).toBe(1);
+    expect(connection.releaseCalls).toBe(1);
+  });
+
+  it('retains text-only behavior when terminal capability is absent', async () => {
+    const connection = new RecordingConnection();
+    const { agent } = buildFakeAgent(
+      [
+        shellToolCallEvent('shell-fallback', 'echo text-output'),
+        shellToolResultEvent('shell-fallback', 'text-output'),
+        doneEvent,
+      ],
+      { run_shell_command: 'execute' },
+    );
+    const session = new Session(
+      'test-session-id',
+      agent,
+      buildMinimalConfig(),
+      connection as unknown as acp.AgentSideConnection,
+    );
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'echo' }],
+    });
+
+    expect(connection.createTerminalCalls).toHaveLength(0);
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        content: [
+          { type: 'content', content: { type: 'text', text: 'text-output' } },
+        ],
+      }),
+    );
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type * as acp from '@agentclientprotocol/sdk';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import { buildCommandToExecute } from '@vybestack/llxprt-code-tools';
 
 import { Session } from './zedIntegration.js';
 import { TerminalManager } from './zed-terminal-manager.js';
@@ -18,12 +19,9 @@ import {
 } from './zed-test-helpers.js';
 
 const createdSessions: Session[] = [];
-// Hardcoded mirror of buildCommandToExecute('echo hello', false, '/tmp/shell.tmp')
-// from packages/tools/src/tools/shell-helpers.ts. This function is not exported
-// from the tools package, so we cannot import it directly. If the wrapping
-// format in buildCommandToExecute changes, this constant MUST be updated to match.
-const preparedEcho =
-  '{ echo hello; }; __code=$?; pgrep -g 0 >/tmp/shell.tmp 2>&1; exit $__code;';
+// Derived from the production buildCommandToExecute so the wrapping format
+// stays in sync automatically.
+const preparedEcho = buildCommandToExecute('echo hello', false, '/tmp/shell.tmp');
 
 function terminalManager(
   connection: RecordingConnection,

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Config } from '@vybestack/llxprt-code-core';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  buildBlockingFakeAgent,
+  RecordingConnection,
+  buildMinimalConfig,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  for (const session of createdSessions.splice(0)) {
+    await session.dispose();
+  }
+}
+
+function createTerminalSession(
+  events: readonly AgentEvent[],
+  connection: RecordingConnection,
+  config: Config = buildMinimalConfig(),
+  terminalEnabled = true,
+): Session {
+  const { agent } = buildFakeAgent(events, { run_shell_command: 'execute' });
+  return new Session(
+    'test-session-id',
+    agent,
+    config,
+    connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
+  );
+}
+
+function createBlockingTerminalSession(
+  events: readonly AgentEvent[],
+  connection: RecordingConnection,
+  config: Config = buildMinimalConfig(),
+  terminalEnabled = true,
+): Session {
+  const { agent } = buildBlockingFakeAgent(events, {
+    run_shell_command: 'execute',
+  });
+  return new Session(
+    'test-session-id',
+    agent,
+    config,
+    connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
+  );
+}
+
+function shellToolCallEvent(toolCallId: string, command: string): AgentEvent {
+  return {
+    type: 'tool-call',
+    call: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      args: { command },
+    },
+  };
+}
+
+function shellToolStatusEvent(toolCallId: string): AgentEvent {
+  return {
+    type: 'tool-status',
+    update: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      status: 'executing',
+    },
+  };
+}
+
+function shellToolResultEvent(toolCallId: string, output: string): AgentEvent {
+  return {
+    type: 'tool-result',
+    result: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      output,
+    },
+  };
+}
+
+const doneEvent: AgentEvent = { type: 'done', reason: 'stop' };
+
+describe('Zed Session — terminal capability integration', () => {
+  afterEach(disposeCreatedSessions);
+
+  describe('terminal-enabled sessions', () => {
+    it('emits terminal content on shell tool calls when terminal capability is present', async () => {
+      const toolCallId = 'shell-1';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('hello');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo hello'),
+          shellToolStatusEvent(toolCallId),
+          shellToolResultEvent(toolCallId, 'hello'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'run echo' }],
+      });
+
+      const toolCallUpdates = connection
+        .onlySessionUpdates()
+        .filter(
+          (
+            u,
+          ): u is Extract<acp.SessionUpdate, { sessionUpdate: 'tool_call' }> =>
+            u.sessionUpdate === 'tool_call',
+        );
+      expect(toolCallUpdates).toHaveLength(1);
+      expect(toolCallUpdates[0].kind).toBe('execute');
+
+      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some(
+          (c): c is Extract<typeof c, { type: 'terminal' }> =>
+            c.type === 'terminal',
+        );
+      });
+      expect(hasTerminalContent).toBe(true);
+    });
+
+    it('creates a terminal via connection.createTerminal for shell commands', async () => {
+      const toolCallId = 'shell-create';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('file1\nfile2');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'ls'),
+          shellToolResultEvent(toolCallId, 'file1\nfile2'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'list files' }],
+      });
+
+      expect(connection.createTerminalCalls).toHaveLength(1);
+      const call = connection.createTerminalCalls[0];
+      expect(call.command).toBe('ls');
+      expect(call.sessionId).toBe('test-session-id');
+    });
+
+    it('releases terminals on normal completion', async () => {
+      const toolCallId = 'shell-release';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('done');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo done'),
+          shellToolResultEvent(toolCallId, 'done'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'echo' }],
+      });
+
+      expect(connection.releaseCalls).toBe(1);
+    });
+
+    it('kills and releases terminals on cancel', async () => {
+      const toolCallId = 'shell-cancel';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('');
+      connection.delayTerminalExit();
+      const session = createBlockingTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'sleep 999'),
+          shellToolStatusEvent(toolCallId),
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      const promptPromise = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'sleep' }],
+      });
+
+      await connection.waitForTerminalCreated();
+      await session.cancelPendingPrompt();
+      await promptPromise;
+
+      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+    });
+
+    it('kills and releases terminals on dispose', async () => {
+      const toolCallId = 'shell-dispose';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('');
+      connection.delayTerminalExit();
+      const session = createBlockingTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'sleep 999'),
+          shellToolStatusEvent(toolCallId),
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      const promptPromise = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'sleep' }],
+      });
+
+      await connection.waitForTerminalCreated();
+      await session.dispose();
+      await promptPromise.catch(() => undefined);
+
+      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('terminal-disabled sessions (fallback)', () => {
+    it('does not create terminals and emits text content when terminal capability is absent', async () => {
+      const toolCallId = 'shell-fallback';
+      const connection = new RecordingConnection();
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo text-output'),
+          shellToolResultEvent(toolCallId, 'text-output'),
+          doneEvent,
+        ],
+        connection,
+        undefined,
+        false,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'echo' }],
+      });
+
+      expect(connection.createTerminalCalls).toHaveLength(0);
+
+      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some((c) => c.type === 'terminal');
+      });
+      expect(hasTerminalContent).toBe(false);
+
+      const hasTextContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some(
+          (c): c is Extract<typeof c, { type: 'content' }> =>
+            c.type === 'content',
+        );
+      });
+      expect(hasTextContent).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -20,9 +20,15 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map(async (session) => {
+      try {
+        await session.dispose();
+      } catch {
+        // Continue disposing remaining sessions even if one fails
+      }
+    }),
+  );
 }
 
 function createTerminalSession(

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -112,6 +112,76 @@ describe('Zed terminal execution', () => {
     expect(connection.releaseCalls).toBe(1);
   });
 
+  it('correlates a raw command that already ends with a semicolon', async () => {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-semicolon',
+      name: 'run_shell_command',
+      args: { command: 'echo hello;' },
+    });
+
+    await terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'shell-semicolon',
+        content: [{ type: 'terminal', terminalId: 'terminal-1' }],
+      }),
+    );
+  });
+
+  it('retries terminal correlation after update delivery fails', async () => {
+    const connection = new RecordingConnection();
+    connection.delayTerminalExit();
+    let deliveryAttempt = 0;
+    const terminals = terminalManager(connection, async (update) => {
+      deliveryAttempt += 1;
+      if (deliveryAttempt === 1) {
+        throw new Error('transport unavailable');
+      }
+      await connection.sessionUpdate({
+        sessionId: 'test-session-id',
+        update,
+      });
+    });
+    const execution = terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(
+      terminals.observeToolCall({
+        id: 'shell-retry',
+        name: 'run_shell_command',
+        args: { command: 'echo hello' },
+      }),
+    ).rejects.toThrow('transport unavailable');
+    await terminals.observeToolCall({
+      id: 'shell-retry',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
+    });
+    connection.resolveDelayedTerminalExit();
+    await execution;
+
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'shell-retry',
+      }),
+    );
+  });
+
   it('does not create a terminal for an already-cancelled execution', async () => {
     const connection = new RecordingConnection();
     const controller = new AbortController();

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -218,7 +218,7 @@ describe('Zed Session — terminal capability integration', () => {
       await session.cancelPendingPrompt();
       await promptPromise;
 
-      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+      expect(connection.killCalls).toBe(1);
     });
 
     it('kills and releases terminals on dispose', async () => {
@@ -244,7 +244,7 @@ describe('Zed Session — terminal capability integration', () => {
       await session.dispose();
       await promptPromise.catch(() => undefined);
 
-      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+      expect(connection.killCalls).toBe(1);
     });
   });
 

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -18,8 +18,10 @@ import {
 } from './zed-test-helpers.js';
 
 const createdSessions: Session[] = [];
-// Mirrors the output of buildCommandToExecute('echo hello', false, '/tmp/shell.tmp')
-// from packages/tools/src/tools/shell-helpers.ts. Update together if the wrapping format changes.
+// Hardcoded mirror of buildCommandToExecute('echo hello', false, '/tmp/shell.tmp')
+// from packages/tools/src/tools/shell-helpers.ts. This function is not exported
+// from the tools package, so we cannot import it directly. If the wrapping
+// format in buildCommandToExecute changes, this constant MUST be updated to match.
 const preparedEcho =
   '{ echo hello; }; __code=$?; pgrep -g 0 >/tmp/shell.tmp 2>&1; exit $__code;';
 

--- a/packages/cli/src/zed-integration/zedIntegration.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.test.ts
@@ -149,6 +149,7 @@ describe('ZedAgent.newSession', () => {
       getProfileManager: () => undefined,
       getEphemeralSetting: () => undefined,
       getTargetDir: () => '/project',
+      getSessionRecordingService: () => undefined,
     } as unknown as Config;
     const connection = {
       readTextFile: vi.fn(async (_params: { sessionId: string }) => ({

--- a/packages/cli/src/zed-integration/zedIntegration.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.test.ts
@@ -155,6 +155,7 @@ describe('ZedAgent.newSession', () => {
         content: 'client',
       })),
       writeTextFile: vi.fn(async () => undefined),
+      sessionUpdate: vi.fn(async () => undefined),
     };
     const mod = await import('./zedIntegration.js');
     const zedAgent = new mod.ZedAgent(

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -36,17 +36,10 @@ import {
   buildSessionModes,
   buildUsageUpdate,
   describeSessionUpdateForLog,
-  mapDoneReasonToStopReason,
-  extractThoughtText,
-  translateErrorEvent,
-  translateIdleTimeout,
 } from './zed-helpers.js';
 import { ZedPathResolver } from './zed-path-resolver.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 import {
-  emitToolCallStart,
-  emitToolStatus,
-  emitToolResult,
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
@@ -82,7 +75,12 @@ import {
   buildZedSession,
   enableZedSessionRecording,
 } from './zed-agent-setup.js';
+import { handleZedAgentEvent } from './zed-agent-event-handler.js';
 import { buildZedPlanUpdate } from './zed-plan-update.js';
+import {
+  SessionTitleTracker,
+  buildSessionInfoUpdate,
+} from './zed-session-info.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -388,7 +386,13 @@ export class Session {
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
   private readonly stopConfigUpdates: () => void;
-  private updatedAt = new Date().toISOString();
+  private readonly sessionInfo = new SessionTitleTracker();
+  /**
+   * Stable timestamp captured once at construction so getLifecycleInfo returns
+   * a consistent updatedAt before the first turn completes (issue #1611
+   * finding 4) rather than generating a new value per getter call.
+   */
+  private readonly createdAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
@@ -399,6 +403,12 @@ export class Session {
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
+    const recordedTitle = config
+      .getSessionRecordingService()
+      ?.getSessionMetadataTitle();
+    if (recordedTitle !== undefined) {
+      this.sessionInfo.hydrateFromMetadata(recordedTitle);
+    }
     this.todoListener = (event: TodoUpdateEvent) => {
       const eventAgentId = event.agentId ?? DEFAULT_AGENT_ID;
       if (event.sessionId === this.id && eventAgentId === DEFAULT_AGENT_ID) {
@@ -434,10 +444,13 @@ export class Session {
   }
   getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
   getLifecycleInfo(): LifecycleSession {
+    const title = this.sessionInfo.getTitle();
     return {
       sessionId: this.id,
       cwd: this.config.getProjectRoot(),
-      updatedAt: this.updatedAt,
+      updatedAt: this.sessionInfo.getUpdatedAt() ?? this.createdAt,
+      createdAt: this.createdAt,
+      ...(title === undefined ? {} : { title }),
     };
   }
   async cancelPendingPrompt(): Promise<void> {
@@ -484,83 +497,169 @@ export class Session {
     }
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
-    this.updatedAt = new Date().toISOString();
     await this.cancelPendingPrompt();
-    const commandResult = await tryHandleZedCommand(
-      params.prompt,
-      this.agent,
-      (update) => this.sendUpdateStrict(update),
-    );
-    if (commandResult !== null) return commandResult.response;
-    const pendingSend = new AbortController();
-    this.pendingPrompt = pendingSend;
-    this.promptGeneration += 1;
-    const promptGeneration = this.promptGeneration;
-    const promptId = Math.random().toString(16).slice(2);
+    // Finding 1: consume title eligibility SYNCHRONOUSLY at acceptance time,
+    // before any async work, so overlapping prompts cannot both claim the title.
+    const eligibility = this.sessionInfo.consumeTitleEligibility(params.prompt);
+    // Issue #1611: record session_metadata immediately at acceptance so the
+    // title persists even for slash/failure sessions that never emit a content
+    // event. session_metadata materializes the recording file.
+    this.recordMetadataTitle(eligibility.title);
     try {
-      let parts: ContractPart[];
-      try {
-        parts = await this.pathResolver.resolvePrompt(
-          params.prompt,
-          pendingSend.signal,
-        );
-      } catch (error) {
-        if (
-          pendingSend.signal.aborted ||
-          (error instanceof Error && error.name === 'AbortError')
-        ) {
-          return { stopReason: 'cancelled' };
-        }
-        throw error;
-      }
-      const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
-        'auto') as FilterConfiguration['mode'];
-      const batcher = new StreamBatcher(
-        new EmojiFilter({ mode: emojiMode }),
-        (u) => this.sendUpdate(u),
+      const commandResult = await tryHandleZedCommand(
+        params.prompt,
+        this.agent,
+        (update) => this.sendUpdateStrict(update),
       );
-      let terminalStopReason: acp.StopReason | null = null;
+      if (commandResult !== null) {
+        return commandResult.response;
+      }
+      const pendingSend = new AbortController();
+      this.pendingPrompt = pendingSend;
+      this.promptGeneration += 1;
+      const promptGeneration = this.promptGeneration;
+      const promptId = Math.random().toString(16).slice(2);
       try {
-        terminalStopReason = await this.consumeAgentStream(
-          parts,
+        return await this.runPromptTurn(
+          params,
           pendingSend,
           promptId,
           promptGeneration,
-          batcher,
         );
-      } catch (error) {
-        if (getErrorStatus(error) === 429) {
-          throw new acp.RequestError(
-            429,
-            'Rate limit exceeded. Try again later.',
-          );
-        }
-        if (
-          pendingSend.signal.aborted ||
-          (error instanceof Error && error.name === 'AbortError')
-        ) {
-          return { stopReason: 'cancelled' };
-        }
-        throw error;
       } finally {
-        try {
-          await batcher.flush();
-        } finally {
-          batcher.dispose();
+        if (this.pendingPrompt === pendingSend) {
+          this.pendingPrompt = null;
         }
       }
-      if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+    } finally {
+      // Finding 3: exact-once metadata finally shared by command and prompt
+      // paths (success, cancel, or error). Best-effort transport — sendUpdate
+      // swallows transient errors so metadata never replaces the turn outcome.
+      await this.emitTurnMetadata(eligibility);
+    }
+  }
+
+  private async runPromptTurn(
+    params: acp.PromptRequest,
+    pendingSend: AbortController,
+    promptId: string,
+    promptGeneration: number,
+  ): Promise<acp.PromptResponse> {
+    let parts: ContractPart[];
+    try {
+      parts = await this.pathResolver.resolvePrompt(
+        params.prompt,
+        pendingSend.signal,
+      );
+    } catch (error) {
+      if (
+        pendingSend.signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
         return { stopReason: 'cancelled' };
       }
-      if (terminalStopReason !== null) {
-        return { stopReason: terminalStopReason };
+      throw error;
+    }
+    const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
+      'auto') as FilterConfiguration['mode'];
+    const batcher = new StreamBatcher(
+      new EmojiFilter({ mode: emojiMode }),
+      (u) => this.sendUpdate(u),
+    );
+    let terminalStopReason: acp.StopReason | null = null;
+    try {
+      terminalStopReason = await this.consumeAgentStream(
+        parts,
+        pendingSend,
+        promptId,
+        promptGeneration,
+        batcher,
+      );
+    } catch (error) {
+      if (getErrorStatus(error) === 429) {
+        throw new acp.RequestError(
+          429,
+          'Rate limit exceeded. Try again later.',
+        );
       }
-      return { stopReason: 'end_turn' };
+      if (
+        pendingSend.signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return { stopReason: 'cancelled' };
+      }
+      throw error;
     } finally {
-      if (this.pendingPrompt === pendingSend) {
-        this.pendingPrompt = null;
+      try {
+        await batcher.flush();
+      } finally {
+        batcher.dispose();
       }
     }
+    if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+      return { stopReason: 'cancelled' };
+    }
+    if (terminalStopReason !== null) {
+      return { stopReason: terminalStopReason };
+    }
+    return { stopReason: 'end_turn' };
+  }
+
+  private async emitTurnMetadata(eligibility: {
+    readonly wonTitle: boolean;
+    readonly title: string | undefined;
+  }): Promise<void> {
+    const { updates } = this.sessionInfo.recordTurn(new Date().toISOString());
+    const updatedAt = updates[0]?.updatedAt ?? undefined;
+    if (eligibility.wonTitle && eligibility.title !== undefined) {
+      await this.sendTitleUpdate(
+        buildSessionInfoUpdate({ title: eligibility.title, updatedAt }),
+        eligibility.title,
+      );
+      return;
+    }
+    for (const update of updates) {
+      const title = update.title;
+      if (typeof title === 'string') {
+        await this.sendTitleUpdate(update, title);
+      } else {
+        await this.sendUpdate(update);
+      }
+    }
+  }
+
+  /**
+   * Sends a title-bearing session_info_update, retrying on transport failure
+   * (issue #1611). Uses sendUpdateStrict (not the swallowing sendUpdate) so a
+   * transport error is detected; the title is then marked pending so the next
+   * turn's metadata emission re-sends it.
+   */
+  private async sendTitleUpdate(
+    update: acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' },
+    title: string,
+  ): Promise<void> {
+    try {
+      await this.sendUpdateStrict(update);
+    } catch (error) {
+      this.logger.debug(
+        () =>
+          `sendTitleUpdate ERROR (will retry next turn): ${error instanceof Error ? error.message : String(error)}`,
+      );
+      this.sessionInfo.markPendingTitle(title);
+    }
+  }
+
+  /**
+   * Records the session_metadata title to the durable recording service.
+   * Called at prompt-acceptance time (issue #1611) so the title persists
+   * immediately, materializing the recording for slash/failure sessions.
+   */
+  private recordMetadataTitle(title: string | undefined): void {
+    const recording = this.config.getSessionRecordingService();
+    if (recording?.isActive() !== true) {
+      return;
+    }
+    recording.recordSessionMetadata(title ?? null);
   }
   private async consumeAgentStream(
     parts: ContractPart[],
@@ -582,96 +681,21 @@ export class Session {
         }
         continue;
       }
-      const stopReason = await this.handleAgentEvent(
-        event,
-        batcher,
-        promptGeneration,
-        pendingSend,
-      );
+      const stopReason = await handleZedAgentEvent(event, batcher, {
+        sendUpdate: (update) => this.sendUpdate(update),
+        sendUsage: (usage) => this.sendUsageUpdate(usage),
+        handleConfirmation: (confirmation) =>
+          this.handleToolConfirmation(
+            confirmation,
+            promptGeneration,
+            pendingSend,
+          ),
+      });
       if (stopReason !== null) {
         terminalStopReason = stopReason;
       }
     }
     return terminalStopReason;
-  }
-  private async handleAgentEvent(
-    event: AgentEvent,
-    batcher: StreamBatcher,
-    promptGeneration: number,
-    pendingSend: AbortController,
-  ): Promise<acp.StopReason | null> {
-    switch (event.type) {
-      case 'text':
-        batcher.append(event.text, false);
-        return null;
-      case 'thinking': {
-        const thoughtText = extractThoughtText(event.thought);
-        if (thoughtText.length > 0) {
-          batcher.append(thoughtText, true);
-        }
-        return null;
-      }
-      case 'tool-call':
-        await batcher.flush();
-        await emitToolCallStart(event.call, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-status':
-        await batcher.flush();
-        await emitToolStatus(event.update, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-result':
-        await batcher.flush();
-        await emitToolResult(event.result, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-confirmation':
-        await batcher.flush();
-        await this.handleToolConfirmation(event, promptGeneration, pendingSend);
-        return null;
-      case 'done':
-        await batcher.flush();
-        return mapDoneReasonToStopReason(event.reason);
-      case 'error':
-        await batcher.flush();
-        throw translateErrorEvent(event);
-      case 'idle-timeout':
-        await batcher.flush();
-        throw translateIdleTimeout(event);
-      case 'invalid-stream':
-        await batcher.flush();
-        throw new Error(
-          'Agent produced an invalid stream that could not be recovered.',
-        );
-      case 'hook-blocked':
-        await batcher.flush();
-        throw new Error(
-          event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
-        );
-      case 'loop-detected':
-        await batcher.flush();
-        return 'end_turn';
-      case 'notice':
-        await batcher.flush();
-        await this.sendUpdate({
-          sessionUpdate: 'agent_message_chunk',
-          content: { type: 'text', text: event.message },
-        });
-        return null;
-      case 'usage': {
-        await batcher.flush();
-        await this.sendUsageUpdate(event.usage);
-        return null;
-      }
-      case 'context-warning':
-      case 'compression':
-      case 'model-info':
-      case 'retry':
-      case 'citation':
-        return null;
-      default: {
-        const exhaustive: never = event;
-        throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
-      }
-    }
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -784,6 +808,9 @@ export class Session {
         throw wrapReplayFailure(this.id, error);
       }
     }
+    // Finding 2: hydrate title from restored history so later prompts never
+    // retitle a restored session. Idempotent — a no-op if already titled.
+    this.sessionInfo.hydrateFromHistory(items);
   }
   async replayLiveHistory() {
     await this.streamHistory(

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -16,6 +16,7 @@ import {
   DebugLogger,
   EmojiFilter,
   type FilterConfiguration,
+  type IContent,
   type TodoUpdateEvent,
   type Todo,
   type ApprovalMode,
@@ -49,6 +50,8 @@ import {
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
+import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
+import { StreamBatcher } from './zed-stream-batcher.js';
 
 export { parseZedAuthMethodId } from './zed-helpers.js';
 
@@ -180,7 +183,7 @@ export class ZedAgent {
       protocolVersion: acp.PROTOCOL_VERSION,
       authMethods,
       agentCapabilities: {
-        loadSession: false,
+        loadSession: true,
         promptCapabilities: {
           image: true,
           audio: true,
@@ -206,27 +209,15 @@ export class ZedAgent {
   }: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
     try {
       const sessionId = randomUUID();
-      const baseFileSystemService = this.config.getFileSystemService();
-      const sessionFileSystemService = this.clientCapabilities?.fs
-        ? new AcpFileSystemService(
-            this.connection,
-            sessionId,
-            this.clientCapabilities.fs,
-            baseFileSystemService,
-          )
-        : baseFileSystemService;
-      const sessionConfig = createSessionScopedConfig(
-        this.config,
-        sessionFileSystemService,
-        resolveSessionTargetDir(this.config, cwd),
-      );
-
-      this.logger.debug(() => `newSession - creating session ${sessionId}`);
-
-      const agent = await fromConfig({
-        config: sessionConfig,
+      const { agent, config: sessionConfig } = await this.buildSessionAgent(
         sessionId,
-      });
+        cwd,
+      );
+      // Enable continuous session recording so the conversation is persisted to
+      // a JSONL session file (under <projectTempDir>/chats) and can later be
+      // resumed via loadSession. Recording must never break session creation, so
+      // a startup failure is logged and swallowed.
+      await this.enableRecording(agent, sessionId);
 
       const session = new Session(
         sessionId,
@@ -246,6 +237,126 @@ export class ZedAgent {
     } catch (error) {
       this.logger.debug(() => `ERROR in newSession: ${error}`);
       throw error;
+    }
+  }
+
+  /**
+   * Loads (resumes) a previously recorded session so its conversation can be
+   * continued (issue #1604). The persisted history is replayed to the client as
+   * ordered session/update notifications BEFORE this resolves, so the Zed
+   * transcript is reconstructed. A fresh Agent (bound to a session-scoped Config
+   * + AcpFileSystemService, identical to newSession) is created for the loaded
+   * session id, and `agent.session.resume` restores the history AND re-subscribes
+   * continuous recording so subsequent turns keep appending to the SAME file.
+   *
+   * Reconnect friendliness: if a session with this id is already loaded, the
+   * prior Session is disposed and replaced (Zed may call loadSession again on
+   * reconnect; replacing is friendlier than rejecting).
+   *
+   * On resume failure (not found / locked / corrupted) a JSON-RPC
+   * resourceNotFound error is thrown carrying the session id.
+   */
+  async loadSession(
+    params: acp.LoadSessionRequest,
+  ): Promise<acp.LoadSessionResponse> {
+    const { sessionId } = params;
+    this.logger.debug(() => `loadSession - loading session ${sessionId}`);
+
+    const existing = this.sessions.get(sessionId);
+    if (existing !== undefined) {
+      this.sessions.delete(sessionId);
+      await existing.dispose();
+    }
+
+    const { agent, config: sessionConfig } = await this.buildSessionAgent(
+      sessionId,
+      params.cwd,
+    );
+
+    let history: readonly IContent[];
+    try {
+      history = await agent.session.resume(sessionId);
+    } catch (error) {
+      // The resume machinery failed to discover/lock/replay the session. Tear
+      // down the freshly built agent so no lock/recording leaks, then surface a
+      // resourceNotFound JSON-RPC error (the closest ACP-standard code) rather
+      // than inventing a custom code.
+      await agent.dispose().catch(() => undefined);
+      this.logger.debug(() => `loadSession - resume failed: ${error}`);
+      throw acp.RequestError.resourceNotFound(sessionId);
+    }
+
+    const session = new Session(
+      sessionId,
+      agent,
+      sessionConfig,
+      this.connection,
+    );
+    this.sessions.set(sessionId, session);
+
+    // Replay the restored conversation to the client before returning so the
+    // transcript is reconstructed on the Zed side.
+    await session.streamHistory(history);
+
+    return {
+      modes: {
+        availableModes: buildAvailableModes(),
+        currentModeId: agent.getApprovalMode(),
+      },
+    };
+  }
+
+  /**
+   * Shared per-session Agent construction used by BOTH newSession and
+   * loadSession: builds the session-scoped Config proxy (with an
+   * AcpFileSystemService when the client advertises fs capabilities) rooted at
+   * the resolved target dir, then creates the Agent-API agent bound to that
+   * Config and session id. Extracted to avoid duplicating the setup across the
+   * two entry points.
+   */
+  private async buildSessionAgent(
+    sessionId: string,
+    cwd: string | undefined,
+  ): Promise<{ agent: Agent; config: Config }> {
+    const baseFileSystemService = this.config.getFileSystemService();
+    const sessionFileSystemService = this.clientCapabilities?.fs
+      ? new AcpFileSystemService(
+          this.connection,
+          sessionId,
+          this.clientCapabilities.fs,
+          baseFileSystemService,
+        )
+      : baseFileSystemService;
+    const sessionConfig = createSessionScopedConfig(
+      this.config,
+      sessionFileSystemService,
+      resolveSessionTargetDir(this.config, cwd),
+    );
+
+    this.logger.debug(() => `buildSessionAgent - session ${sessionId}`);
+
+    const agent = await fromConfig({
+      config: sessionConfig,
+      sessionId,
+    });
+    return { agent, config: sessionConfig };
+  }
+
+  /**
+   * Enables continuous session recording for a freshly created session. Failures
+   * are logged and swallowed so recording startup can never break session
+   * creation (the session remains fully usable, just unrecorded).
+   */
+  private async enableRecording(
+    agent: Agent,
+    sessionId: string,
+  ): Promise<void> {
+    try {
+      await agent.session.setRecording({ enabled: true });
+    } catch (error) {
+      this.logger.debug(
+        () => `enableRecording failed for session ${sessionId}: ${error}`,
+      );
     }
   }
 
@@ -756,6 +867,24 @@ export class Session {
     await this.sendUpdate({ sessionUpdate: 'plan', entries });
   }
 
+  /**
+   * Replays a resumed conversation (ordered IContent[]) to the client as
+   * session/update notifications, in order, for ACP session/load (issue #1604).
+   * The neutral history is mapped to ACP updates by the pure
+   * mapHistoryToSessionUpdates helper (human text -> user_message_chunk, ai text
+   * -> agent_message_chunk, ai thinking -> agent_thought_chunk, ai tool_call ->
+   * tool_call, tool tool_response -> tool_call_update). Replay text is sent
+   * verbatim (NOT routed through the EmojiFilter): the recorded transcript was
+   * already filtered when first streamed, so re-filtering on replay would be
+   * redundant and could double-alter historical content.
+   */
+  async streamHistory(items: readonly IContent[]): Promise<void> {
+    const updates = mapHistoryToSessionUpdates(items);
+    for (const update of updates) {
+      await this.sendUpdate(update);
+    }
+  }
+
   async dispose(): Promise<void> {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
@@ -768,94 +897,6 @@ export class Session {
       } catch (error) {
         debugLogger.error('Failed to dispose Zed session agent:', error);
       }
-    }
-  }
-}
-
-const BATCH_INTERVAL_MS = 100;
-
-class StreamBatcher {
-  private pendingChunks: Array<{ kind: 'text' | 'thought'; text: string }> = [];
-  private batchTimer: ReturnType<typeof setTimeout> | null = null;
-  private flushChain: Promise<void> = Promise.resolve();
-
-  constructor(
-    private readonly emojiFilter: EmojiFilter,
-    private readonly sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
-  ) {}
-
-  append(text: string, isThought: boolean): void {
-    const filterResult = isThought
-      ? this.emojiFilter.filterText(text)
-      : this.emojiFilter.filterStreamChunk(text);
-    if (filterResult.blocked) {
-      const pending = this.flushChain
-        .then(() => this.doFlush())
-        .then(() =>
-          this.sendUpdate({
-            sessionUpdate: 'agent_message_chunk',
-            content: {
-              type: 'text',
-              text: '[Error: Response blocked due to emoji detection]',
-            },
-          }),
-        );
-      this.flushChain = pending.catch(() => undefined);
-      return;
-    }
-    const filteredText =
-      typeof filterResult.filtered === 'string' ? filterResult.filtered : '';
-    if (filteredText.length === 0) {
-      return;
-    }
-    this.appendPendingChunk(isThought ? 'thought' : 'text', filteredText);
-    this.batchTimer ??= setTimeout(() => {
-      this.batchTimer = null;
-      void this.flush();
-    }, BATCH_INTERVAL_MS);
-  }
-
-  async flush(): Promise<void> {
-    if (this.batchTimer !== null) {
-      clearTimeout(this.batchTimer);
-      this.batchTimer = null;
-    }
-    const pending = this.flushChain
-      .then(() => this.doFlush())
-      .then(() => this.flushEmojiBuffer());
-    this.flushChain = pending.catch(() => undefined);
-    await pending;
-  }
-
-  private async flushEmojiBuffer(): Promise<void> {
-    const remaining = this.emojiFilter.flushBuffer();
-    if (remaining.length === 0) {
-      return;
-    }
-    this.appendPendingChunk('text', remaining);
-    await this.doFlush();
-  }
-
-  private appendPendingChunk(kind: 'text' | 'thought', text: string): void {
-    const lastChunk = this.pendingChunks.at(-1);
-    if (lastChunk?.kind === kind) {
-      lastChunk.text += text;
-      return;
-    }
-    this.pendingChunks.push({ kind, text });
-  }
-
-  private async doFlush(): Promise<void> {
-    const chunks = this.pendingChunks;
-    this.pendingChunks = [];
-    for (const chunk of chunks) {
-      await this.sendUpdate({
-        sessionUpdate:
-          chunk.kind === 'thought'
-            ? 'agent_thought_chunk'
-            : 'agent_message_chunk',
-        content: { type: 'text', text: chunk.text },
-      });
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -40,7 +40,8 @@ import {
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
-import { TerminalManager } from './zed-terminal-manager.js';
+import type { TerminalManager } from './zed-terminal-manager.js';
+import { buildZedTerminalSetup } from './zed-terminal-setup.js';
 import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
 import { wrapReplayFailure } from './zed-session-errors.js';
 import {
@@ -163,14 +164,20 @@ export class ZedAgent {
   }: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
     try {
       const sessionId = randomUUID();
-      const { agent, config: sessionConfig } = await this.buildSessionAgent(
-        sessionId,
-        cwd,
-      );
+      const {
+        agent,
+        config: sessionConfig,
+        terminals,
+      } = await this.buildSessionAgent(sessionId, cwd);
       await enableZedSessionRecording(agent, (error) =>
         this.logger.debug(() => `Recording failed for ${sessionId}: ${error}`),
       );
-      const session = await this.createSession(sessionId, agent, sessionConfig);
+      const session = await this.createSession(
+        sessionId,
+        agent,
+        sessionConfig,
+        terminals,
+      );
       await session.sendAvailableCommands();
       this.sessions.set(sessionId, session);
       return {
@@ -190,10 +197,18 @@ export class ZedAgent {
   resumeSession(params: acp.ResumeSessionRequest) {
     return this.lifecycle.resume(params);
   }
-  private supportsConfigOptions = () =>
-    this.clientCapabilities?.session?.configOptions != null;
-  private supportsTerminal = () => this.clientCapabilities?.terminal === true;
-  private createSession(id: string, agent: Agent, config: Config) {
+  private supportsConfigOptions(): boolean {
+    return this.clientCapabilities?.session?.configOptions === true;
+  }
+  private supportsTerminal(): boolean {
+    return this.clientCapabilities?.terminal === true;
+  }
+  private createSession(
+    id: string,
+    agent: Agent,
+    config: Config,
+    terminals: TerminalManager | null,
+  ) {
     return buildZedSession(
       agent,
       () =>
@@ -203,7 +218,7 @@ export class ZedAgent {
           config,
           this.connection,
           this.supportsConfigOptions(),
-          this.supportsTerminal(),
+          terminals,
         ),
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
@@ -294,10 +309,11 @@ export class ZedAgent {
     sessionId: string,
     cwd: string | undefined,
   ): Promise<{ session: Session; history: readonly IContent[] }> {
-    const { agent, config: sessionConfig } = await this.buildSessionAgent(
-      sessionId,
-      cwd,
-    );
+    const {
+      agent,
+      config: sessionConfig,
+      terminals,
+    } = await this.buildSessionAgent(sessionId, cwd);
     try {
       const history = await resumeAgentHistory(
         agent,
@@ -311,7 +327,7 @@ export class ZedAgent {
         sessionConfig,
         this.connection,
         this.supportsConfigOptions(),
-        this.supportsTerminal(),
+        terminals,
       );
       return { session, history };
     } catch (error) {
@@ -323,7 +339,11 @@ export class ZedAgent {
   private async buildSessionAgent(
     sessionId: string,
     cwd: string | undefined,
-  ): Promise<{ agent: Agent; config: Config }> {
+  ): Promise<{
+    agent: Agent;
+    config: Config;
+    terminals: TerminalManager | null;
+  }> {
     const baseFileSystemService = this.config.getFileSystemService();
     const sessionFileSystemService = this.clientCapabilities?.fs
       ? new AcpFileSystemService(
@@ -333,17 +353,35 @@ export class ZedAgent {
           baseFileSystemService,
         )
       : baseFileSystemService;
+    let terminalSetup: ReturnType<typeof buildZedTerminalSetup> | undefined;
     const sessionConfig = createSessionScopedConfig(
       this.config,
       sessionFileSystemService,
       resolveSessionTargetDir(this.config, cwd),
+      () => terminalSetup?.registry,
     );
+    if (this.supportsTerminal()) {
+      terminalSetup = buildZedTerminalSetup(
+        sessionId,
+        sessionConfig,
+        this.config.getToolRegistry(),
+        this.connection,
+        this.logger,
+      );
+    }
     this.logger.debug(() => `buildSessionAgent - session ${sessionId}`);
     const agent = await fromConfig({
       config: sessionConfig,
       sessionId,
+      ...(terminalSetup === undefined
+        ? {}
+        : { messageBus: terminalSetup.messageBus }),
     });
-    return { agent, config: sessionConfig };
+    return {
+      agent,
+      config: sessionConfig,
+      terminals: terminalSetup?.terminals ?? null,
+    };
   }
   deleteSession(params: DeleteSessionRequest) {
     return this.lifecycle.delete(params);
@@ -399,11 +437,6 @@ export class Session {
   private readonly todoListener: (event: TodoUpdateEvent) => void;
   private readonly stopConfigUpdates: () => void;
   private readonly sessionInfo = new SessionTitleTracker();
-  /**
-   * Stable timestamp captured once at construction so getLifecycleInfo returns
-   * a consistent updatedAt before the first turn completes (issue #1611
-   * finding 4) rather than generating a new value per getter call.
-   */
   private readonly createdAt = new Date().toISOString();
   private readonly terminals: TerminalManager | null;
 
@@ -413,17 +446,9 @@ export class Session {
     private readonly config: Config,
     private readonly connection: acp.AgentSideConnection,
     configOptionsEnabled = false,
-    terminalEnabled = false,
+    terminals: TerminalManager | null = null,
   ) {
-    this.terminals = terminalEnabled
-      ? new TerminalManager(
-          id,
-          connection,
-          config.getTargetDir(),
-          (update) => this.sendUpdate(update),
-          this.logger,
-        )
-      : null;
+    this.terminals = terminals;
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
@@ -523,12 +548,7 @@ export class Session {
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     await this.cancelPendingPrompt();
-    // Finding 1: consume title eligibility SYNCHRONOUSLY at acceptance time,
-    // before any async work, so overlapping prompts cannot both claim the title.
     const eligibility = this.sessionInfo.consumeTitleEligibility(params.prompt);
-    // Issue #1611: record session_metadata immediately at acceptance so the
-    // title persists even for slash/failure sessions that never emit a content
-    // event. session_metadata materializes the recording file.
     this.recordMetadataTitle(eligibility.title);
     try {
       const commandResult = await tryHandleZedCommand(
@@ -602,6 +622,7 @@ export class Session {
         ),
       isPromptStale: (gen, send) => this.isPromptStale(gen, send),
       maxTurns: this.config.getMaxSessionTurns(),
+      logger: this.logger,
     };
   }
 
@@ -628,12 +649,6 @@ export class Session {
     }
   }
 
-  /**
-   * Sends a title-bearing session_info_update, retrying on transport failure
-   * (issue #1611). Uses sendUpdateStrict (not the swallowing sendUpdate) so a
-   * transport error is detected; the title is then marked pending so the next
-   * turn's metadata emission re-sends it.
-   */
   private async sendTitleUpdate(
     update: acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' },
     title: string,
@@ -649,11 +664,6 @@ export class Session {
     }
   }
 
-  /**
-   * Records the session_metadata title to the durable recording service.
-   * Called at prompt-acceptance time (issue #1611) so the title persists
-   * immediately, materializing the recording for slash/failure sessions.
-   */
   private recordMetadataTitle(title: string | undefined): void {
     const recording = this.config.getSessionRecordingService();
     if (recording?.isActive() !== true) {
@@ -773,8 +783,6 @@ export class Session {
         throw wrapReplayFailure(this.id, error);
       }
     }
-    // Finding 2: hydrate title from restored history so later prompts never
-    // retitle a restored session. Idempotent — a no-op if already titled.
     this.sessionInfo.hydrateFromHistory(items);
   }
   async replayLiveHistory() {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -69,6 +69,8 @@ import {
   createSessionScopedConfig,
   resolveSessionTargetDir,
 } from './zed-session-config.js';
+import { buildAvailableCommandsUpdate } from './zed-command-registry.js';
+import { tryHandleZedCommand } from './zed-prompt-command.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -155,6 +157,7 @@ export class ZedAgent {
         agent,
         sessionConfig,
       );
+      await session.sendAvailableCommands();
       this.sessions.set(sessionId, session);
       return {
         sessionId,
@@ -203,10 +206,12 @@ export class ZedAgent {
     this.logger.debug(() => `loadSession - loading session ${sessionId}`);
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
+      await reattached.sendAvailableCommands();
       return { modes: buildSessionModes(reattached.getApprovalMode()) };
     }
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
+    await session.sendAvailableCommands();
     return { modes: buildSessionModes(session.getApprovalMode()) };
   }
   private async tryReattachLiveSession(
@@ -506,6 +511,15 @@ export class Session {
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     this.updatedAt = new Date().toISOString();
     await this.cancelPendingPrompt();
+    const commandResult = await tryHandleZedCommand(
+      params.prompt,
+      this.agent,
+      this.config,
+      (u) => this.sendUpdateStrict(u),
+    );
+    if (commandResult !== null) {
+      return commandResult.response;
+    }
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;
     this.promptGeneration += 1;
@@ -554,12 +568,6 @@ export class Session {
         }
         throw error;
       } finally {
-        // Flush any buffered chunks, THEN dispose so the batch timer is cleared
-        // on completion/abort and no delayed flush fires after the turn ends
-        // (FINDING F9). The batcher is per-prompt, so disposing here bounds its
-        // timer to the prompt lifecycle. dispose() runs even when flush()
-        // rejects (e.g. a dead transport) — otherwise the pending timer would
-        // leak past the turn.
         try {
           await batcher.flush();
         } finally {
@@ -664,13 +672,9 @@ export class Session {
           event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
         );
       case 'loop-detected':
-        // The agent detects a tool-call loop. Map to end_turn so the client
-        // sees a clean turn end rather than an indefinite hang.
         await batcher.flush();
         return 'end_turn';
       case 'notice':
-        // Informational notices have no direct ACP SessionUpdate; surface as
-        // an agent message so the user sees them.
         await batcher.flush();
         await this.sendUpdate({
           sessionUpdate: 'agent_message_chunk',
@@ -687,14 +691,8 @@ export class Session {
       case 'model-info':
       case 'retry':
       case 'citation':
-        // These variants have no faithful ACP translation: usage is mapped
-        // separately, compression/model-info/citation are metadata, retry is
-        // an internal agent detail, and context-warning is advisory. They are
-        // intentionally consumed without surfacing to ACP.
         return null;
       default: {
-        // Exhaustiveness guard: any future AgentEvent variant added to the
-        // union without an explicit case above will fail to type-check here.
         const exhaustive: never = event;
         throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
       }
@@ -703,10 +701,6 @@ export class Session {
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
   ): Promise<void> {
-    // size = the configured context window (user override -> provider limit ->
-    // model lookup, the shared #2251 resolver), used = tokens now in context —
-    // so the client renders consumption against the real window (issue #1607)
-    // instead of the previous used===size placeholder.
     const update = buildUsageUpdate(
       usage,
       getTokenLimitForConfiguredContext(this.config.getModel(), this.config),
@@ -787,6 +781,9 @@ export class Session {
     this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate({ sessionId: this.id, update });
   }
+  async sendAvailableCommands(): Promise<void> {
+    await this.sendUpdateStrict(buildAvailableCommandsUpdate());
+  }
   private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
       await this.sendUpdateStrict(update);
@@ -810,41 +807,13 @@ export class Session {
     }));
     await this.sendUpdate({ sessionUpdate: 'plan', entries });
   }
-  /**
-   * Replays a resumed conversation (ordered IContent[]) to the client as
-   * session/update notifications, in order, for ACP session/load (issue #1604).
-   * The neutral history is mapped to ACP updates by the pure
-   * mapHistoryToSessionUpdates helper (human text -> user_message_chunk, ai text
-   * -> agent_message_chunk, ai thinking -> agent_thought_chunk, ai tool_call ->
-   * tool_call, tool tool_response -> tool_call_update). Replay text is sent
-   * verbatim (NOT routed through the EmojiFilter): the recorded transcript was
-   * already filtered when first streamed, so re-filtering on replay would be
-   * redundant and could double-alter historical content.
-   */
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
     for (const update of updates) {
-      // STRICT: a failed delivery here (dead/failing transport) must reject so
-      // loadSession can clean up and report the failure instead of resolving as
-      // a success with a lost transcript (FINDING A). wrapReplayFailure maps the
-      // rejection to a precise internalError (passing an existing RequestError
-      // through unchanged) for loadSession's catch path.
-      try {
-        await this.sendUpdateStrict(update);
-      } catch (error) {
-        throw wrapReplayFailure(this.id, error);
-      }
+      try { await this.sendUpdateStrict(update); }
+      catch (error) { throw wrapReplayFailure(this.id, error); }
     }
   }
-  /**
-   * Re-attach replay for ACP session/load (#1604): replays this live session's
-   * IN-MEMORY conversation, used when a load targets a still-live session with
-   * no on-disk recording yet (unprompted; JSONL not materialized). History is
-   * read + wrapped by readAgentHistoryForReplay and maps through the SAME
-   * strict {@link streamHistory} path a disk resume uses (empty history → zero
-   * updates). Any failure rejects as a well-formed replay RequestError; the
-   * caller deliberately does NOT dispose the session — it remains healthy.
-   */
   async replayLiveHistory(): Promise<void> {
     await this.streamHistory(
       await readAgentHistoryForReplay(this.agent, this.id),

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -123,7 +123,7 @@ export async function runZedIntegration(
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
   private clientCapabilities: acp.ClientCapabilities | undefined;
-  private readonly logger = new DebugLogger('llxprt:zed');
+  private readonly logger = new DebugLogger('llxprt:zed-integration');
   private readonly lifecycle: SessionLifecycle;
   constructor(
     private config: Config,
@@ -149,7 +149,7 @@ export class ZedAgent {
   ): Promise<acp.ListSessionsResponse> {
     return this.lifecycle.list(params);
   }
-  authenticate({ methodId }: acp.AuthenticateRequest) {
+  authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
     return authenticateZedAgent(this.config, methodId);
   }
   async newSession({
@@ -185,19 +185,23 @@ export class ZedAgent {
   resumeSession(params: acp.ResumeSessionRequest) {
     return this.lifecycle.resume(params);
   }
-  private configEnabled = () =>
+  private supportsConfigOptions = () =>
     this.clientCapabilities?.session?.configOptions != null;
   private createSession(id: string, agent: Agent, config: Config) {
     return buildZedSession(
       agent,
       () =>
-        new Session(id, agent, config, this.connection, this.configEnabled()),
+        new Session(
+          id,
+          agent,
+          config,
+          this.connection,
+          this.supportsConfigOptions(),
+        ),
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
   }
-  async loadSession(
-    params: acp.LoadSessionRequest,
-  ): Promise<acp.LoadSessionResponse> {
+  async loadSession(params: acp.LoadSessionRequest) {
     return this.lifecycle.runSerialized(params.sessionId, () =>
       this.performLoadSession(params),
     );
@@ -294,7 +298,13 @@ export class ZedAgent {
         sessionConfig,
         this.sessionFileLister,
       );
-      const session = await this.createSession(sessionId, agent, sessionConfig);
+      const session = new Session(
+        sessionId,
+        agent,
+        sessionConfig,
+        this.connection,
+        this.supportsConfigOptions(),
+      );
       return { session, history };
     } catch (error) {
       await agent.dispose().catch(() => undefined);
@@ -333,7 +343,7 @@ export class ZedAgent {
   closeSession(params: acp.CloseSessionRequest) {
     return this.lifecycle.close(params);
   }
-  async setSessionMode(params: acp.SetSessionModeRequest) {
+  setSessionMode(params: acp.SetSessionModeRequest) {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
@@ -345,7 +355,7 @@ export class ZedAgent {
       dispatchZedConfigOption(this.clientCapabilities, this.sessions, params),
     );
   }
-  async cancel({ sessionId }: acp.CancelNotification): Promise<void> {
+  async cancel({ sessionId }: acp.CancelNotification) {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
     await session.cancelPendingPrompt();
@@ -357,7 +367,7 @@ export class ZedAgent {
     }
     return session.prompt(params);
   }
-  async disposeAll(): Promise<void> {
+  async disposeAll() {
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     await Promise.allSettled(sessions.map((session) => session.dispose()));
@@ -365,7 +375,7 @@ export class ZedAgent {
 }
 export class Session {
   private pendingPrompt: AbortController | null = null;
-  private readonly logger = new DebugLogger('llxprt:zed');
+  private readonly logger = new DebugLogger('llxprt:zed-integration');
   private pathResolver: ZedPathResolver;
   private activeConfirmations = new Map<
     string,
@@ -419,10 +429,7 @@ export class Session {
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
-  async setConfigOption(
-    configId: string,
-    value: string | boolean,
-  ): Promise<acp.SetSessionConfigOptionResponse> {
+  setConfigOption(configId: string, value: string | boolean) {
     return setZedConfigOption(this.agent, this.config, configId, value);
   }
   getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
@@ -778,12 +785,12 @@ export class Session {
       }
     }
   }
-  async replayLiveHistory(): Promise<void> {
+  async replayLiveHistory() {
     await this.streamHistory(
       await readAgentHistoryForReplay(this.agent, this.id),
     );
   }
-  async dispose(): Promise<void> {
+  async dispose() {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
       this.stopConfigUpdates();

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -532,10 +532,11 @@ export class Session {
         }
       }
     } finally {
-      // Finding 3: exact-once metadata finally shared by command and prompt
-      // paths (success, cancel, or error). Best-effort transport — sendUpdate
-      // swallows transient errors so metadata never replaces the turn outcome.
-      await this.emitTurnMetadata(eligibility);
+      try {
+        await this.emitTurnMetadata(eligibility);
+      } catch (error) {
+        this.logger.debug(() => `emitTurnMetadata ERROR: ${String(error)}`);
+      }
     }
   }
 

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -515,11 +515,9 @@ export class Session {
       params.prompt,
       this.agent,
       this.config,
-      (u) => this.sendUpdateStrict(u),
+      (update) => this.sendUpdateStrict(update),
     );
-    if (commandResult !== null) {
-      return commandResult.response;
-    }
+    if (commandResult !== null) return commandResult.response;
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;
     this.promptGeneration += 1;
@@ -810,8 +808,11 @@ export class Session {
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
     for (const update of updates) {
-      try { await this.sendUpdateStrict(update); }
-      catch (error) { throw wrapReplayFailure(this.id, error); }
+      try {
+        await this.sendUpdateStrict(update);
+      } catch (error) {
+        throw wrapReplayFailure(this.id, error);
+      }
     }
   }
   async replayLiveHistory(): Promise<void> {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -405,7 +405,7 @@ export class Session {
   >();
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
-  private readonly createdAt = new Date().toISOString();
+  private updatedAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
@@ -453,7 +453,7 @@ export class Session {
     return {
       sessionId: this.id,
       cwd: this.config.getProjectRoot(),
-      updatedAt: this.createdAt,
+      updatedAt: this.updatedAt,
     };
   }
   async cancelPendingPrompt(): Promise<void> {
@@ -504,6 +504,7 @@ export class Session {
     }
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
+    this.updatedAt = new Date().toISOString();
     await this.cancelPendingPrompt();
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -39,6 +39,7 @@ import {
   parseZedAuthMethodId,
   buildAvailableModes,
   buildSessionModes,
+  describeSessionUpdateForLog,
   mapDoneReasonToStopReason,
   extractThoughtText,
   translateErrorEvent,
@@ -989,7 +990,9 @@ export class Session {
    */
   private async sendUpdateStrict(update: acp.SessionUpdate): Promise<void> {
     const params: acp.SessionNotification = { sessionId: this.id, update };
+    this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate(params);
+    this.logger.debug(() => 'sendUpdate: delivered');
   }
 
   /**

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -84,7 +84,9 @@ import {
 } from './zed-session-info.js';
 import type {
   CloseSessionRequest,
+  CloseSessionResponse,
   DeleteSessionRequest,
+  DeleteSessionResponse,
   ClientCapabilitiesWithSession,
 } from './acp-types.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
@@ -98,7 +100,6 @@ export async function runZedIntegration(
   const { stdout: workingStdout } = createInkStdio();
   const stdout = Writable.toWeb(workingStdout) as WritableStream;
   const stdin = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
-  logger.debug(() => 'Streams created');
   setCliRuntimeContext(config.getSettingsService(), config, {
     runtimeId: 'cli.runtime.zed',
     metadata: { source: 'zed-integration', stage: 'bootstrap' },
@@ -108,11 +109,9 @@ export async function runZedIntegration(
   try {
     const stream = acp.ndJsonStream(stdout, stdin);
     const connection = new acp.AgentSideConnection((conn) => {
-      logger.debug(() => 'Creating ZedAgent');
       zedAgent = new ZedAgent(config, settings, conn);
       return zedAgent;
     }, stream);
-    logger.debug(() => 'AgentSideConnection created successfully');
     try {
       await connection.closed;
     } finally {
@@ -194,7 +193,7 @@ export class ZedAgent {
       throw error;
     }
   }
-  resumeSession(params: acp.ResumeSessionRequest) {
+  resumeSession(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
     return this.lifecycle.resume(params);
   }
   private supportsConfigOptions(): boolean {
@@ -223,7 +222,7 @@ export class ZedAgent {
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
   }
-  async loadSession(params: acp.LoadSessionRequest) {
+  async loadSession(params: acp.LoadSessionRequest): Promise<acp.LoadSessionResponse> {
     return this.lifecycle.runSerialized(params.sessionId, () =>
       this.performLoadSession(params),
     );
@@ -232,7 +231,6 @@ export class ZedAgent {
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
     const { sessionId } = params;
-    this.logger.debug(() => `loadSession - loading session ${sessionId}`);
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
       await reattached.sendAvailableCommands();
@@ -264,11 +262,7 @@ export class ZedAgent {
     if (recordingExists) {
       return null;
     }
-    this.logger.debug(
-      () =>
-        `loadSession - re-attaching live session ${sessionId} (no on-disk ` +
-        `recording; replaying in-memory history)`,
-    );
+    this.logger.debug(() => `loadSession - re-attaching live session ${sessionId}`);
     await existing.replayLiveHistory();
     return existing;
   }
@@ -292,14 +286,7 @@ export class ZedAgent {
       await session.streamHistory(history);
     } catch (error) {
       this.sessions.delete(sessionId);
-      try {
-        await session.dispose();
-      } catch (disposeError) {
-        this.logger.debug(
-          () =>
-            `loadSession - dispose after replay failure also failed (original error rethrown): ${disposeError}`,
-        );
-      }
+      try { await session.dispose(); } catch { /* original error rethrown */ }
       this.logger.debug(() => `loadSession - replay failed: ${error}`);
       throw error;
     }
@@ -369,7 +356,6 @@ export class ZedAgent {
         this.logger,
       );
     }
-    this.logger.debug(() => `buildSessionAgent - session ${sessionId}`);
     const agent = await fromConfig({
       config: sessionConfig,
       sessionId,
@@ -383,10 +369,10 @@ export class ZedAgent {
       terminals: terminalSetup?.terminals ?? null,
     };
   }
-  deleteSession(params: DeleteSessionRequest) {
+  deleteSession(params: DeleteSessionRequest): Promise<DeleteSessionResponse> {
     return this.lifecycle.delete(params);
   }
-  closeSession(params: CloseSessionRequest) {
+  closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     return this.lifecycle.close(params);
   }
   setSessionMode(
@@ -403,7 +389,7 @@ export class ZedAgent {
       dispatchZedConfigOption(this.clientCapabilities, this.sessions, params),
     );
   }
-  async cancel({ sessionId }: acp.CancelNotification) {
+  async cancel({ sessionId }: acp.CancelNotification): Promise<void> {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
     await session.cancelPendingPrompt();
@@ -415,7 +401,7 @@ export class ZedAgent {
     }
     return session.prompt(params);
   }
-  async disposeAll() {
+  async disposeAll(): Promise<void> {
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     await Promise.allSettled(sessions.map((session) => session.dispose()));
@@ -488,7 +474,7 @@ export class Session {
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
-  setConfigOption(configId: string, value: string | boolean) {
+  setConfigOption(configId: string, value: string) {
     return setZedConfigOption(this.agent, this.config, configId, value);
   }
   getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
@@ -785,12 +771,12 @@ export class Session {
     }
     this.sessionInfo.hydrateFromHistory(items);
   }
-  async replayLiveHistory() {
+  async replayLiveHistory(): Promise<void> {
     await this.streamHistory(
       await readAgentHistoryForReplay(this.agent, this.id),
     );
   }
-  async dispose() {
+  async dispose(): Promise<void> {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
       this.stopConfigUpdates();

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -50,9 +50,7 @@ import {
 import { ZedPathResolver } from './zed-path-resolver.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 import {
-  emitToolCallStart,
-  emitToolStatus,
-  emitToolResult,
+  emitAgentToolEvent,
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
@@ -88,9 +86,6 @@ export async function runZedIntegration(
 
   logger.debug(() => 'Streams created');
 
-  // Deliberate foreground hand-off: the Zed integration replaces the CLI
-  // bootstrap runtime as the process default. allowDefaultHandoff opts past the
-  // write-once guard for this one intentional transition (issue #2300).
   setCliRuntimeContext(config.getSettingsService(), config, {
     runtimeId: 'cli.runtime.zed',
     metadata: { source: 'zed-integration', stage: 'bootstrap' },
@@ -135,14 +130,6 @@ export class ZedAgent {
   private clientCapabilities: acp.ClientCapabilities | undefined;
   private logger: DebugLogger;
 
-  /**
-   * Directory lister used by the loadSession re-attach probe (#1604) to decide
-   * whether an on-disk recording already exists for a session id. Defaults to
-   * the real `node:fs/promises` readdir wrapper; injectable via the constructor
-   * as an HONEST readdir-like seam (returns directory entry names) so tests can
-   * exercise the real chats-dir derivation + filename matching without stubbing
-   * our own decision logic.
-   */
   private readonly sessionFileLister: ChatSessionFileLister;
 
   constructor(
@@ -203,10 +190,6 @@ export class ZedAgent {
         sessionId,
         cwd,
       );
-      // Enable continuous session recording so the conversation is persisted to
-      // a JSONL session file (under <projectTempDir>/chats) and can later be
-      // resumed via loadSession. Recording must never break session creation, so
-      // a startup failure is logged and swallowed.
       await this.enableRecording(agent, sessionId);
 
       const session = await this.buildSessionForAgent(
@@ -226,13 +209,6 @@ export class ZedAgent {
     }
   }
 
-  /**
-   * Constructs the Session wrapper for a freshly built agent, disposing the
-   * agent (releasing its recording lock) if the Session constructor throws
-   * (FINDING F12), so a ctor failure never leaks the agent — mirroring the
-   * loadSession-side guard in buildAndResumeSession. A dispose failure during
-   * cleanup is logged and swallowed so the ORIGINAL ctor error is rethrown.
-   */
   private async buildSessionForAgent(
     sessionId: string,
     agent: Agent,
@@ -253,58 +229,10 @@ export class ZedAgent {
     }
   }
 
-  /**
-   * Loads (resumes) a previously recorded session so its conversation can be
-   * continued (issue #1604). The history is replayed to the client as ordered
-   * session/update notifications BEFORE this resolves, so the Zed transcript is
-   * reconstructed.
-   *
-   * Two paths, chosen by whether a recording exists on disk (see
-   * {@link performLoadSession}):
-   *
-   * 1. RE-ATTACH (live session, no on-disk recording): a session that was created
-   *    via session/new but never prompted has NO recording file — SessionRecordingService
-   *    materializes the JSONL only on the FIRST content event — so a disk resume
-   *    would fail with "No sessions found for this project" AND the destroy-first
-   *    step would have thrown away a perfectly healthy live session. Instead we
-   *    KEEP the live session, replay its IN-MEMORY history (empty for a fresh
-   *    unprompted session → zero updates), and return its modes. This keeps ACP
-   *    loadSession conformant (an agent that advertises loadSession must not error
-   *    on a just-created session) and lets a Zed reconnect to an unprompted session
-   *    succeed. Because the live session is healthy, a replay failure here does NOT
-   *    dispose it — the wrapped internalError is simply propagated.
-   *
-   * 2. DISK RESUME (recording present, or no live session): a fresh Agent (bound
-   *    to a session-scoped Config + AcpFileSystemService, identical to newSession)
-   *    is created and `agent.session.resume` restores the recorded history AND
-   *    re-subscribes continuous recording so subsequent turns keep appending to the
-   *    SAME file. Replace-order + lock semantics: an already-loaded same-id Session
-   *    holds the on-disk session lock (SessionLockManager), so the fresh agent's
-   *    resume CANNOT acquire the lock until the prior Session is disposed; disposing
-   *    first is therefore unavoidable. To keep the destructive step safe we (a)
-   *    dispose the prior Session AND remove it from this.sessions up front so no
-   *    half-dead entry survives a subsequent failure, then (b) build + resume the
-   *    replacement; if that fails, the fresh agent is disposed and a precise
-   *    RequestError (carrying the lower-layer reason, see mapResumeError) is thrown,
-   *    leaving this.sessions with NO entry for the id so a later retry can cleanly
-   *    load again. On success the replacement is installed and the restored
-   *    transcript is streamed.
-   *
-   * Concurrency: same-id loads are SERIALIZED (FINDING F5) via loadSessionQueues
-   * so two concurrent session/load calls for one id cannot both build agents and
-   * race to install (which would orphan the earlier load's recording lock);
-   * distinct ids remain fully parallel. The re-attach probe + replay run INSIDE
-   * this serialization too.
-   */
   async loadSession(
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
     const { sessionId } = params;
-    // Chain this load after any in-flight load for the SAME id so the
-    // dispose-prior -> build -> resume -> install sequence runs to completion
-    // before the next same-id load begins (FINDING F5). We chain off the prior
-    // load's settlement (ignoring its outcome) rather than awaiting it directly
-    // so a rejected prior load does not reject this one.
     const prior = this.loadSessionQueues.get(sessionId);
     const run = (prior ?? Promise.resolve()).then(
       () => this.performLoadSession(params),
@@ -521,11 +449,6 @@ export class ZedAgent {
     return { agent, config: sessionConfig };
   }
 
-  /**
-   * Enables continuous session recording for a freshly created session. Failures
-   * are logged and swallowed so recording startup can never break session
-   * creation (the session remains fully usable, just unrecorded).
-   */
   private async enableRecording(
     agent: Agent,
     sessionId: string,
@@ -627,11 +550,6 @@ export class Session {
     return {};
   }
 
-  /**
-   * Returns the session's current approval mode, delegating to the underlying
-   * Agent. Used by loadSession to advertise the resumed session's currentModeId
-   * without reaching through to the private agent from the ZedAgent orchestrator.
-   */
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
@@ -822,16 +740,14 @@ export class Session {
         return null;
       }
       case 'tool-call':
-        await batcher.flush();
-        await emitToolCallStart(event.call, (u) => this.sendUpdate(u));
-        return null;
       case 'tool-status':
-        await batcher.flush();
-        await emitToolStatus(event.update, (u) => this.sendUpdate(u));
-        return null;
       case 'tool-result':
         await batcher.flush();
-        await emitToolResult(event.result, (u) => this.sendUpdate(u));
+        await emitAgentToolEvent(
+          event,
+          (update) => this.sendUpdate(update),
+          this.agent.tools,
+        );
         return null;
       case 'tool-confirmation':
         await batcher.flush();
@@ -857,13 +773,9 @@ export class Session {
           event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
         );
       case 'loop-detected':
-        // The agent detects a tool-call loop. Map to end_turn so the client
-        // sees a clean turn end rather than an indefinite hang.
         await batcher.flush();
         return 'end_turn';
       case 'notice':
-        // Informational notices have no direct ACP SessionUpdate; surface as
-        // an agent message so the user sees them.
         await batcher.flush();
         await this.sendUpdate({
           sessionUpdate: 'agent_message_chunk',
@@ -880,14 +792,8 @@ export class Session {
       case 'model-info':
       case 'retry':
       case 'citation':
-        // These variants have no faithful ACP translation: usage is mapped
-        // separately, compression/model-info/citation are metadata, retry is
-        // an internal agent detail, and context-warning is advisory. They are
-        // intentionally consumed without surfacing to ACP.
         return null;
       default: {
-        // Exhaustiveness guard: any future AgentEvent variant added to the
-        // union without an explicit case above will fail to type-check here.
         const exhaustive: never = event;
         throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
       }
@@ -897,10 +803,6 @@ export class Session {
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
   ): Promise<void> {
-    // size = the configured context window (user override -> provider limit ->
-    // model lookup, the shared #2251 resolver), used = tokens now in context —
-    // so the client renders consumption against the real window (issue #1607)
-    // instead of the previous used===size placeholder.
     const update = buildUsageUpdate(
       usage,
       getTokenLimitForConfiguredContext(this.config.getModel(), this.config),
@@ -949,6 +851,7 @@ export class Session {
           event.confirmation.name,
           event.confirmation.details,
           this.connection,
+          this.agent.tools.get(event.confirmation.name)?.kind,
         ),
         cancelled,
       ] as const);
@@ -984,25 +887,12 @@ export class Session {
     }
   }
 
-  /**
-   * STRICT delivery of a single session/update: rethrows any transport failure.
-   * Used ONLY by streamHistory (ACP session/load replay) so a dead/failing
-   * client connection fails the load rather than silently losing the transcript
-   * while loadSession still resolves successfully (FINDING A). The best-effort
-   * live path (sendUpdate) must NOT use this.
-   */
   private async sendUpdateStrict(update: acp.SessionUpdate): Promise<void> {
     this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate({ sessionId: this.id, update });
     this.logger.debug(() => 'sendUpdate: delivered');
   }
 
-  /**
-   * BEST-EFFORT delivery for the LIVE prompt path: a transient client error
-   * must not abort an in-flight turn, so delivery failures are logged and
-   * swallowed. Replay uses sendUpdateStrict instead so lost history surfaces as
-   * a failed load.
-   */
   private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
       await this.sendUpdateStrict(update);
@@ -1029,25 +919,10 @@ export class Session {
     await this.sendUpdate({ sessionUpdate: 'plan', entries });
   }
 
-  /**
-   * Replays a resumed conversation (ordered IContent[]) to the client as
-   * session/update notifications, in order, for ACP session/load (issue #1604).
-   * The neutral history is mapped to ACP updates by the pure
-   * mapHistoryToSessionUpdates helper (human text -> user_message_chunk, ai text
-   * -> agent_message_chunk, ai thinking -> agent_thought_chunk, ai tool_call ->
-   * tool_call, tool tool_response -> tool_call_update). Replay text is sent
-   * verbatim (NOT routed through the EmojiFilter): the recorded transcript was
-   * already filtered when first streamed, so re-filtering on replay would be
-   * redundant and could double-alter historical content.
-   */
+  /** Replays resumed history as ordered, strictly delivered ACP updates. */
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
     for (const update of updates) {
-      // STRICT: a failed delivery here (dead/failing transport) must reject so
-      // loadSession can clean up and report the failure instead of resolving as
-      // a success with a lost transcript (FINDING A). wrapReplayFailure maps the
-      // rejection to a precise internalError (passing an existing RequestError
-      // through unchanged) for loadSession's catch path.
       try {
         await this.sendUpdateStrict(update);
       } catch (error) {
@@ -1056,15 +931,7 @@ export class Session {
     }
   }
 
-  /**
-   * Re-attach replay for ACP session/load (#1604): replays this live session's
-   * IN-MEMORY conversation, used when a load targets a still-live session with
-   * no on-disk recording yet (unprompted; JSONL not materialized). History is
-   * read + wrapped by readAgentHistoryForReplay and maps through the SAME
-   * strict {@link streamHistory} path a disk resume uses (empty history → zero
-   * updates). Any failure rejects as a well-formed replay RequestError; the
-   * caller deliberately does NOT dispose the session — it remains healthy.
-   */
+  /** Replays a live session whose recording has not materialized yet. */
   async replayLiveHistory(): Promise<void> {
     await this.streamHistory(
       await readAgentHistoryForReplay(this.agent, this.id),

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -60,7 +60,7 @@ import {
   resumeAgentHistory,
   toLoadRequestError,
   hasRecordedSessionFile,
-  readAgentHistoryAsIContent,
+  readAgentHistoryForReplay,
   nodeChatSessionFileLister,
   type ChatSessionFileLister,
 } from './zed-session-loader.js';
@@ -989,9 +989,8 @@ export class Session {
    * live path (sendUpdate) must NOT use this.
    */
   private async sendUpdateStrict(update: acp.SessionUpdate): Promise<void> {
-    const params: acp.SessionNotification = { sessionId: this.id, update };
     this.logger.debug(() => describeSessionUpdateForLog(update));
-    await this.connection.sessionUpdate(params);
+    await this.connection.sessionUpdate({ sessionId: this.id, update });
     this.logger.debug(() => 'sendUpdate: delivered');
   }
 
@@ -1056,20 +1055,17 @@ export class Session {
 
   /**
    * Re-attach replay for ACP session/load (#1604): replays this live session's
-   * IN-MEMORY conversation to the client, used when a session/load targets a
-   * still-live session that has no on-disk recording yet (an unprompted session,
-   * whose JSONL file has not materialized). The live agent's history is read via
-   * the Agent API and converted to neutral IContent[] (readAgentHistoryAsIContent)
-   * so it maps through the SAME strict {@link streamHistory} path a disk resume
-   * uses. A fresh unprompted session has empty history → ZERO updates. Delivery
-   * is strict: a transport failure rejects (wrapped by streamHistory) so a lost
-   * transcript is reported rather than silently resolving; the caller
-   * (reattachLiveSession) deliberately does NOT dispose the session on failure
-   * because it remains healthy.
+   * IN-MEMORY conversation, used when a load targets a still-live session with
+   * no on-disk recording yet (unprompted; JSONL not materialized). History is
+   * read + wrapped by readAgentHistoryForReplay and maps through the SAME
+   * strict {@link streamHistory} path a disk resume uses (empty history → zero
+   * updates). Any failure rejects as a well-formed replay RequestError; the
+   * caller deliberately does NOT dispose the session — it remains healthy.
    */
   async replayLiveHistory(): Promise<void> {
-    const items = await readAgentHistoryAsIContent(this.agent);
-    await this.streamHistory(items);
+    await this.streamHistory(
+      await readAgentHistoryForReplay(this.agent, this.id),
+    );
   }
 
   async dispose(): Promise<void> {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -459,7 +459,15 @@ export class ZedAgent {
       cwd,
     );
     try {
-      const history = await resumeAgentHistory(agent, sessionId, sessionConfig);
+      // FINDING C1: pass the SAME injected lister the re-attach probe uses so
+      // BOTH on-disk session-file probes (re-attach + corrupt-vs-missing resume)
+      // read through one injectable seam rather than one hardcoding readdir.
+      const history = await resumeAgentHistory(
+        agent,
+        sessionId,
+        sessionConfig,
+        this.sessionFileLister,
+      );
       const session = new Session(
         sessionId,
         agent,

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -25,8 +25,6 @@ import {
   fromConfig,
   type Agent,
   type AgentEvent,
-  type DoneReason,
-  type ThoughtSummary,
 } from '@vybestack/llxprt-code-agents';
 import { Readable, Writable } from 'node:stream';
 import { type LoadedSettings } from '../config/settings.js';
@@ -37,7 +35,15 @@ import {
 } from '@vybestack/llxprt-code-providers/runtime.js';
 import { runExitCleanup } from '../utils/cleanup.js';
 import { AcpFileSystemService } from './fileSystemService.js';
-import { parseZedAuthMethodId, buildAvailableModes } from './zed-helpers.js';
+import {
+  parseZedAuthMethodId,
+  buildAvailableModes,
+  buildSessionModes,
+  mapDoneReasonToStopReason,
+  extractThoughtText,
+  translateErrorEvent,
+  translateIdleTimeout,
+} from './zed-helpers.js';
 import { ZedPathResolver } from './zed-path-resolver.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 import {
@@ -52,6 +58,10 @@ import { wrapReplayFailure } from './zed-session-errors.js';
 import {
   resumeAgentHistory,
   toLoadRequestError,
+  hasRecordedSessionFile,
+  readAgentHistoryAsIContent,
+  nodeChatSessionFileLister,
+  type ChatSessionFileLister,
 } from './zed-session-loader.js';
 import { StreamBatcher } from './zed-stream-batcher.js';
 import {
@@ -122,12 +132,24 @@ export class ZedAgent {
   private clientCapabilities: acp.ClientCapabilities | undefined;
   private logger: DebugLogger;
 
+  /**
+   * Directory lister used by the loadSession re-attach probe (#1604) to decide
+   * whether an on-disk recording already exists for a session id. Defaults to
+   * the real `node:fs/promises` readdir wrapper; injectable via the constructor
+   * as an HONEST readdir-like seam (returns directory entry names) so tests can
+   * exercise the real chats-dir derivation + filename matching without stubbing
+   * our own decision logic.
+   */
+  private readonly sessionFileLister: ChatSessionFileLister;
+
   constructor(
     private config: Config,
     _settings: LoadedSettings,
     private connection: acp.AgentSideConnection,
+    sessionFileLister: ChatSessionFileLister = nodeChatSessionFileLister,
   ) {
     this.logger = new DebugLogger('llxprt:zed-integration');
+    this.sessionFileLister = sessionFileLister;
   }
 
   async initialize(
@@ -193,10 +215,7 @@ export class ZedAgent {
 
       return {
         sessionId,
-        modes: {
-          availableModes: buildAvailableModes(),
-          currentModeId: agent.getApprovalMode(),
-        },
+        modes: buildSessionModes(agent.getApprovalMode()),
       };
     } catch (error) {
       this.logger.debug(() => `ERROR in newSession: ${error}`);
@@ -233,34 +252,46 @@ export class ZedAgent {
 
   /**
    * Loads (resumes) a previously recorded session so its conversation can be
-   * continued (issue #1604). The persisted history is replayed to the client as
-   * ordered session/update notifications BEFORE this resolves, so the Zed
-   * transcript is reconstructed. A fresh Agent (bound to a session-scoped Config
-   * + AcpFileSystemService, identical to newSession) is created for the loaded
-   * session id, and `agent.session.resume` restores the history AND re-subscribes
-   * continuous recording so subsequent turns keep appending to the SAME file.
+   * continued (issue #1604). The history is replayed to the client as ordered
+   * session/update notifications BEFORE this resolves, so the Zed transcript is
+   * reconstructed.
    *
-   * Replace-order + lock semantics: an already-loaded same-id Session holds the
-   * on-disk session lock (SessionLockManager), so the fresh agent's resume CANNOT
-   * acquire the lock until the prior Session is disposed. Disposing first is
-   * therefore unavoidable. To keep the destructive step safe we (a) dispose the
-   * prior Session AND remove it from this.sessions up front so no half-dead entry
-   * survives a subsequent failure, then (b) build + resume the replacement; if
-   * that fails, the fresh agent is disposed and a precise RequestError (carrying
-   * the lower-layer reason, see mapResumeError) is thrown, leaving this.sessions
-   * with NO entry for the id so a later retry can cleanly load again. On success
-   * the replacement is installed and the restored transcript is streamed.
+   * Two paths, chosen by whether a recording exists on disk (see
+   * {@link performLoadSession}):
    *
-   * Full-replay-on-reconnect: even when a healthy in-memory Session already
-   * exists for this id, we still perform the disk-based replace (fresh agent +
-   * resume + replay) rather than short-circuiting, because Zed expects a complete
-   * history replay on every session/load (e.g. a client reconnect rebuilding its
-   * transcript). The in-memory Session is not a substitute for that replay.
+   * 1. RE-ATTACH (live session, no on-disk recording): a session that was created
+   *    via session/new but never prompted has NO recording file — SessionRecordingService
+   *    materializes the JSONL only on the FIRST content event — so a disk resume
+   *    would fail with "No sessions found for this project" AND the destroy-first
+   *    step would have thrown away a perfectly healthy live session. Instead we
+   *    KEEP the live session, replay its IN-MEMORY history (empty for a fresh
+   *    unprompted session → zero updates), and return its modes. This keeps ACP
+   *    loadSession conformant (an agent that advertises loadSession must not error
+   *    on a just-created session) and lets a Zed reconnect to an unprompted session
+   *    succeed. Because the live session is healthy, a replay failure here does NOT
+   *    dispose it — the wrapped internalError is simply propagated.
+   *
+   * 2. DISK RESUME (recording present, or no live session): a fresh Agent (bound
+   *    to a session-scoped Config + AcpFileSystemService, identical to newSession)
+   *    is created and `agent.session.resume` restores the recorded history AND
+   *    re-subscribes continuous recording so subsequent turns keep appending to the
+   *    SAME file. Replace-order + lock semantics: an already-loaded same-id Session
+   *    holds the on-disk session lock (SessionLockManager), so the fresh agent's
+   *    resume CANNOT acquire the lock until the prior Session is disposed; disposing
+   *    first is therefore unavoidable. To keep the destructive step safe we (a)
+   *    dispose the prior Session AND remove it from this.sessions up front so no
+   *    half-dead entry survives a subsequent failure, then (b) build + resume the
+   *    replacement; if that fails, the fresh agent is disposed and a precise
+   *    RequestError (carrying the lower-layer reason, see mapResumeError) is thrown,
+   *    leaving this.sessions with NO entry for the id so a later retry can cleanly
+   *    load again. On success the replacement is installed and the restored
+   *    transcript is streamed.
    *
    * Concurrency: same-id loads are SERIALIZED (FINDING F5) via loadSessionQueues
    * so two concurrent session/load calls for one id cannot both build agents and
    * race to install (which would orphan the earlier load's recording lock);
-   * distinct ids remain fully parallel.
+   * distinct ids remain fully parallel. The re-attach probe + replay run INSIDE
+   * this serialization too.
    */
   async loadSession(
     params: acp.LoadSessionRequest,
@@ -290,9 +321,15 @@ export class ZedAgent {
   }
 
   /**
-   * Performs a single (already-serialized, see {@link loadSession}) session/load:
-   * disposes any prior same-id Session to release its on-disk lock, then builds +
-   * resumes + installs the replacement and streams the restored transcript.
+   * Performs a single (already-serialized, see {@link loadSession}) session/load.
+   *
+   * Decision: if a live same-id session exists AND no recording file exists on
+   * disk for it, RE-ATTACH the live session (an unprompted session has no
+   * recording — the file materializes on first content — so a disk resume would
+   * both fail and needlessly destroy the healthy live session). Otherwise fall
+   * back to the disk path: dispose any prior same-id Session to release its
+   * on-disk lock, then build + resume + install the replacement and stream the
+   * restored transcript.
    */
   private async performLoadSession(
     params: acp.LoadSessionRequest,
@@ -300,15 +337,51 @@ export class ZedAgent {
     const { sessionId } = params;
     this.logger.debug(() => `loadSession - loading session ${sessionId}`);
 
+    const reattached = await this.tryReattachLiveSession(sessionId);
+    if (reattached !== null) {
+      return { modes: buildSessionModes(reattached.getApprovalMode()) };
+    }
+
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
+    return { modes: buildSessionModes(session.getApprovalMode()) };
+  }
 
-    return {
-      modes: {
-        availableModes: buildAvailableModes(),
-        currentModeId: session.getApprovalMode(),
-      },
-    };
+  /**
+   * RE-ATTACH decision + replay (#1604). Returns the live same-id Session (after
+   * replaying its in-memory history) when one exists AND has no on-disk recording
+   * yet (an unprompted session, whose JSONL file has not materialized) — a disk
+   * resume would both fail and needlessly destroy the healthy live session, so we
+   * keep it and replay instead. Returns null (so the caller takes the disk-resume
+   * path) when there is no live session OR a recording file already exists. For a
+   * fresh unprompted session the in-memory history is empty, so ZERO replay
+   * updates are sent. A replay failure is propagated (already wrapped as a precise
+   * RequestError by Session.streamHistory) WITHOUT disposing the session — it was
+   * healthy and the client can retry — the re-attach cleanup contract (no destroy
+   * on failure), distinct from the disk path's destroy-on-failure.
+   */
+  private async tryReattachLiveSession(
+    sessionId: string,
+  ): Promise<Session | null> {
+    const existing = this.sessions.get(sessionId);
+    if (existing === undefined) {
+      return null;
+    }
+    const recordingExists = await hasRecordedSessionFile(
+      this.config,
+      sessionId,
+      this.sessionFileLister,
+    );
+    if (recordingExists) {
+      return null;
+    }
+    this.logger.debug(
+      () =>
+        `loadSession - re-attaching live session ${sessionId} (no on-disk ` +
+        `recording; replaying in-memory history)`,
+    );
+    await existing.replayLiveHistory();
+    return existing;
   }
 
   /**
@@ -485,29 +558,6 @@ export class ZedAgent {
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     await Promise.allSettled(sessions.map((session) => session.dispose()));
-  }
-}
-
-function mapDoneReasonToStopReason(reason: DoneReason): acp.StopReason {
-  switch (reason) {
-    case 'stop':
-    case 'loop-detected':
-      return 'end_turn';
-    case 'aborted':
-      return 'cancelled';
-    case 'max-turns':
-      return 'max_turn_requests';
-    case 'context-overflow':
-      return 'max_tokens';
-    case 'refusal':
-      return 'refusal';
-    case 'error':
-    case 'hook-stopped':
-      throw new Error(`Agent stopped with terminal reason: ${reason}`);
-    default: {
-      const exhaustive: never = reason;
-      return exhaustive;
-    }
   }
 }
 
@@ -749,7 +799,7 @@ export class Session {
         batcher.append(event.text, false);
         return null;
       case 'thinking': {
-        const thoughtText = this.extractThoughtText(event.thought);
+        const thoughtText = extractThoughtText(event.thought);
         if (thoughtText.length > 0) {
           batcher.append(thoughtText, true);
         }
@@ -776,10 +826,10 @@ export class Session {
         return mapDoneReasonToStopReason(event.reason);
       case 'error':
         await batcher.flush();
-        throw this.translateErrorEvent(event);
+        throw translateErrorEvent(event);
       case 'idle-timeout':
         await batcher.flush();
-        throw this.translateIdleTimeout(event);
+        throw translateIdleTimeout(event);
       case 'invalid-stream':
         await batcher.flush();
         throw new Error(
@@ -917,29 +967,6 @@ export class Session {
     }
   }
 
-  private extractThoughtText(thought: ThoughtSummary): string {
-    const parts = [thought.subject, thought.description].filter(
-      (v) => v.length > 0,
-    );
-    return parts.join(parts.length > 1 ? ' ' : '');
-  }
-
-  private translateErrorEvent(
-    event: Extract<AgentEvent, { type: 'error' }>,
-  ): Error {
-    const error = new Error(event.error.message);
-    if (event.error.status !== undefined) {
-      Object.assign(error, { status: event.error.status });
-    }
-    return error;
-  }
-
-  private translateIdleTimeout(
-    event: Extract<AgentEvent, { type: 'idle-timeout' }>,
-  ): Error {
-    return new Error(event.error.message);
-  }
-
   /**
    * STRICT delivery of a single session/update: rethrows any transport failure.
    * Used ONLY by streamHistory (ACP session/load replay) so a dead/failing
@@ -1009,6 +1036,24 @@ export class Session {
         throw wrapReplayFailure(this.id, error);
       }
     }
+  }
+
+  /**
+   * Re-attach replay for ACP session/load (#1604): replays this live session's
+   * IN-MEMORY conversation to the client, used when a session/load targets a
+   * still-live session that has no on-disk recording yet (an unprompted session,
+   * whose JSONL file has not materialized). The live agent's history is read via
+   * the Agent API and converted to neutral IContent[] (readAgentHistoryAsIContent)
+   * so it maps through the SAME strict {@link streamHistory} path a disk resume
+   * uses. A fresh unprompted session has empty history → ZERO updates. Delivery
+   * is strict: a transport failure rejects (wrapped by streamHistory) so a lost
+   * transcript is reported rather than silently resolving; the caller
+   * (reattachLiveSession) deliberately does NOT dispose the session on failure
+   * because it remains healthy.
+   */
+  async replayLiveHistory(): Promise<void> {
+    const items = await readAgentHistoryAsIContent(this.agent);
+    await this.streamHistory(items);
   }
 
   async dispose(): Promise<void> {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -9,7 +9,6 @@ import {
   getErrorStatus,
   todoEvents,
   DEFAULT_AGENT_ID,
-  isWithinRoot,
   debugLogger,
   createInkStdio,
   type ContractPart,
@@ -20,7 +19,6 @@ import {
   type TodoUpdateEvent,
   type Todo,
   type ApprovalMode,
-  type RuntimeProviderManager,
 } from '@vybestack/llxprt-code-core';
 import * as acp from '@agentclientprotocol/sdk';
 import {
@@ -31,7 +29,6 @@ import {
   type ThoughtSummary,
 } from '@vybestack/llxprt-code-agents';
 import { Readable, Writable } from 'node:stream';
-import * as path from 'node:path';
 import { type LoadedSettings } from '../config/settings.js';
 import { randomUUID } from 'crypto';
 import {
@@ -57,8 +54,13 @@ import {
   toLoadRequestError,
 } from './zed-session-loader.js';
 import { StreamBatcher } from './zed-stream-batcher.js';
+import {
+  createSessionScopedConfig,
+  resolveSessionTargetDir,
+} from './zed-session-config.js';
 
 export { parseZedAuthMethodId } from './zed-helpers.js';
+export { createSessionScopedConfig } from './zed-session-config.js';
 
 export async function runZedIntegration(
   config: Config,
@@ -105,60 +107,18 @@ export async function runZedIntegration(
   }
 }
 
-function resolveSessionTargetDir(
-  config: Config,
-  cwd: string | undefined,
-): string {
-  if (cwd === undefined || cwd.trim().length === 0) {
-    return config.getTargetDir();
-  }
-  const candidate = path.isAbsolute(cwd)
-    ? cwd
-    : path.resolve(config.getTargetDir(), cwd);
-  return isWithinRoot(candidate, config.getTargetDir())
-    ? candidate
-    : config.getTargetDir();
-}
-
-export function createSessionScopedConfig(
-  config: Config,
-  initialFileSystemService: ReturnType<Config['getFileSystemService']>,
-  targetDir: string = config.getTargetDir(),
-): Config {
-  let fileSystemService = initialFileSystemService;
-  let providerManager: RuntimeProviderManager | undefined =
-    config.getProviderManager();
-  return new Proxy(config, {
-    get(target, property, receiver) {
-      if (property === 'getFileSystemService') {
-        return () => fileSystemService;
-      }
-      if (property === 'setFileSystemService') {
-        return (nextFileSystemService: typeof fileSystemService) => {
-          fileSystemService = nextFileSystemService;
-        };
-      }
-      if (property === 'getProviderManager') {
-        return () => providerManager;
-      }
-      if (property === 'setProviderManager') {
-        return (nextProviderManager: RuntimeProviderManager) => {
-          providerManager = nextProviderManager;
-        };
-      }
-      if (property === 'getProjectRoot') {
-        return () => targetDir;
-      }
-      if (property === 'getTargetDir') {
-        return () => targetDir;
-      }
-      return Reflect.get(target, property, receiver);
-    },
-  });
-}
-
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
+  /**
+   * Per-sessionId serialization of in-flight loadSession calls (FINDING F5).
+   * Two concurrent session/load calls for the SAME id must not both build agents
+   * and race to install (the later install would overwrite the earlier, orphaning
+   * its recording lock). Each load chains after any in-flight load for the same
+   * id; distinct ids stay fully parallel. The entry is cleared in finally only
+   * when it is still the same promise (a later chained load may have replaced it).
+   */
+  private loadSessionQueues: Map<string, Promise<acp.LoadSessionResponse>> =
+    new Map();
   private clientCapabilities: acp.ClientCapabilities | undefined;
   private logger: DebugLogger;
 
@@ -224,11 +184,10 @@ export class ZedAgent {
       // a startup failure is logged and swallowed.
       await this.enableRecording(agent, sessionId);
 
-      const session = new Session(
+      const session = await this.buildSessionForAgent(
         sessionId,
         agent,
         sessionConfig,
-        this.connection,
       );
       this.sessions.set(sessionId, session);
 
@@ -241,6 +200,33 @@ export class ZedAgent {
       };
     } catch (error) {
       this.logger.debug(() => `ERROR in newSession: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Constructs the Session wrapper for a freshly built agent, disposing the
+   * agent (releasing its recording lock) if the Session constructor throws
+   * (FINDING F12), so a ctor failure never leaks the agent — mirroring the
+   * loadSession-side guard in buildAndResumeSession. A dispose failure during
+   * cleanup is logged and swallowed so the ORIGINAL ctor error is rethrown.
+   */
+  private async buildSessionForAgent(
+    sessionId: string,
+    agent: Agent,
+    sessionConfig: Config,
+  ): Promise<Session> {
+    try {
+      return new Session(sessionId, agent, sessionConfig, this.connection);
+    } catch (error) {
+      try {
+        await agent.dispose();
+      } catch (disposeError) {
+        this.logger.debug(
+          () =>
+            `newSession - dispose after Session ctor failure also failed (original error rethrown): ${disposeError}`,
+        );
+      }
       throw error;
     }
   }
@@ -270,8 +256,45 @@ export class ZedAgent {
    * resume + replay) rather than short-circuiting, because Zed expects a complete
    * history replay on every session/load (e.g. a client reconnect rebuilding its
    * transcript). The in-memory Session is not a substitute for that replay.
+   *
+   * Concurrency: same-id loads are SERIALIZED (FINDING F5) via loadSessionQueues
+   * so two concurrent session/load calls for one id cannot both build agents and
+   * race to install (which would orphan the earlier load's recording lock);
+   * distinct ids remain fully parallel.
    */
   async loadSession(
+    params: acp.LoadSessionRequest,
+  ): Promise<acp.LoadSessionResponse> {
+    const { sessionId } = params;
+    // Chain this load after any in-flight load for the SAME id so the
+    // dispose-prior -> build -> resume -> install sequence runs to completion
+    // before the next same-id load begins (FINDING F5). We chain off the prior
+    // load's settlement (ignoring its outcome) rather than awaiting it directly
+    // so a rejected prior load does not reject this one.
+    const prior = this.loadSessionQueues.get(sessionId);
+    const run = (prior ?? Promise.resolve()).then(
+      () => this.performLoadSession(params),
+      () => this.performLoadSession(params),
+    );
+    this.loadSessionQueues.set(sessionId, run);
+    try {
+      return await run;
+    } finally {
+      // Clear the queue entry only if it is still THIS load (a later chained
+      // same-id load may have replaced it); deleting unconditionally could drop
+      // a newer in-flight load's entry.
+      if (this.loadSessionQueues.get(sessionId) === run) {
+        this.loadSessionQueues.delete(sessionId);
+      }
+    }
+  }
+
+  /**
+   * Performs a single (already-serialized, see {@link loadSession}) session/load:
+   * disposes any prior same-id Session to release its on-disk lock, then builds +
+   * resumes + installs the replacement and streams the restored transcript.
+   */
+  private async performLoadSession(
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
     const { sessionId } = params;
@@ -324,7 +347,18 @@ export class ZedAgent {
       await session.streamHistory(history);
     } catch (error) {
       this.sessions.delete(sessionId);
-      await session.dispose();
+      // FINDING F13: guard the cleanup dispose so a dispose failure does not
+      // mask the ORIGINAL replay error. The replay error is the actionable one
+      // the client must see; a dispose failure is logged and swallowed, and the
+      // original error is rethrown.
+      try {
+        await session.dispose();
+      } catch (disposeError) {
+        this.logger.debug(
+          () =>
+            `loadSession - dispose after replay failure also failed (original error rethrown): ${disposeError}`,
+        );
+      }
       this.logger.debug(() => `loadSession - replay failed: ${error}`);
       throw error;
     }
@@ -647,7 +681,12 @@ export class Session {
         }
         throw error;
       } finally {
+        // Flush any buffered chunks, THEN dispose so the batch timer is cleared
+        // on completion/abort and no delayed flush fires after the turn ends
+        // (FINDING F9). The batcher is per-prompt, so disposing here bounds its
+        // timer to the prompt lifecycle.
         await batcher.flush();
+        batcher.dispose();
       }
 
       if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -3,7 +3,6 @@
  * Copyright 2025 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import {
   type Config,
   getErrorStatus,
@@ -30,14 +29,10 @@ import {
 import { Readable, Writable } from 'node:stream';
 import { type LoadedSettings } from '../config/settings.js';
 import { randomUUID } from 'crypto';
-import {
-  loadProfileByName,
-  setCliRuntimeContext,
-} from '@vybestack/llxprt-code-providers/runtime.js';
+import { setCliRuntimeContext } from '@vybestack/llxprt-code-providers/runtime.js';
 import { runExitCleanup } from '../utils/cleanup.js';
 import { AcpFileSystemService } from './fileSystemService.js';
 import {
-  parseZedAuthMethodId,
   buildAvailableModes,
   buildSessionModes,
   buildUsageUpdate,
@@ -67,38 +62,31 @@ import {
   type ChatSessionFileLister,
 } from './zed-session-loader.js';
 import { StreamBatcher } from './zed-stream-batcher.js';
+import { SessionLifecycle } from './zed-session-lifecycle.js';
+import type { LifecycleSession } from './zed-session-pagination.js';
+import { authenticateZedAgent, initializeZedAgent } from './zed-initialize.js';
 import {
   createSessionScopedConfig,
   resolveSessionTargetDir,
 } from './zed-session-config.js';
-
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
-
 export async function runZedIntegration(
   config: Config,
   settings: LoadedSettings,
 ): Promise<void> {
   const logger = new DebugLogger('llxprt:zed-integration');
   logger.debug(() => 'Starting Zed integration');
-
   const { stdout: workingStdout } = createInkStdio();
   const stdout = Writable.toWeb(workingStdout) as WritableStream;
   const stdin = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
-
   logger.debug(() => 'Streams created');
-
-  // Deliberate foreground hand-off: the Zed integration replaces the CLI
-  // bootstrap runtime as the process default. allowDefaultHandoff opts past the
-  // write-once guard for this one intentional transition (issue #2300).
   setCliRuntimeContext(config.getSettingsService(), config, {
     runtimeId: 'cli.runtime.zed',
     metadata: { source: 'zed-integration', stage: 'bootstrap' },
     allowDefaultHandoff: true,
   });
-
   let zedAgent: ZedAgent | undefined;
-
   try {
     const stream = acp.ndJsonStream(stdout, stdin);
     const connection = new acp.AgentSideConnection((conn) => {
@@ -107,7 +95,6 @@ export async function runZedIntegration(
       return zedAgent;
     }, stream);
     logger.debug(() => 'AgentSideConnection created successfully');
-
     try {
       await connection.closed;
     } finally {
@@ -119,80 +106,39 @@ export async function runZedIntegration(
     throw e;
   }
 }
-
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
-  /**
-   * Per-sessionId serialization of in-flight loadSession calls (FINDING F5).
-   * Two concurrent session/load calls for the SAME id must not both build agents
-   * and race to install (the later install would overwrite the earlier, orphaning
-   * its recording lock). Each load chains after any in-flight load for the same
-   * id; distinct ids stay fully parallel. The entry is cleared in finally only
-   * when it is still the same promise (a later chained load may have replaced it).
-   */
-  private loadSessionQueues: Map<string, Promise<acp.LoadSessionResponse>> =
-    new Map();
   private clientCapabilities: acp.ClientCapabilities | undefined;
-  private logger: DebugLogger;
-
-  /**
-   * Directory lister used by the loadSession re-attach probe (#1604) to decide
-   * whether an on-disk recording already exists for a session id. Defaults to
-   * the real `node:fs/promises` readdir wrapper; injectable via the constructor
-   * as an HONEST readdir-like seam (returns directory entry names) so tests can
-   * exercise the real chats-dir derivation + filename matching without stubbing
-   * our own decision logic.
-   */
+  private logger = new DebugLogger('llxprt:zed-integration');
+  private readonly lifecycle: SessionLifecycle;
   private readonly sessionFileLister: ChatSessionFileLister;
-
   constructor(
     private config: Config,
     _settings: LoadedSettings,
     private connection: acp.AgentSideConnection,
     sessionFileLister: ChatSessionFileLister = nodeChatSessionFileLister,
   ) {
-    this.logger = new DebugLogger('llxprt:zed-integration');
     this.sessionFileLister = sessionFileLister;
+    this.lifecycle = new SessionLifecycle(
+      config,
+      this.sessions,
+      (sessionId, cwd) => this.buildAndResumeSession(sessionId, cwd),
+    );
   }
-
   async initialize(
     args: acp.InitializeRequest,
   ): Promise<acp.InitializeResponse> {
     this.clientCapabilities = args.clientCapabilities;
-    const profileManager = this.config.getProfileManager();
-    const profileNames = profileManager
-      ? await profileManager.listProfiles()
-      : [];
-    const authMethods = profileNames.map((name) => ({
-      id: name,
-      name,
-      description: null,
-    }));
-
-    return {
-      protocolVersion: acp.PROTOCOL_VERSION,
-      authMethods,
-      agentCapabilities: {
-        loadSession: true,
-        promptCapabilities: {
-          image: true,
-          audio: true,
-          embeddedContext: true,
-        },
-      },
-    };
+    return initializeZedAgent(this.config);
   }
-
-  async authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
-    const profileManager = this.config.getProfileManager();
-    const availableProfiles = profileManager
-      ? await profileManager.listProfiles()
-      : [];
-    const profileName = parseZedAuthMethodId(methodId, availableProfiles);
-
-    await loadProfileByName(profileName);
+  listSessions(
+    params: acp.ListSessionsRequest,
+  ): Promise<acp.ListSessionsResponse> {
+    return this.lifecycle.list(params);
   }
-
+  authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
+    return authenticateZedAgent(this.config, methodId);
+  }
   async newSession({
     cwd,
     mcpServers: _mcpServers,
@@ -203,19 +149,13 @@ export class ZedAgent {
         sessionId,
         cwd,
       );
-      // Enable continuous session recording so the conversation is persisted to
-      // a JSONL session file (under <projectTempDir>/chats) and can later be
-      // resumed via loadSession. Recording must never break session creation, so
-      // a startup failure is logged and swallowed.
       await this.enableRecording(agent, sessionId);
-
       const session = await this.buildSessionForAgent(
         sessionId,
         agent,
         sessionConfig,
       );
       this.sessions.set(sessionId, session);
-
       return {
         sessionId,
         modes: buildSessionModes(agent.getApprovalMode()),
@@ -225,14 +165,6 @@ export class ZedAgent {
       throw error;
     }
   }
-
-  /**
-   * Constructs the Session wrapper for a freshly built agent, disposing the
-   * agent (releasing its recording lock) if the Session constructor throws
-   * (FINDING F12), so a ctor failure never leaks the agent — mirroring the
-   * loadSession-side guard in buildAndResumeSession. A dispose failure during
-   * cleanup is logged and swallowed so the ORIGINAL ctor error is rethrown.
-   */
   private async buildSessionForAgent(
     sessionId: string,
     agent: Agent,
@@ -252,117 +184,31 @@ export class ZedAgent {
       throw error;
     }
   }
-
-  /**
-   * Loads (resumes) a previously recorded session so its conversation can be
-   * continued (issue #1604). The history is replayed to the client as ordered
-   * session/update notifications BEFORE this resolves, so the Zed transcript is
-   * reconstructed.
-   *
-   * Two paths, chosen by whether a recording exists on disk (see
-   * {@link performLoadSession}):
-   *
-   * 1. RE-ATTACH (live session, no on-disk recording): a session that was created
-   *    via session/new but never prompted has NO recording file — SessionRecordingService
-   *    materializes the JSONL only on the FIRST content event — so a disk resume
-   *    would fail with "No sessions found for this project" AND the destroy-first
-   *    step would have thrown away a perfectly healthy live session. Instead we
-   *    KEEP the live session, replay its IN-MEMORY history (empty for a fresh
-   *    unprompted session → zero updates), and return its modes. This keeps ACP
-   *    loadSession conformant (an agent that advertises loadSession must not error
-   *    on a just-created session) and lets a Zed reconnect to an unprompted session
-   *    succeed. Because the live session is healthy, a replay failure here does NOT
-   *    dispose it — the wrapped internalError is simply propagated.
-   *
-   * 2. DISK RESUME (recording present, or no live session): a fresh Agent (bound
-   *    to a session-scoped Config + AcpFileSystemService, identical to newSession)
-   *    is created and `agent.session.resume` restores the recorded history AND
-   *    re-subscribes continuous recording so subsequent turns keep appending to the
-   *    SAME file. Replace-order + lock semantics: an already-loaded same-id Session
-   *    holds the on-disk session lock (SessionLockManager), so the fresh agent's
-   *    resume CANNOT acquire the lock until the prior Session is disposed; disposing
-   *    first is therefore unavoidable. To keep the destructive step safe we (a)
-   *    dispose the prior Session AND remove it from this.sessions up front so no
-   *    half-dead entry survives a subsequent failure, then (b) build + resume the
-   *    replacement; if that fails, the fresh agent is disposed and a precise
-   *    RequestError (carrying the lower-layer reason, see mapResumeError) is thrown,
-   *    leaving this.sessions with NO entry for the id so a later retry can cleanly
-   *    load again. On success the replacement is installed and the restored
-   *    transcript is streamed.
-   *
-   * Concurrency: same-id loads are SERIALIZED (FINDING F5) via loadSessionQueues
-   * so two concurrent session/load calls for one id cannot both build agents and
-   * race to install (which would orphan the earlier load's recording lock);
-   * distinct ids remain fully parallel. The re-attach probe + replay run INSIDE
-   * this serialization too.
-   */
+  resumeSession(
+    params: acp.ResumeSessionRequest,
+  ): Promise<acp.ResumeSessionResponse> {
+    return this.lifecycle.resume(params);
+  }
   async loadSession(
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
-    const { sessionId } = params;
-    // Chain this load after any in-flight load for the SAME id so the
-    // dispose-prior -> build -> resume -> install sequence runs to completion
-    // before the next same-id load begins (FINDING F5). We chain off the prior
-    // load's settlement (ignoring its outcome) rather than awaiting it directly
-    // so a rejected prior load does not reject this one.
-    const prior = this.loadSessionQueues.get(sessionId);
-    const run = (prior ?? Promise.resolve()).then(
-      () => this.performLoadSession(params),
-      () => this.performLoadSession(params),
+    return this.lifecycle.runSerialized(params.sessionId, () =>
+      this.performLoadSession(params),
     );
-    this.loadSessionQueues.set(sessionId, run);
-    try {
-      return await run;
-    } finally {
-      // Clear the queue entry only if it is still THIS load (a later chained
-      // same-id load may have replaced it); deleting unconditionally could drop
-      // a newer in-flight load's entry.
-      if (this.loadSessionQueues.get(sessionId) === run) {
-        this.loadSessionQueues.delete(sessionId);
-      }
-    }
   }
-
-  /**
-   * Performs a single (already-serialized, see {@link loadSession}) session/load.
-   *
-   * Decision: if a live same-id session exists AND no recording file exists on
-   * disk for it, RE-ATTACH the live session (an unprompted session has no
-   * recording — the file materializes on first content — so a disk resume would
-   * both fail and needlessly destroy the healthy live session). Otherwise fall
-   * back to the disk path: dispose any prior same-id Session to release its
-   * on-disk lock, then build + resume + install the replacement and stream the
-   * restored transcript.
-   */
   private async performLoadSession(
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
     const { sessionId } = params;
     this.logger.debug(() => `loadSession - loading session ${sessionId}`);
-
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
       return { modes: buildSessionModes(reattached.getApprovalMode()) };
     }
-
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
     return { modes: buildSessionModes(session.getApprovalMode()) };
   }
-
-  /**
-   * RE-ATTACH decision + replay (#1604). Returns the live same-id Session (after
-   * replaying its in-memory history) when one exists AND has no on-disk recording
-   * yet (an unprompted session, whose JSONL file has not materialized) — a disk
-   * resume would both fail and needlessly destroy the healthy live session, so we
-   * keep it and replay instead. Returns null (so the caller takes the disk-resume
-   * path) when there is no live session OR a recording file already exists. For a
-   * fresh unprompted session the in-memory history is empty, so ZERO replay
-   * updates are sent. A replay failure is propagated (already wrapped as a precise
-   * RequestError by Session.streamHistory) WITHOUT disposing the session — it was
-   * healthy and the client can retry — the re-attach cleanup contract (no destroy
-   * on failure), distinct from the disk path's destroy-on-failure.
-   */
   private async tryReattachLiveSession(
     sessionId: string,
   ): Promise<Session | null> {
@@ -386,7 +232,6 @@ export class ZedAgent {
     await existing.replayLiveHistory();
     return existing;
   }
-
   /**
    * Disposes + drops any prior same-id Session FIRST so it releases the on-disk
    * session lock the replacement resume needs, and so a later failure cannot
@@ -399,7 +244,6 @@ export class ZedAgent {
       await existing.dispose();
     }
   }
-
   /**
    * Builds + resumes the replacement Session, installs it in this.sessions, then
    * replays the restored transcript to the client BEFORE returning. Install
@@ -423,10 +267,6 @@ export class ZedAgent {
       await session.streamHistory(history);
     } catch (error) {
       this.sessions.delete(sessionId);
-      // FINDING F13: guard the cleanup dispose so a dispose failure does not
-      // mask the ORIGINAL replay error. The replay error is the actionable one
-      // the client must see; a dispose failure is logged and swallowed, and the
-      // original error is rethrown.
       try {
         await session.dispose();
       } catch (disposeError) {
@@ -440,19 +280,6 @@ export class ZedAgent {
     }
     return session;
   }
-
-  /**
-   * Builds the replacement Agent for a loadSession and resumes its recorded
-   * history. Everything AFTER fromConfig runs under a guard that disposes the
-   * fresh agent before rethrowing (FINDING E), so neither a resume rejection nor
-   * a throw while constructing the Session (after resume already adopted the
-   * recording + lock) can leak the lock/recording. A resume rejection is mapped
-   * to a precise ACP RequestError (see resumeAgentHistory / classifyResumeFailure:
-   * not-found-but-file-present becomes internalError, genuine missing becomes
-   * resourceNotFound); any other post-fromConfig throw is wrapped as internalError
-   * (an already-constructed RequestError passes through unchanged). Extracted from
-   * loadSession so the orchestration stays within the lint complexity/line budgets.
-   */
   private async buildAndResumeSession(
     sessionId: string,
     cwd: string | undefined,
@@ -462,9 +289,6 @@ export class ZedAgent {
       cwd,
     );
     try {
-      // FINDING C1: pass the SAME injected lister the re-attach probe uses so
-      // BOTH on-disk session-file probes (re-attach + corrupt-vs-missing resume)
-      // read through one injectable seam rather than one hardcoding readdir.
       const history = await resumeAgentHistory(
         agent,
         sessionId,
@@ -484,7 +308,6 @@ export class ZedAgent {
       throw toLoadRequestError(sessionId, error);
     }
   }
-
   /**
    * Shared per-session Agent construction used by BOTH newSession and
    * loadSession: builds the session-scoped Config proxy (with an
@@ -511,21 +334,13 @@ export class ZedAgent {
       sessionFileSystemService,
       resolveSessionTargetDir(this.config, cwd),
     );
-
     this.logger.debug(() => `buildSessionAgent - session ${sessionId}`);
-
     const agent = await fromConfig({
       config: sessionConfig,
       sessionId,
     });
     return { agent, config: sessionConfig };
   }
-
-  /**
-   * Enables continuous session recording for a freshly created session. Failures
-   * are logged and swallowed so recording startup can never break session
-   * creation (the session remains fully usable, just unrecorded).
-   */
   private async enableRecording(
     agent: Agent,
     sessionId: string,
@@ -538,7 +353,16 @@ export class ZedAgent {
       );
     }
   }
-
+  deleteSession(
+    params: acp.DeleteSessionRequest,
+  ): Promise<acp.DeleteSessionResponse> {
+    return this.lifecycle.delete(params);
+  }
+  closeSession(
+    params: acp.CloseSessionRequest,
+  ): Promise<acp.CloseSessionResponse> {
+    return this.lifecycle.close(params);
+  }
   async setSessionMode(
     params: acp.SetSessionModeRequest,
   ): Promise<acp.SetSessionModeResponse> {
@@ -548,15 +372,11 @@ export class ZedAgent {
     }
     return session.setMode(params.modeId);
   }
-
   async cancel(params: acp.CancelNotification): Promise<void> {
     const session = this.sessions.get(params.sessionId);
-    if (!session) {
-      throw new Error(`Session not found: ${params.sessionId}`);
-    }
+    if (!session) throw new Error(`Session not found: ${params.sessionId}`);
     await session.cancelPendingPrompt();
   }
-
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
@@ -564,14 +384,12 @@ export class ZedAgent {
     }
     return session.prompt(params);
   }
-
   async disposeAll(): Promise<void> {
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     await Promise.allSettled(sessions.map((session) => session.dispose()));
   }
 }
-
 export class Session {
   private pendingPrompt: AbortController | null = null;
   private emojiFilter: EmojiFilter;
@@ -587,7 +405,7 @@ export class Session {
   >();
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
-
+  private readonly createdAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
@@ -601,11 +419,9 @@ export class Session {
     const emojiFilterMode = configuredEmojiFilterMode ?? 'auto';
     const filterConfig: FilterConfiguration = { mode: emojiFilterMode };
     this.emojiFilter = new EmojiFilter(filterConfig);
-
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
-
     this.todoListener = (event: TodoUpdateEvent) => {
       const eventAgentId = event.agentId ?? DEFAULT_AGENT_ID;
       if (event.sessionId === this.id && eventAgentId === DEFAULT_AGENT_ID) {
@@ -616,7 +432,6 @@ export class Session {
     };
     todoEvents.onTodoUpdated(this.todoListener);
   }
-
   setMode(modeId: acp.SessionModeId): acp.SetSessionModeResponse {
     const availableModes = buildAvailableModes();
     const mode = availableModes.find((m) => m.id === modeId);
@@ -626,7 +441,6 @@ export class Session {
     this.agent.setApprovalMode(mode.id as ApprovalMode);
     return {};
   }
-
   /**
    * Returns the session's current approval mode, delegating to the underlying
    * Agent. Used by loadSession to advertise the resumed session's currentModeId
@@ -635,7 +449,13 @@ export class Session {
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
-
+  getLifecycleInfo(): LifecycleSession {
+    return {
+      sessionId: this.id,
+      cwd: this.config.getProjectRoot(),
+      updatedAt: this.createdAt,
+    };
+  }
   async cancelPendingPrompt(): Promise<void> {
     this.settleActiveConfirmation();
     if (!this.pendingPrompt) {
@@ -644,14 +464,11 @@ export class Session {
     this.pendingPrompt.abort();
     this.pendingPrompt = null;
   }
-
   private settleActiveConfirmation(): void {
     const confirmations = [...this.activeConfirmations.entries()];
     this.activeConfirmations.clear();
     for (const [confirmationId, state] of confirmations) {
-      if (state.settled) {
-        continue;
-      }
+      if (state.settled) continue;
       state.settled = true;
       try {
         this.agent.tools.respondToConfirmation(
@@ -665,7 +482,6 @@ export class Session {
       }
     }
   }
-
   private settleConfirmation(confirmationId: string): void {
     const state = this.activeConfirmations.get(confirmationId);
     if (state === undefined) {
@@ -687,16 +503,13 @@ export class Session {
       state.cancelWaiter();
     }
   }
-
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     await this.cancelPendingPrompt();
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;
     this.promptGeneration += 1;
     const promptGeneration = this.promptGeneration;
-
     const promptId = Math.random().toString(16).slice(2);
-
     try {
       let parts: ContractPart[];
       try {
@@ -713,12 +526,10 @@ export class Session {
         }
         throw error;
       }
-
       const batcher = new StreamBatcher(this.emojiFilter, (u) =>
         this.sendUpdate(u),
       );
       let terminalStopReason: acp.StopReason | null = null;
-
       try {
         terminalStopReason = await this.consumeAgentStream(
           parts,
@@ -754,15 +565,12 @@ export class Session {
           batcher.dispose();
         }
       }
-
       if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
         return { stopReason: 'cancelled' };
       }
-
       if (terminalStopReason !== null) {
         return { stopReason: terminalStopReason };
       }
-
       return { stopReason: 'end_turn' };
     } finally {
       if (this.pendingPrompt === pendingSend) {
@@ -770,7 +578,6 @@ export class Session {
       }
     }
   }
-
   private async consumeAgentStream(
     parts: ContractPart[],
     pendingSend: AbortController,
@@ -803,7 +610,6 @@ export class Session {
     }
     return terminalStopReason;
   }
-
   private async handleAgentEvent(
     event: AgentEvent,
     batcher: StreamBatcher,
@@ -893,7 +699,6 @@ export class Session {
       }
     }
   }
-
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
   ): Promise<void> {
@@ -909,7 +714,6 @@ export class Session {
       await this.sendUpdate(update);
     }
   }
-
   private isPromptStale(
     promptGeneration: number,
     pendingSend: AbortController,
@@ -920,7 +724,6 @@ export class Session {
       pendingSend.signal.aborted
     );
   }
-
   private async handleToolConfirmation(
     event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
     promptGeneration: number,
@@ -934,12 +737,10 @@ export class Session {
         settled: false,
       });
     });
-
     if (this.isPromptStale(promptGeneration, pendingSend)) {
       this.settleConfirmation(confirmationId);
       return;
     }
-
     let result: PermissionRoundTripResult | null;
     try {
       result = await Promise.race([
@@ -956,7 +757,6 @@ export class Session {
       this.settleConfirmation(confirmationId);
       throw error;
     }
-
     const state = this.activeConfirmations.get(confirmationId);
     if (
       result === null ||
@@ -966,7 +766,6 @@ export class Session {
     ) {
       return;
     }
-
     state.settled = true;
     this.activeConfirmations.delete(confirmationId);
     try {
@@ -983,26 +782,10 @@ export class Session {
       );
     }
   }
-
-  /**
-   * STRICT delivery of a single session/update: rethrows any transport failure.
-   * Used ONLY by streamHistory (ACP session/load replay) so a dead/failing
-   * client connection fails the load rather than silently losing the transcript
-   * while loadSession still resolves successfully (FINDING A). The best-effort
-   * live path (sendUpdate) must NOT use this.
-   */
   private async sendUpdateStrict(update: acp.SessionUpdate): Promise<void> {
     this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate({ sessionId: this.id, update });
-    this.logger.debug(() => 'sendUpdate: delivered');
   }
-
-  /**
-   * BEST-EFFORT delivery for the LIVE prompt path: a transient client error
-   * must not abort an in-flight turn, so delivery failures are logged and
-   * swallowed. Replay uses sendUpdateStrict instead so lost history surfaces as
-   * a failed load.
-   */
   private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
       await this.sendUpdateStrict(update);
@@ -1013,13 +796,11 @@ export class Session {
       );
     }
   }
-
   debug(msg: string) {
     if (this.config.getDebugMode()) {
       debugLogger.warn(msg);
     }
   }
-
   private async sendPlanUpdate(todos: Todo[]): Promise<void> {
     const entries: acp.PlanEntry[] = todos.map((todo) => ({
       content: todo.content,
@@ -1028,7 +809,6 @@ export class Session {
     }));
     await this.sendUpdate({ sessionUpdate: 'plan', entries });
   }
-
   /**
    * Replays a resumed conversation (ordered IContent[]) to the client as
    * session/update notifications, in order, for ACP session/load (issue #1604).
@@ -1055,7 +835,6 @@ export class Session {
       }
     }
   }
-
   /**
    * Re-attach replay for ACP session/load (#1604): replays this live session's
    * IN-MEMORY conversation, used when a load targets a still-live session with
@@ -1070,7 +849,6 @@ export class Session {
       await readAgentHistoryForReplay(this.agent, this.id),
     );
   }
-
   async dispose(): Promise<void> {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
@@ -1078,11 +856,7 @@ export class Session {
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {
-      try {
-        await this.agent.dispose();
-      } catch (error) {
-        debugLogger.error('Failed to dispose Zed session agent:', error);
-      }
+      await this.agent.dispose();
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -16,7 +16,6 @@ import {
   type FilterConfiguration,
   type IContent,
   type TodoUpdateEvent,
-  type Todo,
   type ApprovalMode,
 } from '@vybestack/llxprt-code-core';
 import * as acp from '@agentclientprotocol/sdk';
@@ -71,6 +70,19 @@ import {
 } from './zed-session-config.js';
 import { buildAvailableCommandsUpdate } from './zed-command-registry.js';
 import { tryHandleZedCommand } from './zed-prompt-command.js';
+import {
+  buildZedConfigOptions,
+  dispatchZedConfigOption,
+  observeZedConfigOptions,
+  setZedConfigOption,
+  zedConfigOptionsForClient,
+  zedSessionConfigOptions,
+} from './zed-config-options.js';
+import {
+  buildZedSession,
+  enableZedSessionRecording,
+} from './zed-agent-setup.js';
+import { buildZedPlanUpdate } from './zed-plan-update.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -111,20 +123,19 @@ export async function runZedIntegration(
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
   private clientCapabilities: acp.ClientCapabilities | undefined;
-  private logger = new DebugLogger('llxprt:zed-integration');
+  private readonly logger = new DebugLogger('llxprt:zed');
   private readonly lifecycle: SessionLifecycle;
-  private readonly sessionFileLister: ChatSessionFileLister;
   constructor(
     private config: Config,
     _settings: LoadedSettings,
     private connection: acp.AgentSideConnection,
-    sessionFileLister: ChatSessionFileLister = nodeChatSessionFileLister,
+    private readonly sessionFileLister: ChatSessionFileLister = nodeChatSessionFileLister,
   ) {
-    this.sessionFileLister = sessionFileLister;
     this.lifecycle = new SessionLifecycle(
       config,
       this.sessions,
       (sessionId, cwd) => this.buildAndResumeSession(sessionId, cwd),
+      (session) => zedSessionConfigOptions(this.clientCapabilities, session),
     );
   }
   async initialize(
@@ -138,7 +149,7 @@ export class ZedAgent {
   ): Promise<acp.ListSessionsResponse> {
     return this.lifecycle.list(params);
   }
-  authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
+  authenticate({ methodId }: acp.AuthenticateRequest) {
     return authenticateZedAgent(this.config, methodId);
   }
   async newSession({
@@ -151,46 +162,38 @@ export class ZedAgent {
         sessionId,
         cwd,
       );
-      await this.enableRecording(agent, sessionId);
-      const session = await this.buildSessionForAgent(
-        sessionId,
-        agent,
-        sessionConfig,
+      await enableZedSessionRecording(agent, (error) =>
+        this.logger.debug(() => `Recording failed for ${sessionId}: ${error}`),
       );
+      const session = await this.createSession(sessionId, agent, sessionConfig);
       await session.sendAvailableCommands();
       this.sessions.set(sessionId, session);
       return {
         sessionId,
         modes: buildSessionModes(agent.getApprovalMode()),
+        ...(await zedConfigOptionsForClient(
+          this.clientCapabilities,
+          agent,
+          sessionConfig,
+        )),
       };
     } catch (error) {
       this.logger.debug(() => `ERROR in newSession: ${error}`);
       throw error;
     }
   }
-  private async buildSessionForAgent(
-    sessionId: string,
-    agent: Agent,
-    sessionConfig: Config,
-  ): Promise<Session> {
-    try {
-      return new Session(sessionId, agent, sessionConfig, this.connection);
-    } catch (error) {
-      try {
-        await agent.dispose();
-      } catch (disposeError) {
-        this.logger.debug(
-          () =>
-            `newSession - dispose after Session ctor failure also failed (original error rethrown): ${disposeError}`,
-        );
-      }
-      throw error;
-    }
-  }
-  resumeSession(
-    params: acp.ResumeSessionRequest,
-  ): Promise<acp.ResumeSessionResponse> {
+  resumeSession(params: acp.ResumeSessionRequest) {
     return this.lifecycle.resume(params);
+  }
+  private configEnabled = () =>
+    this.clientCapabilities?.session?.configOptions != null;
+  private createSession(id: string, agent: Agent, config: Config) {
+    return buildZedSession(
+      agent,
+      () =>
+        new Session(id, agent, config, this.connection, this.configEnabled()),
+      (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
+    );
   }
   async loadSession(
     params: acp.LoadSessionRequest,
@@ -207,12 +210,18 @@ export class ZedAgent {
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
       await reattached.sendAvailableCommands();
-      return { modes: buildSessionModes(reattached.getApprovalMode()) };
+      return {
+        modes: buildSessionModes(reattached.getApprovalMode()),
+        ...(await zedSessionConfigOptions(this.clientCapabilities, reattached)),
+      };
     }
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
     await session.sendAvailableCommands();
-    return { modes: buildSessionModes(session.getApprovalMode()) };
+    return {
+      modes: buildSessionModes(session.getApprovalMode()),
+      ...(await zedSessionConfigOptions(this.clientCapabilities, session)),
+    };
   }
   private async tryReattachLiveSession(
     sessionId: string,
@@ -237,11 +246,6 @@ export class ZedAgent {
     await existing.replayLiveHistory();
     return existing;
   }
-  /**
-   * Disposes + drops any prior same-id Session FIRST so it releases the on-disk
-   * session lock the replacement resume needs, and so a later failure cannot
-   * leave a stale/half-disposed entry in this.sessions.
-   */
   private async disposePriorSession(sessionId: string): Promise<void> {
     const existing = this.sessions.get(sessionId);
     if (existing !== undefined) {
@@ -249,16 +253,6 @@ export class ZedAgent {
       await existing.dispose();
     }
   }
-  /**
-   * Builds + resumes the replacement Session, installs it in this.sessions, then
-   * replays the restored transcript to the client BEFORE returning. Install
-   * order is failure-safe (FINDING A): the map entry is added only after a
-   * successful build/resume, and if the strict history replay fails (a
-   * dead/failing transport, see Session.streamHistory) the entry is removed and
-   * the Session disposed (releasing the recording lock) before the precise
-   * RequestError is rethrown — so a failed load never leaves a stale entry or a
-   * leaked lock, and a later retry for the same id can cleanly load again.
-   */
   private async installResumedSession(
     sessionId: string,
     cwd: string | undefined,
@@ -300,12 +294,7 @@ export class ZedAgent {
         sessionConfig,
         this.sessionFileLister,
       );
-      const session = new Session(
-        sessionId,
-        agent,
-        sessionConfig,
-        this.connection,
-      );
+      const session = await this.createSession(sessionId, agent, sessionConfig);
       return { session, history };
     } catch (error) {
       await agent.dispose().catch(() => undefined);
@@ -313,14 +302,6 @@ export class ZedAgent {
       throw toLoadRequestError(sessionId, error);
     }
   }
-  /**
-   * Shared per-session Agent construction used by BOTH newSession and
-   * loadSession: builds the session-scoped Config proxy (with an
-   * AcpFileSystemService when the client advertises fs capabilities) rooted at
-   * the resolved target dir, then creates the Agent-API agent bound to that
-   * Config and session id. Extracted to avoid duplicating the setup across the
-   * two entry points.
-   */
   private async buildSessionAgent(
     sessionId: string,
     cwd: string | undefined,
@@ -346,40 +327,27 @@ export class ZedAgent {
     });
     return { agent, config: sessionConfig };
   }
-  private async enableRecording(
-    agent: Agent,
-    sessionId: string,
-  ): Promise<void> {
-    try {
-      await agent.session.setRecording({ enabled: true });
-    } catch (error) {
-      this.logger.debug(
-        () => `enableRecording failed for session ${sessionId}: ${error}`,
-      );
-    }
-  }
-  deleteSession(
-    params: acp.DeleteSessionRequest,
-  ): Promise<acp.DeleteSessionResponse> {
+  deleteSession(params: acp.DeleteSessionRequest) {
     return this.lifecycle.delete(params);
   }
-  closeSession(
-    params: acp.CloseSessionRequest,
-  ): Promise<acp.CloseSessionResponse> {
+  closeSession(params: acp.CloseSessionRequest) {
     return this.lifecycle.close(params);
   }
-  async setSessionMode(
-    params: acp.SetSessionModeRequest,
-  ): Promise<acp.SetSessionModeResponse> {
+  async setSessionMode(params: acp.SetSessionModeRequest) {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
     }
     return session.setMode(params.modeId);
   }
-  async cancel(params: acp.CancelNotification): Promise<void> {
-    const session = this.sessions.get(params.sessionId);
-    if (!session) throw new Error(`Session not found: ${params.sessionId}`);
+  setSessionConfigOption(params: acp.SetSessionConfigOptionRequest) {
+    return this.lifecycle.runSerialized(params.sessionId, () =>
+      dispatchZedConfigOption(this.clientCapabilities, this.sessions, params),
+    );
+  }
+  async cancel({ sessionId }: acp.CancelNotification): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Session not found: ${sessionId}`);
     await session.cancelPendingPrompt();
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
@@ -397,8 +365,7 @@ export class ZedAgent {
 }
 export class Session {
   private pendingPrompt: AbortController | null = null;
-  private emojiFilter: EmojiFilter;
-  private logger: DebugLogger;
+  private readonly logger = new DebugLogger('llxprt:zed');
   private pathResolver: ZedPathResolver;
   private activeConfirmations = new Map<
     string,
@@ -410,20 +377,15 @@ export class Session {
   >();
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
+  private readonly stopConfigUpdates: () => void;
   private updatedAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
     private readonly config: Config,
     private readonly connection: acp.AgentSideConnection,
+    configOptionsEnabled = false,
   ) {
-    this.logger = new DebugLogger('llxprt:zed-integration');
-    const configuredEmojiFilterMode = this.config.getEphemeralSetting(
-      'emojifilter',
-    ) as 'allowed' | 'auto' | 'warn' | 'error' | undefined;
-    const emojiFilterMode = configuredEmojiFilterMode ?? 'auto';
-    const filterConfig: FilterConfiguration = { mode: emojiFilterMode };
-    this.emojiFilter = new EmojiFilter(filterConfig);
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
@@ -436,6 +398,14 @@ export class Session {
       }
     };
     todoEvents.onTodoUpdated(this.todoListener);
+    this.stopConfigUpdates = configOptionsEnabled
+      ? observeZedConfigOptions(
+          this.agent,
+          this.config,
+          (update) => this.sendUpdateStrict(update),
+          (error) => this.logger.debug(() => `Config update failed: ${error}`),
+        )
+      : () => undefined;
   }
   setMode(modeId: acp.SessionModeId): acp.SetSessionModeResponse {
     const availableModes = buildAvailableModes();
@@ -446,14 +416,16 @@ export class Session {
     this.agent.setApprovalMode(mode.id as ApprovalMode);
     return {};
   }
-  /**
-   * Returns the session's current approval mode, delegating to the underlying
-   * Agent. Used by loadSession to advertise the resumed session's currentModeId
-   * without reaching through to the private agent from the ZedAgent orchestrator.
-   */
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
+  async setConfigOption(
+    configId: string,
+    value: string | boolean,
+  ): Promise<acp.SetSessionConfigOptionResponse> {
+    return setZedConfigOption(this.agent, this.config, configId, value);
+  }
+  getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
   getLifecycleInfo(): LifecycleSession {
     return {
       sessionId: this.id,
@@ -489,13 +461,9 @@ export class Session {
   }
   private settleConfirmation(confirmationId: string): void {
     const state = this.activeConfirmations.get(confirmationId);
-    if (state === undefined) {
-      return;
-    }
+    if (state === undefined) return;
     this.activeConfirmations.delete(confirmationId);
-    if (state.settled) {
-      return;
-    }
+    if (state.settled) return;
     state.settled = true;
     try {
       this.agent.tools.respondToConfirmation(
@@ -538,8 +506,11 @@ export class Session {
         }
         throw error;
       }
-      const batcher = new StreamBatcher(this.emojiFilter, (u) =>
-        this.sendUpdate(u),
+      const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
+        'auto') as FilterConfiguration['mode'];
+      const batcher = new StreamBatcher(
+        new EmojiFilter({ mode: emojiMode }),
+        (u) => this.sendUpdate(u),
       );
       let terminalStopReason: acp.StopReason | null = null;
       try {
@@ -778,8 +749,8 @@ export class Session {
     this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate({ sessionId: this.id, update });
   }
-  async sendAvailableCommands(): Promise<void> {
-    await this.sendUpdateStrict(buildAvailableCommandsUpdate());
+  sendAvailableCommands(): Promise<void> {
+    return this.sendUpdateStrict(buildAvailableCommandsUpdate());
   }
   private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
@@ -792,17 +763,10 @@ export class Session {
     }
   }
   debug(msg: string) {
-    if (this.config.getDebugMode()) {
-      debugLogger.warn(msg);
-    }
+    if (this.config.getDebugMode()) debugLogger.warn(msg);
   }
-  private async sendPlanUpdate(todos: Todo[]): Promise<void> {
-    const entries: acp.PlanEntry[] = todos.map((todo) => ({
-      content: todo.content,
-      status: todo.status,
-      priority: 'medium' as const,
-    }));
-    await this.sendUpdate({ sessionUpdate: 'plan', entries });
+  private sendPlanUpdate(todos: TodoUpdateEvent['todos']): Promise<void> {
+    return this.sendUpdate(buildZedPlanUpdate(todos));
   }
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
@@ -822,6 +786,7 @@ export class Session {
   async dispose(): Promise<void> {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
+      this.stopConfigUpdates();
       this.settleActiveConfirmation();
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -51,6 +51,7 @@ import {
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
 import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
+import { mapResumeError } from './zed-session-errors.js';
 import { StreamBatcher } from './zed-stream-batcher.js';
 
 export { parseZedAuthMethodId } from './zed-helpers.js';
@@ -249,12 +250,22 @@ export class ZedAgent {
    * session id, and `agent.session.resume` restores the history AND re-subscribes
    * continuous recording so subsequent turns keep appending to the SAME file.
    *
-   * Reconnect friendliness: if a session with this id is already loaded, the
-   * prior Session is disposed and replaced (Zed may call loadSession again on
-   * reconnect; replacing is friendlier than rejecting).
+   * Replace-order + lock semantics: an already-loaded same-id Session holds the
+   * on-disk session lock (SessionLockManager), so the fresh agent's resume CANNOT
+   * acquire the lock until the prior Session is disposed. Disposing first is
+   * therefore unavoidable. To keep the destructive step safe we (a) dispose the
+   * prior Session AND remove it from this.sessions up front so no half-dead entry
+   * survives a subsequent failure, then (b) build + resume the replacement; if
+   * that fails, the fresh agent is disposed and a precise RequestError (carrying
+   * the lower-layer reason, see mapResumeError) is thrown, leaving this.sessions
+   * with NO entry for the id so a later retry can cleanly load again. On success
+   * the replacement is installed and the restored transcript is streamed.
    *
-   * On resume failure (not found / locked / corrupted) a JSON-RPC
-   * resourceNotFound error is thrown carrying the session id.
+   * Full-replay-on-reconnect: even when a healthy in-memory Session already
+   * exists for this id, we still perform the disk-based replace (fresh agent +
+   * resume + replay) rather than short-circuiting, because Zed expects a complete
+   * history replay on every session/load (e.g. a client reconnect rebuilding its
+   * transcript). The in-memory Session is not a substitute for that replay.
    */
   async loadSession(
     params: acp.LoadSessionRequest,
@@ -262,35 +273,18 @@ export class ZedAgent {
     const { sessionId } = params;
     this.logger.debug(() => `loadSession - loading session ${sessionId}`);
 
+    // Dispose + drop any prior same-id Session FIRST so it releases the on-disk
+    // session lock the replacement resume needs, and so a resume failure below
+    // cannot leave a stale/half-disposed entry in this.sessions.
     const existing = this.sessions.get(sessionId);
     if (existing !== undefined) {
       this.sessions.delete(sessionId);
       await existing.dispose();
     }
 
-    const { agent, config: sessionConfig } = await this.buildSessionAgent(
+    const { session, history } = await this.buildAndResumeSession(
       sessionId,
       params.cwd,
-    );
-
-    let history: readonly IContent[];
-    try {
-      history = await agent.session.resume(sessionId);
-    } catch (error) {
-      // The resume machinery failed to discover/lock/replay the session. Tear
-      // down the freshly built agent so no lock/recording leaks, then surface a
-      // resourceNotFound JSON-RPC error (the closest ACP-standard code) rather
-      // than inventing a custom code.
-      await agent.dispose().catch(() => undefined);
-      this.logger.debug(() => `loadSession - resume failed: ${error}`);
-      throw acp.RequestError.resourceNotFound(sessionId);
-    }
-
-    const session = new Session(
-      sessionId,
-      agent,
-      sessionConfig,
-      this.connection,
     );
     this.sessions.set(sessionId, session);
 
@@ -301,9 +295,44 @@ export class ZedAgent {
     return {
       modes: {
         availableModes: buildAvailableModes(),
-        currentModeId: agent.getApprovalMode(),
+        currentModeId: session.getApprovalMode(),
       },
     };
+  }
+
+  /**
+   * Builds the replacement Agent for a loadSession and resumes its recorded
+   * history. On resume failure the freshly built agent is disposed (so no
+   * lock/recording leaks) and the failure is mapped to a precise ACP
+   * RequestError via mapResumeError — a not-found reason becomes resourceNotFound
+   * while a locked/corrupt/other reason becomes internalError carrying the
+   * underlying detail. Extracted from loadSession so the destructive dispose-first
+   * orchestration and the build/resume/error-mapping stay individually small and
+   * within the lint complexity/line budgets.
+   */
+  private async buildAndResumeSession(
+    sessionId: string,
+    cwd: string | undefined,
+  ): Promise<{ session: Session; history: readonly IContent[] }> {
+    const { agent, config: sessionConfig } = await this.buildSessionAgent(
+      sessionId,
+      cwd,
+    );
+    let history: readonly IContent[];
+    try {
+      history = await agent.session.resume(sessionId);
+    } catch (error) {
+      await agent.dispose().catch(() => undefined);
+      this.logger.debug(() => `loadSession - resume failed: ${error}`);
+      throw mapResumeError(sessionId, error);
+    }
+    const session = new Session(
+      sessionId,
+      agent,
+      sessionConfig,
+      this.connection,
+    );
+    return { session, history };
   }
 
   /**
@@ -469,6 +498,15 @@ export class Session {
     }
     this.agent.setApprovalMode(mode.id as ApprovalMode);
     return {};
+  }
+
+  /**
+   * Returns the session's current approval mode, delegating to the underlying
+   * Agent. Used by loadSession to advertise the resumed session's currentModeId
+   * without reaching through to the private agent from the ZedAgent orchestrator.
+   */
+  getApprovalMode(): ApprovalMode {
+    return this.agent.getApprovalMode();
   }
 
   async cancelPendingPrompt(): Promise<void> {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -23,6 +23,7 @@ import {
 import * as acp from '@agentclientprotocol/sdk';
 import {
   fromConfig,
+  getTokenLimitForConfiguredContext,
   type Agent,
   type AgentEvent,
 } from '@vybestack/llxprt-code-agents';
@@ -39,6 +40,7 @@ import {
   parseZedAuthMethodId,
   buildAvailableModes,
   buildSessionModes,
+  buildUsageUpdate,
   describeSessionUpdateForLog,
   mapDoneReasonToStopReason,
   extractThoughtText,
@@ -895,16 +897,17 @@ export class Session {
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
   ): Promise<void> {
-    const outputTokens = usage.candidatesTokenCount ?? 0;
-    const size = usage.totalTokenCount ?? outputTokens;
-    if (size === 0 && outputTokens === 0) {
-      return;
+    // size = the configured context window (user override -> provider limit ->
+    // model lookup, the shared #2251 resolver), used = tokens now in context —
+    // so the client renders consumption against the real window (issue #1607)
+    // instead of the previous used===size placeholder.
+    const update = buildUsageUpdate(
+      usage,
+      getTokenLimitForConfiguredContext(this.config.getModel(), this.config),
+    );
+    if (update !== null) {
+      await this.sendUpdate(update);
     }
-    await this.sendUpdate({
-      sessionUpdate: 'usage_update',
-      used: size,
-      size,
-    });
   }
 
   private isPromptStale(

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -514,7 +514,6 @@ export class Session {
     const commandResult = await tryHandleZedCommand(
       params.prompt,
       this.agent,
-      this.config,
       (update) => this.sendUpdateStrict(update),
     );
     if (commandResult !== null) return commandResult.response;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -177,7 +177,12 @@ export class ZedAgent {
         sessionConfig,
         terminals,
       );
-      await session.sendAvailableCommands();
+      try {
+        await session.sendAvailableCommands();
+      } catch (error) {
+        await session.dispose();
+        throw error;
+      }
       this.sessions.set(sessionId, session);
       return {
         sessionId,
@@ -193,7 +198,9 @@ export class ZedAgent {
       throw error;
     }
   }
-  resumeSession(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
+  resumeSession(
+    params: acp.ResumeSessionRequest,
+  ): Promise<acp.ResumeSessionResponse> {
     return this.lifecycle.resume(params);
   }
   private supportsConfigOptions(): boolean {
@@ -222,7 +229,9 @@ export class ZedAgent {
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
   }
-  async loadSession(params: acp.LoadSessionRequest): Promise<acp.LoadSessionResponse> {
+  async loadSession(
+    params: acp.LoadSessionRequest,
+  ): Promise<acp.LoadSessionResponse> {
     return this.lifecycle.runSerialized(params.sessionId, () =>
       this.performLoadSession(params),
     );
@@ -262,7 +271,9 @@ export class ZedAgent {
     if (recordingExists) {
       return null;
     }
-    this.logger.debug(() => `loadSession - re-attaching live session ${sessionId}`);
+    this.logger.debug(
+      () => `loadSession - re-attaching live session ${sessionId}`,
+    );
     await existing.replayLiveHistory();
     return existing;
   }
@@ -286,7 +297,11 @@ export class ZedAgent {
       await session.streamHistory(history);
     } catch (error) {
       this.sessions.delete(sessionId);
-      try { await session.dispose(); } catch { /* original error rethrown */ }
+      try {
+        await session.dispose();
+      } catch {
+        /* original error rethrown */
+      }
       this.logger.debug(() => `loadSession - replay failed: ${error}`);
       throw error;
     }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -250,7 +250,12 @@ export class ZedAgent {
     }
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
-    await session.sendAvailableCommands();
+    try {
+      await session.sendAvailableCommands();
+    } catch (error) {
+      await this.rollbackSession(sessionId, session);
+      throw error;
+    }
     return {
       modes: buildSessionModes(session.getApprovalMode()),
       ...(await zedSessionConfigOptions(this.clientCapabilities, session)),
@@ -277,12 +282,16 @@ export class ZedAgent {
     await existing.replayLiveHistory();
     return existing;
   }
+  private async rollbackSession(
+    sessionId: string,
+    session: Session,
+  ): Promise<void> {
+    this.sessions.delete(sessionId);
+    await session.dispose().catch(() => undefined);
+  }
   private async disposePriorSession(sessionId: string): Promise<void> {
     const existing = this.sessions.get(sessionId);
-    if (existing !== undefined) {
-      this.sessions.delete(sessionId);
-      await existing.dispose();
-    }
+    if (existing !== undefined) await this.rollbackSession(sessionId, existing);
   }
   private async installResumedSession(
     sessionId: string,
@@ -296,12 +305,7 @@ export class ZedAgent {
     try {
       await session.streamHistory(history);
     } catch (error) {
-      this.sessions.delete(sessionId);
-      try {
-        await session.dispose();
-      } catch {
-        /* original error rethrown */
-      }
+      await this.rollbackSession(sessionId, session);
       this.logger.debug(() => `loadSession - replay failed: ${error}`);
       throw error;
     }
@@ -505,29 +509,18 @@ export class Session {
   }
   async cancelPendingPrompt(): Promise<void> {
     this.settleActiveConfirmation();
-    await this.terminals?.settleAll();
-    if (!this.pendingPrompt) {
-      return;
-    }
+    await this.terminals
+      ?.settleAll()
+      .catch((e: unknown) =>
+        this.logger.debug(() => `Terminal settleAll failed: ${e}`),
+      );
+    if (!this.pendingPrompt) return;
     this.pendingPrompt.abort();
     this.pendingPrompt = null;
   }
   private settleActiveConfirmation(): void {
-    const confirmations = [...this.activeConfirmations.entries()];
-    this.activeConfirmations.clear();
-    for (const [confirmationId, state] of confirmations) {
-      if (state.settled) continue;
-      state.settled = true;
-      try {
-        this.agent.tools.respondToConfirmation(
-          confirmationId,
-          ToolConfirmationOutcome.Cancel,
-        );
-      } catch (error) {
-        debugLogger.error('Failed to cancel active tool confirmation:', error);
-      } finally {
-        state.cancelWaiter();
-      }
+    for (const confirmationId of [...this.activeConfirmations.keys()]) {
+      this.settleConfirmation(confirmationId);
     }
   }
   private settleConfirmation(confirmationId: string): void {
@@ -641,9 +634,8 @@ export class Session {
       return;
     }
     for (const update of updates) {
-      const title = update.title;
-      if (typeof title === 'string') {
-        await this.sendTitleUpdate(update, title);
+      if (typeof update.title === 'string') {
+        await this.sendTitleUpdate(update, update.title);
       } else {
         await this.sendUpdate(update);
       }
@@ -657,9 +649,9 @@ export class Session {
     try {
       await this.sendUpdateStrict(update);
     } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
       this.logger.debug(
-        () =>
-          `sendTitleUpdate ERROR (will retry next turn): ${error instanceof Error ? error.message : String(error)}`,
+        () => `sendTitleUpdate ERROR (will retry next turn): ${msg}`,
       );
       this.sessionInfo.markPendingTitle(title);
     }
@@ -667,10 +659,8 @@ export class Session {
 
   private recordMetadataTitle(title: string | undefined): void {
     const recording = this.config.getSessionRecordingService();
-    if (recording?.isActive() !== true) {
-      return;
-    }
-    recording.recordSessionMetadata(title ?? null);
+    if (recording?.isActive() === true)
+      recording.recordSessionMetadata(title ?? null);
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -679,9 +669,7 @@ export class Session {
       usage,
       getTokenLimitForConfiguredContext(this.config.getModel(), this.config),
     );
-    if (update !== null) {
-      await this.sendUpdate(update);
-    }
+    if (update !== null) await this.sendUpdate(update);
   }
   private isPromptStale(
     promptGeneration: number,
@@ -800,13 +788,11 @@ export class Session {
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {
-      try {
-        await this.agent.dispose();
-      } catch (error) {
-        this.logger.debug(
-          () => `Failed to dispose Zed session agent: ${error}`,
+      await this.agent
+        .dispose()
+        .catch((e: unknown) =>
+          this.logger.debug(() => `Failed to dispose Zed session agent: ${e}`),
         );
-      }
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -242,7 +242,12 @@ export class ZedAgent {
     const { sessionId } = params;
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
-      await reattached.sendAvailableCommands();
+      try {
+        await reattached.sendAvailableCommands();
+      } catch (error) {
+        await this.rollbackSession(sessionId, reattached);
+        throw error;
+      }
       return {
         modes: buildSessionModes(reattached.getApprovalMode()),
         ...(await zedSessionConfigOptions(this.clientCapabilities, reattached)),

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -742,9 +742,14 @@ export class Session {
         // Flush any buffered chunks, THEN dispose so the batch timer is cleared
         // on completion/abort and no delayed flush fires after the turn ends
         // (FINDING F9). The batcher is per-prompt, so disposing here bounds its
-        // timer to the prompt lifecycle.
-        await batcher.flush();
-        batcher.dispose();
+        // timer to the prompt lifecycle. dispose() runs even when flush()
+        // rejects (e.g. a dead transport) — otherwise the pending timer would
+        // leak past the turn.
+        try {
+          await batcher.flush();
+        } finally {
+          batcher.dispose();
+        }
       }
 
       if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -691,6 +691,7 @@ export class Session {
             promptGeneration,
             pendingSend,
           ),
+        resolveToolKind: (toolName) => this.agent.tools.get(toolName)?.kind,
       });
       if (stopReason !== null) {
         terminalStopReason = stopReason;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -51,7 +51,11 @@ import {
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
 import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
-import { mapResumeError } from './zed-session-errors.js';
+import { wrapReplayFailure } from './zed-session-errors.js';
+import {
+  resumeAgentHistory,
+  toLoadRequestError,
+} from './zed-session-loader.js';
 import { StreamBatcher } from './zed-stream-batcher.js';
 
 export { parseZedAuthMethodId } from './zed-helpers.js';
@@ -273,24 +277,8 @@ export class ZedAgent {
     const { sessionId } = params;
     this.logger.debug(() => `loadSession - loading session ${sessionId}`);
 
-    // Dispose + drop any prior same-id Session FIRST so it releases the on-disk
-    // session lock the replacement resume needs, and so a resume failure below
-    // cannot leave a stale/half-disposed entry in this.sessions.
-    const existing = this.sessions.get(sessionId);
-    if (existing !== undefined) {
-      this.sessions.delete(sessionId);
-      await existing.dispose();
-    }
-
-    const { session, history } = await this.buildAndResumeSession(
-      sessionId,
-      params.cwd,
-    );
-    this.sessions.set(sessionId, session);
-
-    // Replay the restored conversation to the client before returning so the
-    // transcript is reconstructed on the Zed side.
-    await session.streamHistory(history);
+    await this.disposePriorSession(sessionId);
+    const session = await this.installResumedSession(sessionId, params.cwd);
 
     return {
       modes: {
@@ -301,14 +289,59 @@ export class ZedAgent {
   }
 
   /**
+   * Disposes + drops any prior same-id Session FIRST so it releases the on-disk
+   * session lock the replacement resume needs, and so a later failure cannot
+   * leave a stale/half-disposed entry in this.sessions.
+   */
+  private async disposePriorSession(sessionId: string): Promise<void> {
+    const existing = this.sessions.get(sessionId);
+    if (existing !== undefined) {
+      this.sessions.delete(sessionId);
+      await existing.dispose();
+    }
+  }
+
+  /**
+   * Builds + resumes the replacement Session, installs it in this.sessions, then
+   * replays the restored transcript to the client BEFORE returning. Install
+   * order is failure-safe (FINDING A): the map entry is added only after a
+   * successful build/resume, and if the strict history replay fails (a
+   * dead/failing transport, see Session.streamHistory) the entry is removed and
+   * the Session disposed (releasing the recording lock) before the precise
+   * RequestError is rethrown — so a failed load never leaves a stale entry or a
+   * leaked lock, and a later retry for the same id can cleanly load again.
+   */
+  private async installResumedSession(
+    sessionId: string,
+    cwd: string | undefined,
+  ): Promise<Session> {
+    const { session, history } = await this.buildAndResumeSession(
+      sessionId,
+      cwd,
+    );
+    this.sessions.set(sessionId, session);
+    try {
+      await session.streamHistory(history);
+    } catch (error) {
+      this.sessions.delete(sessionId);
+      await session.dispose();
+      this.logger.debug(() => `loadSession - replay failed: ${error}`);
+      throw error;
+    }
+    return session;
+  }
+
+  /**
    * Builds the replacement Agent for a loadSession and resumes its recorded
-   * history. On resume failure the freshly built agent is disposed (so no
-   * lock/recording leaks) and the failure is mapped to a precise ACP
-   * RequestError via mapResumeError — a not-found reason becomes resourceNotFound
-   * while a locked/corrupt/other reason becomes internalError carrying the
-   * underlying detail. Extracted from loadSession so the destructive dispose-first
-   * orchestration and the build/resume/error-mapping stay individually small and
-   * within the lint complexity/line budgets.
+   * history. Everything AFTER fromConfig runs under a guard that disposes the
+   * fresh agent before rethrowing (FINDING E), so neither a resume rejection nor
+   * a throw while constructing the Session (after resume already adopted the
+   * recording + lock) can leak the lock/recording. A resume rejection is mapped
+   * to a precise ACP RequestError (see resumeAgentHistory / classifyResumeFailure:
+   * not-found-but-file-present becomes internalError, genuine missing becomes
+   * resourceNotFound); any other post-fromConfig throw is wrapped as internalError
+   * (an already-constructed RequestError passes through unchanged). Extracted from
+   * loadSession so the orchestration stays within the lint complexity/line budgets.
    */
   private async buildAndResumeSession(
     sessionId: string,
@@ -318,21 +351,20 @@ export class ZedAgent {
       sessionId,
       cwd,
     );
-    let history: readonly IContent[];
     try {
-      history = await agent.session.resume(sessionId);
+      const history = await resumeAgentHistory(agent, sessionId, sessionConfig);
+      const session = new Session(
+        sessionId,
+        agent,
+        sessionConfig,
+        this.connection,
+      );
+      return { session, history };
     } catch (error) {
       await agent.dispose().catch(() => undefined);
-      this.logger.debug(() => `loadSession - resume failed: ${error}`);
-      throw mapResumeError(sessionId, error);
+      this.logger.debug(() => `loadSession - build/resume failed: ${error}`);
+      throw toLoadRequestError(sessionId, error);
     }
-    const session = new Session(
-      sessionId,
-      agent,
-      sessionConfig,
-      this.connection,
-    );
-    return { session, history };
   }
 
   /**
@@ -869,19 +901,27 @@ export class Session {
     return new Error(event.error.message);
   }
 
-  private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
+  /**
+   * STRICT delivery of a single session/update: rethrows any transport failure.
+   * Used ONLY by streamHistory (ACP session/load replay) so a dead/failing
+   * client connection fails the load rather than silently losing the transcript
+   * while loadSession still resolves successfully (FINDING A). The best-effort
+   * live path (sendUpdate) must NOT use this.
+   */
+  private async sendUpdateStrict(update: acp.SessionUpdate): Promise<void> {
     const params: acp.SessionNotification = { sessionId: this.id, update };
-    this.logger.debug(
-      () =>
-        `sendUpdate: ${update.sessionUpdate} ${
-          'content' in update && update.content && 'text' in update.content
-            ? `(${(update.content as { text: string }).text.length} chars)`
-            : ''
-        }`,
-    );
+    await this.connection.sessionUpdate(params);
+  }
+
+  /**
+   * BEST-EFFORT delivery for the LIVE prompt path: a transient client error
+   * must not abort an in-flight turn, so delivery failures are logged and
+   * swallowed. Replay uses sendUpdateStrict instead so lost history surfaces as
+   * a failed load.
+   */
+  private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
-      await this.connection.sessionUpdate(params);
-      this.logger.debug(() => 'sendUpdate: delivered');
+      await this.sendUpdateStrict(update);
     } catch (error) {
       this.logger.debug(
         () =>
@@ -919,7 +959,16 @@ export class Session {
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
     for (const update of updates) {
-      await this.sendUpdate(update);
+      // STRICT: a failed delivery here (dead/failing transport) must reject so
+      // loadSession can clean up and report the failure instead of resolving as
+      // a success with a lost transcript (FINDING A). wrapReplayFailure maps the
+      // rejection to a precise internalError (passing an existing RequestError
+      // through unchanged) for loadSession's catch path.
+      try {
+        await this.sendUpdateStrict(update);
+      } catch (error) {
+        throw wrapReplayFailure(this.id, error);
+      }
     }
   }
 

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -828,7 +828,13 @@ export class Session {
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {
-      await this.agent.dispose();
+      try {
+        await this.agent.dispose();
+      } catch (error) {
+        this.logger.debug(
+          () => `Failed to dispose Zed session agent: ${error}`,
+        );
+      }
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -5,14 +5,11 @@
  */
 import {
   type Config,
-  getErrorStatus,
   todoEvents,
   DEFAULT_AGENT_ID,
   debugLogger,
   createInkStdio,
-  type ContractPart,
   DebugLogger,
-  EmojiFilter,
   type FilterConfiguration,
   type IContent,
   type TodoUpdateEvent,
@@ -43,6 +40,7 @@ import {
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
+import { TerminalManager } from './zed-terminal-manager.js';
 import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
 import { wrapReplayFailure } from './zed-session-errors.js';
 import {
@@ -53,7 +51,6 @@ import {
   nodeChatSessionFileLister,
   type ChatSessionFileLister,
 } from './zed-session-loader.js';
-import { StreamBatcher } from './zed-stream-batcher.js';
 import { SessionLifecycle } from './zed-session-lifecycle.js';
 import type { LifecycleSession } from './zed-session-pagination.js';
 import { authenticateZedAgent, initializeZedAgent } from './zed-initialize.js';
@@ -75,12 +72,20 @@ import {
   buildZedSession,
   enableZedSessionRecording,
 } from './zed-agent-setup.js';
-import { handleZedAgentEvent } from './zed-agent-event-handler.js';
+import {
+  runPromptTurn as executePromptTurn,
+  type SessionStreamDeps,
+} from './zed-session-events.js';
 import { buildZedPlanUpdate } from './zed-plan-update.js';
 import {
   SessionTitleTracker,
   buildSessionInfoUpdate,
 } from './zed-session-info.js';
+import type {
+  CloseSessionRequest,
+  DeleteSessionRequest,
+  ClientCapabilitiesWithSession,
+} from './acp-types.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -120,7 +125,7 @@ export async function runZedIntegration(
 }
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
-  private clientCapabilities: acp.ClientCapabilities | undefined;
+  private clientCapabilities: ClientCapabilitiesWithSession | undefined;
   private readonly logger = new DebugLogger('llxprt:zed-integration');
   private readonly lifecycle: SessionLifecycle;
   constructor(
@@ -139,7 +144,9 @@ export class ZedAgent {
   async initialize(
     args: acp.InitializeRequest,
   ): Promise<acp.InitializeResponse> {
-    this.clientCapabilities = args.clientCapabilities;
+    this.clientCapabilities = args.clientCapabilities as
+      | ClientCapabilitiesWithSession
+      | undefined;
     return initializeZedAgent(this.config);
   }
   listSessions(
@@ -185,6 +192,7 @@ export class ZedAgent {
   }
   private supportsConfigOptions = () =>
     this.clientCapabilities?.session?.configOptions != null;
+  private supportsTerminal = () => this.clientCapabilities?.terminal === true;
   private createSession(id: string, agent: Agent, config: Config) {
     return buildZedSession(
       agent,
@@ -195,6 +203,7 @@ export class ZedAgent {
           config,
           this.connection,
           this.supportsConfigOptions(),
+          this.supportsTerminal(),
         ),
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
@@ -302,6 +311,7 @@ export class ZedAgent {
         sessionConfig,
         this.connection,
         this.supportsConfigOptions(),
+        this.supportsTerminal(),
       );
       return { session, history };
     } catch (error) {
@@ -335,18 +345,20 @@ export class ZedAgent {
     });
     return { agent, config: sessionConfig };
   }
-  deleteSession(params: acp.DeleteSessionRequest) {
+  deleteSession(params: DeleteSessionRequest) {
     return this.lifecycle.delete(params);
   }
-  closeSession(params: acp.CloseSessionRequest) {
+  closeSession(params: CloseSessionRequest) {
     return this.lifecycle.close(params);
   }
-  setSessionMode(params: acp.SetSessionModeRequest) {
+  setSessionMode(
+    params: acp.SetSessionModeRequest,
+  ): Promise<acp.SetSessionModeResponse> {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
     }
-    return session.setMode(params.modeId);
+    return Promise.resolve(session.setMode(params.modeId));
   }
   setSessionConfigOption(params: acp.SetSessionConfigOptionRequest) {
     return this.lifecycle.runSerialized(params.sessionId, () =>
@@ -393,13 +405,25 @@ export class Session {
    * finding 4) rather than generating a new value per getter call.
    */
   private readonly createdAt = new Date().toISOString();
+  private readonly terminals: TerminalManager | null;
+
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
     private readonly config: Config,
     private readonly connection: acp.AgentSideConnection,
     configOptionsEnabled = false,
+    terminalEnabled = false,
   ) {
+    this.terminals = terminalEnabled
+      ? new TerminalManager(
+          id,
+          connection,
+          config.getTargetDir(),
+          (update) => this.sendUpdate(update),
+          this.logger,
+        )
+      : null;
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
@@ -455,6 +479,7 @@ export class Session {
   }
   async cancelPendingPrompt(): Promise<void> {
     this.settleActiveConfirmation();
+    await this.terminals?.settleAll();
     if (!this.pendingPrompt) {
       return;
     }
@@ -546,64 +571,38 @@ export class Session {
     promptId: string,
     promptGeneration: number,
   ): Promise<acp.PromptResponse> {
-    let parts: ContractPart[];
-    try {
-      parts = await this.pathResolver.resolvePrompt(
-        params.prompt,
-        pendingSend.signal,
-      );
-    } catch (error) {
-      if (
-        pendingSend.signal.aborted ||
-        (error instanceof Error && error.name === 'AbortError')
-      ) {
-        return { stopReason: 'cancelled' };
-      }
-      throw error;
-    }
-    const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
-      'auto') as FilterConfiguration['mode'];
-    const batcher = new StreamBatcher(
-      new EmojiFilter({ mode: emojiMode }),
-      (u) => this.sendUpdate(u),
+    return executePromptTurn(
+      {
+        pathResolver: this.pathResolver,
+        emojiFilterMode: (this.config.getEphemeralSetting('emojifilter') ??
+          'auto') as FilterConfiguration['mode'],
+        streamDeps: this.buildStreamDeps(promptGeneration, pendingSend),
+      },
+      params,
+      pendingSend,
+      promptId,
+      promptGeneration,
     );
-    let terminalStopReason: acp.StopReason | null = null;
-    try {
-      terminalStopReason = await this.consumeAgentStream(
-        parts,
-        pendingSend,
-        promptId,
-        promptGeneration,
-        batcher,
-      );
-    } catch (error) {
-      if (getErrorStatus(error) === 429) {
-        throw new acp.RequestError(
-          429,
-          'Rate limit exceeded. Try again later.',
-        );
-      }
-      if (
-        pendingSend.signal.aborted ||
-        (error instanceof Error && error.name === 'AbortError')
-      ) {
-        return { stopReason: 'cancelled' };
-      }
-      throw error;
-    } finally {
-      try {
-        await batcher.flush();
-      } finally {
-        batcher.dispose();
-      }
-    }
-    if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
-      return { stopReason: 'cancelled' };
-    }
-    if (terminalStopReason !== null) {
-      return { stopReason: terminalStopReason };
-    }
-    return { stopReason: 'end_turn' };
+  }
+
+  private buildStreamDeps(
+    promptGeneration: number,
+    pendingSend: AbortController,
+  ): SessionStreamDeps {
+    return {
+      agent: this.agent,
+      terminals: this.terminals,
+      sendUpdate: (update) => this.sendUpdate(update),
+      sendUsage: (usage) => this.sendUsageUpdate(usage),
+      handleConfirmation: (confirmation) =>
+        this.handleToolConfirmation(
+          confirmation,
+          promptGeneration,
+          pendingSend,
+        ),
+      isPromptStale: (gen, send) => this.isPromptStale(gen, send),
+      maxTurns: this.config.getMaxSessionTurns(),
+    };
   }
 
   private async emitTurnMetadata(eligibility: {
@@ -661,43 +660,6 @@ export class Session {
       return;
     }
     recording.recordSessionMetadata(title ?? null);
-  }
-  private async consumeAgentStream(
-    parts: ContractPart[],
-    pendingSend: AbortController,
-    promptId: string,
-    promptGeneration: number,
-    batcher: StreamBatcher,
-  ): Promise<acp.StopReason | null> {
-    const eventStream = this.agent.stream(parts, {
-      signal: pendingSend.signal,
-      promptId,
-      maxTurns: this.config.getMaxSessionTurns(),
-    });
-    let terminalStopReason: acp.StopReason | null = null;
-    for await (const event of eventStream) {
-      if (this.isPromptStale(promptGeneration, pendingSend)) {
-        if (event.type === 'done') {
-          return 'cancelled';
-        }
-        continue;
-      }
-      const stopReason = await handleZedAgentEvent(event, batcher, {
-        sendUpdate: (update) => this.sendUpdate(update),
-        sendUsage: (usage) => this.sendUsageUpdate(usage),
-        handleConfirmation: (confirmation) =>
-          this.handleToolConfirmation(
-            confirmation,
-            promptGeneration,
-            pendingSend,
-          ),
-        resolveToolKind: (toolName) => this.agent.tools.get(toolName)?.kind,
-      });
-      if (stopReason !== null) {
-        terminalStopReason = stopReason;
-      }
-    }
-    return terminalStopReason;
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -825,6 +787,7 @@ export class Session {
       todoEvents.offTodoUpdated(this.todoListener);
       this.stopConfigUpdates();
       this.settleActiveConfirmation();
+      await this.terminals?.settleAll();
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -355,6 +355,10 @@
       "bun": "./src/tools-adapters/CoreMessageBusAdapter.ts",
       "import": "./dist/src/tools-adapters/CoreMessageBusAdapter.js"
     },
+    "./tools-adapters/CoreShellToolHostAdapter.js": {
+      "bun": "./src/tools-adapters/CoreShellToolHostAdapter.ts",
+      "import": "./dist/src/tools-adapters/CoreShellToolHostAdapter.js"
+    },
     "./tools-adapters/CoreToolRegistryHostAdapter.js": {
       "bun": "./src/tools-adapters/CoreToolRegistryHostAdapter.ts",
       "import": "./dist/src/tools-adapters/CoreToolRegistryHostAdapter.js"

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -314,7 +314,7 @@ function handleSessionMetadata(
     return;
   }
   const title = payload.title;
-  if (title === null || typeof title === 'string') {
+  if (title === null || title === undefined || typeof title === 'string') {
     acc.metadata.title = title;
   } else {
     acc.malformedCount++;

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -290,6 +290,40 @@ function handleSessionEvent(
   }
 }
 
+/**
+ * @requirement issue #1611: session_metadata — update metadata.title (tri-state).
+ *
+ * The title is tri-state: undefined (field absent) is legacy and does NOT
+ * modify metadata.title; null sets it to null (explicit untitled); string sets
+ * it to that string. Malformed title values (non-string, non-null, non-
+ * undefined) are recorded as malformed.
+ */
+function handleSessionMetadata(
+  payload: Record<string, unknown>,
+  acc: ReplayAccumulators,
+  lineNumber: number,
+): void {
+  if (acc.metadata === null) {
+    acc.malformedCount++;
+    acc.warnings.push(
+      `Line ${lineNumber}: session_metadata before session_start, skipping`,
+    );
+    return;
+  }
+  if (!('title' in payload)) {
+    return;
+  }
+  const title = payload.title;
+  if (title === null || typeof title === 'string') {
+    acc.metadata.title = title;
+  } else {
+    acc.malformedCount++;
+    acc.warnings.push(
+      `Line ${lineNumber}: malformed session_metadata title, skipping`,
+    );
+  }
+}
+
 /** @pseudocode line 126-131: directories_changed — update metadata or record malformed. */
 function handleDirectoriesChanged(
   payload: Record<string, unknown>,
@@ -381,6 +415,9 @@ function dispatchEvent(
       break;
     case 'session_event':
       handleSessionEvent(payload, acc, lineNumber);
+      break;
+    case 'session_metadata':
+      handleSessionMetadata(payload, acc, lineNumber);
       break;
     case 'directories_changed':
       handleDirectoriesChanged(payload, acc, lineNumber);

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -167,6 +167,7 @@ function handleSessionStart(
     provider: startPayload.provider,
     model: startPayload.model,
     workspaceDirs: resolveWorkspaceDirs(startPayload.workspaceDirs),
+    ...(typeof startPayload.cwd === 'string' ? { cwd: startPayload.cwd } : {}),
     startTime: startPayload.startTime,
   };
   return undefined;

--- a/packages/core/src/recording/SessionDiscovery.test.ts
+++ b/packages/core/src/recording/SessionDiscovery.test.ts
@@ -54,6 +54,7 @@ function makeConfig(
     projectHash: overrides.projectHash ?? PROJECT_HASH,
     chatsDir,
     workspaceDirs: overrides.workspaceDirs ?? ['/test/workspace'],
+    cwd: overrides.cwd ?? '/test/workspace',
     provider: overrides.provider ?? 'anthropic',
     model: overrides.model ?? 'claude-4',
   };
@@ -265,6 +266,7 @@ describe('SessionDiscovery @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
       expect(sessions[0].sessionId).toBe(sessionId);
       expect(sessions[0].provider).toBe('google');
       expect(sessions[0].model).toBe('gemini-3');
+      expect(sessions[0].cwd).toBe('/test/workspace');
       expect(sessions[0].projectHash).toBe(PROJECT_HASH);
       expect(sessions[0].filePath).toBeTruthy();
       expect(sessions[0].lastModified).toBeInstanceOf(Date);

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -421,16 +421,20 @@ function extractSessionMetadataTitle(line: string): string | null | undefined {
   if (!line.trim()) {
     return undefined;
   }
-  let event: Record<string, unknown>;
+  let event: unknown;
   try {
-    event = JSON.parse(line) as Record<string, unknown>;
+    event = JSON.parse(line);
   } catch {
     return undefined;
   }
-  if (event.type !== 'session_metadata') {
+  if (event === null || typeof event !== 'object') {
     return undefined;
   }
-  const payload = event.payload as Record<string, unknown> | undefined;
+  const record = event as Record<string, unknown>;
+  if (record.type !== 'session_metadata') {
+    return undefined;
+  }
+  const payload = record.payload as Record<string, unknown> | undefined;
   if (!payload || typeof payload !== 'object') {
     return undefined;
   }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -301,13 +301,14 @@ export class SessionDiscovery {
   static async readSessionMetadataTitle(
     filePath: string,
   ): Promise<string | null | undefined> {
+    let reader: readline.Interface | undefined;
     try {
-      const lines = readline.createInterface({
+      reader = readline.createInterface({
         input: createReadStream(filePath, { encoding: 'utf8' }),
         crlfDelay: Infinity,
       });
       let title: string | null | undefined;
-      for await (const line of lines) {
+      for await (const line of reader) {
         const result = extractSessionMetadataTitle(line);
         if (result !== undefined) {
           title = result;
@@ -316,6 +317,8 @@ export class SessionDiscovery {
       return title;
     } catch {
       return undefined;
+    } finally {
+      reader?.close();
     }
   }
 }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -167,7 +167,7 @@ export class SessionDiscovery {
         return { session: sessions[indexNum - 1] };
       }
       return {
-        error: resumeSessionIndexOutOfRangeMessage(ref, sessions.length),
+        error: resumeSessionIndexOutOfRangeMessage(indexNum, sessions.length),
       };
     }
 

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -24,8 +24,10 @@
  * for the resume flow.
  */
 
+import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import * as readline from 'node:readline';
 import { type SessionSummary, type SessionStartPayload } from './types.js';
 import { readSessionHeader } from './ReplayEngine.js';
 import {
@@ -300,10 +302,12 @@ export class SessionDiscovery {
     filePath: string,
   ): Promise<string | null | undefined> {
     try {
-      const fileContent = await fs.readFile(filePath, 'utf-8');
-      const lines = fileContent.split('\n');
+      const lines = readline.createInterface({
+        input: createReadStream(filePath, { encoding: 'utf8' }),
+        crlfDelay: Infinity,
+      });
       let title: string | null | undefined;
-      for (const line of lines) {
+      for await (const line of lines) {
         const result = extractSessionMetadataTitle(line);
         if (result !== undefined) {
           title = result;

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -28,7 +28,11 @@ import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
-import { type SessionSummary, type SessionStartPayload } from './types.js';
+import {
+  SESSION_TITLE_MAX_LENGTH,
+  type SessionSummary,
+  type SessionStartPayload,
+} from './types.js';
 import { readSessionHeader } from './ReplayEngine.js';
 import {
   resumeSessionIndexOutOfRangeMessage,
@@ -274,7 +278,7 @@ export class SessionDiscovery {
    */
   static async readFirstUserMessage(
     filePath: string,
-    maxLength: number = 120,
+    maxLength: number = SESSION_TITLE_MAX_LENGTH,
   ): Promise<string | null> {
     try {
       const fileContent = await fs.readFile(filePath, 'utf-8');
@@ -301,32 +305,26 @@ export class SessionDiscovery {
   static async readSessionMetadataTitle(
     filePath: string,
   ): Promise<string | null | undefined> {
+    const stream = createReadStream(filePath, { encoding: 'utf8' });
     let reader: readline.Interface | undefined;
     try {
-      const stream = createReadStream(filePath, { encoding: 'utf8' });
-      const streamError = new Promise<never>((_, reject) => {
-        stream.on('error', (err: NodeJS.ErrnoException) => reject(err));
-      });
-      const rl = readline.createInterface({
+      reader = readline.createInterface({
         input: stream,
         crlfDelay: Infinity,
       });
-      reader = rl;
       let title: string | null | undefined;
-      const iterate = (async () => {
-        for await (const line of rl) {
-          const result = extractSessionMetadataTitle(line);
-          if (result !== undefined) {
-            title = result;
-          }
+      for await (const line of reader) {
+        const result = extractSessionMetadataTitle(line);
+        if (result !== undefined) {
+          title = result;
         }
-      })();
-      await Promise.race([iterate, streamError]);
+      }
       return title;
     } catch {
       return undefined;
     } finally {
       reader?.close();
+      stream.destroy();
     }
   }
 }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -314,6 +314,7 @@ async function readSessionSummary(
     fileSize: stat.size,
     provider: header.provider,
     model: header.model,
+    ...(typeof header.cwd === 'string' ? { cwd: header.cwd } : {}),
   };
 }
 

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -28,6 +28,10 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { type SessionSummary, type SessionStartPayload } from './types.js';
 import { readSessionHeader } from './ReplayEngine.js';
+import {
+  resumeSessionIndexOutOfRangeMessage,
+  resumeSessionNotFoundMessage,
+} from './resumeNotFoundMessages.js';
 
 /**
  * Result of successfully resolving a session reference.
@@ -163,7 +167,7 @@ export class SessionDiscovery {
         return { session: sessions[indexNum - 1] };
       }
       return {
-        error: `Session index ${ref} out of range (1-${sessions.length})`,
+        error: resumeSessionIndexOutOfRangeMessage(ref, sessions.length),
       };
     }
 
@@ -176,7 +180,7 @@ export class SessionDiscovery {
       };
     }
 
-    return { error: `Session not found for this project: ${ref}` };
+    return { error: resumeSessionNotFoundMessage(ref) };
   }
 
   /**

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -303,17 +303,25 @@ export class SessionDiscovery {
   ): Promise<string | null | undefined> {
     let reader: readline.Interface | undefined;
     try {
-      reader = readline.createInterface({
-        input: createReadStream(filePath, { encoding: 'utf8' }),
+      const stream = createReadStream(filePath, { encoding: 'utf8' });
+      const streamError = new Promise<never>((_, reject) => {
+        stream.on('error', (err: NodeJS.ErrnoException) => reject(err));
+      });
+      const rl = readline.createInterface({
+        input: stream,
         crlfDelay: Infinity,
       });
+      reader = rl;
       let title: string | null | undefined;
-      for await (const line of reader) {
-        const result = extractSessionMetadataTitle(line);
-        if (result !== undefined) {
-          title = result;
+      const iterate = (async () => {
+        for await (const line of rl) {
+          const result = extractSessionMetadataTitle(line);
+          if (result !== undefined) {
+            title = result;
+          }
         }
-      }
+      })();
+      await Promise.race([iterate, streamError]);
       return title;
     } catch {
       return undefined;

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -38,6 +38,7 @@ import {
   resumeSessionIndexOutOfRangeMessage,
   resumeSessionNotFoundMessage,
 } from './resumeNotFoundMessages.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 /**
  * Result of successfully resolving a session reference.
@@ -320,7 +321,11 @@ export class SessionDiscovery {
         }
       }
       return title;
-    } catch {
+    } catch (error) {
+      debugLogger.debug(
+        () =>
+          `readSessionMetadataTitle failed for ${filePath}: ${String(error)}`,
+      );
       return undefined;
     } finally {
       reader?.close();

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -288,6 +288,32 @@ export class SessionDiscovery {
       return null;
     }
   }
+
+  /**
+   * Read the tri-state title from the last valid `session_metadata` event in a
+   * session file (issue #1611). Returns:
+   * - `undefined` when no `session_metadata` event exists (legacy fallback).
+   * - `null` when the event explicitly asserts untitled.
+   * - `string` when the event carries a concrete title.
+   */
+  static async readSessionMetadataTitle(
+    filePath: string,
+  ): Promise<string | null | undefined> {
+    try {
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const lines = fileContent.split('\n');
+      let title: string | null | undefined;
+      for (const line of lines) {
+        const result = extractSessionMetadataTitle(line);
+        if (result !== undefined) {
+          title = result;
+        }
+      }
+      return title;
+    } catch {
+      return undefined;
+    }
+  }
 }
 
 async function readSessionSummary(
@@ -315,6 +341,9 @@ async function readSessionSummary(
     provider: header.provider,
     model: header.model,
     ...(typeof header.cwd === 'string' ? { cwd: header.cwd } : {}),
+    ...(typeof header.startTime === 'string'
+      ? { createdAt: header.startTime }
+      : {}),
   };
 }
 
@@ -371,4 +400,42 @@ function extractUserMessageText(line: string): string | null {
     .join('');
 
   return text || null;
+}
+
+/**
+ * Extract the title from a `session_metadata` JSONL line.
+ * Returns:
+ * - `undefined` when the line is not a valid `session_metadata` event (so
+ *   callers can continue scanning).
+ * - `null` when title is explicitly null (untitled).
+ * - `string` when a concrete title is present.
+ */
+function extractSessionMetadataTitle(line: string): string | null | undefined {
+  if (!line.trim()) {
+    return undefined;
+  }
+  let event: Record<string, unknown>;
+  try {
+    event = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+  if (event.type !== 'session_metadata') {
+    return undefined;
+  }
+  const payload = event.payload as Record<string, unknown> | undefined;
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+  if (!('title' in payload)) {
+    return undefined;
+  }
+  const title = payload.title;
+  if (title === null) {
+    return null;
+  }
+  if (typeof title === 'string') {
+    return title;
+  }
+  return undefined;
 }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -306,9 +306,10 @@ export class SessionDiscovery {
   static async readSessionMetadataTitle(
     filePath: string,
   ): Promise<string | null | undefined> {
-    const stream = createReadStream(filePath, { encoding: 'utf8' });
+    let stream: ReturnType<typeof createReadStream> | undefined;
     let reader: readline.Interface | undefined;
     try {
+      stream = createReadStream(filePath, { encoding: 'utf8' });
       reader = readline.createInterface({
         input: stream,
         crlfDelay: Infinity,
@@ -329,7 +330,7 @@ export class SessionDiscovery {
       return undefined;
     } finally {
       reader?.close();
-      stream.destroy();
+      stream?.destroy();
     }
   }
 }

--- a/packages/core/src/recording/SessionRecordingService.test.ts
+++ b/packages/core/src/recording/SessionRecordingService.test.ts
@@ -51,6 +51,7 @@ function makeConfig(
     projectHash: overrides.projectHash ?? 'abc123def456',
     chatsDir: overrides.chatsDir ?? '/tmp/test-chats',
     workspaceDirs: overrides.workspaceDirs ?? ['/home/user/project'],
+    cwd: overrides.cwd ?? '/home/user/project',
     provider: overrides.provider ?? 'anthropic',
     model: overrides.model ?? 'claude-4',
   };
@@ -1211,6 +1212,7 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
           expect(startPayload.workspaceDirs).toStrictEqual(
             config.workspaceDirs,
           );
+          expect(startPayload.cwd).toBe(config.cwd);
           expect(typeof startPayload.startTime).toBe('string');
           expect(isValidIso8601(startPayload.startTime as string)).toBe(true);
 

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -26,8 +26,6 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-export const SESSION_FILE_ID_PREFIX_LENGTH = 12;
-
 import { mkdirSync, existsSync, watch, type FSWatcher } from 'node:fs';
 import { type IContent } from '../services/history/IContent.js';
 import { debugLogger } from '../utils/debugLogger.js';
@@ -36,6 +34,8 @@ import {
   type SessionEventType,
   type SessionRecordLine,
 } from './types.js';
+
+export const SESSION_FILE_ID_PREFIX_LENGTH = 12;
 
 /**
  * Core service for recording session events to a JSONL file.

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -71,6 +71,7 @@ export class SessionRecordingService {
       sessionId: config.sessionId,
       projectHash: config.projectHash,
       workspaceDirs: config.workspaceDirs,
+      ...(config.cwd === undefined ? {} : { cwd: config.cwd }),
       provider: config.provider,
       model: config.model,
       startTime: new Date().toISOString(),

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -26,6 +26,8 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+export const SESSION_FILE_ID_PREFIX_LENGTH = 12;
+
 import { mkdirSync, existsSync, watch, type FSWatcher } from 'node:fs';
 import { type IContent } from '../services/history/IContent.js';
 import { debugLogger } from '../utils/debugLogger.js';
@@ -142,7 +144,7 @@ export class SessionRecordingService {
   private materialize(): void {
     const now = new Date();
     const timestamp = now.toISOString().slice(0, 19).replace(/:/g, '-');
-    const prefix = this.sessionId.substring(0, 12);
+    const prefix = this.sessionId.substring(0, SESSION_FILE_ID_PREFIX_LENGTH);
     const fileName = `session-${timestamp}-${prefix}.jsonl`;
     this.filePath = path.join(this.chatsDir, fileName);
     mkdirSync(this.chatsDir, { recursive: true });

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -57,6 +57,7 @@ export class SessionRecordingService {
   private readonly chatsDir: string;
   private preContentBuffer: SessionRecordLine[] = [];
   private chatsDirWatcher: FSWatcher | null = null;
+  private sessionTitle: string | null | undefined;
 
   /**
    * @plan PLAN-20260211-SESSIONRECORDING.P05
@@ -109,7 +110,10 @@ export class SessionRecordingService {
   enqueue(type: SessionEventType, payload: unknown): void {
     if (!this.active) return;
 
-    if (type === 'content' && !this.materialized) {
+    if (
+      (type === 'content' || type === 'session_metadata') &&
+      !this.materialized
+    ) {
       this.materialize();
       for (const buffered of this.preContentBuffer) {
         this.queue.push(buffered);
@@ -310,11 +314,16 @@ export class SessionRecordingService {
    * @requirement REQ-REC-008
    * @pseudocode session-recording-service.md lines 174-179
    */
-  initializeForResume(filePath: string, lastSeq: number): void {
+  initializeForResume(
+    filePath: string,
+    lastSeq: number,
+    title?: string | null,
+  ): void {
     this.filePath = filePath;
     this.seq = lastSeq;
     this.materialized = true;
     this.preContentBuffer = [];
+    this.sessionTitle = title;
     this.startChatsDirWatcher();
   }
 
@@ -470,5 +479,26 @@ export class SessionRecordingService {
    */
   recordDirectoriesChanged(directories: string[]): void {
     this.enqueue('directories_changed', { directories });
+  }
+
+  /**
+   * Record a session_metadata event — persisted human-readable title.
+   * The title is tri-state: `string` for a concrete title, `null` for explicit
+   * untitled, `undefined` for legacy (field absent). Like `content`, this event
+   * materializes the file so slash/failure sessions persist metadata even
+   * without a content event.
+   *
+   * @requirement REQ-REC-002
+   */
+  recordSessionMetadata(title: string | null): void {
+    if (!this.active) {
+      return;
+    }
+    this.sessionTitle = title;
+    this.enqueue('session_metadata', { title });
+  }
+
+  getSessionMetadataTitle(): string | null | undefined {
+    return this.sessionTitle;
   }
 }

--- a/packages/core/src/recording/index.ts
+++ b/packages/core/src/recording/index.ts
@@ -44,6 +44,14 @@ export {
   type ResumeError,
 } from './resumeSession.js';
 export {
+  RESUME_NO_SESSIONS_FOUND,
+  RESUME_SESSION_NOT_FOUND_PREFIX,
+  RESUME_SESSION_INDEX_OUT_OF_RANGE_PREFIX,
+  RESUME_SESSION_INDEX_OUT_OF_RANGE_RE,
+  resumeSessionNotFoundMessage,
+  resumeSessionIndexOutOfRangeMessage,
+} from './resumeNotFoundMessages.js';
+export {
   listSessions,
   deleteSession,
   type ListSessionsResult,

--- a/packages/core/src/recording/index.ts
+++ b/packages/core/src/recording/index.ts
@@ -57,6 +57,7 @@ export {
 export {
   listSessions,
   deleteSession,
+  deleteSessionById,
   type ListSessionsResult,
   type DeleteSessionResult,
   type DeleteSessionError,

--- a/packages/core/src/recording/index.ts
+++ b/packages/core/src/recording/index.ts
@@ -21,7 +21,10 @@
  */
 
 export * from './types.js';
-export { SessionRecordingService } from './SessionRecordingService.js';
+export {
+  SessionRecordingService,
+  SESSION_FILE_ID_PREFIX_LENGTH,
+} from './SessionRecordingService.js';
 export { replaySession, readSessionHeader } from './ReplayEngine.js';
 export { SessionLockManager, type LockHandle } from './SessionLockManager.js';
 export { RecordingIntegration } from './RecordingIntegration.js';

--- a/packages/core/src/recording/replay-test-helpers.ts
+++ b/packages/core/src/recording/replay-test-helpers.ts
@@ -200,6 +200,20 @@ export function _directoriesChangedLine(
 }
 
 /**
+ * Build a valid JSONL line for a session_metadata event (issue #1611).
+ * The title is tri-state: string, null, or undefined (omitted from payload).
+ */
+export function sessionMetadataLine(seq: number, title: string | null): string {
+  return JSON.stringify({
+    v: 1,
+    seq,
+    ts: new Date().toISOString(),
+    type: 'session_metadata',
+    payload: { title },
+  });
+}
+
+/**
  * Write raw JSONL lines to a file.
  */
 export async function writeJsonlFile(

--- a/packages/core/src/recording/replay-test-helpers.ts
+++ b/packages/core/src/recording/replay-test-helpers.ts
@@ -201,7 +201,7 @@ export function _directoriesChangedLine(
 
 /**
  * Build a valid JSONL line for a session_metadata event (issue #1611).
- * The title is tri-state: string, null, or undefined (omitted from payload).
+ * The title is either a concrete string or explicit null.
  */
 export function sessionMetadataLine(seq: number, title: string | null): string {
   return JSON.stringify({

--- a/packages/core/src/recording/resumeNotFoundMessages.ts
+++ b/packages/core/src/recording/resumeNotFoundMessages.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The "session not found"-style messages the resume/discovery flow emits, as
+ * shared constants so downstream classifiers (e.g. the Zed ACP loadSession
+ * error mapper) can match them WITHOUT string-literal coupling that would
+ * silently break if the wording changed. The emitting sites
+ * (resumeSession.ts, SessionDiscovery.ts) and every matcher must reference
+ * these — never inline copies of the sentences.
+ */
+
+/** Emitted by resumeSession when the project has no recorded sessions at all. */
+export const RESUME_NO_SESSIONS_FOUND = 'No sessions found for this project';
+
+/**
+ * Prefix of the SessionDiscovery.resolveSessionRef message for an unknown
+ * session reference; the full message appends `: <ref>`.
+ */
+export const RESUME_SESSION_NOT_FOUND_PREFIX =
+  'Session not found for this project:';
+
+/**
+ * Builds the full SessionDiscovery.resolveSessionRef not-found message for a
+ * specific reference.
+ */
+export function resumeSessionNotFoundMessage(ref: string): string {
+  return `${RESUME_SESSION_NOT_FOUND_PREFIX} ${ref}`;
+}
+
+/**
+ * Prefix of the SessionDiscovery.resolveSessionRef message for a numeric
+ * session index outside the listing range; the full message is
+ * `Session index <n> out of range (1-<m>)`.
+ */
+export const RESUME_SESSION_INDEX_OUT_OF_RANGE_PREFIX = 'Session index ';
+
+/**
+ * Builds the full SessionDiscovery.resolveSessionRef out-of-range message for
+ * a specific index and session count.
+ */
+export function resumeSessionIndexOutOfRangeMessage(
+  ref: string | number,
+  count: number,
+): string {
+  return `${RESUME_SESSION_INDEX_OUT_OF_RANGE_PREFIX}${ref} out of range (1-${count})`;
+}
+
+/**
+ * Matches the out-of-range message shape for classifiers that only have the
+ * final (envelope-wrapped) detail string to inspect.
+ */
+export const RESUME_SESSION_INDEX_OUT_OF_RANGE_RE =
+  /Session index \d+ out of range/;

--- a/packages/core/src/recording/resumeNotFoundMessages.ts
+++ b/packages/core/src/recording/resumeNotFoundMessages.ts
@@ -69,4 +69,4 @@ export function resumeSessionIndexOutOfRangeMessage(
  * final (envelope-wrapped) detail string to inspect.
  */
 export const RESUME_SESSION_INDEX_OUT_OF_RANGE_RE =
-  /Session index \d+ out of range/;
+  /^(?:Failed to resume session: )?Session index \d+ out of range \(1-\d+\)$/;

--- a/packages/core/src/recording/resumeNotFoundMessages.ts
+++ b/packages/core/src/recording/resumeNotFoundMessages.ts
@@ -27,8 +27,10 @@
 export const RESUME_NO_SESSIONS_FOUND = 'No sessions found for this project';
 
 /**
- * Prefix of the SessionDiscovery.resolveSessionRef message for an unknown
- * session reference; the full message appends `: <ref>`.
+ * Prefix (including the trailing colon) of the
+ * SessionDiscovery.resolveSessionRef message for an unknown session reference;
+ * the full message appends ` <ref>` (space + ref) after it — see
+ * {@link resumeSessionNotFoundMessage}.
  */
 export const RESUME_SESSION_NOT_FOUND_PREFIX =
   'Session not found for this project:';
@@ -50,10 +52,13 @@ export const RESUME_SESSION_INDEX_OUT_OF_RANGE_PREFIX = 'Session index ';
 
 /**
  * Builds the full SessionDiscovery.resolveSessionRef out-of-range message for
- * a specific index and session count.
+ * a specific index and session count. `ref` must render as digits (a number,
+ * or the digit-only string the caller already validated with /^\d+$/) so the
+ * produced message stays matchable by
+ * {@link RESUME_SESSION_INDEX_OUT_OF_RANGE_RE}.
  */
 export function resumeSessionIndexOutOfRangeMessage(
-  ref: string | number,
+  ref: number | `${number}`,
   count: number,
 ): string {
   return `${RESUME_SESSION_INDEX_OUT_OF_RANGE_PREFIX}${ref} out of range (1-${count})`;

--- a/packages/core/src/recording/resumeSession.ts
+++ b/packages/core/src/recording/resumeSession.ts
@@ -139,6 +139,7 @@ function initializeRecordingForResume(
   recording.initializeForResume(
     lockedSession.targetFilePath,
     replayResult.lastSeq,
+    replayResult.metadata.title,
   );
 
   if (

--- a/packages/core/src/recording/resumeSession.ts
+++ b/packages/core/src/recording/resumeSession.ts
@@ -30,6 +30,7 @@ import { SessionRecordingService } from './SessionRecordingService.js';
 import { SessionDiscovery } from './SessionDiscovery.js';
 import { SessionLockManager, type LockHandle } from './SessionLockManager.js';
 import { replaySession } from './ReplayEngine.js';
+import { RESUME_NO_SESSIONS_FOUND } from './resumeNotFoundMessages.js';
 
 /**
  * Sentinel constant for "resume most recent session".
@@ -180,7 +181,7 @@ export async function resumeSession(
   );
 
   if (sessions.length === 0) {
-    return { ok: false, error: 'No sessions found for this project' };
+    return { ok: false, error: RESUME_NO_SESSIONS_FOUND };
   }
 
   // Step 2: Resolve which session to resume

--- a/packages/core/src/recording/sessionManagement.test.ts
+++ b/packages/core/src/recording/sessionManagement.test.ts
@@ -34,7 +34,11 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { SessionRecordingService } from './SessionRecordingService.js';
 import { SessionLockManager } from './SessionLockManager.js';
-import { listSessions, deleteSession } from './sessionManagement.js';
+import {
+  listSessions,
+  deleteSession,
+  deleteSessionById,
+} from './sessionManagement.js';
 import { type SessionRecordingServiceConfig } from './types.js';
 import { type IContent } from '../services/history/IContent.js';
 
@@ -401,6 +405,35 @@ describe('sessionManagement @plan:PLAN-20260211-SESSIONRECORDING.P22', () => {
         expect(result.deletedSessionId).toBe(sessionId);
       }
     });
+  });
+
+  describe('deleteSessionById', () => {
+    itProp(
+      'deletes only an exact session ID and never resolves a prefix',
+      async () => {
+        const sessionId = 'exact-session-identifier';
+        const { filePath } = await createTestSession(chatsDir, { sessionId });
+
+        const prefixResult = await deleteSessionById(
+          'exact-session',
+          chatsDir,
+          PROJECT_HASH,
+        );
+        expect(prefixResult.ok).toBe(false);
+        expect(await fileExists(filePath)).toBe(true);
+
+        const exactResult = await deleteSessionById(
+          sessionId,
+          chatsDir,
+          PROJECT_HASH,
+        );
+        expect(exactResult).toStrictEqual({
+          ok: true,
+          deletedSessionId: sessionId,
+        });
+        expect(await fileExists(filePath)).toBe(false);
+      },
+    );
   });
 
   // =========================================================================

--- a/packages/core/src/recording/sessionManagement.ts
+++ b/packages/core/src/recording/sessionManagement.ts
@@ -85,38 +85,54 @@ export async function deleteSession(
     return { ok: false, error: resolved.error };
   }
 
-  const target = resolved.session;
+  return deleteResolvedSession(resolved.session, chatsDir);
+}
 
-  const locked = await SessionLockManager.isLocked(chatsDir, target.sessionId);
-  if (locked) {
-    const stale = await SessionLockManager.isStale(chatsDir, target.sessionId);
-    if (stale) {
-      await SessionLockManager.removeStaleLock(chatsDir, target.sessionId);
-    } else {
+/** Delete a session only when the supplied identifier is an exact match. */
+export async function deleteSessionById(
+  sessionId: string,
+  chatsDir: string,
+  projectHash: string,
+): Promise<DeleteSessionResult | DeleteSessionError> {
+  const sessions = await SessionDiscovery.listSessions(chatsDir, projectHash);
+  const target = sessions.find((session) => session.sessionId === sessionId);
+  if (target === undefined) {
+    return { ok: false, error: `Session not found: ${sessionId}` };
+  }
+
+  return deleteResolvedSession(target, chatsDir);
+}
+
+async function deleteResolvedSession(
+  target: SessionSummary,
+  chatsDir: string,
+): Promise<DeleteSessionResult | DeleteSessionError> {
+  let lock;
+  try {
+    lock = await SessionLockManager.acquire(chatsDir, target.sessionId);
+  } catch (error: unknown) {
+    if ((error as Error).message === 'Session is in use by another process') {
       return {
         ok: false,
         error: 'Cannot delete: session is in use by another process',
       };
     }
+    return {
+      ok: false,
+      error: `Failed to lock session for deletion: ${(error as Error).message}`,
+    };
   }
 
   const { unlink } = await import('node:fs/promises');
-
   try {
     await unlink(target.filePath);
+    return { ok: true, deletedSessionId: target.sessionId };
   } catch (error: unknown) {
     return {
       ok: false,
       error: `Failed to delete session: ${(error as Error).message}`,
     };
+  } finally {
+    await lock.release();
   }
-
-  const lockPath = SessionLockManager.getLockPath(chatsDir, target.sessionId);
-  try {
-    await unlink(lockPath);
-  } catch {
-    // Lock file may not exist
-  }
-
-  return { ok: true, deletedSessionId: target.sessionId };
 }

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the session_metadata recording event (issue #1611).
+ *
+ * Verifies:
+ * - recordSessionMetadata writes a typed session_metadata event (not a
+ *   session_event sentinel) to the JSONL file.
+ * - The title is tri-state: string (concrete), null (explicit untitled).
+ * - session_metadata materializes the recording file BEFORE any content event,
+ *   so slash/failure sessions persist their metadata.
+ * - ReplayEngine restores the tri-state title from session_metadata events.
+ * - SessionDiscovery.readSessionMetadataTitle extracts the tri-state title.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SessionRecordingService } from './SessionRecordingService.js';
+import { replaySession } from './ReplayEngine.js';
+import { SessionDiscovery } from './SessionDiscovery.js';
+import {
+  makeConfig,
+  sessionStartLine,
+  sessionMetadataLine,
+  contentLine,
+  makeContent,
+  writeJsonlFile,
+  PROJECT_HASH,
+  assertReplayOk,
+} from './replay-test-helpers.js';
+
+const tempDirs: string[] = [];
+
+describe('session_metadata recording (issue #1611)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function makeTempChatsDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'session-metadata-'));
+    tempDirs.push(dir);
+    const chatsDir = path.join(dir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+    return chatsDir;
+  }
+
+  describe('SessionRecordingService.recordSessionMetadata', () => {
+    it('writes a typed session_metadata event (not a session_event sentinel)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('My session title');
+      await service.flush();
+
+      const filePath = service.getFilePath();
+      expect(filePath).not.toBeNull();
+      const fileContent = await fs.readFile(filePath!, 'utf-8');
+      const lines = fileContent.trim().split('\n');
+      const types = lines.map((line) => JSON.parse(line).type);
+
+      expect(types).toContain('session_metadata');
+      const metadataLine = lines
+        .map((line) => JSON.parse(line))
+        .find((line) => line.type === 'session_metadata');
+      expect(metadataLine.payload).toStrictEqual({ title: 'My session title' });
+      await service.dispose();
+    });
+
+    it('records a null title for explicit untitled', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata(null);
+      await service.flush();
+
+      const filePath = service.getFilePath()!;
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const metadataLine = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+        .find((line) => line.type === 'session_metadata');
+      expect(metadataLine.payload).toStrictEqual({ title: null });
+      await service.dispose();
+    });
+
+    it('materializes the recording BEFORE any content event (slash/failure sessions)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('Slash command title');
+      await service.flush();
+
+      expect(service.getFilePath()).not.toBeNull();
+      const fileContent = await fs.readFile(service.getFilePath()!, 'utf-8');
+      const types = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line).type);
+      expect(types).toContain('session_start');
+      expect(types).toContain('session_metadata');
+      expect(types).not.toContain('content');
+      await service.dispose();
+    });
+
+    it('preserves ordering: session_start before session_metadata before content', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('Ordered title');
+      service.recordContent(makeContent('hello'));
+      await service.flush();
+
+      const fileContent = await fs.readFile(service.getFilePath()!, 'utf-8');
+      const types = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line).type);
+      const startIdx = types.indexOf('session_start');
+      const metaIdx = types.indexOf('session_metadata');
+      const contentIdx = types.indexOf('content');
+      expect(startIdx).toBeLessThan(metaIdx);
+      expect(metaIdx).toBeLessThan(contentIdx);
+      await service.dispose();
+    });
+  });
+
+  describe('ReplayEngine session_metadata handling', () => {
+    it('replays a string title from session_metadata', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-str.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'Replayed title'),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBe('Replayed title');
+    });
+
+    it('replays a null title (explicit untitled)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-null.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, null),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBeNull();
+    });
+
+    it('leaves title undefined (legacy) when no session_metadata event exists', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-legacy.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        contentLine(2, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBeUndefined();
+    });
+
+    it('last session_metadata title wins when multiple exist', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-multi.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'First title'),
+        contentLine(3, makeContent('turn 1')),
+        sessionMetadataLine(4, 'Updated title'),
+        contentLine(5, makeContent('turn 2')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBe('Updated title');
+    });
+
+    it('records a warning for session_metadata before session_start', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-early.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionMetadataLine(1, 'Too early'),
+        sessionStartLine(2),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      expect(result.ok).toBe(false);
+    });
+
+    it('records a warning for malformed session_metadata title (non-string, non-null)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-malformed.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        JSON.stringify({
+          v: 1,
+          seq: 2,
+          ts: '2026-07-12T00:00:00.000Z',
+          type: 'session_metadata',
+          payload: { title: 12345 },
+        }),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(
+        result.warnings.some((w) => w.includes('malformed session_metadata')),
+      ).toBe(true);
+    });
+  });
+
+  describe('SessionDiscovery.readSessionMetadataTitle', () => {
+    it('reads a string title from a session_metadata event', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-str.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'Discovery title'),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBe('Discovery title');
+    });
+
+    it('reads null for explicit untitled', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-null.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, null),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBeNull();
+    });
+
+    it('returns undefined when no session_metadata event exists (legacy)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-legacy.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        contentLine(2, makeContent('hello')),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBeUndefined();
+    });
+
+    it('reads the last valid session_metadata title when multiple exist', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-multi.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'First metadata'),
+        contentLine(3, makeContent('turn')),
+        sessionMetadataLine(4, 'Second metadata'),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBe('Second metadata');
+    });
+  });
+
+  describe('SessionSummary createdAt (immutable ordering)', () => {
+    it('includes createdAt from session_start.startTime', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+      service.recordContent(makeContent('hello'));
+      await service.flush();
+      await service.dispose();
+
+      const sessions = await SessionDiscovery.listSessions(
+        chatsDir,
+        PROJECT_HASH,
+      );
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].createdAt).toBeDefined();
+      expect(typeof sessions[0].createdAt).toBe('string');
+      expect(Number.isNaN(Date.parse(sessions[0].createdAt!))).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -191,7 +191,7 @@ describe('session_metadata recording (issue #1611)', () => {
       expect(result.metadata.title).toBe('Updated title');
     });
 
-    it('records a warning for session_metadata before session_start', async () => {
+    it('returns a fatal replay error when session_metadata precedes session_start', async () => {
       const chatsDir = await makeTempChatsDir();
       const filePath = path.join(chatsDir, 'session-test-meta-early.jsonl');
       await writeJsonlFile(filePath, [

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -263,6 +263,15 @@ describe('session_metadata recording (issue #1611)', () => {
       expect(title).toBeUndefined();
     });
 
+    it('returns undefined when the source stream cannot be opened', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'missing-session.jsonl');
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+
+      expect(title).toBeUndefined();
+    });
+
     it('reads the last valid session_metadata title when multiple exist', async () => {
       const chatsDir = await makeTempChatsDir();
       const filePath = path.join(chatsDir, 'session-discovery-multi.jsonl');

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -25,6 +25,8 @@
 
 import { type IContent } from '../services/history/IContent.js';
 
+export const SESSION_TITLE_MAX_LENGTH = 120;
+
 // ---------------------------------------------------------------------------
 // Event type discriminator
 // ---------------------------------------------------------------------------

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -74,6 +74,8 @@ export interface SessionStartPayload {
   sessionId: string;
   projectHash: string;
   workspaceDirs: string[];
+  /** Effective absolute working directory, when recorded by newer clients. */
+  cwd?: string;
   provider: string;
   model: string;
   /** ISO-8601 timestamp of when the session started. */
@@ -141,6 +143,8 @@ export interface SessionRecordingServiceConfig {
   projectHash: string;
   chatsDir: string;
   workspaceDirs: string[];
+  /** Effective absolute working directory for lifecycle discovery. */
+  cwd?: string;
   provider: string;
   model: string;
 }
@@ -159,6 +163,7 @@ export interface SessionMetadata {
   provider: string;
   model: string;
   workspaceDirs: string[];
+  cwd?: string;
   startTime: string;
 }
 
@@ -199,4 +204,5 @@ export interface SessionSummary {
   fileSize: number;
   provider: string;
   model: string;
+  cwd?: string;
 }

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -30,7 +30,7 @@ import { type IContent } from '../services/history/IContent.js';
 // ---------------------------------------------------------------------------
 
 /**
- * The seven event types that can appear in a session JSONL file.
+ * The event types that can appear in a session JSONL file.
  */
 export type SessionEventType =
   | 'session_start'
@@ -39,6 +39,7 @@ export type SessionEventType =
   | 'rewind'
   | 'provider_switch'
   | 'session_event'
+  | 'session_metadata'
   | 'directories_changed';
 
 // ---------------------------------------------------------------------------
@@ -125,6 +126,19 @@ export interface SessionEventPayload {
 }
 
 /**
+ * Payload for the `session_metadata` event — session-level metadata updates
+ * (currently only the human-readable title). The title is tri-state:
+ * - `undefined` (field absent): legacy event, no title assertion.
+ * - `null`: explicit untitled (the caller asserts there is no meaningful title).
+ * - `string`: a concrete title.
+ *
+ * This is a typed first-class recording event, NOT a `session_event` sentinel.
+ */
+export interface SessionMetadataPayload {
+  readonly title?: string | null;
+}
+
+/**
  * Payload for the `directories_changed` event.
  */
 export interface DirectoriesChangedPayload {
@@ -155,7 +169,14 @@ export interface SessionRecordingServiceConfig {
 
 /**
  * Metadata extracted from a session's `session_start` event and updated
- * by subsequent `provider_switch` / `directories_changed` events.
+ * by subsequent `provider_switch` / `directories_changed` / `session_metadata`
+ * events.
+ *
+ * The title is tri-state:
+ * - `undefined`: no `session_metadata` event seen (legacy file). Callers fall
+ *   back to first-human-text heuristics.
+ * - `null`: explicit untitled (`session_metadata` asserted no title).
+ * - `string`: a concrete title.
  */
 export interface SessionMetadata {
   sessionId: string;
@@ -165,6 +186,7 @@ export interface SessionMetadata {
   workspaceDirs: string[];
   cwd?: string;
   startTime: string;
+  title?: string | null;
 }
 
 /**
@@ -205,4 +227,16 @@ export interface SessionSummary {
   provider: string;
   model: string;
   cwd?: string;
+  /**
+   * Tri-state title from a persisted `session_metadata` event:
+   * - `undefined`: no `session_metadata` event seen (legacy fallback).
+   * - `null`: explicit untitled.
+   * - `string`: a concrete title.
+   */
+  title?: string | null;
+  /**
+   * Immutable creation timestamp extracted from `session_start.startTime`.
+   * Used for stable ordering independent of file `lastModified` mutations.
+   */
+  createdAt?: string;
 }

--- a/packages/storage/src/config/storage.test.ts
+++ b/packages/storage/src/config/storage.test.ts
@@ -390,6 +390,12 @@ describe('Storage – instance (workspace-local) helpers', () => {
     );
   });
 
+  it('getProjectChatsDir is the chats folder directly under the project temp dir (shared writer/prober contract)', () => {
+    expect(storage.getProjectChatsDir()).toBe(
+      path.join(storage.getProjectTempDir(), 'chats'),
+    );
+  });
+
   it('getProjectTempDir is deterministic for a given project root', () => {
     const a = new Storage(projectRoot).getProjectTempDir();
     const b = new Storage(projectRoot).getProjectTempDir();

--- a/packages/storage/src/config/storage.ts
+++ b/packages/storage/src/config/storage.ts
@@ -288,6 +288,17 @@ export class Storage {
     return path.join(this.getProjectTempDir(), 'checkpoints');
   }
 
+  /**
+   * The single source of truth for the chats directory, where session
+   * recordings/persistence files live (`<projectTempDir>/chats`). Every
+   * consumer (session recording, resume probes, session cleanup, chat
+   * persistence) must derive the path through this helper so the writers and
+   * the readers/probes can never drift apart on the location.
+   */
+  getProjectChatsDir(): string {
+    return path.join(this.getProjectTempDir(), 'chats');
+  }
+
   getExtensionsDir(): string {
     return path.join(this.getLlxprtDir(), 'extensions');
   }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -276,6 +276,7 @@ export {
   OUTPUT_UPDATE_INTERVAL_MS,
   type ShellToolParams,
 } from './tools/shell.js';
+export { buildCommandToExecute } from './tools/shell-helpers.js';
 export {
   DISCOVERED_TOOL_PREFIX,
   ToolRegistry,


### PR DESCRIPTION
## Summary

Implements ACP `session/load` for the Zed integration with continuous session recording, replacing the previous `loadSession: null` (unsupported) capability. Part of the #1603 umbrella; stacked on PR #2498 (SDK 0.14.1 -> 1.2.1 upgrade), so this PR targets the `issue2496` branch and should be retargeted/merged after #2498 lands.

Fixes #1604

## What this adds

### Continuous session recording (packages/agents)
- `SessionControl.setRecording({ enabled })` now snapshots current history AND subscribes a `RecordingIntegration` to the live `HistoryService`, so every subsequent turn is appended to the JSONL recording continuously (not a one-shot snapshot).
- Recording control is serialized against `resume()`/`stopRecording()` races: the last-submitted operation wins with a consistent final state and no orphaned `.lock` files (behavioral tests A1/A2/A3 cover racing resume-vs-stop, atomic swap, and bounded re-attach when the HistoryService materializes late).
- Bounded re-attach: if no `HistoryService` exists when recording is enabled, the integration is wired at the start of the next state-mutating operation.

### session/load (packages/cli zed-integration)
- `loadSession` advertises `loadSession: true` and implements the full ACP flow: dispose any prior same-id session (releasing its disk lock), build + resume + install the replacement, then stream the restored transcript as `session/update` notifications before returning.
- **Live re-attach path:** a live same-id session with NO recording on disk (an unprompted session never materializes a file) is RE-ATTACHED rather than destroyed by a doomed disk resume.
- **Same-id concurrency:** loads for the same session id are serialized via a per-id promise queue (`loadSessionQueues`), so dispose -> build -> resume -> install never interleaves between two loads.
- **Corrupt vs missing:** resume failures are classified by probing the recorded file (`session-<ts>-<first12>.jsonl` naming rule shared between the loader probe and the resume-failure classifier): a genuinely-missing session maps to `resourceNotFound`, a present-but-corrupt file maps to `internalError` with structured data, and an indeterminate probe (EACCES etc.) is surfaced as `internalError` rather than a misleading not-found.
- **Replay fidelity:** history is mapped to ACP updates via a pure `mapHistoryToSessionUpdates`: user/agent text, thought chunks, tool_call (in_progress, with locations/kind/rawInput inferred via the SAME helpers as the live path) and ordered tool_call_update pairing; unpaired calls get a synthetic `failed` terminal update. Replay delivery is strict: a rejected `session/update` fails the load (`phase: 'replay'` internalError) instead of silently succeeding.
- **Malformed persisted data hardening:** every item and every block read back from disk is narrowed before use (null/primitive/type-less items and blocks, non-string tool ids/callIds/names, non-object parameters) so one corrupt JSONL line degrades gracefully instead of aborting the whole replay.
- **Stream batching:** replayed updates flow through a per-prompt stream batcher; the prompt finally block flushes then disposes it even when flush rejects, bounding the batch timer to the turn lifecycle.

## Review hardening (open-code-review, all findings addressed)
- Replay tool_call starts always carry `rawInput` (`{}` for malformed/missing recorded parameters) — wire-identical with the live start path which unconditionally sends `call.args`.
- `inferToolKind` only consulted for validated string tool names.
- Batcher disposal survives flush rejection (timer leak).
- Test helper temp-dir cleanup survives `buildAgent` rejection.
- Loader test asserts warn diagnostics (session id + errno) instead of pinning message phrasing.
- `findMatchingSessionFile` 12-char-prefix granularity documented and tested (inherited from the recording service naming scheme; ids are UUIDs).

## Verification
- `npm run test` (full monorepo) green
- `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build` green
- open-code-review: 20 files reviewed, all findings remediated; re-review of remediation commit clean (0 comments)
- Smoke test (`bun scripts/start.ts --profile-load ollamakimi`) currently blocked by an ollama.com monthly usage cap (provider-side quota, unrelated to this change)

## Test coverage added
- `zed-session-replay.test.ts` / `zed-session-replay.malformed.test.ts` — mapping fidelity + malformed-data degradation (44 tests)
- `zedIntegration.loadSession.test.ts` — end-to-end load flow, live re-attach, same-id serialization, replay failure surfacing (12 tests)
- `zed-session-errors.test.ts` — corrupt/missing/indeterminate classification + file matcher (28 tests)
- `zed-session-loader.test.ts` — recording-presence probe fail-open semantics (8 tests)
- `sessionControl.recording.behavior.test.ts` / `sessionControl.concurrency.behavior.test.ts` — continuous recording + concurrency/atomicity against a real Agent (8 tests)
- `zed-stream-batcher.test.ts` — batching/flush/dispose lifecycle
