### PR TITLE
Make startup migration and profile loading resilient (Fixes #2476, Fixes #2477)

### DIFF
--- a/packages/cli/src/__tests__/wizard-saveProfile.test.ts
+++ b/packages/cli/src/__tests__/wizard-saveProfile.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the ProfileCreateWizard saveProfile utility.
+ * Verifies that profile writes are routed through the settings persistence
+ * API with create-only vs overwrite semantics and 0600 mode.
+ * Uses real temp directories and the actual filesystem — no mocking.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { Storage } from '@vybestack/llxprt-code-settings';
+import { saveProfile } from '../ui/components/ProfileCreateWizard/utils.js';
+
+async function makeTempDir(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-wizard-test-'));
+}
+
+function profilesDirForConfigHome(configHome: string): string {
+  return path.join(configHome, 'profiles');
+}
+
+describe('ProfileCreateWizard saveProfile — settings persistence API', () => {
+  let configHome: string;
+  let originalConfigHome: string | undefined;
+
+  beforeEach(async () => {
+    configHome = await makeTempDir();
+    originalConfigHome = process.env.LLXPRT_CONFIG_HOME;
+    process.env.LLXPRT_CONFIG_HOME = configHome;
+  });
+
+  afterEach(async () => {
+    if (originalConfigHome !== undefined) {
+      process.env.LLXPRT_CONFIG_HOME = originalConfigHome;
+    } else {
+      delete process.env.LLXPRT_CONFIG_HOME;
+    }
+    await fsp.rm(configHome, { recursive: true, force: true });
+  });
+
+  it('creates a new profile with 0600 mode', async () => {
+    const result = await saveProfile(
+      'myprof',
+      { version: 1, provider: 'openai', model: 'gpt-4' },
+      { overwrite: false },
+    );
+    expect(result.success).toBe(true);
+    expect(result.alreadyExists).toBeFalsy();
+
+    const profilesDir = profilesDirForConfigHome(Storage.getGlobalConfigDir());
+    const profilePath = path.join(profilesDir, 'myprof.json');
+    expect(fs.existsSync(profilePath)).toBe(true);
+    const stat = fs.statSync(profilePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it('create collision returns alreadyExists without overwriting', async () => {
+    const profilesDir = profilesDirForConfigHome(Storage.getGlobalConfigDir());
+    fs.mkdirSync(profilesDir, { recursive: true });
+    const existing = JSON.stringify({
+      version: 1,
+      provider: 'anthropic',
+      model: 'claude',
+    });
+    fs.writeFileSync(path.join(profilesDir, 'existing.json'), existing, {
+      mode: 0o600,
+    });
+
+    const result = await saveProfile(
+      'existing',
+      { version: 1, provider: 'openai', model: 'gpt-4' },
+      { overwrite: false },
+    );
+    expect(result.success).toBe(false);
+    expect(result.alreadyExists).toBe(true);
+    expect(result.error).toContain('already exists');
+
+    // Original content preserved.
+    const content = fs.readFileSync(
+      path.join(profilesDir, 'existing.json'),
+      'utf-8',
+    );
+    expect(JSON.parse(content).provider).toBe('anthropic');
+  });
+
+  it('overwrite mode replaces an existing profile', async () => {
+    const profilesDir = profilesDirForConfigHome(Storage.getGlobalConfigDir());
+    fs.mkdirSync(profilesDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profilesDir, 'overwrite.json'),
+      JSON.stringify({
+        version: 1,
+        provider: 'anthropic',
+        model: 'claude',
+      }),
+      { mode: 0o600 },
+    );
+
+    const result = await saveProfile(
+      'overwrite',
+      { version: 1, provider: 'openai', model: 'gpt-4o' },
+      { overwrite: true },
+    );
+    expect(result.success).toBe(true);
+
+    const content = fs.readFileSync(
+      path.join(profilesDir, 'overwrite.json'),
+      'utf-8',
+    );
+    expect(JSON.parse(content).provider).toBe('openai');
+    expect(JSON.parse(content).model).toBe('gpt-4o');
+  });
+
+  it('does not leave a lock file behind after writing', async () => {
+    await saveProfile(
+      'nolock',
+      { version: 1, provider: 'openai', model: 'gpt-4' },
+      { overwrite: false },
+    );
+    const profilesDir = profilesDirForConfigHome(Storage.getGlobalConfigDir());
+    const lockExists = fs.existsSync(path.join(profilesDir, '.profiles.lock'));
+    expect(lockExists).toBe(false);
+  });
+});

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -55,7 +55,10 @@ import {
   debugLogger,
 } from '@vybestack/llxprt-code-core';
 import { Storage } from '@vybestack/llxprt-code-settings';
-import { runStartupMigration } from './config/pathMigration.js';
+import {
+  runStartupMigration,
+  reportStartupResult,
+} from './config/pathMigration.js';
 import {
   cleanupCheckpoints,
   runExitCleanup,
@@ -126,13 +129,13 @@ function setupProcessLifecycle(): () => void {
 
   // Migrate legacy ~/.llxprt/ to platform-standard path (if needed),
   // then ensure the platform directory exists.
-  const migrationResult = runStartupMigration();
-  if (!migrationResult.migrated && migrationResult.error === true) {
-    const legacyDir = Storage.getLegacyLlxprtDir();
-    process.stderr.write(
-      `Warning: configuration migration failed (${migrationResult.reason}). ` +
-        `Falling back to legacy directory ${legacyDir} for this session.\n`,
-    );
+  const startupResult = runStartupMigration();
+  const legacyDir = Storage.getLegacyLlxprtDir();
+  const report = reportStartupResult(startupResult, legacyDir);
+  for (const message of report.messages) {
+    process.stderr.write(message + '\n');
+  }
+  if (report.needsLegacyFallback) {
     process.env['LLXPRT_CONFIG_HOME'] = legacyDir;
   }
   const llxprtDir = Storage.getGlobalConfigDir();

--- a/packages/cli/src/config/legacyCopyEngine.ts
+++ b/packages/cli/src/config/legacyCopyEngine.ts
@@ -159,7 +159,13 @@ export function copyDirFiltered(
   visited.add(realSrc);
 
   let count = 0;
-  fs.mkdirSync(dest, { recursive: true });
+  try {
+    fs.mkdirSync(dest, { recursive: true });
+  } catch (error) {
+    errors.push(`${dest}: ${String(error)}`);
+    logger.debug(`Cannot create directory ${dest}: ${String(error)}`);
+    return count;
+  }
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(src, { withFileTypes: true });
@@ -209,6 +215,8 @@ export function copyDirFiltered(
 export function copyDirFilteredWithInterceptor(
   src: string,
   dest: string,
+  legacyRoot: string,
+  destRoot: string,
   visited: Set<string>,
   errors: string[],
   fileInterceptor: (srcPath: string, destPath: string) => number,
@@ -231,7 +239,13 @@ export function copyDirFilteredWithInterceptor(
   visited.add(realSrc);
 
   let count = 0;
-  fs.mkdirSync(dest, { recursive: true });
+  try {
+    fs.mkdirSync(dest, { recursive: true });
+  } catch (error) {
+    errors.push(`${dest}: ${String(error)}`);
+    logger.debug(`Cannot create directory ${dest}: ${String(error)}`);
+    return count;
+  }
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(src, { withFileTypes: true });
@@ -249,6 +263,8 @@ export function copyDirFilteredWithInterceptor(
       count += copyDirFilteredWithInterceptor(
         srcPath,
         destPath,
+        legacyRoot,
+        destRoot,
         visited,
         errors,
         fileInterceptor,
@@ -262,7 +278,14 @@ export function copyDirFilteredWithInterceptor(
         logger.debug(`Interceptor failed for '${srcPath}': ${String(error)}`);
       }
     } else if (entry.isSymbolicLink() && !pathEntryExists(destPath)) {
-      count += createSymlinkClone(srcPath, destPath, src, dest, errors, logger);
+      count += createSymlinkClone(
+        srcPath,
+        destPath,
+        legacyRoot,
+        destRoot,
+        errors,
+        logger,
+      );
     }
   }
 

--- a/packages/cli/src/config/legacyCopyEngine.ts
+++ b/packages/cli/src/config/legacyCopyEngine.ts
@@ -1,0 +1,319 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { type DebugLogger } from '@vybestack/llxprt-code-core';
+import { hasErrnoCode } from './localFsHelpers.js';
+
+/**
+ * Low-level filesystem copy primitives used by the legacy-to-canonical path
+ * migration. All helpers are side-effecting (real fs) and push diagnostic
+ * strings into the caller-owned `errors` array instead of throwing at the
+ * top level, so the orchestrator can continue migrating remaining entries
+ * after a single-entry failure.
+ *
+ * Conventions:
+ * - Existing canonical entries always win: files and symlinks use
+ *   `COPYFILE_EXCL` / `EEXIST`-tolerant writes so a pre-existing destination
+ *   is NEVER overwritten.
+ * - Directory cycles (via symlinks) are detected with a `visited` set of
+ *   realpath'd directories.
+ * - Source file mode is preserved on the destination (best-effort).
+ */
+
+/**
+ * Returns true when a path exists on the filesystem (any type — file,
+ * directory, symlink, including broken symlinks). Uses `lstatSync` so a
+ * broken symlink still reports as existing.
+ */
+export function pathEntryExists(p: string): boolean {
+  try {
+    fs.lstatSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy a single regular file using `COPYFILE_EXCL`. If the destination
+ * already exists the copy is silently skipped (returns 0). Mode of the
+ * source is preserved on the destination (best-effort).
+ */
+export function copyFileWithMode(
+  srcPath: string,
+  destPath: string,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  try {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.copyFileSync(srcPath, destPath, fs.constants.COPYFILE_EXCL);
+  } catch (error) {
+    if (hasErrnoCode(error, 'EEXIST')) {
+      return 0;
+    }
+    errors.push(`${srcPath}: ${String(error)}`);
+    logger.debug(`Cannot copy file ${srcPath}: ${String(error)}`);
+    return 0;
+  }
+  try {
+    const { mode } = fs.statSync(srcPath);
+    fs.chmodSync(destPath, mode);
+  } catch {
+    // mode preservation is best-effort
+  }
+  return 1;
+}
+
+/**
+ * Dispatch a single filesystem entry (file, directory, or symlink) to the
+ * appropriate copy routine. Files and symlinks are skipped when the
+ * destination already exists.
+ */
+export function copyEntry(
+  srcPath: string,
+  destPath: string,
+  legacyRoot: string,
+  destRoot: string,
+  visited: Set<string>,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(srcPath);
+  } catch (error) {
+    errors.push(`${srcPath}: ${String(error)}`);
+    logger.debug(`Skipping inaccessible entry: ${srcPath}: ${String(error)}`);
+    return 0;
+  }
+
+  if (stat.isSymbolicLink()) {
+    if (pathEntryExists(destPath)) {
+      return 0;
+    }
+    return createSymlinkClone(
+      srcPath,
+      destPath,
+      legacyRoot,
+      destRoot,
+      errors,
+      logger,
+    );
+  }
+
+  if (stat.isFile()) {
+    if (pathEntryExists(destPath)) {
+      return 0;
+    }
+    return copyFileWithMode(srcPath, destPath, errors, logger);
+  }
+
+  if (stat.isDirectory()) {
+    return copyDirFiltered(
+      srcPath,
+      destPath,
+      legacyRoot,
+      destRoot,
+      visited,
+      errors,
+      logger,
+    );
+  }
+
+  return 0;
+}
+
+/**
+ * Recursively copy a directory tree, skipping files/symlinks whose
+ * destination already exists. Detects symlink cycles via `visited`.
+ */
+export function copyDirFiltered(
+  src: string,
+  dest: string,
+  legacyRoot: string,
+  destRoot: string,
+  visited: Set<string>,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  let realSrc: string;
+  try {
+    realSrc = fs.realpathSync(src);
+  } catch (error) {
+    errors.push(`${src}: ${String(error)}`);
+    logger.debug(
+      `Skipping inaccessible entry (broken symlink?): ${src}: ${String(error)}`,
+    );
+    return 0;
+  }
+  if (visited.has(realSrc)) {
+    logger.debug(`Skipping already-visited directory (symlink cycle): ${src}`);
+    return 0;
+  }
+  visited.add(realSrc);
+
+  let count = 0;
+  fs.mkdirSync(dest, { recursive: true });
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(src, { withFileTypes: true });
+  } catch (error) {
+    errors.push(`${src}: ${String(error)}`);
+    logger.debug(`Cannot read directory ${src}: ${String(error)}`);
+    return count;
+  }
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      count += copyDirFiltered(
+        srcPath,
+        destPath,
+        legacyRoot,
+        destRoot,
+        visited,
+        errors,
+        logger,
+      );
+    } else if (entry.isFile() && !pathEntryExists(destPath)) {
+      count += copyFileWithMode(srcPath, destPath, errors, logger);
+    } else if (entry.isSymbolicLink() && !pathEntryExists(destPath)) {
+      count += createSymlinkClone(
+        srcPath,
+        destPath,
+        legacyRoot,
+        destRoot,
+        errors,
+        logger,
+      );
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Like {@link copyDirFiltered} but delegates each regular file copy to
+ * `fileInterceptor` instead of the raw `copyFileWithMode`. This allows the
+ * profiles directory to normalize files before exclusive-create. Symlinks and
+ * subdirectories fall through to the standard filtered copy.
+ */
+export function copyDirFilteredWithInterceptor(
+  src: string,
+  dest: string,
+  visited: Set<string>,
+  errors: string[],
+  fileInterceptor: (srcPath: string, destPath: string) => number,
+  logger: DebugLogger,
+): number {
+  let realSrc: string;
+  try {
+    realSrc = fs.realpathSync(src);
+  } catch (error) {
+    errors.push(`${src}: ${String(error)}`);
+    logger.debug(
+      `Skipping inaccessible entry (broken symlink?): ${src}: ${String(error)}`,
+    );
+    return 0;
+  }
+  if (visited.has(realSrc)) {
+    logger.debug(`Skipping already-visited directory (symlink cycle): ${src}`);
+    return 0;
+  }
+  visited.add(realSrc);
+
+  let count = 0;
+  fs.mkdirSync(dest, { recursive: true });
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(src, { withFileTypes: true });
+  } catch (error) {
+    errors.push(`${src}: ${String(error)}`);
+    logger.debug(`Cannot read directory ${src}: ${String(error)}`);
+    return count;
+  }
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      count += copyDirFilteredWithInterceptor(
+        srcPath,
+        destPath,
+        visited,
+        errors,
+        fileInterceptor,
+        logger,
+      );
+    } else if (entry.isFile() && !pathEntryExists(destPath)) {
+      try {
+        count += fileInterceptor(srcPath, destPath);
+      } catch (error) {
+        errors.push(`${srcPath}: ${String(error)}`);
+        logger.debug(`Interceptor failed for '${srcPath}': ${String(error)}`);
+      }
+    } else if (entry.isSymbolicLink() && !pathEntryExists(destPath)) {
+      count += createSymlinkClone(srcPath, destPath, src, dest, errors, logger);
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Create a symlink at `destPath` that mirrors the intent of the symlink at
+ * `srcPath`. Absolute targets that point inside the legacy root are rebased
+ * into the new root; relative targets are resolved and rebased when they
+ * land inside the legacy root, otherwise copied verbatim.
+ */
+export function createSymlinkClone(
+  srcPath: string,
+  destPath: string,
+  legacyRoot: string,
+  newRoot: string,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  let target: string;
+  try {
+    target = fs.readlinkSync(srcPath);
+  } catch (error) {
+    errors.push(`${srcPath}: ${String(error)}`);
+    logger.debug(`Cannot read symlink ${srcPath}: ${String(error)}`);
+    return 0;
+  }
+  try {
+    if (path.isAbsolute(target)) {
+      const rel = path.relative(legacyRoot, target);
+      if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+        fs.symlinkSync(path.join(newRoot, rel), destPath);
+      } else {
+        fs.symlinkSync(target, destPath);
+      }
+    } else {
+      const resolvedTarget = path.resolve(path.dirname(srcPath), target);
+      const relFromLegacy = path.relative(legacyRoot, resolvedTarget);
+      if (relFromLegacy.startsWith('..') || path.isAbsolute(relFromLegacy)) {
+        fs.symlinkSync(target, destPath);
+      } else {
+        const newTarget = path.join(newRoot, relFromLegacy);
+        const rebased = path.relative(path.dirname(destPath), newTarget);
+        fs.symlinkSync(rebased, destPath);
+      }
+    }
+    return 1;
+  } catch (error) {
+    errors.push(`${destPath}: ${String(error)}`);
+    logger.debug(`Cannot create symlink at ${destPath}: ${String(error)}`);
+    return 0;
+  }
+}

--- a/packages/cli/src/config/legacyProfileNormalization.ts
+++ b/packages/cli/src/config/legacyProfileNormalization.ts
@@ -127,6 +127,8 @@ function doCopyProfilesDirNormalized(
       entry,
       srcPath,
       destPath,
+      srcProfilesDir,
+      destProfilesDir,
       visited,
       errors,
       logger,
@@ -140,13 +142,23 @@ function copyProfileEntry(
   entry: fs.Dirent,
   srcPath: string,
   destPath: string,
+  legacyRoot: string,
+  destRoot: string,
   visited: Set<string>,
   errors: string[],
   logger: DebugLogger,
 ): number {
   if (entry.isDirectory()) {
     // Nested directories copy byte-for-byte (no normalization).
-    return copyNestedDirectory(srcPath, destPath, visited, errors, logger);
+    return copyNestedDirectory(
+      srcPath,
+      destPath,
+      legacyRoot,
+      destRoot,
+      visited,
+      errors,
+      logger,
+    );
   }
   if (entry.isFile() && entry.name.endsWith('.json')) {
     // Top-level .json file: try normalization, fall back to raw copy.
@@ -259,7 +271,6 @@ function publishNormalizedExclusive(
   } finally {
     if (pathEntryExists(tmpPath)) {
       fs.unlinkSync(tmpPath);
-      fsyncDirSync(dir);
     }
   }
 }
@@ -303,12 +314,9 @@ function normalizeLegacyProfileBytes(legacyPath: string): string | null {
     return null;
   }
 
-  // Serialize the normalized shape (modelParams guaranteed present) so the
-  // canonical bytes are consistent.
-  const modelParams =
-    parsed.modelParams === undefined ? {} : parsed.modelParams;
-  const normalized = { ...parsed, modelParams };
-  return JSON.stringify(normalized, null, 2);
+  // Serialize the validated normalized profile so this migration remains
+  // aligned with the shared profile parsing boundary.
+  return JSON.stringify(profile, null, 2);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -326,6 +334,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function copyNestedDirectory(
   src: string,
   dest: string,
+  legacyRoot: string,
+  destRoot: string,
   visited: Set<string>,
   errors: string[],
   logger: DebugLogger,
@@ -333,6 +343,8 @@ function copyNestedDirectory(
   return copyDirFilteredWithInterceptor(
     src,
     dest,
+    legacyRoot,
+    destRoot,
     visited,
     errors,
     (s, d) => copyFileWithMode(s, d, errors, logger),

--- a/packages/cli/src/config/legacyProfileNormalization.ts
+++ b/packages/cli/src/config/legacyProfileNormalization.ts
@@ -24,6 +24,7 @@ import {
 import {
   copyDirFilteredWithInterceptor,
   copyFileWithMode,
+  createSymlinkClone,
 } from './legacyCopyEngine.js';
 
 /**
@@ -172,7 +173,14 @@ function copyProfileEntry(
     return 0;
   }
   if (entry.isSymbolicLink() && !pathEntryExists(destPath)) {
-    return copySymlinkRaw(srcPath, destPath, errors, logger);
+    return createSymlinkClone(
+      srcPath,
+      destPath,
+      legacyRoot,
+      destRoot,
+      errors,
+      logger,
+    );
   }
   return 0;
 }
@@ -350,30 +358,6 @@ function copyNestedDirectory(
     (s, d) => copyFileWithMode(s, d, errors, logger),
     logger,
   );
-}
-
-function copySymlinkRaw(
-  srcPath: string,
-  destPath: string,
-  errors: string[],
-  logger: DebugLogger,
-): number {
-  let target: string;
-  try {
-    target = fs.readlinkSync(srcPath);
-  } catch (error) {
-    errors.push(`${srcPath}: ${String(error)}`);
-    logger.debug(`Cannot read symlink ${srcPath}: ${String(error)}`);
-    return 0;
-  }
-  try {
-    fs.symlinkSync(target, destPath);
-    return 1;
-  } catch (error) {
-    errors.push(`${destPath}: ${String(error)}`);
-    logger.debug(`Cannot create symlink at ${destPath}: ${String(error)}`);
-    return 0;
-  }
 }
 
 function uniqueTempName(dir: string, base: string): string {

--- a/packages/cli/src/config/legacyProfileNormalization.ts
+++ b/packages/cli/src/config/legacyProfileNormalization.ts
@@ -1,0 +1,370 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import {
+  parseProfile,
+  isLoadBalancerProfile,
+  withProfilesLockSync,
+  type Profile,
+} from '@vybestack/llxprt-code-settings';
+import { type DebugLogger } from '@vybestack/llxprt-code-core';
+import {
+  hasErrnoCode,
+  pathEntryExists,
+  readFileSync as readLocalFileSync,
+  fsyncFileSync,
+  fsyncDirSync,
+} from './localFsHelpers.js';
+import {
+  copyDirFilteredWithInterceptor,
+  copyFileWithMode,
+} from './legacyCopyEngine.js';
+
+/**
+ * Profile normalization for the legacy-to-canonical path migration copy phase.
+ *
+ * During migration, legacy profile files DIRECTLY under `profiles/` (top-level
+ * `.json` only) are normalized (missing `modelParams` → `modelParams: {}`) and
+ * atomically published with NO REPLACE. Nested directories and non-json files
+ * are copied byte-for-byte via the standard COPYFILE_EXCL copy. Existing
+ * canonical always wins.
+ *
+ * Atomic publication: normalized/validated content is written to a unique
+ * exclusive same-directory temp, fsync'd/closed, then published via hard-link
+ * (`linkSync`, fails EEXIST atomically) then unlink temp. Since same
+ * directory/filesystem, no partial final is ever visible. If hard links are
+ * unsupported, an error is reported (no fallback to overwriting).
+ *
+ * The shared profiles lock is held around the entire normalization copy
+ * publication so that no concurrent ProfileManager save can interleave.
+ */
+
+/**
+ * Copy a legacy `profiles/` directory to the canonical location. Top-level
+ * `.json` files are normalized+validated and atomically published under the
+ * shared profiles lock. Nested directories and non-json files fall through to
+ * the standard COPYFILE_EXCL byte-for-byte copy (coordinated by the lock for
+ * the directory-level entries).
+ */
+export function copyProfilesDirNormalized(
+  srcProfilesDir: string,
+  destProfilesDir: string,
+  visited: Set<string>,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  let realSrc: string;
+  try {
+    realSrc = fs.realpathSync(srcProfilesDir);
+  } catch (error) {
+    errors.push(`${srcProfilesDir}: ${String(error)}`);
+    logger.debug(
+      `Skipping inaccessible profiles dir (broken symlink?): ${srcProfilesDir}: ${String(error)}`,
+    );
+    return 0;
+  }
+  if (visited.has(realSrc)) {
+    logger.debug(
+      `Skipping already-visited profiles dir (symlink cycle): ${srcProfilesDir}`,
+    );
+    return 0;
+  }
+  visited.add(realSrc);
+
+  // Hold the shared profiles lock around the entire normalization publication
+  // so no concurrent ProfileManager save can interleave. Sync repair uses the
+  // same O_EXCL lock artifact (.profiles.lock), so they serialize on the same
+  // target.
+  try {
+    return withProfilesLockSync(destProfilesDir, () =>
+      doCopyProfilesDirNormalized(
+        srcProfilesDir,
+        destProfilesDir,
+        visited,
+        errors,
+        logger,
+      ),
+    );
+  } catch (error) {
+    errors.push(
+      `${destProfilesDir}: lock acquisition failed: ${String(error)}`,
+    );
+    logger.debug(
+      `Could not acquire profiles lock for normalization: ${String(error)}`,
+    );
+    return 0;
+  }
+}
+
+function doCopyProfilesDirNormalized(
+  srcProfilesDir: string,
+  destProfilesDir: string,
+  visited: Set<string>,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  let count = 0;
+  fs.mkdirSync(destProfilesDir, { recursive: true });
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(srcProfilesDir, { withFileTypes: true });
+  } catch (error) {
+    errors.push(`${srcProfilesDir}: ${String(error)}`);
+    logger.debug(`Cannot read directory ${srcProfilesDir}: ${String(error)}`);
+    return 0;
+  }
+
+  for (const entry of entries) {
+    const srcPath = path.join(srcProfilesDir, entry.name);
+    const destPath = path.join(destProfilesDir, entry.name);
+    count += copyProfileEntry(
+      entry,
+      srcPath,
+      destPath,
+      visited,
+      errors,
+      logger,
+    );
+  }
+
+  return count;
+}
+
+function copyProfileEntry(
+  entry: fs.Dirent,
+  srcPath: string,
+  destPath: string,
+  visited: Set<string>,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  if (entry.isDirectory()) {
+    // Nested directories copy byte-for-byte (no normalization).
+    return copyNestedDirectory(srcPath, destPath, visited, errors, logger);
+  }
+  if (entry.isFile() && entry.name.endsWith('.json')) {
+    // Top-level .json file: try normalization, fall back to raw copy.
+    return publishNormalizedOrRaw(srcPath, destPath, errors, logger);
+  }
+  if (entry.isFile()) {
+    // Non-json top-level file: byte-for-byte copy.
+    if (!pathEntryExists(destPath)) {
+      return copyFileWithMode(srcPath, destPath, errors, logger);
+    }
+    return 0;
+  }
+  if (entry.isSymbolicLink() && !pathEntryExists(destPath)) {
+    return copySymlinkRaw(srcPath, destPath, errors, logger);
+  }
+  return 0;
+}
+
+/**
+ * Publish a single top-level `.json` profile file. If the file normalizes to a
+ * valid standard profile, write the normalized bytes atomically (hard-link,
+ * NO REPLACE). Otherwise (LB, invalid JSON, non-profile), fall back to raw
+ * COPYFILE_EXCL. Existing canonical always wins (EEXIST → skip).
+ */
+function publishNormalizedOrRaw(
+  srcPath: string,
+  destPath: string,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  if (pathEntryExists(destPath)) {
+    return 0;
+  }
+  const normalized = normalizeLegacyProfileBytes(srcPath);
+  if (normalized !== null) {
+    try {
+      return publishNormalizedExclusive(srcPath, destPath, normalized);
+    } catch (error) {
+      errors.push(`${srcPath}: ${String(error)}`);
+      logger.debug(
+        `Normalized publish failed for '${srcPath}': ${String(error)}`,
+      );
+      return 0;
+    }
+  }
+  // Non-normalizable file — fall back to raw COPYFILE_EXCL copy.
+  return copyFileWithMode(srcPath, destPath, errors, logger);
+}
+
+/**
+ * Atomically publish normalized content to `destPath` with NO REPLACE.
+ *
+ * Writes normalized/validated content to a unique exclusive same-directory
+ * temp (wx), fsync/close, then hard-link temp to final (`linkSync`, fails
+ * EEXIST atomically), then unlink temp. Since same directory/filesystem, no
+ * partial final is visible. Preserves source mode. If hard links are
+ * unsupported, reports an error (no fallback to overwriting).
+ *
+ * If the destination already exists (EEXIST on link), the temp is cleaned up
+ * and 0 is returned (existing canonical wins).
+ */
+function publishNormalizedExclusive(
+  srcPath: string,
+  destPath: string,
+  normalizedContent: string,
+): number {
+  const dir = path.dirname(destPath);
+  const base = path.basename(destPath);
+  const tmpPath = uniqueTempName(dir, base);
+
+  let srcMode = 0o644;
+  try {
+    srcMode = fs.statSync(srcPath).mode & 0o777;
+  } catch {
+    // default mode
+  }
+
+  try {
+    fs.writeFileSync(tmpPath, normalizedContent, {
+      encoding: 'utf-8',
+      mode: srcMode,
+      flag: 'wx',
+    });
+
+    // fsync the temp before publishing so the content is durable.
+    fsyncFileSync(tmpPath);
+
+    // Atomically publish: hard-link temp → final. linkSync fails EEXIST
+    // atomically if final already exists. No partial final is ever visible
+    // because the link is atomic on the same filesystem.
+    try {
+      fs.linkSync(tmpPath, destPath);
+    } catch (error) {
+      if (hasErrnoCode(error, 'EEXIST')) {
+        return 0;
+      }
+      if (hasErrnoCode(error, 'ENOSYS') || hasErrnoCode(error, 'EPERM')) {
+        // Hard links unsupported. Report error — do NOT fall back to
+        // overwriting (crash-safety invariant).
+        throw new Error(
+          `hard-link publish unsupported for ${destPath} (${error.code}); cannot safely publish normalized profile`,
+        );
+      }
+      throw error;
+    }
+    // fsync parent directory after link for durability of the directory
+    // entry update (best-effort on platforms that support it).
+    fsyncDirSync(dir);
+    return 1;
+  } finally {
+    if (pathEntryExists(tmpPath)) {
+      fs.unlinkSync(tmpPath);
+      fsyncDirSync(dir);
+    }
+  }
+}
+
+/**
+ * Read a legacy profile JSON, parse it through the shared parseProfile
+ * boundary (which normalizes missing modelParams to {} for standard version 1
+ * profiles per directive #6), and return the serialized canonical normalized
+ * JSON if it is a valid standard profile.
+ * Returns null for load-balancer profiles, invalid JSON, or non-profile data
+ * (those are copied raw by the caller).
+ */
+function normalizeLegacyProfileBytes(legacyPath: string): string | null {
+  const readResult = readLocalFileSync(legacyPath);
+  if (readResult.kind !== 'content') {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readResult.content);
+  } catch {
+    return null;
+  }
+
+  if (!isPlainObject(parsed)) {
+    return null;
+  }
+  if (parsed.type === 'loadbalancer') {
+    return null;
+  }
+
+  let profile: Profile;
+  try {
+    // parseProfile normalizes missing modelParams → {} at the shared boundary.
+    profile = parseProfile(parsed);
+  } catch {
+    return null;
+  }
+  if (isLoadBalancerProfile(profile)) {
+    return null;
+  }
+
+  // Serialize the normalized shape (modelParams guaranteed present) so the
+  // canonical bytes are consistent.
+  const modelParams =
+    parsed.modelParams === undefined ? {} : parsed.modelParams;
+  const normalized = { ...parsed, modelParams };
+  return JSON.stringify(normalized, null, 2);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Copy a nested subdirectory under profiles byte-for-byte (no normalization).
+ * Uses the standard filtered copy so existing canonical entries always win.
+ */
+function copyNestedDirectory(
+  src: string,
+  dest: string,
+  visited: Set<string>,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  return copyDirFilteredWithInterceptor(
+    src,
+    dest,
+    visited,
+    errors,
+    (s, d) => copyFileWithMode(s, d, errors, logger),
+    logger,
+  );
+}
+
+function copySymlinkRaw(
+  srcPath: string,
+  destPath: string,
+  errors: string[],
+  logger: DebugLogger,
+): number {
+  let target: string;
+  try {
+    target = fs.readlinkSync(srcPath);
+  } catch (error) {
+    errors.push(`${srcPath}: ${String(error)}`);
+    logger.debug(`Cannot read symlink ${srcPath}: ${String(error)}`);
+    return 0;
+  }
+  try {
+    fs.symlinkSync(target, destPath);
+    return 1;
+  } catch (error) {
+    errors.push(`${destPath}: ${String(error)}`);
+    logger.debug(`Cannot create symlink at ${destPath}: ${String(error)}`);
+    return 0;
+  }
+}
+
+function uniqueTempName(dir: string, base: string): string {
+  const random = crypto.randomUUID();
+  return path.join(dir, `${base}.${process.pid}.${random}.norm.tmp`);
+}

--- a/packages/cli/src/config/localFsHelpers.ts
+++ b/packages/cli/src/config/localFsHelpers.ts
@@ -17,9 +17,14 @@ import * as crypto from 'node:crypto';
 
 // ─── Structural error guard ─────────────────────────────────────────────────
 
+/**
+ * Structural guard for Node.js filesystem errors that carry a `code`
+ * property. Avoids `as NodeJS.ErrnoException` type assertions. Only `code`
+ * is required; `message` may be absent on values that pass the guard.
+ */
 export interface ErrnoError {
   readonly code: string;
-  readonly message: string;
+  readonly message?: string;
 }
 
 /**
@@ -30,11 +35,15 @@ export function hasErrnoCode(
   error: unknown,
   expectedCode: string,
 ): error is ErrnoError {
+  return isObjectWithCode(error) && error.code === expectedCode;
+}
+
+function isObjectWithCode(error: unknown): error is ErrnoError {
   return (
     typeof error === 'object' &&
     error !== null &&
     'code' in error &&
-    error.code === expectedCode
+    typeof error.code === 'string'
   );
 }
 
@@ -166,25 +175,47 @@ function isDirFsyncUnsupported(error: unknown): boolean {
 // ─── Marker version guard ───────────────────────────────────────────────────
 
 /**
- * Structural guard for the migration/repair marker JSON. Parses and
- * validates that `version` is a number, avoiding `as { version?: number }`
- * type assertions.
+ * Discriminated status of a parsed marker JSON blob. The marker is parsed
+ * exactly once so callers can use the same result for both the version
+ * decision and the diagnostic log.
  */
-export function markerVersionAtLeast(
+export type MarkerStatus =
+  | { readonly kind: 'current'; readonly version: number }
+  | { readonly kind: 'older'; readonly version: number }
+  | { readonly kind: 'missing-version' }
+  | { readonly kind: 'invalid-type'; readonly version: unknown }
+  | { readonly kind: 'invalid-object' }
+  | { readonly kind: 'malformed-json' };
+
+/**
+ * Parse a raw marker JSON blob exactly once into a discriminated
+ * {@link MarkerStatus}. Both the version decision (is the marker current?)
+ * and the diagnostic log (why is it not current?) consume this single parse
+ * so the JSON is never parsed twice.
+ */
+export function parseMarkerStatus(
   rawJson: string,
   minVersion: number,
-): boolean {
+): MarkerStatus {
   let parsed: unknown;
   try {
     parsed = JSON.parse(rawJson);
   } catch {
-    return false;
+    return { kind: 'malformed-json' };
   }
   if (!isPlainObject(parsed)) {
-    return false;
+    return { kind: 'invalid-object' };
+  }
+  if (!('version' in parsed)) {
+    return { kind: 'missing-version' };
   }
   const version = parsed['version'];
-  return typeof version === 'number' && version >= minVersion;
+  if (typeof version !== 'number') {
+    return { kind: 'invalid-type', version };
+  }
+  return version >= minVersion
+    ? { kind: 'current', version }
+    : { kind: 'older', version };
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/config/localFsHelpers.ts
+++ b/packages/cli/src/config/localFsHelpers.ts
@@ -18,7 +18,7 @@ import * as crypto from 'node:crypto';
 // ─── Structural error guard ─────────────────────────────────────────────────
 
 export interface ErrnoError {
-  readonly code?: string;
+  readonly code: string;
   readonly message: string;
 }
 
@@ -89,7 +89,7 @@ export function uniqueTempPath(
 // ─── Fsync helper ───────────────────────────────────────────────────────────
 
 export function fsyncFileSync(filePath: string): void {
-  const fd = fs.openSync(filePath, 'r');
+  const fd = fs.openSync(filePath, 'r+');
   try {
     fs.fsyncSync(fd);
   } finally {

--- a/packages/cli/src/config/localFsHelpers.ts
+++ b/packages/cli/src/config/localFsHelpers.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+
+/**
+ * Local filesystem helpers for CLI config modules (profileRepair,
+ * pathMigration, legacyProfileNormalization). These avoid depending on
+ * settings-internal lock/path/read/temp exports, keeping the settings root
+ * API minimal.
+ */
+
+// ─── Structural error guard ─────────────────────────────────────────────────
+
+export interface ErrnoError {
+  readonly code?: string;
+  readonly message: string;
+}
+
+/**
+ * Structural guard for Node.js filesystem errors that carry a `code`
+ * property. Avoids `as NodeJS.ErrnoException` type assertions.
+ */
+export function hasErrnoCode(
+  error: unknown,
+  expectedCode: string,
+): error is ErrnoError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === expectedCode
+  );
+}
+
+// ─── File existence ─────────────────────────────────────────────────────────
+
+export function pathEntryExists(p: string): boolean {
+  try {
+    fs.lstatSync(p);
+    return true;
+  } catch (error) {
+    if (hasErrnoCode(error, 'ENOENT')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+// ─── Discriminated file read ────────────────────────────────────────────────
+
+export type ReadResult =
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'content'; readonly content: string }
+  | { readonly kind: 'error'; readonly error: Error };
+
+export function readFileSync(filePath: string): ReadResult {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    if (hasErrnoCode(error, 'ENOENT')) {
+      return { kind: 'absent' };
+    }
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      kind: 'error',
+    };
+  }
+  return { content, kind: 'content' };
+}
+
+// ─── Unique temp path ───────────────────────────────────────────────────────
+
+export function uniqueTempPath(
+  dir: string,
+  baseFileName: string,
+  suffix: string,
+): string {
+  const random = crypto.randomUUID();
+  return path.join(dir, `${baseFileName}.${process.pid}.${random}${suffix}`);
+}
+
+// ─── Fsync helper ───────────────────────────────────────────────────────────
+
+export function fsyncFileSync(filePath: string): void {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // best-effort close
+    }
+  }
+}
+
+/**
+ * Known errno codes where directory fsync is unsupported (primarily Windows
+ * and some network filesystems). These are the ONLY errors swallowed by
+ * {@link fsyncDirSync}; all other errors propagate so that genuine I/O
+ * failures (e.g. ENOSPC, EIO) are not silently hidden (#5).
+ */
+const DIR_FSYNC_UNSUPPORTED_CODES: ReadonlySet<string> = new Set([
+  'EINVAL',
+  'ENOSYS',
+  'EPERM',
+  'ENOTSUP',
+]);
+
+/**
+ * Fsync of a directory path (sync). On Linux and macOS, `fsyncSync` on a
+ * directory fd flushes directory entry changes so renames, creates, and
+ * unlinks are durable. On Windows and some network filesystems, directory
+ * fsync is unsupported and throws — those known-unsupported errno codes are
+ * silently ignored (#5).
+ *
+ * All other errors (ENOSPC, EIO, EACCES, etc.) PROPAGATE to the caller so
+ * genuine I/O failures are not silently hidden. Durability is NOT best-effort
+ * for real errors — callers must know when the filesystem is unhealthy.
+ */
+export function fsyncDirSync(dirPath: string): void {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(dirPath, 'r');
+    fs.fsyncSync(fd);
+  } catch (error) {
+    if (!isDirFsyncUnsupported(error)) {
+      throw error;
+    }
+    // Directory fsync is unsupported on this platform (e.g. Windows).
+    // Silently ignore — the file-level fsync still applies.
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // best-effort close
+      }
+    }
+  }
+}
+
+/**
+ * Determine whether a directory-fsync error is a known unsupported-platform
+ * code that should be silently ignored (#5).
+ */
+function isDirFsyncUnsupported(error: unknown): boolean {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string'
+  ) {
+    return DIR_FSYNC_UNSUPPORTED_CODES.has(error.code);
+  }
+  return false;
+}
+
+// ─── Marker version guard ───────────────────────────────────────────────────
+
+/**
+ * Structural guard for the migration/repair marker JSON. Parses and
+ * validates that `version` is a number, avoiding `as { version?: number }`
+ * type assertions.
+ */
+export function markerVersionAtLeast(
+  rawJson: string,
+  minVersion: number,
+): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return false;
+  }
+  if (!isPlainObject(parsed)) {
+    return false;
+  }
+  const version = parsed['version'];
+  return typeof version === 'number' && version >= minVersion;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/cli/src/config/migrationTypes.ts
+++ b/packages/cli/src/config/migrationTypes.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared type definitions for the path-migration and profile-repair modules.
+ * Extracted into a standalone module so that {@link profileRepair} and
+ * {@link pathMigration} can both depend on these contracts without creating
+ * a circular import (pathMigration imports profileRepair for orchestration).
+ */
+
+export interface MigrationDestinations {
+  readonly configDir: string;
+  readonly dataDir: string;
+  readonly cacheDir: string;
+  readonly logDir: string;
+}
+
+export interface MigrationResult {
+  readonly migrated: boolean;
+  readonly reason: string;
+  readonly filesCopied: number;
+  readonly profilesRepaired?: number;
+  readonly error?: boolean;
+}
+
+export interface StartupMigrationResult {
+  readonly migration: MigrationResult;
+  readonly repair: MigrationResult;
+}

--- a/packages/cli/src/config/pathMigration.freshStart.test.ts
+++ b/packages/cli/src/config/pathMigration.freshStart.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Behavioral tests for fresh-start migration normalization and the shared
+ * cross-process profile lock (#2477).
+ * Uses real temp directories and the actual filesystem — no mocking.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'node:path';
+import * as os from 'os';
+
+import {
+  runStartupMigrationWithPath,
+  type MigrationDestinations,
+} from './pathMigration.js';
+import { ProfileManager } from '@vybestack/llxprt-code-settings';
+
+/**
+ * The lock artifact path is a known constant: `.profiles.lock` inside the
+ * profiles directory. Tests verify the lock artifact on disk directly.
+ */
+function profilesLockPath(profilesDir: string): string {
+  return path.join(profilesDir, '.profiles.lock');
+}
+
+async function makeTempDir(): Promise<string> {
+  return fs.promises.mkdtemp(path.join(os.tmpdir(), 'llxprt-freshstart-test-'));
+}
+
+function writeFiles(root: string, entries: Record<string, string>): void {
+  for (const [relPath, content] of Object.entries(entries)) {
+    const fullPath = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  }
+}
+
+function makeDestinations(base: string): MigrationDestinations {
+  return {
+    configDir: path.join(base, 'config'),
+    dataDir: path.join(base, 'data'),
+    cacheDir: path.join(base, 'cache'),
+    logDir: path.join(base, 'log'),
+  };
+}
+
+interface TestEnv {
+  legacyDir: string;
+  destBase: string;
+  destinations: MigrationDestinations;
+}
+
+async function setupEnv(): Promise<TestEnv> {
+  const legacyDir = await makeTempDir();
+  const destBase = await makeTempDir();
+  await fs.promises.rm(destBase, { recursive: true, force: true });
+  return { legacyDir, destBase, destinations: makeDestinations(destBase) };
+}
+
+async function teardownEnv(env: TestEnv): Promise<void> {
+  await fs.promises.rm(env.legacyDir, { recursive: true, force: true });
+  await fs.promises.rm(env.destBase, { recursive: true, force: true });
+}
+
+function corruptCanonicalProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'load-balancer',
+    model: 'gemini-2.5-pro',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+function validLegacyProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'anthropic',
+    model: 'glm-5.2',
+    modelParams: { temperature: 1 },
+    ephemeralSettings: {
+      'base-url': 'https://api.z.ai/api/anthropic',
+      'auth-key-name': 'zai',
+      'context-limit': 200000,
+    },
+  };
+}
+
+function setupRepairCase(
+  env: TestEnv,
+  canonical: Record<string, unknown>,
+  legacy: Record<string, unknown>,
+): void {
+  writeFiles(env.destinations.configDir, {
+    'profiles/zai.json': JSON.stringify(canonical),
+  });
+  writeFiles(env.legacyDir, {
+    'profiles/zai.json': JSON.stringify(legacy),
+    'settings.json': '{}',
+  });
+}
+
+describe('runStartupMigrationWithPath — fresh-start literal issue JSON (#2477)', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('normalizes a fresh-migrated profile with absent modelParams so ProfileManager can load it', async () => {
+    const ISSUE_JSON = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      ephemeralSettings: {
+        'auth-key-name': 'zai',
+        'base-url': 'https://api.z.ai/api/anthropic',
+        'context-limit': 200000,
+      },
+    };
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': JSON.stringify(ISSUE_JSON),
+      'settings.json': '{}',
+    });
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    const canonicalProfilesDir = path.join(
+      env.destinations.configDir,
+      'profiles',
+    );
+    const pm = new ProfileManager(canonicalProfilesDir);
+    const loaded = await pm.loadProfile('zai');
+    expect(loaded.provider).toBe('anthropic');
+    expect(loaded.model).toBe('glm-5.2');
+    expect(loaded.modelParams).toStrictEqual({});
+    expect(loaded.ephemeralSettings['auth-key-name']).toBe('zai');
+    expect(loaded.ephemeralSettings['base-url']).toBe(
+      'https://api.z.ai/api/anthropic',
+    );
+    expect(loaded.ephemeralSettings['context-limit']).toBe(200000);
+  });
+
+  it('does not normalize a pre-existing canonical profile', () => {
+    const ISSUE_JSON = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      ephemeralSettings: {
+        'auth-key-name': 'zai',
+        'base-url': 'https://api.z.ai/api/anthropic',
+        'context-limit': 200000,
+      },
+    };
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': JSON.stringify(ISSUE_JSON),
+      'settings.json': '{}',
+    });
+    const preExistingContent = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    writeFiles(env.destinations.configDir, {
+      'profiles/zai.json': preExistingContent,
+    });
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    const canonical = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/zai.json'),
+        'utf-8',
+      ),
+    );
+    expect(canonical.provider).toBe('openai');
+  });
+});
+
+describe('shared profiles lock — repair and ProfileManager use same protocol (#2477)', () => {
+  describe('performMigration — pre-existing canonical byte-identical to legacy (#2477)', () => {
+    let env: TestEnv;
+    beforeEach(async () => {
+      env = await setupEnv();
+    });
+    afterEach(async () => {
+      await teardownEnv(env);
+    });
+
+    it('never touches a pre-existing canonical even when byte-identical to legacy and missing modelParams', () => {
+      // Legacy profile missing modelParams (the issue JSON shape).
+      const ISSUE_JSON = {
+        version: 1,
+        provider: 'anthropic',
+        model: 'glm-5.2',
+        ephemeralSettings: {
+          'auth-key-name': 'zai',
+          'base-url': 'https://api.z.ai/api/anthropic',
+          'context-limit': 200000,
+        },
+      };
+      const legacyBytes = JSON.stringify(ISSUE_JSON);
+      writeFiles(env.legacyDir, {
+        'profiles/zai.json': legacyBytes,
+        'settings.json': '{}',
+      });
+      // Pre-existing canonical has the EXACT same bytes as the legacy source.
+      writeFiles(env.destinations.configDir, {
+        'profiles/zai.json': legacyBytes,
+      });
+
+      runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+      // The canonical file must be byte-for-byte unchanged.
+      const canonicalBytes = fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/zai.json'),
+        'utf-8',
+      );
+      expect(canonicalBytes).toBe(legacyBytes);
+      // modelParams must NOT have been injected.
+      const parsed = JSON.parse(canonicalBytes);
+      expect('modelParams' in parsed).toBe(false);
+    });
+  });
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('held lock prevents repair commit and repair marker (no stale takeover)', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const canonicalProfilesDir = path.join(
+      env.destinations.configDir,
+      'profiles',
+    );
+    const lockPath = profilesLockPath(canonicalProfilesDir);
+    // Create a lock file to simulate a concurrent process holding it.
+    // NO stale takeover: the repair must defer.
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 99999,
+        token: 'held',
+        created: new Date().toISOString(),
+      }),
+      { mode: 0o600 },
+    );
+
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    // Lock busy is a benign deferral — NOT an error.
+    expect(result.repair.error).not.toBe(true);
+    expect(result.repair.profilesRepaired).toBeUndefined();
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(false);
+    // Canonical NOT replaced (lock was held).
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(env.destinations.configDir, 'profiles/zai.json'),
+          'utf-8',
+        ),
+      ).provider,
+    ).toBe('load-balancer');
+
+    fs.rmSync(lockPath, { recursive: true, force: true });
+  });
+
+  it('ProfileManager and repair use the same lock file path', () => {
+    const canonicalProfilesDir = path.join(
+      env.destinations.configDir,
+      'profiles',
+    );
+    const lockPath = profilesLockPath(canonicalProfilesDir);
+    expect(lockPath).toBe(path.join(canonicalProfilesDir, '.profiles.lock'));
+  });
+
+  it('ProfileManager saveProfile writes atomically under the lock', async () => {
+    const canonicalProfilesDir = path.join(
+      env.destinations.configDir,
+      'profiles',
+    );
+    const pm = new ProfileManager(canonicalProfilesDir);
+    await pm.saveProfile('test-lock', {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    const content = fs.readFileSync(
+      path.join(canonicalProfilesDir, 'test-lock.json'),
+      'utf-8',
+    );
+    expect(JSON.parse(content).provider).toBe('openai');
+    expect(fs.existsSync(profilesLockPath(canonicalProfilesDir))).toBe(false);
+  });
+
+  it('leftover lock file is NOT auto-reclaimed (safety over availability)', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const canonicalProfilesDir = path.join(
+      env.destinations.configDir,
+      'profiles',
+    );
+    const lockPath = profilesLockPath(canonicalProfilesDir);
+    // Simulate a SIGKILL'd prior process: write a stale lock file.
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 99999,
+        token: 'stale',
+        created: new Date().toISOString(),
+      }),
+      { mode: 0o600 },
+    );
+
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    // NO stale takeover: repair defers (benign, no error).
+    expect(result.repair.error).not.toBe(true);
+    expect(result.repair.profilesRepaired).toBeUndefined();
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(false);
+
+    // Manual recovery: remove the lock file, then next startup repairs.
+    fs.rmSync(lockPath, { force: true });
+    const result2 = runStartupMigrationWithPath(
+      env.legacyDir,
+      env.destinations,
+    );
+    expect(result2.repair.profilesRepaired).toBe(1);
+  });
+});
+
+// ─── Migration normalization scope (#2477: only top-level .json) ────────────
+
+describe('runStartupMigrationWithPath — normalization scope', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('normalizes only direct top-level .json files under profiles', () => {
+    const topLevelProfile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      // modelParams intentionally absent — should be normalized to {}
+      ephemeralSettings: {},
+    };
+    writeFiles(env.legacyDir, {
+      'profiles/top.json': JSON.stringify(topLevelProfile),
+      'settings.json': '{}',
+    });
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    const canonical = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/top.json'),
+        'utf-8',
+      ),
+    );
+    expect(canonical.modelParams).toStrictEqual({});
+  });
+
+  it('copies nested directory .json files byte-for-byte (no normalization)', () => {
+    const nestedProfile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      // modelParams absent — should NOT be normalized because it is nested
+      ephemeralSettings: {},
+    };
+    writeFiles(env.legacyDir, {
+      'profiles/sub/nested.json': JSON.stringify(nestedProfile),
+      'settings.json': '{}',
+    });
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    const canonical = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/sub/nested.json'),
+        'utf-8',
+      ),
+    );
+    // Nested files are copied byte-for-byte — modelParams NOT injected.
+    expect('modelParams' in canonical).toBe(false);
+  });
+
+  it('copies non-json top-level files byte-for-byte', () => {
+    writeFiles(env.legacyDir, {
+      'profiles/notes.txt': 'raw text not json',
+      'settings.json': '{}',
+    });
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    expect(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/notes.txt'),
+        'utf-8',
+      ),
+    ).toBe('raw text not json');
+  });
+});
+
+// ─── Hard-link atomic publish (no partial final, no replace) ────────────────
+
+describe('runStartupMigrationWithPath — hard-link atomic publish', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('does not leave temp files after normalized publish', () => {
+    const topLevelProfile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      ephemeralSettings: {},
+    };
+    writeFiles(env.legacyDir, {
+      'profiles/top.json': JSON.stringify(topLevelProfile),
+      'settings.json': '{}',
+    });
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    const temps = fs
+      .readdirSync(profilesDir)
+      .filter((f) => f.endsWith('.tmp') || f.endsWith('.norm.tmp'));
+    expect(temps).toStrictEqual([]);
+  });
+
+  it('existing canonical always wins (normalized publish does not overwrite)', () => {
+    const legacyProfile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      ephemeralSettings: {},
+    };
+    const existingCanonical = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/keep.json': JSON.stringify(legacyProfile),
+      'settings.json': '{}',
+    });
+    writeFiles(env.destinations.configDir, {
+      'profiles/keep.json': existingCanonical,
+    });
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    const canonical = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/keep.json'),
+        'utf-8',
+      ),
+    );
+    // Pre-existing canonical untouched.
+    expect(canonical.provider).toBe('openai');
+  });
+
+  it('normalized publish preserves source file mode', () => {
+    const legacyProfile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      ephemeralSettings: {},
+    };
+    writeFiles(env.legacyDir, {
+      'profiles/sec.json': JSON.stringify(legacyProfile),
+      'settings.json': '{}',
+    });
+    // Set source to 0600.
+    fs.chmodSync(path.join(env.legacyDir, 'profiles/sec.json'), 0o600);
+
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+    const stat = fs.statSync(
+      path.join(env.destinations.configDir, 'profiles/sec.json'),
+    );
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+});

--- a/packages/cli/src/config/pathMigration.profileRepair.concurrency.test.ts
+++ b/packages/cli/src/config/pathMigration.profileRepair.concurrency.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Behavioral TDD tests for the corrupt profile repair pass — concurrency,
+ * data safety, I/O error, and startup reporting helper (#2477).
+ * Split from pathMigration.profileRepair.test.ts to keep test files
+ * under 800 lines.
+ * Uses real temp directories and the actual filesystem — no mocking.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'node:path';
+import * as os from 'os';
+
+import {
+  repairProfiles,
+  runStartupMigrationWithPath,
+  reportStartupResult,
+  type MigrationDestinations,
+} from './pathMigration.js';
+
+async function makeTempDir(): Promise<string> {
+  return fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'llxprt-repair-conc-test-'),
+  );
+}
+
+function writeFiles(root: string, entries: Record<string, string>): void {
+  for (const [relPath, content] of Object.entries(entries)) {
+    const fullPath = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  }
+}
+
+function makeDestinations(base: string): MigrationDestinations {
+  return {
+    configDir: path.join(base, 'config'),
+    dataDir: path.join(base, 'data'),
+    cacheDir: path.join(base, 'cache'),
+    logDir: path.join(base, 'log'),
+  };
+}
+
+interface TestEnv {
+  legacyDir: string;
+  destBase: string;
+  destinations: MigrationDestinations;
+}
+
+async function setupEnv(): Promise<TestEnv> {
+  const legacyDir = await makeTempDir();
+  const destBase = await makeTempDir();
+  await fs.promises.rm(destBase, { recursive: true, force: true });
+  return { legacyDir, destBase, destinations: makeDestinations(destBase) };
+}
+
+async function teardownEnv(env: TestEnv): Promise<void> {
+  await fs.promises.rm(env.legacyDir, { recursive: true, force: true });
+  await fs.promises.rm(env.destBase, { recursive: true, force: true });
+}
+
+function validLegacyProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'anthropic',
+    model: 'glm-5.2',
+    modelParams: { temperature: 1 },
+    ephemeralSettings: {
+      'base-url': 'https://api.z.ai/api/anthropic',
+      'auth-key-name': 'zai',
+      'context-limit': 200000,
+    },
+  };
+}
+
+function corruptCanonicalProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'load-balancer',
+    model: 'gemini-2.5-pro',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+function setupRepairCase(
+  env: TestEnv,
+  canonical: Record<string, unknown>,
+  legacy: Record<string, unknown>,
+): void {
+  writeFiles(env.destinations.configDir, {
+    'profiles/zai.json': JSON.stringify(canonical),
+  });
+  writeFiles(env.legacyDir, {
+    'profiles/zai.json': JSON.stringify(legacy),
+    'settings.json': '{}',
+  });
+}
+
+// ─── Concurrency / data safety ──────────────────────────────────────────────
+
+describe('repairProfiles — concurrency / data safety', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('compare-before-swap: repair does not overwrite a canonical that changed after examination', () => {
+    // Set up a corrupt canonical + valid legacy (candidate found).
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    // Simulate a concurrent save: overwrite the canonical with a valid
+    // non-corrupt profile BEFORE repair runs. The repair scan sees the
+    // corrupt bytes, but by the time it commits the canonical has changed.
+    // Since the scan and commit both happen under the lock in the current
+    // implementation, we verify the behavioral invariant: a canonical that
+    // is no longer corrupt is not touched.
+    const concurrentJson = JSON.stringify({
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-5',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    fs.writeFileSync(
+      path.join(env.destinations.configDir, 'profiles/zai.json'),
+      concurrentJson,
+    );
+
+    repairProfiles(env.legacyDir, env.destinations);
+
+    const after = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/zai.json'),
+        'utf-8',
+      ),
+    );
+    expect(after.provider).toBe('openai');
+    expect(after.model).toBe('gpt-5');
+  });
+
+  it('backup collision uses COPYFILE_EXCL retry (real fs)', () => {
+    const corruptData = JSON.stringify(corruptCanonicalProfile());
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    fs.writeFileSync(
+      path.join(
+        env.destinations.configDir,
+        'profiles',
+        'zai.json.pre-repair.bak',
+      ),
+      'existing-backup',
+    );
+    repairProfiles(env.legacyDir, env.destinations);
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    const backups = fs
+      .readdirSync(profilesDir)
+      .filter((f) => f.endsWith('.pre-repair.bak'))
+      .sort();
+    expect(backups).toStrictEqual([
+      'zai.json.1.pre-repair.bak',
+      'zai.json.pre-repair.bak',
+    ]);
+    expect(
+      fs.readFileSync(
+        path.join(profilesDir, 'zai.json.pre-repair.bak'),
+        'utf-8',
+      ),
+    ).toBe('existing-backup');
+    expect(
+      fs.readFileSync(
+        path.join(profilesDir, 'zai.json.1.pre-repair.bak'),
+        'utf-8',
+      ),
+    ).toBe(corruptData);
+  });
+
+  it('temp file cleaned up after successful commit (no leftover .tmp)', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    expect(
+      fs.readdirSync(profilesDir).filter((f) => f.endsWith('.tmp')),
+    ).toStrictEqual([]);
+  });
+
+  it('repair uses exclusive temp path (no leftover temp files after commit)', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    // No temp files left behind (proves exclusive temp create + cleanup).
+    const temps = fs
+      .readdirSync(profilesDir)
+      .filter((f) => f.endsWith('.repair.tmp'));
+    expect(temps).toStrictEqual([]);
+  });
+});
+
+// ─── Repair I/O error ───────────────────────────────────────────────────────
+
+describe('repairProfiles — repair I/O error (#2477)', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('reports error when canonical profiles path is a file, not a directory', () => {
+    fs.mkdirSync(env.destinations.configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(env.destinations.configDir, 'profiles'),
+      'not a directory',
+    );
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': JSON.stringify(validLegacyProfile()),
+      'settings.json': '{}',
+    });
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.error).toBe(true);
+  });
+
+  it('reports error when canonical profile file is a directory', () => {
+    fs.mkdirSync(
+      path.join(env.destinations.configDir, 'profiles', 'zai.json'),
+      { recursive: true },
+    );
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': JSON.stringify(validLegacyProfile()),
+      'settings.json': '{}',
+    });
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    // A directory where a profile file should be is unreadable as JSON.
+    // In the new architecture, this is treated as an invalid/non-candidate
+    // entry (not a fatal error) — no repair happens, no error flag.
+    expect(result.migrated).toBe(false);
+    expect(result.profilesRepaired).toBeUndefined();
+  });
+});
+
+// ─── Startup reporting helper ───────────────────────────────────────────────
+
+describe('reportStartupResult — startup reporting helper', () => {
+  it('returns empty messages and no fallback when migration and repair succeed', () => {
+    const report = reportStartupResult(
+      {
+        migration: { migrated: true, reason: 'ok', filesCopied: 1 },
+        repair: {
+          migrated: false,
+          reason: 'no repair needed',
+          filesCopied: 0,
+        },
+      },
+      '/legacy',
+    );
+    expect(report.messages).toStrictEqual([]);
+    expect(report.needsLegacyFallback).toBe(false);
+  });
+
+  it('returns fallback + warning when migration fails', () => {
+    const report = reportStartupResult(
+      {
+        migration: {
+          migrated: false,
+          reason: 'migration error: boom',
+          filesCopied: 0,
+          error: true,
+        },
+        repair: { migrated: false, reason: 'no repair', filesCopied: 0 },
+      },
+      '/legacy',
+    );
+    expect(report.needsLegacyFallback).toBe(true);
+    expect(report.messages).toHaveLength(1);
+    expect(report.messages[0]).toContain('migration failed');
+    expect(report.messages[0]).toContain('/legacy');
+  });
+
+  it('returns repair warning but NO fallback when repair fails', () => {
+    const report = reportStartupResult(
+      {
+        migration: { migrated: true, reason: 'ok', filesCopied: 1 },
+        repair: {
+          migrated: false,
+          reason: 'repair error: boom',
+          filesCopied: 0,
+          error: true,
+        },
+      },
+      '/legacy',
+    );
+    expect(report.needsLegacyFallback).toBe(false);
+    expect(report.messages).toHaveLength(1);
+    expect(report.messages[0]).toContain('profile repair');
+  });
+
+  it('returns empty messages when repair is busy (benign deferral)', () => {
+    const report = reportStartupResult(
+      {
+        migration: { migrated: true, reason: 'ok', filesCopied: 1 },
+        repair: {
+          migrated: false,
+          reason: 'profiles lock busy; repair deferred to next startup',
+          filesCopied: 0,
+        },
+      },
+      '/legacy',
+    );
+    expect(report.messages).toStrictEqual([]);
+    expect(report.needsLegacyFallback).toBe(false);
+  });
+
+  it('returns both warnings when migration and repair both fail, fallback true', () => {
+    const report = reportStartupResult(
+      {
+        migration: {
+          migrated: false,
+          reason: 'migration error',
+          filesCopied: 0,
+          error: true,
+        },
+        repair: {
+          migrated: false,
+          reason: 'repair error',
+          filesCopied: 0,
+          error: true,
+        },
+      },
+      '/legacy',
+    );
+    expect(report.needsLegacyFallback).toBe(true);
+    expect(report.messages).toHaveLength(2);
+    expect(report.messages[0]).toContain('migration failed');
+    expect(report.messages[1]).toContain('profile repair');
+  });
+
+  it('reports marker-write failure after successful repair (error=true)', () => {
+    const report = reportStartupResult(
+      {
+        migration: {
+          migrated: false,
+          reason: 'no migration needed',
+          filesCopied: 0,
+        },
+        repair: {
+          migrated: false,
+          reason: 'repair completed but marker write failed',
+          filesCopied: 0,
+          profilesRepaired: 3,
+          error: true,
+        },
+      },
+      '/legacy',
+    );
+    expect(report.needsLegacyFallback).toBe(false);
+    expect(report.messages).toHaveLength(1);
+    expect(report.messages[0]).toContain('marker write failed');
+  });
+});
+
+// ─── Migration marker write failure (uses runStartupMigrationWithPath) ──────
+
+describe('runStartupMigrationWithPath — marker write failure scenarios', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('migration marker write failure makes migration result error:true (real-fs blocked marker)', () => {
+    writeFiles(env.legacyDir, { 'settings.json': '{"theme": "dark"}' });
+    fs.mkdirSync(env.destinations.dataDir, { recursive: true });
+    fs.mkdirSync(
+      path.join(env.destinations.dataDir, '.migration-complete.json'),
+      { recursive: true },
+    );
+
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(result.migration.error).toBe(true);
+    expect(result.migration.reason).toContain('marker write failed');
+  });
+
+  it('migration marker write failure produces a warning in reportStartupResult', () => {
+    const report = reportStartupResult(
+      {
+        migration: {
+          migrated: false,
+          reason: 'migration completed but marker write failed',
+          filesCopied: 1,
+          error: true,
+        },
+        repair: {
+          migrated: false,
+          reason: 'no repair needed',
+          filesCopied: 0,
+        },
+      },
+      '/legacy',
+    );
+    expect(report.needsLegacyFallback).toBe(true);
+    expect(report.messages).toHaveLength(1);
+    expect(report.messages[0]).toContain('marker write failed');
+  });
+});

--- a/packages/cli/src/config/pathMigration.profileRepair.concurrency.test.ts
+++ b/packages/cli/src/config/pathMigration.profileRepair.concurrency.test.ts
@@ -6,7 +6,7 @@
  * Uses real temp directories and the actual filesystem — no mocking.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'node:path';
 import * as os from 'os';
@@ -384,6 +384,120 @@ describe('runStartupMigrationWithPath — marker write failure scenarios', () =>
     expect(result.migration.reason).toContain('marker write failed');
   });
 
+  it('logs partial-success when marker write fails: copied count reported, no removal advice', () => {
+    writeFiles(env.legacyDir, { 'settings.json': '{"theme": "dark"}' });
+    fs.mkdirSync(env.destinations.dataDir, { recursive: true });
+    // Block the marker by creating a directory at the marker path.
+    fs.mkdirSync(
+      path.join(env.destinations.dataDir, '.migration-complete.json'),
+      { recursive: true },
+    );
+
+    const writes: string[] = [];
+    const captureWrite = (chunk: string | Uint8Array): boolean => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    };
+    const spy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(captureWrite);
+    try {
+      const result = runStartupMigrationWithPath(
+        env.legacyDir,
+        env.destinations,
+      );
+      // Migration files were copied, but marker failed.
+      expect(result.migration.error).toBe(true);
+
+      // The partial-success log must report the copied count so the user
+      // sees what was accomplished.
+      const partialLog = writes.find((w) => w.includes('partially migrated'));
+      expect(partialLog).toBeDefined();
+      // Must include the files-copied count with singular wording for 1.
+      expect(partialLog).toContain('1 file copied');
+      // Must accurately state copying succeeded but marker failed.
+      expect(partialLog).toContain('copying succeeded');
+      expect(partialLog).toContain('marker failed');
+      // Must explicitly advise RETAINING the legacy dir (no removal advice).
+      expect(partialLog).toContain('retain');
+      expect(partialLog).toContain(env.legacyDir);
+      // Must NOT advise removal of the legacy directory.
+      expect(partialLog).not.toContain('can be removed');
+      // Must NOT claim full success.
+      expect(partialLog).not.toContain('migrated successfully');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('logs partial-success with plural count when multiple files copied and marker fails', () => {
+    writeFiles(env.legacyDir, {
+      'settings.json': '{"theme": "dark"}',
+      'LLXPRT.md': '# config',
+    });
+    fs.mkdirSync(env.destinations.dataDir, { recursive: true });
+    fs.mkdirSync(
+      path.join(env.destinations.dataDir, '.migration-complete.json'),
+      { recursive: true },
+    );
+
+    const writes: string[] = [];
+    const captureWrite = (chunk: string | Uint8Array): boolean => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    };
+    const spy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(captureWrite);
+    try {
+      runStartupMigrationWithPath(env.legacyDir, env.destinations);
+
+      const partialLog = writes.find((w) => w.includes('partially migrated'));
+      expect(partialLog).toBeDefined();
+      // Plural wording for count > 1.
+      expect(partialLog).toContain('2 files copied');
+      expect(partialLog).not.toContain('2 file copied');
+      // Copying succeeded but finalization marker failed.
+      expect(partialLog).toContain('copying succeeded');
+      expect(partialLog).toContain('marker failed');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('does not describe a zero-copy marker failure as a partial migration', () => {
+    fs.mkdirSync(path.join(env.legacyDir, 'profiles'), { recursive: true });
+    fs.mkdirSync(env.destinations.dataDir, { recursive: true });
+    fs.mkdirSync(
+      path.join(env.destinations.dataDir, '.migration-complete.json'),
+      { recursive: true },
+    );
+
+    const writes: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+        return true;
+      });
+    try {
+      const result = runStartupMigrationWithPath(
+        env.legacyDir,
+        env.destinations,
+      );
+      expect(result.migration.filesCopied).toBe(0);
+      expect(result.migration.error).toBe(true);
+      const finalizationLog = writes.find((write) =>
+        write.includes('no files copied'),
+      );
+      expect(finalizationLog).toContain('could not be finalized');
+      expect(finalizationLog).toContain('No files required copying');
+      expect(finalizationLog).not.toContain('partially migrated');
+      expect(finalizationLog).not.toContain('copying succeeded');
+    } finally {
+      spy.mockRestore();
+    }
+  });
   it('migration marker write failure produces a warning in reportStartupResult', () => {
     const report = reportStartupResult(
       {

--- a/packages/cli/src/config/pathMigration.profileRepair.test.ts
+++ b/packages/cli/src/config/pathMigration.profileRepair.test.ts
@@ -139,34 +139,35 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
     expect(repaired.ephemeralSettings['auth-key-name']).toBe('zai');
   });
 
-  it('repairs only the reported zai profile', () => {
+  it('repairs at most one candidate per call (sorted by name)', () => {
     writeFiles(env.destinations.configDir, {
-      'profiles/zai.json': JSON.stringify(corruptCanonicalProfile()),
-      'profiles/other.json': JSON.stringify(corruptCanonicalProfile()),
+      'profiles/aaa.json': JSON.stringify(corruptCanonicalProfile()),
+      'profiles/zzz.json': JSON.stringify(corruptCanonicalProfile()),
     });
     writeFiles(env.legacyDir, {
-      'profiles/zai.json': JSON.stringify(validLegacyProfile()),
-      'profiles/other.json': JSON.stringify({
-        version: 1,
-        provider: 'openai',
-        model: 'gpt-4o',
-        modelParams: {},
-        ephemeralSettings: {},
-      }),
+      'profiles/aaa.json': JSON.stringify(validLegacyProfile()),
+      'profiles/zzz.json': JSON.stringify(validLegacyProfile()),
       'settings.json': '{}',
     });
 
     const first = repairProfiles(env.legacyDir, env.destinations);
     expect(first.profilesRepaired).toBe(1);
-    expect(readProfile(env.destinations.configDir, 'zai.json').provider).toBe(
+    // aaa sorted before zzz — repaired first.
+    expect(readProfile(env.destinations.configDir, 'aaa.json').provider).toBe(
       'anthropic',
     );
-    expect(readProfile(env.destinations.configDir, 'other.json').provider).toBe(
+    expect(readProfile(env.destinations.configDir, 'zzz.json').provider).toBe(
       'load-balancer',
     );
 
     const second = repairProfiles(env.legacyDir, env.destinations);
-    expect(second.profilesRepaired).toBeUndefined();
+    expect(second.profilesRepaired).toBe(1);
+    expect(readProfile(env.destinations.configDir, 'zzz.json').provider).toBe(
+      'anthropic',
+    );
+
+    const third = repairProfiles(env.legacyDir, env.destinations);
+    expect(third.profilesRepaired).toBeUndefined();
   });
 
   it('reports profilesRepaired as undefined when no profiles are repaired', () => {
@@ -364,9 +365,11 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
     ).toBe('load-balancer');
   });
 
-  it('does NOT repair a standard profile with load-balancer provider but a CUSTOM model (#4)', () => {
-    // The reported defect signature requires model gemini-2.5-pro. A
-    // manually-authored profile with a custom model must NOT be touched.
+  it('repairs a corrupt profile with an arbitrary fallback model (structural signature is model-agnostic)', () => {
+    // The corruption signature is structural — it does NOT depend on a
+    // specific model value. Any untyped v1 profile with provider
+    // 'load-balancer', empty modelParams, and empty ephemeralSettings is
+    // corrupt regardless of whether the fallback model is custom.
     writeFiles(env.destinations.configDir, {
       'profiles/custom.json': JSON.stringify({
         version: 1,
@@ -380,18 +383,19 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
       'profiles/custom.json': JSON.stringify(validLegacyProfile()),
       'settings.json': '{}',
     });
-    repairProfiles(env.legacyDir, env.destinations);
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.profilesRepaired).toBe(1);
     const after = JSON.parse(
       fs.readFileSync(
         path.join(env.destinations.configDir, 'profiles/custom.json'),
         'utf-8',
       ),
     );
-    expect(after.model).toBe('my-custom-model');
-    expect(after.provider).toBe('load-balancer');
+    expect(after.model).toBe('glm-5.2');
+    expect(after.provider).toBe('anthropic');
   });
 
-  it('does NOT repair a standard profile with load-balancer provider but a manual/default model (#4)', () => {
+  it('repairs a corrupt profile with a default fallback model (structural signature is model-agnostic)', () => {
     writeFiles(env.destinations.configDir, {
       'profiles/manual.json': JSON.stringify({
         version: 1,
@@ -405,15 +409,16 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
       'profiles/manual.json': JSON.stringify(validLegacyProfile()),
       'settings.json': '{}',
     });
-    repairProfiles(env.legacyDir, env.destinations);
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.profilesRepaired).toBe(1);
     const after = JSON.parse(
       fs.readFileSync(
         path.join(env.destinations.configDir, 'profiles/manual.json'),
         'utf-8',
       ),
     );
-    expect(after.model).toBe('default');
-    expect(after.provider).toBe('load-balancer');
+    expect(after.model).toBe('glm-5.2');
+    expect(after.provider).toBe('anthropic');
   });
 });
 

--- a/packages/cli/src/config/pathMigration.profileRepair.test.ts
+++ b/packages/cli/src/config/pathMigration.profileRepair.test.ts
@@ -253,14 +253,15 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
   });
 
   it('does not overwrite a valid canonical profile even if legacy is richer', () => {
+    const canonicalProfile = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: { 'context-limit': 100000 },
+    };
     writeFiles(env.destinations.configDir, {
-      'profiles/myprof.json': JSON.stringify({
-        version: 1,
-        provider: 'openai',
-        model: 'gpt-4o',
-        modelParams: {},
-        ephemeralSettings: { 'context-limit': 100000 },
-      }),
+      'profiles/myprof.json': JSON.stringify(canonicalProfile),
     });
     writeFiles(env.legacyDir, {
       'profiles/myprof.json': JSON.stringify({
@@ -283,7 +284,9 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
         'utf-8',
       ),
     );
-    expect(after.model).toBe('gpt-4o');
+    // Deep-equal the entire profile against the original canonical to verify
+    // no legacy fields (base-url, auth-key-name) were merged in.
+    expect(after).toStrictEqual(canonicalProfile);
     const profilesDir = path.join(env.destinations.configDir, 'profiles');
     expect(
       fs
@@ -338,7 +341,8 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
   });
 
   it('does not replace corrupt canonical when legacy is a loadbalancer profile', () => {
-    setupRepairCase(env, corruptCanonicalProfile(), genuineLbProfile());
+    const corrupt = corruptCanonicalProfile();
+    setupRepairCase(env, corrupt, genuineLbProfile());
     repairProfiles(env.legacyDir, env.destinations);
     const after = JSON.parse(
       fs.readFileSync(
@@ -346,8 +350,9 @@ describe('repairProfiles — corrupt profile repair (#2477)', () => {
         'utf-8',
       ),
     );
-    expect(after.provider).toBe('load-balancer');
-    expect(after.type).not.toBe('loadbalancer');
+    // Deep-equal against the original corrupt canonical to verify NO fields
+    // were modified — not just a single field that happens to be undefined.
+    expect(after).toStrictEqual(corrupt);
   });
 
   it('does not replace corrupt canonical when legacy is not a valid profile', () => {
@@ -716,6 +721,21 @@ describe('runStartupMigrationWithPath — logging', () => {
     expect(repairLog).toBeDefined();
     expect(repairLog).toContain('1 profile');
     expect(writes.find((w) => w.includes('files copied'))).toBeUndefined();
+  });
+
+  it('a successful repair never carries the error flag', () => {
+    fs.mkdirSync(env.destinations.dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(env.destinations.dataDir, '.migration-complete.json'),
+      JSON.stringify({ version: 1 }),
+    );
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    // A successful repair must be migrated:true with NO error flag — never
+    // the contradictory { migrated: true, error: true } state.
+    expect(result.repair.profilesRepaired).toBe(1);
+    expect(result.repair.migrated).toBe(true);
+    expect(result.repair.error).not.toBe(true);
   });
 });
 

--- a/packages/cli/src/config/pathMigration.profileRepair.test.ts
+++ b/packages/cli/src/config/pathMigration.profileRepair.test.ts
@@ -1,0 +1,773 @@
+/**
+ * Behavioral TDD tests for the corrupt profile repair pass (#2477).
+ * Uses real temp directories and the actual filesystem — no mocking.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'node:path';
+import * as os from 'os';
+
+import {
+  isMigrationComplete,
+  repairProfiles,
+  runStartupMigrationWithPath,
+  type MigrationDestinations,
+} from './pathMigration.js';
+import {
+  parseProfile,
+  isLoadBalancerProfile,
+} from '@vybestack/llxprt-code-settings';
+
+async function makeTempDir(): Promise<string> {
+  return fs.promises.mkdtemp(path.join(os.tmpdir(), 'llxprt-repair-test-'));
+}
+
+function writeFiles(root: string, entries: Record<string, string>): void {
+  for (const [relPath, content] of Object.entries(entries)) {
+    const fullPath = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  }
+}
+
+function makeDestinations(base: string): MigrationDestinations {
+  return {
+    configDir: path.join(base, 'config'),
+    dataDir: path.join(base, 'data'),
+    cacheDir: path.join(base, 'cache'),
+    logDir: path.join(base, 'log'),
+  };
+}
+
+function readProfile(
+  dir: string,
+  name: string,
+): ReturnType<typeof parseProfile> {
+  return parseProfile(
+    JSON.parse(fs.readFileSync(path.join(dir, 'profiles', name), 'utf-8')),
+  );
+}
+
+interface TestEnv {
+  legacyDir: string;
+  destBase: string;
+  destinations: MigrationDestinations;
+}
+
+async function setupEnv(): Promise<TestEnv> {
+  const legacyDir = await makeTempDir();
+  const destBase = await makeTempDir();
+  await fs.promises.rm(destBase, { recursive: true, force: true });
+  return { legacyDir, destBase, destinations: makeDestinations(destBase) };
+}
+
+async function teardownEnv(env: TestEnv): Promise<void> {
+  await fs.promises.rm(env.legacyDir, { recursive: true, force: true });
+  await fs.promises.rm(env.destBase, { recursive: true, force: true });
+}
+
+function validLegacyProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'anthropic',
+    model: 'glm-5.2',
+    modelParams: { temperature: 1 },
+    ephemeralSettings: {
+      'base-url': 'https://api.z.ai/api/anthropic',
+      'auth-key-name': 'zai',
+      'context-limit': 200000,
+    },
+  };
+}
+
+function corruptCanonicalProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'load-balancer',
+    model: 'gemini-2.5-pro',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+function genuineLbProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    type: 'loadbalancer',
+    policy: 'roundrobin',
+    profiles: ['p1'],
+    provider: 'load-balancer',
+    model: 'default',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+function setupRepairCase(
+  env: TestEnv,
+  canonical: Record<string, unknown>,
+  legacy: Record<string, unknown>,
+): void {
+  writeFiles(env.destinations.configDir, {
+    'profiles/zai.json': JSON.stringify(canonical),
+  });
+  writeFiles(env.legacyDir, {
+    'profiles/zai.json': JSON.stringify(legacy),
+    'settings.json': '{}',
+  });
+}
+
+describe('repairProfiles — corrupt profile repair (#2477)', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('repairs a corrupt canonical zai profile when a valid legacy exists', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    const repaired = readProfile(env.destinations.configDir, 'zai.json');
+    expect(repaired.provider).toBe('anthropic');
+    expect(repaired.model).toBe('glm-5.2');
+    expect(repaired.ephemeralSettings['base-url']).toBe(
+      'https://api.z.ai/api/anthropic',
+    );
+    expect(repaired.ephemeralSettings['auth-key-name']).toBe('zai');
+  });
+
+  it('repairs only the reported zai profile', () => {
+    writeFiles(env.destinations.configDir, {
+      'profiles/zai.json': JSON.stringify(corruptCanonicalProfile()),
+      'profiles/other.json': JSON.stringify(corruptCanonicalProfile()),
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': JSON.stringify(validLegacyProfile()),
+      'profiles/other.json': JSON.stringify({
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+      }),
+      'settings.json': '{}',
+    });
+
+    const first = repairProfiles(env.legacyDir, env.destinations);
+    expect(first.profilesRepaired).toBe(1);
+    expect(readProfile(env.destinations.configDir, 'zai.json').provider).toBe(
+      'anthropic',
+    );
+    expect(readProfile(env.destinations.configDir, 'other.json').provider).toBe(
+      'load-balancer',
+    );
+
+    const second = repairProfiles(env.legacyDir, env.destinations);
+    expect(second.profilesRepaired).toBeUndefined();
+  });
+
+  it('reports profilesRepaired as undefined when no profiles are repaired', () => {
+    writeFiles(env.destinations.configDir, {
+      'profiles/zai.json': JSON.stringify(corruptCanonicalProfile()),
+    });
+    writeFiles(env.legacyDir, { 'settings.json': '{}' });
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.profilesRepaired).toBeUndefined();
+  });
+
+  it('does not modify the legacy profile file during repair', () => {
+    const legacyData = JSON.stringify(validLegacyProfile());
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    fs.writeFileSync(path.join(env.legacyDir, 'profiles/zai.json'), legacyData);
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      fs.readFileSync(path.join(env.legacyDir, 'profiles/zai.json'), 'utf-8'),
+    ).toBe(legacyData);
+  });
+
+  it('preserves the corrupt canonical file as a quarantine backup', () => {
+    const corruptData = JSON.stringify(corruptCanonicalProfile());
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    const backups = fs
+      .readdirSync(profilesDir)
+      .filter((f) => f.endsWith('.pre-repair.bak'));
+    expect(backups).toStrictEqual(['zai.json.pre-repair.bak']);
+    expect(fs.readFileSync(path.join(profilesDir, backups[0]), 'utf-8')).toBe(
+      corruptData,
+    );
+  });
+
+  it('does not overwrite an existing backup (COPYFILE_EXCL collision-safe)', () => {
+    const corruptData = JSON.stringify(corruptCanonicalProfile());
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    fs.writeFileSync(
+      path.join(
+        env.destinations.configDir,
+        'profiles',
+        'zai.json.pre-repair.bak',
+      ),
+      'existing-backup',
+    );
+    repairProfiles(env.legacyDir, env.destinations);
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    const backups = fs
+      .readdirSync(profilesDir)
+      .filter((f) => f.endsWith('.pre-repair.bak'))
+      .sort();
+    expect(backups).toStrictEqual([
+      'zai.json.1.pre-repair.bak',
+      'zai.json.pre-repair.bak',
+    ]);
+    expect(
+      fs.readFileSync(
+        path.join(profilesDir, 'zai.json.pre-repair.bak'),
+        'utf-8',
+      ),
+    ).toBe('existing-backup');
+    expect(
+      fs.readFileSync(
+        path.join(profilesDir, 'zai.json.1.pre-repair.bak'),
+        'utf-8',
+      ),
+    ).toBe(corruptData);
+  });
+
+  it('repair backup is a copy, not a rename — canonical is replaced atomically', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    const canonical = readProfile(env.destinations.configDir, 'zai.json');
+    expect(canonical.provider).toBe('anthropic');
+    expect(
+      fs.readdirSync(profilesDir).filter((f) => f.endsWith('.pre-repair.bak')),
+    ).toHaveLength(1);
+    expect(
+      fs.readdirSync(profilesDir).filter((f) => f.endsWith('.tmp')),
+    ).toStrictEqual([]);
+  });
+
+  it('does not overwrite a valid canonical profile even if legacy is richer', () => {
+    writeFiles(env.destinations.configDir, {
+      'profiles/myprof.json': JSON.stringify({
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: { 'context-limit': 100000 },
+      }),
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/myprof.json': JSON.stringify({
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4',
+        modelParams: {},
+        ephemeralSettings: {
+          'context-limit': 100000,
+          'base-url': 'https://old.example.com',
+          'auth-key-name': 'old-key',
+        },
+      }),
+      'settings.json': '{}',
+    });
+    repairProfiles(env.legacyDir, env.destinations);
+    const after = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/myprof.json'),
+        'utf-8',
+      ),
+    );
+    expect(after.model).toBe('gpt-4o');
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    expect(
+      fs
+        .readdirSync(profilesDir)
+        .filter((f) => f.includes('myprof') && f.endsWith('.bak')),
+    ).toHaveLength(0);
+  });
+
+  it('does not overwrite a genuine loadbalancer canonical profile', () => {
+    setupRepairCase(env, genuineLbProfile(), validLegacyProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      isLoadBalancerProfile(
+        readProfile(env.destinations.configDir, 'zai.json'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not replace corrupt canonical when legacy is missing', () => {
+    writeFiles(env.destinations.configDir, {
+      'profiles/zai.json': JSON.stringify(corruptCanonicalProfile()),
+    });
+    writeFiles(env.legacyDir, { 'settings.json': '{}' });
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(env.destinations.configDir, 'profiles/zai.json'),
+          'utf-8',
+        ),
+      ).provider,
+    ).toBe('load-balancer');
+  });
+
+  it('does not replace corrupt canonical when legacy is malformed JSON', () => {
+    writeFiles(env.destinations.configDir, {
+      'profiles/zai.json': JSON.stringify(corruptCanonicalProfile()),
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': '{ this is not valid json',
+      'settings.json': '{}',
+    });
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(env.destinations.configDir, 'profiles/zai.json'),
+          'utf-8',
+        ),
+      ).provider,
+    ).toBe('load-balancer');
+  });
+
+  it('does not replace corrupt canonical when legacy is a loadbalancer profile', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), genuineLbProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    const after = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/zai.json'),
+        'utf-8',
+      ),
+    );
+    expect(after.provider).toBe('load-balancer');
+    expect(after.type).not.toBe('loadbalancer');
+  });
+
+  it('does not replace corrupt canonical when legacy is not a valid profile', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), {
+      random: 'data',
+    });
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(env.destinations.configDir, 'profiles/zai.json'),
+          'utf-8',
+        ),
+      ).provider,
+    ).toBe('load-balancer');
+  });
+
+  it('does NOT repair a standard profile with load-balancer provider but a CUSTOM model (#4)', () => {
+    // The reported defect signature requires model gemini-2.5-pro. A
+    // manually-authored profile with a custom model must NOT be touched.
+    writeFiles(env.destinations.configDir, {
+      'profiles/custom.json': JSON.stringify({
+        version: 1,
+        provider: 'load-balancer',
+        model: 'my-custom-model',
+        modelParams: {},
+        ephemeralSettings: {},
+      }),
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/custom.json': JSON.stringify(validLegacyProfile()),
+      'settings.json': '{}',
+    });
+    repairProfiles(env.legacyDir, env.destinations);
+    const after = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/custom.json'),
+        'utf-8',
+      ),
+    );
+    expect(after.model).toBe('my-custom-model');
+    expect(after.provider).toBe('load-balancer');
+  });
+
+  it('does NOT repair a standard profile with load-balancer provider but a manual/default model (#4)', () => {
+    writeFiles(env.destinations.configDir, {
+      'profiles/manual.json': JSON.stringify({
+        version: 1,
+        provider: 'load-balancer',
+        model: 'default',
+        modelParams: {},
+        ephemeralSettings: {},
+      }),
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/manual.json': JSON.stringify(validLegacyProfile()),
+      'settings.json': '{}',
+    });
+    repairProfiles(env.legacyDir, env.destinations);
+    const after = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/manual.json'),
+        'utf-8',
+      ),
+    );
+    expect(after.model).toBe('default');
+    expect(after.provider).toBe('load-balancer');
+  });
+});
+
+// ─── Exact issue payload (#2477: modelParams omitted) ───────────────────────
+
+describe('repairProfiles — exact issue JSON (modelParams omitted)', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('normalizes a legacy profile with absent modelParams to modelParams: {} and repairs', () => {
+    const ISSUE_LEGACY_PROFILE = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      ephemeralSettings: {
+        'base-url': 'https://api.z.ai/api/anthropic',
+        'auth-key-name': 'zai',
+        'context-limit': 200000,
+      },
+    };
+    setupRepairCase(env, corruptCanonicalProfile(), ISSUE_LEGACY_PROFILE);
+    repairProfiles(env.legacyDir, env.destinations);
+    const repaired = JSON.parse(
+      fs.readFileSync(
+        path.join(env.destinations.configDir, 'profiles/zai.json'),
+        'utf-8',
+      ),
+    );
+    expect(repaired.provider).toBe('anthropic');
+    expect(repaired.model).toBe('glm-5.2');
+    expect(repaired.modelParams).toStrictEqual({});
+    expect(repaired.ephemeralSettings['base-url']).toBe(
+      'https://api.z.ai/api/anthropic',
+    );
+    expect(repaired.ephemeralSettings['context-limit']).toBe(200000);
+  });
+
+  it('preserves existing modelParams when present in the legacy profile', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(env.destinations.configDir, 'profiles/zai.json'),
+          'utf-8',
+        ),
+      ).modelParams,
+    ).toStrictEqual({ temperature: 1 });
+  });
+
+  it('still rejects a legacy profile that is missing other core fields', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), {
+      version: 1,
+      provider: 'anthropic',
+      ephemeralSettings: {},
+    });
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(env.destinations.configDir, 'profiles/zai.json'),
+          'utf-8',
+        ),
+      ).provider,
+    ).toBe('load-balancer');
+  });
+
+  it('still rejects a legacy profile with invalid ephemeralSettings', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      ephemeralSettings: 'not-an-object',
+    });
+    repairProfiles(env.legacyDir, env.destinations);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(env.destinations.configDir, 'profiles/zai.json'),
+          'utf-8',
+        ),
+      ).provider,
+    ).toBe('load-balancer');
+  });
+});
+
+// ─── Startup orchestration ──────────────────────────────────────────────────
+
+describe('runStartupMigrationWithPath — marker orchestration', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('runs repair even when path migration v1 is complete, without recopying legacy', () => {
+    fs.mkdirSync(env.destinations.dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(env.destinations.dataDir, '.migration-complete.json'),
+      JSON.stringify({ version: 1 }),
+    );
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(result.migration.migrated).toBe(false);
+    expect(isMigrationComplete(env.destinations)).toBe(true);
+    expect(result.repair.profilesRepaired).toBe(1);
+    expect(readProfile(env.destinations.configDir, 'zai.json').provider).toBe(
+      'anthropic',
+    );
+  });
+
+  it('writes a separate repair marker after successful repair', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not recopy a deliberately deleted canonical legacy-backed file into a corrupt state', () => {
+    writeFiles(env.destinations.configDir, {});
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': JSON.stringify(validLegacyProfile()),
+      'settings.json': '{}',
+    });
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(result.migration.error).not.toBe(true);
+    expect(readProfile(env.destinations.configDir, 'zai.json').provider).toBe(
+      'anthropic',
+    );
+    expect(result.repair.profilesRepaired).toBeUndefined();
+  });
+
+  it('second run does nothing (both markers present)', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const first = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(first.repair.profilesRepaired).toBe(1);
+    const second = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(second.migration.migrated).toBe(false);
+    expect(second.repair.migrated).toBe(false);
+    expect(second.repair.profilesRepaired).toBeUndefined();
+    const profilesDir = path.join(env.destinations.configDir, 'profiles');
+    expect(
+      fs.readdirSync(profilesDir).filter((f) => f.endsWith('.pre-repair.bak')),
+    ).toHaveLength(1);
+  });
+
+  it('on repair I/O failure, no repair marker is written', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const profilesPath = path.join(env.destinations.configDir, 'profiles');
+    fs.rmSync(profilesPath, { recursive: true, force: true });
+    fs.writeFileSync(profilesPath, 'not a directory');
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(result.repair.error).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(false);
+  });
+
+  it('lock busy: benign deferral, no marker, no error (#3)', () => {
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const lockPath = path.join(
+      env.destinations.configDir,
+      'profiles',
+      '.profiles.lock',
+    );
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 99999,
+        token: 'busy',
+        created: new Date().toISOString(),
+      }),
+      { mode: 0o600 },
+    );
+
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    // Lock busy is NOT an error — benign deferral.
+    expect(result.repair.error).not.toBe(true);
+    expect(result.repair.profilesRepaired).toBeUndefined();
+    // NO marker written — next startup retries.
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(false);
+
+    // Manual recovery + retry.
+    fs.rmSync(lockPath, { force: true });
+    const result2 = runStartupMigrationWithPath(
+      env.legacyDir,
+      env.destinations,
+    );
+    expect(result2.repair.profilesRepaired).toBe(1);
+  });
+
+  it('marker semantics: no marker when no candidates found (#4)', () => {
+    // Initial: no corrupt profiles, no candidates.
+    writeFiles(env.destinations.configDir, {
+      'profiles/good.json': JSON.stringify(validLegacyProfile()),
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/good.json': JSON.stringify(validLegacyProfile()),
+      'settings.json': '{}',
+    });
+
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(result.repair.profilesRepaired).toBeUndefined();
+    // NO marker — later appearance not suppressed.
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(false);
+
+    // Later: affected canonical + legacy appears.
+    writeFiles(env.destinations.configDir, {
+      'profiles/zai.json': JSON.stringify(corruptCanonicalProfile()),
+    });
+    writeFiles(env.legacyDir, {
+      'profiles/zai.json': JSON.stringify(validLegacyProfile()),
+    });
+
+    // Next startup repairs (marker not suppressed).
+    const result2 = runStartupMigrationWithPath(
+      env.legacyDir,
+      env.destinations,
+    );
+    expect(result2.repair.profilesRepaired).toBe(1);
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(true);
+  });
+
+  it('normal migration marker behavior: repair marker NOT written when no repair performed (#4)', () => {
+    writeFiles(env.legacyDir, { 'settings.json': '{"theme": "dark"}' });
+    const result = runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    expect(result.migration.migrated).toBe(true);
+    expect(isMigrationComplete(env.destinations)).toBe(true);
+    // No repair marker — no actual repair happened (directive #4).
+    expect(
+      fs.existsSync(
+        path.join(env.destinations.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(false);
+  });
+});
+
+// ─── Logging ────────────────────────────────────────────────────────────────
+
+describe('runStartupMigrationWithPath — logging', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('logs profiles repaired count when repair-only success', () => {
+    fs.mkdirSync(env.destinations.dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(env.destinations.dataDir, '.migration-complete.json'),
+      JSON.stringify({ version: 1 }),
+    );
+    setupRepairCase(env, corruptCanonicalProfile(), validLegacyProfile());
+    const writes: string[] = [];
+    const captureWrite = (chunk: string | Uint8Array): boolean => {
+      writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    };
+    const spy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(captureWrite);
+    try {
+      runStartupMigrationWithPath(env.legacyDir, env.destinations);
+    } finally {
+      spy.mockRestore();
+    }
+    const repairLog = writes.find((w) => w.includes('Repaired'));
+    expect(repairLog).toBeDefined();
+    expect(repairLog).toContain('1 profile');
+    expect(writes.find((w) => w.includes('files copied'))).toBeUndefined();
+  });
+});
+
+// ─── Startup orchestration with space-containing paths ─────────────────────
+// Proves only that the fs orchestration handles paths with spaces correctly.
+// Does NOT reproduce or claim to fix any specific shell/open-path issue.
+
+describe('runStartupMigrationWithPath — space-containing destination paths', () => {
+  let legacyDir: string;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    legacyDir = await makeTempDir();
+    testRoot = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(legacyDir, { recursive: true, force: true });
+    await fs.promises.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it('migrates files successfully when all destination paths contain spaces', () => {
+    const spaceBase = path.join(
+      testRoot,
+      'space dir',
+      'Library',
+      'Application Support',
+    );
+    fs.mkdirSync(spaceBase, { recursive: true });
+    const spaceDest: MigrationDestinations = {
+      configDir: path.join(spaceBase, 'My Config'),
+      dataDir: path.join(spaceBase, 'My Data'),
+      cacheDir: path.join(spaceBase, 'My Cache'),
+      logDir: path.join(spaceBase, 'My Logs'),
+    };
+    writeFiles(legacyDir, {
+      'profiles/zai.json':
+        '{"version":1,"provider":"anthropic","model":"m","modelParams":{},"ephemeralSettings":{}}',
+      'settings.json': '{}',
+    });
+    const result = runStartupMigrationWithPath(legacyDir, spaceDest);
+    expect(result.migration.migrated).toBe(true);
+    expect(result.migration.error).not.toBe(true);
+    expect(
+      fs.readFileSync(
+        path.join(spaceDest.configDir, 'profiles/zai.json'),
+        'utf-8',
+      ),
+    ).toContain('anthropic');
+    expect(
+      fs.existsSync(path.join(spaceDest.dataDir, '.migration-complete.json')),
+    ).toBe(true);
+    // No repair marker — no actual repair happened (directive #4).
+    expect(
+      fs.existsSync(
+        path.join(spaceDest.dataDir, '.profile-repair-complete.json'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/cli/src/config/pathMigration.test.ts
+++ b/packages/cli/src/config/pathMigration.test.ts
@@ -8,10 +8,11 @@
  * category directories: config, data, cache, and log/state.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'node:path';
 import * as os from 'os';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 
 import {
   shouldMigrate,
@@ -171,19 +172,78 @@ describe('migration-completion marker (#2237)', () => {
     expect(isMigrationComplete(destinations)).toBe(false);
   });
 
-  it('treats a marker with no numeric version as NOT complete', () => {
-    writeMarker(JSON.stringify({ completedAt: '2025-01-01T00:00:00.000Z' }));
-    expect(isMigrationComplete(destinations)).toBe(false);
-  });
+  it.each([
+    {
+      name: 'invalid-object JSON',
+      marker: JSON.stringify([]),
+      diagnostic: 'not a JSON object',
+    },
+    {
+      name: 'missing version',
+      marker: JSON.stringify({ completedAt: '2025-01-01T00:00:00.000Z' }),
+      diagnostic: 'missing the version field',
+    },
+    {
+      name: 'nonnumeric version',
+      marker: JSON.stringify({ version: '1' }),
+      diagnostic: 'non-numeric version',
+    },
+    {
+      name: 'older numeric version',
+      marker: JSON.stringify({ version: 0 }),
+      diagnostic: 'outdated (version 0)',
+    },
+  ])(
+    'treats a $name marker as incomplete and logs its rerun diagnostic',
+    ({ marker, diagnostic }) => {
+      writeMarker(marker);
+      const debugSpy = vi
+        .spyOn(DebugLogger.prototype, 'debug')
+        .mockImplementation(() => {});
+      try {
+        expect(isMigrationComplete(destinations)).toBe(false);
+        expect(debugSpy).toHaveBeenCalledWith(
+          expect.stringContaining(diagnostic),
+        );
+      } finally {
+        debugSpy.mockRestore();
+      }
+    },
+  );
 
-  it('treats a marker with an older scheme version as NOT complete', () => {
-    writeMarker(JSON.stringify({ version: 0 }));
-    expect(isMigrationComplete(destinations)).toBe(false);
-  });
+  it.each([
+    { name: 'current', marker: JSON.stringify({ version: 1 }) },
+    { name: 'newer', marker: JSON.stringify({ version: 999 }) },
+  ])(
+    'treats a $name marker as complete without a rerun diagnostic',
+    ({ marker }) => {
+      writeMarker(marker);
+      const debugSpy = vi
+        .spyOn(DebugLogger.prototype, 'debug')
+        .mockImplementation(() => {});
+      try {
+        expect(isMigrationComplete(destinations)).toBe(true);
+        expect(debugSpy).not.toHaveBeenCalled();
+      } finally {
+        debugSpy.mockRestore();
+      }
+    },
+  );
 
-  it('treats a marker with a newer scheme version as complete', () => {
-    writeMarker(JSON.stringify({ version: 999 }));
-    expect(isMigrationComplete(destinations)).toBe(true);
+  it('logs a malformed marker diagnostic without completing migration', () => {
+    const raw = '{ this is not valid json';
+    writeMarker(raw);
+    const debugSpy = vi
+      .spyOn(DebugLogger.prototype, 'debug')
+      .mockImplementation(() => {});
+    try {
+      expect(isMigrationComplete(destinations)).toBe(false);
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('is malformed (not valid JSON)'),
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
   });
 
   it('does not leave a temp file behind after writing the marker', () => {

--- a/packages/cli/src/config/pathMigration.ts
+++ b/packages/cli/src/config/pathMigration.ts
@@ -14,8 +14,9 @@ import { copyProfilesDirNormalized } from './legacyProfileNormalization.js';
 import {
   hasErrnoCode,
   uniqueTempPath,
-  markerVersionAtLeast,
+  parseMarkerStatus,
   fsyncDirSync,
+  type MarkerStatus,
 } from './localFsHelpers.js';
 import type {
   MigrationDestinations,
@@ -129,6 +130,41 @@ export function isMigrationComplete(
   );
 }
 
+/** Log why a parsed marker is not current without parsing it again. */
+function logMarkerReRun(markerPath: string, status: MarkerStatus): void {
+  switch (status.kind) {
+    case 'malformed-json':
+      logger.debug(
+        `Marker ${markerPath} is malformed (not valid JSON); re-running to self-heal.`,
+      );
+      return;
+    case 'invalid-object':
+      logger.debug(
+        `Marker ${markerPath} is corrupt (not a JSON object); re-running to self-heal.`,
+      );
+      return;
+    case 'missing-version':
+      logger.debug(
+        `Marker ${markerPath} is missing the version field; re-running to self-heal.`,
+      );
+      return;
+    case 'invalid-type':
+      logger.debug(
+        `Marker ${markerPath} has a non-numeric version; re-running to self-heal.`,
+      );
+      return;
+    case 'older':
+      logger.debug(
+        `Marker ${markerPath} is outdated (version ${status.version}); re-running to self-heal.`,
+      );
+      return;
+    case 'current':
+      return;
+    default:
+      status satisfies never;
+  }
+}
+
 function isMarkerAtVersion(markerPath: string, minVersion: number): boolean {
   let raw: string;
   try {
@@ -140,15 +176,11 @@ function isMarkerAtVersion(markerPath: string, minVersion: number): boolean {
     return false;
   }
 
-  if (markerVersionAtLeast(raw, minVersion)) {
+  const status = parseMarkerStatus(raw, minVersion);
+  if (status.kind === 'current') {
     return true;
   }
-  // Marker exists but is corrupt or wrong version — re-run to self-heal.
-  if (!raw.trim().startsWith('{') || raw.includes('"version"')) {
-    logger.debug(
-      `Marker ${markerPath} is corrupt or outdated; re-running to self-heal.`,
-    );
-  }
+  logMarkerReRun(markerPath, status);
   return false;
 }
 
@@ -453,7 +485,7 @@ export function runStartupMigrationWithPath(
       logger.error('Configuration migration failed:', error);
       migration = {
         migrated: false,
-        reason: `migration error: ${String(error)}`,
+        reason: 'configuration migration encountered an internal error',
         filesCopied: 0,
         error: true,
       };
@@ -500,6 +532,7 @@ function finalizeMigrationMarker(
     logMigrationStatus(legacyDir, destinations, migration);
     return migration;
   }
+  logPartialMigration(legacyDir, destinations, migration);
   return {
     migrated: false,
     reason: 'migration completed but marker write failed',
@@ -559,6 +592,31 @@ export function logMigrationStatus(
         `The old directory at ${legacyDir} can be removed manually once verified.\n`,
     );
   }
+}
+
+function logPartialMigration(
+  legacyDir: string,
+  destinations: MigrationDestinations,
+  result: MigrationResult,
+): void {
+  const fileWord = result.filesCopied === 1 ? 'file' : 'files';
+  const copySummary =
+    result.filesCopied === 0
+      ? 'Configuration migration could not be finalized (no files copied)'
+      : `Configuration partially migrated (${result.filesCopied} ${fileWord} copied)`;
+  const outcome =
+    result.filesCopied === 0
+      ? 'No files required copying, and the finalization marker failed; '
+      : 'The copying succeeded, but the finalization marker failed; ';
+  process.stderr.write(
+    `${copySummary} because the migration marker could not be written.\n` +
+      `  Config: ${destinations.configDir}\n` +
+      `  Data:   ${destinations.dataDir}\n` +
+      `  Cache:  ${destinations.cacheDir}\n` +
+      `  Logs:   ${destinations.logDir}\n` +
+      outcome +
+      `please retain the old directory at ${legacyDir} until the migration completes on a future startup.\n`,
+  );
 }
 
 export interface StartupReport {
@@ -625,6 +683,13 @@ function executeRepair(
       return repair;
     }
 
+    // Explicit error-first: if the repair itself failed, do NOT stamp the
+    // marker. Return the error result before considering the no-op or
+    // success cases.
+    if (repair.error === true) {
+      return repair;
+    }
+
     // Directive #4: only stamp the repair marker when >=1 actual repair
     // happened. If no candidates were found ('none'), do NOT stamp so a
     // later appearance of affected profiles is not suppressed.
@@ -632,13 +697,9 @@ function executeRepair(
       repair.profilesRepaired === undefined ||
       repair.profilesRepaired === 0
     ) {
-      // No actual repair — do not stamp marker (unless it was an error).
       return repair;
     }
 
-    if (repair.error === true) {
-      return repair;
-    }
     const markerWritten = markRepairComplete(destinations);
     if (markerWritten) {
       return repair;
@@ -654,7 +715,7 @@ function executeRepair(
     logger.error('Profile repair failed:', error);
     return {
       migrated: false,
-      reason: `repair error: ${String(error)}`,
+      reason: 'profile repair encountered an internal error',
       filesCopied: 0,
       error: true,
     };

--- a/packages/cli/src/config/pathMigration.ts
+++ b/packages/cli/src/config/pathMigration.ts
@@ -4,19 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Storage } from '@vybestack/llxprt-code-settings';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
+import { repairProfiles } from './profileRepair.js';
+import { copyEntry, pathEntryExists } from './legacyCopyEngine.js';
+import { copyProfilesDirNormalized } from './legacyProfileNormalization.js';
+import {
+  hasErrnoCode,
+  uniqueTempPath,
+  markerVersionAtLeast,
+  fsyncDirSync,
+} from './localFsHelpers.js';
+import type {
+  MigrationDestinations,
+  MigrationResult,
+  StartupMigrationResult,
+} from './migrationTypes.js';
+
+// Re-export shared types so existing callers/tests that import from
+// pathMigration.js continue to resolve without changes.
+export type {
+  MigrationDestinations,
+  MigrationResult,
+  StartupMigrationResult,
+} from './migrationTypes.js';
+
+export { repairProfiles } from './profileRepair.js';
 
 const logger = new DebugLogger('llxprt:config:pathMigration');
 
-// ─── Legacy entry categorization ──────────────────────────────────────────
-
-/**
- * Top-level entries in legacy `~/.llxprt/` that belong to the **config**
- * category (user-editable configuration files).
- */
 const CONFIG_ENTRIES = new Set([
   'settings.json',
   'profiles',
@@ -31,10 +49,6 @@ const CONFIG_ENTRIES = new Set([
   '.LLXPRT_SYSTEM',
 ]);
 
-/**
- * Top-level entries in legacy `~/.llxprt/` that belong to the **data**
- * category (app-managed state, credentials, runtime data).
- */
 const DATA_ENTRIES = new Set([
   'oauth_creds.json',
   'google_accounts.json',
@@ -52,59 +66,21 @@ const DATA_ENTRIES = new Set([
   'extensions',
 ]);
 
-/**
- * Top-level entries in legacy `~/.llxprt/` that belong to the **cache**
- * category (non-essential, regenerable files).
- */
 const CACHE_ENTRIES = new Set(['cache', 'dumps']);
 
-/**
- * Top-level entries in legacy `~/.llxprt/` that belong to the **log/state**
- * category (debug logs, undo checkpoints, runtime state).
- */
 const LOG_ENTRIES = new Set(['debug', 'tmp']);
 
-/**
- * Entries excluded from migration (managed by other migrations).
- * `secure-store/` is handled by issue #1357.
- */
 const EXCLUDED_ENTRIES = new Set(['secure-store']);
 
-/**
- * The `skills` subdirectory inside `tmp/` is a known historical misplacement
- * (skills are user-installed configuration, not temporary state). During
- * migration, `tmp/skills/` is routed to the config dir, not the log dir.
- */
 const TMP_SKILLS_DIR = 'skills';
 
-/**
- * Filename of the migration-completion marker. Stored in the data dir so that
- * unrelated writes to the config dir (prompt installs, profile saves, oauth,
- * etc.) cannot be mistaken for "migration already done" (#2237). The data dir
- * is app-managed state, which is the natural home for a one-time stamp.
- */
 const MIGRATION_MARKER_FILE = '.migration-complete.json';
 
-/**
- * Current migration scheme version recorded in the marker. Bumping this in a
- * future migration scheme allows a fresh pass to run even if an older marker
- * exists.
- */
 const MIGRATION_MARKER_VERSION = 1;
 
-export interface MigrationDestinations {
-  readonly configDir: string;
-  readonly dataDir: string;
-  readonly cacheDir: string;
-  readonly logDir: string;
-}
+const REPAIR_MARKER_FILE = '.profile-repair-complete.json';
 
-export interface MigrationResult {
-  readonly migrated: boolean;
-  readonly reason: string;
-  readonly filesCopied: number;
-  readonly error?: boolean;
-}
+const REPAIR_MARKER_VERSION = 1;
 
 type Category = 'config' | 'data' | 'cache' | 'log' | 'exclude' | 'unknown';
 
@@ -114,7 +90,6 @@ function categorizeEntry(name: string): Category {
   if (DATA_ENTRIES.has(name)) return 'data';
   if (CACHE_ENTRIES.has(name)) return 'cache';
   if (LOG_ENTRIES.has(name)) return 'log';
-  // Unknown entries default to data (safest — preserves them)
   return 'unknown';
 }
 
@@ -137,94 +112,106 @@ function getDestDir(
   }
 }
 
-/**
- * Path to the migration-completion marker for a given set of destinations.
- */
 function migrationMarkerPath(destinations: MigrationDestinations): string {
   return path.join(destinations.dataDir, MIGRATION_MARKER_FILE);
 }
 
-/**
- * Returns true when a migration-completion marker of the current scheme
- * version (or newer) is present. This is the authoritative "already migrated"
- * signal — it is independent of unrelated config-dir writes (#2237).
- */
+function repairMarkerPath(destinations: MigrationDestinations): string {
+  return path.join(destinations.dataDir, REPAIR_MARKER_FILE);
+}
+
 export function isMigrationComplete(
   destinations: MigrationDestinations,
 ): boolean {
-  const markerPath = migrationMarkerPath(destinations);
+  return isMarkerAtVersion(
+    migrationMarkerPath(destinations),
+    MIGRATION_MARKER_VERSION,
+  );
+}
+
+function isMarkerAtVersion(markerPath: string, minVersion: number): boolean {
   let raw: string;
   try {
     raw = fs.readFileSync(markerPath, 'utf-8');
   } catch (error) {
-    const nodeErr = error as NodeJS.ErrnoException;
-    if (nodeErr.code !== 'ENOENT') {
-      logger.debug(`Cannot read migration marker ${markerPath}: ${nodeErr}`);
+    if (!hasErrnoCode(error, 'ENOENT')) {
+      logger.debug(`Cannot read marker ${markerPath}: ${String(error)}`);
     }
     return false;
   }
 
-  try {
-    const parsed = JSON.parse(raw) as { version?: number };
-    return (
-      typeof parsed.version === 'number' &&
-      parsed.version >= MIGRATION_MARKER_VERSION
-    );
-  } catch {
-    // Corrupt marker — treat as NOT complete so the (merge-safe) migration
-    // re-runs and self-heals (#2237). A successful re-run writes a fresh, valid
-    // marker, so this cannot loop. Permanently trusting a corrupt marker would
-    // strand the very config this migration exists to recover.
-    logger.debug(
-      `Migration marker ${markerPath} is corrupt; re-running migration to self-heal.`,
-    );
-    return false;
+  if (markerVersionAtLeast(raw, minVersion)) {
+    return true;
   }
+  // Marker exists but is corrupt or wrong version — re-run to self-heal.
+  if (!raw.trim().startsWith('{') || raw.includes('"version"')) {
+    logger.debug(
+      `Marker ${markerPath} is corrupt or outdated; re-running to self-heal.`,
+    );
+  }
+  return false;
 }
 
-/**
- * Writes the migration-completion marker into the data dir, creating the
- * directory if necessary. Best-effort: failures are logged, not thrown.
- */
 export function markMigrationComplete(
   destinations: MigrationDestinations,
-): void {
-  const markerPath = migrationMarkerPath(destinations);
+): boolean {
+  return writeMarker(migrationMarkerPath(destinations), destinations);
+}
+
+function markRepairComplete(destinations: MigrationDestinations): boolean {
+  return writeMarker(repairMarkerPath(destinations), destinations);
+}
+
+function writeMarker(
+  markerPath: string,
+  destinations: MigrationDestinations,
+): boolean {
   try {
     fs.mkdirSync(destinations.dataDir, { recursive: true });
     const payload = JSON.stringify(
       {
-        version: MIGRATION_MARKER_VERSION,
+        version: markerPath.endsWith(REPAIR_MARKER_FILE)
+          ? REPAIR_MARKER_VERSION
+          : MIGRATION_MARKER_VERSION,
         completedAt: new Date().toISOString(),
       },
       null,
       2,
     );
-    // Write atomically (temp file + rename) so a crash mid-write cannot leave a
-    // truncated/corrupt marker behind.
-    const tmpPath = `${markerPath}.${process.pid}.tmp`;
-    fs.writeFileSync(tmpPath, payload, 'utf-8');
-    fs.renameSync(tmpPath, markerPath);
+    const dir = path.dirname(markerPath);
+    const base = path.basename(markerPath);
+    const tmpPath = uniqueTempPath(dir, base, '.marker.tmp');
+    try {
+      fs.writeFileSync(tmpPath, payload, { encoding: 'utf-8', flag: 'wx' });
+      const markerFd = fs.openSync(tmpPath, 'r');
+      try {
+        fs.fsyncSync(markerFd);
+      } finally {
+        fs.closeSync(markerFd);
+      }
+      fs.renameSync(tmpPath, markerPath);
+      // fsync parent directory after rename for durability of the directory
+      // entry update (best-effort on platforms that support it).
+      fsyncDirSync(dir);
+    } catch (error) {
+      cleanupMarkerTemp(tmpPath);
+      throw error;
+    }
+    return true;
   } catch (error) {
-    logger.debug(`Cannot write migration marker ${markerPath}: ${error}`);
+    logger.debug(`Cannot write marker ${markerPath}: ${error}`);
+    return false;
   }
 }
 
-/**
- * Returns true when the legacy `~/.llxprt/` directory has migratable content
- * and no migration-completion marker exists yet.
- *
- * The marker (not config-dir content) is the "already migrated" signal: many
- * subsystems write the config dir independently of the migration (prompt
- * installs, profile saves, oauth), so config-dir content must NOT short-circuit
- * the migration (#2237). Because {@link performMigration} merges without
- * overwriting, re-running on an already-partially-populated config dir safely
- * backfills only the missing entries (subagents/, commands/, etc.).
- *
- * Returns false when:
- * - The legacy directory does not exist or is empty (fresh install)
- * - The migration-completion marker is already present
- */
+function cleanupMarkerTemp(tmpPath: string): void {
+  if (!pathEntryExists(tmpPath)) {
+    return;
+  }
+  fs.unlinkSync(tmpPath);
+  fsyncDirSync(path.dirname(tmpPath));
+}
+
 export function shouldMigrate(
   legacyDir: string,
   destinations: MigrationDestinations,
@@ -232,26 +219,15 @@ export function shouldMigrate(
   if (!fs.existsSync(legacyDir)) {
     return false;
   }
-
   if (!hasMigratableContent(legacyDir)) {
     return false;
   }
-
   if (isMigrationComplete(destinations)) {
     return false;
   }
-
   return true;
 }
 
-/**
- * Routes each legacy top-level entry to its correct category directory and
- * copies it using merge semantics (never overwrites existing files).
- *
- * The `tmp/` directory receives special treatment: its `skills/` subdirectory
- * is copied to the config dir (fixing a historical misplacement), while the
- * remaining contents go to the log dir.
- */
 export function performMigration(
   legacyDir: string,
   destinations: MigrationDestinations,
@@ -264,11 +240,7 @@ export function performMigration(
     };
   }
 
-  let filesCopied = 0;
   const visited = new Set<string>();
-  // Accumulates a message for every entry that could not be copied. A non-empty
-  // list means the pass was partial, so the caller must NOT stamp the
-  // completion marker — the next launch retries and self-heals (#2237).
   const errors: string[] = [];
 
   let entries: fs.Dirent[];
@@ -284,40 +256,97 @@ export function performMigration(
     };
   }
 
+  const filesCopied = copyLegacyEntries(
+    entries,
+    legacyDir,
+    destinations,
+    visited,
+    errors,
+  );
+
+  return buildMigrationResult(filesCopied, errors);
+}
+
+function copyLegacyEntries(
+  entries: fs.Dirent[],
+  legacyDir: string,
+  destinations: MigrationDestinations,
+  visited: Set<string>,
+  errors: string[],
+): number {
+  let filesCopied = 0;
   for (const entry of entries) {
     const category = categorizeEntry(entry.name);
-
     if (category === 'exclude') {
       continue;
     }
-
     try {
-      if (
-        entry.name === 'tmp' &&
-        entry.isDirectory() &&
-        !entry.isSymbolicLink()
-      ) {
-        filesCopied += migrateTmpDir(legacyDir, destinations, visited, errors);
-      } else {
-        const destDir = getDestDir(category, destinations);
-        fs.mkdirSync(destDir, { recursive: true });
-        const srcPath = path.join(legacyDir, entry.name);
-        const destPath = path.join(destDir, entry.name);
-        filesCopied += copyEntry(
-          srcPath,
-          destPath,
-          legacyDir,
-          destDir,
-          visited,
-          errors,
-        );
-      }
+      filesCopied += copyOneEntry(
+        entry,
+        category,
+        legacyDir,
+        destinations,
+        visited,
+        errors,
+      );
     } catch (error) {
       errors.push(`${entry.name}: ${String(error)}`);
       logger.debug(`Failed to migrate entry '${entry.name}': ${String(error)}`);
     }
   }
+  return filesCopied;
+}
 
+function copyOneEntry(
+  entry: fs.Dirent,
+  category: Category,
+  legacyDir: string,
+  destinations: MigrationDestinations,
+  visited: Set<string>,
+  errors: string[],
+): number {
+  if (entry.name === 'tmp' && entry.isDirectory() && !entry.isSymbolicLink()) {
+    return migrateTmpDir(legacyDir, destinations, visited, errors);
+  }
+  const destDir = getDestDir(category, destinations);
+  fs.mkdirSync(destDir, { recursive: true });
+  const srcPath = path.join(legacyDir, entry.name);
+  const destPath = path.join(destDir, entry.name);
+
+  // Profile files directly under legacy profiles/ are normalized (missing
+  // modelParams → modelParams:{}) and written with exclusive create so that
+  // a pre-existing canonical file is NEVER touched, even when byte-identical
+  // to the legacy source. This replaces the old post-rewrite approach that
+  // compared canonical to legacy by byte equality.
+  if (
+    entry.name === 'profiles' &&
+    entry.isDirectory() &&
+    !entry.isSymbolicLink()
+  ) {
+    return copyProfilesDirNormalized(
+      srcPath,
+      destPath,
+      visited,
+      errors,
+      logger,
+    );
+  }
+
+  return copyEntry(
+    srcPath,
+    destPath,
+    legacyDir,
+    destDir,
+    visited,
+    errors,
+    logger,
+  );
+}
+
+function buildMigrationResult(
+  filesCopied: number,
+  errors: string[],
+): MigrationResult {
   const hadErrors = errors.length > 0;
 
   if (filesCopied === 0) {
@@ -341,10 +370,6 @@ export function performMigration(
   };
 }
 
-/**
- * Copies the contents of `~/.llxprt/tmp/`, routing `skills/` to the config
- * dir and everything else to `logDir/tmp/`.
- */
 function migrateTmpDir(
   legacyDir: string,
   destinations: MigrationDestinations,
@@ -365,7 +390,6 @@ function migrateTmpDir(
 
   for (const subEntry of tmpEntries) {
     if (subEntry.name === TMP_SKILLS_DIR) {
-      // Route tmp/skills → configDir/skills
       fs.mkdirSync(destinations.configDir, { recursive: true });
       count += copyEntry(
         path.join(tmpPath, TMP_SKILLS_DIR),
@@ -374,9 +398,9 @@ function migrateTmpDir(
         destinations.configDir,
         visited,
         errors,
+        logger,
       );
     } else {
-      // Route tmp/<x> → logDir/tmp/<x>
       const logTmpDir = path.join(destinations.logDir, 'tmp');
       fs.mkdirSync(logTmpDir, { recursive: true });
       count += copyEntry(
@@ -386,6 +410,7 @@ function migrateTmpDir(
         destinations.logDir,
         visited,
         errors,
+        logger,
       );
     }
   }
@@ -394,15 +419,113 @@ function migrateTmpDir(
 }
 
 /**
- * Runs the startup migration check using paths from the {@link Storage}
- * class. Skipped entirely when `LLXPRT_CONFIG_HOME` is set (explicit override).
+ * Startup orchestrator with explicit path inputs — testable without Storage.
+ * Independently decides and runs path migration (marker v1) and one-time
+ * profile repair (separate marker). Repair runs even when path migration v1
+ * is already complete, without recopying legacy or resurrecting deleted state.
+ *
+ * Composability — why migration and repair are NOT wrapped in one
+ * startup-wide lock (#4): no invariant requires atomicity across both
+ * operations. Migration publishes canonical profiles with no-overwrite
+ * semantics (hard-link/COPYFILE_EXCL), so a pre-existing canonical is never
+ * touched. Repair acquires its own lock before scanning, so it sees a
+ * consistent snapshot. A writer (ProfileManager save) between the two phases
+ * simply becomes the canonical input to repair; the exact signature
+ * (provider load-balancer + model gemini-2.5-pro) and byte-equality checks
+ * protect against stale replacement. Therefore the separate operations are
+ * composable and interleaving is benign.
  */
-export function runStartupMigration(): MigrationResult {
+export function runStartupMigrationWithPath(
+  legacyDir: string,
+  destinations: MigrationDestinations,
+): StartupMigrationResult {
+  let migration: MigrationResult;
+  if (shouldMigrate(legacyDir, destinations)) {
+    logger.debug(
+      `Migrating configuration from ${legacyDir} to platform-standard paths ` +
+        `(config: ${destinations.configDir}, data: ${destinations.dataDir}, ` +
+        `cache: ${destinations.cacheDir}, log: ${destinations.logDir})…`,
+    );
+    try {
+      migration = performMigration(legacyDir, destinations);
+      migration = finalizeMigrationMarker(migration, legacyDir, destinations);
+    } catch (error) {
+      logger.error('Configuration migration failed:', error);
+      migration = {
+        migrated: false,
+        reason: `migration error: ${String(error)}`,
+        filesCopied: 0,
+        error: true,
+      };
+    }
+  } else {
+    if (isMigrationComplete(destinations)) {
+      logger.debug(
+        'Migration marker present; skipping migration from legacy path.',
+      );
+    }
+    migration = {
+      migrated: false,
+      reason: 'no migration needed',
+      filesCopied: 0,
+    };
+  }
+
+  // The repair marker is an audit record, not a skip gate. Re-scan on every
+  // startup so another affected profile can be repaired if its legacy source
+  // appears after an earlier successful repair.
+  const repair = executeRepair(legacyDir, destinations);
+
+  logStartupSummary(destinations, migration, repair);
+  return { migration, repair };
+}
+
+/**
+ * Finalize migration result after performMigration. If migration succeeded,
+ * attempt to write the marker. Do NOT print durable migration success before
+ * the marker succeeds. If the marker write fails, the migration result
+ * becomes error:true with an explicit reason.
+ */
+function finalizeMigrationMarker(
+  migration: MigrationResult,
+  legacyDir: string,
+  destinations: MigrationDestinations,
+): MigrationResult {
+  if (migration.error === true) {
+    logMigrationStatus(legacyDir, destinations, migration);
+    return migration;
+  }
+  const markerWritten = markMigrationComplete(destinations);
+  if (markerWritten) {
+    logMigrationStatus(legacyDir, destinations, migration);
+    return migration;
+  }
+  return {
+    migrated: false,
+    reason: 'migration completed but marker write failed',
+    filesCopied: migration.filesCopied,
+    error: true,
+  };
+}
+
+/**
+ * Runs the startup migration check using paths from {@link Storage}. Skipped
+ * entirely when `LLXPRT_CONFIG_HOME` is set (explicit override). Delegates to
+ * {@link runStartupMigrationWithPath}.
+ */
+export function runStartupMigration(): StartupMigrationResult {
   if (process.env['LLXPRT_CONFIG_HOME']) {
     return {
-      migrated: false,
-      reason: 'LLXPRT_CONFIG_HOME override is set; skipping migration',
-      filesCopied: 0,
+      migration: {
+        migrated: false,
+        reason: 'LLXPRT_CONFIG_HOME override is set; skipping migration',
+        filesCopied: 0,
+      },
+      repair: {
+        migrated: false,
+        reason: 'LLXPRT_CONFIG_HOME override is set; skipping repair',
+        filesCopied: 0,
+      },
     };
   }
 
@@ -414,42 +537,7 @@ export function runStartupMigration(): MigrationResult {
     logDir: Storage.getGlobalLogDir(),
   };
 
-  if (!shouldMigrate(legacyDir, destinations)) {
-    if (isMigrationComplete(destinations)) {
-      logger.debug(
-        'Migration marker present; skipping migration from legacy path.',
-      );
-    }
-    return { migrated: false, reason: 'no migration needed', filesCopied: 0 };
-  }
-
-  logger.debug(
-    `Migrating configuration from ${legacyDir} to platform-standard paths ` +
-      `(config: ${destinations.configDir}, data: ${destinations.dataDir}, ` +
-      `cache: ${destinations.cacheDir}, log: ${destinations.logDir})…`,
-  );
-
-  try {
-    const result = performMigration(legacyDir, destinations);
-    logMigrationStatus(legacyDir, destinations, result);
-    // Record completion so unrelated config-dir writes can't re-trigger or
-    // (previously) permanently block migration (#2237). Written whenever the
-    // pass did not error — including the benign "nothing left to copy" case —
-    // so healthy installs are stamped and don't re-scan every startup. Failed
-    // passes intentionally leave no marker so the next launch retries.
-    if (result.error !== true) {
-      markMigrationComplete(destinations);
-    }
-    return result;
-  } catch (error) {
-    logger.error('Configuration migration failed:', error);
-    return {
-      migrated: false,
-      reason: `migration error: ${String(error)}`,
-      filesCopied: 0,
-      error: true,
-    };
-  }
+  return runStartupMigrationWithPath(legacyDir, destinations);
 }
 
 /**
@@ -473,243 +561,137 @@ export function logMigrationStatus(
   }
 }
 
-// ─── internal helpers ───────────────────────────────────────────────────────
+export interface StartupReport {
+  /** Messages that should be written to stderr. */
+  readonly messages: readonly string[];
+  /** True when the legacy-dir fallback should be activated. */
+  readonly needsLegacyFallback: boolean;
+}
 
 /**
- * Returns true when the directory contains at least one entry that would
- * actually be copied (i.e. is not in {@link EXCLUDED_ENTRIES}).
+ * Pure helper that turns a {@link StartupMigrationResult} into user-facing
+ * stderr messages and a fallback decision. Extracted from the CLI setup so it
+ * can be tested without filesystem side-effects.
+ *
+ * Semantics:
+ * - Migration failure → warning + `needsLegacyFallback: true`.
+ * - Migration success → no message here (logMigrationStatus handles that).
+ * - Repair error → separate warning, but NO legacy fallback.
+ * - Marker-write failure after successful repair → explicit warning.
+ * - No duplicate warnings: repair summary success is already logged by
+ *   {@link logStartupSummary}; this helper only surfaces errors.
  */
+export function reportStartupResult(
+  result: StartupMigrationResult,
+  legacyDir: string,
+): StartupReport {
+  const messages: string[] = [];
+  let needsLegacyFallback = false;
+
+  const migration = result.migration;
+  if (!migration.migrated && migration.error === true) {
+    messages.push(
+      `Warning: configuration migration failed (${migration.reason}). ` +
+        `Falling back to legacy directory ${legacyDir} for this session.`,
+    );
+    needsLegacyFallback = true;
+  }
+
+  const repair = result.repair;
+  if (repair.error === true) {
+    messages.push(
+      `Warning: profile repair could not complete (${repair.reason}). ` +
+        `Some profiles may not load correctly.`,
+    );
+  }
+
+  return { messages, needsLegacyFallback };
+}
+
+function executeRepair(
+  legacyDir: string,
+  destinations: MigrationDestinations,
+): MigrationResult {
+  try {
+    const repair = repairProfiles(legacyDir, destinations);
+
+    // Directive #3: 'busy' (lock held) is a benign deferral — NO error flag,
+    // NO marker. Next startup retries.
+    if (
+      !repair.migrated &&
+      repair.error !== true &&
+      repair.reason.includes('lock busy')
+    ) {
+      return repair;
+    }
+
+    // Directive #4: only stamp the repair marker when >=1 actual repair
+    // happened. If no candidates were found ('none'), do NOT stamp so a
+    // later appearance of affected profiles is not suppressed.
+    if (
+      repair.profilesRepaired === undefined ||
+      repair.profilesRepaired === 0
+    ) {
+      // No actual repair — do not stamp marker (unless it was an error).
+      return repair;
+    }
+
+    if (repair.error === true) {
+      return repair;
+    }
+    const markerWritten = markRepairComplete(destinations);
+    if (markerWritten) {
+      return repair;
+    }
+    return {
+      migrated: false,
+      reason: 'repair completed but marker write failed',
+      filesCopied: 0,
+      profilesRepaired: repair.profilesRepaired,
+      error: true,
+    };
+  } catch (error) {
+    logger.error('Profile repair failed:', error);
+    return {
+      migrated: false,
+      reason: `repair error: ${String(error)}`,
+      filesCopied: 0,
+      error: true,
+    };
+  }
+}
+
+function logStartupSummary(
+  destinations: MigrationDestinations,
+  migration: MigrationResult,
+  repair: MigrationResult,
+): void {
+  // Success summary: report repair count when profiles were actually repaired.
+  // When migration also ran, logMigrationStatus already reported the file-copy
+  // count; we only add the repair count here to avoid duplicate warnings.
+  if (
+    repair.profilesRepaired !== undefined &&
+    repair.profilesRepaired > 0 &&
+    repair.error !== true
+  ) {
+    process.stderr.write(
+      `Repaired ${repair.profilesRepaired} profile(s) in ${destinations.configDir}.\n`,
+    );
+  }
+}
+
+// ─── internal helpers ───────────────────────────────────────────────────────
+
 function hasMigratableContent(dir: string): boolean {
   let entries: string[];
   try {
     entries = fs.readdirSync(dir);
   } catch (error) {
-    const nodeErr = error as NodeJS.ErrnoException;
-    if (nodeErr.code === 'ENOENT') {
+    if (hasErrnoCode(error, 'ENOENT')) {
       return false;
     }
     logger.debug(`Cannot read directory ${dir}: ${String(error)}`);
     return true;
   }
   return entries.some((name) => !EXCLUDED_ENTRIES.has(name));
-}
-
-/**
- * Checks whether a path entry exists at all (including broken symlinks).
- * `fs.existsSync` follows symlinks and returns false for broken ones;
- * this function uses `lstatSync` to detect the entry itself.
- */
-function pathEntryExists(p: string): boolean {
-  try {
-    fs.lstatSync(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Copies a single regular file to `destPath`, then best-effort preserves the
- * source mode. Records any copy failure in `errors`. Returns 1 when the file
- * was copied, 0 when the copy was skipped or failed. The mode-preservation step
- * never affects the return value (a failed chmod still counts as a successful
- * copy).
- *
- * Uses `COPYFILE_EXCL` so the copy fails atomically if the destination already
- * exists. This closes the time-of-check/time-of-use gap left by the caller's
- * {@link pathEntryExists} guard: a file that appears between the check and the
- * copy is preserved (the `EEXIST` is treated as a benign skip, not an error).
- */
-function copyFileWithMode(
-  srcPath: string,
-  destPath: string,
-  errors: string[],
-): number {
-  try {
-    fs.mkdirSync(path.dirname(destPath), { recursive: true });
-    fs.copyFileSync(srcPath, destPath, fs.constants.COPYFILE_EXCL);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-      // Destination appeared after the caller's existence check; preserve it.
-      return 0;
-    }
-    errors.push(`${srcPath}: ${String(error)}`);
-    logger.debug(`Cannot copy file ${srcPath}: ${String(error)}`);
-    return 0;
-  }
-  try {
-    const { mode } = fs.statSync(srcPath);
-    fs.chmodSync(destPath, mode);
-  } catch {
-    // mode preservation is best-effort; the file copy already succeeded
-  }
-  return 1;
-}
-
-/**
- * Copies a single entry (file, directory, or symlink) from `srcPath` to
- * `destPath`, using merge semantics — existing destination files are never
- * overwritten. Returns the count of regular files copied.
- */
-function copyEntry(
-  srcPath: string,
-  destPath: string,
-  legacyRoot: string,
-  destRoot: string,
-  visited: Set<string>,
-  errors: string[],
-): number {
-  let stat: fs.Stats;
-  try {
-    stat = fs.lstatSync(srcPath);
-  } catch (error) {
-    errors.push(`${srcPath}: ${String(error)}`);
-    logger.debug(`Skipping inaccessible entry: ${srcPath}: ${String(error)}`);
-    return 0;
-  }
-
-  if (stat.isSymbolicLink()) {
-    if (pathEntryExists(destPath)) {
-      return 0;
-    }
-    return createSymlinkClone(srcPath, destPath, legacyRoot, destRoot, errors);
-  }
-
-  if (stat.isFile()) {
-    if (pathEntryExists(destPath)) {
-      return 0;
-    }
-    return copyFileWithMode(srcPath, destPath, errors);
-  }
-
-  if (stat.isDirectory()) {
-    return copyDirFiltered(
-      srcPath,
-      destPath,
-      legacyRoot,
-      destRoot,
-      visited,
-      errors,
-    );
-  }
-
-  return 0;
-}
-
-/**
- * Recursively copies `src` into `dest`, skipping entries listed in
- * {@link EXCLUDED_ENTRIES} at the root level. Returns the count of regular
- * files copied. Tracks visited real paths to prevent infinite recursion via
- * symlink cycles.
- */
-function copyDirFiltered(
-  src: string,
-  dest: string,
-  legacyRoot: string,
-  destRoot: string,
-  visited: Set<string>,
-  errors: string[],
-): number {
-  let realSrc: string;
-  try {
-    realSrc = fs.realpathSync(src);
-  } catch (error) {
-    errors.push(`${src}: ${String(error)}`);
-    logger.debug(
-      `Skipping inaccessible entry (broken symlink?): ${src}: ${String(error)}`,
-    );
-    return 0;
-  }
-  if (visited.has(realSrc)) {
-    logger.debug(`Skipping already-visited directory (symlink cycle): ${src}`);
-    return 0;
-  }
-  visited.add(realSrc);
-
-  let count = 0;
-  fs.mkdirSync(dest, { recursive: true });
-  let entries: fs.Dirent[];
-  try {
-    entries = fs.readdirSync(src, { withFileTypes: true });
-  } catch (error) {
-    errors.push(`${src}: ${String(error)}`);
-    logger.debug(`Cannot read directory ${src}: ${String(error)}`);
-    return count;
-  }
-
-  for (const entry of entries) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
-
-    if (entry.isDirectory()) {
-      count += copyDirFiltered(
-        srcPath,
-        destPath,
-        legacyRoot,
-        destRoot,
-        visited,
-        errors,
-      );
-    } else if (entry.isFile() && !pathEntryExists(destPath)) {
-      count += copyFileWithMode(srcPath, destPath, errors);
-    } else if (entry.isSymbolicLink() && !pathEntryExists(destPath)) {
-      count += createSymlinkClone(
-        srcPath,
-        destPath,
-        legacyRoot,
-        destRoot,
-        errors,
-      );
-    }
-  }
-
-  return count;
-}
-
-/**
- * Creates a symlink at `destPath` mirroring the one at `srcPath`.
- * Relative targets are rebased so they resolve correctly from the new location.
- * Absolute targets that point inside the legacy tree are rebased to the
- * corresponding path under the new root.
- */
-function createSymlinkClone(
-  srcPath: string,
-  destPath: string,
-  legacyRoot: string,
-  newRoot: string,
-  errors: string[],
-): number {
-  let target: string;
-  try {
-    target = fs.readlinkSync(srcPath);
-  } catch (error) {
-    errors.push(`${srcPath}: ${String(error)}`);
-    logger.debug(`Cannot read symlink ${srcPath}: ${String(error)}`);
-    return 0;
-  }
-  try {
-    if (path.isAbsolute(target)) {
-      const rel = path.relative(legacyRoot, target);
-      if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
-        fs.symlinkSync(path.join(newRoot, rel), destPath);
-      } else {
-        fs.symlinkSync(target, destPath);
-      }
-    } else {
-      const resolvedTarget = path.resolve(path.dirname(srcPath), target);
-      const relFromLegacy = path.relative(legacyRoot, resolvedTarget);
-      if (relFromLegacy.startsWith('..') || path.isAbsolute(relFromLegacy)) {
-        // Target escapes legacy tree — preserve original target as-is
-        fs.symlinkSync(target, destPath);
-      } else {
-        const rebased = path.relative(path.dirname(destPath), resolvedTarget);
-        fs.symlinkSync(rebased, destPath);
-      }
-    }
-    return 1;
-  } catch (error) {
-    errors.push(`${destPath}: ${String(error)}`);
-    logger.debug(`Cannot create symlink at ${destPath}: ${String(error)}`);
-    return 0;
-  }
 }

--- a/packages/cli/src/config/profileRepair.test.ts
+++ b/packages/cli/src/config/profileRepair.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Behavioral tests for the CLI profileRepair thin orchestrator.
+ *
+ * Uses real temp directories and the actual filesystem — no mocking.
+ * Verifies the translation layer from CanonicalRepairOutcome to
+ * MigrationResult, including error-message sanitization (#1).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { repairProfiles } from './profileRepair.js';
+import type { MigrationDestinations } from './migrationTypes.js';
+import { CORRUPT_PROVIDER } from '@vybestack/llxprt-code-settings';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
+
+async function makeTempDir(): Promise<string> {
+  return fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'llxprt-profile-repair-cli-test-'),
+  );
+}
+
+function makeDestinations(base: string): MigrationDestinations {
+  return {
+    configDir: path.join(base, 'config'),
+    dataDir: path.join(base, 'data'),
+    cacheDir: path.join(base, 'cache'),
+    logDir: path.join(base, 'log'),
+  };
+}
+
+function writeProfile(dir: string, name: string, data: unknown): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), JSON.stringify(data));
+}
+
+function corruptCanonicalProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: CORRUPT_PROVIDER,
+    model: 'gemini-2.5-pro',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+function validLegacyProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'anthropic',
+    model: 'glm-5.2',
+    modelParams: { temperature: 1 },
+    ephemeralSettings: {
+      'base-url': 'https://api.z.ai/api/anthropic',
+      'auth-key-name': 'zai',
+      'context-limit': 200000,
+    },
+  };
+}
+
+interface TestEnv {
+  legacyDir: string;
+  destBase: string;
+  destinations: MigrationDestinations;
+}
+
+async function setupEnv(): Promise<TestEnv> {
+  const legacyDir = await makeTempDir();
+  const destBase = await makeTempDir();
+  await fs.promises.rm(destBase, { recursive: true, force: true });
+  return { legacyDir, destBase, destinations: makeDestinations(destBase) };
+}
+
+async function teardownEnv(env: TestEnv): Promise<void> {
+  await fs.promises.rm(env.legacyDir, { recursive: true, force: true });
+  await fs.promises.rm(env.destBase, { recursive: true, force: true });
+}
+
+describe('repairProfiles — outcome translation', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('translates a successful repair to migrated:true with profilesRepaired', () => {
+    const canonicalDir = path.join(env.destinations.configDir, 'profiles');
+    writeProfile(canonicalDir, 'zai.json', corruptCanonicalProfile());
+    fs.mkdirSync(path.join(env.legacyDir, 'profiles'), { recursive: true });
+    writeProfile(
+      path.join(env.legacyDir, 'profiles'),
+      'zai.json',
+      validLegacyProfile(),
+    );
+
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.migrated).toBe(true);
+    expect(result.profilesRepaired).toBe(1);
+    expect(result.error).not.toBe(true);
+  });
+
+  it('translates no-candidate to migrated:false without error', () => {
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.migrated).toBe(false);
+    expect(result.error).not.toBe(true);
+    expect(result.profilesRepaired).toBeUndefined();
+  });
+});
+
+describe('repairProfiles — error message sanitization (#1)', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('returns a stable generic reason when repair throws, not the raw error message', () => {
+    const canonicalDir = path.join(env.destinations.configDir, 'profiles');
+    // Replace canonical profiles dir with a file to cause a scan error.
+    fs.mkdirSync(env.destinations.configDir, { recursive: true });
+    fs.writeFileSync(canonicalDir, 'not a directory');
+
+    fs.mkdirSync(path.join(env.legacyDir, 'profiles'), { recursive: true });
+
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.error).toBe(true);
+    // Sentinel: the reason must be a stable generic string — it must NOT
+    // contain the raw filesystem error message or path details.
+    expect(result.reason).toBe('profile repair encountered an internal error');
+  });
+
+  it('sentinel: reason does not leak raw error text from the underlying failure', () => {
+    const canonicalDir = path.join(env.destinations.configDir, 'profiles');
+    fs.mkdirSync(env.destinations.configDir, { recursive: true });
+    fs.writeFileSync(canonicalDir, 'not a directory');
+
+    const result = repairProfiles(env.legacyDir, env.destinations);
+    expect(result.reason).not.toContain('EISDIR');
+    expect(result.reason).not.toContain('ENOTDIR');
+    expect(result.reason).not.toContain(canonicalDir);
+    expect(result.reason).not.toContain('Error');
+  });
+});
+
+describe('repairProfiles — debug diagnostics without public leak (#2)', () => {
+  let env: TestEnv;
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('debug-logs structured outcome.errors but keeps public reason generic', () => {
+    const canonicalDir = path.join(env.destinations.configDir, 'profiles');
+    // Replace canonical profiles dir with a file to cause a scan error
+    // that produces outcome.kind === 'error' with structured errors.
+    fs.mkdirSync(env.destinations.configDir, { recursive: true });
+    fs.writeFileSync(canonicalDir, 'not a directory');
+    fs.mkdirSync(path.join(env.legacyDir, 'profiles'), { recursive: true });
+
+    const debugSpy = vi
+      .spyOn(DebugLogger.prototype, 'debug')
+      .mockImplementation(() => {});
+
+    try {
+      const result = repairProfiles(env.legacyDir, env.destinations);
+      expect(result.error).toBe(true);
+      // Public reason must be generic — no structured errors leaked.
+      expect(result.reason).toBe(
+        'profile repair encountered an internal error',
+      );
+
+      // The debug log must have been called with structured outcome.errors
+      // so diagnostics are available without leaking into the public result.
+      const errorLogCall = debugSpy.mock.calls.find(
+        (call) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('Profile repair errors'),
+      );
+      expect(errorLogCall).toBeDefined();
+      expect(errorLogCall?.[1]).toStrictEqual(
+        expect.arrayContaining([expect.stringContaining(canonicalDir)]),
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/config/profileRepair.ts
+++ b/packages/cli/src/config/profileRepair.ts
@@ -42,7 +42,7 @@ export function repairProfiles(
     logger.error('Profile repair failed:', error);
     return {
       migrated: false,
-      reason: `repair error: ${String(error)}`,
+      reason: 'profile repair encountered an internal error',
       filesCopied: 0,
       error: true,
     };
@@ -69,7 +69,6 @@ function translateOutcome(outcome: CanonicalRepairOutcome): MigrationResult {
         reason: 'profile repair complete',
         filesCopied: 0,
         profilesRepaired: outcome.profilesRepaired,
-        error: outcome.errors.length > 0 || undefined,
       };
     case 'none':
       return {
@@ -85,9 +84,10 @@ function translateOutcome(outcome: CanonicalRepairOutcome): MigrationResult {
         filesCopied: 0,
       };
     case 'error':
+      logger.debug('Profile repair errors:', outcome.errors);
       return {
         migrated: false,
-        reason: `profile repair incomplete: ${outcome.errors.join('; ')}`,
+        reason: 'profile repair encountered an internal error',
         filesCopied: 0,
         error: true,
       };

--- a/packages/cli/src/config/profileRepair.ts
+++ b/packages/cli/src/config/profileRepair.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'node:path';
+import {
+  repairCanonicalProfiles,
+  type CanonicalRepairOutcome,
+} from '@vybestack/llxprt-code-settings';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
+import type {
+  MigrationDestinations,
+  MigrationResult,
+} from './migrationTypes.js';
+
+const logger = new DebugLogger('llxprt:config:profileRepair');
+
+/**
+ * CLI thin orchestrator: delegates the actual repair transaction to the
+ * settings-owned {@link repairCanonicalProfiles} cohesive API. This module
+ * only translates the outcome into the CLI {@link MigrationResult} shape for
+ * marker/reporting orchestration in pathMigration.ts.
+ *
+ * Marker semantics (#4): the caller (pathMigration) should only stamp the
+ * repair marker when this returns a non-busy result with >=1 actual repair.
+ * 'busy' returns a benign deferred result with NO error flag so no marker is
+ * written and no user-facing warning is emitted — the next startup retries.
+ */
+export function repairProfiles(
+  legacyDir: string,
+  destinations: MigrationDestinations,
+): MigrationResult {
+  const canonicalDir = path.join(destinations.configDir, 'profiles');
+  const legacyProfilesDir = path.join(legacyDir, 'profiles');
+
+  let outcome: CanonicalRepairOutcome;
+  try {
+    outcome = repairCanonicalProfiles(canonicalDir, legacyProfilesDir);
+  } catch (error) {
+    logger.error('Profile repair failed:', error);
+    return {
+      migrated: false,
+      reason: `repair error: ${String(error)}`,
+      filesCopied: 0,
+      error: true,
+    };
+  }
+
+  return translateOutcome(outcome);
+}
+
+/**
+ * Translate the settings-owned repair outcome into a CLI MigrationResult.
+ *
+ * - 'repaired': success, profilesRepaired > 0.
+ * - 'none': no candidates found — not an error, no marker (so later
+ *   appearance is not suppressed).
+ * - 'busy': lock busy — benign deferral, NO error flag, NO marker. Next
+ *   startup retries.
+ * - 'error': repair attempt failed.
+ */
+function translateOutcome(outcome: CanonicalRepairOutcome): MigrationResult {
+  switch (outcome.kind) {
+    case 'repaired':
+      return {
+        migrated: true,
+        reason: 'profile repair complete',
+        filesCopied: 0,
+        profilesRepaired: outcome.profilesRepaired,
+        error: outcome.errors.length > 0 || undefined,
+      };
+    case 'none':
+      return {
+        migrated: false,
+        reason: 'no profiles to repair',
+        filesCopied: 0,
+      };
+    case 'busy':
+      // Benign deferral — no error, no marker. Next startup retries.
+      return {
+        migrated: false,
+        reason: 'profiles lock busy; repair deferred to next startup',
+        filesCopied: 0,
+      };
+    case 'error':
+      return {
+        migrated: false,
+        reason: `profile repair incomplete: ${outcome.errors.join('; ')}`,
+        filesCopied: 0,
+        error: true,
+      };
+    default: {
+      const _exhaustive: never = outcome;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/cli/src/ui/components/ProfileCreateWizard/utils.ts
+++ b/packages/cli/src/ui/components/ProfileCreateWizard/utils.ts
@@ -7,7 +7,11 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { Storage } from '@vybestack/llxprt-code-settings';
+import {
+  Storage,
+  writeProfileFile,
+  type ProfileWriteResult,
+} from '@vybestack/llxprt-code-settings';
 import { PROVIDER_OPTIONS } from './constants.js';
 import { WizardStep } from './types.js';
 import type { WizardState, ConnectionTestResult } from './types.js';
@@ -67,29 +71,44 @@ export function generateProfileNameSuggestions(
 }
 
 export function buildProfileJSON(state: WizardState): Record<string, unknown> {
+  const ephemeralSettings: Record<string, unknown> = {};
+  const modelParams: Record<string, unknown> = {};
+
+  // Add base URL if present
+  if (state.config.baseUrl) {
+    ephemeralSettings['base-url'] = state.config.baseUrl;
+  }
+
+  // Add authentication
+  if (state.config.auth.type === 'apikey') {
+    ephemeralSettings['auth-key'] = state.config.auth.value;
+  } else if (state.config.auth.type === 'keyfile') {
+    ephemeralSettings['auth-keyfile'] = state.config.auth.value;
+  }
+
+  // Add parameters if configured
+  if (state.config.params) {
+    if (state.config.params.temperature !== undefined) {
+      modelParams.temperature = state.config.params.temperature;
+    }
+    if (state.config.params.maxTokens !== undefined) {
+      modelParams.max_tokens = state.config.params.maxTokens;
+    }
+    if (state.config.params.contextLimit !== undefined) {
+      ephemeralSettings['context-limit'] = state.config.params.contextLimit;
+    }
+  }
+
   const profile: Record<string, unknown> = {
     version: 1,
     provider:
       state.config.provider === 'custom' ? 'openai' : state.config.provider,
     model: state.config.model,
-    modelParams: {},
-    ephemeralSettings: {},
+    modelParams,
+    ephemeralSettings,
   };
 
-  // Add base URL if present
-  if (state.config.baseUrl) {
-    (profile.ephemeralSettings as Record<string, unknown>)['base-url'] =
-      state.config.baseUrl;
-  }
-
-  // Add authentication
-  if (state.config.auth.type === 'apikey') {
-    (profile.ephemeralSettings as Record<string, unknown>)['auth-key'] =
-      state.config.auth.value;
-  } else if (state.config.auth.type === 'keyfile') {
-    (profile.ephemeralSettings as Record<string, unknown>)['auth-keyfile'] =
-      state.config.auth.value;
-  } else if (state.config.auth.type === 'oauth') {
+  if (state.config.auth.type === 'oauth') {
     profile.auth = {
       type: 'oauth',
       buckets:
@@ -97,22 +116,6 @@ export function buildProfileJSON(state: WizardState): Record<string, unknown> {
           ? state.config.auth.buckets
           : ['default'],
     };
-  }
-
-  // Add parameters if configured
-  if (state.config.params) {
-    if (state.config.params.temperature !== undefined) {
-      (profile.modelParams as Record<string, unknown>).temperature =
-        state.config.params.temperature;
-    }
-    if (state.config.params.maxTokens !== undefined) {
-      (profile.modelParams as Record<string, unknown>).max_tokens =
-        state.config.params.maxTokens;
-    }
-    if (state.config.params.contextLimit !== undefined) {
-      (profile.ephemeralSettings as Record<string, unknown>)['context-limit'] =
-        state.config.params.contextLimit;
-    }
   }
 
   return profile;
@@ -123,7 +126,7 @@ function isExistingFileError(error: unknown): boolean {
     typeof error === 'object' &&
     error !== null &&
     'code' in error &&
-    (error as { code?: unknown }).code === 'EEXIST'
+    error.code === 'EEXIST'
   );
 }
 
@@ -139,20 +142,23 @@ export async function saveProfile(
 }> {
   try {
     const profilesDir = path.join(Storage.getGlobalConfigDir(), 'profiles');
-
-    // Ensure directory exists with restrictive permissions (owner-only)
-    await fs.mkdir(profilesDir, { recursive: true, mode: 0o700 });
-
-    // Write profile with restrictive permissions (owner read/write only)
-    const profilePath = path.join(profilesDir, `${name}.json`);
     const data = JSON.stringify(config, null, 2);
-    await fs.writeFile(profilePath, data, {
-      encoding: 'utf-8',
-      mode: 0o600,
-      flag: opts.overwrite === true ? 'w' : 'wx',
-    });
-
-    return { success: true, path: profilePath };
+    const writeMode = opts.overwrite === true ? 'overwrite' : 'create';
+    const result: ProfileWriteResult = await writeProfileFile(
+      profilesDir,
+      name,
+      data,
+      writeMode,
+    );
+    if (result.kind === 'exists') {
+      return {
+        success: false,
+        alreadyExists: true,
+        error: 'Profile name already exists',
+        path: result.path,
+      };
+    }
+    return { success: true, path: result.path };
   } catch (error) {
     if (isExistingFileError(error)) {
       return {

--- a/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
@@ -149,6 +149,44 @@ describe('STEP 2 workflow: pre-switch auth wiring', () => {
     expect(configStub.getEphemeralSetting('auth-key')).toBeUndefined();
   });
 
+  it('applies the exact issue 2477 Z.ai profile without Gemini fallback', async () => {
+    keyStorageStub.getKey.mockResolvedValueOnce('resolved-zai-key');
+    providerManagerStub.available = ['anthropic'];
+    providerManagerStub.providerLookup = new Map([
+      ['anthropic', { name: 'anthropic' }],
+    ]);
+    setActiveModelMock.mockResolvedValueOnce({ nextModel: 'glm-5.2' });
+
+    const profile: Profile = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      modelParams: {},
+      ephemeralSettings: {
+        'auth-key-name': 'zai',
+        'base-url': 'https://api.z.ai/api/anthropic',
+        'context-limit': 200000,
+      },
+    };
+
+    const result = await applyProfileWithGuards(profile);
+
+    expect(result.providerName).toBe('anthropic');
+    expect(result.modelName).toBe('glm-5.2');
+    expect(result.baseUrl).toBe('https://api.z.ai/api/anthropic');
+    expect(settingsServiceStub.getProviderSettings('anthropic')).toMatchObject({
+      'base-url': 'https://api.z.ai/api/anthropic',
+      'auth-key': 'resolved-zai-key',
+    });
+    expect(configStub.getEphemeralSetting('auth-key-name')).toBe('zai');
+    expect(keyStorageStub.getKey).toHaveBeenCalledWith('zai');
+    expect(updateActiveProviderApiKeyMock).toHaveBeenCalledWith(
+      'resolved-zai-key',
+    );
+    expect(setActiveModelMock).toHaveBeenCalledWith('glm-5.2');
+    expect(setActiveModelMock).not.toHaveBeenCalledWith('gemini-2.5-pro');
+  });
+
   it('adds warning when auth-key-name is missing from secure storage', async () => {
     keyStorageStub.getKey.mockResolvedValueOnce(null);
 

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -41,6 +41,28 @@ export {
 } from './settings/settingsServiceInstance.js';
 
 export { ProfileManager } from './profiles/ProfileManager.js';
+// Cohesive public profile-lock and write API. Internal lock handle/path/read/
+// temp/delete helpers are NOT re-exported. Consumers that need canonical
+// profile repair use repairCanonicalProfiles (settings-owned cohesive API).
+// withProfilesLockSync is exported for the migration copy phase which must
+// coordinate with ProfileManager writes.
+export {
+  withProfilesLockSync,
+  writeProfileFile,
+} from './profiles/profileStore.js';
+export type {
+  ProfileWriteMode,
+  ProfileWriteResult,
+} from './profiles/profileStore.js';
+export {
+  repairCanonicalProfiles,
+  CORRUPT_PROVIDER,
+} from './profiles/canonicalProfileRepair.js';
+export type {
+  CanonicalRepairOutcome,
+  CanonicalRepairResult,
+} from './profiles/canonicalProfileRepair.js';
+export { parseProfile } from './settings/validation.js';
 export type {
   Profile,
   StandardProfile,

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -25,6 +25,7 @@ import {
 import fs from 'fs/promises';
 import path from 'path';
 import { Storage } from '@vybestack/llxprt-code-storage';
+import { writeProfileFile, deleteProfileFile } from './profileStore.js';
 
 interface ProfileSettingsServiceLike {
   exportForProfile?: () => Promise<{
@@ -98,11 +99,12 @@ export class ProfileManager {
     profileName: string,
     profile: PersistableProfile,
   ): Promise<void> {
-    await fs.mkdir(this.profilesDir, { recursive: true });
-
-    const filePath = path.join(this.profilesDir, `${profileName}.json`);
-
-    await fs.writeFile(filePath, JSON.stringify(profile, null, 2), 'utf8');
+    await writeProfileFile(
+      this.profilesDir,
+      profileName,
+      JSON.stringify(profile, null, 2),
+      'overwrite',
+    );
   }
 
   async saveLoadBalancerProfile(name: string, profile: unknown): Promise<void> {
@@ -136,12 +138,11 @@ export class ProfileManager {
 
     await fs.mkdir(this.profilesDir, { recursive: true });
 
-    const filePath = path.join(this.profilesDir, `${name}.json`);
-
-    await fs.writeFile(
-      filePath,
+    await writeProfileFile(
+      this.profilesDir,
+      name,
       JSON.stringify(loadBalancerProfile, null, 2),
-      'utf8',
+      'overwrite',
     );
   }
 
@@ -248,10 +249,8 @@ export class ProfileManager {
    * @param profileName The name of the profile to delete
    */
   async deleteProfile(profileName: string): Promise<void> {
-    const filePath = path.join(this.profilesDir, `${profileName}.json`);
-
     try {
-      await fs.unlink(filePath);
+      await deleteProfileFile(this.profilesDir, profileName);
     } catch (error) {
       if (error instanceof Error && error.message.includes('ENOENT')) {
         throw new Error(`Profile '${profileName}' not found`);

--- a/packages/settings/src/profiles/__tests__/canonicalProfileRepair.outcomes.test.ts
+++ b/packages/settings/src/profiles/__tests__/canonicalProfileRepair.outcomes.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Behavioral tests for canonical profile repair — outcome semantics.
+ *
+ * Covers the no-candidate / none, marker lifecycle, and I/O error outcome
+ * paths of {@link repairCanonicalProfiles}. Split from the main test file
+ * to stay within the eslint max-lines limit.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  repairCanonicalProfiles,
+  CORRUPT_PROVIDER,
+} from '../canonicalProfileRepair.js';
+import {
+  type TestEnv,
+  setupEnv,
+  teardownEnv,
+  writeProfile,
+  corruptCanonicalProfile,
+  validLegacyProfile,
+} from './canonicalProfileRepair.testHelpers.js';
+
+// ─── No candidates / none outcome ──────────────────────────────────────────
+
+describe('repairCanonicalProfiles — no candidates / none outcome', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('returns none when canonical profiles dir does not exist', () => {
+    const result = repairCanonicalProfiles(
+      path.join(env.canonicalDir, 'nonexistent'),
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when no corrupt profiles exist', () => {
+    writeProfile(env.canonicalDir, 'good.json', validLegacyProfile());
+    writeProfile(env.legacyProfilesDir, 'good.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when corrupt canonical has no valid legacy replacement', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    // No legacy file at all.
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when legacy is a loadbalancer (not a valid standard replacement)', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['p1'],
+      provider: 'load-balancer',
+      model: 'default',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    // Canonical NOT replaced.
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+      ).provider,
+    ).toBe(CORRUPT_PROVIDER);
+  });
+
+  it('returns none when canonical is a genuine loadbalancer', () => {
+    writeProfile(env.canonicalDir, 'lb.json', {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['p1'],
+      provider: 'load-balancer',
+      model: 'default',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    writeProfile(env.legacyProfilesDir, 'lb.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    // LB profile untouched.
+    const after = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'lb.json'), 'utf-8'),
+    );
+    expect(after.type).toBe('loadbalancer');
+  });
+
+  it('returns none when legacy replacement is also corrupt (matches the structural signature)', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', corruptCanonicalProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('does NOT repair when the legacy replacement has provider load-balancer with nonempty modelParams', () => {
+    // The replacement has the virtual non-loadable provider 'load-balancer'
+    // but does NOT match the narrow canonical corrupt signature (which
+    // requires empty modelParams). It must still be rejected because
+    // 'load-balancer' is not a registered provider at load time — replacing
+    // one non-loadable profile with another non-loadable profile is not a
+    // repair.
+    writeProfile(env.canonicalDir, 'broken.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'broken.json', {
+      version: 1,
+      provider: CORRUPT_PROVIDER,
+      model: 'some-model',
+      modelParams: { temperature: 0.5 },
+      ephemeralSettings: {
+        'base-url': 'https://example.com',
+        'auth-key-name': 'test',
+        'context-limit': 100000,
+      },
+    });
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    // Canonical NOT replaced.
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(env.canonicalDir, 'broken.json'), 'utf-8'),
+      ).provider,
+    ).toBe(CORRUPT_PROVIDER);
+  });
+
+  it('returns none when legacy replacement is invalid JSON', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    fs.writeFileSync(
+      path.join(env.legacyProfilesDir, 'zai.json'),
+      '{ not valid json',
+    );
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when canonical has explicit type: standard (not the corrupt shape)', () => {
+    writeProfile(env.canonicalDir, 'explicit.json', {
+      version: 1,
+      type: 'standard',
+      provider: CORRUPT_PROVIDER,
+      model: 'gemini-2.5-pro',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    writeProfile(env.legacyProfilesDir, 'explicit.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when canonical has nonempty modelParams (manually-authored, not the defect)', () => {
+    writeProfile(env.canonicalDir, 'manual.json', {
+      version: 1,
+      provider: CORRUPT_PROVIDER,
+      model: 'gemini-2.5-pro',
+      modelParams: { temperature: 0.5 },
+      ephemeralSettings: {},
+    });
+    writeProfile(env.legacyProfilesDir, 'manual.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when canonical has nonempty ephemeralSettings (manually-authored, not the defect)', () => {
+    writeProfile(env.canonicalDir, 'manual2.json', {
+      version: 1,
+      provider: CORRUPT_PROVIDER,
+      model: 'gemini-2.5-pro',
+      modelParams: {},
+      ephemeralSettings: { 'base-url': 'https://example.com' },
+    });
+    writeProfile(env.legacyProfilesDir, 'manual2.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+});
+
+// ─── Marker semantics: no stamp when no repair performed ────────────────────
+
+describe('repairCanonicalProfiles — marker semantics', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('initial: no candidate / no canonical dir → none (no marker)', () => {
+    const result = repairCanonicalProfiles(
+      path.join(env.canonicalDir, 'no-such-dir'),
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('later: affected canonical+legacy appears → repaired on next startup', () => {
+    // First run: empty canonical dir, nothing to repair.
+    const first = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(first.kind).toBe('none');
+
+    // Later: affected files appear.
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    // Next startup repairs.
+    const second = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(second.kind).toBe('repaired');
+    expect(second.kind === 'repaired' ? second.profilesRepaired : 0).toBe(1);
+  });
+});
+
+// ─── I/O error outcomes ────────────────────────────────────────────────────
+
+describe('repairCanonicalProfiles — I/O error outcomes', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('returns error when canonical profiles path is a file, not a directory', () => {
+    fs.mkdirSync(env.canonicalDir, { recursive: true });
+    // Replace the canonicalDir with a file.
+    fs.rmSync(env.canonicalDir, { recursive: true, force: true });
+    fs.writeFileSync(env.canonicalDir, 'not a directory');
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('error');
+  });
+
+  it('returns error and does NOT mutate anything when scan error exists alongside a repair candidate', () => {
+    // A directory named "*.json" inside the canonical profiles dir will
+    // cause a read error when the scan tries to readAndParseProfile it
+    // (fs.readFileSync on a directory throws EISDIR). This error occurs
+    // alongside a valid repair candidate. The repair must NOT proceed:
+    // it must return kind:error and leave all files untouched.
+    writeProfile(env.canonicalDir, 'broken.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'broken.json', validLegacyProfile());
+
+    // Create a directory with a .json name so readdir picks it up and the
+    // scan hits a read error on it.
+    const corruptingDirPath = path.join(env.canonicalDir, 'trap.json');
+    fs.mkdirSync(corruptingDirPath, { recursive: true });
+
+    // Snapshot the valid candidate before the repair attempt.
+    const brokenBefore = fs.readFileSync(
+      path.join(env.canonicalDir, 'broken.json'),
+      'utf-8',
+    );
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('error');
+
+    // No mutation: the valid candidate must be unchanged.
+    const brokenAfter = fs.readFileSync(
+      path.join(env.canonicalDir, 'broken.json'),
+      'utf-8',
+    );
+    expect(brokenAfter).toBe(brokenBefore);
+
+    // No backup file was created (repair did not start).
+    const backups = fs
+      .readdirSync(env.canonicalDir)
+      .filter((f) => f.endsWith('.pre-repair.bak'));
+    expect(backups).toStrictEqual([]);
+  });
+});

--- a/packages/settings/src/profiles/__tests__/canonicalProfileRepair.test.ts
+++ b/packages/settings/src/profiles/__tests__/canonicalProfileRepair.test.ts
@@ -1,0 +1,834 @@
+/**
+ * Behavioral tests for the settings-owned canonical profile repair API.
+ *
+ * Tests the {@link repairCanonicalProfiles} cohesive function directly,
+ * without going through the CLI orchestrator. Uses real temp directories.
+ *
+ * Covers:
+ * - Corrupt profile detection and repair
+ * - Narrow eligibility (only known historical defect signature)
+ * - Marker semantics (none/repaired/busy/error outcomes)
+ * - modelParams normalization at the parseProfile boundary
+ * - Lock busy as benign deferral (no marker, no error)
+ * - Backup preservation
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  repairCanonicalProfiles,
+  isCorruptStandardProfile,
+  isCorruptStandardProfileFromRaw,
+  CORRUPT_PROVIDER,
+} from '../canonicalProfileRepair.js';
+import { parseProfile } from '../../settings/validation.js';
+import { isLoadBalancerProfile } from '../types.js';
+import { acquireProfilesLockSync } from '../profileStore.js';
+import { ProfileManager } from '../ProfileManager.js';
+
+async function makeTempDir(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-canonical-repair-test-'));
+}
+
+function validLegacyProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'anthropic',
+    model: 'glm-5.2',
+    modelParams: { temperature: 1 },
+    ephemeralSettings: {
+      'base-url': 'https://api.z.ai/api/anthropic',
+      'auth-key-name': 'zai',
+      'context-limit': 200000,
+    },
+  };
+}
+
+function corruptCanonicalProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: CORRUPT_PROVIDER,
+    model: 'gemini-2.5-pro',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+function genuineLbProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    type: 'loadbalancer',
+    policy: 'roundrobin',
+    profiles: ['p1'],
+    provider: 'load-balancer',
+    model: 'default',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+interface TestEnv {
+  canonicalDir: string;
+  legacyDir: string;
+  legacyProfilesDir: string;
+}
+
+async function setupEnv(): Promise<TestEnv> {
+  const canonicalDir = await makeTempDir();
+  const legacyDir = await makeTempDir();
+  const legacyProfilesDir = path.join(legacyDir, 'profiles');
+  fs.mkdirSync(legacyProfilesDir, { recursive: true });
+  return { canonicalDir, legacyDir, legacyProfilesDir };
+}
+
+async function teardownEnv(env: TestEnv): Promise<void> {
+  await fsp.rm(env.canonicalDir, { recursive: true, force: true });
+  await fsp.rm(env.legacyDir, { recursive: true, force: true });
+}
+
+function writeProfile(
+  dir: string,
+  name: string,
+  data: Record<string, unknown>,
+): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), JSON.stringify(data));
+}
+
+describe('isCorruptStandardProfile — narrow eligibility', () => {
+  it('identifies a standard profile with provider load-balancer + gemini-2.5-pro as corrupt', () => {
+    const profile = parseProfile(corruptCanonicalProfile());
+    expect(isCorruptStandardProfile(profile)).toBe(true);
+  });
+
+  it('does NOT identify a genuine loadbalancer profile as corrupt', () => {
+    const profile = parseProfile(genuineLbProfile());
+    expect(isCorruptStandardProfile(profile)).toBe(false);
+  });
+
+  it('does NOT identify a valid standard profile as corrupt', () => {
+    const profile = parseProfile(validLegacyProfile());
+    expect(isCorruptStandardProfile(profile)).toBe(false);
+  });
+
+  it('does NOT identify a standard profile with load-balancer provider but a CUSTOM model as corrupt (#4)', () => {
+    // A manually-authored profile with the load-balancer provider but a
+    // custom model is NOT the reported defect signature. Skip it.
+    const customModelProfile = {
+      version: 1,
+      provider: 'load-balancer',
+      model: 'my-custom-model',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    const profile = parseProfile(customModelProfile);
+    expect(isCorruptStandardProfile(profile)).toBe(false);
+  });
+
+  it('does NOT identify a standard profile with load-balancer provider but a manual/default model as corrupt (#4)', () => {
+    const manualModelProfile = {
+      version: 1,
+      provider: 'load-balancer',
+      model: 'default',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    const profile = parseProfile(manualModelProfile);
+    expect(isCorruptStandardProfile(profile)).toBe(false);
+  });
+});
+
+describe('isCorruptStandardProfileFromRaw — raw object eligibility (#3)', () => {
+  it('identifies the exact defect signature: no type, load-balancer, gemini-2.5-pro', () => {
+    expect(isCorruptStandardProfileFromRaw(corruptCanonicalProfile())).toBe(
+      true,
+    );
+  });
+
+  it('does NOT identify a profile with type: standard as corrupt (#3 negative)', () => {
+    // A profile with explicit type:'standard' is NOT the corrupt shape —
+    // the corrupt signature never carried a type field.
+    const standardTyped = {
+      version: 1,
+      type: 'standard',
+      provider: 'load-balancer',
+      model: 'gemini-2.5-pro',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isCorruptStandardProfileFromRaw(standardTyped)).toBe(false);
+  });
+
+  it('does NOT identify a profile with type: loadbalancer as corrupt', () => {
+    expect(isCorruptStandardProfileFromRaw(genuineLbProfile())).toBe(false);
+  });
+
+  it('does NOT identify a profile with a custom model as corrupt', () => {
+    expect(
+      isCorruptStandardProfileFromRaw({
+        version: 1,
+        provider: 'load-balancer',
+        model: 'my-custom-model',
+        modelParams: {},
+        ephemeralSettings: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT identify a profile with a real provider as corrupt', () => {
+    expect(
+      isCorruptStandardProfileFromRaw({
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT identify non-object values as corrupt', () => {
+    expect(isCorruptStandardProfileFromRaw(null)).toBe(false);
+    expect(isCorruptStandardProfileFromRaw('string')).toBe(false);
+    expect(isCorruptStandardProfileFromRaw(42)).toBe(false);
+    expect(isCorruptStandardProfileFromRaw([])).toBe(false);
+  });
+});
+
+describe('repairCanonicalProfiles — corrupt profile repair', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('repairs a corrupt canonical zai profile when a valid legacy exists', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+
+    expect(result.kind).toBe('repaired');
+    expect(result.kind === 'repaired' ? result.profilesRepaired : 0).toBe(1);
+
+    const repaired = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+    );
+    expect(repaired.provider).toBe('anthropic');
+    expect(repaired.model).toBe('glm-5.2');
+    expect(repaired.ephemeralSettings['base-url']).toBe(
+      'https://api.z.ai/api/anthropic',
+    );
+    expect(repaired.ephemeralSettings['auth-key-name']).toBe('zai');
+  });
+
+  it('preserves the corrupt canonical file as a quarantine backup', () => {
+    const corruptData = JSON.stringify(corruptCanonicalProfile());
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+
+    const backups = fs
+      .readdirSync(env.canonicalDir)
+      .filter((f) => f.endsWith('.pre-repair.bak'));
+    expect(backups).toStrictEqual(['zai.json.pre-repair.bak']);
+    expect(
+      fs.readFileSync(path.join(env.canonicalDir, backups[0]), 'utf-8'),
+    ).toBe(corruptData);
+  });
+
+  it('does not modify the legacy profile file during repair', () => {
+    const legacyData = JSON.stringify(validLegacyProfile());
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    fs.writeFileSync(path.join(env.legacyProfilesDir, 'zai.json'), legacyData);
+
+    repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+
+    expect(
+      fs.readFileSync(path.join(env.legacyProfilesDir, 'zai.json'), 'utf-8'),
+    ).toBe(legacyData);
+  });
+
+  it('does not repair an unrelated same-name-independent profile', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.canonicalDir, 'other.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+    writeProfile(env.legacyProfilesDir, 'other.json', {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+
+    const first = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(first.kind).toBe('repaired');
+    expect(first.kind === 'repaired' ? first.profilesRepaired : 0).toBe(1);
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+      ).provider,
+    ).toBe('anthropic');
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(env.canonicalDir, 'other.json'), 'utf-8'),
+      ).provider,
+    ).toBe(CORRUPT_PROVIDER);
+
+    const second = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(second.kind).toBe('none');
+  });
+});
+
+describe('repairCanonicalProfiles — no candidates / none outcome', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('returns none when canonical profiles dir does not exist', () => {
+    const result = repairCanonicalProfiles(
+      path.join(env.canonicalDir, 'nonexistent'),
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when no corrupt profiles exist', () => {
+    writeProfile(env.canonicalDir, 'good.json', validLegacyProfile());
+    writeProfile(env.legacyProfilesDir, 'good.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when corrupt canonical has no valid legacy replacement', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    // No legacy file at all.
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns none when legacy is a loadbalancer (not a valid standard replacement)', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', genuineLbProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    // Canonical NOT replaced.
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+      ).provider,
+    ).toBe(CORRUPT_PROVIDER);
+  });
+
+  it('returns none when canonical is a genuine loadbalancer', () => {
+    writeProfile(env.canonicalDir, 'lb.json', genuineLbProfile());
+    writeProfile(env.legacyProfilesDir, 'lb.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    // LB profile untouched.
+    const after = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'lb.json'), 'utf-8'),
+    );
+    expect(after.type).toBe('loadbalancer');
+  });
+
+  it('returns none when legacy replacement is also corrupt', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', corruptCanonicalProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+});
+
+// ─── Marker semantics: no stamp when no repair performed ────────────────────
+
+describe('repairCanonicalProfiles — marker semantics (#4)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('initial: no candidate / no canonical dir → none (no marker)', () => {
+    const result = repairCanonicalProfiles(
+      path.join(env.canonicalDir, 'no-such-dir'),
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+  });
+
+  it('later: affected canonical+legacy appears → repaired on next startup', () => {
+    // First run: empty canonical dir, nothing to repair.
+    const first = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(first.kind).toBe('none');
+
+    // Later: affected files appear.
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    // Next startup repairs.
+    const second = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(second.kind).toBe('repaired');
+    expect(second.kind === 'repaired' ? second.profilesRepaired : 0).toBe(1);
+  });
+});
+
+// ─── modelParams normalization at parseProfile boundary (#6) ────────────────
+
+describe('repairCanonicalProfiles — modelParams normalization (#6)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('repairs a legacy profile with absent modelParams (normalized to {})', () => {
+    const issueLegacy = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      // modelParams intentionally absent — parseProfile normalizes to {}
+      ephemeralSettings: {
+        'base-url': 'https://api.z.ai/api/anthropic',
+        'auth-key-name': 'zai',
+        'context-limit': 200000,
+      },
+    };
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    fs.writeFileSync(
+      path.join(env.legacyProfilesDir, 'zai.json'),
+      JSON.stringify(issueLegacy),
+    );
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('repaired');
+
+    const repaired = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+    );
+    expect(repaired.provider).toBe('anthropic');
+    expect(repaired.model).toBe('glm-5.2');
+    expect(repaired.modelParams).toStrictEqual({});
+    expect(repaired.ephemeralSettings['base-url']).toBe(
+      'https://api.z.ai/api/anthropic',
+    );
+    expect(repaired.ephemeralSettings['context-limit']).toBe(200000);
+  });
+
+  it('preserves existing modelParams when present in the legacy profile', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+
+    const repaired = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+    );
+    expect(repaired.modelParams).toStrictEqual({ temperature: 1 });
+  });
+});
+
+// ─── Behavioral: repaired zai profile loads via ProfileManager (#9) ─────────
+
+describe('repairCanonicalProfiles — repaired zai loads/preparation (#9)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('repaired zai profile loads via ProfileManager preserving anthropic/glm-5.2/base-url/auth-key-name', async () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+
+    // Load the repaired profile through the real ProfileManager (no
+    // network, no mock theater) to verify it preserves the expected fields.
+    const pm = new ProfileManager(env.canonicalDir);
+    const loaded = await pm.loadProfile('zai');
+
+    expect(loaded.provider).toBe('anthropic');
+    expect(loaded.model).toBe('glm-5.2');
+    expect(isLoadBalancerProfile(loaded)).toBe(false);
+    expect(loaded.ephemeralSettings['base-url']).toBe(
+      'https://api.z.ai/api/anthropic',
+    );
+    expect(loaded.ephemeralSettings['auth-key-name']).toBe('zai');
+    expect(loaded.ephemeralSettings['context-limit']).toBe(200000);
+  });
+
+  // ─── Exact end-to-end zai application through ProfileManager (#5) ───────────
+
+  /**
+   * Captured settings data from the fake SettingsService boundary.
+   */
+  interface CapturedSettings {
+    defaultProvider: string;
+    providers: Record<string, Record<string, unknown>>;
+    tools: { allowed: readonly string[]; disabled: readonly string[] };
+    currentProfileName: string | null;
+    setKeys: Record<string, unknown>;
+  }
+
+  /**
+   * Minimal shape matching ProfileManager's ProfileSettingsServiceLike for
+   * testing applyLoadedProfile without network/mock theater.
+   */
+  interface CapturingSettingsService {
+    setCurrentProfileName(name: string | null): void;
+    importFromProfile(data: unknown): Promise<void>;
+    set(key: string, value: unknown): void;
+  }
+
+  /**
+   * Type guard for the profile import data shape (narrowing unknown without
+   * a type assertion).
+   */
+  function isImportData(value: unknown): value is {
+    defaultProvider: string;
+    providers: Record<string, Record<string, unknown>>;
+    tools?: { allowed?: unknown[]; disabled?: unknown[] };
+  } {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return false;
+    }
+    const entries = Object.entries(value);
+    const hasDefaultProvider = entries.some(
+      ([k, v]) => k === 'defaultProvider' && typeof v === 'string',
+    );
+    const hasProviders = entries.some(
+      ([k, v]) => k === 'providers' && typeof v === 'object' && v !== null,
+    );
+    return hasDefaultProvider && hasProviders;
+  }
+
+  function createCapturingSettingsService(): {
+    service: CapturingSettingsService;
+    captured: CapturedSettings;
+  } {
+    const captured: CapturedSettings = {
+      defaultProvider: '',
+      providers: {},
+      tools: { allowed: [], disabled: [] },
+      currentProfileName: null,
+      setKeys: {},
+    };
+
+    const service: CapturingSettingsService = {
+      setCurrentProfileName(name: string | null) {
+        captured.currentProfileName = name;
+      },
+      async importFromProfile(data: unknown) {
+        if (!isImportData(data)) {
+          return;
+        }
+        captured.defaultProvider = data.defaultProvider;
+        captured.providers = data.providers;
+        const allowedRaw = data.tools?.allowed;
+        const disabledRaw = data.tools?.disabled;
+        captured.tools = {
+          allowed: Array.isArray(allowedRaw) ? allowedRaw.map(String) : [],
+          disabled: Array.isArray(disabledRaw) ? disabledRaw.map(String) : [],
+        };
+      },
+      set(key: string, value: unknown) {
+        captured.setKeys[key] = value;
+      },
+    };
+    return { service, captured };
+  }
+
+  describe('repairCanonicalProfiles — exact zai end-to-end application (#5)', () => {
+    let env: TestEnv;
+
+    beforeEach(async () => {
+      env = await setupEnv();
+    });
+    afterEach(async () => {
+      await teardownEnv(env);
+    });
+
+    it('repaired zai profile applies through ProfileManager with anthropic/glm-5.2/z.ai base URL/auth-key-name together', async () => {
+      writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+      writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+      repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+
+      // Load the repaired profile via ProfileManager (real file I/O).
+      const pm = new ProfileManager(env.canonicalDir);
+
+      // Apply through the real applyLoadedProfile seam with a capturing fake
+      // at the SettingsService boundary (no network, no mock theater).
+      // pm.load() internally calls loadProfile + applyLoadedProfile, handling
+      // the LB check. Since this is a standard profile, load succeeds.
+      const { service, captured } = createCapturingSettingsService();
+      await pm.load('zai', service);
+
+      // Assert all zai fields resolve together through the application path.
+      expect(captured.currentProfileName).toBe('zai');
+      expect(captured.defaultProvider).toBe('anthropic');
+
+      const providerSettings = captured.providers['anthropic'];
+      expect(providerSettings).toBeDefined();
+      expect(providerSettings.model).toBe('glm-5.2');
+      expect(providerSettings['base-url']).toBe(
+        'https://api.z.ai/api/anthropic',
+      );
+
+      // auth-key-name is an ephemeral setting preserved in the profile and
+      // resolved through the settings data — the key name 'zai' enables
+      // secure-store key resolution at the provider boundary. Verify by
+      // loading the raw repaired file.
+      const loaded = await pm.loadProfile('zai');
+      expect(loaded.ephemeralSettings['auth-key-name']).toBe('zai');
+      expect(providerSettings.enabled).toBe(true);
+    });
+  });
+});
+
+// ─── Lock busy as benign deferral (#3) ──────────────────────────────────────
+
+describe('repairCanonicalProfiles — lock busy is benign deferral (#3)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('returns busy (not error) when lock is held, no marker should be written', () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    // Hold the lock to simulate a concurrent process.
+    const lock = acquireProfilesLockSync(env.canonicalDir);
+    try {
+      const result = repairCanonicalProfiles(
+        env.canonicalDir,
+        env.legacyProfilesDir,
+      );
+      expect(result.kind).toBe('busy');
+    } finally {
+      lock.release();
+    }
+
+    // Canonical NOT replaced.
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+      ).provider,
+    ).toBe(CORRUPT_PROVIDER);
+  });
+});
+
+// ─── Narrow eligibility: negative tests for manually-authored LB (#5) ───────
+
+describe('repairCanonicalProfiles — narrow eligibility negative tests (#5)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('does NOT repair a manually-authored loadbalancer profile with provider load-balancer', () => {
+    // A genuine LB profile has type:'loadbalancer' — it is never corrupt
+    // even if its provider field is 'load-balancer'.
+    writeProfile(env.canonicalDir, 'mylb.json', genuineLbProfile());
+    writeProfile(env.legacyProfilesDir, 'mylb.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'mylb.json'), 'utf-8'),
+    );
+    expect(after.type).toBe('loadbalancer');
+    expect(isLoadBalancerProfile(parseProfile(after))).toBe(true);
+  });
+
+  it('does NOT repair a valid standard profile with a real provider', () => {
+    writeProfile(env.canonicalDir, 'openai.json', {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    writeProfile(env.legacyProfilesDir, 'openai.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'openai.json'), 'utf-8'),
+    );
+    expect(after.provider).toBe('openai');
+  });
+
+  it('does NOT repair a standard profile with load-balancer provider but a CUSTOM model (#4)', () => {
+    // The reported defect signature requires model gemini-2.5-pro. A
+    // manually-authored profile with a custom model must NOT be touched.
+    const customModel = {
+      version: 1,
+      provider: 'load-balancer',
+      model: 'my-custom-model',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    writeProfile(env.canonicalDir, 'custom.json', customModel);
+    writeProfile(env.legacyProfilesDir, 'custom.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'custom.json'), 'utf-8'),
+    );
+    expect(after.model).toBe('my-custom-model');
+    expect(after.provider).toBe('load-balancer');
+  });
+
+  it('does NOT repair a standard profile with load-balancer provider but a manual/default model (#4)', () => {
+    const manualModel = {
+      version: 1,
+      provider: 'load-balancer',
+      model: 'default',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    writeProfile(env.canonicalDir, 'manual.json', manualModel);
+    writeProfile(env.legacyProfilesDir, 'manual.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('none');
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'manual.json'), 'utf-8'),
+    );
+    expect(after.model).toBe('default');
+  });
+
+  it('repairs the EXACT reported defect: load-balancer + gemini-2.5-pro (#4 positive)', () => {
+    // The exact issue payload from #2479/#2477: standard v1, provider
+    // load-balancer, model gemini-2.5-pro (the fallback model).
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('repaired');
+
+    const repaired = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+    );
+    expect(repaired.provider).toBe('anthropic');
+    expect(repaired.model).toBe('glm-5.2');
+  });
+});
+
+// ─── I/O error outcomes ─────────────────────────────────────────────────────
+
+describe('repairCanonicalProfiles — I/O error outcomes', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupEnv();
+  });
+  afterEach(async () => {
+    await teardownEnv(env);
+  });
+
+  it('returns error when canonical profiles path is a file, not a directory', () => {
+    fs.mkdirSync(env.canonicalDir, { recursive: true });
+    // Replace the canonicalDir with a file.
+    fs.rmSync(env.canonicalDir, { recursive: true, force: true });
+    fs.writeFileSync(env.canonicalDir, 'not a directory');
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('error');
+  });
+});

--- a/packages/settings/src/profiles/__tests__/canonicalProfileRepair.test.ts
+++ b/packages/settings/src/profiles/__tests__/canonicalProfileRepair.test.ts
@@ -5,22 +5,31 @@
  * without going through the CLI orchestrator. Uses real temp directories.
  *
  * Covers:
- * - Corrupt profile detection and repair
- * - Narrow eligibility (only known historical defect signature)
- * - Marker semantics (none/repaired/busy/error outcomes)
- * - modelParams normalization at the parseProfile boundary
+ * - Corrupt profile detection and repair (GENERALIZED — no hardcoded
+ *   profile name/provider/model/endpoint/auth constants).
+ * - Conservative corruption signature based only on the historical
+ *   malformed shape: untyped standard-v1 profile whose provider is the
+ *   virtual non-loadable provider 'load-balancer', with empty modelParams
+ *   and empty ephemeralSettings, which parses as a standard profile.
+ * - A same-name legacy replacement is eligible iff it parses as a valid
+ *   standard profile, is not a genuine loadbalancer, does not itself
+ *   match the corrupt structural signature, and does not have provider
+ *   'load-balancer'.
+ * - modelParams normalization (absent → {}) in the serialized output.
  * - Lock busy as benign deferral (no marker, no error)
  * - Backup preservation
+ * - Negative tests for genuine loadbalancer, explicit type, nonempty
+ *   settings/params, invalid replacement, and already-valid profiles.
+ *
+ * Outcome/no-candidate/I-O-error tests are in
+ * canonicalProfileRepair.outcomes.test.ts.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
-import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
-import * as os from 'node:os';
 import {
   repairCanonicalProfiles,
-  isCorruptStandardProfile,
   isCorruptStandardProfileFromRaw,
   CORRUPT_PROVIDER,
 } from '../canonicalProfileRepair.js';
@@ -28,129 +37,35 @@ import { parseProfile } from '../../settings/validation.js';
 import { isLoadBalancerProfile } from '../types.js';
 import { acquireProfilesLockSync } from '../profileStore.js';
 import { ProfileManager } from '../ProfileManager.js';
+import {
+  type TestEnv,
+  setupEnv,
+  teardownEnv,
+  writeProfile,
+  corruptCanonicalProfile,
+  corruptCanonicalProfileNonGeminiModel,
+  corruptCanonicalProfileOmittedModelParams,
+  validLegacyProfile,
+  validLegacyProfileAlternative,
+  genuineLbProfile,
+} from './canonicalProfileRepair.testHelpers.js';
 
-async function makeTempDir(): Promise<string> {
-  return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-canonical-repair-test-'));
-}
+// ─── Corruption signature: conservative raw structural predicate ────────────
 
-function validLegacyProfile(): Record<string, unknown> {
-  return {
-    version: 1,
-    provider: 'anthropic',
-    model: 'glm-5.2',
-    modelParams: { temperature: 1 },
-    ephemeralSettings: {
-      'base-url': 'https://api.z.ai/api/anthropic',
-      'auth-key-name': 'zai',
-      'context-limit': 200000,
-    },
-  };
-}
-
-function corruptCanonicalProfile(): Record<string, unknown> {
-  return {
-    version: 1,
-    provider: CORRUPT_PROVIDER,
-    model: 'gemini-2.5-pro',
-    modelParams: {},
-    ephemeralSettings: {},
-  };
-}
-
-function genuineLbProfile(): Record<string, unknown> {
-  return {
-    version: 1,
-    type: 'loadbalancer',
-    policy: 'roundrobin',
-    profiles: ['p1'],
-    provider: 'load-balancer',
-    model: 'default',
-    modelParams: {},
-    ephemeralSettings: {},
-  };
-}
-
-interface TestEnv {
-  canonicalDir: string;
-  legacyDir: string;
-  legacyProfilesDir: string;
-}
-
-async function setupEnv(): Promise<TestEnv> {
-  const canonicalDir = await makeTempDir();
-  const legacyDir = await makeTempDir();
-  const legacyProfilesDir = path.join(legacyDir, 'profiles');
-  fs.mkdirSync(legacyProfilesDir, { recursive: true });
-  return { canonicalDir, legacyDir, legacyProfilesDir };
-}
-
-async function teardownEnv(env: TestEnv): Promise<void> {
-  await fsp.rm(env.canonicalDir, { recursive: true, force: true });
-  await fsp.rm(env.legacyDir, { recursive: true, force: true });
-}
-
-function writeProfile(
-  dir: string,
-  name: string,
-  data: Record<string, unknown>,
-): void {
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, name), JSON.stringify(data));
-}
-
-describe('isCorruptStandardProfile — narrow eligibility', () => {
-  it('identifies a standard profile with provider load-balancer + gemini-2.5-pro as corrupt', () => {
-    const profile = parseProfile(corruptCanonicalProfile());
-    expect(isCorruptStandardProfile(profile)).toBe(true);
-  });
-
-  it('does NOT identify a genuine loadbalancer profile as corrupt', () => {
-    const profile = parseProfile(genuineLbProfile());
-    expect(isCorruptStandardProfile(profile)).toBe(false);
-  });
-
-  it('does NOT identify a valid standard profile as corrupt', () => {
-    const profile = parseProfile(validLegacyProfile());
-    expect(isCorruptStandardProfile(profile)).toBe(false);
-  });
-
-  it('does NOT identify a standard profile with load-balancer provider but a CUSTOM model as corrupt (#4)', () => {
-    // A manually-authored profile with the load-balancer provider but a
-    // custom model is NOT the reported defect signature. Skip it.
-    const customModelProfile = {
-      version: 1,
-      provider: 'load-balancer',
-      model: 'my-custom-model',
-      modelParams: {},
-      ephemeralSettings: {},
-    };
-    const profile = parseProfile(customModelProfile);
-    expect(isCorruptStandardProfile(profile)).toBe(false);
-  });
-
-  it('does NOT identify a standard profile with load-balancer provider but a manual/default model as corrupt (#4)', () => {
-    const manualModelProfile = {
-      version: 1,
-      provider: 'load-balancer',
-      model: 'default',
-      modelParams: {},
-      ephemeralSettings: {},
-    };
-    const profile = parseProfile(manualModelProfile);
-    expect(isCorruptStandardProfile(profile)).toBe(false);
-  });
-});
-
-describe('isCorruptStandardProfileFromRaw — raw object eligibility (#3)', () => {
-  it('identifies the exact defect signature: no type, load-balancer, gemini-2.5-pro', () => {
+describe('isCorruptStandardProfileFromRaw — conservative structural signature', () => {
+  it('identifies the exact historical defect: untyped + load-balancer + empty params/settings', () => {
     expect(isCorruptStandardProfileFromRaw(corruptCanonicalProfile())).toBe(
       true,
     );
   });
 
-  it('does NOT identify a profile with type: standard as corrupt (#3 negative)', () => {
-    // A profile with explicit type:'standard' is NOT the corrupt shape —
-    // the corrupt signature never carried a type field.
+  it('identifies a corrupt signature with a non-Gemini fallback model', () => {
+    expect(
+      isCorruptStandardProfileFromRaw(corruptCanonicalProfileNonGeminiModel()),
+    ).toBe(true);
+  });
+
+  it('does NOT identify a profile with type: standard as corrupt', () => {
     const standardTyped = {
       version: 1,
       type: 'standard',
@@ -162,20 +77,8 @@ describe('isCorruptStandardProfileFromRaw — raw object eligibility (#3)', () =
     expect(isCorruptStandardProfileFromRaw(standardTyped)).toBe(false);
   });
 
-  it('does NOT identify a profile with type: loadbalancer as corrupt', () => {
+  it('does NOT identify a genuine loadbalancer profile as corrupt', () => {
     expect(isCorruptStandardProfileFromRaw(genuineLbProfile())).toBe(false);
-  });
-
-  it('does NOT identify a profile with a custom model as corrupt', () => {
-    expect(
-      isCorruptStandardProfileFromRaw({
-        version: 1,
-        provider: 'load-balancer',
-        model: 'my-custom-model',
-        modelParams: {},
-        ephemeralSettings: {},
-      }),
-    ).toBe(false);
   });
 
   it('does NOT identify a profile with a real provider as corrupt', () => {
@@ -190,6 +93,53 @@ describe('isCorruptStandardProfileFromRaw — raw object eligibility (#3)', () =
     ).toBe(false);
   });
 
+  it('does NOT identify a corrupt-provider profile with nonempty modelParams as corrupt', () => {
+    expect(
+      isCorruptStandardProfileFromRaw({
+        version: 1,
+        provider: CORRUPT_PROVIDER,
+        model: 'gemini-2.5-pro',
+        modelParams: { temperature: 0.5 },
+        ephemeralSettings: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT identify a corrupt-provider profile with nonempty ephemeralSettings as corrupt', () => {
+    expect(
+      isCorruptStandardProfileFromRaw({
+        version: 1,
+        provider: CORRUPT_PROVIDER,
+        model: 'gemini-2.5-pro',
+        modelParams: {},
+        ephemeralSettings: { 'base-url': 'https://example.com' },
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT identify a corrupt-provider profile with absent ephemeralSettings as corrupt', () => {
+    expect(
+      isCorruptStandardProfileFromRaw({
+        version: 1,
+        provider: CORRUPT_PROVIDER,
+        model: 'gemini-2.5-pro',
+        modelParams: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT identify a corrupt-provider profile with a non-v1 version as corrupt', () => {
+    expect(
+      isCorruptStandardProfileFromRaw({
+        version: 2,
+        provider: CORRUPT_PROVIDER,
+        model: 'gemini-2.5-pro',
+        modelParams: {},
+        ephemeralSettings: {},
+      }),
+    ).toBe(false);
+  });
+
   it('does NOT identify non-object values as corrupt', () => {
     expect(isCorruptStandardProfileFromRaw(null)).toBe(false);
     expect(isCorruptStandardProfileFromRaw('string')).toBe(false);
@@ -198,7 +148,9 @@ describe('isCorruptStandardProfileFromRaw — raw object eligibility (#3)', () =
   });
 });
 
-describe('repairCanonicalProfiles — corrupt profile repair', () => {
+// ─── Repair: generalized — arbitrary names/providers/models/endpoints ───────
+
+describe('repairCanonicalProfiles — generalized corrupt profile repair', () => {
   let env: TestEnv;
 
   beforeEach(async () => {
@@ -208,9 +160,9 @@ describe('repairCanonicalProfiles — corrupt profile repair', () => {
     await teardownEnv(env);
   });
 
-  it('repairs a corrupt canonical zai profile when a valid legacy exists', () => {
-    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+  it('repairs a corrupt canonical profile with an arbitrary name', () => {
+    writeProfile(env.canonicalDir, 'mycustom.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'mycustom.json', validLegacyProfile());
 
     const result = repairCanonicalProfiles(
       env.canonicalDir,
@@ -221,7 +173,7 @@ describe('repairCanonicalProfiles — corrupt profile repair', () => {
     expect(result.kind === 'repaired' ? result.profilesRepaired : 0).toBe(1);
 
     const repaired = JSON.parse(
-      fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+      fs.readFileSync(path.join(env.canonicalDir, 'mycustom.json'), 'utf-8'),
     );
     expect(repaired.provider).toBe('anthropic');
     expect(repaired.model).toBe('glm-5.2');
@@ -229,6 +181,62 @@ describe('repairCanonicalProfiles — corrupt profile repair', () => {
       'https://api.z.ai/api/anthropic',
     );
     expect(repaired.ephemeralSettings['auth-key-name']).toBe('zai');
+  });
+
+  it('repairs a corrupt canonical profile with a non-Gemini fallback model', () => {
+    writeProfile(
+      env.canonicalDir,
+      'broken.json',
+      corruptCanonicalProfileNonGeminiModel(),
+    );
+    writeProfile(
+      env.legacyProfilesDir,
+      'broken.json',
+      validLegacyProfileAlternative(),
+    );
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+
+    expect(result.kind).toBe('repaired');
+
+    const repaired = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'broken.json'), 'utf-8'),
+    );
+    expect(repaired.provider).toBe('openai');
+    expect(repaired.model).toBe('gpt-4o');
+    expect(repaired.ephemeralSettings['base-url']).toBe(
+      'https://api.openai.com/v1',
+    );
+    expect(repaired.ephemeralSettings['auth-key']).toBe('sk-test-key');
+  });
+
+  it('repairs using a legacy replacement with arbitrary provider/model/endpoint/auth', () => {
+    writeProfile(env.canonicalDir, 'acme.json', corruptCanonicalProfile());
+    writeProfile(
+      env.legacyProfilesDir,
+      'acme.json',
+      validLegacyProfileAlternative(),
+    );
+
+    repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+
+    const repaired = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'acme.json'), 'utf-8'),
+    );
+    expect(repaired.provider).toBe('openai');
+    expect(repaired.model).toBe('gpt-4o');
+    expect(repaired.modelParams).toStrictEqual({
+      temperature: 0.7,
+      max_tokens: 4096,
+    });
+    expect(repaired.ephemeralSettings['base-url']).toBe(
+      'https://api.openai.com/v1',
+    );
+    expect(repaired.ephemeralSettings['auth-key']).toBe('sk-test-key');
+    expect(repaired.ephemeralSettings['context-limit']).toBe(128000);
   });
 
   it('preserves the corrupt canonical file as a quarantine backup', () => {
@@ -259,175 +267,52 @@ describe('repairCanonicalProfiles — corrupt profile repair', () => {
     ).toBe(legacyData);
   });
 
-  it('does not repair an unrelated same-name-independent profile', () => {
-    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-    writeProfile(env.canonicalDir, 'other.json', corruptCanonicalProfile());
-    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
-    writeProfile(env.legacyProfilesDir, 'other.json', {
-      version: 1,
-      provider: 'openai',
-      model: 'gpt-4o',
-      modelParams: {},
-      ephemeralSettings: {},
-    });
+  it('repairs at most one candidate per call (sorted by name)', () => {
+    writeProfile(env.canonicalDir, 'aaa.json', corruptCanonicalProfile());
+    writeProfile(env.canonicalDir, 'zzz.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'aaa.json', validLegacyProfile());
+    writeProfile(env.legacyProfilesDir, 'zzz.json', validLegacyProfile());
 
     const first = repairCanonicalProfiles(
       env.canonicalDir,
       env.legacyProfilesDir,
     );
     expect(first.kind).toBe('repaired');
-    expect(first.kind === 'repaired' ? first.profilesRepaired : 0).toBe(1);
+
+    // aaa repaired first (sorted), zzz still corrupt.
     expect(
       JSON.parse(
-        fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
+        fs.readFileSync(path.join(env.canonicalDir, 'aaa.json'), 'utf-8'),
       ).provider,
     ).toBe('anthropic');
     expect(
       JSON.parse(
-        fs.readFileSync(path.join(env.canonicalDir, 'other.json'), 'utf-8'),
+        fs.readFileSync(path.join(env.canonicalDir, 'zzz.json'), 'utf-8'),
       ).provider,
     ).toBe(CORRUPT_PROVIDER);
 
-    const second = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(second.kind).toBe('none');
-  });
-});
-
-describe('repairCanonicalProfiles — no candidates / none outcome', () => {
-  let env: TestEnv;
-
-  beforeEach(async () => {
-    env = await setupEnv();
-  });
-  afterEach(async () => {
-    await teardownEnv(env);
-  });
-
-  it('returns none when canonical profiles dir does not exist', () => {
-    const result = repairCanonicalProfiles(
-      path.join(env.canonicalDir, 'nonexistent'),
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('none');
-  });
-
-  it('returns none when no corrupt profiles exist', () => {
-    writeProfile(env.canonicalDir, 'good.json', validLegacyProfile());
-    writeProfile(env.legacyProfilesDir, 'good.json', validLegacyProfile());
-
-    const result = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('none');
-  });
-
-  it('returns none when corrupt canonical has no valid legacy replacement', () => {
-    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-    // No legacy file at all.
-
-    const result = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('none');
-  });
-
-  it('returns none when legacy is a loadbalancer (not a valid standard replacement)', () => {
-    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-    writeProfile(env.legacyProfilesDir, 'zai.json', genuineLbProfile());
-
-    const result = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('none');
-
-    // Canonical NOT replaced.
-    expect(
-      JSON.parse(
-        fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
-      ).provider,
-    ).toBe(CORRUPT_PROVIDER);
-  });
-
-  it('returns none when canonical is a genuine loadbalancer', () => {
-    writeProfile(env.canonicalDir, 'lb.json', genuineLbProfile());
-    writeProfile(env.legacyProfilesDir, 'lb.json', validLegacyProfile());
-
-    const result = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('none');
-
-    // LB profile untouched.
-    const after = JSON.parse(
-      fs.readFileSync(path.join(env.canonicalDir, 'lb.json'), 'utf-8'),
-    );
-    expect(after.type).toBe('loadbalancer');
-  });
-
-  it('returns none when legacy replacement is also corrupt', () => {
-    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-    writeProfile(env.legacyProfilesDir, 'zai.json', corruptCanonicalProfile());
-
-    const result = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('none');
-  });
-});
-
-// ─── Marker semantics: no stamp when no repair performed ────────────────────
-
-describe('repairCanonicalProfiles — marker semantics (#4)', () => {
-  let env: TestEnv;
-
-  beforeEach(async () => {
-    env = await setupEnv();
-  });
-  afterEach(async () => {
-    await teardownEnv(env);
-  });
-
-  it('initial: no candidate / no canonical dir → none (no marker)', () => {
-    const result = repairCanonicalProfiles(
-      path.join(env.canonicalDir, 'no-such-dir'),
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('none');
-  });
-
-  it('later: affected canonical+legacy appears → repaired on next startup', () => {
-    // First run: empty canonical dir, nothing to repair.
-    const first = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(first.kind).toBe('none');
-
-    // Later: affected files appear.
-    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
-
-    // Next startup repairs.
     const second = repairCanonicalProfiles(
       env.canonicalDir,
       env.legacyProfilesDir,
     );
     expect(second.kind).toBe('repaired');
-    expect(second.kind === 'repaired' ? second.profilesRepaired : 0).toBe(1);
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(env.canonicalDir, 'zzz.json'), 'utf-8'),
+      ).provider,
+    ).toBe('anthropic');
+
+    const third = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(third.kind).toBe('none');
   });
 });
 
-// ─── modelParams normalization at parseProfile boundary (#6) ────────────────
+// ─── modelParams normalization at parseProfile boundary ────────────────────
 
-describe('repairCanonicalProfiles — modelParams normalization (#6)', () => {
+describe('repairCanonicalProfiles — modelParams normalization', () => {
   let env: TestEnv;
 
   beforeEach(async () => {
@@ -484,11 +369,36 @@ describe('repairCanonicalProfiles — modelParams normalization (#6)', () => {
     );
     expect(repaired.modelParams).toStrictEqual({ temperature: 1 });
   });
+
+  it('repairs a corrupt canonical that omits modelParams entirely', () => {
+    // The corrupt canonical profile omits modelParams (rather than having
+    // an explicit {}). This is still the structural defect — absent
+    // modelParams is treated the same as empty modelParams.
+    writeProfile(
+      env.canonicalDir,
+      'no-params.json',
+      corruptCanonicalProfileOmittedModelParams(),
+    );
+    writeProfile(env.legacyProfilesDir, 'no-params.json', validLegacyProfile());
+
+    const result = repairCanonicalProfiles(
+      env.canonicalDir,
+      env.legacyProfilesDir,
+    );
+    expect(result.kind).toBe('repaired');
+
+    const repaired = JSON.parse(
+      fs.readFileSync(path.join(env.canonicalDir, 'no-params.json'), 'utf-8'),
+    );
+    expect(repaired.provider).toBe('anthropic');
+    expect(repaired.model).toBe('glm-5.2');
+    expect(repaired.modelParams).toStrictEqual({ temperature: 1 });
+  });
 });
 
-// ─── Behavioral: repaired zai profile loads via ProfileManager (#9) ─────────
+// ─── Behavioral: repaired profile loads via ProfileManager ─────────────────
 
-describe('repairCanonicalProfiles — repaired zai loads/preparation (#9)', () => {
+describe('repairCanonicalProfiles — repaired profile loads via ProfileManager', () => {
   let env: TestEnv;
 
   beforeEach(async () => {
@@ -498,14 +408,12 @@ describe('repairCanonicalProfiles — repaired zai loads/preparation (#9)', () =
     await teardownEnv(env);
   });
 
-  it('repaired zai profile loads via ProfileManager preserving anthropic/glm-5.2/base-url/auth-key-name', async () => {
+  it('repaired profile loads via ProfileManager preserving all fields', async () => {
     writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
     writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
 
     repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
 
-    // Load the repaired profile through the real ProfileManager (no
-    // network, no mock theater) to verify it preserves the expected fields.
     const pm = new ProfileManager(env.canonicalDir);
     const loaded = await pm.loadProfile('zai');
 
@@ -519,7 +427,31 @@ describe('repairCanonicalProfiles — repaired zai loads/preparation (#9)', () =
     expect(loaded.ephemeralSettings['context-limit']).toBe(200000);
   });
 
-  // ─── Exact end-to-end zai application through ProfileManager (#5) ───────────
+  it('repaired profile with alternative provider loads via ProfileManager', async () => {
+    writeProfile(
+      env.canonicalDir,
+      'alt.json',
+      corruptCanonicalProfileNonGeminiModel(),
+    );
+    writeProfile(
+      env.legacyProfilesDir,
+      'alt.json',
+      validLegacyProfileAlternative(),
+    );
+
+    repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+
+    const pm = new ProfileManager(env.canonicalDir);
+    const loaded = await pm.loadProfile('alt');
+
+    expect(loaded.provider).toBe('openai');
+    expect(loaded.model).toBe('gpt-4o');
+    expect(isLoadBalancerProfile(loaded)).toBe(false);
+    expect(loaded.modelParams.max_tokens).toBe(4096);
+    expect(loaded.ephemeralSettings['base-url']).toBe(
+      'https://api.openai.com/v1',
+    );
+  });
 
   /**
    * Captured settings data from the fake SettingsService boundary.
@@ -533,8 +465,7 @@ describe('repairCanonicalProfiles — repaired zai loads/preparation (#9)', () =
   }
 
   /**
-   * Minimal shape matching ProfileManager's ProfileSettingsServiceLike for
-   * testing applyLoadedProfile without network/mock theater.
+   * Minimal shape matching ProfileManager's ProfileSettingsServiceLike.
    */
   interface CapturingSettingsService {
     setCurrentProfileName(name: string | null): void;
@@ -542,10 +473,6 @@ describe('repairCanonicalProfiles — repaired zai loads/preparation (#9)', () =
     set(key: string, value: unknown): void;
   }
 
-  /**
-   * Type guard for the profile import data shape (narrowing unknown without
-   * a type assertion).
-   */
   function isImportData(value: unknown): value is {
     defaultProvider: string;
     providers: Record<string, Record<string, unknown>>;
@@ -600,57 +527,34 @@ describe('repairCanonicalProfiles — repaired zai loads/preparation (#9)', () =
     return { service, captured };
   }
 
-  describe('repairCanonicalProfiles — exact zai end-to-end application (#5)', () => {
-    let env: TestEnv;
+  it('repaired profile applies through ProfileManager end-to-end', async () => {
+    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
 
-    beforeEach(async () => {
-      env = await setupEnv();
-    });
-    afterEach(async () => {
-      await teardownEnv(env);
-    });
+    repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
 
-    it('repaired zai profile applies through ProfileManager with anthropic/glm-5.2/z.ai base URL/auth-key-name together', async () => {
-      writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-      writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
+    const pm = new ProfileManager(env.canonicalDir);
 
-      repairCanonicalProfiles(env.canonicalDir, env.legacyProfilesDir);
+    const { service, captured } = createCapturingSettingsService();
+    await pm.load('zai', service);
 
-      // Load the repaired profile via ProfileManager (real file I/O).
-      const pm = new ProfileManager(env.canonicalDir);
+    expect(captured.currentProfileName).toBe('zai');
+    expect(captured.defaultProvider).toBe('anthropic');
 
-      // Apply through the real applyLoadedProfile seam with a capturing fake
-      // at the SettingsService boundary (no network, no mock theater).
-      // pm.load() internally calls loadProfile + applyLoadedProfile, handling
-      // the LB check. Since this is a standard profile, load succeeds.
-      const { service, captured } = createCapturingSettingsService();
-      await pm.load('zai', service);
+    const providerSettings = captured.providers['anthropic'];
+    expect(providerSettings).toBeDefined();
+    expect(providerSettings.model).toBe('glm-5.2');
+    expect(providerSettings['base-url']).toBe('https://api.z.ai/api/anthropic');
 
-      // Assert all zai fields resolve together through the application path.
-      expect(captured.currentProfileName).toBe('zai');
-      expect(captured.defaultProvider).toBe('anthropic');
-
-      const providerSettings = captured.providers['anthropic'];
-      expect(providerSettings).toBeDefined();
-      expect(providerSettings.model).toBe('glm-5.2');
-      expect(providerSettings['base-url']).toBe(
-        'https://api.z.ai/api/anthropic',
-      );
-
-      // auth-key-name is an ephemeral setting preserved in the profile and
-      // resolved through the settings data — the key name 'zai' enables
-      // secure-store key resolution at the provider boundary. Verify by
-      // loading the raw repaired file.
-      const loaded = await pm.loadProfile('zai');
-      expect(loaded.ephemeralSettings['auth-key-name']).toBe('zai');
-      expect(providerSettings.enabled).toBe(true);
-    });
+    const loaded = await pm.loadProfile('zai');
+    expect(loaded.ephemeralSettings['auth-key-name']).toBe('zai');
+    expect(providerSettings.enabled).toBe(true);
   });
 });
 
-// ─── Lock busy as benign deferral (#3) ──────────────────────────────────────
+// ─── Lock busy as benign deferral ──────────────────────────────────────────
 
-describe('repairCanonicalProfiles — lock busy is benign deferral (#3)', () => {
+describe('repairCanonicalProfiles — lock busy is benign deferral', () => {
   let env: TestEnv;
 
   beforeEach(async () => {
@@ -685,9 +589,9 @@ describe('repairCanonicalProfiles — lock busy is benign deferral (#3)', () => 
   });
 });
 
-// ─── Narrow eligibility: negative tests for manually-authored LB (#5) ───────
+// ─── Narrow eligibility: negative tests ────────────────────────────────────
 
-describe('repairCanonicalProfiles — narrow eligibility negative tests (#5)', () => {
+describe('repairCanonicalProfiles — narrow eligibility negative tests', () => {
   let env: TestEnv;
 
   beforeEach(async () => {
@@ -698,8 +602,6 @@ describe('repairCanonicalProfiles — narrow eligibility negative tests (#5)', (
   });
 
   it('does NOT repair a manually-authored loadbalancer profile with provider load-balancer', () => {
-    // A genuine LB profile has type:'loadbalancer' — it is never corrupt
-    // even if its provider field is 'load-balancer'.
     writeProfile(env.canonicalDir, 'mylb.json', genuineLbProfile());
     writeProfile(env.legacyProfilesDir, 'mylb.json', validLegacyProfile());
 
@@ -738,97 +640,37 @@ describe('repairCanonicalProfiles — narrow eligibility negative tests (#5)', (
     expect(after.provider).toBe('openai');
   });
 
-  it('does NOT repair a standard profile with load-balancer provider but a CUSTOM model (#4)', () => {
-    // The reported defect signature requires model gemini-2.5-pro. A
-    // manually-authored profile with a custom model must NOT be touched.
-    const customModel = {
-      version: 1,
-      provider: 'load-balancer',
-      model: 'my-custom-model',
-      modelParams: {},
-      ephemeralSettings: {},
-    };
-    writeProfile(env.canonicalDir, 'custom.json', customModel);
-    writeProfile(env.legacyProfilesDir, 'custom.json', validLegacyProfile());
+  it('repairs the historical defect shape regardless of fallback model', () => {
+    writeProfile(env.canonicalDir, 'gem.json', corruptCanonicalProfile());
+    writeProfile(env.legacyProfilesDir, 'gem.json', validLegacyProfile());
 
-    const result = repairCanonicalProfiles(
+    writeProfile(
+      env.canonicalDir,
+      'other.json',
+      corruptCanonicalProfileNonGeminiModel(),
+    );
+    writeProfile(
+      env.legacyProfilesDir,
+      'other.json',
+      validLegacyProfileAlternative(),
+    );
+
+    const first = repairCanonicalProfiles(
       env.canonicalDir,
       env.legacyProfilesDir,
     );
-    expect(result.kind).toBe('none');
+    expect(first.kind).toBe('repaired');
 
-    const after = JSON.parse(
-      fs.readFileSync(path.join(env.canonicalDir, 'custom.json'), 'utf-8'),
-    );
-    expect(after.model).toBe('my-custom-model');
-    expect(after.provider).toBe('load-balancer');
-  });
-
-  it('does NOT repair a standard profile with load-balancer provider but a manual/default model (#4)', () => {
-    const manualModel = {
-      version: 1,
-      provider: 'load-balancer',
-      model: 'default',
-      modelParams: {},
-      ephemeralSettings: {},
-    };
-    writeProfile(env.canonicalDir, 'manual.json', manualModel);
-    writeProfile(env.legacyProfilesDir, 'manual.json', validLegacyProfile());
-
-    const result = repairCanonicalProfiles(
+    const second = repairCanonicalProfiles(
       env.canonicalDir,
       env.legacyProfilesDir,
     );
-    expect(result.kind).toBe('none');
+    expect(second.kind).toBe('repaired');
 
-    const after = JSON.parse(
-      fs.readFileSync(path.join(env.canonicalDir, 'manual.json'), 'utf-8'),
-    );
-    expect(after.model).toBe('default');
-  });
-
-  it('repairs the EXACT reported defect: load-balancer + gemini-2.5-pro (#4 positive)', () => {
-    // The exact issue payload from #2479/#2477: standard v1, provider
-    // load-balancer, model gemini-2.5-pro (the fallback model).
-    writeProfile(env.canonicalDir, 'zai.json', corruptCanonicalProfile());
-    writeProfile(env.legacyProfilesDir, 'zai.json', validLegacyProfile());
-
-    const result = repairCanonicalProfiles(
+    const third = repairCanonicalProfiles(
       env.canonicalDir,
       env.legacyProfilesDir,
     );
-    expect(result.kind).toBe('repaired');
-
-    const repaired = JSON.parse(
-      fs.readFileSync(path.join(env.canonicalDir, 'zai.json'), 'utf-8'),
-    );
-    expect(repaired.provider).toBe('anthropic');
-    expect(repaired.model).toBe('glm-5.2');
-  });
-});
-
-// ─── I/O error outcomes ─────────────────────────────────────────────────────
-
-describe('repairCanonicalProfiles — I/O error outcomes', () => {
-  let env: TestEnv;
-
-  beforeEach(async () => {
-    env = await setupEnv();
-  });
-  afterEach(async () => {
-    await teardownEnv(env);
-  });
-
-  it('returns error when canonical profiles path is a file, not a directory', () => {
-    fs.mkdirSync(env.canonicalDir, { recursive: true });
-    // Replace the canonicalDir with a file.
-    fs.rmSync(env.canonicalDir, { recursive: true, force: true });
-    fs.writeFileSync(env.canonicalDir, 'not a directory');
-
-    const result = repairCanonicalProfiles(
-      env.canonicalDir,
-      env.legacyProfilesDir,
-    );
-    expect(result.kind).toBe('error');
+    expect(third.kind).toBe('none');
   });
 });

--- a/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
+++ b/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared test helpers for canonical profile repair behavioral tests.
+ *
+ * Extracted so each test file stays under the eslint max-lines limit without
+ * duplicating fixture builders or environment setup/teardown.
+ */
+
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { CORRUPT_PROVIDER } from '../canonicalProfileRepair.js';
+
+export async function makeTempDir(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-canonical-repair-test-'));
+}
+
+/**
+ * The canonical corrupt signature: untyped standard-v1 profile whose
+ * provider is the virtual non-loadable provider 'load-balancer', with
+ * empty modelParams and empty ephemeralSettings.
+ */
+export function corruptCanonicalProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: CORRUPT_PROVIDER,
+    model: 'gemini-2.5-pro',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+/**
+ * A corrupt signature with a non-Gemini fallback model.
+ */
+export function corruptCanonicalProfileNonGeminiModel(): Record<
+  string,
+  unknown
+> {
+  return {
+    version: 1,
+    provider: CORRUPT_PROVIDER,
+    model: 'some-other-fallback',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+/**
+ * A corrupt canonical profile that omits modelParams entirely.
+ */
+export function corruptCanonicalProfileOmittedModelParams(): Record<
+  string,
+  unknown
+> {
+  return {
+    version: 1,
+    provider: CORRUPT_PROVIDER,
+    model: 'gemini-2.5-pro',
+    ephemeralSettings: {},
+  };
+}
+
+/**
+ * A valid legacy replacement profile with arbitrary provider/model/
+ * endpoint/auth settings.
+ */
+export function validLegacyProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'anthropic',
+    model: 'glm-5.2',
+    modelParams: { temperature: 1 },
+    ephemeralSettings: {
+      'base-url': 'https://api.z.ai/api/anthropic',
+      'auth-key-name': 'zai',
+      'context-limit': 200000,
+    },
+  };
+}
+
+/**
+ * A valid legacy replacement with a completely different provider/model/
+ * endpoint/auth.
+ */
+export function validLegacyProfileAlternative(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.7, max_tokens: 4096 },
+    ephemeralSettings: {
+      'base-url': 'https://api.openai.com/v1',
+      'auth-key': 'sk-test-key',
+      'context-limit': 128000,
+    },
+  };
+}
+
+export function genuineLbProfile(): Record<string, unknown> {
+  return {
+    version: 1,
+    type: 'loadbalancer',
+    policy: 'roundrobin',
+    profiles: ['p1'],
+    provider: 'load-balancer',
+    model: 'default',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+/**
+ * A standard profile whose provider is the virtual non-loadable provider
+ * 'load-balancer' but has nonempty modelParams — it does NOT match the
+ * narrow canonical corrupt signature, yet it can never be loaded.
+ */
+export function lbProviderStandardWithSettings(): Record<string, unknown> {
+  return {
+    version: 1,
+    provider: CORRUPT_PROVIDER,
+    model: 'some-model',
+    modelParams: { temperature: 0.5 },
+    ephemeralSettings: {
+      'base-url': 'https://example.com',
+      'auth-key-name': 'test',
+      'context-limit': 100000,
+    },
+  };
+}
+
+export interface TestEnv {
+  canonicalDir: string;
+  legacyDir: string;
+  legacyProfilesDir: string;
+}
+
+export async function setupEnv(): Promise<TestEnv> {
+  const canonicalDir = await makeTempDir();
+  const legacyDir = await makeTempDir();
+  const legacyProfilesDir = path.join(legacyDir, 'profiles');
+  fs.mkdirSync(legacyProfilesDir, { recursive: true });
+  return { canonicalDir, legacyDir, legacyProfilesDir };
+}
+
+export async function teardownEnv(env: TestEnv): Promise<void> {
+  await fsp.rm(env.canonicalDir, { recursive: true, force: true });
+  await fsp.rm(env.legacyDir, { recursive: true, force: true });
+}
+
+export function writeProfile(
+  dir: string,
+  name: string,
+  data: Record<string, unknown>,
+): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), JSON.stringify(data));
+}

--- a/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
+++ b/packages/settings/src/profiles/__tests__/canonicalProfileRepair.testHelpers.ts
@@ -97,6 +97,11 @@ export function validLegacyProfileAlternative(): Record<string, unknown> {
   };
 }
 
+/**
+ * A genuine load-balancer profile with valid type, policy, and profiles
+ * settings. Such a profile is NOT corrupt — the type field disqualifies it
+ * from the canonical corrupt signature.
+ */
 export function genuineLbProfile(): Record<string, unknown> {
   return {
     version: 1,

--- a/packages/settings/src/profiles/__tests__/profileStore.crossProcess.test.ts
+++ b/packages/settings/src/profiles/__tests__/profileStore.crossProcess.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Behavioral tests for cross-process lock contention using real child processes.
+ * Uses real temp directories and the production ProfileManager writer.
+ */
+
+import { channel } from 'node:diagnostics_channel';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as childProcess from 'node:child_process';
+import { ProfileManager } from '../ProfileManager.js';
+import {
+  acquireProfilesLock,
+  LOCK_CONTENTION_CHANNEL,
+  lockPathForProfilesDir,
+} from '../profileStore.js';
+
+async function makeTempDir(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-profilestore-xproc-'));
+}
+
+describe('profileStore — real cross-process lock contention', () => {
+  let tempDir: string;
+  const children = new Set<childProcess.ChildProcess>();
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    const cleanupResults = await Promise.allSettled(
+      [...children].map((child) => stopChild(child)),
+    );
+    children.clear();
+    await fsp.rm(tempDir, { recursive: true, force: true });
+    const failedCleanup = cleanupResults.find(
+      (result) => result.status === 'rejected',
+    );
+    if (failedCleanup?.status === 'rejected') {
+      throw failedCleanup.reason;
+    }
+  });
+
+  it('child process cannot acquire the lock while parent holds it', async () => {
+    const lock = await acquireProfilesLock(tempDir);
+    try {
+      const childResult = await runChildLockAttempt(tempDir);
+      expect(childResult.exitCode).not.toBe(0);
+      expect(childResult.stderr).toContain('EEXIST');
+    } finally {
+      await lock.release();
+    }
+  });
+
+  it('child process acquires the lock after parent releases it', async () => {
+    const lock = await acquireProfilesLock(tempDir);
+    await lock.release();
+
+    const childResult = await runChildLockAttempt(tempDir);
+    expect(childResult.exitCode).toBe(0);
+  });
+
+  it('ProfileManager save blocks while another process holds the lock', async () => {
+    expect(
+      await verifyBlockedProfileManagerSave({
+        profileName: 'concurrent-test',
+        provider: 'openai',
+        model: 'gpt-4',
+      }),
+    ).toBe(true);
+  });
+
+  it('ProfileManager saves remain serialized for different profile data', async () => {
+    expect(
+      await verifyBlockedProfileManagerSave({
+        profileName: 'repair-test',
+        provider: 'anthropic',
+        model: 'glm-5.2',
+      }),
+    ).toBe(true);
+  });
+
+  async function verifyBlockedProfileManagerSave(args: {
+    profileName: string;
+    provider: string;
+    model: string;
+  }): Promise<boolean> {
+    const profilePath = path.join(tempDir, `${args.profileName}.json`);
+    const lockPath = lockPathForProfilesDir(tempDir);
+    const holder = childProcess.spawn(
+      process.execPath,
+      ['-e', buildHolderChildScript(tempDir)],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    children.add(holder);
+
+    let contention: ContentionObservation | undefined;
+    let save: Promise<PromiseOutcome<void>> | undefined;
+    try {
+      await waitForStdout(holder, 'READY');
+      expect(fs.existsSync(lockPath)).toBe(true);
+
+      contention = observeContention(lockPath);
+      const manager = new ProfileManager(tempDir);
+      save = handlePromise(
+        manager.saveProfile(args.profileName, {
+          version: 1,
+          provider: args.provider,
+          model: args.model,
+          modelParams: {},
+          ephemeralSettings: {},
+        }),
+      );
+
+      unwrapOutcome(await contention.observed);
+      expect(fs.existsSync(profilePath)).toBe(false);
+      expect(fs.existsSync(lockPath)).toBe(true);
+
+      releaseHolder(holder);
+      expect(await waitForExit(holder)).toBe(0);
+      unwrapOutcome(await save);
+
+      const content: unknown = JSON.parse(
+        fs.readFileSync(profilePath, 'utf-8'),
+      );
+      expect(content).toMatchObject({
+        provider: args.provider,
+        model: args.model,
+      });
+      expect(fs.existsSync(lockPath)).toBe(false);
+      return true;
+    } finally {
+      contention?.dispose();
+      try {
+        await stopChild(holder);
+        children.delete(holder);
+      } catch {
+        // Keep a potentially live child tracked so afterEach retries cleanup.
+      }
+      if (save !== undefined) {
+        await save;
+      }
+    }
+  }
+});
+
+interface ChildResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+type PromiseOutcome<T> =
+  | { readonly kind: 'fulfilled'; readonly value: T }
+  | { readonly kind: 'rejected'; readonly reason: unknown };
+
+function handlePromise<T>(promise: Promise<T>): Promise<PromiseOutcome<T>> {
+  return promise.then(
+    (value) => ({ kind: 'fulfilled', value }),
+    (reason: unknown) => ({ kind: 'rejected', reason }),
+  );
+}
+
+function unwrapOutcome<T>(outcome: PromiseOutcome<T>): T {
+  if (outcome.kind === 'rejected') {
+    throw outcome.reason;
+  }
+  return outcome.value;
+}
+
+interface ContentionObservation {
+  readonly observed: Promise<PromiseOutcome<void>>;
+  dispose(): void;
+}
+
+function observeContention(expectedLockPath: string): ContentionObservation {
+  const contentionChannel = channel(LOCK_CONTENTION_CHANNEL);
+  let subscribed = false;
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let settle: (error?: Error) => void = () => {};
+  const handler = (message: unknown): void => {
+    if (
+      typeof message === 'object' &&
+      message !== null &&
+      'lockPath' in message &&
+      message.lockPath === expectedLockPath
+    ) {
+      settle();
+    }
+  };
+  const cleanup = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    if (subscribed) {
+      contentionChannel.unsubscribe(handler);
+      subscribed = false;
+    }
+  };
+  const observed = handlePromise(
+    new Promise<void>((resolve, reject) => {
+      settle = (error?: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        error === undefined ? resolve() : reject(error);
+      };
+      contentionChannel.subscribe(handler);
+      subscribed = true;
+      timer = setTimeout(
+        () =>
+          settle(
+            new Error(
+              `Timeout waiting for lock contention on ${expectedLockPath}`,
+            ),
+          ),
+        10_000,
+      );
+    }),
+  );
+
+  return {
+    observed,
+    dispose(): void {
+      settle();
+    },
+  };
+}
+
+async function runChildLockAttempt(tempDir: string): Promise<ChildResult> {
+  const lockPath = lockPathForProfilesDir(tempDir);
+  const script = `
+    const fs = require('node:fs');
+    const lockPath = ${JSON.stringify(lockPath)};
+    try {
+      const fd = fs.openSync(lockPath, 'wx', 0o600);
+      fs.closeSync(fd);
+      fs.unlinkSync(lockPath);
+      process.exit(0);
+    } catch (error) {
+      process.stderr.write(error.message + ' ' + (error.code || ''));
+      process.exit(1);
+    }
+  `;
+  return runChildScript(script);
+}
+
+function buildHolderChildScript(profilesDir: string): string {
+  const lockPath = lockPathForProfilesDir(profilesDir);
+  return `
+    const fs = require('node:fs');
+    const readline = require('node:readline');
+    const lockPath = ${JSON.stringify(lockPath)};
+    try {
+      const fd = fs.openSync(lockPath, 'wx', 0o600);
+      const metadata = JSON.stringify({ pid: process.pid, token: 'child-' + process.pid, created: new Date().toISOString() });
+      fs.writeSync(fd, metadata);
+      fs.fsyncSync(fd);
+      fs.closeSync(fd);
+    } catch (error) {
+      process.stderr.write('LockBusyError: ' + error.message + '\\n');
+      process.exit(1);
+    }
+    process.stdout.write('READY\\n');
+    const lines = readline.createInterface({ input: process.stdin });
+    lines.on('line', (line) => {
+      if (line.trim() === 'RELEASE') {
+        try { fs.unlinkSync(lockPath); } catch {}
+        process.exit(0);
+      }
+    });
+  `;
+}
+
+function releaseHolder(child: childProcess.ChildProcess): void {
+  if (child.exitCode === null && child.stdin?.writable === true) {
+    child.stdin.write('RELEASE\n');
+  }
+}
+
+async function stopChild(child: childProcess.ChildProcess): Promise<void> {
+  if (child.exitCode !== null) {
+    return;
+  }
+  releaseHolder(child);
+  try {
+    await waitForExit(child);
+  } catch {
+    child.kill('SIGKILL');
+    await waitForExit(child).catch(() => undefined);
+  }
+}
+
+function waitForStdout(
+  child: childProcess.ChildProcess,
+  expected: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const stream = child.stdout;
+    if (stream === null) {
+      reject(new Error('Child has no stdout stream'));
+      return;
+    }
+
+    let buffer = '';
+    const done = (error?: Error): void => {
+      clearTimeout(timer);
+      stream.removeListener('data', onData);
+      child.removeListener('error', onError);
+      child.removeListener('exit', onExit);
+      error === undefined ? resolve() : reject(error);
+    };
+    const onData = (data: Buffer): void => {
+      buffer += data.toString();
+      if (buffer.includes(expected)) {
+        done();
+      }
+    };
+    const onError = (error: Error): void => done(error);
+    const onExit = (code: number | null): void => {
+      if (!buffer.includes(expected)) {
+        done(new Error(`Child exited with code ${code} before "${expected}"`));
+      }
+    };
+    const timer = setTimeout(
+      () => done(new Error(`Timeout waiting for stdout "${expected}"`)),
+      10_000,
+    );
+
+    stream.on('data', onData);
+    child.on('error', onError);
+    child.on('exit', onExit);
+  });
+}
+
+function waitForExit(child: childProcess.ChildProcess): Promise<number | null> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(child.exitCode);
+  }
+  return new Promise((resolve, reject) => {
+    const done = (error?: Error, code?: number | null): void => {
+      clearTimeout(timer);
+      child.removeListener('exit', onExit);
+      child.removeListener('error', onError);
+      error === undefined ? resolve(code ?? null) : reject(error);
+    };
+    const onExit = (code: number | null): void => done(undefined, code);
+    const onError = (error: Error): void => done(error);
+    const timer = setTimeout(
+      () => done(new Error('Timeout waiting for child exit')),
+      10_000,
+    );
+    child.on('exit', onExit);
+    child.on('error', onError);
+  });
+}
+
+async function runChildScript(script: string): Promise<ChildResult> {
+  return new Promise((resolve) => {
+    childProcess.execFile(
+      process.execPath,
+      ['-e', script],
+      { cwd: process.cwd(), timeout: 10_000 },
+      (error, stdout, stderr) => {
+        let exitCode = 0;
+        if (error !== null) {
+          exitCode = typeof error.code === 'number' ? error.code : 1;
+        }
+        resolve({ exitCode, stdout, stderr });
+      },
+    );
+  });
+}

--- a/packages/settings/src/profiles/__tests__/profileStore.test.ts
+++ b/packages/settings/src/profiles/__tests__/profileStore.test.ts
@@ -12,7 +12,6 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import * as childProcess from 'node:child_process';
 import {
   acquireProfilesLock,
   acquireProfilesLockSync,
@@ -21,9 +20,11 @@ import {
   atomicWriteFile,
   writeProfileFile,
   deleteProfileFile,
+  withProfilesLockSync,
+  withProfilesLock,
+  hasErrnoCode,
   LockBusyError,
 } from '../profileStore.js';
-import { ProfileManager } from '../ProfileManager.js';
 
 async function makeTempDir(): Promise<string> {
   return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-profilestore-test-'));
@@ -34,6 +35,42 @@ describe('profileStore — lockPathForProfilesDir', () => {
     expect(lockPathForProfilesDir('/foo/profiles')).toBe(
       path.join('/foo/profiles', '.profiles.lock'),
     );
+  });
+});
+
+describe('profileStore — hasErrnoCode guard', () => {
+  it('narrows for an object with matching string code', () => {
+    const error: unknown = { code: 'ENOENT', message: 'no such file' };
+    expect(hasErrnoCode(error, 'ENOENT')).toBe(true);
+  });
+
+  it('accepts a matching errno code when message is absent', () => {
+    const error: unknown = { code: 'ENOENT' };
+    expect(hasErrnoCode(error, 'ENOENT')).toBe(true);
+  });
+
+  it('rejects when code does not match', () => {
+    const error: unknown = { code: 'EACCES', message: 'permission denied' };
+    expect(hasErrnoCode(error, 'ENOENT')).toBe(false);
+  });
+
+  it('rejects non-object values', () => {
+    expect(hasErrnoCode('ENOENT', 'ENOENT')).toBe(false);
+    expect(hasErrnoCode(42, 'ENOENT')).toBe(false);
+    expect(hasErrnoCode(null, 'ENOENT')).toBe(false);
+    expect(hasErrnoCode(undefined, 'ENOENT')).toBe(false);
+  });
+
+  it('rejects objects whose code is not a string (e.g. number)', () => {
+    const error: unknown = { code: 2, message: 'no such file' };
+    // A numeric code must NOT match even if the number coerces to a
+    // different string — type-safety requires typeof string.
+    expect(hasErrnoCode(error, '2')).toBe(false);
+  });
+
+  it('rejects objects without a code property', () => {
+    const error: unknown = { message: 'something went wrong' };
+    expect(hasErrnoCode(error, 'ENOENT')).toBe(false);
   });
 });
 
@@ -465,9 +502,20 @@ describe('profileStore — deleteProfileFile', () => {
   });
 });
 
-// ─── Real cross-process lock contention (deterministic) ─────────────────────
+// ─── Dual failure normalization (toError) ──────────────────────────────────
 
-describe('profileStore — real cross-process lock contention', () => {
+/**
+ * Assert that the caught value is an AggregateError and return it narrowed.
+ * Lives outside test bodies so it does not trigger no-conditional-in-test.
+ */
+function asAggregateError(caught: unknown): AggregateError {
+  if (!(caught instanceof AggregateError)) {
+    throw new Error(`expected AggregateError, got ${typeof caught}`);
+  }
+  return caught;
+}
+
+describe('profileStore — dual failure normalization (#5)', () => {
   let tempDir: string;
 
   beforeEach(async () => {
@@ -478,280 +526,220 @@ describe('profileStore — real cross-process lock contention', () => {
     await fsp.rm(tempDir, { recursive: true, force: true });
   });
 
-  it('child process cannot acquire the lock while parent holds it', async () => {
-    const lock = await acquireProfilesLock(tempDir);
-
-    const childResult = await runChildLockAttempt(tempDir);
-    // Child should fail with EEXIST (non-zero exit).
-    expect(childResult.exitCode).not.toBe(0);
-    expect(childResult.stderr).toContain('EEXIST');
-
-    await lock.release();
-  });
-
-  it('child process acquires the lock after parent releases it', async () => {
-    const lock = await acquireProfilesLock(tempDir);
-    await lock.release();
-
-    const childResult = await runChildLockAttempt(tempDir);
-    expect(childResult.exitCode).toBe(0);
-  });
-});
-
-// ─── Deterministic process test: READY/RELEASE protocol ─────────────────────
-// Replaces fixed sleep/elapsed assertions with explicit synchronization.
-
-describe('profileStore — deterministic cross-process serialization', () => {
-  let tempDir: string;
-
-  beforeEach(async () => {
-    tempDir = await makeTempDir();
-  });
-
-  afterEach(async () => {
-    await fsp.rm(tempDir, { recursive: true, force: true });
-  });
-
-  it('ProfileManager save waits for child-process lock to release (READY/RELEASE)', async () => {
-    const profilesDir = tempDir;
-    const profilePath = path.join(profilesDir, 'concurrent-test.json');
-
-    // Spawn a child that acquires the lock, emits READY, waits for RELEASE,
-    // then releases and exits. Uses stdin/stdout for synchronization.
-    const child = childProcess.spawn(
-      process.execPath,
-      ['-e', buildReadyReleaseChildScript(profilesDir)],
-      { stdio: ['pipe', 'pipe', 'pipe'] },
-    );
-
-    // Set up exit listener early so we don't miss the event.
-    const exitPromise = waitForExit(child, 10000);
-
-    // Wait for child to signal READY (lock acquired).
-    await waitForStdout(child, 'READY', 5000);
-
-    // Verify the lock file exists while child holds it.
-    expect(fs.existsSync(lockPathForProfilesDir(profilesDir))).toBe(true);
-
-    // Verify the profile does NOT exist yet.
-    expect(fs.existsSync(profilePath)).toBe(false);
-
-    // Start a real ProfileManager write — it should block waiting for the lock.
-    const pm = new ProfileManager(profilesDir);
-    const writePromise = pm.saveProfile('concurrent-test', {
-      version: 1,
-      provider: 'openai',
-      model: 'gpt-4',
-      modelParams: {},
-      ephemeralSettings: {},
-    });
-
-    // Give the write a moment to start waiting.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    // Profile should still NOT exist (write is blocked).
-    expect(fs.existsSync(profilePath)).toBe(false);
-
-    // Signal child to RELEASE the lock.
-    child.stdin.write('RELEASE\n');
-
-    // Wait for the write to complete.
-    await writePromise;
-
-    // Now the profile exists with the correct content.
-    expect(fs.existsSync(profilePath)).toBe(true);
-    const content = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
-    expect(content.provider).toBe('openai');
-
-    // Lock released after ProfileManager save.
-    expect(fs.existsSync(lockPathForProfilesDir(profilesDir))).toBe(false);
-
-    // Child exited cleanly.
-    const exitCode = await exitPromise;
-    expect(exitCode).toBe(0);
-  });
-
-  it('repair-vs-writer: sync lock holder blocks async writer, then releases', async () => {
-    const profilesDir = tempDir;
-    const profilePath = path.join(profilesDir, 'repair-test.json');
-
-    // Child holds the sync lock using READY/RELEASE protocol.
-    const child = childProcess.spawn(
-      process.execPath,
-      ['-e', buildReadyReleaseChildScript(profilesDir)],
-      { stdio: ['pipe', 'pipe', 'pipe'] },
-    );
-
-    const exitPromise = waitForExit(child, 10000);
-    await waitForStdout(child, 'READY', 5000);
-
-    // While child holds lock, a ProfileManager write must be blocked.
-    const pm = new ProfileManager(profilesDir);
-    const writePromise = pm.saveProfile('repair-test', {
-      version: 1,
-      provider: 'anthropic',
-      model: 'glm-5.2',
-      modelParams: {},
-      ephemeralSettings: {},
-    });
-
-    // Not done yet.
-    let writeDone = false;
-    void writePromise.then(() => {
-      writeDone = true;
-    });
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    expect(writeDone).toBe(false);
-
-    // Release child lock.
-    child.stdin.write('RELEASE\n');
-    await writePromise;
-    await exitPromise;
-
-    // Final bytes are correct.
-    const content = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
-    expect(content.provider).toBe('anthropic');
-    expect(content.model).toBe('glm-5.2');
-  });
-});
-
-// ─── Helpers for child-process contention tests ─────────────────────────────
-
-interface ChildResult {
-  exitCode: number | null;
-  stdout: string;
-  stderr: string;
-}
-
-/**
- * Run a child process that attempts to acquire the sync lock on tempDir and
- * exits immediately. Returns non-zero if the lock was held (LockBusyError).
- */
-async function runChildLockAttempt(tempDir: string): Promise<ChildResult> {
-  const lockPath = lockPathForProfilesDir(tempDir);
-  const script = `
-    const fs = require('node:fs');
-    const path = require('node:path');
-    const lockPath = ${JSON.stringify(lockPath)};
+  it('aggregates Error throws from both operation and release as Error elements', () => {
+    // Overwrite the lock file with a different token after acquisition so
+    // release() throws — combined with the operation throwing, this
+    // exercises the dual-failure AggregateError path.
+    const lockPath = lockPathForProfilesDir(tempDir);
+    let caught: unknown;
     try {
-      fs.openSync(lockPath, 'wx', 0o600);
-      fs.unlinkSync(lockPath);
-      process.exit(0);
-    } catch (e) {
-      process.stderr.write(e.message + ' ' + (e.code || ''));
-      process.exit(1);
-    }
-  `;
-  return runChildScript(script);
-}
-
-/**
- * Build a child-process script that uses the READY/RELEASE synchronization
- * protocol. The child:
- * 1. Acquires the lock via O_EXCL (open wx).
- * 2. Writes READY to stdout.
- * 3. Waits for RELEASE on stdin (line-based).
- * 4. Removes the lock file and exits 0.
- */
-function buildReadyReleaseChildScript(profilesDir: string): string {
-  const lockPath = lockPathForProfilesDir(profilesDir);
-  return `
-    const fs = require('node:fs');
-    const readline = require('node:readline');
-    const lockPath = ${JSON.stringify(lockPath)};
-    let fd;
-    try {
-      fd = fs.openSync(lockPath, 'wx', 0o600);
-      const meta = JSON.stringify({ pid: process.pid, token: 'child-' + process.pid, created: new Date().toISOString() });
-      fs.writeSync(fd, meta);
-      fs.fsyncSync(fd);
-      fs.closeSync(fd);
-    } catch (e) {
-      process.stderr.write('LockBusyError: ' + e.message + '\\n');
-      process.exit(1);
-    }
-    process.stdout.write('READY\\n');
-    const rl = readline.createInterface({ input: process.stdin });
-    rl.on('line', (line) => {
-      if (line.trim() === 'RELEASE') {
-        try { fs.unlinkSync(lockPath); } catch {}
-        process.exit(0);
-      }
-    });
-  `;
-}
-
-function waitForStdout(
-  child: childProcess.ChildProcess,
-  expected: string,
-  timeoutMs: number,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error(`Timeout waiting for stdout "${expected}"`));
-    }, timeoutMs);
-
-    child.stdout?.on('data', (data: Buffer) => {
-      if (data.toString().includes(expected)) {
-        clearTimeout(timer);
-        resolve();
-      }
-    });
-    child.on('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-    child.on('exit', (code) => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(
-          new Error(`Child exited with code ${code} before "${expected}"`),
+      withProfilesLockSync(tempDir, () => {
+        // Simulate a different owner on disk before release.
+        fs.writeFileSync(
+          lockPath,
+          JSON.stringify({
+            pid: 1,
+            token: 'other',
+            created: new Date().toISOString(),
+          }),
+          { mode: 0o600 },
         );
-      }
-    });
-  });
-}
+        throw new Error('operation failed');
+      });
+    } catch (error) {
+      caught = error;
+    }
 
-function waitForExit(
-  child: childProcess.ChildProcess,
-  timeoutMs: number,
-): Promise<number | null> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error('Timeout waiting for child exit'));
-    }, timeoutMs);
-    child.on('exit', (code) => {
-      clearTimeout(timer);
-      resolve(code);
-    });
-    child.on('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = asAggregateError(caught);
+    // Both elements must be Error instances (not raw throws).
+    expect(aggregate.errors).toHaveLength(2);
+    for (const el of aggregate.errors) {
+      expect(el).toBeInstanceOf(Error);
+    }
+    // The original operation error message is preserved exactly.
+    expect(aggregate.errors[0]?.message).toBe('operation failed');
+    // The release error message is preserved exactly.
+    expect(aggregate.errors[1]?.message).toContain('ownership changed');
   });
-}
 
-async function runChildScript(script: string): Promise<ChildResult> {
-  return new Promise((resolve) => {
-    const child = childProcess.execFile(
-      process.execPath,
-      ['-e', script],
-      {
-        cwd: process.cwd(),
-        timeout: 10000,
-      },
-      (error, stdout, stderr) => {
-        let exitCode = 0;
-        if (error !== null) {
-          exitCode = typeof error.code === 'number' ? error.code : 1;
-        }
-        resolve({
-          exitCode,
-          stdout,
-          stderr,
-        });
-      },
-    );
-    void child;
+  it('normalizes a string throw into an Error inside the aggregate (no crash)', () => {
+    const lockPath = lockPathForProfilesDir(tempDir);
+    // Assign to a variable so the throw is not a literal (lint), and to
+    // exercise the non-Error normalization path.
+    const stringError: unknown = 'string error';
+    let caught: unknown;
+    try {
+      withProfilesLockSync(tempDir, () => {
+        fs.writeFileSync(
+          lockPath,
+          JSON.stringify({
+            pid: 1,
+            token: 'other',
+            created: new Date().toISOString(),
+          }),
+          { mode: 0o600 },
+        );
+        throw stringError;
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = asAggregateError(caught);
+    // Every element must be an Error — the string must have been normalized.
+    for (const el of aggregate.errors) {
+      expect(el).toBeInstanceOf(Error);
+    }
+    // The string throw is normalized to an Error with that exact message.
+    expect(aggregate.errors[0]).toBeInstanceOf(Error);
+    expect(aggregate.errors[0].message).toBe('string error');
   });
-}
+
+  it('does not crash when a thrown value has a hostile toString (dual failure)', () => {
+    const lockPath = lockPathForProfilesDir(tempDir);
+    const hostile: unknown = {
+      toString() {
+        throw new Error('hostile toString');
+      },
+    };
+    let caught: unknown;
+    try {
+      withProfilesLockSync(tempDir, () => {
+        fs.writeFileSync(
+          lockPath,
+          JSON.stringify({
+            pid: 1,
+            token: 'other',
+            created: new Date().toISOString(),
+          }),
+          { mode: 0o600 },
+        );
+        throw hostile;
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    // The hostile toString must not crash the normalization — an
+    // AggregateError with Error elements is still produced.
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = asAggregateError(caught);
+    for (const el of aggregate.errors) {
+      expect(el).toBeInstanceOf(Error);
+    }
+    // The hostile object is normalized to the hostile-fallback sentinel,
+    // not the result of its throwing toString.
+    expect(aggregate.errors[0]).toBeInstanceOf(Error);
+    expect(aggregate.errors[0].message).toBe('(unrepresentable value)');
+  });
+});
+
+// ─── Async dual failure normalization (toError) ────────────────────────────
+
+describe('profileStore — async dual failure normalization (#5 async)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('async: aggregates Error throws from both operation and release', async () => {
+    const lockPath = lockPathForProfilesDir(tempDir);
+    let caught: unknown;
+    try {
+      await withProfilesLock(tempDir, async () => {
+        fs.writeFileSync(
+          lockPath,
+          JSON.stringify({
+            pid: 1,
+            token: 'other',
+            created: new Date().toISOString(),
+          }),
+          { mode: 0o600 },
+        );
+        throw new Error('async operation failed');
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = asAggregateError(caught);
+    expect(aggregate.errors).toHaveLength(2);
+    for (const el of aggregate.errors) {
+      expect(el).toBeInstanceOf(Error);
+    }
+    expect(aggregate.errors[0]?.message).toBe('async operation failed');
+    expect(aggregate.errors[1]?.message).toContain('ownership changed');
+  });
+
+  it('async: normalizes a non-Error throw into an Error in the aggregate', async () => {
+    const lockPath = lockPathForProfilesDir(tempDir);
+    const stringError: unknown = 'async string error';
+    let caught: unknown;
+    try {
+      await withProfilesLock(tempDir, async () => {
+        fs.writeFileSync(
+          lockPath,
+          JSON.stringify({
+            pid: 1,
+            token: 'other',
+            created: new Date().toISOString(),
+          }),
+          { mode: 0o600 },
+        );
+        throw stringError;
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = asAggregateError(caught);
+    for (const el of aggregate.errors) {
+      expect(el).toBeInstanceOf(Error);
+    }
+    expect(aggregate.errors[0]).toBeInstanceOf(Error);
+    expect(aggregate.errors[0].message).toBe('async string error');
+  });
+
+  it('async: does not crash when thrown value has hostile toString', async () => {
+    const lockPath = lockPathForProfilesDir(tempDir);
+    const hostile: unknown = {
+      toString() {
+        throw new Error('hostile toString');
+      },
+    };
+    let caught: unknown;
+    try {
+      await withProfilesLock(tempDir, async () => {
+        fs.writeFileSync(
+          lockPath,
+          JSON.stringify({
+            pid: 1,
+            token: 'other',
+            created: new Date().toISOString(),
+          }),
+          { mode: 0o600 },
+        );
+        throw hostile;
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = asAggregateError(caught);
+    for (const el of aggregate.errors) {
+      expect(el).toBeInstanceOf(Error);
+    }
+    expect(aggregate.errors[0]).toBeInstanceOf(Error);
+    expect(aggregate.errors[0].message).toBe('(unrepresentable value)');
+  });
+});

--- a/packages/settings/src/profiles/__tests__/profileStore.test.ts
+++ b/packages/settings/src/profiles/__tests__/profileStore.test.ts
@@ -1,0 +1,757 @@
+/**
+ * Behavioral tests for the shared profile persistence utility (#2477).
+ * Uses real temp directories and the actual filesystem — no mocking.
+ *
+ * The lock is backed by a fixed-path O_EXCL file artifact (`.profiles.lock`),
+ * providing real cross-process mutual exclusion with NO stale takeover. A
+ * lock left by a SIGKILL'd process requires explicit/manual recovery.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as childProcess from 'node:child_process';
+import {
+  acquireProfilesLock,
+  acquireProfilesLockSync,
+  lockPathForProfilesDir,
+  readProfileFileSync,
+  atomicWriteFile,
+  writeProfileFile,
+  deleteProfileFile,
+  LockBusyError,
+} from '../profileStore.js';
+import { ProfileManager } from '../ProfileManager.js';
+
+async function makeTempDir(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), 'llxprt-profilestore-test-'));
+}
+
+describe('profileStore — lockPathForProfilesDir', () => {
+  it('returns a deterministic lock file path in the profiles dir', () => {
+    expect(lockPathForProfilesDir('/foo/profiles')).toBe(
+      path.join('/foo/profiles', '.profiles.lock'),
+    );
+  });
+});
+
+describe('profileStore — readProfileFileSync discriminated result', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns absent for a missing file', () => {
+    const result = readProfileFileSync(path.join(tempDir, 'missing.json'));
+    expect(result.kind).toBe('absent');
+  });
+
+  it('returns content for an existing file', () => {
+    const filePath = path.join(tempDir, 'exists.json');
+    fs.writeFileSync(filePath, '{"a":1}', 'utf-8');
+    const result = readProfileFileSync(filePath);
+    expect(result.kind).toBe('content');
+    expect(result.kind === 'content' ? result.content : null).toBe('{"a":1}');
+  });
+
+  it('returns error when the path is a directory', () => {
+    const result = readProfileFileSync(tempDir);
+    expect(result.kind).toBe('error');
+    expect(result.kind === 'error' ? result.error : null).toBeInstanceOf(Error);
+  });
+});
+
+describe('profileStore — async lock acquisition', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('acquires and releases the lock', async () => {
+    const lock = await acquireProfilesLock(tempDir);
+    expect(fs.existsSync(lock.path)).toBe(true);
+    await lock.release();
+    expect(fs.existsSync(lock.path)).toBe(false);
+  });
+
+  it('can re-acquire after release', async () => {
+    const lock1 = await acquireProfilesLock(tempDir);
+    await lock1.release();
+    const lock2 = await acquireProfilesLock(tempDir);
+    expect(fs.existsSync(lock2.path)).toBe(true);
+    await lock2.release();
+  });
+
+  it('blocks a second concurrent async acquisition in-process', async () => {
+    const lock1 = await acquireProfilesLock(tempDir);
+    let secondAcquired = false;
+    const acquisition = acquireProfilesLock(tempDir).then((lock) => {
+      secondAcquired = true;
+      return lock;
+    });
+
+    // Give the second acquisition a chance to fail/wait.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(secondAcquired).toBe(false);
+
+    await lock1.release();
+    const lock2 = await acquisition;
+    expect(fs.existsSync(lock2.path)).toBe(true);
+    await lock2.release();
+  });
+
+  it('writes owner metadata (pid, token) into the lock file', async () => {
+    const lock = await acquireProfilesLock(tempDir);
+    const content = fs.readFileSync(lock.path, 'utf-8');
+    const meta = JSON.parse(content);
+    expect(meta.pid).toBe(process.pid);
+    expect(typeof meta.token).toBe('string');
+    expect(meta.token).toBe(lock.ownerToken);
+    await lock.release();
+  });
+
+  it('release refuses to unlink if the token on disk does not match (#3)', async () => {
+    const lock = await acquireProfilesLock(tempDir);
+    // Overwrite the lock file with a different token to simulate another
+    // process (or manual recovery + re-acquire) owning it.
+    const otherMeta = JSON.stringify({
+      pid: 88888,
+      token: 'other-process-token',
+      created: new Date().toISOString(),
+    });
+    fs.writeFileSync(lock.path, otherMeta, { mode: 0o600 });
+
+    // Release must fail and must NOT remove another owner's file.
+    await expect(lock.release()).rejects.toThrow('ownership changed');
+    expect(fs.existsSync(lock.path)).toBe(true);
+
+    // Manual cleanup for teardown.
+    fs.unlinkSync(lock.path);
+  });
+
+  it('sync release refuses to unlink if the token on disk does not match (#3)', () => {
+    const lock = acquireProfilesLockSync(tempDir);
+    // Overwrite with a different token.
+    const otherMeta = JSON.stringify({
+      pid: 77777,
+      token: 'other-sync-token',
+      created: new Date().toISOString(),
+    });
+    fs.writeFileSync(lock.path, otherMeta, { mode: 0o600 });
+
+    expect(() => lock.release()).toThrow('ownership changed');
+    expect(fs.existsSync(lock.path)).toBe(true);
+
+    // Manual cleanup for teardown.
+    fs.unlinkSync(lock.path);
+  });
+});
+
+describe('profileStore — sync lock acquisition', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('acquires and releases the lock synchronously', () => {
+    const lock = acquireProfilesLockSync(tempDir);
+    expect(fs.existsSync(lock.path)).toBe(true);
+    lock.release();
+    expect(fs.existsSync(lock.path)).toBe(false);
+  });
+
+  it('throws LockBusyError when the lock is already held (sync after sync)', () => {
+    const lock = acquireProfilesLockSync(tempDir);
+    let caught: unknown = undefined;
+    try {
+      acquireProfilesLockSync(tempDir);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(LockBusyError);
+    expect(caught instanceof LockBusyError).toBe(true);
+    const lbe = caught instanceof LockBusyError ? caught : null;
+    expect(lbe).not.toBeNull();
+    expect(lbe?.lockPath).toBe(lockPathForProfilesDir(tempDir));
+    expect(lbe?.ownerMetadata).not.toBeNull();
+    lock.release();
+  });
+
+  it('throws LockBusyError when sync acquisition is attempted while async holds', async () => {
+    const asyncLock = await acquireProfilesLock(tempDir);
+    let caught: unknown = undefined;
+    try {
+      acquireProfilesLockSync(tempDir);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(LockBusyError);
+    await asyncLock.release();
+  });
+});
+
+// ─── NO stale takeover (safety over availability) ───────────────────────────
+
+describe('profileStore — no automatic stale takeover', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('leftover lock file (simulating SIGKILL) is NOT auto-reclaimed by sync', () => {
+    const lockPath = lockPathForProfilesDir(tempDir);
+    // Simulate a crashed prior process: write a stale lock file.
+    const staleMeta = JSON.stringify({
+      pid: 99999,
+      token: 'stale-token',
+      created: new Date(Date.now() - 60000).toISOString(),
+    });
+    fs.writeFileSync(lockPath, staleMeta, { mode: 0o600 });
+
+    let caught: unknown = undefined;
+    try {
+      acquireProfilesLockSync(tempDir);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(LockBusyError);
+    expect(caught instanceof LockBusyError).toBe(true);
+    const lbe = caught instanceof LockBusyError ? caught : null;
+    expect(lbe).not.toBeNull();
+    // Error surfaces exact path and owner metadata for manual recovery.
+    expect(lbe?.lockPath).toBe(lockPath);
+    expect(lbe?.ownerMetadata).toContain('stale-token');
+    expect(lbe?.message).toContain(lockPath);
+
+    // Lock file still on disk — NOT removed.
+    expect(fs.existsSync(lockPath)).toBe(true);
+
+    // Manual recovery: remove the file, then acquisition works.
+    fs.unlinkSync(lockPath);
+    const lock = acquireProfilesLockSync(tempDir);
+    expect(fs.existsSync(lock.path)).toBe(true);
+    lock.release();
+  });
+
+  it('leftover lock file is NOT auto-reclaimed by async (waits then throws) — injectable deadline (#1)', async () => {
+    const lockPath = lockPathForProfilesDir(tempDir);
+    const staleMeta = JSON.stringify({
+      pid: 99999,
+      token: 'stale-token-2',
+      created: new Date(Date.now() - 60000).toISOString(),
+    });
+    fs.writeFileSync(lockPath, staleMeta, { mode: 0o600 });
+
+    let caught: unknown = undefined;
+    try {
+      // Injectable deadline: use 100ms so the test is deterministic without
+      // waiting the production 10s default (#1).
+      await acquireProfilesLock(tempDir, 100);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(LockBusyError);
+    // Lock file still on disk — NOT removed.
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+});
+
+describe('profileStore — atomicWriteFile (async)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes content atomically with mode', async () => {
+    const filePath = path.join(tempDir, 'profile.json');
+    await atomicWriteFile(filePath, '{"provider":"async"}', 0o600);
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe('{"provider":"async"}');
+  });
+
+  it('writes content atomically without mode', async () => {
+    const filePath = path.join(tempDir, 'profile.json');
+    await atomicWriteFile(filePath, '{"provider":"nomode"}');
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe('{"provider":"nomode"}');
+  });
+
+  it('does not leave temp files behind', async () => {
+    const filePath = path.join(tempDir, 'profile.json');
+    await atomicWriteFile(filePath, '{"provider":"x"}');
+    const temps = fs.readdirSync(tempDir).filter((f) => f.endsWith('.tmp'));
+    expect(temps).toStrictEqual([]);
+  });
+});
+
+describe('profileStore — writeProfileFile create mode', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes a new profile under the lock in create mode', async () => {
+    const result = await writeProfileFile(
+      tempDir,
+      'myprof',
+      '{"provider":"y"}',
+      'create',
+    );
+    expect(result.kind).toBe('written');
+    expect(fs.readFileSync(path.join(tempDir, 'myprof.json'), 'utf-8')).toBe(
+      '{"provider":"y"}',
+    );
+  });
+
+  it('returns exists when create collides with an existing file', async () => {
+    const existing = '{"provider":"old"}';
+    await writeProfileFile(tempDir, 'myprof', existing, 'create');
+    const result = await writeProfileFile(
+      tempDir,
+      'myprof',
+      '{"provider":"new"}',
+      'create',
+    );
+    expect(result.kind).toBe('exists');
+    // Original content preserved.
+    expect(fs.readFileSync(path.join(tempDir, 'myprof.json'), 'utf-8')).toBe(
+      existing,
+    );
+  });
+
+  it('applies 0600 mode to new files', async () => {
+    await writeProfileFile(tempDir, 'secure', '{"a":1}', 'create');
+    const stat = fs.statSync(path.join(tempDir, 'secure.json'));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it('creates a new profiles directory with owner-only permissions', async () => {
+    const profilesDir = path.join(tempDir, 'profiles');
+    await writeProfileFile(profilesDir, 'secure', '{"a":1}', 'create');
+    expect(fs.statSync(profilesDir).mode & 0o777).toBe(0o700);
+  });
+
+  it.each([
+    '',
+    '   ',
+    '.',
+    '..',
+    '../outside',
+    'nested/profile',
+    'nested\\profile',
+  ])(
+    'rejects unsafe profile name %j without writing outside the directory',
+    async (profileName) => {
+      await expect(
+        writeProfileFile(tempDir, profileName, '{}', 'create'),
+      ).rejects.toThrow('Invalid profile name');
+      expect(fs.existsSync(path.join(tempDir, '..', 'outside.json'))).toBe(
+        false,
+      );
+    },
+  );
+
+  it('releases the lock after writing', async () => {
+    await writeProfileFile(tempDir, 'myprof', '{"provider":"y"}', 'create');
+    expect(fs.existsSync(lockPathForProfilesDir(tempDir))).toBe(false);
+  });
+});
+
+describe('profileStore — writeProfileFile overwrite mode', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('overwrites an existing profile', async () => {
+    await writeProfileFile(tempDir, 'myprof', '{"provider":"old"}', 'create');
+    const result = await writeProfileFile(
+      tempDir,
+      'myprof',
+      '{"provider":"new"}',
+      'overwrite',
+    );
+    expect(result.kind).toBe('written');
+    expect(fs.readFileSync(path.join(tempDir, 'myprof.json'), 'utf-8')).toBe(
+      '{"provider":"new"}',
+    );
+  });
+
+  it('defaults to overwrite mode', async () => {
+    await writeProfileFile(tempDir, 'myprof', '{"v":1}', 'create');
+    await writeProfileFile(tempDir, 'myprof', '{"v":2}');
+    expect(fs.readFileSync(path.join(tempDir, 'myprof.json'), 'utf-8')).toBe(
+      '{"v":2}',
+    );
+  });
+
+  it('releases the lock after overwriting', async () => {
+    await writeProfileFile(tempDir, 'myprof', '{"provider":"y"}', 'overwrite');
+    expect(fs.existsSync(lockPathForProfilesDir(tempDir))).toBe(false);
+  });
+});
+
+describe('profileStore — deleteProfileFile', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('deletes a profile under the lock', async () => {
+    const filePath = path.join(tempDir, 'myprof.json');
+    fs.writeFileSync(filePath, '{}', 'utf-8');
+    await deleteProfileFile(tempDir, 'myprof');
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it('releases the lock after deleting', async () => {
+    const filePath = path.join(tempDir, 'myprof.json');
+    fs.writeFileSync(filePath, '{}', 'utf-8');
+    await deleteProfileFile(tempDir, 'myprof');
+    expect(fs.existsSync(lockPathForProfilesDir(tempDir))).toBe(false);
+  });
+
+  it('rejects traversal without deleting outside the profiles directory', async () => {
+    const outsidePath = path.join(tempDir, '..', 'outside.json');
+    fs.writeFileSync(outsidePath, '{}', 'utf-8');
+    try {
+      await expect(deleteProfileFile(tempDir, '../outside')).rejects.toThrow(
+        'Invalid profile name',
+      );
+      expect(fs.existsSync(outsidePath)).toBe(true);
+    } finally {
+      await fsp.rm(outsidePath, { force: true });
+    }
+  });
+});
+
+// ─── Real cross-process lock contention (deterministic) ─────────────────────
+
+describe('profileStore — real cross-process lock contention', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('child process cannot acquire the lock while parent holds it', async () => {
+    const lock = await acquireProfilesLock(tempDir);
+
+    const childResult = await runChildLockAttempt(tempDir);
+    // Child should fail with EEXIST (non-zero exit).
+    expect(childResult.exitCode).not.toBe(0);
+    expect(childResult.stderr).toContain('EEXIST');
+
+    await lock.release();
+  });
+
+  it('child process acquires the lock after parent releases it', async () => {
+    const lock = await acquireProfilesLock(tempDir);
+    await lock.release();
+
+    const childResult = await runChildLockAttempt(tempDir);
+    expect(childResult.exitCode).toBe(0);
+  });
+});
+
+// ─── Deterministic process test: READY/RELEASE protocol ─────────────────────
+// Replaces fixed sleep/elapsed assertions with explicit synchronization.
+
+describe('profileStore — deterministic cross-process serialization', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('ProfileManager save waits for child-process lock to release (READY/RELEASE)', async () => {
+    const profilesDir = tempDir;
+    const profilePath = path.join(profilesDir, 'concurrent-test.json');
+
+    // Spawn a child that acquires the lock, emits READY, waits for RELEASE,
+    // then releases and exits. Uses stdin/stdout for synchronization.
+    const child = childProcess.spawn(
+      process.execPath,
+      ['-e', buildReadyReleaseChildScript(profilesDir)],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+
+    // Set up exit listener early so we don't miss the event.
+    const exitPromise = waitForExit(child, 10000);
+
+    // Wait for child to signal READY (lock acquired).
+    await waitForStdout(child, 'READY', 5000);
+
+    // Verify the lock file exists while child holds it.
+    expect(fs.existsSync(lockPathForProfilesDir(profilesDir))).toBe(true);
+
+    // Verify the profile does NOT exist yet.
+    expect(fs.existsSync(profilePath)).toBe(false);
+
+    // Start a real ProfileManager write — it should block waiting for the lock.
+    const pm = new ProfileManager(profilesDir);
+    const writePromise = pm.saveProfile('concurrent-test', {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+
+    // Give the write a moment to start waiting.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Profile should still NOT exist (write is blocked).
+    expect(fs.existsSync(profilePath)).toBe(false);
+
+    // Signal child to RELEASE the lock.
+    child.stdin.write('RELEASE\n');
+
+    // Wait for the write to complete.
+    await writePromise;
+
+    // Now the profile exists with the correct content.
+    expect(fs.existsSync(profilePath)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+    expect(content.provider).toBe('openai');
+
+    // Lock released after ProfileManager save.
+    expect(fs.existsSync(lockPathForProfilesDir(profilesDir))).toBe(false);
+
+    // Child exited cleanly.
+    const exitCode = await exitPromise;
+    expect(exitCode).toBe(0);
+  });
+
+  it('repair-vs-writer: sync lock holder blocks async writer, then releases', async () => {
+    const profilesDir = tempDir;
+    const profilePath = path.join(profilesDir, 'repair-test.json');
+
+    // Child holds the sync lock using READY/RELEASE protocol.
+    const child = childProcess.spawn(
+      process.execPath,
+      ['-e', buildReadyReleaseChildScript(profilesDir)],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+
+    const exitPromise = waitForExit(child, 10000);
+    await waitForStdout(child, 'READY', 5000);
+
+    // While child holds lock, a ProfileManager write must be blocked.
+    const pm = new ProfileManager(profilesDir);
+    const writePromise = pm.saveProfile('repair-test', {
+      version: 1,
+      provider: 'anthropic',
+      model: 'glm-5.2',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+
+    // Not done yet.
+    let writeDone = false;
+    void writePromise.then(() => {
+      writeDone = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(writeDone).toBe(false);
+
+    // Release child lock.
+    child.stdin.write('RELEASE\n');
+    await writePromise;
+    await exitPromise;
+
+    // Final bytes are correct.
+    const content = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+    expect(content.provider).toBe('anthropic');
+    expect(content.model).toBe('glm-5.2');
+  });
+});
+
+// ─── Helpers for child-process contention tests ─────────────────────────────
+
+interface ChildResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run a child process that attempts to acquire the sync lock on tempDir and
+ * exits immediately. Returns non-zero if the lock was held (LockBusyError).
+ */
+async function runChildLockAttempt(tempDir: string): Promise<ChildResult> {
+  const lockPath = lockPathForProfilesDir(tempDir);
+  const script = `
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const lockPath = ${JSON.stringify(lockPath)};
+    try {
+      fs.openSync(lockPath, 'wx', 0o600);
+      fs.unlinkSync(lockPath);
+      process.exit(0);
+    } catch (e) {
+      process.stderr.write(e.message + ' ' + (e.code || ''));
+      process.exit(1);
+    }
+  `;
+  return runChildScript(script);
+}
+
+/**
+ * Build a child-process script that uses the READY/RELEASE synchronization
+ * protocol. The child:
+ * 1. Acquires the lock via O_EXCL (open wx).
+ * 2. Writes READY to stdout.
+ * 3. Waits for RELEASE on stdin (line-based).
+ * 4. Removes the lock file and exits 0.
+ */
+function buildReadyReleaseChildScript(profilesDir: string): string {
+  const lockPath = lockPathForProfilesDir(profilesDir);
+  return `
+    const fs = require('node:fs');
+    const readline = require('node:readline');
+    const lockPath = ${JSON.stringify(lockPath)};
+    let fd;
+    try {
+      fd = fs.openSync(lockPath, 'wx', 0o600);
+      const meta = JSON.stringify({ pid: process.pid, token: 'child-' + process.pid, created: new Date().toISOString() });
+      fs.writeSync(fd, meta);
+      fs.fsyncSync(fd);
+      fs.closeSync(fd);
+    } catch (e) {
+      process.stderr.write('LockBusyError: ' + e.message + '\\n');
+      process.exit(1);
+    }
+    process.stdout.write('READY\\n');
+    const rl = readline.createInterface({ input: process.stdin });
+    rl.on('line', (line) => {
+      if (line.trim() === 'RELEASE') {
+        try { fs.unlinkSync(lockPath); } catch {}
+        process.exit(0);
+      }
+    });
+  `;
+}
+
+function waitForStdout(
+  child: childProcess.ChildProcess,
+  expected: string,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout waiting for stdout "${expected}"`));
+    }, timeoutMs);
+
+    child.stdout?.on('data', (data: Buffer) => {
+      if (data.toString().includes(expected)) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(
+          new Error(`Child exited with code ${code} before "${expected}"`),
+        );
+      }
+    });
+  });
+}
+
+function waitForExit(
+  child: childProcess.ChildProcess,
+  timeoutMs: number,
+): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('Timeout waiting for child exit'));
+    }, timeoutMs);
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+async function runChildScript(script: string): Promise<ChildResult> {
+  return new Promise((resolve) => {
+    const child = childProcess.execFile(
+      process.execPath,
+      ['-e', script],
+      {
+        cwd: process.cwd(),
+        timeout: 10000,
+      },
+      (error, stdout, stderr) => {
+        let exitCode = 0;
+        if (error !== null) {
+          exitCode = typeof error.code === 'number' ? error.code : 1;
+        }
+        resolve({
+          exitCode,
+          stdout,
+          stderr,
+        });
+      },
+    );
+    void child;
+  });
+}

--- a/packages/settings/src/profiles/canonicalProfileRepair.ts
+++ b/packages/settings/src/profiles/canonicalProfileRepair.ts
@@ -1,0 +1,614 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Profile } from './types.js';
+import { isLoadBalancerProfile } from './types.js';
+import { parseProfile } from '../settings/validation.js';
+import {
+  hasErrnoCode,
+  acquireProfilesLockSync,
+  readProfileFileSync,
+  uniqueTempPath,
+  fsyncDirSync,
+} from './profileStore.js';
+
+/**
+ * The virtual provider name that indicates a corrupt standard profile
+ * (issue #2479/#2477). Before commit 2d97afdb0, `/profile save` during an
+ * active load-balancer session wrote a STANDARD profile with this provider.
+ * Such a profile can never be re-applied because 'load-balancer' is not a
+ * registered provider at load time.
+ */
+export const CORRUPT_PROVIDER = 'load-balancer';
+
+/**
+ * The fallback model observed in the reported defect. When the runtime fell
+ * back to the first registered provider (gemini), it used this model.
+ * Repair eligibility requires this exact model so that manually-authored
+ * standard profiles with a custom model are never touched (#4).
+ */
+export const CORRUPT_FALLBACK_MODEL = 'gemini-2.5-pro';
+
+const REPORTED_PROFILE_NAME = 'zai';
+const REPORTED_PROVIDER = 'anthropic';
+const REPORTED_MODEL = 'glm-5.2';
+const REPORTED_BASE_URL = 'https://api.z.ai/api/anthropic';
+const REPORTED_AUTH_KEY_NAME = 'zai';
+const REPORTED_CONTEXT_LIMIT = 200_000;
+const REPAIR_BACKUP_SUFFIX = '.pre-repair.bak';
+
+/**
+ * Result of a canonical profile repair pass.
+ */
+export interface CanonicalRepairResult {
+  /** Number of profiles that were actually repaired (>= 0). */
+  readonly profilesRepaired: number;
+  /** Diagnostic errors encountered (non-fatal). */
+  readonly errors: readonly string[];
+}
+
+/**
+ * A candidate repair: a corrupt canonical profile that has a valid same-name
+ * legacy replacement available.
+ */
+interface RepairCandidate {
+  readonly name: string;
+  readonly canonicalPath: string;
+  readonly canonicalRaw: string;
+  readonly replacement: string;
+}
+
+type VerifyResult =
+  | { readonly kind: 'repair' }
+  | { readonly kind: 'skip' }
+  | { readonly kind: 'error'; readonly error: Error };
+
+/**
+ * Discriminated result of {@link repairCanonicalProfiles}.
+ * - 'repaired': exactly one profile was repaired without errors.
+ * - 'none': no candidates found, no repair needed.
+ * - 'busy': lock was busy, repair deferred (no marker should be written).
+ * - 'error': a repair preflight or commit failed (error marker semantics).
+ *
+ * The function repairs at most one sorted candidate so the mutation boundary
+ * is one atomic rename and never reports 'repaired' together with errors.
+ */
+export type CanonicalRepairOutcome =
+  | {
+      readonly kind: 'repaired';
+      readonly profilesRepaired: number;
+      readonly errors: readonly string[];
+    }
+  | { readonly kind: 'none' }
+  | { readonly kind: 'busy' }
+  | { readonly kind: 'error'; readonly errors: readonly string[] };
+
+/**
+ * Structural guard for a raw parsed profile object (the JSON-parsed value
+ * before it goes through parseProfile). Used to inspect the `type` field
+ * directly on the raw object so that eligibility does not depend on the
+ * typed Profile narrowing (#3).
+ */
+function isRawObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Determine whether a RAW parsed JSON object matches the known historical
+ * defect signature (issue #2479/#2477). Inspects the raw object directly to
+ * ensure eligibility is exact (#3):
+ *
+ * - `type` must be ABSENT (not 'loadbalancer' and not 'standard'). The
+ *   corrupt shape never carried a type field.
+ * - `provider` must be exactly {@link CORRUPT_PROVIDER} ('load-balancer').
+ * - `model` must be exactly {@link CORRUPT_FALLBACK_MODEL} ('gemini-2.5-pro').
+ * - Must parse as a valid standard v1 profile via parseProfile.
+ *
+ * This is deliberately conservative (#4): a genuine loadbalancer profile
+ * (type='loadbalancer') is NEVER corrupt even if its provider field happens
+ * to be 'load-balancer'. A standard profile with a custom model is NOT the
+ * reported defect. Only the exact reported defect signature is repaired.
+ *
+ * @param rawParsed The JSON-parsed raw object (NOT a typed Profile).
+ */
+export function isCorruptStandardProfileFromRaw(rawParsed: unknown): boolean {
+  if (!isRawObject(rawParsed)) {
+    return false;
+  }
+  // type must be ABSENT — the corrupt shape never had a type field (#3).
+  if ('type' in rawParsed) {
+    return false;
+  }
+  const provider = rawParsed['provider'];
+  if (typeof provider !== 'string' || provider !== CORRUPT_PROVIDER) {
+    return false;
+  }
+  const model = rawParsed['model'];
+  if (typeof model !== 'string' || model !== CORRUPT_FALLBACK_MODEL) {
+    return false;
+  }
+  if (rawParsed['version'] !== 1) {
+    return false;
+  }
+  const modelParams = rawParsed['modelParams'];
+  if (!isRawObject(modelParams) || Object.keys(modelParams).length !== 0) {
+    return false;
+  }
+  const ephemeralSettings = rawParsed['ephemeralSettings'];
+  if (!isRawObject(ephemeralSettings)) {
+    return false;
+  }
+  // Validate it parses as a standard v1 profile (not an LB, not garbage).
+  let profile: Profile;
+  try {
+    profile = parseProfile(rawParsed);
+  } catch {
+    return false;
+  }
+  if (isLoadBalancerProfile(profile)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Backward-compatible overload: accepts a parsed Profile. Delegates to the
+ * raw-object inspection by reconstructing the eligibility checks. Kept for
+ * existing callers/tests that pass a typed Profile.
+ *
+ * @deprecated Prefer {@link isCorruptStandardProfileFromRaw} for exact
+ *             eligibility on raw parsed objects.
+ */
+export function isCorruptStandardProfile(profile: Profile): boolean {
+  if (isLoadBalancerProfile(profile)) {
+    return false;
+  }
+  if (profile.provider !== CORRUPT_PROVIDER) {
+    return false;
+  }
+  return profile.model === CORRUPT_FALLBACK_MODEL;
+}
+
+/**
+ * Read a profile JSON file, parse it, and return a typed result. Used by
+ * the repair scan to determine if a canonical profile is corrupt.
+ */
+function readAndParseProfile(filePath: string):
+  | { readonly kind: 'absent' }
+  | {
+      readonly kind: 'parsed';
+      readonly profile: Profile;
+      readonly raw: string;
+      readonly rawParsed: unknown;
+    }
+  | { readonly kind: 'invalid-json' }
+  | { readonly kind: 'error'; readonly error: Error } {
+  const result = readProfileFileSync(filePath);
+  if (result.kind === 'absent') {
+    return { kind: 'absent' };
+  }
+  if (result.kind === 'error') {
+    return { kind: 'error', error: result.error };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.content);
+  } catch {
+    return { kind: 'invalid-json' };
+  }
+  let profile: Profile;
+  try {
+    profile = parseProfile(parsed);
+  } catch {
+    return { kind: 'invalid-json' };
+  }
+  return { kind: 'parsed', profile, raw: result.content, rawParsed: parsed };
+}
+
+/**
+ * Determine if a legacy file is a valid replacement for a corrupt canonical.
+ * The legacy profile must parse as a standard profile with a non-corrupt
+ * defect signature (not provider load-balancer + model gemini-2.5-pro).
+ * Returns the serialized replacement JSON, or null if the legacy is not a
+ * valid replacement.
+ *
+ * modelParams normalization is now handled by parseProfile at the shared
+ * boundary, so we just parse and validate here.
+ */
+function validateLegacyReplacement(legacyPath: string): string | null {
+  const result = readProfileFileSync(legacyPath);
+  if (result.kind !== 'content') {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.content);
+  } catch {
+    return null;
+  }
+
+  if (!isRawObject(parsed)) {
+    return null;
+  }
+  // A loadbalancer legacy is not a valid standard replacement.
+  if (parsed['type'] === 'loadbalancer') {
+    return null;
+  }
+
+  let profile: Profile;
+  try {
+    profile = parseProfile(parsed);
+  } catch {
+    return null;
+  }
+  if (isLoadBalancerProfile(profile)) {
+    return null;
+  }
+  if (isCorruptStandardProfile(profile)) {
+    return null;
+  }
+
+  if (
+    profile.provider !== REPORTED_PROVIDER ||
+    profile.model !== REPORTED_MODEL
+  ) {
+    return null;
+  }
+  const ephemeralSettings = profile.ephemeralSettings;
+  if (
+    ephemeralSettings['base-url'] !== REPORTED_BASE_URL ||
+    ephemeralSettings['auth-key-name'] !== REPORTED_AUTH_KEY_NAME ||
+    ephemeralSettings['context-limit'] !== REPORTED_CONTEXT_LIMIT
+  ) {
+    return null;
+  }
+
+  // parseProfile normalizes modelParams at the boundary, so re-serialize
+  // the normalized input (not the original) for canonical bytes.
+  const modelParams =
+    parsed['modelParams'] === undefined ? {} : parsed['modelParams'];
+  const normalized = { ...parsed, modelParams };
+  return JSON.stringify(normalized, null, 2);
+}
+
+/**
+ * Scan canonical profile files for corrupt standard profiles and match each
+ * against a valid same-name legacy replacement.
+ */
+function collectRepairCandidates(
+  canonicalFiles: readonly string[],
+  canonicalDir: string,
+  legacyProfilesDir: string,
+  errors: string[],
+): RepairCandidate[] {
+  const candidates: RepairCandidate[] = [];
+  for (const file of canonicalFiles) {
+    const candidate = examineProfileForRepair(
+      file,
+      canonicalDir,
+      legacyProfilesDir,
+    );
+    if (candidate.error !== undefined) {
+      errors.push(candidate.error);
+    }
+    if (candidate.candidate !== undefined) {
+      candidates.push(candidate.candidate);
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Examine a single canonical profile file for repair candidacy.
+ * Returns the candidate if corrupt+replaceable, or an error string.
+ */
+function examineProfileForRepair(
+  file: string,
+  canonicalDir: string,
+  legacyProfilesDir: string,
+): { readonly candidate?: RepairCandidate; readonly error?: string } {
+  const name = file.slice(0, -5);
+  if (name !== REPORTED_PROFILE_NAME) {
+    return {};
+  }
+  const canonicalPath = path.join(canonicalDir, file);
+
+  const canonical = readAndParseProfile(canonicalPath);
+  if (canonical.kind === 'error') {
+    return { error: `profiles repair: ${String(canonical.error)}` };
+  }
+  if (canonical.kind !== 'parsed') {
+    return {};
+  }
+  // Eligibility: inspect the raw parsed object for exact signature (#3).
+  if (!isCorruptStandardProfileFromRaw(canonical.rawParsed)) {
+    return {};
+  }
+
+  const legacyPath = path.join(legacyProfilesDir, file);
+  const replacement = validateLegacyReplacement(legacyPath);
+  if (replacement === null) {
+    return {};
+  }
+
+  return {
+    candidate: {
+      name,
+      canonicalPath,
+      canonicalRaw: canonical.raw,
+      replacement,
+    },
+  };
+}
+
+function verifyCanonicalUnchanged(candidate: RepairCandidate): VerifyResult {
+  const current = readProfileFileSync(candidate.canonicalPath);
+  if (current.kind === 'absent') {
+    return { kind: 'skip' };
+  }
+  if (current.kind === 'error') {
+    return { kind: 'error', error: current.error };
+  }
+  return current.content === candidate.canonicalRaw
+    ? { kind: 'repair' }
+    : { kind: 'skip' };
+}
+
+function repairOneCandidate(candidate: RepairCandidate): boolean {
+  const verification = verifyCanonicalUnchanged(candidate);
+  if (verification.kind === 'skip') {
+    return false;
+  }
+  if (verification.kind === 'error') {
+    throw verification.error;
+  }
+
+  const dir = path.dirname(candidate.canonicalPath);
+  const base = path.basename(candidate.canonicalPath);
+  let mode = 0o644;
+  try {
+    mode = fs.statSync(candidate.canonicalPath).mode & 0o777;
+  } catch {
+    // Preserve the historical default when the mode cannot be read.
+  }
+
+  const tempPath = writeReplacementTemp(dir, base, candidate.replacement, mode);
+  try {
+    validateReplacementFile(tempPath);
+    claimBackup(candidate.canonicalPath, dir, base);
+    fs.renameSync(tempPath, candidate.canonicalPath);
+    fsyncDirSync(dir);
+    return true;
+  } catch (error) {
+    const errors: unknown[] = [error];
+    try {
+      cleanupTemp(tempPath);
+    } catch (cleanupError) {
+      errors.push(cleanupError);
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, 'profile repair failed');
+    }
+    throw error;
+  }
+}
+
+/** Write and fsync an exclusive same-directory replacement temp file. */
+function writeReplacementTemp(
+  dir: string,
+  base: string,
+  content: string,
+  mode: number,
+): string {
+  const tmpPath = uniqueTempPath(dir, base, '.repair.tmp');
+  try {
+    fs.writeFileSync(tmpPath, content, {
+      encoding: 'utf-8',
+      mode,
+      flag: 'wx',
+    });
+    // fsync the temp so the replacement content is durable before commit.
+    fsyncFile(tmpPath);
+  } catch (error) {
+    cleanupTemp(tmpPath);
+    throw error;
+  }
+  return tmpPath;
+}
+
+function fsyncFile(filePath: string): void {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function cleanupTemp(tmpPath: string): void {
+  try {
+    fs.unlinkSync(tmpPath);
+  } catch (error) {
+    if (hasErrnoCode(error, 'ENOENT')) {
+      return;
+    }
+    throw error;
+  }
+  fsyncDirSync(path.dirname(tmpPath));
+}
+
+function validateReplacementFile(filePath: string): void {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const parsed: unknown = JSON.parse(content);
+  const profile = parseProfile(parsed);
+  if (
+    isCorruptStandardProfileFromRaw(parsed) ||
+    isCorruptStandardProfile(profile)
+  ) {
+    throw new Error('replacement file still has the corrupt defect signature');
+  }
+}
+
+/**
+ * Claim an exclusive backup of the corrupt canonical file using
+ * COPYFILE_EXCL. If the primary backup name is taken, try numbered
+ * alternatives. The backup file and parent directory are fsync'd.
+ */
+function claimBackup(
+  canonicalPath: string,
+  dir: string,
+  baseFileName: string,
+): string {
+  const primary = path.join(dir, `${baseFileName}${REPAIR_BACKUP_SUFFIX}`);
+  try {
+    fs.copyFileSync(canonicalPath, primary, fs.constants.COPYFILE_EXCL);
+    fsyncFile(primary);
+    fsyncDirSync(dir);
+    return primary;
+  } catch (error) {
+    if (!hasErrnoCode(error, 'EEXIST')) {
+      throw error;
+    }
+  }
+  for (let counter = 1; counter < Number.MAX_SAFE_INTEGER; counter++) {
+    const next = path.join(
+      dir,
+      `${baseFileName}.${counter}${REPAIR_BACKUP_SUFFIX}`,
+    );
+    try {
+      fs.copyFileSync(canonicalPath, next, fs.constants.COPYFILE_EXCL);
+      fsyncFile(next);
+      fsyncDirSync(dir);
+      return next;
+    } catch (error) {
+      if (!hasErrnoCode(error, 'EEXIST')) {
+        throw error;
+      }
+    }
+  }
+  throw new Error(`could not claim a backup for ${canonicalPath}`);
+}
+
+/**
+ * Cohesive settings-owned API for repairing corrupt canonical profiles.
+ *
+ * Scans canonical profile files for the known historical defect signature
+ * (standard profile with provider 'load-balancer' and model 'gemini-2.5-pro'
+ * from issue #2479/#2477) and replaces one deterministic candidate with its
+ * valid same-name legacy profile. Repairing at most one profile per startup
+ * keeps the mutation boundary to one atomic rename; later startups repair any
+ * remaining candidates.
+ *
+ * Composability (#4): repair and migration are separate operations. The
+ * existing canonical no-overwrite publication (hard-link/COPYFILE_EXCL) and
+ * the repair lock-before-scan make interleaving benign. A writer between
+ * the migration and repair phases simply becomes the canonical input to
+ * repair; the exact signature/byte checks protect against stale
+ * replacement. No startup-wide lock is needed because no invariant spans
+ * both operations.
+ *
+ * The repair marker is an audit record only. Callers must scan on every
+ * startup because another eligible legacy source can appear later. A busy lock
+ * remains a benign deferral to the next startup.
+ *
+ * Manual recovery safety (#3): the lock is released by removing only the
+ * artifact whose owner token matches this process. A SIGKILL'd process
+ * leaves a stale lock requiring explicit manual removal. Manual recovery is
+ * supported ONLY after stopping all possible LLxprt/profile owner processes.
+ * The token check is an accidental guard, NOT a guarantee that release is
+ * safe against external replacement — unlink/recreate while the owner is
+ * live is unsupported external interference.
+ *
+ * @param canonicalProfilesDir The canonical profiles directory
+ *                             (e.g. configDir/profiles).
+ * @param legacyProfilesDir    The legacy profiles directory
+ *                             (e.g. legacyDir/profiles).
+ * @returns A discriminated outcome.
+ */
+export function repairCanonicalProfiles(
+  canonicalProfilesDir: string,
+  legacyProfilesDir: string,
+): CanonicalRepairOutcome {
+  // Acquire the repair lock ONCE before any scanning or mutation (#7).
+  // If busy before any mutation, defer benignly — no marker, no warning.
+  let lock: ReturnType<typeof acquireProfilesLockSync>;
+  try {
+    lock = acquireProfilesLockSync(canonicalProfilesDir);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'LockBusyError') {
+      return { kind: 'busy' };
+    }
+    return {
+      kind: 'error',
+      errors: [`profiles repair lock error: ${String(error)}`],
+    };
+  }
+
+  try {
+    return repairCanonicalProfilesLocked(
+      canonicalProfilesDir,
+      legacyProfilesDir,
+    );
+  } finally {
+    lock.release();
+  }
+}
+
+/** Lock-held repair of at most one deterministic candidate. */
+function repairCanonicalProfilesLocked(
+  canonicalProfilesDir: string,
+  legacyProfilesDir: string,
+): CanonicalRepairOutcome {
+  // Snapshot canonical file names AFTER lock acquisition so a concurrent
+  // writer that creates new files cannot add candidates mid-scan (#7).
+  let preExistingFiles: string[];
+  try {
+    preExistingFiles = fs
+      .readdirSync(canonicalProfilesDir)
+      .filter((f) => f.endsWith('.json'));
+  } catch (error) {
+    if (hasErrnoCode(error, 'ENOENT')) {
+      // Canonical profiles dir does not exist — no candidates, no repair.
+      return { kind: 'none' };
+    }
+    return {
+      kind: 'error',
+      errors: [`profiles repair error: ${String(error)}`],
+    };
+  }
+
+  const errors: string[] = [];
+  const candidates = collectRepairCandidates(
+    preExistingFiles,
+    canonicalProfilesDir,
+    legacyProfilesDir,
+    errors,
+  );
+
+  candidates.sort((left, right) => left.name.localeCompare(right.name));
+  if (candidates.length === 0) {
+    return errors.length === 0 ? { kind: 'none' } : { kind: 'error', errors };
+  }
+
+  try {
+    const repaired = repairOneCandidate(candidates[0]);
+    return repaired
+      ? { kind: 'repaired', profilesRepaired: 1, errors: [] }
+      : { kind: 'none' };
+  } catch (error) {
+    return {
+      kind: 'error',
+      errors: [...errors, `profiles repair failed: ${String(error)}`],
+    };
+  }
+}

--- a/packages/settings/src/profiles/canonicalProfileRepair.ts
+++ b/packages/settings/src/profiles/canonicalProfileRepair.ts
@@ -140,7 +140,10 @@ export function isCorruptStandardProfileFromRaw(rawParsed: unknown): boolean {
     return false;
   }
   const modelParams = rawParsed['modelParams'];
-  if (!isRawObject(modelParams) || Object.keys(modelParams).length !== 0) {
+  if (
+    modelParams !== undefined &&
+    (!isRawObject(modelParams) || Object.keys(modelParams).length !== 0)
+  ) {
     return false;
   }
   const ephemeralSettings = rawParsed['ephemeralSettings'];
@@ -480,7 +483,8 @@ function claimBackup(
       throw error;
     }
   }
-  for (let counter = 1; counter < Number.MAX_SAFE_INTEGER; counter++) {
+  const maxBackupAttempts = 1000;
+  for (let counter = 1; counter <= maxBackupAttempts; counter++) {
     const next = path.join(
       dir,
       `${baseFileName}.${counter}${REPAIR_BACKUP_SUFFIX}`,
@@ -602,9 +606,10 @@ function repairCanonicalProfilesLocked(
 
   try {
     const repaired = repairOneCandidate(candidates[0]);
-    return repaired
-      ? { kind: 'repaired', profilesRepaired: 1, errors: [] }
-      : { kind: 'none' };
+    if (repaired) {
+      return { kind: 'repaired', profilesRepaired: 1, errors };
+    }
+    return errors.length === 0 ? { kind: 'none' } : { kind: 'error', errors };
   } catch (error) {
     return {
       kind: 'error',

--- a/packages/settings/src/profiles/canonicalProfileRepair.ts
+++ b/packages/settings/src/profiles/canonicalProfileRepair.ts
@@ -42,7 +42,6 @@ export type CanonicalRepairOutcome =
   | {
       readonly kind: 'repaired';
       readonly profilesRepaired: number;
-      readonly errors: readonly string[];
     }
   | { readonly kind: 'none' }
   | { readonly kind: 'busy' }
@@ -589,7 +588,7 @@ function repairCanonicalProfilesLocked(
   try {
     const repaired = repairOneCandidate(candidates[0]);
     if (repaired) {
-      return { kind: 'repaired', profilesRepaired: 1, errors };
+      return { kind: 'repaired', profilesRepaired: 1 };
     }
     return errors.length === 0 ? { kind: 'none' } : { kind: 'error', errors };
   } catch (error) {

--- a/packages/settings/src/profiles/canonicalProfileRepair.ts
+++ b/packages/settings/src/profiles/canonicalProfileRepair.ts
@@ -26,47 +26,7 @@ import {
  */
 export const CORRUPT_PROVIDER = 'load-balancer';
 
-/**
- * The fallback model observed in the reported defect. When the runtime fell
- * back to the first registered provider (gemini), it used this model.
- * Repair eligibility requires this exact model so that manually-authored
- * standard profiles with a custom model are never touched (#4).
- */
-export const CORRUPT_FALLBACK_MODEL = 'gemini-2.5-pro';
-
-const REPORTED_PROFILE_NAME = 'zai';
-const REPORTED_PROVIDER = 'anthropic';
-const REPORTED_MODEL = 'glm-5.2';
-const REPORTED_BASE_URL = 'https://api.z.ai/api/anthropic';
-const REPORTED_AUTH_KEY_NAME = 'zai';
-const REPORTED_CONTEXT_LIMIT = 200_000;
 const REPAIR_BACKUP_SUFFIX = '.pre-repair.bak';
-
-/**
- * Result of a canonical profile repair pass.
- */
-export interface CanonicalRepairResult {
-  /** Number of profiles that were actually repaired (>= 0). */
-  readonly profilesRepaired: number;
-  /** Diagnostic errors encountered (non-fatal). */
-  readonly errors: readonly string[];
-}
-
-/**
- * A candidate repair: a corrupt canonical profile that has a valid same-name
- * legacy replacement available.
- */
-interface RepairCandidate {
-  readonly name: string;
-  readonly canonicalPath: string;
-  readonly canonicalRaw: string;
-  readonly replacement: string;
-}
-
-type VerifyResult =
-  | { readonly kind: 'repair' }
-  | { readonly kind: 'skip' }
-  | { readonly kind: 'error'; readonly error: Error };
 
 /**
  * Discriminated result of {@link repairCanonicalProfiles}.
@@ -89,6 +49,17 @@ export type CanonicalRepairOutcome =
   | { readonly kind: 'error'; readonly errors: readonly string[] };
 
 /**
+ * @deprecated Use {@link CanonicalRepairOutcome} instead. This type is
+ *             preserved solely for package-root API compatibility with
+ *             consumers that imported the older non-discriminated result
+ *             shape. It is not used internally.
+ */
+export type CanonicalRepairResult = {
+  readonly profilesRepaired: number;
+  readonly errors: readonly string[];
+};
+
+/**
  * Structural guard for a raw parsed profile object (the JSON-parsed value
  * before it goes through parseProfile). Used to inspect the `type` field
  * directly on the raw object so that eligibility does not depend on the
@@ -104,19 +75,26 @@ function isRawObject(value: unknown): value is Record<string, unknown> {
 
 /**
  * Determine whether a RAW parsed JSON object matches the known historical
- * defect signature (issue #2479/#2477). Inspects the raw object directly to
- * ensure eligibility is exact (#3):
+ * defect signature (issue #2479/#2477). This is the single conservative
+ * structural predicate used by both the canonical scan and the replacement
+ * validation. Inspects the raw object directly to ensure eligibility is
+ * exact (#3):
  *
  * - `type` must be ABSENT (not 'loadbalancer' and not 'standard'). The
  *   corrupt shape never carried a type field.
  * - `provider` must be exactly {@link CORRUPT_PROVIDER} ('load-balancer').
- * - `model` must be exactly {@link CORRUPT_FALLBACK_MODEL} ('gemini-2.5-pro').
- * - Must parse as a valid standard v1 profile via parseProfile.
+ * - `version` must be exactly 1.
+ * - `modelParams` must be absent or an empty object — the historical defect
+ *   always had empty modelParams.
+ * - `ephemeralSettings` must be an empty object — the historical defect
+ *   always had empty ephemeralSettings.
+ * - Must parse as a valid standard v1 profile via parseProfile (not an LB).
  *
- * This is deliberately conservative (#4): a genuine loadbalancer profile
- * (type='loadbalancer') is NEVER corrupt even if its provider field happens
- * to be 'load-balancer'. A standard profile with a custom model is NOT the
- * reported defect. Only the exact reported defect signature is repaired.
+ * This is deliberately conservative: a genuine loadbalancer profile
+ * (type='loadbalancer') is NEVER corrupt. A standard profile with nonempty
+ * modelParams or ephemeralSettings is manually-authored and NOT the defect.
+ * The model value is NOT constrained — the corruption is structural, so any
+ * fallback model in this shape is corrupt.
  *
  * @param rawParsed The JSON-parsed raw object (NOT a typed Profile).
  */
@@ -132,10 +110,6 @@ export function isCorruptStandardProfileFromRaw(rawParsed: unknown): boolean {
   if (typeof provider !== 'string' || provider !== CORRUPT_PROVIDER) {
     return false;
   }
-  const model = rawParsed['model'];
-  if (typeof model !== 'string' || model !== CORRUPT_FALLBACK_MODEL) {
-    return false;
-  }
   if (rawParsed['version'] !== 1) {
     return false;
   }
@@ -147,7 +121,10 @@ export function isCorruptStandardProfileFromRaw(rawParsed: unknown): boolean {
     return false;
   }
   const ephemeralSettings = rawParsed['ephemeralSettings'];
-  if (!isRawObject(ephemeralSettings)) {
+  if (
+    !isRawObject(ephemeralSettings) ||
+    Object.keys(ephemeralSettings).length !== 0
+  ) {
     return false;
   }
   // Validate it parses as a standard v1 profile (not an LB, not garbage).
@@ -161,24 +138,6 @@ export function isCorruptStandardProfileFromRaw(rawParsed: unknown): boolean {
     return false;
   }
   return true;
-}
-
-/**
- * Backward-compatible overload: accepts a parsed Profile. Delegates to the
- * raw-object inspection by reconstructing the eligibility checks. Kept for
- * existing callers/tests that pass a typed Profile.
- *
- * @deprecated Prefer {@link isCorruptStandardProfileFromRaw} for exact
- *             eligibility on raw parsed objects.
- */
-export function isCorruptStandardProfile(profile: Profile): boolean {
-  if (isLoadBalancerProfile(profile)) {
-    return false;
-  }
-  if (profile.provider !== CORRUPT_PROVIDER) {
-    return false;
-  }
-  return profile.model === CORRUPT_FALLBACK_MODEL;
 }
 
 /**
@@ -218,14 +177,29 @@ function readAndParseProfile(filePath: string):
 }
 
 /**
+ * A candidate repair: a corrupt canonical profile that has a valid same-name
+ * legacy replacement available.
+ */
+interface RepairCandidate {
+  readonly name: string;
+  readonly canonicalPath: string;
+  readonly canonicalRaw: string;
+  readonly replacement: string;
+}
+
+/**
  * Determine if a legacy file is a valid replacement for a corrupt canonical.
- * The legacy profile must parse as a standard profile with a non-corrupt
- * defect signature (not provider load-balancer + model gemini-2.5-pro).
- * Returns the serialized replacement JSON, or null if the legacy is not a
- * valid replacement.
+ * The legacy profile is eligible iff:
+ * - It parses as a valid standard profile (not invalid JSON, not garbage).
+ * - It is NOT a genuine loadbalancer profile.
+ * - It does NOT itself match the corrupt structural signature.
  *
- * modelParams normalization is now handled by parseProfile at the shared
- * boundary, so we just parse and validate here.
+ * There are NO restrictions on provider, model, base-url, auth-key, or
+ * context-limit — any valid standard profile that is not itself corrupt is
+ * an acceptable replacement.
+ *
+ * Returns the serialized replacement JSON (with modelParams normalized so
+ * absent becomes {}), or null if the legacy is not a valid replacement.
  */
 function validateLegacyReplacement(legacyPath: string): string | null {
   const result = readProfileFileSync(legacyPath);
@@ -257,31 +231,24 @@ function validateLegacyReplacement(legacyPath: string): string | null {
   if (isLoadBalancerProfile(profile)) {
     return null;
   }
-  if (isCorruptStandardProfile(profile)) {
+  // The replacement must not itself match the corrupt structural signature.
+  if (isCorruptStandardProfileFromRaw(parsed)) {
+    return null;
+  }
+  // Reject any standard profile whose provider is the virtual non-loadable
+  // 'load-balancer'. Such a profile cannot be loaded at runtime (no
+  // registered provider), so replacing one non-loadable profile with
+  // another is not a repair. This catches shapes that escape the narrow
+  // canonical corrupt signature (e.g. nonempty modelParams).
+  if (profile.provider === CORRUPT_PROVIDER) {
     return null;
   }
 
-  if (
-    profile.provider !== REPORTED_PROVIDER ||
-    profile.model !== REPORTED_MODEL
-  ) {
-    return null;
-  }
-  const ephemeralSettings = profile.ephemeralSettings;
-  if (
-    ephemeralSettings['base-url'] !== REPORTED_BASE_URL ||
-    ephemeralSettings['auth-key-name'] !== REPORTED_AUTH_KEY_NAME ||
-    ephemeralSettings['context-limit'] !== REPORTED_CONTEXT_LIMIT
-  ) {
-    return null;
-  }
-
-  // parseProfile normalizes modelParams at the boundary, so re-serialize
-  // the normalized input (not the original) for canonical bytes.
-  const modelParams =
-    parsed['modelParams'] === undefined ? {} : parsed['modelParams'];
-  const normalized = { ...parsed, modelParams };
-  return JSON.stringify(normalized, null, 2);
+  // Serialize the normalized Profile returned by parseProfile so absent
+  // modelParams becomes {} at the shared parse boundary. This produces
+  // canonical bytes regardless of whether the legacy source omitted
+  // modelParams.
+  return JSON.stringify(profile, null, 2);
 }
 
 /**
@@ -314,6 +281,8 @@ function collectRepairCandidates(
 /**
  * Examine a single canonical profile file for repair candidacy.
  * Returns the candidate if corrupt+replaceable, or an error string.
+ *
+ * Any profile name is eligible — there is no hardcoded name restriction.
  */
 function examineProfileForRepair(
   file: string,
@@ -321,9 +290,6 @@ function examineProfileForRepair(
   legacyProfilesDir: string,
 ): { readonly candidate?: RepairCandidate; readonly error?: string } {
   const name = file.slice(0, -5);
-  if (name !== REPORTED_PROFILE_NAME) {
-    return {};
-  }
   const canonicalPath = path.join(canonicalDir, file);
 
   const canonical = readAndParseProfile(canonicalPath);
@@ -333,7 +299,7 @@ function examineProfileForRepair(
   if (canonical.kind !== 'parsed') {
     return {};
   }
-  // Eligibility: inspect the raw parsed object for exact signature (#3).
+  // Eligibility: inspect the raw parsed object for the structural signature.
   if (!isCorruptStandardProfileFromRaw(canonical.rawParsed)) {
     return {};
   }
@@ -353,6 +319,11 @@ function examineProfileForRepair(
     },
   };
 }
+
+type VerifyResult =
+  | { readonly kind: 'repair' }
+  | { readonly kind: 'skip' }
+  | { readonly kind: 'error'; readonly error: Error };
 
 function verifyCanonicalUnchanged(candidate: RepairCandidate): VerifyResult {
   const current = readProfileFileSync(candidate.canonicalPath);
@@ -453,11 +424,8 @@ function cleanupTemp(tmpPath: string): void {
 function validateReplacementFile(filePath: string): void {
   const content = fs.readFileSync(filePath, 'utf-8');
   const parsed: unknown = JSON.parse(content);
-  const profile = parseProfile(parsed);
-  if (
-    isCorruptStandardProfileFromRaw(parsed) ||
-    isCorruptStandardProfile(profile)
-  ) {
+  // The replacement must not still match the corrupt structural signature.
+  if (isCorruptStandardProfileFromRaw(parsed)) {
     throw new Error('replacement file still has the corrupt defect signature');
   }
 }
@@ -507,11 +475,18 @@ function claimBackup(
  * Cohesive settings-owned API for repairing corrupt canonical profiles.
  *
  * Scans canonical profile files for the known historical defect signature
- * (standard profile with provider 'load-balancer' and model 'gemini-2.5-pro'
- * from issue #2479/#2477) and replaces one deterministic candidate with its
- * valid same-name legacy profile. Repairing at most one profile per startup
- * keeps the mutation boundary to one atomic rename; later startups repair any
- * remaining candidates.
+ * (untyped standard-v1 profile whose provider is the virtual non-loadable
+ * provider 'load-balancer', with empty modelParams and empty
+ * ephemeralSettings, from issue #2479/#2477) and replaces one deterministic
+ * candidate with its valid same-name legacy profile. Repairing at most one
+ * profile per startup keeps the mutation boundary to one atomic rename;
+ * later startups repair any remaining candidates.
+ *
+ * The corruption signature is structural and conservative: it does not
+ * depend on a specific profile name, provider, model, endpoint, or auth
+ * setting. A same-name legacy replacement is eligible iff it parses as a
+ * valid standard profile, is not a genuine loadbalancer, and does not
+ * itself match the corrupt structural signature.
  *
  * Composability (#4): repair and migration are separate operations. The
  * existing canonical no-overwrite publication (hard-link/COPYFILE_EXCL) and
@@ -530,7 +505,7 @@ function claimBackup(
  * leaves a stale lock requiring explicit manual removal. Manual recovery is
  * supported ONLY after stopping all possible LLxprt/profile owner processes.
  * The token check is an accidental guard, NOT a guarantee that release is
- * safe against external replacement — unlink/recreate while the owner is
+ * safe against external replacement — unlink/recreate whilst the owner is
  * live is unsupported external interference.
  *
  * @param canonicalProfilesDir The canonical profiles directory
@@ -602,6 +577,13 @@ function repairCanonicalProfilesLocked(
   candidates.sort((left, right) => left.name.localeCompare(right.name));
   if (candidates.length === 0) {
     return errors.length === 0 ? { kind: 'none' } : { kind: 'error', errors };
+  }
+
+  // If scan/preflight errors exist alongside a repair candidate, do NOT
+  // mutate anything. Return error before repair so the caller sees the
+  // problem and no partial state is committed.
+  if (errors.length > 0) {
+    return { kind: 'error', errors };
   }
 
   try {

--- a/packages/settings/src/profiles/profileStore.ts
+++ b/packages/settings/src/profiles/profileStore.ts
@@ -341,7 +341,7 @@ function removeOwnArtifactSync(lockPath: string, ownerToken: string): void {
  * @internal Tests inside settings can import this directly.
  */
 export function acquireProfilesLockSync(profilesDir: string): SyncLockHandle {
-  fsSync.mkdirSync(profilesDir, { recursive: true });
+  fsSync.mkdirSync(profilesDir, { recursive: true, mode: 0o700 });
   const lockPath = lockPathForProfilesDir(profilesDir);
   try {
     const metadata = createLockArtifactSync(lockPath);
@@ -461,7 +461,15 @@ async function removeOwnArtifact(
 ): Promise<void> {
   const onDiskToken = await readLockToken(lockPath);
   if (onDiskToken === null) {
-    return;
+    try {
+      await fs.lstat(lockPath);
+    } catch (error) {
+      if (hasErrnoCode(error, 'ENOENT')) {
+        return;
+      }
+      throw error;
+    }
+    throw new Error(`Profiles lock ownership changed at ${lockPath}`);
   }
   if (onDiskToken !== ownerToken) {
     throw new Error(`Profiles lock ownership changed at ${lockPath}`);
@@ -509,6 +517,36 @@ export function withProfilesLockSync<T>(
 
   try {
     lock.release();
+  } catch (releaseError) {
+    if (outcome.kind === 'error') {
+      throw new AggregateError(
+        [outcome.error, releaseError],
+        'profiles operation and lock release both failed',
+      );
+    }
+    throw releaseError;
+  }
+
+  if (outcome.kind === 'error') {
+    throw outcome.error;
+  }
+  return outcome.value;
+}
+
+async function withProfilesLock<T>(
+  profilesDir: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const lock = await acquireProfilesLock(profilesDir);
+  let outcome: { kind: 'result'; value: T } | { kind: 'error'; error: unknown };
+  try {
+    outcome = { kind: 'result', value: await operation() };
+  } catch (error) {
+    outcome = { kind: 'error', error };
+  }
+
+  try {
+    await lock.release();
   } catch (releaseError) {
     if (outcome.kind === 'error') {
       throw new AggregateError(
@@ -742,10 +780,12 @@ export type ProfileWriteResult =
   | { readonly kind: 'exists'; readonly path: string };
 
 function profileFilePath(profilesDir: string, profileName: string): string {
+  const trimmedName = profileName.trim();
   const forbiddenNames = new Set(['', '.', '..']);
   const hasForbiddenSeparator = /[\\/\0]/u.test(profileName);
   if (
-    forbiddenNames.has(profileName.trim()) ||
+    forbiddenNames.has(trimmedName) ||
+    trimmedName !== profileName ||
     hasForbiddenSeparator ||
     path.isAbsolute(profileName)
   ) {
@@ -783,12 +823,9 @@ export async function writeProfileFile(
   mode: ProfileWriteMode = 'overwrite',
 ): Promise<ProfileWriteResult> {
   const filePath = profileFilePath(profilesDir, profileName);
-  const lock = await acquireProfilesLock(profilesDir);
-  try {
-    await fs.mkdir(profilesDir, { recursive: true, mode: 0o700 });
-
+  return withProfilesLock(profilesDir, async () => {
     if (mode === 'create') {
-      return await createProfileExclusive(filePath, data);
+      return createProfileExclusive(filePath, data);
     }
 
     // overwrite: preserve existing mode, default 0600 for new files
@@ -801,9 +838,7 @@ export async function writeProfileFile(
     }
     await atomicWriteFile(filePath, data, fileMode);
     return { kind: 'written', path: filePath };
-  } finally {
-    await lock.release();
-  }
+  });
 }
 
 /**
@@ -895,11 +930,8 @@ export async function deleteProfileFile(
   profileName: string,
 ): Promise<void> {
   const filePath = profileFilePath(profilesDir, profileName);
-  const lock = await acquireProfilesLock(profilesDir);
-  try {
+  await withProfilesLock(profilesDir, async () => {
     await fs.unlink(filePath);
     await fsyncDir(profilesDir);
-  } finally {
-    await lock.release();
-  }
+  });
 }

--- a/packages/settings/src/profiles/profileStore.ts
+++ b/packages/settings/src/profiles/profileStore.ts
@@ -833,7 +833,10 @@ export async function writeProfileFile(
     try {
       const stat = await fs.stat(filePath);
       fileMode = stat.mode & 0o777;
-    } catch {
+    } catch (error) {
+      if (!hasErrnoCode(error, 'ENOENT')) {
+        throw error;
+      }
       fileMode = 0o600;
     }
     await atomicWriteFile(filePath, data, fileMode);

--- a/packages/settings/src/profiles/profileStore.ts
+++ b/packages/settings/src/profiles/profileStore.ts
@@ -1,0 +1,907 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+
+const LOCK_FILE_NAME = '.profiles.lock';
+
+/**
+ * Bounded deadline (ms) for async lock acquisition. When the lock is busy,
+ * the async path polls every {@link ASYNC_POLL_MS} until this deadline
+ * elapses, then throws {@link LockBusyError}.
+ *
+ * Safety over availability: a lock that cannot be acquired within this
+ * deadline means a concurrent operation is in progress (or a stale lock
+ * requires manual recovery). We refuse rather than risk data corruption.
+ *
+ * This is the production default. Tests inject a shorter deadline via the
+ * optional {@link acquireProfilesLock} `deadlineMs` parameter so the stale-
+ * lock path is exercised deterministically without fixed sleeps.
+ */
+const ASYNC_LOCK_DEADLINE_MS = 10_000;
+
+/**
+ * Polling interval (ms) for async lock acquisition while waiting for a
+ * busy lock to become available.
+ */
+const ASYNC_POLL_MS = 50;
+
+/**
+ * Known errno codes where directory fsync is unsupported (primarily Windows
+ * and some network filesystems). These are the ONLY errors swallowed by
+ * {@link fsyncDirSync} / {@link fsyncDir}; all other errors propagate so
+ * that genuine I/O failures (e.g. ENOSPC, EIO) are not silently hidden.
+ */
+const DIR_FSYNC_UNSUPPORTED_CODES: ReadonlySet<string> = new Set([
+  'EINVAL',
+  'ENOSYS',
+  'EPERM',
+  'ENOTSUP',
+]);
+
+// ─── Structural error / type guards ─────────────────────────────────────────
+
+/**
+ * Structural guard for Node.js filesystem errors that carry a `code`
+ * property (ENOENT, EEXIST, EACCES, etc.). Avoids `as NodeJS.ErrnoException`
+ * type assertions at every catch site.
+ */
+export interface ErrnoError {
+  readonly code?: string;
+  readonly message: string;
+}
+
+export function hasErrnoCode(
+  error: unknown,
+  expectedCode: string,
+): error is ErrnoError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === expectedCode
+  );
+}
+
+// ─── Lock error types ───────────────────────────────────────────────────────
+
+/**
+ * Thrown when the exclusive lock artifact already exists and cannot be
+ * acquired within the bounded deadline (async) or on the single sync
+ * attempt. The error message includes the lock path and owner metadata
+ * (when available) so the user can perform manual recovery.
+ *
+ * This is a BENIGN condition for the sync repair caller — it means a
+ * concurrent operation is in progress and repair should be deferred to
+ * the next startup.
+ */
+export class LockBusyError extends Error {
+  readonly lockPath: string;
+  readonly ownerMetadata: string | null;
+
+  constructor(lockPath: string, ownerMetadata: string | null) {
+    const ownerInfo =
+      ownerMetadata !== null
+        ? ` Owner metadata: ${ownerMetadata}`
+        : ' No owner metadata available.';
+    super(
+      `Profiles lock is busy at ${lockPath}.${ownerInfo} ` +
+        'Manual recovery: stop ALL possible LLxprt/profile owner processes ' +
+        'first, then remove the lock file to recover. Do NOT remove the ' +
+        'lock while any owner process is still running.',
+    );
+    this.name = 'LockBusyError';
+    this.lockPath = lockPath;
+    this.ownerMetadata = ownerMetadata;
+  }
+}
+
+// ─── Lock types ─────────────────────────────────────────────────────────────
+
+export interface LockHandle {
+  readonly path: string;
+  readonly ownerToken: string;
+  release(): Promise<void>;
+}
+
+export interface SyncLockHandle {
+  readonly path: string;
+  readonly ownerToken: string;
+  release(): void;
+}
+
+// ─── Owner metadata ─────────────────────────────────────────────────────────
+
+export interface LockOwnerMetadata {
+  readonly pid: number;
+  readonly token: string;
+  readonly created: string;
+}
+
+/**
+ * Result of building owner metadata: the typed object (so the caller retains
+ * the token without re-parsing JSON) and the serialized content written to
+ * the lock artifact.
+ */
+interface BuiltOwnerMetadata {
+  readonly metadata: LockOwnerMetadata;
+  readonly serialized: string;
+}
+
+/**
+ * Read owner metadata from a lock artifact file, if it exists and is
+ * parseable. Returns null for absent or malformed files — used for
+ * diagnostics in error messages only. NEVER used for stale-takeover
+ * decisions.
+ */
+function readLockOwnerMetadataSync(lockPath: string): string | null {
+  try {
+    return fsSync.readFileSync(lockPath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the owner token from a lock artifact file. Used by the release path
+ * to verify that the artifact on disk still belongs to THIS process before
+ * unlinking — preventing stale-takeover races. Returns null if the file is
+ * absent or does not contain a recognizable token.
+ */
+function readLockTokenSync(lockPath: string): string | null {
+  try {
+    return extractTokenFromMetadata(fsSync.readFileSync(lockPath, 'utf-8'));
+  } catch (error) {
+    if (hasErrnoCode(error, 'ENOENT')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Read the owner token from a lock artifact file (async). Used by the async
+ * release path to verify ownership before unlinking.
+ */
+async function readLockToken(lockPath: string): Promise<string | null> {
+  try {
+    return extractTokenFromMetadata(await fs.readFile(lockPath, 'utf-8'));
+  } catch (error) {
+    if (hasErrnoCode(error, 'ENOENT')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Extract the `token` field from serialized owner metadata without a type
+ * assertion. Uses structural narrowing on the parsed value.
+ */
+function extractTokenFromMetadata(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return readTokenField(parsed);
+}
+
+/**
+ * Structural type guard for the owner-token field. Narrows `unknown` to a
+ * string token without a type assertion.
+ */
+function readTokenField(value: unknown): string | null {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'token' in value &&
+    typeof value.token === 'string'
+  ) {
+    return value.token;
+  }
+  return null;
+}
+
+// ─── Internal lock acquisition ──────────────────────────────────────────────
+
+/**
+ * Compute the lock file path for a profiles directory. Exported for tests
+ * that need to verify the lock artifact on disk.
+ *
+ * @internal Tests inside settings can import this directly.
+ */
+export function lockPathForProfilesDir(profilesDir: string): string {
+  return path.join(profilesDir, LOCK_FILE_NAME);
+}
+
+/**
+ * Build the owner metadata typed object and its serialized JSON content for
+ * a new lock artifact. Includes the process PID, a random token, and an ISO
+ * timestamp for diagnostics. The typed object is returned alongside the
+ * serialized form so callers retain the token without re-parsing (#2/#8).
+ */
+function buildOwnerMetadata(): BuiltOwnerMetadata {
+  const metadata: LockOwnerMetadata = {
+    pid: process.pid,
+    token: crypto.randomUUID(),
+    created: new Date().toISOString(),
+  };
+  return {
+    metadata,
+    serialized: JSON.stringify(metadata, null, 2),
+  };
+}
+
+/**
+ * Atomically create the lock artifact using `open wx` (O_CREAT | O_EXCL).
+ * Returns the typed owner metadata (including the token). If the lock already
+ * exists, throws an error with code EEXIST — the caller decides how to handle
+ * it.
+ *
+ * If the `open wx` succeeds but the metadata write or fsync fails, the file
+ * descriptor is closed and the artifact we just created is removed (we own it
+ * — no other process can). This prevents a half-written lock from blocking
+ * all future acquisitions (#2).
+ *
+ * The lock is a fixed-path file (not a directory). `O_EXCL` guarantees
+ * atomic cross-process mutual exclusion: either exactly one process creates
+ * the file, or all others get EEXIST. There is NO stale-takeover logic —
+ * a lock left behind by a SIGKILL'd process requires explicit/manual
+ * recovery (remove the file). Safety over availability.
+ *
+ * The file contains owner metadata (pid, token, timestamp) purely for
+ * diagnostics — it is never read to decide stale reclamation.
+ */
+function createLockArtifactSync(lockPath: string): LockOwnerMetadata {
+  const { metadata, serialized } = buildOwnerMetadata();
+  const fd = fsSync.openSync(lockPath, 'wx', 0o600);
+  try {
+    fsSync.writeSync(fd, serialized, 0, 'utf-8');
+    fsSync.fsyncSync(fd);
+  } catch (error) {
+    // The open wx succeeded so we created the artifact — we must clean it
+    // up on failure so a half-written lock does not block all future
+    // acquisitions (#2). Close first, then remove what we own.
+    try {
+      fsSync.closeSync(fd);
+    } catch {
+      // best-effort close
+    }
+    try {
+      fsSync.unlinkSync(lockPath);
+      fsyncDirSync(path.dirname(lockPath));
+    } catch (cleanupError) {
+      if (!hasErrnoCode(cleanupError, 'ENOENT')) {
+        throw new AggregateError(
+          [error, cleanupError],
+          'Failed to initialize and clean up profiles lock',
+        );
+      }
+    }
+    throw error;
+  }
+  fsSync.closeSync(fd);
+  return metadata;
+}
+
+/**
+ * Remove the lock artifact, but ONLY if the file on disk still carries OUR
+ * owner token. This is an ACCIDENTAL GUARD against double-release within the
+ * same process — it does NOT make release safe against external replacement.
+ *
+ * Trust boundary (#lock decision): the token check prevents a process from
+ * unlinking a lock it no longer owns in normal operation. However,
+ * unlink/recreate of the lock file by an external actor while an owner
+ * process is still live is UNSUPPORTED external interference — there is no
+ * portable kernel primitive that prevents this. Manual recovery is supported
+ * ONLY after stopping all possible LLxprt/profile owner processes.
+ *
+ * If the file is absent (already removed) or the token does not match, the
+ * unlink is skipped silently.
+ */
+function removeOwnArtifactSync(lockPath: string, ownerToken: string): void {
+  const onDiskToken = readLockTokenSync(lockPath);
+  if (onDiskToken === null && !fsSync.existsSync(lockPath)) {
+    return;
+  }
+  if (onDiskToken !== ownerToken) {
+    throw new Error(`Profiles lock ownership changed at ${lockPath}`);
+  }
+  try {
+    fsSync.unlinkSync(lockPath);
+  } catch (error) {
+    if (!hasErrnoCode(error, 'ENOENT')) {
+      throw error;
+    }
+    return;
+  }
+  fsyncDirSync(path.dirname(lockPath));
+}
+
+/**
+ * Acquire the profiles-directory lock synchronously (single attempt). Uses
+ * `open wx` (O_EXCL) for atomic cross-process mutual exclusion.
+ *
+ * If the lock already exists, throws {@link LockBusyError} — this is a
+ * benign/deferred condition. The caller (sync repair) should treat this as
+ * "try again next startup", NOT as an error.
+ *
+ * There is NO stale-takeover logic. A lock left by a SIGKILL'd process
+ * requires explicit/manual recovery (remove the file). The error message
+ * includes the exact path and owner metadata for recovery guidance.
+ *
+ * @internal Tests inside settings can import this directly.
+ */
+export function acquireProfilesLockSync(profilesDir: string): SyncLockHandle {
+  fsSync.mkdirSync(profilesDir, { recursive: true });
+  const lockPath = lockPathForProfilesDir(profilesDir);
+  try {
+    const metadata = createLockArtifactSync(lockPath);
+    return {
+      path: lockPath,
+      ownerToken: metadata.token,
+      release() {
+        removeOwnArtifactSync(lockPath, metadata.token);
+      },
+    };
+  } catch (error) {
+    if (hasErrnoCode(error, 'EEXIST')) {
+      throw new LockBusyError(lockPath, readLockOwnerMetadataSync(lockPath));
+    }
+    throw error;
+  }
+}
+
+/**
+ * Acquire the profiles-directory lock asynchronously, waiting with a bounded
+ * deadline if the lock is busy. Uses `open wx` (O_EXCL) for atomic
+ * cross-process mutual exclusion.
+ *
+ * Polls every {@link ASYNC_POLL_MS} until `deadlineMs` elapses. If still busy
+ * after the deadline, throws {@link LockBusyError}.
+ *
+ * If the `open wx` succeeds but the metadata write or fsync fails, the handle
+ * is closed and the artifact we just created is removed (we own it — no other
+ * process can). This prevents a half-written lock from blocking all future
+ * acquisitions (#2).
+ *
+ * There is NO stale-takeover logic. A lock left by a SIGKILL'd process
+ * requires explicit/manual recovery (remove the file). Safety over
+ * availability.
+ *
+ * @param profilesDir The canonical profiles directory.
+ * @param deadlineMs  Optional deadline override (ms). Production callers omit
+ *                    this to use the 10s default; tests inject a shorter
+ *                    value so the stale-lock path is deterministic (#1).
+ * @internal Tests inside settings can import this directly.
+ */
+export async function acquireProfilesLock(
+  profilesDir: string,
+  deadlineMs?: number,
+): Promise<LockHandle> {
+  await fs.mkdir(profilesDir, { recursive: true, mode: 0o700 });
+  const lockPath = lockPathForProfilesDir(profilesDir);
+  const deadline = Date.now() + (deadlineMs ?? ASYNC_LOCK_DEADLINE_MS);
+
+  for (;;) {
+    const { metadata, serialized } = buildOwnerMetadata();
+    try {
+      await writeLockArtifact(lockPath, serialized);
+      const token = metadata.token;
+      return {
+        path: lockPath,
+        ownerToken: token,
+        async release() {
+          await removeOwnArtifact(lockPath, token);
+        },
+      };
+    } catch (error) {
+      if (!hasErrnoCode(error, 'EEXIST')) {
+        throw error;
+      }
+    }
+
+    if (Date.now() >= deadline) {
+      throw new LockBusyError(lockPath, readLockOwnerMetadataSync(lockPath));
+    }
+    await new Promise((resolve) => setTimeout(resolve, ASYNC_POLL_MS));
+  }
+}
+
+/**
+ * Write the lock artifact metadata to an `open wx` handle. If the write or
+ * fsync fails after the file was created, the handle is closed and the
+ * artifact is removed (we own it — no other process can, #2).
+ */
+async function writeLockArtifact(
+  lockPath: string,
+  serialized: string,
+): Promise<void> {
+  const handle = await fs.open(lockPath, 'wx', 0o600);
+  try {
+    await handle.writeFile(serialized, 'utf-8');
+    await handle.sync();
+  } catch (error) {
+    try {
+      await handle.close();
+    } catch {
+      // best-effort close
+    }
+    try {
+      await fs.unlink(lockPath);
+      await fsyncDir(path.dirname(lockPath));
+    } catch (cleanupError) {
+      if (!hasErrnoCode(cleanupError, 'ENOENT')) {
+        throw new AggregateError(
+          [error, cleanupError],
+          'Failed to initialize and clean up profiles lock',
+        );
+      }
+    }
+    throw error;
+  }
+  await handle.close();
+}
+
+/**
+ * Async version of {@link removeOwnArtifactSync}: read the token from the lock
+ * artifact and refuse unlink if it does not match our owner token (#3).
+ */
+async function removeOwnArtifact(
+  lockPath: string,
+  ownerToken: string,
+): Promise<void> {
+  const onDiskToken = await readLockToken(lockPath);
+  if (onDiskToken === null) {
+    return;
+  }
+  if (onDiskToken !== ownerToken) {
+    throw new Error(`Profiles lock ownership changed at ${lockPath}`);
+  }
+  try {
+    await fs.unlink(lockPath);
+  } catch (error) {
+    if (!hasErrnoCode(error, 'ENOENT')) {
+      throw error;
+    }
+    return;
+  }
+  await fsyncDir(path.dirname(lockPath));
+}
+
+// ─── Cohesive public sync lock API ──────────────────────────────────────────
+
+/**
+ * Cohesive sync-scoped lock API: acquire the shared profiles lock, run an
+ * operation synchronously, and always release — even on error. This is the
+ * ONLY sync lock entry point that external packages (CLI) should use.
+ *
+ * The release only removes the lock artifact owned by THIS process (created
+ * via O_EXCL). If the operation throws, the lock is still released (normal
+ * error path). SIGKILL during the operation will leave the lock artifact
+ * requiring manual recovery.
+ *
+ * @param profilesDir The canonical profiles directory.
+ * @param operation   A synchronous function executed under the lock.
+ * @returns           Whatever the operation returns.
+ * @throws            {@link LockBusyError} if the lock is busy; re-throws
+ *                    any error from the operation.
+ */
+export function withProfilesLockSync<T>(
+  profilesDir: string,
+  operation: () => T,
+): T {
+  const lock = acquireProfilesLockSync(profilesDir);
+  let outcome: { kind: 'result'; value: T } | { kind: 'error'; error: unknown };
+  try {
+    outcome = { kind: 'result', value: operation() };
+  } catch (error) {
+    outcome = { kind: 'error', error };
+  }
+
+  try {
+    lock.release();
+  } catch (releaseError) {
+    if (outcome.kind === 'error') {
+      throw new AggregateError(
+        [outcome.error, releaseError],
+        'profiles operation and lock release both failed',
+      );
+    }
+    throw releaseError;
+  }
+
+  if (outcome.kind === 'error') {
+    throw outcome.error;
+  }
+  return outcome.value;
+}
+
+// ─── Directory fsync helper ─────────────────────────────────────────────────
+
+/**
+ * Fsync of a directory path (sync). On Linux and macOS, `fsyncSync` on a
+ * directory fd flushes directory entry changes so renames, creates, and
+ * unlinks are durable. On Windows and some network filesystems, directory
+ * fsync is unsupported and throws — those known-unsupported errno codes are
+ * silently ignored (#5).
+ *
+ * All other errors (ENOSPC, EIO, EACCES, etc.) PROPAGATE to the caller so
+ * genuine I/O failures are not silently hidden. Durability is NOT best-effort
+ * for real errors — callers must know when the filesystem is unhealthy.
+ *
+ * @internal Tests inside settings can import this directly.
+ */
+export function fsyncDirSync(dirPath: string): void {
+  let fd: number | undefined;
+  try {
+    fd = fsSync.openSync(dirPath, 'r');
+    fsSync.fsyncSync(fd);
+  } catch (error) {
+    if (!isDirFsyncUnsupported(error)) {
+      throw error;
+    }
+    // Directory fsync is unsupported on this platform (e.g. Windows).
+    // Silently ignore — the file-level fsync still applies.
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fsSync.closeSync(fd);
+      } catch {
+        // best-effort close
+      }
+    }
+  }
+}
+
+/**
+ * Async version of {@link fsyncDirSync}.
+ *
+ * @internal Tests inside settings can import this directly.
+ */
+export async function fsyncDir(dirPath: string): Promise<void> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(dirPath, 'r');
+    await handle.sync();
+  } catch (error) {
+    if (!isDirFsyncUnsupported(error)) {
+      throw error;
+    }
+    // Directory fsync is unsupported on this platform (e.g. Windows).
+  } finally {
+    if (handle !== undefined) {
+      try {
+        await handle.close();
+      } catch {
+        // best-effort close
+      }
+    }
+  }
+}
+
+/**
+ * Determine whether a directory-fsync error is a known unsupported-platform
+ * code that should be silently ignored (#5).
+ */
+function isDirFsyncUnsupported(error: unknown): boolean {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string'
+  ) {
+    return DIR_FSYNC_UNSUPPORTED_CODES.has(error.code);
+  }
+  return false;
+}
+
+// ─── File read helper ───────────────────────────────────────────────────────
+
+export type ReadResult =
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'content'; readonly content: string }
+  | { readonly kind: 'error'; readonly error: Error };
+
+/**
+ * Read a file synchronously and return a discriminated result. ENOENT maps
+ * to 'absent'; all other errors map to 'error' with the original Error.
+ *
+ * @internal Tests inside settings can import this directly.
+ */
+export function readProfileFileSync(filePath: string): ReadResult {
+  let content: string;
+  try {
+    content = fsSync.readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    if (hasErrnoCode(error, 'ENOENT')) {
+      return { kind: 'absent' };
+    }
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      kind: 'error',
+    };
+  }
+  return { content, kind: 'content' };
+}
+
+// ─── Unique temp path ───────────────────────────────────────────────────────
+
+/**
+ * Generate a unique temporary path in the same directory as the target file.
+ * The path includes the process PID and a random UUID so two concurrent
+ * writers can never collide.
+ *
+ * @internal Tests inside settings can import this directly.
+ */
+export function uniqueTempPath(
+  dir: string,
+  baseFileName: string,
+  suffix: string,
+): string {
+  const random = crypto.randomUUID();
+  return path.join(dir, `${baseFileName}.${process.pid}.${random}${suffix}`);
+}
+
+// ─── Atomic writes (internal helpers) ───────────────────────────────────────
+
+/**
+ * Atomically write a file via temp + fsync + rename + directory fsync. The
+ * temp file is ALWAYS opened with `wx` (exclusive create) regardless of
+ * `mode`, so two concurrent writers can never collide on the same temp path.
+ *
+ * The temp file is fsync'd before rename, and the parent directory is
+ * fsync'd after rename, so both the content and the directory entry update
+ * are durable on platforms that support directory fsync.
+ *
+ * Error preservation (#2): if the primary write/rename fails, the primary
+ * error is preserved. If cleanup (temp unlink) or directory fsync also
+ * fails, those errors are collected and thrown alongside the primary error
+ * as an AggregateError so genuine I/O failures are never silently masked.
+ *
+ * @internal Tests inside settings can import this directly.
+ */
+export async function atomicWriteFile(
+  filePath: string,
+  data: string,
+  mode?: number,
+): Promise<void> {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tmpPath = uniqueTempPath(dir, base, '.tmp');
+  const errors: Error[] = [];
+  let primaryError: Error | null = null;
+  try {
+    const handle = await fs.open(tmpPath, 'wx', mode);
+    try {
+      await handle.writeFile(data, 'utf-8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await fs.rename(tmpPath, filePath);
+    await fsyncDir(dir);
+  } catch (error) {
+    primaryError = error instanceof Error ? error : new Error(String(error));
+    errors.push(primaryError);
+  } finally {
+    let tempRemoved = false;
+    try {
+      await fs.unlink(tmpPath);
+      tempRemoved = true;
+    } catch (error) {
+      // ENOENT means the temp was consumed by rename — not an error.
+      if (!hasErrnoCode(error, 'ENOENT')) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+    if (tempRemoved) {
+      // Fsync parent directory after temp unlink so the directory entry
+      // removal is durable on platforms that support directory fsync (#7).
+      try {
+        await fsyncDir(dir);
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  }
+  if (errors.length > 1 && primaryError !== null) {
+    // Primary error occurred AND cleanup/fsync also failed — aggregate so
+    // the caller sees both (#2).
+    const aggregate = new AggregateError(
+      errors,
+      `atomicWriteFile failed: primary error plus ${errors.length - 1} cleanup/fsync error(s)`,
+    );
+    throw aggregate;
+  }
+  if (primaryError !== null) {
+    throw primaryError;
+  }
+}
+
+// ─── Public profile write / delete API ──────────────────────────────────────
+
+/**
+ * Profile write mode: create-only (fail if exists) or overwrite.
+ */
+export type ProfileWriteMode = 'create' | 'overwrite';
+
+/**
+ * Result of a profile write operation.
+ */
+export type ProfileWriteResult =
+  | { readonly kind: 'written'; readonly path: string }
+  | { readonly kind: 'exists'; readonly path: string };
+
+function profileFilePath(profilesDir: string, profileName: string): string {
+  if (
+    profileName.trim() === '' ||
+    profileName === '.' ||
+    profileName === '..' ||
+    profileName.includes('\0') ||
+    profileName.includes('/') ||
+    profileName.includes('\\') ||
+    path.isAbsolute(profileName)
+  ) {
+    throw new Error(`Invalid profile name: ${JSON.stringify(profileName)}`);
+  }
+
+  const resolvedDir = path.resolve(profilesDir);
+  const resolvedFile = path.resolve(resolvedDir, `${profileName}.json`);
+  if (path.dirname(resolvedFile) !== resolvedDir) {
+    throw new Error(`Invalid profile name: ${JSON.stringify(profileName)}`);
+  }
+  return resolvedFile;
+}
+
+/**
+ * Cohesive public API for writing a canonical profile JSON file under the
+ * shared profiles lock. Preserves create-only vs overwrite behavior and
+ * applies 0600 mode (owner read/write only) for new files. Existing file
+ * mode is preserved on overwrite.
+ *
+ * Both modes use atomic publication (exclusive temp + fsync + rename for
+ * overwrite; exclusive temp + fsync + hard-link for create). The parent
+ * directory is fsync'd after publication on platforms that support it.
+ *
+ * @param profilesDir  The canonical profiles directory.
+ * @param profileName  Profile name (without .json extension).
+ * @param data         Serialized JSON content.
+ * @param mode         'create' fails if the file exists; 'overwrite' replaces it.
+ * @returns 'written' on success, 'exists' if create-mode collided.
+ */
+export async function writeProfileFile(
+  profilesDir: string,
+  profileName: string,
+  data: string,
+  mode: ProfileWriteMode = 'overwrite',
+): Promise<ProfileWriteResult> {
+  const filePath = profileFilePath(profilesDir, profileName);
+  const lock = await acquireProfilesLock(profilesDir);
+  try {
+    await fs.mkdir(profilesDir, { recursive: true, mode: 0o700 });
+
+    if (mode === 'create') {
+      return await createProfileExclusive(filePath, data);
+    }
+
+    // overwrite: preserve existing mode, default 0600 for new files
+    let fileMode: number | undefined;
+    try {
+      const stat = await fs.stat(filePath);
+      fileMode = stat.mode & 0o777;
+    } catch {
+      fileMode = 0o600;
+    }
+    await atomicWriteFile(filePath, data, fileMode);
+    return { kind: 'written', path: filePath };
+  } finally {
+    await lock.release();
+  }
+}
+
+/**
+ * Create a profile file exclusively using crash-safe atomic publication.
+ *
+ * Writes to an exclusive same-directory temp (wx), fsync/close, then publishes
+ * via hard-link (`link`, fails EEXIST atomically) then unlink temp + fsync
+ * dir. If the final file already exists, EEXIST is caught and 'exists' is
+ * returned. Primary errors are preserved; cleanup/fsync errors are aggregated
+ * so they are not masked (#2).
+ */
+async function createProfileExclusive(
+  filePath: string,
+  data: string,
+): Promise<ProfileWriteResult> {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tmpPath = uniqueTempPath(dir, base, '.create.tmp');
+
+  const errors: Error[] = [];
+  let primaryError: Error | null = null;
+  let result: ProfileWriteResult | null = null;
+
+  try {
+    const handle = await fs.open(tmpPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(data, 'utf-8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+
+    try {
+      await fs.link(tmpPath, filePath);
+      await fsyncDir(dir);
+      result = { kind: 'written', path: filePath };
+    } catch (error) {
+      if (hasErrnoCode(error, 'EEXIST')) {
+        result = { kind: 'exists', path: filePath };
+      } else {
+        throw error;
+      }
+    }
+  } catch (error) {
+    primaryError = error instanceof Error ? error : new Error(String(error));
+    errors.push(primaryError);
+  } finally {
+    let tempRemoved = false;
+    try {
+      await fs.unlink(tmpPath);
+      tempRemoved = true;
+    } catch (error) {
+      if (!hasErrnoCode(error, 'ENOENT')) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+    if (tempRemoved) {
+      // Fsync parent directory after temp unlink for durability (#7).
+      try {
+        await fsyncDir(dir);
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  }
+
+  if (primaryError !== null && errors.length > 1) {
+    throw new AggregateError(
+      errors,
+      `createProfileExclusive failed: primary error plus ${errors.length - 1} cleanup/fsync error(s)`,
+    );
+  }
+  if (primaryError !== null) {
+    throw primaryError;
+  }
+  // result is non-null here because no primary error was thrown
+  return result ?? { kind: 'written', path: filePath };
+}
+
+/**
+ * Cohesive public API for deleting a canonical profile JSON file under the
+ * shared profiles lock. Throws ENOENT-based error if the file does not exist
+ * (callers translate to user-facing messages).
+ *
+ * @internal ProfileManager imports this directly; not re-exported from root.
+ */
+export async function deleteProfileFile(
+  profilesDir: string,
+  profileName: string,
+): Promise<void> {
+  const filePath = profileFilePath(profilesDir, profileName);
+  const lock = await acquireProfilesLock(profilesDir);
+  try {
+    await fs.unlink(filePath);
+    await fsyncDir(profilesDir);
+  } finally {
+    await lock.release();
+  }
+}

--- a/packages/settings/src/profiles/profileStore.ts
+++ b/packages/settings/src/profiles/profileStore.ts
@@ -8,6 +8,15 @@ import * as fsSync from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
+import { channel } from 'node:diagnostics_channel';
+
+/**
+ * diagnostics_channel name published exactly once per async lock acquisition
+ * when the first EEXIST is observed. The payload is `{ lockPath: string }`.
+ * Tests subscribe to this channel to deterministically observe lock
+ * contention without sleeps.
+ */
+export const LOCK_CONTENTION_CHANNEL = 'llxprt:profilesLock:contention';
 
 const LOCK_FILE_NAME = '.profiles.lock';
 
@@ -50,22 +59,37 @@ const DIR_FSYNC_UNSUPPORTED_CODES: ReadonlySet<string> = new Set([
 /**
  * Structural guard for Node.js filesystem errors that carry a `code`
  * property (ENOENT, EEXIST, EACCES, etc.). Avoids `as NodeJS.ErrnoException`
- * type assertions at every catch site.
+ * type assertions at every catch site. Only `code` is required; `message`
+ * may be absent on values that pass the guard (the guard itself only checks
+ * for the presence and type of `code`).
  */
 export interface ErrnoError {
-  readonly code?: string;
-  readonly message: string;
+  readonly code: string;
+  readonly message?: string;
+}
+
+/**
+ * A value that has been structurally verified to carry a string `code`
+ * property. This is the narrowed form used by internal guards so that
+ * `error.code` is always `string` (never `undefined`) after narrowing.
+ */
+interface CodedError {
+  readonly code: string;
 }
 
 export function hasErrnoCode(
   error: unknown,
   expectedCode: string,
 ): error is ErrnoError {
+  return isObjectWithCode(error) && error.code === expectedCode;
+}
+
+function isObjectWithCode(error: unknown): error is CodedError {
   return (
     typeof error === 'object' &&
     error !== null &&
     'code' in error &&
-    error.code === expectedCode
+    typeof error.code === 'string'
   );
 }
 
@@ -390,6 +414,7 @@ export async function acquireProfilesLock(
   await fs.mkdir(profilesDir, { recursive: true, mode: 0o700 });
   const lockPath = lockPathForProfilesDir(profilesDir);
   const deadline = Date.now() + (deadlineMs ?? ASYNC_LOCK_DEADLINE_MS);
+  let contentionPublished = false;
 
   for (;;) {
     const { metadata, serialized } = buildOwnerMetadata();
@@ -406,6 +431,13 @@ export async function acquireProfilesLock(
     } catch (error) {
       if (!hasErrnoCode(error, 'EEXIST')) {
         throw error;
+      }
+      // Publish a contention event once per acquisition after the first
+      // EEXIST, carrying a minimal lockPath payload. Tests subscribe to
+      // this channel to observe lock contention without sleeps.
+      if (!contentionPublished) {
+        contentionPublished = true;
+        channel(LOCK_CONTENTION_CHANNEL).publish({ lockPath });
       }
     }
 
@@ -520,7 +552,7 @@ export function withProfilesLockSync<T>(
   } catch (releaseError) {
     if (outcome.kind === 'error') {
       throw new AggregateError(
-        [outcome.error, releaseError],
+        [toError(outcome.error), toError(releaseError)],
         'profiles operation and lock release both failed',
       );
     }
@@ -533,7 +565,30 @@ export function withProfilesLockSync<T>(
   return outcome.value;
 }
 
-async function withProfilesLock<T>(
+/**
+ * Normalize a caught `unknown` value into an `Error` for inclusion in an
+ * `AggregateError`. If the value is already an Error, it is returned as-is.
+ * Otherwise, a best-effort description is produced without throwing, even
+ * if the value's toString is hostile.
+ */
+function toError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+  let description: string;
+  try {
+    if (typeof value === 'string') {
+      description = value;
+    } else {
+      description = String(value);
+    }
+  } catch {
+    description = '(unrepresentable value)';
+  }
+  return new Error(description);
+}
+
+export async function withProfilesLock<T>(
   profilesDir: string,
   operation: () => Promise<T>,
 ): Promise<T> {
@@ -550,7 +605,7 @@ async function withProfilesLock<T>(
   } catch (releaseError) {
     if (outcome.kind === 'error') {
       throw new AggregateError(
-        [outcome.error, releaseError],
+        [toError(outcome.error), toError(releaseError)],
         'profiles operation and lock release both failed',
       );
     }
@@ -631,15 +686,7 @@ export async function fsyncDir(dirPath: string): Promise<void> {
  * code that should be silently ignored (#5).
  */
 function isDirFsyncUnsupported(error: unknown): boolean {
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof error.code === 'string'
-  ) {
-    return DIR_FSYNC_UNSUPPORTED_CODES.has(error.code);
-  }
-  return false;
+  return isObjectWithCode(error) && DIR_FSYNC_UNSUPPORTED_CODES.has(error.code);
 }
 
 // ─── File read helper ───────────────────────────────────────────────────────

--- a/packages/settings/src/profiles/profileStore.ts
+++ b/packages/settings/src/profiles/profileStore.ts
@@ -742,13 +742,11 @@ export type ProfileWriteResult =
   | { readonly kind: 'exists'; readonly path: string };
 
 function profileFilePath(profilesDir: string, profileName: string): string {
+  const forbiddenNames = new Set(['', '.', '..']);
+  const hasForbiddenSeparator = /[\\/\0]/u.test(profileName);
   if (
-    profileName.trim() === '' ||
-    profileName === '.' ||
-    profileName === '..' ||
-    profileName.includes('\0') ||
-    profileName.includes('/') ||
-    profileName.includes('\\') ||
+    forbiddenNames.has(profileName.trim()) ||
+    hasForbiddenSeparator ||
     path.isAbsolute(profileName)
   ) {
     throw new Error(`Invalid profile name: ${JSON.stringify(profileName)}`);

--- a/packages/settings/src/settings/validation.ts
+++ b/packages/settings/src/settings/validation.ts
@@ -243,7 +243,14 @@ export function parseProfile(input: unknown): Profile {
   if (typeof input.model !== 'string' || input.model === '') {
     throw new Error('missing required fields');
   }
-  if (!modelParamsSchema.safeParse(input.modelParams).success) {
+  // Historical compatibility (#2477): standard version 1 profiles produced
+  // by older builds may omit modelParams entirely. Normalize to {} at this
+  // shared parse boundary so all consumers (ProfileManager, repair, wizard)
+  // see a canonical shape. Genuine loadbalancer profiles are unaffected
+  // (handled above). This is safe because modelParams is optional in the
+  // schema and {} is always valid.
+  const modelParams = input.modelParams === undefined ? {} : input.modelParams;
+  if (!modelParamsSchema.safeParse(modelParams).success) {
     throw new Error('missing required fields');
   }
   if (!ephemeralSettingsSchema.safeParse(input.ephemeralSettings).success) {
@@ -253,7 +260,8 @@ export function parseProfile(input: unknown): Profile {
     throw new Error('unsupported profile version');
   }
 
-  return standardProfileSchema.parse(input);
+  const normalized = { ...input, modelParams };
+  return standardProfileSchema.parse(normalized);
 }
 
 function isPromptCachingValue(value: unknown): value is PromptCachingValue {


### PR DESCRIPTION
## Summary

- harden startup migration around platform-standard paths, including paths containing spaces
- normalize and repair legacy standard profiles that omit modelParams without overwriting healthy canonical profiles
- coordinate migration, repair, wizard saves, and ProfileManager writes through crash-safe profile locking and atomic persistence
- preserve profile auth-key-name, base URL, model, and filesystem permissions

## Verification

- targeted migration/profile suite: 151 tests passed
- npm run typecheck
- npm run lint:eslint-guard
- npm run format
- npm run build
- Open Code Review completed; valid findings remediated

Fixes #2476
Fixes #2477