### PR TITLE
Add stable ACP session lifecycle management (Fixes #1609)

### DIFF
--- a/docs/zed-integration.md
+++ b/docs/zed-integration.md
@@ -176,6 +176,23 @@ Logs go to `~/.llxprt/debug/`. Only enable when troubleshooting — they get lar
 
 **Profile not found** — list profiles with `llxprt` then `/profile list`. Names are case-sensitive.
 
+## Extension Namespace (`llxprt/`)
+
+LLxprt reserves the `llxprt/` prefix for vendor-specific ACP extension methods and notifications. This namespace is documented for future use; no `llxprt/`-prefixed extension methods are implemented yet.
+
+When a concrete use case arrives (e.g. subagent status, memory operations, debug toggles, provider hints), the method name will be `llxprt/<feature>` and will be advertised here. Clients that do not recognize a `llxprt/` method MUST ignore it per the ACP [extensibility](https://agentclientprotocol.com/protocol/extensibility) rules (`_meta` / extension handling).
+
+## Session Metadata
+
+LLxprt emits ACP `session_info_update` notifications carrying:
+
+- **`title`** — a truncated preview of the first user prompt (derived once, consistent with the on-disk session listing).
+- **`updatedAt`** — an ISO 8601 timestamp refreshed after every turn (success, cancel, or error).
+
+This metadata also populates the `listSessions` response so Zed's session sidebar shows descriptive names and freshness without reading the recording files.
+
+When a session has both a durable on-disk recording and live in-memory metadata (e.g. the agent process is still running), `listSessions` merges them: the durable recording's title takes precedence (it is the authoritative first-user-message preview), while `updatedAt` is the newer of the two. A session with no durable recording yet shows the live title and `updatedAt` only.
+
 ## Related
 
 - [Zed External Agents Documentation](https://zed.dev/docs/ai/external-agents)

--- a/docs/zed-integration.md
+++ b/docs/zed-integration.md
@@ -193,6 +193,14 @@ This metadata also populates the `listSessions` response so Zed's session sideba
 
 When a session has both a durable on-disk recording and live in-memory metadata (e.g. the agent process is still running), `listSessions` merges them: the durable recording's title takes precedence (it is the authoritative first-user-message preview), while `updatedAt` is the newer of the two. A session with no durable recording yet shows the live title and `updatedAt` only.
 
+## Terminal Integration
+
+When the client advertises the `terminal` capability (`terminal: true` in `ClientCapabilities`), LLxprt creates an ACP terminal for each shell tool call via `connection.createTerminal`. This delegates command execution to Zed's native terminal renderer, giving the user live inline output as the command runs.
+
+The terminal is correlated to the originating tool call (by command and working directory) and embedded in the tool call's content as a `terminal` content block. The terminal is released after the tool call completes, and killed and released on cancel or session dispose.
+
+When the terminal capability is absent (or `false`), shell output is captured as text and emitted via the standard `content` content block — the same behavior as non-terminal ACP clients.
+
 ## Related
 
 - [Zed External Agents Documentation](https://zed.dev/docs/ai/external-agents)

--- a/packages/agents/src/api/control/sessionControl.ts
+++ b/packages/agents/src/api/control/sessionControl.ts
@@ -32,14 +32,13 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import type { Content } from '@google/genai';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import {
   Logger,
   SessionRecordingService,
   RecordingIntegration,
   resumeSession,
   CONTINUE_LATEST,
-  getProjectHash,
   type ResumeRequest,
   type LockHandle,
 } from '@vybestack/llxprt-code-core';
@@ -267,7 +266,7 @@ export class SessionControl implements AgentSessionControl {
     this.ensureSubscribed();
     const request: ResumeRequest = {
       continueRef: target === 'latest' ? CONTINUE_LATEST : target,
-      projectHash: getProjectHash(this.deps.config.getProjectRoot()),
+      projectHash: this.persistenceProjectHash(),
       chatsDir: this.chatsDir(),
       currentProvider: this.deps.getProvider(),
       currentModel: this.deps.getModel(),
@@ -598,9 +597,10 @@ export class SessionControl implements AgentSessionControl {
     await this.stopRecording();
     const service = new SessionRecordingService({
       sessionId: this.deps.sessionId(),
-      projectHash: getProjectHash(this.deps.config.getProjectRoot()),
+      projectHash: this.persistenceProjectHash(),
       chatsDir: this.chatsDir(),
       workspaceDirs: this.workspaceDirs(),
+      cwd: this.deps.config.getProjectRoot(),
       provider: this.deps.getProvider(),
       model: this.deps.getModel(),
     });
@@ -891,6 +891,10 @@ export class SessionControl implements AgentSessionControl {
     } catch {
       return [];
     }
+  }
+
+  private persistenceProjectHash(): string {
+    return basename(this.deps.config.storage.getProjectTempDir());
   }
 
   // ─── Path derivation ─────────────────────────────────────────────────────

--- a/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
+++ b/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
@@ -63,6 +63,17 @@ export class AcpTerminalShellHost implements IShellToolHost {
     onOutput: (event: ShellOutputEvent) => void,
     signal: AbortSignal,
   ): Promise<ShellExecutionResult> {
+    const allowed = this.delegate.isCommandAllowed(command);
+    if (!allowed.allowed) {
+      return Promise.resolve({
+        output: '',
+        exitCode: null,
+        signal: null,
+        error: new Error(allowed.reason ?? 'Command not allowed'),
+        aborted: false,
+        pid: undefined,
+      });
+    }
     return this.terminals.executeShellCommand(command, cwd, onOutput, signal);
   }
 

--- a/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
+++ b/packages/cli/src/zed-integration/acp-terminal-shell-host.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  IShellToolHost,
+  ShellExecutionResult,
+  ShellOutputEvent,
+} from '@vybestack/llxprt-code-tools';
+import type { TerminalManager } from './zed-terminal-manager.js';
+
+export class AcpTerminalShellHost implements IShellToolHost {
+  constructor(
+    private readonly delegate: IShellToolHost,
+    private readonly terminals: TerminalManager,
+  ) {}
+
+  getTargetDir(): string {
+    return this.delegate.getTargetDir();
+  }
+
+  getWorkspaceContext() {
+    return this.delegate.getWorkspaceContext();
+  }
+
+  isCommandAllowed(command: string) {
+    return this.delegate.isCommandAllowed(command);
+  }
+
+  isShellInvocationAllowlisted(command: string, toolName: string): boolean {
+    return this.delegate.isShellInvocationAllowlisted(command, toolName);
+  }
+
+  isInteractive(): boolean {
+    return this.delegate.isInteractive();
+  }
+
+  isYoloMode(): boolean {
+    return this.delegate.isYoloMode();
+  }
+
+  getDebugMode(): boolean {
+    return this.delegate.getDebugMode();
+  }
+
+  getShellExecutionConfig() {
+    return this.delegate.getShellExecutionConfig();
+  }
+
+  getTimeoutConfig() {
+    return this.delegate.getTimeoutConfig();
+  }
+
+  getOutputLimits() {
+    return this.delegate.getOutputLimits();
+  }
+
+  executeShellCommand(
+    command: string,
+    cwd: string,
+    onOutput: (event: ShellOutputEvent) => void,
+    signal: AbortSignal,
+  ): Promise<ShellExecutionResult> {
+    return this.terminals.executeShellCommand(command, cwd, onOutput, signal);
+  }
+
+  getCommandRoots(command: string): string[] {
+    return this.delegate.getCommandRoots(command);
+  }
+
+  stripShellWrapper(command: string): string {
+    return this.delegate.stripShellWrapper(command);
+  }
+
+  validatePathWithinWorkspace(
+    workspaceContext: ReturnType<IShellToolHost['getWorkspaceContext']>,
+    dirPath: string,
+    label: string,
+  ): string | null {
+    return this.delegate.validatePathWithinWorkspace(
+      workspaceContext,
+      dirPath,
+      label,
+    );
+  }
+
+  isPtyActive(pid: number): boolean {
+    return this.delegate.isPtyActive(pid);
+  }
+
+  formatMemoryUsage(bytes: number): string {
+    return this.delegate.formatMemoryUsage(bytes);
+  }
+
+  trySummarizeOutput(
+    content: string,
+    signal: AbortSignal,
+    tokenBudget?: number,
+  ): Promise<string> {
+    return this.delegate.trySummarizeOutput(content, signal, tokenBudget);
+  }
+
+  getSummarizeConfig() {
+    return this.delegate.getSummarizeConfig();
+  }
+
+  limitOutputTokens(content: string) {
+    return this.delegate.limitOutputTokens(content);
+  }
+}

--- a/packages/cli/src/zed-integration/acp-types.ts
+++ b/packages/cli/src/zed-integration/acp-types.ts
@@ -26,13 +26,10 @@ export interface DeleteSessionRequest {
 
 export type DeleteSessionResponse = Record<string, never>;
 
-export interface ClientCapabilitiesWithSession {
-  readonly fs?: {
-    readonly readTextFile?: boolean;
-    readonly writeTextFile?: boolean;
-  };
-  readonly terminal?: boolean;
+export type ClientCapabilitiesWithSession = NonNullable<
+  acp.InitializeRequest['clientCapabilities']
+> & {
   readonly session?: {
     readonly configOptions?: boolean;
   };
-}
+};

--- a/packages/cli/src/zed-integration/acp-types.ts
+++ b/packages/cli/src/zed-integration/acp-types.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+
+/**
+ * The pinned ACP SDK (0.14.1) does not yet export `CloseSessionRequest`,
+ * `DeleteSessionRequest`, or their responses, nor does its
+ * `ClientCapabilities` type include the `session` field used for
+ * config-option gating.  These local type aliases keep the integration
+ * strongly-typed without resorting to `any`.
+ */
+
+export interface CloseSessionRequest {
+  readonly sessionId: acp.SessionId;
+}
+
+export type CloseSessionResponse = Record<string, never>;
+
+export interface DeleteSessionRequest {
+  readonly sessionId: acp.SessionId;
+}
+
+export type DeleteSessionResponse = Record<string, never>;
+
+export interface ClientCapabilitiesWithSession {
+  readonly fs?: {
+    readonly readTextFile?: boolean;
+    readonly writeTextFile?: boolean;
+  };
+  readonly terminal?: boolean;
+  readonly session?: {
+    readonly configOptions?: boolean;
+  };
+}

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -155,6 +155,6 @@ async function handleNotice(
   return null;
 }
 
-function assertNever(event: never): acp.StopReason | null {
+function assertNever(event: never): never {
   throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -158,6 +158,6 @@ function assertNever(event: never): never {
   const detail =
     typeof event === 'object' && 'type' in event
       ? String((event as { type: unknown }).type)
-      : JSON.stringify(event);
+      : String(event);
   throw new Error(`Unhandled agent event: ${detail}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import {
+  extractThoughtText,
+  mapDoneReasonToStopReason,
+  translateErrorEvent,
+  translateIdleTimeout,
+} from './zed-helpers.js';
+import type { StreamBatcher } from './zed-stream-batcher.js';
+import {
+  emitToolCallStart,
+  emitToolResult,
+  emitToolStatus,
+} from './zed-tool-handler.js';
+
+interface AgentEventHandlers {
+  sendUpdate(update: acp.SessionUpdate): Promise<void>;
+  sendUsage(
+    usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
+  ): Promise<void>;
+  handleConfirmation(
+    event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
+  ): Promise<void>;
+}
+
+export async function handleZedAgentEvent(
+  event: AgentEvent,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<acp.StopReason | null> {
+  switch (event.type) {
+    case 'text':
+      batcher.append(event.text, false);
+      return null;
+    case 'thinking': {
+      const thoughtText = extractThoughtText(event.thought);
+      if (thoughtText.length > 0) batcher.append(thoughtText, true);
+      return null;
+    }
+    case 'tool-call':
+      await batcher.flush();
+      await emitToolCallStart(event.call, handlers.sendUpdate);
+      return null;
+    case 'tool-status':
+      await batcher.flush();
+      await emitToolStatus(event.update, handlers.sendUpdate);
+      return null;
+    case 'tool-result':
+      await batcher.flush();
+      await emitToolResult(event.result, handlers.sendUpdate);
+      return null;
+    case 'tool-confirmation':
+      await batcher.flush();
+      await handlers.handleConfirmation(event);
+      return null;
+    case 'done':
+      await batcher.flush();
+      return mapDoneReasonToStopReason(event.reason);
+    case 'error':
+      await batcher.flush();
+      throw translateErrorEvent(event);
+    case 'idle-timeout':
+      await batcher.flush();
+      throw translateIdleTimeout(event);
+    case 'invalid-stream':
+      await batcher.flush();
+      throw new Error(
+        'Agent produced an invalid stream that could not be recovered.',
+      );
+    case 'hook-blocked':
+      await batcher.flush();
+      throw new Error(
+        event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
+      );
+    case 'loop-detected':
+      await batcher.flush();
+      return 'end_turn';
+    case 'notice':
+      await batcher.flush();
+      await handlers.sendUpdate({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: event.message },
+      });
+      return null;
+    case 'usage':
+      await batcher.flush();
+      await handlers.sendUsage(event.usage);
+      return null;
+    case 'context-warning':
+    case 'compression':
+    case 'model-info':
+    case 'retry':
+    case 'citation':
+      return null;
+    default: {
+      const exhaustive: never = event;
+      throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -155,10 +155,5 @@ async function handleNotice(
 }
 
 function assertNever(event: never): never {
-  const record = event as Record<string, unknown> | null;
-  const detail =
-    record !== null && typeof record.type === 'string'
-      ? record.type
-      : String(event);
-  throw new Error(`Unhandled agent event: ${detail}`);
+  throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -155,9 +155,10 @@ async function handleNotice(
 }
 
 function assertNever(event: never): never {
+  const record = event as Record<string, unknown> | null;
   const detail =
-    typeof event === 'object' && 'type' in event
-      ? String((event as { type: unknown }).type)
+    record !== null && typeof record.type === 'string'
+      ? record.type
       : String(event);
   throw new Error(`Unhandled agent event: ${detail}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -27,6 +27,7 @@ interface AgentEventHandlers {
   handleConfirmation(
     event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
   ): Promise<void>;
+  resolveToolKind(toolName: string): string | undefined;
 }
 
 export async function handleZedAgentEvent(
@@ -45,15 +46,27 @@ export async function handleZedAgentEvent(
     }
     case 'tool-call':
       await batcher.flush();
-      await emitToolCallStart(event.call, handlers.sendUpdate);
+      await emitToolCallStart(
+        event.call,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.call.name),
+      );
       return null;
     case 'tool-status':
       await batcher.flush();
-      await emitToolStatus(event.update, handlers.sendUpdate);
+      await emitToolStatus(
+        event.update,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.update.name),
+      );
       return null;
     case 'tool-result':
       await batcher.flush();
-      await emitToolResult(event.result, handlers.sendUpdate);
+      await emitToolResult(
+        event.result,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.result.name),
+      );
       return null;
     case 'tool-confirmation':
       await batcher.flush();

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -42,7 +42,7 @@ export async function handleZedAgentEvent(
     case 'thinking':
       return handleThinking(event, batcher);
     case 'tool-call':
-      return handleToolEvent(event, batcher, handlers, emitToolCallStart);
+      return handleToolEvent(event, batcher, handlers);
     case 'tool-status':
       return handleToolUpdate(event, batcher, handlers);
     case 'tool-result':
@@ -103,10 +103,9 @@ async function handleToolEvent(
   event: Extract<AgentEvent, { type: 'tool-call' }>,
   batcher: StreamBatcher,
   handlers: AgentEventHandlers,
-  emit: typeof emitToolCallStart,
 ): Promise<null> {
   await batcher.flush();
-  await emit(
+  await emitToolCallStart(
     event.call,
     handlers.sendUpdate,
     handlers.resolveToolKind(event.call.name),
@@ -156,5 +155,9 @@ async function handleNotice(
 }
 
 function assertNever(event: never): never {
-  throw new Error(`Unhandled agent event: ${String(event)}`);
+  const detail =
+    typeof event === 'object' && 'type' in event
+      ? String((event as { type: unknown }).type)
+      : JSON.stringify(event);
+  throw new Error(`Unhandled agent event: ${detail}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -39,35 +39,14 @@ export async function handleZedAgentEvent(
     case 'text':
       batcher.append(event.text, false);
       return null;
-    case 'thinking': {
-      const thoughtText = extractThoughtText(event.thought);
-      if (thoughtText.length > 0) batcher.append(thoughtText, true);
-      return null;
-    }
+    case 'thinking':
+      return handleThinking(event, batcher);
     case 'tool-call':
-      await batcher.flush();
-      await emitToolCallStart(
-        event.call,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.call.name),
-      );
-      return null;
+      return handleToolEvent(event, batcher, handlers, emitToolCallStart);
     case 'tool-status':
-      await batcher.flush();
-      await emitToolStatus(
-        event.update,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.update.name),
-      );
-      return null;
+      return handleToolUpdate(event, batcher, handlers);
     case 'tool-result':
-      await batcher.flush();
-      await emitToolResult(
-        event.result,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.result.name),
-      );
-      return null;
+      return handleToolResultEvent(event, batcher, handlers);
     case 'tool-confirmation':
       await batcher.flush();
       await handlers.handleConfirmation(event);
@@ -95,12 +74,7 @@ export async function handleZedAgentEvent(
       await batcher.flush();
       return 'end_turn';
     case 'notice':
-      await batcher.flush();
-      await handlers.sendUpdate({
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: event.message },
-      });
-      return null;
+      return handleNotice(event, batcher, handlers);
     case 'usage':
       await batcher.flush();
       await handlers.sendUsage(event.usage);
@@ -111,9 +85,76 @@ export async function handleZedAgentEvent(
     case 'retry':
     case 'citation':
       return null;
-    default: {
-      const exhaustive: never = event;
-      throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
-    }
+    default:
+      return assertNever(event);
   }
+}
+
+function handleThinking(
+  event: Extract<AgentEvent, { type: 'thinking' }>,
+  batcher: StreamBatcher,
+): null {
+  const thoughtText = extractThoughtText(event.thought);
+  if (thoughtText.length > 0) batcher.append(thoughtText, true);
+  return null;
+}
+
+async function handleToolEvent(
+  event: Extract<AgentEvent, { type: 'tool-call' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+  emit: typeof emitToolCallStart,
+): Promise<null> {
+  await batcher.flush();
+  await emit(
+    event.call,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.call.name),
+  );
+  return null;
+}
+
+async function handleToolUpdate(
+  event: Extract<AgentEvent, { type: 'tool-status' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await emitToolStatus(
+    event.update,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.update.name),
+  );
+  return null;
+}
+
+async function handleToolResultEvent(
+  event: Extract<AgentEvent, { type: 'tool-result' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await emitToolResult(
+    event.result,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.result.name),
+  );
+  return null;
+}
+
+async function handleNotice(
+  event: Extract<AgentEvent, { type: 'notice' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await handlers.sendUpdate({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: event.message },
+  });
+  return null;
+}
+
+function assertNever(event: never): acp.StopReason | null {
+  throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-setup.ts
+++ b/packages/cli/src/zed-integration/zed-agent-setup.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Agent } from '@vybestack/llxprt-code-agents';
+
+export async function enableZedSessionRecording(
+  agent: Agent,
+  onFailure: (error: unknown) => void,
+): Promise<void> {
+  try {
+    await agent.session.setRecording({ enabled: true });
+  } catch (error) {
+    onFailure(error);
+  }
+}
+
+export async function buildZedSession<T>(
+  agent: Agent,
+  build: () => T | Promise<T>,
+  onDisposeFailure: (error: unknown) => void,
+): Promise<T> {
+  try {
+    return await build();
+  } catch (error) {
+    try {
+      await agent.dispose();
+    } catch (disposeError) {
+      onDisposeFailure(disposeError);
+    }
+    throw error;
+  }
+}

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -49,6 +49,10 @@ describe('Zed available commands', () => {
       name: 'model',
       args: 'ignored',
     });
+    expect(parseZedCommandPrompt('/model')).toStrictEqual({
+      name: 'model',
+      args: '',
+    });
     await expect(
       executeZedCommand('/unknown', { agent: buildAgent() }),
     ).resolves.toBeNull();

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { Config } from '@vybestack/llxprt-code-core';
+import {
+  buildAvailableCommandsUpdate,
+  executeZedCommand,
+  getZedAvailableCommands,
+  parseZedCommandPrompt,
+} from './zed-command-registry.js';
+import { tryHandleZedCommand } from './zed-prompt-command.js';
+
+function buildAgent(): Agent {
+  return {
+    getModel: () => 'test-model',
+    compress: vi.fn(async () => ({ status: 'compressed' as const })),
+    tools: { list: () => [] },
+    memory: { getFilePaths: () => [] },
+    profiles: { list: () => [] },
+    tasks: { list: () => [] },
+  } as unknown as Agent;
+}
+
+const config = {} as Config;
+
+describe('Zed available commands', () => {
+  it('advertises only commands backed by honest Agent API reads/actions', () => {
+    const commands = getZedAvailableCommands();
+    expect(new Set(commands.map(({ name }) => name))).toStrictEqual(
+      new Set(['compact', 'tools', 'memory', 'profile', 'model', 'task']),
+    );
+    expect(commands.every(({ description }) => description.length > 0)).toBe(
+      true,
+    );
+    expect(buildAvailableCommandsUpdate()).toStrictEqual({
+      sessionUpdate: 'available_commands_update',
+      availableCommands: commands,
+    });
+  });
+
+  it('parses arguments and leaves unknown commands for the model', async () => {
+    expect(parseZedCommandPrompt('')).toBeNull();
+    expect(parseZedCommandPrompt('/')).toBeNull();
+    expect(parseZedCommandPrompt('   ')).toBeNull();
+    expect(parseZedCommandPrompt('/model ignored')).toStrictEqual({
+      name: 'model',
+      args: 'ignored',
+    });
+    await expect(
+      executeZedCommand('/unknown', { agent: buildAgent(), config }),
+    ).resolves.toBeNull();
+  });
+
+  it('returns a protocol-visible error when command execution fails', async () => {
+    const agent = buildAgent();
+    vi.mocked(agent.compress).mockRejectedValue(
+      new Error('compression unavailable'),
+    );
+    await expect(
+      executeZedCommand('/compact', { agent, config }),
+    ).resolves.toStrictEqual({
+      text: 'Command /compact failed: compression unavailable',
+    });
+  });
+
+  it('executes a command and emits a protocol-visible result', async () => {
+    const updates: acp.SessionUpdate[] = [];
+    const handled = await tryHandleZedCommand(
+      [{ type: 'text', text: '/model' }],
+      buildAgent(),
+      config,
+      async (update) => {
+        updates.push(update);
+      },
+    );
+
+    expect(handled).toStrictEqual({ response: { stopReason: 'end_turn' } });
+    expect(updates).toStrictEqual([
+      {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'Current model: test-model' },
+      },
+    ]);
+  });
+
+  it('does not dispatch command-looking text when another block is present', async () => {
+    const updates: acp.SessionUpdate[] = [];
+    const result = await tryHandleZedCommand(
+      [
+        { type: 'text', text: '/compact' },
+        { type: 'image', data: 'image', mimeType: 'image/png' },
+      ],
+      buildAgent(),
+      config,
+      async (update) => {
+        updates.push(update);
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(updates).toStrictEqual([]);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -7,7 +7,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import type { Config } from '@vybestack/llxprt-code-core';
 import {
   buildAvailableCommandsUpdate,
   executeZedCommand,
@@ -26,8 +25,6 @@ function buildAgent(): Agent {
     tasks: { list: () => [] },
   } as unknown as Agent;
 }
-
-const config = {} as Config;
 
 describe('Zed available commands', () => {
   it('advertises only commands backed by honest Agent API reads/actions', () => {
@@ -53,10 +50,10 @@ describe('Zed available commands', () => {
       args: 'ignored',
     });
     await expect(
-      executeZedCommand('/unknown', { agent: buildAgent(), config }),
+      executeZedCommand('/unknown', { agent: buildAgent() }),
     ).resolves.toBeNull();
     await expect(
-      executeZedCommand('/MODEL', { agent: buildAgent(), config }),
+      executeZedCommand('/MODEL', { agent: buildAgent() }),
     ).resolves.toStrictEqual({ text: 'Current model: test-model' });
   });
 
@@ -66,7 +63,7 @@ describe('Zed available commands', () => {
       new Error('compression unavailable'),
     );
     await expect(
-      executeZedCommand('/compact', { agent, config }),
+      executeZedCommand('/compact', { agent }),
     ).resolves.toStrictEqual({
       text: 'Command /compact failed.',
     });
@@ -77,7 +74,6 @@ describe('Zed available commands', () => {
     const handled = await tryHandleZedCommand(
       [{ type: 'text', text: '/model' }],
       buildAgent(),
-      config,
       async (update) => {
         updates.push(update);
       },
@@ -100,7 +96,6 @@ describe('Zed available commands', () => {
         { type: 'image', data: 'image', mimeType: 'image/png' },
       ],
       buildAgent(),
-      config,
       async (update) => {
         updates.push(update);
       },

--- a/packages/cli/src/zed-integration/zed-command-registry.test.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.test.ts
@@ -55,6 +55,9 @@ describe('Zed available commands', () => {
     await expect(
       executeZedCommand('/unknown', { agent: buildAgent(), config }),
     ).resolves.toBeNull();
+    await expect(
+      executeZedCommand('/MODEL', { agent: buildAgent(), config }),
+    ).resolves.toStrictEqual({ text: 'Current model: test-model' });
   });
 
   it('returns a protocol-visible error when command execution fails', async () => {
@@ -65,7 +68,7 @@ describe('Zed available commands', () => {
     await expect(
       executeZedCommand('/compact', { agent, config }),
     ).resolves.toStrictEqual({
-      text: 'Command /compact failed: compression unavailable',
+      text: 'Command /compact failed.',
     });
   });
 

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { Config } from '@vybestack/llxprt-code-core';
+
+export interface ZedCommandContext {
+  readonly agent: Agent;
+  readonly config: Config;
+}
+
+export interface ZedCommandResult {
+  readonly text: string;
+  readonly stopReason?: acp.StopReason;
+}
+
+interface ZedCommandDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly inputHint?: string;
+  readonly handler: (
+    context: ZedCommandContext,
+    args: string,
+  ) => Promise<ZedCommandResult>;
+}
+
+export function parseZedCommandPrompt(
+  prompt: string,
+): { readonly name: string; readonly args: string } | null {
+  if (!prompt.startsWith('/')) return null;
+  const value = prompt.slice(1).trimStart();
+  if (value.length === 0) return null;
+  const boundary = value.search(/\s/);
+  return boundary === -1
+    ? { name: value, args: '' }
+    : {
+        name: value.slice(0, boundary),
+        args: value.slice(boundary + 1).trim(),
+      };
+}
+
+function formatCompression(
+  result: Awaited<ReturnType<Agent['compress']>>,
+): string {
+  const counts =
+    result.originalTokenCount === undefined ||
+    result.newTokenCount === undefined
+      ? ''
+      : ` (${result.originalTokenCount} → ${result.newTokenCount} tokens)`;
+  return `Context compression ${result.status}${counts}.`;
+}
+
+const COMMANDS: readonly ZedCommandDefinition[] = [
+  {
+    name: 'compact',
+    description: 'Compress conversation history to free context space',
+    handler: async ({ agent }) => ({
+      text: formatCompression(await agent.compress()),
+    }),
+  },
+  {
+    name: 'tools',
+    description: 'List available tools and their enabled status',
+    handler: async ({ agent }) => {
+      const tools = agent.tools.list();
+      return {
+        text:
+          tools.length === 0
+            ? 'No tools available.'
+            : `Available tools:\n${tools
+                .map((tool) => `  ${tool.enabled ? '[x]' : '[ ]'} ${tool.name}`)
+                .join('\n')}`,
+      };
+    },
+  },
+  {
+    name: 'memory',
+    description: 'Show memory files currently in use',
+    handler: async ({ agent }) => {
+      const paths = agent.memory.getFilePaths();
+      return {
+        text:
+          paths.length === 0
+            ? 'No memory files in use.'
+            : `Memory files:\n${paths.map((path) => `  ${path}`).join('\n')}`,
+      };
+    },
+  },
+  {
+    name: 'profile',
+    description: 'List saved profiles and identify the startup default',
+    handler: async ({ agent }) => {
+      const profiles = agent.profiles.list();
+      return {
+        text:
+          profiles.length === 0
+            ? 'No profiles available.'
+            : `Profiles:\n${profiles
+                .map(
+                  (profile) =>
+                    `  ${profile.name}${profile.isDefault ? ' (default)' : ''}`,
+                )
+                .join('\n')}`,
+      };
+    },
+  },
+  {
+    name: 'model',
+    description: 'Show the current model',
+    handler: async ({ agent }) => ({
+      text: `Current model: ${agent.getModel()}`,
+    }),
+  },
+  {
+    name: 'task',
+    description: 'Show active subagent tasks',
+    handler: async ({ agent }) => {
+      const tasks = agent.tasks.list();
+      return {
+        text:
+          tasks.length === 0
+            ? 'No active subagent tasks.'
+            : `Subagent tasks:\n${tasks
+                .map((task) => `  [${task.status}] ${task.goalPrompt}`)
+                .join('\n')}`,
+      };
+    },
+  },
+];
+
+const COMMAND_MAP = new Map(COMMANDS.map((command) => [command.name, command]));
+
+export function getZedAvailableCommands(): acp.AvailableCommand[] {
+  return COMMANDS.map(({ name, description, inputHint }) => ({
+    name,
+    description,
+    ...(inputHint === undefined ? {} : { input: { hint: inputHint } }),
+  }));
+}
+
+export function buildAvailableCommandsUpdate(): acp.SessionUpdate {
+  return {
+    sessionUpdate: 'available_commands_update',
+    availableCommands: getZedAvailableCommands(),
+  };
+}
+
+export async function executeZedCommand(
+  prompt: string,
+  context: ZedCommandContext,
+): Promise<ZedCommandResult | null> {
+  const parsed = parseZedCommandPrompt(prompt);
+  const command = parsed === null ? undefined : COMMAND_MAP.get(parsed.name);
+  if (command === undefined) return null;
+  try {
+    return await command.handler(context, parsed?.args ?? '');
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { text: `Command /${command.name} failed: ${detail}` };
+  }
+}

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -161,7 +161,10 @@ export async function executeZedCommand(
   try {
     return await command.handler(context, parsed.args);
   } catch (error) {
-    logger.error(() => `Command /${command.name} failed: ${String(error)}`);
+    logger.error(
+      () =>
+        `Command /${command.name} failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -154,12 +154,12 @@ export async function executeZedCommand(
   context: ZedCommandContext,
 ): Promise<ZedCommandResult | null> {
   const parsed = parseZedCommandPrompt(prompt);
-  const command = parsed === null ? undefined : COMMAND_MAP.get(parsed.name);
+  if (parsed === null) return null;
+  const command = COMMAND_MAP.get(parsed.name.toLowerCase());
   if (command === undefined) return null;
   try {
-    return await command.handler(context, parsed?.args ?? '');
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    return { text: `Command /${command.name} failed: ${detail}` };
+    return await command.handler(context, parsed.args);
+  } catch {
+    return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -6,13 +6,12 @@
 
 import type * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 
 const logger = new DebugLogger('llxprt:zed-integration:commands');
 
 export interface ZedCommandContext {
   readonly agent: Agent;
-  readonly config: Config;
 }
 
 export interface ZedCommandResult {

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -161,7 +161,7 @@ export async function executeZedCommand(
   try {
     return await command.handler(context, parsed.args);
   } catch (error) {
-    logger.debug(() => `Command /${command.name} failed: ${String(error)}`);
+    logger.error(() => `Command /${command.name} failed: ${String(error)}`);
     return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-command-registry.ts
+++ b/packages/cli/src/zed-integration/zed-command-registry.ts
@@ -6,7 +6,9 @@
 
 import type * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import type { Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+
+const logger = new DebugLogger('llxprt:zed-integration:commands');
 
 export interface ZedCommandContext {
   readonly agent: Agent;
@@ -159,7 +161,8 @@ export async function executeZedCommand(
   if (command === undefined) return null;
   try {
     return await command.handler(context, parsed.args);
-  } catch {
+  } catch (error) {
+    logger.debug(() => `Command /${command.name} failed: ${String(error)}`);
     return { text: `Command /${command.name} failed.` };
   }
 }

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -188,6 +188,27 @@ describe('Zed config options', () => {
     );
   });
 
+  it('wraps model switch failures as structured ACP internal errors', async () => {
+    const failure = applyZedConfigOption(
+      {
+        setModel: async () => {
+          throw new Error('provider disconnected');
+        },
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      } as unknown as Agent,
+      configFixture(),
+      'model',
+      'beta',
+    );
+
+    await expect(failure).rejects.toMatchObject({ code: -32603 });
+  });
+
   it('publishes agent-side setting changes and removes listeners on teardown', async () => {
     const sendUpdate = vi.fn(async () => undefined);
     const stop = observeZedConfigOptions(
@@ -204,11 +225,15 @@ describe('Zed config options', () => {
       vi.fn(),
     );
 
-    coreEvents.emitSettingsChanged();
-    await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
-    stop();
-    coreEvents.emitSettingsChanged();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(sendUpdate).toHaveBeenCalledOnce();
+    try {
+      coreEvents.emitSettingsChanged();
+      await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
+      stop();
+      coreEvents.emitSettingsChanged();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(sendUpdate).toHaveBeenCalledOnce();
+    } finally {
+      stop();
+    }
   });
 });

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import {
+  coreEvents,
+  type Config,
+  type RuntimeModel,
+} from '@vybestack/llxprt-code-core';
+import {
+  applyZedConfigOption,
+  buildZedConfigOptions,
+  observeZedConfigOptions,
+  setZedConfigOption,
+  zedConfigOptionsForClient,
+} from './zed-config-options.js';
+
+function configFixture(values: Record<string, unknown> = {}): Config {
+  const models: RuntimeModel[] = [
+    { id: 'alpha', name: 'Alpha', provider: 'test' },
+    { id: 'beta', name: 'Beta', provider: 'test' },
+  ];
+  return {
+    getModel: () => 'alpha',
+    getEphemeralSetting: (key: string) => values[key],
+    setEphemeralSetting: (key: string, value: unknown) => {
+      values[key] = value;
+    },
+    getProviderManager: () => ({ getAvailableModels: async () => models }),
+  } as Config;
+}
+
+describe('Zed config options', () => {
+  it('maps active-provider models and current settings to strict ACP selects', async () => {
+    const options = await buildZedConfigOptions(
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      },
+      configFixture({ 'reasoning.effort': 'high', emojifilter: 'warn' }),
+    );
+
+    expect(
+      options.map(({ id, currentValue }) => ({ id, currentValue })),
+    ).toStrictEqual([
+      { id: 'model', currentValue: 'alpha' },
+      { id: 'reasoning.effort', currentValue: 'high' },
+      { id: 'emojifilter', currentValue: 'warn' },
+    ]);
+    expect(options[0]).toMatchObject({
+      category: 'model',
+      options: [
+        { value: 'alpha', name: 'Alpha' },
+        { value: 'beta', name: 'Beta' },
+      ],
+    });
+  });
+
+  it('applies validated settings and returns the updated snapshot', async () => {
+    const values: Record<string, unknown> = {};
+    const options = await applyZedConfigOption(
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      } as Agent,
+      configFixture(values),
+      'emojifilter',
+      'error',
+    );
+
+    expect(values.emojifilter).toBe('error');
+    expect(options.find(({ id }) => id === 'emojifilter')).toMatchObject({
+      currentValue: 'error',
+    });
+  });
+
+  it('omits initial options unless the client advertises config support', async () => {
+    const config = configFixture();
+    await expect(
+      zedConfigOptionsForClient(
+        undefined,
+        {
+          getModel: () => 'alpha',
+          getProviderStatus: () => ({
+            provider: 'test',
+            model: 'alpha',
+            authStatus: 'authenticated' as const,
+          }),
+        },
+        config,
+      ),
+    ).resolves.toStrictEqual({});
+    const supported = await zedConfigOptionsForClient(
+      { session: { configOptions: {} } },
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      },
+      config,
+    );
+    expect(supported.configOptions?.map(({ id }) => id)).toStrictEqual([
+      'model',
+      'reasoning.effort',
+      'emojifilter',
+    ]);
+  });
+
+  it('switches models and strictly publishes the updated full snapshot', async () => {
+    const config = configFixture();
+    const setModel = vi.fn(async () => undefined);
+    const result = await setZedConfigOption(
+      {
+        setModel,
+        getModel: () => 'beta',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      } as unknown as Agent,
+      config,
+      'model',
+      'beta',
+    );
+
+    expect(setModel).toHaveBeenCalledWith('beta');
+    expect(result.configOptions).toHaveLength(3);
+  });
+
+  it('publishes agent-side setting changes and removes listeners on teardown', async () => {
+    const sendUpdate = vi.fn(async () => undefined);
+    const stop = observeZedConfigOptions(
+      {
+        getModel: () => 'alpha',
+        getProviderStatus: () => ({
+          provider: 'test',
+          model: 'alpha',
+          authStatus: 'authenticated' as const,
+        }),
+      },
+      configFixture(),
+      sendUpdate,
+      vi.fn(),
+    );
+
+    coreEvents.emitSettingsChanged();
+    await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
+    stop();
+    coreEvents.emitSettingsChanged();
+    await Promise.resolve();
+    expect(sendUpdate).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -76,7 +76,7 @@ describe('Zed config options', () => {
           model: 'alpha',
           authStatus: 'authenticated' as const,
         }),
-      } as Agent,
+      } as unknown as Agent,
       configFixture(values),
       'emojifilter',
       'error',
@@ -158,17 +158,19 @@ describe('Zed config options', () => {
           value: 'warn',
         },
       ),
-    ).toThrow('Resource not found');
+    ).toThrow('Config options not supported by client');
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it('switches models and strictly publishes the updated full snapshot', async () => {
     const config = configFixture();
-    const setModel = vi.fn(async () => undefined);
+    let currentModel = 'alpha';
     const result = await setZedConfigOption(
       {
-        setModel,
-        getModel: () => 'beta',
+        setModel: async (model: string) => {
+          currentModel = model;
+        },
+        getModel: () => currentModel,
         getProviderStatus: () => ({
           provider: 'test',
           model: 'alpha',
@@ -180,7 +182,7 @@ describe('Zed config options', () => {
       'beta',
     );
 
-    expect(setModel).toHaveBeenCalledWith('beta');
+    expect(currentModel).toBe('beta');
     expect(result.configOptions.find(({ id }) => id === 'model')).toMatchObject(
       { currentValue: 'beta' },
     );

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -103,7 +103,7 @@ describe('Zed config options', () => {
       ),
     ).resolves.toStrictEqual({});
     const supported = await zedConfigOptionsForClient(
-      { session: { configOptions: {} } },
+      { session: { configOptions: true } },
       {
         getModel: () => 'alpha',
         getProviderStatus: () => ({

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -55,7 +55,7 @@ describe('Zed config options', () => {
       { id: 'reasoning.effort', currentValue: 'high' },
       { id: 'emojifilter', currentValue: 'warn' },
     ]);
-    expect(options[0]).toMatchObject({
+    expect(options.find(({ id }) => id === 'model')).toMatchObject({
       category: 'model',
       options: [
         { value: 'alpha', name: 'Alpha' },
@@ -140,7 +140,9 @@ describe('Zed config options', () => {
     );
 
     expect(setModel).toHaveBeenCalledWith('beta');
-    expect(result.configOptions).toHaveLength(3);
+    expect(result.configOptions.find(({ id }) => id === 'model')).toMatchObject(
+      { currentValue: 'beta' },
+    );
   });
 
   it('publishes agent-side setting changes and removes listeners on teardown', async () => {

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -14,9 +14,11 @@ import {
 import {
   applyZedConfigOption,
   buildZedConfigOptions,
+  dispatchZedConfigOption,
   observeZedConfigOptions,
   setZedConfigOption,
   zedConfigOptionsForClient,
+  zedSessionConfigOptions,
 } from './zed-config-options.js';
 
 function configFixture(values: Record<string, unknown> = {}): Config {
@@ -119,6 +121,45 @@ describe('Zed config options', () => {
       'reasoning.effort',
       'emojifilter',
     ]);
+    await expect(
+      zedConfigOptionsForClient(
+        { session: { configOptions: false } },
+        {
+          getModel: () => 'alpha',
+          getProviderStatus: () => ({
+            provider: 'test',
+            model: 'alpha',
+            authStatus: 'authenticated' as const,
+          }),
+        },
+        config,
+      ),
+    ).resolves.toStrictEqual({});
+  });
+
+  it('gates loaded snapshots and mutations on explicit client support', async () => {
+    const getConfigOptions = vi.fn(async () => []);
+    await expect(
+      zedSessionConfigOptions(
+        { session: { configOptions: false } },
+        { getConfigOptions },
+      ),
+    ).resolves.toStrictEqual({});
+    expect(getConfigOptions).not.toHaveBeenCalled();
+
+    const setConfigOption = vi.fn(async () => ({ configOptions: [] }));
+    expect(() =>
+      dispatchZedConfigOption(
+        { session: { configOptions: false } },
+        new Map([['session-1', { setConfigOption }]]),
+        {
+          sessionId: 'session-1',
+          configId: 'emojifilter',
+          value: 'warn',
+        },
+      ),
+    ).toThrow('Resource not found');
+    expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it('switches models and strictly publishes the updated full snapshot', async () => {
@@ -165,7 +206,7 @@ describe('Zed config options', () => {
     await vi.waitFor(() => expect(sendUpdate).toHaveBeenCalledOnce());
     stop();
     coreEvents.emitSettingsChanged();
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(sendUpdate).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -140,9 +140,9 @@ export async function zedConfigOptionsForClient(
   agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
   config: Config,
 ): Promise<Pick<acp.NewSessionResponse, 'configOptions'>> {
-  return capabilities?.session?.configOptions == null
-    ? {}
-    : { configOptions: await buildZedConfigOptions(agent, config) };
+  return capabilities?.session?.configOptions === true
+    ? { configOptions: await buildZedConfigOptions(agent, config) }
+    : {};
 }
 
 export async function setZedConfigOption(
@@ -175,7 +175,7 @@ export function dispatchZedConfigOption(
   params: acp.SetSessionConfigOptionRequest,
 ): Promise<acp.SetSessionConfigOptionResponse> {
   const session = sessions.get(params.sessionId);
-  if (session === undefined || capabilities?.session?.configOptions == null) {
+  if (session === undefined || capabilities?.session?.configOptions !== true) {
     throw acp.RequestError.resourceNotFound(params.sessionId);
   }
   return session.setConfigOption(params.configId, params.value);
@@ -216,8 +216,16 @@ export function observeZedConfigOptions(
   coreEvents.on(CoreEvent.SettingsChanged, refresh);
   return () => {
     stopped = true;
-    coreEvents.off(CoreEvent.ModelChanged, refresh);
-    coreEvents.off(CoreEvent.SettingsChanged, refresh);
+    try {
+      coreEvents.off(CoreEvent.ModelChanged, refresh);
+    } catch {
+      // Listener removal is best-effort during teardown.
+    }
+    try {
+      coreEvents.off(CoreEvent.SettingsChanged, refresh);
+    } catch {
+      // Listener removal is best-effort during teardown.
+    }
   };
 }
 
@@ -225,7 +233,7 @@ export function zedSessionConfigOptions(
   capabilities: ClientCapabilitiesWithSession | undefined,
   session: { getConfigOptions(): Promise<acp.SessionConfigOption[]> },
 ): Promise<Pick<acp.LoadSessionResponse, 'configOptions'>> {
-  return capabilities?.session?.configOptions == null
-    ? Promise.resolve({})
-    : session.getConfigOptions().then((configOptions) => ({ configOptions }));
+  return capabilities?.session?.configOptions === true
+    ? session.getConfigOptions().then((configOptions) => ({ configOptions }))
+    : Promise.resolve({});
 }

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -13,6 +13,7 @@ import {
   type RuntimeModel,
 } from '@vybestack/llxprt-code-core';
 import { parseEphemeralSettingValue } from '@vybestack/llxprt-code-providers/runtime.js';
+import type { ClientCapabilitiesWithSession } from './acp-types.js';
 
 const REASONING_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'];
 const EMOJI_VALUES = ['allowed', 'auto', 'warn', 'error'];
@@ -135,7 +136,7 @@ export async function applyZedConfigOption(
 }
 
 export async function zedConfigOptionsForClient(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
   config: Config,
 ): Promise<Pick<acp.NewSessionResponse, 'configOptions'>> {
@@ -169,7 +170,7 @@ interface ConfigurableZedSession {
 }
 
 export function dispatchZedConfigOption(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   sessions: ReadonlyMap<string, ConfigurableZedSession>,
   params: acp.SetSessionConfigOptionRequest,
 ): Promise<acp.SetSessionConfigOptionResponse> {
@@ -221,7 +222,7 @@ export function observeZedConfigOptions(
 }
 
 export function zedSessionConfigOptions(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   session: { getConfigOptions(): Promise<acp.SessionConfigOption[]> },
 ): Promise<Pick<acp.LoadSessionResponse, 'configOptions'>> {
   return capabilities?.session?.configOptions == null

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -206,23 +206,25 @@ export function observeZedConfigOptions(
     pending = true;
     if (running) return;
     running = true;
-    void (async () => {
+    void runRefreshLoop();
+  };
+
+  async function runRefreshLoop(): Promise<void> {
+    try {
       while (pending && !stopped) {
         pending = false;
-        try {
-          const configOptions = await buildZedConfigOptions(agent, config);
-          if (isStopped()) return;
-          await sendUpdate({
-            sessionUpdate: 'config_option_update',
-            configOptions,
-          });
-        } catch (error) {
-          onError(error);
-        }
+        await sendConfigOptionUpdate(
+          agent,
+          config,
+          sendUpdate,
+          isStopped,
+          onError,
+        );
       }
+    } finally {
       running = false;
-    })();
-  };
+    }
+  }
   coreEvents.on(CoreEvent.ModelChanged, refresh);
   coreEvents.on(CoreEvent.SettingsChanged, refresh);
   return () => {
@@ -247,4 +249,23 @@ export function zedSessionConfigOptions(
   return capabilities?.session?.configOptions === true
     ? session.getConfigOptions().then((configOptions) => ({ configOptions }))
     : Promise.resolve({});
+}
+
+async function sendConfigOptionUpdate(
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
+  isStopped: () => boolean,
+  onError: (error: unknown) => void,
+): Promise<void> {
+  try {
+    const configOptions = await buildZedConfigOptions(agent, config);
+    if (isStopped()) return;
+    await sendUpdate({
+      sessionUpdate: 'config_option_update',
+      configOptions,
+    });
+  } catch (error) {
+    onError(error);
+  }
 }

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -108,8 +108,9 @@ export async function applyZedConfigOption(
   if (configId === 'model') {
     const models = await availableModels(agent, config);
     if (
+      models !== undefined &&
       value !== agent.getModel() &&
-      models?.some(({ id }) => id === value) !== true
+      !models.some(({ id }) => id === value)
     ) {
       throw acp.RequestError.invalidParams({ value }, 'Unavailable model.');
     }
@@ -149,14 +150,8 @@ export async function setZedConfigOption(
   agent: Agent,
   config: Config,
   configId: string,
-  value: string | boolean,
+  value: string,
 ): Promise<acp.SetSessionConfigOptionResponse> {
-  if (typeof value !== 'string') {
-    throw acp.RequestError.invalidParams(
-      { configId },
-      'Expected select value.',
-    );
-  }
   return {
     configOptions: await applyZedConfigOption(agent, config, configId, value),
   };
@@ -165,7 +160,7 @@ export async function setZedConfigOption(
 interface ConfigurableZedSession {
   setConfigOption(
     configId: string,
-    value: string | boolean,
+    value: string,
   ): Promise<acp.SetSessionConfigOptionResponse>;
 }
 
@@ -175,8 +170,20 @@ export function dispatchZedConfigOption(
   params: acp.SetSessionConfigOptionRequest,
 ): Promise<acp.SetSessionConfigOptionResponse> {
   const session = sessions.get(params.sessionId);
-  if (session === undefined || capabilities?.session?.configOptions !== true) {
+  if (session === undefined) {
     throw acp.RequestError.resourceNotFound(params.sessionId);
+  }
+  if (capabilities?.session?.configOptions !== true) {
+    throw acp.RequestError.invalidParams(
+      { sessionId: params.sessionId },
+      'Config options not supported by client.',
+    );
+  }
+  if (typeof params.value !== 'string') {
+    throw acp.RequestError.invalidParams(
+      { configId: params.configId },
+      'Expected select value.',
+    );
   }
   return session.setConfigOption(params.configId, params.value);
 }

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -114,7 +114,11 @@ export async function applyZedConfigOption(
     ) {
       throw acp.RequestError.invalidParams({ value }, 'Unavailable model.');
     }
-    await agent.setModel(value);
+    try {
+      await agent.setModel(value);
+    } catch (error) {
+      throw acp.RequestError.internalError({ configId, error: String(error) });
+    }
     return buildZedConfigOptions(agent, config);
   }
   if (configId !== 'reasoning.effort' && configId !== 'emojifilter') {

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import {
+  coreEvents,
+  CoreEvent,
+  type Config,
+  type RuntimeModel,
+} from '@vybestack/llxprt-code-core';
+import { parseEphemeralSettingValue } from '@vybestack/llxprt-code-providers/runtime.js';
+
+const REASONING_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+const EMOJI_VALUES = ['allowed', 'auto', 'warn', 'error'];
+
+function selectOption(value: string): acp.SessionConfigSelectOption {
+  return { value, name: value };
+}
+
+function settingOption(
+  config: Config,
+  id: string,
+  name: string,
+  category: acp.SessionConfigOptionCategory,
+  values: readonly string[],
+  fallback: string,
+): acp.SessionConfigOption {
+  const current = config.getEphemeralSetting(id);
+  return {
+    type: 'select',
+    id,
+    name,
+    category,
+    currentValue: typeof current === 'string' ? current : fallback,
+    options: values.map(selectOption),
+  };
+}
+
+function modelOption(
+  currentModel: string,
+  models: readonly RuntimeModel[],
+): acp.SessionConfigOption {
+  const available = models.some(({ id }) => id === currentModel)
+    ? models
+    : [{ id: currentModel, name: currentModel, provider: '' }, ...models];
+  return {
+    type: 'select',
+    id: 'model',
+    name: 'Model',
+    category: 'model',
+    currentValue: currentModel,
+    options: available.map((model) => ({ value: model.id, name: model.name })),
+  };
+}
+
+async function availableModels(
+  agent: Pick<Agent, 'getProviderStatus'>,
+  config: Config,
+): Promise<RuntimeModel[] | undefined> {
+  try {
+    const provider = agent.getProviderStatus().provider;
+    return (
+      (await config.getProviderManager()?.getAvailableModels(provider)) ?? []
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildZedConfigOptions(
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+): Promise<acp.SessionConfigOption[]> {
+  const currentModel = agent.getModel();
+  const models = await availableModels(agent, config);
+  return [
+    ...(models === undefined ? [] : [modelOption(currentModel, models)]),
+    settingOption(
+      config,
+      'reasoning.effort',
+      'Thinking level',
+      'thought_level',
+      REASONING_VALUES,
+      'medium',
+    ),
+    settingOption(
+      config,
+      'emojifilter',
+      'Emoji filter',
+      '_display',
+      EMOJI_VALUES,
+      'auto',
+    ),
+  ];
+}
+
+export async function applyZedConfigOption(
+  agent: Agent,
+  config: Config,
+  configId: string,
+  value: string,
+): Promise<acp.SessionConfigOption[]> {
+  if (configId === 'model') {
+    const models = await availableModels(agent, config);
+    if (
+      value !== agent.getModel() &&
+      models?.some(({ id }) => id === value) !== true
+    ) {
+      throw acp.RequestError.invalidParams({ value }, 'Unavailable model.');
+    }
+    await agent.setModel(value);
+    return buildZedConfigOptions(agent, config);
+  }
+  if (configId !== 'reasoning.effort' && configId !== 'emojifilter') {
+    throw acp.RequestError.invalidParams(
+      { configId },
+      'Unknown config option.',
+    );
+  }
+  const parsed = parseEphemeralSettingValue(configId, value);
+  if (!parsed.success) {
+    throw acp.RequestError.invalidParams({ configId }, parsed.message);
+  }
+  try {
+    config.setEphemeralSetting(configId, parsed.value);
+    coreEvents.emitSettingsChanged();
+  } catch (error) {
+    throw acp.RequestError.internalError({ configId, error: String(error) });
+  }
+  return buildZedConfigOptions(agent, config);
+}
+
+export async function zedConfigOptionsForClient(
+  capabilities: acp.ClientCapabilities | undefined,
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+): Promise<Pick<acp.NewSessionResponse, 'configOptions'>> {
+  return capabilities?.session?.configOptions == null
+    ? {}
+    : { configOptions: await buildZedConfigOptions(agent, config) };
+}
+
+export async function setZedConfigOption(
+  agent: Agent,
+  config: Config,
+  configId: string,
+  value: string | boolean,
+): Promise<acp.SetSessionConfigOptionResponse> {
+  if (typeof value !== 'string') {
+    throw acp.RequestError.invalidParams(
+      { configId },
+      'Expected select value.',
+    );
+  }
+  return {
+    configOptions: await applyZedConfigOption(agent, config, configId, value),
+  };
+}
+
+interface ConfigurableZedSession {
+  setConfigOption(
+    configId: string,
+    value: string | boolean,
+  ): Promise<acp.SetSessionConfigOptionResponse>;
+}
+
+export function dispatchZedConfigOption(
+  capabilities: acp.ClientCapabilities | undefined,
+  sessions: ReadonlyMap<string, ConfigurableZedSession>,
+  params: acp.SetSessionConfigOptionRequest,
+): Promise<acp.SetSessionConfigOptionResponse> {
+  const session = sessions.get(params.sessionId);
+  if (session === undefined || capabilities?.session?.configOptions == null) {
+    throw acp.RequestError.resourceNotFound(params.sessionId);
+  }
+  return session.setConfigOption(params.configId, params.value);
+}
+
+export function observeZedConfigOptions(
+  agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
+  config: Config,
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
+  onError: (error: unknown) => void,
+): () => void {
+  let stopped = false;
+  let running = false;
+  let pending = false;
+  const isStopped = () => stopped;
+  const refresh = () => {
+    pending = true;
+    if (running) return;
+    running = true;
+    void (async () => {
+      while (pending && !stopped) {
+        pending = false;
+        try {
+          const configOptions = await buildZedConfigOptions(agent, config);
+          if (isStopped()) return;
+          await sendUpdate({
+            sessionUpdate: 'config_option_update',
+            configOptions,
+          });
+        } catch (error) {
+          onError(error);
+        }
+      }
+      running = false;
+    })();
+  };
+  coreEvents.on(CoreEvent.ModelChanged, refresh);
+  coreEvents.on(CoreEvent.SettingsChanged, refresh);
+  return () => {
+    stopped = true;
+    coreEvents.off(CoreEvent.ModelChanged, refresh);
+    coreEvents.off(CoreEvent.SettingsChanged, refresh);
+  };
+}
+
+export function zedSessionConfigOptions(
+  capabilities: acp.ClientCapabilities | undefined,
+  session: { getConfigOptions(): Promise<acp.SessionConfigOption[]> },
+): Promise<Pick<acp.LoadSessionResponse, 'configOptions'>> {
+  return capabilities?.session?.configOptions == null
+    ? Promise.resolve({})
+    : session.getConfigOptions().then((configOptions) => ({ configOptions }));
+}

--- a/packages/cli/src/zed-integration/zed-initialize.ts
+++ b/packages/cli/src/zed-integration/zed-initialize.ts
@@ -25,8 +25,6 @@ export async function initializeZedAgent(
       sessionCapabilities: {
         list: {},
         resume: {},
-        delete: {},
-        close: {},
       },
       promptCapabilities: {
         image: true,

--- a/packages/cli/src/zed-integration/zed-initialize.ts
+++ b/packages/cli/src/zed-integration/zed-initialize.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@vybestack/llxprt-code-core';
+import * as acp from '@agentclientprotocol/sdk';
+import { loadProfileByName } from '@vybestack/llxprt-code-providers/runtime.js';
+import { parseZedAuthMethodId } from './zed-helpers.js';
+
+export async function initializeZedAgent(
+  config: Config,
+): Promise<acp.InitializeResponse> {
+  const profileNames = await getAvailableProfileNames(config);
+  return {
+    protocolVersion: acp.PROTOCOL_VERSION,
+    authMethods: profileNames.map((name) => ({
+      id: name,
+      name,
+      description: null,
+    })),
+    agentCapabilities: {
+      loadSession: true,
+      sessionCapabilities: {
+        list: {},
+        resume: {},
+        delete: {},
+        close: {},
+      },
+      promptCapabilities: {
+        image: true,
+        audio: true,
+        embeddedContext: true,
+      },
+    },
+  };
+}
+
+export async function authenticateZedAgent(
+  config: Config,
+  methodId: string,
+): Promise<void> {
+  await loadProfileByName(
+    parseZedAuthMethodId(methodId, await getAvailableProfileNames(config)),
+  );
+}
+
+async function getAvailableProfileNames(config: Config): Promise<string[]> {
+  return (await config.getProfileManager()?.listProfiles()) ?? [];
+}

--- a/packages/cli/src/zed-integration/zed-plan-update.ts
+++ b/packages/cli/src/zed-integration/zed-plan-update.ts
@@ -13,6 +13,7 @@ export function buildZedPlanUpdate(todos: readonly Todo[]): acp.SessionUpdate {
     entries: todos.map((todo) => ({
       content: todo.content,
       status: todo.status,
+      // ACP plan entries only support a fixed 'medium' priority.
       priority: 'medium',
     })),
   };

--- a/packages/cli/src/zed-integration/zed-plan-update.ts
+++ b/packages/cli/src/zed-integration/zed-plan-update.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Todo } from '@vybestack/llxprt-code-core';
+
+export function buildZedPlanUpdate(todos: readonly Todo[]): acp.SessionUpdate {
+  return {
+    sessionUpdate: 'plan',
+    entries: todos.map((todo) => ({
+      content: todo.content,
+      status: todo.status,
+      priority: 'medium',
+    })),
+  };
+}

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -43,7 +43,6 @@ export function extractPromptText(
  *
  * @param prompt The raw ACP content blocks from the prompt request.
  * @param agent The session's real Agent.
- * @param config The session's real Config.
  * @param sendUpdate Callback to stream an `agent_message_chunk`.
  */
 export async function tryHandleZedCommand(

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -68,7 +68,7 @@ export async function tryHandleZedCommand(
   } catch (error) {
     logger.debug(() => `Command response delivery failed: ${String(error)}`);
     throw acp.RequestError.internalError(
-      {},
+      { cause: String(error) },
       'Command response delivery failed.',
     );
   }

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as acp from '@agentclientprotocol/sdk';
+import * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
 import type { Config } from '@vybestack/llxprt-code-core';
 
@@ -61,10 +61,17 @@ export async function tryHandleZedCommand(
   if (result === null) {
     return null;
   }
-  await sendUpdate({
-    sessionUpdate: 'agent_message_chunk',
-    content: { type: 'text', text: result.text },
-  });
+  try {
+    await sendUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: result.text },
+    });
+  } catch {
+    throw acp.RequestError.internalError(
+      {},
+      'Command response delivery failed.',
+    );
+  }
   return {
     response: { stopReason: result.stopReason ?? 'end_turn' },
   };

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Agent } from '@vybestack/llxprt-code-agents';
+import type { Config } from '@vybestack/llxprt-code-core';
+
+import {
+  executeZedCommand,
+  type ZedCommandResult,
+} from './zed-command-registry.js';
+
+/**
+ * Extracts the first text content from an ACP prompt content-block array. A
+ * Zed slash command arrives as a single text block, so only the first text
+ * block's text is relevant for command detection.
+ *
+ * Returns `null` when the prompt has no text block (e.g. only image/audio),
+ * so the caller treats it as an ordinary (non-slash) prompt.
+ */
+export function extractPromptText(
+  prompt: readonly acp.ContentBlock[],
+): string | null {
+  if (prompt.length !== 1 || prompt[0].type !== 'text') {
+    return null;
+  }
+  return prompt[0].text;
+}
+
+/**
+ * Attempts to handle a prompt as a Zed slash command. When the prompt is a
+ * known Zed command (e.g. `/compact`, `/tools`), this executes the command,
+ * streams the result text as an `agent_message_chunk` via the provided
+ * `sendUpdate` callback, and returns the final {@link acp.PromptResponse}.
+ *
+ * Returns `null` when the prompt is NOT a slash command (or is an unknown
+ * command), so the caller continues with ordinary model-streaming.
+ *
+ * @param prompt The raw ACP content blocks from the prompt request.
+ * @param agent The session's real Agent.
+ * @param config The session's real Config.
+ * @param sendUpdate Callback to stream an `agent_message_chunk`.
+ */
+export async function tryHandleZedCommand(
+  prompt: readonly acp.ContentBlock[],
+  agent: Agent,
+  config: Config,
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
+): Promise<{ response: acp.PromptResponse } | null> {
+  const text = extractPromptText(prompt);
+  if (text === null) {
+    return null;
+  }
+  const result: ZedCommandResult | null = await executeZedCommand(text, {
+    agent,
+    config,
+  });
+  if (result === null) {
+    return null;
+  }
+  await sendUpdate({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: result.text },
+  });
+  return {
+    response: { stopReason: result.stopReason ?? 'end_turn' },
+  };
+}

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -6,7 +6,9 @@
 
 import * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import type { Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+
+const logger = new DebugLogger('llxprt:zed-integration:prompt-command');
 
 import {
   executeZedCommand,
@@ -66,7 +68,8 @@ export async function tryHandleZedCommand(
       sessionUpdate: 'agent_message_chunk',
       content: { type: 'text', text: result.text },
     });
-  } catch {
+  } catch (error) {
+    logger.debug(() => `Command response delivery failed: ${String(error)}`);
     throw acp.RequestError.internalError(
       {},
       'Command response delivery failed.',

--- a/packages/cli/src/zed-integration/zed-prompt-command.ts
+++ b/packages/cli/src/zed-integration/zed-prompt-command.ts
@@ -6,7 +6,7 @@
 
 import * as acp from '@agentclientprotocol/sdk';
 import type { Agent } from '@vybestack/llxprt-code-agents';
-import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 
 const logger = new DebugLogger('llxprt:zed-integration:prompt-command');
 
@@ -49,7 +49,6 @@ export function extractPromptText(
 export async function tryHandleZedCommand(
   prompt: readonly acp.ContentBlock[],
   agent: Agent,
-  config: Config,
   sendUpdate: (update: acp.SessionUpdate) => Promise<void>,
 ): Promise<{ response: acp.PromptResponse } | null> {
   const text = extractPromptText(prompt);
@@ -58,7 +57,6 @@ export async function tryHandleZedCommand(
   }
   const result: ZedCommandResult | null = await executeZedCommand(text, {
     agent,
-    config,
   });
   if (result === null) {
     return null;

--- a/packages/cli/src/zed-integration/zed-session-config.ts
+++ b/packages/cli/src/zed-integration/zed-session-config.ts
@@ -19,6 +19,7 @@ import {
   type RuntimeProviderManager,
 } from '@vybestack/llxprt-code-core';
 import type { FileSystemService } from '@vybestack/llxprt-code-storage';
+import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
 
 /**
  * Resolves the effective target directory for a session from an optional
@@ -61,12 +62,16 @@ export function createSessionScopedConfig(
   config: Config,
   initialFileSystemService: FileSystemService,
   targetDir: string = config.getTargetDir(),
+  resolveToolRegistry?: () => ToolRegistry | undefined,
 ): Config {
   let fileSystemService = initialFileSystemService;
   let providerManager: RuntimeProviderManager | undefined =
     config.getProviderManager();
   return new Proxy(config, {
     get(target, property, receiver) {
+      if (property === 'getToolRegistry' && resolveToolRegistry !== undefined) {
+        return () => resolveToolRegistry() ?? config.getToolRegistry();
+      }
       if (property === 'getFileSystemService') {
         return () => fileSystemService;
       }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -71,7 +71,11 @@ export async function consumeAgentStream(
     return terminalStopReason;
   } finally {
     if (deps.terminals !== null) {
-      await deps.terminals.settleAll();
+      try {
+        await deps.terminals.settleAll();
+      } catch {
+        // Swallow cleanup errors so they don't mask the original error
+      }
     }
   }
 }
@@ -141,6 +145,7 @@ export async function runPromptTurn(
     (u) => deps.streamDeps.sendUpdate(u),
   );
   let terminalStopReason: acp.StopReason | null = null;
+  let thrownError: unknown = null;
   try {
     terminalStopReason = await consumeAgentStream(
       deps.streamDeps,
@@ -151,21 +156,21 @@ export async function runPromptTurn(
       batcher,
     );
   } catch (error) {
-    if (getErrorStatus(error) === 429) {
-      await safeFlush(batcher);
+    thrownError = error;
+  }
+  await safeFlush(batcher);
+  batcher.dispose();
+  if (thrownError !== null) {
+    if (getErrorStatus(thrownError) === 429) {
       throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     if (
       pendingSend.signal.aborted ||
-      (error instanceof Error && error.name === 'AbortError')
+      (thrownError instanceof Error && thrownError.name === 'AbortError')
     ) {
-      await safeFlush(batcher);
       return { stopReason: 'cancelled' };
     }
-    await safeFlush(batcher);
-    throw error;
-  } finally {
-    batcher.dispose();
+    throw thrownError;
   }
   if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
     return { stopReason: 'cancelled' };

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -98,19 +98,35 @@ async function processStreamEvent(
     handleConfirmation: deps.handleConfirmation,
     resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
   });
-  if (
-    event.type === 'tool-call' &&
-    deps.terminals !== null &&
-    TerminalManager.isShellToolCall(
-      event.call,
-      deps.agent.tools.get(event.call.name)?.kind,
-    )
-  ) {
-    await deps.terminals.observeToolCall(event.call);
-  } else if (event.type === 'tool-result' && deps.terminals !== null) {
-    deps.terminals.completeToolCall(event.result.id);
-  }
+  await trackTerminalEvent(event, deps);
   return stopReason;
+}
+
+/**
+ * Best-effort terminal bookkeeping after each event. Extracted so terminal
+ * tracking errors never mask the stop reason from `handleZedAgentEvent`.
+ * The single `deps.terminals !== null` check addresses the repeated null guard.
+ */
+async function trackTerminalEvent(
+  event: AgentEvent,
+  deps: SessionStreamDeps,
+): Promise<void> {
+  if (deps.terminals === null) return;
+  try {
+    if (
+      event.type === 'tool-call' &&
+      TerminalManager.isShellToolCall(
+        event.call,
+        deps.agent.tools.get(event.call.name)?.kind,
+      )
+    ) {
+      await deps.terminals.observeToolCall(event.call);
+    } else if (event.type === 'tool-result') {
+      deps.terminals.completeToolCall(event.result.id);
+    }
+  } catch (error) {
+    deps.logger.debug(() => `Terminal tracking failed: ${String(error)}`);
+  }
 }
 
 export interface PromptTurnDeps {
@@ -173,11 +189,11 @@ export async function runPromptTurn(
     }
     throw thrownError;
   }
-  if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
-    return { stopReason: 'cancelled' };
-  }
   if (terminalStopReason !== null) {
     return { stopReason: terminalStopReason };
+  }
+  if (pendingSend.signal.aborted) {
+    return { stopReason: 'cancelled' };
   }
   return { stopReason: 'end_turn' };
 }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -56,44 +56,63 @@ export async function consumeAgentStream(
     maxTurns: deps.maxTurns,
   });
   let terminalStopReason: acp.StopReason | null = null;
-  for await (const event of eventStream) {
-    if (deps.isPromptStale(promptGeneration, pendingSend)) {
-      if (event.type === 'done') {
-        return 'cancelled';
-      }
-      continue;
+  try {
+    for await (const event of eventStream) {
+      const result = await processStreamEvent(
+        event,
+        deps,
+        batcher,
+        promptGeneration,
+        pendingSend,
+      );
+      if (result === 'cancelled') return 'cancelled';
+      if (result !== null) terminalStopReason = result;
     }
-    if (
-      event.type === 'tool-call' &&
-      deps.terminals !== null &&
-      TerminalManager.isShellToolCall(
-        event.call,
-        deps.agent.tools.get(event.call.name)?.kind,
-      )
-    ) {
-      await deps.terminals.handleToolCall(event.call);
-    }
-    try {
-      const stopReason = await handleZedAgentEvent(event, batcher, {
-        sendUpdate: deps.sendUpdate,
-        sendUsage: deps.sendUsage,
-        handleConfirmation: deps.handleConfirmation,
-        resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-      });
-      if (event.type === 'tool-result' && deps.terminals !== null) {
-        await deps.terminals.releaseTerminal(event.result.id);
-      }
-      if (stopReason !== null) {
-        terminalStopReason = stopReason;
-      }
-    } catch (error) {
-      if (deps.terminals !== null) {
-        await deps.terminals.settleAll();
-      }
-      throw error;
+    return terminalStopReason;
+  } finally {
+    if (deps.terminals !== null) {
+      await deps.terminals.settleAll();
     }
   }
-  return terminalStopReason;
+}
+
+async function processStreamEvent(
+  event: AgentEvent,
+  deps: SessionStreamDeps,
+  batcher: StreamBatcher,
+  promptGeneration: number,
+  pendingSend: AbortController,
+): Promise<acp.StopReason | null | 'cancelled'> {
+  if (deps.isPromptStale(promptGeneration, pendingSend)) {
+    return event.type === 'done' ? 'cancelled' : null;
+  }
+  if (
+    event.type === 'tool-call' &&
+    deps.terminals !== null &&
+    TerminalManager.isShellToolCall(
+      event.call,
+      deps.agent.tools.get(event.call.name)?.kind,
+    )
+  ) {
+    await deps.terminals.handleToolCall(event.call);
+  }
+  try {
+    const stopReason = await handleZedAgentEvent(event, batcher, {
+      sendUpdate: deps.sendUpdate,
+      sendUsage: deps.sendUsage,
+      handleConfirmation: deps.handleConfirmation,
+      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+    });
+    if (event.type === 'tool-result' && deps.terminals !== null) {
+      await deps.terminals.releaseTerminal(event.result.id);
+    }
+    return stopReason;
+  } catch (error) {
+    if (deps.terminals !== null) {
+      await deps.terminals.settleAll();
+    }
+    throw error;
+  }
 }
 
 export interface PromptTurnDeps {

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import { type Agent, type AgentEvent } from '@vybestack/llxprt-code-agents';
+import {
+  EmojiFilter,
+  type ContractPart,
+  type FilterConfiguration,
+  getErrorStatus,
+} from '@vybestack/llxprt-code-core';
+import { handleZedAgentEvent } from './zed-agent-event-handler.js';
+import { StreamBatcher } from './zed-stream-batcher.js';
+import type { ZedPathResolver } from './zed-path-resolver.js';
+import { TerminalManager } from './zed-terminal-manager.js';
+
+type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+type SendUsageFn = (
+  usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
+) => Promise<void>;
+type HandleConfirmationFn = (
+  event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
+) => Promise<void>;
+
+export interface SessionStreamDeps {
+  readonly agent: Agent;
+  readonly terminals: TerminalManager | null;
+  readonly sendUpdate: SendUpdateFn;
+  readonly sendUsage: SendUsageFn;
+  readonly handleConfirmation: HandleConfirmationFn;
+  readonly isPromptStale: (
+    promptGeneration: number,
+    pendingSend: AbortController,
+  ) => boolean;
+  readonly maxTurns: number;
+}
+
+/**
+ * Consumes the agent event stream, forwarding each event to the Zed handler
+ * and managing terminal lifecycle for shell tool calls.
+ */
+export async function consumeAgentStream(
+  deps: SessionStreamDeps,
+  parts: readonly ContractPart[],
+  pendingSend: AbortController,
+  promptId: string,
+  promptGeneration: number,
+  batcher: StreamBatcher,
+): Promise<acp.StopReason | null> {
+  const eventStream = deps.agent.stream(parts, {
+    signal: pendingSend.signal,
+    promptId,
+    maxTurns: deps.maxTurns,
+  });
+  let terminalStopReason: acp.StopReason | null = null;
+  for await (const event of eventStream) {
+    if (deps.isPromptStale(promptGeneration, pendingSend)) {
+      if (event.type === 'done') {
+        return 'cancelled';
+      }
+      continue;
+    }
+    if (
+      event.type === 'tool-call' &&
+      deps.terminals !== null &&
+      TerminalManager.isShellToolCall(
+        event.call,
+        deps.agent.tools.get(event.call.name)?.kind,
+      )
+    ) {
+      await deps.terminals.handleToolCall(event.call);
+    }
+    const stopReason = await handleZedAgentEvent(event, batcher, {
+      sendUpdate: deps.sendUpdate,
+      sendUsage: deps.sendUsage,
+      handleConfirmation: deps.handleConfirmation,
+      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+    });
+    if (event.type === 'tool-result' && deps.terminals !== null) {
+      await deps.terminals.releaseTerminal(event.result.id);
+    }
+    if (stopReason !== null) {
+      terminalStopReason = stopReason;
+    }
+  }
+  return terminalStopReason;
+}
+
+export interface PromptTurnDeps {
+  readonly pathResolver: ZedPathResolver;
+  readonly emojiFilterMode: FilterConfiguration['mode'];
+  readonly streamDeps: SessionStreamDeps;
+}
+
+export async function runPromptTurn(
+  deps: PromptTurnDeps,
+  params: acp.PromptRequest,
+  pendingSend: AbortController,
+  promptId: string,
+  promptGeneration: number,
+): Promise<acp.PromptResponse> {
+  let parts: ContractPart[];
+  try {
+    parts = await deps.pathResolver.resolvePrompt(
+      params.prompt,
+      pendingSend.signal,
+    );
+  } catch (error) {
+    if (
+      pendingSend.signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return { stopReason: 'cancelled' };
+    }
+    throw error;
+  }
+  const batcher = new StreamBatcher(
+    new EmojiFilter({ mode: deps.emojiFilterMode }),
+    (u) => deps.streamDeps.sendUpdate(u),
+  );
+  let terminalStopReason: acp.StopReason | null = null;
+  try {
+    terminalStopReason = await consumeAgentStream(
+      deps.streamDeps,
+      parts,
+      pendingSend,
+      promptId,
+      promptGeneration,
+      batcher,
+    );
+  } catch (error) {
+    if (getErrorStatus(error) === 429) {
+      throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
+    }
+    if (
+      pendingSend.signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return { stopReason: 'cancelled' };
+    }
+    throw error;
+  } finally {
+    try {
+      await batcher.flush();
+    } finally {
+      batcher.dispose();
+    }
+  }
+  if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+    return { stopReason: 'cancelled' };
+  }
+  if (terminalStopReason !== null) {
+    return { stopReason: terminalStopReason };
+  }
+  return { stopReason: 'end_turn' };
+}

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -90,7 +90,7 @@ async function processStreamEvent(
   pendingSend: AbortController,
 ): Promise<acp.StopReason | null | 'cancelled'> {
   if (deps.isPromptStale(promptGeneration, pendingSend)) {
-    return event.type === 'done' ? 'cancelled' : null;
+    return 'cancelled';
   }
   const stopReason = await handleZedAgentEvent(event, batcher, {
     sendUpdate: deps.sendUpdate,

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -178,14 +178,14 @@ export async function runPromptTurn(
   await safeFlush(batcher, deps.streamDeps.logger);
   batcher.dispose();
   if (thrownError !== null) {
-    if (getErrorStatus(thrownError) === 429) {
-      throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
-    }
     if (
       pendingSend.signal.aborted ||
       (thrownError instanceof Error && thrownError.name === 'AbortError')
     ) {
       return { stopReason: 'cancelled' };
+    }
+    if (getErrorStatus(thrownError) === 429) {
+      throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     throw thrownError;
   }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -9,6 +9,7 @@ import { type Agent, type AgentEvent } from '@vybestack/llxprt-code-agents';
 import {
   EmojiFilter,
   type ContractPart,
+  type DebugLogger,
   type FilterConfiguration,
   getErrorStatus,
 } from '@vybestack/llxprt-code-core';
@@ -36,6 +37,7 @@ export interface SessionStreamDeps {
     pendingSend: AbortController,
   ) => boolean;
   readonly maxTurns: number;
+  readonly logger: Pick<DebugLogger, 'debug'>;
 }
 
 /**
@@ -73,8 +75,8 @@ export async function consumeAgentStream(
     if (deps.terminals !== null) {
       try {
         await deps.terminals.settleAll();
-      } catch {
-        // Swallow cleanup errors so they don't mask the original error
+      } catch (error) {
+        deps.logger.debug(() => `Terminal cleanup failed: ${String(error)}`);
       }
     }
   }
@@ -90,6 +92,12 @@ async function processStreamEvent(
   if (deps.isPromptStale(promptGeneration, pendingSend)) {
     return event.type === 'done' ? 'cancelled' : null;
   }
+  const stopReason = await handleZedAgentEvent(event, batcher, {
+    sendUpdate: deps.sendUpdate,
+    sendUsage: deps.sendUsage,
+    handleConfirmation: deps.handleConfirmation,
+    resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+  });
   if (
     event.type === 'tool-call' &&
     deps.terminals !== null &&
@@ -98,16 +106,9 @@ async function processStreamEvent(
       deps.agent.tools.get(event.call.name)?.kind,
     )
   ) {
-    await deps.terminals.handleToolCall(event.call);
-  }
-  const stopReason = await handleZedAgentEvent(event, batcher, {
-    sendUpdate: deps.sendUpdate,
-    sendUsage: deps.sendUsage,
-    handleConfirmation: deps.handleConfirmation,
-    resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-  });
-  if (event.type === 'tool-result' && deps.terminals !== null) {
-    await deps.terminals.releaseTerminal(event.result.id);
+    await deps.terminals.observeToolCall(event.call);
+  } else if (event.type === 'tool-result' && deps.terminals !== null) {
+    deps.terminals.completeToolCall(event.result.id);
   }
   return stopReason;
 }
@@ -158,7 +159,7 @@ export async function runPromptTurn(
   } catch (error) {
     thrownError = error;
   }
-  await safeFlush(batcher);
+  await safeFlush(batcher, deps.streamDeps.logger);
   batcher.dispose();
   if (thrownError !== null) {
     if (getErrorStatus(thrownError) === 429) {
@@ -181,11 +182,13 @@ export async function runPromptTurn(
   return { stopReason: 'end_turn' };
 }
 
-async function safeFlush(batcher: StreamBatcher): Promise<void> {
+async function safeFlush(
+  batcher: StreamBatcher,
+  logger: Pick<DebugLogger, 'debug'>,
+): Promise<void> {
   try {
     await batcher.flush();
-  } catch {
-    // Swallow flush errors so the original error from consumeAgentStream
-    // is not masked by a secondary flush failure.
+  } catch (error) {
+    logger.debug(() => `Stream flush failed: ${String(error)}`);
   }
 }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -73,17 +73,24 @@ export async function consumeAgentStream(
     ) {
       await deps.terminals.handleToolCall(event.call);
     }
-    const stopReason = await handleZedAgentEvent(event, batcher, {
-      sendUpdate: deps.sendUpdate,
-      sendUsage: deps.sendUsage,
-      handleConfirmation: deps.handleConfirmation,
-      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-    });
-    if (event.type === 'tool-result' && deps.terminals !== null) {
-      await deps.terminals.releaseTerminal(event.result.id);
-    }
-    if (stopReason !== null) {
-      terminalStopReason = stopReason;
+    try {
+      const stopReason = await handleZedAgentEvent(event, batcher, {
+        sendUpdate: deps.sendUpdate,
+        sendUsage: deps.sendUsage,
+        handleConfirmation: deps.handleConfirmation,
+        resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+      });
+      if (event.type === 'tool-result' && deps.terminals !== null) {
+        await deps.terminals.releaseTerminal(event.result.id);
+      }
+      if (stopReason !== null) {
+        terminalStopReason = stopReason;
+      }
+    } catch (error) {
+      if (deps.terminals !== null) {
+        await deps.terminals.settleAll();
+      }
+      throw error;
     }
   }
   return terminalStopReason;
@@ -133,21 +140,20 @@ export async function runPromptTurn(
     );
   } catch (error) {
     if (getErrorStatus(error) === 429) {
+      await safeFlush(batcher);
       throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     if (
       pendingSend.signal.aborted ||
       (error instanceof Error && error.name === 'AbortError')
     ) {
+      await safeFlush(batcher);
       return { stopReason: 'cancelled' };
     }
+    await safeFlush(batcher);
     throw error;
   } finally {
-    try {
-      await batcher.flush();
-    } finally {
-      batcher.dispose();
-    }
+    batcher.dispose();
   }
   if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
     return { stopReason: 'cancelled' };
@@ -156,4 +162,13 @@ export async function runPromptTurn(
     return { stopReason: terminalStopReason };
   }
   return { stopReason: 'end_turn' };
+}
+
+async function safeFlush(batcher: StreamBatcher): Promise<void> {
+  try {
+    await batcher.flush();
+  } catch {
+    // Swallow flush errors so the original error from consumeAgentStream
+    // is not masked by a secondary flush failure.
+  }
 }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -96,23 +96,16 @@ async function processStreamEvent(
   ) {
     await deps.terminals.handleToolCall(event.call);
   }
-  try {
-    const stopReason = await handleZedAgentEvent(event, batcher, {
-      sendUpdate: deps.sendUpdate,
-      sendUsage: deps.sendUsage,
-      handleConfirmation: deps.handleConfirmation,
-      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-    });
-    if (event.type === 'tool-result' && deps.terminals !== null) {
-      await deps.terminals.releaseTerminal(event.result.id);
-    }
-    return stopReason;
-  } catch (error) {
-    if (deps.terminals !== null) {
-      await deps.terminals.settleAll();
-    }
-    throw error;
+  const stopReason = await handleZedAgentEvent(event, batcher, {
+    sendUpdate: deps.sendUpdate,
+    sendUsage: deps.sendUsage,
+    handleConfirmation: deps.handleConfirmation,
+    resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+  });
+  if (event.type === 'tool-result' && deps.terminals !== null) {
+    await deps.terminals.releaseTerminal(event.result.id);
   }
+  return stopReason;
 }
 
 export interface PromptTurnDeps {

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -73,6 +73,11 @@ describe('deriveSessionTitle (issue #1611: first-prompt title)', () => {
     expect(deriveSessionTitle([])).toBeNull();
   });
 
+  it('preserves whitespace-only text without trimming to null', () => {
+    const title = deriveSessionTitle([{ type: 'text', text: '   ' }]);
+    expect(title).toBe('   ');
+  });
+
   // Finding #5: live normalization must match durable SessionDiscovery behavior
   // (extractUserMessageText: join with '', NO trim, NO newline collapse).
   it('does NOT trim leading/trailing whitespace, matching durable behavior (finding 5)', () => {
@@ -146,6 +151,14 @@ describe('deriveTitleFromHistory (issue #1611: restored-session title hydration)
       humanContent('Second human has text'),
     ];
     expect(deriveTitleFromHistory(history)).toBe('Second human has text');
+  });
+
+  it('skips human entries with an empty blocks array', () => {
+    const history: IContent[] = [
+      { speaker: 'human', blocks: [] },
+      humanContent('Next human has text'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Next human has text');
   });
 
   it('returns null for empty history', () => {
@@ -306,6 +319,7 @@ describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restore
       { type: 'text', text: 'First live prompt' },
     ]);
     expect(result.wonTitle).toBe(false);
+    expect(result.title).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -21,7 +21,10 @@
 
 import { describe, it, expect } from 'vitest';
 import type * as acp from '@agentclientprotocol/sdk';
-import type { IContent } from '@vybestack/llxprt-code-core';
+import {
+  SESSION_TITLE_MAX_LENGTH,
+  type IContent,
+} from '@vybestack/llxprt-code-core';
 import {
   deriveSessionTitle,
   deriveTitleFromHistory,
@@ -48,9 +51,8 @@ describe('deriveSessionTitle (issue #1611: first-prompt title)', () => {
   it('truncates a long prompt to the bounded length used by the listing', () => {
     const long = 'x'.repeat(500);
     const title = deriveSessionTitle([{ type: 'text', text: long }]);
-    // Consistent with SessionDiscovery.readFirstUserMessage (maxLength 120).
-    expect(title).toHaveLength(120);
-    expect(title).toBe(long.slice(0, 120));
+    expect(title).toHaveLength(SESSION_TITLE_MAX_LENGTH);
+    expect(title).toBe(long.slice(0, SESSION_TITLE_MAX_LENGTH));
   });
 
   it('ignores non-text blocks (images, resource links) and still titles from text', () => {
@@ -168,7 +170,9 @@ describe('deriveTitleFromHistory (issue #1611: restored-session title hydration)
   it('truncates long history text to the bounded length', () => {
     const long = 'y'.repeat(500);
     const history: IContent[] = [humanContent(long)];
-    expect(deriveTitleFromHistory(history)).toBe(long.slice(0, 120));
+    expect(deriveTitleFromHistory(history)).toBe(
+      long.slice(0, SESSION_TITLE_MAX_LENGTH),
+    );
   });
 
   it('does NOT trim or collapse newlines, matching durable behavior (finding 5)', () => {

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -296,17 +296,16 @@ describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restore
     expect(title).toBe('First title');
   });
 
-  it('returns undefined when history has no human text', () => {
+  it('consumes title eligibility when restored history has no human text', () => {
     const tracker = new SessionTitleTracker();
     const title = tracker.hydrateFromHistory([
       { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
     ]);
     expect(title).toBeUndefined();
-    // Eligibility NOT consumed — a later text prompt can still win the title.
     const result = tracker.consumeTitleEligibility([
       { type: 'text', text: 'First live prompt' },
     ]);
-    expect(result.wonTitle).toBe(true);
+    expect(result.wonTitle).toBe(false);
   });
 });
 

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -1,0 +1,341 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for session-info derivation (issue #1611):
+ * - The title is a truncated preview of the first user prompt, derived
+ *   consistently with SessionDiscovery.readFirstUserMessage (which feeds the
+ *   durable session listing). No LLM call.
+ * - The ACP session_info_update notification carries title and/or updatedAt
+ *   using the SDK's discriminated-union variant directly (no casts).
+ * - Title eligibility is consumed synchronously (race-safe for overlapping
+ *   prompts), even when the first prompt has no text (finding 1).
+ * - Restored sessions hydrate title from history so later prompts never retitle
+ *   them (finding 2).
+ * - Live title normalization matches durable SessionDiscovery behavior
+ *   (finding 5): no trimming, no newline collapsing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { IContent } from '@vybestack/llxprt-code-core';
+import {
+  deriveSessionTitle,
+  deriveTitleFromHistory,
+  buildSessionInfoUpdate,
+  SessionTitleTracker,
+} from './zed-session-info.js';
+
+describe('deriveSessionTitle (issue #1611: first-prompt title)', () => {
+  it('extracts text from a single text block', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'Investigate session lifecycle' },
+    ]);
+    expect(title).toBe('Investigate session lifecycle');
+  });
+
+  it('concatenates text across multiple text blocks', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'Fix the ' },
+      { type: 'text', text: 'bug in parser' },
+    ]);
+    expect(title).toBe('Fix the bug in parser');
+  });
+
+  it('truncates a long prompt to the bounded length used by the listing', () => {
+    const long = 'x'.repeat(500);
+    const title = deriveSessionTitle([{ type: 'text', text: long }]);
+    // Consistent with SessionDiscovery.readFirstUserMessage (maxLength 120).
+    expect(title).toHaveLength(120);
+    expect(title).toBe(long.slice(0, 120));
+  });
+
+  it('ignores non-text blocks (images, resource links) and still titles from text', () => {
+    const title = deriveSessionTitle([
+      { type: 'resource_link', uri: 'file:///p', name: 'p.ts' },
+      { type: 'text', text: 'Review this file' },
+    ]);
+    expect(title).toBe('Review this file');
+  });
+
+  it('returns null when the prompt has no text content (only media/resources)', () => {
+    const title = deriveSessionTitle([
+      { type: 'image', data: 'base64', mimeType: 'image/png' },
+      { type: 'resource_link', uri: 'file:///p', name: 'p.ts' },
+    ]);
+    expect(title).toBeNull();
+  });
+
+  it('returns null for an empty prompt', () => {
+    expect(deriveSessionTitle([])).toBeNull();
+  });
+
+  // Finding #5: live normalization must match durable SessionDiscovery behavior
+  // (extractUserMessageText: join with '', NO trim, NO newline collapse).
+  it('does NOT trim leading/trailing whitespace, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: '  hello world  ' },
+    ]);
+    // Durable extractUserMessageText does NOT trim — live must match.
+    expect(title).toBe('  hello world  ');
+  });
+
+  it('does NOT collapse newlines, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'line one\nline two\nline three' },
+    ]);
+    // Durable extractUserMessageText does NOT replace newlines — live must
+    // match so the durable listing title and the live title are identical.
+    expect(title).toBe('line one\nline two\nline three');
+  });
+
+  it('does NOT collapse tabs or other whitespace, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([{ type: 'text', text: 'col1\tcol2' }]);
+    expect(title).toBe('col1\tcol2');
+  });
+});
+
+describe('deriveTitleFromHistory (issue #1611: restored-session title hydration)', () => {
+  function humanContent(text: string): IContent {
+    return {
+      speaker: 'human',
+      blocks: [{ type: 'text', text }],
+    };
+  }
+
+  it('extracts the first human-speaker text from history', () => {
+    const history: IContent[] = [
+      humanContent('First user message'),
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('First user message');
+  });
+
+  it('skips ai/tool entries and uses the first human text', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'welcome' }] },
+      { speaker: 'tool', blocks: [{ type: 'text', text: 'result' }] },
+      humanContent('Actual first user message'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Actual first user message');
+  });
+
+  it('returns null when history has no human text', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ];
+    expect(deriveTitleFromHistory(history)).toBeNull();
+  });
+
+  it('skips human entries with no text blocks', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            data: 'base64',
+            mimeType: 'image/png',
+            encoding: 'base64',
+          },
+        ],
+      },
+      humanContent('Second human has text'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Second human has text');
+  });
+
+  it('returns null for empty history', () => {
+    expect(deriveTitleFromHistory([])).toBeNull();
+  });
+
+  it('truncates long history text to the bounded length', () => {
+    const long = 'y'.repeat(500);
+    const history: IContent[] = [humanContent(long)];
+    expect(deriveTitleFromHistory(history)).toBe(long.slice(0, 120));
+  });
+
+  it('does NOT trim or collapse newlines, matching durable behavior (finding 5)', () => {
+    const history: IContent[] = [humanContent('  line one\nline two  ')];
+    expect(deriveTitleFromHistory(history)).toBe('  line one\nline two  ');
+  });
+});
+
+describe('buildSessionInfoUpdate (issue #1611: ACP session_info_update)', () => {
+  it('builds a title-only update using the SDK discriminated-union variant', () => {
+    const update = buildSessionInfoUpdate({ title: 'My session' });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      title: 'My session',
+    });
+  });
+
+  it('builds an updatedAt-only update', () => {
+    const update = buildSessionInfoUpdate({
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+
+  it('builds a combined title + updatedAt update', () => {
+    const update = buildSessionInfoUpdate({
+      title: 'My session',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      title: 'My session',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+});
+
+describe('SessionTitleTracker.consumeTitleEligibility (issue #1611 finding 1: synchronous, race-safe)', () => {
+  it('wins the title on the first text-bearing prompt', () => {
+    const tracker = new SessionTitleTracker();
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First prompt here' },
+    ]);
+    expect(result.wonTitle).toBe(true);
+    expect(result.title).toBe('First prompt here');
+  });
+
+  it('consumes eligibility even when the first prompt has no text (no retitle later)', () => {
+    const tracker = new SessionTitleTracker();
+    const first = tracker.consumeTitleEligibility([
+      { type: 'image', data: 'base64', mimeType: 'image/png' },
+    ]);
+    expect(first.wonTitle).toBe(false);
+    expect(first.title).toBeUndefined();
+
+    // A LATER text-bearing prompt must NOT win — eligibility was consumed.
+    const second = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Now with text' },
+    ]);
+    expect(second.wonTitle).toBe(false);
+    expect(second.title).toBeUndefined();
+  });
+
+  it('does NOT win on the second prompt (title set once, eligibility consumed once)', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First prompt here' },
+    ]);
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Second prompt here' },
+    ]);
+    expect(result.wonTitle).toBe(false);
+    expect(result.title).toBe('First prompt here');
+  });
+
+  it('is race-safe: only the first synchronous call wins, regardless of turn completion order', () => {
+    // Simulate overlapping prompts: both call consumeTitleEligibility before
+    // either turn completes. Only the first wins.
+    const tracker = new SessionTitleTracker();
+    const promptA = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Prompt A' },
+    ]);
+    const promptB = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Prompt B' },
+    ]);
+    expect(promptA.wonTitle).toBe(true);
+    expect(promptA.title).toBe('Prompt A');
+    expect(promptB.wonTitle).toBe(false);
+    expect(promptB.title).toBe('Prompt A');
+  });
+});
+
+describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restored sessions)', () => {
+  it('sets the title from the first human text in restored history', () => {
+    const tracker = new SessionTitleTracker();
+    const title = tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored session title' }],
+      },
+    ]);
+    expect(title).toBe('Restored session title');
+    expect(tracker.getTitle()).toBe('Restored session title');
+  });
+
+  it('consumes title eligibility so a later live prompt never retitles', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored title' }],
+      },
+    ]);
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'New prompt after restore' },
+    ]);
+    expect(result.wonTitle).toBe(false);
+    expect(result.title).toBe('Restored title');
+  });
+
+  it('is idempotent: a second hydrate is a no-op', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'First title' }],
+      },
+    ]);
+    const title = tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Second title' }],
+      },
+    ]);
+    expect(title).toBe('First title');
+  });
+
+  it('returns undefined when history has no human text', () => {
+    const tracker = new SessionTitleTracker();
+    const title = tracker.hydrateFromHistory([
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ]);
+    expect(title).toBeUndefined();
+    // Eligibility NOT consumed — a later text prompt can still win the title.
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First live prompt' },
+    ]);
+    expect(result.wonTitle).toBe(true);
+  });
+});
+
+describe('SessionTitleTracker.recordTurn (issue #1611: updatedAt-per-turn)', () => {
+  it('returns an updatedAt update', () => {
+    const tracker = new SessionTitleTracker();
+    const result = tracker.recordTurn('2026-07-12T00:00:00Z');
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+
+  it('advances updatedAt on each turn', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.recordTurn('2026-07-12T00:00:00Z');
+    const result = tracker.recordTurn('2026-07-12T00:01:00Z');
+    expect(result.updates[0]).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:01:00Z',
+    });
+    expect(tracker.getUpdatedAt()).toBe('2026-07-12T00:01:00Z');
+  });
+
+  it('does not carry a title field (title is handled by consumeTitleEligibility)', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.consumeTitleEligibility([{ type: 'text', text: 'First' }]);
+    const result = tracker.recordTurn('2026-07-12T00:00:00Z');
+    expect(result.updates[0]).not.toHaveProperty('title');
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -28,14 +28,16 @@ const TITLE_MAX_LENGTH = 120;
 export function deriveSessionTitle(
   prompt: readonly acp.ContentBlock[],
 ): string | null {
-  const text = prompt
+  return extractTitleText(prompt);
+}
+
+function extractTitleText(
+  blocks: ReadonlyArray<{ readonly type: string; readonly text?: unknown }>,
+): string | null {
+  const text = blocks
     .filter(
-      (
-        block,
-      ): block is acp.ContentBlock & {
-        type: 'text';
-        text: string;
-      } => block.type === 'text',
+      (block): block is { readonly type: 'text'; readonly text: string } =>
+        block.type === 'text' && typeof block.text === 'string',
     )
     .map((block) => block.text)
     .join('');
@@ -61,17 +63,9 @@ export function deriveTitleFromHistory(
     if (item.speaker !== 'human') {
       continue;
     }
-    const text = item.blocks
-      .filter(
-        (block): block is { type: 'text'; text: string } =>
-          block.type === 'text',
-      )
-      .map((block) => block.text)
-      .join('');
-    if (text.length > 0) {
-      return text.length > TITLE_MAX_LENGTH
-        ? text.slice(0, TITLE_MAX_LENGTH)
-        : text;
+    const title = extractTitleText(item.blocks);
+    if (title !== null) {
+      return title;
     }
   }
   return null;
@@ -116,9 +110,8 @@ export interface TitleEligibilityResult {
 
 export interface SessionInfoRecordResult {
   /**
-   * The session_info_update notification to emit for this turn: always an
-   * updatedAt update (title is emitted via consumeTitleEligibility). Empty only
-   * if updatedAt is unchanged.
+   * The session_info_update notifications to emit for this turn: always an
+   * updatedAt update, optionally preceded by a pending title retry.
    */
   readonly updates: ReadonlyArray<
     acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -5,13 +5,10 @@
  */
 
 import type * as acp from '@agentclientprotocol/sdk';
-import type { IContent } from '@vybestack/llxprt-code-core';
-
-/**
- * Maximum title length, matching SessionDiscovery.readFirstUserMessage so the
- * live session_info_update title and the durable on-disk listing title agree.
- */
-const TITLE_MAX_LENGTH = 120;
+import {
+  SESSION_TITLE_MAX_LENGTH,
+  type IContent,
+} from '@vybestack/llxprt-code-core';
 
 /**
  * Derives a human-readable title from the first user prompt by concatenating
@@ -44,8 +41,8 @@ function extractTitleText(
   if (text.length === 0) {
     return null;
   }
-  return text.length > TITLE_MAX_LENGTH
-    ? text.slice(0, TITLE_MAX_LENGTH)
+  return text.length > SESSION_TITLE_MAX_LENGTH
+    ? text.slice(0, SESSION_TITLE_MAX_LENGTH)
     : text;
 }
 

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -201,11 +201,11 @@ export class SessionTitleTracker {
       return this.title;
     }
     const derived = deriveTitleFromHistory(history);
+    this.titleEligibilityConsumed = true;
     if (derived === null) {
       return undefined;
     }
     this.title = derived;
-    this.titleEligibilityConsumed = true;
     return this.title;
   }
 

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+/**
+ * Maximum title length, matching SessionDiscovery.readFirstUserMessage so the
+ * live session_info_update title and the durable on-disk listing title agree.
+ */
+const TITLE_MAX_LENGTH = 120;
+
+/**
+ * Derives a human-readable title from the first user prompt by concatenating
+ * its text blocks (ignoring media/resources) and truncating to the bounded
+ * length the session listing uses. Returns null when the prompt carries no
+ * text. No LLM call — consistent with the durable listing convention.
+ *
+ * Normalization intentionally matches the durable path
+ * (SessionDiscovery.readFirstUserMessage → extractUserMessageText): text blocks
+ * are joined with an empty separator and truncated — NO trimming or newline
+ * collapsing — so the live title is byte-identical to the on-disk listing
+ * title for the same first user message.
+ */
+export function deriveSessionTitle(
+  prompt: readonly acp.ContentBlock[],
+): string | null {
+  const text = prompt
+    .filter(
+      (
+        block,
+      ): block is acp.ContentBlock & {
+        type: 'text';
+        text: string;
+      } => block.type === 'text',
+    )
+    .map((block) => block.text)
+    .join('');
+  if (text.length === 0) {
+    return null;
+  }
+  return text.length > TITLE_MAX_LENGTH
+    ? text.slice(0, TITLE_MAX_LENGTH)
+    : text;
+}
+
+/**
+ * Extracts the first human-speaker text from a resumed history, using the SAME
+ * join + truncate normalization as {@link deriveSessionTitle} and the durable
+ * SessionDiscovery.readFirstUserMessage. Returns null when the history has no
+ * human text block, so a restored session with only ai/tool entries is not
+ * titled (matching the durable listing, which shows no title for such sessions).
+ */
+export function deriveTitleFromHistory(
+  history: readonly IContent[],
+): string | null {
+  for (const item of history) {
+    if (item.speaker !== 'human') {
+      continue;
+    }
+    const text = item.blocks
+      .filter(
+        (block): block is { type: 'text'; text: string } =>
+          block.type === 'text',
+      )
+      .map((block) => block.text)
+      .join('');
+    if (text.length > 0) {
+      return text.length > TITLE_MAX_LENGTH
+        ? text.slice(0, TITLE_MAX_LENGTH)
+        : text;
+    }
+  }
+  return null;
+}
+
+/**
+ * Builds an ACP `session_info_update` {@link acp.SessionUpdate} using the SDK's
+ * discriminated-union variant directly (no casts). Only the supplied fields are
+ * carried so partial title/updatedAt updates are emitted without nulling the
+ * other.
+ */
+export function buildSessionInfoUpdate(fields: {
+  readonly title?: string;
+  readonly updatedAt?: string;
+}): acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' } {
+  const update: acp.SessionInfoUpdate & {
+    sessionUpdate: 'session_info_update';
+  } = {
+    sessionUpdate: 'session_info_update',
+  };
+  if (fields.title !== undefined) {
+    update.title = fields.title;
+  }
+  if (fields.updatedAt !== undefined) {
+    update.updatedAt = fields.updatedAt;
+  }
+  return update;
+}
+
+export interface TitleEligibilityResult {
+  /**
+   * True when THIS call won the title — i.e. the derived title was freshly set.
+   * The caller emits a session_info_update carrying the title exactly once.
+   */
+  readonly wonTitle: boolean;
+  /**
+   * The current title (undefined until the first text-bearing prompt wins or
+   * hydration sets it from history).
+   */
+  readonly title: string | undefined;
+}
+
+export interface SessionInfoRecordResult {
+  /**
+   * The session_info_update notification to emit for this turn: always an
+   * updatedAt update (title is emitted via consumeTitleEligibility). Empty only
+   * if updatedAt is unchanged.
+   */
+  readonly updates: ReadonlyArray<
+    acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }
+  >;
+  /**
+   * The current title (undefined until the first text-bearing prompt wins or
+   * hydration sets it from history).
+   */
+  readonly title: string | undefined;
+}
+
+/**
+ * Tracks per-session title (derived once from the first text-bearing prompt)
+ * and updatedAt (refreshed every turn). Keeping this state in a cohesive
+ * helper lets zedIntegration.ts stay within its max-lines budget and makes the
+ * externally observable session_info_update semantics unit-testable in
+ * isolation.
+ *
+ * Title eligibility is consumed SYNCHRONOUSLY at prompt-acceptance time via
+ * {@link consumeTitleEligibility}, not deferred to turn completion, so
+ * overlapping prompts cannot both claim the title (race-safety, issue #1611
+ * finding 1). Restored sessions hydrate the title from history via
+ * {@link hydrateFromHistory} so later prompts never retitle them (finding 2).
+ */
+export class SessionTitleTracker {
+  private title: string | undefined;
+  private updatedAt: string | undefined;
+  /**
+   * Once consumed, no future call can win the title — even if the winning
+   * prompt had no text (so a no-text first prompt still suppresses a later
+   * retitle).
+   */
+  private titleEligibilityConsumed = false;
+  /**
+   * A title that won eligibility but whose session_info_update notification
+   * failed transport. Retried (prepended) on the next turn's metadata emission
+   * so a transient transport error doesn't permanently lose the title.
+   * Issue #1611: pending title notification retry after transport failure.
+   */
+  private pendingTitle: string | undefined;
+
+  /**
+   * Synchronously consumes title eligibility for a prompt: on the FIRST call
+   * (whether or not the prompt has text), eligibility is permanently consumed.
+   * If the prompt has text and no title is set yet, the title is derived and
+   * set. Returns whether THIS call won the title (so the caller emits the
+   * session_info_update exactly once) and the current title.
+   */
+  consumeTitleEligibility(
+    prompt: readonly acp.ContentBlock[],
+  ): TitleEligibilityResult {
+    if (this.titleEligibilityConsumed) {
+      return { wonTitle: false, title: this.title };
+    }
+    this.titleEligibilityConsumed = true;
+    if (this.title !== undefined) {
+      return { wonTitle: false, title: this.title };
+    }
+    const derived = deriveSessionTitle(prompt);
+    if (derived === null) {
+      return { wonTitle: false, title: undefined };
+    }
+    this.title = derived;
+    return { wonTitle: true, title: this.title };
+  }
+
+  hydrateFromMetadata(title: string | null): string | undefined {
+    if (this.titleEligibilityConsumed) {
+      return this.title;
+    }
+    this.titleEligibilityConsumed = true;
+    if (title !== null) {
+      this.title = title;
+    }
+    return this.title;
+  }
+
+  /**
+   * Hydrates the title from a resumed history (issue #1611 finding 2). Called
+   * after a load/resume replays the conversation, BEFORE any new prompt. If the
+   * history's first human text yields a title, it is set AND eligibility is
+   * consumed, so the next live prompt can never retitle the session. Idempotent:
+   * a no-op if a title was already set or eligibility already consumed.
+   */
+  hydrateFromHistory(history: readonly IContent[]): string | undefined {
+    if (this.title !== undefined || this.titleEligibilityConsumed) {
+      return this.title;
+    }
+    const derived = deriveTitleFromHistory(history);
+    if (derived === null) {
+      return undefined;
+    }
+    this.title = derived;
+    this.titleEligibilityConsumed = true;
+    return this.title;
+  }
+
+  /**
+   * Records a completed turn: advances updatedAt and returns the
+   * session_info_update notification the caller should push. Title is handled
+   * separately via {@link consumeTitleEligibility} at acceptance time.
+   *
+   * If a pending title exists (from a previous transport failure), it is
+   * prepended to the updates so the caller retries it this turn.
+   */
+  recordTurn(updatedAt: string): SessionInfoRecordResult {
+    this.updatedAt = updatedAt;
+    const updates: Array<
+      acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }
+    > = [];
+    if (this.pendingTitle !== undefined) {
+      updates.push(
+        buildSessionInfoUpdate({
+          title: this.pendingTitle,
+          updatedAt,
+        }),
+      );
+      this.pendingTitle = undefined;
+    }
+    updates.push(buildSessionInfoUpdate({ updatedAt }));
+    return { updates, title: this.title };
+  }
+
+  /**
+   * Marks a title as pending for retry (issue #1611). Called by the caller
+   * when the title-bearing session_info_update notification fails transport.
+   * The next {@link recordTurn} will prepend the title to its updates.
+   */
+  markPendingTitle(title: string): void {
+    this.pendingTitle = title;
+  }
+
+  /**
+   * Returns the pending title (for testing) or undefined when none is pending.
+   */
+  getPendingTitle(): string | undefined {
+    return this.pendingTitle;
+  }
+
+  getTitle(): string | undefined {
+    return this.title;
+  }
+
+  getUpdatedAt(): string | undefined {
+    return this.updatedAt;
+  }
+}

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -19,6 +19,7 @@ export interface LifecycleSessionHandle {
   getApprovalMode(): ApprovalMode;
   getLifecycleInfo(): LifecycleSession;
   dispose(): Promise<void>;
+  sendAvailableCommands(): Promise<void>;
 }
 
 interface RestoredSession {
@@ -86,6 +87,7 @@ export class SessionLifecycle {
       if (live.getLifecycleInfo().cwd !== params.cwd) {
         throw acp.RequestError.resourceNotFound(params.sessionId);
       }
+      await live.sendAvailableCommands();
       return { modes: buildSessionModes(live.getApprovalMode()) };
     }
     const listed = await this.list({ cwd: params.cwd });
@@ -93,6 +95,7 @@ export class SessionLifecycle {
       throw acp.RequestError.resourceNotFound(params.sessionId);
     }
     const { session } = await this.restore(params.sessionId, params.cwd);
+    await session.sendAvailableCommands();
     this.sessions.set(params.sessionId, session);
     return { modes: buildSessionModes(session.getApprovalMode()) };
   }

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -148,8 +148,11 @@ export class SessionLifecycle {
     if (live === undefined) {
       return false;
     }
-    await live.dispose();
-    this.sessions.delete(sessionId);
+    try {
+      await live.dispose();
+    } finally {
+      this.sessions.delete(sessionId);
+    }
     return true;
   }
 }

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import {
+  deleteSessionById,
+  getProjectHash,
+  type ApprovalMode,
+  type Config,
+} from '@vybestack/llxprt-code-core';
+import { buildSessionModes } from './zed-helpers.js';
+import { listRecordedSessions } from './zed-session-listing.js';
+import type { LifecycleSession } from './zed-session-pagination.js';
+
+export interface LifecycleSessionHandle {
+  getApprovalMode(): ApprovalMode;
+  getLifecycleInfo(): LifecycleSession;
+  dispose(): Promise<void>;
+}
+
+interface RestoredSession {
+  readonly session: LifecycleSessionHandle;
+}
+
+export class SessionLifecycle {
+  private readonly queues = new Map<string, Promise<unknown>>();
+
+  constructor(
+    private readonly config: Config,
+    private readonly sessions: Map<string, LifecycleSessionHandle>,
+    private readonly restore: (
+      sessionId: string,
+      cwd: string | undefined,
+    ) => Promise<RestoredSession>,
+  ) {}
+
+  list(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
+    const projectRoot = this.config.getProjectRoot();
+    return listRecordedSessions(
+      this.config.storage.getProjectChatsDir(),
+      getProjectHash(projectRoot),
+      projectRoot,
+      params,
+      [...this.sessions.values()].map((session) => session.getLifecycleInfo()),
+    );
+  }
+
+  resume(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
+    return this.runSerialized(params.sessionId, () =>
+      this.performResume(params),
+    );
+  }
+
+  close(params: acp.CloseSessionRequest): Promise<acp.CloseSessionResponse> {
+    return this.runSerialized(params.sessionId, async () => {
+      await this.disposeLive(params.sessionId);
+      return {};
+    });
+  }
+
+  delete(params: acp.DeleteSessionRequest): Promise<acp.DeleteSessionResponse> {
+    return this.runSerialized(params.sessionId, () =>
+      this.performDelete(params),
+    );
+  }
+
+  runSerialized<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    const prior = this.queues.get(sessionId);
+    const run = (prior ?? Promise.resolve()).then(operation, operation);
+    this.queues.set(sessionId, run);
+    return run.finally(() => {
+      if (this.queues.get(sessionId) === run) {
+        this.queues.delete(sessionId);
+      }
+    });
+  }
+
+  private async performResume(
+    params: acp.ResumeSessionRequest,
+  ): Promise<acp.ResumeSessionResponse> {
+    const live = this.sessions.get(params.sessionId);
+    if (live !== undefined) {
+      if (live.getLifecycleInfo().cwd !== params.cwd) {
+        throw acp.RequestError.resourceNotFound(params.sessionId);
+      }
+      return { modes: buildSessionModes(live.getApprovalMode()) };
+    }
+    const listed = await this.list({ cwd: params.cwd });
+    if (!listed.sessions.some((item) => item.sessionId === params.sessionId)) {
+      throw acp.RequestError.resourceNotFound(params.sessionId);
+    }
+    const { session } = await this.restore(params.sessionId, params.cwd);
+    this.sessions.set(params.sessionId, session);
+    return { modes: buildSessionModes(session.getApprovalMode()) };
+  }
+
+  private async performDelete(
+    params: acp.DeleteSessionRequest,
+  ): Promise<acp.DeleteSessionResponse> {
+    const hadLiveSession = await this.disposeLive(params.sessionId);
+    const projectRoot = this.config.getProjectRoot();
+    const result = await deleteSessionById(
+      params.sessionId,
+      this.config.storage.getProjectChatsDir(),
+      getProjectHash(projectRoot),
+    );
+    if (result.ok) {
+      return {};
+    }
+    if (result.error.startsWith('Session not found:')) {
+      if (hadLiveSession) {
+        return {};
+      }
+      throw acp.RequestError.resourceNotFound(params.sessionId);
+    }
+    throw acp.RequestError.internalError({
+      sessionId: params.sessionId,
+      reason: result.error,
+    });
+  }
+
+  private async disposeLive(sessionId: string): Promise<boolean> {
+    const live = this.sessions.get(sessionId);
+    if (live === undefined) {
+      return false;
+    }
+    await live.dispose();
+    this.sessions.delete(sessionId);
+    return true;
+  }
+}

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -20,6 +20,7 @@ export interface LifecycleSessionHandle {
   getLifecycleInfo(): LifecycleSession;
   dispose(): Promise<void>;
   sendAvailableCommands(): Promise<void>;
+  getConfigOptions(): Promise<acp.SessionConfigOption[]>;
 }
 
 interface RestoredSession {
@@ -36,6 +37,11 @@ export class SessionLifecycle {
       sessionId: string,
       cwd: string | undefined,
     ) => Promise<RestoredSession>,
+    private readonly configOptions: (
+      session: LifecycleSessionHandle,
+    ) => Promise<
+      Pick<acp.ResumeSessionResponse, 'configOptions'>
+    > = async () => ({}),
   ) {}
 
   list(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
@@ -88,7 +94,10 @@ export class SessionLifecycle {
         throw acp.RequestError.resourceNotFound(params.sessionId);
       }
       await live.sendAvailableCommands();
-      return { modes: buildSessionModes(live.getApprovalMode()) };
+      return {
+        modes: buildSessionModes(live.getApprovalMode()),
+        ...(await this.configOptions(live)),
+      };
     }
     const listed = await this.list({ cwd: params.cwd });
     if (!listed.sessions.some((item) => item.sessionId === params.sessionId)) {
@@ -97,7 +106,10 @@ export class SessionLifecycle {
     const { session } = await this.restore(params.sessionId, params.cwd);
     await session.sendAvailableCommands();
     this.sessions.set(params.sessionId, session);
-    return { modes: buildSessionModes(session.getApprovalMode()) };
+    return {
+      modes: buildSessionModes(session.getApprovalMode()),
+      ...(await this.configOptions(session)),
+    };
   }
 
   private async performDelete(

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -14,6 +14,12 @@ import {
 import { buildSessionModes } from './zed-helpers.js';
 import { listRecordedSessions } from './zed-session-listing.js';
 import type { LifecycleSession } from './zed-session-pagination.js';
+import type {
+  CloseSessionRequest,
+  CloseSessionResponse,
+  DeleteSessionRequest,
+  DeleteSessionResponse,
+} from './acp-types.js';
 
 export interface LifecycleSessionHandle {
   getApprovalMode(): ApprovalMode;
@@ -61,14 +67,14 @@ export class SessionLifecycle {
     );
   }
 
-  close(params: acp.CloseSessionRequest): Promise<acp.CloseSessionResponse> {
+  close(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     return this.runSerialized(params.sessionId, async () => {
       await this.disposeLive(params.sessionId);
       return {};
     });
   }
 
-  delete(params: acp.DeleteSessionRequest): Promise<acp.DeleteSessionResponse> {
+  delete(params: DeleteSessionRequest): Promise<DeleteSessionResponse> {
     return this.runSerialized(params.sessionId, () =>
       this.performDelete(params),
     );
@@ -113,8 +119,8 @@ export class SessionLifecycle {
   }
 
   private async performDelete(
-    params: acp.DeleteSessionRequest,
-  ): Promise<acp.DeleteSessionResponse> {
+    params: DeleteSessionRequest,
+  ): Promise<DeleteSessionResponse> {
     const hadLiveSession = await this.disposeLive(params.sessionId);
     const projectRoot = this.config.getProjectRoot();
     const result = await deleteSessionById(

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -453,6 +453,9 @@ describe('recorded ACP session listing', () => {
       const updatedAt = result.sessions[0].updatedAt;
       expect(updatedAt).toBeDefined();
       expect(new Date(updatedAt ?? '').toISOString()).toBe(updatedAt);
+      expect(new Date(updatedAt!).getTime()).toBeGreaterThan(
+        Date.now() - 10_000,
+      );
     });
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -93,4 +93,329 @@ describe('recorded ACP session listing', () => {
       false,
     );
   });
+
+  it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+
+    const liveSession = {
+      sessionId: 'live-only-session',
+      cwd: '/workspace',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+      title: 'Live session title from first prompt',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'live-only-session',
+      cwd: '/workspace',
+      title: 'Live session title from first prompt',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+    });
+  });
+
+  it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'merged-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Durable title from disk' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const liveSession = {
+      sessionId: 'merged-session',
+      cwd: '/workspace',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+      title: 'Live title that should be overridden',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Durable title wins over live title.
+    expect(result.sessions[0].title).toBe('Durable title from disk');
+  });
+
+  it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'freshness-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Some title' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const liveSession = {
+      sessionId: 'freshness-session',
+      cwd: '/workspace',
+      // Live updatedAt is newer than the durable file mtime.
+      updatedAt: '2099-01-01T00:00:00.000Z',
+      title: 'Live title',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // updatedAt should be the live (newer) value.
+    expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
+  });
+});
+describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  // The durable path (SessionDiscovery.readFirstUserMessage →
+  // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
+  // NO newline collapse. The live path (deriveSessionTitle) must match exactly
+  // so the on-disk listing title and the session_info_update title agree.
+  const cases: Array<{ name: string; text: string }> = [
+    { name: 'multiline', text: 'line one\nline two\nline three' },
+    { name: 'leading/trailing whitespace', text: '  padded title  ' },
+    { name: 'tabs', text: 'col1\tcol2' },
+    { name: 'multiple text blocks', text: 'part1part2' },
+  ];
+
+  for (const { name, text } of cases) {
+    it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
+      const { deriveSessionTitle } = await import('./zed-session-info.js');
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'consistency-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      const content: IContent = {
+        speaker: 'human',
+        blocks:
+          name === 'multiple text blocks'
+            ? [
+                { type: 'text', text: 'part1' },
+                { type: 'text', text: 'part2' },
+              ]
+            : [{ type: 'text', text }],
+      };
+      service.recordContent(content);
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+      const durableTitle = result.sessions[0].title;
+
+      const liveTitle = deriveSessionTitle(
+        name === 'multiple text blocks'
+          ? [
+              { type: 'text', text: 'part1' },
+              { type: 'text', text: 'part2' },
+            ]
+          : [{ type: 'text', text }],
+      );
+
+      expect(durableTitle).toBe(liveTitle);
+    });
+  }
+});
+
+describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it('uses the session_metadata title when present', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'metadata-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // Record a metadata title BEFORE the content event.
+    service.recordSessionMetadata('Metadata title from ACP');
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Different first human text' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // The session_metadata title wins over the first-human-text fallback.
+    expect(result.sessions[0].title).toBe('Metadata title from ACP');
+  });
+
+  it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'legacy-metadata-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // No recordSessionMetadata — legacy behavior.
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Legacy first human text' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Falls back to first-human-text for legacy sessions.
+    expect(result.sessions[0].title).toBe('Legacy first human text');
+  });
+
+  it('omits title when session_metadata is explicit null (untitled)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'untitled-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // Explicit null title.
+    service.recordSessionMetadata(null);
+    service.recordContent({
+      speaker: 'human',
+      blocks: [
+        { type: 'text', text: 'Human text that should NOT be the title' },
+      ],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Explicit null → no title surfaced (consistent with legacy no-human-text).
+    expect(result.sessions[0]).not.toHaveProperty('title');
+  });
+
+  it('includes createdAt in the listing for immutable ordering (issue #1611)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'created-at-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordSessionMetadata('Title');
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+  });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -12,6 +12,7 @@ import {
   SessionRecordingService,
   type IContent,
 } from '@vybestack/llxprt-code-core';
+import { deriveSessionTitle } from './zed-session-info.js';
 import { listRecordedSessions } from './zed-session-listing.js';
 
 const roots: string[] = [];
@@ -22,218 +23,15 @@ describe('recorded ACP session listing', () => {
       roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
     );
   });
-  it('returns persisted cwd, first human text title, and updated timestamp', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'listed-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    const content: IContent = {
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
-    };
-    service.recordContent(content);
-    await service.flush();
-    await service.dispose();
 
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'listed-session',
-      cwd: '/workspace',
-      title: 'Investigate session lifecycle',
-    });
-    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
-  });
-
-  it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'legacy-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: [],
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'ai',
-      blocks: [{ type: 'text', text: 'agent-only content' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions[0].cwd).toBe('/fallback');
-    expect(result.sessions[0]).not.toHaveProperty('title');
-    expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
-      false,
-    );
-  });
-
-  it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-
-    const liveSession = {
-      sessionId: 'live-only-session',
-      cwd: '/workspace',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-      title: 'Live session title from first prompt',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'live-only-session',
-      cwd: '/workspace',
-      title: 'Live session title from first prompt',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-    });
-  });
-
-  it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'merged-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Durable title from disk' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const liveSession = {
-      sessionId: 'merged-session',
-      cwd: '/workspace',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-      title: 'Live title that should be overridden',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Durable title wins over live title.
-    expect(result.sessions[0].title).toBe('Durable title from disk');
-  });
-
-  it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'freshness-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Some title' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const liveSession = {
-      sessionId: 'freshness-session',
-      cwd: '/workspace',
-      // Live updatedAt is newer than the durable file mtime.
-      updatedAt: '2099-01-01T00:00:00.000Z',
-      title: 'Live title',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // updatedAt should be the live (newer) value.
-    expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
-  });
-});
-describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
-  afterEach(async () => {
-    await Promise.all(
-      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-    );
-  });
-
-  // The durable path (SessionDiscovery.readFirstUserMessage →
-  // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
-  // NO newline collapse. The live path (deriveSessionTitle) must match exactly
-  // so the on-disk listing title and the session_info_update title agree.
-  const cases: Array<{ name: string; text: string }> = [
-    { name: 'multiline', text: 'line one\nline two\nline three' },
-    { name: 'leading/trailing whitespace', text: '  padded title  ' },
-    { name: 'tabs', text: 'col1\tcol2' },
-    { name: 'multiple text blocks', text: 'part1part2' },
-  ];
-
-  for (const { name, text } of cases) {
-    it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
-      const { deriveSessionTitle } = await import('./zed-session-info.js');
+  describe('listing and live merging', () => {
+    it('returns persisted cwd, first human text title, and updated timestamp', async () => {
       const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
       roots.push(root);
       const chatsDir = join(root, 'chats');
       await mkdir(chatsDir);
       const service = new SessionRecordingService({
-        sessionId: 'consistency-session',
+        sessionId: 'listed-session',
         projectHash: 'project-hash',
         chatsDir,
         workspaceDirs: ['/workspace'],
@@ -243,13 +41,7 @@ describe('durable + live title normalization consistency (issue #1611 finding 5)
       });
       const content: IContent = {
         speaker: 'human',
-        blocks:
-          name === 'multiple text blocks'
-            ? [
-                { type: 'text', text: 'part1' },
-                { type: 'text', text: 'part2' },
-              ]
-            : [{ type: 'text', text }],
+        blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
       };
       service.recordContent(content);
       await service.flush();
@@ -261,161 +53,362 @@ describe('durable + live title normalization consistency (issue #1611 finding 5)
         '/fallback',
         {},
       );
-      const durableTitle = result.sessions[0].title;
 
-      const liveTitle = deriveSessionTitle(
-        name === 'multiple text blocks'
-          ? [
-              { type: 'text', text: 'part1' },
-              { type: 'text', text: 'part2' },
-            ]
-          : [{ type: 'text', text }],
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]).toMatchObject({
+        sessionId: 'listed-session',
+        cwd: '/workspace',
+        title: 'Investigate session lifecycle',
+      });
+      expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+    });
+
+    it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'legacy-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: [],
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'agent-only content' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
       );
 
-      expect(durableTitle).toBe(liveTitle);
+      expect(result.sessions[0].cwd).toBe('/fallback');
+      expect(result.sessions[0]).not.toHaveProperty('title');
+      expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
+        false,
+      );
     });
-  }
-});
 
-describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
-  afterEach(async () => {
-    await Promise.all(
-      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-    );
+    it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+
+      const liveSession = {
+        sessionId: 'live-only-session',
+        cwd: '/workspace',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        title: 'Live session title from first prompt',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]).toMatchObject({
+        sessionId: 'live-only-session',
+        cwd: '/workspace',
+        title: 'Live session title from first prompt',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+      });
+    });
+
+    it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'merged-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Durable title from disk' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'merged-session',
+        cwd: '/workspace',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        title: 'Live title that should be overridden',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Durable title wins over live title.
+      expect(result.sessions[0].title).toBe('Durable title from disk');
+    });
+
+    it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'freshness-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Some title' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'freshness-session',
+        cwd: '/workspace',
+        // Live updatedAt is newer than the durable file mtime.
+        updatedAt: '2099-01-01T00:00:00.000Z',
+        title: 'Live title',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // updatedAt should be the live (newer) value.
+      expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
+    });
+  });
+  describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
+    // The durable path (SessionDiscovery.readFirstUserMessage →
+    // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
+    // NO newline collapse. The live path (deriveSessionTitle) must match exactly
+    // so the on-disk listing title and the session_info_update title agree.
+    const cases: Array<{ name: string; text: string }> = [
+      { name: 'multiline', text: 'line one\nline two\nline three' },
+      { name: 'leading/trailing whitespace', text: '  padded title  ' },
+      { name: 'tabs', text: 'col1\tcol2' },
+      { name: 'multiple text blocks', text: 'part1part2' },
+    ];
+
+    for (const { name, text } of cases) {
+      it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
+        const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+        roots.push(root);
+        const chatsDir = join(root, 'chats');
+        await mkdir(chatsDir);
+        const service = new SessionRecordingService({
+          sessionId: 'consistency-session',
+          projectHash: 'project-hash',
+          chatsDir,
+          workspaceDirs: ['/workspace'],
+          cwd: '/workspace',
+          provider: 'openai',
+          model: 'test-model',
+        });
+        const content: IContent = {
+          speaker: 'human',
+          blocks:
+            name === 'multiple text blocks'
+              ? [
+                  { type: 'text', text: 'part1' },
+                  { type: 'text', text: 'part2' },
+                ]
+              : [{ type: 'text', text }],
+        };
+        service.recordContent(content);
+        await service.flush();
+        await service.dispose();
+
+        const result = await listRecordedSessions(
+          chatsDir,
+          'project-hash',
+          '/fallback',
+          {},
+        );
+        const durableTitle = result.sessions[0].title;
+
+        const liveTitle = deriveSessionTitle(
+          name === 'multiple text blocks'
+            ? [
+                { type: 'text', text: 'part1' },
+                { type: 'text', text: 'part2' },
+              ]
+            : [{ type: 'text', text }],
+        );
+
+        expect(durableTitle).toBe(liveTitle);
+      });
+    }
   });
 
-  it('uses the session_metadata title when present', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'metadata-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
+  describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
+    it('uses the session_metadata title when present', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'metadata-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // Record a metadata title BEFORE the content event.
+      service.recordSessionMetadata('Metadata title from ACP');
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Different first human text' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // The session_metadata title wins over the first-human-text fallback.
+      expect(result.sessions[0].title).toBe('Metadata title from ACP');
     });
-    // Record a metadata title BEFORE the content event.
-    service.recordSessionMetadata('Metadata title from ACP');
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Different first human text' }],
+
+    it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'legacy-metadata-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // No recordSessionMetadata — legacy behavior.
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Legacy first human text' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Falls back to first-human-text for legacy sessions.
+      expect(result.sessions[0].title).toBe('Legacy first human text');
     });
-    await service.flush();
-    await service.dispose();
 
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
+    it('omits title when session_metadata is explicit null (untitled)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'untitled-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // Explicit null title.
+      service.recordSessionMetadata(null);
+      service.recordContent({
+        speaker: 'human',
+        blocks: [
+          { type: 'text', text: 'Human text that should NOT be the title' },
+        ],
+      });
+      await service.flush();
+      await service.dispose();
 
-    expect(result.sessions).toHaveLength(1);
-    // The session_metadata title wins over the first-human-text fallback.
-    expect(result.sessions[0].title).toBe('Metadata title from ACP');
-  });
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
 
-  it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'legacy-metadata-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
+      expect(result.sessions).toHaveLength(1);
+      // Explicit null → no title surfaced (consistent with legacy no-human-text).
+      expect(result.sessions[0]).not.toHaveProperty('title');
     });
-    // No recordSessionMetadata — legacy behavior.
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Legacy first human text' }],
+
+    it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'created-at-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordSessionMetadata('Title');
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      const updatedAt = result.sessions[0].updatedAt;
+      expect(updatedAt).toBeDefined();
+      expect(new Date(updatedAt ?? '').toISOString()).toBe(updatedAt);
     });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Falls back to first-human-text for legacy sessions.
-    expect(result.sessions[0].title).toBe('Legacy first human text');
-  });
-
-  it('omits title when session_metadata is explicit null (untitled)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'untitled-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    // Explicit null title.
-    service.recordSessionMetadata(null);
-    service.recordContent({
-      speaker: 'human',
-      blocks: [
-        { type: 'text', text: 'Human text that should NOT be the title' },
-      ],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Explicit null → no title surfaced (consistent with legacy no-human-text).
-    expect(result.sessions[0]).not.toHaveProperty('title');
-  });
-
-  it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'created-at-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordSessionMetadata('Title');
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -260,6 +260,16 @@ describe('recorded ACP session listing', () => {
     // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
     // NO newline collapse. The live path (deriveSessionTitle) must match exactly
     // so the on-disk listing title and the session_info_update title agree.
+
+    function buildBlocks(name: string, text: string) {
+      return name === 'multiple text blocks'
+        ? [
+            { type: 'text' as const, text: 'part1' },
+            { type: 'text' as const, text: 'part2' },
+          ]
+        : [{ type: 'text' as const, text }];
+    }
+
     const cases: Array<{ name: string; text: string }> = [
       { name: 'multiline', text: 'line one\nline two\nline three' },
       { name: 'leading/trailing whitespace', text: '  padded title  ' },
@@ -283,15 +293,10 @@ describe('recorded ACP session listing', () => {
           provider: 'openai',
           model: 'test-model',
         });
+        const blocks = buildBlocks(name, text);
         const content: IContent = {
           speaker: 'human',
-          blocks:
-            name === 'multiple text blocks'
-              ? [
-                  { type: 'text', text: 'part1' },
-                  { type: 'text', text: 'part2' },
-                ]
-              : [{ type: 'text', text }],
+          blocks,
         };
         service.recordContent(content);
         await service.flush();
@@ -305,14 +310,7 @@ describe('recorded ACP session listing', () => {
         );
         const durableTitle = result.sessions[0].title;
 
-        const liveTitle = deriveSessionTitle(
-          name === 'multiple text blocks'
-            ? [
-                { type: 'text', text: 'part1' },
-                { type: 'text', text: 'part2' },
-              ]
-            : [{ type: 'text', text }],
-        );
+        const liveTitle = deriveSessionTitle(blocks);
 
         expect(durableTitle).toBe(liveTitle);
       });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  SessionRecordingService,
+  type IContent,
+} from '@vybestack/llxprt-code-core';
+import { listRecordedSessions } from './zed-session-listing.js';
+
+const roots: string[] = [];
+
+describe('recorded ACP session listing', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+  it('returns persisted cwd, first human text title, and updated timestamp', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'listed-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    const content: IContent = {
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
+    };
+    service.recordContent(content);
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'listed-session',
+      cwd: '/workspace',
+      title: 'Investigate session lifecycle',
+    });
+    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'legacy-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: [],
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'agent-only content' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions[0].cwd).toBe('/fallback');
+    expect(result.sessions[0]).not.toHaveProperty('title');
+    expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -390,7 +390,7 @@ describe('session_metadata title takes precedence over legacy first-human-text (
     expect(result.sessions[0]).not.toHaveProperty('title');
   });
 
-  it('includes createdAt in the listing for immutable ordering (issue #1611)', async () => {
+  it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
     const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
     roots.push(root);
     const chatsDir = join(root, 'chats');

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -209,6 +209,51 @@ describe('recorded ACP session listing', () => {
       // updatedAt should be the live (newer) value.
       expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
     });
+
+    it('preserves the durable updatedAt when it is newer than the live value', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'durable-newer-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Some title' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'durable-newer-session',
+        cwd: '/workspace',
+        // Live updatedAt is older than the durable file mtime.
+        updatedAt: '2000-01-01T00:00:00.000Z',
+        title: 'Live title',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Durable mtime is newer than the live value, so it should be preserved.
+      expect(result.sessions[0].updatedAt).not.toBe('2000-01-01T00:00:00.000Z');
+      expect(new Date(result.sessions[0].updatedAt!).getTime()).toBeGreaterThan(
+        new Date('2000-01-01T00:00:00.000Z').getTime(),
+      );
+    });
   });
   describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
     // The durable path (SessionDiscovery.readFirstUserMessage →
@@ -220,6 +265,7 @@ describe('recorded ACP session listing', () => {
       { name: 'leading/trailing whitespace', text: '  padded title  ' },
       { name: 'tabs', text: 'col1\tcol2' },
       { name: 'multiple text blocks', text: 'part1part2' },
+      { name: 'truncation (>120 chars)', text: 'z'.repeat(200) },
     ];
 
     for (const { name, text } of cases) {

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -51,6 +51,11 @@ export async function listRecordedSessions(
     }
     return {
       ...live,
+      // createdAt is immutable — durable recording wins (live sessions may not
+      // have it until the session_start is persisted). Issue #1611.
+      ...(durable.createdAt !== undefined
+        ? { createdAt: durable.createdAt }
+        : {}),
       updatedAt:
         durable.updatedAt > live.updatedAt ? durable.updatedAt : live.updatedAt,
       ...(durable.title === undefined ? {} : { title: durable.title }),
@@ -58,16 +63,33 @@ export async function listRecordedSessions(
   }
 }
 
+/**
+ * Resolves the tri-state title for a durable session.
+ *
+ * Issue #1611: a persisted `session_metadata` event is the source of truth.
+ * For legacy files without one (title === undefined), fall back to the first
+ * human message (which returns null for no-human-text sessions, omitted from
+ * the output). A null metadata title (explicit untitled) is preserved.
+ */
 async function toLifecycleSession(
   summary: SessionSummary,
   fallbackCwd: string,
 ): Promise<LifecycleSession> {
-  const title = await SessionDiscovery.readFirstUserMessage(summary.filePath);
+  const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
+    summary.filePath,
+  );
+  const resolvedTitle =
+    metadataTitle === undefined
+      ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
+      : metadataTitle;
   return {
     sessionId: summary.sessionId,
     cwd: summary.cwd ?? fallbackCwd,
     updatedAt: summary.lastModified.toISOString(),
-    ...(title === null ? {} : { title }),
+    ...(summary.createdAt !== undefined
+      ? { createdAt: summary.createdAt }
+      : {}),
+    ...(typeof resolvedTitle === 'string' ? { title: resolvedTitle } : {}),
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -69,7 +69,8 @@ export async function listRecordedSessions(
  * Issue #1611: a persisted `session_metadata` event is the source of truth.
  * For legacy files without one (title === undefined), fall back to the first
  * human message (which returns null for no-human-text sessions, omitted from
- * the output). A null metadata title (explicit untitled) is preserved.
+ * the output). A null metadata title remains explicitly untitled by suppressing
+ * that legacy fallback and omitting the ACP title property.
  */
 async function toLifecycleSession(
   summary: SessionSummary,
@@ -78,7 +79,7 @@ async function toLifecycleSession(
   const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
     summary.filePath,
   );
-  const resolvedTitle =
+  const displayTitle =
     metadataTitle === undefined
       ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
       : metadataTitle;
@@ -89,7 +90,7 @@ async function toLifecycleSession(
     ...(summary.createdAt !== undefined
       ? { createdAt: summary.createdAt }
       : {}),
-    ...(typeof resolvedTitle === 'string' ? { title: resolvedTitle } : {}),
+    ...(typeof displayTitle === 'string' ? { title: displayTitle } : {}),
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SessionSummary } from '@vybestack/llxprt-code-core';
+import { SessionDiscovery } from '@vybestack/llxprt-code-core';
+import type * as acp from '@agentclientprotocol/sdk';
+import {
+  paginateSessions,
+  type LifecycleSession,
+} from './zed-session-pagination.js';
+
+const SESSION_PAGE_SIZE = 50;
+
+export async function listRecordedSessions(
+  chatsDir: string,
+  projectHash: string,
+  fallbackCwd: string,
+  request: acp.ListSessionsRequest,
+  liveSessions: readonly LifecycleSession[] = [],
+): Promise<acp.ListSessionsResponse> {
+  const summaries = await SessionDiscovery.listSessions(chatsDir, projectHash);
+  const records = await Promise.all(
+    summaries.map((summary) => toLifecycleSession(summary, fallbackCwd)),
+  );
+  const merged = new Map(
+    records.map((session) => [session.sessionId, session] as const),
+  );
+  for (const session of liveSessions) {
+    const durable = merged.get(session.sessionId);
+    merged.set(session.sessionId, mergeLifecycleSession(durable, session));
+  }
+  const page = paginateSessions(
+    [...merged.values()],
+    { cwd: request.cwd ?? null, cursor: request.cursor ?? null },
+    SESSION_PAGE_SIZE,
+  );
+  return {
+    sessions: page.sessions.map(toSessionInfo),
+    ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+  };
+
+  function mergeLifecycleSession(
+    durable: LifecycleSession | undefined,
+    live: LifecycleSession,
+  ): LifecycleSession {
+    if (durable === undefined) {
+      return live;
+    }
+    return {
+      ...live,
+      updatedAt:
+        durable.updatedAt > live.updatedAt ? durable.updatedAt : live.updatedAt,
+      ...(durable.title === undefined ? {} : { title: durable.title }),
+    };
+  }
+}
+
+async function toLifecycleSession(
+  summary: SessionSummary,
+  fallbackCwd: string,
+): Promise<LifecycleSession> {
+  const title = await SessionDiscovery.readFirstUserMessage(summary.filePath);
+  return {
+    sessionId: summary.sessionId,
+    cwd: summary.cwd ?? fallbackCwd,
+    updatedAt: summary.lastModified.toISOString(),
+    ...(title === null ? {} : { title }),
+  };
+}
+
+function toSessionInfo(session: LifecycleSession): acp.SessionInfo {
+  return {
+    sessionId: session.sessionId,
+    cwd: session.cwd,
+    updatedAt: session.updatedAt,
+    ...(session.title === undefined ? {} : { title: session.title }),
+  };
+}

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -76,12 +76,14 @@ async function toLifecycleSession(
   summary: SessionSummary,
   fallbackCwd: string,
 ): Promise<LifecycleSession> {
-  const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
-    summary.filePath,
+  const metadataTitle = await readTitleSafe(() =>
+    SessionDiscovery.readSessionMetadataTitle(summary.filePath),
   );
   const displayTitle =
     metadataTitle === undefined
-      ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
+      ? await readTitleSafe(() =>
+          SessionDiscovery.readFirstUserMessage(summary.filePath),
+        )
       : metadataTitle;
   return {
     sessionId: summary.sessionId,
@@ -92,6 +94,16 @@ async function toLifecycleSession(
       : {}),
     ...(typeof displayTitle === 'string' ? { title: displayTitle } : {}),
   };
+}
+
+async function readTitleSafe(
+  read: () => Promise<string | null | undefined>,
+): Promise<string | null | undefined> {
+  try {
+    return await read();
+  } catch {
+    return undefined;
+  }
 }
 
 function toSessionInfo(session: LifecycleSession): acp.SessionInfo {

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -5,7 +5,7 @@
  */
 
 import type { SessionSummary } from '@vybestack/llxprt-code-core';
-import { SessionDiscovery } from '@vybestack/llxprt-code-core';
+import { SessionDiscovery, DebugLogger } from '@vybestack/llxprt-code-core';
 import type * as acp from '@agentclientprotocol/sdk';
 import {
   paginateSessions,
@@ -13,6 +13,8 @@ import {
 } from './zed-session-pagination.js';
 
 const SESSION_PAGE_SIZE = 50;
+
+const logger = new DebugLogger('llxprt:zed-integration:session-listing');
 
 export async function listRecordedSessions(
   chatsDir: string,
@@ -101,7 +103,8 @@ async function readTitleSafe(
 ): Promise<string | null | undefined> {
   try {
     return await read();
-  } catch {
+  } catch (error) {
+    logger.debug(() => `Title resolution failed: ${String(error)}`);
     return undefined;
   }
 }

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -180,4 +180,20 @@ describe('session lifecycle pagination', () => {
       'c',
     ]);
   });
+
+  it('returns empty sessions with no nextCursor for an empty list', () => {
+    const result = paginateSessions([], { cwd: null, cursor: null }, 10);
+    expect(result.sessions).toStrictEqual([]);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('returns no nextCursor when results fit exactly within pageSize', () => {
+    const exact: LifecycleSession[] = [
+      { sessionId: 'x', cwd: '/w', updatedAt: '2026-01-02T00:00:00.000Z' },
+      { sessionId: 'y', cwd: '/w', updatedAt: '2026-01-01T00:00:00.000Z' },
+    ];
+    const result = paginateSessions(exact, { cwd: null, cursor: null }, 2);
+    expect(result.sessions.map((s) => s.sessionId)).toStrictEqual(['x', 'y']);
+    expect(result.nextCursor).toBeUndefined();
+  });
 });

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -78,8 +78,8 @@ describe('session lifecycle pagination', () => {
   });
 
   it('updatedAt changes cannot omit sessions: immutable createdAt ordering (issue #1611)', () => {
-    // Two sessions with the SAME createdAt but different updatedAt (simulating
-    // a session that was updated mid-pagination). Ordering must be stable by
+    // Two sessions with different createdAt and updatedAt values. Ordering must
+    // remain stable when a session is updated mid-pagination because it uses
     // createdAt + sessionId, so the cursor is not invalidated.
     const stable: LifecycleSession[] = [
       {

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  paginateSessions,
+  type LifecycleSession,
+} from './zed-session-pagination.js';
+
+const sessions: readonly LifecycleSession[] = [
+  { sessionId: 'b', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
+  { sessionId: 'a', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
+  { sessionId: 'c', cwd: '/b', updatedAt: '2026-01-02T00:00:00.000Z' },
+];
+
+describe('session lifecycle pagination', () => {
+  it('orders by updatedAt then sessionId descending and continues with an opaque cursor', () => {
+    const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
+    expect(first.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'b',
+      'a',
+    ]);
+    expect(first.nextCursor).toStrictEqual(expect.any(String));
+
+    const second = paginateSessions(
+      sessions,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      2,
+    );
+    expect(second).toStrictEqual({ sessions: [sessions[2]] });
+  });
+
+  it('filters by exact cwd before pagination', () => {
+    const result = paginateSessions(sessions, { cwd: '/a', cursor: null }, 10);
+    expect(result.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'b',
+      'a',
+    ]);
+  });
+
+  it('rejects a malformed cursor', () => {
+    expect(() =>
+      paginateSessions(sessions, { cwd: null, cursor: 'not-a-cursor' }, 2),
+    ).toThrow(/cursor/i);
+  });
+
+  it('rejects a cursor created for a different cwd filter', () => {
+    const first = paginateSessions(sessions, { cwd: '/a', cursor: null }, 1);
+    expect(() =>
+      paginateSessions(
+        sessions,
+        { cwd: '/b', cursor: first.nextCursor ?? null },
+        1,
+      ),
+    ).toThrow(/cursor/i);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -142,6 +142,24 @@ describe('session lifecycle pagination', () => {
     ]);
   });
 
+  it('continues a legacy page when updatedAt is valid but not canonical', () => {
+    const legacy: LifecycleSession[] = [
+      { sessionId: 'new', cwd: '/w', updatedAt: '2026-06-01T00:00:00Z' },
+      { sessionId: 'old', cwd: '/w', updatedAt: '2026-01-01T00:00:00Z' },
+    ];
+    const first = paginateSessions(legacy, { cwd: null, cursor: null }, 1);
+
+    const second = paginateSessions(
+      legacy,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      1,
+    );
+
+    expect(second.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'old',
+    ]);
+  });
+
   it('rejects a legacy v1 cursor (version mismatch)', () => {
     const v1Cursor = Buffer.from(
       JSON.stringify({

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -10,14 +10,33 @@ import {
   type LifecycleSession,
 } from './zed-session-pagination.js';
 
+/**
+ * Issue #1611: pagination now orders by immutable createdAt + sessionId
+ * (not updatedAt, which can change and cause session omission).
+ */
 const sessions: readonly LifecycleSession[] = [
-  { sessionId: 'b', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
-  { sessionId: 'a', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
-  { sessionId: 'c', cwd: '/b', updatedAt: '2026-01-02T00:00:00.000Z' },
+  {
+    sessionId: 'b',
+    cwd: '/a',
+    updatedAt: '2026-01-03T00:00:00.000Z',
+    createdAt: '2026-01-03T00:00:00.000Z',
+  },
+  {
+    sessionId: 'a',
+    cwd: '/a',
+    updatedAt: '2026-01-03T00:00:00.000Z',
+    createdAt: '2026-01-03T00:00:00.000Z',
+  },
+  {
+    sessionId: 'c',
+    cwd: '/b',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    createdAt: '2026-01-02T00:00:00.000Z',
+  },
 ];
 
 describe('session lifecycle pagination', () => {
-  it('orders by updatedAt then sessionId descending and continues with an opaque cursor', () => {
+  it('orders by createdAt then sessionId descending and continues with an opaque cursor', () => {
     const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
     expect(first.sessions.map((session) => session.sessionId)).toStrictEqual([
       'b',
@@ -55,6 +74,85 @@ describe('session lifecycle pagination', () => {
         { cwd: '/b', cursor: first.nextCursor ?? null },
         1,
       ),
+    ).toThrow(/cursor/i);
+  });
+
+  it('updatedAt changes cannot omit sessions: immutable createdAt ordering (issue #1611)', () => {
+    // Two sessions with the SAME createdAt but different updatedAt (simulating
+    // a session that was updated mid-pagination). Ordering must be stable by
+    // createdAt + sessionId, so the cursor is not invalidated.
+    const stable: LifecycleSession[] = [
+      {
+        sessionId: 'x',
+        cwd: '/w',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        createdAt: '2026-07-10T10:00:00.000Z',
+      },
+      {
+        sessionId: 'y',
+        cwd: '/w',
+        updatedAt: '2026-07-12T13:00:00.000Z',
+        createdAt: '2026-07-10T09:00:00.000Z',
+      },
+    ];
+    const first = paginateSessions(stable, { cwd: null, cursor: null }, 1);
+    expect(first.sessions[0].sessionId).toBe('x');
+
+    // Simulate the "updatedAt changed between pages" scenario:
+    // After page 1, the first session's updatedAt changes — but createdAt
+    // is immutable, so the cursor still correctly filters.
+    const firstAfterMutation: LifecycleSession = {
+      ...stable[0],
+      updatedAt: '2026-07-12T23:59:59.000Z',
+    };
+    const secondSet = [firstAfterMutation, stable[1]];
+    const second = paginateSessions(
+      secondSet,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      10,
+    );
+    expect(second.sessions.map((s) => s.sessionId)).toStrictEqual(['y']);
+  });
+
+  it('v2 cursor is self-contained and process-independent (issue #1611)', () => {
+    // The cursor encodes the full (createdAt, sessionId) tuple so the next
+    // page can be computed without shared state.
+    const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
+    expect(first.nextCursor).toStrictEqual(expect.any(String));
+
+    // Decode the cursor to verify it's self-contained.
+    const decoded = JSON.parse(
+      Buffer.from(first.nextCursor!, 'base64url').toString('utf8'),
+    );
+    expect(decoded.v).toBe(2);
+    expect(decoded.createdAt).toBeDefined();
+    expect(decoded.sessionId).toBe('a');
+    expect(decoded.cwd).toBeNull();
+  });
+
+  it('falls back to updatedAt when createdAt is absent (legacy)', () => {
+    const legacy: LifecycleSession[] = [
+      { sessionId: 'old', cwd: '/w', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { sessionId: 'new', cwd: '/w', updatedAt: '2026-06-01T00:00:00.000Z' },
+    ];
+    const result = paginateSessions(legacy, { cwd: null, cursor: null }, 10);
+    expect(result.sessions.map((s) => s.sessionId)).toStrictEqual([
+      'new',
+      'old',
+    ]);
+  });
+
+  it('rejects a legacy v1 cursor (version mismatch)', () => {
+    const v1Cursor = Buffer.from(
+      JSON.stringify({
+        version: 1,
+        cwd: null,
+        updatedAt: '2026-01-03T00:00:00.000Z',
+        sessionId: 'b',
+      }),
+    ).toString('base64url');
+    expect(() =>
+      paginateSessions(sessions, { cwd: null, cursor: v1Cursor }, 2),
     ).toThrow(/cursor/i);
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -160,7 +160,7 @@ describe('session lifecycle pagination', () => {
     ]);
   });
 
-  it('rejects a legacy v1 cursor (version mismatch)', () => {
+  it('continues from a legacy v1 cursor using its updatedAt boundary', () => {
     const v1Cursor = Buffer.from(
       JSON.stringify({
         version: 1,
@@ -169,8 +169,15 @@ describe('session lifecycle pagination', () => {
         sessionId: 'b',
       }),
     ).toString('base64url');
-    expect(() =>
-      paginateSessions(sessions, { cwd: null, cursor: v1Cursor }, 2),
-    ).toThrow(/cursor/i);
+    const result = paginateSessions(
+      sessions,
+      { cwd: null, cursor: v1Cursor },
+      2,
+    );
+
+    expect(result.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'a',
+      'c',
+    ]);
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -85,9 +85,9 @@ export function paginateSessions(
  */
 function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
   return compareByCreatedAtAndId(
-    a.createdAt ?? a.updatedAt,
+    getCreatedAt(a),
     a.sessionId,
-    b.createdAt ?? b.updatedAt,
+    getCreatedAt(b),
     b.sessionId,
   );
 }
@@ -97,7 +97,7 @@ function compareWithCursor(
   cursor: CursorPayload,
 ): number {
   return compareByCreatedAtAndId(
-    session.createdAt ?? session.updatedAt,
+    getCreatedAt(session),
     session.sessionId,
     cursor.createdAt,
     cursor.sessionId,
@@ -121,11 +121,17 @@ function compareDescending(a: string, b: string): number {
   return a > b ? -1 : 1;
 }
 
+function getCreatedAt(session: LifecycleSession): string {
+  const value = session.createdAt ?? session.updatedAt;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : value;
+}
+
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
   const payload: CursorPayload = {
     v: 2,
     cwd,
-    createdAt: session.createdAt ?? session.updatedAt,
+    createdAt: getCreatedAt(session),
     sessionId: session.sessionId,
   };
   return Buffer.from(JSON.stringify(payload)).toString('base64url');

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -33,6 +33,13 @@ interface CursorPayload {
   readonly sessionId: string;
 }
 
+interface LegacyCursorPayload {
+  readonly version: 1;
+  readonly cwd: string | null;
+  readonly updatedAt: string;
+  readonly sessionId: string;
+}
+
 interface PaginationRequest {
   readonly cwd: string | null;
   readonly cursor: string | null;
@@ -148,10 +155,11 @@ function decodeCursor(
     const value: unknown = JSON.parse(
       Buffer.from(cursor, 'base64url').toString('utf8'),
     );
-    if (!isCursorPayload(value) || value.cwd !== cwd) {
+    const decoded = normalizeCursorPayload(value);
+    if (decoded === null || decoded.cwd !== cwd) {
       throw new Error('cursor does not match this request');
     }
-    return value;
+    return decoded;
   } catch (error) {
     const detail = error instanceof Error ? error.message : 'invalid encoding';
     throw acp.RequestError.invalidParams(
@@ -161,20 +169,51 @@ function decodeCursor(
   }
 }
 
+function normalizeCursorPayload(value: unknown): CursorPayload | null {
+  if (isCursorPayload(value)) {
+    return value;
+  }
+  if (!isLegacyCursorPayload(value)) {
+    return null;
+  }
+  return {
+    v: 2,
+    cwd: value.cwd,
+    createdAt: new Date(Date.parse(value.updatedAt)).toISOString(),
+    sessionId: value.sessionId,
+  };
+}
+
 function isCursorPayload(value: unknown): value is CursorPayload {
   if (value === null || typeof value !== 'object') {
     return false;
   }
   const record = value as Record<string, unknown>;
+  return (
+    record.v === 2 &&
+    hasValidCursorIdentity(record) &&
+    isCanonicalTimestamp(record.createdAt)
+  );
+}
+
+function isLegacyCursorPayload(value: unknown): value is LegacyCursorPayload {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.version === 1 &&
+    hasValidCursorIdentity(record) &&
+    typeof record.updatedAt === 'string' &&
+    Number.isFinite(Date.parse(record.updatedAt))
+  );
+}
+
+function hasValidCursorIdentity(record: Record<string, unknown>): boolean {
   const hasValidCwd = record.cwd === null || typeof record.cwd === 'string';
   const hasValidSessionId =
     typeof record.sessionId === 'string' && record.sessionId.length > 0;
-  return (
-    record.v === 2 &&
-    hasValidCwd &&
-    isCanonicalTimestamp(record.createdAt) &&
-    hasValidSessionId
-  );
+  return hasValidCwd && hasValidSessionId;
 }
 
 function isCanonicalTimestamp(value: unknown): value is string {

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -11,12 +11,25 @@ export interface LifecycleSession {
   readonly cwd: string;
   readonly updatedAt: string;
   readonly title?: string;
+  /**
+   * Immutable creation timestamp used for stable ordering (issue #1611).
+   * Falls back to updatedAt for legacy sessions without a persisted createdAt.
+   */
+  readonly createdAt?: string;
 }
 
+/**
+ * Self-contained, process-independent snapshot cursor (issue #1611).
+ *
+ * The cursor encodes the full (createdAt, sessionId) tuple of the last item on
+ * the previous page so the next page can be computed from the cursor alone,
+ * without any shared in-process state. The `v` field distinguishes v1 (legacy
+ * updatedAt-based, unstable) from v2 (createdAt-based, immutable).
+ */
 interface CursorPayload {
-  readonly version: 1;
+  readonly v: 2;
   readonly cwd: string | null;
-  readonly updatedAt: string;
+  readonly createdAt: string;
   readonly sessionId: string;
 }
 
@@ -60,11 +73,21 @@ export function paginateSessions(
   return { sessions: page, nextCursor: encodeCursor(last, request.cwd) };
 }
 
+/**
+ * Orders sessions by createdAt DESC then sessionId DESC.
+ *
+ * createdAt is the immutable session_start timestamp — it never changes when
+ * a session is updated (issue #1611). Falls back to updatedAt when createdAt
+ * is absent (legacy sessions recorded before this change) so they still sort
+ * deterministically. Using updatedAt as a fallback is acceptable because legacy
+ * sessions are static (no new writes), so their updatedAt is effectively
+ * immutable too.
+ */
 function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
-  return compareByUpdatedAtAndId(
-    a.updatedAt,
+  return compareByCreatedAtAndId(
+    a.createdAt ?? a.updatedAt,
     a.sessionId,
-    b.updatedAt,
+    b.createdAt ?? b.updatedAt,
     b.sessionId,
   );
 }
@@ -73,21 +96,21 @@ function compareWithCursor(
   session: LifecycleSession,
   cursor: CursorPayload,
 ): number {
-  return compareByUpdatedAtAndId(
-    session.updatedAt,
+  return compareByCreatedAtAndId(
+    session.createdAt ?? session.updatedAt,
     session.sessionId,
-    cursor.updatedAt,
+    cursor.createdAt,
     cursor.sessionId,
   );
 }
 
-function compareByUpdatedAtAndId(
-  aUpdatedAt: string,
+function compareByCreatedAtAndId(
+  aCreatedAt: string,
   aId: string,
-  bUpdatedAt: string,
+  bCreatedAt: string,
   bId: string,
 ): number {
-  const timestamp = compareDescending(aUpdatedAt, bUpdatedAt);
+  const timestamp = compareDescending(aCreatedAt, bCreatedAt);
   return timestamp === 0 ? compareDescending(aId, bId) : timestamp;
 }
 
@@ -100,9 +123,9 @@ function compareDescending(a: string, b: string): number {
 
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
   const payload: CursorPayload = {
-    version: 1,
+    v: 2,
     cwd,
-    updatedAt: session.updatedAt,
+    createdAt: session.createdAt ?? session.updatedAt,
     sessionId: session.sessionId,
   };
   return Buffer.from(JSON.stringify(payload)).toString('base64url');
@@ -138,10 +161,22 @@ function isCursorPayload(value: unknown): value is CursorPayload {
   }
   const record = value as Record<string, unknown>;
   const hasValidCwd = record.cwd === null || typeof record.cwd === 'string';
+  const hasValidSessionId =
+    typeof record.sessionId === 'string' && record.sessionId.length > 0;
   return (
-    record.version === 1 &&
+    record.v === 2 &&
     hasValidCwd &&
-    typeof record.updatedAt === 'string' &&
-    typeof record.sessionId === 'string'
+    isCanonicalTimestamp(record.createdAt) &&
+    hasValidSessionId
+  );
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false;
+  }
+  const timestamp = Date.parse(value);
+  return (
+    Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value
   );
 }

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+
+export interface LifecycleSession {
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly updatedAt: string;
+  readonly title?: string;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly cwd: string | null;
+  readonly updatedAt: string;
+  readonly sessionId: string;
+}
+
+interface PaginationRequest {
+  readonly cwd: string | null;
+  readonly cursor: string | null;
+}
+
+interface PaginationResult {
+  readonly sessions: readonly LifecycleSession[];
+  readonly nextCursor?: string;
+}
+
+export function paginateSessions(
+  sessions: readonly LifecycleSession[],
+  request: PaginationRequest,
+  pageSize: number,
+): PaginationResult {
+  if (!Number.isInteger(pageSize) || pageSize <= 0) {
+    throw acp.RequestError.invalidParams(
+      { pageSize },
+      'pageSize must be a positive integer',
+    );
+  }
+  const cursor = decodeCursor(request.cursor, request.cwd);
+  const ordered = [...sessions]
+    .filter((session) => request.cwd === null || session.cwd === request.cwd)
+    .sort(compareSessions);
+  const remaining =
+    cursor === null
+      ? ordered
+      : ordered.filter((session) => compareWithCursor(session, cursor) > 0);
+  const page = remaining.slice(0, pageSize);
+  if (remaining.length <= pageSize) {
+    return { sessions: page };
+  }
+  const last = page.at(-1);
+  if (last === undefined) {
+    return { sessions: page };
+  }
+  return { sessions: page, nextCursor: encodeCursor(last, request.cwd) };
+}
+
+function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
+  return compareByUpdatedAtAndId(
+    a.updatedAt,
+    a.sessionId,
+    b.updatedAt,
+    b.sessionId,
+  );
+}
+
+function compareWithCursor(
+  session: LifecycleSession,
+  cursor: CursorPayload,
+): number {
+  return compareByUpdatedAtAndId(
+    session.updatedAt,
+    session.sessionId,
+    cursor.updatedAt,
+    cursor.sessionId,
+  );
+}
+
+function compareByUpdatedAtAndId(
+  aUpdatedAt: string,
+  aId: string,
+  bUpdatedAt: string,
+  bId: string,
+): number {
+  const timestamp = compareDescending(aUpdatedAt, bUpdatedAt);
+  return timestamp === 0 ? compareDescending(aId, bId) : timestamp;
+}
+
+function compareDescending(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  return a > b ? -1 : 1;
+}
+
+function encodeCursor(session: LifecycleSession, cwd: string | null): string {
+  const payload: CursorPayload = {
+    version: 1,
+    cwd,
+    updatedAt: session.updatedAt,
+    sessionId: session.sessionId,
+  };
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+function decodeCursor(
+  cursor: string | null,
+  cwd: string | null,
+): CursorPayload | null {
+  if (cursor === null) {
+    return null;
+  }
+  try {
+    const value: unknown = JSON.parse(
+      Buffer.from(cursor, 'base64url').toString('utf8'),
+    );
+    if (!isCursorPayload(value) || value.cwd !== cwd) {
+      throw new Error('cursor does not match this request');
+    }
+    return value;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'invalid encoding';
+    throw acp.RequestError.invalidParams(
+      { cursor },
+      `Invalid session cursor: ${detail}`,
+    );
+  }
+}
+
+function isCursorPayload(value: unknown): value is CursorPayload {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  const hasValidCwd = record.cwd === null || typeof record.cwd === 'string';
+  return (
+    record.version === 1 &&
+    hasValidCwd &&
+    typeof record.updatedAt === 'string' &&
+    typeof record.sessionId === 'string'
+  );
+}

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -131,7 +131,13 @@ function compareDescending(a: string, b: string): number {
 function getCreatedAt(session: LifecycleSession): string {
   const value = session.createdAt ?? session.updatedAt;
   const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : value;
+  if (Number.isFinite(timestamp)) {
+    return new Date(timestamp).toISOString();
+  }
+  // Invalid or non-standard timestamp (corrupted/legacy data). Fall back to
+  // the epoch sentinel so sort order is deterministic and cursor encoding
+  // never embeds an invalid value that would break decode (issue #1611).
+  return new Date(0).toISOString();
 }
 
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
@@ -151,22 +157,26 @@ function decodeCursor(
   if (cursor === null) {
     return null;
   }
+  let detail: string;
   try {
     const value: unknown = JSON.parse(
       Buffer.from(cursor, 'base64url').toString('utf8'),
     );
     const decoded = normalizeCursorPayload(value);
-    if (decoded === null || decoded.cwd !== cwd) {
-      throw new Error('cursor does not match this request');
+    if (decoded === null) {
+      throw new Error('malformed cursor payload');
+    }
+    if (decoded.cwd !== cwd) {
+      throw new Error('cursor cwd does not match request cwd');
     }
     return decoded;
   } catch (error) {
-    const detail = error instanceof Error ? error.message : 'invalid encoding';
-    throw acp.RequestError.invalidParams(
-      { cursor },
-      `Invalid session cursor: ${detail}`,
-    );
+    detail = error instanceof Error ? error.message : 'invalid encoding';
   }
+  throw acp.RequestError.invalidParams(
+    { cursor },
+    `Invalid session cursor: ${detail}`,
+  );
 }
 
 function normalizeCursorPayload(value: unknown): CursorPayload | null {

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -12,6 +12,10 @@ type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Manages ACP terminal lifecycle for a single Zed session.
  *
@@ -64,7 +68,9 @@ export class TerminalManager {
         sessionId: this.sessionId,
       });
     } catch (error) {
-      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      this.logger.debug(
+        () => `Failed to create ACP terminal: ${errorMessage(error)}`,
+      );
       return;
     }
     const existing = this.activeTerminals.get(call.id);
@@ -73,7 +79,9 @@ export class TerminalManager {
       try {
         await existing.release();
       } catch (error) {
-        this.logger.debug(() => `Prior terminal release failed: ${error}`);
+        this.logger.debug(
+          () => `Prior terminal release failed: ${errorMessage(error)}`,
+        );
       }
     }
     this.activeTerminals.set(call.id, handle);
@@ -89,9 +97,13 @@ export class TerminalManager {
       try {
         await handle.release();
       } catch (releaseError) {
-        this.logger.debug(() => `Terminal release failed: ${releaseError}`);
+        this.logger.debug(
+          () => `Terminal release failed: ${errorMessage(releaseError)}`,
+        );
       }
-      this.logger.debug(() => `Terminal update send failed: ${error}`);
+      this.logger.debug(
+        () => `Terminal update send failed: ${errorMessage(error)}`,
+      );
     }
   }
 
@@ -106,7 +118,9 @@ export class TerminalManager {
     try {
       await handle.release();
     } catch (error) {
-      this.logger.debug(() => `Terminal release failed: ${error}`);
+      this.logger.debug(
+        () => `Terminal release failed: ${errorMessage(error)}`,
+      );
     }
   }
 
@@ -122,12 +136,16 @@ export class TerminalManager {
         try {
           await handle.kill();
         } catch (error) {
-          this.logger.debug(() => `Terminal kill failed: ${error}`);
+          this.logger.debug(
+            () => `Terminal kill failed: ${errorMessage(error)}`,
+          );
         }
         try {
           await handle.release();
         } catch (error) {
-          this.logger.debug(() => `Terminal release failed: ${error}`);
+          this.logger.debug(
+            () => `Terminal release failed: ${errorMessage(error)}`,
+          );
         }
       }),
     );

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -211,6 +211,20 @@ export class TerminalManager {
       }
       previousOutput = current.output;
     }
+    // Final poll after exit settles so output produced between the last poll
+    // and process exit is never lost.
+    if (exit !== undefined) {
+      try {
+        const final = await active.handle.currentOutput();
+        const finalDelta = outputDelta(previousOutput, final.output);
+        if (finalDelta !== '') {
+          onOutput({ type: 'data', chunk: finalDelta });
+        }
+        previousOutput = final.output;
+      } catch {
+        // Swallow transient poll errors after exit.
+      }
+    }
     return {
       output: previousOutput,
       exitCode: exit?.exitCode ?? null,

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -8,11 +8,7 @@ import type * as acp from '@agentclientprotocol/sdk';
 import type { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
 
-interface PendingShellCall {
-  readonly toolCallId: string;
-  readonly command: string;
-  readonly cwd: string;
-}
+type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
 
@@ -21,13 +17,12 @@ type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
  *
  * When the client advertises the `terminal` capability, shell tool-calls
  * trigger terminal creation via `connection.createTerminal`.  Each terminal
- * is correlated to its tool-call (by command/cwd matching) so that terminal
- * content can be emitted inline and terminals are cleaned up on completion,
- * cancel, and dispose.
+ * is correlated to its tool-call by `toolCallId` so that terminal content can
+ * be emitted inline and terminals are cleaned up on completion, cancel, and
+ * dispose.
  */
 export class TerminalManager {
-  private readonly activeTerminals = new Map<string, acp.TerminalHandle>();
-  private readonly pendingShellCalls: PendingShellCall[] = [];
+  private readonly activeTerminals = new Map<string, TerminalHandleLike>();
 
   constructor(
     private readonly sessionId: string,
@@ -49,9 +44,9 @@ export class TerminalManager {
   }
 
   /**
-   * Records a pending shell tool-call and creates an ACP terminal for it.
-   * Emits an early terminal-content update so the client renders the terminal
-   * inline during execution.
+   * Creates an ACP terminal for a shell tool-call and immediately correlates
+   * it by `toolCallId`.  Emits a terminal-content update so the client renders
+   * the terminal inline during execution.
    */
   async handleToolCall(call: AgentToolCall): Promise<void> {
     const command =
@@ -61,7 +56,6 @@ export class TerminalManager {
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']
         : this.targetDir;
-    this.pendingShellCalls.push({ toolCallId: call.id, command, cwd });
     try {
       const handle = await this.connection.createTerminal({
         command,
@@ -69,32 +63,16 @@ export class TerminalManager {
         sessionId: this.sessionId,
         args: ['-c', command],
       });
-      await this.registerTerminal(command, cwd, handle);
+      this.activeTerminals.set(call.id, handle);
+      await this.sendUpdate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: call.id,
+        status: 'in_progress',
+        content: [{ type: 'terminal', terminalId: handle.id }],
+      });
     } catch (error) {
       this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
     }
-  }
-
-  /**
-   * Correlates a created terminal to its tool-call by matching command/cwd,
-   * records the handle, and emits the terminal-content update.
-   */
-  async registerTerminal(
-    command: string,
-    cwd: string,
-    handle: acp.TerminalHandle,
-  ): Promise<void> {
-    const match = this.pendingShellCalls.find(
-      (entry) => entry.command === command && entry.cwd === cwd,
-    );
-    if (match === undefined) return;
-    this.activeTerminals.set(match.toolCallId, handle);
-    await this.sendUpdate({
-      sessionUpdate: 'tool_call_update',
-      toolCallId: match.toolCallId,
-      status: 'in_progress',
-      content: [{ type: 'terminal', terminalId: handle.id }],
-    });
   }
 
   /**
@@ -105,10 +83,6 @@ export class TerminalManager {
     const handle = this.activeTerminals.get(toolCallId);
     if (handle === undefined) return;
     this.activeTerminals.delete(toolCallId);
-    const idx = this.pendingShellCalls.findIndex(
-      (entry) => entry.toolCallId === toolCallId,
-    );
-    if (idx >= 0) this.pendingShellCalls.splice(idx, 1);
     try {
       await handle.release();
     } catch (error) {

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -4,29 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as path from 'node:path';
 import type * as acp from '@agentclientprotocol/sdk';
 import type { DebugLogger } from '@vybestack/llxprt-code-core';
+import { getShellConfiguration } from '@vybestack/llxprt-code-core';
 import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
+import type {
+  ShellExecutionResult,
+  ShellOutputEvent,
+} from '@vybestack/llxprt-code-tools';
 
-type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
+const OUTPUT_POLL_INTERVAL_MS = 100;
+const APPROXIMATE_BYTES_PER_TOKEN = 4;
+const KILL_GRACE_PERIOD_MS = 5000;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+
+interface PendingShellCall {
+  readonly id: string;
+  readonly command: string;
+  readonly cwd: string;
+}
+
+interface ActiveTerminal {
+  readonly handle: acp.TerminalHandle;
+  readonly command: string;
+  readonly cwd: string;
+  toolCallId: string | undefined;
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/**
- * Manages ACP terminal lifecycle for a single Zed session.
- *
- * When the client advertises the `terminal` capability, shell tool-calls
- * trigger terminal creation via `connection.createTerminal`.  Each terminal
- * is correlated to its tool-call by `toolCallId` so that terminal content can
- * be emitted inline and terminals are cleaned up on completion, cancel, and
- * dispose.
- */
 export class TerminalManager {
-  private readonly activeTerminals = new Map<string, TerminalHandleLike>();
+  private readonly pendingCalls: PendingShellCall[] = [];
+  private readonly activeTerminals = new Set<ActiveTerminal>();
 
   constructor(
     private readonly sessionId: string,
@@ -34,12 +47,9 @@ export class TerminalManager {
     private readonly targetDir: string,
     private readonly sendUpdate: SendUpdateFn,
     private readonly logger: DebugLogger,
+    private readonly maxOutputTokens?: number,
   ) {}
 
-  /**
-   * Returns `true` if the tool-call is an execute-kind shell command that
-   * should trigger terminal creation.
-   */
   static isShellToolCall(
     call: AgentToolCall,
     kind: string | undefined,
@@ -47,107 +57,235 @@ export class TerminalManager {
     return kind === 'execute' && typeof call.args['command'] === 'string';
   }
 
-  /**
-   * Creates an ACP terminal for a shell tool-call and immediately correlates
-   * it by `toolCallId`.  Emits a terminal-content update so the client renders
-   * the terminal inline during execution.
-   */
-  async handleToolCall(call: AgentToolCall): Promise<void> {
-    const command =
-      typeof call.args['command'] === 'string' ? call.args['command'] : '';
-    if (command.trim() === '') return;
-    const cwd =
-      typeof call.args['dir_path'] === 'string'
-        ? call.args['dir_path']
-        : this.targetDir;
-    let handle: TerminalHandleLike;
-    try {
-      handle = await this.connection.createTerminal({
-        command,
-        cwd,
-        sessionId: this.sessionId,
-      });
-    } catch (error) {
-      this.logger.debug(
-        () => `Failed to create ACP terminal: ${errorMessage(error)}`,
-      );
+  async observeToolCall(call: AgentToolCall): Promise<void> {
+    const command = readCommand(call);
+    if (command === null) {
       return;
     }
-    const existing = this.activeTerminals.get(call.id);
-    if (existing !== undefined) {
-      this.activeTerminals.delete(call.id);
-      try {
-        await existing.release();
-      } catch (error) {
-        this.logger.debug(
-          () => `Prior terminal release failed: ${errorMessage(error)}`,
-        );
-      }
+    const pending: PendingShellCall = {
+      id: call.id,
+      command,
+      cwd: resolveCallCwd(call, this.targetDir),
+    };
+    const active = [...this.activeTerminals].find(
+      (terminal) =>
+        terminal.toolCallId === undefined &&
+        terminal.cwd === pending.cwd &&
+        commandsMatch(terminal.command, pending.command),
+    );
+    if (active === undefined) {
+      this.pendingCalls.push(pending);
+      return;
     }
-    this.activeTerminals.set(call.id, handle);
-    try {
-      await this.sendUpdate({
-        sessionUpdate: 'tool_call_update',
-        toolCallId: call.id,
-        status: 'in_progress',
-        content: [{ type: 'terminal', terminalId: handle.id }],
-      });
-    } catch (error) {
-      this.activeTerminals.delete(call.id);
-      try {
-        await handle.release();
-      } catch (releaseError) {
-        this.logger.debug(
-          () => `Terminal release failed: ${errorMessage(releaseError)}`,
-        );
-      }
-      this.logger.debug(
-        () => `Terminal update send failed: ${errorMessage(error)}`,
-      );
+    active.toolCallId = pending.id;
+    await this.sendTerminalUpdate(active);
+  }
+
+  completeToolCall(toolCallId: string): void {
+    const pendingIndex = this.pendingCalls.findIndex(
+      (pending) => pending.id === toolCallId,
+    );
+    if (pendingIndex >= 0) {
+      this.pendingCalls.splice(pendingIndex, 1);
     }
   }
 
-  /**
-   * Releases a terminal after its tool call has completed.  Safe to call
-   * multiple times — the handle is removed on first call.
-   */
-  async releaseTerminal(toolCallId: string): Promise<void> {
-    const handle = this.activeTerminals.get(toolCallId);
-    if (handle === undefined) return;
-    this.activeTerminals.delete(toolCallId);
+  async executeShellCommand(
+    command: string,
+    cwd: string,
+    onOutput: (event: ShellOutputEvent) => void,
+    signal: AbortSignal,
+  ): Promise<ShellExecutionResult> {
+    if (signal.aborted) {
+      return abortedResult();
+    }
+    const shell = getShellConfiguration();
+    const handle = await this.connection.createTerminal({
+      command: shell.executable,
+      args: [...shell.argsPrefix, command],
+      cwd,
+      sessionId: this.sessionId,
+      ...(this.maxOutputTokens === undefined
+        ? {}
+        : {
+            outputByteLimit: this.maxOutputTokens * APPROXIMATE_BYTES_PER_TOKEN,
+          }),
+    });
+    const active: ActiveTerminal = {
+      handle,
+      command,
+      cwd,
+      toolCallId: this.claimPendingCall(command, cwd),
+    };
+    this.activeTerminals.add(active);
     try {
-      await handle.release();
+      if (active.toolCallId !== undefined) {
+        await this.sendTerminalUpdate(active);
+      }
+      return await this.waitForTerminal(active, onOutput, signal);
+    } catch (error) {
+      if (this.activeTerminals.delete(active)) {
+        await this.killAndRelease(active);
+      }
+      throw error;
+    } finally {
+      if (this.activeTerminals.delete(active)) {
+        await this.release(active);
+      }
+    }
+  }
+
+  async settleAll(): Promise<void> {
+    this.pendingCalls.splice(0);
+    const terminals = [...this.activeTerminals];
+    this.activeTerminals.clear();
+    for (const terminal of terminals) {
+      await this.killAndRelease(terminal);
+    }
+  }
+
+  private claimPendingCall(command: string, cwd: string): string | undefined {
+    const index = this.pendingCalls.findIndex(
+      (pending) =>
+        pending.cwd === cwd && commandsMatch(command, pending.command),
+    );
+    if (index < 0) {
+      return undefined;
+    }
+    return this.pendingCalls.splice(index, 1)[0]?.id;
+  }
+
+  private async sendTerminalUpdate(active: ActiveTerminal): Promise<void> {
+    if (active.toolCallId === undefined) {
+      return;
+    }
+    await this.sendUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: active.toolCallId,
+      status: 'in_progress',
+      content: [{ type: 'terminal', terminalId: active.handle.id }],
+    });
+  }
+
+  private async waitForTerminal(
+    active: ActiveTerminal,
+    onOutput: (event: ShellOutputEvent) => void,
+    signal: AbortSignal,
+  ): Promise<ShellExecutionResult> {
+    let exit: acp.WaitForTerminalExitResponse | undefined;
+    let exitError: unknown;
+    const exitPromise = active.handle
+      .waitForExit()
+      .then((result) => {
+        exit = result;
+      })
+      .catch((error: unknown) => {
+        exitError = error;
+      });
+    let previousOutput = '';
+    let killed = false;
+    const killDeadline = Date.now() + KILL_GRACE_PERIOD_MS;
+    let done = false;
+    while (!done) {
+      if (exitError !== undefined) {
+        throw exitError;
+      }
+      if (signal.aborted && !killed) {
+        killed = true;
+        await this.kill(active);
+      }
+      done = exit !== undefined || (killed && Date.now() >= killDeadline);
+      if (done) {
+        continue;
+      }
+      await Promise.race([exitPromise, delay(OUTPUT_POLL_INTERVAL_MS)]);
+      const current = await active.handle.currentOutput();
+      const chunk = outputDelta(previousOutput, current.output);
+      if (chunk !== '') {
+        onOutput({ type: 'data', chunk });
+      }
+      previousOutput = current.output;
+    }
+    return {
+      output: previousOutput,
+      exitCode: exit?.exitCode ?? null,
+      signal: exit?.signal ?? null,
+      error: null,
+      aborted: signal.aborted,
+      pid: undefined,
+    };
+  }
+
+  private async killAndRelease(active: ActiveTerminal): Promise<void> {
+    await this.kill(active);
+    await this.release(active);
+  }
+
+  private async kill(active: ActiveTerminal): Promise<void> {
+    try {
+      await active.handle.kill();
+    } catch (error) {
+      this.logger.debug(() => `Terminal kill failed: ${errorMessage(error)}`);
+    }
+  }
+
+  private async release(active: ActiveTerminal): Promise<void> {
+    try {
+      await active.handle.release();
     } catch (error) {
       this.logger.debug(
         () => `Terminal release failed: ${errorMessage(error)}`,
       );
     }
   }
+}
 
-  /**
-   * Kills and releases all active terminals.  Called on cancel and dispose
-   * so no terminal is leaked.
-   */
-  async settleAll(): Promise<void> {
-    const entries = [...this.activeTerminals.entries()];
-    this.activeTerminals.clear();
-    await Promise.allSettled(
-      entries.map(async ([, handle]) => {
-        try {
-          await handle.kill();
-        } catch (error) {
-          this.logger.debug(
-            () => `Terminal kill failed: ${errorMessage(error)}`,
-          );
-        }
-        try {
-          await handle.release();
-        } catch (error) {
-          this.logger.debug(
-            () => `Terminal release failed: ${errorMessage(error)}`,
-          );
-        }
-      }),
-    );
+function readCommand(call: AgentToolCall): string | null {
+  const command = call.args['command'];
+  return typeof command === 'string' && command.trim() !== '' ? command : null;
+}
+
+function resolveCallCwd(call: AgentToolCall, targetDir: string): string {
+  const dirPath = call.args['dir_path'];
+  const directory = call.args['directory'];
+  let value = '';
+  if (typeof dirPath === 'string') {
+    value = dirPath;
+  } else if (typeof directory === 'string') {
+    value = directory;
   }
+  if (value === '') {
+    return targetDir;
+  }
+  return path.isAbsolute(value) ? value : path.resolve(targetDir, value);
+}
+
+function commandsMatch(preparedCommand: string, rawCommand: string): boolean {
+  const trimmed = rawCommand.trim();
+  if (preparedCommand === trimmed) {
+    return true;
+  }
+  const terminated = trimmed.endsWith('&') ? trimmed : `${trimmed};`;
+  return preparedCommand.startsWith(`{ ${terminated} }; __code=$?;`);
+}
+
+function abortedResult(): ShellExecutionResult {
+  return {
+    output: '',
+    exitCode: null,
+    signal: null,
+    error: null,
+    aborted: true,
+    pid: undefined,
+  };
+}
+
+function outputDelta(previous: string, current: string): string {
+  return current.startsWith(previous)
+    ? current.slice(previous.length)
+    : current;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -78,7 +78,12 @@ export class TerminalManager {
       return;
     }
     active.toolCallId = pending.id;
-    await this.sendTerminalUpdate(active);
+    try {
+      await this.sendTerminalUpdate(active);
+    } catch (error) {
+      active.toolCallId = undefined;
+      throw error;
+    }
   }
 
   completeToolCall(toolCallId: string): void {
@@ -265,7 +270,8 @@ function commandsMatch(preparedCommand: string, rawCommand: string): boolean {
   if (preparedCommand === trimmed) {
     return true;
   }
-  const terminated = trimmed.endsWith('&') ? trimmed : `${trimmed};`;
+  const terminated =
+    trimmed.endsWith('&') || trimmed.endsWith(';') ? trimmed : `${trimmed};`;
   return preparedCommand.startsWith(`{ ${terminated} }; __code=$?;`);
 }
 

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -56,13 +56,28 @@ export class TerminalManager {
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']
         : this.targetDir;
+    let handle: TerminalHandleLike;
     try {
-      const handle = await this.connection.createTerminal({
+      handle = await this.connection.createTerminal({
         command,
         cwd,
         sessionId: this.sessionId,
       });
-      this.activeTerminals.set(call.id, handle);
+    } catch (error) {
+      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      return;
+    }
+    const existing = this.activeTerminals.get(call.id);
+    if (existing !== undefined) {
+      this.activeTerminals.delete(call.id);
+      try {
+        await existing.release();
+      } catch (error) {
+        this.logger.debug(() => `Prior terminal release failed: ${error}`);
+      }
+    }
+    this.activeTerminals.set(call.id, handle);
+    try {
       await this.sendUpdate({
         sessionUpdate: 'tool_call_update',
         toolCallId: call.id,
@@ -70,7 +85,13 @@ export class TerminalManager {
         content: [{ type: 'terminal', terminalId: handle.id }],
       });
     } catch (error) {
-      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      this.activeTerminals.delete(call.id);
+      try {
+        await handle.release();
+      } catch (releaseError) {
+        this.logger.debug(() => `Terminal release failed: ${releaseError}`);
+      }
+      this.logger.debug(() => `Terminal update send failed: ${error}`);
     }
   }
 

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -61,7 +61,6 @@ export class TerminalManager {
         command,
         cwd,
         sessionId: this.sessionId,
-        args: ['-c', command],
       });
       this.activeTerminals.set(call.id, handle);
       await this.sendUpdate({

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { DebugLogger } from '@vybestack/llxprt-code-core';
+import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
+
+interface PendingShellCall {
+  readonly toolCallId: string;
+  readonly command: string;
+  readonly cwd: string;
+}
+
+type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+
+/**
+ * Manages ACP terminal lifecycle for a single Zed session.
+ *
+ * When the client advertises the `terminal` capability, shell tool-calls
+ * trigger terminal creation via `connection.createTerminal`.  Each terminal
+ * is correlated to its tool-call (by command/cwd matching) so that terminal
+ * content can be emitted inline and terminals are cleaned up on completion,
+ * cancel, and dispose.
+ */
+export class TerminalManager {
+  private readonly activeTerminals = new Map<string, acp.TerminalHandle>();
+  private readonly pendingShellCalls: PendingShellCall[] = [];
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly connection: acp.AgentSideConnection,
+    private readonly targetDir: string,
+    private readonly sendUpdate: SendUpdateFn,
+    private readonly logger: DebugLogger,
+  ) {}
+
+  /**
+   * Returns `true` if the tool-call is an execute-kind shell command that
+   * should trigger terminal creation.
+   */
+  static isShellToolCall(
+    call: AgentToolCall,
+    kind: string | undefined,
+  ): boolean {
+    return kind === 'execute' && typeof call.args['command'] === 'string';
+  }
+
+  /**
+   * Records a pending shell tool-call and creates an ACP terminal for it.
+   * Emits an early terminal-content update so the client renders the terminal
+   * inline during execution.
+   */
+  async handleToolCall(call: AgentToolCall): Promise<void> {
+    const command =
+      typeof call.args['command'] === 'string' ? call.args['command'] : '';
+    if (command === '') return;
+    const cwd =
+      typeof call.args['dir_path'] === 'string'
+        ? call.args['dir_path']
+        : this.targetDir;
+    this.pendingShellCalls.push({ toolCallId: call.id, command, cwd });
+    try {
+      const handle = await this.connection.createTerminal({
+        command,
+        cwd,
+        sessionId: this.sessionId,
+        args: ['-c', command],
+      });
+      await this.registerTerminal(command, cwd, handle);
+    } catch (error) {
+      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+    }
+  }
+
+  /**
+   * Correlates a created terminal to its tool-call by matching command/cwd,
+   * records the handle, and emits the terminal-content update.
+   */
+  async registerTerminal(
+    command: string,
+    cwd: string,
+    handle: acp.TerminalHandle,
+  ): Promise<void> {
+    const match = this.pendingShellCalls.find(
+      (entry) => entry.command === command && entry.cwd === cwd,
+    );
+    if (match === undefined) return;
+    this.activeTerminals.set(match.toolCallId, handle);
+    await this.sendUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: match.toolCallId,
+      status: 'in_progress',
+      content: [{ type: 'terminal', terminalId: handle.id }],
+    });
+  }
+
+  /**
+   * Releases a terminal after its tool call has completed.  Safe to call
+   * multiple times — the handle is removed on first call.
+   */
+  async releaseTerminal(toolCallId: string): Promise<void> {
+    const handle = this.activeTerminals.get(toolCallId);
+    if (handle === undefined) return;
+    this.activeTerminals.delete(toolCallId);
+    const idx = this.pendingShellCalls.findIndex(
+      (entry) => entry.toolCallId === toolCallId,
+    );
+    if (idx >= 0) this.pendingShellCalls.splice(idx, 1);
+    try {
+      await handle.release();
+    } catch (error) {
+      this.logger.debug(() => `Terminal release failed: ${error}`);
+    }
+  }
+
+  /**
+   * Kills and releases all active terminals.  Called on cancel and dispose
+   * so no terminal is leaked.
+   */
+  async settleAll(): Promise<void> {
+    const entries = [...this.activeTerminals.entries()];
+    this.activeTerminals.clear();
+    await Promise.allSettled(
+      entries.map(async ([, handle]) => {
+        try {
+          await handle.kill();
+        } catch (error) {
+          this.logger.debug(() => `Terminal kill failed: ${error}`);
+        }
+        try {
+          await handle.release();
+        } catch (error) {
+          this.logger.debug(() => `Terminal release failed: ${error}`);
+        }
+      }),
+    );
+  }
+}

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -51,7 +51,7 @@ export class TerminalManager {
   async handleToolCall(call: AgentToolCall): Promise<void> {
     const command =
       typeof call.args['command'] === 'string' ? call.args['command'] : '';
-    if (command === '') return;
+    if (command.trim() === '') return;
     const cwd =
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']

--- a/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
@@ -38,7 +38,7 @@ describe('buildZedTerminalSetup', () => {
       new DebugLogger('llxprt:zed-terminal-setup-test'),
     );
 
-    expect(setup.registry.getTool('run_shell_command')).toBeUndefined();
+    expect(setup.registry.getTool(ShellTool.Name)).toBeUndefined();
   });
 
   it('registers a terminal-backed ShellTool when the base registry includes one', () => {

--- a/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import { DebugLogger, type Config } from '@vybestack/llxprt-code-core';
+import {
+  ShellTool,
+  type IShellToolHost,
+  type ToolRegistry,
+} from '@vybestack/llxprt-code-tools';
+import { buildZedTerminalSetup } from './zed-terminal-setup.js';
+import { RecordingConnection } from './zed-test-helpers.js';
+
+function configFixture(): Config {
+  return {
+    getPolicyEngine: () => undefined,
+    getDebugMode: () => false,
+    getTargetDir: () => '/project',
+    getEphemeralSetting: () => undefined,
+  } as unknown as Config;
+}
+
+describe('buildZedTerminalSetup', () => {
+  it('does not enable a shell tool excluded from the base registry', () => {
+    const baseRegistry = {
+      getAllTools: vi.fn(() => []),
+    } as unknown as ToolRegistry;
+
+    const setup = buildZedTerminalSetup(
+      'session-1',
+      configFixture(),
+      baseRegistry,
+      new RecordingConnection() as unknown as acp.AgentSideConnection,
+      new DebugLogger('llxprt:zed-terminal-setup-test'),
+    );
+
+    expect(setup.registry.getTool('run_shell_command')).toBeUndefined();
+  });
+
+  it('registers a terminal-backed ShellTool when the base registry includes one', () => {
+    const baseShellTool = new ShellTool({} as unknown as IShellToolHost);
+    const baseRegistry = {
+      getAllTools: vi.fn(() => [baseShellTool]),
+    } as unknown as ToolRegistry;
+
+    const setup = buildZedTerminalSetup(
+      'session-1',
+      configFixture(),
+      baseRegistry,
+      new RecordingConnection() as unknown as acp.AgentSideConnection,
+      new DebugLogger('llxprt:zed-terminal-setup-test'),
+    );
+
+    const tool = setup.registry.getTool('run_shell_command');
+    expect(tool).toBeDefined();
+    expect(tool).not.toBe(baseShellTool);
+  });
+});

--- a/packages/cli/src/zed-integration/zed-terminal-setup.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-setup.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import {
+  type Config,
+  type DebugLogger,
+  MessageBus,
+} from '@vybestack/llxprt-code-core';
+import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
+import { CoreShellToolHostAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreShellToolHostAdapter.js';
+import { CoreToolRegistryHostAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreToolRegistryHostAdapter.js';
+import { ShellTool, ToolRegistry } from '@vybestack/llxprt-code-tools';
+import { AcpTerminalShellHost } from './acp-terminal-shell-host.js';
+import { TerminalManager } from './zed-terminal-manager.js';
+
+export interface ZedTerminalSetup {
+  readonly messageBus: MessageBus;
+  readonly registry: ToolRegistry;
+  readonly terminals: TerminalManager;
+}
+
+export function buildZedTerminalSetup(
+  sessionId: string,
+  config: Config,
+  baseRegistry: ToolRegistry,
+  connection: acp.AgentSideConnection,
+  logger: DebugLogger,
+): ZedTerminalSetup {
+  const messageBus = new MessageBus(
+    config.getPolicyEngine(),
+    config.getDebugMode(),
+  );
+  const outputLimit = config.getEphemeralSetting('tool-output-max-tokens');
+  const terminals = new TerminalManager(
+    sessionId,
+    connection,
+    config.getTargetDir(),
+    (update) => connection.sessionUpdate({ sessionId, update }),
+    logger,
+    typeof outputLimit === 'number' ? outputLimit : undefined,
+  );
+  const messageBusAdapter = new CoreMessageBusAdapter(messageBus);
+  const registry = new ToolRegistry(
+    new CoreToolRegistryHostAdapter(config),
+    messageBusAdapter,
+  );
+  const baseTools = baseRegistry.getAllTools();
+  let hasShellTool = false;
+  for (const tool of baseTools) {
+    if (tool.name === ShellTool.Name) {
+      hasShellTool = true;
+      continue;
+    }
+    registry.registerTool(tool);
+  }
+  if (hasShellTool) {
+    registry.registerTool(
+      new ShellTool(
+        new AcpTerminalShellHost(
+          new CoreShellToolHostAdapter(config),
+          terminals,
+        ),
+        messageBusAdapter,
+      ),
+    );
+  }
+  return { messageBus, registry, terminals };
+}

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -184,7 +184,7 @@ export class RecordingConnection {
 
   private terminalOutput = '';
   private terminalExitDelayed = false;
-  private terminalExitResolve: ((value: void) => void) | null = null;
+  private terminalExitResolves = new Map<string, () => void>();
 
   setTerminalOutput(output: string): void {
     this.terminalOutput = output;
@@ -194,13 +194,23 @@ export class RecordingConnection {
     this.terminalExitDelayed = true;
   }
 
-  resolveDelayedTerminalExit(): void {
-    if (this.terminalExitResolve !== null) {
-      const fn = this.terminalExitResolve;
-      this.terminalExitResolve = null;
-      this.terminalExitDelayed = false;
+  resolveDelayedTerminalExit(terminalId?: string): void {
+    if (terminalId !== undefined) {
+      const fn = this.terminalExitResolves.get(terminalId);
+      if (fn !== undefined) {
+        this.terminalExitResolves.delete(terminalId);
+        fn();
+      }
+      if (this.terminalExitResolves.size === 0) {
+        this.terminalExitDelayed = false;
+      }
+      return;
+    }
+    for (const fn of this.terminalExitResolves.values()) {
       fn();
     }
+    this.terminalExitResolves.clear();
+    this.terminalExitDelayed = false;
   }
 
   /**
@@ -212,16 +222,24 @@ export class RecordingConnection {
     if (this.hasTerminalContentUpdate()) return Promise.resolve();
     const deadline = Date.now() + timeoutMs;
     return new Promise<void>((resolve, reject) => {
-      const check = (): void => {
-        if (this.hasTerminalContentUpdate()) {
-          resolve();
-        } else if (Date.now() >= deadline) {
-          reject(new Error('waitForTerminalCreated timed out'));
-        } else {
-          setTimeout(check, 5);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const cleanup = (): void => {
+        if (timer !== undefined) {
+          clearTimeout(timer);
         }
       };
-      setTimeout(check, 5);
+      const check = (): void => {
+        if (this.hasTerminalContentUpdate()) {
+          cleanup();
+          resolve();
+        } else if (Date.now() >= deadline) {
+          cleanup();
+          reject(new Error('waitForTerminalCreated timed out'));
+        } else {
+          timer = setTimeout(check, 5);
+        }
+      };
+      timer = setTimeout(check, 5);
     });
   }
 
@@ -385,19 +403,19 @@ export class RecordingConnection {
       waitForExit: vi.fn(async () => {
         if (this.terminalExitDelayed) {
           await new Promise<void>((resolve) => {
-            this.terminalExitResolve = resolve;
+            this.terminalExitResolves.set(terminalId, resolve);
           });
         }
         return { exitCode: 0, signal: null };
       }),
       kill: vi.fn(async () => {
         this.killCalls += 1;
-        this.resolveDelayedTerminalExit();
+        this.resolveDelayedTerminalExit(terminalId);
         return {};
       }),
       release: vi.fn(async () => {
         this.releaseCalls += 1;
-        this.resolveDelayedTerminalExit();
+        this.resolveDelayedTerminalExit(terminalId);
         return {};
       }),
     };

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -404,6 +404,12 @@ export class RecordingConnection {
     return handle;
   }
 
+  /**
+   * Returns content-focused session updates, excluding infrastructure
+   * notifications (`available_commands_update` and `session_info_update`).
+   * Use {@link sessionInfoUpdates} for title/updatedAt assertions and
+   * {@link availableCommandUpdates} for command-registry assertions.
+   */
   onlySessionUpdates(): acp.SessionUpdate[] {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -209,19 +209,21 @@ export class RecordingConnection {
    * a `terminal` content block) has been recorded — i.e., the Session has
    * created and registered a terminal.
    */
-  waitForTerminalCreated(): Promise<void> {
-    return this.hasTerminalContentUpdate()
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          const check = (): void => {
-            if (this.hasTerminalContentUpdate()) {
-              resolve();
-            } else {
-              setTimeout(check, 5);
-            }
-          };
+  waitForTerminalCreated(timeoutMs = 5000): Promise<void> {
+    if (this.hasTerminalContentUpdate()) return Promise.resolve();
+    const deadline = Date.now() + timeoutMs;
+    return new Promise<void>((resolve, reject) => {
+      const check = (): void => {
+        if (this.hasTerminalContentUpdate()) {
+          resolve();
+        } else if (Date.now() >= deadline) {
+          reject(new Error('waitForTerminalCreated timed out'));
+        } else {
           setTimeout(check, 5);
-        });
+        }
+      };
+      setTimeout(check, 5);
+    });
   }
 
   private hasTerminalContentUpdate(): boolean {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -90,6 +90,7 @@ export function buildBlockingScriptedAgent(
       if (signal !== undefined && !signal.aborted) {
         await new Promise<void>((resolve) => {
           signal.addEventListener('abort', () => resolve(), { once: true });
+          if (signal.aborted) resolve();
         });
       }
     },

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -68,6 +68,63 @@ export function buildScriptedAgent(
   return { agent, confirmations };
 }
 
+/**
+ * Like {@link buildScriptedAgent} but the stream blocks after yielding all
+ * events until the abort signal fires.  Used to test cancel/dispose while a
+ * prompt turn is still in-flight.
+ */
+export function buildBlockingScriptedAgent(
+  nextEvents: () => readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
+  agent: Agent;
+  confirmations: ConfirmationCapture[];
+} {
+  const confirmations: ConfirmationCapture[] = [];
+  const agent = {
+    async *stream(_input: unknown, opts?: unknown): AsyncIterable<AgentEvent> {
+      for (const e of nextEvents()) {
+        yield e;
+      }
+      const signal = (opts as { signal?: AbortSignal } | undefined)?.signal;
+      if (signal !== undefined && !signal.aborted) {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+    },
+    getApprovalMode: (): ApprovalMode => 'default' as ApprovalMode,
+    setApprovalMode: vi.fn(),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    tools: {
+      get: (name: string) =>
+        Object.hasOwn(toolKinds, name) ? { kind: toolKinds[name] } : undefined,
+      respondToConfirmation: (
+        confirmationId: string,
+        decision: ToolConfirmationOutcome,
+        payload?: ToolConfirmationPayload,
+        requiresUserConfirmation?: boolean,
+      ) => {
+        confirmations.push({
+          confirmationId,
+          decision,
+          ...(payload === undefined ? {} : { payload }),
+          ...(requiresUserConfirmation === undefined
+            ? {}
+            : { requiresUserConfirmation }),
+        });
+      },
+      onConfirmationRequest: () => () => {},
+      onToolUpdate: () => () => {},
+      setEditorCallbacks: () => {},
+      setEnabled: vi.fn().mockResolvedValue(undefined),
+      list: () => [],
+      keys: {},
+    },
+  } as unknown as Agent;
+  return { agent, confirmations };
+}
+
 export function buildFakeAgent(
   events: readonly AgentEvent[],
   toolKinds: Readonly<Record<string, string>> = {},
@@ -76,6 +133,16 @@ export function buildFakeAgent(
   confirmations: ConfirmationCapture[];
 } {
   return buildScriptedAgent(() => events, toolKinds);
+}
+
+export function buildBlockingFakeAgent(
+  events: readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
+  agent: Agent;
+  confirmations: ConfirmationCapture[];
+} {
+  return buildBlockingScriptedAgent(() => events, toolKinds);
 }
 
 export class RecordingConnection {
@@ -95,6 +162,70 @@ export class RecordingConnection {
   private sessionUpdateFailAfter: number | null = null;
   private sessionUpdateError: Error | null = null;
   private sessionUpdateCalls = 0;
+
+  // --- Terminal test-double state ---
+
+  readonly createTerminalCalls: Array<{
+    command: string;
+    cwd?: string | null;
+    sessionId: string;
+    args?: string[];
+    env?: Array<{ name: string; value: string }>;
+    outputByteLimit?: number | null;
+  }> = [];
+
+  killCalls = 0;
+  releaseCalls = 0;
+
+  private terminalOutput = '';
+  private terminalExitDelayed = false;
+  private terminalExitResolve: ((value: void) => void) | null = null;
+
+  setTerminalOutput(output: string): void {
+    this.terminalOutput = output;
+  }
+
+  delayTerminalExit(): void {
+    this.terminalExitDelayed = true;
+  }
+
+  resolveDelayedTerminalExit(): void {
+    if (this.terminalExitResolve !== null) {
+      const fn = this.terminalExitResolve;
+      this.terminalExitResolve = null;
+      this.terminalExitDelayed = false;
+      fn();
+    }
+  }
+
+  /**
+   * Resolves once at least one terminal content update (tool_call_update with
+   * a `terminal` content block) has been recorded — i.e., the Session has
+   * created and registered a terminal.
+   */
+  waitForTerminalCreated(): Promise<void> {
+    return this.hasTerminalContentUpdate()
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          const check = (): void => {
+            if (this.hasTerminalContentUpdate()) {
+              resolve();
+            } else {
+              setTimeout(check, 5);
+            }
+          };
+          setTimeout(check, 5);
+        });
+  }
+
+  private hasTerminalContentUpdate(): boolean {
+    return this.messages.some(
+      (m) =>
+        m.kind === 'sessionUpdate' &&
+        m.update.sessionUpdate === 'tool_call_update' &&
+        (m.update.content ?? []).some((c) => c.type === 'terminal'),
+    );
+  }
 
   /**
    * Arms sessionUpdate to REJECT starting with the (0-based) `afterCount`-th
@@ -218,6 +349,58 @@ export class RecordingConnection {
     },
   );
 
+  createTerminal: Mock = vi.fn(
+    async (params: acp.CreateTerminalRequest): Promise<acp.TerminalHandle> => {
+      const call = {
+        command: params.command,
+        cwd: params.cwd,
+        sessionId: params.sessionId,
+        ...(params.args !== undefined ? { args: params.args } : {}),
+        ...(params.env !== undefined ? { env: params.env } : {}),
+        ...(params.outputByteLimit !== undefined
+          ? { outputByteLimit: params.outputByteLimit }
+          : {}),
+      };
+      this.createTerminalCalls.push(call);
+      const terminalId = `terminal-${this.createTerminalCalls.length}`;
+      return this.buildFakeTerminalHandle(terminalId);
+    },
+  );
+
+  private buildFakeTerminalHandle(terminalId: string): acp.TerminalHandle {
+    const handle = {
+      id: terminalId,
+      currentOutput: vi.fn(async () => ({
+        output: this.terminalOutput,
+        exitStatus: null,
+        truncated: false,
+      })),
+      waitForExit: vi.fn(async () => {
+        if (this.terminalExitDelayed) {
+          await new Promise<void>((resolve) => {
+            this.terminalExitResolve = resolve;
+          });
+        }
+        return { exitCode: 0, signal: null };
+      }),
+      kill: vi.fn(async () => {
+        this.killCalls += 1;
+        this.resolveDelayedTerminalExit();
+        return {};
+      }),
+      release: vi.fn(async () => {
+        this.releaseCalls += 1;
+        this.resolveDelayedTerminalExit();
+        return {};
+      }),
+      [Symbol.asyncDispose]: vi.fn(async () => {
+        this.releaseCalls += 1;
+        this.resolveDelayedTerminalExit();
+      }),
+    };
+    return handle as unknown as acp.TerminalHandle;
+  }
+
   onlySessionUpdates(): acp.SessionUpdate[] {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
@@ -291,12 +474,15 @@ export function createSession(
   agent: Agent,
   connection: RecordingConnection,
   config: Config = buildMinimalConfig(),
+  terminalEnabled = false,
 ): Session {
   return new Session(
     'test-session-id',
     agent,
     config,
     connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
   );
 }
 

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -203,7 +203,21 @@ export class RecordingConnection {
   onlySessionUpdates(): acp.SessionUpdate[] {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
-      .map((m) => (m as { update: acp.SessionUpdate }).update);
+      .map((m) => (m as { update: acp.SessionUpdate }).update)
+      .filter((update) => update.sessionUpdate !== 'available_commands_update');
+  }
+
+  availableCommandUpdates(): acp.AvailableCommandsUpdate[] {
+    return this.messages
+      .filter((m) => m.kind === 'sessionUpdate')
+      .map((m) => (m as { update: acp.SessionUpdate }).update)
+      .filter(
+        (
+          update,
+        ): update is acp.AvailableCommandsUpdate & {
+          sessionUpdate: 'available_commands_update';
+        } => update.sessionUpdate === 'available_commands_update',
+      );
   }
 
   sessionUpdateKinds(): string[] {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -145,6 +145,11 @@ export function buildBlockingFakeAgent(
   return buildBlockingScriptedAgent(() => events, toolKinds);
 }
 
+export type FakeTerminalHandle = Pick<
+  acp.TerminalHandle,
+  'id' | 'currentOutput' | 'waitForExit' | 'kill' | 'release'
+>;
+
 export class RecordingConnection {
   readonly messages: Array<
     | { kind: 'sessionUpdate'; update: acp.SessionUpdate }
@@ -350,7 +355,7 @@ export class RecordingConnection {
   );
 
   createTerminal: Mock = vi.fn(
-    async (params: acp.CreateTerminalRequest): Promise<acp.TerminalHandle> => {
+    async (params: acp.CreateTerminalRequest): Promise<FakeTerminalHandle> => {
       const call = {
         command: params.command,
         cwd: params.cwd,
@@ -367,7 +372,7 @@ export class RecordingConnection {
     },
   );
 
-  private buildFakeTerminalHandle(terminalId: string): acp.TerminalHandle {
+  private buildFakeTerminalHandle(terminalId: string): FakeTerminalHandle {
     const handle = {
       id: terminalId,
       currentOutput: vi.fn(async () => ({
@@ -393,12 +398,8 @@ export class RecordingConnection {
         this.resolveDelayedTerminalExit();
         return {};
       }),
-      [Symbol.asyncDispose]: vi.fn(async () => {
-        this.releaseCalls += 1;
-        this.resolveDelayedTerminalExit();
-      }),
     };
-    return handle as unknown as acp.TerminalHandle;
+    return handle;
   }
 
   onlySessionUpdates(): acp.SessionUpdate[] {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -112,6 +112,16 @@ export class RecordingConnection {
     this.sessionUpdateError = null;
     this.sessionUpdateCalls = 0;
   }
+
+  clearSessionInfoUpdates(): void {
+    const retained = this.messages.filter(
+      (message) =>
+        message.kind !== 'sessionUpdate' ||
+        message.update.sessionUpdate !== 'session_info_update',
+    );
+    this.messages.splice(0, this.messages.length, ...retained);
+  }
+
   private gatedDeferred: {
     resolve: (o: acp.RequestPermissionOutcome) => void;
     promise: Promise<acp.RequestPermissionOutcome>;

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -90,7 +90,6 @@ export function buildBlockingScriptedAgent(
       if (signal !== undefined && !signal.aborted) {
         await new Promise<void>((resolve) => {
           signal.addEventListener('abort', () => resolve(), { once: true });
-          if (signal.aborted) resolve();
         });
       }
     },
@@ -478,15 +477,12 @@ export function createSession(
   agent: Agent,
   connection: RecordingConnection,
   config: Config = buildMinimalConfig(),
-  terminalEnabled = false,
 ): Session {
   return new Session(
     'test-session-id',
     agent,
     config,
     connection as unknown as acp.AgentSideConnection,
-    false,
-    terminalEnabled,
   );
 }
 

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -204,7 +204,27 @@ export class RecordingConnection {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
       .map((m) => (m as { update: acp.SessionUpdate }).update)
-      .filter((update) => update.sessionUpdate !== 'available_commands_update');
+      .filter(
+        (update) =>
+          update.sessionUpdate !== 'available_commands_update' &&
+          update.sessionUpdate !== 'session_info_update',
+      );
+  }
+
+  sessionInfoUpdates(): Array<
+    Extract<acp.SessionUpdate, { sessionUpdate: 'session_info_update' }>
+  > {
+    return this.messages
+      .filter((m) => m.kind === 'sessionUpdate')
+      .map((m) => (m as { update: acp.SessionUpdate }).update)
+      .filter(
+        (
+          update,
+        ): update is Extract<
+          acp.SessionUpdate,
+          { sessionUpdate: 'session_info_update' }
+        > => update.sessionUpdate === 'session_info_update',
+      );
   }
 
   availableCommandUpdates(): acp.AvailableCommandsUpdate[] {
@@ -232,6 +252,7 @@ export function buildMinimalConfig(): Config {
     getApprovalMode: () => 'default' as ApprovalMode,
     setApprovalMode: () => {},
     getTargetDir: () => '/project',
+    getProjectRoot: () => '/project',
     getFileService: () => ({ shouldIgnoreFile: () => false }),
     getFileFilteringOptions: () => ({
       respectGitIgnore: true,
@@ -244,6 +265,7 @@ export function buildMinimalConfig(): Config {
     // window via getTokenLimitForConfiguredContext(model, config).
     getModel: () => 'test-model',
     getContentGeneratorConfig: () => undefined,
+    getSessionRecordingService: () => undefined,
   } as unknown as Config;
 }
 

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -327,7 +327,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     ).rejects.toThrow(/Session not found/);
   });
 
-  it('closeSession keeps a session tracked when agent disposal fails', async () => {
+  it('closeSession succeeds and removes the session even when agent disposal fails', async () => {
     const stub = buildStubAgent({});
     stub.dispose.mockRejectedValueOnce(new Error('dispose failed'));
     mockFromConfig.mockResolvedValue(stub.agent);
@@ -342,14 +342,10 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
 
     await expect(
       zedAgent.closeSession({ sessionId: created.sessionId }),
-    ).rejects.toThrow('dispose failed');
+    ).resolves.toEqual({});
     await expect(
-      zedAgent.resumeSession({
-        sessionId: created.sessionId,
-        cwd: '/project',
-        mcpServers: [],
-      }),
-    ).resolves.toMatchObject({ modes: expect.any(Object) });
+      zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
+    ).rejects.toThrow(/Session not found/);
   });
 
   it('initialize() advertises loadSession: true', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -739,14 +739,14 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     mockFromConfig.mockResolvedValue(stub.agent);
 
     const connection = new RecordingConnection();
-    // Dead transport: the first (and only) replay update rejects.
-    connection.failSessionUpdateAfter(0, new Error('transport is dead'));
     const zedAgent = await makeZedAgent(connection, emptyChatsLister);
 
     const created = await zedAgent.newSession({
       cwd: '/project',
       mcpServers: [],
     } as acp.NewSessionRequest);
+    connection.clearSessionUpdateFailure();
+    connection.failSessionUpdateAfter(0, new Error('transport is dead'));
 
     let caught: unknown;
     try {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -163,6 +163,9 @@ function buildBaseConfig(): Config {
     getTargetDir: () => '/project',
     getProjectRoot: () => '/project',
     getMaxSessionTurns: () => 50,
+    // No recording service in loadSession tests — the session lifecycle under
+    // test does not depend on session recording (only the re-attach/resume
+    // probes and session-info hydration paths are exercised here).
     getSessionRecordingService: () => undefined,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
     // storage.getProjectChatsDir(); point it at a dir that never exists so the

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -161,6 +161,7 @@ function buildBaseConfig(): Config {
     getEphemeralSetting: () => undefined,
     getDebugMode: () => false,
     getTargetDir: () => '/project',
+    getProjectRoot: () => '/project',
     getMaxSessionTurns: () => 50,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
     // storage.getProjectChatsDir(); point it at a dir that never exists so the
@@ -222,6 +223,134 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     mockFromConfig.mockReset();
   });
 
+  it('resumeSession reattaches a live session without replaying history', async () => {
+    const stub = buildStubAgent({
+      liveHistory: [modelMessage('must not replay')],
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection, async () => []);
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    const response = await zedAgent.resumeSession({
+      sessionId: created.sessionId,
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    expect(response.modes?.currentModeId).toBe('default');
+    expect(connection.onlySessionUpdates()).toStrictEqual([]);
+    expect(stub.resume).not.toHaveBeenCalled();
+  });
+
+  it('resumeSession rejects an unknown session without replaying updates', async () => {
+    const connection = new RecordingConnection();
+    const zedAgent = await makeZedAgent(connection, async () => []);
+
+    await expect(
+      zedAgent.resumeSession({
+        sessionId: 'missing-session',
+        cwd: '/project',
+        mcpServers: [],
+      }),
+    ).rejects.toMatchObject({ code: -32002 });
+    expect(connection.onlySessionUpdates()).toStrictEqual([]);
+  });
+
+  it('closeSession disposes a live session and is idempotent', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.closeSession({ sessionId: created.sessionId }),
+    ).resolves.toStrictEqual({});
+    await expect(
+      zedAgent.closeSession({ sessionId: created.sessionId }),
+    ).resolves.toStrictEqual({});
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
+    await expect(
+      zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
+    ).rejects.toThrow(/Session not found/);
+  });
+
+  it('resumeSession rejects a live session when cwd does not match', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.resumeSession({
+        sessionId: created.sessionId,
+        cwd: '/project/other',
+        mcpServers: [],
+      }),
+    ).rejects.toMatchObject({ code: -32002 });
+  });
+
+  it('deleteSession succeeds for a live session before recording materializes', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.deleteSession({ sessionId: created.sessionId }),
+    ).resolves.toStrictEqual({});
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
+    await expect(
+      zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
+    ).rejects.toThrow(/Session not found/);
+  });
+
+  it('closeSession keeps a session tracked when agent disposal fails', async () => {
+    const stub = buildStubAgent({});
+    stub.dispose.mockRejectedValueOnce(new Error('dispose failed'));
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      async () => [],
+    );
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    await expect(
+      zedAgent.closeSession({ sessionId: created.sessionId }),
+    ).rejects.toThrow('dispose failed');
+    await expect(
+      zedAgent.resumeSession({
+        sessionId: created.sessionId,
+        cwd: '/project',
+        mcpServers: [],
+      }),
+    ).resolves.toMatchObject({ modes: expect.any(Object) });
+  });
+
   it('initialize() advertises loadSession: true', async () => {
     const connection = new RecordingConnection();
     const mod = await import('./zedIntegration.js');
@@ -234,6 +363,12 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     );
     const response = await zedAgent.initialize(buildInitializeRequest());
     expect(response.agentCapabilities?.loadSession).toBe(true);
+    expect(response.agentCapabilities?.sessionCapabilities).toStrictEqual({
+      list: {},
+      resume: {},
+      delete: {},
+      close: {},
+    });
   });
 
   it('streams the restored conversation as ordered session/update notifications and returns modes', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -112,6 +112,7 @@ function buildStubAgent(options: {
   resumeError?: Error;
   liveHistory?: readonly AgentMessage[];
   streamText?: string;
+  recordingError?: Error;
 }): StubAgentHandle {
   const resume = vi.fn(async () => {
     if (options.resumeError !== undefined) {
@@ -119,7 +120,11 @@ function buildStubAgent(options: {
     }
     return options.resumeHistory ?? [];
   });
-  const setRecording = vi.fn(async () => undefined);
+  const setRecording = vi.fn(async () => {
+    if (options.recordingError !== undefined) {
+      throw options.recordingError;
+    }
+  });
   const dispose = vi.fn(async () => undefined);
   const getHistory = vi.fn(async () => options.liveHistory ?? []);
   const streamText = options.streamText;
@@ -225,6 +230,38 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
   // to need.
   beforeEach(() => {
     mockFromConfig.mockReset();
+  });
+
+  it('continues creating a session when optional recording setup fails', async () => {
+    const stub = buildStubAgent({
+      recordingError: new Error('recording unavailable'),
+    });
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const zedAgent = await makeZedAgent(
+      new RecordingConnection(),
+      emptyChatsLister,
+    );
+
+    const created = await zedAgent.newSession({
+      cwd: '/project',
+      mcpServers: [],
+    });
+
+    expect(created.sessionId).toStrictEqual(expect.any(String));
+    expect(stub.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes a new session when initial command advertisement fails', async () => {
+    const stub = buildStubAgent({});
+    mockFromConfig.mockResolvedValue(stub.agent);
+    const connection = new RecordingConnection();
+    connection.failSessionUpdateAfter(0, new Error('transport unavailable'));
+    const zedAgent = await makeZedAgent(connection, emptyChatsLister);
+
+    await expect(
+      zedAgent.newSession({ cwd: '/project', mcpServers: [] }),
+    ).rejects.toThrow('transport unavailable');
+    expect(stub.dispose).toHaveBeenCalledTimes(1);
   });
 
   it('resumeSession reattaches a live session without replaying history', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -163,6 +163,7 @@ function buildBaseConfig(): Config {
     getTargetDir: () => '/project',
     getProjectRoot: () => '/project',
     getMaxSessionTurns: () => 50,
+    getSessionRecordingService: () => undefined,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
     // storage.getProjectChatsDir(); point it at a dir that never exists so the
     // disk-resume probe's REAL readdir hits ENOENT (falling back to the plain

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -342,7 +342,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
 
     await expect(
       zedAgent.closeSession({ sessionId: created.sessionId }),
-    ).resolves.toEqual({});
+    ).resolves.toStrictEqual({});
     await expect(
       zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
     ).rejects.toThrow(/Session not found/);
@@ -363,8 +363,6 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     expect(response.agentCapabilities?.sessionCapabilities).toStrictEqual({
       list: {},
       resume: {},
-      delete: {},
-      close: {},
     });
   });
 

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -25,9 +25,9 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map((session) => session.dispose()),
+  );
 }
 
 describe('Zed Session.prompt (Agent API) - streaming output', () => {
@@ -806,7 +806,7 @@ describe('Zed Session.prompt (Agent API) - session_info_update (issue #1611)', (
       sessionId: 'test-session-id',
       prompt: [{ type: 'text', text: 'First prompt here' }],
     });
-    connection.messages.length = 0;
+    const firstInfoUpdates = connection.sessionInfoUpdates();
 
     await session.prompt({
       sessionId: 'test-session-id',
@@ -814,9 +814,10 @@ describe('Zed Session.prompt (Agent API) - session_info_update (issue #1611)', (
     });
 
     const infoUpdates = connection.sessionInfoUpdates();
-    expect(infoUpdates).toHaveLength(1);
-    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
-    expect(infoUpdates[0].title).toBeUndefined();
+    expect(firstInfoUpdates).toHaveLength(1);
+    expect(infoUpdates).toHaveLength(2);
+    expect(infoUpdates[1].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[1].title).toBeUndefined();
   });
 
   it('emits updatedAt after a cancelled turn', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -423,6 +423,7 @@ describe('Zed Session.prompt (Agent API) - tool permission round-trip', () => {
       'sessionUpdate',
       'requestPermission',
       'sessionUpdate',
+      'sessionUpdate',
     ]);
     expect(confirmations).toStrictEqual([
       { confirmationId, decision: ToolConfirmationOutcome.ProceedOnce },
@@ -736,5 +737,119 @@ describe('Zed Session (Agent API) - lifecycle', () => {
     });
     await new Promise((r) => setImmediate(r));
     expect(connection.sessionUpdateKinds()).not.toContain('plan');
+  });
+});
+
+describe('Zed Session.prompt (Agent API) - session_info_update (issue #1611)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('emits a session_info_update with a title derived from the first prompt', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Investigate session lifecycle' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBe('Investigate session lifecycle');
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('emits updatedAt on a subsequent prompt without regenerating the title', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'First prompt here' }],
+    });
+    connection.messages.length = 0;
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Second prompt here' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('emits updatedAt after a cancelled turn', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'aborted' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const response = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'A prompt that gets cancelled' }],
+    });
+
+    expect(response.stopReason).toBe('cancelled');
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('emits updatedAt after a failed turn (error event)', async () => {
+    const { agent } = buildFakeAgent([
+      { type: 'error', error: { message: 'kaboom' } },
+    ]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await expect(
+      session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'A prompt that errors' }],
+      }),
+    ).rejects.toThrow(/kaboom/);
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('does not emit a title when the first prompt has no text content', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('exposes the derived title and updatedAt via getLifecycleInfo for the session listing', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Listing title here' }],
+    });
+
+    const info = session.getLifecycleInfo();
+    expect(info.title).toBe('Listing title here');
+    expect(info.updatedAt).toStrictEqual(expect.any(String));
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -85,7 +85,7 @@ describe('Zed Session - session_info_update findings (issue #1611 remediation)',
       sessionId: 'test-session-id',
       prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
     });
-    connection.messages.length = 0;
+    connection.clearSessionInfoUpdates();
 
     await session.prompt({
       sessionId: 'test-session-id',

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -25,9 +25,9 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map((session) => session.dispose()),
+  );
 }
 
 describe('Zed Session - session_info_update findings (issue #1611 remediation)', () => {

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -13,7 +13,7 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { Session } from './zedIntegration.js';
+import type { Session } from './zedIntegration.js';
 import {
   buildFakeAgent,
   buildScriptedAgent,

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for session_info_update remediation findings (issue #1611):
+ * - Finding 1: title eligibility consumed synchronously at acceptance, race-safe.
+ * - Finding 3: slash command success/failure shares exact-once metadata finally.
+ * - Finding 4: pre-turn listing timestamp stable (initialized once).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  buildScriptedAgent,
+  RecordingConnection,
+  createSession,
+  editConfirmation,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  for (const session of createdSessions.splice(0)) {
+    await session.dispose();
+  }
+}
+
+describe('Zed Session - session_info_update findings (issue #1611 remediation)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('finding 1: the first ACCEPTED prompt wins the title even if a later overlapping prompt finishes first', async () => {
+    let promptCount = 0;
+    const { agent } = buildScriptedAgent(() => {
+      promptCount += 1;
+      return promptCount === 1
+        ? [
+            {
+              type: 'tool-call',
+              call: { id: 'race-tool', name: 'edit', args: {} },
+            },
+            editConfirmation('race-conf', 'race-tool'),
+            { type: 'done', reason: 'stop' },
+          ]
+        : [
+            { type: 'text', text: 'second response' },
+            { type: 'done', reason: 'stop' },
+          ];
+    });
+    const connection = new RecordingConnection();
+    const gate = connection.armPermissionGate();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const firstPrompt = session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Prompt A title' }],
+    });
+    await gate.arrived;
+    const secondPrompt = session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Prompt B title' }],
+    });
+    const firstResponse = await firstPrompt;
+    const secondResponse = await secondPrompt;
+
+    expect(firstResponse.stopReason).toBe('cancelled');
+    expect(secondResponse.stopReason).toBe('end_turn');
+
+    const info = session.getLifecycleInfo();
+    expect(info.title).toBe('Prompt A title');
+  });
+
+  it('finding 1: a no-text first prompt consumes eligibility so a later text prompt does not retitle', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
+    });
+    connection.messages.length = 0;
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Should not become the title' }],
+    });
+
+    expect(session.getLifecycleInfo().title).toBeUndefined();
+  });
+
+  it('finding 3: a slash command emits exact-once session_info_update metadata (updatedAt)', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: '/tools' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('finding 3: a slash command as the first text prompt still wins the title (shared finally)', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: '/help me with something' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBe('/help me with something');
+  });
+
+  it('retries a title notification after a transient transport failure without failing either prompt', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    connection.failSessionUpdateAfter(0, new Error('transport down'));
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const first = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Persistent title' }],
+    });
+    expect(first.stopReason).toBe('end_turn');
+    expect(connection.sessionInfoUpdates()).toHaveLength(0);
+
+    connection.clearSessionUpdateFailure();
+    const second = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Second prompt' }],
+    });
+    expect(second.stopReason).toBe('end_turn');
+    expect(connection.sessionInfoUpdates()).toContainEqual(
+      expect.objectContaining({ title: 'Persistent title' }),
+    );
+  });
+
+  it('finding 4: getLifecycleInfo returns a stable updatedAt before the first turn', () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const first = session.getLifecycleInfo();
+    const second = session.getLifecycleInfo();
+    expect(first.updatedAt).toBe(second.updatedAt);
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
@@ -20,9 +20,9 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map((session) => session.dispose()),
+  );
 }
 
 describe('Zed Session.prompt (Agent API) - stale prompt terminal events', () => {
@@ -79,6 +79,40 @@ describe('Zed Session.prompt (Agent API) - stale prompt terminal events', () => 
 
     expect(firstResponse.stopReason).toBe('cancelled');
     expect(secondResponse.stopReason).toBe('end_turn');
+  });
+
+  it('stops consuming a stream at the first event after a prompt becomes stale', async () => {
+    let promptCount = 0;
+    let staleEventsProduced = 0;
+    const { agent } = buildScriptedAgent(() => []);
+    agent.stream = async function* () {
+      promptCount += 1;
+      if (promptCount === 1) {
+        yield {
+          type: 'tool-call',
+          call: { id: 'stale-stop-tool', name: 'edit', args: {} },
+        } as const;
+        yield editConfirmation('stale-stop-confirmation', 'stale-stop-tool');
+        staleEventsProduced += 1;
+        yield { type: 'text', text: 'first stale event' } as const;
+        staleEventsProduced += 1;
+        yield { type: 'text', text: 'second stale event' } as const;
+        return;
+      }
+      yield { type: 'done', reason: 'stop' } as const;
+    };
+    const connection = new RecordingConnection();
+    const gate = connection.armPermissionGate();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const firstPrompt = runPrompt(session);
+    await gate.arrived;
+    const secondPrompt = runPrompt(session);
+    await firstPrompt;
+    await secondPrompt;
+
+    expect(staleEventsProduced).toBe(1);
   });
 
   it('returns cancelled (not an error) when a cancelled prompt ends with done:hook-stopped', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.stale.test.ts
@@ -27,6 +27,26 @@ async function disposeCreatedSessions(): Promise<void> {
 
 describe('Zed Session.prompt (Agent API) - stale prompt terminal events', () => {
   afterEach(disposeCreatedSessions);
+
+  it('preserves a completed turn when cancellation arrives after done', async () => {
+    const sessionRef: { current: Session | null } = { current: null };
+    const { agent } = buildFakeAgent([]);
+    agent.stream = async function* () {
+      yield { type: 'done', reason: 'stop' } as const;
+      const currentSession = sessionRef.current;
+      if (currentSession === null) throw new Error('Session not initialized');
+      await currentSession.cancelPendingPrompt();
+    };
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    sessionRef.current = session;
+    createdSessions.push(session);
+
+    const response = await runPrompt(session);
+
+    expect(response.stopReason).toBe('end_turn');
+  });
+
   it('returns cancelled (not an error) when a superseded prompt ends with done:error', async () => {
     const toolCallId = 'stale-error-tool';
     let promptCount = 0;

--- a/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for Session.streamHistory restored-session title hydration
+ * (issue #1611 finding 2). Exercises the real streamHistory orchestration that
+ * load/resume uses (not a faked restoration) to verify the title is hydrated
+ * from restored history so a later prompt never retitles the session.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  RecordingConnection,
+  createSession,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  const sessions = createdSessions.splice(0);
+  await Promise.allSettled(sessions.map((session) => session.dispose()));
+}
+
+describe('Zed Session.streamHistory - restored-session title hydration (issue #1611 finding 2)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('hydrates the title from restored history so a later prompt does not retitle', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored session title' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'prior response' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBe('Restored session title');
+
+    connection.messages.length = 0;
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'New prompt after restore' }],
+    });
+
+    expect(session.getLifecycleInfo().title).toBe('Restored session title');
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('does not set a title when restored history has no human text', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'agent-only content' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBeUndefined();
+  });
+
+  it('uses the first human text when restored history has multiple human entries', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'First restored message' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'response one' }],
+      },
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Second restored message' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBe('First restored message');
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
@@ -51,7 +51,7 @@ describe('Zed Session.streamHistory - restored-session title hydration (issue #1
 
     expect(session.getLifecycleInfo().title).toBe('Restored session title');
 
-    connection.messages.length = 0;
+    connection.clearSessionInfoUpdates();
     await session.prompt({
       sessionId: 'test-session-id',
       prompt: [{ type: 'text', text: 'New prompt after restore' }],

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -6,64 +6,34 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import type * as acp from '@agentclientprotocol/sdk';
-import type { Config } from '@vybestack/llxprt-code-core';
+import { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { AgentEvent } from '@vybestack/llxprt-code-agents';
 
 import { Session } from './zedIntegration.js';
+import { TerminalManager } from './zed-terminal-manager.js';
 import {
   buildFakeAgent,
-  buildBlockingFakeAgent,
   RecordingConnection,
   buildMinimalConfig,
 } from './zed-test-helpers.js';
 
 const createdSessions: Session[] = [];
+// Mirrors the output of buildCommandToExecute('echo hello', false, '/tmp/shell.tmp')
+// from packages/tools/src/tools/shell-helpers.ts. Update together if the wrapping format changes.
+const preparedEcho =
+  '{ echo hello; }; __code=$?; pgrep -g 0 >/tmp/shell.tmp 2>&1; exit $__code;';
 
-async function disposeCreatedSessions(): Promise<void> {
-  await Promise.allSettled(
-    createdSessions.splice(0).map(async (session) => {
-      try {
-        await session.dispose();
-      } catch {
-        // Continue disposing remaining sessions even if one fails
-      }
-    }),
-  );
-}
-
-function createTerminalSession(
-  events: readonly AgentEvent[],
+function terminalManager(
   connection: RecordingConnection,
-  config: Config = buildMinimalConfig(),
-  terminalEnabled = true,
-): Session {
-  const { agent } = buildFakeAgent(events, { run_shell_command: 'execute' });
-  return new Session(
+  sendUpdate: (update: acp.SessionUpdate) => Promise<void> = (update) =>
+    connection.sessionUpdate({ sessionId: 'test-session-id', update }),
+): TerminalManager {
+  return new TerminalManager(
     'test-session-id',
-    agent,
-    config,
     connection as unknown as acp.AgentSideConnection,
-    false,
-    terminalEnabled,
-  );
-}
-
-function createBlockingTerminalSession(
-  events: readonly AgentEvent[],
-  connection: RecordingConnection,
-  config: Config = buildMinimalConfig(),
-  terminalEnabled = true,
-): Session {
-  const { agent } = buildBlockingFakeAgent(events, {
-    run_shell_command: 'execute',
-  });
-  return new Session(
-    'test-session-id',
-    agent,
-    config,
-    connection as unknown as acp.AgentSideConnection,
-    false,
-    terminalEnabled,
+    '/project',
+    sendUpdate,
+    new DebugLogger('llxprt:zed-terminal-test'),
   );
 }
 
@@ -74,17 +44,6 @@ function shellToolCallEvent(toolCallId: string, command: string): AgentEvent {
       id: toolCallId,
       name: 'run_shell_command',
       args: { command },
-    },
-  };
-}
-
-function shellToolStatusEvent(toolCallId: string): AgentEvent {
-  return {
-    type: 'tool-status',
-    update: {
-      id: toolCallId,
-      name: 'run_shell_command',
-      status: 'executing',
     },
   };
 }
@@ -102,191 +61,179 @@ function shellToolResultEvent(toolCallId: string, output: string): AgentEvent {
 
 const doneEvent: AgentEvent = { type: 'done', reason: 'stop' };
 
-describe('Zed Session — terminal capability integration', () => {
-  afterEach(disposeCreatedSessions);
-
-  describe('terminal-enabled sessions', () => {
-    it('emits terminal content on shell tool calls when terminal capability is present', async () => {
-      const toolCallId = 'shell-1';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('hello');
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'echo hello'),
-          shellToolStatusEvent(toolCallId),
-          shellToolResultEvent(toolCallId, 'hello'),
-          doneEvent,
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'run echo' }],
-      });
-
-      const toolCallUpdates = connection
-        .onlySessionUpdates()
-        .filter(
-          (
-            u,
-          ): u is Extract<acp.SessionUpdate, { sessionUpdate: 'tool_call' }> =>
-            u.sessionUpdate === 'tool_call',
-        );
-      expect(toolCallUpdates).toHaveLength(1);
-      expect(toolCallUpdates[0].kind).toBe('execute');
-
-      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
-        if (u.sessionUpdate !== 'tool_call_update') return false;
-        const content = u.content ?? [];
-        return content.some(
-          (c): c is Extract<typeof c, { type: 'terminal' }> =>
-            c.type === 'terminal',
-        );
-      });
-      expect(hasTerminalContent).toBe(true);
-    });
-
-    it('creates a terminal via connection.createTerminal for shell commands', async () => {
-      const toolCallId = 'shell-create';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('file1\nfile2');
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'ls'),
-          shellToolResultEvent(toolCallId, 'file1\nfile2'),
-          doneEvent,
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'list files' }],
-      });
-
-      expect(connection.createTerminalCalls).toHaveLength(1);
-      const call = connection.createTerminalCalls[0];
-      expect(call.command).toBe('ls');
-      expect(call.sessionId).toBe('test-session-id');
-    });
-
-    it('releases terminals on normal completion', async () => {
-      const toolCallId = 'shell-release';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('done');
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'echo done'),
-          shellToolResultEvent(toolCallId, 'done'),
-          doneEvent,
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'echo' }],
-      });
-
-      expect(connection.releaseCalls).toBe(1);
-    });
-
-    it('kills and releases terminals on cancel', async () => {
-      const toolCallId = 'shell-cancel';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('');
-      connection.delayTerminalExit();
-      const session = createBlockingTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'sleep 999'),
-          shellToolStatusEvent(toolCallId),
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      const promptPromise = session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'sleep' }],
-      });
-
-      await connection.waitForTerminalCreated();
-      await session.cancelPendingPrompt();
-      await promptPromise;
-
-      expect(connection.killCalls).toBe(1);
-    });
-
-    it('kills and releases terminals on dispose', async () => {
-      const toolCallId = 'shell-dispose';
-      const connection = new RecordingConnection();
-      connection.setTerminalOutput('');
-      connection.delayTerminalExit();
-      const session = createBlockingTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'sleep 999'),
-          shellToolStatusEvent(toolCallId),
-        ],
-        connection,
-      );
-      createdSessions.push(session);
-
-      const promptPromise = session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'sleep' }],
-      });
-
-      await connection.waitForTerminalCreated();
-      await session.dispose();
-      await promptPromise.catch(() => undefined);
-
-      expect(connection.killCalls).toBe(1);
-    });
+describe('Zed terminal execution', () => {
+  afterEach(async () => {
+    await Promise.allSettled(
+      createdSessions.splice(0).map((session) => session.dispose()),
+    );
   });
 
-  describe('terminal-disabled sessions (fallback)', () => {
-    it('does not create terminals and emits text content when terminal capability is absent', async () => {
-      const toolCallId = 'shell-fallback';
-      const connection = new RecordingConnection();
-      const session = createTerminalSession(
-        [
-          shellToolCallEvent(toolCallId, 'echo text-output'),
-          shellToolResultEvent(toolCallId, 'text-output'),
-          doneEvent,
-        ],
-        connection,
-        undefined,
-        false,
-      );
-      createdSessions.push(session);
-
-      await session.prompt({
-        sessionId: 'test-session-id',
-        prompt: [{ type: 'text', text: 'echo' }],
-      });
-
-      expect(connection.createTerminalCalls).toHaveLength(0);
-
-      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
-        if (u.sessionUpdate !== 'tool_call_update') return false;
-        const content = u.content ?? [];
-        return content.some((c) => c.type === 'terminal');
-      });
-      expect(hasTerminalContent).toBe(false);
-
-      const hasTextContent = connection.onlySessionUpdates().some((u) => {
-        if (u.sessionUpdate !== 'tool_call_update') return false;
-        const content = u.content ?? [];
-        return content.some(
-          (c): c is Extract<typeof c, { type: 'content' }> =>
-            c.type === 'content',
-        );
-      });
-      expect(hasTextContent).toBe(true);
+  it('delegates shell execution to the ACP terminal exactly once', async () => {
+    const connection = new RecordingConnection();
+    connection.setTerminalOutput('hello\n');
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-1',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
     });
+    const chunks: string[] = [];
+
+    const result = await terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      (event) => {
+        if (event.type === 'data' && event.chunk !== undefined) {
+          chunks.push(event.chunk);
+        }
+      },
+      new AbortController().signal,
+    );
+
+    expect(connection.createTerminalCalls).toStrictEqual([
+      {
+        command: 'bash',
+        args: ['-c', preparedEcho],
+        cwd: '/project',
+        sessionId: 'test-session-id',
+      },
+    ]);
+    expect(result).toMatchObject({ output: 'hello\n', exitCode: 0 });
+    expect(chunks.join('')).toBe('hello\n');
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'shell-1',
+        content: [{ type: 'terminal', terminalId: 'terminal-1' }],
+      }),
+    );
+    expect(connection.releaseCalls).toBe(1);
+  });
+
+  it('does not create a terminal for an already-cancelled execution', async () => {
+    const connection = new RecordingConnection();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      terminalManager(connection).executeShellCommand(
+        preparedEcho,
+        '/project',
+        () => undefined,
+        controller.signal,
+      ),
+    ).resolves.toMatchObject({ aborted: true });
+    expect(connection.createTerminalCalls).toHaveLength(0);
+  });
+
+  it('does not mirror a shell command merely by observing its agent event', async () => {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection);
+    const { agent } = buildFakeAgent(
+      [
+        shellToolCallEvent('shell-observed', 'touch side-effect'),
+        shellToolResultEvent('shell-observed', 'locally executed'),
+        doneEvent,
+      ],
+      { run_shell_command: 'execute' },
+    );
+    const session = new Session(
+      'test-session-id',
+      agent,
+      buildMinimalConfig(),
+      connection as unknown as acp.AgentSideConnection,
+      false,
+      terminals,
+    );
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'run it once' }],
+    });
+
+    expect(connection.createTerminalCalls).toHaveLength(0);
+  });
+
+  it('kills and releases delegated execution on cancellation', async () => {
+    const connection = new RecordingConnection();
+    connection.delayTerminalExit();
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-cancel',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
+    });
+    const controller = new AbortController();
+    const execution = terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      controller.signal,
+    );
+
+    await connection.waitForTerminalCreated();
+    controller.abort();
+    await execution;
+
+    expect(connection.killCalls).toBe(1);
+    expect(connection.releaseCalls).toBe(1);
+  });
+
+  it('cleans up the client process when terminal update delivery fails', async () => {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection, async () => {
+      throw new Error('transport closed');
+    });
+    await terminals.observeToolCall({
+      id: 'shell-failure',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
+    });
+
+    await expect(
+      terminals.executeShellCommand(
+        preparedEcho,
+        '/project',
+        () => undefined,
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow('transport closed');
+    expect(connection.killCalls).toBe(1);
+    expect(connection.releaseCalls).toBe(1);
+  });
+
+  it('retains text-only behavior when terminal capability is absent', async () => {
+    const connection = new RecordingConnection();
+    const { agent } = buildFakeAgent(
+      [
+        shellToolCallEvent('shell-fallback', 'echo text-output'),
+        shellToolResultEvent('shell-fallback', 'text-output'),
+        doneEvent,
+      ],
+      { run_shell_command: 'execute' },
+    );
+    const session = new Session(
+      'test-session-id',
+      agent,
+      buildMinimalConfig(),
+      connection as unknown as acp.AgentSideConnection,
+    );
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'echo' }],
+    });
+
+    expect(connection.createTerminalCalls).toHaveLength(0);
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        content: [
+          { type: 'content', content: { type: 'text', text: 'text-output' } },
+        ],
+      }),
+    );
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Config } from '@vybestack/llxprt-code-core';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  buildBlockingFakeAgent,
+  RecordingConnection,
+  buildMinimalConfig,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  for (const session of createdSessions.splice(0)) {
+    await session.dispose();
+  }
+}
+
+function createTerminalSession(
+  events: readonly AgentEvent[],
+  connection: RecordingConnection,
+  config: Config = buildMinimalConfig(),
+  terminalEnabled = true,
+): Session {
+  const { agent } = buildFakeAgent(events, { run_shell_command: 'execute' });
+  return new Session(
+    'test-session-id',
+    agent,
+    config,
+    connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
+  );
+}
+
+function createBlockingTerminalSession(
+  events: readonly AgentEvent[],
+  connection: RecordingConnection,
+  config: Config = buildMinimalConfig(),
+  terminalEnabled = true,
+): Session {
+  const { agent } = buildBlockingFakeAgent(events, {
+    run_shell_command: 'execute',
+  });
+  return new Session(
+    'test-session-id',
+    agent,
+    config,
+    connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
+  );
+}
+
+function shellToolCallEvent(toolCallId: string, command: string): AgentEvent {
+  return {
+    type: 'tool-call',
+    call: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      args: { command },
+    },
+  };
+}
+
+function shellToolStatusEvent(toolCallId: string): AgentEvent {
+  return {
+    type: 'tool-status',
+    update: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      status: 'executing',
+    },
+  };
+}
+
+function shellToolResultEvent(toolCallId: string, output: string): AgentEvent {
+  return {
+    type: 'tool-result',
+    result: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      output,
+    },
+  };
+}
+
+const doneEvent: AgentEvent = { type: 'done', reason: 'stop' };
+
+describe('Zed Session — terminal capability integration', () => {
+  afterEach(disposeCreatedSessions);
+
+  describe('terminal-enabled sessions', () => {
+    it('emits terminal content on shell tool calls when terminal capability is present', async () => {
+      const toolCallId = 'shell-1';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('hello');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo hello'),
+          shellToolStatusEvent(toolCallId),
+          shellToolResultEvent(toolCallId, 'hello'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'run echo' }],
+      });
+
+      const toolCallUpdates = connection
+        .onlySessionUpdates()
+        .filter(
+          (
+            u,
+          ): u is Extract<acp.SessionUpdate, { sessionUpdate: 'tool_call' }> =>
+            u.sessionUpdate === 'tool_call',
+        );
+      expect(toolCallUpdates).toHaveLength(1);
+      expect(toolCallUpdates[0].kind).toBe('execute');
+
+      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some(
+          (c): c is Extract<typeof c, { type: 'terminal' }> =>
+            c.type === 'terminal',
+        );
+      });
+      expect(hasTerminalContent).toBe(true);
+    });
+
+    it('creates a terminal via connection.createTerminal for shell commands', async () => {
+      const toolCallId = 'shell-create';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('file1\nfile2');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'ls'),
+          shellToolResultEvent(toolCallId, 'file1\nfile2'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'list files' }],
+      });
+
+      expect(connection.createTerminalCalls).toHaveLength(1);
+      const call = connection.createTerminalCalls[0];
+      expect(call.command).toBe('ls');
+      expect(call.sessionId).toBe('test-session-id');
+    });
+
+    it('releases terminals on normal completion', async () => {
+      const toolCallId = 'shell-release';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('done');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo done'),
+          shellToolResultEvent(toolCallId, 'done'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'echo' }],
+      });
+
+      expect(connection.releaseCalls).toBe(1);
+    });
+
+    it('kills and releases terminals on cancel', async () => {
+      const toolCallId = 'shell-cancel';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('');
+      connection.delayTerminalExit();
+      const session = createBlockingTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'sleep 999'),
+          shellToolStatusEvent(toolCallId),
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      const promptPromise = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'sleep' }],
+      });
+
+      await connection.waitForTerminalCreated();
+      await session.cancelPendingPrompt();
+      await promptPromise;
+
+      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+    });
+
+    it('kills and releases terminals on dispose', async () => {
+      const toolCallId = 'shell-dispose';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('');
+      connection.delayTerminalExit();
+      const session = createBlockingTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'sleep 999'),
+          shellToolStatusEvent(toolCallId),
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      const promptPromise = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'sleep' }],
+      });
+
+      await connection.waitForTerminalCreated();
+      await session.dispose();
+      await promptPromise.catch(() => undefined);
+
+      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('terminal-disabled sessions (fallback)', () => {
+    it('does not create terminals and emits text content when terminal capability is absent', async () => {
+      const toolCallId = 'shell-fallback';
+      const connection = new RecordingConnection();
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo text-output'),
+          shellToolResultEvent(toolCallId, 'text-output'),
+          doneEvent,
+        ],
+        connection,
+        undefined,
+        false,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'echo' }],
+      });
+
+      expect(connection.createTerminalCalls).toHaveLength(0);
+
+      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some((c) => c.type === 'terminal');
+      });
+      expect(hasTerminalContent).toBe(false);
+
+      const hasTextContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some(
+          (c): c is Extract<typeof c, { type: 'content' }> =>
+            c.type === 'content',
+        );
+      });
+      expect(hasTextContent).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -20,9 +20,15 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map(async (session) => {
+      try {
+        await session.dispose();
+      } catch {
+        // Continue disposing remaining sessions even if one fails
+      }
+    }),
+  );
 }
 
 function createTerminalSession(

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -112,6 +112,76 @@ describe('Zed terminal execution', () => {
     expect(connection.releaseCalls).toBe(1);
   });
 
+  it('correlates a raw command that already ends with a semicolon', async () => {
+    const connection = new RecordingConnection();
+    const terminals = terminalManager(connection);
+    await terminals.observeToolCall({
+      id: 'shell-semicolon',
+      name: 'run_shell_command',
+      args: { command: 'echo hello;' },
+    });
+
+    await terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'shell-semicolon',
+        content: [{ type: 'terminal', terminalId: 'terminal-1' }],
+      }),
+    );
+  });
+
+  it('retries terminal correlation after update delivery fails', async () => {
+    const connection = new RecordingConnection();
+    connection.delayTerminalExit();
+    let deliveryAttempt = 0;
+    const terminals = terminalManager(connection, async (update) => {
+      deliveryAttempt += 1;
+      if (deliveryAttempt === 1) {
+        throw new Error('transport unavailable');
+      }
+      await connection.sessionUpdate({
+        sessionId: 'test-session-id',
+        update,
+      });
+    });
+    const execution = terminals.executeShellCommand(
+      preparedEcho,
+      '/project',
+      () => undefined,
+      new AbortController().signal,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(
+      terminals.observeToolCall({
+        id: 'shell-retry',
+        name: 'run_shell_command',
+        args: { command: 'echo hello' },
+      }),
+    ).rejects.toThrow('transport unavailable');
+    await terminals.observeToolCall({
+      id: 'shell-retry',
+      name: 'run_shell_command',
+      args: { command: 'echo hello' },
+    });
+    connection.resolveDelayedTerminalExit();
+    await execution;
+
+    expect(connection.onlySessionUpdates()).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'shell-retry',
+      }),
+    );
+  });
+
   it('does not create a terminal for an already-cancelled execution', async () => {
     const connection = new RecordingConnection();
     const controller = new AbortController();

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -218,7 +218,7 @@ describe('Zed Session — terminal capability integration', () => {
       await session.cancelPendingPrompt();
       await promptPromise;
 
-      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+      expect(connection.killCalls).toBe(1);
     });
 
     it('kills and releases terminals on dispose', async () => {
@@ -244,7 +244,7 @@ describe('Zed Session — terminal capability integration', () => {
       await session.dispose();
       await promptPromise.catch(() => undefined);
 
-      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+      expect(connection.killCalls).toBe(1);
     });
   });
 

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -18,8 +18,10 @@ import {
 } from './zed-test-helpers.js';
 
 const createdSessions: Session[] = [];
-// Mirrors the output of buildCommandToExecute('echo hello', false, '/tmp/shell.tmp')
-// from packages/tools/src/tools/shell-helpers.ts. Update together if the wrapping format changes.
+// Hardcoded mirror of buildCommandToExecute('echo hello', false, '/tmp/shell.tmp')
+// from packages/tools/src/tools/shell-helpers.ts. This function is not exported
+// from the tools package, so we cannot import it directly. If the wrapping
+// format in buildCommandToExecute changes, this constant MUST be updated to match.
 const preparedEcho =
   '{ echo hello; }; __code=$?; pgrep -g 0 >/tmp/shell.tmp 2>&1; exit $__code;';
 

--- a/packages/cli/src/zed-integration/zedIntegration.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.test.ts
@@ -149,6 +149,7 @@ describe('ZedAgent.newSession', () => {
       getProfileManager: () => undefined,
       getEphemeralSetting: () => undefined,
       getTargetDir: () => '/project',
+      getSessionRecordingService: () => undefined,
     } as unknown as Config;
     const connection = {
       readTextFile: vi.fn(async (_params: { sessionId: string }) => ({

--- a/packages/cli/src/zed-integration/zedIntegration.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.test.ts
@@ -155,6 +155,7 @@ describe('ZedAgent.newSession', () => {
         content: 'client',
       })),
       writeTextFile: vi.fn(async () => undefined),
+      sessionUpdate: vi.fn(async () => undefined),
     };
     const mod = await import('./zedIntegration.js');
     const zedAgent = new mod.ZedAgent(

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -36,17 +36,10 @@ import {
   buildSessionModes,
   buildUsageUpdate,
   describeSessionUpdateForLog,
-  mapDoneReasonToStopReason,
-  extractThoughtText,
-  translateErrorEvent,
-  translateIdleTimeout,
 } from './zed-helpers.js';
 import { ZedPathResolver } from './zed-path-resolver.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 import {
-  emitToolCallStart,
-  emitToolStatus,
-  emitToolResult,
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
@@ -82,7 +75,12 @@ import {
   buildZedSession,
   enableZedSessionRecording,
 } from './zed-agent-setup.js';
+import { handleZedAgentEvent } from './zed-agent-event-handler.js';
 import { buildZedPlanUpdate } from './zed-plan-update.js';
+import {
+  SessionTitleTracker,
+  buildSessionInfoUpdate,
+} from './zed-session-info.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -388,7 +386,13 @@ export class Session {
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
   private readonly stopConfigUpdates: () => void;
-  private updatedAt = new Date().toISOString();
+  private readonly sessionInfo = new SessionTitleTracker();
+  /**
+   * Stable timestamp captured once at construction so getLifecycleInfo returns
+   * a consistent updatedAt before the first turn completes (issue #1611
+   * finding 4) rather than generating a new value per getter call.
+   */
+  private readonly createdAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
@@ -399,6 +403,12 @@ export class Session {
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
+    const recordedTitle = config
+      .getSessionRecordingService()
+      ?.getSessionMetadataTitle();
+    if (recordedTitle !== undefined) {
+      this.sessionInfo.hydrateFromMetadata(recordedTitle);
+    }
     this.todoListener = (event: TodoUpdateEvent) => {
       const eventAgentId = event.agentId ?? DEFAULT_AGENT_ID;
       if (event.sessionId === this.id && eventAgentId === DEFAULT_AGENT_ID) {
@@ -434,10 +444,13 @@ export class Session {
   }
   getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
   getLifecycleInfo(): LifecycleSession {
+    const title = this.sessionInfo.getTitle();
     return {
       sessionId: this.id,
       cwd: this.config.getProjectRoot(),
-      updatedAt: this.updatedAt,
+      updatedAt: this.sessionInfo.getUpdatedAt() ?? this.createdAt,
+      createdAt: this.createdAt,
+      ...(title === undefined ? {} : { title }),
     };
   }
   async cancelPendingPrompt(): Promise<void> {
@@ -484,83 +497,169 @@ export class Session {
     }
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
-    this.updatedAt = new Date().toISOString();
     await this.cancelPendingPrompt();
-    const commandResult = await tryHandleZedCommand(
-      params.prompt,
-      this.agent,
-      (update) => this.sendUpdateStrict(update),
-    );
-    if (commandResult !== null) return commandResult.response;
-    const pendingSend = new AbortController();
-    this.pendingPrompt = pendingSend;
-    this.promptGeneration += 1;
-    const promptGeneration = this.promptGeneration;
-    const promptId = Math.random().toString(16).slice(2);
+    // Finding 1: consume title eligibility SYNCHRONOUSLY at acceptance time,
+    // before any async work, so overlapping prompts cannot both claim the title.
+    const eligibility = this.sessionInfo.consumeTitleEligibility(params.prompt);
+    // Issue #1611: record session_metadata immediately at acceptance so the
+    // title persists even for slash/failure sessions that never emit a content
+    // event. session_metadata materializes the recording file.
+    this.recordMetadataTitle(eligibility.title);
     try {
-      let parts: ContractPart[];
-      try {
-        parts = await this.pathResolver.resolvePrompt(
-          params.prompt,
-          pendingSend.signal,
-        );
-      } catch (error) {
-        if (
-          pendingSend.signal.aborted ||
-          (error instanceof Error && error.name === 'AbortError')
-        ) {
-          return { stopReason: 'cancelled' };
-        }
-        throw error;
-      }
-      const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
-        'auto') as FilterConfiguration['mode'];
-      const batcher = new StreamBatcher(
-        new EmojiFilter({ mode: emojiMode }),
-        (u) => this.sendUpdate(u),
+      const commandResult = await tryHandleZedCommand(
+        params.prompt,
+        this.agent,
+        (update) => this.sendUpdateStrict(update),
       );
-      let terminalStopReason: acp.StopReason | null = null;
+      if (commandResult !== null) {
+        return commandResult.response;
+      }
+      const pendingSend = new AbortController();
+      this.pendingPrompt = pendingSend;
+      this.promptGeneration += 1;
+      const promptGeneration = this.promptGeneration;
+      const promptId = Math.random().toString(16).slice(2);
       try {
-        terminalStopReason = await this.consumeAgentStream(
-          parts,
+        return await this.runPromptTurn(
+          params,
           pendingSend,
           promptId,
           promptGeneration,
-          batcher,
         );
-      } catch (error) {
-        if (getErrorStatus(error) === 429) {
-          throw new acp.RequestError(
-            429,
-            'Rate limit exceeded. Try again later.',
-          );
-        }
-        if (
-          pendingSend.signal.aborted ||
-          (error instanceof Error && error.name === 'AbortError')
-        ) {
-          return { stopReason: 'cancelled' };
-        }
-        throw error;
       } finally {
-        try {
-          await batcher.flush();
-        } finally {
-          batcher.dispose();
+        if (this.pendingPrompt === pendingSend) {
+          this.pendingPrompt = null;
         }
       }
-      if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+    } finally {
+      // Finding 3: exact-once metadata finally shared by command and prompt
+      // paths (success, cancel, or error). Best-effort transport — sendUpdate
+      // swallows transient errors so metadata never replaces the turn outcome.
+      await this.emitTurnMetadata(eligibility);
+    }
+  }
+
+  private async runPromptTurn(
+    params: acp.PromptRequest,
+    pendingSend: AbortController,
+    promptId: string,
+    promptGeneration: number,
+  ): Promise<acp.PromptResponse> {
+    let parts: ContractPart[];
+    try {
+      parts = await this.pathResolver.resolvePrompt(
+        params.prompt,
+        pendingSend.signal,
+      );
+    } catch (error) {
+      if (
+        pendingSend.signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
         return { stopReason: 'cancelled' };
       }
-      if (terminalStopReason !== null) {
-        return { stopReason: terminalStopReason };
+      throw error;
+    }
+    const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
+      'auto') as FilterConfiguration['mode'];
+    const batcher = new StreamBatcher(
+      new EmojiFilter({ mode: emojiMode }),
+      (u) => this.sendUpdate(u),
+    );
+    let terminalStopReason: acp.StopReason | null = null;
+    try {
+      terminalStopReason = await this.consumeAgentStream(
+        parts,
+        pendingSend,
+        promptId,
+        promptGeneration,
+        batcher,
+      );
+    } catch (error) {
+      if (getErrorStatus(error) === 429) {
+        throw new acp.RequestError(
+          429,
+          'Rate limit exceeded. Try again later.',
+        );
       }
-      return { stopReason: 'end_turn' };
+      if (
+        pendingSend.signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return { stopReason: 'cancelled' };
+      }
+      throw error;
     } finally {
-      if (this.pendingPrompt === pendingSend) {
-        this.pendingPrompt = null;
+      try {
+        await batcher.flush();
+      } finally {
+        batcher.dispose();
       }
     }
+    if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+      return { stopReason: 'cancelled' };
+    }
+    if (terminalStopReason !== null) {
+      return { stopReason: terminalStopReason };
+    }
+    return { stopReason: 'end_turn' };
+  }
+
+  private async emitTurnMetadata(eligibility: {
+    readonly wonTitle: boolean;
+    readonly title: string | undefined;
+  }): Promise<void> {
+    const { updates } = this.sessionInfo.recordTurn(new Date().toISOString());
+    const updatedAt = updates[0]?.updatedAt ?? undefined;
+    if (eligibility.wonTitle && eligibility.title !== undefined) {
+      await this.sendTitleUpdate(
+        buildSessionInfoUpdate({ title: eligibility.title, updatedAt }),
+        eligibility.title,
+      );
+      return;
+    }
+    for (const update of updates) {
+      const title = update.title;
+      if (typeof title === 'string') {
+        await this.sendTitleUpdate(update, title);
+      } else {
+        await this.sendUpdate(update);
+      }
+    }
+  }
+
+  /**
+   * Sends a title-bearing session_info_update, retrying on transport failure
+   * (issue #1611). Uses sendUpdateStrict (not the swallowing sendUpdate) so a
+   * transport error is detected; the title is then marked pending so the next
+   * turn's metadata emission re-sends it.
+   */
+  private async sendTitleUpdate(
+    update: acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' },
+    title: string,
+  ): Promise<void> {
+    try {
+      await this.sendUpdateStrict(update);
+    } catch (error) {
+      this.logger.debug(
+        () =>
+          `sendTitleUpdate ERROR (will retry next turn): ${error instanceof Error ? error.message : String(error)}`,
+      );
+      this.sessionInfo.markPendingTitle(title);
+    }
+  }
+
+  /**
+   * Records the session_metadata title to the durable recording service.
+   * Called at prompt-acceptance time (issue #1611) so the title persists
+   * immediately, materializing the recording for slash/failure sessions.
+   */
+  private recordMetadataTitle(title: string | undefined): void {
+    const recording = this.config.getSessionRecordingService();
+    if (recording?.isActive() !== true) {
+      return;
+    }
+    recording.recordSessionMetadata(title ?? null);
   }
   private async consumeAgentStream(
     parts: ContractPart[],
@@ -582,96 +681,21 @@ export class Session {
         }
         continue;
       }
-      const stopReason = await this.handleAgentEvent(
-        event,
-        batcher,
-        promptGeneration,
-        pendingSend,
-      );
+      const stopReason = await handleZedAgentEvent(event, batcher, {
+        sendUpdate: (update) => this.sendUpdate(update),
+        sendUsage: (usage) => this.sendUsageUpdate(usage),
+        handleConfirmation: (confirmation) =>
+          this.handleToolConfirmation(
+            confirmation,
+            promptGeneration,
+            pendingSend,
+          ),
+      });
       if (stopReason !== null) {
         terminalStopReason = stopReason;
       }
     }
     return terminalStopReason;
-  }
-  private async handleAgentEvent(
-    event: AgentEvent,
-    batcher: StreamBatcher,
-    promptGeneration: number,
-    pendingSend: AbortController,
-  ): Promise<acp.StopReason | null> {
-    switch (event.type) {
-      case 'text':
-        batcher.append(event.text, false);
-        return null;
-      case 'thinking': {
-        const thoughtText = extractThoughtText(event.thought);
-        if (thoughtText.length > 0) {
-          batcher.append(thoughtText, true);
-        }
-        return null;
-      }
-      case 'tool-call':
-        await batcher.flush();
-        await emitToolCallStart(event.call, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-status':
-        await batcher.flush();
-        await emitToolStatus(event.update, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-result':
-        await batcher.flush();
-        await emitToolResult(event.result, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-confirmation':
-        await batcher.flush();
-        await this.handleToolConfirmation(event, promptGeneration, pendingSend);
-        return null;
-      case 'done':
-        await batcher.flush();
-        return mapDoneReasonToStopReason(event.reason);
-      case 'error':
-        await batcher.flush();
-        throw translateErrorEvent(event);
-      case 'idle-timeout':
-        await batcher.flush();
-        throw translateIdleTimeout(event);
-      case 'invalid-stream':
-        await batcher.flush();
-        throw new Error(
-          'Agent produced an invalid stream that could not be recovered.',
-        );
-      case 'hook-blocked':
-        await batcher.flush();
-        throw new Error(
-          event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
-        );
-      case 'loop-detected':
-        await batcher.flush();
-        return 'end_turn';
-      case 'notice':
-        await batcher.flush();
-        await this.sendUpdate({
-          sessionUpdate: 'agent_message_chunk',
-          content: { type: 'text', text: event.message },
-        });
-        return null;
-      case 'usage': {
-        await batcher.flush();
-        await this.sendUsageUpdate(event.usage);
-        return null;
-      }
-      case 'context-warning':
-      case 'compression':
-      case 'model-info':
-      case 'retry':
-      case 'citation':
-        return null;
-      default: {
-        const exhaustive: never = event;
-        throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
-      }
-    }
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -784,6 +808,9 @@ export class Session {
         throw wrapReplayFailure(this.id, error);
       }
     }
+    // Finding 2: hydrate title from restored history so later prompts never
+    // retitle a restored session. Idempotent — a no-op if already titled.
+    this.sessionInfo.hydrateFromHistory(items);
   }
   async replayLiveHistory() {
     await this.streamHistory(

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -40,7 +40,8 @@ import {
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
-import { TerminalManager } from './zed-terminal-manager.js';
+import type { TerminalManager } from './zed-terminal-manager.js';
+import { buildZedTerminalSetup } from './zed-terminal-setup.js';
 import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
 import { wrapReplayFailure } from './zed-session-errors.js';
 import {
@@ -163,14 +164,20 @@ export class ZedAgent {
   }: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
     try {
       const sessionId = randomUUID();
-      const { agent, config: sessionConfig } = await this.buildSessionAgent(
-        sessionId,
-        cwd,
-      );
+      const {
+        agent,
+        config: sessionConfig,
+        terminals,
+      } = await this.buildSessionAgent(sessionId, cwd);
       await enableZedSessionRecording(agent, (error) =>
         this.logger.debug(() => `Recording failed for ${sessionId}: ${error}`),
       );
-      const session = await this.createSession(sessionId, agent, sessionConfig);
+      const session = await this.createSession(
+        sessionId,
+        agent,
+        sessionConfig,
+        terminals,
+      );
       await session.sendAvailableCommands();
       this.sessions.set(sessionId, session);
       return {
@@ -190,10 +197,18 @@ export class ZedAgent {
   resumeSession(params: acp.ResumeSessionRequest) {
     return this.lifecycle.resume(params);
   }
-  private supportsConfigOptions = () =>
-    this.clientCapabilities?.session?.configOptions != null;
-  private supportsTerminal = () => this.clientCapabilities?.terminal === true;
-  private createSession(id: string, agent: Agent, config: Config) {
+  private supportsConfigOptions(): boolean {
+    return this.clientCapabilities?.session?.configOptions === true;
+  }
+  private supportsTerminal(): boolean {
+    return this.clientCapabilities?.terminal === true;
+  }
+  private createSession(
+    id: string,
+    agent: Agent,
+    config: Config,
+    terminals: TerminalManager | null,
+  ) {
     return buildZedSession(
       agent,
       () =>
@@ -203,7 +218,7 @@ export class ZedAgent {
           config,
           this.connection,
           this.supportsConfigOptions(),
-          this.supportsTerminal(),
+          terminals,
         ),
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
@@ -294,10 +309,11 @@ export class ZedAgent {
     sessionId: string,
     cwd: string | undefined,
   ): Promise<{ session: Session; history: readonly IContent[] }> {
-    const { agent, config: sessionConfig } = await this.buildSessionAgent(
-      sessionId,
-      cwd,
-    );
+    const {
+      agent,
+      config: sessionConfig,
+      terminals,
+    } = await this.buildSessionAgent(sessionId, cwd);
     try {
       const history = await resumeAgentHistory(
         agent,
@@ -311,7 +327,7 @@ export class ZedAgent {
         sessionConfig,
         this.connection,
         this.supportsConfigOptions(),
-        this.supportsTerminal(),
+        terminals,
       );
       return { session, history };
     } catch (error) {
@@ -323,7 +339,11 @@ export class ZedAgent {
   private async buildSessionAgent(
     sessionId: string,
     cwd: string | undefined,
-  ): Promise<{ agent: Agent; config: Config }> {
+  ): Promise<{
+    agent: Agent;
+    config: Config;
+    terminals: TerminalManager | null;
+  }> {
     const baseFileSystemService = this.config.getFileSystemService();
     const sessionFileSystemService = this.clientCapabilities?.fs
       ? new AcpFileSystemService(
@@ -333,17 +353,35 @@ export class ZedAgent {
           baseFileSystemService,
         )
       : baseFileSystemService;
+    let terminalSetup: ReturnType<typeof buildZedTerminalSetup> | undefined;
     const sessionConfig = createSessionScopedConfig(
       this.config,
       sessionFileSystemService,
       resolveSessionTargetDir(this.config, cwd),
+      () => terminalSetup?.registry,
     );
+    if (this.supportsTerminal()) {
+      terminalSetup = buildZedTerminalSetup(
+        sessionId,
+        sessionConfig,
+        this.config.getToolRegistry(),
+        this.connection,
+        this.logger,
+      );
+    }
     this.logger.debug(() => `buildSessionAgent - session ${sessionId}`);
     const agent = await fromConfig({
       config: sessionConfig,
       sessionId,
+      ...(terminalSetup === undefined
+        ? {}
+        : { messageBus: terminalSetup.messageBus }),
     });
-    return { agent, config: sessionConfig };
+    return {
+      agent,
+      config: sessionConfig,
+      terminals: terminalSetup?.terminals ?? null,
+    };
   }
   deleteSession(params: DeleteSessionRequest) {
     return this.lifecycle.delete(params);
@@ -399,11 +437,6 @@ export class Session {
   private readonly todoListener: (event: TodoUpdateEvent) => void;
   private readonly stopConfigUpdates: () => void;
   private readonly sessionInfo = new SessionTitleTracker();
-  /**
-   * Stable timestamp captured once at construction so getLifecycleInfo returns
-   * a consistent updatedAt before the first turn completes (issue #1611
-   * finding 4) rather than generating a new value per getter call.
-   */
   private readonly createdAt = new Date().toISOString();
   private readonly terminals: TerminalManager | null;
 
@@ -413,17 +446,9 @@ export class Session {
     private readonly config: Config,
     private readonly connection: acp.AgentSideConnection,
     configOptionsEnabled = false,
-    terminalEnabled = false,
+    terminals: TerminalManager | null = null,
   ) {
-    this.terminals = terminalEnabled
-      ? new TerminalManager(
-          id,
-          connection,
-          config.getTargetDir(),
-          (update) => this.sendUpdate(update),
-          this.logger,
-        )
-      : null;
+    this.terminals = terminals;
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
@@ -523,12 +548,7 @@ export class Session {
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     await this.cancelPendingPrompt();
-    // Finding 1: consume title eligibility SYNCHRONOUSLY at acceptance time,
-    // before any async work, so overlapping prompts cannot both claim the title.
     const eligibility = this.sessionInfo.consumeTitleEligibility(params.prompt);
-    // Issue #1611: record session_metadata immediately at acceptance so the
-    // title persists even for slash/failure sessions that never emit a content
-    // event. session_metadata materializes the recording file.
     this.recordMetadataTitle(eligibility.title);
     try {
       const commandResult = await tryHandleZedCommand(
@@ -602,6 +622,7 @@ export class Session {
         ),
       isPromptStale: (gen, send) => this.isPromptStale(gen, send),
       maxTurns: this.config.getMaxSessionTurns(),
+      logger: this.logger,
     };
   }
 
@@ -628,12 +649,6 @@ export class Session {
     }
   }
 
-  /**
-   * Sends a title-bearing session_info_update, retrying on transport failure
-   * (issue #1611). Uses sendUpdateStrict (not the swallowing sendUpdate) so a
-   * transport error is detected; the title is then marked pending so the next
-   * turn's metadata emission re-sends it.
-   */
   private async sendTitleUpdate(
     update: acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' },
     title: string,
@@ -649,11 +664,6 @@ export class Session {
     }
   }
 
-  /**
-   * Records the session_metadata title to the durable recording service.
-   * Called at prompt-acceptance time (issue #1611) so the title persists
-   * immediately, materializing the recording for slash/failure sessions.
-   */
   private recordMetadataTitle(title: string | undefined): void {
     const recording = this.config.getSessionRecordingService();
     if (recording?.isActive() !== true) {
@@ -773,8 +783,6 @@ export class Session {
         throw wrapReplayFailure(this.id, error);
       }
     }
-    // Finding 2: hydrate title from restored history so later prompts never
-    // retitle a restored session. Idempotent — a no-op if already titled.
     this.sessionInfo.hydrateFromHistory(items);
   }
   async replayLiveHistory() {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -69,6 +69,8 @@ import {
   createSessionScopedConfig,
   resolveSessionTargetDir,
 } from './zed-session-config.js';
+import { buildAvailableCommandsUpdate } from './zed-command-registry.js';
+import { tryHandleZedCommand } from './zed-prompt-command.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -155,6 +157,7 @@ export class ZedAgent {
         agent,
         sessionConfig,
       );
+      await session.sendAvailableCommands();
       this.sessions.set(sessionId, session);
       return {
         sessionId,
@@ -203,10 +206,12 @@ export class ZedAgent {
     this.logger.debug(() => `loadSession - loading session ${sessionId}`);
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
+      await reattached.sendAvailableCommands();
       return { modes: buildSessionModes(reattached.getApprovalMode()) };
     }
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
+    await session.sendAvailableCommands();
     return { modes: buildSessionModes(session.getApprovalMode()) };
   }
   private async tryReattachLiveSession(
@@ -506,6 +511,15 @@ export class Session {
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     this.updatedAt = new Date().toISOString();
     await this.cancelPendingPrompt();
+    const commandResult = await tryHandleZedCommand(
+      params.prompt,
+      this.agent,
+      this.config,
+      (u) => this.sendUpdateStrict(u),
+    );
+    if (commandResult !== null) {
+      return commandResult.response;
+    }
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;
     this.promptGeneration += 1;
@@ -554,12 +568,6 @@ export class Session {
         }
         throw error;
       } finally {
-        // Flush any buffered chunks, THEN dispose so the batch timer is cleared
-        // on completion/abort and no delayed flush fires after the turn ends
-        // (FINDING F9). The batcher is per-prompt, so disposing here bounds its
-        // timer to the prompt lifecycle. dispose() runs even when flush()
-        // rejects (e.g. a dead transport) — otherwise the pending timer would
-        // leak past the turn.
         try {
           await batcher.flush();
         } finally {
@@ -664,13 +672,9 @@ export class Session {
           event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
         );
       case 'loop-detected':
-        // The agent detects a tool-call loop. Map to end_turn so the client
-        // sees a clean turn end rather than an indefinite hang.
         await batcher.flush();
         return 'end_turn';
       case 'notice':
-        // Informational notices have no direct ACP SessionUpdate; surface as
-        // an agent message so the user sees them.
         await batcher.flush();
         await this.sendUpdate({
           sessionUpdate: 'agent_message_chunk',
@@ -687,14 +691,8 @@ export class Session {
       case 'model-info':
       case 'retry':
       case 'citation':
-        // These variants have no faithful ACP translation: usage is mapped
-        // separately, compression/model-info/citation are metadata, retry is
-        // an internal agent detail, and context-warning is advisory. They are
-        // intentionally consumed without surfacing to ACP.
         return null;
       default: {
-        // Exhaustiveness guard: any future AgentEvent variant added to the
-        // union without an explicit case above will fail to type-check here.
         const exhaustive: never = event;
         throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
       }
@@ -703,10 +701,6 @@ export class Session {
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
   ): Promise<void> {
-    // size = the configured context window (user override -> provider limit ->
-    // model lookup, the shared #2251 resolver), used = tokens now in context —
-    // so the client renders consumption against the real window (issue #1607)
-    // instead of the previous used===size placeholder.
     const update = buildUsageUpdate(
       usage,
       getTokenLimitForConfiguredContext(this.config.getModel(), this.config),
@@ -787,6 +781,9 @@ export class Session {
     this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate({ sessionId: this.id, update });
   }
+  async sendAvailableCommands(): Promise<void> {
+    await this.sendUpdateStrict(buildAvailableCommandsUpdate());
+  }
   private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
       await this.sendUpdateStrict(update);
@@ -810,41 +807,13 @@ export class Session {
     }));
     await this.sendUpdate({ sessionUpdate: 'plan', entries });
   }
-  /**
-   * Replays a resumed conversation (ordered IContent[]) to the client as
-   * session/update notifications, in order, for ACP session/load (issue #1604).
-   * The neutral history is mapped to ACP updates by the pure
-   * mapHistoryToSessionUpdates helper (human text -> user_message_chunk, ai text
-   * -> agent_message_chunk, ai thinking -> agent_thought_chunk, ai tool_call ->
-   * tool_call, tool tool_response -> tool_call_update). Replay text is sent
-   * verbatim (NOT routed through the EmojiFilter): the recorded transcript was
-   * already filtered when first streamed, so re-filtering on replay would be
-   * redundant and could double-alter historical content.
-   */
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
     for (const update of updates) {
-      // STRICT: a failed delivery here (dead/failing transport) must reject so
-      // loadSession can clean up and report the failure instead of resolving as
-      // a success with a lost transcript (FINDING A). wrapReplayFailure maps the
-      // rejection to a precise internalError (passing an existing RequestError
-      // through unchanged) for loadSession's catch path.
-      try {
-        await this.sendUpdateStrict(update);
-      } catch (error) {
-        throw wrapReplayFailure(this.id, error);
-      }
+      try { await this.sendUpdateStrict(update); }
+      catch (error) { throw wrapReplayFailure(this.id, error); }
     }
   }
-  /**
-   * Re-attach replay for ACP session/load (#1604): replays this live session's
-   * IN-MEMORY conversation, used when a load targets a still-live session with
-   * no on-disk recording yet (unprompted; JSONL not materialized). History is
-   * read + wrapped by readAgentHistoryForReplay and maps through the SAME
-   * strict {@link streamHistory} path a disk resume uses (empty history → zero
-   * updates). Any failure rejects as a well-formed replay RequestError; the
-   * caller deliberately does NOT dispose the session — it remains healthy.
-   */
   async replayLiveHistory(): Promise<void> {
     await this.streamHistory(
       await readAgentHistoryForReplay(this.agent, this.id),

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -123,7 +123,7 @@ export async function runZedIntegration(
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
   private clientCapabilities: acp.ClientCapabilities | undefined;
-  private readonly logger = new DebugLogger('llxprt:zed');
+  private readonly logger = new DebugLogger('llxprt:zed-integration');
   private readonly lifecycle: SessionLifecycle;
   constructor(
     private config: Config,
@@ -149,7 +149,7 @@ export class ZedAgent {
   ): Promise<acp.ListSessionsResponse> {
     return this.lifecycle.list(params);
   }
-  authenticate({ methodId }: acp.AuthenticateRequest) {
+  authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
     return authenticateZedAgent(this.config, methodId);
   }
   async newSession({
@@ -185,19 +185,23 @@ export class ZedAgent {
   resumeSession(params: acp.ResumeSessionRequest) {
     return this.lifecycle.resume(params);
   }
-  private configEnabled = () =>
+  private supportsConfigOptions = () =>
     this.clientCapabilities?.session?.configOptions != null;
   private createSession(id: string, agent: Agent, config: Config) {
     return buildZedSession(
       agent,
       () =>
-        new Session(id, agent, config, this.connection, this.configEnabled()),
+        new Session(
+          id,
+          agent,
+          config,
+          this.connection,
+          this.supportsConfigOptions(),
+        ),
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
   }
-  async loadSession(
-    params: acp.LoadSessionRequest,
-  ): Promise<acp.LoadSessionResponse> {
+  async loadSession(params: acp.LoadSessionRequest) {
     return this.lifecycle.runSerialized(params.sessionId, () =>
       this.performLoadSession(params),
     );
@@ -294,7 +298,13 @@ export class ZedAgent {
         sessionConfig,
         this.sessionFileLister,
       );
-      const session = await this.createSession(sessionId, agent, sessionConfig);
+      const session = new Session(
+        sessionId,
+        agent,
+        sessionConfig,
+        this.connection,
+        this.supportsConfigOptions(),
+      );
       return { session, history };
     } catch (error) {
       await agent.dispose().catch(() => undefined);
@@ -333,7 +343,7 @@ export class ZedAgent {
   closeSession(params: acp.CloseSessionRequest) {
     return this.lifecycle.close(params);
   }
-  async setSessionMode(params: acp.SetSessionModeRequest) {
+  setSessionMode(params: acp.SetSessionModeRequest) {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
@@ -345,7 +355,7 @@ export class ZedAgent {
       dispatchZedConfigOption(this.clientCapabilities, this.sessions, params),
     );
   }
-  async cancel({ sessionId }: acp.CancelNotification): Promise<void> {
+  async cancel({ sessionId }: acp.CancelNotification) {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
     await session.cancelPendingPrompt();
@@ -357,7 +367,7 @@ export class ZedAgent {
     }
     return session.prompt(params);
   }
-  async disposeAll(): Promise<void> {
+  async disposeAll() {
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     await Promise.allSettled(sessions.map((session) => session.dispose()));
@@ -365,7 +375,7 @@ export class ZedAgent {
 }
 export class Session {
   private pendingPrompt: AbortController | null = null;
-  private readonly logger = new DebugLogger('llxprt:zed');
+  private readonly logger = new DebugLogger('llxprt:zed-integration');
   private pathResolver: ZedPathResolver;
   private activeConfirmations = new Map<
     string,
@@ -419,10 +429,7 @@ export class Session {
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
-  async setConfigOption(
-    configId: string,
-    value: string | boolean,
-  ): Promise<acp.SetSessionConfigOptionResponse> {
+  setConfigOption(configId: string, value: string | boolean) {
     return setZedConfigOption(this.agent, this.config, configId, value);
   }
   getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
@@ -778,12 +785,12 @@ export class Session {
       }
     }
   }
-  async replayLiveHistory(): Promise<void> {
+  async replayLiveHistory() {
     await this.streamHistory(
       await readAgentHistoryForReplay(this.agent, this.id),
     );
   }
-  async dispose(): Promise<void> {
+  async dispose() {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
       this.stopConfigUpdates();

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -532,10 +532,11 @@ export class Session {
         }
       }
     } finally {
-      // Finding 3: exact-once metadata finally shared by command and prompt
-      // paths (success, cancel, or error). Best-effort transport — sendUpdate
-      // swallows transient errors so metadata never replaces the turn outcome.
-      await this.emitTurnMetadata(eligibility);
+      try {
+        await this.emitTurnMetadata(eligibility);
+      } catch (error) {
+        this.logger.debug(() => `emitTurnMetadata ERROR: ${String(error)}`);
+      }
     }
   }
 

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -515,11 +515,9 @@ export class Session {
       params.prompt,
       this.agent,
       this.config,
-      (u) => this.sendUpdateStrict(u),
+      (update) => this.sendUpdateStrict(update),
     );
-    if (commandResult !== null) {
-      return commandResult.response;
-    }
+    if (commandResult !== null) return commandResult.response;
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;
     this.promptGeneration += 1;
@@ -810,8 +808,11 @@ export class Session {
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
     for (const update of updates) {
-      try { await this.sendUpdateStrict(update); }
-      catch (error) { throw wrapReplayFailure(this.id, error); }
+      try {
+        await this.sendUpdateStrict(update);
+      } catch (error) {
+        throw wrapReplayFailure(this.id, error);
+      }
     }
   }
   async replayLiveHistory(): Promise<void> {

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -405,7 +405,7 @@ export class Session {
   >();
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
-  private readonly createdAt = new Date().toISOString();
+  private updatedAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
@@ -453,7 +453,7 @@ export class Session {
     return {
       sessionId: this.id,
       cwd: this.config.getProjectRoot(),
-      updatedAt: this.createdAt,
+      updatedAt: this.updatedAt,
     };
   }
   async cancelPendingPrompt(): Promise<void> {
@@ -504,6 +504,7 @@ export class Session {
     }
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
+    this.updatedAt = new Date().toISOString();
     await this.cancelPendingPrompt();
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -84,7 +84,9 @@ import {
 } from './zed-session-info.js';
 import type {
   CloseSessionRequest,
+  CloseSessionResponse,
   DeleteSessionRequest,
+  DeleteSessionResponse,
   ClientCapabilitiesWithSession,
 } from './acp-types.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
@@ -98,7 +100,6 @@ export async function runZedIntegration(
   const { stdout: workingStdout } = createInkStdio();
   const stdout = Writable.toWeb(workingStdout) as WritableStream;
   const stdin = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
-  logger.debug(() => 'Streams created');
   setCliRuntimeContext(config.getSettingsService(), config, {
     runtimeId: 'cli.runtime.zed',
     metadata: { source: 'zed-integration', stage: 'bootstrap' },
@@ -108,11 +109,9 @@ export async function runZedIntegration(
   try {
     const stream = acp.ndJsonStream(stdout, stdin);
     const connection = new acp.AgentSideConnection((conn) => {
-      logger.debug(() => 'Creating ZedAgent');
       zedAgent = new ZedAgent(config, settings, conn);
       return zedAgent;
     }, stream);
-    logger.debug(() => 'AgentSideConnection created successfully');
     try {
       await connection.closed;
     } finally {
@@ -194,7 +193,7 @@ export class ZedAgent {
       throw error;
     }
   }
-  resumeSession(params: acp.ResumeSessionRequest) {
+  resumeSession(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
     return this.lifecycle.resume(params);
   }
   private supportsConfigOptions(): boolean {
@@ -223,7 +222,7 @@ export class ZedAgent {
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
   }
-  async loadSession(params: acp.LoadSessionRequest) {
+  async loadSession(params: acp.LoadSessionRequest): Promise<acp.LoadSessionResponse> {
     return this.lifecycle.runSerialized(params.sessionId, () =>
       this.performLoadSession(params),
     );
@@ -232,7 +231,6 @@ export class ZedAgent {
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
     const { sessionId } = params;
-    this.logger.debug(() => `loadSession - loading session ${sessionId}`);
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
       await reattached.sendAvailableCommands();
@@ -264,11 +262,7 @@ export class ZedAgent {
     if (recordingExists) {
       return null;
     }
-    this.logger.debug(
-      () =>
-        `loadSession - re-attaching live session ${sessionId} (no on-disk ` +
-        `recording; replaying in-memory history)`,
-    );
+    this.logger.debug(() => `loadSession - re-attaching live session ${sessionId}`);
     await existing.replayLiveHistory();
     return existing;
   }
@@ -292,14 +286,7 @@ export class ZedAgent {
       await session.streamHistory(history);
     } catch (error) {
       this.sessions.delete(sessionId);
-      try {
-        await session.dispose();
-      } catch (disposeError) {
-        this.logger.debug(
-          () =>
-            `loadSession - dispose after replay failure also failed (original error rethrown): ${disposeError}`,
-        );
-      }
+      try { await session.dispose(); } catch { /* original error rethrown */ }
       this.logger.debug(() => `loadSession - replay failed: ${error}`);
       throw error;
     }
@@ -369,7 +356,6 @@ export class ZedAgent {
         this.logger,
       );
     }
-    this.logger.debug(() => `buildSessionAgent - session ${sessionId}`);
     const agent = await fromConfig({
       config: sessionConfig,
       sessionId,
@@ -383,10 +369,10 @@ export class ZedAgent {
       terminals: terminalSetup?.terminals ?? null,
     };
   }
-  deleteSession(params: DeleteSessionRequest) {
+  deleteSession(params: DeleteSessionRequest): Promise<DeleteSessionResponse> {
     return this.lifecycle.delete(params);
   }
-  closeSession(params: CloseSessionRequest) {
+  closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     return this.lifecycle.close(params);
   }
   setSessionMode(
@@ -403,7 +389,7 @@ export class ZedAgent {
       dispatchZedConfigOption(this.clientCapabilities, this.sessions, params),
     );
   }
-  async cancel({ sessionId }: acp.CancelNotification) {
+  async cancel({ sessionId }: acp.CancelNotification): Promise<void> {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
     await session.cancelPendingPrompt();
@@ -415,7 +401,7 @@ export class ZedAgent {
     }
     return session.prompt(params);
   }
-  async disposeAll() {
+  async disposeAll(): Promise<void> {
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     await Promise.allSettled(sessions.map((session) => session.dispose()));
@@ -488,7 +474,7 @@ export class Session {
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
-  setConfigOption(configId: string, value: string | boolean) {
+  setConfigOption(configId: string, value: string) {
     return setZedConfigOption(this.agent, this.config, configId, value);
   }
   getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
@@ -785,12 +771,12 @@ export class Session {
     }
     this.sessionInfo.hydrateFromHistory(items);
   }
-  async replayLiveHistory() {
+  async replayLiveHistory(): Promise<void> {
     await this.streamHistory(
       await readAgentHistoryForReplay(this.agent, this.id),
     );
   }
-  async dispose() {
+  async dispose(): Promise<void> {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
       this.stopConfigUpdates();

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -3,7 +3,6 @@
  * Copyright 2025 Vybestack LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import {
   type Config,
   getErrorStatus,
@@ -30,14 +29,10 @@ import {
 import { Readable, Writable } from 'node:stream';
 import { type LoadedSettings } from '../config/settings.js';
 import { randomUUID } from 'crypto';
-import {
-  loadProfileByName,
-  setCliRuntimeContext,
-} from '@vybestack/llxprt-code-providers/runtime.js';
+import { setCliRuntimeContext } from '@vybestack/llxprt-code-providers/runtime.js';
 import { runExitCleanup } from '../utils/cleanup.js';
 import { AcpFileSystemService } from './fileSystemService.js';
 import {
-  parseZedAuthMethodId,
   buildAvailableModes,
   buildSessionModes,
   buildUsageUpdate,
@@ -67,38 +62,31 @@ import {
   type ChatSessionFileLister,
 } from './zed-session-loader.js';
 import { StreamBatcher } from './zed-stream-batcher.js';
+import { SessionLifecycle } from './zed-session-lifecycle.js';
+import type { LifecycleSession } from './zed-session-pagination.js';
+import { authenticateZedAgent, initializeZedAgent } from './zed-initialize.js';
 import {
   createSessionScopedConfig,
   resolveSessionTargetDir,
 } from './zed-session-config.js';
-
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
-
 export async function runZedIntegration(
   config: Config,
   settings: LoadedSettings,
 ): Promise<void> {
   const logger = new DebugLogger('llxprt:zed-integration');
   logger.debug(() => 'Starting Zed integration');
-
   const { stdout: workingStdout } = createInkStdio();
   const stdout = Writable.toWeb(workingStdout) as WritableStream;
   const stdin = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
-
   logger.debug(() => 'Streams created');
-
-  // Deliberate foreground hand-off: the Zed integration replaces the CLI
-  // bootstrap runtime as the process default. allowDefaultHandoff opts past the
-  // write-once guard for this one intentional transition (issue #2300).
   setCliRuntimeContext(config.getSettingsService(), config, {
     runtimeId: 'cli.runtime.zed',
     metadata: { source: 'zed-integration', stage: 'bootstrap' },
     allowDefaultHandoff: true,
   });
-
   let zedAgent: ZedAgent | undefined;
-
   try {
     const stream = acp.ndJsonStream(stdout, stdin);
     const connection = new acp.AgentSideConnection((conn) => {
@@ -107,7 +95,6 @@ export async function runZedIntegration(
       return zedAgent;
     }, stream);
     logger.debug(() => 'AgentSideConnection created successfully');
-
     try {
       await connection.closed;
     } finally {
@@ -119,80 +106,39 @@ export async function runZedIntegration(
     throw e;
   }
 }
-
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
-  /**
-   * Per-sessionId serialization of in-flight loadSession calls (FINDING F5).
-   * Two concurrent session/load calls for the SAME id must not both build agents
-   * and race to install (the later install would overwrite the earlier, orphaning
-   * its recording lock). Each load chains after any in-flight load for the same
-   * id; distinct ids stay fully parallel. The entry is cleared in finally only
-   * when it is still the same promise (a later chained load may have replaced it).
-   */
-  private loadSessionQueues: Map<string, Promise<acp.LoadSessionResponse>> =
-    new Map();
   private clientCapabilities: acp.ClientCapabilities | undefined;
-  private logger: DebugLogger;
-
-  /**
-   * Directory lister used by the loadSession re-attach probe (#1604) to decide
-   * whether an on-disk recording already exists for a session id. Defaults to
-   * the real `node:fs/promises` readdir wrapper; injectable via the constructor
-   * as an HONEST readdir-like seam (returns directory entry names) so tests can
-   * exercise the real chats-dir derivation + filename matching without stubbing
-   * our own decision logic.
-   */
+  private logger = new DebugLogger('llxprt:zed-integration');
+  private readonly lifecycle: SessionLifecycle;
   private readonly sessionFileLister: ChatSessionFileLister;
-
   constructor(
     private config: Config,
     _settings: LoadedSettings,
     private connection: acp.AgentSideConnection,
     sessionFileLister: ChatSessionFileLister = nodeChatSessionFileLister,
   ) {
-    this.logger = new DebugLogger('llxprt:zed-integration');
     this.sessionFileLister = sessionFileLister;
+    this.lifecycle = new SessionLifecycle(
+      config,
+      this.sessions,
+      (sessionId, cwd) => this.buildAndResumeSession(sessionId, cwd),
+    );
   }
-
   async initialize(
     args: acp.InitializeRequest,
   ): Promise<acp.InitializeResponse> {
     this.clientCapabilities = args.clientCapabilities;
-    const profileManager = this.config.getProfileManager();
-    const profileNames = profileManager
-      ? await profileManager.listProfiles()
-      : [];
-    const authMethods = profileNames.map((name) => ({
-      id: name,
-      name,
-      description: null,
-    }));
-
-    return {
-      protocolVersion: acp.PROTOCOL_VERSION,
-      authMethods,
-      agentCapabilities: {
-        loadSession: true,
-        promptCapabilities: {
-          image: true,
-          audio: true,
-          embeddedContext: true,
-        },
-      },
-    };
+    return initializeZedAgent(this.config);
   }
-
-  async authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
-    const profileManager = this.config.getProfileManager();
-    const availableProfiles = profileManager
-      ? await profileManager.listProfiles()
-      : [];
-    const profileName = parseZedAuthMethodId(methodId, availableProfiles);
-
-    await loadProfileByName(profileName);
+  listSessions(
+    params: acp.ListSessionsRequest,
+  ): Promise<acp.ListSessionsResponse> {
+    return this.lifecycle.list(params);
   }
-
+  authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
+    return authenticateZedAgent(this.config, methodId);
+  }
   async newSession({
     cwd,
     mcpServers: _mcpServers,
@@ -203,19 +149,13 @@ export class ZedAgent {
         sessionId,
         cwd,
       );
-      // Enable continuous session recording so the conversation is persisted to
-      // a JSONL session file (under <projectTempDir>/chats) and can later be
-      // resumed via loadSession. Recording must never break session creation, so
-      // a startup failure is logged and swallowed.
       await this.enableRecording(agent, sessionId);
-
       const session = await this.buildSessionForAgent(
         sessionId,
         agent,
         sessionConfig,
       );
       this.sessions.set(sessionId, session);
-
       return {
         sessionId,
         modes: buildSessionModes(agent.getApprovalMode()),
@@ -225,14 +165,6 @@ export class ZedAgent {
       throw error;
     }
   }
-
-  /**
-   * Constructs the Session wrapper for a freshly built agent, disposing the
-   * agent (releasing its recording lock) if the Session constructor throws
-   * (FINDING F12), so a ctor failure never leaks the agent — mirroring the
-   * loadSession-side guard in buildAndResumeSession. A dispose failure during
-   * cleanup is logged and swallowed so the ORIGINAL ctor error is rethrown.
-   */
   private async buildSessionForAgent(
     sessionId: string,
     agent: Agent,
@@ -252,117 +184,31 @@ export class ZedAgent {
       throw error;
     }
   }
-
-  /**
-   * Loads (resumes) a previously recorded session so its conversation can be
-   * continued (issue #1604). The history is replayed to the client as ordered
-   * session/update notifications BEFORE this resolves, so the Zed transcript is
-   * reconstructed.
-   *
-   * Two paths, chosen by whether a recording exists on disk (see
-   * {@link performLoadSession}):
-   *
-   * 1. RE-ATTACH (live session, no on-disk recording): a session that was created
-   *    via session/new but never prompted has NO recording file — SessionRecordingService
-   *    materializes the JSONL only on the FIRST content event — so a disk resume
-   *    would fail with "No sessions found for this project" AND the destroy-first
-   *    step would have thrown away a perfectly healthy live session. Instead we
-   *    KEEP the live session, replay its IN-MEMORY history (empty for a fresh
-   *    unprompted session → zero updates), and return its modes. This keeps ACP
-   *    loadSession conformant (an agent that advertises loadSession must not error
-   *    on a just-created session) and lets a Zed reconnect to an unprompted session
-   *    succeed. Because the live session is healthy, a replay failure here does NOT
-   *    dispose it — the wrapped internalError is simply propagated.
-   *
-   * 2. DISK RESUME (recording present, or no live session): a fresh Agent (bound
-   *    to a session-scoped Config + AcpFileSystemService, identical to newSession)
-   *    is created and `agent.session.resume` restores the recorded history AND
-   *    re-subscribes continuous recording so subsequent turns keep appending to the
-   *    SAME file. Replace-order + lock semantics: an already-loaded same-id Session
-   *    holds the on-disk session lock (SessionLockManager), so the fresh agent's
-   *    resume CANNOT acquire the lock until the prior Session is disposed; disposing
-   *    first is therefore unavoidable. To keep the destructive step safe we (a)
-   *    dispose the prior Session AND remove it from this.sessions up front so no
-   *    half-dead entry survives a subsequent failure, then (b) build + resume the
-   *    replacement; if that fails, the fresh agent is disposed and a precise
-   *    RequestError (carrying the lower-layer reason, see mapResumeError) is thrown,
-   *    leaving this.sessions with NO entry for the id so a later retry can cleanly
-   *    load again. On success the replacement is installed and the restored
-   *    transcript is streamed.
-   *
-   * Concurrency: same-id loads are SERIALIZED (FINDING F5) via loadSessionQueues
-   * so two concurrent session/load calls for one id cannot both build agents and
-   * race to install (which would orphan the earlier load's recording lock);
-   * distinct ids remain fully parallel. The re-attach probe + replay run INSIDE
-   * this serialization too.
-   */
+  resumeSession(
+    params: acp.ResumeSessionRequest,
+  ): Promise<acp.ResumeSessionResponse> {
+    return this.lifecycle.resume(params);
+  }
   async loadSession(
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
-    const { sessionId } = params;
-    // Chain this load after any in-flight load for the SAME id so the
-    // dispose-prior -> build -> resume -> install sequence runs to completion
-    // before the next same-id load begins (FINDING F5). We chain off the prior
-    // load's settlement (ignoring its outcome) rather than awaiting it directly
-    // so a rejected prior load does not reject this one.
-    const prior = this.loadSessionQueues.get(sessionId);
-    const run = (prior ?? Promise.resolve()).then(
-      () => this.performLoadSession(params),
-      () => this.performLoadSession(params),
+    return this.lifecycle.runSerialized(params.sessionId, () =>
+      this.performLoadSession(params),
     );
-    this.loadSessionQueues.set(sessionId, run);
-    try {
-      return await run;
-    } finally {
-      // Clear the queue entry only if it is still THIS load (a later chained
-      // same-id load may have replaced it); deleting unconditionally could drop
-      // a newer in-flight load's entry.
-      if (this.loadSessionQueues.get(sessionId) === run) {
-        this.loadSessionQueues.delete(sessionId);
-      }
-    }
   }
-
-  /**
-   * Performs a single (already-serialized, see {@link loadSession}) session/load.
-   *
-   * Decision: if a live same-id session exists AND no recording file exists on
-   * disk for it, RE-ATTACH the live session (an unprompted session has no
-   * recording — the file materializes on first content — so a disk resume would
-   * both fail and needlessly destroy the healthy live session). Otherwise fall
-   * back to the disk path: dispose any prior same-id Session to release its
-   * on-disk lock, then build + resume + install the replacement and stream the
-   * restored transcript.
-   */
   private async performLoadSession(
     params: acp.LoadSessionRequest,
   ): Promise<acp.LoadSessionResponse> {
     const { sessionId } = params;
     this.logger.debug(() => `loadSession - loading session ${sessionId}`);
-
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
       return { modes: buildSessionModes(reattached.getApprovalMode()) };
     }
-
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
     return { modes: buildSessionModes(session.getApprovalMode()) };
   }
-
-  /**
-   * RE-ATTACH decision + replay (#1604). Returns the live same-id Session (after
-   * replaying its in-memory history) when one exists AND has no on-disk recording
-   * yet (an unprompted session, whose JSONL file has not materialized) — a disk
-   * resume would both fail and needlessly destroy the healthy live session, so we
-   * keep it and replay instead. Returns null (so the caller takes the disk-resume
-   * path) when there is no live session OR a recording file already exists. For a
-   * fresh unprompted session the in-memory history is empty, so ZERO replay
-   * updates are sent. A replay failure is propagated (already wrapped as a precise
-   * RequestError by Session.streamHistory) WITHOUT disposing the session — it was
-   * healthy and the client can retry — the re-attach cleanup contract (no destroy
-   * on failure), distinct from the disk path's destroy-on-failure.
-   */
   private async tryReattachLiveSession(
     sessionId: string,
   ): Promise<Session | null> {
@@ -386,7 +232,6 @@ export class ZedAgent {
     await existing.replayLiveHistory();
     return existing;
   }
-
   /**
    * Disposes + drops any prior same-id Session FIRST so it releases the on-disk
    * session lock the replacement resume needs, and so a later failure cannot
@@ -399,7 +244,6 @@ export class ZedAgent {
       await existing.dispose();
     }
   }
-
   /**
    * Builds + resumes the replacement Session, installs it in this.sessions, then
    * replays the restored transcript to the client BEFORE returning. Install
@@ -423,10 +267,6 @@ export class ZedAgent {
       await session.streamHistory(history);
     } catch (error) {
       this.sessions.delete(sessionId);
-      // FINDING F13: guard the cleanup dispose so a dispose failure does not
-      // mask the ORIGINAL replay error. The replay error is the actionable one
-      // the client must see; a dispose failure is logged and swallowed, and the
-      // original error is rethrown.
       try {
         await session.dispose();
       } catch (disposeError) {
@@ -440,19 +280,6 @@ export class ZedAgent {
     }
     return session;
   }
-
-  /**
-   * Builds the replacement Agent for a loadSession and resumes its recorded
-   * history. Everything AFTER fromConfig runs under a guard that disposes the
-   * fresh agent before rethrowing (FINDING E), so neither a resume rejection nor
-   * a throw while constructing the Session (after resume already adopted the
-   * recording + lock) can leak the lock/recording. A resume rejection is mapped
-   * to a precise ACP RequestError (see resumeAgentHistory / classifyResumeFailure:
-   * not-found-but-file-present becomes internalError, genuine missing becomes
-   * resourceNotFound); any other post-fromConfig throw is wrapped as internalError
-   * (an already-constructed RequestError passes through unchanged). Extracted from
-   * loadSession so the orchestration stays within the lint complexity/line budgets.
-   */
   private async buildAndResumeSession(
     sessionId: string,
     cwd: string | undefined,
@@ -462,9 +289,6 @@ export class ZedAgent {
       cwd,
     );
     try {
-      // FINDING C1: pass the SAME injected lister the re-attach probe uses so
-      // BOTH on-disk session-file probes (re-attach + corrupt-vs-missing resume)
-      // read through one injectable seam rather than one hardcoding readdir.
       const history = await resumeAgentHistory(
         agent,
         sessionId,
@@ -484,7 +308,6 @@ export class ZedAgent {
       throw toLoadRequestError(sessionId, error);
     }
   }
-
   /**
    * Shared per-session Agent construction used by BOTH newSession and
    * loadSession: builds the session-scoped Config proxy (with an
@@ -511,21 +334,13 @@ export class ZedAgent {
       sessionFileSystemService,
       resolveSessionTargetDir(this.config, cwd),
     );
-
     this.logger.debug(() => `buildSessionAgent - session ${sessionId}`);
-
     const agent = await fromConfig({
       config: sessionConfig,
       sessionId,
     });
     return { agent, config: sessionConfig };
   }
-
-  /**
-   * Enables continuous session recording for a freshly created session. Failures
-   * are logged and swallowed so recording startup can never break session
-   * creation (the session remains fully usable, just unrecorded).
-   */
   private async enableRecording(
     agent: Agent,
     sessionId: string,
@@ -538,7 +353,16 @@ export class ZedAgent {
       );
     }
   }
-
+  deleteSession(
+    params: acp.DeleteSessionRequest,
+  ): Promise<acp.DeleteSessionResponse> {
+    return this.lifecycle.delete(params);
+  }
+  closeSession(
+    params: acp.CloseSessionRequest,
+  ): Promise<acp.CloseSessionResponse> {
+    return this.lifecycle.close(params);
+  }
   async setSessionMode(
     params: acp.SetSessionModeRequest,
   ): Promise<acp.SetSessionModeResponse> {
@@ -548,15 +372,11 @@ export class ZedAgent {
     }
     return session.setMode(params.modeId);
   }
-
   async cancel(params: acp.CancelNotification): Promise<void> {
     const session = this.sessions.get(params.sessionId);
-    if (!session) {
-      throw new Error(`Session not found: ${params.sessionId}`);
-    }
+    if (!session) throw new Error(`Session not found: ${params.sessionId}`);
     await session.cancelPendingPrompt();
   }
-
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
@@ -564,14 +384,12 @@ export class ZedAgent {
     }
     return session.prompt(params);
   }
-
   async disposeAll(): Promise<void> {
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     await Promise.allSettled(sessions.map((session) => session.dispose()));
   }
 }
-
 export class Session {
   private pendingPrompt: AbortController | null = null;
   private emojiFilter: EmojiFilter;
@@ -587,7 +405,7 @@ export class Session {
   >();
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
-
+  private readonly createdAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
@@ -601,11 +419,9 @@ export class Session {
     const emojiFilterMode = configuredEmojiFilterMode ?? 'auto';
     const filterConfig: FilterConfiguration = { mode: emojiFilterMode };
     this.emojiFilter = new EmojiFilter(filterConfig);
-
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
-
     this.todoListener = (event: TodoUpdateEvent) => {
       const eventAgentId = event.agentId ?? DEFAULT_AGENT_ID;
       if (event.sessionId === this.id && eventAgentId === DEFAULT_AGENT_ID) {
@@ -616,7 +432,6 @@ export class Session {
     };
     todoEvents.onTodoUpdated(this.todoListener);
   }
-
   setMode(modeId: acp.SessionModeId): acp.SetSessionModeResponse {
     const availableModes = buildAvailableModes();
     const mode = availableModes.find((m) => m.id === modeId);
@@ -626,7 +441,6 @@ export class Session {
     this.agent.setApprovalMode(mode.id as ApprovalMode);
     return {};
   }
-
   /**
    * Returns the session's current approval mode, delegating to the underlying
    * Agent. Used by loadSession to advertise the resumed session's currentModeId
@@ -635,7 +449,13 @@ export class Session {
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
-
+  getLifecycleInfo(): LifecycleSession {
+    return {
+      sessionId: this.id,
+      cwd: this.config.getProjectRoot(),
+      updatedAt: this.createdAt,
+    };
+  }
   async cancelPendingPrompt(): Promise<void> {
     this.settleActiveConfirmation();
     if (!this.pendingPrompt) {
@@ -644,14 +464,11 @@ export class Session {
     this.pendingPrompt.abort();
     this.pendingPrompt = null;
   }
-
   private settleActiveConfirmation(): void {
     const confirmations = [...this.activeConfirmations.entries()];
     this.activeConfirmations.clear();
     for (const [confirmationId, state] of confirmations) {
-      if (state.settled) {
-        continue;
-      }
+      if (state.settled) continue;
       state.settled = true;
       try {
         this.agent.tools.respondToConfirmation(
@@ -665,7 +482,6 @@ export class Session {
       }
     }
   }
-
   private settleConfirmation(confirmationId: string): void {
     const state = this.activeConfirmations.get(confirmationId);
     if (state === undefined) {
@@ -687,16 +503,13 @@ export class Session {
       state.cancelWaiter();
     }
   }
-
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
     await this.cancelPendingPrompt();
     const pendingSend = new AbortController();
     this.pendingPrompt = pendingSend;
     this.promptGeneration += 1;
     const promptGeneration = this.promptGeneration;
-
     const promptId = Math.random().toString(16).slice(2);
-
     try {
       let parts: ContractPart[];
       try {
@@ -713,12 +526,10 @@ export class Session {
         }
         throw error;
       }
-
       const batcher = new StreamBatcher(this.emojiFilter, (u) =>
         this.sendUpdate(u),
       );
       let terminalStopReason: acp.StopReason | null = null;
-
       try {
         terminalStopReason = await this.consumeAgentStream(
           parts,
@@ -754,15 +565,12 @@ export class Session {
           batcher.dispose();
         }
       }
-
       if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
         return { stopReason: 'cancelled' };
       }
-
       if (terminalStopReason !== null) {
         return { stopReason: terminalStopReason };
       }
-
       return { stopReason: 'end_turn' };
     } finally {
       if (this.pendingPrompt === pendingSend) {
@@ -770,7 +578,6 @@ export class Session {
       }
     }
   }
-
   private async consumeAgentStream(
     parts: ContractPart[],
     pendingSend: AbortController,
@@ -803,7 +610,6 @@ export class Session {
     }
     return terminalStopReason;
   }
-
   private async handleAgentEvent(
     event: AgentEvent,
     batcher: StreamBatcher,
@@ -893,7 +699,6 @@ export class Session {
       }
     }
   }
-
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
   ): Promise<void> {
@@ -909,7 +714,6 @@ export class Session {
       await this.sendUpdate(update);
     }
   }
-
   private isPromptStale(
     promptGeneration: number,
     pendingSend: AbortController,
@@ -920,7 +724,6 @@ export class Session {
       pendingSend.signal.aborted
     );
   }
-
   private async handleToolConfirmation(
     event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
     promptGeneration: number,
@@ -934,12 +737,10 @@ export class Session {
         settled: false,
       });
     });
-
     if (this.isPromptStale(promptGeneration, pendingSend)) {
       this.settleConfirmation(confirmationId);
       return;
     }
-
     let result: PermissionRoundTripResult | null;
     try {
       result = await Promise.race([
@@ -956,7 +757,6 @@ export class Session {
       this.settleConfirmation(confirmationId);
       throw error;
     }
-
     const state = this.activeConfirmations.get(confirmationId);
     if (
       result === null ||
@@ -966,7 +766,6 @@ export class Session {
     ) {
       return;
     }
-
     state.settled = true;
     this.activeConfirmations.delete(confirmationId);
     try {
@@ -983,26 +782,10 @@ export class Session {
       );
     }
   }
-
-  /**
-   * STRICT delivery of a single session/update: rethrows any transport failure.
-   * Used ONLY by streamHistory (ACP session/load replay) so a dead/failing
-   * client connection fails the load rather than silently losing the transcript
-   * while loadSession still resolves successfully (FINDING A). The best-effort
-   * live path (sendUpdate) must NOT use this.
-   */
   private async sendUpdateStrict(update: acp.SessionUpdate): Promise<void> {
     this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate({ sessionId: this.id, update });
-    this.logger.debug(() => 'sendUpdate: delivered');
   }
-
-  /**
-   * BEST-EFFORT delivery for the LIVE prompt path: a transient client error
-   * must not abort an in-flight turn, so delivery failures are logged and
-   * swallowed. Replay uses sendUpdateStrict instead so lost history surfaces as
-   * a failed load.
-   */
   private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
       await this.sendUpdateStrict(update);
@@ -1013,13 +796,11 @@ export class Session {
       );
     }
   }
-
   debug(msg: string) {
     if (this.config.getDebugMode()) {
       debugLogger.warn(msg);
     }
   }
-
   private async sendPlanUpdate(todos: Todo[]): Promise<void> {
     const entries: acp.PlanEntry[] = todos.map((todo) => ({
       content: todo.content,
@@ -1028,7 +809,6 @@ export class Session {
     }));
     await this.sendUpdate({ sessionUpdate: 'plan', entries });
   }
-
   /**
    * Replays a resumed conversation (ordered IContent[]) to the client as
    * session/update notifications, in order, for ACP session/load (issue #1604).
@@ -1055,7 +835,6 @@ export class Session {
       }
     }
   }
-
   /**
    * Re-attach replay for ACP session/load (#1604): replays this live session's
    * IN-MEMORY conversation, used when a load targets a still-live session with
@@ -1070,7 +849,6 @@ export class Session {
       await readAgentHistoryForReplay(this.agent, this.id),
     );
   }
-
   async dispose(): Promise<void> {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
@@ -1078,11 +856,7 @@ export class Session {
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {
-      try {
-        await this.agent.dispose();
-      } catch (error) {
-        debugLogger.error('Failed to dispose Zed session agent:', error);
-      }
+      await this.agent.dispose();
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -16,7 +16,6 @@ import {
   type FilterConfiguration,
   type IContent,
   type TodoUpdateEvent,
-  type Todo,
   type ApprovalMode,
 } from '@vybestack/llxprt-code-core';
 import * as acp from '@agentclientprotocol/sdk';
@@ -71,6 +70,19 @@ import {
 } from './zed-session-config.js';
 import { buildAvailableCommandsUpdate } from './zed-command-registry.js';
 import { tryHandleZedCommand } from './zed-prompt-command.js';
+import {
+  buildZedConfigOptions,
+  dispatchZedConfigOption,
+  observeZedConfigOptions,
+  setZedConfigOption,
+  zedConfigOptionsForClient,
+  zedSessionConfigOptions,
+} from './zed-config-options.js';
+import {
+  buildZedSession,
+  enableZedSessionRecording,
+} from './zed-agent-setup.js';
+import { buildZedPlanUpdate } from './zed-plan-update.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -111,20 +123,19 @@ export async function runZedIntegration(
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
   private clientCapabilities: acp.ClientCapabilities | undefined;
-  private logger = new DebugLogger('llxprt:zed-integration');
+  private readonly logger = new DebugLogger('llxprt:zed');
   private readonly lifecycle: SessionLifecycle;
-  private readonly sessionFileLister: ChatSessionFileLister;
   constructor(
     private config: Config,
     _settings: LoadedSettings,
     private connection: acp.AgentSideConnection,
-    sessionFileLister: ChatSessionFileLister = nodeChatSessionFileLister,
+    private readonly sessionFileLister: ChatSessionFileLister = nodeChatSessionFileLister,
   ) {
-    this.sessionFileLister = sessionFileLister;
     this.lifecycle = new SessionLifecycle(
       config,
       this.sessions,
       (sessionId, cwd) => this.buildAndResumeSession(sessionId, cwd),
+      (session) => zedSessionConfigOptions(this.clientCapabilities, session),
     );
   }
   async initialize(
@@ -138,7 +149,7 @@ export class ZedAgent {
   ): Promise<acp.ListSessionsResponse> {
     return this.lifecycle.list(params);
   }
-  authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
+  authenticate({ methodId }: acp.AuthenticateRequest) {
     return authenticateZedAgent(this.config, methodId);
   }
   async newSession({
@@ -151,46 +162,38 @@ export class ZedAgent {
         sessionId,
         cwd,
       );
-      await this.enableRecording(agent, sessionId);
-      const session = await this.buildSessionForAgent(
-        sessionId,
-        agent,
-        sessionConfig,
+      await enableZedSessionRecording(agent, (error) =>
+        this.logger.debug(() => `Recording failed for ${sessionId}: ${error}`),
       );
+      const session = await this.createSession(sessionId, agent, sessionConfig);
       await session.sendAvailableCommands();
       this.sessions.set(sessionId, session);
       return {
         sessionId,
         modes: buildSessionModes(agent.getApprovalMode()),
+        ...(await zedConfigOptionsForClient(
+          this.clientCapabilities,
+          agent,
+          sessionConfig,
+        )),
       };
     } catch (error) {
       this.logger.debug(() => `ERROR in newSession: ${error}`);
       throw error;
     }
   }
-  private async buildSessionForAgent(
-    sessionId: string,
-    agent: Agent,
-    sessionConfig: Config,
-  ): Promise<Session> {
-    try {
-      return new Session(sessionId, agent, sessionConfig, this.connection);
-    } catch (error) {
-      try {
-        await agent.dispose();
-      } catch (disposeError) {
-        this.logger.debug(
-          () =>
-            `newSession - dispose after Session ctor failure also failed (original error rethrown): ${disposeError}`,
-        );
-      }
-      throw error;
-    }
-  }
-  resumeSession(
-    params: acp.ResumeSessionRequest,
-  ): Promise<acp.ResumeSessionResponse> {
+  resumeSession(params: acp.ResumeSessionRequest) {
     return this.lifecycle.resume(params);
+  }
+  private configEnabled = () =>
+    this.clientCapabilities?.session?.configOptions != null;
+  private createSession(id: string, agent: Agent, config: Config) {
+    return buildZedSession(
+      agent,
+      () =>
+        new Session(id, agent, config, this.connection, this.configEnabled()),
+      (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
+    );
   }
   async loadSession(
     params: acp.LoadSessionRequest,
@@ -207,12 +210,18 @@ export class ZedAgent {
     const reattached = await this.tryReattachLiveSession(sessionId);
     if (reattached !== null) {
       await reattached.sendAvailableCommands();
-      return { modes: buildSessionModes(reattached.getApprovalMode()) };
+      return {
+        modes: buildSessionModes(reattached.getApprovalMode()),
+        ...(await zedSessionConfigOptions(this.clientCapabilities, reattached)),
+      };
     }
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
     await session.sendAvailableCommands();
-    return { modes: buildSessionModes(session.getApprovalMode()) };
+    return {
+      modes: buildSessionModes(session.getApprovalMode()),
+      ...(await zedSessionConfigOptions(this.clientCapabilities, session)),
+    };
   }
   private async tryReattachLiveSession(
     sessionId: string,
@@ -237,11 +246,6 @@ export class ZedAgent {
     await existing.replayLiveHistory();
     return existing;
   }
-  /**
-   * Disposes + drops any prior same-id Session FIRST so it releases the on-disk
-   * session lock the replacement resume needs, and so a later failure cannot
-   * leave a stale/half-disposed entry in this.sessions.
-   */
   private async disposePriorSession(sessionId: string): Promise<void> {
     const existing = this.sessions.get(sessionId);
     if (existing !== undefined) {
@@ -249,16 +253,6 @@ export class ZedAgent {
       await existing.dispose();
     }
   }
-  /**
-   * Builds + resumes the replacement Session, installs it in this.sessions, then
-   * replays the restored transcript to the client BEFORE returning. Install
-   * order is failure-safe (FINDING A): the map entry is added only after a
-   * successful build/resume, and if the strict history replay fails (a
-   * dead/failing transport, see Session.streamHistory) the entry is removed and
-   * the Session disposed (releasing the recording lock) before the precise
-   * RequestError is rethrown — so a failed load never leaves a stale entry or a
-   * leaked lock, and a later retry for the same id can cleanly load again.
-   */
   private async installResumedSession(
     sessionId: string,
     cwd: string | undefined,
@@ -300,12 +294,7 @@ export class ZedAgent {
         sessionConfig,
         this.sessionFileLister,
       );
-      const session = new Session(
-        sessionId,
-        agent,
-        sessionConfig,
-        this.connection,
-      );
+      const session = await this.createSession(sessionId, agent, sessionConfig);
       return { session, history };
     } catch (error) {
       await agent.dispose().catch(() => undefined);
@@ -313,14 +302,6 @@ export class ZedAgent {
       throw toLoadRequestError(sessionId, error);
     }
   }
-  /**
-   * Shared per-session Agent construction used by BOTH newSession and
-   * loadSession: builds the session-scoped Config proxy (with an
-   * AcpFileSystemService when the client advertises fs capabilities) rooted at
-   * the resolved target dir, then creates the Agent-API agent bound to that
-   * Config and session id. Extracted to avoid duplicating the setup across the
-   * two entry points.
-   */
   private async buildSessionAgent(
     sessionId: string,
     cwd: string | undefined,
@@ -346,40 +327,27 @@ export class ZedAgent {
     });
     return { agent, config: sessionConfig };
   }
-  private async enableRecording(
-    agent: Agent,
-    sessionId: string,
-  ): Promise<void> {
-    try {
-      await agent.session.setRecording({ enabled: true });
-    } catch (error) {
-      this.logger.debug(
-        () => `enableRecording failed for session ${sessionId}: ${error}`,
-      );
-    }
-  }
-  deleteSession(
-    params: acp.DeleteSessionRequest,
-  ): Promise<acp.DeleteSessionResponse> {
+  deleteSession(params: acp.DeleteSessionRequest) {
     return this.lifecycle.delete(params);
   }
-  closeSession(
-    params: acp.CloseSessionRequest,
-  ): Promise<acp.CloseSessionResponse> {
+  closeSession(params: acp.CloseSessionRequest) {
     return this.lifecycle.close(params);
   }
-  async setSessionMode(
-    params: acp.SetSessionModeRequest,
-  ): Promise<acp.SetSessionModeResponse> {
+  async setSessionMode(params: acp.SetSessionModeRequest) {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
     }
     return session.setMode(params.modeId);
   }
-  async cancel(params: acp.CancelNotification): Promise<void> {
-    const session = this.sessions.get(params.sessionId);
-    if (!session) throw new Error(`Session not found: ${params.sessionId}`);
+  setSessionConfigOption(params: acp.SetSessionConfigOptionRequest) {
+    return this.lifecycle.runSerialized(params.sessionId, () =>
+      dispatchZedConfigOption(this.clientCapabilities, this.sessions, params),
+    );
+  }
+  async cancel({ sessionId }: acp.CancelNotification): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Session not found: ${sessionId}`);
     await session.cancelPendingPrompt();
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
@@ -397,8 +365,7 @@ export class ZedAgent {
 }
 export class Session {
   private pendingPrompt: AbortController | null = null;
-  private emojiFilter: EmojiFilter;
-  private logger: DebugLogger;
+  private readonly logger = new DebugLogger('llxprt:zed');
   private pathResolver: ZedPathResolver;
   private activeConfirmations = new Map<
     string,
@@ -410,20 +377,15 @@ export class Session {
   >();
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
+  private readonly stopConfigUpdates: () => void;
   private updatedAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
     private readonly config: Config,
     private readonly connection: acp.AgentSideConnection,
+    configOptionsEnabled = false,
   ) {
-    this.logger = new DebugLogger('llxprt:zed-integration');
-    const configuredEmojiFilterMode = this.config.getEphemeralSetting(
-      'emojifilter',
-    ) as 'allowed' | 'auto' | 'warn' | 'error' | undefined;
-    const emojiFilterMode = configuredEmojiFilterMode ?? 'auto';
-    const filterConfig: FilterConfiguration = { mode: emojiFilterMode };
-    this.emojiFilter = new EmojiFilter(filterConfig);
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
@@ -436,6 +398,14 @@ export class Session {
       }
     };
     todoEvents.onTodoUpdated(this.todoListener);
+    this.stopConfigUpdates = configOptionsEnabled
+      ? observeZedConfigOptions(
+          this.agent,
+          this.config,
+          (update) => this.sendUpdateStrict(update),
+          (error) => this.logger.debug(() => `Config update failed: ${error}`),
+        )
+      : () => undefined;
   }
   setMode(modeId: acp.SessionModeId): acp.SetSessionModeResponse {
     const availableModes = buildAvailableModes();
@@ -446,14 +416,16 @@ export class Session {
     this.agent.setApprovalMode(mode.id as ApprovalMode);
     return {};
   }
-  /**
-   * Returns the session's current approval mode, delegating to the underlying
-   * Agent. Used by loadSession to advertise the resumed session's currentModeId
-   * without reaching through to the private agent from the ZedAgent orchestrator.
-   */
   getApprovalMode(): ApprovalMode {
     return this.agent.getApprovalMode();
   }
+  async setConfigOption(
+    configId: string,
+    value: string | boolean,
+  ): Promise<acp.SetSessionConfigOptionResponse> {
+    return setZedConfigOption(this.agent, this.config, configId, value);
+  }
+  getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
   getLifecycleInfo(): LifecycleSession {
     return {
       sessionId: this.id,
@@ -489,13 +461,9 @@ export class Session {
   }
   private settleConfirmation(confirmationId: string): void {
     const state = this.activeConfirmations.get(confirmationId);
-    if (state === undefined) {
-      return;
-    }
+    if (state === undefined) return;
     this.activeConfirmations.delete(confirmationId);
-    if (state.settled) {
-      return;
-    }
+    if (state.settled) return;
     state.settled = true;
     try {
       this.agent.tools.respondToConfirmation(
@@ -538,8 +506,11 @@ export class Session {
         }
         throw error;
       }
-      const batcher = new StreamBatcher(this.emojiFilter, (u) =>
-        this.sendUpdate(u),
+      const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
+        'auto') as FilterConfiguration['mode'];
+      const batcher = new StreamBatcher(
+        new EmojiFilter({ mode: emojiMode }),
+        (u) => this.sendUpdate(u),
       );
       let terminalStopReason: acp.StopReason | null = null;
       try {
@@ -778,8 +749,8 @@ export class Session {
     this.logger.debug(() => describeSessionUpdateForLog(update));
     await this.connection.sessionUpdate({ sessionId: this.id, update });
   }
-  async sendAvailableCommands(): Promise<void> {
-    await this.sendUpdateStrict(buildAvailableCommandsUpdate());
+  sendAvailableCommands(): Promise<void> {
+    return this.sendUpdateStrict(buildAvailableCommandsUpdate());
   }
   private async sendUpdate(update: acp.SessionUpdate): Promise<void> {
     try {
@@ -792,17 +763,10 @@ export class Session {
     }
   }
   debug(msg: string) {
-    if (this.config.getDebugMode()) {
-      debugLogger.warn(msg);
-    }
+    if (this.config.getDebugMode()) debugLogger.warn(msg);
   }
-  private async sendPlanUpdate(todos: Todo[]): Promise<void> {
-    const entries: acp.PlanEntry[] = todos.map((todo) => ({
-      content: todo.content,
-      status: todo.status,
-      priority: 'medium' as const,
-    }));
-    await this.sendUpdate({ sessionUpdate: 'plan', entries });
+  private sendPlanUpdate(todos: TodoUpdateEvent['todos']): Promise<void> {
+    return this.sendUpdate(buildZedPlanUpdate(todos));
   }
   async streamHistory(items: readonly IContent[]): Promise<void> {
     const updates = mapHistoryToSessionUpdates(items);
@@ -822,6 +786,7 @@ export class Session {
   async dispose(): Promise<void> {
     try {
       todoEvents.offTodoUpdated(this.todoListener);
+      this.stopConfigUpdates();
       this.settleActiveConfirmation();
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -514,7 +514,6 @@ export class Session {
     const commandResult = await tryHandleZedCommand(
       params.prompt,
       this.agent,
-      this.config,
       (update) => this.sendUpdateStrict(update),
     );
     if (commandResult !== null) return commandResult.response;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -177,7 +177,12 @@ export class ZedAgent {
         sessionConfig,
         terminals,
       );
-      await session.sendAvailableCommands();
+      try {
+        await session.sendAvailableCommands();
+      } catch (error) {
+        await session.dispose();
+        throw error;
+      }
       this.sessions.set(sessionId, session);
       return {
         sessionId,
@@ -193,7 +198,9 @@ export class ZedAgent {
       throw error;
     }
   }
-  resumeSession(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
+  resumeSession(
+    params: acp.ResumeSessionRequest,
+  ): Promise<acp.ResumeSessionResponse> {
     return this.lifecycle.resume(params);
   }
   private supportsConfigOptions(): boolean {
@@ -222,7 +229,9 @@ export class ZedAgent {
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
   }
-  async loadSession(params: acp.LoadSessionRequest): Promise<acp.LoadSessionResponse> {
+  async loadSession(
+    params: acp.LoadSessionRequest,
+  ): Promise<acp.LoadSessionResponse> {
     return this.lifecycle.runSerialized(params.sessionId, () =>
       this.performLoadSession(params),
     );
@@ -262,7 +271,9 @@ export class ZedAgent {
     if (recordingExists) {
       return null;
     }
-    this.logger.debug(() => `loadSession - re-attaching live session ${sessionId}`);
+    this.logger.debug(
+      () => `loadSession - re-attaching live session ${sessionId}`,
+    );
     await existing.replayLiveHistory();
     return existing;
   }
@@ -286,7 +297,11 @@ export class ZedAgent {
       await session.streamHistory(history);
     } catch (error) {
       this.sessions.delete(sessionId);
-      try { await session.dispose(); } catch { /* original error rethrown */ }
+      try {
+        await session.dispose();
+      } catch {
+        /* original error rethrown */
+      }
       this.logger.debug(() => `loadSession - replay failed: ${error}`);
       throw error;
     }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -250,7 +250,12 @@ export class ZedAgent {
     }
     await this.disposePriorSession(sessionId);
     const session = await this.installResumedSession(sessionId, params.cwd);
-    await session.sendAvailableCommands();
+    try {
+      await session.sendAvailableCommands();
+    } catch (error) {
+      await this.rollbackSession(sessionId, session);
+      throw error;
+    }
     return {
       modes: buildSessionModes(session.getApprovalMode()),
       ...(await zedSessionConfigOptions(this.clientCapabilities, session)),
@@ -277,12 +282,16 @@ export class ZedAgent {
     await existing.replayLiveHistory();
     return existing;
   }
+  private async rollbackSession(
+    sessionId: string,
+    session: Session,
+  ): Promise<void> {
+    this.sessions.delete(sessionId);
+    await session.dispose().catch(() => undefined);
+  }
   private async disposePriorSession(sessionId: string): Promise<void> {
     const existing = this.sessions.get(sessionId);
-    if (existing !== undefined) {
-      this.sessions.delete(sessionId);
-      await existing.dispose();
-    }
+    if (existing !== undefined) await this.rollbackSession(sessionId, existing);
   }
   private async installResumedSession(
     sessionId: string,
@@ -296,12 +305,7 @@ export class ZedAgent {
     try {
       await session.streamHistory(history);
     } catch (error) {
-      this.sessions.delete(sessionId);
-      try {
-        await session.dispose();
-      } catch {
-        /* original error rethrown */
-      }
+      await this.rollbackSession(sessionId, session);
       this.logger.debug(() => `loadSession - replay failed: ${error}`);
       throw error;
     }
@@ -505,29 +509,18 @@ export class Session {
   }
   async cancelPendingPrompt(): Promise<void> {
     this.settleActiveConfirmation();
-    await this.terminals?.settleAll();
-    if (!this.pendingPrompt) {
-      return;
-    }
+    await this.terminals
+      ?.settleAll()
+      .catch((e: unknown) =>
+        this.logger.debug(() => `Terminal settleAll failed: ${e}`),
+      );
+    if (!this.pendingPrompt) return;
     this.pendingPrompt.abort();
     this.pendingPrompt = null;
   }
   private settleActiveConfirmation(): void {
-    const confirmations = [...this.activeConfirmations.entries()];
-    this.activeConfirmations.clear();
-    for (const [confirmationId, state] of confirmations) {
-      if (state.settled) continue;
-      state.settled = true;
-      try {
-        this.agent.tools.respondToConfirmation(
-          confirmationId,
-          ToolConfirmationOutcome.Cancel,
-        );
-      } catch (error) {
-        debugLogger.error('Failed to cancel active tool confirmation:', error);
-      } finally {
-        state.cancelWaiter();
-      }
+    for (const confirmationId of [...this.activeConfirmations.keys()]) {
+      this.settleConfirmation(confirmationId);
     }
   }
   private settleConfirmation(confirmationId: string): void {
@@ -641,9 +634,8 @@ export class Session {
       return;
     }
     for (const update of updates) {
-      const title = update.title;
-      if (typeof title === 'string') {
-        await this.sendTitleUpdate(update, title);
+      if (typeof update.title === 'string') {
+        await this.sendTitleUpdate(update, update.title);
       } else {
         await this.sendUpdate(update);
       }
@@ -657,9 +649,9 @@ export class Session {
     try {
       await this.sendUpdateStrict(update);
     } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
       this.logger.debug(
-        () =>
-          `sendTitleUpdate ERROR (will retry next turn): ${error instanceof Error ? error.message : String(error)}`,
+        () => `sendTitleUpdate ERROR (will retry next turn): ${msg}`,
       );
       this.sessionInfo.markPendingTitle(title);
     }
@@ -667,10 +659,8 @@ export class Session {
 
   private recordMetadataTitle(title: string | undefined): void {
     const recording = this.config.getSessionRecordingService();
-    if (recording?.isActive() !== true) {
-      return;
-    }
-    recording.recordSessionMetadata(title ?? null);
+    if (recording?.isActive() === true)
+      recording.recordSessionMetadata(title ?? null);
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -679,9 +669,7 @@ export class Session {
       usage,
       getTokenLimitForConfiguredContext(this.config.getModel(), this.config),
     );
-    if (update !== null) {
-      await this.sendUpdate(update);
-    }
+    if (update !== null) await this.sendUpdate(update);
   }
   private isPromptStale(
     promptGeneration: number,
@@ -800,13 +788,11 @@ export class Session {
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {
-      try {
-        await this.agent.dispose();
-      } catch (error) {
-        this.logger.debug(
-          () => `Failed to dispose Zed session agent: ${error}`,
+      await this.agent
+        .dispose()
+        .catch((e: unknown) =>
+          this.logger.debug(() => `Failed to dispose Zed session agent: ${e}`),
         );
-      }
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -691,6 +691,7 @@ export class Session {
             promptGeneration,
             pendingSend,
           ),
+        resolveToolKind: (toolName) => this.agent.tools.get(toolName)?.kind,
       });
       if (stopReason !== null) {
         terminalStopReason = stopReason;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -828,7 +828,13 @@ export class Session {
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {
-      await this.agent.dispose();
+      try {
+        await this.agent.dispose();
+      } catch (error) {
+        this.logger.debug(
+          () => `Failed to dispose Zed session agent: ${error}`,
+        );
+      }
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -5,14 +5,11 @@
  */
 import {
   type Config,
-  getErrorStatus,
   todoEvents,
   DEFAULT_AGENT_ID,
   debugLogger,
   createInkStdio,
-  type ContractPart,
   DebugLogger,
-  EmojiFilter,
   type FilterConfiguration,
   type IContent,
   type TodoUpdateEvent,
@@ -43,6 +40,7 @@ import {
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
+import { TerminalManager } from './zed-terminal-manager.js';
 import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
 import { wrapReplayFailure } from './zed-session-errors.js';
 import {
@@ -53,7 +51,6 @@ import {
   nodeChatSessionFileLister,
   type ChatSessionFileLister,
 } from './zed-session-loader.js';
-import { StreamBatcher } from './zed-stream-batcher.js';
 import { SessionLifecycle } from './zed-session-lifecycle.js';
 import type { LifecycleSession } from './zed-session-pagination.js';
 import { authenticateZedAgent, initializeZedAgent } from './zed-initialize.js';
@@ -75,12 +72,20 @@ import {
   buildZedSession,
   enableZedSessionRecording,
 } from './zed-agent-setup.js';
-import { handleZedAgentEvent } from './zed-agent-event-handler.js';
+import {
+  runPromptTurn as executePromptTurn,
+  type SessionStreamDeps,
+} from './zed-session-events.js';
 import { buildZedPlanUpdate } from './zed-plan-update.js';
 import {
   SessionTitleTracker,
   buildSessionInfoUpdate,
 } from './zed-session-info.js';
+import type {
+  CloseSessionRequest,
+  DeleteSessionRequest,
+  ClientCapabilitiesWithSession,
+} from './acp-types.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -120,7 +125,7 @@ export async function runZedIntegration(
 }
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
-  private clientCapabilities: acp.ClientCapabilities | undefined;
+  private clientCapabilities: ClientCapabilitiesWithSession | undefined;
   private readonly logger = new DebugLogger('llxprt:zed-integration');
   private readonly lifecycle: SessionLifecycle;
   constructor(
@@ -139,7 +144,9 @@ export class ZedAgent {
   async initialize(
     args: acp.InitializeRequest,
   ): Promise<acp.InitializeResponse> {
-    this.clientCapabilities = args.clientCapabilities;
+    this.clientCapabilities = args.clientCapabilities as
+      | ClientCapabilitiesWithSession
+      | undefined;
     return initializeZedAgent(this.config);
   }
   listSessions(
@@ -185,6 +192,7 @@ export class ZedAgent {
   }
   private supportsConfigOptions = () =>
     this.clientCapabilities?.session?.configOptions != null;
+  private supportsTerminal = () => this.clientCapabilities?.terminal === true;
   private createSession(id: string, agent: Agent, config: Config) {
     return buildZedSession(
       agent,
@@ -195,6 +203,7 @@ export class ZedAgent {
           config,
           this.connection,
           this.supportsConfigOptions(),
+          this.supportsTerminal(),
         ),
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
@@ -302,6 +311,7 @@ export class ZedAgent {
         sessionConfig,
         this.connection,
         this.supportsConfigOptions(),
+        this.supportsTerminal(),
       );
       return { session, history };
     } catch (error) {
@@ -335,18 +345,20 @@ export class ZedAgent {
     });
     return { agent, config: sessionConfig };
   }
-  deleteSession(params: acp.DeleteSessionRequest) {
+  deleteSession(params: DeleteSessionRequest) {
     return this.lifecycle.delete(params);
   }
-  closeSession(params: acp.CloseSessionRequest) {
+  closeSession(params: CloseSessionRequest) {
     return this.lifecycle.close(params);
   }
-  setSessionMode(params: acp.SetSessionModeRequest) {
+  setSessionMode(
+    params: acp.SetSessionModeRequest,
+  ): Promise<acp.SetSessionModeResponse> {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
     }
-    return session.setMode(params.modeId);
+    return Promise.resolve(session.setMode(params.modeId));
   }
   setSessionConfigOption(params: acp.SetSessionConfigOptionRequest) {
     return this.lifecycle.runSerialized(params.sessionId, () =>
@@ -393,13 +405,25 @@ export class Session {
    * finding 4) rather than generating a new value per getter call.
    */
   private readonly createdAt = new Date().toISOString();
+  private readonly terminals: TerminalManager | null;
+
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
     private readonly config: Config,
     private readonly connection: acp.AgentSideConnection,
     configOptionsEnabled = false,
+    terminalEnabled = false,
   ) {
+    this.terminals = terminalEnabled
+      ? new TerminalManager(
+          id,
+          connection,
+          config.getTargetDir(),
+          (update) => this.sendUpdate(update),
+          this.logger,
+        )
+      : null;
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
@@ -455,6 +479,7 @@ export class Session {
   }
   async cancelPendingPrompt(): Promise<void> {
     this.settleActiveConfirmation();
+    await this.terminals?.settleAll();
     if (!this.pendingPrompt) {
       return;
     }
@@ -546,64 +571,38 @@ export class Session {
     promptId: string,
     promptGeneration: number,
   ): Promise<acp.PromptResponse> {
-    let parts: ContractPart[];
-    try {
-      parts = await this.pathResolver.resolvePrompt(
-        params.prompt,
-        pendingSend.signal,
-      );
-    } catch (error) {
-      if (
-        pendingSend.signal.aborted ||
-        (error instanceof Error && error.name === 'AbortError')
-      ) {
-        return { stopReason: 'cancelled' };
-      }
-      throw error;
-    }
-    const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
-      'auto') as FilterConfiguration['mode'];
-    const batcher = new StreamBatcher(
-      new EmojiFilter({ mode: emojiMode }),
-      (u) => this.sendUpdate(u),
+    return executePromptTurn(
+      {
+        pathResolver: this.pathResolver,
+        emojiFilterMode: (this.config.getEphemeralSetting('emojifilter') ??
+          'auto') as FilterConfiguration['mode'],
+        streamDeps: this.buildStreamDeps(promptGeneration, pendingSend),
+      },
+      params,
+      pendingSend,
+      promptId,
+      promptGeneration,
     );
-    let terminalStopReason: acp.StopReason | null = null;
-    try {
-      terminalStopReason = await this.consumeAgentStream(
-        parts,
-        pendingSend,
-        promptId,
-        promptGeneration,
-        batcher,
-      );
-    } catch (error) {
-      if (getErrorStatus(error) === 429) {
-        throw new acp.RequestError(
-          429,
-          'Rate limit exceeded. Try again later.',
-        );
-      }
-      if (
-        pendingSend.signal.aborted ||
-        (error instanceof Error && error.name === 'AbortError')
-      ) {
-        return { stopReason: 'cancelled' };
-      }
-      throw error;
-    } finally {
-      try {
-        await batcher.flush();
-      } finally {
-        batcher.dispose();
-      }
-    }
-    if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
-      return { stopReason: 'cancelled' };
-    }
-    if (terminalStopReason !== null) {
-      return { stopReason: terminalStopReason };
-    }
-    return { stopReason: 'end_turn' };
+  }
+
+  private buildStreamDeps(
+    promptGeneration: number,
+    pendingSend: AbortController,
+  ): SessionStreamDeps {
+    return {
+      agent: this.agent,
+      terminals: this.terminals,
+      sendUpdate: (update) => this.sendUpdate(update),
+      sendUsage: (usage) => this.sendUsageUpdate(usage),
+      handleConfirmation: (confirmation) =>
+        this.handleToolConfirmation(
+          confirmation,
+          promptGeneration,
+          pendingSend,
+        ),
+      isPromptStale: (gen, send) => this.isPromptStale(gen, send),
+      maxTurns: this.config.getMaxSessionTurns(),
+    };
   }
 
   private async emitTurnMetadata(eligibility: {
@@ -661,43 +660,6 @@ export class Session {
       return;
     }
     recording.recordSessionMetadata(title ?? null);
-  }
-  private async consumeAgentStream(
-    parts: ContractPart[],
-    pendingSend: AbortController,
-    promptId: string,
-    promptGeneration: number,
-    batcher: StreamBatcher,
-  ): Promise<acp.StopReason | null> {
-    const eventStream = this.agent.stream(parts, {
-      signal: pendingSend.signal,
-      promptId,
-      maxTurns: this.config.getMaxSessionTurns(),
-    });
-    let terminalStopReason: acp.StopReason | null = null;
-    for await (const event of eventStream) {
-      if (this.isPromptStale(promptGeneration, pendingSend)) {
-        if (event.type === 'done') {
-          return 'cancelled';
-        }
-        continue;
-      }
-      const stopReason = await handleZedAgentEvent(event, batcher, {
-        sendUpdate: (update) => this.sendUpdate(update),
-        sendUsage: (usage) => this.sendUsageUpdate(usage),
-        handleConfirmation: (confirmation) =>
-          this.handleToolConfirmation(
-            confirmation,
-            promptGeneration,
-            pendingSend,
-          ),
-        resolveToolKind: (toolName) => this.agent.tools.get(toolName)?.kind,
-      });
-      if (stopReason !== null) {
-        terminalStopReason = stopReason;
-      }
-    }
-    return terminalStopReason;
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -825,6 +787,7 @@ export class Session {
       todoEvents.offTodoUpdated(this.todoListener);
       this.stopConfigUpdates();
       this.settleActiveConfirmation();
+      await this.terminals?.settleAll();
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -355,6 +355,10 @@
       "bun": "./src/tools-adapters/CoreMessageBusAdapter.ts",
       "import": "./dist/src/tools-adapters/CoreMessageBusAdapter.js"
     },
+    "./tools-adapters/CoreShellToolHostAdapter.js": {
+      "bun": "./src/tools-adapters/CoreShellToolHostAdapter.ts",
+      "import": "./dist/src/tools-adapters/CoreShellToolHostAdapter.js"
+    },
     "./tools-adapters/CoreToolRegistryHostAdapter.js": {
       "bun": "./src/tools-adapters/CoreToolRegistryHostAdapter.ts",
       "import": "./dist/src/tools-adapters/CoreToolRegistryHostAdapter.js"

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -314,7 +314,7 @@ function handleSessionMetadata(
     return;
   }
   const title = payload.title;
-  if (title === null || typeof title === 'string') {
+  if (title === null || title === undefined || typeof title === 'string') {
     acc.metadata.title = title;
   } else {
     acc.malformedCount++;

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -290,6 +290,40 @@ function handleSessionEvent(
   }
 }
 
+/**
+ * @requirement issue #1611: session_metadata — update metadata.title (tri-state).
+ *
+ * The title is tri-state: undefined (field absent) is legacy and does NOT
+ * modify metadata.title; null sets it to null (explicit untitled); string sets
+ * it to that string. Malformed title values (non-string, non-null, non-
+ * undefined) are recorded as malformed.
+ */
+function handleSessionMetadata(
+  payload: Record<string, unknown>,
+  acc: ReplayAccumulators,
+  lineNumber: number,
+): void {
+  if (acc.metadata === null) {
+    acc.malformedCount++;
+    acc.warnings.push(
+      `Line ${lineNumber}: session_metadata before session_start, skipping`,
+    );
+    return;
+  }
+  if (!('title' in payload)) {
+    return;
+  }
+  const title = payload.title;
+  if (title === null || typeof title === 'string') {
+    acc.metadata.title = title;
+  } else {
+    acc.malformedCount++;
+    acc.warnings.push(
+      `Line ${lineNumber}: malformed session_metadata title, skipping`,
+    );
+  }
+}
+
 /** @pseudocode line 126-131: directories_changed — update metadata or record malformed. */
 function handleDirectoriesChanged(
   payload: Record<string, unknown>,
@@ -381,6 +415,9 @@ function dispatchEvent(
       break;
     case 'session_event':
       handleSessionEvent(payload, acc, lineNumber);
+      break;
+    case 'session_metadata':
+      handleSessionMetadata(payload, acc, lineNumber);
       break;
     case 'directories_changed':
       handleDirectoriesChanged(payload, acc, lineNumber);

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -167,6 +167,7 @@ function handleSessionStart(
     provider: startPayload.provider,
     model: startPayload.model,
     workspaceDirs: resolveWorkspaceDirs(startPayload.workspaceDirs),
+    ...(typeof startPayload.cwd === 'string' ? { cwd: startPayload.cwd } : {}),
     startTime: startPayload.startTime,
   };
   return undefined;

--- a/packages/core/src/recording/SessionDiscovery.test.ts
+++ b/packages/core/src/recording/SessionDiscovery.test.ts
@@ -54,6 +54,7 @@ function makeConfig(
     projectHash: overrides.projectHash ?? PROJECT_HASH,
     chatsDir,
     workspaceDirs: overrides.workspaceDirs ?? ['/test/workspace'],
+    cwd: overrides.cwd ?? '/test/workspace',
     provider: overrides.provider ?? 'anthropic',
     model: overrides.model ?? 'claude-4',
   };
@@ -265,6 +266,7 @@ describe('SessionDiscovery @plan:PLAN-20260211-SESSIONRECORDING.P19', () => {
       expect(sessions[0].sessionId).toBe(sessionId);
       expect(sessions[0].provider).toBe('google');
       expect(sessions[0].model).toBe('gemini-3');
+      expect(sessions[0].cwd).toBe('/test/workspace');
       expect(sessions[0].projectHash).toBe(PROJECT_HASH);
       expect(sessions[0].filePath).toBeTruthy();
       expect(sessions[0].lastModified).toBeInstanceOf(Date);

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -421,16 +421,20 @@ function extractSessionMetadataTitle(line: string): string | null | undefined {
   if (!line.trim()) {
     return undefined;
   }
-  let event: Record<string, unknown>;
+  let event: unknown;
   try {
-    event = JSON.parse(line) as Record<string, unknown>;
+    event = JSON.parse(line);
   } catch {
     return undefined;
   }
-  if (event.type !== 'session_metadata') {
+  if (event === null || typeof event !== 'object') {
     return undefined;
   }
-  const payload = event.payload as Record<string, unknown> | undefined;
+  const record = event as Record<string, unknown>;
+  if (record.type !== 'session_metadata') {
+    return undefined;
+  }
+  const payload = record.payload as Record<string, unknown> | undefined;
   if (!payload || typeof payload !== 'object') {
     return undefined;
   }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -301,13 +301,14 @@ export class SessionDiscovery {
   static async readSessionMetadataTitle(
     filePath: string,
   ): Promise<string | null | undefined> {
+    let reader: readline.Interface | undefined;
     try {
-      const lines = readline.createInterface({
+      reader = readline.createInterface({
         input: createReadStream(filePath, { encoding: 'utf8' }),
         crlfDelay: Infinity,
       });
       let title: string | null | undefined;
-      for await (const line of lines) {
+      for await (const line of reader) {
         const result = extractSessionMetadataTitle(line);
         if (result !== undefined) {
           title = result;
@@ -316,6 +317,8 @@ export class SessionDiscovery {
       return title;
     } catch {
       return undefined;
+    } finally {
+      reader?.close();
     }
   }
 }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -24,8 +24,10 @@
  * for the resume flow.
  */
 
+import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import * as readline from 'node:readline';
 import { type SessionSummary, type SessionStartPayload } from './types.js';
 import { readSessionHeader } from './ReplayEngine.js';
 import {
@@ -300,10 +302,12 @@ export class SessionDiscovery {
     filePath: string,
   ): Promise<string | null | undefined> {
     try {
-      const fileContent = await fs.readFile(filePath, 'utf-8');
-      const lines = fileContent.split('\n');
+      const lines = readline.createInterface({
+        input: createReadStream(filePath, { encoding: 'utf8' }),
+        crlfDelay: Infinity,
+      });
       let title: string | null | undefined;
-      for (const line of lines) {
+      for await (const line of lines) {
         const result = extractSessionMetadataTitle(line);
         if (result !== undefined) {
           title = result;

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -28,7 +28,11 @@ import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
-import { type SessionSummary, type SessionStartPayload } from './types.js';
+import {
+  SESSION_TITLE_MAX_LENGTH,
+  type SessionSummary,
+  type SessionStartPayload,
+} from './types.js';
 import { readSessionHeader } from './ReplayEngine.js';
 import {
   resumeSessionIndexOutOfRangeMessage,
@@ -274,7 +278,7 @@ export class SessionDiscovery {
    */
   static async readFirstUserMessage(
     filePath: string,
-    maxLength: number = 120,
+    maxLength: number = SESSION_TITLE_MAX_LENGTH,
   ): Promise<string | null> {
     try {
       const fileContent = await fs.readFile(filePath, 'utf-8');
@@ -301,32 +305,26 @@ export class SessionDiscovery {
   static async readSessionMetadataTitle(
     filePath: string,
   ): Promise<string | null | undefined> {
+    const stream = createReadStream(filePath, { encoding: 'utf8' });
     let reader: readline.Interface | undefined;
     try {
-      const stream = createReadStream(filePath, { encoding: 'utf8' });
-      const streamError = new Promise<never>((_, reject) => {
-        stream.on('error', (err: NodeJS.ErrnoException) => reject(err));
-      });
-      const rl = readline.createInterface({
+      reader = readline.createInterface({
         input: stream,
         crlfDelay: Infinity,
       });
-      reader = rl;
       let title: string | null | undefined;
-      const iterate = (async () => {
-        for await (const line of rl) {
-          const result = extractSessionMetadataTitle(line);
-          if (result !== undefined) {
-            title = result;
-          }
+      for await (const line of reader) {
+        const result = extractSessionMetadataTitle(line);
+        if (result !== undefined) {
+          title = result;
         }
-      })();
-      await Promise.race([iterate, streamError]);
+      }
       return title;
     } catch {
       return undefined;
     } finally {
       reader?.close();
+      stream.destroy();
     }
   }
 }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -314,6 +314,7 @@ async function readSessionSummary(
     fileSize: stat.size,
     provider: header.provider,
     model: header.model,
+    ...(typeof header.cwd === 'string' ? { cwd: header.cwd } : {}),
   };
 }
 

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -303,17 +303,25 @@ export class SessionDiscovery {
   ): Promise<string | null | undefined> {
     let reader: readline.Interface | undefined;
     try {
-      reader = readline.createInterface({
-        input: createReadStream(filePath, { encoding: 'utf8' }),
+      const stream = createReadStream(filePath, { encoding: 'utf8' });
+      const streamError = new Promise<never>((_, reject) => {
+        stream.on('error', (err: NodeJS.ErrnoException) => reject(err));
+      });
+      const rl = readline.createInterface({
+        input: stream,
         crlfDelay: Infinity,
       });
+      reader = rl;
       let title: string | null | undefined;
-      for await (const line of reader) {
-        const result = extractSessionMetadataTitle(line);
-        if (result !== undefined) {
-          title = result;
+      const iterate = (async () => {
+        for await (const line of rl) {
+          const result = extractSessionMetadataTitle(line);
+          if (result !== undefined) {
+            title = result;
+          }
         }
-      }
+      })();
+      await Promise.race([iterate, streamError]);
       return title;
     } catch {
       return undefined;

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -38,6 +38,7 @@ import {
   resumeSessionIndexOutOfRangeMessage,
   resumeSessionNotFoundMessage,
 } from './resumeNotFoundMessages.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 /**
  * Result of successfully resolving a session reference.
@@ -320,7 +321,11 @@ export class SessionDiscovery {
         }
       }
       return title;
-    } catch {
+    } catch (error) {
+      debugLogger.debug(
+        () =>
+          `readSessionMetadataTitle failed for ${filePath}: ${String(error)}`,
+      );
       return undefined;
     } finally {
       reader?.close();

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -288,6 +288,32 @@ export class SessionDiscovery {
       return null;
     }
   }
+
+  /**
+   * Read the tri-state title from the last valid `session_metadata` event in a
+   * session file (issue #1611). Returns:
+   * - `undefined` when no `session_metadata` event exists (legacy fallback).
+   * - `null` when the event explicitly asserts untitled.
+   * - `string` when the event carries a concrete title.
+   */
+  static async readSessionMetadataTitle(
+    filePath: string,
+  ): Promise<string | null | undefined> {
+    try {
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const lines = fileContent.split('\n');
+      let title: string | null | undefined;
+      for (const line of lines) {
+        const result = extractSessionMetadataTitle(line);
+        if (result !== undefined) {
+          title = result;
+        }
+      }
+      return title;
+    } catch {
+      return undefined;
+    }
+  }
 }
 
 async function readSessionSummary(
@@ -315,6 +341,9 @@ async function readSessionSummary(
     provider: header.provider,
     model: header.model,
     ...(typeof header.cwd === 'string' ? { cwd: header.cwd } : {}),
+    ...(typeof header.startTime === 'string'
+      ? { createdAt: header.startTime }
+      : {}),
   };
 }
 
@@ -371,4 +400,42 @@ function extractUserMessageText(line: string): string | null {
     .join('');
 
   return text || null;
+}
+
+/**
+ * Extract the title from a `session_metadata` JSONL line.
+ * Returns:
+ * - `undefined` when the line is not a valid `session_metadata` event (so
+ *   callers can continue scanning).
+ * - `null` when title is explicitly null (untitled).
+ * - `string` when a concrete title is present.
+ */
+function extractSessionMetadataTitle(line: string): string | null | undefined {
+  if (!line.trim()) {
+    return undefined;
+  }
+  let event: Record<string, unknown>;
+  try {
+    event = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+  if (event.type !== 'session_metadata') {
+    return undefined;
+  }
+  const payload = event.payload as Record<string, unknown> | undefined;
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+  if (!('title' in payload)) {
+    return undefined;
+  }
+  const title = payload.title;
+  if (title === null) {
+    return null;
+  }
+  if (typeof title === 'string') {
+    return title;
+  }
+  return undefined;
 }

--- a/packages/core/src/recording/SessionRecordingService.test.ts
+++ b/packages/core/src/recording/SessionRecordingService.test.ts
@@ -51,6 +51,7 @@ function makeConfig(
     projectHash: overrides.projectHash ?? 'abc123def456',
     chatsDir: overrides.chatsDir ?? '/tmp/test-chats',
     workspaceDirs: overrides.workspaceDirs ?? ['/home/user/project'],
+    cwd: overrides.cwd ?? '/home/user/project',
     provider: overrides.provider ?? 'anthropic',
     model: overrides.model ?? 'claude-4',
   };
@@ -1211,6 +1212,7 @@ describe('SessionRecordingService @plan:PLAN-20260211-SESSIONRECORDING.P04', () 
           expect(startPayload.workspaceDirs).toStrictEqual(
             config.workspaceDirs,
           );
+          expect(startPayload.cwd).toBe(config.cwd);
           expect(typeof startPayload.startTime).toBe('string');
           expect(isValidIso8601(startPayload.startTime as string)).toBe(true);
 

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -71,6 +71,7 @@ export class SessionRecordingService {
       sessionId: config.sessionId,
       projectHash: config.projectHash,
       workspaceDirs: config.workspaceDirs,
+      ...(config.cwd === undefined ? {} : { cwd: config.cwd }),
       provider: config.provider,
       model: config.model,
       startTime: new Date().toISOString(),

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -57,6 +57,7 @@ export class SessionRecordingService {
   private readonly chatsDir: string;
   private preContentBuffer: SessionRecordLine[] = [];
   private chatsDirWatcher: FSWatcher | null = null;
+  private sessionTitle: string | null | undefined;
 
   /**
    * @plan PLAN-20260211-SESSIONRECORDING.P05
@@ -109,7 +110,10 @@ export class SessionRecordingService {
   enqueue(type: SessionEventType, payload: unknown): void {
     if (!this.active) return;
 
-    if (type === 'content' && !this.materialized) {
+    if (
+      (type === 'content' || type === 'session_metadata') &&
+      !this.materialized
+    ) {
       this.materialize();
       for (const buffered of this.preContentBuffer) {
         this.queue.push(buffered);
@@ -310,11 +314,16 @@ export class SessionRecordingService {
    * @requirement REQ-REC-008
    * @pseudocode session-recording-service.md lines 174-179
    */
-  initializeForResume(filePath: string, lastSeq: number): void {
+  initializeForResume(
+    filePath: string,
+    lastSeq: number,
+    title?: string | null,
+  ): void {
     this.filePath = filePath;
     this.seq = lastSeq;
     this.materialized = true;
     this.preContentBuffer = [];
+    this.sessionTitle = title;
     this.startChatsDirWatcher();
   }
 
@@ -470,5 +479,26 @@ export class SessionRecordingService {
    */
   recordDirectoriesChanged(directories: string[]): void {
     this.enqueue('directories_changed', { directories });
+  }
+
+  /**
+   * Record a session_metadata event — persisted human-readable title.
+   * The title is tri-state: `string` for a concrete title, `null` for explicit
+   * untitled, `undefined` for legacy (field absent). Like `content`, this event
+   * materializes the file so slash/failure sessions persist metadata even
+   * without a content event.
+   *
+   * @requirement REQ-REC-002
+   */
+  recordSessionMetadata(title: string | null): void {
+    if (!this.active) {
+      return;
+    }
+    this.sessionTitle = title;
+    this.enqueue('session_metadata', { title });
+  }
+
+  getSessionMetadataTitle(): string | null | undefined {
+    return this.sessionTitle;
   }
 }

--- a/packages/core/src/recording/index.ts
+++ b/packages/core/src/recording/index.ts
@@ -57,6 +57,7 @@ export {
 export {
   listSessions,
   deleteSession,
+  deleteSessionById,
   type ListSessionsResult,
   type DeleteSessionResult,
   type DeleteSessionError,

--- a/packages/core/src/recording/replay-test-helpers.ts
+++ b/packages/core/src/recording/replay-test-helpers.ts
@@ -200,6 +200,20 @@ export function _directoriesChangedLine(
 }
 
 /**
+ * Build a valid JSONL line for a session_metadata event (issue #1611).
+ * The title is tri-state: string, null, or undefined (omitted from payload).
+ */
+export function sessionMetadataLine(seq: number, title: string | null): string {
+  return JSON.stringify({
+    v: 1,
+    seq,
+    ts: new Date().toISOString(),
+    type: 'session_metadata',
+    payload: { title },
+  });
+}
+
+/**
  * Write raw JSONL lines to a file.
  */
 export async function writeJsonlFile(

--- a/packages/core/src/recording/replay-test-helpers.ts
+++ b/packages/core/src/recording/replay-test-helpers.ts
@@ -201,7 +201,7 @@ export function _directoriesChangedLine(
 
 /**
  * Build a valid JSONL line for a session_metadata event (issue #1611).
- * The title is tri-state: string, null, or undefined (omitted from payload).
+ * The title is either a concrete string or explicit null.
  */
 export function sessionMetadataLine(seq: number, title: string | null): string {
   return JSON.stringify({

--- a/packages/core/src/recording/resumeSession.ts
+++ b/packages/core/src/recording/resumeSession.ts
@@ -139,6 +139,7 @@ function initializeRecordingForResume(
   recording.initializeForResume(
     lockedSession.targetFilePath,
     replayResult.lastSeq,
+    replayResult.metadata.title,
   );
 
   if (

--- a/packages/core/src/recording/sessionManagement.test.ts
+++ b/packages/core/src/recording/sessionManagement.test.ts
@@ -34,7 +34,11 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { SessionRecordingService } from './SessionRecordingService.js';
 import { SessionLockManager } from './SessionLockManager.js';
-import { listSessions, deleteSession } from './sessionManagement.js';
+import {
+  listSessions,
+  deleteSession,
+  deleteSessionById,
+} from './sessionManagement.js';
 import { type SessionRecordingServiceConfig } from './types.js';
 import { type IContent } from '../services/history/IContent.js';
 
@@ -401,6 +405,35 @@ describe('sessionManagement @plan:PLAN-20260211-SESSIONRECORDING.P22', () => {
         expect(result.deletedSessionId).toBe(sessionId);
       }
     });
+  });
+
+  describe('deleteSessionById', () => {
+    itProp(
+      'deletes only an exact session ID and never resolves a prefix',
+      async () => {
+        const sessionId = 'exact-session-identifier';
+        const { filePath } = await createTestSession(chatsDir, { sessionId });
+
+        const prefixResult = await deleteSessionById(
+          'exact-session',
+          chatsDir,
+          PROJECT_HASH,
+        );
+        expect(prefixResult.ok).toBe(false);
+        expect(await fileExists(filePath)).toBe(true);
+
+        const exactResult = await deleteSessionById(
+          sessionId,
+          chatsDir,
+          PROJECT_HASH,
+        );
+        expect(exactResult).toStrictEqual({
+          ok: true,
+          deletedSessionId: sessionId,
+        });
+        expect(await fileExists(filePath)).toBe(false);
+      },
+    );
   });
 
   // =========================================================================

--- a/packages/core/src/recording/sessionManagement.ts
+++ b/packages/core/src/recording/sessionManagement.ts
@@ -85,38 +85,54 @@ export async function deleteSession(
     return { ok: false, error: resolved.error };
   }
 
-  const target = resolved.session;
+  return deleteResolvedSession(resolved.session, chatsDir);
+}
 
-  const locked = await SessionLockManager.isLocked(chatsDir, target.sessionId);
-  if (locked) {
-    const stale = await SessionLockManager.isStale(chatsDir, target.sessionId);
-    if (stale) {
-      await SessionLockManager.removeStaleLock(chatsDir, target.sessionId);
-    } else {
+/** Delete a session only when the supplied identifier is an exact match. */
+export async function deleteSessionById(
+  sessionId: string,
+  chatsDir: string,
+  projectHash: string,
+): Promise<DeleteSessionResult | DeleteSessionError> {
+  const sessions = await SessionDiscovery.listSessions(chatsDir, projectHash);
+  const target = sessions.find((session) => session.sessionId === sessionId);
+  if (target === undefined) {
+    return { ok: false, error: `Session not found: ${sessionId}` };
+  }
+
+  return deleteResolvedSession(target, chatsDir);
+}
+
+async function deleteResolvedSession(
+  target: SessionSummary,
+  chatsDir: string,
+): Promise<DeleteSessionResult | DeleteSessionError> {
+  let lock;
+  try {
+    lock = await SessionLockManager.acquire(chatsDir, target.sessionId);
+  } catch (error: unknown) {
+    if ((error as Error).message === 'Session is in use by another process') {
       return {
         ok: false,
         error: 'Cannot delete: session is in use by another process',
       };
     }
+    return {
+      ok: false,
+      error: `Failed to lock session for deletion: ${(error as Error).message}`,
+    };
   }
 
   const { unlink } = await import('node:fs/promises');
-
   try {
     await unlink(target.filePath);
+    return { ok: true, deletedSessionId: target.sessionId };
   } catch (error: unknown) {
     return {
       ok: false,
       error: `Failed to delete session: ${(error as Error).message}`,
     };
+  } finally {
+    await lock.release();
   }
-
-  const lockPath = SessionLockManager.getLockPath(chatsDir, target.sessionId);
-  try {
-    await unlink(lockPath);
-  } catch {
-    // Lock file may not exist
-  }
-
-  return { ok: true, deletedSessionId: target.sessionId };
 }

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the session_metadata recording event (issue #1611).
+ *
+ * Verifies:
+ * - recordSessionMetadata writes a typed session_metadata event (not a
+ *   session_event sentinel) to the JSONL file.
+ * - The title is tri-state: string (concrete), null (explicit untitled).
+ * - session_metadata materializes the recording file BEFORE any content event,
+ *   so slash/failure sessions persist their metadata.
+ * - ReplayEngine restores the tri-state title from session_metadata events.
+ * - SessionDiscovery.readSessionMetadataTitle extracts the tri-state title.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SessionRecordingService } from './SessionRecordingService.js';
+import { replaySession } from './ReplayEngine.js';
+import { SessionDiscovery } from './SessionDiscovery.js';
+import {
+  makeConfig,
+  sessionStartLine,
+  sessionMetadataLine,
+  contentLine,
+  makeContent,
+  writeJsonlFile,
+  PROJECT_HASH,
+  assertReplayOk,
+} from './replay-test-helpers.js';
+
+const tempDirs: string[] = [];
+
+describe('session_metadata recording (issue #1611)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function makeTempChatsDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'session-metadata-'));
+    tempDirs.push(dir);
+    const chatsDir = path.join(dir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+    return chatsDir;
+  }
+
+  describe('SessionRecordingService.recordSessionMetadata', () => {
+    it('writes a typed session_metadata event (not a session_event sentinel)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('My session title');
+      await service.flush();
+
+      const filePath = service.getFilePath();
+      expect(filePath).not.toBeNull();
+      const fileContent = await fs.readFile(filePath!, 'utf-8');
+      const lines = fileContent.trim().split('\n');
+      const types = lines.map((line) => JSON.parse(line).type);
+
+      expect(types).toContain('session_metadata');
+      const metadataLine = lines
+        .map((line) => JSON.parse(line))
+        .find((line) => line.type === 'session_metadata');
+      expect(metadataLine.payload).toStrictEqual({ title: 'My session title' });
+      await service.dispose();
+    });
+
+    it('records a null title for explicit untitled', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata(null);
+      await service.flush();
+
+      const filePath = service.getFilePath()!;
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const metadataLine = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+        .find((line) => line.type === 'session_metadata');
+      expect(metadataLine.payload).toStrictEqual({ title: null });
+      await service.dispose();
+    });
+
+    it('materializes the recording BEFORE any content event (slash/failure sessions)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('Slash command title');
+      await service.flush();
+
+      expect(service.getFilePath()).not.toBeNull();
+      const fileContent = await fs.readFile(service.getFilePath()!, 'utf-8');
+      const types = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line).type);
+      expect(types).toContain('session_start');
+      expect(types).toContain('session_metadata');
+      expect(types).not.toContain('content');
+      await service.dispose();
+    });
+
+    it('preserves ordering: session_start before session_metadata before content', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('Ordered title');
+      service.recordContent(makeContent('hello'));
+      await service.flush();
+
+      const fileContent = await fs.readFile(service.getFilePath()!, 'utf-8');
+      const types = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line).type);
+      const startIdx = types.indexOf('session_start');
+      const metaIdx = types.indexOf('session_metadata');
+      const contentIdx = types.indexOf('content');
+      expect(startIdx).toBeLessThan(metaIdx);
+      expect(metaIdx).toBeLessThan(contentIdx);
+      await service.dispose();
+    });
+  });
+
+  describe('ReplayEngine session_metadata handling', () => {
+    it('replays a string title from session_metadata', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-str.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'Replayed title'),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBe('Replayed title');
+    });
+
+    it('replays a null title (explicit untitled)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-null.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, null),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBeNull();
+    });
+
+    it('leaves title undefined (legacy) when no session_metadata event exists', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-legacy.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        contentLine(2, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBeUndefined();
+    });
+
+    it('last session_metadata title wins when multiple exist', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-multi.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'First title'),
+        contentLine(3, makeContent('turn 1')),
+        sessionMetadataLine(4, 'Updated title'),
+        contentLine(5, makeContent('turn 2')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBe('Updated title');
+    });
+
+    it('records a warning for session_metadata before session_start', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-early.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionMetadataLine(1, 'Too early'),
+        sessionStartLine(2),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      expect(result.ok).toBe(false);
+    });
+
+    it('records a warning for malformed session_metadata title (non-string, non-null)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-malformed.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        JSON.stringify({
+          v: 1,
+          seq: 2,
+          ts: '2026-07-12T00:00:00.000Z',
+          type: 'session_metadata',
+          payload: { title: 12345 },
+        }),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(
+        result.warnings.some((w) => w.includes('malformed session_metadata')),
+      ).toBe(true);
+    });
+  });
+
+  describe('SessionDiscovery.readSessionMetadataTitle', () => {
+    it('reads a string title from a session_metadata event', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-str.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'Discovery title'),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBe('Discovery title');
+    });
+
+    it('reads null for explicit untitled', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-null.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, null),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBeNull();
+    });
+
+    it('returns undefined when no session_metadata event exists (legacy)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-legacy.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        contentLine(2, makeContent('hello')),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBeUndefined();
+    });
+
+    it('reads the last valid session_metadata title when multiple exist', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-multi.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'First metadata'),
+        contentLine(3, makeContent('turn')),
+        sessionMetadataLine(4, 'Second metadata'),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBe('Second metadata');
+    });
+  });
+
+  describe('SessionSummary createdAt (immutable ordering)', () => {
+    it('includes createdAt from session_start.startTime', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+      service.recordContent(makeContent('hello'));
+      await service.flush();
+      await service.dispose();
+
+      const sessions = await SessionDiscovery.listSessions(
+        chatsDir,
+        PROJECT_HASH,
+      );
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].createdAt).toBeDefined();
+      expect(typeof sessions[0].createdAt).toBe('string');
+      expect(Number.isNaN(Date.parse(sessions[0].createdAt!))).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -191,7 +191,7 @@ describe('session_metadata recording (issue #1611)', () => {
       expect(result.metadata.title).toBe('Updated title');
     });
 
-    it('records a warning for session_metadata before session_start', async () => {
+    it('returns a fatal replay error when session_metadata precedes session_start', async () => {
       const chatsDir = await makeTempChatsDir();
       const filePath = path.join(chatsDir, 'session-test-meta-early.jsonl');
       await writeJsonlFile(filePath, [

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -263,6 +263,15 @@ describe('session_metadata recording (issue #1611)', () => {
       expect(title).toBeUndefined();
     });
 
+    it('returns undefined when the source stream cannot be opened', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'missing-session.jsonl');
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+
+      expect(title).toBeUndefined();
+    });
+
     it('reads the last valid session_metadata title when multiple exist', async () => {
       const chatsDir = await makeTempChatsDir();
       const filePath = path.join(chatsDir, 'session-discovery-multi.jsonl');

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -25,6 +25,8 @@
 
 import { type IContent } from '../services/history/IContent.js';
 
+export const SESSION_TITLE_MAX_LENGTH = 120;
+
 // ---------------------------------------------------------------------------
 // Event type discriminator
 // ---------------------------------------------------------------------------

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -74,6 +74,8 @@ export interface SessionStartPayload {
   sessionId: string;
   projectHash: string;
   workspaceDirs: string[];
+  /** Effective absolute working directory, when recorded by newer clients. */
+  cwd?: string;
   provider: string;
   model: string;
   /** ISO-8601 timestamp of when the session started. */
@@ -141,6 +143,8 @@ export interface SessionRecordingServiceConfig {
   projectHash: string;
   chatsDir: string;
   workspaceDirs: string[];
+  /** Effective absolute working directory for lifecycle discovery. */
+  cwd?: string;
   provider: string;
   model: string;
 }
@@ -159,6 +163,7 @@ export interface SessionMetadata {
   provider: string;
   model: string;
   workspaceDirs: string[];
+  cwd?: string;
   startTime: string;
 }
 
@@ -199,4 +204,5 @@ export interface SessionSummary {
   fileSize: number;
   provider: string;
   model: string;
+  cwd?: string;
 }

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -30,7 +30,7 @@ import { type IContent } from '../services/history/IContent.js';
 // ---------------------------------------------------------------------------
 
 /**
- * The seven event types that can appear in a session JSONL file.
+ * The event types that can appear in a session JSONL file.
  */
 export type SessionEventType =
   | 'session_start'
@@ -39,6 +39,7 @@ export type SessionEventType =
   | 'rewind'
   | 'provider_switch'
   | 'session_event'
+  | 'session_metadata'
   | 'directories_changed';
 
 // ---------------------------------------------------------------------------
@@ -125,6 +126,19 @@ export interface SessionEventPayload {
 }
 
 /**
+ * Payload for the `session_metadata` event — session-level metadata updates
+ * (currently only the human-readable title). The title is tri-state:
+ * - `undefined` (field absent): legacy event, no title assertion.
+ * - `null`: explicit untitled (the caller asserts there is no meaningful title).
+ * - `string`: a concrete title.
+ *
+ * This is a typed first-class recording event, NOT a `session_event` sentinel.
+ */
+export interface SessionMetadataPayload {
+  readonly title?: string | null;
+}
+
+/**
  * Payload for the `directories_changed` event.
  */
 export interface DirectoriesChangedPayload {
@@ -155,7 +169,14 @@ export interface SessionRecordingServiceConfig {
 
 /**
  * Metadata extracted from a session's `session_start` event and updated
- * by subsequent `provider_switch` / `directories_changed` events.
+ * by subsequent `provider_switch` / `directories_changed` / `session_metadata`
+ * events.
+ *
+ * The title is tri-state:
+ * - `undefined`: no `session_metadata` event seen (legacy file). Callers fall
+ *   back to first-human-text heuristics.
+ * - `null`: explicit untitled (`session_metadata` asserted no title).
+ * - `string`: a concrete title.
  */
 export interface SessionMetadata {
   sessionId: string;
@@ -165,6 +186,7 @@ export interface SessionMetadata {
   workspaceDirs: string[];
   cwd?: string;
   startTime: string;
+  title?: string | null;
 }
 
 /**
@@ -205,4 +227,16 @@ export interface SessionSummary {
   provider: string;
   model: string;
   cwd?: string;
+  /**
+   * Tri-state title from a persisted `session_metadata` event:
+   * - `undefined`: no `session_metadata` event seen (legacy fallback).
+   * - `null`: explicit untitled.
+   * - `string`: a concrete title.
+   */
+  title?: string | null;
+  /**
+   * Immutable creation timestamp extracted from `session_start.startTime`.
+   * Used for stable ordering independent of file `lastModified` mutations.
+   */
+  createdAt?: string;
 }


### PR DESCRIPTION
## Summary

- implement stable ACP session list, resume, delete, and close capabilities
- persist backward-compatible cwd metadata and merge durable recordings with live unmaterialized sessions
- use opaque keyset pagination with deterministic ordering and exact cwd filtering
- serialize conflicting lifecycle operations per session while preserving parallelism across session IDs
- make exact-ID deletion lock-safe across processes and preserve durable recordings on close

## Validation

- npm run lint
- npm run typecheck
- npm run format
- npm run build
- focused ACP lifecycle tests: 24 passed
- core session management tests: 22 passed
- full test suite: one timing-budget guard exceeded its threshold under aggregate load and passed 13/13 in isolation
- Open Code Review completed across all 18 changed files, including tests; high and medium findings remediated
- ollamakimi smoke attempted but blocked by external Ollama stream idle timeout/account allowance

## Stack

This PR targets issue1604 because it builds on the ACP session/load implementation in that branch.

Fixes #1609