### PR TITLE
Lower DEFAULT_TOKEN_LIMIT to 200K, add GLM catalog, consolidate resolution (Fixes #2527)

### DIFF
--- a/packages/agents/src/compression/__tests__/loadbalancer-context-limit.test.ts
+++ b/packages/agents/src/compression/__tests__/loadbalancer-context-limit.test.ts
@@ -108,16 +108,16 @@ describe('CompressionHandler.computeContextLimits() — LB provider-derived cont
     mockContentGenerator = buildMockContentGenerator();
   });
 
-  it('uses the provider-derived limit (200K), not DEFAULT_TOKEN_LIMIT, under LB with no explicit override', () => {
+  it('uses the provider-derived limit (150K), not DEFAULT_TOKEN_LIMIT, under LB with no explicit override', () => {
     const runtimeContext = buildLbRuntimeContext(historyService, {
-      providerContextLimit: 200_000,
+      providerContextLimit: 150_000,
     });
 
     const chat = new ChatSession(runtimeContext, mockContentGenerator, {}, []);
     const lbProvider = runtimeContext.provider.getActiveProvider();
 
     const limits = chat['compressionHandler'].computeContextLimits(lbProvider);
-    expect(limits.limit).toBe(200_000);
+    expect(limits.limit).toBe(150_000);
     expect(limits.limit).not.toBe(DEFAULT_TOKEN_LIMIT);
   });
 
@@ -144,9 +144,9 @@ describe('CompressionHandler.computeContextLimits() — LB provider-derived cont
     const provider = runtimeContext.provider.getActiveProvider();
 
     const limits = chat['compressionHandler'].computeContextLimits(provider);
-    // gpt-4o resolves to 128K, distinct from DEFAULT_TOKEN_LIMIT (1M), so this
-    // genuinely proves the model-lookup path rather than coincidentally hitting
-    // the default constant.
+    // gpt-4o resolves to 128K, distinct from DEFAULT_TOKEN_LIMIT (200K), so
+    // this genuinely proves the model-lookup path rather than coincidentally
+    // hitting the default constant.
     expect(limits.limit).toBe(tokenLimit('gpt-4o'));
     expect(limits.limit).not.toBe(DEFAULT_TOKEN_LIMIT);
   });

--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -48,11 +48,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.modelinfo.test.ts
@@ -26,7 +26,10 @@ import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
 import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
-import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
+import {
+  tokenLimit,
+  resolveEffectiveContextLimit,
+} from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import {
   buildEffectiveModelIdentity,
   type EffectiveModelIdentity,
@@ -34,12 +37,26 @@ import {
 
 const mockTurnRun = vi.fn();
 
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn(
     (_model: string, userContextLimit?: number) =>
       userContextLimit ?? 1_000_000,
-  ),
-}));
+  );
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 
 vi.mock('./turn.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./turn.js')>();
@@ -351,10 +368,13 @@ describe('MessageStreamOrchestrator — ModelInfo emission (issue #1770)', () =>
 
     await collectModelInfos(orchestrator, 'prompt-context-limit');
 
-    expect(vi.mocked(tokenLimit).mock.calls).toContainEqual([
-      'claude-opus-4-8',
-      200_000,
-    ]);
+    expect(
+      vi
+        .mocked(resolveEffectiveContextLimit)
+        .mock.calls.some(
+          (call) => call[0] === 'claude-opus-4-8' && call[1] === 200_000,
+        ),
+    ).toBe(true);
   });
 
   it('B1: load-balancer profile reports the active sub-profile model, not the config default', async () => {

--- a/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
@@ -56,11 +56,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.todoPause.test.ts
@@ -45,12 +45,26 @@ import type { Todo } from '@vybestack/llxprt-code-tools';
 
 const mockTurnRun = vi.fn();
 
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn(
     (_model: string, userContextLimit?: number) =>
       userContextLimit ?? 1_000_000,
-  ),
-}));
+  );
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 
 vi.mock('./turn.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./turn.js')>();

--- a/packages/agents/src/core/chatSession.contextlimit.test.ts
+++ b/packages/agents/src/core/chatSession.contextlimit.test.ts
@@ -235,7 +235,7 @@ describe('ChatSession Context Limit Enforcement', () => {
     // Reduced token counts to account for completion budget
     // Using smaller completion budget (4096) to keep total reasonable
     // Total: 10000 (history) + 5000 (pending) + 4096 (budget) = 19096
-    // This is well under DEFAULT_TOKEN_LIMIT (1,048,576) and demonstrates the fallback
+    // This is well under DEFAULT_TOKEN_LIMIT (200,000) and demonstrates the fallback
     vi.spyOn(historyService, 'getTotalTokens').mockReturnValue(10000);
     vi.spyOn(historyService, 'waitForTokenUpdates').mockResolvedValue(
       undefined,
@@ -282,14 +282,10 @@ describe('ChatSession Context Limit Enforcement', () => {
       chat['enforceContextWindow'](pendingTokens, 'test-prompt-id'),
     ).resolves.not.toThrow();
 
-    // Verify tokenLimit was called with a fallback (undefined) followed by provider default
-    expect(tokenLimitsModule.tokenLimit).toHaveBeenNthCalledWith(
-      1,
-      configWithoutLimit.getModel(),
-      undefined,
-    );
-    expect(tokenLimitsModule.tokenLimit).toHaveBeenNthCalledWith(
-      2,
+    // resolveEffectiveContextLimit handles the model lookup internally
+    // (same-module call, not visible to the export spy). The spy only sees
+    // the CompressionHandler call with the resolved default limit.
+    expect(tokenLimitsModule.tokenLimit).toHaveBeenCalledWith(
       configWithoutLimit.getModel(),
       DEFAULT_TOKEN_LIMIT,
     );

--- a/packages/agents/src/core/client.editor-context.test.ts
+++ b/packages/agents/src/core/client.editor-context.test.ts
@@ -172,11 +172,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.editor-context.test.ts
+++ b/packages/agents/src/core/client.editor-context.test.ts
@@ -164,9 +164,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.hooks.test.ts
+++ b/packages/agents/src/core/client.hooks.test.ts
@@ -174,11 +174,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.hooks.test.ts
+++ b/packages/agents/src/core/client.hooks.test.ts
@@ -166,9 +166,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.ide-context.test.ts
+++ b/packages/agents/src/core/client.ide-context.test.ts
@@ -165,9 +165,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.ide-context.test.ts
+++ b/packages/agents/src/core/client.ide-context.test.ts
@@ -173,11 +173,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.lifecycle.test.ts
+++ b/packages/agents/src/core/client.lifecycle.test.ts
@@ -170,9 +170,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.lifecycle.test.ts
+++ b/packages/agents/src/core/client.lifecycle.test.ts
@@ -178,11 +178,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.methods.test.ts
+++ b/packages/agents/src/core/client.methods.test.ts
@@ -181,11 +181,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.methods.test.ts
+++ b/packages/agents/src/core/client.methods.test.ts
@@ -173,9 +173,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.model-profile.test.ts
+++ b/packages/agents/src/core/client.model-profile.test.ts
@@ -171,9 +171,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.model-profile.test.ts
+++ b/packages/agents/src/core/client.model-profile.test.ts
@@ -179,11 +179,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.sendMessageStream-errors.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-errors.test.ts
@@ -172,11 +172,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.sendMessageStream-errors.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-errors.test.ts
@@ -164,9 +164,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
@@ -170,9 +170,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow-compression.test.ts
@@ -178,11 +178,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
@@ -171,9 +171,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-overflow.test.ts
@@ -179,11 +179,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.sendMessageStream-thinking.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-thinking.test.ts
@@ -177,11 +177,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.sendMessageStream-thinking.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream-thinking.test.ts
@@ -169,9 +169,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/client.sendMessageStream.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream.test.ts
@@ -181,11 +181,9 @@ vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
       (model: string, userCtx?: number, provCtx?: number) => {
         const ok = (v: unknown): v is number =>
           typeof v === 'number' && Number.isFinite(v) && v > 0;
-        return ok(userCtx)
-          ? userCtx
-          : ok(provCtx)
-            ? provCtx
-            : tokenLimit(model);
+        if (ok(userCtx)) return userCtx;
+        if (ok(provCtx)) return provCtx;
+        return tokenLimit(model);
       },
     ),
   };

--- a/packages/agents/src/core/client.sendMessageStream.test.ts
+++ b/packages/agents/src/core/client.sendMessageStream.test.ts
@@ -173,9 +173,23 @@ vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
     },
   };
 });
-vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => ({
-  tokenLimit: vi.fn(),
-}));
+vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const tokenLimit = vi.fn();
+  return {
+    tokenLimit,
+    resolveEffectiveContextLimit: vi.fn(
+      (model: string, userCtx?: number, provCtx?: number) => {
+        const ok = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v > 0;
+        return ok(userCtx)
+          ? userCtx
+          : ok(provCtx)
+            ? provCtx
+            : tokenLimit(model);
+      },
+    ),
+  };
+});
 vi.mock('@vybestack/llxprt-code-core/telemetry/uiTelemetry.js', () => ({
   uiTelemetryService: {
     setLastPromptTokenCount: vi.fn(),

--- a/packages/agents/src/core/contextLimitResolver.test.ts
+++ b/packages/agents/src/core/contextLimitResolver.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { DEFAULT_TOKEN_LIMIT } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import { getTokenLimitForConfiguredContext } from './contextLimitResolver.js';
 
 /**
@@ -63,17 +64,17 @@ describe('getTokenLimitForConfiguredContext', () => {
   it('falls back to the model-name window when neither override nor provider limit is set', () => {
     const config = makeConfig({ model: 'gpt-4o' });
 
-    // gpt-4o resolves to 128K, distinct from DEFAULT_TOKEN_LIMIT (1M), so the
-    // model-lookup path is genuinely exercised rather than coincidental.
+    // gpt-4o resolves to 128K, distinct from DEFAULT_TOKEN_LIMIT (200K), so
+    // the model-lookup path is genuinely exercised rather than coincidental.
     expect(getTokenLimitForConfiguredContext('gpt-4o', config)).toBe(128_000);
   });
 
   it('returns DEFAULT_TOKEN_LIMIT for an unrecognized model with no overrides', () => {
     const config = makeConfig({ model: 'load-balancer' });
 
-    expect(
-      getTokenLimitForConfiguredContext('load-balancer', config),
-    ).toBeGreaterThanOrEqual(1_000_000);
+    expect(getTokenLimitForConfiguredContext('load-balancer', config)).toBe(
+      DEFAULT_TOKEN_LIMIT,
+    );
   });
 
   it('ignores a non-positive provider limit and falls back to the model lookup', () => {

--- a/packages/agents/src/core/contextLimitResolver.ts
+++ b/packages/agents/src/core/contextLimitResolver.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
+import { resolveEffectiveContextLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 
 export interface ContextLimitConfig {
   getEphemeralSetting(key: string): unknown;
@@ -58,14 +58,17 @@ function getProviderContextLimit(
  * 1. explicit live user `context-limit` override,
  * 2. the active provider's getContextLimit() (e.g. load-balancer pool min),
  * 3. the model-name lookup via tokenLimit(model).
+ *
+ * Delegates to the shared `resolveEffectiveContextLimit` in core so the
+ * precedence lives in exactly one place (issues #2270 / #2527 DRY).
  */
 export function getTokenLimitForConfiguredContext(
   model: string,
   config: ContextLimitConfig,
 ): number {
-  const contextLimit =
-    getConfiguredContextLimit(config) ?? getProviderContextLimit(config);
-  return contextLimit === undefined
-    ? tokenLimit(model)
-    : tokenLimit(model, contextLimit);
+  return resolveEffectiveContextLimit(
+    model,
+    getConfiguredContextLimit(config),
+    getProviderContextLimit(config),
+  );
 }

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useStreamEventHandlers.contextLimit.test.ts
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useStreamEventHandlers.contextLimit.test.ts
@@ -31,7 +31,7 @@ describe('contextLimit helper (cli wrapper)', () => {
   });
 
   it('falls back to the model-name window when no context-limit is configured', () => {
-    // gpt-4o resolves to a 128K window, distinct from DEFAULT_TOKEN_LIMIT (1M),
+    // gpt-4o resolves to a 128K window, distinct from DEFAULT_TOKEN_LIMIT (200K),
     // so the model-lookup path is genuinely exercised.
     const configWithoutLimit = {
       getModel: vi.fn(() => 'gpt-4o'),

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { tokenLimit, DEFAULT_TOKEN_LIMIT } from './tokenLimits.js';
+import {
+  tokenLimit,
+  DEFAULT_TOKEN_LIMIT,
+  resolveEffectiveContextLimit,
+} from './tokenLimits.js';
 
 describe('tokenLimit', () => {
   describe('Gemini models', () => {
@@ -177,6 +181,62 @@ describe('tokenLimit', () => {
     });
   });
 
+  describe('GLM (z.ai) models', () => {
+    it('should return 200K for glm-5.2', () => {
+      expect(tokenLimit('glm-5.2')).toBe(200_000);
+    });
+
+    it('should return 200K for glm-5.1', () => {
+      expect(tokenLimit('glm-5.1')).toBe(200_000);
+    });
+
+    it('should return 200K for glm-5', () => {
+      expect(tokenLimit('glm-5')).toBe(200_000);
+    });
+
+    it('should return 200K for future/dated glm-5 variants via prefix', () => {
+      expect(tokenLimit('glm-5.3')).toBe(200_000);
+      expect(tokenLimit('glm-5-air')).toBe(200_000);
+    });
+
+    it('should return 128K for glm-4.6', () => {
+      expect(tokenLimit('glm-4.6')).toBe(128_000);
+    });
+
+    it('should return 128K for glm-4.5', () => {
+      expect(tokenLimit('glm-4.5')).toBe(128_000);
+    });
+
+    it('should return 128K for glm-4', () => {
+      expect(tokenLimit('glm-4')).toBe(128_000);
+    });
+
+    it('should return 128K for future/dated glm-4 variants via prefix', () => {
+      expect(tokenLimit('glm-4-plus')).toBe(128_000);
+      expect(tokenLimit('glm-4-flash')).toBe(128_000);
+    });
+
+    it('should honor a user-supplied context limit override for glm-5.2', () => {
+      expect(tokenLimit('glm-5.2', 150_000)).toBe(150_000);
+    });
+  });
+
+  describe('Gemini variant prefix matching (issue #2527)', () => {
+    it('should return 1M for gemini-2.0-flash-exp via prefix', () => {
+      expect(tokenLimit('gemini-2.0-flash-exp')).toBe(1_048_576);
+    });
+
+    it('should still return 32K for the image-generation exact entry', () => {
+      expect(tokenLimit('gemini-2.0-flash-preview-image-generation')).toBe(
+        32_000,
+      );
+    });
+
+    it('should return 1M for future gemini-2.5-pro previews via prefix', () => {
+      expect(tokenLimit('gemini-2.5-pro-preview-07-07')).toBe(1_048_576);
+    });
+  });
+
   describe('Default behavior', () => {
     it('should return default limit for unknown models', () => {
       expect(tokenLimit('unknown-model')).toBe(DEFAULT_TOKEN_LIMIT);
@@ -198,5 +258,64 @@ describe('tokenLimit', () => {
       expect(tokenLimit('gemini:gemini-1.5-pro')).toBe(2_097_152);
       expect(tokenLimit('gemini:gemini-1.5-flash')).toBe(1_048_576);
     });
+  });
+});
+
+describe('resolveEffectiveContextLimit', () => {
+  it('prefers a positive user context limit over provider and model', () => {
+    expect(resolveEffectiveContextLimit('gpt-4o', 50_000, 200_000)).toBe(
+      50_000,
+    );
+  });
+
+  it('falls back to the provider limit when user limit is absent', () => {
+    expect(
+      resolveEffectiveContextLimit('load-balancer', undefined, 200_000),
+    ).toBe(200_000);
+  });
+
+  it('falls back to the model lookup when neither override is set', () => {
+    expect(resolveEffectiveContextLimit('gpt-4o')).toBe(128_000);
+  });
+
+  it('falls back to DEFAULT_TOKEN_LIMIT for an unrecognized model', () => {
+    expect(resolveEffectiveContextLimit('unknown-model')).toBe(
+      DEFAULT_TOKEN_LIMIT,
+    );
+  });
+
+  it('ignores a non-positive user limit and uses the provider limit', () => {
+    expect(resolveEffectiveContextLimit('gpt-4o', 0, 200_000)).toBe(200_000);
+  });
+
+  it('ignores NaN and Infinity values', () => {
+    expect(resolveEffectiveContextLimit('gpt-4o', NaN, 200_000)).toBe(200_000);
+    expect(resolveEffectiveContextLimit('gpt-4o', Infinity, 200_000)).toBe(
+      200_000,
+    );
+    expect(resolveEffectiveContextLimit('gpt-4o', undefined, NaN)).toBe(
+      128_000,
+    );
+    expect(resolveEffectiveContextLimit('gpt-4o', undefined, Infinity)).toBe(
+      128_000,
+    );
+  });
+
+  it('ignores a non-positive provider limit and uses the model lookup', () => {
+    expect(resolveEffectiveContextLimit('gpt-4o', undefined, 0)).toBe(128_000);
+  });
+
+  it('falls back to model default when both user and provider limits are invalid', () => {
+    expect(resolveEffectiveContextLimit('gpt-4o', 0, 0)).toBe(128_000);
+    expect(resolveEffectiveContextLimit('gpt-4o', -1, NaN)).toBe(128_000);
+    expect(resolveEffectiveContextLimit('gpt-4o', Infinity, Infinity)).toBe(
+      128_000,
+    );
+  });
+
+  it('respects a user override that is larger than the model default', () => {
+    expect(resolveEffectiveContextLimit('gpt-4o', 500_000, undefined)).toBe(
+      500_000,
+    );
   });
 });

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -7,7 +7,16 @@
 type Model = string;
 type TokenCount = number;
 
-export const DEFAULT_TOKEN_LIMIT = 1_048_576;
+/**
+ * Conservative fallback for unrecognized models.
+ *
+ * Lowered from 1M to 200K (issue #2270 / #2527): the overwhelmingly common
+ * real-world floor is 200K (Claude, many GLM/Gemini variants). Defaulting to
+ * 200K instead of 1M makes the unrecognized-model case fail-safe — proactive
+ * compression fires conservatively rather than silently overrunning a
+ * sub-200K backend.
+ */
+export const DEFAULT_TOKEN_LIMIT = 200_000;
 
 const OPENAI_128K_PREFIXES = [
   'o4-mini',
@@ -27,9 +36,31 @@ interface PrefixLimit {
 const PREFIX_LIMITS: PrefixLimit[] = [
   { prefix: 'gpt-4.1', limit: 1_000_000 },
   { prefix: 'gpt-3.5-turbo', limit: 16_385 },
+  // Gemini 2.x variants (experimental, preview, dated snapshots) — all 1M.
+  // Exact entries above take precedence, so the 32K image-generation variant
+  // is unaffected. Prevents the lowered DEFAULT_TOKEN_LIMIT from silently
+  // shrinking recognized Gemini variants (issue #2527).
+  { prefix: 'gemini-2.5-pro', limit: 1_048_576 },
+  { prefix: 'gemini-2.5-flash', limit: 1_048_576 },
+  { prefix: 'gemini-2.0-flash', limit: 1_048_576 },
+  // GLM-5 family — 200K context window (z.ai API docs)
+  { prefix: 'glm-5', limit: 200_000 },
+  // GLM-4 family — 128K context window (z.ai API docs)
+  { prefix: 'glm-4', limit: 128_000 },
 ];
 
 const EXACT_LIMITS: Record<string, TokenCount> = {
+  // GLM (z.ai) models — exact entries for commonly used variants.
+  // The GLM-5 family (glm-5, glm-5.1, glm-5.2, …) exposes a 200K context
+  // window; the GLM-4 family (glm-4, glm-4.5, glm-4.6, …) exposes 128K.
+  // Prefix-based fallbacks below cover future/dated variants.
+  'glm-5.2': 200_000,
+  'glm-5.1': 200_000,
+  'glm-5': 200_000,
+  'glm-4.6': 128_000,
+  'glm-4.5': 128_000,
+  'glm-4': 128_000,
+
   // Gemini models
   'gemini-1.5-pro': 2_097_152,
   'gemini-1.5-flash': 1_048_576,
@@ -152,4 +183,39 @@ export function tokenLimit(
   }
 
   return DEFAULT_TOKEN_LIMIT;
+}
+
+/**
+ * Returns true when *value* is a positive, finite number suitable as a
+ * context-window override.
+ */
+function isPositiveFiniteLimit(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Single source of truth for the three-tier context-window precedence
+ * (issues #2270 / #2527 DRY consolidation):
+ *
+ * 1. explicit user `context-limit` override (from /set, profile, or settings),
+ * 2. the active provider's reported context limit (e.g. a load-balancer pool's
+ *    min-across-sub-profiles limit),
+ * 3. the model-name lookup via `tokenLimit(model)`.
+ *
+ * Both `ephemerals.contextLimit()` (core runtime) and
+ * `getTokenLimitForConfiguredContext()` (agents layer) delegate to this
+ * function so the precedence lives in exactly one place.
+ */
+export function resolveEffectiveContextLimit(
+  model: string,
+  userContextLimit?: number,
+  providerContextLimit?: number,
+): number {
+  if (isPositiveFiniteLimit(userContextLimit)) {
+    return userContextLimit;
+  }
+  if (isPositiveFiniteLimit(providerContextLimit)) {
+    return providerContextLimit;
+  }
+  return tokenLimit(model);
 }

--- a/packages/core/src/integration-tests/chatSession-isolation.integration.test.ts
+++ b/packages/core/src/integration-tests/chatSession-isolation.integration.test.ts
@@ -21,7 +21,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Config } from '../config/config.js';
 import { createAgentRuntimeContext } from '../runtime/createAgentRuntimeContext.js';
 import { createAgentRuntimeState } from '../runtime/AgentRuntimeState.js';
-import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
 import type {
   ReadonlySettingsSnapshot,
   ApiRequestEvent,
@@ -711,7 +710,9 @@ describe('ChatSession Isolation Integration Tests', () => {
 
       // THEN: Default values used (from createAgentRuntimeContext EPHEMERAL_DEFAULTS)
       expect(threshold).toBe(0.85);
-      expect(limit).toBe(DEFAULT_TOKEN_LIMIT);
+      // gemini-2.0-flash-exp resolves to 1M via the gemini-2.0-flash prefix
+      // entry, not DEFAULT_TOKEN_LIMIT (200K).
+      expect(limit).toBe(1_048_576);
       expect(preserve).toBe(0.4);
     });
 
@@ -737,7 +738,8 @@ describe('ChatSession Isolation Integration Tests', () => {
 
       // THEN: Specified value used, rest default
       expect(threshold).toBe(0.75); // Specified
-      expect(limit).toBe(DEFAULT_TOKEN_LIMIT); // Default
+      // gemini-2.0-flash-exp resolves to 1M via prefix entry
+      expect(limit).toBe(1_048_576);
       expect(preserve).toBe(0.4); // Default
     });
   });

--- a/packages/core/src/runtime/createAgentRuntimeContext.test.ts
+++ b/packages/core/src/runtime/createAgentRuntimeContext.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createAgentRuntimeContext } from './createAgentRuntimeContext.js';
+import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
 import type {
   AgentRuntimeContextFactoryOptions,
   ReadonlySettingsSnapshot,
@@ -703,7 +704,9 @@ describe('createAgentRuntimeContext', () => {
       };
 
       const context = createAgentRuntimeContext(options);
-      expect(context.ephemerals.contextLimit()).toBe(1_048_576);
+      // load-balancer is not in the model catalog, so this falls back to
+      // DEFAULT_TOKEN_LIMIT (200K after issue #2270/#2527).
+      expect(context.ephemerals.contextLimit()).toBe(DEFAULT_TOKEN_LIMIT);
     });
 
     it('falls back to the model default when getActiveProvider throws', () => {
@@ -729,7 +732,9 @@ describe('createAgentRuntimeContext', () => {
       };
 
       const context = createAgentRuntimeContext(options);
-      expect(context.ephemerals.contextLimit()).toBe(1_048_576);
+      // load-balancer is not in the model catalog; falls back to the lowered
+      // DEFAULT_TOKEN_LIMIT (200K).
+      expect(context.ephemerals.contextLimit()).toBe(DEFAULT_TOKEN_LIMIT);
     });
   });
 });

--- a/packages/core/src/runtime/createAgentRuntimeContext.ts
+++ b/packages/core/src/runtime/createAgentRuntimeContext.ts
@@ -20,7 +20,7 @@ import type {
 } from './AgentRuntimeContext.js';
 import type { ProviderRuntimeContext } from './providerRuntimeContext.js';
 import type { RuntimeSettingsState } from './providerRuntimeContext.js';
-import { tokenLimit } from '../core/tokenLimits.js';
+import { resolveEffectiveContextLimit } from '../core/tokenLimits.js';
 /** @plan PLAN-20260211-COMPRESSION.P12 */
 import { getSettingSpec } from '@vybestack/llxprt-code-settings';
 
@@ -143,22 +143,14 @@ function buildCompressionEphemerals(
         'context-limit',
         options.settings.contextLimit,
       );
-      const liveOverride =
-        typeof liveLimit === 'number' &&
-        Number.isFinite(liveLimit) &&
-        liveLimit > 0
-          ? liveLimit
-          : undefined;
-      if (liveOverride !== undefined) {
-        return liveOverride;
-      }
       const providerContextLimit = resolveProviderContextLimit(
         options.provider,
       );
-      if (providerContextLimit !== undefined) {
-        return providerContextLimit;
-      }
-      return tokenLimit(options.state.model, undefined);
+      return resolveEffectiveContextLimit(
+        options.state.model,
+        liveLimit,
+        providerContextLimit,
+      );
     },
     preserveThreshold: (): number =>
       options.settings.preserveThreshold ??


### PR DESCRIPTION
## Summary

This PR addresses issue #2527 — the 0.11.0 follow-up / consolidation tracker for the context-window resolution gaps that produce a 1M fallback for unrecognized models.

### Three changes

**1. Lower `DEFAULT_TOKEN_LIMIT` from 1,048,576 to 200,000** (#2270)

The overwhelmingly common real-world floor is 200K (Claude, many GLM/Gemini variants). Defaulting to 200K instead of 1M makes the unrecognized-model case **fail-safe**: proactive compression fires conservatively rather than silently overrunning a sub-200K backend.

**2. Add GLM model family to the token-limit catalog** (#2280)

Added exact entries and prefix-based matching for the GLM (z.ai) family:
- `glm-5.2`, `glm-5.1`, `glm-5` and the `glm-5` prefix → 200K
- `glm-4.6`, `glm-4.5`, `glm-4` and the `glm-4` prefix → 128K

Also added Gemini prefix entries (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash` → 1M) to prevent regressions from the lowered default — these models previously fell through to `DEFAULT_TOKEN_LIMIT` and would now incorrectly get 200K instead of their actual 1M window.

**3. Consolidate the two duplicated context-window resolution paths** (#2270 DRY item)

Extracted a single `resolveEffectiveContextLimit(model, userContextLimit?, providerContextLimit?)` function in `packages/core/src/core/tokenLimits.ts` that implements the three-tier precedence:
1. Explicit user `context-limit` override
2. Provider's `getContextLimit()` (e.g. load-balancer pool min)
3. Model-name lookup via `tokenLimit(model)`

Both consumers now delegate to it:
- `getTokenLimitForConfiguredContext` in `packages/agents/src/core/contextLimitResolver.ts`
- `ephemerals.contextLimit()` in `packages/core/src/runtime/createAgentRuntimeContext.ts`

Previously these two paths implemented the same precedence independently — a latent correctness gap where a future regression in one path would make the two diverge, and the `runtimeContext`-based consumers would silently fall back to the (now 200K) default.

### Test changes

- Updated all tests referencing the old 1M default for unrecognized models to use `DEFAULT_TOKEN_LIMIT` constant or the new 200K value
- Added GLM model tests (glm-5.x → 200K, glm-4.x → 128K, prefix variants, user override)
- Added Gemini prefix tests to verify no regression from lowered default
- Added comprehensive `resolveEffectiveContextLimit` test suite (precedence, NaN/Infinity rejection, non-positive values, combined-invalid fallback)
- Updated 13 test file `vi.mock` factories to include `resolveEffectiveContextLimit` with validation matching the real implementation (addresses OCR finding: mock used `??` which accepts 0/NaN/Infinity, unlike real `isPositiveFiniteLimit`)
- Updated `MessageStreamOrchestrator.modelinfo.test.ts` assertion to check `resolveEffectiveContextLimit` calls (code now uses shared function instead of `tokenLimit` directly)
- Updated `chatSession.contextlimit.test.ts` assertions (spy can't intercept same-module internal calls from `resolveEffectiveContextLimit` to `tokenLimit`)

### Pre-existing failures (not caused by this PR)

- `packages/agents/src/api/__tests__/publicSurface.guard.test.ts` — snapshot comparison fails on `main` too (4 removed exports: `AgentActivationPreflightResult`, `ActivationPreflightToken`, `AgentSessionStartResult`, `preflightAgentActivation`)
- `packages/core/src/debug/ConfigurationManager.test.ts` (2 failures), `FileOutput.test.ts` (1), `policy/shell-safety.test.ts` (4) — all pre-existing on `main`
- Typecheck errors in `packages/mcp/` — pre-existing, unrelated to token limits

### Related issues

- #2270 — Default token limit should be 200K not 1M; DRY/dead-code cleanup (OPEN, 0.11.0) — **primary overlap**
- #2280 — Make default model limits data-driven (OPEN, 0.11.0)
- #2477 — zai profile routes to gemini-2.5-pro instead of glm-5.2 (CLOSED via #2504; resolved the active symptom)

Fixes #2527