### PR TITLE
Hard-fail E2E on provider quota/rate-limit errors (Fixes #2279)

### DIFF
--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -26,6 +26,13 @@ import {
   LLXPRT_CONFIG_DIR,
   DEFAULT_CONTEXT_FILENAME,
 } from '@vybestack/llxprt-code-tools';
+// Import the quota-guard module directly (not the package index): the index
+// re-exports test-rig.ts which imports from 'vitest', and vitest cannot be
+// imported inside globalSetup (it runs in a different context).
+import {
+  clearQuotaGuard,
+  getQuotaGuardTrip,
+} from '@vybestack/llxprt-code-test-utils/src/quota-guard.js';
 
 // Handle the case where import.meta.url might be undefined in CI
 const __dirname = import.meta?.url
@@ -75,6 +82,9 @@ export async function setup() {
   }
 
   process.env['INTEGRATION_TEST_FILE_DIR'] = runDir;
+  // Clear any stale quota-guard sentinel from a previous run. `runDir` is fresh
+  // per run so this is defensive, but cheap insurance against leaked state.
+  clearQuotaGuard();
   // Don't set LLXPRT_CODE_INTEGRATION_TEST anymore - we use --ide-mode disable instead
   process.env['TELEMETRY_LOG_FILE'] = join(runDir, 'telemetry.log');
   // Ensure IDE detection doesn't trigger during tests
@@ -89,6 +99,10 @@ export async function setup() {
 }
 
 export async function teardown() {
+  // Capture the quota-guard trip BEFORE any cleanup: the sentinel lives inside
+  // `runDir` (INTEGRATION_TEST_FILE_DIR), which the cleanup below removes.
+  const trip = getQuotaGuardTrip();
+
   // Cleanup the test run directory unless KEEP_OUTPUT is set
   if (process.env['KEEP_OUTPUT'] !== 'true' && runDir) {
     try {
@@ -107,5 +121,26 @@ export async function teardown() {
     } catch {
       // File might not exist if the test failed before creating it.
     }
+  }
+
+  // A tripped guard means the run aborted early on a provider quota/rate-limit
+  // wall. Surface a prominent banner and throw so vitest exits non-zero even
+  // though the executed tests were skipped (not failed) — this is an
+  // infrastructure/quota failure, not a code regression. globalSetup may be
+  // subject to no-console lint, so use process.stdout.write.
+  if (trip !== null) {
+    const divider = '='.repeat(72);
+    const banner = [
+      divider,
+      'E2E RUN ABORTED: provider quota/rate-limit exhausted',
+      trip.reason,
+      'Remaining tests were skipped; this is an infrastructure/quota failure, not a code regression.',
+      divider,
+      '',
+    ].join('\n');
+    process.stdout.write(banner);
+    throw new Error(
+      `E2E aborted: provider quota/rate-limit exhausted — ${trip.reason}`,
+    );
   }
 }

--- a/integration-tests/setup-quota-guard.ts
+++ b/integration-tests/setup-quota-guard.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach } from 'vitest';
+import { getQuotaGuardTrip } from './test-helper.js';
+
+/**
+ * Per-test short-circuit for the E2E quota guard.
+ *
+ * Once any real-provider run has hit a quota / rate-limit wall, the guard
+ * sentinel is tripped (see `@vybestack/llxprt-code-test-utils`). From that
+ * point on, running further tests against the provider is pointless and only
+ * burns quota, so this hook stops each remaining test from touching the API.
+ *
+ * CRITICAL semantics (verified against vitest 3.2 — do not change):
+ *  - On a FRESH test (retryCount === 0), `ctx.skip(note)` throws a skip signal
+ *    BEFORE the test file's own `beforeEach`/test body run, so no API call is
+ *    made and the test is reported as skipped with the quota note.
+ *  - On a RETRY of an already-failed test (retryCount > 0), skipping would
+ *    ERASE the original failure and let the whole run exit 0 — masking the
+ *    quota outage as success. Retries must therefore THROW instead, which
+ *    fails fast (no API call) while preserving a non-zero outcome.
+ */
+beforeEach((ctx) => {
+  const trip = getQuotaGuardTrip();
+  if (!trip) {
+    return;
+  }
+
+  const retryCount = ctx.task.result?.retryCount ?? 0;
+  if (retryCount === 0) {
+    ctx.skip(
+      `E2E aborted: provider quota/rate-limit exhausted — ${trip.reason}`,
+    );
+  } else {
+    throw new Error(
+      `E2E aborted: provider quota/rate-limit exhausted — failing retry fast without calling the API: ${trip.reason}`,
+    );
+  }
+});

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     testTimeout: 300000, // 5 minutes
     globalSetup: './globalSetup.ts',
-    setupFiles: ['./setup-fast-check.ts'],
+    setupFiles: ['./setup-fast-check.ts', './setup-quota-guard.ts'],
     reporters: ['default'],
     include: ['**/*.test.ts'],
     retry: 2,

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -6,4 +6,5 @@
 
 export * from './export-surface-helpers.js';
 export * from './file-system-test-helpers.js';
+export * from './quota-guard.js';
 export * from './test-rig.js';

--- a/packages/test-utils/src/interactive-run.test.ts
+++ b/packages/test-utils/src/interactive-run.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as pty from '@lydell/node-pty';
+import { createDiagnosticsSink } from './diagnostics.js';
+import { InteractiveRun } from './interactive-run.js';
+import { clearQuotaGuard, getQuotaGuardTrip } from './quota-guard.js';
+
+/**
+ * Generous per-test budget: each case spawns a real PTY child and waits out a
+ * short poll/exit window. Well under this, but padded for slow CI.
+ */
+const TEST_TIMEOUT_MS = 20000;
+
+const tempDirs: string[] = [];
+const liveRuns: InteractiveRun[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'interactive-run-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Stub a fresh, isolated guard state directory and disable both CI annotations
+ * and the fake-responses env so each test exercises the real guard behaviour.
+ * Returns the state dir (also used as the child cwd).
+ */
+function activateGuard(): string {
+  const dir = makeTempDir();
+  vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+  vi.stubEnv('GITHUB_ACTIONS', 'false');
+  vi.stubEnv('LLXPRT_FAKE_RESPONSES', undefined);
+  clearQuotaGuard();
+  return dir;
+}
+
+/**
+ * Spawn a real PTY around `node -e <script>` and wrap it in an InteractiveRun.
+ * Uses the genuine diagnostics sink (infrastructure, not the code under test),
+ * so nothing about the quota-detection path is mocked.
+ */
+function spawnInteractive(
+  cwd: string,
+  script: string,
+  quotaGuardEnabled: boolean,
+): InteractiveRun {
+  const ptyProcess = pty.spawn(process.execPath, ['-e', script], {
+    name: 'xterm-color',
+    cols: 80,
+    rows: 30,
+    cwd,
+    env: process.env,
+  });
+  const run = new InteractiveRun(ptyProcess, createDiagnosticsSink(null), {
+    quotaGuardEnabled,
+  });
+  liveRuns.push(run);
+  return run;
+}
+
+/** A child that prints `message`, then stays alive until killed in cleanup. */
+function keepAliveScript(message: string): string {
+  return `process.stdout.write(${JSON.stringify(`${message}\n`)}); setInterval(() => {}, 1000);`;
+}
+
+/** A child that prints `message`, then exits with `code` after a short delay. */
+function printThenExitScript(message: string, code: number): string {
+  return `process.stdout.write(${JSON.stringify(`${message}\n`)}); setTimeout(() => process.exit(${code}), 300);`;
+}
+
+function asError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+  throw new Error(
+    `Expected rejection to be an Error, received: ${String(value)}`,
+  );
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    return asError(error);
+  }
+  throw new Error('Expected the promise to reject, but it resolved');
+}
+
+/** Poll until the run reports it has exited, or throw after `timeoutMs`. */
+async function waitUntilExited(
+  run: InteractiveRun,
+  timeoutMs: number,
+): Promise<void> {
+  const start = Date.now();
+  while (!run.exited) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('Timed out waiting for the PTY child to exit');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+describe('InteractiveRun quota guard integration', () => {
+  afterEach(async () => {
+    for (const run of liveRuns) {
+      await run.kill();
+    }
+    liveRuns.length = 0;
+    clearQuotaGuard();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it(
+    'trips the guard and throws a labelled error when expectText times out after a quota signal',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        keepAliveScript('HTTP 429 Too Many Requests'),
+        true,
+      );
+
+      const error = await captureRejection(
+        run.expectText('this-text-never-appears', 800),
+      );
+
+      expect(error.message).toContain('[QUOTA/RATE-LIMIT]');
+      expect(getQuotaGuardTrip()).not.toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'does not trip the guard when expectText times out without a quota signal',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        keepAliveScript('ordinary interactive output, nothing unusual'),
+        true,
+      );
+
+      const error = await captureRejection(
+        run.expectText('this-text-never-appears', 800),
+      );
+
+      expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+      expect(getQuotaGuardTrip()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'does not trip the guard on a quota signal when quota detection is disabled (fake responses)',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        keepAliveScript('HTTP 429 Too Many Requests'),
+        false,
+      );
+
+      const error = await captureRejection(
+        run.expectText('this-text-never-appears', 800),
+      );
+
+      expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+      expect(getQuotaGuardTrip()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'trips the guard and rejects with a labelled error when the PTY exits non-zero after a quota signal',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        printThenExitScript('Rate limit exceeded. Please wait a moment', 1),
+        true,
+      );
+
+      const error = await captureRejection(run.expectExit(5000));
+
+      expect(error.message).toContain('[QUOTA/RATE-LIMIT]');
+      expect(getQuotaGuardTrip()).not.toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'resolves with the exit code (and does not trip) on an ordinary non-zero exit',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        printThenExitScript('ordinary failure, no quota involved', 3),
+        true,
+      );
+
+      const exitCode = await run.expectExit(5000);
+
+      expect(exitCode).toBe(3);
+      expect(getQuotaGuardTrip()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'resolves with 0 (and does not trip) on a clean exit even when quota detection is enabled',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        printThenExitScript('all good here', 0),
+        true,
+      );
+
+      const exitCode = await run.expectExit(5000);
+
+      expect(exitCode).toBe(0);
+      expect(getQuotaGuardTrip()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'trips the guard when expectExit is called AFTER the PTY already exited on a quota wall',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        printThenExitScript('quota exceeded for this project', 1),
+        true,
+      );
+
+      // The quota wall kills the child before the test awaits its exit. This
+      // exercises the already-exited fast path of expectExit, which must still
+      // detect the signal rather than hang until the timeout.
+      await waitUntilExited(run, 5000);
+
+      const error = await captureRejection(run.expectExit(5000));
+
+      expect(error.message).toContain('[QUOTA/RATE-LIMIT]');
+      expect(getQuotaGuardTrip()).not.toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'trips the guard and rejects with a labelled error when expectExit times out after a quota signal',
+    async () => {
+      const dir = activateGuard();
+      // The child prints a quota signal then hangs forever (never exits), so the
+      // ONLY way expectExit can surface the quota wall is by scanning output on
+      // the timeout path — the exit event never fires.
+      const run = spawnInteractive(
+        dir,
+        keepAliveScript('HTTP 429 Too Many Requests'),
+        true,
+      );
+
+      const error = await captureRejection(run.expectExit(1000));
+
+      expect(error.message).toContain('[QUOTA/RATE-LIMIT]');
+      // The plain timeout context is preserved alongside the quota label so the
+      // reader still sees that the process failed to exit.
+      expect(error.message.toLowerCase()).toContain('exit');
+      expect(getQuotaGuardTrip()).not.toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'rejects with a plain timeout error (and does not trip) when expectExit times out without a quota signal',
+    async () => {
+      const dir = activateGuard();
+      const run = spawnInteractive(
+        dir,
+        keepAliveScript('ordinary interactive output, nothing unusual'),
+        true,
+      );
+
+      const error = await captureRejection(run.expectExit(1000));
+
+      expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+      expect(error.message).toContain('did not exit');
+      expect(getQuotaGuardTrip()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/test-utils/src/interactive-run.test.ts
+++ b/packages/test-utils/src/interactive-run.test.ts
@@ -41,7 +41,19 @@ function activateGuard(): string {
   const dir = makeTempDir();
   vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
   vi.stubEnv('GITHUB_ACTIONS', 'false');
+  vi.stubEnv('LLXPRT_QUOTA_GUARD_DISABLED', undefined);
   clearQuotaGuard();
+  return dir;
+}
+
+/**
+ * Like {@link activateGuard} but with the global disable switch on. Even with
+ * `quotaGuardEnabled: true` at construction, a globally disabled guard must not
+ * relabel interactive failures as `[QUOTA/RATE-LIMIT]` nor record a sentinel.
+ */
+function activateDisabledGuard(): string {
+  const dir = activateGuard();
+  vi.stubEnv('LLXPRT_QUOTA_GUARD_DISABLED', 'true');
   return dir;
 }
 
@@ -190,6 +202,52 @@ describe('InteractiveRun quota guard integration', () => {
       );
 
       expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+      expect(getQuotaGuardTrip()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'preserves the ordinary expectExit timeout (no quota label, no trip) when the guard is globally disabled',
+    async () => {
+      // Disable-switch regression on the interactive TIMEOUT classification
+      // path (_exitTimeoutError): even though quotaGuardEnabled is true and the
+      // hung child's output carries a 429, a globally disabled guard must yield
+      // the plain "did not exit" timeout error — exactly like the non-disabled
+      // "rejects with a plain timeout error" case for non-quota output — and
+      // must record no trip.
+      const dir = activateDisabledGuard();
+      const run = spawnInteractive(
+        dir,
+        keepAliveScript('HTTP 429 Too Many Requests'),
+        true,
+      );
+
+      const error = await captureRejection(run.expectExit(1000));
+
+      expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+      expect(error.message).toContain('did not exit');
+      expect(getQuotaGuardTrip()).toBeNull();
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'resolves with the exit code (no quota label, no trip) on a non-zero quota exit when the guard is globally disabled',
+    async () => {
+      // Disable-switch regression on the interactive NON-ZERO EXIT path: a
+      // quota-looking non-zero exit must resolve with the ordinary exit code
+      // (not reject with a labelled quota error) and record no trip.
+      const dir = activateDisabledGuard();
+      const run = spawnInteractive(
+        dir,
+        printThenExitScript('Rate limit exceeded. Please wait a moment', 1),
+        true,
+      );
+
+      const exitCode = await run.expectExit(5000);
+
+      expect(exitCode).toBe(1);
       expect(getQuotaGuardTrip()).toBeNull();
     },
     TEST_TIMEOUT_MS,

--- a/packages/test-utils/src/interactive-run.test.ts
+++ b/packages/test-utils/src/interactive-run.test.ts
@@ -29,15 +29,18 @@ function makeTempDir(): string {
 }
 
 /**
- * Stub a fresh, isolated guard state directory and disable both CI annotations
- * and the fake-responses env so each test exercises the real guard behaviour.
- * Returns the state dir (also used as the child cwd).
+ * Stub a fresh, isolated guard state directory and disable CI annotations so
+ * each test exercises the real guard behaviour. Returns the state dir (also
+ * used as the child cwd).
+ *
+ * Unlike the non-interactive process-run path, InteractiveRun's guard is gated
+ * solely by the explicit `quotaGuardEnabled` constructor flag (never by
+ * `LLXPRT_FAKE_RESPONSES`), so no fake-responses env stubbing is needed here.
  */
 function activateGuard(): string {
   const dir = makeTempDir();
   vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
   vi.stubEnv('GITHUB_ACTIONS', 'false');
-  vi.stubEnv('LLXPRT_FAKE_RESPONSES', undefined);
   clearQuotaGuard();
   return dir;
 }
@@ -110,15 +113,24 @@ async function waitUntilExited(
 
 describe('InteractiveRun quota guard integration', () => {
   afterEach(async () => {
-    for (const run of liveRuns) {
-      await run.kill();
-    }
+    // Kill every live run concurrently: each kill() may wait out a SIGTERM
+    // grace period before SIGKILL, so awaiting them sequentially would cost
+    // N × gracePeriod. Best-effort — swallow per-run kill errors so one failure
+    // never blocks cleanup of the rest.
+    await Promise.all(liveRuns.map((run) => run.kill().catch(() => {})));
     liveRuns.length = 0;
     clearQuotaGuard();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true });
+      // The temp dir is (was) the PTY child's cwd; if the OS has not fully
+      // reaped the just-killed child, rmSync can hit EBUSY/EPERM. Swallow it so
+      // the remaining dirs are still cleaned up; leftovers are OS-reclaimed.
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Ignore — best-effort cleanup.
+      }
     }
     tempDirs.length = 0;
   });

--- a/packages/test-utils/src/interactive-run.ts
+++ b/packages/test-utils/src/interactive-run.ts
@@ -11,6 +11,24 @@ import type * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
 import type { DiagnosticsSink } from './diagnostics.js';
 import { getDefaultTimeout, poll } from './util.js';
+import { detectQuotaSignal, tripQuotaGuard } from './quota-guard.js';
+
+/**
+ * Construction-time options for {@link InteractiveRun}.
+ */
+export interface InteractiveRunConstructorOptions {
+  /**
+   * Whether the E2E quota guard should observe this interactive session.
+   *
+   * The PTY child owns its own environment, so InteractiveRun cannot know
+   * whether the run is backed by fake responses. {@link TestRig.runInteractive}
+   * therefore decides applicability (real provider ⇒ enabled) and passes it in
+   * explicitly. Fake-responses runs never touch a real provider, so leaving
+   * this `false` keeps fixture text from producing false quota trips. Defaults
+   * to `false` so a bare InteractiveRun never mutates shared guard state.
+   */
+  readonly quotaGuardEnabled?: boolean;
+}
 
 /**
  * Manages a PTY-backed interactive CLI session for e2e/integration tests.
@@ -22,10 +40,16 @@ export class InteractiveRun {
   private _exitCode: number | null = null;
   private _killed = false;
   private readonly _diagnostics: DiagnosticsSink;
+  private readonly _quotaGuardEnabled: boolean;
 
-  constructor(ptyProcess: pty.IPty, diagnostics: DiagnosticsSink) {
+  constructor(
+    ptyProcess: pty.IPty,
+    diagnostics: DiagnosticsSink,
+    options: InteractiveRunConstructorOptions = {},
+  ) {
     this.ptyProcess = ptyProcess;
     this._diagnostics = diagnostics;
+    this._quotaGuardEnabled = options.quotaGuardEnabled ?? false;
     ptyProcess.onData((data) => {
       this._output.push(data);
       if (env['KEEP_OUTPUT'] === 'true' || env['VERBOSE'] === 'true') {
@@ -36,6 +60,65 @@ export class InteractiveRun {
       this._exited = true;
       this._exitCode = exitCode;
     });
+  }
+
+  /**
+   * Scan the accumulated output for a provider quota / rate-limit signal on a
+   * FAILURE path, tripping the shared sentinel on the first match.
+   *
+   * Kept strictly failure-only: callers must invoke this solely when an
+   * interaction has already failed (timeout / non-zero exit). Scanning a
+   * successful interaction would risk false trips from a model legitimately
+   * echoing phrases like "rate limit". No-op (returns `null`) when the guard is
+   * disabled for this run. Returns the human-readable reason when a signal is
+   * found, otherwise `null`.
+   */
+  private detectAndTripQuota(): string | null {
+    if (!this._quotaGuardEnabled) {
+      return null;
+    }
+    const reason = detectQuotaSignal(stripAnsi(this.output));
+    if (reason === null) {
+      return null;
+    }
+    tripQuotaGuard(reason);
+    return reason;
+  }
+
+  /**
+   * Build the labelled quota error for an interactive FAILURE path, or `null`
+   * when the guard is disabled or no signal is present.
+   *
+   * Scanning trips the shared sentinel as a side effect (via
+   * {@link detectAndTripQuota}). The `[QUOTA/RATE-LIMIT]` prefix mirrors the
+   * non-interactive paths in process-run.ts so both surface identically.
+   *
+   * @param context Short description of the failure path, embedded in the error.
+   */
+  private quotaError(context: string): Error | null {
+    const reason = this.detectAndTripQuota();
+    if (reason === null) {
+      return null;
+    }
+    return new Error(`[QUOTA/RATE-LIMIT] ${context}; ${reason}`);
+  }
+
+  /**
+   * Fail fast on a quota wall from an interactive FAILURE path by THROWING the
+   * labelled error when one applies.
+   *
+   * Intended for `async` failure paths (e.g. an `expectText` poll timeout or an
+   * interactive-readiness timeout) where a throw propagates naturally as a
+   * rejected promise. A no-op when the guard is disabled or no signal is
+   * present, letting the caller surface its ordinary assertion failure instead.
+   *
+   * @param context Short description of the failure path, embedded in the error.
+   */
+  failFastOnQuota(context: string): void {
+    const error = this.quotaError(context);
+    if (error !== null) {
+      throw error;
+    }
   }
 
   /**
@@ -73,11 +156,20 @@ export class InteractiveRun {
 
   async expectText(text: string, timeout?: number) {
     const effectiveTimeout = timeout ?? getDefaultTimeout();
-    await poll(
+    const found = await poll(
       () => stripAnsi(this.output).toLowerCase().includes(text.toLowerCase()),
       effectiveTimeout,
       200,
     );
+    // Failure-only quota check: a missing text after the poll window is the
+    // common interactive quota symptom (the model never responds, or the UI
+    // shows a 429). Trip the guard and fail fast with the labelled error before
+    // the ordinary assertion so remaining tests skip instead of burning quota.
+    if (!found) {
+      this.failFastOnQuota(
+        `interactive run timed out after ${effectiveTimeout}ms waiting for text "${text}"`,
+      );
+    }
     expect(stripAnsi(this.output).toLowerCase()).toContain(text.toLowerCase());
   }
 
@@ -171,19 +263,73 @@ export class InteractiveRun {
   expectExit(timeout?: number): Promise<number> {
     const effectiveTimeout = timeout ?? getDefaultTimeout();
     return new Promise((resolve, reject) => {
+      // If the PTY already exited, the constructor's onExit handler captured
+      // the code; a late onExit registration here would never fire (node-pty
+      // does not replay the event), so settle synchronously instead of hanging
+      // until the timeout.
+      if (this._exited) {
+        this._settleExit(this._exitCode ?? 0, resolve, reject);
+        return;
+      }
       const timer = setTimeout(
-        () =>
-          reject(
-            new Error(
-              `Test timed out: process did not exit within ${effectiveTimeout}ms.`,
-            ),
-          ),
+        () => reject(this._exitTimeoutError(effectiveTimeout)),
         effectiveTimeout,
       );
       this.ptyProcess.onExit(({ exitCode }) => {
         clearTimeout(timer);
-        resolve(exitCode);
+        this._settleExit(exitCode, resolve, reject);
       });
     });
+  }
+
+  /**
+   * Build the rejection error for an {@link expectExit} TIMEOUT, upgrading it to
+   * the labelled `[QUOTA/RATE-LIMIT]` error (and tripping the guard) when the
+   * accumulated output carries a quota / rate-limit signal.
+   *
+   * A PTY child that prints a 429 and then hangs never fires an exit event, so
+   * the timeout is the ONLY place the wall can be observed for such a child —
+   * without this scan the sentinel would never trip and the rest of the suite
+   * would keep burning quota. Falls back to the ordinary timeout error when the
+   * guard is disabled or no signal is present, preserving callers that assert on
+   * the plain message. Extracted from {@link expectExit} to keep that method's
+   * complexity within lint limits.
+   */
+  private _exitTimeoutError(effectiveTimeout: number): Error {
+    const quota = this.quotaError(
+      `interactive run did not exit within ${effectiveTimeout}ms`,
+    );
+    if (quota !== null) {
+      return quota;
+    }
+    return new Error(
+      `Test timed out: process did not exit within ${effectiveTimeout}ms.`,
+    );
+  }
+
+  /**
+   * Resolve or reject an {@link expectExit} promise for a given exit code.
+   *
+   * Failure-only quota check: a non-zero exit whose accumulated output carries
+   * a quota / rate-limit signal trips the guard and rejects with the labelled
+   * `[QUOTA/RATE-LIMIT]` error. A clean exit — or a non-zero exit without a
+   * quota signal — resolves with the code exactly as before, preserving callers
+   * that assert on the returned exit code.
+   */
+  private _settleExit(
+    exitCode: number,
+    resolve: (code: number) => void,
+    reject: (error: Error) => void,
+  ): void {
+    if (exitCode !== 0) {
+      const error = this.quotaError(
+        `interactive run exited with code ${exitCode}`,
+      );
+      if (error !== null) {
+        reject(error);
+        return;
+      }
+    }
+    resolve(exitCode);
   }
 }

--- a/packages/test-utils/src/interactive-run.ts
+++ b/packages/test-utils/src/interactive-run.ts
@@ -13,6 +13,7 @@ import type { DiagnosticsSink } from './diagnostics.js';
 import { getDefaultTimeout, poll } from './util.js';
 import {
   detectQuotaSignal,
+  formatQuotaError,
   isQuotaGuardActive,
   tripQuotaGuard,
 } from './quota-guard.js';
@@ -106,8 +107,9 @@ export class InteractiveRun {
    * when the guard is disabled or no signal is present.
    *
    * Scanning trips the shared sentinel as a side effect (via
-   * {@link detectAndTripQuota}). The `[QUOTA/RATE-LIMIT]` prefix mirrors the
-   * non-interactive paths in process-run.ts so both surface identically.
+   * {@link detectAndTripQuota}). Uses the shared {@link formatQuotaError}
+   * formatter so the error layout is identical to the non-interactive paths in
+   * process-run.ts.
    *
    * @param context Short description of the failure path, embedded in the error.
    */
@@ -116,7 +118,7 @@ export class InteractiveRun {
     if (reason === null) {
       return null;
     }
-    return new Error(`[QUOTA/RATE-LIMIT] ${context}; ${reason}`);
+    return new Error(formatQuotaError(reason, context));
   }
 
   /**

--- a/packages/test-utils/src/interactive-run.ts
+++ b/packages/test-utils/src/interactive-run.ts
@@ -263,19 +263,35 @@ export class InteractiveRun {
   expectExit(timeout?: number): Promise<number> {
     const effectiveTimeout = timeout ?? getDefaultTimeout();
     return new Promise((resolve, reject) => {
+      // Latch so exactly one of the exit/timeout paths proceeds. Without it a
+      // fired timeout (which rejects via _exitTimeoutError and runs quota
+      // detection) could be followed by a late onExit — node-pty fires onExit
+      // whenever the child finally dies — that re-enters _settleExit and
+      // re-runs quota detection as a spurious side effect. Mirrors the
+      // documented `settled` latch in process-run.ts's spawnRunWithTimeout.
+      let settled = false;
+
       // If the PTY already exited, the constructor's onExit handler captured
       // the code; a late onExit registration here would never fire (node-pty
       // does not replay the event), so settle synchronously instead of hanging
       // until the timeout.
       if (this._exited) {
+        settled = true;
         this._settleExit(this._exitCode ?? 0, resolve, reject);
         return;
       }
-      const timer = setTimeout(
-        () => reject(this._exitTimeoutError(effectiveTimeout)),
-        effectiveTimeout,
-      );
+      const timer = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        reject(this._exitTimeoutError(effectiveTimeout));
+      }, effectiveTimeout);
       this.ptyProcess.onExit(({ exitCode }) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
         clearTimeout(timer);
         this._settleExit(exitCode, resolve, reject);
       });

--- a/packages/test-utils/src/interactive-run.ts
+++ b/packages/test-utils/src/interactive-run.ts
@@ -11,7 +11,11 @@ import type * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
 import type { DiagnosticsSink } from './diagnostics.js';
 import { getDefaultTimeout, poll } from './util.js';
-import { detectQuotaSignal, tripQuotaGuard } from './quota-guard.js';
+import {
+  detectQuotaSignal,
+  isQuotaGuardActive,
+  tripQuotaGuard,
+} from './quota-guard.js';
 
 /**
  * Construction-time options for {@link InteractiveRun}.
@@ -72,9 +76,21 @@ export class InteractiveRun {
    * echoing phrases like "rate limit". No-op (returns `null`) when the guard is
    * disabled for this run. Returns the human-readable reason when a signal is
    * found, otherwise `null`.
+   *
+   * Two independent gates must both be open before any scanning happens:
+   *   1. `_quotaGuardEnabled` — the per-run fake-response gate. A fake-backed
+   *      interactive session never touches a real provider, so fixture text
+   *      that merely echoes "rate limit" must not trip the guard.
+   *   2. {@link isQuotaGuardActive} — the shared global gate. Under
+   *      `LLXPRT_QUOTA_GUARD_DISABLED=true` (or with no sentinel state dir)
+   *      `tripQuotaGuard` silently no-ops, so returning a reason here would
+   *      mislabel an ordinary timeout / non-zero exit as `[QUOTA/RATE-LIMIT]`
+   *      even though nothing was recorded. Reusing the guard's own predicate
+   *      keeps this path in lockstep with the sentinel instead of re-deriving
+   *      the disabled-state logic.
    */
   private detectAndTripQuota(): string | null {
-    if (!this._quotaGuardEnabled) {
+    if (!this._quotaGuardEnabled || !isQuotaGuardActive()) {
       return null;
     }
     const reason = detectQuotaSignal(stripAnsi(this.output));

--- a/packages/test-utils/src/process-run.test.ts
+++ b/packages/test-utils/src/process-run.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  spawnRun,
+  spawnRunWithTimeout,
+  type RunContext,
+} from './process-run.js';
+import {
+  clearQuotaGuard,
+  getQuotaGuardTrip,
+  tripQuotaGuard,
+} from './quota-guard.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'process-run-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Stub a fresh, isolated guard state directory and disable both the
+ * fake-responses short-circuit and CI annotations so each test exercises the
+ * real guard behaviour.
+ */
+function activateGuard(): string {
+  const dir = makeTempDir();
+  vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+  vi.stubEnv('GITHUB_ACTIONS', 'false');
+  vi.stubEnv('LLXPRT_FAKE_RESPONSES', undefined);
+  clearQuotaGuard();
+  return dir;
+}
+
+/**
+ * Narrow an unknown rejection value to an Error without a type assertion so
+ * we can make behavioural assertions against its message.
+ */
+function asError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+  throw new Error(
+    `Expected rejection to be an Error, received: ${String(value)}`,
+  );
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    return asError(error);
+  }
+  throw new Error('Expected the promise to reject, but it resolved');
+}
+
+const identityTransform = (stdout: string): string => stdout;
+
+describe('process-run quota guard integration', () => {
+  afterEach(() => {
+    clearQuotaGuard();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it('trips the guard and prefixes the error when a failing run emits a quota signal', async () => {
+    const dir = activateGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: [
+        '-e',
+        'console.error("HTTP 429 Too Many Requests"); process.exit(1)',
+      ],
+      testDir: dir,
+    };
+
+    const error = await captureRejection(
+      spawnRun(ctx, {}, false, identityTransform),
+    );
+
+    expect(error.message).toContain('[QUOTA/RATE-LIMIT]');
+    expect(getQuotaGuardTrip()).not.toBeNull();
+  });
+
+  it('does not trip the guard for an ordinary non-quota failure', async () => {
+    const dir = activateGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: ['-e', 'console.error("ordinary failure"); process.exit(1)'],
+      testDir: dir,
+    };
+
+    const error = await captureRejection(
+      spawnRun(ctx, {}, false, identityTransform),
+    );
+
+    expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+    expect(error.message).toContain('Process exited with code');
+    expect(getQuotaGuardTrip()).toBeNull();
+  });
+
+  it('does not trip the guard when the run uses fake responses', async () => {
+    const dir = activateGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: [
+        '-e',
+        'console.error("HTTP 429 Too Many Requests"); process.exit(1)',
+      ],
+      testDir: dir,
+      childEnv: { ...process.env, LLXPRT_FAKE_RESPONSES: '/tmp/fake.jsonl' },
+    };
+
+    const error = await captureRejection(
+      spawnRun(ctx, {}, false, identityTransform),
+    );
+
+    expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+    expect(getQuotaGuardTrip()).toBeNull();
+  });
+
+  it('refuses to start a new run once the guard is already tripped', async () => {
+    const dir = activateGuard();
+    tripQuotaGuard('test trip');
+
+    const markerPath = join(dir, 'child-ran.marker');
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: [
+        '-e',
+        `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "ran")`,
+      ],
+      testDir: dir,
+    };
+
+    const error = await captureRejection(
+      spawnRun(ctx, {}, false, identityTransform),
+    );
+
+    expect(error.message).toContain('refusing to start');
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it('trips the guard when a timed-out run emitted a quota signal', async () => {
+    const dir = activateGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: [
+        '-e',
+        'console.error("Rate limit exceeded. Please wait"); setTimeout(() => {}, 10000)',
+      ],
+      testDir: dir,
+    };
+
+    const error = await captureRejection(
+      spawnRunWithTimeout(ctx, {}, false, identityTransform, 800),
+    );
+
+    expect(error.message).toContain('[QUOTA/RATE-LIMIT]');
+    expect(error.message).toContain('timed out');
+    expect(getQuotaGuardTrip()).not.toBeNull();
+  });
+
+  it('never trips on a successful run even when the output mentions rate limits', async () => {
+    const dir = activateGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: ['-e', 'console.log("rate limit"); process.exit(0)'],
+      testDir: dir,
+    };
+
+    const result = await spawnRun(ctx, {}, false, identityTransform);
+
+    expect(result).toContain('rate limit');
+    expect(getQuotaGuardTrip()).toBeNull();
+  });
+});

--- a/packages/test-utils/src/process-run.test.ts
+++ b/packages/test-utils/src/process-run.test.ts
@@ -112,6 +112,29 @@ describe('process-run quota guard integration', () => {
     expect(getQuotaGuardTrip()).toBeNull();
   });
 
+  it('reports the signal name (not "code null") when the child is signal-killed', async () => {
+    const dir = activateGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: [
+        '-e',
+        // The child terminates itself with SIGTERM, so Node's close event emits
+        // `code: null, signal: "SIGTERM"`. The error message must name the
+        // signal rather than the misleading "exited with code null".
+        'process.kill(process.pid, "SIGTERM")',
+      ],
+      testDir: dir,
+    };
+
+    const error = await captureRejection(
+      spawnRun(ctx, {}, false, identityTransform),
+    );
+
+    expect(error.message).toContain('terminated by signal SIGTERM');
+    expect(error.message).not.toContain('code null');
+    expect(getQuotaGuardTrip()).toBeNull();
+  });
+
   it('does not trip the guard when the run uses fake responses', async () => {
     const dir = activateGuard();
     const ctx: RunContext = {

--- a/packages/test-utils/src/process-run.test.ts
+++ b/packages/test-utils/src/process-run.test.ts
@@ -37,7 +37,20 @@ function activateGuard(): string {
   vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
   vi.stubEnv('GITHUB_ACTIONS', 'false');
   vi.stubEnv('LLXPRT_FAKE_RESPONSES', undefined);
+  vi.stubEnv('LLXPRT_QUOTA_GUARD_DISABLED', undefined);
   clearQuotaGuard();
+  return dir;
+}
+
+/**
+ * Like {@link activateGuard} but with the global disable switch flipped on.
+ * A configured state dir proves the ONLY thing suppressing the guard is
+ * `LLXPRT_QUOTA_GUARD_DISABLED=true`, so failure classification must fall back
+ * to the ordinary (non-quota) error even on quota-looking output.
+ */
+function activateDisabledGuard(): string {
+  const dir = activateGuard();
+  vi.stubEnv('LLXPRT_QUOTA_GUARD_DISABLED', 'true');
   return dir;
 }
 
@@ -109,6 +122,53 @@ describe('process-run quota guard integration', () => {
 
     expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
     expect(error.message).toContain('Process exited with code');
+    expect(getQuotaGuardTrip()).toBeNull();
+  });
+
+  it('preserves the ordinary exit failure (no quota label, no trip) when the guard is disabled', async () => {
+    // Regression for the disable switch: with LLXPRT_QUOTA_GUARD_DISABLED=true
+    // the guard no-ops, so a failing run whose output DOES contain a quota
+    // signal must still surface as the plain "exited with code" error and must
+    // NOT be relabelled [QUOTA/RATE-LIMIT] nor record a sentinel.
+    const dir = activateDisabledGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: [
+        '-e',
+        'console.error("HTTP 429 Too Many Requests"); process.exit(1)',
+      ],
+      testDir: dir,
+    };
+
+    const error = await captureRejection(
+      spawnRun(ctx, {}, false, identityTransform),
+    );
+
+    expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+    expect(error.message).toContain('Process exited with code');
+    expect(getQuotaGuardTrip()).toBeNull();
+  });
+
+  it('preserves the ordinary timeout failure (no quota label, no trip) when the guard is disabled', async () => {
+    // Same disable-switch regression on the timeout classification path: a
+    // quota-looking hang must time out as the plain timeout error, never the
+    // labelled quota timeout, and must not trip the sentinel.
+    const dir = activateDisabledGuard();
+    const ctx: RunContext = {
+      command: process.execPath,
+      commandArgs: [
+        '-e',
+        'console.error("Rate limit exceeded. Please wait"); setTimeout(() => {}, 10000)',
+      ],
+      testDir: dir,
+    };
+
+    const error = await captureRejection(
+      spawnRunWithTimeout(ctx, {}, false, identityTransform, 800),
+    );
+
+    expect(error.message).not.toContain('[QUOTA/RATE-LIMIT]');
+    expect(error.message).toContain('timed out');
     expect(getQuotaGuardTrip()).toBeNull();
   });
 

--- a/packages/test-utils/src/process-run.ts
+++ b/packages/test-utils/src/process-run.ts
@@ -10,6 +10,7 @@ import type { Writable } from 'node:stream';
 import {
   detectQuotaSignal,
   getQuotaGuardTrip,
+  isQuotaGuardActive,
   tripQuotaGuard,
 } from './quota-guard.js';
 
@@ -60,20 +61,39 @@ export interface RunContext {
 }
 
 /**
- * Whether the E2E quota guard should observe this run.
+ * Whether this run uses fake responses (and therefore must NOT be observed by
+ * the quota guard).
  *
  * Runs backed by fake responses never touch a real provider, so quota/
  * rate-limit detection is meaningless for them and could produce false trips
- * from fixture text. The guard therefore does NOT apply when
- * `LLXPRT_FAKE_RESPONSES` is set in the child environment (or, when the child
- * inherits the parent environment, in `process.env`).
+ * from fixture text. Applicability is read from the child environment when the
+ * caller supplies one, otherwise from `process.env` (the child inherits it).
  */
-function guardApplies(ctx: RunContext): boolean {
+function usesFakeResponses(ctx: RunContext): boolean {
   const fakeResponses =
     ctx.childEnv !== undefined
       ? ctx.childEnv['LLXPRT_FAKE_RESPONSES']
       : process.env['LLXPRT_FAKE_RESPONSES'];
-  return fakeResponses === undefined || fakeResponses === '';
+  return fakeResponses !== undefined && fakeResponses !== '';
+}
+
+/**
+ * Whether the E2E quota guard should observe this run.
+ *
+ * Two independent conditions must both hold:
+ *   1. The run is NOT fake-response-backed (see {@link usesFakeResponses}).
+ *   2. The shared guard is globally active ({@link isQuotaGuardActive}) — i.e.
+ *      a sentinel state dir is configured and `LLXPRT_QUOTA_GUARD_DISABLED` is
+ *      not `true`.
+ *
+ * Folding the global predicate in here means that with the guard disabled,
+ * `tripQuotaGuard` (which no-ops) is never even reached and, crucially, the
+ * failure-classification paths keep the ORIGINAL exit/timeout error instead of
+ * relabelling it `[QUOTA/RATE-LIMIT]`. Reusing the guard's own predicate keeps
+ * this in lockstep with the sentinel rather than re-deriving disabled-state.
+ */
+function guardApplies(ctx: RunContext): boolean {
+  return !usesFakeResponses(ctx) && isQuotaGuardActive();
 }
 
 /**

--- a/packages/test-utils/src/process-run.ts
+++ b/packages/test-utils/src/process-run.ts
@@ -9,6 +9,7 @@ import { env } from 'node:process';
 import type { Writable } from 'node:stream';
 import {
   detectQuotaSignal,
+  formatQuotaError,
   getQuotaGuardTrip,
   isQuotaGuardActive,
   tripQuotaGuard,
@@ -160,7 +161,7 @@ function buildExitFailureError(
   const baseMessage = `${detail}:\n${accumulator.stderr}`;
   const reason = detectAndTripQuota(ctx, accumulator);
   if (reason !== null) {
-    return new Error(`[QUOTA/RATE-LIMIT] ${reason}\n${baseMessage}`);
+    return new Error(formatQuotaError(reason, baseMessage));
   }
   return new Error(baseMessage);
 }
@@ -178,7 +179,7 @@ function buildTimeoutError(
   const reason = detectAndTripQuota(ctx, accumulator);
   if (reason !== null) {
     return new Error(
-      `[QUOTA/RATE-LIMIT] TestRig.run() timed out after ${timeoutMs}ms; output contained quota/rate-limit signal: ${reason}`,
+      formatQuotaError(reason, `TestRig.run() timed out after ${timeoutMs}ms`),
     );
   }
   return new Error(`TestRig.run() timed out after ${timeoutMs}ms`);

--- a/packages/test-utils/src/process-run.ts
+++ b/packages/test-utils/src/process-run.ts
@@ -120,13 +120,24 @@ function detectAndTripQuota(
  * Build the rejection error for a non-zero exit, upgrading it to a labelled
  * quota error (and tripping the guard) when the output looks like a provider
  * quota/rate-limit wall.
+ *
+ * Node's `close` event reports EITHER a numeric exit `code` (with `signal`
+ * `null`) or a `signal` name (with `code` `null`) when the child was terminated
+ * by a signal. The message distinguishes the two so a signal-killed child reads
+ * as "terminated by signal SIGTERM" rather than a misleading
+ * "exited with code null".
  */
 function buildExitFailureError(
   ctx: RunContext,
-  code: number,
+  code: number | null,
+  signal: NodeJS.Signals | null,
   accumulator: StreamAccumulator,
 ): Error {
-  const baseMessage = `Process exited with code ${code}:\n${accumulator.stderr}`;
+  const detail =
+    code !== null
+      ? `Process exited with code ${code}`
+      : `Process terminated by signal ${signal ?? 'unknown'}`;
+  const baseMessage = `${detail}:\n${accumulator.stderr}`;
   const reason = detectAndTripQuota(ctx, accumulator);
   if (reason !== null) {
     return new Error(`[QUOTA/RATE-LIMIT] ${reason}\n${baseMessage}`);
@@ -182,14 +193,14 @@ export function spawnRun(
   child.stderr.on('data', onStderr);
 
   return new Promise<string>((resolve, reject) => {
-    child.on('close', (code: number) => {
+    child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
       if (code === 0) {
         const transformed = transform(accumulator.stdout);
         resolve(
           maybeAppendStderr(transformed, accumulator.stderr, isJsonOutput),
         );
       } else {
-        reject(buildExitFailureError(ctx, code, accumulator));
+        reject(buildExitFailureError(ctx, code, signal, accumulator));
       }
     });
   });
@@ -229,7 +240,7 @@ export function spawnRunWithTimeout(
   let settled = false;
   let timeoutHandle: NodeJS.Timeout;
   const processPromise = new Promise<string>((resolve, reject) => {
-    child.on('close', (code: number) => {
+    child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
       if (settled) {
         return;
       }
@@ -241,7 +252,7 @@ export function spawnRunWithTimeout(
           maybeAppendStderr(transformed, accumulator.stderr, isJsonOutput),
         );
       } else {
-        reject(buildExitFailureError(ctx, code, accumulator));
+        reject(buildExitFailureError(ctx, code, signal, accumulator));
       }
     });
   });

--- a/packages/test-utils/src/process-run.ts
+++ b/packages/test-utils/src/process-run.ts
@@ -7,6 +7,11 @@
 import { spawn } from 'node:child_process';
 import { env } from 'node:process';
 import type { Writable } from 'node:stream';
+import {
+  detectQuotaSignal,
+  getQuotaGuardTrip,
+  tripQuotaGuard,
+} from './quota-guard.js';
 
 /**
  * Stream handler that accumulates stdout/stderr and mirrors them to the
@@ -55,6 +60,100 @@ export interface RunContext {
 }
 
 /**
+ * Whether the E2E quota guard should observe this run.
+ *
+ * Runs backed by fake responses never touch a real provider, so quota/
+ * rate-limit detection is meaningless for them and could produce false trips
+ * from fixture text. The guard therefore does NOT apply when
+ * `LLXPRT_FAKE_RESPONSES` is set in the child environment (or, when the child
+ * inherits the parent environment, in `process.env`).
+ */
+function guardApplies(ctx: RunContext): boolean {
+  const fakeResponses =
+    ctx.childEnv !== undefined
+      ? ctx.childEnv['LLXPRT_FAKE_RESPONSES']
+      : process.env['LLXPRT_FAKE_RESPONSES'];
+  return fakeResponses === undefined || fakeResponses === '';
+}
+
+/**
+ * Pre-spawn short-circuit: once the guard has tripped, refuse to launch any
+ * further real-provider CLI runs. Returns the rejection error, or `null` when
+ * the run may proceed.
+ */
+function preSpawnGuardError(ctx: RunContext): Error | null {
+  if (!guardApplies(ctx)) {
+    return null;
+  }
+  const trip = getQuotaGuardTrip();
+  if (trip === null) {
+    return null;
+  }
+  return new Error(
+    `E2E quota guard tripped — refusing to start CLI run: ${trip.reason}`,
+  );
+}
+
+/**
+ * Scan accumulated child output for a quota/rate-limit signal, tripping the
+ * guard on the first match. Returns the reason when a signal is present and
+ * the guard applies, otherwise `null`.
+ */
+function detectAndTripQuota(
+  ctx: RunContext,
+  accumulator: StreamAccumulator,
+): string | null {
+  if (!guardApplies(ctx)) {
+    return null;
+  }
+  const reason = detectQuotaSignal(
+    `${accumulator.stdout}\n${accumulator.stderr}`,
+  );
+  if (reason === null) {
+    return null;
+  }
+  tripQuotaGuard(reason);
+  return reason;
+}
+
+/**
+ * Build the rejection error for a non-zero exit, upgrading it to a labelled
+ * quota error (and tripping the guard) when the output looks like a provider
+ * quota/rate-limit wall.
+ */
+function buildExitFailureError(
+  ctx: RunContext,
+  code: number,
+  accumulator: StreamAccumulator,
+): Error {
+  const baseMessage = `Process exited with code ${code}:\n${accumulator.stderr}`;
+  const reason = detectAndTripQuota(ctx, accumulator);
+  if (reason !== null) {
+    return new Error(`[QUOTA/RATE-LIMIT] ${reason}\n${baseMessage}`);
+  }
+  return new Error(baseMessage);
+}
+
+/**
+ * Build the rejection error for a timed-out run, upgrading it to a labelled
+ * quota error (and tripping the guard) when the accumulated output looks like
+ * a provider quota/rate-limit wall.
+ */
+function buildTimeoutError(
+  ctx: RunContext,
+  timeoutMs: number,
+  accumulator: StreamAccumulator,
+): Error {
+  const reason = detectAndTripQuota(ctx, accumulator);
+  if (reason !== null) {
+    return new Error(
+      `[QUOTA/RATE-LIMIT] TestRig.run() timed out after ${timeoutMs}ms; output contained quota/rate-limit signal: ${reason}`,
+    );
+  }
+  return new Error(`TestRig.run() timed out after ${timeoutMs}ms`);
+}
+
+/**
  * Spawn a child process for `TestRig.run` / `runCommand` and resolve with the
  * captured stdout. Mirrors output when verbose mode is enabled.
  */
@@ -64,6 +163,11 @@ export function spawnRun(
   isJsonOutput: boolean,
   transform: (stdout: string) => string,
 ): Promise<string> {
+  const preSpawnError = preSpawnGuardError(ctx);
+  if (preSpawnError !== null) {
+    return Promise.reject(preSpawnError);
+  }
+
   const { onStdout, onStderr, accumulator } = createStreamHandlers();
 
   const child = spawn(ctx.command, ctx.commandArgs, {
@@ -85,9 +189,7 @@ export function spawnRun(
           maybeAppendStderr(transformed, accumulator.stderr, isJsonOutput),
         );
       } else {
-        reject(
-          new Error(`Process exited with code ${code}:\n${accumulator.stderr}`),
-        );
+        reject(buildExitFailureError(ctx, code, accumulator));
       }
     });
   });
@@ -103,6 +205,11 @@ export function spawnRunWithTimeout(
   transform: (stdout: string) => string,
   timeoutMs: number,
 ): Promise<string> {
+  const preSpawnError = preSpawnGuardError(ctx);
+  if (preSpawnError !== null) {
+    return Promise.reject(preSpawnError);
+  }
+
   const { onStdout, onStderr, accumulator } = createStreamHandlers();
 
   const child = spawn(ctx.command, ctx.commandArgs, {
@@ -116,9 +223,17 @@ export function spawnRunWithTimeout(
   child.stdout.on('data', onStdout);
   child.stderr.on('data', onStderr);
 
+  // Ensures exactly one of the close/timeout paths settles the race. Without
+  // this, a timed-out child still emits a late 'close' event that would re-run
+  // quota detection (a redundant, and in tests cross-boundary, side effect).
+  let settled = false;
   let timeoutHandle: NodeJS.Timeout;
   const processPromise = new Promise<string>((resolve, reject) => {
     child.on('close', (code: number) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       clearTimeout(timeoutHandle);
       if (code === 0) {
         const transformed = transform(accumulator.stdout);
@@ -126,17 +241,19 @@ export function spawnRunWithTimeout(
           maybeAppendStderr(transformed, accumulator.stderr, isJsonOutput),
         );
       } else {
-        reject(
-          new Error(`Process exited with code ${code}:\n${accumulator.stderr}`),
-        );
+        reject(buildExitFailureError(ctx, code, accumulator));
       }
     });
   });
 
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
     timeoutHandle = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       child.kill('SIGTERM');
-      reject(new Error(`TestRig.run() timed out after ${timeoutMs}ms`));
+      reject(buildTimeoutError(ctx, timeoutMs, accumulator));
     }, timeoutMs);
   });
 

--- a/packages/test-utils/src/quota-guard-vitest-integration.test.ts
+++ b/packages/test-utils/src/quota-guard-vitest-integration.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { SENTINEL_FILENAME } from './quota-guard.js';
 
 /**
  * Real-process proof of the vitest-level acceptance mechanism.
@@ -152,6 +153,8 @@ function createFixture(): { root: string; stateDir: string } {
  */
 function childEnv(stateDir: string): NodeJS.ProcessEnv {
   const next: NodeJS.ProcessEnv = { ...process.env };
+  // `Object.keys` snapshots the keys up front, so deleting entries from `next`
+  // while iterating that snapshot is safe (we never mutate the array we loop).
   for (const key of Object.keys(next)) {
     if (key.startsWith('VITEST')) {
       delete next[key];
@@ -167,7 +170,15 @@ function childEnv(stateDir: string): NodeJS.ProcessEnv {
 describe('quota guard vitest acceptance semantics', () => {
   afterEach(() => {
     for (const root of fixtureRoots) {
-      rmSync(root, { recursive: true, force: true });
+      // Best-effort: an orphaned vitest worker may still hold the fixture cwd
+      // for a beat after a SIGKILL timeout, so a rmSync can hit EBUSY/EPERM.
+      // Swallow it so the remaining fixture roots are still cleaned up; the OS
+      // temp dir is reclaimed regardless.
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // Ignore — leftover temp dirs are harmless and OS-reclaimed.
+      }
     }
     fixtureRoots.length = 0;
   });
@@ -183,6 +194,13 @@ describe('quota guard vitest acceptance semantics', () => {
         env: childEnv(stateDir),
         encoding: 'utf8',
         timeout: 90000,
+        // On timeout, SIGKILL (not the default SIGTERM) the vitest child so it
+        // cannot linger in a graceful-shutdown handler; SIGTERM alone reaches
+        // only the direct child, letting vitest worker processes orphan and
+        // race the afterEach rmSync of their cwd. SIGKILL plus best-effort
+        // cleanup below is the practical mitigation (a post-hoc process-group
+        // kill is not possible with spawnSync).
+        killSignal: 'SIGKILL',
       },
     );
 
@@ -203,7 +221,7 @@ describe('quota guard vitest acceptance semantics', () => {
 
     // The sentinel was actually tripped inside the child (real cross-process
     // file handshake, not a simulation).
-    expect(existsSync(join(stateDir, 'quota-guard-tripped.json'))).toBe(true);
+    expect(existsSync(join(stateDir, SENTINEL_FILENAME))).toBe(true);
 
     // The reporter surfaced the quota skip note for the skipped test...
     expect(combinedOutput).toContain(SKIP_NOTE);

--- a/packages/test-utils/src/quota-guard-vitest-integration.test.ts
+++ b/packages/test-utils/src/quota-guard-vitest-integration.test.ts
@@ -9,13 +9,15 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { SENTINEL_FILENAME } from './quota-guard.js';
 
@@ -32,10 +34,61 @@ import { SENTINEL_FILENAME } from './quota-guard.js';
  * effects. That is exactly what this test does.
  */
 
-// From packages/test-utils/src/ up to the repo root.
-const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
-const REPO_NODE_MODULES = join(REPO_ROOT, 'node_modules');
-const VITEST_ENTRY = join(REPO_NODE_MODULES, 'vitest', 'vitest.mjs');
+// Resolve vitest via Node's module resolution rather than a hardcoded relative
+// depth or an assumed root-hoisted layout. `createRequire` is anchored at THIS
+// file, so it honours whatever node_modules actually resolves vitest for the
+// test-utils package — hoisted to the repo root, nested per-package, or a
+// pnpm-style store. If this file ever moves to a different package depth, or a
+// different package manager changes the install layout, resolution still finds
+// the installed vitest instead of silently breaking on a stale relative path.
+const require = createRequire(import.meta.url);
+
+/**
+ * Absolute path to the installed `vitest` CLI entry (its `bin`).
+ *
+ * `require.resolve('vitest/vitest.mjs')` returns the real bin file directly, so
+ * we never assume it is hoisted to a specific node_modules. Throws a
+ * descriptive error (rather than letting a later spawn fail with an opaque
+ * ENOENT) if vitest cannot be resolved at all.
+ */
+function resolveVitestEntry(): string {
+  try {
+    return require.resolve('vitest/vitest.mjs');
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to resolve the vitest CLI entry ('vitest/vitest.mjs') from ` +
+        `${import.meta.url}. Is vitest installed for @vybestack/llxprt-code-` +
+        `test-utils? Underlying resolver error: ${detail}`,
+    );
+  }
+}
+
+/**
+ * Absolute path to the node_modules directory that actually provides vitest.
+ *
+ * Derived from the resolved `vitest/package.json` (`.../node_modules/vitest/
+ * package.json` → `.../node_modules`) so the fixture symlinks in the SAME
+ * install tree the child `vitest` will load from — no root-hoist assumption and
+ * no directory-depth walking. Throws descriptively when vitest is unresolvable.
+ */
+function resolveNodeModulesDir(): string {
+  try {
+    // dirname(vitest/package.json) => .../node_modules/vitest
+    // dirname(that)                => .../node_modules
+    return dirname(dirname(require.resolve('vitest/package.json')));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to resolve 'vitest/package.json' from ${import.meta.url} to ` +
+        `locate the node_modules that provides vitest. Underlying resolver ` +
+        `error: ${detail}`,
+    );
+  }
+}
+
+const VITEST_ENTRY = resolveVitestEntry();
+const REPO_NODE_MODULES = resolveNodeModulesDir();
 // file:// URL so the fixture (which lives outside the repo tree) can import the
 // real guard module by absolute specifier on every platform, including Windows.
 const QUOTA_GUARD_MODULE_URL = new URL('./quota-guard.js', import.meta.url)
@@ -45,6 +98,12 @@ const MARKER_FILENAME = 'test-two-body-ran.marker';
 const SKIP_NOTE = 'E2E aborted: provider quota/rate-limit exhausted';
 const ORIGINAL_FAILURE_MARKER = 'ORIGINAL_FAILURE_PRESERVED';
 const TRIP_REASON = 'matched HTTP 429 status: "simulated provider wall"';
+
+// Number of concurrent worker processes for the atomic-publication race. Each
+// runs in its own forked vitest child and calls tripQuotaGuard with a distinct
+// reason, so publication is genuinely contended across real OS processes.
+const RACE_WORKER_COUNT = 8;
+const RACE_REASON_PREFIX = 'matched HTTP 429 status: "race worker ';
 
 const fixtureRoots: string[] = [];
 
@@ -132,7 +191,15 @@ function createFixture(): { root: string; stateDir: string } {
   const root = mkdtempSync(join(tmpdir(), 'quota-guard-vitest-'));
   fixtureRoots.push(root);
 
-  symlinkSync(REPO_NODE_MODULES, join(root, 'node_modules'), 'dir');
+  // Link the real install's node_modules into the fixture so the child vitest
+  // (and `vitest/config`) resolves without a local install. On Windows a 'dir'
+  // symlink needs administrator privileges or developer mode and fails EPERM in
+  // ordinary CI/contributor shells; a 'junction' needs neither and works for an
+  // ABSOLUTE target — which REPO_NODE_MODULES always is (it comes from
+  // require.resolve, not a relative guess) — so it is the correct cross-platform
+  // choice here. Elsewhere a directory symlink is retained.
+  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+  symlinkSync(REPO_NODE_MODULES, join(root, 'node_modules'), linkType);
 
   const stateDir = join(root, 'state');
   mkdirSync(stateDir, { recursive: true });
@@ -142,6 +209,115 @@ function createFixture(): { root: string; stateDir: string } {
   writeFileSync(join(root, 'vitest.config.ts'), fixtureConfigSource());
 
   return { root, stateDir };
+}
+
+/**
+ * One worker fixture file for the atomic-publication race. Each worker runs in
+ * its OWN forked vitest process. To force genuine contention rather than a
+ * happens-to-be-serial sequence, every worker first announces readiness (a
+ * `ready-N` file) then synchronously barrier-waits until all workers are ready
+ * before calling {@link tripQuotaGuard}, so the publications fire together and
+ * actually race for the single sentinel.
+ */
+function raceWorkerSource(index: number): string {
+  const reason = `${RACE_REASON_PREFIX}${index}"`;
+  return `import { it, expect } from 'vitest';
+import { readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tripQuotaGuard } from ${JSON.stringify(QUOTA_GUARD_MODULE_URL)};
+
+// Synchronous cross-process barrier sleep (no async in a sync test body).
+const sab = new Int32Array(new SharedArrayBuffer(4));
+function sleep(ms) {
+  Atomics.wait(sab, 0, 0, ms);
+}
+
+it('race worker ${index} publishes under contention', () => {
+  const stateDir = process.env['INTEGRATION_TEST_FILE_DIR'];
+  if (stateDir === undefined) {
+    throw new Error('INTEGRATION_TEST_FILE_DIR not set in race worker ${index}');
+  }
+  writeFileSync(join(stateDir, 'ready-${index}'), '1');
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    const ready = readdirSync(stateDir).filter((f) =>
+      f.startsWith('ready-'),
+    ).length;
+    if (ready >= ${RACE_WORKER_COUNT}) {
+      break;
+    }
+    sleep(10);
+  }
+  tripQuotaGuard(${JSON.stringify(reason)});
+  expect(true).toBe(true);
+});
+`;
+}
+
+/**
+ * vitest config for the race fixture. A forks pool with fileParallelism and
+ * min/max workers pinned to the worker count launches all worker files as
+ * concurrent OS processes, so the sentinel publication is genuinely contended.
+ */
+function raceConfigSource(): string {
+  return `import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['race-*.fixture.ts'],
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: false } },
+    fileParallelism: true,
+    minWorkers: ${RACE_WORKER_COUNT},
+    maxWorkers: ${RACE_WORKER_COUNT},
+    reporters: ['default'],
+  },
+});
+`;
+}
+
+/**
+ * Materialize a self-contained vitest project whose {@link RACE_WORKER_COUNT}
+ * worker files each trip the guard from a separate forked process. Shares the
+ * same node_modules symlink strategy as {@link createFixture}.
+ */
+function createRaceFixture(): { root: string; stateDir: string } {
+  const root = mkdtempSync(join(tmpdir(), 'quota-guard-race-'));
+  fixtureRoots.push(root);
+
+  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+  symlinkSync(REPO_NODE_MODULES, join(root, 'node_modules'), linkType);
+
+  const stateDir = join(root, 'state');
+  mkdirSync(stateDir, { recursive: true });
+
+  for (let i = 0; i < RACE_WORKER_COUNT; i++) {
+    writeFileSync(join(root, `race-${i}.fixture.ts`), raceWorkerSource(i));
+  }
+  writeFileSync(join(root, 'vitest.config.ts'), raceConfigSource());
+
+  return { root, stateDir };
+}
+
+/**
+ * The set of complete reason strings any race worker could legitimately have
+ * published. Used to assert the winning sentinel holds a WHOLE, valid reason
+ * (never a truncated or empty payload), which is the crux of atomic
+ * publication.
+ */
+function expectedRaceReasons(): ReadonlySet<string> {
+  const reasons = new Set<string>();
+  for (let i = 0; i < RACE_WORKER_COUNT; i++) {
+    reasons.add(`${RACE_REASON_PREFIX}${i}"`);
+  }
+  return reasons;
+}
+
+/** Names of any leftover atomic-publication temp files in the state dir. */
+function leftoverTempFiles(stateDir: string): string[] {
+  return readdirSync(stateDir).filter(
+    (name) => name.startsWith(SENTINEL_FILENAME) && name.endsWith('.tmp'),
+  );
 }
 
 /**
@@ -227,5 +403,66 @@ describe('quota guard vitest acceptance semantics', () => {
     expect(combinedOutput).toContain(SKIP_NOTE);
     // ...and the original failure was preserved (not erased by the retry).
     expect(combinedOutput).toContain(ORIGINAL_FAILURE_MARKER);
+  }, 120000);
+
+  it('atomically publishes exactly one complete sentinel under real multi-process contention, leaving no temp files', () => {
+    const { root, stateDir } = createRaceFixture();
+
+    // Launch one vitest run whose forks pool spawns RACE_WORKER_COUNT worker
+    // PROCESSES; each barrier-waits for the others, then calls tripQuotaGuard
+    // simultaneously, so publication is genuinely contended across real OS
+    // processes rather than a lucky serial order.
+    const result = spawnSync(
+      process.execPath,
+      [VITEST_ENTRY, 'run', '--root', root],
+      {
+        cwd: root,
+        env: childEnv(stateDir),
+        encoding: 'utf8',
+        timeout: 90000,
+        killSignal: 'SIGKILL',
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+
+    // Every worker's own `it` passes (tripQuotaGuard never throws), so the race
+    // run exits zero — this is a plain multi-process publication race, not the
+    // suite-abort acceptance scenario above.
+    const combinedOutput = `${result.stdout}
+${result.stderr}`;
+    expect(result.status).toBe(0);
+
+    // All workers actually reached the barrier — i.e. we really did have
+    // RACE_WORKER_COUNT concurrent processes contending, not a degenerate one.
+    const readyFiles = readdirSync(stateDir).filter((name) =>
+      name.startsWith('ready-'),
+    );
+    expect(readyFiles.length).toBe(RACE_WORKER_COUNT);
+
+    // First-writer-wins: exactly ONE sentinel exists after the race.
+    const sentinelPath = join(stateDir, SENTINEL_FILENAME);
+    expect(existsSync(sentinelPath)).toBe(true);
+
+    // Complete publication: the sentinel parses and holds a WHOLE, valid reason
+    // from one specific worker — never a truncated/empty payload. This is the
+    // property the atomic temp-write + hard-link guarantees and the old
+    // `writeFileSync(..., 'wx')` could not (a reader could catch a 0-byte file).
+    const raw = readFileSync(sentinelPath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    expect(typeof parsed).toBe('object');
+    expect(parsed).not.toBeNull();
+    const record = parsed as Record<string, unknown>;
+    expect(typeof record['reason']).toBe('string');
+    expect(expectedRaceReasons().has(record['reason'] as string)).toBe(true);
+    expect(typeof record['timestamp']).toBe('string');
+
+    // No leftover temp files: every staged temp (winner's and losers') was
+    // cleaned up in the finally block, so the state dir holds no `*.tmp`.
+    expect(leftoverTempFiles(stateDir)).toStrictEqual([]);
+
+    // Surface child output if the run somehow misbehaved (kept last so the
+    // structural assertions above report first).
+    expect(combinedOutput).not.toContain('ERR_');
   }, 120000);
 });

--- a/packages/test-utils/src/quota-guard-vitest-integration.test.ts
+++ b/packages/test-utils/src/quota-guard-vitest-integration.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * Real-process proof of the vitest-level acceptance mechanism.
+ *
+ * The quota guard's promise is that once the sentinel trips, the remainder of
+ * the E2E suite (a) SKIPS fresh tests via `ctx.skip` in the shared beforeEach
+ * hook, (b) THROWS on retries so an original failure is preserved, and (c)
+ * makes the overall run exit non-zero. Those are vitest runtime semantics, not
+ * pure functions — the only faithful way to verify them is to run a real nested
+ * `vitest` against a fixture that mirrors integration-tests/setup-quota-guard.ts
+ * and observe the process outcome, the reporter output, and the filesystem side
+ * effects. That is exactly what this test does.
+ */
+
+// From packages/test-utils/src/ up to the repo root.
+const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+const REPO_NODE_MODULES = join(REPO_ROOT, 'node_modules');
+const VITEST_ENTRY = join(REPO_NODE_MODULES, 'vitest', 'vitest.mjs');
+// file:// URL so the fixture (which lives outside the repo tree) can import the
+// real guard module by absolute specifier on every platform, including Windows.
+const QUOTA_GUARD_MODULE_URL = new URL('./quota-guard.js', import.meta.url)
+  .href;
+
+const MARKER_FILENAME = 'test-two-body-ran.marker';
+const SKIP_NOTE = 'E2E aborted: provider quota/rate-limit exhausted';
+const ORIGINAL_FAILURE_MARKER = 'ORIGINAL_FAILURE_PRESERVED';
+const TRIP_REASON = 'matched HTTP 429 status: "simulated provider wall"';
+
+const fixtureRoots: string[] = [];
+
+/**
+ * Setup file for the fixture. Mirrors the retry/skip contract of the real
+ * integration-tests/setup-quota-guard.ts: fresh attempts skip with the quota
+ * note; retries throw so the original failure is not erased and the run stays
+ * non-zero.
+ */
+function setupFileSource(): string {
+  return `import { beforeEach } from 'vitest';
+import { getQuotaGuardTrip } from ${JSON.stringify(QUOTA_GUARD_MODULE_URL)};
+
+beforeEach((ctx) => {
+  const trip = getQuotaGuardTrip();
+  if (!trip) {
+    return;
+  }
+  const retryCount = ctx.task.result?.retryCount ?? 0;
+  if (retryCount === 0) {
+    ctx.skip('${SKIP_NOTE} — ' + trip.reason);
+  } else {
+    throw new Error('${SKIP_NOTE} — failing retry fast: ' + trip.reason);
+  }
+});
+`;
+}
+
+/**
+ * The fixture test file. Test one trips the guard then fails for real (proving
+ * the original failure survives retries). Test two writes a marker file from its
+ * body — if the skip works, that body never runs and the marker never appears.
+ */
+function fixtureTestSource(): string {
+  return `import { describe, it, expect } from 'vitest';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tripQuotaGuard } from ${JSON.stringify(QUOTA_GUARD_MODULE_URL)};
+
+describe('quota guard acceptance fixture', () => {
+  it('test one: trips the guard then fails for real', () => {
+    tripQuotaGuard('${TRIP_REASON}');
+    throw new Error('${ORIGINAL_FAILURE_MARKER}');
+  });
+
+  it('test two: body must never run once the guard is tripped', () => {
+    const stateDir = process.env['INTEGRATION_TEST_FILE_DIR'];
+    if (stateDir === undefined) {
+      throw new Error('INTEGRATION_TEST_FILE_DIR not set in fixture child');
+    }
+    writeFileSync(join(stateDir, '${MARKER_FILENAME}'), 'ran');
+    expect(true).toBe(true);
+  });
+});
+`;
+}
+
+/**
+ * vitest config for the fixture. retry >= 1 exercises the retry-throw branch;
+ * fileParallelism:false and a single include keep ordering deterministic so the
+ * tripping test always precedes the skip candidate, exactly like the real suite.
+ */
+function fixtureConfigSource(): string {
+  return `import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['cases.fixture.ts'],
+    setupFiles: ['./setup.ts'],
+    retry: 1,
+    fileParallelism: false,
+    reporters: ['default'],
+  },
+});
+`;
+}
+
+/**
+ * Materialize a self-contained vitest project in an OS temp dir. The repo's
+ * node_modules is symlinked in so the child `vitest` (and `vitest/config`)
+ * resolves without a local install. Returns the fixture root and its sentinel
+ * state dir.
+ */
+function createFixture(): { root: string; stateDir: string } {
+  const root = mkdtempSync(join(tmpdir(), 'quota-guard-vitest-'));
+  fixtureRoots.push(root);
+
+  symlinkSync(REPO_NODE_MODULES, join(root, 'node_modules'), 'dir');
+
+  const stateDir = join(root, 'state');
+  mkdirSync(stateDir, { recursive: true });
+
+  writeFileSync(join(root, 'setup.ts'), setupFileSource());
+  writeFileSync(join(root, 'cases.fixture.ts'), fixtureTestSource());
+  writeFileSync(join(root, 'vitest.config.ts'), fixtureConfigSource());
+
+  return { root, stateDir };
+}
+
+/**
+ * Child environment for the nested vitest. Points the guard at the fixture's
+ * own sentinel dir and neutralizes GitHub Actions annotation env so a tripped
+ * guard inside the fixture can never write to the OUTER run's real CI step
+ * summary. Inherited VITEST_* worker vars are stripped so the child starts a
+ * clean runner rather than mistaking itself for a nested worker.
+ */
+function childEnv(stateDir: string): NodeJS.ProcessEnv {
+  const next: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(next)) {
+    if (key.startsWith('VITEST')) {
+      delete next[key];
+    }
+  }
+  next['INTEGRATION_TEST_FILE_DIR'] = stateDir;
+  delete next['GITHUB_ACTIONS'];
+  delete next['GITHUB_STEP_SUMMARY'];
+  delete next['LLXPRT_QUOTA_GUARD_DISABLED'];
+  return next;
+}
+
+describe('quota guard vitest acceptance semantics', () => {
+  afterEach(() => {
+    for (const root of fixtureRoots) {
+      rmSync(root, { recursive: true, force: true });
+    }
+    fixtureRoots.length = 0;
+  });
+
+  it('skips fresh tests, preserves the original failure on retry, and exits non-zero', () => {
+    const { root, stateDir } = createFixture();
+
+    const result = spawnSync(
+      process.execPath,
+      [VITEST_ENTRY, 'run', '--root', root],
+      {
+        cwd: root,
+        env: childEnv(stateDir),
+        encoding: 'utf8',
+        timeout: 90000,
+      },
+    );
+
+    // Surface spawn failures / timeouts as a clear error rather than a
+    // confusing downstream content-assertion miss.
+    expect(result.error).toBeUndefined();
+
+    // spawnSync with `encoding: 'utf8'` types stdout/stderr as string.
+    const combinedOutput = `${result.stdout}\n${result.stderr}`;
+
+    // (c) The overall run must exit non-zero — the outage is surfaced as a
+    // failure, never masked as success.
+    expect(result.status).not.toBe(0);
+
+    // (a) Test two's body never executed: its marker file was never written,
+    // proving `ctx.skip` short-circuited before the API-touching body.
+    expect(existsSync(join(stateDir, MARKER_FILENAME))).toBe(false);
+
+    // The sentinel was actually tripped inside the child (real cross-process
+    // file handshake, not a simulation).
+    expect(existsSync(join(stateDir, 'quota-guard-tripped.json'))).toBe(true);
+
+    // The reporter surfaced the quota skip note for the skipped test...
+    expect(combinedOutput).toContain(SKIP_NOTE);
+    // ...and the original failure was preserved (not erased by the retry).
+    expect(combinedOutput).toContain(ORIGINAL_FAILURE_MARKER);
+  }, 120000);
+});

--- a/packages/test-utils/src/quota-guard-vitest-integration.test.ts
+++ b/packages/test-utils/src/quota-guard-vitest-integration.test.ts
@@ -233,7 +233,7 @@ import { readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tripQuotaGuard } from ${JSON.stringify(QUOTA_GUARD_MODULE_URL)};
 
-// Synchronous cross-process barrier sleep (no async in a sync test body).
+// Local blocking sleep while filesystem ready files implement the barrier.
 const sab = new Int32Array(new SharedArrayBuffer(4));
 function sleep(ms: number) {
   Atomics.wait(sab, 0, 0, ms);

--- a/packages/test-utils/src/quota-guard-vitest-integration.test.ts
+++ b/packages/test-utils/src/quota-guard-vitest-integration.test.ts
@@ -182,24 +182,31 @@ export default defineConfig({
 }
 
 /**
- * Materialize a self-contained vitest project in an OS temp dir. The repo's
- * node_modules is symlinked in so the child `vitest` (and `vitest/config`)
- * resolves without a local install. Returns the fixture root and its sentinel
- * state dir.
+ * Link the real install's node_modules into a fixture root so the child vitest
+ * (and `vitest/config`) resolves without a local install.
+ *
+ * On Windows a 'dir' symlink needs administrator privileges or developer mode
+ * and fails EPERM in ordinary CI/contributor shells; a 'junction' needs neither
+ * and works for an ABSOLUTE target — which {@link REPO_NODE_MODULES} always is
+ * (it comes from require.resolve, not a relative guess) — so it is the correct
+ * cross-platform choice here. Elsewhere a directory symlink is retained.
+ * Centralised so both {@link createFixture} and {@link createRaceFixture} share
+ * one definition of the target, destination, and platform-specific link type.
+ */
+function linkNodeModules(root: string): void {
+  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+  symlinkSync(REPO_NODE_MODULES, join(root, 'node_modules'), linkType);
+}
+
+/**
+ * Materialize a self-contained vitest project in an OS temp dir. Returns the
+ * fixture root and its sentinel state dir.
  */
 function createFixture(): { root: string; stateDir: string } {
   const root = mkdtempSync(join(tmpdir(), 'quota-guard-vitest-'));
   fixtureRoots.push(root);
 
-  // Link the real install's node_modules into the fixture so the child vitest
-  // (and `vitest/config`) resolves without a local install. On Windows a 'dir'
-  // symlink needs administrator privileges or developer mode and fails EPERM in
-  // ordinary CI/contributor shells; a 'junction' needs neither and works for an
-  // ABSOLUTE target — which REPO_NODE_MODULES always is (it comes from
-  // require.resolve, not a relative guess) — so it is the correct cross-platform
-  // choice here. Elsewhere a directory symlink is retained.
-  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
-  symlinkSync(REPO_NODE_MODULES, join(root, 'node_modules'), linkType);
+  linkNodeModules(root);
 
   const stateDir = join(root, 'state');
   mkdirSync(stateDir, { recursive: true });
@@ -228,7 +235,7 @@ import { tripQuotaGuard } from ${JSON.stringify(QUOTA_GUARD_MODULE_URL)};
 
 // Synchronous cross-process barrier sleep (no async in a sync test body).
 const sab = new Int32Array(new SharedArrayBuffer(4));
-function sleep(ms) {
+function sleep(ms: number) {
   Atomics.wait(sab, 0, 0, ms);
 }
 
@@ -285,8 +292,7 @@ function createRaceFixture(): { root: string; stateDir: string } {
   const root = mkdtempSync(join(tmpdir(), 'quota-guard-race-'));
   fixtureRoots.push(root);
 
-  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
-  symlinkSync(REPO_NODE_MODULES, join(root, 'node_modules'), linkType);
+  linkNodeModules(root);
 
   const stateDir = join(root, 'state');
   mkdirSync(stateDir, { recursive: true });
@@ -343,18 +349,60 @@ function childEnv(stateDir: string): NodeJS.ProcessEnv {
   return next;
 }
 
+/**
+ * Remove a fixture root, best-effort, with a short retry for transient
+ * EBUSY/EPERM (an orphaned vitest worker may briefly hold the fixture cwd
+ * after a SIGKILL timeout). A transient retry that eventually succeeds is
+ * silent. Only an error that persists (or is not a known transient code)
+ * produces a test-diagnostics warning so a genuinely broken cleanup is
+ * visible rather than silently swallowed. The remaining fixture roots are
+ * always processed regardless of any individual failure.
+ */
+const CLEANUP_RETRY_COUNT = 3;
+const CLEANUP_RETRY_DELAY_MS = 200;
+
+// Synchronous sleep for the cleanup retry backoff (no async in afterEach).
+// Atomics.wait blocks the thread efficiently (no busy-wait CPU burn).
+const cleanupSab = new Int32Array(new SharedArrayBuffer(4));
+
+function sleepSync(ms: number): void {
+  Atomics.wait(cleanupSab, 0, 0, ms);
+}
+
+function isTransientCleanupError(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  return code === 'EBUSY' || code === 'EPERM' || code === 'ENOTEMPTY';
+}
+
+function removeFixtureRoot(root: string): void {
+  for (let attempt = 0; attempt <= CLEANUP_RETRY_COUNT; attempt++) {
+    try {
+      rmSync(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt < CLEANUP_RETRY_COUNT && isTransientCleanupError(error)) {
+        sleepSync(CLEANUP_RETRY_DELAY_MS);
+        continue;
+      }
+      // Non-transient error or retries exhausted — surface a diagnostic
+      // warning so the failure is visible rather than silently swallowed.
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `[quota-guard-vitest-integration] WARNING: failed to clean up fixture root ${root}: ${detail}
+`,
+      );
+      return;
+    }
+  }
+}
+
 describe('quota guard vitest acceptance semantics', () => {
   afterEach(() => {
     for (const root of fixtureRoots) {
-      // Best-effort: an orphaned vitest worker may still hold the fixture cwd
-      // for a beat after a SIGKILL timeout, so a rmSync can hit EBUSY/EPERM.
-      // Swallow it so the remaining fixture roots are still cleaned up; the OS
-      // temp dir is reclaimed regardless.
-      try {
-        rmSync(root, { recursive: true, force: true });
-      } catch {
-        // Ignore — leftover temp dirs are harmless and OS-reclaimed.
-      }
+      removeFixtureRoot(root);
     }
     fixtureRoots.length = 0;
   });

--- a/packages/test-utils/src/quota-guard.test.ts
+++ b/packages/test-utils/src/quota-guard.test.ts
@@ -18,10 +18,10 @@ import {
   clearQuotaGuard,
   detectQuotaSignal,
   getQuotaGuardTrip,
+  SENTINEL_FILENAME,
   tripQuotaGuard,
 } from './quota-guard.js';
 
-const SENTINEL_FILENAME = 'quota-guard-tripped.json';
 const ANNOTATION_MARKER = '::error title=E2E quota guard tripped::';
 
 const tempDirs: string[] = [];
@@ -87,6 +87,10 @@ describe('quota-guard', () => {
       // Classic OpenAI 429 body wording that carries no status/code context.
       'You exceeded your current quota, please check your plan and billing details.',
       'You have reached your daily gemini-2.5-pro quota limit',
+      // "quota limit" WITH a trailing exhaustion verb is a genuine wall; the
+      // bare-"limit" form (see negative cases) must stay green.
+      'quota limit exceeded',
+      'quota limit reached',
       'RESOURCE_EXHAUSTED',
       'insufficient_quota',
     ];
@@ -108,6 +112,9 @@ describe('quota-guard', () => {
       'tests for rate limits',
       // "quota" without exhaustion context must stay green.
       'quota check passed',
+      // A bare "quota limit" that merely NAMES the limit (config/help text) is
+      // not a wall — only "quota limit reached/exceeded/hit" trips the guard.
+      'Config: quota limit = 60',
       '',
     ];
 
@@ -140,6 +147,57 @@ describe('quota-guard', () => {
       tripQuotaGuard('second');
 
       expect(getQuotaGuardTrip()).toStrictEqual({ reason: 'first' });
+    });
+
+    it('keeps a reason written externally by another worker (wx never clobbers)', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      // Simulate a concurrent worker that already won the race by pre-creating
+      // the sentinel out-of-band (not via tripQuotaGuard in this process). The
+      // exclusive `wx` create must fail with EEXIST and leave reason A intact.
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      writeFileSync(
+        sentinelPath,
+        JSON.stringify({
+          reason: 'external worker reason A',
+          timestamp: new Date().toISOString(),
+        }),
+      );
+
+      tripQuotaGuard('reason B from this worker');
+
+      expect(getQuotaGuardTrip()).toStrictEqual({
+        reason: 'external worker reason A',
+      });
+    });
+
+    it('does not emit a CI annotation when it loses the exclusive-create race', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'true');
+      vi.stubEnv('GITHUB_STEP_SUMMARY', undefined);
+
+      // The sentinel already exists (another worker won), so this trip must hit
+      // the EEXIST branch and return before emitting an annotation — only the
+      // winning writer announces the wall.
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      writeFileSync(
+        sentinelPath,
+        JSON.stringify({
+          reason: 'already tripped',
+          timestamp: new Date().toISOString(),
+        }),
+      );
+
+      const spy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      tripQuotaGuard('late loser reason');
+
+      expect(callsIncludeAnnotation(spy.mock.calls)).toBe(false);
     });
 
     it('returns null after the guard is cleared', () => {

--- a/packages/test-utils/src/quota-guard.test.ts
+++ b/packages/test-utils/src/quota-guard.test.ts
@@ -150,22 +150,19 @@ describe('quota-guard', () => {
       expect(formatted.startsWith(`${QUOTA_ERROR_PREFIX} `)).toBe(true);
       // Reason comes first for at-a-glance triage.
       expect(formatted).toContain('matched HTTP 429 status');
-      expect(formatted).toContain(
-        String.fromCharCode(10) + 'Process exited with code 1',
-      );
+      expect(formatted).toContain('\nProcess exited with code 1');
     });
 
     it('separates reason and context with exactly one newline', () => {
       const formatted = formatQuotaError('reason-here', 'context-here');
       const withoutPrefix = formatted.slice(`${QUOTA_ERROR_PREFIX} `.length);
-      expect(withoutPrefix).toBe(
-        'reason-here' + String.fromCharCode(10) + 'context-here',
-      );
+      expect(withoutPrefix).toBe('reason-here\ncontext-here');
     });
 
     it('preserves multi-line context verbatim', () => {
-      const nl = String.fromCharCode(10);
-      const multiLineContext = ['Line one', 'Line two', 'Line three'].join(nl);
+      const multiLineContext = ['Line one', 'Line two', 'Line three'].join(
+        '\n',
+      );
       const formatted = formatQuotaError('quota wall', multiLineContext);
       expect(formatted).toContain(multiLineContext);
     });

--- a/packages/test-utils/src/quota-guard.test.ts
+++ b/packages/test-utils/src/quota-guard.test.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearQuotaGuard,
+  detectQuotaSignal,
+  getQuotaGuardTrip,
+  tripQuotaGuard,
+} from './quota-guard.js';
+
+const SENTINEL_FILENAME = 'quota-guard-tripped.json';
+const ANNOTATION_MARKER = '::error title=E2E quota guard tripped::';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'quota-guard-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function callsIncludeAnnotation(
+  calls: ReadonlyArray<readonly unknown[]>,
+): boolean {
+  return calls.some(
+    (call) =>
+      typeof call[0] === 'string' && call[0].includes(ANNOTATION_MARKER),
+  );
+}
+
+/**
+ * Return the first `::error ...::` workflow-command line written to the stdout
+ * spy, or `null` when none was emitted. Used to assert on the exact escaped
+ * payload of the GitHub Actions annotation.
+ */
+function findAnnotationLine(
+  calls: ReadonlyArray<readonly unknown[]>,
+): string | null {
+  for (const call of calls) {
+    if (typeof call[0] === 'string' && call[0].includes(ANNOTATION_MARKER)) {
+      return call[0];
+    }
+  }
+  return null;
+}
+
+describe('quota-guard', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  describe('detectQuotaSignal', () => {
+    const positiveCases: readonly string[] = [
+      'Process exited with code 1: something (Status: 429)',
+      'HTTP 429 Too Many Requests',
+      // camelCase and snake_case status-code fields carry no other quota
+      // keyword, so they genuinely exercise the extended status(_)?code branch.
+      'Provider rejected the request with statusCode: 429',
+      'openai.APIStatusError status_code: 429',
+      '{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}',
+      'Rate limit exceeded. Please wait a moment and retry',
+      // Contextual rate-limit forms: an error-context word ("limited",
+      // "_error", "exceeded", "reached", "hit") disambiguates a genuine
+      // provider wall from prose that merely mentions rate limits.
+      'Rate limited',
+      'rate_limit_error',
+      'Rate limit exceeded',
+      'rate limit reached',
+      // Classic OpenAI 429 body wording that carries no status/code context.
+      'You exceeded your current quota, please check your plan and billing details.',
+      'You have reached your daily gemini-2.5-pro quota limit',
+      'RESOURCE_EXHAUSTED',
+      'insufficient_quota',
+    ];
+
+    for (const input of positiveCases) {
+      it(`detects a quota signal in: ${input.slice(0, 48)}`, () => {
+        expect(detectQuotaSignal(input)).not.toBeNull();
+      });
+    }
+
+    const negativeCases: readonly string[] = [
+      'Error: expected 2 to be 3\n    at file.test.ts:10',
+      'Expected to find list_directory tool call(s). Found: none.',
+      'Processed 429 items successfully',
+      // Bare, non-contextual mentions of rate limiting are prose a failing test
+      // could legitimately echo — they must NOT trip the guard and mask a real
+      // regression.
+      'Expected the CLI to explain rate limit behavior',
+      'tests for rate limits',
+      // "quota" without exhaustion context must stay green.
+      'quota check passed',
+      '',
+    ];
+
+    for (const input of negativeCases) {
+      it(`ignores non-quota output: ${input.slice(0, 48) || '(empty)'}`, () => {
+        expect(detectQuotaSignal(input)).toBeNull();
+      });
+    }
+  });
+
+  describe('quota guard sentinel lifecycle', () => {
+    it('round-trips a trip reason through the sentinel file', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      tripQuotaGuard('quota exhausted for provider X');
+
+      expect(getQuotaGuardTrip()).toStrictEqual({
+        reason: 'quota exhausted for provider X',
+      });
+    });
+
+    it('is idempotent and keeps the first reason', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      tripQuotaGuard('first');
+      tripQuotaGuard('second');
+
+      expect(getQuotaGuardTrip()).toStrictEqual({ reason: 'first' });
+    });
+
+    it('returns null after the guard is cleared', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      tripQuotaGuard('boom');
+      expect(getQuotaGuardTrip()).not.toBeNull();
+
+      clearQuotaGuard();
+      expect(getQuotaGuardTrip()).toBeNull();
+    });
+
+    it('is inactive when INTEGRATION_TEST_FILE_DIR is unset', () => {
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', undefined);
+
+      expect(() => tripQuotaGuard('ignored')).not.toThrow();
+      expect(getQuotaGuardTrip()).toBeNull();
+    });
+
+    it('writes nothing and reads null when explicitly disabled', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('LLXPRT_QUOTA_GUARD_DISABLED', 'true');
+
+      tripQuotaGuard('should not persist');
+
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      expect(existsSync(sentinelPath)).toBe(false);
+
+      writeFileSync(
+        sentinelPath,
+        JSON.stringify({
+          reason: 'manual',
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      expect(getQuotaGuardTrip()).toBeNull();
+    });
+
+    it('clears a sentinel even while the guard is disabled', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('LLXPRT_QUOTA_GUARD_DISABLED', 'true');
+
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      writeFileSync(
+        sentinelPath,
+        JSON.stringify({
+          reason: 'manual',
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      expect(existsSync(sentinelPath)).toBe(true);
+
+      clearQuotaGuard();
+      expect(existsSync(sentinelPath)).toBe(false);
+    });
+
+    it('returns null for a malformed sentinel file', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      writeFileSync(sentinelPath, 'not-json{{');
+
+      expect(getQuotaGuardTrip()).toBeNull();
+    });
+
+    it('returns null when the persisted reason is not a string', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      writeFileSync(sentinelPath, JSON.stringify({ reason: 42 }));
+
+      expect(getQuotaGuardTrip()).toBeNull();
+    });
+  });
+
+  describe('GitHub Actions integration', () => {
+    it('emits an error annotation and step summary in CI', () => {
+      const dir = makeTempDir();
+      const summaryPath = join(dir, 'summary.md');
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'true');
+      vi.stubEnv('GITHUB_STEP_SUMMARY', summaryPath);
+
+      const spy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      tripQuotaGuard('provider quota exhausted');
+
+      expect(callsIncludeAnnotation(spy.mock.calls)).toBe(true);
+
+      spy.mockRestore();
+
+      const summary = readFileSync(summaryPath, 'utf8');
+      expect(summary).toContain('provider quota exhausted');
+    });
+
+    it('escapes newlines and percent signs in the annotation payload', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'true');
+      vi.stubEnv('GITHUB_STEP_SUMMARY', undefined);
+
+      const spy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      // A reason containing the characters GitHub treats specially in a
+      // workflow-command message: percent, carriage return and newline. Raw,
+      // the newline would prematurely terminate the `::error::` command and the
+      // second line would leak as plain log output.
+      const cr = String.fromCharCode(13);
+      const lf = String.fromCharCode(10);
+      tripQuotaGuard(`boom 50% off${cr}${lf}second line`);
+
+      const annotation = findAnnotationLine(spy.mock.calls);
+      spy.mockRestore();
+
+      expect(annotation).not.toBeNull();
+      const line = annotation ?? '';
+      // The single workflow command must be one physical line: the special
+      // characters are percent-encoded, so only the writer's trailing newline
+      // remains raw.
+      expect(line).toBe(
+        `::error title=E2E quota guard tripped::boom 50%25 off%0D%0Asecond line${lf}`,
+      );
+      expect(line).toContain('%25');
+      expect(line).toContain('%0A');
+      expect(line).toContain('%0D');
+      // The escaped payload itself must not contain a raw CR, nor a raw LF
+      // before the writer's trailing newline.
+      expect(line.slice(0, -1)).not.toContain(lf);
+      expect(line).not.toContain(cr);
+    });
+
+    it('does not emit an annotation outside of CI', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      const spy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      tripQuotaGuard('provider quota exhausted');
+
+      expect(callsIncludeAnnotation(spy.mock.calls)).toBe(false);
+    });
+  });
+});

--- a/packages/test-utils/src/quota-guard.test.ts
+++ b/packages/test-utils/src/quota-guard.test.ts
@@ -7,6 +7,7 @@
 import {
   existsSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -30,6 +31,18 @@ function makeTempDir(): string {
   const dir = mkdtempSync(join(tmpdir(), 'quota-guard-'));
   tempDirs.push(dir);
   return dir;
+}
+
+/**
+ * Names of any leftover atomic-publication temp files in `dir`. The guard
+ * stages the payload as `<SENTINEL_FILENAME>.<pid>.<uuid>.tmp` in the sentinel's
+ * own directory before hard-linking it into place, so a correct implementation
+ * leaves none of these behind on any path.
+ */
+function leftoverTempFiles(dir: string): string[] {
+  return readdirSync(dir).filter(
+    (name) => name.startsWith(SENTINEL_FILENAME) && name.endsWith('.tmp'),
+  );
 }
 
 function callsIncludeAnnotation(
@@ -173,6 +186,42 @@ describe('quota-guard', () => {
       });
     });
 
+    it('leaves no temp file behind after a winning publication', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      tripQuotaGuard('winner reason');
+
+      // The sentinel is published and the staged temp inode was unlinked in the
+      // finally block — only the sentinel itself remains.
+      expect(getQuotaGuardTrip()).toStrictEqual({ reason: 'winner reason' });
+      expect(leftoverTempFiles(dir)).toStrictEqual([]);
+    });
+
+    it('leaves no temp file behind when it loses the publication race (EEXIST)', () => {
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      // Pre-create the sentinel so this worker's hard-link fails with EEXIST.
+      // The loser still stages a temp file first; it must clean that temp up in
+      // the finally block rather than leaking one temp per losing worker/retry.
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      writeFileSync(
+        sentinelPath,
+        JSON.stringify({
+          reason: 'first winner',
+          timestamp: new Date().toISOString(),
+        }),
+      );
+
+      tripQuotaGuard('losing reason');
+
+      expect(getQuotaGuardTrip()).toStrictEqual({ reason: 'first winner' });
+      expect(leftoverTempFiles(dir)).toStrictEqual([]);
+    });
+
     it('does not emit a CI annotation when it loses the exclusive-create race', () => {
       const dir = makeTempDir();
       vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
@@ -276,6 +325,24 @@ describe('quota-guard', () => {
 
       const sentinelPath = join(dir, SENTINEL_FILENAME);
       writeFileSync(sentinelPath, JSON.stringify({ reason: 42 }));
+
+      expect(getQuotaGuardTrip()).toBeNull();
+    });
+
+    it('returns null when the sentinel JSON is a top-level array carrying a reason index', () => {
+      // A top-level JSON array is malformed for our schema even though
+      // `typeof [] === 'object'`. Because the array's index 0 holds the string
+      // "reason", a record guard that failed to exclude arrays would read
+      // `value['reason']` as the array METHOD/undefined and could mis-narrow;
+      // more importantly the guard must treat this structurally-wrong payload as
+      // malformed → null rather than surfacing a bogus trip. Arrays are excluded
+      // explicitly in isRecord, so this stays null.
+      const dir = makeTempDir();
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', dir);
+      vi.stubEnv('GITHUB_ACTIONS', 'false');
+
+      const sentinelPath = join(dir, SENTINEL_FILENAME);
+      writeFileSync(sentinelPath, JSON.stringify(['reason', 'still an array']));
 
       expect(getQuotaGuardTrip()).toBeNull();
     });

--- a/packages/test-utils/src/quota-guard.test.ts
+++ b/packages/test-utils/src/quota-guard.test.ts
@@ -354,5 +354,29 @@ describe('quota-guard', () => {
 
       expect(callsIncludeAnnotation(spy.mock.calls)).toBe(false);
     });
+
+    it('stays silent when the sentinel write fails with a non-EEXIST error', () => {
+      // Point the guard at a state dir whose PARENT does not exist, so the
+      // exclusive `wx` write throws ENOENT rather than EEXIST. No sentinel is
+      // created, so there is no cross-process latch to dedupe against. If the
+      // guard emitted here, every worker (and every subsequent call) would hit
+      // the same failing write and announce its own wall — flooding CI with
+      // duplicate annotations. It must therefore stay silent; the quota wall is
+      // still surfaced by the failing test itself.
+      const dir = makeTempDir();
+      const missingStateDir = join(dir, 'missing-parent', 'state');
+      vi.stubEnv('INTEGRATION_TEST_FILE_DIR', missingStateDir);
+      vi.stubEnv('GITHUB_ACTIONS', 'true');
+      vi.stubEnv('GITHUB_STEP_SUMMARY', undefined);
+
+      const spy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      expect(() => tripQuotaGuard('provider quota exhausted')).not.toThrow();
+
+      expect(callsIncludeAnnotation(spy.mock.calls)).toBe(false);
+      expect(getQuotaGuardTrip()).toBeNull();
+    });
   });
 });

--- a/packages/test-utils/src/quota-guard.test.ts
+++ b/packages/test-utils/src/quota-guard.test.ts
@@ -18,7 +18,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   clearQuotaGuard,
   detectQuotaSignal,
+  formatQuotaError,
   getQuotaGuardTrip,
+  QUOTA_ERROR_PREFIX,
   SENTINEL_FILENAME,
   tripQuotaGuard,
 } from './quota-guard.js';
@@ -136,6 +138,37 @@ describe('quota-guard', () => {
         expect(detectQuotaSignal(input)).toBeNull();
       });
     }
+  });
+
+  describe('formatQuotaError', () => {
+    it('produces a stable prefix, reason, newline, then context', () => {
+      const formatted = formatQuotaError(
+        'matched HTTP 429 status: "429 Too Many Requests"',
+        'Process exited with code 1',
+      );
+      // Uniform prefix that both interactive and non-interactive paths share.
+      expect(formatted.startsWith(`${QUOTA_ERROR_PREFIX} `)).toBe(true);
+      // Reason comes first for at-a-glance triage.
+      expect(formatted).toContain('matched HTTP 429 status');
+      expect(formatted).toContain(
+        String.fromCharCode(10) + 'Process exited with code 1',
+      );
+    });
+
+    it('separates reason and context with exactly one newline', () => {
+      const formatted = formatQuotaError('reason-here', 'context-here');
+      const withoutPrefix = formatted.slice(`${QUOTA_ERROR_PREFIX} `.length);
+      expect(withoutPrefix).toBe(
+        'reason-here' + String.fromCharCode(10) + 'context-here',
+      );
+    });
+
+    it('preserves multi-line context verbatim', () => {
+      const nl = String.fromCharCode(10);
+      const multiLineContext = ['Line one', 'Line two', 'Line three'].join(nl);
+      const formatted = formatQuotaError('quota wall', multiLineContext);
+      expect(formatted).toContain(multiLineContext);
+    });
   });
 
   describe('quota guard sentinel lifecycle', () => {

--- a/packages/test-utils/src/quota-guard.ts
+++ b/packages/test-utils/src/quota-guard.ts
@@ -1,0 +1,238 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+const SENTINEL_FILENAME = 'quota-guard-tripped.json';
+const MAX_EXCERPT_LENGTH = 160;
+
+interface QuotaSignalPattern {
+  readonly label: string;
+  readonly regex: RegExp;
+}
+
+const QUOTA_SIGNAL_PATTERNS: readonly QuotaSignalPattern[] = [
+  {
+    label: 'HTTP 429 status',
+    // Matches `status: 429`, `statusCode: 429`, `status_code: 429`, `code: 429`,
+    // and `HTTP 429`. The optional `[_ ]?code` suffix covers the camelCase and
+    // snake_case field names SDKs emit, while the leading word boundaries keep
+    // the contextual guard against unrelated text like "Processed 429 items".
+    regex: /(?:\bstatus(?:[_ ]?code)?\b|\bcode\b|\bhttp\b)[\s:=]*429\b/i,
+  },
+  // Contextual rate-limit error forms ONLY. A bare "rate limit"/"rate limits"
+  // is deliberately NOT matched: interactive PTY output echoes user/model text,
+  // so a failing test that merely DISCUSSES rate limits must not trip the guard
+  // and mask a real regression. An error-context word is required — either the
+  // "-ed"/"error" suffix ("rate limited", "rate_limit_error", "rate-limit-error")
+  // or a trailing exhaustion verb ("rate limit exceeded/reached/hit").
+  {
+    label: 'rate limit error',
+    regex: /\brate[\s_-]?limit(?:ed|[\s_-]?error)\b/i,
+  },
+  {
+    label: 'rate limit exhausted',
+    regex: /\brate[\s_-]?limits?\s+(?:exceeded|reached|hit)\b/i,
+  },
+  {
+    label: 'quota exceeded',
+    regex: /\bquota\s+(?:exceeded|exhausted|limit)\b/i,
+  },
+  {
+    // Classic OpenAI 429 body wording ("You exceeded your current quota, ...")
+    // that carries no status/code context. The reversed order ("exceeded ...
+    // quota") is not covered by the `quota (exceeded|...)` branch above, yet the
+    // "exceeded your ... quota" phrasing is specific enough not to fire on
+    // benign text like "quota check passed".
+    label: 'exceeded your quota',
+    regex: /\bexceeded your (?:current )?quota\b/i,
+  },
+  { label: 'insufficient quota', regex: /\binsufficient_quota\b/i },
+  { label: 'daily quota reached', regex: /reached your daily .{0,60}quota/i },
+  { label: 'resource exhausted', regex: /\bRESOURCE_EXHAUSTED\b/i },
+  { label: 'too many requests', regex: /\btoo many requests\b/i },
+];
+
+/**
+ * Scans harness output for a provider quota / rate-limit signal.
+ *
+ * Returns a short, human-readable description of the first matching signal
+ * (including the offending line, trimmed and truncated), or `null` when no
+ * quota signal is present.
+ */
+export function detectQuotaSignal(output: string): string | null {
+  for (const { label, regex } of QUOTA_SIGNAL_PATTERNS) {
+    if (!regex.test(output)) {
+      continue;
+    }
+    const matchingLine = output.split('\n').find((line) => regex.test(line));
+    const source = matchingLine ?? output;
+    const excerpt = source.trim().slice(0, MAX_EXCERPT_LENGTH);
+    return `matched ${label}: "${excerpt}"`;
+  }
+  return null;
+}
+
+function getStateDir(): string | null {
+  const dir = process.env['INTEGRATION_TEST_FILE_DIR'];
+  if (dir === undefined || dir === '') {
+    return null;
+  }
+  return dir;
+}
+
+/**
+ * The guard is only usable for cleanup (clear) when we know where the sentinel
+ * lives. `clearQuotaGuard` intentionally works even when the guard is disabled,
+ * so it relies on this rather than {@link isGuardActive}.
+ */
+function getSentinelPath(): string | null {
+  const dir = getStateDir();
+  if (dir === null) {
+    return null;
+  }
+  return join(dir, SENTINEL_FILENAME);
+}
+
+function isGuardActive(): boolean {
+  if (getStateDir() === null) {
+    return false;
+  }
+  return process.env['LLXPRT_QUOTA_GUARD_DISABLED'] !== 'true';
+}
+
+interface QuotaGuardTrip {
+  readonly reason: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isQuotaGuardTrip(value: unknown): value is QuotaGuardTrip {
+  return isRecord(value) && typeof value['reason'] === 'string';
+}
+
+/**
+ * Escape a GitHub Actions workflow-command *message* payload.
+ *
+ * Per the workflow-command spec, the data segment after `::` must have `%`,
+ * carriage return and newline percent-encoded; otherwise an embedded newline
+ * would prematurely terminate the `::error::` command and the remainder would
+ * leak as plain log output (and a literal `%` could corrupt any following
+ * encoded sequence). `%` is intentionally replaced first so the `%0D`/`%0A`
+ * we introduce are not themselves re-escaped. Property values (e.g. a dynamic
+ * `title`) need the additional `:`/`,` escaping, but this guard's title is
+ * static, so only the message data is escaped here.
+ */
+function escapeAnnotationData(data: string): string {
+  return data.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+function emitGitHubAnnotations(reason: string): void {
+  if (process.env['GITHUB_ACTIONS'] !== 'true') {
+    return;
+  }
+  process.stdout.write(
+    `::error title=E2E quota guard tripped::${escapeAnnotationData(reason)}\n`,
+  );
+
+  const summaryPath = process.env['GITHUB_STEP_SUMMARY'];
+  if (summaryPath === undefined || summaryPath === '') {
+    return;
+  }
+  try {
+    appendFileSync(
+      summaryPath,
+      `## E2E aborted: provider quota/rate-limit exhausted\n\n${reason}\n\nRemaining tests were skipped. This is an infrastructure/quota failure, not a code regression.\n`,
+    );
+  } catch {
+    // Best-effort reporting; never fail the run because of summary I/O.
+  }
+}
+
+/**
+ * Records that the harness has hit a provider quota / rate-limit wall.
+ *
+ * No-op when the guard is inactive (no state dir, or explicitly disabled).
+ * Idempotent: the first reason wins and subsequent trips are ignored.
+ */
+export function tripQuotaGuard(reason: string): void {
+  if (!isGuardActive()) {
+    return;
+  }
+  const sentinelPath = getSentinelPath();
+  if (sentinelPath === null) {
+    return;
+  }
+  if (existsSync(sentinelPath)) {
+    return;
+  }
+  try {
+    writeFileSync(
+      sentinelPath,
+      JSON.stringify({ reason, timestamp: new Date().toISOString() }),
+    );
+  } catch {
+    // Best-effort persistence; never fail the run because of sentinel I/O.
+  }
+
+  emitGitHubAnnotations(reason);
+}
+
+/**
+ * Reads the cross-process sentinel, returning the recorded trip reason or
+ * `null` when the guard is inactive, unset, unreadable, or malformed.
+ */
+export function getQuotaGuardTrip(): { reason: string } | null {
+  if (!isGuardActive()) {
+    return null;
+  }
+  const sentinelPath = getSentinelPath();
+  if (sentinelPath === null || !existsSync(sentinelPath)) {
+    return null;
+  }
+  const parsed = readSentinel(sentinelPath);
+  if (!isQuotaGuardTrip(parsed)) {
+    return null;
+  }
+  return { reason: parsed.reason };
+}
+
+function readSentinel(sentinelPath: string): unknown {
+  try {
+    const raw = readFileSync(sentinelPath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Removes the sentinel file, if present. Works even while the guard is
+ * disabled so callers can reset state between runs. Errors are swallowed.
+ */
+export function clearQuotaGuard(): void {
+  const sentinelPath = getSentinelPath();
+  if (sentinelPath === null) {
+    return;
+  }
+  try {
+    if (existsSync(sentinelPath)) {
+      rmSync(sentinelPath, { force: true });
+    }
+  } catch {
+    // Best-effort cleanup; never fail the run because of sentinel I/O.
+  }
+}

--- a/packages/test-utils/src/quota-guard.ts
+++ b/packages/test-utils/src/quota-guard.ts
@@ -367,9 +367,7 @@ export function clearQuotaGuard(): void {
     return;
   }
   try {
-    if (existsSync(sentinelPath)) {
-      rmSync(sentinelPath, { force: true });
-    }
+    rmSync(sentinelPath, { force: true });
   } catch {
     // Best-effort cleanup; never fail the run because of sentinel I/O.
   }

--- a/packages/test-utils/src/quota-guard.ts
+++ b/packages/test-utils/src/quota-guard.ts
@@ -47,7 +47,7 @@ const QUOTA_SIGNAL_PATTERNS: readonly QuotaSignalPattern[] = [
   // "-ed"/"error" suffix ("rate limited", "rate_limit_error", "rate-limit-error")
   // or a trailing exhaustion verb ("rate limit exceeded/reached/hit").
   {
-    label: 'rate limit error',
+    label: 'rate limited or rate limit error',
     regex: /\brate[\s_-]?limit(?:ed|[\s_-]?error)\b/i,
   },
   {
@@ -266,7 +266,7 @@ function publishSentinel(sentinelPath: string, reason: string): boolean {
  * `title`) need the additional `:`/`,` escaping, but this guard's title is
  * static, so only the message data is escaped here.
  */
-function escapeAnnotationData(data: string): string {
+function escapeWorkflowCommandMessage(data: string): string {
   return data.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
 }
 
@@ -275,7 +275,7 @@ function emitGitHubAnnotations(reason: string): void {
     return;
   }
   process.stdout.write(
-    `::error title=E2E quota guard tripped::${escapeAnnotationData(reason)}\n`,
+    `::error title=E2E quota guard tripped::${escapeWorkflowCommandMessage(reason)}\n`,
   );
 
   const summaryPath = process.env['GITHUB_STEP_SUMMARY'];

--- a/packages/test-utils/src/quota-guard.ts
+++ b/packages/test-utils/src/quota-guard.ts
@@ -13,7 +13,15 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 
-const SENTINEL_FILENAME = 'quota-guard-tripped.json';
+/**
+ * Filename of the cross-process trip sentinel written into
+ * `INTEGRATION_TEST_FILE_DIR`.
+ *
+ * Exported so tests (and any harness code) that need to locate, assert on, or
+ * pre-seed the sentinel reference a single source of truth instead of
+ * duplicating the literal string, keeping them in lockstep if it ever changes.
+ */
+export const SENTINEL_FILENAME = 'quota-guard-tripped.json';
 const MAX_EXCERPT_LENGTH = 160;
 
 interface QuotaSignalPattern {
@@ -45,8 +53,14 @@ const QUOTA_SIGNAL_PATTERNS: readonly QuotaSignalPattern[] = [
     regex: /\brate[\s_-]?limits?\s+(?:exceeded|reached|hit)\b/i,
   },
   {
+    // A bare "quota limit" is deliberately NOT matched: benign config/help text
+    // like "Config: quota limit = 60" merely NAMES the limit rather than
+    // reporting a wall. The "limit" branch therefore requires a trailing
+    // exhaustion verb ("quota limit reached/exceeded/hit"), while "quota
+    // exceeded"/"quota exhausted" remain sufficient on their own.
     label: 'quota exceeded',
-    regex: /\bquota\s+(?:exceeded|exhausted|limit)\b/i,
+    regex:
+      /\bquota\s+(?:exceeded|exhausted|limit\s+(?:reached|exceeded|hit))\b/i,
   },
   {
     // Classic OpenAI 429 body wording ("You exceeded your current quota, ...")
@@ -124,6 +138,16 @@ function isQuotaGuardTrip(value: unknown): value is QuotaGuardTrip {
 }
 
 /**
+ * Narrows an unknown caught value to a Node `EEXIST` filesystem error without a
+ * type assertion, so the exclusive-create trip path can recognise "another
+ * worker already won the race" while complying with strict lint rules (no
+ * `any`, no `as NodeJS.ErrnoException` cast).
+ */
+function isEexistError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'EEXIST';
+}
+
+/**
  * Escape a GitHub Actions workflow-command *message* payload.
  *
  * Per the workflow-command spec, the data segment after `::` must have `%`,
@@ -165,7 +189,13 @@ function emitGitHubAnnotations(reason: string): void {
  * Records that the harness has hit a provider quota / rate-limit wall.
  *
  * No-op when the guard is inactive (no state dir, or explicitly disabled).
- * Idempotent: the first reason wins and subsequent trips are ignored.
+ * Idempotent, and the FIRST reason wins even across concurrent vitest worker
+ * processes: the sentinel is created with the exclusive `wx` flag, so exactly
+ * one writer succeeds. A separate `existsSync` pre-check would be a TOCTOU race
+ * (two workers could both observe "absent" and the LAST write would clobber the
+ * first reason); the atomic exclusive create closes that window. Only the
+ * winning writer emits the CI annotation, so a losing worker never duplicates
+ * it or overwrites the recorded reason.
  */
 export function tripQuotaGuard(reason: string): void {
   if (!isGuardActive()) {
@@ -175,16 +205,21 @@ export function tripQuotaGuard(reason: string): void {
   if (sentinelPath === null) {
     return;
   }
-  if (existsSync(sentinelPath)) {
-    return;
-  }
   try {
     writeFileSync(
       sentinelPath,
       JSON.stringify({ reason, timestamp: new Date().toISOString() }),
+      { flag: 'wx' },
     );
-  } catch {
-    // Best-effort persistence; never fail the run because of sentinel I/O.
+  } catch (error) {
+    if (isEexistError(error)) {
+      // Another worker won the race and recorded the first reason. Stay silent:
+      // do not overwrite it, and do not emit a duplicate annotation.
+      return;
+    }
+    // Best-effort persistence for any other error (e.g. disk full): never fail
+    // the run because of sentinel I/O. Fall through so the wall is still
+    // surfaced in CI even when the cross-process sentinel could not be written.
   }
 
   emitGitHubAnnotations(reason);

--- a/packages/test-utils/src/quota-guard.ts
+++ b/packages/test-utils/src/quota-guard.ts
@@ -99,6 +99,40 @@ export function detectQuotaSignal(output: string): string | null {
   return null;
 }
 
+/**
+ * Uniform `[QUOTA/RATE-LIMIT]` prefix for quota-guard rejection errors.
+ *
+ * Both the interactive (PTY) and non-interactive (spawn) failure-classification
+ * paths label a detected quota wall with this exact prefix so tests and humans
+ * can recognise it regardless of the run mode.
+ */
+export const QUOTA_ERROR_PREFIX = '[QUOTA/RATE-LIMIT]';
+
+/**
+ * Format a quota-guard rejection error message with one stable, human/machine-
+ * readable layout.
+ *
+ * Both {@link InteractiveRun} (interactive-run.ts) and the process-run.ts
+ * spawn helpers surface detected quota walls as labelled `Error`s. Without a
+ * shared formatter the two paths drifted — interactive produced
+ * `[QUOTA/RATE-LIMIT] <context>; <reason>` while process-run produced
+ * `[QUOTA/RATE-LIMIT] <reason>\n<context>` — making test assertions and log
+ * grepping fragile. This centralises the layout as:
+ *
+ *   [QUOTA/RATE-LIMIT] <reason>
+ *   <context>
+ *
+ * The reason (the machine-classified quota signal) comes first for at-a-glance
+ * triage; the context (the caller's human-readable failure-path description)
+ * follows on its own line for full detail.
+ *
+ * @param reason The classified quota signal string (from {@link detectQuotaSignal}).
+ * @param context Human-readable description of the failure path (timeout, exit code, etc.).
+ */
+export function formatQuotaError(reason: string, context: string): string {
+  return `${QUOTA_ERROR_PREFIX} ${reason}\n${context}`;
+}
+
 function getStateDir(): string | null {
   const dir = process.env['INTEGRATION_TEST_FILE_DIR'];
   if (dir === undefined || dir === '') {

--- a/packages/test-utils/src/quota-guard.ts
+++ b/packages/test-utils/src/quota-guard.ts
@@ -193,9 +193,16 @@ function emitGitHubAnnotations(reason: string): void {
  * processes: the sentinel is created with the exclusive `wx` flag, so exactly
  * one writer succeeds. A separate `existsSync` pre-check would be a TOCTOU race
  * (two workers could both observe "absent" and the LAST write would clobber the
- * first reason); the atomic exclusive create closes that window. Only the
- * winning writer emits the CI annotation, so a losing worker never duplicates
- * it or overwrites the recorded reason.
+ * first reason); the atomic exclusive create closes that window.
+ *
+ * The CI annotation is emitted ONLY when this process actually wins the
+ * exclusive create, i.e. it now owns the sentinel latch. A worker that loses
+ * the race (EEXIST) stays silent, and — crucially — so does a worker whose
+ * write fails for any OTHER reason (ENOSPC, EACCES, missing parent dir): with
+ * no sentinel there is no latch to dedupe against, so emitting would let every
+ * worker announce its own wall and flood CI with duplicates. Sentinel I/O is
+ * therefore best-effort and never throws; the quota wall is still surfaced by
+ * the failing test itself.
  */
 export function tripQuotaGuard(reason: string): void {
   if (!isGuardActive()) {
@@ -217,11 +224,20 @@ export function tripQuotaGuard(reason: string): void {
       // do not overwrite it, and do not emit a duplicate annotation.
       return;
     }
-    // Best-effort persistence for any other error (e.g. disk full): never fail
-    // the run because of sentinel I/O. Fall through so the wall is still
-    // surfaced in CI even when the cross-process sentinel could not be written.
+    // Any other error (ENOSPC, EACCES, ENOENT for a missing parent dir, ...):
+    // the sentinel — which IS the cross-process latch in the success/EEXIST
+    // paths — was never written, so there is nothing to dedupe subsequent
+    // callers against. Emitting here would make EVERY worker (and every retry)
+    // hit this same failing write and announce its own wall, flooding CI with
+    // duplicate annotations and breaking the "first reason wins / losers stay
+    // silent" guarantee. Return without emitting; the quota wall is still
+    // surfaced by the failing test itself, and we never fail the run because of
+    // sentinel I/O.
+    return;
   }
 
+  // Reached only when the exclusive create above actually succeeded, i.e. this
+  // process is the sole winner that owns the sentinel latch.
   emitGitHubAnnotations(reason);
 }
 

--- a/packages/test-utils/src/quota-guard.ts
+++ b/packages/test-utils/src/quota-guard.ts
@@ -4,14 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { randomUUID } from 'node:crypto';
 import {
   appendFileSync,
   existsSync,
+  linkSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 /**
  * Filename of the cross-process trip sentinel written into
@@ -108,7 +110,7 @@ function getStateDir(): string | null {
 /**
  * The guard is only usable for cleanup (clear) when we know where the sentinel
  * lives. `clearQuotaGuard` intentionally works even when the guard is disabled,
- * so it relies on this rather than {@link isGuardActive}.
+ * so it relies on this rather than {@link isQuotaGuardActive}.
  */
 function getSentinelPath(): string | null {
   const dir = getStateDir();
@@ -118,7 +120,20 @@ function getSentinelPath(): string | null {
   return join(dir, SENTINEL_FILENAME);
 }
 
-function isGuardActive(): boolean {
+/**
+ * Whether the cross-process quota guard is live for the current process.
+ *
+ * The guard is active only when a sentinel state directory is configured
+ * (`INTEGRATION_TEST_FILE_DIR`) AND it has not been explicitly switched off via
+ * `LLXPRT_QUOTA_GUARD_DISABLED=true`. This is the single source of truth for
+ * "should quota/rate-limit detection do anything at all": {@link tripQuotaGuard}
+ * and {@link getQuotaGuardTrip} both gate on it, and the harness failure-
+ * classification paths (interactive-run.ts, process-run.ts) reuse it so the
+ * documented disable switch restores ordinary timeout/exit failures instead of
+ * relabelling them `[QUOTA/RATE-LIMIT]`. Exported so those callers share exactly
+ * this predicate rather than re-deriving the disabled-state logic and drifting.
+ */
+export function isQuotaGuardActive(): boolean {
   if (getStateDir() === null) {
     return false;
   }
@@ -129,8 +144,17 @@ interface QuotaGuardTrip {
   readonly reason: string;
 }
 
+/**
+ * Narrow an unknown value to a non-null, non-array object.
+ *
+ * `typeof [] === 'object'` in JavaScript, so a bare `typeof`/`!== null` check
+ * would wrongly admit arrays as `Record<string, unknown>`. The explicit
+ * `Array.isArray` exclusion keeps the guard semantically correct so that a
+ * malformed sentinel whose top-level JSON is an array (even one that happens to
+ * carry a `reason` index) is not mistaken for a {@link QuotaGuardTrip}.
+ */
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function isQuotaGuardTrip(value: unknown): value is QuotaGuardTrip {
@@ -138,13 +162,62 @@ function isQuotaGuardTrip(value: unknown): value is QuotaGuardTrip {
 }
 
 /**
- * Narrows an unknown caught value to a Node `EEXIST` filesystem error without a
- * type assertion, so the exclusive-create trip path can recognise "another
- * worker already won the race" while complying with strict lint rules (no
- * `any`, no `as NodeJS.ErrnoException` cast).
+ * Best-effort removal of a staged temp file. A leftover uniquely-named temp is
+ * harmless (it can never masquerade as the sentinel), so any failure here is
+ * swallowed — the run must never fail because of guard bookkeeping I/O.
  */
-function isEexistError(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && error.code === 'EEXIST';
+function removeTempFile(tempPath: string): void {
+  try {
+    rmSync(tempPath, { force: true });
+  } catch {
+    // Ignore — a stray temp file is harmless and OS/CI-reclaimed.
+  }
+}
+
+/**
+ * Atomically publish the sentinel with first-writer-wins / no-replace
+ * semantics, returning `true` only for the process that actually wins the race.
+ *
+ * The payload is first written *in full* to a uniquely-named temp file in the
+ * SAME directory as the sentinel (exclusive `wx` create), then hard-linked to
+ * the sentinel path. `linkSync` publishes atomically and fails with `EEXIST`
+ * without replacing an existing sentinel, so exactly one writer wins even
+ * across concurrent vitest worker processes. Crucially, because the link merely
+ * exposes the already-complete temp inode, a reader can never observe a
+ * zero-length or partially-written sentinel (the window the previous
+ * `writeFileSync(..., 'wx')` left open, which {@link getQuotaGuardTrip} would
+ * treat as malformed → `null`, letting a second provider call slip through).
+ * The temp file is always cleaned up. A loser (`EEXIST`) and any other I/O
+ * failure both return `false`, so only the winner emits the CI annotation.
+ */
+function publishSentinel(sentinelPath: string, reason: string): boolean {
+  const payload = JSON.stringify({
+    reason,
+    timestamp: new Date().toISOString(),
+  });
+  const tempPath = join(
+    dirname(sentinelPath),
+    `${SENTINEL_FILENAME}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    writeFileSync(tempPath, payload, { flag: 'wx' });
+  } catch {
+    // Could not even stage the payload (ENOSPC, EACCES, a missing parent dir,
+    // or an astronomically unlikely temp-name collision). Nothing was published
+    // and there is no temp file to remove.
+    return false;
+  }
+  try {
+    linkSync(tempPath, sentinelPath);
+    return true;
+  } catch {
+    // EEXIST => another worker already published the first reason; any other
+    // error => the sentinel was never created. Either way this process is not
+    // the winner and must stay silent.
+    return false;
+  } finally {
+    removeTempFile(tempPath);
+  }
 }
 
 /**
@@ -190,55 +263,35 @@ function emitGitHubAnnotations(reason: string): void {
  *
  * No-op when the guard is inactive (no state dir, or explicitly disabled).
  * Idempotent, and the FIRST reason wins even across concurrent vitest worker
- * processes: the sentinel is created with the exclusive `wx` flag, so exactly
- * one writer succeeds. A separate `existsSync` pre-check would be a TOCTOU race
- * (two workers could both observe "absent" and the LAST write would clobber the
- * first reason); the atomic exclusive create closes that window.
+ * processes. Publication is atomic (see {@link publishSentinel}): the payload
+ * is written in full to a unique temp file in the sentinel's own directory and
+ * then hard-linked into place, so a reader never observes a zero-length or
+ * partial sentinel and exactly one writer wins. A plain `existsSync` pre-check
+ * would be a TOCTOU race (two workers could both observe "absent" and the LAST
+ * write would clobber the first reason); the atomic link closes that window.
  *
  * The CI annotation is emitted ONLY when this process actually wins the
- * exclusive create, i.e. it now owns the sentinel latch. A worker that loses
- * the race (EEXIST) stays silent, and — crucially — so does a worker whose
- * write fails for any OTHER reason (ENOSPC, EACCES, missing parent dir): with
- * no sentinel there is no latch to dedupe against, so emitting would let every
- * worker announce its own wall and flood CI with duplicates. Sentinel I/O is
- * therefore best-effort and never throws; the quota wall is still surfaced by
- * the failing test itself.
+ * publication, i.e. it now owns the sentinel latch. A worker that loses the
+ * race (link `EEXIST`) stays silent, and — crucially — so does a worker whose
+ * staging or link fails for any OTHER reason (ENOSPC, EACCES, missing parent
+ * dir): with no sentinel there is no latch to dedupe against, so emitting would
+ * let every worker announce its own wall and flood CI with duplicates. Sentinel
+ * I/O is therefore best-effort and never throws; the quota wall is still
+ * surfaced by the failing test itself.
  */
 export function tripQuotaGuard(reason: string): void {
-  if (!isGuardActive()) {
+  if (!isQuotaGuardActive()) {
     return;
   }
   const sentinelPath = getSentinelPath();
   if (sentinelPath === null) {
     return;
   }
-  try {
-    writeFileSync(
-      sentinelPath,
-      JSON.stringify({ reason, timestamp: new Date().toISOString() }),
-      { flag: 'wx' },
-    );
-  } catch (error) {
-    if (isEexistError(error)) {
-      // Another worker won the race and recorded the first reason. Stay silent:
-      // do not overwrite it, and do not emit a duplicate annotation.
-      return;
-    }
-    // Any other error (ENOSPC, EACCES, ENOENT for a missing parent dir, ...):
-    // the sentinel — which IS the cross-process latch in the success/EEXIST
-    // paths — was never written, so there is nothing to dedupe subsequent
-    // callers against. Emitting here would make EVERY worker (and every retry)
-    // hit this same failing write and announce its own wall, flooding CI with
-    // duplicate annotations and breaking the "first reason wins / losers stay
-    // silent" guarantee. Return without emitting; the quota wall is still
-    // surfaced by the failing test itself, and we never fail the run because of
-    // sentinel I/O.
-    return;
+  if (publishSentinel(sentinelPath, reason)) {
+    // Reached only when THIS process won the atomic publication, i.e. it is the
+    // sole owner of the sentinel latch.
+    emitGitHubAnnotations(reason);
   }
-
-  // Reached only when the exclusive create above actually succeeded, i.e. this
-  // process is the sole winner that owns the sentinel latch.
-  emitGitHubAnnotations(reason);
 }
 
 /**
@@ -246,7 +299,7 @@ export function tripQuotaGuard(reason: string): void {
  * `null` when the guard is inactive, unset, unreadable, or malformed.
  */
 export function getQuotaGuardTrip(): { reason: string } | null {
-  if (!isGuardActive()) {
+  if (!isQuotaGuardActive()) {
     return null;
   }
   const sentinelPath = getSentinelPath();

--- a/packages/test-utils/src/test-rig.ts
+++ b/packages/test-utils/src/test-rig.ts
@@ -44,6 +44,7 @@ import {
   spawnRunWithTimeout,
   type RunContext,
 } from './process-run.js';
+import { getQuotaGuardTrip } from './quota-guard.js';
 import type { ParsedLog } from './types.js';
 
 // Re-export public types and helpers so existing importers keep working.
@@ -448,10 +449,27 @@ export class TestRig {
       env: childEnv,
     };
 
+    // Real-provider interactive runs participate in the quota guard: a
+    // fake-responses run never hits a real provider, so its output must not be
+    // scanned for quota signals. Compute applicability once, use it for both
+    // the pre-spawn refusal and the InteractiveRun failure-path detection.
+    const quotaGuardEnabled = this.fakeResponsesPath === undefined;
+
+    if (quotaGuardEnabled) {
+      const trip = getQuotaGuardTrip();
+      if (trip !== null) {
+        throw new Error(
+          `E2E quota guard tripped — refusing to start interactive CLI run: ${trip.reason}`,
+        );
+      }
+    }
+
     const executable = command === 'node' ? process.execPath : command;
     const ptyProcess = pty.spawn(executable, commandArgs, ptyOptions);
 
-    const run = new InteractiveRun(ptyProcess, this._diagnostics);
+    const run = new InteractiveRun(ptyProcess, this._diagnostics, {
+      quotaGuardEnabled,
+    });
     this._interactiveRuns.push(run);
 
     return waitForInteractiveReady(run);
@@ -569,6 +587,14 @@ async function waitForInteractiveReady(
     30000,
     200,
   );
+
+  // Failure-only quota check: a quota wall hit at startup means the CLI shows a
+  // 429 (or never responds) and the ready prompt never appears. Trip the guard
+  // and fail fast with the labelled error before the ordinary readiness
+  // assertion, so the rest of the suite skips instead of burning quota.
+  if (!isReady) {
+    run.failFastOnQuota('interactive run never reached readiness');
+  }
 
   expect(isReady).toBe(true);
   return run;


### PR DESCRIPTION
## Summary

Fixes the E2E failure mode where a single provider quota or rate-limit error could cascade into hundreds of downstream failures and keep the suite calling an exhausted provider for many hours.

The implementation adds a cross-process quota guard shared by Vitest workers. The first real-provider failure that contains a contextual quota/rate-limit signal atomically records a sentinel. From that point forward:

- fresh tests are skipped before their bodies run;
- retries fail immediately without making another provider call;
- non-interactive and PTY-backed harness runs refuse to spawn;
- teardown fails the run with a prominent quota/infra banner;
- GitHub Actions receives a dedicated error annotation and step-summary entry.

## Design

### Detection

Signals are scanned only on failure paths, never successful runs, to avoid interpreting legitimate model output as an outage. Covered forms include:

- contextual HTTP 429, including statusCode and status_code;
- rate-limited and contextual rate-limit exhaustion/error wording;
- quota exceeded/exhausted and quota-limit reached/exceeded/hit;
- exceeded-your-current-quota provider messages;
- insufficient_quota, RESOURCE_EXHAUSTED, and too many requests.

Bare prose such as rate limit, quota limit, or Processed 429 items is intentionally ignored.

### Cross-process fail-fast

The guard uses an exclusive-create sentinel under INTEGRATION_TEST_FILE_DIR. This makes the first writer win atomically across Vitest workers and prevents later workers from overwriting the original reason or duplicating CI annotations.

The guard is wired into:

- TestRig.run / runCommand non-zero exits and timeouts;
- InteractiveRun expectText timeouts;
- InteractiveRun expectExit non-zero exits and timeouts;
- interactive startup that never reaches readiness;
- pre-spawn checks for both non-interactive and interactive runs;
- a Vitest setup hook that skips fresh tests and throws on retries;
- global teardown, which preserves a non-zero suite outcome and labels the failure as quota/infra.

Fake-response tests are exempt so fixture text cannot trip the real-provider guard. LLXPRT_QUOTA_GUARD_DISABLED=true provides an explicit escape hatch.

## Behavioral coverage

The new tests use observable behavior rather than mocked internals:

- real child processes for normal failures, quota failures, timeouts, signal termination, and spawn refusal;
- real PTYs for interactive timeout, non-zero exit, clean exit, already-exited, and fake-response-exempt paths;
- real temp files for sentinel lifecycle, exclusive-create semantics, malformed state, and CI summary output;
- a nested real Vitest run proving retries remain failed, later test bodies are skipped, the marker file is not written, and the overall exit code is non-zero.

## Verification

- npm run test
- npm run lint
- npm run lint:eslint-guard
- npm run typecheck
- npm run format
- npm run build
- Live CLI smoke test via the zai profile produced a haiku successfully
- Deep implementation review passed after remediation
- Open Code Review completed clean after all findings were addressed

Fixes #2279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of provider quota and rate-limit failures during integration tests.
  * Prevented additional provider requests after quota exhaustion is detected.
  * Preserved original test failures when retries are skipped due to quota limits.
  * Added clearer `[QUOTA/RATE-LIMIT]` error messages and CI notifications.

* **Tests**
  * Added comprehensive coverage for quota detection, process execution, interactive runs, retries, timeouts, and concurrent test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->