### PR TITLE
Fix Windows test portability

### DIFF
--- a/packages/auth/src/proxy/__tests__/proxy-provider-key-storage.test.ts
+++ b/packages/auth/src/proxy/__tests__/proxy-provider-key-storage.test.ts
@@ -18,6 +18,10 @@ import { encodeFrame, FrameDecoder } from '../framing.js';
 import { ProxySocketClient, PROTOCOL_VERSION } from '../proxy-socket-client.js';
 
 function createTempSocketPath(): string {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\llxprt-proxy-pks-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-pks-test-'));
   return path.join(tmpDir, 'test.sock');
 }
@@ -84,9 +88,11 @@ describe('ProxyProviderKeyStorage', () => {
       }
     });
     try {
-      // Remove the entire temp directory (includes socket file)
-      const tmpDir = path.dirname(socketPath);
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      if (process.platform !== 'win32') {
+        // Remove the entire temp directory (includes socket file)
+        const tmpDir = path.dirname(socketPath);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     } catch {
       // may already be gone
     }

--- a/packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts
+++ b/packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts
@@ -23,9 +23,13 @@ import {
 import { encodeFrame, FrameDecoder } from '../framing.js';
 
 /**
- * Creates a temporary Unix socket path for testing.
+ * Creates a temporary IPC endpoint for testing.
  */
 function createTempSocketPath(): string {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\llxprt-proxy-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-test-'));
   return path.join(tmpDir, 'test.sock');
 }
@@ -79,8 +83,10 @@ describe('ProxySocketClient', () => {
       }
     });
 
-    const socketDir = path.dirname(socketPath);
-    fs.rmSync(socketDir, { recursive: true, force: true });
+    if (process.platform !== 'win32') {
+      const socketDir = path.dirname(socketPath);
+      fs.rmSync(socketDir, { recursive: true, force: true });
+    }
   });
 
   /**

--- a/packages/auth/src/proxy/__tests__/proxy-token-store.test.ts
+++ b/packages/auth/src/proxy/__tests__/proxy-token-store.test.ts
@@ -19,6 +19,10 @@ import { PROTOCOL_VERSION } from '../proxy-socket-client.js';
 import type { OAuthToken, BucketStats } from '../../types.js';
 
 function createTempSocketPath(): string {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\llxprt-proxy-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-ts-test-'));
   return path.join(tmpDir, 'test.sock');
 }

--- a/packages/core/src/config/config-lsp-integration.test.ts
+++ b/packages/core/src/config/config-lsp-integration.test.ts
@@ -446,6 +446,8 @@ describe('Config LSP Integration (P33)', () => {
       ).toBe(true);
     });
 
+    // Live MCP navigation registration depends on the Bun-backed LSP transport,
+    // which is not currently supported by these native Windows test runs (#2509).
     it.skipIf(isWindows)(
       'should register MCP navigation when navigationTools is true',
       async () => {
@@ -471,6 +473,7 @@ describe('Config LSP Integration (P33)', () => {
       },
     );
 
+    // Same transport limitation as the explicit navigationTools case above.
     it.skipIf(isWindows)(
       'should default to enabled when navigationTools is absent',
       async () => {

--- a/packages/core/src/config/config-lsp-integration.test.ts
+++ b/packages/core/src/config/config-lsp-integration.test.ts
@@ -253,6 +253,7 @@ vi.mock('../utils/events.js', async (importOriginal) => {
 });
 
 describe('Config LSP Integration (P33)', () => {
+  const isWindows = process.platform === 'win32';
   const mockTargetDir = fileURLToPath(new URL('../../../../', import.meta.url));
   const mockSessionId = 'test-session-id';
 
@@ -445,49 +446,55 @@ describe('Config LSP Integration (P33)', () => {
       ).toBe(true);
     });
 
-    it('should register MCP navigation when navigationTools is true', async () => {
-      const params = createBaseConfigParams({
-        lsp: {
-          servers: [],
-          navigationTools: true,
-        },
-      });
-      const config = new Config(params);
-      await initializeTestConfig(config);
+    it.skipIf(isWindows)(
+      'should register MCP navigation when navigationTools is true',
+      async () => {
+        const params = createBaseConfigParams({
+          lsp: {
+            servers: [],
+            navigationTools: true,
+          },
+        });
+        const config = new Config(params);
+        await initializeTestConfig(config);
 
-      const lspConfig = config.getLspConfig();
-      expect(lspConfig?.navigationTools).toBe(true);
+        const lspConfig = config.getLspConfig();
+        expect(lspConfig?.navigationTools).toBe(true);
 
-      await vi.waitFor(() => {
-        const tools = config.getToolRegistry().getAllTools();
-        const lspNavTools = tools.filter(
-          (t: { serverName?: string }) => t.serverName === 'lsp-navigation',
-        );
-        expect(lspNavTools.length).toBeGreaterThan(0);
-      });
-    });
+        await vi.waitFor(() => {
+          const tools = config.getToolRegistry().getAllTools();
+          const lspNavTools = tools.filter(
+            (t: { serverName?: string }) => t.serverName === 'lsp-navigation',
+          );
+          expect(lspNavTools.length).toBeGreaterThan(0);
+        });
+      },
+    );
 
-    it('should default to enabled when navigationTools is absent', async () => {
-      const params = createBaseConfigParams({
-        lsp: {
-          servers: [],
-          // navigationTools omitted
-        },
-      });
-      const config = new Config(params);
-      await initializeTestConfig(config);
+    it.skipIf(isWindows)(
+      'should default to enabled when navigationTools is absent',
+      async () => {
+        const params = createBaseConfigParams({
+          lsp: {
+            servers: [],
+            // navigationTools omitted
+          },
+        });
+        const config = new Config(params);
+        await initializeTestConfig(config);
 
-      const lspConfig = config.getLspConfig();
-      expect(lspConfig?.navigationTools).toBeUndefined();
+        const lspConfig = config.getLspConfig();
+        expect(lspConfig?.navigationTools).toBeUndefined();
 
-      await vi.waitFor(() => {
-        const tools = config.getToolRegistry().getAllTools();
-        const lspNavTools = tools.filter(
-          (t: { serverName?: string }) => t.serverName === 'lsp-navigation',
-        );
-        expect(lspNavTools.length).toBeGreaterThan(0);
-      });
-    });
+        await vi.waitFor(() => {
+          const tools = config.getToolRegistry().getAllTools();
+          const lspNavTools = tools.filter(
+            (t: { serverName?: string }) => t.serverName === 'lsp-navigation',
+          );
+          expect(lspNavTools.length).toBeGreaterThan(0);
+        });
+      },
+    );
   });
 
   describe('REQ-NAV-055: Register MCP only after service starts', () => {

--- a/packages/core/src/config/config.d.test.ts
+++ b/packages/core/src/config/config.d.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import path from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ConfigParameters } from './config.js';
 import { Config, ApprovalMode } from './config.js';
@@ -313,7 +314,7 @@ describe('Config JIT context', () => {
       expect(result).toContain('sub memory');
       expect(mockLoadJitSubdirectoryMemory).toHaveBeenCalledWith(
         '/path/to/target/sub/file.ts',
-        [baseParams.targetDir],
+        [path.resolve(baseParams.targetDir)],
         expect.any(Set),
         baseParams.debugMode,
         true,

--- a/packages/core/src/core/prompts.coreMemory.test.ts
+++ b/packages/core/src/core/prompts.coreMemory.test.ts
@@ -106,7 +106,7 @@ describe('Core (System) Memory', () => {
             typeof filePath === 'string' ? filePath : filePath.toString();
           if (
             pathStr.includes('.LLXPRT_SYSTEM') &&
-            pathStr.includes('/my/project')
+            pathStr.includes(path.resolve('/my/project'))
           ) {
             return 'Use pnpm for this project';
           }
@@ -131,7 +131,7 @@ describe('Core (System) Memory', () => {
           }
           if (
             pathStr.includes('.LLXPRT_SYSTEM') &&
-            pathStr.includes('/my/project')
+            pathStr.includes(path.resolve('/my/project'))
           ) {
             return 'Project directive';
           }

--- a/packages/core/src/core/prompts.coreMemory.test.ts
+++ b/packages/core/src/core/prompts.coreMemory.test.ts
@@ -25,6 +25,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
+const PROJECT_DIR = path.resolve('/my/project');
+
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
   return {
@@ -106,7 +108,7 @@ describe('Core (System) Memory', () => {
             typeof filePath === 'string' ? filePath : filePath.toString();
           if (
             pathStr.includes('.LLXPRT_SYSTEM') &&
-            pathStr.includes(path.resolve('/my/project'))
+            pathStr.includes(PROJECT_DIR)
           ) {
             return 'Use pnpm for this project';
           }
@@ -114,7 +116,7 @@ describe('Core (System) Memory', () => {
         },
       );
 
-      const result = await loadCoreMemoryContent('/my/project');
+      const result = await loadCoreMemoryContent(PROJECT_DIR);
       expect(result).toContain('Use pnpm for this project');
     });
 
@@ -131,7 +133,7 @@ describe('Core (System) Memory', () => {
           }
           if (
             pathStr.includes('.LLXPRT_SYSTEM') &&
-            pathStr.includes(path.resolve('/my/project'))
+            pathStr.includes(PROJECT_DIR)
           ) {
             return 'Project directive';
           }
@@ -139,7 +141,7 @@ describe('Core (System) Memory', () => {
         },
       );
 
-      const result = await loadCoreMemoryContent('/my/project');
+      const result = await loadCoreMemoryContent(PROJECT_DIR);
       expect(result).toContain('Global directive');
       expect(result).toContain('Project directive');
     });
@@ -159,7 +161,7 @@ describe('Core (System) Memory', () => {
         },
       );
 
-      const result = await loadCoreMemoryContent('/my/project');
+      const result = await loadCoreMemoryContent(PROJECT_DIR);
       expect(result).toBe('');
     });
   });

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -299,11 +299,13 @@ describe('HookRunner', () => {
 
         // SECURITY: Verify spawn is called with shell executable and expanded path
         // Note: Safe paths without metacharacters may not be quoted
+        const expectedPath =
+          process.platform === 'win32'
+            ? /'\/test\/project'\/hooks\/test\.sh/
+            : /\/test\/project\/hooks\/test\.sh/;
         expect(spawn).toHaveBeenCalledWith(
           expect.stringMatching(/bash|powershell/),
-          expect.arrayContaining([
-            expect.stringMatching(/\/test\/project\/hooks\/test\.sh/),
-          ]),
+          expect.arrayContaining([expect.stringMatching(expectedPath)]),
           expect.objectContaining({
             shell: false,
             env: expect.objectContaining({

--- a/packages/core/src/lsp/__tests__/e2e-lsp.test.ts
+++ b/packages/core/src/lsp/__tests__/e2e-lsp.test.ts
@@ -239,6 +239,7 @@ vi.mock('../../utils/events.js', async (importOriginal) => {
 });
 
 describe('LSP E2E integration (P36)', () => {
+  const isWindows = process.platform === 'win32';
   const repoRoot = fileURLToPath(new URL('../../../../../', import.meta.url));
   const targetDir = repoRoot;
 
@@ -639,16 +640,19 @@ describe('LSP E2E integration (P36)', () => {
   });
 
   // --- 15. MCP Transport Streams ---
-  it('getMcpTransportStreams returns PassThrough streams when alive', async () => {
-    const client = new LspServiceClient({ servers: [] }, targetDir);
-    await client.start();
+  it.skipIf(isWindows)(
+    'getMcpTransportStreams returns PassThrough streams when alive',
+    async () => {
+      const client = new LspServiceClient({ servers: [] }, targetDir);
+      await client.start();
 
-    expect(client.isAlive()).toBe(true);
-    const transport = client.getMcpTransportStreams();
-    expect(transport).not.toBeNull();
-    expect(transport!.readable).toBeDefined();
-    expect(transport!.writable).toBeDefined();
-  });
+      expect(client.isAlive()).toBe(true);
+      const transport = client.getMcpTransportStreams();
+      expect(transport).not.toBeNull();
+      expect(transport!.readable).toBeDefined();
+      expect(transport!.writable).toBeDefined();
+    },
+  );
 
   // --- 16. MCP Transport Null When Not Alive ---
   it('getMcpTransportStreams returns null when not alive', () => {
@@ -683,7 +687,7 @@ describe('LSP E2E integration (P36)', () => {
   });
 
   // --- 18. Shutdown then checkFile is safe ---
-  it('checkFile returns empty after shutdown', async () => {
+  it.skipIf(isWindows)('checkFile returns empty after shutdown', async () => {
     const client = new LspServiceClient({ servers: [] }, targetDir);
     await client.start();
     expect(client.isAlive()).toBe(true);

--- a/packages/core/src/policy/persistence.test.ts
+++ b/packages/core/src/policy/persistence.test.ts
@@ -561,7 +561,7 @@ priority = 100
       // Verify correct path used
       expect(fs.rename).toHaveBeenCalledWith(
         expect.stringMatching(/\.tmp$/),
-        '/home/user/.llxprt/policies/auto-saved.toml',
+        path.join(userPoliciesDir, 'auto-saved.toml'),
       );
 
       // Path should NOT contain Google strings

--- a/packages/core/src/services/contextManager.test.ts
+++ b/packages/core/src/services/contextManager.test.ts
@@ -8,6 +8,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import path from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ContextManager } from './contextManager.js';
 import * as memoryDiscovery from '../utils/memoryDiscovery.js';
@@ -94,7 +95,7 @@ describe('ContextManager', () => {
         false,
       );
       expect(contextManager.getEnvironmentMemory()).toContain(
-        '--- Context from: .llxprt/LLXPRT.md ---',
+        `--- Context from: ${path.join('.llxprt', 'LLXPRT.md')} ---`,
       );
       expect(contextManager.getEnvironmentMemory()).toContain('Env Content');
       expect(contextManager.getEnvironmentMemory()).toContain(

--- a/packages/core/src/utils/shellPathCompletion.test.ts
+++ b/packages/core/src/utils/shellPathCompletion.test.ts
@@ -300,18 +300,21 @@ describe('getPathSuggestions', () => {
     ]);
   });
 
-  it('should handle permission errors gracefully', async () => {
-    const restrictedDir = path.join(testRootDir, 'restricted');
-    await fs.mkdir(restrictedDir);
-    await fs.writeFile(path.join(restrictedDir, 'secret.txt'), '');
-    await fs.chmod(restrictedDir, 0o000);
-    try {
-      const results = await getPathSuggestions('./restricted/', testRootDir);
-      expect(results).toStrictEqual([]);
-    } finally {
-      await fs.chmod(restrictedDir, 0o755);
-    }
-  });
+  it.skipIf(process.platform === 'win32')(
+    'should handle permission errors gracefully',
+    async () => {
+      const restrictedDir = path.join(testRootDir, 'restricted');
+      await fs.mkdir(restrictedDir);
+      await fs.writeFile(path.join(restrictedDir, 'secret.txt'), '');
+      await fs.chmod(restrictedDir, 0o000);
+      try {
+        const results = await getPathSuggestions('./restricted/', testRootDir);
+        expect(results).toStrictEqual([]);
+      } finally {
+        await fs.chmod(restrictedDir, 0o755);
+      }
+    },
+  );
 
   describe('shell special character escaping', () => {
     let spacesDir: string;

--- a/packages/core/test/utils/ripgrepPathResolver.test.ts
+++ b/packages/core/test/utils/ripgrepPathResolver.test.ts
@@ -179,7 +179,10 @@ describe('RipgrepPathResolver - Cross-platform Path Resolution', () => {
 
     // Mock bundle ripgrep
     const mockExistsSync = vi.fn().mockImplementation((filePath: string) => {
-      if (filePath.includes('bundle') && filePath.endsWith('rg')) {
+      if (
+        filePath.includes('bundle') &&
+        (filePath.endsWith('rg') || filePath.endsWith('rg.exe'))
+      ) {
         return true;
       }
       if (filePath.includes('node_modules')) {

--- a/packages/ide-integration/src/lsp/__tests__/lsp-service-client-integration.test.ts
+++ b/packages/ide-integration/src/lsp/__tests__/lsp-service-client-integration.test.ts
@@ -21,7 +21,7 @@ const {
   sendRequestMock: vi.fn(),
 }));
 
-const createWhichProcess = () => {
+const createLocatorProcess = () => {
   const proc = new EventEmitter() as EventEmitter & { stdout: PassThrough };
   proc.stdout = new PassThrough();
   setImmediate(() => {
@@ -115,8 +115,8 @@ describe('LspServiceClient integration contract', () => {
     sendRequestMock.mockReset();
 
     spawnMock.mockImplementation((command: string) => {
-      if (command === 'which') {
-        return createWhichProcess();
+      if (command === 'which' || command === 'where') {
+        return createLocatorProcess();
       }
       return createLspProcess();
     });
@@ -196,13 +196,14 @@ describe('LspServiceClient integration contract', () => {
     expect(client.getMcpTransportStreams()).toBeNull();
   });
 
-  it('live start uses which bun and lsp spawn plus jsonrpc connection', async () => {
+  it('live start locates bun and spawns lsp plus jsonrpc connection', async () => {
     const client = createClient('typescript-language-server');
 
     await client.start();
 
+    const locator = process.platform === 'win32' ? 'where' : 'which';
     expect(spawnMock).toHaveBeenCalledTimes(2);
-    expect(spawnMock.mock.calls.some((call) => call[0] === 'which')).toBe(true);
+    expect(spawnMock.mock.calls.some((call) => call[0] === locator)).toBe(true);
     expect(createMessageConnectionMock).toHaveBeenCalledTimes(1);
     expect(client.isAlive()).toBe(true);
   });

--- a/packages/ide-integration/src/lsp/__tests__/lsp-service-client.test.ts
+++ b/packages/ide-integration/src/lsp/__tests__/lsp-service-client.test.ts
@@ -22,11 +22,15 @@ const {
   sendRequestMock: vi.fn(),
 }));
 
-const createWhichProcess = () => {
+const createLocatorProcess = () => {
   const proc = new EventEmitter() as EventEmitter & { stdout: PassThrough };
   proc.stdout = new PassThrough();
   setImmediate(() => {
-    proc.stdout.write('/usr/bin/bun\n');
+    proc.stdout.write(
+      process.platform === 'win32'
+        ? 'C:\\tools\\bun.exe\r\nC:\\tools\\bun.cmd\r\n'
+        : '/usr/bin/bun\n',
+    );
     proc.emit('exit', 0, null);
   });
   return proc;
@@ -103,8 +107,8 @@ describe('LspServiceClient unit contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     spawnMock.mockImplementation((command: string) => {
-      if (command === 'which') {
-        return createWhichProcess();
+      if (command === 'which' || command === 'where') {
+        return createLocatorProcess();
       }
       return createLspProcess();
     });
@@ -165,6 +169,9 @@ describe('LspServiceClient unit contract', () => {
     const client = makeClient(liveConfig);
     await client.start();
     expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock.mock.calls[1][0]).toBe(
+      process.platform === 'win32' ? 'C:\\tools\\bun.exe' : '/usr/bin/bun',
+    );
   });
 
   it('start should build jsonrpc connection via createMessageConnection', async () => {
@@ -254,7 +261,7 @@ describe('LspServiceClient unit contract', () => {
     // Find the LSP subprocess spawn call (not the 'which' call)
     // spawn is called with (command, args, options) — env is at index 2
     const lspSpawnCalls = spawnMock.mock.calls.filter(
-      (call) => call[0] !== 'which',
+      (call) => call[0] !== 'which' && call[0] !== 'where',
     );
     expect(lspSpawnCalls.length).toBeGreaterThan(0);
     const spawnOptions = lspSpawnCalls[0][2] as Record<string, unknown>;
@@ -274,7 +281,7 @@ describe('LspServiceClient unit contract', () => {
 
     // Find the LSP subprocess spawn call (not the 'which' call)
     const lspSpawnCalls = spawnMock.mock.calls.filter(
-      (call) => call[0] !== 'which',
+      (call) => call[0] !== 'which' && call[0] !== 'where',
     );
     expect(lspSpawnCalls.length).toBeGreaterThan(0);
     const spawnOptions = lspSpawnCalls[0][2] as Record<string, unknown>;
@@ -297,7 +304,7 @@ describe('LspServiceClient unit contract', () => {
     await client.start();
 
     const lspSpawnCalls = spawnMock.mock.calls.filter(
-      (call) => call[0] !== 'which',
+      (call) => call[0] !== 'which' && call[0] !== 'where',
     );
     expect(lspSpawnCalls.length).toBeGreaterThan(0);
     const spawnOptions = lspSpawnCalls[0][2] as Record<string, unknown>;
@@ -316,7 +323,7 @@ describe('LspServiceClient unit contract', () => {
     await client.start();
 
     const lspSpawnCalls = spawnMock.mock.calls.filter(
-      (call) => call[0] !== 'which',
+      (call) => call[0] !== 'which' && call[0] !== 'where',
     );
     expect(lspSpawnCalls.length).toBeGreaterThan(0);
     const spawnOptions = lspSpawnCalls[0][2] as Record<string, unknown>;
@@ -340,7 +347,7 @@ describe('LspServiceClient unit contract', () => {
     await client.start();
 
     const lspSpawnCalls = spawnMock.mock.calls.filter(
-      (call) => call[0] !== 'which',
+      (call) => call[0] !== 'which' && call[0] !== 'where',
     );
     expect(lspSpawnCalls.length).toBeGreaterThan(0);
     const spawnOptions = lspSpawnCalls[0][2] as Record<string, unknown>;
@@ -365,7 +372,7 @@ describe('LspServiceClient unit contract', () => {
     await client.start();
 
     const lspSpawnCalls = spawnMock.mock.calls.filter(
-      (call) => call[0] !== 'which',
+      (call) => call[0] !== 'which' && call[0] !== 'where',
     );
     expect(lspSpawnCalls.length).toBeGreaterThan(0);
     const spawnOptions = lspSpawnCalls[0][2] as Record<string, unknown>;

--- a/packages/ide-integration/src/lsp/lsp-service-client.ts
+++ b/packages/ide-integration/src/lsp/lsp-service-client.ts
@@ -328,8 +328,12 @@ export class LspServiceClient {
       return null;
     }
 
-    const path = Buffer.concat(chunks).toString('utf8').trim();
-    return path.length > 0 ? path : null;
+    const paths = Buffer.concat(chunks)
+      .toString('utf8')
+      .split(/\r?\n/)
+      .map((candidate) => candidate.trim())
+      .filter((candidate) => candidate.length > 0);
+    return paths[0] ?? null;
   }
 
   private async pathIsExecutable(targetPath: string): Promise<boolean> {

--- a/packages/tools/src/__tests__/ripGrep-args.test.ts
+++ b/packages/tools/src/__tests__/ripGrep-args.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildRipgrepArgs,
+  parseRipgrepLine,
   type RipgrepIgnoreOptions,
 } from '../tools/ripGrep.js';
 
@@ -134,5 +135,39 @@ describe('buildRipgrepArgs', () => {
   it('appends the absolute path as the final positional argument', () => {
     const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, defaultIgnore);
     expect(args[args.length - 1]).toBe(ABS_PATH);
+  });
+
+  it('uses null-delimited file paths', () => {
+    const args = buildRipgrepArgs(PATTERN, ABS_PATH, undefined, defaultIgnore);
+    expect(hasFlag(args, '--null')).toBe(true);
+  });
+});
+
+describe('parseRipgrepLine', () => {
+  it('parses null-delimited Windows drive-letter paths', () => {
+    const basePath = 'C:\\repo';
+    const match = parseRipgrepLine(
+      `C:\\repo\\src\\keep.ts${String.fromCharCode(0)}1:needle found`,
+      basePath,
+    );
+
+    expect(match).toEqual({
+      filePath: 'src\\keep.ts',
+      lineNumber: 1,
+      line: 'needle found',
+    });
+  });
+
+  it('preserves colons in matched content', () => {
+    const match = parseRipgrepLine(
+      `/tmp/search-root/keep.ts${String.fromCharCode(0)}3:value: with: colons`,
+      '/tmp/search-root',
+    );
+
+    expect(match).toEqual({
+      filePath: 'keep.ts',
+      lineNumber: 3,
+      line: 'value: with: colons',
+    });
   });
 });

--- a/packages/tools/src/__tests__/ripGrep-args.test.ts
+++ b/packages/tools/src/__tests__/ripGrep-args.test.ts
@@ -144,19 +144,22 @@ describe('buildRipgrepArgs', () => {
 });
 
 describe('parseRipgrepLine', () => {
-  it('parses null-delimited Windows drive-letter paths', () => {
-    const basePath = 'C:\\repo';
-    const match = parseRipgrepLine(
-      `C:\\repo\\src\\keep.ts${String.fromCharCode(0)}1:needle found`,
-      basePath,
-    );
+  it.runIf(process.platform === 'win32')(
+    'parses null-delimited Windows drive-letter paths',
+    () => {
+      const basePath = 'C:\\repo';
+      const match = parseRipgrepLine(
+        `C:\\repo\\src\\keep.ts${String.fromCharCode(0)}1:needle found`,
+        basePath,
+      );
 
-    expect(match).toEqual({
-      filePath: 'src\\keep.ts',
-      lineNumber: 1,
-      line: 'needle found',
-    });
-  });
+      expect(match).toEqual({
+        filePath: 'src\\keep.ts',
+        lineNumber: 1,
+        line: 'needle found',
+      });
+    },
+  );
 
   it('preserves colons in matched content', () => {
     const match = parseRipgrepLine(

--- a/packages/tools/src/tools/ripGrep.ts
+++ b/packages/tools/src/tools/ripGrep.ts
@@ -87,6 +87,7 @@ export function buildRipgrepArgs(
     '--line-number',
     '--no-heading',
     '--with-filename',
+    '--null',
     '--ignore-case',
     '--regexp',
     pattern,
@@ -644,24 +645,33 @@ export class RipGrepTool extends BaseDeclarativeTool<
  * Parses a single ripgrep output line into a GrepMatch, or returns null
  * if the line is blank or malformed.
  */
-function parseRipgrepLine(line: string, basePath: string): GrepMatch | null {
+export function parseRipgrepLine(
+  line: string,
+  basePath: string,
+): GrepMatch | null {
   if (!line.trim()) {
     return null;
   }
 
-  const firstColonIndex = line.indexOf(':');
-  if (firstColonIndex === -1) {
+  const nullSeparatorIndex = line.indexOf('\0');
+  const pathSeparatorIndex =
+    nullSeparatorIndex === -1 ? line.indexOf(':') : nullSeparatorIndex;
+  if (pathSeparatorIndex === -1) {
     return null;
   }
 
-  const secondColonIndex = line.indexOf(':', firstColonIndex + 1);
-  if (secondColonIndex === -1) {
+  const lineNumberStartIndex = pathSeparatorIndex + 1;
+  const contentSeparatorIndex = line.indexOf(':', lineNumberStartIndex);
+  if (contentSeparatorIndex === -1) {
     return null;
   }
 
-  const filePathRaw = line.substring(0, firstColonIndex);
-  const lineNumberStr = line.substring(firstColonIndex + 1, secondColonIndex);
-  const lineContent = line.substring(secondColonIndex + 1);
+  const filePathRaw = line.substring(0, pathSeparatorIndex);
+  const lineNumberStr = line.substring(
+    lineNumberStartIndex,
+    contentSeparatorIndex,
+  );
+  const lineContent = line.substring(contentSeparatorIndex + 1);
 
   const lineNumber = parseInt(lineNumberStr, 10);
   if (isNaN(lineNumber)) {

--- a/scripts/tests/ocr-review-workflow-helpers.js
+++ b/scripts/tests/ocr-review-workflow-helpers.js
@@ -26,13 +26,21 @@ export function normalize(value) {
 export function commandText(step) {
   return String(step?.run ?? step?.with?.script ?? '');
 }
-export function hasPerl() {
+function hasCommand(command, args) {
   try {
-    execFileSync('perl', ['-e', '1'], { stdio: 'ignore' });
+    execFileSync(command, args, { stdio: 'ignore' });
     return true;
   } catch {
     return false;
   }
+}
+
+export function hasPerl() {
+  return hasCommand('perl', ['-e', '1']);
+}
+
+export function hasBashAndPerl() {
+  return hasCommand('bash', ['-c', 'perl -e 1']);
 }
 
 export function stepNamed(job, name) {

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -13,7 +13,7 @@ import {
   expectCommonCredentialsRedacted,
   expectContainsAll,
   extractFunctionSource,
-  hasPerl,
+  hasBashAndPerl,
   makePostSanitizer,
   normalize,
   readRootFile,
@@ -451,60 +451,72 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(sanitized).toBe('first [REDACTED] second [REDACTED]');
     expect(sanitized).not.toContain(secret);
   });
-  it('redacts exact OCR secrets with regex metacharacters and backslashes in notify diagnostics', () => {
-    // Include Perl's \E escape marker to prove quotemeta prevents it from ending literal matching early.
-    const secret = String.raw`tok$^.*+?()[]{}|\slash\Eend`;
+  it.skipIf(!hasBashAndPerl())(
+    'redacts exact OCR secrets with regex metacharacters and backslashes in notify diagnostics',
+    () => {
+      // Include Perl's \E escape marker to prove quotemeta prevents it from ending literal matching early.
+      const secret = String.raw`tok$^.*+?()[]{}|\slash\Eend`;
 
-    const sanitized = runNotifySanitizer(
-      notifyRun,
-      `first ${secret} second ${secret}`,
-      secret,
-    );
+      const sanitized = runNotifySanitizer(
+        notifyRun,
+        `first ${secret} second ${secret}`,
+        secret,
+      );
 
-    expect(sanitized).toBe('first [REDACTED] second [REDACTED]');
-    expect(sanitized).not.toContain(secret);
-  });
+      expect(sanitized).toBe('first [REDACTED] second [REDACTED]');
+      expect(sanitized).not.toContain(secret);
+    },
+  );
 
-  it('redacts common credential patterns in notify diagnostics', () => {
-    const diagnostic = [
-      'Error: OCR review failed for packages/agents/src/core/TurnProcessor.ts:266',
-      'snippet: for await (const event of stream) handle(event);',
-    ].join('\n');
+  it.skipIf(!hasBashAndPerl())(
+    'redacts common credential patterns in notify diagnostics',
+    () => {
+      const diagnostic = [
+        'Error: OCR review failed for packages/agents/src/core/TurnProcessor.ts:266',
+        'snippet: for await (const event of stream) handle(event);',
+      ].join('\n');
 
-    const sanitized = runNotifySanitizer(
-      notifyRun,
-      [commonCredentialInput(), diagnostic].join('\n'),
-      'unused-secret',
-    );
+      const sanitized = runNotifySanitizer(
+        notifyRun,
+        [commonCredentialInput(), diagnostic].join('\n'),
+        'unused-secret',
+      );
 
-    expectCommonCredentialsRedacted(sanitized);
-    expect(sanitized).toContain(diagnostic);
-  });
+      expectCommonCredentialsRedacted(sanitized);
+      expect(sanitized).toContain(diagnostic);
+    },
+  );
 
-  it('does not redact short generic token and secret diagnostic words in notify diagnostics', () => {
-    const diagnostic =
-      'token=expired secret=enabled while auth_token_value remains visible';
+  it.skipIf(!hasBashAndPerl())(
+    'does not redact short generic token and secret diagnostic words in notify diagnostics',
+    () => {
+      const diagnostic =
+        'token=expired secret=enabled while auth_token_value remains visible';
 
-    expect(runNotifySanitizer(notifyRun, diagnostic, 'unused-secret')).toBe(
-      diagnostic,
-    );
-  });
+      expect(runNotifySanitizer(notifyRun, diagnostic, 'unused-secret')).toBe(
+        diagnostic,
+      );
+    },
+  );
 
-  it('redacts the configured OCR LLM URL from notify diagnostics', () => {
-    const url = 'https://llm.example.test/v1/messages?api_key=sk-url-secret';
+  it.skipIf(!hasBashAndPerl())(
+    'redacts the configured OCR LLM URL from notify diagnostics',
+    () => {
+      const url = 'https://llm.example.test/v1/messages?api_key=sk-url-secret';
 
-    const sanitized = runNotifySanitizer(
-      notifyRun,
-      `request failed for ${url}`,
-      'unused-secret',
-      { OCR_LLM_URL: url },
-    );
+      const sanitized = runNotifySanitizer(
+        notifyRun,
+        `request failed for ${url}`,
+        'unused-secret',
+        { OCR_LLM_URL: url },
+      );
 
-    expect(sanitized).toBe('request failed for [REDACTED]');
-    expect(sanitized).not.toContain(url);
-  });
+      expect(sanitized).toBe('request failed for [REDACTED]');
+      expect(sanitized).not.toContain(url);
+    },
+  );
 
-  it.skipIf(!hasPerl())(
+  it.skipIf(!hasBashAndPerl())(
     'fails closed with process details when notify diagnostic sanitization fails',
     () => {
       const secret = 'must-not-leak';

--- a/scripts/tests/publish-integrity.test.ts
+++ b/scripts/tests/publish-integrity.test.ts
@@ -104,7 +104,13 @@ function getPackedPaths(): Set<string> {
   if (packedPathsCache !== undefined) {
     return packedPathsCache;
   }
-  const stdout = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+  const npmArgs = ['pack', '--dry-run', '--json'];
+  const executable = process.platform === 'win32' ? process.env.ComSpec : 'npm';
+  const args =
+    process.platform === 'win32'
+      ? ['/d', '/s', '/c', 'npm', ...npmArgs]
+      : npmArgs;
+  const stdout = execFileSync(executable!, args, {
     cwd: repoRoot,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
@@ -502,7 +508,7 @@ describe('published package no-compile runtime contract (S6)', () => {
     );
 
     expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
-  }, 15000);
+  }, 30000);
 });
 
 describe('release build self-contained generate contract (issue #2392)', () => {

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -302,7 +302,7 @@ describe('orchestrateTests', () => {
       commands.push({ command, cwd });
       if (
         command === failCommand &&
-        cwd.endsWith(failCwdSuffix.replaceAll('/', path.sep))
+        cwd.endsWith(path.normalize(failCwdSuffix))
       ) {
         return { success: false, exitCode: 1 };
       }

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
   mkdirSync,
 } from 'node:fs';
-import { join, resolve } from 'node:path';
+import path, { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   discoverWorkspaces,
@@ -300,7 +300,10 @@ describe('orchestrateTests', () => {
     const commands: Array<{ command: string; cwd: string }> = [];
     const runner: CommandRunner = (command, cwd) => {
       commands.push({ command, cwd });
-      if (command === failCommand && cwd.endsWith(failCwdSuffix)) {
+      if (
+        command === failCommand &&
+        cwd.endsWith(failCwdSuffix.replaceAll('/', path.sep))
+      ) {
         return { success: false, exitCode: 1 };
       }
       return { success: true, exitCode: 0 };
@@ -394,7 +397,7 @@ describe('orchestrateTests', () => {
       failingForA,
     );
     expect(summary.failed).toBeGreaterThan(0);
-    const ranB = commands.some((c) => c.cwd.endsWith('packages/b'));
+    const ranB = commands.some((c) => c.cwd.endsWith(join('packages', 'b')));
     expect(ranB).toBe(false);
   });
 
@@ -421,7 +424,7 @@ describe('orchestrateTests', () => {
     const summary = orchestrateTests(root, opts, failingForA);
     expect(summary.failed).toBe(1);
     expect(summary.passed).toBeGreaterThanOrEqual(1);
-    const ranB = commands.some((c) => c.cwd.endsWith('packages/b'));
+    const ranB = commands.some((c) => c.cwd.endsWith(join('packages', 'b')));
     expect(ranB).toBe(true);
   });
 
@@ -448,7 +451,7 @@ describe('orchestrateTests', () => {
     const summary = orchestrateTests(root, opts, runner);
     expect(summary.totalWorkspaces).toBe(1);
     expect(commands).toHaveLength(1);
-    expect(commands[0].cwd.endsWith('packages/b')).toBe(true);
+    expect(commands[0].cwd.endsWith(join('packages', 'b'))).toBe(true);
   });
 
   it('filters by workspace package name', () => {
@@ -471,7 +474,7 @@ describe('orchestrateTests', () => {
     const summary = orchestrateTests(root, opts, runner);
     expect(summary.totalWorkspaces).toBe(1);
     expect(commands).toHaveLength(1);
-    expect(commands[0].cwd.endsWith('packages/a')).toBe(true);
+    expect(commands[0].cwd.endsWith(join('packages', 'a'))).toBe(true);
   });
 
   it('runs script tests by default', () => {

--- a/scripts/tests/tmux-harness-io.test.js
+++ b/scripts/tests/tmux-harness-io.test.js
@@ -183,7 +183,7 @@ describe('issue #2469: tmux socket isolation', () => {
     expect(typeof socketPath).toBe('string');
     expect(socketPath.length).toBeGreaterThan(0);
     // Must be a -S style socket path (a filesystem path), not a fixed -L name.
-    expect(socketPath).toMatch(/llxprt-tmux-harness-[^/]+\/tmux\.sock$/);
+    expect(socketPath).toMatch(/llxprt-tmux-harness-[^/\\]+[/\\\\]tmux\.sock$/);
     expect(getTmuxSocketPath()).toBe(socketPath);
   });
 
@@ -229,7 +229,7 @@ describe('issue #2469: tmux socket isolation', () => {
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnSyncMock.mock.calls[0];
     expect(args[0]).toBe('-S');
-    expect(args[1]).toMatch(/llxprt-tmux-harness-[^/]+\/tmux\.sock$/);
+    expect(args[1]).toMatch(/llxprt-tmux-harness-[^/\\]+[/\\\\]tmux\.sock$/);
     expect(fs.existsSync(path.dirname(args[1]))).toBe(true);
   });
 });

--- a/scripts/tests/tmux-harness.test.js
+++ b/scripts/tests/tmux-harness.test.js
@@ -8,15 +8,14 @@
 
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { accessSync, constants as fsConstants } from 'node:fs';
+import { quote } from 'shell-quote';
 
 // Both fixtures intentionally point at the test runner's own executable: the
 // harness only needs *a* real, spawnable path — the node-vs-bun distinction
 // under test is which env var the harness reads, not the binary itself.
 const TEST_NODE_EXECUTABLE = process.execPath;
 const TEST_BUN_EXECUTABLE = process.execPath;
-const SHELL_QUOTED_NODE_EXECUTABLE = process.execPath.includes(' ')
-  ? `'${process.execPath}'`
-  : process.execPath;
+const SHELL_QUOTED_NODE_EXECUTABLE = quote([process.execPath]);
 
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/scripts/tests/tmux-harness.test.js
+++ b/scripts/tests/tmux-harness.test.js
@@ -14,6 +14,9 @@ import { accessSync, constants as fsConstants } from 'node:fs';
 // under test is which env var the harness reads, not the binary itself.
 const TEST_NODE_EXECUTABLE = process.execPath;
 const TEST_BUN_EXECUTABLE = process.execPath;
+const SHELL_QUOTED_NODE_EXECUTABLE = process.execPath.includes(' ')
+  ? `'${process.execPath}'`
+  : process.execPath;
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -282,7 +285,7 @@ describe('buildTmuxStartCommand', () => {
     const { buildTmuxStartCommand } = await importHarness();
 
     expect(buildTmuxStartCommand(['node', 'scripts/start.ts'])).toBe(
-      `${TEST_NODE_EXECUTABLE} scripts/start.ts`,
+      `${SHELL_QUOTED_NODE_EXECUTABLE} scripts/start.ts`,
     );
   });
 
@@ -294,7 +297,7 @@ describe('buildTmuxStartCommand', () => {
     expect(
       buildTmuxStartCommand(['node', 'scripts/start.ts'], '/tmp/artifacts'),
     ).toBe(
-      `LLXPRT_TMUX_ARTIFACT_DIR=/tmp/artifacts ${TEST_NODE_EXECUTABLE} scripts/start.ts`,
+      `LLXPRT_TMUX_ARTIFACT_DIR=/tmp/artifacts ${SHELL_QUOTED_NODE_EXECUTABLE} scripts/start.ts`,
     );
   });
 });


### PR DESCRIPTION
﻿## Summary

- make ripgrep output parsing safe for Windows drive-letter paths
- use Windows named pipes in credential-proxy tests and handle multi-result `where bun` output
- normalize cross-platform path assertions and explicitly skip tests that require unsupported Unix tooling/live LSP transport
- make script test harnesses portable across Windows paths, quoting, command lookup, and optional Bash/Perl availability

## Validation

- `npm run format:check`
- direct ESLint across all changed files
- `npm run typecheck`
- `npm run build`
- `npm run test:scripts` (906 passed, 71 skipped)
- core test suite in four no-coverage shards:
  - shard 1/4: 1293 passed, 26 skipped
  - shard 2/4: 1334 passed, 4 skipped
  - shard 3/4: 1343 passed, 19 skipped
  - shard 4/4: 1029 passed, 1 skipped
- targeted tools, auth proxy, IDE integration, and core regression suites

The monolithic core Vitest invocation still terminates abruptly on this Windows host without an assertion summary; all core files pass when split across the four shards above.

Fixes #2509
