### PR TITLE
Keep Codex provider identity coherent during startup (Fixes #2544)

### DIFF
--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -27,6 +27,10 @@ import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
 import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
+import {
+  buildEffectiveModelIdentity,
+  type EffectiveModelIdentity,
+} from './modelInfoHelpers.js';
 
 const mockTurnRun = vi.fn();
 
@@ -55,19 +59,21 @@ import {
 } from './MessageStreamOrchestrator.js';
 
 interface HarnessState {
-  model: string;
-  providerName?: string;
+  identity: EffectiveModelIdentity;
   profileName?: string | null;
-  providerManagerDefaultModel?: string;
-  providerManagerActiveModel?: string;
   lastPromptId?: string;
-  currentSequenceModel: string | null;
   contextLimit?: number;
 }
 
-interface BuildOptions extends Partial<HarnessState> {
+interface BuildOptions {
+  providerName?: string;
+  model?: string;
+  profileName?: string | null;
+  lastPromptId?: string;
+  contextLimit?: number;
   /** Override the stream produced by Turn.run */
   turnStream?: AsyncGenerator<ServerAgentStreamEvent>;
+  identityProvider?: () => EffectiveModelIdentity;
 }
 
 function buildOrchestrator(options: BuildOptions = {}): {
@@ -75,13 +81,12 @@ function buildOrchestrator(options: BuildOptions = {}): {
   state: HarnessState;
 } {
   const state: HarnessState = {
-    model: options.model ?? 'gpt-4',
-    providerName: options.providerName,
+    identity: {
+      providerName: options.providerName ?? 'openai',
+      model: options.model ?? 'gpt-4',
+    },
     profileName: options.profileName ?? null,
-    providerManagerDefaultModel: options.providerManagerDefaultModel,
-    providerManagerActiveModel: options.providerManagerActiveModel,
     lastPromptId: options.lastPromptId,
-    currentSequenceModel: options.currentSequenceModel ?? null,
     contextLimit: options.contextLimit,
   };
 
@@ -91,23 +96,9 @@ function buildOrchestrator(options: BuildOptions = {}): {
     getHistory: vi.fn().mockReturnValue([]),
   };
 
-  const providerManager = {
-    getActiveProviderName: vi.fn(() => state.providerName ?? ''),
-    getActiveProvider: vi.fn(() => ({
-      name: state.providerName ?? 'openai',
-      getCurrentModel: vi.fn(() => state.providerManagerActiveModel ?? ''),
-      getDefaultModel: vi.fn(() => state.providerManagerDefaultModel ?? ''),
-    })),
-  };
-
   const config = {
-    getContentGeneratorConfig: vi.fn(() => ({
-      providerManager,
-      model: state.model,
-    })),
     getMaxSessionTurns: vi.fn(() => 0),
     getIdeMode: vi.fn(() => false),
-    getModel: vi.fn(() => state.model),
     getEphemeralSetting: vi.fn((key: string) =>
       key === 'context-limit' ? state.contextLimit : undefined,
     ),
@@ -130,6 +121,8 @@ function buildOrchestrator(options: BuildOptions = {}): {
     })();
 
   mockTurnRun.mockReturnValue(stream);
+
+  const identityFn = options.identityProvider ?? (() => state.identity);
 
   const deps: MessageStreamDeps = {
     config,
@@ -180,10 +173,7 @@ function buildOrchestrator(options: BuildOptions = {}): {
       fireBeforeAgentHookSafe: vi.fn().mockResolvedValue(undefined),
       fireAfterAgentHookSafe: vi.fn().mockResolvedValue(undefined),
     } as unknown as MessageStreamDeps['agentHookManager'],
-    getEffectiveModel: () => {
-      if (state.currentSequenceModel) return state.currentSequenceModel;
-      return state.model;
-    },
+    getEffectiveModelIdentity: identityFn,
     getHistory: vi.fn().mockResolvedValue([]),
     getSessionTurnCount: vi.fn().mockReturnValue(1),
     incrementSessionTurnCount: vi.fn(),
@@ -206,9 +196,7 @@ function buildOrchestrator(options: BuildOptions = {}): {
     setLastPromptId: (id: string) => {
       state.lastPromptId = id;
     },
-    resetCurrentSequenceModel: () => {
-      state.currentSequenceModel = null;
-    },
+    resetCurrentSequenceModel: vi.fn(),
     updateTelemetryTokenCount: vi.fn(),
     sendMessageStream: vi.fn(),
   };
@@ -274,9 +262,10 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
     state.lastPromptId = 'prompt-1';
 
     // Now simulate a model change during a continuation (same prompt id)
-    state.model = 'claude-3';
-    state.providerName = 'anthropic';
-    state.currentSequenceModel = 'claude-3';
+    state.identity = {
+      providerName: 'anthropic',
+      model: 'claude-3',
+    };
 
     // Re-enter execute with the SAME prompt id (continuation/retry)
     const infos = await collectModelInfos(orchestrator, 'prompt-1');
@@ -323,38 +312,6 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
     expect(infos).toHaveLength(1);
     expect(infos[0]?.profileName).toBe('profile-b');
     expect(infos[0]?.displayLabel).toBe('profile-b:gpt-4');
-  });
-
-  it('prefers provider manager active model over config.getModel', async () => {
-    const { orchestrator } = buildOrchestrator({
-      model: 'config-model',
-      providerName: 'openai',
-      providerManagerActiveModel: 'provider-active-model',
-    });
-
-    const infos = await collectModelInfos(orchestrator, 'prompt-new');
-
-    expect(infos).toHaveLength(1);
-    // The ModelInfo should reflect provider manager active model,
-    // not the config model
-    expect(infos[0]?.model).toBe('provider-active-model');
-  });
-
-  it('does not report provider defaults as the active model when a user-selected provider model exists', async () => {
-    const { orchestrator } = buildOrchestrator({
-      model: 'selected-provider-model',
-      providerName: 'Makora',
-      providerManagerDefaultModel: 'nvidia/Kimi-K2.6-NVFP4',
-      providerManagerActiveModel: 'zai-org/GLM-5.1-FP8',
-    });
-
-    const infos = await collectModelInfos(
-      orchestrator,
-      'prompt-selected-model',
-    );
-
-    expect(infos).toHaveLength(1);
-    expect(infos[0]?.model).toBe('zai-org/GLM-5.1-FP8');
   });
 
   it('restores all committed previous history when initializing the next chat', async () => {
@@ -404,10 +361,9 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
 
   it('B1: load-balancer profile reports the active sub-profile model, not the config default', async () => {
     const { orchestrator } = buildOrchestrator({
-      model: 'gemini-2.5-pro',
+      model: 'glm-5.2',
       providerName: 'load-balancer',
       profileName: 'glm',
-      providerManagerActiveModel: 'glm-5.2',
     });
 
     const infos = await collectModelInfos(orchestrator, 'prompt-lb-active');
@@ -417,23 +373,6 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
     expect(infos[0]?.providerName).toBe('load-balancer');
     expect(infos[0]?.profileName).toBe('glm');
     expect(infos[0]?.displayLabel).toBe('glm:glm-5.2');
-  });
-
-  it('B2: load-balancer profile with no active selection falls back to the provider default model, never the config Gemini default', async () => {
-    const { orchestrator } = buildOrchestrator({
-      model: 'gemini-2.5-pro',
-      providerName: 'load-balancer',
-      profileName: 'glm',
-      providerManagerActiveModel: '',
-      providerManagerDefaultModel: 'glm-5.2',
-    });
-
-    const infos = await collectModelInfos(orchestrator, 'prompt-lb-default');
-
-    expect(infos).toHaveLength(1);
-    expect(infos[0]?.model).toBe('glm-5.2');
-    expect(infos[0]?.displayLabel).toBe('glm:glm-5.2');
-    expect(infos[0]?.model).not.toBe('gemini-2.5-pro');
   });
 
   it('displayLabel shows profile:model when a profile is active (issue #2501)', async () => {
@@ -464,5 +403,147 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
 
     expect(infos).toHaveLength(1);
     expect(infos[0]?.displayLabel).toBe('gpt-5.6-sol');
+  });
+
+  it('issue #2544: reports the routed Codex identity, never a stale manager Gemini identity', async () => {
+    const { orchestrator } = buildOrchestrator({
+      model: 'gpt-5.6-sol',
+      providerName: 'codex',
+      profileName: null,
+    });
+
+    const infos = await collectModelInfos(orchestrator, 'prompt-2544');
+
+    expect(infos).toHaveLength(1);
+    expect(infos[0]?.providerName).toBe('codex');
+    expect(infos[0]?.model).toBe('gpt-5.6-sol');
+    expect(infos[0]?.displayLabel).toBe('gpt-5.6-sol');
+  });
+});
+
+describe('buildEffectiveModelIdentity — model precedence (issue #2544)', () => {
+  it('prefers currentSequenceModel, then routed getCurrentModel, then routed getDefaultModel, then config fallback', () => {
+    const routedProvider = {
+      name: 'codex',
+      getCurrentModel: () => 'routed-current',
+      getDefaultModel: () => 'routed-default',
+    };
+    expect(
+      buildEffectiveModelIdentity('codex', routedProvider, 'seq', 'fallback')
+        .model,
+    ).toBe('seq');
+    expect(
+      buildEffectiveModelIdentity('codex', routedProvider, null, 'fallback')
+        .model,
+    ).toBe('routed-current');
+  });
+
+  it('falls back to routed getDefaultModel when getCurrentModel is blank, then config fallback', () => {
+    const blankCurrent = {
+      name: 'codex',
+      getCurrentModel: () => '',
+      getDefaultModel: () => 'routed-default',
+    };
+    expect(
+      buildEffectiveModelIdentity('codex', blankCurrent, null, 'fallback')
+        .model,
+    ).toBe('routed-default');
+    const blankAll = {
+      name: 'codex',
+      getCurrentModel: () => '',
+      getDefaultModel: () => '',
+    };
+    expect(
+      buildEffectiveModelIdentity('codex', blankAll, null, 'config-fallback')
+        .model,
+    ).toBe('config-fallback');
+  });
+
+  it('returns the config fallback and routed provider name when the routed provider is undefined', () => {
+    const identity = buildEffectiveModelIdentity(
+      'codex',
+      undefined,
+      null,
+      'config-fallback',
+    );
+    expect(identity.model).toBe('config-fallback');
+    expect(identity.providerName).toBe('codex');
+  });
+
+  it('issue #2544: never mixes a stale manager model with a routed provider name', () => {
+    const routedCodexProvider = {
+      name: 'codex',
+      getCurrentModel: () => 'gpt-5.6-sol',
+      getDefaultModel: () => 'gpt-5.6-sol',
+    };
+    const identity = buildEffectiveModelIdentity(
+      'codex',
+      routedCodexProvider,
+      null,
+      'gemini-pro',
+    );
+    expect(identity.providerName).toBe('codex');
+    expect(identity.model).toBe('gpt-5.6-sol');
+    expect(identity.model).not.toBe('gemini-pro');
+  });
+
+  it('does not evaluate provider models when the sequence model is available', () => {
+    const routedProvider = {
+      name: 'codex',
+      getCurrentModel: () => {
+        throw new Error('should not run');
+      },
+      getDefaultModel: () => {
+        throw new Error('should not run');
+      },
+    };
+
+    expect(
+      buildEffectiveModelIdentity(
+        'codex',
+        routedProvider,
+        'sequence',
+        'fallback',
+      ).model,
+    ).toBe('sequence');
+  });
+
+  it('uses the default model when the current model accessor fails', () => {
+    const routedProvider = {
+      name: 'codex',
+      getCurrentModel: () => {
+        throw new Error('unavailable');
+      },
+      getDefaultModel: () => 'routed-default',
+    };
+
+    expect(
+      buildEffectiveModelIdentity('codex', routedProvider, null, 'fallback')
+        .model,
+    ).toBe('routed-default');
+  });
+
+  it('issue #1770 load-balancer: current selection wins over default', () => {
+    const routedProvider = {
+      name: 'Makora',
+      getCurrentModel: () => 'zai-org/GLM-5.1-FP8',
+      getDefaultModel: () => 'nvidia/Kimi-K2.6-NVFP4',
+    };
+    expect(
+      buildEffectiveModelIdentity('Makora', routedProvider, null, 'default')
+        .model,
+    ).toBe('zai-org/GLM-5.1-FP8');
+  });
+
+  it('issue #1770 load-balancer: default wins when no active selection', () => {
+    const routedProvider = {
+      name: 'Makora',
+      getCurrentModel: () => '',
+      getDefaultModel: () => 'nvidia/Kimi-K2.6-NVFP4',
+    };
+    expect(
+      buildEffectiveModelIdentity('Makora', routedProvider, null, 'default')
+        .model,
+    ).toBe('nvidia/Kimi-K2.6-NVFP4');
   });
 });

--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -253,24 +253,22 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
   });
 
   it('emits exactly one ModelInfo on a continuation when model identity changes', async () => {
-    const { orchestrator, state } = buildOrchestrator({
-      model: 'gpt-4',
+    let identity: EffectiveModelIdentity = {
       providerName: 'openai',
+      model: 'gpt-4',
+    };
+    const { orchestrator, state } = buildOrchestrator({
+      identityProvider: () => identity,
     });
 
-    // Simulate the first prompt already completed (lastPromptId is set)
     state.lastPromptId = 'prompt-1';
-
-    // Now simulate a model change during a continuation (same prompt id)
-    state.identity = {
+    identity = {
       providerName: 'anthropic',
       model: 'claude-3',
     };
 
-    // Re-enter execute with the SAME prompt id (continuation/retry)
     const infos = await collectModelInfos(orchestrator, 'prompt-1');
 
-    // Should emit exactly one ModelInfo for the changed identity
     expect(infos).toHaveLength(1);
     expect(infos[0]?.model).toBe('claude-3');
     expect(infos[0]?.providerName).toBe('anthropic');

--- a/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
@@ -232,7 +232,10 @@ function buildOrchestrator(options: BuildOptions = {}): {
         .fn()
         .mockResolvedValue(blockingAfterHookOutput),
     } as unknown as MessageStreamDeps['agentHookManager'],
-    getEffectiveModel: () => 'gpt-4',
+    getEffectiveModelIdentity: () => ({
+      providerName: 'openai',
+      model: 'gpt-4',
+    }),
     getHistory: vi.fn().mockResolvedValue([]),
     getSessionTurnCount: vi.fn().mockReturnValue(1),
     incrementSessionTurnCount: vi.fn(),

--- a/packages/agents/src/core/MessageStreamOrchestrator.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.ts
@@ -18,7 +18,7 @@ import {
 import {
   buildModelInfo,
   modelIdentityKey,
-  resolveProviderName,
+  type EffectiveModelIdentity,
 } from './modelInfoHelpers.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
@@ -51,7 +51,7 @@ export interface MessageStreamDeps {
   todoContinuationService: TodoContinuationService;
   ideContextTracker: IdeContextTracker;
   agentHookManager: AgentHookManager;
-  getEffectiveModel: () => string;
+  getEffectiveModelIdentity: () => EffectiveModelIdentity;
   getHistory: () => Promise<IContent[]>;
   getSessionTurnCount: () => number;
   incrementSessionTurnCount: () => void;
@@ -267,7 +267,7 @@ export class MessageStreamOrchestrator {
     initialRequest: AgentMessageInput,
     ctx: StreamContext,
   ): AsyncGenerator<ServerAgentStreamEvent, Turn | undefined> {
-    const { config, getChat, getSessionTurnCount, getEffectiveModel } =
+    const { config, getChat, getSessionTurnCount, getEffectiveModelIdentity } =
       this.deps;
 
     if (
@@ -296,8 +296,9 @@ export class MessageStreamOrchestrator {
     }
 
     const chat = getChat();
+    const effectiveIdentity = getEffectiveModelIdentity();
     const remainingTokenCount =
-      getTokenLimitForConfiguredContext(getEffectiveModel(), config) -
+      getTokenLimitForConfiguredContext(effectiveIdentity.model, config) -
       chat.getLastPromptTokenCount();
 
     // When history already exceeds the current model's limit (e.g. after a
@@ -837,11 +838,14 @@ export class MessageStreamOrchestrator {
   }
 
   private _getProviderName(): string {
-    return resolveProviderName(this.deps.config);
+    return this.deps.getEffectiveModelIdentity().providerName;
   }
 
   private _buildModelInfo(): ModelInfo {
-    return buildModelInfo(this.deps.config, this.deps.getEffectiveModel());
+    return buildModelInfo(
+      this.deps.config,
+      this.deps.getEffectiveModelIdentity(),
+    );
   }
 
   private *_modelInfoEvents(force: boolean): Generator<ServerAgentStreamEvent> {

--- a/packages/agents/src/core/client.model-profile.test.ts
+++ b/packages/agents/src/core/client.model-profile.test.ts
@@ -501,7 +501,7 @@ describe('AgentClient (client.ts)', () => {
       expect(infos[0]?.model).toBe('test-model');
     });
 
-    it('emits exactly one additional ModelInfo when provider changes during continuation', async () => {
+    it('keeps the routed provider stable during continuation', async () => {
       const mockStream2 = (async function* () {
         yield { type: AgentEventType.Content, value: 'ok' };
         yield { type: AgentEventType.Finished, value: { reason: 'STOP' } };
@@ -567,12 +567,8 @@ describe('AgentClient (client.ts)', () => {
 
       getContentGenSpy.mockRestore();
 
-      // First emission (provider 'backend' — no providerManager), then one
-      // additional for provider change to 'anthropic' — exactly one, not
-      // duplicates.
-      expect(infos).toHaveLength(2);
-      expect(infos[0]?.providerName).toBe('backend');
-      expect(infos[1]?.providerName).toBe('anthropic');
+      expect(infos).toHaveLength(1);
+      expect(infos[0]?.providerName).toBe('gemini');
     });
   });
 });

--- a/packages/agents/src/core/client.sendMessageStream-errors.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-errors.test.ts
@@ -266,7 +266,7 @@ describe('Gemini Client (client.ts)', () => {
           type: AgentEventType.ModelInfo,
           value: {
             model: 'test-model',
-            providerName: 'backend',
+            providerName: 'gemini',
             profileName: null,
             displayLabel: 'test-model',
           },
@@ -338,7 +338,7 @@ describe('Gemini Client (client.ts)', () => {
           type: AgentEventType.ModelInfo,
           value: {
             model: 'test-model',
-            providerName: 'backend',
+            providerName: 'gemini',
             profileName: null,
             displayLabel: 'test-model',
           },

--- a/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
@@ -792,7 +792,7 @@ describe('AgentClient (client.ts)', () => {
           type: AgentEventType.ModelInfo,
           value: {
             model: 'test-model',
-            providerName: 'backend',
+            providerName: 'gemini',
             profileName: null,
             displayLabel: 'test-model',
           },
@@ -861,7 +861,7 @@ describe('AgentClient (client.ts)', () => {
           type: AgentEventType.ModelInfo,
           value: {
             model: 'test-model',
-            providerName: 'backend',
+            providerName: 'gemini',
             profileName: null,
             displayLabel: 'test-model',
           },
@@ -934,7 +934,7 @@ describe('AgentClient (client.ts)', () => {
           type: AgentEventType.ModelInfo,
           value: {
             model: 'test-model',
-            providerName: 'backend',
+            providerName: 'gemini',
             profileName: null,
             displayLabel: 'test-model',
           },

--- a/packages/agents/src/core/client.sendMessageStream.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream.test.ts
@@ -676,7 +676,7 @@ describe('Gemini Client (client.ts)', () => {
           type: AgentEventType.ModelInfo,
           value: {
             model: 'test-model',
-            providerName: 'backend',
+            providerName: 'gemini',
             profileName: null,
             displayLabel: 'test-model',
           },

--- a/packages/agents/src/core/client.ts
+++ b/packages/agents/src/core/client.ts
@@ -69,6 +69,11 @@ import {
   MessageStreamOrchestrator,
   type MessageStreamDeps,
 } from './MessageStreamOrchestrator.js';
+import {
+  buildEffectiveModelIdentity,
+  type EffectiveModelIdentity,
+  type RoutedModelProvider,
+} from './modelInfoHelpers.js';
 
 export class AgentClient implements AgentClientContract {
   private chat?: ChatSession;
@@ -200,7 +205,7 @@ export class AgentClient implements AgentClientContract {
       todoContinuationService: this.todoContinuationService,
       ideContextTracker: this.ideContextTracker,
       agentHookManager: this.agentHookManager,
-      getEffectiveModel: () => this._getEffectiveModelForCurrentTurn(),
+      getEffectiveModelIdentity: () => this._getEffectiveModelIdentity(),
       getHistory: () => this.getHistory(),
       getSessionTurnCount: () => this.sessionTurnCount,
       incrementSessionTurnCount: () => {
@@ -700,14 +705,32 @@ export class AgentClient implements AgentClientContract {
     return chat;
   }
 
-  private _getEffectiveModelForCurrentTurn(): string {
-    if (this.currentSequenceModel) {
-      return this.currentSequenceModel;
+  private _getEffectiveModelIdentity(): EffectiveModelIdentity {
+    const configFallback = this.config.getModel();
+    const runtimeProviderName = this.runtimeState.provider;
+    let routedProviderName = runtimeProviderName;
+    let routedProvider: RoutedModelProvider | undefined = undefined;
+    if (
+      this.chat &&
+      typeof this.chat.resolveProviderForRuntime === 'function'
+    ) {
+      try {
+        const provider = this.chat.resolveProviderForRuntime(
+          'AgentClient.getEffectiveModelIdentity',
+        );
+        routedProviderName = provider.name;
+        routedProvider = provider;
+      } catch {
+        routedProviderName = runtimeProviderName;
+        routedProvider = undefined;
+      }
     }
-
-    // In LLxprt, config.getModel() already handles provider-specific model resolution
-    // and fallback mode, so we just return it directly
-    return this.config.getModel();
+    return buildEffectiveModelIdentity(
+      routedProviderName,
+      routedProvider,
+      this.currentSequenceModel,
+      configFallback,
+    );
   }
 
   async *sendMessageStream(

--- a/packages/agents/src/core/modelInfoHelpers.ts
+++ b/packages/agents/src/core/modelInfoHelpers.ts
@@ -8,20 +8,52 @@ import { AgentEventType } from '@vybestack/llxprt-code-core/core/turn.js';
 import type { ServerAgentStreamEvent } from '@vybestack/llxprt-code-core/core/turn.js';
 import type { ModelInfo } from './turn.js';
 
-/** Resolves the effective model from the active provider or falls back. */
-export function resolveActiveModel(config: Config, fallback: string): string {
-  const activeProvider = config
-    .getContentGeneratorConfig()
-    ?.providerManager?.getActiveProvider();
-  if (activeProvider) {
-    const activeModel = activeProvider.getCurrentModel?.();
-    if (typeof activeModel === 'string' && activeModel.trim() !== '')
-      return activeModel;
-    const defaultModel = activeProvider.getDefaultModel?.();
-    if (typeof defaultModel === 'string' && defaultModel.trim() !== '')
-      return defaultModel;
+export interface EffectiveModelIdentity {
+  readonly providerName: string;
+  readonly model: string;
+}
+
+export type RoutedModelProvider = {
+  readonly name: string;
+  readonly getCurrentModel?: () => string | undefined;
+  readonly getDefaultModel?: () => string | undefined;
+};
+
+function nonBlank(value: string | null | undefined): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+function readModel(
+  getModel: (() => string | undefined) | undefined,
+): string | undefined {
+  try {
+    return nonBlank(getModel?.());
+  } catch {
+    return undefined;
   }
-  return fallback;
+}
+
+export function buildEffectiveModelIdentity(
+  routedProviderName: string,
+  routedProvider: RoutedModelProvider | undefined,
+  currentSequenceModel: string | null,
+  configFallback: string,
+): EffectiveModelIdentity {
+  const sequenceModel = nonBlank(currentSequenceModel);
+  if (sequenceModel) {
+    return { providerName: routedProviderName, model: sequenceModel };
+  }
+
+  const currentModel = readModel(() => routedProvider?.getCurrentModel?.());
+  if (currentModel) {
+    return { providerName: routedProviderName, model: currentModel };
+  }
+
+  const defaultModel = readModel(() => routedProvider?.getDefaultModel?.());
+  return {
+    providerName: routedProviderName,
+    model: defaultModel ?? configFallback,
+  };
 }
 
 /** Resolves the current profile name from the config's settings service. */
@@ -46,27 +78,19 @@ export function resolveProfileName(config: Config): string | null {
   return null;
 }
 
-/** Resolves the provider name from config. */
-export function resolveProviderName(config: Config): string {
-  const activeName = config
-    .getContentGeneratorConfig()
-    ?.providerManager?.getActiveProviderName();
-  return activeName && activeName.length > 0 ? activeName : 'backend';
-}
-
-/** Builds the full ModelInfo from config. */
 export function buildModelInfo(
   config: Config,
-  fallbackModel: string,
+  identity: EffectiveModelIdentity,
 ): ModelInfo {
-  const model = resolveActiveModel(config, fallbackModel);
   const profileName = resolveProfileName(config);
   return {
-    model,
-    providerName: resolveProviderName(config),
+    model: identity.model,
+    providerName: identity.providerName,
     profileName,
     displayLabel:
-      profileName && profileName !== '' ? `${profileName}:${model}` : model,
+      profileName && profileName !== ''
+        ? `${profileName}:${identity.model}`
+        : identity.model,
   };
 }
 
@@ -82,10 +106,10 @@ export function modelIdentityKey(info: ModelInfo): string {
 /** Emits a ModelInfo event for a new sequence (always emitted). */
 export async function* emitModelInfoForNewSequence(
   config: Config,
-  fallbackModel: string,
+  identity: EffectiveModelIdentity,
 ): AsyncGenerator<ServerAgentStreamEvent, void> {
   yield {
     type: AgentEventType.ModelInfo,
-    value: buildModelInfo(config, fallbackModel),
+    value: buildModelInfo(config, identity),
   };
 }

--- a/packages/agents/src/core/preflightRecovery.ts
+++ b/packages/agents/src/core/preflightRecovery.ts
@@ -19,7 +19,10 @@ const CONTEXT_OVERFLOW_THRESHOLD = 0.95;
 
 export interface PreflightOverflowDeps {
   getChat: () => ChatSession;
-  getEffectiveModel: () => string;
+  getEffectiveModelIdentity: () => {
+    readonly providerName: string;
+    readonly model: string;
+  };
   config: Config;
   logger: DebugLogger;
 }
@@ -55,7 +58,7 @@ export async function resolvePreflightOverflow(
     return true;
   }
 
-  const { getChat, getEffectiveModel, config, logger } = deps;
+  const { getChat, getEffectiveModelIdentity, config, logger } = deps;
   const chat = getChat();
   try {
     const result = await chat.performCompression(ctx.promptId, {
@@ -74,8 +77,10 @@ export async function resolvePreflightOverflow(
     // estimate when compression just nulled lastPromptTokenCount) — NOT
     // getLastPromptTokenCount(), which returns 0 right after compression.
     const newRemaining =
-      getTokenLimitForConfiguredContext(getEffectiveModel(), config) -
-      chat.getProjectedPromptBaseline();
+      getTokenLimitForConfiguredContext(
+        getEffectiveModelIdentity().model,
+        config,
+      ) - chat.getProjectedPromptBaseline();
     if (newRemaining <= 0) {
       return true;
     }

--- a/packages/providers/src/runtime/runtimeAccessors.spec.ts
+++ b/packages/providers/src/runtime/runtimeAccessors.spec.ts
@@ -95,16 +95,7 @@ describe('runtimeAccessors', () => {
         isPaidMode: vi.fn().mockReturnValue(false),
       }),
       getActiveProviderName: vi.fn().mockReturnValue('openai'),
-      getProviderByName: vi.fn().mockImplementation((name: string) => {
-        if (name === 'openai') {
-          return {
-            name: 'openai',
-            getDefaultModel: vi.fn().mockReturnValue('gpt-4'),
-            isPaidMode: vi.fn().mockReturnValue(false),
-          };
-        }
-        return undefined;
-      }),
+      getProviderByName: vi.fn().mockReturnValue(undefined),
       listProviders: vi.fn().mockReturnValue(['openai', 'anthropic']),
       getProviderMetrics: vi.fn().mockReturnValue({}),
       getSessionTokenUsage: vi.fn().mockReturnValue({
@@ -403,6 +394,7 @@ describe('runtimeAccessors', () => {
       const status = getActiveProviderStatus();
 
       expect(status.providerName).toBeNull();
+      expect(status.modelName).toBeNull();
       expect(status.isPaidMode).toBeUndefined();
       expect(status.baseURL).toBeUndefined();
       expect(status.displayLabel).toBe('unknown');
@@ -446,6 +438,7 @@ describe('runtimeAccessors', () => {
       const status = getActiveProviderStatus();
 
       expect(status.providerName).toBe('gemini');
+      expect(status.modelName).toBe('gemini-2.5-pro');
       expect(status.isPaidMode).toBe(true);
       expect(status.baseURL).toBeUndefined();
     });

--- a/packages/providers/src/runtime/runtimeAccessors.spec.ts
+++ b/packages/providers/src/runtime/runtimeAccessors.spec.ts
@@ -19,6 +19,7 @@ import { configureCliStatelessHardening } from './statelessHardening.js';
 import { setCliRuntimeContext } from './runtimeLifecycle.js';
 import type {
   Config,
+  RuntimeProvider,
   RuntimeProviderManager,
 } from '@vybestack/llxprt-code-core';
 import type { OAuthManager } from '../auth/index.js';
@@ -94,6 +95,16 @@ describe('runtimeAccessors', () => {
         isPaidMode: vi.fn().mockReturnValue(false),
       }),
       getActiveProviderName: vi.fn().mockReturnValue('openai'),
+      getProviderByName: vi.fn().mockImplementation((name: string) => {
+        if (name === 'openai') {
+          return {
+            name: 'openai',
+            getDefaultModel: vi.fn().mockReturnValue('gpt-4'),
+            isPaidMode: vi.fn().mockReturnValue(false),
+          };
+        }
+        return undefined;
+      }),
       listProviders: vi.fn().mockReturnValue(['openai', 'anthropic']),
       getProviderMetrics: vi.fn().mockReturnValue({}),
       getSessionTokenUsage: vi.fn().mockReturnValue({
@@ -231,6 +242,212 @@ describe('runtimeAccessors', () => {
       expect(status).toHaveProperty('providerName');
       expect(status).toHaveProperty('modelName');
       expect(status).toHaveProperty('displayLabel');
+    });
+  });
+  describe('getActiveProviderStatus provider resolution', () => {
+    type StubProvider = RuntimeProvider & {
+      getBaseURL?: () => string | undefined;
+    };
+
+    const makeProvider = (opts: {
+      name: string;
+      defaultModel?: string;
+      paid?: boolean;
+      baseURL?: string;
+      throwing?: 'isPaidMode' | 'getBaseURL';
+    }): StubProvider => ({
+      name: opts.name,
+      getDefaultModel: () => opts.defaultModel ?? 'model',
+      isPaidMode:
+        opts.throwing === 'isPaidMode'
+          ? () => {
+              throw new Error('boom');
+            }
+          : () => opts.paid ?? false,
+      getModels: () => Promise.resolve([]),
+      getServerTools: () => [],
+      invokeServerTool: () => Promise.resolve(undefined),
+      async *generateChatCompletion() {},
+      ...(opts.baseURL !== undefined
+        ? {
+            getBaseURL:
+              opts.throwing === 'getBaseURL'
+                ? () => {
+                    throw new Error('boom');
+                  }
+                : () => opts.baseURL,
+          }
+        : {}),
+    });
+
+    const configureFor = (opts: {
+      providerName?: string;
+      activeProvider?: string;
+      model?: string;
+      providerSettingsModel?: string;
+    }): void => {
+      vi.mocked(mockConfig.getProvider).mockReturnValue(
+        opts.providerName ?? '',
+      );
+      vi.mocked(mockConfig.getModel).mockReturnValue(opts.model ?? '');
+      vi.mocked(mockSettingsService.get).mockImplementation((key: string) =>
+        key === 'activeProvider'
+          ? (opts.activeProvider ?? opts.providerName)
+          : undefined,
+      );
+      vi.mocked(mockSettingsService.getProviderSettings).mockReturnValue(
+        opts.providerSettingsModel !== undefined
+          ? { model: opts.providerSettingsModel }
+          : {},
+      );
+      setupCompleteRuntime();
+    };
+
+    beforeEach(() => {
+      vi.mocked(mockRuntimeProviderManager.getActiveProvider).mockReturnValue(
+        makeProvider({
+          name: 'gemini',
+          defaultModel: 'gemini-2.5-pro',
+          paid: true,
+          baseURL: 'https://gemini.example/v1',
+        }),
+      );
+      vi.mocked(
+        mockRuntimeProviderManager.getActiveProviderName,
+      ).mockReturnValue('gemini');
+      vi.mocked(
+        mockRuntimeProviderManager.getProviderByName,
+      ).mockImplementation((name: string) => {
+        if (name === 'codex') {
+          return makeProvider({
+            name: 'codex',
+            defaultModel: 'gpt-5.6-sol',
+            paid: false,
+            baseURL: 'https://codex.example/v1',
+          });
+        }
+        if (name === 'gemini') {
+          return makeProvider({
+            name: 'gemini',
+            defaultModel: 'gemini-2.5-pro',
+            paid: true,
+            baseURL: 'https://gemini.example/v1',
+          });
+        }
+        return undefined;
+      });
+    });
+
+    it('reports resolved codex identity and metadata while the active provider is still gemini', () => {
+      configureFor({
+        providerName: 'codex',
+        activeProvider: 'gemini',
+        model: 'gpt-5.6-sol',
+        providerSettingsModel: 'gpt-5.6-sol',
+      });
+
+      const status = getActiveProviderStatus();
+
+      expect(status).toStrictEqual({
+        providerName: 'codex',
+        modelName: 'gpt-5.6-sol',
+        displayLabel: 'codex:gpt-5.6-sol',
+        isPaidMode: false,
+        baseURL: 'https://codex.example/v1',
+      });
+    });
+
+    it('keeps the resolved name but omits metadata when the named provider lookup fails', () => {
+      vi.mocked(
+        mockRuntimeProviderManager.getProviderByName,
+      ).mockImplementation(() => {
+        throw new Error('boom');
+      });
+      configureFor({
+        providerName: 'codex',
+        model: 'gpt-5.6-sol',
+        providerSettingsModel: 'gpt-5.6-sol',
+      });
+
+      const status = getActiveProviderStatus();
+
+      expect(status.providerName).toBe('codex');
+      expect(status.modelName).toBe('gpt-5.6-sol');
+      expect(status.displayLabel).toBe('codex:gpt-5.6-sol');
+      expect(status.isPaidMode).toBeUndefined();
+      expect(status.baseURL).toBeUndefined();
+    });
+
+    it('falls back to the active provider metadata when no provider name is configured', () => {
+      configureFor({ providerName: '', model: '' });
+
+      const status = getActiveProviderStatus();
+
+      expect(status).toStrictEqual({
+        providerName: 'gemini',
+        modelName: 'gemini-2.5-pro',
+        displayLabel: 'gemini:gemini-2.5-pro',
+        isPaidMode: true,
+        baseURL: 'https://gemini.example/v1',
+      });
+    });
+
+    it('degrades to null identity when manager lookups throw or the active provider is missing', () => {
+      vi.mocked(
+        mockRuntimeProviderManager.getActiveProvider,
+      ).mockImplementation(() => {
+        throw new Error('boom');
+      });
+      configureFor({ providerName: '', model: '' });
+
+      const status = getActiveProviderStatus();
+
+      expect(status.providerName).toBeNull();
+      expect(status.isPaidMode).toBeUndefined();
+      expect(status.baseURL).toBeUndefined();
+      expect(status.displayLabel).toBe('unknown');
+    });
+
+    it('isolates the resolved name from a throwing resolved-provider metadata method', () => {
+      vi.mocked(mockRuntimeProviderManager.getProviderByName).mockReturnValue(
+        makeProvider({
+          name: 'codex',
+          defaultModel: 'gpt-5.6-sol',
+          baseURL: 'https://codex.example/v1',
+          throwing: 'isPaidMode',
+        }),
+      );
+      configureFor({
+        providerName: 'codex',
+        model: 'gpt-5.6-sol',
+        providerSettingsModel: 'gpt-5.6-sol',
+      });
+
+      const status = getActiveProviderStatus();
+
+      expect(status.providerName).toBe('codex');
+      expect(status.modelName).toBe('gpt-5.6-sol');
+      expect(status.baseURL).toBe('https://codex.example/v1');
+      expect(status.isPaidMode).toBeUndefined();
+    });
+
+    it('omits baseURL when the active provider base URL accessor throws', () => {
+      vi.mocked(mockRuntimeProviderManager.getActiveProvider).mockReturnValue(
+        makeProvider({
+          name: 'gemini',
+          defaultModel: 'gemini-2.5-pro',
+          paid: true,
+          baseURL: 'https://gemini.example/v1',
+          throwing: 'getBaseURL',
+        }),
+      );
+      configureFor({ providerName: '', model: '' });
+
+      const status = getActiveProviderStatus();
+
+      expect(status.providerName).toBe('gemini');
+      expect(status.isPaidMode).toBe(true);
+      expect(status.baseURL).toBeUndefined();
     });
   });
 

--- a/packages/providers/src/runtime/runtimeAccessors.ts
+++ b/packages/providers/src/runtime/runtimeAccessors.ts
@@ -485,10 +485,11 @@ function buildProviderDisplayLabel(
   return modelName ?? 'unknown';
 }
 
-function safeCall<T>(fn: () => T): T | undefined {
+function safeCall<T>(operation: string, fn: () => T): T | undefined {
   try {
     return fn();
-  } catch {
+  } catch (error) {
+    logger.debug(() => `Unable to ${operation}: ${String(error)}`);
     return undefined;
   }
 }
@@ -509,7 +510,7 @@ function resolveProviderBaseURL(
   if (!provider || !isBaseURLProvider(provider)) {
     return undefined;
   }
-  return safeCall(() => provider.getBaseURL());
+  return safeCall('read provider base URL', () => provider.getBaseURL());
 }
 
 function resolveProviderIsPaidMode(
@@ -518,7 +519,9 @@ function resolveProviderIsPaidMode(
   if (!provider) {
     return undefined;
   }
-  return safeCall(() => provider.isPaidMode?.());
+  return safeCall('read provider paid-mode status', () =>
+    provider.isPaidMode?.(),
+  );
 }
 
 export function getActiveProviderStatus(): ProviderRuntimeStatus {
@@ -530,7 +533,7 @@ export function getActiveProviderStatus(): ProviderRuntimeStatus {
   const resolvedName = resolveActiveProviderName(settingsService, config);
 
   if (resolvedName && resolvedName.trim() !== '') {
-    const provider = safeCall(() =>
+    const provider = safeCall('resolve configured provider', () =>
       providerManager.getProviderByName(resolvedName),
     );
     return {
@@ -542,7 +545,9 @@ export function getActiveProviderStatus(): ProviderRuntimeStatus {
     };
   }
 
-  const activeProvider = safeCall(() => providerManager.getActiveProvider());
+  const activeProvider = safeCall('resolve active provider', () =>
+    providerManager.getActiveProvider(),
+  );
   const providerName = activeProvider?.name ?? null;
 
   return {

--- a/packages/providers/src/runtime/runtimeAccessors.ts
+++ b/packages/providers/src/runtime/runtimeAccessors.ts
@@ -27,6 +27,7 @@ import {
   type Config,
   DebugLogger,
   type RuntimeProviderManager,
+  type RuntimeProvider,
   peekActiveProviderRuntimeContext,
   type HydratedModel,
 } from '@vybestack/llxprt-code-core';
@@ -471,61 +472,86 @@ export interface ProviderRuntimeStatus {
   baseURL?: string;
 }
 
+function buildProviderDisplayLabel(
+  providerName: string | null,
+  modelName: string | null,
+): string {
+  if (providerName && modelName) {
+    return `${providerName}:${modelName}`;
+  }
+  if (providerName) {
+    return providerName;
+  }
+  return modelName ?? 'unknown';
+}
+
+function safeCall<T>(fn: () => T): T | undefined {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
+}
+
+type BaseURLProvider = RuntimeProvider & {
+  getBaseURL: () => string | undefined;
+};
+
+function isBaseURLProvider(
+  provider: RuntimeProvider,
+): provider is BaseURLProvider {
+  return 'getBaseURL' in provider && typeof provider.getBaseURL === 'function';
+}
+
+function resolveProviderBaseURL(
+  provider: RuntimeProvider | undefined,
+): string | undefined {
+  if (!provider || !isBaseURLProvider(provider)) {
+    return undefined;
+  }
+  return safeCall(() => provider.getBaseURL());
+}
+
+function resolveProviderIsPaidMode(
+  provider: RuntimeProvider | undefined,
+): boolean | undefined {
+  if (!provider) {
+    return undefined;
+  }
+  return safeCall(() => provider.isPaidMode?.());
+}
+
 export function getActiveProviderStatus(): ProviderRuntimeStatus {
   const { config, settingsService, providerManager } = getCliRuntimeServices();
   const resolvedModel = getActiveModelName();
   const modelName =
     resolvedModel && resolvedModel.trim() !== '' ? resolvedModel : null;
 
-  try {
-    const provider = providerManager.getActiveProvider();
-    if (!provider) {
-      throw new Error('No active provider is configured.');
-    }
-    const displayLabel = modelName
-      ? `${provider.name}:${modelName}`
-      : provider.name;
+  const resolvedName = resolveActiveProviderName(settingsService, config);
 
-    // Try to get baseURL from provider if it has the method
-    let baseURL: string | undefined;
-    try {
-      if (
-        'getBaseURL' in provider &&
-        typeof (provider as { getBaseURL?: () => string | undefined })
-          .getBaseURL === 'function'
-      ) {
-        baseURL = (
-          provider as { getBaseURL: () => string | undefined }
-        ).getBaseURL();
-      }
-    } catch {
-      baseURL = undefined;
-    }
-
+  if (resolvedName && resolvedName.trim() !== '') {
+    const provider = safeCall(() =>
+      providerManager.getProviderByName(resolvedName),
+    );
     return {
-      providerName: provider.name,
+      providerName: resolvedName,
       modelName,
-      displayLabel,
-      isPaidMode: provider.isPaidMode?.(),
-      baseURL,
-    };
-  } catch {
-    const providerName =
-      resolveActiveProviderName(settingsService, config) ?? null;
-    let fallbackLabel: string;
-    if (providerName && modelName) {
-      fallbackLabel = `${providerName}:${modelName}`;
-    } else if (providerName) {
-      fallbackLabel = providerName;
-    } else {
-      fallbackLabel = modelName ?? 'unknown';
-    }
-    return {
-      providerName,
-      modelName,
-      displayLabel: fallbackLabel,
+      displayLabel: buildProviderDisplayLabel(resolvedName, modelName),
+      isPaidMode: resolveProviderIsPaidMode(provider),
+      baseURL: resolveProviderBaseURL(provider),
     };
   }
+
+  const activeProvider = safeCall(() => providerManager.getActiveProvider());
+  const providerName = activeProvider?.name ?? null;
+
+  return {
+    providerName,
+    modelName,
+    displayLabel: buildProviderDisplayLabel(providerName, modelName),
+    isPaidMode: resolveProviderIsPaidMode(activeProvider),
+    baseURL: resolveProviderBaseURL(activeProvider),
+  };
 }
 
 export async function listAvailableModels(


### PR DESCRIPTION
## Summary

- resolve CLI provider status from the configured runtime identity during the asynchronous provider activation window
- derive agent ModelInfo, context-limit checks, and turn attribution from the provider selected by ChatSession routing
- keep provider/model identity atomic so Codex models are never labeled as Gemini
- preserve continuation deduplication and profile/load-balancer model precedence
- add regression coverage for stale manager state, metadata isolation, routing identity, getter failures, and graceful fallback

## Root cause

The CLI status accessor and agent ModelInfo path independently read the provider manager active slot while provider activation was still in progress. The manager could still hold its construction-time Gemini default even though the requested runtime and model were Codex. That produced mixed identities such as gemini:gpt-5.6-sol.

## Verification

- npm run format
- npm run build
- npm run typecheck
- npm run lint
- npm run test (all workspaces completed; one core timing guard exceeded its budget under concurrent lint/test load and passed immediately in isolated rerun)
- focused affected tests: 80 passed
- bun scripts/start.ts --profile-load ollamakimi with the required haiku prompt
- Open Code Review run against all 12 changed files, including test files

Fixes #2544