### PR TITLE
Fix Windows quoted-path shell guidance (Fixes google-gemini/gemini-cli#5228)

### DIFF
--- a/packages/tools/src/__tests__/shell-helpers-schema.test.ts
+++ b/packages/tools/src/__tests__/shell-helpers-schema.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as os from 'node:os';
+import { ShellTool } from '../index.js';
+import type {
+  IShellExecutionService,
+  ShellResult,
+} from '../interfaces/index.js';
+import { buildCommandToExecute } from '../tools/shell-helpers.js';
+
+vi.mock('node:os');
+
+function createFakeShellService(): IShellExecutionService {
+  return {
+    execute: async (): Promise<ShellResult> => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      aborted: false,
+    }),
+    isCommandAllowed: () => true,
+  };
+}
+
+function createShellTool(): ShellTool {
+  return new ShellTool(createFakeShellService());
+}
+
+describe('ShellTool schema guidance on Windows', () => {
+  beforeEach(() => {
+    vi.mocked(os.platform).mockReturnValue('win32');
+  });
+
+  it('describes the PowerShell runtime invocation', () => {
+    expect(createShellTool().schema).toMatchObject({
+      description: expect.stringMatching(
+        /PowerShell.*powershell\.exe.*pwsh.*-NoProfile -Command/,
+      ),
+    });
+  });
+
+  it('describes the command parameter as PowerShell input', () => {
+    expect(createShellTool().schema).toMatchObject({
+      parametersJsonSchema: {
+        properties: {
+          command: {
+            description: expect.stringMatching(
+              /PowerShell.*-NoProfile -Command.*powershell\.exe.*pwsh/,
+            ),
+          },
+        },
+      },
+    });
+  });
+
+  it('guides the model to quote literal paths using PowerShell syntax', () => {
+    expect(createShellTool().schema.description).toContain(
+      'represent an apostrophe inside a single-quoted path with two single quotes',
+    );
+  });
+
+  it('does not advertise cmd.exe syntax', () => {
+    expect(JSON.stringify(createShellTool().schema)).not.toMatch(
+      /cmd\.exe \/c|start \/b/,
+    );
+  });
+});
+
+describe('Windows command preparation', () => {
+  it.each([
+    [
+      'directory creation',
+      "New-Item -ItemType Directory -Force -Path 'C:\\Users\\UlknAries\\Desktop\\My Games'",
+    ],
+    [
+      'file move with apostrophes and non-ASCII characters',
+      "Move-Item -LiteralPath 'C:\\Users\\UlknAries\\Desktop\\Assassin''s Creed Shadows.url' -Destination 'C:\\Users\\UlknAries\\Desktop\\игры\\Assassin''s Creed Shadows.url'",
+    ],
+  ])('passes through a quoted %s command unchanged', (_behavior, command) => {
+    expect(buildCommandToExecute(command, true, '/unused')).toBe(command);
+  });
+});
+
+describe('ShellTool schema guidance on non-Windows platforms', () => {
+  it('preserves bash guidance', () => {
+    vi.mocked(os.platform).mockReturnValue('darwin');
+
+    expect(createShellTool().schema).toMatchObject({
+      description: expect.stringContaining('bash -c'),
+      parametersJsonSchema: {
+        properties: {
+          command: {
+            description: expect.stringContaining('bash -c'),
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/tools/src/tools/shell-helpers.ts
+++ b/packages/tools/src/tools/shell-helpers.ts
@@ -335,7 +335,7 @@ export function getShellToolDescription(): string {
   const returnedInfo = `\n\n      The following information is returned:\n\n      Command: Executed command.\n      Directory: Directory (relative to project root) where command was executed, or \`(root)\`.\n      Stdout: Output on stdout stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.\n      Stderr: Output on stderr stream. Can be \`(empty)\` or partial on error and for any unwaited background processes.\n      Error: Error or \`(none)\` if no error was reported for the subprocess.\n      Exit Code: Exit code or \`(none)\` if terminated by signal.\n      Signal: Signal number or \`(none)\` if no signal was received.\n      Background PIDs: List of background processes started or \`(none)\`.\n      Process Group PGID: Process group started or \`(none)\``;
 
   if (os.platform() === 'win32') {
-    return `This tool executes a given shell command as \`cmd.exe /c <command>\`. Command can start background processes using \`start /b\`.${returnedInfo}`;
+    return `This tool executes a given shell command using PowerShell (\`powershell.exe\` or \`pwsh\`) with \`-NoProfile -Command <command>\`. Use PowerShell-compatible syntax: quote paths containing spaces with single quotes (for example, \`New-Item -ItemType Directory -Force -Path 'C:\\My Folder'\`) and represent an apostrophe inside a single-quoted path with two single quotes. Independent background processes can be started with \`Start-Process\`.${returnedInfo}`;
   }
   return `This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.${returnedInfo}`;
 }
@@ -345,7 +345,7 @@ export function getCommandDescription(): string {
     '\n*** WARNING: Command substitution using $(), `` ` ``, <(), or >() is not allowed for security reasons.';
   if (os.platform() === 'win32') {
     return (
-      'Exact command to execute as `cmd.exe /c <command>`' +
+      'Exact PowerShell command to execute with `-NoProfile -Command <command>` using `powershell.exe` or `pwsh`' +
       cmd_substitution_warning
     );
   }


### PR DESCRIPTION
## Summary

- align the Windows shell tool schema with the PowerShell runtime actually used by llxprt-code
- teach the model PowerShell-compatible quoting for paths with spaces and apostrophes
- replace cmd.exe background-process guidance with Start-Process
- add behavioral coverage for public schema guidance and unchanged mkdir/move command preparation

## Problem

The Windows shell runtime already launches powershell.exe or pwsh with -NoProfile -Command and passes the command as a single argument. The public tool schema still described cmd.exe /c and start /b, which could lead models to generate cmd-specific commands and quoting that PowerShell then rejected. This matches the failure reported in upstream google-gemini/gemini-cli issue 5228.

Upstream issue: https://github.com/google-gemini/gemini-cli/issues/5228

## Verification

- npm run format
- npm run lint
- npm run lint:eslint-guard
- npm run build
- npm run typecheck after build refreshed workspace declarations
- npm run test
- focused ShellTool schema and Windows shell execution tests: 83 passed
- deep technical review: no findings after remediation
- Open Code Review: 2 files reviewed, no comments

## Smoke test

The repository's documented node scripts/start.js entry point is absent, so the available bun scripts/start.ts entry point was used. Two ollamakimi attempts reached the provider but failed with a stream idle timeout before returning content. This is an external provider response failure; the complete local test, lint, typecheck, format, and build suites passed.
