### PR TITLE
Persist Zed ACP session activity metadata (Fixes #1611)

### DIFF
--- a/docs/zed-integration.md
+++ b/docs/zed-integration.md
@@ -176,6 +176,23 @@ Logs go to `~/.llxprt/debug/`. Only enable when troubleshooting — they get lar
 
 **Profile not found** — list profiles with `llxprt` then `/profile list`. Names are case-sensitive.
 
+## Extension Namespace (`llxprt/`)
+
+LLxprt reserves the `llxprt/` prefix for vendor-specific ACP extension methods and notifications. This namespace is documented for future use; no `llxprt/`-prefixed extension methods are implemented yet.
+
+When a concrete use case arrives (e.g. subagent status, memory operations, debug toggles, provider hints), the method name will be `llxprt/<feature>` and will be advertised here. Clients that do not recognize a `llxprt/` method MUST ignore it per the ACP [extensibility](https://agentclientprotocol.com/protocol/extensibility) rules (`_meta` / extension handling).
+
+## Session Metadata
+
+LLxprt emits ACP `session_info_update` notifications carrying:
+
+- **`title`** — a truncated preview of the first user prompt (derived once, consistent with the on-disk session listing).
+- **`updatedAt`** — an ISO 8601 timestamp refreshed after every turn (success, cancel, or error).
+
+This metadata also populates the `listSessions` response so Zed's session sidebar shows descriptive names and freshness without reading the recording files.
+
+When a session has both a durable on-disk recording and live in-memory metadata (e.g. the agent process is still running), `listSessions` merges them: the durable recording's title takes precedence (it is the authoritative first-user-message preview), while `updatedAt` is the newer of the two. A session with no durable recording yet shows the live title and `updatedAt` only.
+
 ## Related
 
 - [Zed External Agents Documentation](https://zed.dev/docs/ai/external-agents)

--- a/docs/zed-integration.md
+++ b/docs/zed-integration.md
@@ -193,6 +193,14 @@ This metadata also populates the `listSessions` response so Zed's session sideba
 
 When a session has both a durable on-disk recording and live in-memory metadata (e.g. the agent process is still running), `listSessions` merges them: the durable recording's title takes precedence (it is the authoritative first-user-message preview), while `updatedAt` is the newer of the two. A session with no durable recording yet shows the live title and `updatedAt` only.
 
+## Terminal Integration
+
+When the client advertises the `terminal` capability (`terminal: true` in `ClientCapabilities`), LLxprt creates an ACP terminal for each shell tool call via `connection.createTerminal`. This delegates command execution to Zed's native terminal renderer, giving the user live inline output as the command runs.
+
+The terminal is correlated to the originating tool call (by command and working directory) and embedded in the tool call's content as a `terminal` content block. The terminal is released after the tool call completes, and killed and released on cancel or session dispose.
+
+When the terminal capability is absent (or `false`), shell output is captured as text and emitted via the standard `content` content block — the same behavior as non-terminal ACP clients.
+
 ## Related
 
 - [Zed External Agents Documentation](https://zed.dev/docs/ai/external-agents)

--- a/packages/cli/src/zed-integration/acp-types.ts
+++ b/packages/cli/src/zed-integration/acp-types.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+
+/**
+ * The pinned ACP SDK (0.14.1) does not yet export `CloseSessionRequest`,
+ * `DeleteSessionRequest`, or their responses, nor does its
+ * `ClientCapabilities` type include the `session` field used for
+ * config-option gating.  These local type aliases keep the integration
+ * strongly-typed without resorting to `any`.
+ */
+
+export interface CloseSessionRequest {
+  readonly sessionId: acp.SessionId;
+}
+
+export type CloseSessionResponse = Record<string, never>;
+
+export interface DeleteSessionRequest {
+  readonly sessionId: acp.SessionId;
+}
+
+export type DeleteSessionResponse = Record<string, never>;
+
+export interface ClientCapabilitiesWithSession {
+  readonly fs?: {
+    readonly readTextFile?: boolean;
+    readonly writeTextFile?: boolean;
+  };
+  readonly terminal?: boolean;
+  readonly session?: {
+    readonly configOptions?: boolean;
+  };
+}

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -155,6 +155,6 @@ async function handleNotice(
   return null;
 }
 
-function assertNever(event: never): acp.StopReason | null {
+function assertNever(event: never): never {
   throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+import {
+  extractThoughtText,
+  mapDoneReasonToStopReason,
+  translateErrorEvent,
+  translateIdleTimeout,
+} from './zed-helpers.js';
+import type { StreamBatcher } from './zed-stream-batcher.js';
+import {
+  emitToolCallStart,
+  emitToolResult,
+  emitToolStatus,
+} from './zed-tool-handler.js';
+
+interface AgentEventHandlers {
+  sendUpdate(update: acp.SessionUpdate): Promise<void>;
+  sendUsage(
+    usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
+  ): Promise<void>;
+  handleConfirmation(
+    event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
+  ): Promise<void>;
+}
+
+export async function handleZedAgentEvent(
+  event: AgentEvent,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<acp.StopReason | null> {
+  switch (event.type) {
+    case 'text':
+      batcher.append(event.text, false);
+      return null;
+    case 'thinking': {
+      const thoughtText = extractThoughtText(event.thought);
+      if (thoughtText.length > 0) batcher.append(thoughtText, true);
+      return null;
+    }
+    case 'tool-call':
+      await batcher.flush();
+      await emitToolCallStart(event.call, handlers.sendUpdate);
+      return null;
+    case 'tool-status':
+      await batcher.flush();
+      await emitToolStatus(event.update, handlers.sendUpdate);
+      return null;
+    case 'tool-result':
+      await batcher.flush();
+      await emitToolResult(event.result, handlers.sendUpdate);
+      return null;
+    case 'tool-confirmation':
+      await batcher.flush();
+      await handlers.handleConfirmation(event);
+      return null;
+    case 'done':
+      await batcher.flush();
+      return mapDoneReasonToStopReason(event.reason);
+    case 'error':
+      await batcher.flush();
+      throw translateErrorEvent(event);
+    case 'idle-timeout':
+      await batcher.flush();
+      throw translateIdleTimeout(event);
+    case 'invalid-stream':
+      await batcher.flush();
+      throw new Error(
+        'Agent produced an invalid stream that could not be recovered.',
+      );
+    case 'hook-blocked':
+      await batcher.flush();
+      throw new Error(
+        event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
+      );
+    case 'loop-detected':
+      await batcher.flush();
+      return 'end_turn';
+    case 'notice':
+      await batcher.flush();
+      await handlers.sendUpdate({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: event.message },
+      });
+      return null;
+    case 'usage':
+      await batcher.flush();
+      await handlers.sendUsage(event.usage);
+      return null;
+    case 'context-warning':
+    case 'compression':
+    case 'model-info':
+    case 'retry':
+    case 'citation':
+      return null;
+    default: {
+      const exhaustive: never = event;
+      throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -27,6 +27,7 @@ interface AgentEventHandlers {
   handleConfirmation(
     event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
   ): Promise<void>;
+  resolveToolKind(toolName: string): string | undefined;
 }
 
 export async function handleZedAgentEvent(
@@ -45,15 +46,27 @@ export async function handleZedAgentEvent(
     }
     case 'tool-call':
       await batcher.flush();
-      await emitToolCallStart(event.call, handlers.sendUpdate);
+      await emitToolCallStart(
+        event.call,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.call.name),
+      );
       return null;
     case 'tool-status':
       await batcher.flush();
-      await emitToolStatus(event.update, handlers.sendUpdate);
+      await emitToolStatus(
+        event.update,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.update.name),
+      );
       return null;
     case 'tool-result':
       await batcher.flush();
-      await emitToolResult(event.result, handlers.sendUpdate);
+      await emitToolResult(
+        event.result,
+        handlers.sendUpdate,
+        handlers.resolveToolKind(event.result.name),
+      );
       return null;
     case 'tool-confirmation':
       await batcher.flush();

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -42,7 +42,7 @@ export async function handleZedAgentEvent(
     case 'thinking':
       return handleThinking(event, batcher);
     case 'tool-call':
-      return handleToolEvent(event, batcher, handlers, emitToolCallStart);
+      return handleToolEvent(event, batcher, handlers);
     case 'tool-status':
       return handleToolUpdate(event, batcher, handlers);
     case 'tool-result':
@@ -103,10 +103,9 @@ async function handleToolEvent(
   event: Extract<AgentEvent, { type: 'tool-call' }>,
   batcher: StreamBatcher,
   handlers: AgentEventHandlers,
-  emit: typeof emitToolCallStart,
 ): Promise<null> {
   await batcher.flush();
-  await emit(
+  await emitToolCallStart(
     event.call,
     handlers.sendUpdate,
     handlers.resolveToolKind(event.call.name),
@@ -156,5 +155,9 @@ async function handleNotice(
 }
 
 function assertNever(event: never): never {
-  throw new Error(`Unhandled agent event: ${String(event)}`);
+  const detail =
+    typeof event === 'object' && 'type' in event
+      ? String((event as { type: unknown }).type)
+      : JSON.stringify(event);
+  throw new Error(`Unhandled agent event: ${detail}`);
 }

--- a/packages/cli/src/zed-integration/zed-agent-event-handler.ts
+++ b/packages/cli/src/zed-integration/zed-agent-event-handler.ts
@@ -39,35 +39,14 @@ export async function handleZedAgentEvent(
     case 'text':
       batcher.append(event.text, false);
       return null;
-    case 'thinking': {
-      const thoughtText = extractThoughtText(event.thought);
-      if (thoughtText.length > 0) batcher.append(thoughtText, true);
-      return null;
-    }
+    case 'thinking':
+      return handleThinking(event, batcher);
     case 'tool-call':
-      await batcher.flush();
-      await emitToolCallStart(
-        event.call,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.call.name),
-      );
-      return null;
+      return handleToolEvent(event, batcher, handlers, emitToolCallStart);
     case 'tool-status':
-      await batcher.flush();
-      await emitToolStatus(
-        event.update,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.update.name),
-      );
-      return null;
+      return handleToolUpdate(event, batcher, handlers);
     case 'tool-result':
-      await batcher.flush();
-      await emitToolResult(
-        event.result,
-        handlers.sendUpdate,
-        handlers.resolveToolKind(event.result.name),
-      );
-      return null;
+      return handleToolResultEvent(event, batcher, handlers);
     case 'tool-confirmation':
       await batcher.flush();
       await handlers.handleConfirmation(event);
@@ -95,12 +74,7 @@ export async function handleZedAgentEvent(
       await batcher.flush();
       return 'end_turn';
     case 'notice':
-      await batcher.flush();
-      await handlers.sendUpdate({
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: event.message },
-      });
-      return null;
+      return handleNotice(event, batcher, handlers);
     case 'usage':
       await batcher.flush();
       await handlers.sendUsage(event.usage);
@@ -111,9 +85,76 @@ export async function handleZedAgentEvent(
     case 'retry':
     case 'citation':
       return null;
-    default: {
-      const exhaustive: never = event;
-      throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
-    }
+    default:
+      return assertNever(event);
   }
+}
+
+function handleThinking(
+  event: Extract<AgentEvent, { type: 'thinking' }>,
+  batcher: StreamBatcher,
+): null {
+  const thoughtText = extractThoughtText(event.thought);
+  if (thoughtText.length > 0) batcher.append(thoughtText, true);
+  return null;
+}
+
+async function handleToolEvent(
+  event: Extract<AgentEvent, { type: 'tool-call' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+  emit: typeof emitToolCallStart,
+): Promise<null> {
+  await batcher.flush();
+  await emit(
+    event.call,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.call.name),
+  );
+  return null;
+}
+
+async function handleToolUpdate(
+  event: Extract<AgentEvent, { type: 'tool-status' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await emitToolStatus(
+    event.update,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.update.name),
+  );
+  return null;
+}
+
+async function handleToolResultEvent(
+  event: Extract<AgentEvent, { type: 'tool-result' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await emitToolResult(
+    event.result,
+    handlers.sendUpdate,
+    handlers.resolveToolKind(event.result.name),
+  );
+  return null;
+}
+
+async function handleNotice(
+  event: Extract<AgentEvent, { type: 'notice' }>,
+  batcher: StreamBatcher,
+  handlers: AgentEventHandlers,
+): Promise<null> {
+  await batcher.flush();
+  await handlers.sendUpdate({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: event.message },
+  });
+  return null;
+}
+
+function assertNever(event: never): acp.StopReason | null {
+  throw new Error(`Unhandled agent event: ${String(event)}`);
 }

--- a/packages/cli/src/zed-integration/zed-config-options.test.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.test.ts
@@ -103,7 +103,7 @@ describe('Zed config options', () => {
       ),
     ).resolves.toStrictEqual({});
     const supported = await zedConfigOptionsForClient(
-      { session: { configOptions: {} } },
+      { session: { configOptions: true } },
       {
         getModel: () => 'alpha',
         getProviderStatus: () => ({

--- a/packages/cli/src/zed-integration/zed-config-options.ts
+++ b/packages/cli/src/zed-integration/zed-config-options.ts
@@ -13,6 +13,7 @@ import {
   type RuntimeModel,
 } from '@vybestack/llxprt-code-core';
 import { parseEphemeralSettingValue } from '@vybestack/llxprt-code-providers/runtime.js';
+import type { ClientCapabilitiesWithSession } from './acp-types.js';
 
 const REASONING_VALUES = ['minimal', 'low', 'medium', 'high', 'xhigh'];
 const EMOJI_VALUES = ['allowed', 'auto', 'warn', 'error'];
@@ -135,7 +136,7 @@ export async function applyZedConfigOption(
 }
 
 export async function zedConfigOptionsForClient(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   agent: Pick<Agent, 'getModel' | 'getProviderStatus'>,
   config: Config,
 ): Promise<Pick<acp.NewSessionResponse, 'configOptions'>> {
@@ -169,7 +170,7 @@ interface ConfigurableZedSession {
 }
 
 export function dispatchZedConfigOption(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   sessions: ReadonlyMap<string, ConfigurableZedSession>,
   params: acp.SetSessionConfigOptionRequest,
 ): Promise<acp.SetSessionConfigOptionResponse> {
@@ -221,7 +222,7 @@ export function observeZedConfigOptions(
 }
 
 export function zedSessionConfigOptions(
-  capabilities: acp.ClientCapabilities | undefined,
+  capabilities: ClientCapabilitiesWithSession | undefined,
   session: { getConfigOptions(): Promise<acp.SessionConfigOption[]> },
 ): Promise<Pick<acp.LoadSessionResponse, 'configOptions'>> {
   return capabilities?.session?.configOptions == null

--- a/packages/cli/src/zed-integration/zed-initialize.ts
+++ b/packages/cli/src/zed-integration/zed-initialize.ts
@@ -25,8 +25,6 @@ export async function initializeZedAgent(
       sessionCapabilities: {
         list: {},
         resume: {},
-        delete: {},
-        close: {},
       },
       promptCapabilities: {
         image: true,

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -71,7 +71,11 @@ export async function consumeAgentStream(
     return terminalStopReason;
   } finally {
     if (deps.terminals !== null) {
-      await deps.terminals.settleAll();
+      try {
+        await deps.terminals.settleAll();
+      } catch {
+        // Swallow cleanup errors so they don't mask the original error
+      }
     }
   }
 }
@@ -141,6 +145,7 @@ export async function runPromptTurn(
     (u) => deps.streamDeps.sendUpdate(u),
   );
   let terminalStopReason: acp.StopReason | null = null;
+  let thrownError: unknown = null;
   try {
     terminalStopReason = await consumeAgentStream(
       deps.streamDeps,
@@ -151,21 +156,21 @@ export async function runPromptTurn(
       batcher,
     );
   } catch (error) {
-    if (getErrorStatus(error) === 429) {
-      await safeFlush(batcher);
+    thrownError = error;
+  }
+  await safeFlush(batcher);
+  batcher.dispose();
+  if (thrownError !== null) {
+    if (getErrorStatus(thrownError) === 429) {
       throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     if (
       pendingSend.signal.aborted ||
-      (error instanceof Error && error.name === 'AbortError')
+      (thrownError instanceof Error && thrownError.name === 'AbortError')
     ) {
-      await safeFlush(batcher);
       return { stopReason: 'cancelled' };
     }
-    await safeFlush(batcher);
-    throw error;
-  } finally {
-    batcher.dispose();
+    throw thrownError;
   }
   if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
     return { stopReason: 'cancelled' };

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -56,44 +56,63 @@ export async function consumeAgentStream(
     maxTurns: deps.maxTurns,
   });
   let terminalStopReason: acp.StopReason | null = null;
-  for await (const event of eventStream) {
-    if (deps.isPromptStale(promptGeneration, pendingSend)) {
-      if (event.type === 'done') {
-        return 'cancelled';
-      }
-      continue;
+  try {
+    for await (const event of eventStream) {
+      const result = await processStreamEvent(
+        event,
+        deps,
+        batcher,
+        promptGeneration,
+        pendingSend,
+      );
+      if (result === 'cancelled') return 'cancelled';
+      if (result !== null) terminalStopReason = result;
     }
-    if (
-      event.type === 'tool-call' &&
-      deps.terminals !== null &&
-      TerminalManager.isShellToolCall(
-        event.call,
-        deps.agent.tools.get(event.call.name)?.kind,
-      )
-    ) {
-      await deps.terminals.handleToolCall(event.call);
-    }
-    try {
-      const stopReason = await handleZedAgentEvent(event, batcher, {
-        sendUpdate: deps.sendUpdate,
-        sendUsage: deps.sendUsage,
-        handleConfirmation: deps.handleConfirmation,
-        resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-      });
-      if (event.type === 'tool-result' && deps.terminals !== null) {
-        await deps.terminals.releaseTerminal(event.result.id);
-      }
-      if (stopReason !== null) {
-        terminalStopReason = stopReason;
-      }
-    } catch (error) {
-      if (deps.terminals !== null) {
-        await deps.terminals.settleAll();
-      }
-      throw error;
+    return terminalStopReason;
+  } finally {
+    if (deps.terminals !== null) {
+      await deps.terminals.settleAll();
     }
   }
-  return terminalStopReason;
+}
+
+async function processStreamEvent(
+  event: AgentEvent,
+  deps: SessionStreamDeps,
+  batcher: StreamBatcher,
+  promptGeneration: number,
+  pendingSend: AbortController,
+): Promise<acp.StopReason | null | 'cancelled'> {
+  if (deps.isPromptStale(promptGeneration, pendingSend)) {
+    return event.type === 'done' ? 'cancelled' : null;
+  }
+  if (
+    event.type === 'tool-call' &&
+    deps.terminals !== null &&
+    TerminalManager.isShellToolCall(
+      event.call,
+      deps.agent.tools.get(event.call.name)?.kind,
+    )
+  ) {
+    await deps.terminals.handleToolCall(event.call);
+  }
+  try {
+    const stopReason = await handleZedAgentEvent(event, batcher, {
+      sendUpdate: deps.sendUpdate,
+      sendUsage: deps.sendUsage,
+      handleConfirmation: deps.handleConfirmation,
+      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+    });
+    if (event.type === 'tool-result' && deps.terminals !== null) {
+      await deps.terminals.releaseTerminal(event.result.id);
+    }
+    return stopReason;
+  } catch (error) {
+    if (deps.terminals !== null) {
+      await deps.terminals.settleAll();
+    }
+    throw error;
+  }
 }
 
 export interface PromptTurnDeps {

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import { type Agent, type AgentEvent } from '@vybestack/llxprt-code-agents';
+import {
+  EmojiFilter,
+  type ContractPart,
+  type FilterConfiguration,
+  getErrorStatus,
+} from '@vybestack/llxprt-code-core';
+import { handleZedAgentEvent } from './zed-agent-event-handler.js';
+import { StreamBatcher } from './zed-stream-batcher.js';
+import type { ZedPathResolver } from './zed-path-resolver.js';
+import { TerminalManager } from './zed-terminal-manager.js';
+
+type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+type SendUsageFn = (
+  usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
+) => Promise<void>;
+type HandleConfirmationFn = (
+  event: Extract<AgentEvent, { type: 'tool-confirmation' }>,
+) => Promise<void>;
+
+export interface SessionStreamDeps {
+  readonly agent: Agent;
+  readonly terminals: TerminalManager | null;
+  readonly sendUpdate: SendUpdateFn;
+  readonly sendUsage: SendUsageFn;
+  readonly handleConfirmation: HandleConfirmationFn;
+  readonly isPromptStale: (
+    promptGeneration: number,
+    pendingSend: AbortController,
+  ) => boolean;
+  readonly maxTurns: number;
+}
+
+/**
+ * Consumes the agent event stream, forwarding each event to the Zed handler
+ * and managing terminal lifecycle for shell tool calls.
+ */
+export async function consumeAgentStream(
+  deps: SessionStreamDeps,
+  parts: readonly ContractPart[],
+  pendingSend: AbortController,
+  promptId: string,
+  promptGeneration: number,
+  batcher: StreamBatcher,
+): Promise<acp.StopReason | null> {
+  const eventStream = deps.agent.stream(parts, {
+    signal: pendingSend.signal,
+    promptId,
+    maxTurns: deps.maxTurns,
+  });
+  let terminalStopReason: acp.StopReason | null = null;
+  for await (const event of eventStream) {
+    if (deps.isPromptStale(promptGeneration, pendingSend)) {
+      if (event.type === 'done') {
+        return 'cancelled';
+      }
+      continue;
+    }
+    if (
+      event.type === 'tool-call' &&
+      deps.terminals !== null &&
+      TerminalManager.isShellToolCall(
+        event.call,
+        deps.agent.tools.get(event.call.name)?.kind,
+      )
+    ) {
+      await deps.terminals.handleToolCall(event.call);
+    }
+    const stopReason = await handleZedAgentEvent(event, batcher, {
+      sendUpdate: deps.sendUpdate,
+      sendUsage: deps.sendUsage,
+      handleConfirmation: deps.handleConfirmation,
+      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+    });
+    if (event.type === 'tool-result' && deps.terminals !== null) {
+      await deps.terminals.releaseTerminal(event.result.id);
+    }
+    if (stopReason !== null) {
+      terminalStopReason = stopReason;
+    }
+  }
+  return terminalStopReason;
+}
+
+export interface PromptTurnDeps {
+  readonly pathResolver: ZedPathResolver;
+  readonly emojiFilterMode: FilterConfiguration['mode'];
+  readonly streamDeps: SessionStreamDeps;
+}
+
+export async function runPromptTurn(
+  deps: PromptTurnDeps,
+  params: acp.PromptRequest,
+  pendingSend: AbortController,
+  promptId: string,
+  promptGeneration: number,
+): Promise<acp.PromptResponse> {
+  let parts: ContractPart[];
+  try {
+    parts = await deps.pathResolver.resolvePrompt(
+      params.prompt,
+      pendingSend.signal,
+    );
+  } catch (error) {
+    if (
+      pendingSend.signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return { stopReason: 'cancelled' };
+    }
+    throw error;
+  }
+  const batcher = new StreamBatcher(
+    new EmojiFilter({ mode: deps.emojiFilterMode }),
+    (u) => deps.streamDeps.sendUpdate(u),
+  );
+  let terminalStopReason: acp.StopReason | null = null;
+  try {
+    terminalStopReason = await consumeAgentStream(
+      deps.streamDeps,
+      parts,
+      pendingSend,
+      promptId,
+      promptGeneration,
+      batcher,
+    );
+  } catch (error) {
+    if (getErrorStatus(error) === 429) {
+      throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
+    }
+    if (
+      pendingSend.signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return { stopReason: 'cancelled' };
+    }
+    throw error;
+  } finally {
+    try {
+      await batcher.flush();
+    } finally {
+      batcher.dispose();
+    }
+  }
+  if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+    return { stopReason: 'cancelled' };
+  }
+  if (terminalStopReason !== null) {
+    return { stopReason: terminalStopReason };
+  }
+  return { stopReason: 'end_turn' };
+}

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -73,17 +73,24 @@ export async function consumeAgentStream(
     ) {
       await deps.terminals.handleToolCall(event.call);
     }
-    const stopReason = await handleZedAgentEvent(event, batcher, {
-      sendUpdate: deps.sendUpdate,
-      sendUsage: deps.sendUsage,
-      handleConfirmation: deps.handleConfirmation,
-      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-    });
-    if (event.type === 'tool-result' && deps.terminals !== null) {
-      await deps.terminals.releaseTerminal(event.result.id);
-    }
-    if (stopReason !== null) {
-      terminalStopReason = stopReason;
+    try {
+      const stopReason = await handleZedAgentEvent(event, batcher, {
+        sendUpdate: deps.sendUpdate,
+        sendUsage: deps.sendUsage,
+        handleConfirmation: deps.handleConfirmation,
+        resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+      });
+      if (event.type === 'tool-result' && deps.terminals !== null) {
+        await deps.terminals.releaseTerminal(event.result.id);
+      }
+      if (stopReason !== null) {
+        terminalStopReason = stopReason;
+      }
+    } catch (error) {
+      if (deps.terminals !== null) {
+        await deps.terminals.settleAll();
+      }
+      throw error;
     }
   }
   return terminalStopReason;
@@ -133,21 +140,20 @@ export async function runPromptTurn(
     );
   } catch (error) {
     if (getErrorStatus(error) === 429) {
+      await safeFlush(batcher);
       throw new acp.RequestError(429, 'Rate limit exceeded. Try again later.');
     }
     if (
       pendingSend.signal.aborted ||
       (error instanceof Error && error.name === 'AbortError')
     ) {
+      await safeFlush(batcher);
       return { stopReason: 'cancelled' };
     }
+    await safeFlush(batcher);
     throw error;
   } finally {
-    try {
-      await batcher.flush();
-    } finally {
-      batcher.dispose();
-    }
+    batcher.dispose();
   }
   if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
     return { stopReason: 'cancelled' };
@@ -156,4 +162,13 @@ export async function runPromptTurn(
     return { stopReason: terminalStopReason };
   }
   return { stopReason: 'end_turn' };
+}
+
+async function safeFlush(batcher: StreamBatcher): Promise<void> {
+  try {
+    await batcher.flush();
+  } catch {
+    // Swallow flush errors so the original error from consumeAgentStream
+    // is not masked by a secondary flush failure.
+  }
 }

--- a/packages/cli/src/zed-integration/zed-session-events.ts
+++ b/packages/cli/src/zed-integration/zed-session-events.ts
@@ -96,23 +96,16 @@ async function processStreamEvent(
   ) {
     await deps.terminals.handleToolCall(event.call);
   }
-  try {
-    const stopReason = await handleZedAgentEvent(event, batcher, {
-      sendUpdate: deps.sendUpdate,
-      sendUsage: deps.sendUsage,
-      handleConfirmation: deps.handleConfirmation,
-      resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
-    });
-    if (event.type === 'tool-result' && deps.terminals !== null) {
-      await deps.terminals.releaseTerminal(event.result.id);
-    }
-    return stopReason;
-  } catch (error) {
-    if (deps.terminals !== null) {
-      await deps.terminals.settleAll();
-    }
-    throw error;
+  const stopReason = await handleZedAgentEvent(event, batcher, {
+    sendUpdate: deps.sendUpdate,
+    sendUsage: deps.sendUsage,
+    handleConfirmation: deps.handleConfirmation,
+    resolveToolKind: (toolName) => deps.agent.tools.get(toolName)?.kind,
+  });
+  if (event.type === 'tool-result' && deps.terminals !== null) {
+    await deps.terminals.releaseTerminal(event.result.id);
   }
+  return stopReason;
 }
 
 export interface PromptTurnDeps {

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -296,17 +296,16 @@ describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restore
     expect(title).toBe('First title');
   });
 
-  it('returns undefined when history has no human text', () => {
+  it('consumes title eligibility when restored history has no human text', () => {
     const tracker = new SessionTitleTracker();
     const title = tracker.hydrateFromHistory([
       { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
     ]);
     expect(title).toBeUndefined();
-    // Eligibility NOT consumed — a later text prompt can still win the title.
     const result = tracker.consumeTitleEligibility([
       { type: 'text', text: 'First live prompt' },
     ]);
-    expect(result.wonTitle).toBe(true);
+    expect(result.wonTitle).toBe(false);
   });
 });
 

--- a/packages/cli/src/zed-integration/zed-session-info.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.test.ts
@@ -1,0 +1,341 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for session-info derivation (issue #1611):
+ * - The title is a truncated preview of the first user prompt, derived
+ *   consistently with SessionDiscovery.readFirstUserMessage (which feeds the
+ *   durable session listing). No LLM call.
+ * - The ACP session_info_update notification carries title and/or updatedAt
+ *   using the SDK's discriminated-union variant directly (no casts).
+ * - Title eligibility is consumed synchronously (race-safe for overlapping
+ *   prompts), even when the first prompt has no text (finding 1).
+ * - Restored sessions hydrate title from history so later prompts never retitle
+ *   them (finding 2).
+ * - Live title normalization matches durable SessionDiscovery behavior
+ *   (finding 5): no trimming, no newline collapsing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { IContent } from '@vybestack/llxprt-code-core';
+import {
+  deriveSessionTitle,
+  deriveTitleFromHistory,
+  buildSessionInfoUpdate,
+  SessionTitleTracker,
+} from './zed-session-info.js';
+
+describe('deriveSessionTitle (issue #1611: first-prompt title)', () => {
+  it('extracts text from a single text block', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'Investigate session lifecycle' },
+    ]);
+    expect(title).toBe('Investigate session lifecycle');
+  });
+
+  it('concatenates text across multiple text blocks', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'Fix the ' },
+      { type: 'text', text: 'bug in parser' },
+    ]);
+    expect(title).toBe('Fix the bug in parser');
+  });
+
+  it('truncates a long prompt to the bounded length used by the listing', () => {
+    const long = 'x'.repeat(500);
+    const title = deriveSessionTitle([{ type: 'text', text: long }]);
+    // Consistent with SessionDiscovery.readFirstUserMessage (maxLength 120).
+    expect(title).toHaveLength(120);
+    expect(title).toBe(long.slice(0, 120));
+  });
+
+  it('ignores non-text blocks (images, resource links) and still titles from text', () => {
+    const title = deriveSessionTitle([
+      { type: 'resource_link', uri: 'file:///p', name: 'p.ts' },
+      { type: 'text', text: 'Review this file' },
+    ]);
+    expect(title).toBe('Review this file');
+  });
+
+  it('returns null when the prompt has no text content (only media/resources)', () => {
+    const title = deriveSessionTitle([
+      { type: 'image', data: 'base64', mimeType: 'image/png' },
+      { type: 'resource_link', uri: 'file:///p', name: 'p.ts' },
+    ]);
+    expect(title).toBeNull();
+  });
+
+  it('returns null for an empty prompt', () => {
+    expect(deriveSessionTitle([])).toBeNull();
+  });
+
+  // Finding #5: live normalization must match durable SessionDiscovery behavior
+  // (extractUserMessageText: join with '', NO trim, NO newline collapse).
+  it('does NOT trim leading/trailing whitespace, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: '  hello world  ' },
+    ]);
+    // Durable extractUserMessageText does NOT trim — live must match.
+    expect(title).toBe('  hello world  ');
+  });
+
+  it('does NOT collapse newlines, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([
+      { type: 'text', text: 'line one\nline two\nline three' },
+    ]);
+    // Durable extractUserMessageText does NOT replace newlines — live must
+    // match so the durable listing title and the live title are identical.
+    expect(title).toBe('line one\nline two\nline three');
+  });
+
+  it('does NOT collapse tabs or other whitespace, matching durable behavior (finding 5)', () => {
+    const title = deriveSessionTitle([{ type: 'text', text: 'col1\tcol2' }]);
+    expect(title).toBe('col1\tcol2');
+  });
+});
+
+describe('deriveTitleFromHistory (issue #1611: restored-session title hydration)', () => {
+  function humanContent(text: string): IContent {
+    return {
+      speaker: 'human',
+      blocks: [{ type: 'text', text }],
+    };
+  }
+
+  it('extracts the first human-speaker text from history', () => {
+    const history: IContent[] = [
+      humanContent('First user message'),
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('First user message');
+  });
+
+  it('skips ai/tool entries and uses the first human text', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'welcome' }] },
+      { speaker: 'tool', blocks: [{ type: 'text', text: 'result' }] },
+      humanContent('Actual first user message'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Actual first user message');
+  });
+
+  it('returns null when history has no human text', () => {
+    const history: IContent[] = [
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ];
+    expect(deriveTitleFromHistory(history)).toBeNull();
+  });
+
+  it('skips human entries with no text blocks', () => {
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [
+          {
+            type: 'media',
+            data: 'base64',
+            mimeType: 'image/png',
+            encoding: 'base64',
+          },
+        ],
+      },
+      humanContent('Second human has text'),
+    ];
+    expect(deriveTitleFromHistory(history)).toBe('Second human has text');
+  });
+
+  it('returns null for empty history', () => {
+    expect(deriveTitleFromHistory([])).toBeNull();
+  });
+
+  it('truncates long history text to the bounded length', () => {
+    const long = 'y'.repeat(500);
+    const history: IContent[] = [humanContent(long)];
+    expect(deriveTitleFromHistory(history)).toBe(long.slice(0, 120));
+  });
+
+  it('does NOT trim or collapse newlines, matching durable behavior (finding 5)', () => {
+    const history: IContent[] = [humanContent('  line one\nline two  ')];
+    expect(deriveTitleFromHistory(history)).toBe('  line one\nline two  ');
+  });
+});
+
+describe('buildSessionInfoUpdate (issue #1611: ACP session_info_update)', () => {
+  it('builds a title-only update using the SDK discriminated-union variant', () => {
+    const update = buildSessionInfoUpdate({ title: 'My session' });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      title: 'My session',
+    });
+  });
+
+  it('builds an updatedAt-only update', () => {
+    const update = buildSessionInfoUpdate({
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+
+  it('builds a combined title + updatedAt update', () => {
+    const update = buildSessionInfoUpdate({
+      title: 'My session',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+    expect(update).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      title: 'My session',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+});
+
+describe('SessionTitleTracker.consumeTitleEligibility (issue #1611 finding 1: synchronous, race-safe)', () => {
+  it('wins the title on the first text-bearing prompt', () => {
+    const tracker = new SessionTitleTracker();
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First prompt here' },
+    ]);
+    expect(result.wonTitle).toBe(true);
+    expect(result.title).toBe('First prompt here');
+  });
+
+  it('consumes eligibility even when the first prompt has no text (no retitle later)', () => {
+    const tracker = new SessionTitleTracker();
+    const first = tracker.consumeTitleEligibility([
+      { type: 'image', data: 'base64', mimeType: 'image/png' },
+    ]);
+    expect(first.wonTitle).toBe(false);
+    expect(first.title).toBeUndefined();
+
+    // A LATER text-bearing prompt must NOT win — eligibility was consumed.
+    const second = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Now with text' },
+    ]);
+    expect(second.wonTitle).toBe(false);
+    expect(second.title).toBeUndefined();
+  });
+
+  it('does NOT win on the second prompt (title set once, eligibility consumed once)', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First prompt here' },
+    ]);
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Second prompt here' },
+    ]);
+    expect(result.wonTitle).toBe(false);
+    expect(result.title).toBe('First prompt here');
+  });
+
+  it('is race-safe: only the first synchronous call wins, regardless of turn completion order', () => {
+    // Simulate overlapping prompts: both call consumeTitleEligibility before
+    // either turn completes. Only the first wins.
+    const tracker = new SessionTitleTracker();
+    const promptA = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Prompt A' },
+    ]);
+    const promptB = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'Prompt B' },
+    ]);
+    expect(promptA.wonTitle).toBe(true);
+    expect(promptA.title).toBe('Prompt A');
+    expect(promptB.wonTitle).toBe(false);
+    expect(promptB.title).toBe('Prompt A');
+  });
+});
+
+describe('SessionTitleTracker.hydrateFromHistory (issue #1611 finding 2: restored sessions)', () => {
+  it('sets the title from the first human text in restored history', () => {
+    const tracker = new SessionTitleTracker();
+    const title = tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored session title' }],
+      },
+    ]);
+    expect(title).toBe('Restored session title');
+    expect(tracker.getTitle()).toBe('Restored session title');
+  });
+
+  it('consumes title eligibility so a later live prompt never retitles', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored title' }],
+      },
+    ]);
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'New prompt after restore' },
+    ]);
+    expect(result.wonTitle).toBe(false);
+    expect(result.title).toBe('Restored title');
+  });
+
+  it('is idempotent: a second hydrate is a no-op', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'First title' }],
+      },
+    ]);
+    const title = tracker.hydrateFromHistory([
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Second title' }],
+      },
+    ]);
+    expect(title).toBe('First title');
+  });
+
+  it('returns undefined when history has no human text', () => {
+    const tracker = new SessionTitleTracker();
+    const title = tracker.hydrateFromHistory([
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'response' }] },
+    ]);
+    expect(title).toBeUndefined();
+    // Eligibility NOT consumed — a later text prompt can still win the title.
+    const result = tracker.consumeTitleEligibility([
+      { type: 'text', text: 'First live prompt' },
+    ]);
+    expect(result.wonTitle).toBe(true);
+  });
+});
+
+describe('SessionTitleTracker.recordTurn (issue #1611: updatedAt-per-turn)', () => {
+  it('returns an updatedAt update', () => {
+    const tracker = new SessionTitleTracker();
+    const result = tracker.recordTurn('2026-07-12T00:00:00Z');
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:00:00Z',
+    });
+  });
+
+  it('advances updatedAt on each turn', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.recordTurn('2026-07-12T00:00:00Z');
+    const result = tracker.recordTurn('2026-07-12T00:01:00Z');
+    expect(result.updates[0]).toStrictEqual<acp.SessionUpdate>({
+      sessionUpdate: 'session_info_update',
+      updatedAt: '2026-07-12T00:01:00Z',
+    });
+    expect(tracker.getUpdatedAt()).toBe('2026-07-12T00:01:00Z');
+  });
+
+  it('does not carry a title field (title is handled by consumeTitleEligibility)', () => {
+    const tracker = new SessionTitleTracker();
+    tracker.consumeTitleEligibility([{ type: 'text', text: 'First' }]);
+    const result = tracker.recordTurn('2026-07-12T00:00:00Z');
+    expect(result.updates[0]).not.toHaveProperty('title');
+  });
+});

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -28,14 +28,16 @@ const TITLE_MAX_LENGTH = 120;
 export function deriveSessionTitle(
   prompt: readonly acp.ContentBlock[],
 ): string | null {
-  const text = prompt
+  return extractTitleText(prompt);
+}
+
+function extractTitleText(
+  blocks: ReadonlyArray<{ readonly type: string; readonly text?: unknown }>,
+): string | null {
+  const text = blocks
     .filter(
-      (
-        block,
-      ): block is acp.ContentBlock & {
-        type: 'text';
-        text: string;
-      } => block.type === 'text',
+      (block): block is { readonly type: 'text'; readonly text: string } =>
+        block.type === 'text' && typeof block.text === 'string',
     )
     .map((block) => block.text)
     .join('');
@@ -61,17 +63,9 @@ export function deriveTitleFromHistory(
     if (item.speaker !== 'human') {
       continue;
     }
-    const text = item.blocks
-      .filter(
-        (block): block is { type: 'text'; text: string } =>
-          block.type === 'text',
-      )
-      .map((block) => block.text)
-      .join('');
-    if (text.length > 0) {
-      return text.length > TITLE_MAX_LENGTH
-        ? text.slice(0, TITLE_MAX_LENGTH)
-        : text;
+    const title = extractTitleText(item.blocks);
+    if (title !== null) {
+      return title;
     }
   }
   return null;
@@ -116,9 +110,8 @@ export interface TitleEligibilityResult {
 
 export interface SessionInfoRecordResult {
   /**
-   * The session_info_update notification to emit for this turn: always an
-   * updatedAt update (title is emitted via consumeTitleEligibility). Empty only
-   * if updatedAt is unchanged.
+   * The session_info_update notifications to emit for this turn: always an
+   * updatedAt update, optionally preceded by a pending title retry.
    */
   readonly updates: ReadonlyArray<
     acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -201,11 +201,11 @@ export class SessionTitleTracker {
       return this.title;
     }
     const derived = deriveTitleFromHistory(history);
+    this.titleEligibilityConsumed = true;
     if (derived === null) {
       return undefined;
     }
     this.title = derived;
-    this.titleEligibilityConsumed = true;
     return this.title;
   }
 

--- a/packages/cli/src/zed-integration/zed-session-info.ts
+++ b/packages/cli/src/zed-integration/zed-session-info.ts
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+/**
+ * Maximum title length, matching SessionDiscovery.readFirstUserMessage so the
+ * live session_info_update title and the durable on-disk listing title agree.
+ */
+const TITLE_MAX_LENGTH = 120;
+
+/**
+ * Derives a human-readable title from the first user prompt by concatenating
+ * its text blocks (ignoring media/resources) and truncating to the bounded
+ * length the session listing uses. Returns null when the prompt carries no
+ * text. No LLM call — consistent with the durable listing convention.
+ *
+ * Normalization intentionally matches the durable path
+ * (SessionDiscovery.readFirstUserMessage → extractUserMessageText): text blocks
+ * are joined with an empty separator and truncated — NO trimming or newline
+ * collapsing — so the live title is byte-identical to the on-disk listing
+ * title for the same first user message.
+ */
+export function deriveSessionTitle(
+  prompt: readonly acp.ContentBlock[],
+): string | null {
+  const text = prompt
+    .filter(
+      (
+        block,
+      ): block is acp.ContentBlock & {
+        type: 'text';
+        text: string;
+      } => block.type === 'text',
+    )
+    .map((block) => block.text)
+    .join('');
+  if (text.length === 0) {
+    return null;
+  }
+  return text.length > TITLE_MAX_LENGTH
+    ? text.slice(0, TITLE_MAX_LENGTH)
+    : text;
+}
+
+/**
+ * Extracts the first human-speaker text from a resumed history, using the SAME
+ * join + truncate normalization as {@link deriveSessionTitle} and the durable
+ * SessionDiscovery.readFirstUserMessage. Returns null when the history has no
+ * human text block, so a restored session with only ai/tool entries is not
+ * titled (matching the durable listing, which shows no title for such sessions).
+ */
+export function deriveTitleFromHistory(
+  history: readonly IContent[],
+): string | null {
+  for (const item of history) {
+    if (item.speaker !== 'human') {
+      continue;
+    }
+    const text = item.blocks
+      .filter(
+        (block): block is { type: 'text'; text: string } =>
+          block.type === 'text',
+      )
+      .map((block) => block.text)
+      .join('');
+    if (text.length > 0) {
+      return text.length > TITLE_MAX_LENGTH
+        ? text.slice(0, TITLE_MAX_LENGTH)
+        : text;
+    }
+  }
+  return null;
+}
+
+/**
+ * Builds an ACP `session_info_update` {@link acp.SessionUpdate} using the SDK's
+ * discriminated-union variant directly (no casts). Only the supplied fields are
+ * carried so partial title/updatedAt updates are emitted without nulling the
+ * other.
+ */
+export function buildSessionInfoUpdate(fields: {
+  readonly title?: string;
+  readonly updatedAt?: string;
+}): acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' } {
+  const update: acp.SessionInfoUpdate & {
+    sessionUpdate: 'session_info_update';
+  } = {
+    sessionUpdate: 'session_info_update',
+  };
+  if (fields.title !== undefined) {
+    update.title = fields.title;
+  }
+  if (fields.updatedAt !== undefined) {
+    update.updatedAt = fields.updatedAt;
+  }
+  return update;
+}
+
+export interface TitleEligibilityResult {
+  /**
+   * True when THIS call won the title — i.e. the derived title was freshly set.
+   * The caller emits a session_info_update carrying the title exactly once.
+   */
+  readonly wonTitle: boolean;
+  /**
+   * The current title (undefined until the first text-bearing prompt wins or
+   * hydration sets it from history).
+   */
+  readonly title: string | undefined;
+}
+
+export interface SessionInfoRecordResult {
+  /**
+   * The session_info_update notification to emit for this turn: always an
+   * updatedAt update (title is emitted via consumeTitleEligibility). Empty only
+   * if updatedAt is unchanged.
+   */
+  readonly updates: ReadonlyArray<
+    acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }
+  >;
+  /**
+   * The current title (undefined until the first text-bearing prompt wins or
+   * hydration sets it from history).
+   */
+  readonly title: string | undefined;
+}
+
+/**
+ * Tracks per-session title (derived once from the first text-bearing prompt)
+ * and updatedAt (refreshed every turn). Keeping this state in a cohesive
+ * helper lets zedIntegration.ts stay within its max-lines budget and makes the
+ * externally observable session_info_update semantics unit-testable in
+ * isolation.
+ *
+ * Title eligibility is consumed SYNCHRONOUSLY at prompt-acceptance time via
+ * {@link consumeTitleEligibility}, not deferred to turn completion, so
+ * overlapping prompts cannot both claim the title (race-safety, issue #1611
+ * finding 1). Restored sessions hydrate the title from history via
+ * {@link hydrateFromHistory} so later prompts never retitle them (finding 2).
+ */
+export class SessionTitleTracker {
+  private title: string | undefined;
+  private updatedAt: string | undefined;
+  /**
+   * Once consumed, no future call can win the title — even if the winning
+   * prompt had no text (so a no-text first prompt still suppresses a later
+   * retitle).
+   */
+  private titleEligibilityConsumed = false;
+  /**
+   * A title that won eligibility but whose session_info_update notification
+   * failed transport. Retried (prepended) on the next turn's metadata emission
+   * so a transient transport error doesn't permanently lose the title.
+   * Issue #1611: pending title notification retry after transport failure.
+   */
+  private pendingTitle: string | undefined;
+
+  /**
+   * Synchronously consumes title eligibility for a prompt: on the FIRST call
+   * (whether or not the prompt has text), eligibility is permanently consumed.
+   * If the prompt has text and no title is set yet, the title is derived and
+   * set. Returns whether THIS call won the title (so the caller emits the
+   * session_info_update exactly once) and the current title.
+   */
+  consumeTitleEligibility(
+    prompt: readonly acp.ContentBlock[],
+  ): TitleEligibilityResult {
+    if (this.titleEligibilityConsumed) {
+      return { wonTitle: false, title: this.title };
+    }
+    this.titleEligibilityConsumed = true;
+    if (this.title !== undefined) {
+      return { wonTitle: false, title: this.title };
+    }
+    const derived = deriveSessionTitle(prompt);
+    if (derived === null) {
+      return { wonTitle: false, title: undefined };
+    }
+    this.title = derived;
+    return { wonTitle: true, title: this.title };
+  }
+
+  hydrateFromMetadata(title: string | null): string | undefined {
+    if (this.titleEligibilityConsumed) {
+      return this.title;
+    }
+    this.titleEligibilityConsumed = true;
+    if (title !== null) {
+      this.title = title;
+    }
+    return this.title;
+  }
+
+  /**
+   * Hydrates the title from a resumed history (issue #1611 finding 2). Called
+   * after a load/resume replays the conversation, BEFORE any new prompt. If the
+   * history's first human text yields a title, it is set AND eligibility is
+   * consumed, so the next live prompt can never retitle the session. Idempotent:
+   * a no-op if a title was already set or eligibility already consumed.
+   */
+  hydrateFromHistory(history: readonly IContent[]): string | undefined {
+    if (this.title !== undefined || this.titleEligibilityConsumed) {
+      return this.title;
+    }
+    const derived = deriveTitleFromHistory(history);
+    if (derived === null) {
+      return undefined;
+    }
+    this.title = derived;
+    this.titleEligibilityConsumed = true;
+    return this.title;
+  }
+
+  /**
+   * Records a completed turn: advances updatedAt and returns the
+   * session_info_update notification the caller should push. Title is handled
+   * separately via {@link consumeTitleEligibility} at acceptance time.
+   *
+   * If a pending title exists (from a previous transport failure), it is
+   * prepended to the updates so the caller retries it this turn.
+   */
+  recordTurn(updatedAt: string): SessionInfoRecordResult {
+    this.updatedAt = updatedAt;
+    const updates: Array<
+      acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' }
+    > = [];
+    if (this.pendingTitle !== undefined) {
+      updates.push(
+        buildSessionInfoUpdate({
+          title: this.pendingTitle,
+          updatedAt,
+        }),
+      );
+      this.pendingTitle = undefined;
+    }
+    updates.push(buildSessionInfoUpdate({ updatedAt }));
+    return { updates, title: this.title };
+  }
+
+  /**
+   * Marks a title as pending for retry (issue #1611). Called by the caller
+   * when the title-bearing session_info_update notification fails transport.
+   * The next {@link recordTurn} will prepend the title to its updates.
+   */
+  markPendingTitle(title: string): void {
+    this.pendingTitle = title;
+  }
+
+  /**
+   * Returns the pending title (for testing) or undefined when none is pending.
+   */
+  getPendingTitle(): string | undefined {
+    return this.pendingTitle;
+  }
+
+  getTitle(): string | undefined {
+    return this.title;
+  }
+
+  getUpdatedAt(): string | undefined {
+    return this.updatedAt;
+  }
+}

--- a/packages/cli/src/zed-integration/zed-session-lifecycle.ts
+++ b/packages/cli/src/zed-integration/zed-session-lifecycle.ts
@@ -14,6 +14,12 @@ import {
 import { buildSessionModes } from './zed-helpers.js';
 import { listRecordedSessions } from './zed-session-listing.js';
 import type { LifecycleSession } from './zed-session-pagination.js';
+import type {
+  CloseSessionRequest,
+  CloseSessionResponse,
+  DeleteSessionRequest,
+  DeleteSessionResponse,
+} from './acp-types.js';
 
 export interface LifecycleSessionHandle {
   getApprovalMode(): ApprovalMode;
@@ -61,14 +67,14 @@ export class SessionLifecycle {
     );
   }
 
-  close(params: acp.CloseSessionRequest): Promise<acp.CloseSessionResponse> {
+  close(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     return this.runSerialized(params.sessionId, async () => {
       await this.disposeLive(params.sessionId);
       return {};
     });
   }
 
-  delete(params: acp.DeleteSessionRequest): Promise<acp.DeleteSessionResponse> {
+  delete(params: DeleteSessionRequest): Promise<DeleteSessionResponse> {
     return this.runSerialized(params.sessionId, () =>
       this.performDelete(params),
     );
@@ -113,8 +119,8 @@ export class SessionLifecycle {
   }
 
   private async performDelete(
-    params: acp.DeleteSessionRequest,
-  ): Promise<acp.DeleteSessionResponse> {
+    params: DeleteSessionRequest,
+  ): Promise<DeleteSessionResponse> {
     const hadLiveSession = await this.disposeLive(params.sessionId);
     const projectRoot = this.config.getProjectRoot();
     const result = await deleteSessionById(

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -93,4 +93,329 @@ describe('recorded ACP session listing', () => {
       false,
     );
   });
+
+  it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+
+    const liveSession = {
+      sessionId: 'live-only-session',
+      cwd: '/workspace',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+      title: 'Live session title from first prompt',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'live-only-session',
+      cwd: '/workspace',
+      title: 'Live session title from first prompt',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+    });
+  });
+
+  it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'merged-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Durable title from disk' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const liveSession = {
+      sessionId: 'merged-session',
+      cwd: '/workspace',
+      updatedAt: '2026-07-12T12:00:00.000Z',
+      title: 'Live title that should be overridden',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Durable title wins over live title.
+    expect(result.sessions[0].title).toBe('Durable title from disk');
+  });
+
+  it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'freshness-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Some title' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const liveSession = {
+      sessionId: 'freshness-session',
+      cwd: '/workspace',
+      // Live updatedAt is newer than the durable file mtime.
+      updatedAt: '2099-01-01T00:00:00.000Z',
+      title: 'Live title',
+    };
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+      [liveSession],
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // updatedAt should be the live (newer) value.
+    expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
+  });
+});
+describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  // The durable path (SessionDiscovery.readFirstUserMessage →
+  // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
+  // NO newline collapse. The live path (deriveSessionTitle) must match exactly
+  // so the on-disk listing title and the session_info_update title agree.
+  const cases: Array<{ name: string; text: string }> = [
+    { name: 'multiline', text: 'line one\nline two\nline three' },
+    { name: 'leading/trailing whitespace', text: '  padded title  ' },
+    { name: 'tabs', text: 'col1\tcol2' },
+    { name: 'multiple text blocks', text: 'part1part2' },
+  ];
+
+  for (const { name, text } of cases) {
+    it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
+      const { deriveSessionTitle } = await import('./zed-session-info.js');
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'consistency-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      const content: IContent = {
+        speaker: 'human',
+        blocks:
+          name === 'multiple text blocks'
+            ? [
+                { type: 'text', text: 'part1' },
+                { type: 'text', text: 'part2' },
+              ]
+            : [{ type: 'text', text }],
+      };
+      service.recordContent(content);
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+      const durableTitle = result.sessions[0].title;
+
+      const liveTitle = deriveSessionTitle(
+        name === 'multiple text blocks'
+          ? [
+              { type: 'text', text: 'part1' },
+              { type: 'text', text: 'part2' },
+            ]
+          : [{ type: 'text', text }],
+      );
+
+      expect(durableTitle).toBe(liveTitle);
+    });
+  }
+});
+
+describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it('uses the session_metadata title when present', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'metadata-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // Record a metadata title BEFORE the content event.
+    service.recordSessionMetadata('Metadata title from ACP');
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Different first human text' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // The session_metadata title wins over the first-human-text fallback.
+    expect(result.sessions[0].title).toBe('Metadata title from ACP');
+  });
+
+  it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'legacy-metadata-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // No recordSessionMetadata — legacy behavior.
+    service.recordContent({
+      speaker: 'human',
+      blocks: [{ type: 'text', text: 'Legacy first human text' }],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Falls back to first-human-text for legacy sessions.
+    expect(result.sessions[0].title).toBe('Legacy first human text');
+  });
+
+  it('omits title when session_metadata is explicit null (untitled)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'untitled-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    // Explicit null title.
+    service.recordSessionMetadata(null);
+    service.recordContent({
+      speaker: 'human',
+      blocks: [
+        { type: 'text', text: 'Human text that should NOT be the title' },
+      ],
+    });
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    // Explicit null → no title surfaced (consistent with legacy no-human-text).
+    expect(result.sessions[0]).not.toHaveProperty('title');
+  });
+
+  it('includes createdAt in the listing for immutable ordering (issue #1611)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+    roots.push(root);
+    const chatsDir = join(root, 'chats');
+    await mkdir(chatsDir);
+    const service = new SessionRecordingService({
+      sessionId: 'created-at-session',
+      projectHash: 'project-hash',
+      chatsDir,
+      workspaceDirs: ['/workspace'],
+      cwd: '/workspace',
+      provider: 'openai',
+      model: 'test-model',
+    });
+    service.recordSessionMetadata('Title');
+    await service.flush();
+    await service.dispose();
+
+    const result = await listRecordedSessions(
+      chatsDir,
+      'project-hash',
+      '/fallback',
+      {},
+    );
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+  });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -12,6 +12,7 @@ import {
   SessionRecordingService,
   type IContent,
 } from '@vybestack/llxprt-code-core';
+import { deriveSessionTitle } from './zed-session-info.js';
 import { listRecordedSessions } from './zed-session-listing.js';
 
 const roots: string[] = [];
@@ -22,218 +23,15 @@ describe('recorded ACP session listing', () => {
       roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
     );
   });
-  it('returns persisted cwd, first human text title, and updated timestamp', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'listed-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    const content: IContent = {
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
-    };
-    service.recordContent(content);
-    await service.flush();
-    await service.dispose();
 
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'listed-session',
-      cwd: '/workspace',
-      title: 'Investigate session lifecycle',
-    });
-    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
-  });
-
-  it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'legacy-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: [],
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'ai',
-      blocks: [{ type: 'text', text: 'agent-only content' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions[0].cwd).toBe('/fallback');
-    expect(result.sessions[0]).not.toHaveProperty('title');
-    expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
-      false,
-    );
-  });
-
-  it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-
-    const liveSession = {
-      sessionId: 'live-only-session',
-      cwd: '/workspace',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-      title: 'Live session title from first prompt',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'live-only-session',
-      cwd: '/workspace',
-      title: 'Live session title from first prompt',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-    });
-  });
-
-  it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'merged-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Durable title from disk' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const liveSession = {
-      sessionId: 'merged-session',
-      cwd: '/workspace',
-      updatedAt: '2026-07-12T12:00:00.000Z',
-      title: 'Live title that should be overridden',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Durable title wins over live title.
-    expect(result.sessions[0].title).toBe('Durable title from disk');
-  });
-
-  it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'freshness-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Some title' }],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const liveSession = {
-      sessionId: 'freshness-session',
-      cwd: '/workspace',
-      // Live updatedAt is newer than the durable file mtime.
-      updatedAt: '2099-01-01T00:00:00.000Z',
-      title: 'Live title',
-    };
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-      [liveSession],
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // updatedAt should be the live (newer) value.
-    expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
-  });
-});
-describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
-  afterEach(async () => {
-    await Promise.all(
-      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-    );
-  });
-
-  // The durable path (SessionDiscovery.readFirstUserMessage →
-  // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
-  // NO newline collapse. The live path (deriveSessionTitle) must match exactly
-  // so the on-disk listing title and the session_info_update title agree.
-  const cases: Array<{ name: string; text: string }> = [
-    { name: 'multiline', text: 'line one\nline two\nline three' },
-    { name: 'leading/trailing whitespace', text: '  padded title  ' },
-    { name: 'tabs', text: 'col1\tcol2' },
-    { name: 'multiple text blocks', text: 'part1part2' },
-  ];
-
-  for (const { name, text } of cases) {
-    it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
-      const { deriveSessionTitle } = await import('./zed-session-info.js');
+  describe('listing and live merging', () => {
+    it('returns persisted cwd, first human text title, and updated timestamp', async () => {
       const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
       roots.push(root);
       const chatsDir = join(root, 'chats');
       await mkdir(chatsDir);
       const service = new SessionRecordingService({
-        sessionId: 'consistency-session',
+        sessionId: 'listed-session',
         projectHash: 'project-hash',
         chatsDir,
         workspaceDirs: ['/workspace'],
@@ -243,13 +41,7 @@ describe('durable + live title normalization consistency (issue #1611 finding 5)
       });
       const content: IContent = {
         speaker: 'human',
-        blocks:
-          name === 'multiple text blocks'
-            ? [
-                { type: 'text', text: 'part1' },
-                { type: 'text', text: 'part2' },
-              ]
-            : [{ type: 'text', text }],
+        blocks: [{ type: 'text', text: 'Investigate session lifecycle' }],
       };
       service.recordContent(content);
       await service.flush();
@@ -261,161 +53,362 @@ describe('durable + live title normalization consistency (issue #1611 finding 5)
         '/fallback',
         {},
       );
-      const durableTitle = result.sessions[0].title;
 
-      const liveTitle = deriveSessionTitle(
-        name === 'multiple text blocks'
-          ? [
-              { type: 'text', text: 'part1' },
-              { type: 'text', text: 'part2' },
-            ]
-          : [{ type: 'text', text }],
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]).toMatchObject({
+        sessionId: 'listed-session',
+        cwd: '/workspace',
+        title: 'Investigate session lifecycle',
+      });
+      expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
+    });
+
+    it('uses the fallback cwd and omits title for legacy non-human sessions', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'legacy-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: [],
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'agent-only content' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
       );
 
-      expect(durableTitle).toBe(liveTitle);
+      expect(result.sessions[0].cwd).toBe('/fallback');
+      expect(result.sessions[0]).not.toHaveProperty('title');
+      expect(Number.isNaN(Date.parse(result.sessions[0].updatedAt ?? ''))).toBe(
+        false,
+      );
     });
-  }
-});
 
-describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
-  afterEach(async () => {
-    await Promise.all(
-      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-    );
+    it('surfaces a live session title and updatedAt when no durable recording exists yet (issue #1609 feed)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+
+      const liveSession = {
+        sessionId: 'live-only-session',
+        cwd: '/workspace',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        title: 'Live session title from first prompt',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]).toMatchObject({
+        sessionId: 'live-only-session',
+        cwd: '/workspace',
+        title: 'Live session title from first prompt',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+      });
+    });
+
+    it('durable title takes precedence over live title when both exist (issue #1611 finding 6)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'merged-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Durable title from disk' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'merged-session',
+        cwd: '/workspace',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        title: 'Live title that should be overridden',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Durable title wins over live title.
+      expect(result.sessions[0].title).toBe('Durable title from disk');
+    });
+
+    it('durable + live updatedAt merges to the newer value (issue #1611 finding 6)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'freshness-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Some title' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const liveSession = {
+        sessionId: 'freshness-session',
+        cwd: '/workspace',
+        // Live updatedAt is newer than the durable file mtime.
+        updatedAt: '2099-01-01T00:00:00.000Z',
+        title: 'Live title',
+      };
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+        [liveSession],
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // updatedAt should be the live (newer) value.
+      expect(result.sessions[0].updatedAt).toBe('2099-01-01T00:00:00.000Z');
+    });
+  });
+  describe('durable + live title normalization consistency (issue #1611 finding 5)', () => {
+    // The durable path (SessionDiscovery.readFirstUserMessage →
+    // extractUserMessageText) joins text blocks with '' and truncates — NO trim,
+    // NO newline collapse. The live path (deriveSessionTitle) must match exactly
+    // so the on-disk listing title and the session_info_update title agree.
+    const cases: Array<{ name: string; text: string }> = [
+      { name: 'multiline', text: 'line one\nline two\nline three' },
+      { name: 'leading/trailing whitespace', text: '  padded title  ' },
+      { name: 'tabs', text: 'col1\tcol2' },
+      { name: 'multiple text blocks', text: 'part1part2' },
+    ];
+
+    for (const { name, text } of cases) {
+      it(`durable listing title matches live deriveSessionTitle for ${name}`, async () => {
+        const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+        roots.push(root);
+        const chatsDir = join(root, 'chats');
+        await mkdir(chatsDir);
+        const service = new SessionRecordingService({
+          sessionId: 'consistency-session',
+          projectHash: 'project-hash',
+          chatsDir,
+          workspaceDirs: ['/workspace'],
+          cwd: '/workspace',
+          provider: 'openai',
+          model: 'test-model',
+        });
+        const content: IContent = {
+          speaker: 'human',
+          blocks:
+            name === 'multiple text blocks'
+              ? [
+                  { type: 'text', text: 'part1' },
+                  { type: 'text', text: 'part2' },
+                ]
+              : [{ type: 'text', text }],
+        };
+        service.recordContent(content);
+        await service.flush();
+        await service.dispose();
+
+        const result = await listRecordedSessions(
+          chatsDir,
+          'project-hash',
+          '/fallback',
+          {},
+        );
+        const durableTitle = result.sessions[0].title;
+
+        const liveTitle = deriveSessionTitle(
+          name === 'multiple text blocks'
+            ? [
+                { type: 'text', text: 'part1' },
+                { type: 'text', text: 'part2' },
+              ]
+            : [{ type: 'text', text }],
+        );
+
+        expect(durableTitle).toBe(liveTitle);
+      });
+    }
   });
 
-  it('uses the session_metadata title when present', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'metadata-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
+  describe('session_metadata title takes precedence over legacy first-human-text (issue #1611)', () => {
+    it('uses the session_metadata title when present', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'metadata-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // Record a metadata title BEFORE the content event.
+      service.recordSessionMetadata('Metadata title from ACP');
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Different first human text' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // The session_metadata title wins over the first-human-text fallback.
+      expect(result.sessions[0].title).toBe('Metadata title from ACP');
     });
-    // Record a metadata title BEFORE the content event.
-    service.recordSessionMetadata('Metadata title from ACP');
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Different first human text' }],
+
+    it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'legacy-metadata-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // No recordSessionMetadata — legacy behavior.
+      service.recordContent({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Legacy first human text' }],
+      });
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      // Falls back to first-human-text for legacy sessions.
+      expect(result.sessions[0].title).toBe('Legacy first human text');
     });
-    await service.flush();
-    await service.dispose();
 
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
+    it('omits title when session_metadata is explicit null (untitled)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'untitled-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      // Explicit null title.
+      service.recordSessionMetadata(null);
+      service.recordContent({
+        speaker: 'human',
+        blocks: [
+          { type: 'text', text: 'Human text that should NOT be the title' },
+        ],
+      });
+      await service.flush();
+      await service.dispose();
 
-    expect(result.sessions).toHaveLength(1);
-    // The session_metadata title wins over the first-human-text fallback.
-    expect(result.sessions[0].title).toBe('Metadata title from ACP');
-  });
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
 
-  it('falls back to first-human-text when no session_metadata event exists (legacy)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'legacy-metadata-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
+      expect(result.sessions).toHaveLength(1);
+      // Explicit null → no title surfaced (consistent with legacy no-human-text).
+      expect(result.sessions[0]).not.toHaveProperty('title');
     });
-    // No recordSessionMetadata — legacy behavior.
-    service.recordContent({
-      speaker: 'human',
-      blocks: [{ type: 'text', text: 'Legacy first human text' }],
+
+    it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
+      roots.push(root);
+      const chatsDir = join(root, 'chats');
+      await mkdir(chatsDir);
+      const service = new SessionRecordingService({
+        sessionId: 'created-at-session',
+        projectHash: 'project-hash',
+        chatsDir,
+        workspaceDirs: ['/workspace'],
+        cwd: '/workspace',
+        provider: 'openai',
+        model: 'test-model',
+      });
+      service.recordSessionMetadata('Title');
+      await service.flush();
+      await service.dispose();
+
+      const result = await listRecordedSessions(
+        chatsDir,
+        'project-hash',
+        '/fallback',
+        {},
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      const updatedAt = result.sessions[0].updatedAt;
+      expect(updatedAt).toBeDefined();
+      expect(new Date(updatedAt ?? '').toISOString()).toBe(updatedAt);
     });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Falls back to first-human-text for legacy sessions.
-    expect(result.sessions[0].title).toBe('Legacy first human text');
-  });
-
-  it('omits title when session_metadata is explicit null (untitled)', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'untitled-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    // Explicit null title.
-    service.recordSessionMetadata(null);
-    service.recordContent({
-      speaker: 'human',
-      blocks: [
-        { type: 'text', text: 'Human text that should NOT be the title' },
-      ],
-    });
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    // Explicit null → no title surfaced (consistent with legacy no-human-text).
-    expect(result.sessions[0]).not.toHaveProperty('title');
-  });
-
-  it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
-    roots.push(root);
-    const chatsDir = join(root, 'chats');
-    await mkdir(chatsDir);
-    const service = new SessionRecordingService({
-      sessionId: 'created-at-session',
-      projectHash: 'project-hash',
-      chatsDir,
-      workspaceDirs: ['/workspace'],
-      cwd: '/workspace',
-      provider: 'openai',
-      model: 'test-model',
-    });
-    service.recordSessionMetadata('Title');
-    await service.flush();
-    await service.dispose();
-
-    const result = await listRecordedSessions(
-      chatsDir,
-      'project-hash',
-      '/fallback',
-      {},
-    );
-
-    expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0].updatedAt).toStrictEqual(expect.any(String));
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-listing.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.test.ts
@@ -390,7 +390,7 @@ describe('session_metadata title takes precedence over legacy first-human-text (
     expect(result.sessions[0]).not.toHaveProperty('title');
   });
 
-  it('includes createdAt in the listing for immutable ordering (issue #1611)', async () => {
+  it('exposes the creation timestamp as updatedAt for an untouched durable session', async () => {
     const root = await mkdtemp(join(tmpdir(), 'zed-session-list-'));
     roots.push(root);
     const chatsDir = join(root, 'chats');

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -51,6 +51,11 @@ export async function listRecordedSessions(
     }
     return {
       ...live,
+      // createdAt is immutable — durable recording wins (live sessions may not
+      // have it until the session_start is persisted). Issue #1611.
+      ...(durable.createdAt !== undefined
+        ? { createdAt: durable.createdAt }
+        : {}),
       updatedAt:
         durable.updatedAt > live.updatedAt ? durable.updatedAt : live.updatedAt,
       ...(durable.title === undefined ? {} : { title: durable.title }),
@@ -58,16 +63,33 @@ export async function listRecordedSessions(
   }
 }
 
+/**
+ * Resolves the tri-state title for a durable session.
+ *
+ * Issue #1611: a persisted `session_metadata` event is the source of truth.
+ * For legacy files without one (title === undefined), fall back to the first
+ * human message (which returns null for no-human-text sessions, omitted from
+ * the output). A null metadata title (explicit untitled) is preserved.
+ */
 async function toLifecycleSession(
   summary: SessionSummary,
   fallbackCwd: string,
 ): Promise<LifecycleSession> {
-  const title = await SessionDiscovery.readFirstUserMessage(summary.filePath);
+  const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
+    summary.filePath,
+  );
+  const resolvedTitle =
+    metadataTitle === undefined
+      ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
+      : metadataTitle;
   return {
     sessionId: summary.sessionId,
     cwd: summary.cwd ?? fallbackCwd,
     updatedAt: summary.lastModified.toISOString(),
-    ...(title === null ? {} : { title }),
+    ...(summary.createdAt !== undefined
+      ? { createdAt: summary.createdAt }
+      : {}),
+    ...(typeof resolvedTitle === 'string' ? { title: resolvedTitle } : {}),
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-listing.ts
+++ b/packages/cli/src/zed-integration/zed-session-listing.ts
@@ -69,7 +69,8 @@ export async function listRecordedSessions(
  * Issue #1611: a persisted `session_metadata` event is the source of truth.
  * For legacy files without one (title === undefined), fall back to the first
  * human message (which returns null for no-human-text sessions, omitted from
- * the output). A null metadata title (explicit untitled) is preserved.
+ * the output). A null metadata title remains explicitly untitled by suppressing
+ * that legacy fallback and omitting the ACP title property.
  */
 async function toLifecycleSession(
   summary: SessionSummary,
@@ -78,7 +79,7 @@ async function toLifecycleSession(
   const metadataTitle = await SessionDiscovery.readSessionMetadataTitle(
     summary.filePath,
   );
-  const resolvedTitle =
+  const displayTitle =
     metadataTitle === undefined
       ? await SessionDiscovery.readFirstUserMessage(summary.filePath)
       : metadataTitle;
@@ -89,7 +90,7 @@ async function toLifecycleSession(
     ...(summary.createdAt !== undefined
       ? { createdAt: summary.createdAt }
       : {}),
-    ...(typeof resolvedTitle === 'string' ? { title: resolvedTitle } : {}),
+    ...(typeof displayTitle === 'string' ? { title: displayTitle } : {}),
   };
 }
 

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -78,8 +78,8 @@ describe('session lifecycle pagination', () => {
   });
 
   it('updatedAt changes cannot omit sessions: immutable createdAt ordering (issue #1611)', () => {
-    // Two sessions with the SAME createdAt but different updatedAt (simulating
-    // a session that was updated mid-pagination). Ordering must be stable by
+    // Two sessions with different createdAt and updatedAt values. Ordering must
+    // remain stable when a session is updated mid-pagination because it uses
     // createdAt + sessionId, so the cursor is not invalidated.
     const stable: LifecycleSession[] = [
       {

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -142,6 +142,24 @@ describe('session lifecycle pagination', () => {
     ]);
   });
 
+  it('continues a legacy page when updatedAt is valid but not canonical', () => {
+    const legacy: LifecycleSession[] = [
+      { sessionId: 'new', cwd: '/w', updatedAt: '2026-06-01T00:00:00Z' },
+      { sessionId: 'old', cwd: '/w', updatedAt: '2026-01-01T00:00:00Z' },
+    ];
+    const first = paginateSessions(legacy, { cwd: null, cursor: null }, 1);
+
+    const second = paginateSessions(
+      legacy,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      1,
+    );
+
+    expect(second.sessions.map((session) => session.sessionId)).toStrictEqual([
+      'old',
+    ]);
+  });
+
   it('rejects a legacy v1 cursor (version mismatch)', () => {
     const v1Cursor = Buffer.from(
       JSON.stringify({

--- a/packages/cli/src/zed-integration/zed-session-pagination.test.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.test.ts
@@ -10,14 +10,33 @@ import {
   type LifecycleSession,
 } from './zed-session-pagination.js';
 
+/**
+ * Issue #1611: pagination now orders by immutable createdAt + sessionId
+ * (not updatedAt, which can change and cause session omission).
+ */
 const sessions: readonly LifecycleSession[] = [
-  { sessionId: 'b', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
-  { sessionId: 'a', cwd: '/a', updatedAt: '2026-01-03T00:00:00.000Z' },
-  { sessionId: 'c', cwd: '/b', updatedAt: '2026-01-02T00:00:00.000Z' },
+  {
+    sessionId: 'b',
+    cwd: '/a',
+    updatedAt: '2026-01-03T00:00:00.000Z',
+    createdAt: '2026-01-03T00:00:00.000Z',
+  },
+  {
+    sessionId: 'a',
+    cwd: '/a',
+    updatedAt: '2026-01-03T00:00:00.000Z',
+    createdAt: '2026-01-03T00:00:00.000Z',
+  },
+  {
+    sessionId: 'c',
+    cwd: '/b',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    createdAt: '2026-01-02T00:00:00.000Z',
+  },
 ];
 
 describe('session lifecycle pagination', () => {
-  it('orders by updatedAt then sessionId descending and continues with an opaque cursor', () => {
+  it('orders by createdAt then sessionId descending and continues with an opaque cursor', () => {
     const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
     expect(first.sessions.map((session) => session.sessionId)).toStrictEqual([
       'b',
@@ -55,6 +74,85 @@ describe('session lifecycle pagination', () => {
         { cwd: '/b', cursor: first.nextCursor ?? null },
         1,
       ),
+    ).toThrow(/cursor/i);
+  });
+
+  it('updatedAt changes cannot omit sessions: immutable createdAt ordering (issue #1611)', () => {
+    // Two sessions with the SAME createdAt but different updatedAt (simulating
+    // a session that was updated mid-pagination). Ordering must be stable by
+    // createdAt + sessionId, so the cursor is not invalidated.
+    const stable: LifecycleSession[] = [
+      {
+        sessionId: 'x',
+        cwd: '/w',
+        updatedAt: '2026-07-12T12:00:00.000Z',
+        createdAt: '2026-07-10T10:00:00.000Z',
+      },
+      {
+        sessionId: 'y',
+        cwd: '/w',
+        updatedAt: '2026-07-12T13:00:00.000Z',
+        createdAt: '2026-07-10T09:00:00.000Z',
+      },
+    ];
+    const first = paginateSessions(stable, { cwd: null, cursor: null }, 1);
+    expect(first.sessions[0].sessionId).toBe('x');
+
+    // Simulate the "updatedAt changed between pages" scenario:
+    // After page 1, the first session's updatedAt changes — but createdAt
+    // is immutable, so the cursor still correctly filters.
+    const firstAfterMutation: LifecycleSession = {
+      ...stable[0],
+      updatedAt: '2026-07-12T23:59:59.000Z',
+    };
+    const secondSet = [firstAfterMutation, stable[1]];
+    const second = paginateSessions(
+      secondSet,
+      { cwd: null, cursor: first.nextCursor ?? null },
+      10,
+    );
+    expect(second.sessions.map((s) => s.sessionId)).toStrictEqual(['y']);
+  });
+
+  it('v2 cursor is self-contained and process-independent (issue #1611)', () => {
+    // The cursor encodes the full (createdAt, sessionId) tuple so the next
+    // page can be computed without shared state.
+    const first = paginateSessions(sessions, { cwd: null, cursor: null }, 2);
+    expect(first.nextCursor).toStrictEqual(expect.any(String));
+
+    // Decode the cursor to verify it's self-contained.
+    const decoded = JSON.parse(
+      Buffer.from(first.nextCursor!, 'base64url').toString('utf8'),
+    );
+    expect(decoded.v).toBe(2);
+    expect(decoded.createdAt).toBeDefined();
+    expect(decoded.sessionId).toBe('a');
+    expect(decoded.cwd).toBeNull();
+  });
+
+  it('falls back to updatedAt when createdAt is absent (legacy)', () => {
+    const legacy: LifecycleSession[] = [
+      { sessionId: 'old', cwd: '/w', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { sessionId: 'new', cwd: '/w', updatedAt: '2026-06-01T00:00:00.000Z' },
+    ];
+    const result = paginateSessions(legacy, { cwd: null, cursor: null }, 10);
+    expect(result.sessions.map((s) => s.sessionId)).toStrictEqual([
+      'new',
+      'old',
+    ]);
+  });
+
+  it('rejects a legacy v1 cursor (version mismatch)', () => {
+    const v1Cursor = Buffer.from(
+      JSON.stringify({
+        version: 1,
+        cwd: null,
+        updatedAt: '2026-01-03T00:00:00.000Z',
+        sessionId: 'b',
+      }),
+    ).toString('base64url');
+    expect(() =>
+      paginateSessions(sessions, { cwd: null, cursor: v1Cursor }, 2),
     ).toThrow(/cursor/i);
   });
 });

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -85,9 +85,9 @@ export function paginateSessions(
  */
 function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
   return compareByCreatedAtAndId(
-    a.createdAt ?? a.updatedAt,
+    getCreatedAt(a),
     a.sessionId,
-    b.createdAt ?? b.updatedAt,
+    getCreatedAt(b),
     b.sessionId,
   );
 }
@@ -97,7 +97,7 @@ function compareWithCursor(
   cursor: CursorPayload,
 ): number {
   return compareByCreatedAtAndId(
-    session.createdAt ?? session.updatedAt,
+    getCreatedAt(session),
     session.sessionId,
     cursor.createdAt,
     cursor.sessionId,
@@ -121,11 +121,17 @@ function compareDescending(a: string, b: string): number {
   return a > b ? -1 : 1;
 }
 
+function getCreatedAt(session: LifecycleSession): string {
+  const value = session.createdAt ?? session.updatedAt;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : value;
+}
+
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
   const payload: CursorPayload = {
     v: 2,
     cwd,
-    createdAt: session.createdAt ?? session.updatedAt,
+    createdAt: getCreatedAt(session),
     sessionId: session.sessionId,
   };
   return Buffer.from(JSON.stringify(payload)).toString('base64url');

--- a/packages/cli/src/zed-integration/zed-session-pagination.ts
+++ b/packages/cli/src/zed-integration/zed-session-pagination.ts
@@ -11,12 +11,25 @@ export interface LifecycleSession {
   readonly cwd: string;
   readonly updatedAt: string;
   readonly title?: string;
+  /**
+   * Immutable creation timestamp used for stable ordering (issue #1611).
+   * Falls back to updatedAt for legacy sessions without a persisted createdAt.
+   */
+  readonly createdAt?: string;
 }
 
+/**
+ * Self-contained, process-independent snapshot cursor (issue #1611).
+ *
+ * The cursor encodes the full (createdAt, sessionId) tuple of the last item on
+ * the previous page so the next page can be computed from the cursor alone,
+ * without any shared in-process state. The `v` field distinguishes v1 (legacy
+ * updatedAt-based, unstable) from v2 (createdAt-based, immutable).
+ */
 interface CursorPayload {
-  readonly version: 1;
+  readonly v: 2;
   readonly cwd: string | null;
-  readonly updatedAt: string;
+  readonly createdAt: string;
   readonly sessionId: string;
 }
 
@@ -60,11 +73,21 @@ export function paginateSessions(
   return { sessions: page, nextCursor: encodeCursor(last, request.cwd) };
 }
 
+/**
+ * Orders sessions by createdAt DESC then sessionId DESC.
+ *
+ * createdAt is the immutable session_start timestamp — it never changes when
+ * a session is updated (issue #1611). Falls back to updatedAt when createdAt
+ * is absent (legacy sessions recorded before this change) so they still sort
+ * deterministically. Using updatedAt as a fallback is acceptable because legacy
+ * sessions are static (no new writes), so their updatedAt is effectively
+ * immutable too.
+ */
 function compareSessions(a: LifecycleSession, b: LifecycleSession): number {
-  return compareByUpdatedAtAndId(
-    a.updatedAt,
+  return compareByCreatedAtAndId(
+    a.createdAt ?? a.updatedAt,
     a.sessionId,
-    b.updatedAt,
+    b.createdAt ?? b.updatedAt,
     b.sessionId,
   );
 }
@@ -73,21 +96,21 @@ function compareWithCursor(
   session: LifecycleSession,
   cursor: CursorPayload,
 ): number {
-  return compareByUpdatedAtAndId(
-    session.updatedAt,
+  return compareByCreatedAtAndId(
+    session.createdAt ?? session.updatedAt,
     session.sessionId,
-    cursor.updatedAt,
+    cursor.createdAt,
     cursor.sessionId,
   );
 }
 
-function compareByUpdatedAtAndId(
-  aUpdatedAt: string,
+function compareByCreatedAtAndId(
+  aCreatedAt: string,
   aId: string,
-  bUpdatedAt: string,
+  bCreatedAt: string,
   bId: string,
 ): number {
-  const timestamp = compareDescending(aUpdatedAt, bUpdatedAt);
+  const timestamp = compareDescending(aCreatedAt, bCreatedAt);
   return timestamp === 0 ? compareDescending(aId, bId) : timestamp;
 }
 
@@ -100,9 +123,9 @@ function compareDescending(a: string, b: string): number {
 
 function encodeCursor(session: LifecycleSession, cwd: string | null): string {
   const payload: CursorPayload = {
-    version: 1,
+    v: 2,
     cwd,
-    updatedAt: session.updatedAt,
+    createdAt: session.createdAt ?? session.updatedAt,
     sessionId: session.sessionId,
   };
   return Buffer.from(JSON.stringify(payload)).toString('base64url');
@@ -138,10 +161,22 @@ function isCursorPayload(value: unknown): value is CursorPayload {
   }
   const record = value as Record<string, unknown>;
   const hasValidCwd = record.cwd === null || typeof record.cwd === 'string';
+  const hasValidSessionId =
+    typeof record.sessionId === 'string' && record.sessionId.length > 0;
   return (
-    record.version === 1 &&
+    record.v === 2 &&
     hasValidCwd &&
-    typeof record.updatedAt === 'string' &&
-    typeof record.sessionId === 'string'
+    isCanonicalTimestamp(record.createdAt) &&
+    hasValidSessionId
+  );
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false;
+  }
+  const timestamp = Date.parse(value);
+  return (
+    Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value
   );
 }

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -12,6 +12,10 @@ type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Manages ACP terminal lifecycle for a single Zed session.
  *
@@ -64,7 +68,9 @@ export class TerminalManager {
         sessionId: this.sessionId,
       });
     } catch (error) {
-      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      this.logger.debug(
+        () => `Failed to create ACP terminal: ${errorMessage(error)}`,
+      );
       return;
     }
     const existing = this.activeTerminals.get(call.id);
@@ -73,7 +79,9 @@ export class TerminalManager {
       try {
         await existing.release();
       } catch (error) {
-        this.logger.debug(() => `Prior terminal release failed: ${error}`);
+        this.logger.debug(
+          () => `Prior terminal release failed: ${errorMessage(error)}`,
+        );
       }
     }
     this.activeTerminals.set(call.id, handle);
@@ -89,9 +97,13 @@ export class TerminalManager {
       try {
         await handle.release();
       } catch (releaseError) {
-        this.logger.debug(() => `Terminal release failed: ${releaseError}`);
+        this.logger.debug(
+          () => `Terminal release failed: ${errorMessage(releaseError)}`,
+        );
       }
-      this.logger.debug(() => `Terminal update send failed: ${error}`);
+      this.logger.debug(
+        () => `Terminal update send failed: ${errorMessage(error)}`,
+      );
     }
   }
 
@@ -106,7 +118,9 @@ export class TerminalManager {
     try {
       await handle.release();
     } catch (error) {
-      this.logger.debug(() => `Terminal release failed: ${error}`);
+      this.logger.debug(
+        () => `Terminal release failed: ${errorMessage(error)}`,
+      );
     }
   }
 
@@ -122,12 +136,16 @@ export class TerminalManager {
         try {
           await handle.kill();
         } catch (error) {
-          this.logger.debug(() => `Terminal kill failed: ${error}`);
+          this.logger.debug(
+            () => `Terminal kill failed: ${errorMessage(error)}`,
+          );
         }
         try {
           await handle.release();
         } catch (error) {
-          this.logger.debug(() => `Terminal release failed: ${error}`);
+          this.logger.debug(
+            () => `Terminal release failed: ${errorMessage(error)}`,
+          );
         }
       }),
     );

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -8,11 +8,7 @@ import type * as acp from '@agentclientprotocol/sdk';
 import type { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
 
-interface PendingShellCall {
-  readonly toolCallId: string;
-  readonly command: string;
-  readonly cwd: string;
-}
+type TerminalHandleLike = Pick<acp.TerminalHandle, 'id' | 'kill' | 'release'>;
 
 type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
 
@@ -21,13 +17,12 @@ type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
  *
  * When the client advertises the `terminal` capability, shell tool-calls
  * trigger terminal creation via `connection.createTerminal`.  Each terminal
- * is correlated to its tool-call (by command/cwd matching) so that terminal
- * content can be emitted inline and terminals are cleaned up on completion,
- * cancel, and dispose.
+ * is correlated to its tool-call by `toolCallId` so that terminal content can
+ * be emitted inline and terminals are cleaned up on completion, cancel, and
+ * dispose.
  */
 export class TerminalManager {
-  private readonly activeTerminals = new Map<string, acp.TerminalHandle>();
-  private readonly pendingShellCalls: PendingShellCall[] = [];
+  private readonly activeTerminals = new Map<string, TerminalHandleLike>();
 
   constructor(
     private readonly sessionId: string,
@@ -49,9 +44,9 @@ export class TerminalManager {
   }
 
   /**
-   * Records a pending shell tool-call and creates an ACP terminal for it.
-   * Emits an early terminal-content update so the client renders the terminal
-   * inline during execution.
+   * Creates an ACP terminal for a shell tool-call and immediately correlates
+   * it by `toolCallId`.  Emits a terminal-content update so the client renders
+   * the terminal inline during execution.
    */
   async handleToolCall(call: AgentToolCall): Promise<void> {
     const command =
@@ -61,7 +56,6 @@ export class TerminalManager {
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']
         : this.targetDir;
-    this.pendingShellCalls.push({ toolCallId: call.id, command, cwd });
     try {
       const handle = await this.connection.createTerminal({
         command,
@@ -69,32 +63,16 @@ export class TerminalManager {
         sessionId: this.sessionId,
         args: ['-c', command],
       });
-      await this.registerTerminal(command, cwd, handle);
+      this.activeTerminals.set(call.id, handle);
+      await this.sendUpdate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: call.id,
+        status: 'in_progress',
+        content: [{ type: 'terminal', terminalId: handle.id }],
+      });
     } catch (error) {
       this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
     }
-  }
-
-  /**
-   * Correlates a created terminal to its tool-call by matching command/cwd,
-   * records the handle, and emits the terminal-content update.
-   */
-  async registerTerminal(
-    command: string,
-    cwd: string,
-    handle: acp.TerminalHandle,
-  ): Promise<void> {
-    const match = this.pendingShellCalls.find(
-      (entry) => entry.command === command && entry.cwd === cwd,
-    );
-    if (match === undefined) return;
-    this.activeTerminals.set(match.toolCallId, handle);
-    await this.sendUpdate({
-      sessionUpdate: 'tool_call_update',
-      toolCallId: match.toolCallId,
-      status: 'in_progress',
-      content: [{ type: 'terminal', terminalId: handle.id }],
-    });
   }
 
   /**
@@ -105,10 +83,6 @@ export class TerminalManager {
     const handle = this.activeTerminals.get(toolCallId);
     if (handle === undefined) return;
     this.activeTerminals.delete(toolCallId);
-    const idx = this.pendingShellCalls.findIndex(
-      (entry) => entry.toolCallId === toolCallId,
-    );
-    if (idx >= 0) this.pendingShellCalls.splice(idx, 1);
     try {
       await handle.release();
     } catch (error) {

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -56,13 +56,28 @@ export class TerminalManager {
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']
         : this.targetDir;
+    let handle: TerminalHandleLike;
     try {
-      const handle = await this.connection.createTerminal({
+      handle = await this.connection.createTerminal({
         command,
         cwd,
         sessionId: this.sessionId,
       });
-      this.activeTerminals.set(call.id, handle);
+    } catch (error) {
+      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      return;
+    }
+    const existing = this.activeTerminals.get(call.id);
+    if (existing !== undefined) {
+      this.activeTerminals.delete(call.id);
+      try {
+        await existing.release();
+      } catch (error) {
+        this.logger.debug(() => `Prior terminal release failed: ${error}`);
+      }
+    }
+    this.activeTerminals.set(call.id, handle);
+    try {
       await this.sendUpdate({
         sessionUpdate: 'tool_call_update',
         toolCallId: call.id,
@@ -70,7 +85,13 @@ export class TerminalManager {
         content: [{ type: 'terminal', terminalId: handle.id }],
       });
     } catch (error) {
-      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+      this.activeTerminals.delete(call.id);
+      try {
+        await handle.release();
+      } catch (releaseError) {
+        this.logger.debug(() => `Terminal release failed: ${releaseError}`);
+      }
+      this.logger.debug(() => `Terminal update send failed: ${error}`);
     }
   }
 

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -61,7 +61,6 @@ export class TerminalManager {
         command,
         cwd,
         sessionId: this.sessionId,
-        args: ['-c', command],
       });
       this.activeTerminals.set(call.id, handle);
       await this.sendUpdate({

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import type { DebugLogger } from '@vybestack/llxprt-code-core';
+import type { AgentToolCall } from '@vybestack/llxprt-code-agents';
+
+interface PendingShellCall {
+  readonly toolCallId: string;
+  readonly command: string;
+  readonly cwd: string;
+}
+
+type SendUpdateFn = (update: acp.SessionUpdate) => Promise<void>;
+
+/**
+ * Manages ACP terminal lifecycle for a single Zed session.
+ *
+ * When the client advertises the `terminal` capability, shell tool-calls
+ * trigger terminal creation via `connection.createTerminal`.  Each terminal
+ * is correlated to its tool-call (by command/cwd matching) so that terminal
+ * content can be emitted inline and terminals are cleaned up on completion,
+ * cancel, and dispose.
+ */
+export class TerminalManager {
+  private readonly activeTerminals = new Map<string, acp.TerminalHandle>();
+  private readonly pendingShellCalls: PendingShellCall[] = [];
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly connection: acp.AgentSideConnection,
+    private readonly targetDir: string,
+    private readonly sendUpdate: SendUpdateFn,
+    private readonly logger: DebugLogger,
+  ) {}
+
+  /**
+   * Returns `true` if the tool-call is an execute-kind shell command that
+   * should trigger terminal creation.
+   */
+  static isShellToolCall(
+    call: AgentToolCall,
+    kind: string | undefined,
+  ): boolean {
+    return kind === 'execute' && typeof call.args['command'] === 'string';
+  }
+
+  /**
+   * Records a pending shell tool-call and creates an ACP terminal for it.
+   * Emits an early terminal-content update so the client renders the terminal
+   * inline during execution.
+   */
+  async handleToolCall(call: AgentToolCall): Promise<void> {
+    const command =
+      typeof call.args['command'] === 'string' ? call.args['command'] : '';
+    if (command === '') return;
+    const cwd =
+      typeof call.args['dir_path'] === 'string'
+        ? call.args['dir_path']
+        : this.targetDir;
+    this.pendingShellCalls.push({ toolCallId: call.id, command, cwd });
+    try {
+      const handle = await this.connection.createTerminal({
+        command,
+        cwd,
+        sessionId: this.sessionId,
+        args: ['-c', command],
+      });
+      await this.registerTerminal(command, cwd, handle);
+    } catch (error) {
+      this.logger.debug(() => `Failed to create ACP terminal: ${error}`);
+    }
+  }
+
+  /**
+   * Correlates a created terminal to its tool-call by matching command/cwd,
+   * records the handle, and emits the terminal-content update.
+   */
+  async registerTerminal(
+    command: string,
+    cwd: string,
+    handle: acp.TerminalHandle,
+  ): Promise<void> {
+    const match = this.pendingShellCalls.find(
+      (entry) => entry.command === command && entry.cwd === cwd,
+    );
+    if (match === undefined) return;
+    this.activeTerminals.set(match.toolCallId, handle);
+    await this.sendUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: match.toolCallId,
+      status: 'in_progress',
+      content: [{ type: 'terminal', terminalId: handle.id }],
+    });
+  }
+
+  /**
+   * Releases a terminal after its tool call has completed.  Safe to call
+   * multiple times — the handle is removed on first call.
+   */
+  async releaseTerminal(toolCallId: string): Promise<void> {
+    const handle = this.activeTerminals.get(toolCallId);
+    if (handle === undefined) return;
+    this.activeTerminals.delete(toolCallId);
+    const idx = this.pendingShellCalls.findIndex(
+      (entry) => entry.toolCallId === toolCallId,
+    );
+    if (idx >= 0) this.pendingShellCalls.splice(idx, 1);
+    try {
+      await handle.release();
+    } catch (error) {
+      this.logger.debug(() => `Terminal release failed: ${error}`);
+    }
+  }
+
+  /**
+   * Kills and releases all active terminals.  Called on cancel and dispose
+   * so no terminal is leaked.
+   */
+  async settleAll(): Promise<void> {
+    const entries = [...this.activeTerminals.entries()];
+    this.activeTerminals.clear();
+    await Promise.allSettled(
+      entries.map(async ([, handle]) => {
+        try {
+          await handle.kill();
+        } catch (error) {
+          this.logger.debug(() => `Terminal kill failed: ${error}`);
+        }
+        try {
+          await handle.release();
+        } catch (error) {
+          this.logger.debug(() => `Terminal release failed: ${error}`);
+        }
+      }),
+    );
+  }
+}

--- a/packages/cli/src/zed-integration/zed-terminal-manager.ts
+++ b/packages/cli/src/zed-integration/zed-terminal-manager.ts
@@ -51,7 +51,7 @@ export class TerminalManager {
   async handleToolCall(call: AgentToolCall): Promise<void> {
     const command =
       typeof call.args['command'] === 'string' ? call.args['command'] : '';
-    if (command === '') return;
+    if (command.trim() === '') return;
     const cwd =
       typeof call.args['dir_path'] === 'string'
         ? call.args['dir_path']

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -209,19 +209,21 @@ export class RecordingConnection {
    * a `terminal` content block) has been recorded — i.e., the Session has
    * created and registered a terminal.
    */
-  waitForTerminalCreated(): Promise<void> {
-    return this.hasTerminalContentUpdate()
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          const check = (): void => {
-            if (this.hasTerminalContentUpdate()) {
-              resolve();
-            } else {
-              setTimeout(check, 5);
-            }
-          };
+  waitForTerminalCreated(timeoutMs = 5000): Promise<void> {
+    if (this.hasTerminalContentUpdate()) return Promise.resolve();
+    const deadline = Date.now() + timeoutMs;
+    return new Promise<void>((resolve, reject) => {
+      const check = (): void => {
+        if (this.hasTerminalContentUpdate()) {
+          resolve();
+        } else if (Date.now() >= deadline) {
+          reject(new Error('waitForTerminalCreated timed out'));
+        } else {
           setTimeout(check, 5);
-        });
+        }
+      };
+      setTimeout(check, 5);
+    });
   }
 
   private hasTerminalContentUpdate(): boolean {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -90,6 +90,7 @@ export function buildBlockingScriptedAgent(
       if (signal !== undefined && !signal.aborted) {
         await new Promise<void>((resolve) => {
           signal.addEventListener('abort', () => resolve(), { once: true });
+          if (signal.aborted) resolve();
         });
       }
     },

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -68,6 +68,63 @@ export function buildScriptedAgent(
   return { agent, confirmations };
 }
 
+/**
+ * Like {@link buildScriptedAgent} but the stream blocks after yielding all
+ * events until the abort signal fires.  Used to test cancel/dispose while a
+ * prompt turn is still in-flight.
+ */
+export function buildBlockingScriptedAgent(
+  nextEvents: () => readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
+  agent: Agent;
+  confirmations: ConfirmationCapture[];
+} {
+  const confirmations: ConfirmationCapture[] = [];
+  const agent = {
+    async *stream(_input: unknown, opts?: unknown): AsyncIterable<AgentEvent> {
+      for (const e of nextEvents()) {
+        yield e;
+      }
+      const signal = (opts as { signal?: AbortSignal } | undefined)?.signal;
+      if (signal !== undefined && !signal.aborted) {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+    },
+    getApprovalMode: (): ApprovalMode => 'default' as ApprovalMode,
+    setApprovalMode: vi.fn(),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    tools: {
+      get: (name: string) =>
+        Object.hasOwn(toolKinds, name) ? { kind: toolKinds[name] } : undefined,
+      respondToConfirmation: (
+        confirmationId: string,
+        decision: ToolConfirmationOutcome,
+        payload?: ToolConfirmationPayload,
+        requiresUserConfirmation?: boolean,
+      ) => {
+        confirmations.push({
+          confirmationId,
+          decision,
+          ...(payload === undefined ? {} : { payload }),
+          ...(requiresUserConfirmation === undefined
+            ? {}
+            : { requiresUserConfirmation }),
+        });
+      },
+      onConfirmationRequest: () => () => {},
+      onToolUpdate: () => () => {},
+      setEditorCallbacks: () => {},
+      setEnabled: vi.fn().mockResolvedValue(undefined),
+      list: () => [],
+      keys: {},
+    },
+  } as unknown as Agent;
+  return { agent, confirmations };
+}
+
 export function buildFakeAgent(
   events: readonly AgentEvent[],
   toolKinds: Readonly<Record<string, string>> = {},
@@ -76,6 +133,16 @@ export function buildFakeAgent(
   confirmations: ConfirmationCapture[];
 } {
   return buildScriptedAgent(() => events, toolKinds);
+}
+
+export function buildBlockingFakeAgent(
+  events: readonly AgentEvent[],
+  toolKinds: Readonly<Record<string, string>> = {},
+): {
+  agent: Agent;
+  confirmations: ConfirmationCapture[];
+} {
+  return buildBlockingScriptedAgent(() => events, toolKinds);
 }
 
 export class RecordingConnection {
@@ -95,6 +162,70 @@ export class RecordingConnection {
   private sessionUpdateFailAfter: number | null = null;
   private sessionUpdateError: Error | null = null;
   private sessionUpdateCalls = 0;
+
+  // --- Terminal test-double state ---
+
+  readonly createTerminalCalls: Array<{
+    command: string;
+    cwd?: string | null;
+    sessionId: string;
+    args?: string[];
+    env?: Array<{ name: string; value: string }>;
+    outputByteLimit?: number | null;
+  }> = [];
+
+  killCalls = 0;
+  releaseCalls = 0;
+
+  private terminalOutput = '';
+  private terminalExitDelayed = false;
+  private terminalExitResolve: ((value: void) => void) | null = null;
+
+  setTerminalOutput(output: string): void {
+    this.terminalOutput = output;
+  }
+
+  delayTerminalExit(): void {
+    this.terminalExitDelayed = true;
+  }
+
+  resolveDelayedTerminalExit(): void {
+    if (this.terminalExitResolve !== null) {
+      const fn = this.terminalExitResolve;
+      this.terminalExitResolve = null;
+      this.terminalExitDelayed = false;
+      fn();
+    }
+  }
+
+  /**
+   * Resolves once at least one terminal content update (tool_call_update with
+   * a `terminal` content block) has been recorded — i.e., the Session has
+   * created and registered a terminal.
+   */
+  waitForTerminalCreated(): Promise<void> {
+    return this.hasTerminalContentUpdate()
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          const check = (): void => {
+            if (this.hasTerminalContentUpdate()) {
+              resolve();
+            } else {
+              setTimeout(check, 5);
+            }
+          };
+          setTimeout(check, 5);
+        });
+  }
+
+  private hasTerminalContentUpdate(): boolean {
+    return this.messages.some(
+      (m) =>
+        m.kind === 'sessionUpdate' &&
+        m.update.sessionUpdate === 'tool_call_update' &&
+        (m.update.content ?? []).some((c) => c.type === 'terminal'),
+    );
+  }
 
   /**
    * Arms sessionUpdate to REJECT starting with the (0-based) `afterCount`-th
@@ -218,6 +349,58 @@ export class RecordingConnection {
     },
   );
 
+  createTerminal: Mock = vi.fn(
+    async (params: acp.CreateTerminalRequest): Promise<acp.TerminalHandle> => {
+      const call = {
+        command: params.command,
+        cwd: params.cwd,
+        sessionId: params.sessionId,
+        ...(params.args !== undefined ? { args: params.args } : {}),
+        ...(params.env !== undefined ? { env: params.env } : {}),
+        ...(params.outputByteLimit !== undefined
+          ? { outputByteLimit: params.outputByteLimit }
+          : {}),
+      };
+      this.createTerminalCalls.push(call);
+      const terminalId = `terminal-${this.createTerminalCalls.length}`;
+      return this.buildFakeTerminalHandle(terminalId);
+    },
+  );
+
+  private buildFakeTerminalHandle(terminalId: string): acp.TerminalHandle {
+    const handle = {
+      id: terminalId,
+      currentOutput: vi.fn(async () => ({
+        output: this.terminalOutput,
+        exitStatus: null,
+        truncated: false,
+      })),
+      waitForExit: vi.fn(async () => {
+        if (this.terminalExitDelayed) {
+          await new Promise<void>((resolve) => {
+            this.terminalExitResolve = resolve;
+          });
+        }
+        return { exitCode: 0, signal: null };
+      }),
+      kill: vi.fn(async () => {
+        this.killCalls += 1;
+        this.resolveDelayedTerminalExit();
+        return {};
+      }),
+      release: vi.fn(async () => {
+        this.releaseCalls += 1;
+        this.resolveDelayedTerminalExit();
+        return {};
+      }),
+      [Symbol.asyncDispose]: vi.fn(async () => {
+        this.releaseCalls += 1;
+        this.resolveDelayedTerminalExit();
+      }),
+    };
+    return handle as unknown as acp.TerminalHandle;
+  }
+
   onlySessionUpdates(): acp.SessionUpdate[] {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
@@ -291,12 +474,15 @@ export function createSession(
   agent: Agent,
   connection: RecordingConnection,
   config: Config = buildMinimalConfig(),
+  terminalEnabled = false,
 ): Session {
   return new Session(
     'test-session-id',
     agent,
     config,
     connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
   );
 }
 

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -145,6 +145,11 @@ export function buildBlockingFakeAgent(
   return buildBlockingScriptedAgent(() => events, toolKinds);
 }
 
+export type FakeTerminalHandle = Pick<
+  acp.TerminalHandle,
+  'id' | 'currentOutput' | 'waitForExit' | 'kill' | 'release'
+>;
+
 export class RecordingConnection {
   readonly messages: Array<
     | { kind: 'sessionUpdate'; update: acp.SessionUpdate }
@@ -350,7 +355,7 @@ export class RecordingConnection {
   );
 
   createTerminal: Mock = vi.fn(
-    async (params: acp.CreateTerminalRequest): Promise<acp.TerminalHandle> => {
+    async (params: acp.CreateTerminalRequest): Promise<FakeTerminalHandle> => {
       const call = {
         command: params.command,
         cwd: params.cwd,
@@ -367,7 +372,7 @@ export class RecordingConnection {
     },
   );
 
-  private buildFakeTerminalHandle(terminalId: string): acp.TerminalHandle {
+  private buildFakeTerminalHandle(terminalId: string): FakeTerminalHandle {
     const handle = {
       id: terminalId,
       currentOutput: vi.fn(async () => ({
@@ -393,12 +398,8 @@ export class RecordingConnection {
         this.resolveDelayedTerminalExit();
         return {};
       }),
-      [Symbol.asyncDispose]: vi.fn(async () => {
-        this.releaseCalls += 1;
-        this.resolveDelayedTerminalExit();
-      }),
     };
-    return handle as unknown as acp.TerminalHandle;
+    return handle;
   }
 
   onlySessionUpdates(): acp.SessionUpdate[] {

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -112,6 +112,16 @@ export class RecordingConnection {
     this.sessionUpdateError = null;
     this.sessionUpdateCalls = 0;
   }
+
+  clearSessionInfoUpdates(): void {
+    const retained = this.messages.filter(
+      (message) =>
+        message.kind !== 'sessionUpdate' ||
+        message.update.sessionUpdate !== 'session_info_update',
+    );
+    this.messages.splice(0, this.messages.length, ...retained);
+  }
+
   private gatedDeferred: {
     resolve: (o: acp.RequestPermissionOutcome) => void;
     promise: Promise<acp.RequestPermissionOutcome>;

--- a/packages/cli/src/zed-integration/zed-test-helpers.ts
+++ b/packages/cli/src/zed-integration/zed-test-helpers.ts
@@ -204,7 +204,27 @@ export class RecordingConnection {
     return this.messages
       .filter((m) => m.kind === 'sessionUpdate')
       .map((m) => (m as { update: acp.SessionUpdate }).update)
-      .filter((update) => update.sessionUpdate !== 'available_commands_update');
+      .filter(
+        (update) =>
+          update.sessionUpdate !== 'available_commands_update' &&
+          update.sessionUpdate !== 'session_info_update',
+      );
+  }
+
+  sessionInfoUpdates(): Array<
+    Extract<acp.SessionUpdate, { sessionUpdate: 'session_info_update' }>
+  > {
+    return this.messages
+      .filter((m) => m.kind === 'sessionUpdate')
+      .map((m) => (m as { update: acp.SessionUpdate }).update)
+      .filter(
+        (
+          update,
+        ): update is Extract<
+          acp.SessionUpdate,
+          { sessionUpdate: 'session_info_update' }
+        > => update.sessionUpdate === 'session_info_update',
+      );
   }
 
   availableCommandUpdates(): acp.AvailableCommandsUpdate[] {
@@ -232,6 +252,7 @@ export function buildMinimalConfig(): Config {
     getApprovalMode: () => 'default' as ApprovalMode,
     setApprovalMode: () => {},
     getTargetDir: () => '/project',
+    getProjectRoot: () => '/project',
     getFileService: () => ({ shouldIgnoreFile: () => false }),
     getFileFilteringOptions: () => ({
       respectGitIgnore: true,
@@ -244,6 +265,7 @@ export function buildMinimalConfig(): Config {
     // window via getTokenLimitForConfiguredContext(model, config).
     getModel: () => 'test-model',
     getContentGeneratorConfig: () => undefined,
+    getSessionRecordingService: () => undefined,
   } as unknown as Config;
 }
 

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -327,7 +327,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     ).rejects.toThrow(/Session not found/);
   });
 
-  it('closeSession keeps a session tracked when agent disposal fails', async () => {
+  it('closeSession succeeds and removes the session even when agent disposal fails', async () => {
     const stub = buildStubAgent({});
     stub.dispose.mockRejectedValueOnce(new Error('dispose failed'));
     mockFromConfig.mockResolvedValue(stub.agent);
@@ -342,14 +342,10 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
 
     await expect(
       zedAgent.closeSession({ sessionId: created.sessionId }),
-    ).rejects.toThrow('dispose failed');
+    ).resolves.toEqual({});
     await expect(
-      zedAgent.resumeSession({
-        sessionId: created.sessionId,
-        cwd: '/project',
-        mcpServers: [],
-      }),
-    ).resolves.toMatchObject({ modes: expect.any(Object) });
+      zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
+    ).rejects.toThrow(/Session not found/);
   });
 
   it('initialize() advertises loadSession: true', async () => {

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -163,6 +163,7 @@ function buildBaseConfig(): Config {
     getTargetDir: () => '/project',
     getProjectRoot: () => '/project',
     getMaxSessionTurns: () => 50,
+    getSessionRecordingService: () => undefined,
     // The re-attach + corrupt-vs-missing probes derive the chats dir from
     // storage.getProjectChatsDir(); point it at a dir that never exists so the
     // disk-resume probe's REAL readdir hits ENOENT (falling back to the plain

--- a/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.loadSession.test.ts
@@ -342,7 +342,7 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
 
     await expect(
       zedAgent.closeSession({ sessionId: created.sessionId }),
-    ).resolves.toEqual({});
+    ).resolves.toStrictEqual({});
     await expect(
       zedAgent.prompt({ sessionId: created.sessionId, prompt: [] }),
     ).rejects.toThrow(/Session not found/);
@@ -363,8 +363,6 @@ describe('ZedAgent.loadSession orchestration (issue #1604)', () => {
     expect(response.agentCapabilities?.sessionCapabilities).toStrictEqual({
       list: {},
       resume: {},
-      delete: {},
-      close: {},
     });
   });
 

--- a/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.prompt.test.ts
@@ -423,6 +423,7 @@ describe('Zed Session.prompt (Agent API) - tool permission round-trip', () => {
       'sessionUpdate',
       'requestPermission',
       'sessionUpdate',
+      'sessionUpdate',
     ]);
     expect(confirmations).toStrictEqual([
       { confirmationId, decision: ToolConfirmationOutcome.ProceedOnce },
@@ -736,5 +737,119 @@ describe('Zed Session (Agent API) - lifecycle', () => {
     });
     await new Promise((r) => setImmediate(r));
     expect(connection.sessionUpdateKinds()).not.toContain('plan');
+  });
+});
+
+describe('Zed Session.prompt (Agent API) - session_info_update (issue #1611)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('emits a session_info_update with a title derived from the first prompt', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Investigate session lifecycle' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBe('Investigate session lifecycle');
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('emits updatedAt on a subsequent prompt without regenerating the title', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'First prompt here' }],
+    });
+    connection.messages.length = 0;
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Second prompt here' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('emits updatedAt after a cancelled turn', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'aborted' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const response = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'A prompt that gets cancelled' }],
+    });
+
+    expect(response.stopReason).toBe('cancelled');
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('emits updatedAt after a failed turn (error event)', async () => {
+    const { agent } = buildFakeAgent([
+      { type: 'error', error: { message: 'kaboom' } },
+    ]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await expect(
+      session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'A prompt that errors' }],
+      }),
+    ).rejects.toThrow(/kaboom/);
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('does not emit a title when the first prompt has no text content', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('exposes the derived title and updatedAt via getLifecycleInfo for the session listing', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Listing title here' }],
+    });
+
+    const info = session.getLifecycleInfo();
+    expect(info.title).toBe('Listing title here');
+    expect(info.updatedAt).toStrictEqual(expect.any(String));
   });
 });

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -85,7 +85,7 @@ describe('Zed Session - session_info_update findings (issue #1611 remediation)',
       sessionId: 'test-session-id',
       prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
     });
-    connection.messages.length = 0;
+    connection.clearSessionInfoUpdates();
 
     await session.prompt({
       sessionId: 'test-session-id',

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -13,7 +13,7 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { Session } from './zedIntegration.js';
+import type { Session } from './zedIntegration.js';
 import {
   buildFakeAgent,
   buildScriptedAgent,

--- a/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.sessionInfo.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for session_info_update remediation findings (issue #1611):
+ * - Finding 1: title eligibility consumed synchronously at acceptance, race-safe.
+ * - Finding 3: slash command success/failure shares exact-once metadata finally.
+ * - Finding 4: pre-turn listing timestamp stable (initialized once).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  buildScriptedAgent,
+  RecordingConnection,
+  createSession,
+  editConfirmation,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  for (const session of createdSessions.splice(0)) {
+    await session.dispose();
+  }
+}
+
+describe('Zed Session - session_info_update findings (issue #1611 remediation)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('finding 1: the first ACCEPTED prompt wins the title even if a later overlapping prompt finishes first', async () => {
+    let promptCount = 0;
+    const { agent } = buildScriptedAgent(() => {
+      promptCount += 1;
+      return promptCount === 1
+        ? [
+            {
+              type: 'tool-call',
+              call: { id: 'race-tool', name: 'edit', args: {} },
+            },
+            editConfirmation('race-conf', 'race-tool'),
+            { type: 'done', reason: 'stop' },
+          ]
+        : [
+            { type: 'text', text: 'second response' },
+            { type: 'done', reason: 'stop' },
+          ];
+    });
+    const connection = new RecordingConnection();
+    const gate = connection.armPermissionGate();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const firstPrompt = session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Prompt A title' }],
+    });
+    await gate.arrived;
+    const secondPrompt = session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Prompt B title' }],
+    });
+    const firstResponse = await firstPrompt;
+    const secondResponse = await secondPrompt;
+
+    expect(firstResponse.stopReason).toBe('cancelled');
+    expect(secondResponse.stopReason).toBe('end_turn');
+
+    const info = session.getLifecycleInfo();
+    expect(info.title).toBe('Prompt A title');
+  });
+
+  it('finding 1: a no-text first prompt consumes eligibility so a later text prompt does not retitle', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'resource_link', uri: 'file:///p', name: 'p.ts' }],
+    });
+    connection.messages.length = 0;
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Should not become the title' }],
+    });
+
+    expect(session.getLifecycleInfo().title).toBeUndefined();
+  });
+
+  it('finding 3: a slash command emits exact-once session_info_update metadata (updatedAt)', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: '/tools' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].updatedAt).toStrictEqual(expect.any(String));
+  });
+
+  it('finding 3: a slash command as the first text prompt still wins the title (shared finally)', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: '/help me with something' }],
+    });
+
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBe('/help me with something');
+  });
+
+  it('retries a title notification after a transient transport failure without failing either prompt', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    connection.failSessionUpdateAfter(0, new Error('transport down'));
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const first = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Persistent title' }],
+    });
+    expect(first.stopReason).toBe('end_turn');
+    expect(connection.sessionInfoUpdates()).toHaveLength(0);
+
+    connection.clearSessionUpdateFailure();
+    const second = await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'Second prompt' }],
+    });
+    expect(second.stopReason).toBe('end_turn');
+    expect(connection.sessionInfoUpdates()).toContainEqual(
+      expect.objectContaining({ title: 'Persistent title' }),
+    );
+  });
+
+  it('finding 4: getLifecycleInfo returns a stable updatedAt before the first turn', () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const first = session.getLifecycleInfo();
+    const second = session.getLifecycleInfo();
+    expect(first.updatedAt).toBe(second.updatedAt);
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for Session.streamHistory restored-session title hydration
+ * (issue #1611 finding 2). Exercises the real streamHistory orchestration that
+ * load/resume uses (not a faked restoration) to verify the title is hydrated
+ * from restored history so a later prompt never retitles the session.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  RecordingConnection,
+  createSession,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  const sessions = createdSessions.splice(0);
+  await Promise.allSettled(sessions.map((session) => session.dispose()));
+}
+
+describe('Zed Session.streamHistory - restored-session title hydration (issue #1611 finding 2)', () => {
+  afterEach(disposeCreatedSessions);
+
+  it('hydrates the title from restored history so a later prompt does not retitle', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Restored session title' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'prior response' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBe('Restored session title');
+
+    connection.messages.length = 0;
+    await session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'New prompt after restore' }],
+    });
+
+    expect(session.getLifecycleInfo().title).toBe('Restored session title');
+    const infoUpdates = connection.sessionInfoUpdates();
+    expect(infoUpdates).toHaveLength(1);
+    expect(infoUpdates[0].title).toBeUndefined();
+  });
+
+  it('does not set a title when restored history has no human text', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'agent-only content' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBeUndefined();
+  });
+
+  it('uses the first human text when restored history has multiple human entries', async () => {
+    const { agent } = buildFakeAgent([{ type: 'done', reason: 'stop' }]);
+    const connection = new RecordingConnection();
+    const session = createSession(agent, connection);
+    createdSessions.push(session);
+
+    const history: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'First restored message' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'response one' }],
+      },
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Second restored message' }],
+      },
+    ];
+    await session.streamHistory(history);
+
+    expect(session.getLifecycleInfo().title).toBe('First restored message');
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.streamHistory.test.ts
@@ -51,7 +51,7 @@ describe('Zed Session.streamHistory - restored-session title hydration (issue #1
 
     expect(session.getLifecycleInfo().title).toBe('Restored session title');
 
-    connection.messages.length = 0;
+    connection.clearSessionInfoUpdates();
     await session.prompt({
       sessionId: 'test-session-id',
       prompt: [{ type: 'text', text: 'New prompt after restore' }],

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type * as acp from '@agentclientprotocol/sdk';
+import type { Config } from '@vybestack/llxprt-code-core';
+import type { AgentEvent } from '@vybestack/llxprt-code-agents';
+
+import { Session } from './zedIntegration.js';
+import {
+  buildFakeAgent,
+  buildBlockingFakeAgent,
+  RecordingConnection,
+  buildMinimalConfig,
+} from './zed-test-helpers.js';
+
+const createdSessions: Session[] = [];
+
+async function disposeCreatedSessions(): Promise<void> {
+  for (const session of createdSessions.splice(0)) {
+    await session.dispose();
+  }
+}
+
+function createTerminalSession(
+  events: readonly AgentEvent[],
+  connection: RecordingConnection,
+  config: Config = buildMinimalConfig(),
+  terminalEnabled = true,
+): Session {
+  const { agent } = buildFakeAgent(events, { run_shell_command: 'execute' });
+  return new Session(
+    'test-session-id',
+    agent,
+    config,
+    connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
+  );
+}
+
+function createBlockingTerminalSession(
+  events: readonly AgentEvent[],
+  connection: RecordingConnection,
+  config: Config = buildMinimalConfig(),
+  terminalEnabled = true,
+): Session {
+  const { agent } = buildBlockingFakeAgent(events, {
+    run_shell_command: 'execute',
+  });
+  return new Session(
+    'test-session-id',
+    agent,
+    config,
+    connection as unknown as acp.AgentSideConnection,
+    false,
+    terminalEnabled,
+  );
+}
+
+function shellToolCallEvent(toolCallId: string, command: string): AgentEvent {
+  return {
+    type: 'tool-call',
+    call: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      args: { command },
+    },
+  };
+}
+
+function shellToolStatusEvent(toolCallId: string): AgentEvent {
+  return {
+    type: 'tool-status',
+    update: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      status: 'executing',
+    },
+  };
+}
+
+function shellToolResultEvent(toolCallId: string, output: string): AgentEvent {
+  return {
+    type: 'tool-result',
+    result: {
+      id: toolCallId,
+      name: 'run_shell_command',
+      output,
+    },
+  };
+}
+
+const doneEvent: AgentEvent = { type: 'done', reason: 'stop' };
+
+describe('Zed Session — terminal capability integration', () => {
+  afterEach(disposeCreatedSessions);
+
+  describe('terminal-enabled sessions', () => {
+    it('emits terminal content on shell tool calls when terminal capability is present', async () => {
+      const toolCallId = 'shell-1';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('hello');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo hello'),
+          shellToolStatusEvent(toolCallId),
+          shellToolResultEvent(toolCallId, 'hello'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'run echo' }],
+      });
+
+      const toolCallUpdates = connection
+        .onlySessionUpdates()
+        .filter(
+          (
+            u,
+          ): u is Extract<acp.SessionUpdate, { sessionUpdate: 'tool_call' }> =>
+            u.sessionUpdate === 'tool_call',
+        );
+      expect(toolCallUpdates).toHaveLength(1);
+      expect(toolCallUpdates[0].kind).toBe('execute');
+
+      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some(
+          (c): c is Extract<typeof c, { type: 'terminal' }> =>
+            c.type === 'terminal',
+        );
+      });
+      expect(hasTerminalContent).toBe(true);
+    });
+
+    it('creates a terminal via connection.createTerminal for shell commands', async () => {
+      const toolCallId = 'shell-create';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('file1\nfile2');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'ls'),
+          shellToolResultEvent(toolCallId, 'file1\nfile2'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'list files' }],
+      });
+
+      expect(connection.createTerminalCalls).toHaveLength(1);
+      const call = connection.createTerminalCalls[0];
+      expect(call.command).toBe('ls');
+      expect(call.sessionId).toBe('test-session-id');
+    });
+
+    it('releases terminals on normal completion', async () => {
+      const toolCallId = 'shell-release';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('done');
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo done'),
+          shellToolResultEvent(toolCallId, 'done'),
+          doneEvent,
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'echo' }],
+      });
+
+      expect(connection.releaseCalls).toBe(1);
+    });
+
+    it('kills and releases terminals on cancel', async () => {
+      const toolCallId = 'shell-cancel';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('');
+      connection.delayTerminalExit();
+      const session = createBlockingTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'sleep 999'),
+          shellToolStatusEvent(toolCallId),
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      const promptPromise = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'sleep' }],
+      });
+
+      await connection.waitForTerminalCreated();
+      await session.cancelPendingPrompt();
+      await promptPromise;
+
+      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+    });
+
+    it('kills and releases terminals on dispose', async () => {
+      const toolCallId = 'shell-dispose';
+      const connection = new RecordingConnection();
+      connection.setTerminalOutput('');
+      connection.delayTerminalExit();
+      const session = createBlockingTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'sleep 999'),
+          shellToolStatusEvent(toolCallId),
+        ],
+        connection,
+      );
+      createdSessions.push(session);
+
+      const promptPromise = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'sleep' }],
+      });
+
+      await connection.waitForTerminalCreated();
+      await session.dispose();
+      await promptPromise.catch(() => undefined);
+
+      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('terminal-disabled sessions (fallback)', () => {
+    it('does not create terminals and emits text content when terminal capability is absent', async () => {
+      const toolCallId = 'shell-fallback';
+      const connection = new RecordingConnection();
+      const session = createTerminalSession(
+        [
+          shellToolCallEvent(toolCallId, 'echo text-output'),
+          shellToolResultEvent(toolCallId, 'text-output'),
+          doneEvent,
+        ],
+        connection,
+        undefined,
+        false,
+      );
+      createdSessions.push(session);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'echo' }],
+      });
+
+      expect(connection.createTerminalCalls).toHaveLength(0);
+
+      const hasTerminalContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some((c) => c.type === 'terminal');
+      });
+      expect(hasTerminalContent).toBe(false);
+
+      const hasTextContent = connection.onlySessionUpdates().some((u) => {
+        if (u.sessionUpdate !== 'tool_call_update') return false;
+        const content = u.content ?? [];
+        return content.some(
+          (c): c is Extract<typeof c, { type: 'content' }> =>
+            c.type === 'content',
+        );
+      });
+      expect(hasTextContent).toBe(true);
+    });
+  });
+});

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -20,9 +20,15 @@ import {
 const createdSessions: Session[] = [];
 
 async function disposeCreatedSessions(): Promise<void> {
-  for (const session of createdSessions.splice(0)) {
-    await session.dispose();
-  }
+  await Promise.allSettled(
+    createdSessions.splice(0).map(async (session) => {
+      try {
+        await session.dispose();
+      } catch {
+        // Continue disposing remaining sessions even if one fails
+      }
+    }),
+  );
 }
 
 function createTerminalSession(

--- a/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.terminal.test.ts
@@ -218,7 +218,7 @@ describe('Zed Session — terminal capability integration', () => {
       await session.cancelPendingPrompt();
       await promptPromise;
 
-      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+      expect(connection.killCalls).toBe(1);
     });
 
     it('kills and releases terminals on dispose', async () => {
@@ -244,7 +244,7 @@ describe('Zed Session — terminal capability integration', () => {
       await session.dispose();
       await promptPromise.catch(() => undefined);
 
-      expect(connection.killCalls).toBeGreaterThanOrEqual(1);
+      expect(connection.killCalls).toBe(1);
     });
   });
 

--- a/packages/cli/src/zed-integration/zedIntegration.test.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.test.ts
@@ -149,6 +149,7 @@ describe('ZedAgent.newSession', () => {
       getProfileManager: () => undefined,
       getEphemeralSetting: () => undefined,
       getTargetDir: () => '/project',
+      getSessionRecordingService: () => undefined,
     } as unknown as Config;
     const connection = {
       readTextFile: vi.fn(async (_params: { sessionId: string }) => ({

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -36,17 +36,10 @@ import {
   buildSessionModes,
   buildUsageUpdate,
   describeSessionUpdateForLog,
-  mapDoneReasonToStopReason,
-  extractThoughtText,
-  translateErrorEvent,
-  translateIdleTimeout,
 } from './zed-helpers.js';
 import { ZedPathResolver } from './zed-path-resolver.js';
 import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 import {
-  emitToolCallStart,
-  emitToolStatus,
-  emitToolResult,
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
@@ -82,7 +75,12 @@ import {
   buildZedSession,
   enableZedSessionRecording,
 } from './zed-agent-setup.js';
+import { handleZedAgentEvent } from './zed-agent-event-handler.js';
 import { buildZedPlanUpdate } from './zed-plan-update.js';
+import {
+  SessionTitleTracker,
+  buildSessionInfoUpdate,
+} from './zed-session-info.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -388,7 +386,13 @@ export class Session {
   private promptGeneration = 0;
   private readonly todoListener: (event: TodoUpdateEvent) => void;
   private readonly stopConfigUpdates: () => void;
-  private updatedAt = new Date().toISOString();
+  private readonly sessionInfo = new SessionTitleTracker();
+  /**
+   * Stable timestamp captured once at construction so getLifecycleInfo returns
+   * a consistent updatedAt before the first turn completes (issue #1611
+   * finding 4) rather than generating a new value per getter call.
+   */
+  private readonly createdAt = new Date().toISOString();
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
@@ -399,6 +403,12 @@ export class Session {
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
+    const recordedTitle = config
+      .getSessionRecordingService()
+      ?.getSessionMetadataTitle();
+    if (recordedTitle !== undefined) {
+      this.sessionInfo.hydrateFromMetadata(recordedTitle);
+    }
     this.todoListener = (event: TodoUpdateEvent) => {
       const eventAgentId = event.agentId ?? DEFAULT_AGENT_ID;
       if (event.sessionId === this.id && eventAgentId === DEFAULT_AGENT_ID) {
@@ -434,10 +444,13 @@ export class Session {
   }
   getConfigOptions = () => buildZedConfigOptions(this.agent, this.config);
   getLifecycleInfo(): LifecycleSession {
+    const title = this.sessionInfo.getTitle();
     return {
       sessionId: this.id,
       cwd: this.config.getProjectRoot(),
-      updatedAt: this.updatedAt,
+      updatedAt: this.sessionInfo.getUpdatedAt() ?? this.createdAt,
+      createdAt: this.createdAt,
+      ...(title === undefined ? {} : { title }),
     };
   }
   async cancelPendingPrompt(): Promise<void> {
@@ -484,83 +497,169 @@ export class Session {
     }
   }
   async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
-    this.updatedAt = new Date().toISOString();
     await this.cancelPendingPrompt();
-    const commandResult = await tryHandleZedCommand(
-      params.prompt,
-      this.agent,
-      (update) => this.sendUpdateStrict(update),
-    );
-    if (commandResult !== null) return commandResult.response;
-    const pendingSend = new AbortController();
-    this.pendingPrompt = pendingSend;
-    this.promptGeneration += 1;
-    const promptGeneration = this.promptGeneration;
-    const promptId = Math.random().toString(16).slice(2);
+    // Finding 1: consume title eligibility SYNCHRONOUSLY at acceptance time,
+    // before any async work, so overlapping prompts cannot both claim the title.
+    const eligibility = this.sessionInfo.consumeTitleEligibility(params.prompt);
+    // Issue #1611: record session_metadata immediately at acceptance so the
+    // title persists even for slash/failure sessions that never emit a content
+    // event. session_metadata materializes the recording file.
+    this.recordMetadataTitle(eligibility.title);
     try {
-      let parts: ContractPart[];
-      try {
-        parts = await this.pathResolver.resolvePrompt(
-          params.prompt,
-          pendingSend.signal,
-        );
-      } catch (error) {
-        if (
-          pendingSend.signal.aborted ||
-          (error instanceof Error && error.name === 'AbortError')
-        ) {
-          return { stopReason: 'cancelled' };
-        }
-        throw error;
-      }
-      const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
-        'auto') as FilterConfiguration['mode'];
-      const batcher = new StreamBatcher(
-        new EmojiFilter({ mode: emojiMode }),
-        (u) => this.sendUpdate(u),
+      const commandResult = await tryHandleZedCommand(
+        params.prompt,
+        this.agent,
+        (update) => this.sendUpdateStrict(update),
       );
-      let terminalStopReason: acp.StopReason | null = null;
+      if (commandResult !== null) {
+        return commandResult.response;
+      }
+      const pendingSend = new AbortController();
+      this.pendingPrompt = pendingSend;
+      this.promptGeneration += 1;
+      const promptGeneration = this.promptGeneration;
+      const promptId = Math.random().toString(16).slice(2);
       try {
-        terminalStopReason = await this.consumeAgentStream(
-          parts,
+        return await this.runPromptTurn(
+          params,
           pendingSend,
           promptId,
           promptGeneration,
-          batcher,
         );
-      } catch (error) {
-        if (getErrorStatus(error) === 429) {
-          throw new acp.RequestError(
-            429,
-            'Rate limit exceeded. Try again later.',
-          );
-        }
-        if (
-          pendingSend.signal.aborted ||
-          (error instanceof Error && error.name === 'AbortError')
-        ) {
-          return { stopReason: 'cancelled' };
-        }
-        throw error;
       } finally {
-        try {
-          await batcher.flush();
-        } finally {
-          batcher.dispose();
+        if (this.pendingPrompt === pendingSend) {
+          this.pendingPrompt = null;
         }
       }
-      if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+    } finally {
+      // Finding 3: exact-once metadata finally shared by command and prompt
+      // paths (success, cancel, or error). Best-effort transport — sendUpdate
+      // swallows transient errors so metadata never replaces the turn outcome.
+      await this.emitTurnMetadata(eligibility);
+    }
+  }
+
+  private async runPromptTurn(
+    params: acp.PromptRequest,
+    pendingSend: AbortController,
+    promptId: string,
+    promptGeneration: number,
+  ): Promise<acp.PromptResponse> {
+    let parts: ContractPart[];
+    try {
+      parts = await this.pathResolver.resolvePrompt(
+        params.prompt,
+        pendingSend.signal,
+      );
+    } catch (error) {
+      if (
+        pendingSend.signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
         return { stopReason: 'cancelled' };
       }
-      if (terminalStopReason !== null) {
-        return { stopReason: terminalStopReason };
+      throw error;
+    }
+    const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
+      'auto') as FilterConfiguration['mode'];
+    const batcher = new StreamBatcher(
+      new EmojiFilter({ mode: emojiMode }),
+      (u) => this.sendUpdate(u),
+    );
+    let terminalStopReason: acp.StopReason | null = null;
+    try {
+      terminalStopReason = await this.consumeAgentStream(
+        parts,
+        pendingSend,
+        promptId,
+        promptGeneration,
+        batcher,
+      );
+    } catch (error) {
+      if (getErrorStatus(error) === 429) {
+        throw new acp.RequestError(
+          429,
+          'Rate limit exceeded. Try again later.',
+        );
       }
-      return { stopReason: 'end_turn' };
+      if (
+        pendingSend.signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return { stopReason: 'cancelled' };
+      }
+      throw error;
     } finally {
-      if (this.pendingPrompt === pendingSend) {
-        this.pendingPrompt = null;
+      try {
+        await batcher.flush();
+      } finally {
+        batcher.dispose();
       }
     }
+    if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
+      return { stopReason: 'cancelled' };
+    }
+    if (terminalStopReason !== null) {
+      return { stopReason: terminalStopReason };
+    }
+    return { stopReason: 'end_turn' };
+  }
+
+  private async emitTurnMetadata(eligibility: {
+    readonly wonTitle: boolean;
+    readonly title: string | undefined;
+  }): Promise<void> {
+    const { updates } = this.sessionInfo.recordTurn(new Date().toISOString());
+    const updatedAt = updates[0]?.updatedAt ?? undefined;
+    if (eligibility.wonTitle && eligibility.title !== undefined) {
+      await this.sendTitleUpdate(
+        buildSessionInfoUpdate({ title: eligibility.title, updatedAt }),
+        eligibility.title,
+      );
+      return;
+    }
+    for (const update of updates) {
+      const title = update.title;
+      if (typeof title === 'string') {
+        await this.sendTitleUpdate(update, title);
+      } else {
+        await this.sendUpdate(update);
+      }
+    }
+  }
+
+  /**
+   * Sends a title-bearing session_info_update, retrying on transport failure
+   * (issue #1611). Uses sendUpdateStrict (not the swallowing sendUpdate) so a
+   * transport error is detected; the title is then marked pending so the next
+   * turn's metadata emission re-sends it.
+   */
+  private async sendTitleUpdate(
+    update: acp.SessionInfoUpdate & { sessionUpdate: 'session_info_update' },
+    title: string,
+  ): Promise<void> {
+    try {
+      await this.sendUpdateStrict(update);
+    } catch (error) {
+      this.logger.debug(
+        () =>
+          `sendTitleUpdate ERROR (will retry next turn): ${error instanceof Error ? error.message : String(error)}`,
+      );
+      this.sessionInfo.markPendingTitle(title);
+    }
+  }
+
+  /**
+   * Records the session_metadata title to the durable recording service.
+   * Called at prompt-acceptance time (issue #1611) so the title persists
+   * immediately, materializing the recording for slash/failure sessions.
+   */
+  private recordMetadataTitle(title: string | undefined): void {
+    const recording = this.config.getSessionRecordingService();
+    if (recording?.isActive() !== true) {
+      return;
+    }
+    recording.recordSessionMetadata(title ?? null);
   }
   private async consumeAgentStream(
     parts: ContractPart[],
@@ -582,96 +681,21 @@ export class Session {
         }
         continue;
       }
-      const stopReason = await this.handleAgentEvent(
-        event,
-        batcher,
-        promptGeneration,
-        pendingSend,
-      );
+      const stopReason = await handleZedAgentEvent(event, batcher, {
+        sendUpdate: (update) => this.sendUpdate(update),
+        sendUsage: (usage) => this.sendUsageUpdate(usage),
+        handleConfirmation: (confirmation) =>
+          this.handleToolConfirmation(
+            confirmation,
+            promptGeneration,
+            pendingSend,
+          ),
+      });
       if (stopReason !== null) {
         terminalStopReason = stopReason;
       }
     }
     return terminalStopReason;
-  }
-  private async handleAgentEvent(
-    event: AgentEvent,
-    batcher: StreamBatcher,
-    promptGeneration: number,
-    pendingSend: AbortController,
-  ): Promise<acp.StopReason | null> {
-    switch (event.type) {
-      case 'text':
-        batcher.append(event.text, false);
-        return null;
-      case 'thinking': {
-        const thoughtText = extractThoughtText(event.thought);
-        if (thoughtText.length > 0) {
-          batcher.append(thoughtText, true);
-        }
-        return null;
-      }
-      case 'tool-call':
-        await batcher.flush();
-        await emitToolCallStart(event.call, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-status':
-        await batcher.flush();
-        await emitToolStatus(event.update, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-result':
-        await batcher.flush();
-        await emitToolResult(event.result, (u) => this.sendUpdate(u));
-        return null;
-      case 'tool-confirmation':
-        await batcher.flush();
-        await this.handleToolConfirmation(event, promptGeneration, pendingSend);
-        return null;
-      case 'done':
-        await batcher.flush();
-        return mapDoneReasonToStopReason(event.reason);
-      case 'error':
-        await batcher.flush();
-        throw translateErrorEvent(event);
-      case 'idle-timeout':
-        await batcher.flush();
-        throw translateIdleTimeout(event);
-      case 'invalid-stream':
-        await batcher.flush();
-        throw new Error(
-          'Agent produced an invalid stream that could not be recovered.',
-        );
-      case 'hook-blocked':
-        await batcher.flush();
-        throw new Error(
-          event.info.systemMessage ?? 'Agent stopped by a hook blocker.',
-        );
-      case 'loop-detected':
-        await batcher.flush();
-        return 'end_turn';
-      case 'notice':
-        await batcher.flush();
-        await this.sendUpdate({
-          sessionUpdate: 'agent_message_chunk',
-          content: { type: 'text', text: event.message },
-        });
-        return null;
-      case 'usage': {
-        await batcher.flush();
-        await this.sendUsageUpdate(event.usage);
-        return null;
-      }
-      case 'context-warning':
-      case 'compression':
-      case 'model-info':
-      case 'retry':
-      case 'citation':
-        return null;
-      default: {
-        const exhaustive: never = event;
-        throw new Error(`Unhandled agent event: ${String(exhaustive)}`);
-      }
-    }
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -784,6 +808,9 @@ export class Session {
         throw wrapReplayFailure(this.id, error);
       }
     }
+    // Finding 2: hydrate title from restored history so later prompts never
+    // retitle a restored session. Idempotent — a no-op if already titled.
+    this.sessionInfo.hydrateFromHistory(items);
   }
   async replayLiveHistory() {
     await this.streamHistory(

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -532,10 +532,11 @@ export class Session {
         }
       }
     } finally {
-      // Finding 3: exact-once metadata finally shared by command and prompt
-      // paths (success, cancel, or error). Best-effort transport — sendUpdate
-      // swallows transient errors so metadata never replaces the turn outcome.
-      await this.emitTurnMetadata(eligibility);
+      try {
+        await this.emitTurnMetadata(eligibility);
+      } catch (error) {
+        this.logger.debug(() => `emitTurnMetadata ERROR: ${String(error)}`);
+      }
     }
   }
 

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -691,6 +691,7 @@ export class Session {
             promptGeneration,
             pendingSend,
           ),
+        resolveToolKind: (toolName) => this.agent.tools.get(toolName)?.kind,
       });
       if (stopReason !== null) {
         terminalStopReason = stopReason;

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -828,7 +828,13 @@ export class Session {
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {
-      await this.agent.dispose();
+      try {
+        await this.agent.dispose();
+      } catch (error) {
+        this.logger.debug(
+          () => `Failed to dispose Zed session agent: ${error}`,
+        );
+      }
     }
   }
 }

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -5,14 +5,11 @@
  */
 import {
   type Config,
-  getErrorStatus,
   todoEvents,
   DEFAULT_AGENT_ID,
   debugLogger,
   createInkStdio,
-  type ContractPart,
   DebugLogger,
-  EmojiFilter,
   type FilterConfiguration,
   type IContent,
   type TodoUpdateEvent,
@@ -43,6 +40,7 @@ import {
   requestToolConfirmation,
   type PermissionRoundTripResult,
 } from './zed-tool-handler.js';
+import { TerminalManager } from './zed-terminal-manager.js';
 import { mapHistoryToSessionUpdates } from './zed-session-replay.js';
 import { wrapReplayFailure } from './zed-session-errors.js';
 import {
@@ -53,7 +51,6 @@ import {
   nodeChatSessionFileLister,
   type ChatSessionFileLister,
 } from './zed-session-loader.js';
-import { StreamBatcher } from './zed-stream-batcher.js';
 import { SessionLifecycle } from './zed-session-lifecycle.js';
 import type { LifecycleSession } from './zed-session-pagination.js';
 import { authenticateZedAgent, initializeZedAgent } from './zed-initialize.js';
@@ -75,12 +72,20 @@ import {
   buildZedSession,
   enableZedSessionRecording,
 } from './zed-agent-setup.js';
-import { handleZedAgentEvent } from './zed-agent-event-handler.js';
+import {
+  runPromptTurn as executePromptTurn,
+  type SessionStreamDeps,
+} from './zed-session-events.js';
 import { buildZedPlanUpdate } from './zed-plan-update.js';
 import {
   SessionTitleTracker,
   buildSessionInfoUpdate,
 } from './zed-session-info.js';
+import type {
+  CloseSessionRequest,
+  DeleteSessionRequest,
+  ClientCapabilitiesWithSession,
+} from './acp-types.js';
 export { parseZedAuthMethodId } from './zed-helpers.js';
 export { createSessionScopedConfig } from './zed-session-config.js';
 export async function runZedIntegration(
@@ -120,7 +125,7 @@ export async function runZedIntegration(
 }
 export class ZedAgent {
   private sessions: Map<string, Session> = new Map();
-  private clientCapabilities: acp.ClientCapabilities | undefined;
+  private clientCapabilities: ClientCapabilitiesWithSession | undefined;
   private readonly logger = new DebugLogger('llxprt:zed-integration');
   private readonly lifecycle: SessionLifecycle;
   constructor(
@@ -139,7 +144,9 @@ export class ZedAgent {
   async initialize(
     args: acp.InitializeRequest,
   ): Promise<acp.InitializeResponse> {
-    this.clientCapabilities = args.clientCapabilities;
+    this.clientCapabilities = args.clientCapabilities as
+      | ClientCapabilitiesWithSession
+      | undefined;
     return initializeZedAgent(this.config);
   }
   listSessions(
@@ -185,6 +192,7 @@ export class ZedAgent {
   }
   private supportsConfigOptions = () =>
     this.clientCapabilities?.session?.configOptions != null;
+  private supportsTerminal = () => this.clientCapabilities?.terminal === true;
   private createSession(id: string, agent: Agent, config: Config) {
     return buildZedSession(
       agent,
@@ -195,6 +203,7 @@ export class ZedAgent {
           config,
           this.connection,
           this.supportsConfigOptions(),
+          this.supportsTerminal(),
         ),
       (error) => this.logger.debug(() => `Session cleanup failed: ${error}`),
     );
@@ -302,6 +311,7 @@ export class ZedAgent {
         sessionConfig,
         this.connection,
         this.supportsConfigOptions(),
+        this.supportsTerminal(),
       );
       return { session, history };
     } catch (error) {
@@ -335,18 +345,20 @@ export class ZedAgent {
     });
     return { agent, config: sessionConfig };
   }
-  deleteSession(params: acp.DeleteSessionRequest) {
+  deleteSession(params: DeleteSessionRequest) {
     return this.lifecycle.delete(params);
   }
-  closeSession(params: acp.CloseSessionRequest) {
+  closeSession(params: CloseSessionRequest) {
     return this.lifecycle.close(params);
   }
-  setSessionMode(params: acp.SetSessionModeRequest) {
+  setSessionMode(
+    params: acp.SetSessionModeRequest,
+  ): Promise<acp.SetSessionModeResponse> {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
     }
-    return session.setMode(params.modeId);
+    return Promise.resolve(session.setMode(params.modeId));
   }
   setSessionConfigOption(params: acp.SetSessionConfigOptionRequest) {
     return this.lifecycle.runSerialized(params.sessionId, () =>
@@ -393,13 +405,25 @@ export class Session {
    * finding 4) rather than generating a new value per getter call.
    */
   private readonly createdAt = new Date().toISOString();
+  private readonly terminals: TerminalManager | null;
+
   constructor(
     private readonly id: string,
     private readonly agent: Agent,
     private readonly config: Config,
     private readonly connection: acp.AgentSideConnection,
     configOptionsEnabled = false,
+    terminalEnabled = false,
   ) {
+    this.terminals = terminalEnabled
+      ? new TerminalManager(
+          id,
+          connection,
+          config.getTargetDir(),
+          (update) => this.sendUpdate(update),
+          this.logger,
+        )
+      : null;
     this.pathResolver = new ZedPathResolver(this.config, (msg) =>
       this.debug(msg),
     );
@@ -455,6 +479,7 @@ export class Session {
   }
   async cancelPendingPrompt(): Promise<void> {
     this.settleActiveConfirmation();
+    await this.terminals?.settleAll();
     if (!this.pendingPrompt) {
       return;
     }
@@ -546,64 +571,38 @@ export class Session {
     promptId: string,
     promptGeneration: number,
   ): Promise<acp.PromptResponse> {
-    let parts: ContractPart[];
-    try {
-      parts = await this.pathResolver.resolvePrompt(
-        params.prompt,
-        pendingSend.signal,
-      );
-    } catch (error) {
-      if (
-        pendingSend.signal.aborted ||
-        (error instanceof Error && error.name === 'AbortError')
-      ) {
-        return { stopReason: 'cancelled' };
-      }
-      throw error;
-    }
-    const emojiMode = (this.config.getEphemeralSetting('emojifilter') ??
-      'auto') as FilterConfiguration['mode'];
-    const batcher = new StreamBatcher(
-      new EmojiFilter({ mode: emojiMode }),
-      (u) => this.sendUpdate(u),
+    return executePromptTurn(
+      {
+        pathResolver: this.pathResolver,
+        emojiFilterMode: (this.config.getEphemeralSetting('emojifilter') ??
+          'auto') as FilterConfiguration['mode'],
+        streamDeps: this.buildStreamDeps(promptGeneration, pendingSend),
+      },
+      params,
+      pendingSend,
+      promptId,
+      promptGeneration,
     );
-    let terminalStopReason: acp.StopReason | null = null;
-    try {
-      terminalStopReason = await this.consumeAgentStream(
-        parts,
-        pendingSend,
-        promptId,
-        promptGeneration,
-        batcher,
-      );
-    } catch (error) {
-      if (getErrorStatus(error) === 429) {
-        throw new acp.RequestError(
-          429,
-          'Rate limit exceeded. Try again later.',
-        );
-      }
-      if (
-        pendingSend.signal.aborted ||
-        (error instanceof Error && error.name === 'AbortError')
-      ) {
-        return { stopReason: 'cancelled' };
-      }
-      throw error;
-    } finally {
-      try {
-        await batcher.flush();
-      } finally {
-        batcher.dispose();
-      }
-    }
-    if (pendingSend.signal.aborted && terminalStopReason !== 'cancelled') {
-      return { stopReason: 'cancelled' };
-    }
-    if (terminalStopReason !== null) {
-      return { stopReason: terminalStopReason };
-    }
-    return { stopReason: 'end_turn' };
+  }
+
+  private buildStreamDeps(
+    promptGeneration: number,
+    pendingSend: AbortController,
+  ): SessionStreamDeps {
+    return {
+      agent: this.agent,
+      terminals: this.terminals,
+      sendUpdate: (update) => this.sendUpdate(update),
+      sendUsage: (usage) => this.sendUsageUpdate(usage),
+      handleConfirmation: (confirmation) =>
+        this.handleToolConfirmation(
+          confirmation,
+          promptGeneration,
+          pendingSend,
+        ),
+      isPromptStale: (gen, send) => this.isPromptStale(gen, send),
+      maxTurns: this.config.getMaxSessionTurns(),
+    };
   }
 
   private async emitTurnMetadata(eligibility: {
@@ -661,43 +660,6 @@ export class Session {
       return;
     }
     recording.recordSessionMetadata(title ?? null);
-  }
-  private async consumeAgentStream(
-    parts: ContractPart[],
-    pendingSend: AbortController,
-    promptId: string,
-    promptGeneration: number,
-    batcher: StreamBatcher,
-  ): Promise<acp.StopReason | null> {
-    const eventStream = this.agent.stream(parts, {
-      signal: pendingSend.signal,
-      promptId,
-      maxTurns: this.config.getMaxSessionTurns(),
-    });
-    let terminalStopReason: acp.StopReason | null = null;
-    for await (const event of eventStream) {
-      if (this.isPromptStale(promptGeneration, pendingSend)) {
-        if (event.type === 'done') {
-          return 'cancelled';
-        }
-        continue;
-      }
-      const stopReason = await handleZedAgentEvent(event, batcher, {
-        sendUpdate: (update) => this.sendUpdate(update),
-        sendUsage: (usage) => this.sendUsageUpdate(usage),
-        handleConfirmation: (confirmation) =>
-          this.handleToolConfirmation(
-            confirmation,
-            promptGeneration,
-            pendingSend,
-          ),
-        resolveToolKind: (toolName) => this.agent.tools.get(toolName)?.kind,
-      });
-      if (stopReason !== null) {
-        terminalStopReason = stopReason;
-      }
-    }
-    return terminalStopReason;
   }
   private async sendUsageUpdate(
     usage: Extract<AgentEvent, { type: 'usage' }>['usage'],
@@ -825,6 +787,7 @@ export class Session {
       todoEvents.offTodoUpdated(this.todoListener);
       this.stopConfigUpdates();
       this.settleActiveConfirmation();
+      await this.terminals?.settleAll();
       this.pendingPrompt?.abort();
       this.pendingPrompt = null;
     } finally {

--- a/packages/core/src/recording/ReplayEngine.ts
+++ b/packages/core/src/recording/ReplayEngine.ts
@@ -290,6 +290,40 @@ function handleSessionEvent(
   }
 }
 
+/**
+ * @requirement issue #1611: session_metadata — update metadata.title (tri-state).
+ *
+ * The title is tri-state: undefined (field absent) is legacy and does NOT
+ * modify metadata.title; null sets it to null (explicit untitled); string sets
+ * it to that string. Malformed title values (non-string, non-null, non-
+ * undefined) are recorded as malformed.
+ */
+function handleSessionMetadata(
+  payload: Record<string, unknown>,
+  acc: ReplayAccumulators,
+  lineNumber: number,
+): void {
+  if (acc.metadata === null) {
+    acc.malformedCount++;
+    acc.warnings.push(
+      `Line ${lineNumber}: session_metadata before session_start, skipping`,
+    );
+    return;
+  }
+  if (!('title' in payload)) {
+    return;
+  }
+  const title = payload.title;
+  if (title === null || typeof title === 'string') {
+    acc.metadata.title = title;
+  } else {
+    acc.malformedCount++;
+    acc.warnings.push(
+      `Line ${lineNumber}: malformed session_metadata title, skipping`,
+    );
+  }
+}
+
 /** @pseudocode line 126-131: directories_changed — update metadata or record malformed. */
 function handleDirectoriesChanged(
   payload: Record<string, unknown>,
@@ -381,6 +415,9 @@ function dispatchEvent(
       break;
     case 'session_event':
       handleSessionEvent(payload, acc, lineNumber);
+      break;
+    case 'session_metadata':
+      handleSessionMetadata(payload, acc, lineNumber);
       break;
     case 'directories_changed':
       handleDirectoriesChanged(payload, acc, lineNumber);

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -301,13 +301,14 @@ export class SessionDiscovery {
   static async readSessionMetadataTitle(
     filePath: string,
   ): Promise<string | null | undefined> {
+    let reader: readline.Interface | undefined;
     try {
-      const lines = readline.createInterface({
+      reader = readline.createInterface({
         input: createReadStream(filePath, { encoding: 'utf8' }),
         crlfDelay: Infinity,
       });
       let title: string | null | undefined;
-      for await (const line of lines) {
+      for await (const line of reader) {
         const result = extractSessionMetadataTitle(line);
         if (result !== undefined) {
           title = result;
@@ -316,6 +317,8 @@ export class SessionDiscovery {
       return title;
     } catch {
       return undefined;
+    } finally {
+      reader?.close();
     }
   }
 }

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -24,8 +24,10 @@
  * for the resume flow.
  */
 
+import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import * as readline from 'node:readline';
 import { type SessionSummary, type SessionStartPayload } from './types.js';
 import { readSessionHeader } from './ReplayEngine.js';
 import {
@@ -300,10 +302,12 @@ export class SessionDiscovery {
     filePath: string,
   ): Promise<string | null | undefined> {
     try {
-      const fileContent = await fs.readFile(filePath, 'utf-8');
-      const lines = fileContent.split('\n');
+      const lines = readline.createInterface({
+        input: createReadStream(filePath, { encoding: 'utf8' }),
+        crlfDelay: Infinity,
+      });
       let title: string | null | undefined;
-      for (const line of lines) {
+      for await (const line of lines) {
         const result = extractSessionMetadataTitle(line);
         if (result !== undefined) {
           title = result;

--- a/packages/core/src/recording/SessionDiscovery.ts
+++ b/packages/core/src/recording/SessionDiscovery.ts
@@ -288,6 +288,32 @@ export class SessionDiscovery {
       return null;
     }
   }
+
+  /**
+   * Read the tri-state title from the last valid `session_metadata` event in a
+   * session file (issue #1611). Returns:
+   * - `undefined` when no `session_metadata` event exists (legacy fallback).
+   * - `null` when the event explicitly asserts untitled.
+   * - `string` when the event carries a concrete title.
+   */
+  static async readSessionMetadataTitle(
+    filePath: string,
+  ): Promise<string | null | undefined> {
+    try {
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const lines = fileContent.split('\n');
+      let title: string | null | undefined;
+      for (const line of lines) {
+        const result = extractSessionMetadataTitle(line);
+        if (result !== undefined) {
+          title = result;
+        }
+      }
+      return title;
+    } catch {
+      return undefined;
+    }
+  }
 }
 
 async function readSessionSummary(
@@ -315,6 +341,9 @@ async function readSessionSummary(
     provider: header.provider,
     model: header.model,
     ...(typeof header.cwd === 'string' ? { cwd: header.cwd } : {}),
+    ...(typeof header.startTime === 'string'
+      ? { createdAt: header.startTime }
+      : {}),
   };
 }
 
@@ -371,4 +400,42 @@ function extractUserMessageText(line: string): string | null {
     .join('');
 
   return text || null;
+}
+
+/**
+ * Extract the title from a `session_metadata` JSONL line.
+ * Returns:
+ * - `undefined` when the line is not a valid `session_metadata` event (so
+ *   callers can continue scanning).
+ * - `null` when title is explicitly null (untitled).
+ * - `string` when a concrete title is present.
+ */
+function extractSessionMetadataTitle(line: string): string | null | undefined {
+  if (!line.trim()) {
+    return undefined;
+  }
+  let event: Record<string, unknown>;
+  try {
+    event = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+  if (event.type !== 'session_metadata') {
+    return undefined;
+  }
+  const payload = event.payload as Record<string, unknown> | undefined;
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+  if (!('title' in payload)) {
+    return undefined;
+  }
+  const title = payload.title;
+  if (title === null) {
+    return null;
+  }
+  if (typeof title === 'string') {
+    return title;
+  }
+  return undefined;
 }

--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -57,6 +57,7 @@ export class SessionRecordingService {
   private readonly chatsDir: string;
   private preContentBuffer: SessionRecordLine[] = [];
   private chatsDirWatcher: FSWatcher | null = null;
+  private sessionTitle: string | null | undefined;
 
   /**
    * @plan PLAN-20260211-SESSIONRECORDING.P05
@@ -109,7 +110,10 @@ export class SessionRecordingService {
   enqueue(type: SessionEventType, payload: unknown): void {
     if (!this.active) return;
 
-    if (type === 'content' && !this.materialized) {
+    if (
+      (type === 'content' || type === 'session_metadata') &&
+      !this.materialized
+    ) {
       this.materialize();
       for (const buffered of this.preContentBuffer) {
         this.queue.push(buffered);
@@ -310,11 +314,16 @@ export class SessionRecordingService {
    * @requirement REQ-REC-008
    * @pseudocode session-recording-service.md lines 174-179
    */
-  initializeForResume(filePath: string, lastSeq: number): void {
+  initializeForResume(
+    filePath: string,
+    lastSeq: number,
+    title?: string | null,
+  ): void {
     this.filePath = filePath;
     this.seq = lastSeq;
     this.materialized = true;
     this.preContentBuffer = [];
+    this.sessionTitle = title;
     this.startChatsDirWatcher();
   }
 
@@ -470,5 +479,26 @@ export class SessionRecordingService {
    */
   recordDirectoriesChanged(directories: string[]): void {
     this.enqueue('directories_changed', { directories });
+  }
+
+  /**
+   * Record a session_metadata event — persisted human-readable title.
+   * The title is tri-state: `string` for a concrete title, `null` for explicit
+   * untitled, `undefined` for legacy (field absent). Like `content`, this event
+   * materializes the file so slash/failure sessions persist metadata even
+   * without a content event.
+   *
+   * @requirement REQ-REC-002
+   */
+  recordSessionMetadata(title: string | null): void {
+    if (!this.active) {
+      return;
+    }
+    this.sessionTitle = title;
+    this.enqueue('session_metadata', { title });
+  }
+
+  getSessionMetadataTitle(): string | null | undefined {
+    return this.sessionTitle;
   }
 }

--- a/packages/core/src/recording/replay-test-helpers.ts
+++ b/packages/core/src/recording/replay-test-helpers.ts
@@ -200,6 +200,20 @@ export function _directoriesChangedLine(
 }
 
 /**
+ * Build a valid JSONL line for a session_metadata event (issue #1611).
+ * The title is tri-state: string, null, or undefined (omitted from payload).
+ */
+export function sessionMetadataLine(seq: number, title: string | null): string {
+  return JSON.stringify({
+    v: 1,
+    seq,
+    ts: new Date().toISOString(),
+    type: 'session_metadata',
+    payload: { title },
+  });
+}
+
+/**
  * Write raw JSONL lines to a file.
  */
 export async function writeJsonlFile(

--- a/packages/core/src/recording/replay-test-helpers.ts
+++ b/packages/core/src/recording/replay-test-helpers.ts
@@ -201,7 +201,7 @@ export function _directoriesChangedLine(
 
 /**
  * Build a valid JSONL line for a session_metadata event (issue #1611).
- * The title is tri-state: string, null, or undefined (omitted from payload).
+ * The title is either a concrete string or explicit null.
  */
 export function sessionMetadataLine(seq: number, title: string | null): string {
   return JSON.stringify({

--- a/packages/core/src/recording/resumeSession.ts
+++ b/packages/core/src/recording/resumeSession.ts
@@ -139,6 +139,7 @@ function initializeRecordingForResume(
   recording.initializeForResume(
     lockedSession.targetFilePath,
     replayResult.lastSeq,
+    replayResult.metadata.title,
   );
 
   if (

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the session_metadata recording event (issue #1611).
+ *
+ * Verifies:
+ * - recordSessionMetadata writes a typed session_metadata event (not a
+ *   session_event sentinel) to the JSONL file.
+ * - The title is tri-state: string (concrete), null (explicit untitled).
+ * - session_metadata materializes the recording file BEFORE any content event,
+ *   so slash/failure sessions persist their metadata.
+ * - ReplayEngine restores the tri-state title from session_metadata events.
+ * - SessionDiscovery.readSessionMetadataTitle extracts the tri-state title.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SessionRecordingService } from './SessionRecordingService.js';
+import { replaySession } from './ReplayEngine.js';
+import { SessionDiscovery } from './SessionDiscovery.js';
+import {
+  makeConfig,
+  sessionStartLine,
+  sessionMetadataLine,
+  contentLine,
+  makeContent,
+  writeJsonlFile,
+  PROJECT_HASH,
+  assertReplayOk,
+} from './replay-test-helpers.js';
+
+const tempDirs: string[] = [];
+
+describe('session_metadata recording (issue #1611)', () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function makeTempChatsDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'session-metadata-'));
+    tempDirs.push(dir);
+    const chatsDir = path.join(dir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+    return chatsDir;
+  }
+
+  describe('SessionRecordingService.recordSessionMetadata', () => {
+    it('writes a typed session_metadata event (not a session_event sentinel)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('My session title');
+      await service.flush();
+
+      const filePath = service.getFilePath();
+      expect(filePath).not.toBeNull();
+      const fileContent = await fs.readFile(filePath!, 'utf-8');
+      const lines = fileContent.trim().split('\n');
+      const types = lines.map((line) => JSON.parse(line).type);
+
+      expect(types).toContain('session_metadata');
+      const metadataLine = lines
+        .map((line) => JSON.parse(line))
+        .find((line) => line.type === 'session_metadata');
+      expect(metadataLine.payload).toStrictEqual({ title: 'My session title' });
+      await service.dispose();
+    });
+
+    it('records a null title for explicit untitled', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata(null);
+      await service.flush();
+
+      const filePath = service.getFilePath()!;
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const metadataLine = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+        .find((line) => line.type === 'session_metadata');
+      expect(metadataLine.payload).toStrictEqual({ title: null });
+      await service.dispose();
+    });
+
+    it('materializes the recording BEFORE any content event (slash/failure sessions)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('Slash command title');
+      await service.flush();
+
+      expect(service.getFilePath()).not.toBeNull();
+      const fileContent = await fs.readFile(service.getFilePath()!, 'utf-8');
+      const types = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line).type);
+      expect(types).toContain('session_start');
+      expect(types).toContain('session_metadata');
+      expect(types).not.toContain('content');
+      await service.dispose();
+    });
+
+    it('preserves ordering: session_start before session_metadata before content', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+
+      service.recordSessionMetadata('Ordered title');
+      service.recordContent(makeContent('hello'));
+      await service.flush();
+
+      const fileContent = await fs.readFile(service.getFilePath()!, 'utf-8');
+      const types = fileContent
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line).type);
+      const startIdx = types.indexOf('session_start');
+      const metaIdx = types.indexOf('session_metadata');
+      const contentIdx = types.indexOf('content');
+      expect(startIdx).toBeLessThan(metaIdx);
+      expect(metaIdx).toBeLessThan(contentIdx);
+      await service.dispose();
+    });
+  });
+
+  describe('ReplayEngine session_metadata handling', () => {
+    it('replays a string title from session_metadata', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-str.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'Replayed title'),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBe('Replayed title');
+    });
+
+    it('replays a null title (explicit untitled)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-null.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, null),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBeNull();
+    });
+
+    it('leaves title undefined (legacy) when no session_metadata event exists', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-legacy.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        contentLine(2, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBeUndefined();
+    });
+
+    it('last session_metadata title wins when multiple exist', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-multi.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'First title'),
+        contentLine(3, makeContent('turn 1')),
+        sessionMetadataLine(4, 'Updated title'),
+        contentLine(5, makeContent('turn 2')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(result.metadata.title).toBe('Updated title');
+    });
+
+    it('records a warning for session_metadata before session_start', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-early.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionMetadataLine(1, 'Too early'),
+        sessionStartLine(2),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      expect(result.ok).toBe(false);
+    });
+
+    it('records a warning for malformed session_metadata title (non-string, non-null)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-test-meta-malformed.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        JSON.stringify({
+          v: 1,
+          seq: 2,
+          ts: '2026-07-12T00:00:00.000Z',
+          type: 'session_metadata',
+          payload: { title: 12345 },
+        }),
+        contentLine(3, makeContent('hello')),
+      ]);
+
+      const result = await replaySession(filePath, PROJECT_HASH);
+      assertReplayOk(result);
+      expect(
+        result.warnings.some((w) => w.includes('malformed session_metadata')),
+      ).toBe(true);
+    });
+  });
+
+  describe('SessionDiscovery.readSessionMetadataTitle', () => {
+    it('reads a string title from a session_metadata event', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-str.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'Discovery title'),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBe('Discovery title');
+    });
+
+    it('reads null for explicit untitled', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-null.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, null),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBeNull();
+    });
+
+    it('returns undefined when no session_metadata event exists (legacy)', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-legacy.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        contentLine(2, makeContent('hello')),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBeUndefined();
+    });
+
+    it('reads the last valid session_metadata title when multiple exist', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const filePath = path.join(chatsDir, 'session-discovery-multi.jsonl');
+      await writeJsonlFile(filePath, [
+        sessionStartLine(1),
+        sessionMetadataLine(2, 'First metadata'),
+        contentLine(3, makeContent('turn')),
+        sessionMetadataLine(4, 'Second metadata'),
+      ]);
+
+      const title = await SessionDiscovery.readSessionMetadataTitle(filePath);
+      expect(title).toBe('Second metadata');
+    });
+  });
+
+  describe('SessionSummary createdAt (immutable ordering)', () => {
+    it('includes createdAt from session_start.startTime', async () => {
+      const chatsDir = await makeTempChatsDir();
+      const service = new SessionRecordingService(makeConfig({ chatsDir }));
+      service.recordContent(makeContent('hello'));
+      await service.flush();
+      await service.dispose();
+
+      const sessions = await SessionDiscovery.listSessions(
+        chatsDir,
+        PROJECT_HASH,
+      );
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].createdAt).toBeDefined();
+      expect(typeof sessions[0].createdAt).toBe('string');
+      expect(Number.isNaN(Date.parse(sessions[0].createdAt!))).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/recording/sessionMetadata.test.ts
+++ b/packages/core/src/recording/sessionMetadata.test.ts
@@ -191,7 +191,7 @@ describe('session_metadata recording (issue #1611)', () => {
       expect(result.metadata.title).toBe('Updated title');
     });
 
-    it('records a warning for session_metadata before session_start', async () => {
+    it('returns a fatal replay error when session_metadata precedes session_start', async () => {
       const chatsDir = await makeTempChatsDir();
       const filePath = path.join(chatsDir, 'session-test-meta-early.jsonl');
       await writeJsonlFile(filePath, [

--- a/packages/core/src/recording/types.ts
+++ b/packages/core/src/recording/types.ts
@@ -30,7 +30,7 @@ import { type IContent } from '../services/history/IContent.js';
 // ---------------------------------------------------------------------------
 
 /**
- * The seven event types that can appear in a session JSONL file.
+ * The event types that can appear in a session JSONL file.
  */
 export type SessionEventType =
   | 'session_start'
@@ -39,6 +39,7 @@ export type SessionEventType =
   | 'rewind'
   | 'provider_switch'
   | 'session_event'
+  | 'session_metadata'
   | 'directories_changed';
 
 // ---------------------------------------------------------------------------
@@ -125,6 +126,19 @@ export interface SessionEventPayload {
 }
 
 /**
+ * Payload for the `session_metadata` event — session-level metadata updates
+ * (currently only the human-readable title). The title is tri-state:
+ * - `undefined` (field absent): legacy event, no title assertion.
+ * - `null`: explicit untitled (the caller asserts there is no meaningful title).
+ * - `string`: a concrete title.
+ *
+ * This is a typed first-class recording event, NOT a `session_event` sentinel.
+ */
+export interface SessionMetadataPayload {
+  readonly title?: string | null;
+}
+
+/**
  * Payload for the `directories_changed` event.
  */
 export interface DirectoriesChangedPayload {
@@ -155,7 +169,14 @@ export interface SessionRecordingServiceConfig {
 
 /**
  * Metadata extracted from a session's `session_start` event and updated
- * by subsequent `provider_switch` / `directories_changed` events.
+ * by subsequent `provider_switch` / `directories_changed` / `session_metadata`
+ * events.
+ *
+ * The title is tri-state:
+ * - `undefined`: no `session_metadata` event seen (legacy file). Callers fall
+ *   back to first-human-text heuristics.
+ * - `null`: explicit untitled (`session_metadata` asserted no title).
+ * - `string`: a concrete title.
  */
 export interface SessionMetadata {
   sessionId: string;
@@ -165,6 +186,7 @@ export interface SessionMetadata {
   workspaceDirs: string[];
   cwd?: string;
   startTime: string;
+  title?: string | null;
 }
 
 /**
@@ -205,4 +227,16 @@ export interface SessionSummary {
   provider: string;
   model: string;
   cwd?: string;
+  /**
+   * Tri-state title from a persisted `session_metadata` event:
+   * - `undefined`: no `session_metadata` event seen (legacy fallback).
+   * - `null`: explicit untitled.
+   * - `string`: a concrete title.
+   */
+  title?: string | null;
+  /**
+   * Immutable creation timestamp extracted from `session_start.startTime`.
+   * Used for stable ordering independent of file `lastModified` mutations.
+   */
+  createdAt?: string;
 }


### PR DESCRIPTION
## TLDR

Adds durable ACP session activity metadata for Zed. The first accepted prompt determines the session title exactly once, every completed interaction advances updatedAt, and both values remain stable across listing, pagination, and resume.

## Dive Deeper

- Emits typed ACP 1.2.1 session_info_update notifications for title and updatedAt.
- Persists the first accepted prompt decision as a typed session_metadata recording event before command dispatch or model execution.
- Preserves string, explicit-null, and legacy-absent title states across replay and resume.
- Materializes metadata-only recordings for slash commands, failed turns, and non-text prompts.
- Retries title delivery after transient transport failures without changing prompt outcomes.
- Merges durable and live listing metadata consistently.
- Uses immutable createdAt plus session ID in a stateless v2 pagination cursor so updatedAt changes cannot omit sessions between pages.
- Extracts the AgentEvent dispatcher without changing event behavior or loosening lint constraints.
- Documents the reserved llxprt/ extension namespace; implementation remains deferred per the authoritative July 2026 issue scope.

Backward compatibility is preserved for older recordings by deriving their title from the first human message only when no session_metadata event exists.

## Reviewer Test Plan

1. Start a Zed ACP session and send a text prompt. Confirm one session_info_update contains the normalized first-prompt title and updatedAt.
2. Send later prompts, slash commands, and a cancelled or failing turn. Confirm only updatedAt advances and the title does not change.
3. Restart and load the session. Confirm the persisted title remains unchanged, including explicit untitled sessions.
4. Simulate a failed first title notification, recover the connection, and send another prompt. Confirm the original title is retried.
5. List more than one page of sessions, update an unreturned live session between requests, and confirm it still appears exactly once.
6. Run:
   - npm run test
   - npm run lint
   - npm run typecheck
   - npm run format
   - npm run build

The configured scripts/start.js smoke entrypoint is absent in this checkout. The available bun scripts/start.ts fallback produced no output before the command watchdog terminated it.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1611
