### PR TITLE
Fix restored chat rendering one token per line with --continue (Fixes #2549)

### DIFF
--- a/packages/cli/src/ui/utils/iContentToHistoryItems.test.ts
+++ b/packages/cli/src/ui/utils/iContentToHistoryItems.test.ts
@@ -251,6 +251,53 @@ describe('iContentToHistoryItems', () => {
     );
   });
 
+  it('does not add blank lines after text fragments ending in newlines (#2549)', () => {
+    const input: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'text',
+            text: ['First line', ''].join(String.fromCharCode(10)),
+          },
+          {
+            type: 'text',
+            text: ['Second line', ''].join(String.fromCharCode(10)),
+          },
+        ],
+      },
+    ];
+
+    const output = iContentToHistoryItems(input);
+    expect(output).toHaveLength(1);
+    assertHasType(output[0], 'gemini');
+    expect(output[0].text).toBe(
+      ['First line', 'Second line', ''].join(String.fromCharCode(10)),
+    );
+  });
+
+  it('does not add a blank line before code when text supplies the newline (#2549)', () => {
+    const input: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'text',
+            text: ['Here is code:', ''].join(String.fromCharCode(10)),
+          },
+          { type: 'code', code: 'x=1', language: 'ts' },
+        ],
+      },
+    ];
+
+    const output = iContentToHistoryItems(input);
+    expect(output).toHaveLength(1);
+    assertHasType(output[0], 'gemini');
+    expect(output[0].text).toBe(
+      ['Here is code:', '```ts', 'x=1', '```'].join(String.fromCharCode(10)),
+    );
+  });
+
   it('silently drops tool response with no matching tool call', () => {
     const input: IContent[] = [
       {

--- a/packages/cli/src/ui/utils/iContentToHistoryItems.test.ts
+++ b/packages/cli/src/ui/utils/iContentToHistoryItems.test.ts
@@ -204,6 +204,53 @@ describe('iContentToHistoryItems', () => {
     });
   });
 
+  it('concatenates consecutive text blocks without newlines (#2549)', () => {
+    // A resumed AI turn can arrive as several fragmented text blocks (e.g. one
+    // per streamed token). They represent flowing prose, not separate lines.
+    // Separating them with newlines produced one-token-per-line rendering on
+    // restore, so consecutive text blocks must be concatenated directly.
+    const input: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          { type: 'text', text: 'The' },
+          { type: 'text', text: ' quick' },
+          { type: 'text', text: ' brown' },
+          { type: 'text', text: ' fox.' },
+        ],
+      },
+    ];
+
+    const output = iContentToHistoryItems(input);
+    expect(output).toHaveLength(1);
+    assertHasType(output[0], 'gemini');
+    expect(output[0].text).toBe('The quick brown fox.');
+    // No hard line breaks were inserted between the fragments.
+    expect(output[0].text).not.toContain(String.fromCharCode(10));
+  });
+
+  it('keeps text and code blocks on separate lines when fragmented (#2549)', () => {
+    // Text fragments still merge into flowing prose, but a code block remains a
+    // distinct block-level paragraph (its fence needs a surrounding newline).
+    const input: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          { type: 'text', text: 'Here' },
+          { type: 'text', text: ' is code:' },
+          { type: 'code', code: 'x=1', language: 'ts' },
+        ],
+      },
+    ];
+
+    const output = iContentToHistoryItems(input);
+    expect(output).toHaveLength(1);
+    assertHasType(output[0], 'gemini');
+    expect(output[0].text).toBe(
+      ['Here is code:', '```ts', 'x=1', '```'].join(String.fromCharCode(10)),
+    );
+  });
+
   it('silently drops tool response with no matching tool call', () => {
     const input: IContent[] = [
       {

--- a/packages/cli/src/ui/utils/iContentToHistoryItems.ts
+++ b/packages/cli/src/ui/utils/iContentToHistoryItems.ts
@@ -16,6 +16,8 @@ import {
   ToolCallStatus,
 } from '../types.js';
 
+const NEWLINE = String.fromCharCode(10);
+
 function safeToolResultToString(result: unknown): string {
   if (typeof result === 'string') {
     return result;
@@ -51,23 +53,54 @@ function buildResponseMap(
   return map;
 }
 
+/**
+ * Appends a text fragment to the running list of markdown segments. Adjacent
+ * text fragments are concatenated onto the trailing segment so they render as
+ * flowing prose (matching the live streaming path) instead of one line each.
+ */
+function appendTextSegment(segments: string[], text: string): void {
+  if (text === '') return;
+  const lastIndex = segments.length - 1;
+  if (
+    segments.length > 0 &&
+    !isCodeSegment(segments[lastIndex]) &&
+    !segments[lastIndex].endsWith(NEWLINE)
+  ) {
+    segments[lastIndex] += text;
+  } else {
+    segments.push(text);
+  }
+}
+
+/**
+ * A code block is emitted as a fenced markdown segment; detecting it lets us
+ * keep text flowing without merging into a fence.
+ */
+function isCodeSegment(segment: string): boolean {
+  return segment.startsWith('```');
+}
+
 function processAiContent(
   content: IContent,
   responseMap: Map<string, { result: unknown; error?: string }>,
   items: HistoryItem[],
   idCounter: { value: number },
 ): void {
-  const textParts: string[] = [];
+  const segments: string[] = [];
   const thinkingBlocks: ThinkingBlock[] = [];
   const toolCallBlocks: ToolCallBlock[] = [];
 
   for (const block of content.blocks) {
     switch (block.type) {
       case 'text':
-        textParts.push(block.text);
+        // Consecutive text blocks are fragments of the same flowing prose
+        // (e.g. per-streamed-token), so they are concatenated directly to
+        // match the live streaming path. Joining them with newlines caused a
+        // resumed conversation to render one token per line (#2549).
+        appendTextSegment(segments, block.text);
         break;
       case 'code':
-        textParts.push(`\`\`\`${block.language ?? ''}\n${block.code}\n\`\`\``);
+        segments.push(`\`\`\`${block.language ?? ''}\n${block.code}\n\`\`\``);
         break;
       case 'thinking':
         thinkingBlocks.push(block);
@@ -79,7 +112,7 @@ function processAiContent(
         break;
     }
   }
-  const combinedText = textParts.join('\n');
+  const combinedText = segments.join(NEWLINE);
 
   if (combinedText) {
     items.push({

--- a/packages/cli/src/ui/utils/iContentToHistoryItems.ts
+++ b/packages/cli/src/ui/utils/iContentToHistoryItems.ts
@@ -53,31 +53,29 @@ function buildResponseMap(
   return map;
 }
 
-/**
- * Appends a text fragment to the running list of markdown segments. Adjacent
- * text fragments are concatenated onto the trailing segment so they render as
- * flowing prose (matching the live streaming path) instead of one line each.
- */
-function appendTextSegment(segments: string[], text: string): void {
+interface MarkdownSegment {
+  kind: 'text' | 'code';
+  value: string;
+}
+
+function appendTextSegment(segments: MarkdownSegment[], text: string): void {
   if (text === '') return;
-  const lastIndex = segments.length - 1;
-  if (
-    segments.length > 0 &&
-    !isCodeSegment(segments[lastIndex]) &&
-    !segments[lastIndex].endsWith(NEWLINE)
-  ) {
-    segments[lastIndex] += text;
+  const lastSegment = segments.at(-1);
+  if (lastSegment?.kind === 'text') {
+    lastSegment.value += text;
   } else {
-    segments.push(text);
+    segments.push({ kind: 'text', value: text });
   }
 }
 
-/**
- * A code block is emitted as a fenced markdown segment; detecting it lets us
- * keep text flowing without merging into a fence.
- */
-function isCodeSegment(segment: string): boolean {
-  return segment.startsWith('```');
+function combineMarkdownSegments(segments: MarkdownSegment[]): string {
+  return segments.reduce((combined, segment) => {
+    const needsSeparator =
+      combined !== '' &&
+      !combined.endsWith(NEWLINE) &&
+      !segment.value.startsWith(NEWLINE);
+    return combined + (needsSeparator ? NEWLINE : '') + segment.value;
+  }, '');
 }
 
 function processAiContent(
@@ -86,21 +84,20 @@ function processAiContent(
   items: HistoryItem[],
   idCounter: { value: number },
 ): void {
-  const segments: string[] = [];
+  const segments: MarkdownSegment[] = [];
   const thinkingBlocks: ThinkingBlock[] = [];
   const toolCallBlocks: ToolCallBlock[] = [];
 
   for (const block of content.blocks) {
     switch (block.type) {
       case 'text':
-        // Consecutive text blocks are fragments of the same flowing prose
-        // (e.g. per-streamed-token), so they are concatenated directly to
-        // match the live streaming path. Joining them with newlines caused a
-        // resumed conversation to render one token per line (#2549).
         appendTextSegment(segments, block.text);
         break;
       case 'code':
-        segments.push(`\`\`\`${block.language ?? ''}\n${block.code}\n\`\`\``);
+        segments.push({
+          kind: 'code',
+          value: `\`\`\`${block.language ?? ''}\n${block.code}\n\`\`\``,
+        });
         break;
       case 'thinking':
         thinkingBlocks.push(block);
@@ -112,7 +109,7 @@ function processAiContent(
         break;
     }
   }
-  const combinedText = segments.join(NEWLINE);
+  const combinedText = combineMarkdownSegments(segments);
 
   if (combinedText) {
     items.push({


### PR DESCRIPTION
## Summary

Resuming a conversation with `llxprt --continue` rendered the restored chat with approximately **one token per line**, producing an extremely tall, unreadable column of single words. This fixes #2549.

## Root cause

When a session is resumed, the recorded `IContent[]` is converted to UI `HistoryItem[]` by `iContentToHistoryItems` (`packages/cli/src/ui/utils/iContentToHistoryItems.ts`). For an AI turn, the previous implementation collected every text block into an array and joined them with a newline:

```ts
const textParts: string[] = [];
// ... case 'text': textParts.push(block.text);
const combinedText = textParts.join('\n');
```

A resumed AI turn can arrive as **many fragmented text blocks** (e.g. one per streamed token, or one per provider chunk). Joining each fragment with a newline turned every fragment into its own line, so the restored chat rendered one token per line.

This is an asymmetry with the **live streaming path**, which accumulates text fragments by direct concatenation with no separator (`packages/cli/src/ui/hooks/agentStream/contentEventProcessor.ts`):

```ts
const combined = currentAiMessageBuffer + eventValue;
```

So live text always renders as flowing prose, but restored text did not.

## The fix

`processAiContent` now builds markdown **segments** instead of a flat `textParts` array:

- **Consecutive text blocks** are concatenated onto the trailing segment as flowing prose (matching the live path), via the new `appendTextSegment` helper.
- **Code blocks** remain separate segments, so the final `segments.join(NEWLINE)` keeps code fences as distinct block-level paragraphs (preserving the existing text + code + text behavior and its test).

This means fragmented text renders identically whether it was produced live or restored via `--continue`.

## Reproduction proof

A temporary real-Ink repro (run with the ink-stub bypassed) confirmed the bug and the fix. Before the fix, an AI turn with fragmented text blocks rendered each token on its own line. After the fix, the same input renders as wrapped prose across the normal chat width.

## Tests

Added two regression tests to `packages/cli/src/ui/utils/iContentToHistoryItems.test.ts` (test-first: both failed before the fix, pass after):

- `concatenates consecutive text blocks without newlines (#2549)` -- fragmented text blocks merge into flowing prose with no hard line breaks.
- `keeps text and code blocks on separate lines when fragmented (#2549)` -- text fragments still merge, but a code block remains a distinct paragraph.

## Verification

- `npm run test` (all workspaces): green
- `npm run lint` / `npm run lint:eslint-guard`: clean (no lint/complexity rules loosened)
- `npm run typecheck`: changed files clean (only pre-existing, unrelated packages/mcp errors remain)
- `npm run format`: applied
- `npm run build`: green
- Smoke: `bun scripts/start.ts --profile-load ollamakimi "write me a haiku and nothing else"`: green
- Open Code Review (ocr): 1 finding (use NEWLINE constant consistently in the final join) -- addressed.

Fixes #2549
