### PR TITLE
fix(providers): add reasoning.fieldName support to classic openai provider (Fixes #2505)

### DIFF
--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -586,6 +586,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
     mergedHeaders: Record<string, string> | undefined,
     baseURL: string | undefined,
     logger: DebugLogger,
+    reasoningFieldName: string | undefined,
   ): AsyncGenerator<IContent, void, unknown> {
     const { processStreamingResponse } = await import(
       './OpenAIStreamProcessor.js'
@@ -599,6 +600,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
         textToolParser: this.textToolParser,
         logger,
         getBaseURL: () => this.getBaseURL(),
+        reasoningFieldName,
       };
       yield* processStreamingResponse(
         response as AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
@@ -682,6 +684,10 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       getBaseURL: () => this.getBaseURL(),
     });
 
+    const reasoningFieldName = options.settings.get('reasoning.fieldName') as
+      | string
+      | undefined;
+
     yield* this.dispatchResponse(
       response,
       model,
@@ -694,6 +700,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       mergedHeaders,
       baseURL,
       logger,
+      reasoningFieldName,
     );
   }
 

--- a/packages/providers/src/openai/OpenAIProviders.fieldName.test.ts
+++ b/packages/providers/src/openai/OpenAIProviders.fieldName.test.ts
@@ -45,7 +45,7 @@ function makeChunk(
   return {
     id: 'chunk-test',
     object: 'chat.completion.chunk',
-    created: Date.now(),
+    created: 1000000,
     model: 'test-model',
     choices: [
       {

--- a/packages/providers/src/openai/OpenAIProviders.fieldName.test.ts
+++ b/packages/providers/src/openai/OpenAIProviders.fieldName.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for issue #2505: the classic openai provider must honor a
+ * configurable reasoning field name (reasoning.fieldName) with auto-fallback
+ * to delta.reasoning for Ollama, and propagate the actual captured field as
+ * the terminal ThinkingBlock sourceField provenance.
+ *
+ * These tests exercise processStreamingResponse end-to-end (the wiring that
+ * threads StreamProcessorDeps.reasoningFieldName into parseStreamingReasoningDelta
+ * and into the terminal combined thinking block), not just the parser unit.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { ToolCallPipeline } from './ToolCallPipeline.js';
+import { processStreamingResponse } from './OpenAIStreamProcessor.js';
+
+async function collectResults(
+  iterator: AsyncIterable<IContent>,
+): Promise<IContent[]> {
+  const results: IContent[] = [];
+  for await (const chunk of iterator) {
+    results.push(chunk);
+  }
+  return results;
+}
+
+async function* createChunkStream(
+  chunks: unknown[],
+): AsyncGenerator<unknown, void, undefined> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+function makeChunk(
+  delta: Record<string, unknown>,
+  finishReason: string | null,
+) {
+  return {
+    id: 'chunk-test',
+    object: 'chat.completion.chunk',
+    created: Date.now(),
+    model: 'test-model',
+    choices: [
+      {
+        index: 0,
+        delta,
+        finish_reason: finishReason,
+      },
+    ],
+  };
+}
+
+type StreamDeps = Parameters<typeof processStreamingResponse>[9];
+
+function makeDeps(reasoningFieldName: string | undefined): StreamDeps {
+  return {
+    toolCallPipeline: new ToolCallPipeline(),
+    textToolParser: {
+      parse: (text: string) => ({ toolCalls: [], cleanedContent: text }),
+    },
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      log: vi.fn(),
+      error: vi.fn(),
+    },
+    getBaseURL: () => undefined,
+    reasoningFieldName,
+  } as unknown as StreamDeps;
+}
+
+async function runStreaming(
+  chunks: unknown[],
+  reasoningFieldName: string | undefined,
+): Promise<IContent[]> {
+  return collectResults(
+    processStreamingResponse(
+      createChunkStream(chunks) as unknown as Parameters<
+        typeof processStreamingResponse
+      >[0],
+      'test-model',
+      'openai',
+      undefined,
+      {} as Parameters<typeof processStreamingResponse>[4],
+      [],
+      {} as Parameters<typeof processStreamingResponse>[6],
+      undefined,
+      undefined,
+      makeDeps(reasoningFieldName),
+      async function* () {
+        yield* [] as IContent[];
+      } as Parameters<typeof processStreamingResponse>[10],
+    ),
+  );
+}
+
+function findThinkingBlock(
+  results: IContent[],
+):
+  | { type: 'thinking'; thought: string; sourceField: string | undefined }
+  | undefined {
+  for (const content of results) {
+    for (const block of content.blocks) {
+      if (block.type === 'thinking') {
+        return {
+          type: 'thinking',
+          thought: block.thought,
+          sourceField: block.sourceField,
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+describe('issue #2505 – classic openai provider reasoning.fieldName streaming', () => {
+  it('captures delta.reasoning when fieldName is explicitly "reasoning" (Ollama)', async () => {
+    const chunks = [
+      makeChunk({ reasoning: 'ollama thinking trace' }, null),
+      makeChunk({}, 'stop'),
+    ];
+
+    const results = await runStreaming(chunks, 'reasoning');
+
+    const thinking = findThinkingBlock(results);
+    expect(thinking).toBeDefined();
+    expect(thinking).toMatchObject({
+      type: 'thinking',
+      thought: 'ollama thinking trace',
+      sourceField: 'reasoning',
+    });
+  });
+
+  it('auto-falls-back to delta.reasoning when fieldName is unset (Ollama out-of-the-box)', async () => {
+    const chunks = [
+      makeChunk({ reasoning: 'auto-fallback ollama reasoning' }, null),
+      makeChunk({}, 'stop'),
+    ];
+
+    const results = await runStreaming(chunks, undefined);
+
+    expect(findThinkingBlock(results)).toMatchObject({
+      type: 'thinking',
+      thought: 'auto-fallback ollama reasoning',
+      sourceField: 'reasoning',
+    });
+  });
+
+  it('captures reasoning_content when fieldName is unset (standard providers unaffected)', async () => {
+    const chunks = [
+      makeChunk({ reasoning_content: 'standard reasoning' }, null),
+      makeChunk({}, 'stop'),
+    ];
+
+    const results = await runStreaming(chunks, undefined);
+
+    expect(findThinkingBlock(results)).toMatchObject({
+      type: 'thinking',
+      thought: 'standard reasoning',
+      sourceField: 'reasoning_content',
+    });
+  });
+
+  it('prefers reasoning_content over reasoning when both present and unset', async () => {
+    const chunks = [
+      makeChunk({ reasoning_content: 'standard', reasoning: 'fallback' }, null),
+      makeChunk({}, 'stop'),
+    ];
+
+    const results = await runStreaming(chunks, undefined);
+
+    expect(findThinkingBlock(results)).toMatchObject({
+      thought: 'standard',
+      sourceField: 'reasoning_content',
+    });
+  });
+
+  it('ignores reasoning_content when fieldName is explicitly "reasoning"', async () => {
+    const chunks = [
+      makeChunk({ reasoning_content: 'should be ignored' }, null),
+      makeChunk({}, 'stop'),
+    ];
+
+    const results = await runStreaming(chunks, 'reasoning');
+
+    expect(findThinkingBlock(results)).toBeUndefined();
+  });
+
+  it('accumulates multi-chunk Ollama reasoning into one terminal thinking block', async () => {
+    const chunks = [
+      makeChunk({ reasoning: 'part one ' }, null),
+      makeChunk({ reasoning: 'part two' }, null),
+      makeChunk({}, 'stop'),
+    ];
+
+    const results = await runStreaming(chunks, undefined);
+
+    expect(findThinkingBlock(results)).toMatchObject({
+      thought: 'part one part two',
+      sourceField: 'reasoning',
+    });
+  });
+});

--- a/packages/providers/src/openai/OpenAIResponseParser.fieldName.test.ts
+++ b/packages/providers/src/openai/OpenAIResponseParser.fieldName.test.ts
@@ -183,4 +183,34 @@ describe('parseStreamingReasoningDelta — configurable field name (#2505)', () 
     expect(result.thinking?.thought).toBe('standard reasoning');
     expect(result.thinking?.sourceField).toBe('reasoning_content');
   });
+
+  it('trims a whitespace-padded field name before using it as the delta key (issue #2505)', () => {
+    const delta = {
+      reasoning: 'ollama reasoning',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(
+      delta,
+      mockLogger,
+      '  reasoning  ',
+    );
+
+    expect(result.thinking?.thought).toBe('ollama reasoning');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('returns null when an explicit field name is set but its value is non-usable', () => {
+    const delta = {
+      custom_field: { malformed: true },
+      reasoning: 'ollama reasoning',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(
+      delta,
+      mockLogger,
+      'custom_field',
+    );
+
+    expect(result.thinking).toBeNull();
+  });
 });

--- a/packages/providers/src/openai/OpenAIResponseParser.fieldName.test.ts
+++ b/packages/providers/src/openai/OpenAIResponseParser.fieldName.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @issue #2505 — Configurable reasoning field name for the classic openai
+ *   provider (Ollama emits reasoning under delta.reasoning).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { parseStreamingReasoningDelta } from './OpenAIResponseParser.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type OpenAI from 'openai';
+
+const mockLogger: DebugLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+  enabled: false,
+} as unknown as DebugLogger;
+
+type Delta = OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta;
+
+describe('parseStreamingReasoningDelta — configurable field name (#2505)', () => {
+  it('reads reasoning_content by default and reports sourceField provenance', () => {
+    const delta = {
+      reasoning_content: 'thinking via standard field',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking).not.toBeNull();
+    expect(result.thinking?.thought).toBe('thinking via standard field');
+    expect(result.thinking?.sourceField).toBe('reasoning_content');
+  });
+
+  it('auto-falls-back to delta.reasoning when field name is unset (Ollama)', () => {
+    const delta = {
+      reasoning: 'ollama reasoning trace',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking).not.toBeNull();
+    expect(result.thinking?.thought).toBe('ollama reasoning trace');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('prefers reasoning_content over reasoning when both present and unset', () => {
+    const delta = {
+      reasoning_content: 'standard',
+      reasoning: 'fallback',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking?.thought).toBe('standard');
+    expect(result.thinking?.sourceField).toBe('reasoning_content');
+  });
+
+  it('reads only the explicitly configured field name', () => {
+    const delta = {
+      reasoning: 'ollama trace',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger, 'reasoning');
+
+    expect(result.thinking?.thought).toBe('ollama trace');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('ignores reasoning_content when field name is explicitly "reasoning"', () => {
+    const delta = {
+      reasoning_content: 'should be ignored',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger, 'reasoning');
+
+    expect(result.thinking).toBeNull();
+  });
+
+  it('ignores delta.reasoning when field name is explicitly "reasoning_content"', () => {
+    const delta = {
+      reasoning: 'should be ignored',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(
+      delta,
+      mockLogger,
+      'reasoning_content',
+    );
+
+    expect(result.thinking).toBeNull();
+  });
+
+  it('preserves whitespace-only reasoning from the fallback field (issue #721)', () => {
+    const delta = {
+      reasoning: '  \n\t  ',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking?.thought).toBe('  \n\t  ');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('returns null when no reasoning is present on either field', () => {
+    const delta = {
+      content: 'just content',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking).toBeNull();
+  });
+
+  it('falls back to delta.reasoning when reasoning_content is an empty string', () => {
+    const delta = {
+      reasoning_content: '',
+      reasoning: 'ollama reasoning',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking?.thought).toBe('ollama reasoning');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('falls back to delta.reasoning when reasoning_content is a non-string value', () => {
+    const delta = {
+      reasoning_content: { malformed: true },
+      reasoning: 'ollama reasoning',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking?.thought).toBe('ollama reasoning');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('falls back to delta.reasoning when reasoning_content is null', () => {
+    const delta = {
+      reasoning_content: null,
+      reasoning: 'ollama reasoning',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger);
+
+    expect(result.thinking?.thought).toBe('ollama reasoning');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('treats an empty-string field name as unset and auto-falls-back (issue #2505)', () => {
+    const delta = {
+      reasoning: 'ollama reasoning',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger, '');
+
+    expect(result.thinking?.thought).toBe('ollama reasoning');
+    expect(result.thinking?.sourceField).toBe('reasoning');
+  });
+
+  it('treats a whitespace-only field name as unset and auto-falls-back (issue #2505)', () => {
+    const delta = {
+      reasoning_content: 'standard reasoning',
+    } as unknown as Delta;
+
+    const result = parseStreamingReasoningDelta(delta, mockLogger, '   ');
+
+    expect(result.thinking?.thought).toBe('standard reasoning');
+    expect(result.thinking?.sourceField).toBe('reasoning_content');
+  });
+});

--- a/packages/providers/src/openai/OpenAIResponseParser.ts
+++ b/packages/providers/src/openai/OpenAIResponseParser.ts
@@ -33,7 +33,62 @@ const CODE_FENCE_END = new RegExp(CODE_FENCE_END_SOURCE, 'm');
 type DeltaWithReasoning =
   OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta & {
     reasoning_content?: unknown;
+    reasoning?: unknown;
   };
+
+/**
+ * Selects the reasoning value and provenance field name. When fieldName is
+ * unset (undefined) and the primary value is not a usable non-empty string,
+ * falls back to the Ollama delta.reasoning field (issue #2488 / #2505).
+ */
+function resolveReasoningValue(
+  primaryValue: unknown,
+  explicitField: string,
+  ollamaReasoning: unknown,
+  fieldName: string | undefined,
+): { value: unknown; actualFieldName: string } {
+  if (hasUsableReasoning(primaryValue)) {
+    return { value: primaryValue, actualFieldName: explicitField };
+  }
+  if (fieldName === undefined && hasUsableReasoning(ollamaReasoning)) {
+    return { value: ollamaReasoning, actualFieldName: 'reasoning' };
+  }
+  return { value: primaryValue, actualFieldName: explicitField };
+}
+
+function hasUsableReasoning(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function readReasoningFromDelta(
+  delta: DeltaWithReasoning,
+  fieldName: string | undefined,
+): { content: string; actualFieldName: string } | undefined {
+  // Treat empty/whitespace-only field names as unset so auto-fallback still
+  // applies (issue #2505: guards against reasoning.fieldName='' misconfig).
+  const normalizedFieldName =
+    fieldName !== undefined && fieldName.trim().length > 0
+      ? fieldName
+      : undefined;
+  const deltaRecord = delta as Record<string, unknown>;
+  const explicitField = normalizedFieldName ?? 'reasoning_content';
+  const primaryValue =
+    normalizedFieldName === undefined
+      ? delta.reasoning_content
+      : deltaRecord[explicitField];
+
+  const { value, actualFieldName } = resolveReasoningValue(
+    primaryValue,
+    explicitField,
+    delta.reasoning,
+    normalizedFieldName,
+  );
+
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+  return { content: value, actualFieldName };
+}
 
 /**
  * Returns true for parts that carry no textual content and should be skipped.
@@ -393,41 +448,38 @@ export function cleanThinkingContent(
 }
 
 /**
- * Parse reasoning_content from streaming delta.
+ * Parse reasoning from a streaming delta using a configurable field name.
+ *
+ * The delta field name is configurable via the optional fieldName argument
+ * (mirrors the reasoning.fieldName ephemeral). When undefined (unset), the
+ * classic provider auto-falls-back from reasoning_content to delta.reasoning
+ * for Ollama compatibility (issue #2505). The actual captured field name is
+ * propagated to the ThinkingBlock sourceField for provenance.
  *
  * @plan PLAN-20251202-THINKING.P11, PLAN-20251202-THINKING.P16
  * @requirement REQ-THINK-003.1, REQ-THINK-003.3, REQ-THINK-003.4, REQ-KIMI-REASONING-001.1
- * @issue #749
+ * @issue #749, #2505
  */
 export function parseStreamingReasoningDelta(
   delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta | undefined,
   logger: DebugLogger,
+  fieldName?: string,
 ): { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] } {
   if (delta == null) {
     return { thinking: null, toolCalls: [] };
   }
 
-  // Access reasoning_content via type assertion since OpenAI SDK doesn't declare it
-  const reasoningContent = (delta as DeltaWithReasoning).reasoning_content;
-
-  // Handle absent, null, or non-string
-  if (
-    reasoningContent === null ||
-    reasoningContent === undefined ||
-    typeof reasoningContent !== 'string'
-  ) {
-    return { thinking: null, toolCalls: [] };
-  }
-
-  // Handle empty string only - preserve whitespace-only content (spaces, tabs)
-  // to maintain proper formatting in accumulated reasoning (fixes issue #721)
-  if (reasoningContent.length === 0) {
+  const captured = readReasoningFromDelta(
+    delta as DeltaWithReasoning,
+    fieldName,
+  );
+  if (captured === undefined) {
     return { thinking: null, toolCalls: [] };
   }
 
   // Extract Kimi K2 tool calls embedded in reasoning_content (fixes issue #749)
   const { cleanedText, toolCalls } = extractKimiToolCallsFromText(
-    reasoningContent,
+    captured.content,
     logger,
   );
 
@@ -439,7 +491,7 @@ export function parseStreamingReasoningDelta(
       : {
           type: 'thinking' as const,
           thought: cleanedText,
-          sourceField: 'reasoning_content' as const,
+          sourceField: captured.actualFieldName,
           isHidden: false,
         };
 

--- a/packages/providers/src/openai/OpenAIResponseParser.ts
+++ b/packages/providers/src/openai/OpenAIResponseParser.ts
@@ -37,23 +37,24 @@ type DeltaWithReasoning =
   };
 
 /**
- * Selects the reasoning value and provenance field name. When fieldName is
- * unset (undefined) and the primary value is not a usable non-empty string,
- * falls back to the Ollama delta.reasoning field (issue #2488 / #2505).
+ * Selects the reasoning value and provenance field name. Returns undefined
+ * when no usable reasoning is available. When fieldName is unset (undefined)
+ * and the primary value is not a usable non-empty string, falls back to the
+ * Ollama delta.reasoning field (issue #2488 / #2505).
  */
 function resolveReasoningValue(
   primaryValue: unknown,
   explicitField: string,
   ollamaReasoning: unknown,
   fieldName: string | undefined,
-): { value: unknown; actualFieldName: string } {
+): { value: string; actualFieldName: string } | undefined {
   if (hasUsableReasoning(primaryValue)) {
     return { value: primaryValue, actualFieldName: explicitField };
   }
   if (fieldName === undefined && hasUsableReasoning(ollamaReasoning)) {
     return { value: ollamaReasoning, actualFieldName: 'reasoning' };
   }
-  return { value: primaryValue, actualFieldName: explicitField };
+  return undefined;
 }
 
 function hasUsableReasoning(value: unknown): value is string {
@@ -66,10 +67,10 @@ function readReasoningFromDelta(
 ): { content: string; actualFieldName: string } | undefined {
   // Treat empty/whitespace-only field names as unset so auto-fallback still
   // applies (issue #2505: guards against reasoning.fieldName='' misconfig).
+  // Trim a non-empty field name before using it as a delta property key.
+  const trimmed = fieldName?.trim();
   const normalizedFieldName =
-    fieldName !== undefined && fieldName.trim().length > 0
-      ? fieldName
-      : undefined;
+    trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined;
   const deltaRecord = delta as Record<string, unknown>;
   const explicitField = normalizedFieldName ?? 'reasoning_content';
   const primaryValue =
@@ -77,17 +78,20 @@ function readReasoningFromDelta(
       ? delta.reasoning_content
       : deltaRecord[explicitField];
 
-  const { value, actualFieldName } = resolveReasoningValue(
+  const resolved = resolveReasoningValue(
     primaryValue,
     explicitField,
     delta.reasoning,
     normalizedFieldName,
   );
 
-  if (typeof value !== 'string' || value.length === 0) {
+  if (resolved === undefined) {
     return undefined;
   }
-  return { content: value, actualFieldName };
+  return {
+    content: resolved.value,
+    actualFieldName: resolved.actualFieldName,
+  };
 }
 
 /**

--- a/packages/providers/src/openai/OpenAIStreamProcessor.ts
+++ b/packages/providers/src/openai/OpenAIStreamProcessor.ts
@@ -73,6 +73,7 @@ export interface StreamProcessorDeps {
   textToolParser: GemmaToolCallParser;
   logger: DebugLogger;
   getBaseURL: () => string | undefined;
+  reasoningFieldName?: string;
 }
 
 /**
@@ -244,9 +245,14 @@ function processReasoningDelta(
   deps: StreamProcessorDeps,
 ): void {
   const { thinking: reasoningBlock, toolCalls: reasoningToolCalls } =
-    parseStreamingReasoningDelta(choice.delta, deps.logger);
+    parseStreamingReasoningDelta(
+      choice.delta,
+      deps.logger,
+      deps.reasoningFieldName,
+    );
   if (reasoningBlock) {
     state.accumulatedReasoningContent += reasoningBlock.thought;
+    state.reasoningSourceField = reasoningBlock.sourceField;
   }
   if (reasoningToolCalls.length > 0) {
     const stats = deps.toolCallPipeline.getStats();
@@ -586,7 +592,7 @@ function* emitCombinedTerminalContent(
     combinedBlocks.push({
       type: 'thinking',
       thought: cleanedReasoning,
-      sourceField: 'reasoning_content',
+      sourceField: state.reasoningSourceField ?? 'reasoning_content',
       isHidden: false,
     } as ThinkingBlock);
   }

--- a/packages/providers/src/openai/OpenAIStreamProcessorState.ts
+++ b/packages/providers/src/openai/OpenAIStreamProcessorState.ts
@@ -29,6 +29,7 @@ export interface StreamingState {
   accumulatedThinkingContent: string;
   hasEmittedThinking: boolean;
   accumulatedReasoningContent: string;
+  reasoningSourceField: string | undefined;
   streamingUsage: {
     prompt_tokens?: number;
     completion_tokens?: number;
@@ -52,6 +53,7 @@ export function createStreamingState(): StreamingState {
     accumulatedThinkingContent: '',
     hasEmittedThinking: false,
     accumulatedReasoningContent: '',
+    reasoningSourceField: undefined,
     streamingUsage: null,
     lastFinishReason: null,
     hasEmittedTerminalMetadata: false,


### PR DESCRIPTION
## Summary

Fixes #2505.

PR #2491 (Fixes #2488) added a configurable reasoning field name (`reasoning.fieldName`, with auto-fallback to `delta.reasoning` for Ollama) to the **openai-vercel** provider so reasoning models served via Ollama surface their thinking in streaming output. However, that fix was **not** applied to the **classic openai provider** (`packages/providers/src/openai/`), which still hardcoded `delta.reasoning_content`. As a result, Ollama reasoning (emitted under `delta.reasoning`) was silently dropped when using `--provider openai`.

This PR applies the same `reasoning.fieldName` handling to the classic openai provider, mirroring the proven pattern from PR #2491.

## Changes

- **`OpenAIResponseParser.ts`**: `parseStreamingReasoningDelta` now accepts an optional `fieldName`. Added `readReasoningFromDelta` and `resolveReasoningValue` helpers that read the configured field (default `reasoning_content`) and, when the setting is unset, auto-fall-back to `delta.reasoning` (Ollama). The actual captured field name is propagated as the `ThinkingBlock.sourceField` for provenance. Empty/whitespace-only field names are normalized to "unset" so auto-fallback still applies.
- **`OpenAIStreamProcessor.ts`**: Added `reasoningFieldName?` to `StreamProcessorDeps`, threaded it to `parseStreamingReasoningDelta`, and track the actual source field per-chunk in `StreamingState.reasoningSourceField`. The terminal combined thinking block now uses the tracked source field instead of a hardcoded value.
- **`OpenAIStreamProcessorState.ts`**: Added `reasoningSourceField` to `StreamingState`.
- **`OpenAIProvider.ts`**: Reads `options.settings.get('reasoning.fieldName')` and threads it through `dispatchResponse` into the streaming deps.

## Behavior

| Setting | `delta.reasoning_content` | `delta.reasoning` | Result |
|---|---|---|---|
| unset | present | — | captured, sourceField=`reasoning_content` |
| unset | absent | present | captured (auto-fallback), sourceField=`reasoning` |
| unset | present | present | `reasoning_content` wins |
| `reasoning` | — | present | captured, sourceField=`reasoning` |
| `reasoning` | present | — | ignored (explicit field not present) |
| `reasoning_content` | absent | present | ignored (no auto-fallback when explicit) |

Standard providers (LM Studio, vLLM, OpenAI) that emit `reasoning_content` are unaffected by default.

## Tests

- `OpenAIResponseParser.fieldName.test.ts` (new, 13 tests): unit-level behavioral tests for the configurable field name, auto-fallback, precedence, edge cases (null/non-string/empty primary values), and empty/whitespace field-name normalization.
- `OpenAIProviders.fieldName.test.ts` (new, 6 tests): integration tests exercising `processStreamingResponse` end-to-end, verifying the wiring (`reasoningFieldName` → parser → terminal `ThinkingBlock.sourceField`) and multi-chunk accumulation.
- All existing openai provider tests (777) continue to pass.

## Verification

- `npm run typecheck` — pass
- `npm run lint` (changed files) + `check-eslint-guard.ts` — pass (no rules loosened, no suppressions)
- `npm run format` — clean
- `npm run test` — all packages pass (5135+ tests, 0 failures)
- `npm run build` — clean

## Review gates

Open Code Review (ocr) run with `--timeout 20`; both findings addressed (empty-string field-name normalization + tests). Code review by typescriptreviewer subagent; all Medium/Low findings addressed (mixed-source provenance uses last-field-wins matching Vercel, type assertion removed, fallback now triggers on non-usable primary values, integration tests added).