### PR TITLE
Preserve provider quota errors across retry timeouts (Fixes #2559)

### DIFF
--- a/packages/agents/src/api/__tests__/event-schema.spec.ts
+++ b/packages/agents/src/api/__tests__/event-schema.spec.ts
@@ -20,6 +20,10 @@
 import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
 import {
+  STRUCTURED_ERROR_CATEGORIES,
+  STRUCTURED_ERROR_REASONS,
+} from '@vybestack/llxprt-code-core/core/turn.js';
+import {
   AgentEventSchema,
   DoneReasonSchema,
   ToolUpdateStatusSchema,
@@ -451,6 +455,16 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
         reason: 'unknown',
       }).success,
     ).toBe(false);
+    for (const category of STRUCTURED_ERROR_CATEGORIES) {
+      expect(
+        StructuredErrorSchema.parse({ message: category, category }).category,
+      ).toBe(category);
+    }
+    for (const reason of STRUCTURED_ERROR_REASONS) {
+      expect(
+        StructuredErrorSchema.parse({ message: reason, reason }).reason,
+      ).toBe(reason);
+    }
   });
 
   it('AgentStopInfoSchema requires reason, message/contextCleared optional @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {

--- a/packages/agents/src/api/__tests__/event-schema.spec.ts
+++ b/packages/agents/src/api/__tests__/event-schema.spec.ts
@@ -419,9 +419,19 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
     ).toBe(false);
   });
 
-  it('StructuredErrorSchema requires message, status optional @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {
-    expect(StructuredErrorSchema.parse({ message: 'm' })).toStrictEqual({
-      message: 'm',
+  it('StructuredErrorSchema requires message and preserves an optional category @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {
+    expect(
+      StructuredErrorSchema.parse({
+        message: 'Rate limited',
+        status: 429,
+        category: 'rate_limit',
+        reason: 'retries_exhausted',
+      }),
+    ).toStrictEqual({
+      message: 'Rate limited',
+      status: 429,
+      category: 'rate_limit',
+      reason: 'retries_exhausted',
     });
     expect(StructuredErrorSchema.safeParse({ status: 500 }).success).toBe(
       false,

--- a/packages/agents/src/api/__tests__/event-schema.spec.ts
+++ b/packages/agents/src/api/__tests__/event-schema.spec.ts
@@ -22,7 +22,7 @@ import * as fc from 'fast-check';
 import {
   STRUCTURED_ERROR_CATEGORIES,
   STRUCTURED_ERROR_REASONS,
-} from '@vybestack/llxprt-code-core/core/turn.js';
+} from '@vybestack/llxprt-code-core';
 import {
   AgentEventSchema,
   DoneReasonSchema,

--- a/packages/agents/src/api/__tests__/event-schema.spec.ts
+++ b/packages/agents/src/api/__tests__/event-schema.spec.ts
@@ -419,7 +419,10 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
     ).toBe(false);
   });
 
-  it('StructuredErrorSchema requires message and preserves an optional category @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {
+  it('StructuredErrorSchema validates minimal and classified errors @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {
+    expect(
+      StructuredErrorSchema.parse({ message: 'Provider failed' }),
+    ).toStrictEqual({ message: 'Provider failed' });
     expect(
       StructuredErrorSchema.parse({
         message: 'Rate limited',
@@ -436,6 +439,18 @@ describe('Event schema @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', ()
     expect(StructuredErrorSchema.safeParse({ status: 500 }).success).toBe(
       false,
     );
+    expect(
+      StructuredErrorSchema.safeParse({
+        message: 'Provider failed',
+        category: 'unknown',
+      }).success,
+    ).toBe(false);
+    expect(
+      StructuredErrorSchema.safeParse({
+        message: 'Provider failed',
+        reason: 'unknown',
+      }).success,
+    ).toBe(false);
   });
 
   it('AgentStopInfoSchema requires reason, message/contextCleared optional @plan:PLAN-20260617-COREAPI.P04 @requirement:REQ-003', () => {

--- a/packages/agents/src/api/event-schema.ts
+++ b/packages/agents/src/api/event-schema.ts
@@ -4,6 +4,10 @@
  */
 
 import { z } from 'zod';
+import {
+  STRUCTURED_ERROR_CATEGORIES,
+  STRUCTURED_ERROR_REASONS,
+} from '@vybestack/llxprt-code-core/core/turn.js';
 
 export const DoneReasonSchema = z.enum([
   'stop',
@@ -17,19 +21,9 @@ export const DoneReasonSchema = z.enum([
   'refusal',
 ]);
 
-const StructuredErrorCategorySchema = z.enum([
-  'rate_limit',
-  'quota',
-  'authentication',
-  'server_error',
-  'network',
-  'client_error',
-]);
+const StructuredErrorCategorySchema = z.enum(STRUCTURED_ERROR_CATEGORIES);
 
-const StructuredErrorReasonSchema = z.enum([
-  'retries_exhausted',
-  'all_buckets_exhausted',
-]);
+const StructuredErrorReasonSchema = z.enum(STRUCTURED_ERROR_REASONS);
 
 export const StructuredErrorSchema = z.object({
   message: z.string(),

--- a/packages/agents/src/api/event-schema.ts
+++ b/packages/agents/src/api/event-schema.ts
@@ -17,9 +17,25 @@ export const DoneReasonSchema = z.enum([
   'refusal',
 ]);
 
+const StructuredErrorCategorySchema = z.enum([
+  'rate_limit',
+  'quota',
+  'authentication',
+  'server_error',
+  'network',
+  'client_error',
+]);
+
+const StructuredErrorReasonSchema = z.enum([
+  'retries_exhausted',
+  'all_buckets_exhausted',
+]);
+
 export const StructuredErrorSchema = z.object({
   message: z.string(),
   status: z.number().optional(),
+  category: StructuredErrorCategorySchema.optional(),
+  reason: StructuredErrorReasonSchema.optional(),
 });
 
 export const ThoughtSummarySchema = z.object({

--- a/packages/agents/src/core/DirectMessageProcessor.ts
+++ b/packages/agents/src/core/DirectMessageProcessor.ts
@@ -66,6 +66,7 @@ import {
   beforeModelBlockingToModelOutput,
 } from './hookWireAdapter.js';
 import { canonicalizeToolName } from './toolGovernance.js';
+import { isTerminalRetryError } from './turnAbortHelpers.js';
 
 /**
  * Reads the next chunk from the stream iterator, applying idle-timeout
@@ -258,20 +259,29 @@ export class DirectMessageProcessor {
     params: SendMessageParams,
     userIContents: IContent[],
   ): Promise<ModelOutput> {
+    const requestParams: SendMessageParams = {
+      ...params,
+      config: {
+        ...params.config,
+        providerRequestContext: params.config?.providerRequestContext ?? {},
+      },
+    };
     return retryWithBackoff(
       async () =>
-        this._executeDirectProviderCall(provider, params, userIContents),
+        this._executeDirectProviderCall(provider, requestParams, userIContents),
       {
         shouldRetryOnError: (error: unknown) => {
+          if (isTerminalRetryError(error)) return false;
           if (isProviderApiError(error)) {
             const status = error.status ?? 0;
-            if (status === 400) return false;
-            if (isSchemaDepthError(error.message)) return false;
-            if (status === 429) return true;
-            if (status >= 500 && status < 600) return true;
+            if (status === 400 || isSchemaDepthError(error.message)) {
+              return false;
+            }
+            return status === 429 || (status >= 500 && status < 600);
           }
           return false;
         },
+        signal: params.config?.abortSignal,
       },
     );
   }
@@ -417,6 +427,7 @@ export class DirectMessageProcessor {
       effectiveToolsFromConfig,
       runtimeContext,
       timeoutSignal,
+      params.config?.providerRequestContext,
     );
     const { lastResponse, aggregatedText } = await this._consumeStreamResponse(
       streamResponse,
@@ -461,6 +472,7 @@ export class DirectMessageProcessor {
     effectiveToolsFromConfig: ToolGroupArray | undefined,
     runtimeContext: ProviderRuntimeContext,
     timeoutSignal: AbortSignal,
+    requestContext: Record<string, unknown> | undefined,
   ): AsyncIterable<IContent> {
     this.logger.debug(
       () =>
@@ -493,7 +505,10 @@ export class DirectMessageProcessor {
       } as unknown as GenerateChatOptions['invocation'],
       settings:
         runtimeContext.settingsService as GenerateChatOptions['settings'],
-      metadata: runtimeContext.metadata,
+      metadata: {
+        ...runtimeContext.metadata,
+        _retryRequestContext: requestContext,
+      },
       userMemory: resolveUserMemory(runtimeContext.config),
       systemInstruction: extractSystemInstructionText(
         this.generationConfig.systemInstruction,

--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -36,6 +36,7 @@ import type { CompressionHandler } from '../compression/CompressionHandler.js';
 import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { logApiResponse, logApiError } from './turnLogging.js';
 import { EmptyStreamError } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+import { isTerminalRetryError } from './turnAbortHelpers.js';
 import {
   extractResponseTextFromBlocks,
   analyzeBlocksOutcome,
@@ -235,10 +236,12 @@ export class StreamProcessor {
       this._buildAndSendStreamRequest(params, promptId, userContent, provider);
 
     return retryWithBackoff(apiCall, {
-      onPersistent429: () => this._handleBucketFailover(),
+      onPersistent429: () =>
+        this._handleBucketFailover(params.config?.abortSignal),
       signal: params.config?.abortSignal,
       shouldRetryOnError: (error) =>
-        error instanceof EmptyStreamError || isRetryableError(error),
+        error instanceof EmptyStreamError ||
+        (!isTerminalRetryError(error) && isRetryableError(error)),
     });
   }
 
@@ -443,11 +446,13 @@ export class StreamProcessor {
         tools: requestPayload.tools as ProviderToolset | undefined,
         config: runtimeContext.config,
         runtime: runtimeContext,
+        onProviderError: params.config?.onProviderError,
         settings:
           runtimeContext.settingsService as GenerateChatOptions['settings'],
         metadata: {
           ...runtimeContext.metadata,
           abortSignal: params.config?.abortSignal,
+          _retryRequestContext: params.config?.providerRequestContext,
         },
         userMemory,
         systemInstruction: extractSystemInstructionText(
@@ -574,13 +579,15 @@ export class StreamProcessor {
     return buildRequestContentsResult(userContent, this.historyService);
   }
 
-  private async _handleBucketFailover(): Promise<boolean | null> {
+  private async _handleBucketFailover(
+    signal: AbortSignal | undefined,
+  ): Promise<boolean | null> {
     const failoverHandler =
       this.runtimeContext.providerRuntime.config?.getBucketFailoverHandler();
     if (!failoverHandler) return null;
 
     this.logger.debug(() => 'Attempting bucket failover on persistent 429');
-    const success = await failoverHandler.tryFailover();
+    const success = await failoverHandler.tryFailover({ signal });
     if (success) {
       const runtimeId =
         this.runtimeContext.providerRuntime.runtimeId ??

--- a/packages/agents/src/core/StreamProcessor.unbucketed-auth-failover.test.ts
+++ b/packages/agents/src/core/StreamProcessor.unbucketed-auth-failover.test.ts
@@ -27,6 +27,7 @@ describe('StreamProcessor._handleBucketFailover', () => {
 
   it('allows single-bucket handlers to run tryFailover and flush auth scope', async () => {
     const tryFailover = vi.fn().mockResolvedValue(true);
+    const controller = new AbortController();
 
     const processor = Object.create(
       StreamProcessor.prototype,
@@ -54,12 +55,12 @@ describe('StreamProcessor._handleBucketFailover', () => {
 
     const result = await (
       processor as unknown as {
-        _handleBucketFailover: () => Promise<boolean | null>;
+        _handleBucketFailover: (signal: AbortSignal) => Promise<boolean | null>;
       }
-    )._handleBucketFailover();
+    )._handleBucketFailover(controller.signal);
 
     expect(result).toBe(true);
-    expect(tryFailover).toHaveBeenCalledTimes(1);
+    expect(tryFailover).toHaveBeenCalledWith({ signal: controller.signal });
     expect(flushRuntimeAuthScope).toHaveBeenCalledWith('provider-runtime-1739');
   });
 });

--- a/packages/agents/src/core/TurnProcessor.ts
+++ b/packages/agents/src/core/TurnProcessor.ts
@@ -7,7 +7,10 @@
 import type { AgentClientGenerateConfig } from '@vybestack/llxprt-code-core/core/clientContract.js';
 import type { SendMessageParams } from './chatSession.js';
 import { retryWithBackoff } from '@vybestack/llxprt-code-core/utils/retry.js';
-import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import {
+  createAbortError,
+  delay,
+} from '@vybestack/llxprt-code-core/utils/delay.js';
 import {
   nextStreamEventWithIdleTimeout,
   resolveStreamIdleTimeoutMs,
@@ -30,7 +33,6 @@ import { normalizeToolInteractionInput } from './MessageConverter.js';
 import {
   StreamEventType,
   type StreamEvent,
-  isSchemaDepthError,
   INVALID_CONTENT_RETRY_OPTIONS,
 } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
 import {
@@ -56,9 +58,9 @@ import {
   emptyModelOutput,
 } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import { iContentFromBlocks } from '@vybestack/llxprt-code-core/llm-types/index.js';
-import { isProviderApiError } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import type { ContentBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { enrichSchemaDepthError } from './schemaDepthErrorEnrichment.js';
+import { shouldRetryDirectProviderError } from './turnRetryPolicy.js';
 type ToolGroupArray = Array<{
   functionDeclarations: Array<{ name: string }>;
 }>;
@@ -207,13 +209,20 @@ export class TurnProcessor {
     userContents: IContent[],
     onDone: () => void,
   ): AsyncGenerator<StreamEvent> {
+    const requestParams: SendMessageParams = {
+      ...params,
+      config: {
+        ...params.config,
+        providerRequestContext: params.config?.providerRequestContext ?? {},
+      },
+    };
     try {
       let lastError: unknown = new Error('Request failed after all retries.');
       let attempt = 0;
       let retrying = true;
       while (retrying && attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts) {
         const outcome = yield* this._runStreamAttempt(
-          params,
+          requestParams,
           prompt_id,
           userContents,
           attempt,
@@ -222,11 +231,9 @@ export class TurnProcessor {
         if (outcome.action !== 'retry') {
           retrying = false;
         } else {
-          await new Promise((res) =>
-            setTimeout(
-              res,
-              INVALID_CONTENT_RETRY_OPTIONS.initialDelayMs * (attempt + 1),
-            ),
+          await delay(
+            INVALID_CONTENT_RETRY_OPTIONS.initialDelayMs * (attempt + 1),
+            requestParams.config?.abortSignal,
           );
           attempt++;
         }
@@ -379,6 +386,13 @@ export class TurnProcessor {
     provider: IProvider,
     prompt_id: string,
   ): Promise<ModelOutput> {
+    const requestParams: SendMessageParams = {
+      ...params,
+      config: {
+        ...params.config,
+        providerRequestContext: params.config?.providerRequestContext ?? {},
+      },
+    };
     this._validateProvider(provider);
     let providerStartTime = 0;
     let providerRequestStarted = false;
@@ -398,21 +412,12 @@ export class TurnProcessor {
         () =>
           this._executeProviderCall(
             provider,
-            params,
+            requestParams,
             iContents,
             providerBaseUrl,
           ),
         {
-          shouldRetryOnError: (error: unknown) => {
-            if (isProviderApiError(error) && error.message) {
-              const status = error.status ?? 0;
-              if (status === 400 || isSchemaDepthError(error.message))
-                return false;
-              if (status === 429 || (status >= 500 && status < 600))
-                return true;
-            }
-            return false;
-          },
+          shouldRetryOnError: shouldRetryDirectProviderError,
           signal: params.config?.abortSignal,
         },
       );
@@ -530,6 +535,7 @@ export class TurnProcessor {
         tools,
         runtimeContext,
         timeoutController.signal,
+        params.config?.providerRequestContext,
       );
       const lastResponse = await this._consumeProviderStream(
         streamResponse,
@@ -576,6 +582,7 @@ export class TurnProcessor {
     tools: ToolGroupArray | undefined,
     runtimeContext: ProviderRuntimeContext,
     timeoutSignal: AbortSignal,
+    requestContext: Record<string, unknown> | undefined,
   ): AsyncIterable<IContent> {
     return provider.generateChatCompletion({
       contents: requestContents,
@@ -587,7 +594,10 @@ export class TurnProcessor {
       } as unknown as GenerateChatOptions['invocation'],
       settings:
         runtimeContext.settingsService as GenerateChatOptions['settings'],
-      metadata: runtimeContext.metadata,
+      metadata: {
+        ...runtimeContext.metadata,
+        _retryRequestContext: requestContext,
+      },
       userMemory: resolveUserMemory(runtimeContext.config),
       systemInstruction: extractSystemInstructionText(
         this.generationConfig.systemInstruction,

--- a/packages/agents/src/core/TurnProcessor.ts
+++ b/packages/agents/src/core/TurnProcessor.ts
@@ -209,13 +209,7 @@ export class TurnProcessor {
     userContents: IContent[],
     onDone: () => void,
   ): AsyncGenerator<StreamEvent> {
-    const requestParams: SendMessageParams = {
-      ...params,
-      config: {
-        ...params.config,
-        providerRequestContext: params.config?.providerRequestContext ?? {},
-      },
-    };
+    const requestParams = this._withProviderRequestContext(params);
     try {
       let lastError: unknown = new Error('Request failed after all retries.');
       let attempt = 0;
@@ -324,6 +318,18 @@ export class TurnProcessor {
     return normalizeToolInteractionInput(params.message);
   }
 
+  private _withProviderRequestContext(
+    params: SendMessageParams,
+  ): SendMessageParams {
+    return {
+      ...params,
+      config: {
+        ...params.config,
+        providerRequestContext: params.config?.providerRequestContext ?? {},
+      },
+    };
+  }
+
   private _stampTurnMetadata(contents: IContent[]): IContent[] {
     const idGen = this.historyService.getIdGeneratorCallback();
     return contents.map((content) => ({
@@ -386,13 +392,7 @@ export class TurnProcessor {
     provider: IProvider,
     prompt_id: string,
   ): Promise<ModelOutput> {
-    const requestParams: SendMessageParams = {
-      ...params,
-      config: {
-        ...params.config,
-        providerRequestContext: params.config?.providerRequestContext ?? {},
-      },
-    };
+    const requestParams = this._withProviderRequestContext(params);
     this._validateProvider(provider);
     let providerStartTime = 0;
     let providerRequestStarted = false;

--- a/packages/agents/src/core/chatSession.issue2150.test.ts
+++ b/packages/agents/src/core/chatSession.issue2150.test.ts
@@ -44,10 +44,13 @@ import { createConfigParams } from './chatSession-runtime-helpers.js';
 import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { RuntimeGenerateChatOptions as GenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import {
   InvalidStreamError,
   EmptyStreamError,
 } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+import { RetryOrchestrator } from '../../../providers/src/RetryOrchestrator.js';
+import type { IProvider as ConcreteProvider } from '../../../providers/src/IProvider.js';
 
 describe('Issue 2150: transient connection error must retry the turn, not break the loop', () => {
   let settingsService: SettingsService;
@@ -511,5 +514,51 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       .map((e) => JSON.stringify(e))
       .join('');
     expect(chunkText).toContain('recovered response');
+  });
+
+  it('shares one transport budget across agent empty-stream retries', async () => {
+    settingsService.set('retries', 1);
+    let transports = 0;
+    const delegate: ConcreteProvider = {
+      name: 'stub',
+      generateChatCompletion() {
+        transports++;
+        return (async function* (): AsyncGenerator<IContent> {
+          yield* [];
+        })();
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'stub-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => undefined,
+    };
+    const orchestrator = new RetryOrchestrator(delegate, {
+      maxAttempts: 1,
+      initialDelayMs: 0,
+    });
+    manager.registerProvider(orchestrator as unknown as IProvider);
+
+    const chat = buildChatSession();
+    const stream = await chat.sendMessageStream(
+      { message: 'empty response' },
+      'prompt-shared-transport-budget',
+    );
+
+    await expect(collectEvents(stream)).rejects.toMatchObject({
+      name: 'RetriesExhaustedError',
+      message:
+        'Provider retries exhausted after 1 transport attempts: Model stream ended immediately with no content.',
+      category: 'server_error',
+      isRetryable: false,
+      shouldFailover: false,
+      reason: 'retries_exhausted',
+      failures: [
+        {
+          name: 'EmptyStreamError',
+          message: 'Model stream ended immediately with no content.',
+        },
+      ],
+    });
+    expect(transports).toBe(1);
   });
 });

--- a/packages/agents/src/core/chatSession.issue2150.test.ts
+++ b/packages/agents/src/core/chatSession.issue2150.test.ts
@@ -536,7 +536,7 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       maxAttempts: 1,
       initialDelayMs: 0,
     });
-    manager.registerProvider(orchestrator as unknown as IProvider);
+    manager.registerProvider(orchestrator);
 
     const chat = buildChatSession();
     const stream = await chat.sendMessageStream(

--- a/packages/agents/src/core/chatSession.issue2150.test.ts
+++ b/packages/agents/src/core/chatSession.issue2150.test.ts
@@ -49,8 +49,10 @@ import {
   InvalidStreamError,
   EmptyStreamError,
 } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
-import { RetryOrchestrator } from '../../../providers/src/RetryOrchestrator.js';
-import type { IProvider as ConcreteProvider } from '../../../providers/src/IProvider.js';
+import {
+  RetryOrchestrator,
+  type IProvider as ConcreteProvider,
+} from '@vybestack/llxprt-code-providers';
 
 describe('Issue 2150: transient connection error must retry the turn, not break the loop', () => {
   let settingsService: SettingsService;
@@ -546,20 +548,16 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
 
     await expect(collectEvents(stream)).rejects.toMatchObject({
       name: 'RetriesExhaustedError',
-      message:
-        'Provider retries exhausted after 1 transport attempts: Model stream ended immediately with no content.',
       category: 'server_error',
       isRetryable: false,
       shouldFailover: false,
       reason: 'retries_exhausted',
       cause: {
         name: 'EmptyStreamError',
-        message: 'Model stream ended immediately with no content.',
       },
       failures: [
         {
           name: 'EmptyStreamError',
-          message: 'Model stream ended immediately with no content.',
         },
       ],
     });

--- a/packages/agents/src/core/chatSession.issue2150.test.ts
+++ b/packages/agents/src/core/chatSession.issue2150.test.ts
@@ -552,6 +552,10 @@ describe('Issue 2150: transient connection error must retry the turn, not break 
       isRetryable: false,
       shouldFailover: false,
       reason: 'retries_exhausted',
+      cause: {
+        name: 'EmptyStreamError',
+        message: 'Model stream ended immediately with no content.',
+      },
       failures: [
         {
           name: 'EmptyStreamError',

--- a/packages/agents/src/core/chatSession.runtime.timeout.test.ts
+++ b/packages/agents/src/core/chatSession.runtime.timeout.test.ts
@@ -105,6 +105,7 @@ describe('stream idle timeout behavioral tests for TurnProcessor and DirectMessa
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     process.env = originalEnv;
   });

--- a/packages/agents/src/core/chatSession.runtime.timeout.test.ts
+++ b/packages/agents/src/core/chatSession.runtime.timeout.test.ts
@@ -12,7 +12,16 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ChatSession } from './chatSession.js';
+import {
+  AgentEventType,
+  DEFAULT_AGENT_ID,
+  Turn,
+  type ServerAgentStreamEvent,
+} from './turn.js';
 import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { RuntimeGenerateChatOptions as GenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
 import { TestRuntimeProviderManager } from '../test-utils/runtimeProviderManager.js';
 import { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import {
@@ -21,6 +30,7 @@ import {
 } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import type { ContentGenerator } from '@vybestack/llxprt-code-core/core/contentGenerator.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
 import { createAgentRuntimeStateFromConfig } from '@vybestack/llxprt-code-core/runtime/runtimeStateFactory.js';
 import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
 import {
@@ -29,6 +39,58 @@ import {
   createToolRegistryViewFromRegistry,
 } from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
 import { createConfigParams } from './chatSession-runtime-helpers.js';
+
+function createContentGeneratorStub(): ContentGenerator {
+  return {
+    generateContent: vi.fn(),
+    generateContentStream: vi.fn(),
+    countTokens: vi.fn(async () => ({ totalTokens: 0 })),
+    embedContent: vi.fn(async () => ({ embeddings: [] })),
+  };
+}
+
+function createNoncooperativeStream(
+  onPendingRead: () => void,
+): AsyncIterableIterator<IContent> {
+  let deliveredFirstChunk = false;
+  const pendingResult = new Promise<IteratorResult<IContent>>(() => undefined);
+  return {
+    next(): Promise<IteratorResult<IContent>> {
+      if (!deliveredFirstChunk) {
+        deliveredFirstChunk = true;
+        return Promise.resolve({
+          done: false,
+          value: {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'Hanging' }],
+          },
+        });
+      }
+      onPendingRead();
+      return pendingResult;
+    },
+    return(): Promise<IteratorResult<IContent>> {
+      return pendingResult;
+    },
+    [Symbol.asyncIterator](): AsyncIterableIterator<IContent> {
+      return this;
+    },
+  };
+}
+
+async function collectTurnEvents(
+  turn: Turn,
+  request: string,
+): Promise<ServerAgentStreamEvent[]> {
+  const events: ServerAgentStreamEvent[] = [];
+  for await (const event of turn.run(
+    [{ type: 'text', text: request }],
+    new AbortController().signal,
+  )) {
+    events.push(event);
+  }
+  return events;
+}
 
 describe('stream idle timeout behavioral tests for TurnProcessor and DirectMessageProcessor', () => {
   const originalEnv = process.env;
@@ -156,6 +218,109 @@ describe('stream idle timeout behavioral tests for TurnProcessor and DirectMessa
       expect(
         configFromChat?.getEphemeralSetting('stream-idle-timeout-ms'),
       ).toBe(0);
+    });
+
+    it('starts a second real ChatSession send after timeout while the first provider iterator remains blocked', async () => {
+      vi.useFakeTimers();
+      const timeoutMs = 30_000;
+      localSettingsService = new SettingsService();
+      localConfig = new Config(createConfigParams(localSettingsService));
+      localConfig.setEphemeralSetting('stream-idle-timeout-ms', timeoutMs);
+      localProviderRuntime = createProviderRuntimeContext({
+        settingsService: localSettingsService,
+        config: localConfig,
+        runtimeId: 'test.runtime.deadlock',
+        metadata: { source: 'deadlock-test' },
+      });
+      localManager = new TestRuntimeProviderManager(localProviderRuntime);
+      localManager.setConfig(localConfig);
+      localConfig.setProviderManager(localManager);
+      let transports = 0;
+      let pendingReads = 0;
+      const provider: IProvider = {
+        name: 'stub',
+        isDefault: true,
+        getModels: vi.fn(async () => []),
+        getDefaultModel: () => 'stub-model',
+        generateChatCompletion: vi.fn(
+          (_options: GenerateChatOptions): AsyncIterableIterator<IContent> => {
+            transports++;
+            if (transports === 1) {
+              return createNoncooperativeStream(() => {
+                pendingReads++;
+              });
+            }
+            return (async function* () {
+              yield {
+                speaker: 'ai',
+                blocks: [{ type: 'text', text: 'OK' }],
+              };
+              yield {
+                speaker: 'ai',
+                blocks: [],
+                metadata: { finishReason: 'stop' },
+              };
+            })();
+          },
+        ),
+        getServerTools: () => [],
+        invokeServerTool: vi.fn(),
+      };
+      localManager.registerProvider(provider);
+      localManager.setActiveProvider('stub');
+      const chat = new ChatSession(
+        createAgentRuntimeContext({
+          state: createAgentRuntimeState({
+            runtimeId: 'test.runtime.deadlock',
+            provider: 'stub',
+            model: 'stub-model',
+            sessionId: localConfig.getSessionId(),
+          }),
+          history: new HistoryService(),
+          settings: { compressionThreshold: 0.8 },
+          provider: createProviderAdapterFromManager(localManager),
+          telemetry: createTelemetryAdapterFromConfig(localConfig),
+          tools: createToolRegistryViewFromRegistry(
+            localConfig.getToolRegistry(),
+          ),
+          providerRuntime: localProviderRuntime,
+        }),
+        createContentGeneratorStub(),
+        {},
+        [],
+      );
+      const firstEventsPromise = collectTurnEvents(
+        new Turn(chat, 'first-prompt', DEFAULT_AGENT_ID, 'stub'),
+        'first request',
+      );
+
+      await vi.waitFor(() => expect(pendingReads).toBe(1), {
+        interval: 1,
+        timeout: 100,
+      });
+      await vi.advanceTimersByTimeAsync(timeoutMs + 1);
+      const secondEventsPromise = collectTurnEvents(
+        new Turn(chat, 'second-prompt', DEFAULT_AGENT_ID, 'stub'),
+        'second request',
+      );
+      await vi.waitFor(() => expect(transports).toBe(2), {
+        interval: 1,
+        timeout: 100,
+      });
+
+      const [firstEvents, secondEvents] = await Promise.all([
+        firstEventsPromise,
+        secondEventsPromise,
+      ]);
+      expect(firstEvents).toContainEqual(
+        expect.objectContaining({ type: AgentEventType.StreamIdleTimeout }),
+      );
+      expect(secondEvents).toContainEqual(
+        expect.objectContaining({
+          type: AgentEventType.Content,
+          value: 'OK',
+        }),
+      );
     });
 
     it('env var precedence: env var overrides config setting', async () => {

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -14,6 +14,7 @@ import type {
 } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import type { ToolGroupArray } from './streamRequestHelpers.js';
 import type { ContentBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { StructuredError } from '@vybestack/llxprt-code-core/core/turn.js';
 
 /**
  * Neutral generation config carried by ChatSession. Extends the neutral
@@ -25,6 +26,8 @@ import type { ContentBlock } from '@vybestack/llxprt-code-core/services/history/
  */
 export interface ChatSessionConfig extends ModelGenerationSettings {
   abortSignal?: AbortSignal;
+  onProviderError?: (error: StructuredError) => void;
+  providerRequestContext?: Record<string, unknown>;
   tools?: ToolGroupArray;
   toolConfig?: unknown;
 }

--- a/packages/agents/src/core/iteratorCleanup.test.ts
+++ b/packages/agents/src/core/iteratorCleanup.test.ts
@@ -30,13 +30,17 @@ describe('closeIteratorBounded', () => {
   it('bounds cleanup for a noncooperative iterator', async () => {
     vi.useFakeTimers();
     let completed = false;
+    let cleanupRequested = false;
 
-    const closing = closeIteratorBounded(createNoncooperativeIterator()).then(
-      () => {
-        completed = true;
-      },
-    );
+    const closing = closeIteratorBounded(
+      createNoncooperativeIterator(() => {
+        cleanupRequested = true;
+      }),
+    ).then(() => {
+      completed = true;
+    });
 
+    expect(cleanupRequested).toBe(true);
     await vi.advanceTimersByTimeAsync(
       CLEANUP_TIMEOUT_MS - TIMEOUT_BOUNDARY_MARGIN_MS,
     );

--- a/packages/agents/src/core/iteratorCleanup.test.ts
+++ b/packages/agents/src/core/iteratorCleanup.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { closeIteratorBounded } from './iteratorCleanup.js';
+
+function createNoncooperativeIterator(
+  onReturn?: () => void,
+): AsyncIterator<string> {
+  return {
+    next: () => new Promise<IteratorResult<string>>(() => {}),
+    return: () => {
+      onReturn?.();
+      return new Promise<IteratorResult<string>>(() => {});
+    },
+  };
+}
+
+describe('closeIteratorBounded', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('bounds cleanup for a noncooperative iterator', async () => {
+    vi.useFakeTimers();
+    let completed = false;
+
+    const closing = closeIteratorBounded(createNoncooperativeIterator()).then(
+      () => {
+        completed = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(completed).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await closing;
+    expect(completed).toBe(true);
+  });
+
+  it('requests cleanup without scheduling a timer after abort', async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    abortController.abort();
+    let cleanupRequested = false;
+
+    await closeIteratorBounded(
+      createNoncooperativeIterator(() => {
+        cleanupRequested = true;
+      }),
+      abortController.signal,
+    );
+
+    expect(cleanupRequested).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('stops waiting and clears the cleanup timer when aborted', async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    const closing = closeIteratorBounded(
+      createNoncooperativeIterator(),
+      abortController.signal,
+    );
+
+    expect(vi.getTimerCount()).toBe(1);
+    abortController.abort();
+    await closing;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/agents/src/core/iteratorCleanup.test.ts
+++ b/packages/agents/src/core/iteratorCleanup.test.ts
@@ -27,6 +27,18 @@ describe('closeIteratorBounded', () => {
     vi.useRealTimers();
   });
 
+  it('returns immediately when no iterator was acquired', async () => {
+    await expect(closeIteratorBounded(undefined)).resolves.toBeUndefined();
+  });
+
+  it('returns immediately when the iterator has no return method', async () => {
+    const iterator: AsyncIterator<string> = {
+      next: async () => ({ done: true, value: undefined }),
+    };
+
+    await expect(closeIteratorBounded(iterator)).resolves.toBeUndefined();
+  });
+
   it('bounds cleanup for a noncooperative iterator', async () => {
     vi.useFakeTimers();
     let completed = false;

--- a/packages/agents/src/core/iteratorCleanup.test.ts
+++ b/packages/agents/src/core/iteratorCleanup.test.ts
@@ -7,6 +7,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { closeIteratorBounded } from './iteratorCleanup.js';
 
+const CLEANUP_TIMEOUT_MS = 1_000;
+const TIMEOUT_BOUNDARY_MARGIN_MS = 1;
+
 function createNoncooperativeIterator(
   onReturn?: () => void,
 ): AsyncIterator<string> {
@@ -34,12 +37,58 @@ describe('closeIteratorBounded', () => {
       },
     );
 
-    await vi.advanceTimersByTimeAsync(999);
+    await vi.advanceTimersByTimeAsync(
+      CLEANUP_TIMEOUT_MS - TIMEOUT_BOUNDARY_MARGIN_MS,
+    );
     expect(completed).toBe(false);
 
+    await vi.advanceTimersByTimeAsync(TIMEOUT_BOUNDARY_MARGIN_MS);
+    await closing;
+    expect(completed).toBe(true);
+  });
+
+  it('uses a caller-provided cleanup timeout', async () => {
+    vi.useFakeTimers();
+    let completed = false;
+
+    const closing = closeIteratorBounded(
+      createNoncooperativeIterator(),
+      undefined,
+      25,
+    ).then(() => {
+      completed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(24);
+    expect(completed).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
     await closing;
     expect(completed).toBe(true);
+  });
+
+  it('returns as soon as cooperative cleanup completes', async () => {
+    vi.useFakeTimers();
+    const iterator: AsyncIterator<string> = {
+      next: async () => ({ done: true, value: undefined }),
+      return: async () => ({ done: true, value: undefined }),
+    };
+
+    await closeIteratorBounded(iterator);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('contains rejected cleanup without leaving a timer', async () => {
+    vi.useFakeTimers();
+    const iterator: AsyncIterator<string> = {
+      next: async () => ({ done: true, value: undefined }),
+      return: async () => {
+        throw new Error('cleanup failed');
+      },
+    };
+
+    await expect(closeIteratorBounded(iterator)).resolves.toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('requests cleanup without scheduling a timer after abort', async () => {

--- a/packages/agents/src/core/iteratorCleanup.ts
+++ b/packages/agents/src/core/iteratorCleanup.ts
@@ -9,6 +9,7 @@ const ITERATOR_CLEANUP_TIMEOUT_MS = 1_000;
 export async function closeIteratorBounded<T>(
   iterator: AsyncIterator<T> | undefined,
   abortSignal?: AbortSignal,
+  cleanupTimeoutMs = ITERATOR_CLEANUP_TIMEOUT_MS,
 ): Promise<void> {
   if (iterator?.return === undefined) return;
 
@@ -31,7 +32,7 @@ export async function closeIteratorBounded<T>(
           abortSignal.addEventListener('abort', onAbort, { once: true });
         });
   const timeout = new Promise<void>((resolve) => {
-    timeoutId = setTimeout(resolve, ITERATOR_CLEANUP_TIMEOUT_MS);
+    timeoutId = setTimeout(resolve, cleanupTimeoutMs);
   });
   try {
     await Promise.race(

--- a/packages/agents/src/core/iteratorCleanup.ts
+++ b/packages/agents/src/core/iteratorCleanup.ts
@@ -8,10 +8,10 @@ const ITERATOR_CLEANUP_TIMEOUT_MS = 1_000;
 
 export async function closeIteratorBounded<T>(
   iterator: AsyncIterator<T> | undefined,
+  abortSignal?: AbortSignal,
 ): Promise<void> {
   if (iterator?.return === undefined) return;
 
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   let cleanup: Promise<unknown>;
   try {
     cleanup = Promise.resolve(iterator.return());
@@ -19,12 +19,30 @@ export async function closeIteratorBounded<T>(
     return;
   }
   const settledCleanup = cleanup.catch(() => undefined);
+  if (abortSignal?.aborted === true) return;
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  const aborted =
+    abortSignal === undefined
+      ? undefined
+      : new Promise<void>((resolve) => {
+          onAbort = resolve;
+          abortSignal.addEventListener('abort', onAbort, { once: true });
+        });
   const timeout = new Promise<void>((resolve) => {
     timeoutId = setTimeout(resolve, ITERATOR_CLEANUP_TIMEOUT_MS);
   });
   try {
-    await Promise.race([settledCleanup, timeout]);
+    await Promise.race(
+      aborted === undefined
+        ? [settledCleanup, timeout]
+        : [settledCleanup, timeout, aborted],
+    );
   } finally {
+    if (onAbort !== undefined) {
+      abortSignal?.removeEventListener('abort', onAbort);
+    }
     if (timeoutId !== undefined) clearTimeout(timeoutId);
   }
 }

--- a/packages/agents/src/core/iteratorCleanup.ts
+++ b/packages/agents/src/core/iteratorCleanup.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const ITERATOR_CLEANUP_TIMEOUT_MS = 1_000;
+
+export async function closeIteratorBounded<T>(
+  iterator: AsyncIterator<T> | undefined,
+): Promise<void> {
+  if (iterator?.return === undefined) return;
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let cleanup: Promise<unknown>;
+  try {
+    cleanup = Promise.resolve(iterator.return());
+  } catch {
+    return;
+  }
+  const settledCleanup = cleanup.catch(() => undefined);
+  const timeout = new Promise<void>((resolve) => {
+    timeoutId = setTimeout(resolve, ITERATOR_CLEANUP_TIMEOUT_MS);
+  });
+  try {
+    await Promise.race([settledCleanup, timeout]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}

--- a/packages/agents/src/core/processorRetryBoundary.test.ts
+++ b/packages/agents/src/core/processorRetryBoundary.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { DirectMessageProcessor } from './DirectMessageProcessor.js';
+import { TurnProcessor } from './TurnProcessor.js';
+import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import { isTerminalRetryError } from './turnAbortHelpers.js';
+
+vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  retryWithBackoff: vi.fn(
+    async <T>(
+      fn: () => Promise<T>,
+      options?: {
+        shouldRetryOnError?: (error: unknown) => boolean;
+        signal?: AbortSignal;
+      },
+    ): Promise<T> => {
+      if (options?.signal?.aborted === true) throw createAbortError();
+      try {
+        return await fn();
+      } catch (error) {
+        if (options?.shouldRetryOnError?.(error) === true) return fn();
+        throw error;
+      }
+    },
+  ),
+}));
+
+function terminalError(): Error & {
+  readonly isRetryable: false;
+  readonly failures: readonly Error[];
+} {
+  const cause = new Error('transport exhausted');
+  return Object.assign(new Error('retries exhausted'), {
+    isRetryable: false as const,
+    failures: [cause] as readonly Error[],
+  });
+}
+
+describe('agent processor retry boundaries', () => {
+  it('TurnProcessor does not retry a terminal provider aggregate', async () => {
+    const error = terminalError();
+    let calls = 0;
+    const processor = Object.create(TurnProcessor.prototype) as TurnProcessor;
+    Object.assign(processor, {
+      compressionHandler: {
+        enforceProviderContents: async ({
+          contents,
+        }: {
+          contents: unknown[];
+        }) => contents,
+        clearProviderCompressionCallback: () => undefined,
+      },
+      runtimeContext: {
+        state: { model: 'test-model' },
+        providerRuntime: {},
+        telemetry: { logApiError: () => undefined },
+      },
+      resolveProviderBaseUrl: () => undefined,
+      generationConfig: {},
+      _executeProviderCall: async () => {
+        calls++;
+        throw error;
+      },
+      _validateProvider: () => undefined,
+      _enforceAndLogProviderContents: async (contents: unknown[]) => contents,
+    });
+
+    await expect(
+      Reflect.apply(
+        (
+          processor as unknown as {
+            _executeSendWithRetry: (...args: unknown[]) => Promise<unknown>;
+          }
+        )._executeSendWithRetry,
+        processor,
+        [
+          { message: 'test' },
+          [{ speaker: 'human', blocks: [] }],
+          { name: 'test-provider' },
+          'prompt-id',
+        ],
+      ),
+    ).rejects.toBe(error);
+    expect(calls).toBe(1);
+  });
+
+  it('DirectMessageProcessor passes the signal and does not retry a terminal aggregate', async () => {
+    const error = terminalError();
+    const controller = new AbortController();
+    let calls = 0;
+    const processor = Object.create(
+      DirectMessageProcessor.prototype,
+    ) as DirectMessageProcessor;
+    Object.assign(processor, {
+      _executeDirectProviderCall: async () => {
+        calls++;
+        throw error;
+      },
+    });
+
+    await expect(
+      Reflect.apply(
+        (
+          processor as unknown as {
+            _executeWithRetry: (...args: unknown[]) => Promise<unknown>;
+          }
+        )._executeWithRetry,
+        processor,
+        [
+          { name: 'test-provider' },
+          { message: 'test', config: { abortSignal: controller.signal } },
+          [{ speaker: 'human', blocks: [] }],
+        ],
+      ),
+    ).rejects.toBe(error);
+    expect(calls).toBe(1);
+    expect(isTerminalRetryError(error)).toBe(true);
+  });
+
+  it('DirectMessageProcessor honors an already-aborted signal before transport', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let calls = 0;
+    const processor = Object.create(
+      DirectMessageProcessor.prototype,
+    ) as DirectMessageProcessor;
+    Object.assign(processor, {
+      _executeDirectProviderCall: async () => {
+        calls++;
+      },
+    });
+
+    await expect(
+      Reflect.apply(
+        (
+          processor as unknown as {
+            _executeWithRetry: (...args: unknown[]) => Promise<unknown>;
+          }
+        )._executeWithRetry,
+        processor,
+        [
+          { name: 'test-provider' },
+          { message: 'test', config: { abortSignal: controller.signal } },
+          [{ speaker: 'human', blocks: [] }],
+        ],
+      ),
+    ).rejects.toThrow(/abort/i);
+    expect(calls).toBe(0);
+  });
+
+  it('TurnProcessor stops when aborted during the retry delay', async () => {
+    const controller = new AbortController();
+    let attempts = 0;
+    let releaseAttempt!: () => void;
+    const attemptStarted = new Promise<void>((resolve) => {
+      releaseAttempt = resolve;
+    });
+    const processor = Object.create(TurnProcessor.prototype) as TurnProcessor;
+    Object.assign(processor, {
+      async *_runStreamAttempt() {
+        attempts++;
+        releaseAttempt();
+        yield* [];
+        return { error: new Error('retry me'), action: 'retry' as const };
+      },
+    });
+
+    const generator = Reflect.apply(
+      (
+        processor as unknown as {
+          _createStreamGenerator: (
+            ...args: unknown[]
+          ) => AsyncGenerator<unknown>;
+        }
+      )._createStreamGenerator,
+      processor,
+      [
+        { message: 'test', config: { abortSignal: controller.signal } },
+        'prompt-id',
+        [],
+        () => undefined,
+      ],
+    );
+    const pending = generator.next();
+    await attemptStarted;
+    controller.abort();
+
+    await expect(pending).rejects.toThrow(/abort/i);
+    expect(attempts).toBe(1);
+  });
+});

--- a/packages/agents/src/core/processorRetryBoundary.test.ts
+++ b/packages/agents/src/core/processorRetryBoundary.test.ts
@@ -4,31 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { DirectMessageProcessor } from './DirectMessageProcessor.js';
 import { TurnProcessor } from './TurnProcessor.js';
-import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { isTerminalRetryError } from './turnAbortHelpers.js';
-
-vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
-  retryWithBackoff: vi.fn(
-    async <T>(
-      fn: () => Promise<T>,
-      options?: {
-        shouldRetryOnError?: (error: unknown) => boolean;
-        signal?: AbortSignal;
-      },
-    ): Promise<T> => {
-      if (options?.signal?.aborted === true) throw createAbortError();
-      try {
-        return await fn();
-      } catch (error) {
-        if (options?.shouldRetryOnError?.(error) === true) return fn();
-        throw error;
-      }
-    },
-  ),
-}));
 
 function terminalError(): Error & {
   readonly isRetryable: false;

--- a/packages/agents/src/core/processorRetryBoundary.test.ts
+++ b/packages/agents/src/core/processorRetryBoundary.test.ts
@@ -128,7 +128,7 @@ describe('agent processor retry boundaries', () => {
           [{ speaker: 'human', blocks: [] }],
         ],
       ),
-    ).rejects.toThrow(/abort/i);
+    ).rejects.toMatchObject({ name: 'AbortError' });
     expect(calls).toBe(0);
   });
 

--- a/packages/agents/src/core/turn.abort-timeout.test.ts
+++ b/packages/agents/src/core/turn.abort-timeout.test.ts
@@ -303,22 +303,30 @@ describe('Turn run - abort and idle timeout', () => {
         'test',
       );
 
-      const mockResponseStream = (async function* () {
-        yield {
-          type: StreamEventType.CHUNK,
-          value: mockChunk({ text: 'First part' }),
-        };
-        await new Promise<void>(() => {});
-      })();
-
       mockSendMessageStream.mockImplementation(async (params) => {
         const config = params as {
           config?: { abortSignal?: AbortSignal };
         };
-        if (config.config?.abortSignal) {
-          abortSignals.push(config.config.abortSignal);
+        const providerSignal = config.config?.abortSignal;
+        if (providerSignal === undefined) {
+          throw new Error('Provider abort signal is required');
         }
-        return mockResponseStream;
+        abortSignals.push(providerSignal);
+        return (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'First part' }),
+          };
+          if (!providerSignal.aborted) {
+            await new Promise<void>((_resolve, reject) => {
+              providerSignal.addEventListener(
+                'abort',
+                () => reject(new DOMException('Aborted', 'AbortError')),
+                { once: true },
+              );
+            });
+          }
+        })();
       });
 
       const eventsPromise = (async () => {
@@ -385,14 +393,23 @@ describe('Turn run - abort and idle timeout', () => {
         'test',
       );
 
-      const createMockStream = (shouldHang: boolean) =>
+      const createMockStream = (
+        shouldHang: boolean,
+        providerSignal: AbortSignal,
+      ) =>
         (async function* () {
           yield {
             type: StreamEventType.CHUNK,
             value: mockChunk({ text: shouldHang ? 'Hanging' : 'OK' }),
           };
-          if (shouldHang) {
-            await new Promise<void>(() => {});
+          if (shouldHang && !providerSignal.aborted) {
+            await new Promise<void>((_resolve, reject) => {
+              providerSignal.addEventListener(
+                'abort',
+                () => reject(new DOMException('Aborted', 'AbortError')),
+                { once: true },
+              );
+            });
           }
         })();
 
@@ -401,10 +418,12 @@ describe('Turn run - abort and idle timeout', () => {
         const config = params as {
           config?: { abortSignal?: AbortSignal };
         };
-        if (config.config?.abortSignal) {
-          abortSignals.push(config.config.abortSignal);
+        const providerSignal = config.config?.abortSignal;
+        if (providerSignal === undefined) {
+          throw new Error('Provider abort signal is required');
         }
-        return createMockStream(callCount === 1);
+        abortSignals.push(providerSignal);
+        return createMockStream(callCount === 1, providerSignal);
       });
 
       const events1Promise = (async () => {

--- a/packages/agents/src/core/turn.abort-timeout.test.ts
+++ b/packages/agents/src/core/turn.abort-timeout.test.ts
@@ -18,6 +18,26 @@ const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
   mockGetHistory: vi.fn(),
 }));
 
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}
+
+function rejectWhenAborted(signal: AbortSignal): Promise<never> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException('Aborted', 'AbortError'));
+  }
+  return new Promise<never>((_resolve, reject) => {
+    signal.addEventListener(
+      'abort',
+      () => reject(new DOMException('Aborted', 'AbortError')),
+      { once: true },
+    );
+  });
+}
+
 vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
   reportError: vi.fn(),
 }));
@@ -126,11 +146,7 @@ describe('Turn run - abort and idle timeout', () => {
             type: StreamEventType.CHUNK,
             value: mockChunk({ text: 'First part' }),
           };
-          await new Promise<void>((resolve) => {
-            abortController.signal.addEventListener('abort', () => resolve(), {
-              once: true,
-            });
-          });
+          await waitForAbort(abortController.signal);
           yield {
             type: StreamEventType.CHUNK,
             value: mockChunk({
@@ -317,15 +333,7 @@ describe('Turn run - abort and idle timeout', () => {
             type: StreamEventType.CHUNK,
             value: mockChunk({ text: 'First part' }),
           };
-          if (!providerSignal.aborted) {
-            await new Promise<void>((_resolve, reject) => {
-              providerSignal.addEventListener(
-                'abort',
-                () => reject(new DOMException('Aborted', 'AbortError')),
-                { once: true },
-              );
-            });
-          }
+          await rejectWhenAborted(providerSignal);
         })();
       });
 
@@ -362,108 +370,6 @@ describe('Turn run - abort and idle timeout', () => {
       ]);
       expect(abortSignals).toHaveLength(1);
       expect(abortSignals[0]?.aborted).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('should allow subsequent calls after idle timeout (sendPromise deadlock prevention)', async () => {
-    vi.useFakeTimers();
-    try {
-      const testTimeoutMs = 30_000;
-      let callCount = 0;
-      const abortSignals: AbortSignal[] = [];
-
-      mockChatInstance = {
-        sendMessageStream: mockSendMessageStream,
-        getHistory: mockGetHistory,
-        getConfig: () => ({
-          getEphemeralSetting: (key: string) => {
-            if (key === 'stream-idle-timeout-ms') {
-              return testTimeoutMs;
-            }
-            return undefined;
-          },
-        }),
-      };
-      turn = new Turn(
-        mockChatInstance as unknown as ChatSession,
-        'prompt-id-1',
-        DEFAULT_AGENT_ID,
-        'test',
-      );
-
-      const createMockStream = (
-        shouldHang: boolean,
-        providerSignal: AbortSignal,
-      ) =>
-        (async function* () {
-          yield {
-            type: StreamEventType.CHUNK,
-            value: mockChunk({ text: shouldHang ? 'Hanging' : 'OK' }),
-          };
-          if (shouldHang && !providerSignal.aborted) {
-            await new Promise<void>((_resolve, reject) => {
-              providerSignal.addEventListener(
-                'abort',
-                () => reject(new DOMException('Aborted', 'AbortError')),
-                { once: true },
-              );
-            });
-          }
-        })();
-
-      mockSendMessageStream.mockImplementation(async (params) => {
-        callCount++;
-        const config = params as {
-          config?: { abortSignal?: AbortSignal };
-        };
-        const providerSignal = config.config?.abortSignal;
-        if (providerSignal === undefined) {
-          throw new Error('Provider abort signal is required');
-        }
-        abortSignals.push(providerSignal);
-        return createMockStream(callCount === 1, providerSignal);
-      });
-
-      const events1Promise = (async () => {
-        const events: ServerAgentStreamEvent[] = [];
-        for await (const event of turn.run(
-          [{ text: 'First call (will timeout)' }],
-          new AbortController().signal,
-        )) {
-          events.push(event);
-        }
-        return events;
-      })();
-
-      await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
-      const events1 = await events1Promise;
-
-      expect(events1).toContainEqual(
-        expect.objectContaining({ type: AgentEventType.StreamIdleTimeout }),
-      );
-      expect(callCount).toBe(1);
-
-      const events2Promise = (async () => {
-        const events: ServerAgentStreamEvent[] = [];
-        for await (const event of turn.run(
-          [{ text: 'Second call (should work)' }],
-          new AbortController().signal,
-        )) {
-          events.push(event);
-        }
-        return events;
-      })();
-
-      await vi.advanceTimersByTimeAsync(100);
-      const events2 = await events2Promise;
-
-      expect(callCount).toBe(2);
-      expect(events2).toContainEqual({
-        type: AgentEventType.Content,
-        value: 'OK',
-      });
     } finally {
       vi.useRealTimers();
     }

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -14,12 +14,14 @@ import { type MockedChatInstance, mockChunk } from './turn-test-helpers.js';
 import { DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
-import { ProviderManager } from '../../../providers/src/ProviderManager.js';
-import { LoadBalancingProvider } from '../../../providers/src/LoadBalancingProvider.js';
 import type {
   GenerateChatOptions,
   IProvider,
-} from '../../../providers/src/IProvider.js';
+} from '@vybestack/llxprt-code-providers';
+import {
+  LoadBalancingProvider,
+  ProviderManager,
+} from '@vybestack/llxprt-code-providers';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 
 const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
@@ -264,7 +266,7 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     mockSendMessageStream.mockImplementation(
       (params: {
         config: {
-          onProviderError: (error: typeof rateLimitError) => void;
+          onProviderError: (error: StructuredError) => void;
         };
       }) => {
         params.config.onProviderError(rateLimitError);
@@ -624,16 +626,24 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     const { turn } = buildTurn(0);
 
     let returnCalled = false;
+    const firstNextFailure = Object.assign(new Error('first next failed'), {
+      status: 502,
+      category: 'server_error',
+    });
+    const cleanupFailure = Object.assign(new Error('cleanup failed'), {
+      status: 504,
+      category: 'network',
+    });
     const throwingIterator: AsyncIterator<{
       type: StreamEventType;
       value: ModelStreamChunk;
     }> = {
       async next(): Promise<never> {
-        throw new Error('first next failed');
+        throw firstNextFailure;
       },
       async return() {
         returnCalled = true;
-        throw new Error('cleanup failed');
+        throw cleanupFailure;
       },
     };
     mockSendMessageStream.mockResolvedValue({
@@ -653,7 +663,12 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     expect(returnCalled).toBe(true);
     expect(events).toContainEqual({
       type: AgentEventType.Error,
-      value: { error: { message: 'first next failed' } },
+      value: {
+        error: expect.objectContaining({
+          status: 502,
+          category: 'server_error',
+        }),
+      },
     });
   });
 

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -5,13 +5,22 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ServerAgentStreamEvent } from './turn.js';
+import type { ServerAgentStreamEvent, StructuredError } from './turn.js';
 import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
 import type { ChatSession } from './chatSession.js';
 import { StreamEventType } from './chatSession.js';
 import type { ModelStreamChunk } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import { type MockedChatInstance, mockChunk } from './turn-test-helpers.js';
 import { DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { ProviderManager } from '../../../providers/src/ProviderManager.js';
+import { LoadBalancingProvider } from '../../../providers/src/LoadBalancingProvider.js';
+import type {
+  GenerateChatOptions,
+  IProvider,
+} from '../../../providers/src/IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 
 const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
   mockSendMessageStream: vi.fn(),
@@ -245,6 +254,261 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     expect(events.some((e) => e.type === AgentEventType.Error)).toBe(false);
   });
 
+  it('prefers a provider 429 observed during retry over a racing first-response timeout', async () => {
+    const { turn } = buildTurn(20);
+    const rateLimitError: StructuredError = {
+      message: 'Rate limited by provider',
+      status: 429,
+      category: 'rate_limit',
+    };
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config: {
+          onProviderError: (error: typeof rateLimitError) => void;
+        };
+      }) => {
+        params.config.onProviderError(rateLimitError);
+        return Promise.resolve(createStreamWithStalledFirstNext());
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    expect(events).toContainEqual({
+      type: AgentEventType.Error,
+      value: { error: rateLimitError },
+    });
+    expect(
+      events.some((event) => event.type === AgentEventType.StreamIdleTimeout),
+    ).toBe(false);
+  });
+  it('keeps observed provider failures scoped to one run', async () => {
+    const { turn } = buildTurn(20);
+    const rateLimitError: StructuredError = {
+      message: 'First request was rate limited',
+      status: 429,
+      category: 'rate_limit',
+    };
+    mockSendMessageStream
+      .mockImplementationOnce(
+        (params: {
+          config: {
+            onProviderError: (error: StructuredError) => void;
+          };
+        }) => {
+          params.config.onProviderError(rateLimitError);
+          return Promise.resolve(createStreamWithStalledFirstNext());
+        },
+      )
+      .mockResolvedValueOnce(createStreamWithStalledFirstNext());
+
+    const firstEvents: ServerAgentStreamEvent[] = [];
+    const firstRun = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'first' }],
+        new AbortController().signal,
+      )) {
+        firstEvents.push(event);
+      }
+    })();
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await firstRun;
+
+    const secondEvents: ServerAgentStreamEvent[] = [];
+    const secondRun = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'second' }],
+        new AbortController().signal,
+      )) {
+        secondEvents.push(event);
+      }
+    })();
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await secondRun;
+
+    expect({ firstEvents, secondEvents }).toStrictEqual({
+      firstEvents: [
+        {
+          type: AgentEventType.Error,
+          value: { error: rateLimitError },
+        },
+      ],
+      secondEvents: [
+        {
+          type: AgentEventType.StreamIdleTimeout,
+          value: {
+            error: {
+              message:
+                'Stream idle timeout: no response received within the allowed time.',
+              status: undefined,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it('retains an LB-observed 429 when the failover backend stalls until Turn timeout', async () => {
+    const { turn } = buildTurn(20);
+    const settings = new SettingsService();
+    const providerConfig = createRuntimeConfigStub(settings);
+    const providerManager = new ProviderManager({
+      settingsService: settings,
+      config: providerConfig,
+    });
+    providerManager.getProviderByName = (name: string) =>
+      name === 'delegate' ? delegate : undefined;
+    let transports = 0;
+    let secondTransportStarted!: () => void;
+    const secondTransport = new Promise<void>((resolve) => {
+      secondTransportStarted = resolve;
+    });
+    const delegate: IProvider = {
+      name: 'delegate',
+      async *generateChatCompletion(
+        options: GenerateChatOptions,
+      ): AsyncGenerator<IContent> {
+        transports++;
+        if (transports === 1) {
+          const error = new Error('provider rate limit') as Error & {
+            status: number;
+          };
+          error.status = 429;
+          throw error;
+        }
+        secondTransportStarted();
+        const signal = options.metadata?.abortSignal;
+        if (!(signal instanceof AbortSignal)) throw new Error('missing signal');
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true },
+          );
+        });
+        yield* [];
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'model',
+      getServerTools: () => [],
+      invokeServerTool: async () => undefined,
+    };
+    providerManager.registerProvider(delegate);
+    const lb = new LoadBalancingProvider(
+      {
+        profileName: 'turn-timeout-lb',
+        strategy: 'failover',
+        subProfiles: [
+          { name: 'first', providerName: 'delegate', modelId: 'model' },
+          { name: 'second', providerName: 'delegate', modelId: 'model' },
+        ],
+        lbProfileEphemeralSettings: { timeout_ms: 0 },
+      },
+      providerManager,
+    );
+    mockSendMessageStream.mockImplementation(
+      async (params: {
+        config: {
+          abortSignal: AbortSignal;
+          onProviderError: (error: StructuredError) => void;
+        };
+      }) => {
+        const source = lb.generateChatCompletion({
+          contents: [],
+          onProviderError: params.config.onProviderError,
+          metadata: { abortSignal: params.config.abortSignal },
+        });
+        return (async function* () {
+          for await (const _chunk of source) {
+            yield {
+              type: StreamEventType.CHUNK,
+              value: mockChunk({ text: 'unexpected' }),
+            };
+          }
+        })();
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+    await vi.advanceTimersByTimeAsync(0);
+    await secondTransport;
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    expect(transports).toBe(2);
+    expect(events.at(-1)).toMatchObject({
+      type: AgentEventType.Error,
+      value: { error: { status: 429, category: 'rate_limit' } },
+    });
+  });
+
+  it('reports a genuine idle timeout after content instead of a stale observed 429', async () => {
+    const { turn } = buildTurn(100, 20);
+    const rateLimitError: StructuredError = {
+      message: 'Transient provider rate limit',
+      status: 429,
+      category: 'rate_limit',
+    };
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config: { onProviderError: (error: StructuredError) => void };
+      }) => {
+        params.config.onProviderError(rateLimitError);
+        return Promise.resolve(
+          (async function* () {
+            yield {
+              type: StreamEventType.CHUNK,
+              value: mockChunk({ text: 'progress' }),
+            };
+            await new Promise<void>(() => {});
+          })(),
+        );
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    expect(events.some((event) => event.type === AgentEventType.Content)).toBe(
+      true,
+    );
+    expect(events.at(-1)?.type).toBe(AgentEventType.StreamIdleTimeout);
+  });
+
   it('resource cleanup: when the timeout wins but the first .next() resolves LATE, the acquired iterator is closed (no provider connection leak)', async () => {
     // Race edge case: timeoutController.abort() is asynchronous, so the
     // in-flight first .next() can still resolve successfully a moment AFTER the
@@ -319,6 +583,41 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     // The late-resolving iterator MUST have been closed to release the provider
     // connection.
     expect(cleanup.returnCalled).toBe(true);
+  });
+
+  it('invokes iterator return promptly when first next never settles', async () => {
+    const { turn } = buildTurn(20);
+    let returnCalls = 0;
+    const iterator: AsyncIterator<{
+      type: StreamEventType;
+      value: ModelStreamChunk;
+    }> = {
+      next: () => new Promise(() => {}),
+      async return() {
+        returnCalls++;
+        return { done: true, value: undefined };
+      },
+    };
+    mockSendMessageStream.mockResolvedValue({
+      [Symbol.asyncIterator]: () => iterator,
+    });
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    expect(returnCalls).toBe(1);
+    expect(events.at(-1)?.type).toBe(AgentEventType.StreamIdleTimeout);
   });
 
   it('resource cleanup (disabled path): when first-response is DISABLED (0) and the first .next() throws, the acquired iterator is closed (no leak)', async () => {

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -268,10 +268,17 @@ describe('Turn - first-response timeout (issue #2379)', () => {
         config: {
           onProviderError: (error: StructuredError) => void;
         };
-      }) => {
-        params.config.onProviderError(rateLimitError);
-        return Promise.resolve(createStreamWithStalledFirstNext());
-      },
+      }) =>
+        Promise.resolve({
+          [Symbol.asyncIterator]: () => ({
+            next: () => {
+              queueMicrotask(() =>
+                params.config.onProviderError(rateLimitError),
+              );
+              return new Promise<IteratorResult<never>>(() => {});
+            },
+          }),
+        }),
     );
 
     const events: ServerAgentStreamEvent[] = [];
@@ -461,9 +468,14 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     await runPromise;
 
     expect(transports).toBe(2);
-    expect(events.at(-1)).toMatchObject({
+    expect(events).toContainEqual({
       type: AgentEventType.Error,
-      value: { error: { status: 429, category: 'rate_limit' } },
+      value: {
+        error: expect.objectContaining({
+          status: 429,
+          category: 'rate_limit',
+        }),
+      },
     });
   });
 
@@ -509,6 +521,13 @@ describe('Turn - first-response timeout (issue #2379)', () => {
       true,
     );
     expect(events.at(-1)?.type).toBe(AgentEventType.StreamIdleTimeout);
+    expect(
+      events.some(
+        (event) =>
+          event.type === AgentEventType.Error &&
+          event.value.error.status === 429,
+      ),
+    ).toBe(false);
   });
 
   it('resource cleanup: when the timeout wins but the first .next() resolves LATE, the acquired iterator is closed (no provider connection leak)', async () => {
@@ -670,6 +689,13 @@ describe('Turn - first-response timeout (issue #2379)', () => {
         }),
       },
     });
+    expect(
+      events.some(
+        (event) =>
+          event.type === AgentEventType.Error &&
+          event.value.error.status === 504,
+      ),
+    ).toBe(false);
   });
 
   it('control: first-response DISABLED (0) with a normal fast stream → events flow, no timeout', async () => {

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -633,7 +633,7 @@ describe('Turn - first-response timeout (issue #2379)', () => {
       },
       async return() {
         returnCalled = true;
-        return { done: true, value: undefined };
+        throw new Error('cleanup failed');
       },
     };
     mockSendMessageStream.mockResolvedValue({
@@ -649,9 +649,12 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     }
 
     // The failing iterator MUST have been closed to release the provider
-    // connection, and the error surfaces terminally (not a timeout).
+    // connection, and the provider error surfaces instead of the cleanup error.
     expect(returnCalled).toBe(true);
-    expect(events.some((e) => e.type === AgentEventType.Error)).toBe(true);
+    expect(events).toContainEqual({
+      type: AgentEventType.Error,
+      value: { error: { message: 'first next failed' } },
+    });
   });
 
   it('control: first-response DISABLED (0) with a normal fast stream → events flow, no timeout', async () => {

--- a/packages/agents/src/core/turn.test.ts
+++ b/packages/agents/src/core/turn.test.ts
@@ -83,7 +83,10 @@ describe('Turn', () => {
       expect(mockSendMessageStream).toHaveBeenCalledWith(
         {
           message: reqParts,
-          config: { abortSignal: expect.any(AbortSignal) },
+          config: {
+            abortSignal: expect.any(AbortSignal),
+            onProviderError: expect.any(Function),
+          },
         },
         'prompt-id-1',
       );
@@ -259,7 +262,7 @@ describe('Turn', () => {
       const errorEvent = events[0] as ServerErrorEvent;
       expect(errorEvent.type).toBe(AgentEventType.Error);
       expect(errorEvent.value).toStrictEqual({
-        error: { message: 'API Error', status: undefined },
+        error: { message: 'API Error' },
       });
       expect(turn.getDebugResponses().length).toBe(0);
       expect(reportError).toHaveBeenCalledWith(

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -38,6 +38,7 @@ import {
   StreamEventType,
   type StreamEvent,
 } from './chatSession.js';
+import { closeIteratorBounded } from './iteratorCleanup.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { getCodeAssistServer } from '@vybestack/llxprt-code-core/code_assist/codeAssist.js';
 import { UserTierId } from '@vybestack/llxprt-code-core/code_assist/types.js';
@@ -435,6 +436,7 @@ export class Turn {
     signal: AbortSignal,
     effectiveTimeoutMs: number,
     idleFlag: { timedOut: boolean },
+    onStreamProgress: () => void,
     firstResult?: IteratorResult<StreamEvent>,
   ): AsyncGenerator<ServerAgentStreamEvent> {
     let cumulativeOutcome = this.createEmptyResponseOutcome();
@@ -485,6 +487,7 @@ export class Turn {
         return;
       }
       if (dispatch.action === 'process' && dispatch.chunk != null) {
+        onStreamProgress();
         cumulativeOutcome = this.mergeResponseOutcome(
           cumulativeOutcome,
           dispatch.chunk,
@@ -567,8 +570,42 @@ export class Turn {
     if (typeof error !== 'object' || error === null || !('status' in error)) {
       return undefined;
     }
-    const status = (error as { status: unknown }).status;
-    return typeof status === 'number' ? status : undefined;
+    return typeof error.status === 'number' ? error.status : undefined;
+  }
+
+  private extractErrorCategory(
+    error: unknown,
+  ): StructuredError['category'] | undefined {
+    if (typeof error !== 'object' || error === null || !('category' in error)) {
+      return undefined;
+    }
+    const category = error.category;
+    switch (category) {
+      case 'rate_limit':
+      case 'quota':
+      case 'authentication':
+      case 'server_error':
+      case 'network':
+      case 'client_error':
+        return category;
+      default:
+        return undefined;
+    }
+  }
+
+  private extractErrorReason(
+    error: unknown,
+  ): StructuredError['reason'] | undefined {
+    if (typeof error !== 'object' || error === null || !('reason' in error)) {
+      return undefined;
+    }
+    switch (error.reason) {
+      case 'retries_exhausted':
+      case 'all_buckets_exhausted':
+        return error.reason;
+      default:
+        return undefined;
+    }
   }
 
   private async *handleRunError(
@@ -576,9 +613,18 @@ export class Turn {
     req: TurnRequest,
     signal: AbortSignal,
     idleFlag: { timedOut: boolean },
+    observedProviderError: StructuredError | undefined,
   ): AsyncGenerator<ServerAgentStreamEvent> {
     if (signal.aborted) {
       yield { type: AgentEventType.UserCancelled };
+      return;
+    }
+
+    if (idleFlag.timedOut && observedProviderError !== undefined) {
+      yield {
+        type: AgentEventType.Error,
+        value: { error: observedProviderError },
+      };
       return;
     }
 
@@ -613,9 +659,13 @@ export class Turn {
       'Turn.run-sendMessageStream',
     );
     const status = this.extractErrorStatus(error);
+    const category = this.extractErrorCategory(error);
+    const reason = this.extractErrorReason(error);
     const structuredError: StructuredError = {
       message: getErrorMessage(error),
-      status,
+      ...(status !== undefined ? { status } : {}),
+      ...(category !== undefined ? { category } : {}),
+      ...(reason !== undefined ? { reason } : {}),
     };
     yield { type: AgentEventType.Error, value: { error: structuredError } };
   }
@@ -626,6 +676,10 @@ export class Turn {
     signal: AbortSignal,
   ): AsyncGenerator<ServerAgentStreamEvent> {
     const idleFlag: { timedOut: boolean } = { timedOut: false };
+    let observedProviderError: StructuredError | undefined;
+    const onProviderError = (error: StructuredError): void => {
+      observedProviderError = error;
+    };
     this.logger.debug('Turn.run called', {
       req: safeJsonStringify(req, 2),
       typeofReq: typeof req,
@@ -664,6 +718,7 @@ export class Turn {
           timeoutController,
           firstResponseTimeoutMs,
           idleFlag,
+          onProviderError,
         );
         streamIterator = iterator;
 
@@ -673,15 +728,24 @@ export class Turn {
           signal,
           effectiveTimeoutMs,
           idleFlag,
+          () => {
+            observedProviderError = undefined;
+          },
           firstResult,
         );
       } finally {
-        streamIterator?.return?.().catch(() => {});
         timeoutController.abort();
+        await closeIteratorBounded(streamIterator);
         signal.removeEventListener('abort', onParentAbort);
       }
     } catch (e) {
-      yield* this.handleRunError(e, req, signal, idleFlag);
+      yield* this.handleRunError(
+        e,
+        req,
+        signal,
+        idleFlag,
+        observedProviderError,
+      );
     }
   }
 
@@ -705,6 +769,7 @@ export class Turn {
     timeoutController: AbortController,
     firstResponseTimeoutMs: number,
     idleFlag: { timedOut: boolean },
+    onProviderError: (error: StructuredError) => void,
   ): Promise<{
     iterator: AsyncIterator<StreamEvent>;
     firstResult: IteratorResult<StreamEvent>;
@@ -714,6 +779,7 @@ export class Turn {
       const iterator = await this.openResponseStreamIterator(
         req,
         timeoutSignal,
+        onProviderError,
       );
       try {
         const firstResult = await iterator.next();
@@ -722,7 +788,7 @@ export class Turn {
         // On a first-next failure the iterator has not yet been handed to
         // run() (streamIterator is still unassigned there), so close it here to
         // avoid leaking the provider connection before rethrowing.
-        await iterator.return?.().catch(() => {});
+        await closeIteratorBounded(iterator);
         throw error;
       }
     }
@@ -760,6 +826,7 @@ export class Turn {
       const iterator = await this.openResponseStreamIterator(
         req,
         timeoutSignal,
+        onProviderError,
       );
       acquiredIterator = iterator;
       const firstResult = await iterator.next();
@@ -786,13 +853,14 @@ export class Turn {
       // resolves LATE (first event arrived just after the abort) or REJECTS (the
       // aborted provider throws), and swallow the rejection to avoid an
       // unhandled rejection under strict Node modes.
+      await closeIteratorBounded(acquiredIterator);
       firstEventPromise
-        .then((late) => {
-          late.iterator.return?.().catch(() => {});
+        .then(async (late) => {
+          if (late.iterator !== acquiredIterator) {
+            await closeIteratorBounded(late.iterator);
+          }
         })
-        .catch(() => {
-          acquiredIterator?.return?.().catch(() => {});
-        });
+        .catch(() => undefined);
       throw error;
     } finally {
       firstResponseTimer.abort();
@@ -807,6 +875,7 @@ export class Turn {
   private async openResponseStreamIterator(
     req: TurnRequest,
     timeoutSignal: AbortSignal,
+    onProviderError: (error: StructuredError) => void,
   ): Promise<AsyncIterator<StreamEvent>> {
     // Bridge: chatSession.sendMessageStream still expects Google-shaped
     // SendMessageParameters (until P21). The value is structurally compatible;
@@ -818,6 +887,7 @@ export class Turn {
         >[0]['message'],
         config: {
           abortSignal: timeoutSignal,
+          onProviderError,
         },
       },
       this.prompt_id,

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -735,7 +735,7 @@ export class Turn {
         );
       } finally {
         timeoutController.abort();
-        await closeIteratorBounded(streamIterator);
+        await closeIteratorBounded(streamIterator, timeoutSignal);
         signal.removeEventListener('abort', onParentAbort);
       }
     } catch (e) {
@@ -788,7 +788,7 @@ export class Turn {
         // On a first-next failure the iterator has not yet been handed to
         // run() (streamIterator is still unassigned there), so close it here to
         // avoid leaking the provider connection before rethrowing.
-        await closeIteratorBounded(iterator);
+        await closeIteratorBounded(iterator, timeoutSignal);
         throw error;
       }
     }
@@ -853,11 +853,11 @@ export class Turn {
       // resolves LATE (first event arrived just after the abort) or REJECTS (the
       // aborted provider throws), and swallow the rejection to avoid an
       // unhandled rejection under strict Node modes.
-      await closeIteratorBounded(acquiredIterator);
+      await closeIteratorBounded(acquiredIterator, timeoutSignal);
       firstEventPromise
         .then(async (late) => {
           if (late.iterator !== acquiredIterator) {
-            await closeIteratorBounded(late.iterator);
+            await closeIteratorBounded(late.iterator, timeoutSignal);
           }
         })
         .catch(() => undefined);

--- a/packages/agents/src/core/turnAbortHelpers.ts
+++ b/packages/agents/src/core/turnAbortHelpers.ts
@@ -24,6 +24,15 @@ import {
 } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
 import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
 
+export function isTerminalRetryError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isRetryable' in error &&
+    error.isRetryable === false
+  );
+}
+
 /**
  * Determines whether an error represents a genuine user/system abort, as
  * opposed to a retryable transient network error whose phrasing merely
@@ -72,7 +81,7 @@ export function shouldRetryStreamAttempt(
   attempt: number,
 ): boolean {
   const withinBudget = attempt < INVALID_CONTENT_RETRY_OPTIONS.maxAttempts - 1;
-  if (!withinBudget) return false;
+  if (!withinBudget || isTerminalRetryError(error)) return false;
   if (
     error instanceof InvalidStreamError ||
     error instanceof EmptyStreamError

--- a/packages/agents/src/core/turnRetryPolicy.ts
+++ b/packages/agents/src/core/turnRetryPolicy.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isSchemaDepthError } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+import { isProviderApiError } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import { isTerminalRetryError } from './turnAbortHelpers.js';
+
+export function shouldRetryDirectProviderError(error: unknown): boolean {
+  if (isTerminalRetryError(error)) return false;
+  if (!isProviderApiError(error) || !error.message) return false;
+  const status = error.status ?? 0;
+  if (status === 400 || isSchemaDepthError(error.message)) return false;
+  return status === 429 || (status >= 500 && status < 600);
+}

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -28,6 +28,7 @@ type ParsedStreamEvent = {
   status?: string;
   severity?: string;
   message?: string;
+  category?: string;
   error?: { type?: string; message?: string };
 };
 
@@ -367,6 +368,50 @@ describe('processAgentStream', () => {
     ).rejects.toThrow('API connection failed');
   });
 
+  it('preserves a quota category in stream-json and the thrown error', async () => {
+    const streamFormatter = new StreamJsonFormatter();
+    const events: AgentEvent[] = [
+      {
+        type: 'error',
+        error: {
+          message: 'Rate limit retries exhausted after 2 attempts',
+          status: 429,
+          category: 'rate_limit',
+        },
+      },
+    ];
+
+    let thrownError: unknown;
+    try {
+      await processAgentStream(
+        streamFromEvents(events),
+        createContext({ streamFormatter }),
+        Date.now(),
+        () => uiTelemetryService.getMetrics(),
+      );
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect({
+      thrownError,
+      emittedEvents: parseJsonStdoutEvents(processStdoutSpy.mock.calls),
+    }).toMatchObject({
+      thrownError: {
+        message: 'Rate limit retries exhausted after 2 attempts',
+        status: 429,
+        category: 'rate_limit',
+      },
+      emittedEvents: [
+        {
+          type: JsonStreamEventType.ERROR,
+          severity: 'error',
+          category: 'rate_limit',
+        },
+      ],
+    });
+  });
+
   it('emits a flat JSON object with session_id, response, and stats on completion', async () => {
     const metrics = uiTelemetryService.getMetrics();
     const events: AgentEvent[] = [
@@ -636,7 +681,10 @@ describe('processAgentStream', () => {
     const events: AgentEvent[] = [
       {
         type: 'idle-timeout',
-        error: { message: 'no response received within the allowed time.' },
+        error: {
+          message:
+            'Stream idle timeout: no response received within the allowed time.',
+        },
       },
     ];
 
@@ -647,13 +695,17 @@ describe('processAgentStream', () => {
         Date.now(),
         () => uiTelemetryService.getMetrics(),
       ),
-    ).rejects.toThrow('no response received within the allowed time.');
+    ).rejects.toThrow(
+      'Stream idle timeout: no response received within the allowed time.',
+    );
 
     const jsonEvents = parseJsonStdoutEvents(processStdoutSpy.mock.calls);
     const streamError = jsonEvents.find(
       (event) => event.type === JsonStreamEventType.ERROR,
     );
-    expect(streamError?.message).toContain('Stream idle timeout');
+    expect(streamError?.message).toBe(
+      'Stream idle timeout: no response received within the allowed time.',
+    );
   });
 
   it('preserves the tool errorType in the stream-json TOOL_RESULT record', async () => {

--- a/packages/cli/src/nonInteractiveCliSupport.ts
+++ b/packages/cli/src/nonInteractiveCliSupport.ts
@@ -22,6 +22,7 @@ import type {
   StructuredError,
 } from '@vybestack/llxprt-code-agents';
 import { MAX_TURNS_MESSAGE } from './utils/errors.js';
+import { markMachineErrorReported } from './session/machineErrorReporting.js';
 import { REFUSAL_NOTICE_MESSAGE } from './utils/refusalNotice.js';
 
 type StreamConsumerContext = {
@@ -47,12 +48,18 @@ function emitStreamError(
   formatter: StreamJsonFormatter | null,
   severity: 'warning' | 'error',
   message: string,
+  structured?: Pick<StructuredError, 'status' | 'category' | 'reason'>,
 ): void {
   formatter?.emitEvent({
     type: JsonStreamEventType.ERROR,
     timestamp: new Date().toISOString(),
     severity,
     message,
+    ...(structured?.status !== undefined ? { status: structured.status } : {}),
+    ...(structured?.category !== undefined
+      ? { category: structured.category }
+      : {}),
+    ...(structured?.reason !== undefined ? { reason: structured.reason } : {}),
   });
 }
 
@@ -273,11 +280,33 @@ function emitFinalResult(
  * property without a type assertion.
  */
 function reconstructError(structured: StructuredError): Error {
-  const err: Error & { status?: number } = new Error(structured.message);
+  const err: Error & {
+    status?: number;
+    category?: StructuredError['category'];
+    reason?: StructuredError['reason'];
+  } = new Error(structured.message);
   if (structured.status !== undefined) {
     err.status = structured.status;
   }
+  if (structured.category !== undefined) {
+    err.category = structured.category;
+  }
+  if (structured.reason !== undefined) {
+    err.reason = structured.reason;
+  }
   return err;
+}
+
+function throwStructuredStreamError(
+  structured: StructuredError,
+  formatter: StreamJsonFormatter | null,
+): never {
+  emitStreamError(formatter, 'error', structured.message, structured);
+  const error = reconstructError(structured);
+  if (formatter !== null) {
+    markMachineErrorReported(error);
+  }
+  throw error;
 }
 
 function handleDone(
@@ -430,14 +459,9 @@ function dispatchAgentEvent(
       return;
     }
     case 'idle-timeout':
-      emitStreamError(
-        context.streamFormatter,
-        'error',
-        'Stream idle timeout: no response received within the allowed time.',
-      );
-      throw reconstructError(event.error);
+      return throwStructuredStreamError(event.error, context.streamFormatter);
     case 'error':
-      throw reconstructError(event.error);
+      return throwStructuredStreamError(event.error, context.streamFormatter);
     case 'done':
       state.pendingDone = event;
       return;

--- a/packages/cli/src/session/errorReporting.test.ts
+++ b/packages/cli/src/session/errorReporting.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OutputFormat } from '@vybestack/llxprt-code-core';
+import type { Config } from '@vybestack/llxprt-code-core';
+import { reportNonInteractiveError } from './errorReporting.js';
+import { markMachineErrorReported } from './machineErrorReporting.js';
+
+const { writeToStderr } = vi.hoisted(() => ({
+  writeToStderr: vi.fn(),
+}));
+
+vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
+  return { ...actual, writeToStderr };
+});
+
+describe('reportNonInteractiveError', () => {
+  beforeEach(() => {
+    writeToStderr.mockClear();
+  });
+
+  it('preserves a provider category in emitted stream-json output', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.STREAM_JSON,
+    };
+    const error: Error & { status?: number; category?: string } = new Error(
+      'Rate limit retries exhausted',
+    );
+    error.status = 429;
+    error.category = 'rate_limit';
+
+    reportNonInteractiveError(config, error);
+
+    expect(JSON.parse(String(writeToStderr.mock.calls[0][0]))).toMatchObject({
+      type: 'error',
+      severity: 'error',
+      category: 'rate_limit',
+    });
+  });
+
+  it('does not emit a second terminal record already reported by stream processing', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.STREAM_JSON,
+    };
+    const error = new Error('already reported');
+    markMachineErrorReported(error);
+
+    reportNonInteractiveError(config, error);
+
+    expect(writeToStderr).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/session/errorReporting.test.ts
+++ b/packages/cli/src/session/errorReporting.test.ts
@@ -31,6 +31,7 @@ describe('reportNonInteractiveError', () => {
 
     reportNonInteractiveError(config, error);
 
+    expect(writeToStderr).toHaveBeenCalledTimes(1);
     expect(JSON.parse(String(writeToStderr.mock.calls[0][0]))).toMatchObject({
       type: 'error',
       severity: 'error',
@@ -60,5 +61,15 @@ describe('reportNonInteractiveError', () => {
     reportNonInteractiveError(config, error);
 
     expect(writeToStderr).not.toHaveBeenCalled();
+  });
+
+  it('reports a frozen unmarked error without mutating it', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.STREAM_JSON,
+    };
+    const error = Object.freeze(new Error('frozen provider failure'));
+
+    expect(() => reportNonInteractiveError(config, error)).not.toThrow();
+    expect(writeToStderr).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/session/errorReporting.test.ts
+++ b/packages/cli/src/session/errorReporting.test.ts
@@ -19,24 +19,94 @@ describe('reportNonInteractiveError', () => {
     writeToStderr.mockClear();
   });
 
-  it('preserves a provider category in emitted stream-json output', () => {
+  it('preserves structured fields in emitted stream-json output', () => {
     const config: Pick<Config, 'getOutputFormat'> = {
       getOutputFormat: () => OutputFormat.STREAM_JSON,
     };
-    const error: Error & { status?: number; category?: string } = new Error(
-      'Rate limit retries exhausted',
-    );
+    const error: Error & {
+      status?: number;
+      category?: string;
+      reason?: string;
+    } = new Error('Rate limit retries exhausted');
     error.status = 429;
     error.category = 'rate_limit';
+    error.reason = 'retries_exhausted';
 
     reportNonInteractiveError(config, error);
 
     expect(writeToStderr).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(String(writeToStderr.mock.calls[0][0]))).toMatchObject({
+    expect(JSON.parse(String(writeToStderr.mock.calls[0][0]))).toStrictEqual({
       type: 'error',
+      timestamp: expect.any(String),
       severity: 'error',
+      message: expect.stringContaining('Rate limit retries exhausted'),
+      status: 429,
       category: 'rate_limit',
+      reason: 'retries_exhausted',
     });
+  });
+
+  it('serializes a terminal error in JSON output', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.JSON,
+    };
+    const error: Error & { status?: number; category?: string } = new Error(
+      'JSON provider failure',
+    );
+    error.status = 503;
+    error.category = 'server_error';
+
+    reportNonInteractiveError(config, error);
+
+    expect(JSON.parse(String(writeToStderr.mock.calls[0][0]))).toStrictEqual({
+      error: {
+        type: 'Error',
+        message: 'JSON provider failure',
+        status: 503,
+        category: 'server_error',
+      },
+    });
+    expect(String(writeToStderr.mock.calls[0][0])).toMatch(/\n$/);
+  });
+
+  it('formats a terminal error in text output', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.TEXT,
+    };
+    const error = new Error('text provider failure');
+
+    reportNonInteractiveError(config, error);
+
+    expect(String(writeToStderr.mock.calls[0][0])).toMatch(
+      /^Non-interactive run failed: \[API Error: text provider failure\]/,
+    );
+  });
+
+  it('marks an emitted error so reporting it twice produces one record', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.STREAM_JSON,
+    };
+    const error = new Error('single terminal record');
+
+    reportNonInteractiveError(config, error);
+    reportNonInteractiveError(config, error);
+
+    expect(writeToStderr).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks suppression per error identity', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.STREAM_JSON,
+    };
+    const reported = new Error('reported');
+    const unreported = new Error('unreported');
+    markMachineErrorReported(reported);
+
+    reportNonInteractiveError(config, reported);
+    reportNonInteractiveError(config, unreported);
+
+    expect(writeToStderr).toHaveBeenCalledTimes(1);
+    expect(String(writeToStderr.mock.calls[0][0])).toContain('unreported');
   });
 
   it('does not emit a second terminal record already reported by stream processing', () => {

--- a/packages/cli/src/session/errorReporting.test.ts
+++ b/packages/cli/src/session/errorReporting.test.ts
@@ -49,4 +49,16 @@ describe('reportNonInteractiveError', () => {
 
     expect(writeToStderr).not.toHaveBeenCalled();
   });
+
+  it('tracks a frozen error without mutating it', () => {
+    const config: Pick<Config, 'getOutputFormat'> = {
+      getOutputFormat: () => OutputFormat.STREAM_JSON,
+    };
+    const error = Object.freeze(new Error('already reported'));
+
+    expect(() => markMachineErrorReported(error)).not.toThrow();
+    reportNonInteractiveError(config, error);
+
+    expect(writeToStderr).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/session/errorReporting.ts
+++ b/packages/cli/src/session/errorReporting.ts
@@ -1,7 +1,8 @@
 import {
   type Config,
-  type StructuredErrorCategory,
-  type StructuredErrorReason,
+  getSafeCategory,
+  getSafeReason,
+  getSafeStatus,
   parseAndFormatApiError,
   OutputFormat,
   JsonFormatter,
@@ -40,44 +41,6 @@ function normalizeErrorForJson(error: unknown): Error {
   return new Error(formatNonInteractiveError(error));
 }
 
-function getErrorCategory(error: unknown): StructuredErrorCategory | undefined {
-  if (typeof error !== 'object' || error === null || !('category' in error)) {
-    return undefined;
-  }
-  const category = error.category;
-  switch (category) {
-    case 'rate_limit':
-    case 'quota':
-    case 'authentication':
-    case 'server_error':
-    case 'network':
-    case 'client_error':
-      return category;
-    default:
-      return undefined;
-  }
-}
-
-function getErrorStatus(error: unknown): number | undefined {
-  if (typeof error !== 'object' || error === null || !('status' in error)) {
-    return undefined;
-  }
-  return typeof error.status === 'number' ? error.status : undefined;
-}
-
-function getErrorReason(error: unknown): StructuredErrorReason | undefined {
-  if (typeof error !== 'object' || error === null || !('reason' in error)) {
-    return undefined;
-  }
-  switch (error.reason) {
-    case 'retries_exhausted':
-    case 'all_buckets_exhausted':
-      return error.reason;
-    default:
-      return undefined;
-  }
-}
-
 /**
  * Format and report a non-interactive error to stderr, using JSON formatters
  * when JSON output is configured. Extracted so both the auth-validation catch
@@ -100,9 +63,9 @@ export function reportNonInteractiveError(
     writeToStderr(`${formatter.formatError(normalizedError)}\n`);
   } else if (outputFormat === OutputFormat.STREAM_JSON) {
     const streamFormatter = new StreamJsonFormatter();
-    const category = getErrorCategory(error);
-    const status = getErrorStatus(error);
-    const reason = getErrorReason(error);
+    const category = getSafeCategory(error);
+    const status = getSafeStatus(error);
+    const reason = getSafeReason(error);
     writeToStderr(
       streamFormatter.formatEvent({
         type: JsonStreamEventType.ERROR,

--- a/packages/cli/src/session/errorReporting.ts
+++ b/packages/cli/src/session/errorReporting.ts
@@ -1,5 +1,7 @@
 import {
   type Config,
+  type StructuredErrorCategory,
+  type StructuredErrorReason,
   parseAndFormatApiError,
   OutputFormat,
   JsonFormatter,
@@ -7,10 +9,6 @@ import {
   JsonStreamEventType,
   writeToStderr,
 } from '@vybestack/llxprt-code-core';
-import type {
-  StructuredErrorCategory,
-  StructuredErrorReason,
-} from '@vybestack/llxprt-code-core/core/turn.js';
 import { wasMachineErrorReported } from './machineErrorReporting.js';
 
 export function formatNonInteractiveError(error: unknown): string {

--- a/packages/cli/src/session/errorReporting.ts
+++ b/packages/cli/src/session/errorReporting.ts
@@ -7,6 +7,11 @@ import {
   JsonStreamEventType,
   writeToStderr,
 } from '@vybestack/llxprt-code-core';
+import type {
+  StructuredErrorCategory,
+  StructuredErrorReason,
+} from '@vybestack/llxprt-code-core/core/turn.js';
+import { wasMachineErrorReported } from './machineErrorReporting.js';
 
 export function formatNonInteractiveError(error: unknown): string {
   const formatted = parseAndFormatApiError(error);
@@ -37,15 +42,54 @@ function normalizeErrorForJson(error: unknown): Error {
   return new Error(formatNonInteractiveError(error));
 }
 
+function getErrorCategory(error: unknown): StructuredErrorCategory | undefined {
+  if (typeof error !== 'object' || error === null || !('category' in error)) {
+    return undefined;
+  }
+  const category = error.category;
+  switch (category) {
+    case 'rate_limit':
+    case 'quota':
+    case 'authentication':
+    case 'server_error':
+    case 'network':
+    case 'client_error':
+      return category;
+    default:
+      return undefined;
+  }
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null || !('status' in error)) {
+    return undefined;
+  }
+  return typeof error.status === 'number' ? error.status : undefined;
+}
+
+function getErrorReason(error: unknown): StructuredErrorReason | undefined {
+  if (typeof error !== 'object' || error === null || !('reason' in error)) {
+    return undefined;
+  }
+  switch (error.reason) {
+    case 'retries_exhausted':
+    case 'all_buckets_exhausted':
+      return error.reason;
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Format and report a non-interactive error to stderr, using JSON formatters
  * when JSON output is configured. Extracted so both the auth-validation catch
  * and the run-phase catch share a single error-reporting path.
  */
 export function reportNonInteractiveError(
-  config: Config,
+  config: Pick<Config, 'getOutputFormat'>,
   error: unknown,
 ): void {
+  if (wasMachineErrorReported(error)) return;
   const outputFormat = config.getOutputFormat();
   if (outputFormat === OutputFormat.JSON) {
     const formatter = new JsonFormatter();
@@ -58,12 +102,18 @@ export function reportNonInteractiveError(
     writeToStderr(`${formatter.formatError(normalizedError)}\n`);
   } else if (outputFormat === OutputFormat.STREAM_JSON) {
     const streamFormatter = new StreamJsonFormatter();
+    const category = getErrorCategory(error);
+    const status = getErrorStatus(error);
+    const reason = getErrorReason(error);
     writeToStderr(
       streamFormatter.formatEvent({
         type: JsonStreamEventType.ERROR,
         timestamp: new Date().toISOString(),
         severity: 'error',
         message: formatNonInteractiveError(error),
+        ...(status !== undefined ? { status } : {}),
+        ...(category !== undefined ? { category } : {}),
+        ...(reason !== undefined ? { reason } : {}),
       }),
     );
   } else {

--- a/packages/cli/src/session/errorReporting.ts
+++ b/packages/cli/src/session/errorReporting.ts
@@ -10,7 +10,10 @@ import {
   JsonStreamEventType,
   writeToStderr,
 } from '@vybestack/llxprt-code-core';
-import { wasMachineErrorReported } from './machineErrorReporting.js';
+import {
+  markMachineErrorReported,
+  wasMachineErrorReported,
+} from './machineErrorReporting.js';
 
 export function formatNonInteractiveError(error: unknown): string {
   const formatted = parseAndFormatApiError(error);
@@ -81,4 +84,5 @@ export function reportNonInteractiveError(
     const printableError = formatNonInteractiveError(error);
     writeToStderr(`Non-interactive run failed: ${printableError}\n`);
   }
+  if (error instanceof Error) markMachineErrorReported(error);
 }

--- a/packages/cli/src/session/machineErrorReporting.ts
+++ b/packages/cli/src/session/machineErrorReporting.ts
@@ -1,0 +1,13 @@
+const MACHINE_ERROR_REPORTED = Symbol('llxprt.machineErrorReported');
+
+export function markMachineErrorReported(error: Error): void {
+  Object.defineProperty(error, MACHINE_ERROR_REPORTED, { value: true });
+}
+
+export function wasMachineErrorReported(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    MACHINE_ERROR_REPORTED in error
+  );
+}

--- a/packages/cli/src/session/machineErrorReporting.ts
+++ b/packages/cli/src/session/machineErrorReporting.ts
@@ -1,13 +1,9 @@
-const MACHINE_ERROR_REPORTED = Symbol('llxprt.machineErrorReported');
+const machineReportedErrors = new WeakSet<Error>();
 
 export function markMachineErrorReported(error: Error): void {
-  Object.defineProperty(error, MACHINE_ERROR_REPORTED, { value: true });
+  machineReportedErrors.add(error);
 }
 
 export function wasMachineErrorReported(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    MACHINE_ERROR_REPORTED in error
-  );
+  return error instanceof Error && machineReportedErrors.has(error);
 }

--- a/packages/core/src/config/configTypes.ts
+++ b/packages/core/src/config/configTypes.ts
@@ -280,6 +280,7 @@ export interface ActiveExtension {
 export interface FailoverContext {
   triggeringStatus?: number;
   authRetryTimeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 /**
@@ -299,6 +300,7 @@ export interface OnAuthErrorHandler {
     providerId: string;
     profileId?: string;
     errorStatus: number;
+    signal?: AbortSignal;
   }): Promise<void>;
 }
 

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -82,9 +82,23 @@ export type ServerContextWindowWillOverflowEvent = {
   };
 };
 
+export type StructuredErrorCategory =
+  | 'rate_limit'
+  | 'quota'
+  | 'authentication'
+  | 'server_error'
+  | 'network'
+  | 'client_error';
+
+export type StructuredErrorReason =
+  | 'retries_exhausted'
+  | 'all_buckets_exhausted';
+
 export interface StructuredError {
   message: string;
   status?: number;
+  category?: StructuredErrorCategory;
+  reason?: StructuredErrorReason;
 }
 
 export interface AgentErrorEventValue {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -82,17 +82,24 @@ export type ServerContextWindowWillOverflowEvent = {
   };
 };
 
-export type StructuredErrorCategory =
-  | 'rate_limit'
-  | 'quota'
-  | 'authentication'
-  | 'server_error'
-  | 'network'
-  | 'client_error';
+export const STRUCTURED_ERROR_CATEGORIES = [
+  'rate_limit',
+  'quota',
+  'authentication',
+  'server_error',
+  'network',
+  'client_error',
+] as const;
 
-export type StructuredErrorReason =
-  | 'retries_exhausted'
-  | 'all_buckets_exhausted';
+export type StructuredErrorCategory =
+  (typeof STRUCTURED_ERROR_CATEGORIES)[number];
+
+export const STRUCTURED_ERROR_REASONS = [
+  'retries_exhausted',
+  'all_buckets_exhausted',
+] as const;
+
+export type StructuredErrorReason = (typeof STRUCTURED_ERROR_REASONS)[number];
 
 export interface StructuredError {
   message: string;

--- a/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
+++ b/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
@@ -22,6 +22,7 @@ import type { SettingsService } from '@vybestack/llxprt-code-settings';
 import type { ProviderRuntimeContext } from '../providerRuntimeContext.js';
 import type { RuntimeInvocationContext } from '../RuntimeInvocationContext.js';
 import type { TelemetryContext } from './TelemetryContext.js';
+import type { StructuredError } from '../../core/turn.js';
 
 export interface RuntimeProviderTool {
   type: 'function';
@@ -53,6 +54,7 @@ export interface RuntimeGenerateChatOptions {
   config?: Config;
   runtime?: ProviderRuntimeContext;
   invocation?: RuntimeInvocationContext;
+  onProviderError?: (error: StructuredError) => void;
   metadata?: Record<string, unknown>;
   resolved?: {
     model?: string;

--- a/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
+++ b/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
@@ -47,6 +47,14 @@ export interface RuntimeAuthTokenProvider {
 
 export type RuntimeResolvedAuthToken = string | RuntimeAuthTokenProvider;
 
+export interface RuntimeUserMemoryProfileProvider {
+  getProfile:
+    | (() => Promise<string | Record<string, unknown> | undefined>)
+    | (() => string | Record<string, unknown> | undefined);
+}
+
+export type RuntimeUserMemoryInput = string | RuntimeUserMemoryProfileProvider;
+
 export interface RuntimeGenerateChatOptions {
   contents: IContent[];
   tools?: RuntimeProviderToolset;
@@ -65,7 +73,7 @@ export interface RuntimeGenerateChatOptions {
     maxTokens?: number;
     streaming?: boolean;
   };
-  userMemory?: unknown;
+  userMemory?: RuntimeUserMemoryInput;
   /**
    * Caller-supplied system instruction (e.g. a subagent persona/task prompt).
    * When present, providers SHOULD merge this into their system prompt so the

--- a/packages/core/src/utils/delay.test.ts
+++ b/packages/core/src/utils/delay.test.ts
@@ -51,24 +51,28 @@ describe('abortableDelay', () => {
 
   it('rejects immediately if the signal is already aborted', async () => {
     const controller = new AbortController();
-    controller.abort();
+    const reason = new Error('request deadline expired');
+    controller.abort(reason);
 
     await expect(delay(50, controller.signal)).rejects.toMatchObject({
       name: 'AbortError',
       message: 'Aborted',
+      cause: reason,
     });
   });
 
   it('rejects if the signal aborts while waiting', async () => {
     const controller = new AbortController();
+    const reason = new Error('user cancelled request');
     const promise = delay(500, controller.signal);
 
     await vi.advanceTimersByTimeAsync(100);
-    controller.abort();
+    controller.abort(reason);
 
     await expect(promise).rejects.toMatchObject({
       name: 'AbortError',
       message: 'Aborted',
+      cause: reason,
     });
   });
 

--- a/packages/core/src/utils/delay.ts
+++ b/packages/core/src/utils/delay.ts
@@ -7,8 +7,11 @@
 /**
  * Factory to create a standard abort error for delay helpers.
  */
-export function createAbortError(): Error {
-  const abortError = new Error('Aborted');
+export function createAbortError(reason?: unknown): Error {
+  const abortError =
+    reason === undefined
+      ? new Error('Aborted')
+      : new Error('Aborted', { cause: reason });
   abortError.name = 'AbortError';
   (abortError as NodeJS.ErrnoException).code = 'ABORT_ERR';
   return abortError;

--- a/packages/core/src/utils/delay.ts
+++ b/packages/core/src/utils/delay.ts
@@ -31,7 +31,7 @@ export function delay(ms: number, signal?: AbortSignal): Promise<void> {
 
   // Immediately reject if signal has already been aborted
   if (signal.aborted) {
-    return Promise.reject(createAbortError());
+    return Promise.reject(createAbortError(signal.reason));
   }
 
   // remove abort and timeout listeners to prevent memory-leaks
@@ -39,7 +39,7 @@ export function delay(ms: number, signal?: AbortSignal): Promise<void> {
     const onAbort = () => {
       clearTimeout(timeoutId);
       signal.removeEventListener('abort', onAbort);
-      reject(createAbortError());
+      reject(createAbortError(signal.reason));
     };
 
     const timeoutId = setTimeout(() => {

--- a/packages/core/src/utils/output-format.test.ts
+++ b/packages/core/src/utils/output-format.test.ts
@@ -6,12 +6,55 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  JsonFormatter,
   JsonStreamEventType,
   StreamJsonFormatter,
   type MessageEvent,
 } from './output-format.js';
 
+describe('JsonFormatter', () => {
+  it('preserves safe machine-readable provider classification', () => {
+    const formatter = new JsonFormatter();
+    const error: Error & {
+      status?: number;
+      category?: string;
+      reason?: string;
+    } = new Error('retry budget exhausted');
+    error.status = 429;
+    error.category = 'rate_limit';
+    error.reason = 'retries_exhausted';
+
+    expect(JSON.parse(formatter.formatError(error))).toStrictEqual({
+      error: {
+        type: 'Error',
+        message: 'retry budget exhausted',
+        status: 429,
+        category: 'rate_limit',
+        reason: 'retries_exhausted',
+      },
+    });
+  });
+});
+
 describe('StreamJsonFormatter', () => {
+  it('serializes status, category, and terminal reason on error events', () => {
+    const formatter = new StreamJsonFormatter();
+    const formatted = formatter.formatEvent({
+      type: JsonStreamEventType.ERROR,
+      timestamp: '2026-06-26T00:00:00.000Z',
+      severity: 'error',
+      message: 'retry budget exhausted',
+      status: 429,
+      category: 'rate_limit',
+      reason: 'retries_exhausted',
+    });
+
+    expect(JSON.parse(formatted)).toMatchObject({
+      status: 429,
+      category: 'rate_limit',
+      reason: 'retries_exhausted',
+    });
+  });
   it('emits newline-delimited JSON records with escaped content newlines', () => {
     const formatter = new StreamJsonFormatter();
     const event: MessageEvent = {

--- a/packages/core/src/utils/output-format.test.ts
+++ b/packages/core/src/utils/output-format.test.ts
@@ -11,6 +11,10 @@ import {
   StreamJsonFormatter,
   type MessageEvent,
 } from './output-format.js';
+import {
+  STRUCTURED_ERROR_CATEGORIES,
+  STRUCTURED_ERROR_REASONS,
+} from '../core/turn.js';
 
 describe('JsonFormatter', () => {
   it('preserves safe machine-readable provider classification', () => {
@@ -33,6 +37,25 @@ describe('JsonFormatter', () => {
         reason: 'retries_exhausted',
       },
     });
+  });
+
+  it('accepts every canonical structured category and reason', () => {
+    for (const category of STRUCTURED_ERROR_CATEGORIES) {
+      const formatted = JSON.parse(
+        new JsonFormatter().formatError(
+          Object.assign(new Error(category), { category }),
+        ),
+      );
+      expect(formatted.error.category).toBe(category);
+    }
+    for (const reason of STRUCTURED_ERROR_REASONS) {
+      const formatted = JSON.parse(
+        new JsonFormatter().formatError(
+          Object.assign(new Error(reason), { reason }),
+        ),
+      );
+      expect(formatted.error.reason).toBe(reason);
+    }
   });
 
   it('omits unrecognized machine-readable provider classification', () => {

--- a/packages/core/src/utils/output-format.test.ts
+++ b/packages/core/src/utils/output-format.test.ts
@@ -73,6 +73,36 @@ describe('JsonFormatter', () => {
       },
     });
   });
+
+  it.each([
+    {
+      category: 'rate_limit',
+      reason: 'future_reason',
+      expected: { category: 'rate_limit' },
+    },
+    {
+      category: 'future_category',
+      reason: 'retries_exhausted',
+      expected: { reason: 'retries_exhausted' },
+    },
+  ])(
+    'preserves recognized fields independently for $category and $reason',
+    ({ category, reason, expected }) => {
+      const error: Error & { category?: string; reason?: string } = new Error(
+        'provider failed',
+      );
+      error.category = category;
+      error.reason = reason;
+
+      expect(
+        JSON.parse(new JsonFormatter().formatError(error)).error,
+      ).toStrictEqual({
+        type: 'Error',
+        message: 'provider failed',
+        ...expected,
+      });
+    },
+  );
 });
 
 describe('StreamJsonFormatter', () => {

--- a/packages/core/src/utils/output-format.test.ts
+++ b/packages/core/src/utils/output-format.test.ts
@@ -34,6 +34,22 @@ describe('JsonFormatter', () => {
       },
     });
   });
+
+  it('omits unrecognized machine-readable provider classification', () => {
+    const formatter = new JsonFormatter();
+    const error: Error & { category?: string; reason?: string } = new Error(
+      'provider failed',
+    );
+    error.category = 'future_category';
+    error.reason = 'future_reason';
+
+    expect(JSON.parse(formatter.formatError(error))).toStrictEqual({
+      error: {
+        type: 'Error',
+        message: 'provider failed',
+      },
+    });
+  });
 });
 
 describe('StreamJsonFormatter', () => {

--- a/packages/core/src/utils/output-format.ts
+++ b/packages/core/src/utils/output-format.ts
@@ -5,9 +5,11 @@
  */
 
 import type { SessionMetrics } from '../telemetry/uiTelemetry.js';
-import type {
-  StructuredErrorCategory,
-  StructuredErrorReason,
+import {
+  STRUCTURED_ERROR_CATEGORIES,
+  STRUCTURED_ERROR_REASONS,
+  type StructuredErrorCategory,
+  type StructuredErrorReason,
 } from '../core/turn.js';
 
 /**
@@ -128,36 +130,23 @@ export function getSafeStatus(error: unknown): number | undefined {
   return typeof error.status === 'number' ? error.status : undefined;
 }
 
-const STRUCTURED_ERROR_CATEGORIES = {
-  rate_limit: true,
-  quota: true,
-  authentication: true,
-  server_error: true,
-  network: true,
-  client_error: true,
-} satisfies Readonly<Record<StructuredErrorCategory, true>>;
-
-const STRUCTURED_ERROR_REASONS = {
-  retries_exhausted: true,
-  all_buckets_exhausted: true,
-} satisfies Readonly<Record<StructuredErrorReason, true>>;
+function includesString<const Values extends readonly string[]>(
+  values: Values,
+  value: unknown,
+): value is Values[number] {
+  return typeof value === 'string' && values.some((item) => item === value);
+}
 
 function isStructuredErrorCategory(
   value: unknown,
 ): value is StructuredErrorCategory {
-  return (
-    typeof value === 'string' &&
-    Object.prototype.hasOwnProperty.call(STRUCTURED_ERROR_CATEGORIES, value)
-  );
+  return includesString(STRUCTURED_ERROR_CATEGORIES, value);
 }
 
 function isStructuredErrorReason(
   value: unknown,
 ): value is StructuredErrorReason {
-  return (
-    typeof value === 'string' &&
-    Object.prototype.hasOwnProperty.call(STRUCTURED_ERROR_REASONS, value)
-  );
+  return includesString(STRUCTURED_ERROR_REASONS, value);
 }
 
 export function getSafeCategory(

--- a/packages/core/src/utils/output-format.ts
+++ b/packages/core/src/utils/output-format.ts
@@ -121,13 +121,17 @@ export type JsonStreamEvent =
   | ErrorEvent
   | ResultEvent;
 
-function getSafeStatus(error: Error): number | undefined {
-  return 'status' in error && typeof error.status === 'number'
-    ? error.status
-    : undefined;
+export function getSafeStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null || !('status' in error)) {
+    return undefined;
+  }
+  return typeof error.status === 'number' ? error.status : undefined;
 }
 
-function getSafeCategory(error: Error): StructuredErrorCategory | undefined {
+export function getSafeCategory(
+  error: unknown,
+): StructuredErrorCategory | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
   if (!('category' in error)) return undefined;
   switch (error.category) {
     case 'rate_limit':
@@ -142,8 +146,12 @@ function getSafeCategory(error: Error): StructuredErrorCategory | undefined {
   }
 }
 
-function getSafeReason(error: Error): StructuredErrorReason | undefined {
-  if (!('reason' in error)) return undefined;
+export function getSafeReason(
+  error: unknown,
+): StructuredErrorReason | undefined {
+  if (typeof error !== 'object' || error === null || !('reason' in error)) {
+    return undefined;
+  }
   switch (error.reason) {
     case 'retries_exhausted':
     case 'all_buckets_exhausted':

--- a/packages/core/src/utils/output-format.ts
+++ b/packages/core/src/utils/output-format.ts
@@ -5,6 +5,10 @@
  */
 
 import type { SessionMetrics } from '../telemetry/uiTelemetry.js';
+import type {
+  StructuredErrorCategory,
+  StructuredErrorReason,
+} from '../core/turn.js';
 
 /**
  * Output format for CLI responses
@@ -19,6 +23,9 @@ export interface JsonError {
   type: string;
   message: string;
   code?: string | number;
+  status?: number;
+  category?: StructuredErrorCategory;
+  reason?: StructuredErrorReason;
 }
 
 export interface JsonOutput {
@@ -83,6 +90,9 @@ export interface ErrorEvent extends BaseJsonStreamEvent {
   type: JsonStreamEventType.ERROR;
   severity: 'warning' | 'error';
   message: string;
+  status?: number;
+  category?: StructuredErrorCategory;
+  reason?: StructuredErrorReason;
 }
 
 export interface StreamStats {
@@ -111,6 +121,38 @@ export type JsonStreamEvent =
   | ErrorEvent
   | ResultEvent;
 
+function getSafeStatus(error: Error): number | undefined {
+  return 'status' in error && typeof error.status === 'number'
+    ? error.status
+    : undefined;
+}
+
+function getSafeCategory(error: Error): StructuredErrorCategory | undefined {
+  if (!('category' in error)) return undefined;
+  switch (error.category) {
+    case 'rate_limit':
+    case 'quota':
+    case 'authentication':
+    case 'server_error':
+    case 'network':
+    case 'client_error':
+      return error.category;
+    default:
+      return undefined;
+  }
+}
+
+function getSafeReason(error: Error): StructuredErrorReason | undefined {
+  if (!('reason' in error)) return undefined;
+  switch (error.reason) {
+    case 'retries_exhausted':
+    case 'all_buckets_exhausted':
+      return error.reason;
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Formats errors as JSON for programmatic consumption
  */
@@ -122,12 +164,18 @@ export class JsonFormatter {
    * @returns JSON string representation of the error
    */
   formatError(error: Error, code?: string | number): string {
+    const status = getSafeStatus(error);
+    const category = getSafeCategory(error);
+    const reason = getSafeReason(error);
     return JSON.stringify(
       {
         error: {
           type: error.constructor.name,
           message: error.message,
           ...(code !== undefined && { code }),
+          ...(status !== undefined && { status }),
+          ...(category !== undefined && { category }),
+          ...(reason !== undefined && { reason }),
         },
       },
       null,

--- a/packages/core/src/utils/output-format.ts
+++ b/packages/core/src/utils/output-format.ts
@@ -128,22 +128,45 @@ export function getSafeStatus(error: unknown): number | undefined {
   return typeof error.status === 'number' ? error.status : undefined;
 }
 
+const STRUCTURED_ERROR_CATEGORIES = {
+  rate_limit: true,
+  quota: true,
+  authentication: true,
+  server_error: true,
+  network: true,
+  client_error: true,
+} satisfies Readonly<Record<StructuredErrorCategory, true>>;
+
+const STRUCTURED_ERROR_REASONS = {
+  retries_exhausted: true,
+  all_buckets_exhausted: true,
+} satisfies Readonly<Record<StructuredErrorReason, true>>;
+
+function isStructuredErrorCategory(
+  value: unknown,
+): value is StructuredErrorCategory {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(STRUCTURED_ERROR_CATEGORIES, value)
+  );
+}
+
+function isStructuredErrorReason(
+  value: unknown,
+): value is StructuredErrorReason {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(STRUCTURED_ERROR_REASONS, value)
+  );
+}
+
 export function getSafeCategory(
   error: unknown,
 ): StructuredErrorCategory | undefined {
-  if (typeof error !== 'object' || error === null) return undefined;
-  if (!('category' in error)) return undefined;
-  switch (error.category) {
-    case 'rate_limit':
-    case 'quota':
-    case 'authentication':
-    case 'server_error':
-    case 'network':
-    case 'client_error':
-      return error.category;
-    default:
-      return undefined;
+  if (typeof error !== 'object' || error === null || !('category' in error)) {
+    return undefined;
   }
+  return isStructuredErrorCategory(error.category) ? error.category : undefined;
 }
 
 export function getSafeReason(
@@ -152,13 +175,7 @@ export function getSafeReason(
   if (typeof error !== 'object' || error === null || !('reason' in error)) {
     return undefined;
   }
-  switch (error.reason) {
-    case 'retries_exhausted':
-    case 'all_buckets_exhausted':
-      return error.reason;
-    default:
-      return undefined;
-  }
+  return isStructuredErrorReason(error.reason) ? error.reason : undefined;
 }
 
 /**

--- a/packages/providers/src/BaseProviderNormalization.ts
+++ b/packages/providers/src/BaseProviderNormalization.ts
@@ -19,6 +19,7 @@ import type {
   ProviderSettings,
 } from './BaseProvider.js';
 import type { ResolvedAuthToken } from './types/providerRuntime.js';
+import { isAbortSignal } from './utils/abortSignal.js';
 
 interface RuntimeGuardInput {
   providerKey: string;
@@ -238,14 +239,7 @@ function extractLegacySignal(invocation: unknown): AbortSignal | undefined {
     return undefined;
   }
   const signal = (invocation as { signal?: unknown }).signal;
-  if (
-    typeof signal === 'object' &&
-    signal !== null &&
-    typeof (signal as { aborted?: unknown }).aborted === 'boolean'
-  ) {
-    return signal as AbortSignal;
-  }
-  return undefined;
+  return isAbortSignal(signal) ? signal : undefined;
 }
 
 interface InvocationNormalizationInput {
@@ -266,7 +260,11 @@ function createNormalizedInvocation(
   )
     ? input.providedOptions.invocation
     : undefined;
-  const legacySignal = extractLegacySignal(input.providedOptions.invocation);
+  const metadataSignal = extractLegacySignal({
+    signal: input.providedOptions.metadata?.abortSignal,
+  });
+  const legacySignal =
+    extractLegacySignal(input.providedOptions.invocation) ?? metadataSignal;
   if (providedInvocation) {
     const providedSignal = extractLegacySignal(providedInvocation);
     return createRuntimeInvocationContext({
@@ -284,7 +282,9 @@ function createNormalizedInvocation(
       metadata: providedInvocation.metadata,
       userMemory: providedInvocation.userMemory,
       redaction: providedInvocation.redaction,
-      ...(providedSignal ? { signal: providedSignal } : {}),
+      ...((providedSignal ?? metadataSignal)
+        ? { signal: providedSignal ?? metadataSignal }
+        : {}),
       fallbackRuntimeId: providedInvocation.runtimeId,
     });
   }

--- a/packages/providers/src/IProvider.ts
+++ b/packages/providers/src/IProvider.ts
@@ -83,6 +83,7 @@ export interface GenerateChatOptions {
 export interface IProvider {
   name: string;
   isDefault?: boolean;
+  transportAttemptOwnership?: 'provider';
   getModels(): Promise<IModel[]>;
   /**
    * @plan PLAN-20250218-STATELESSPROVIDER.P04

--- a/packages/providers/src/IProvider.ts
+++ b/packages/providers/src/IProvider.ts
@@ -21,6 +21,7 @@ import type { SettingsService } from '@vybestack/llxprt-code-settings';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import type { RuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import type { StructuredError } from '@vybestack/llxprt-code-core/core/turn.js';
 import type {
   ProviderTelemetryContext,
   ResolvedAuthToken,
@@ -52,6 +53,7 @@ export interface GenerateChatOptions {
   config?: Config;
   runtime?: ProviderRuntimeContext;
   invocation?: RuntimeInvocationContext;
+  onProviderError?: (error: StructuredError) => void;
   metadata?: Record<string, unknown>;
   resolved?: {
     model?: string;

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -15,7 +15,9 @@ import type { ProviderManager } from './ProviderManager.js';
 import { coreEvents } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { getErrorStatus } from '@vybestack/llxprt-code-core/utils/retry.js';
+import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { LoadBalancerFailoverError } from './errors.js';
+import { markProviderErrorObservationHandled } from './providerErrorObservation.js';
 import { CircuitBreakerManager } from './loadBalancing/circuitBreakerManager.js';
 import { TPMTracker } from './loadBalancing/tpmTracker.js';
 import { BackendMetricsCollector } from './loadBalancing/backendMetrics.js';
@@ -25,12 +27,27 @@ import {
   isImmediateFailoverError as isImmediateFailover,
 } from './loadBalancing/failoverSettings.js';
 import {
-  wrapWithTimeout as wrapWithFirstChunkTimeout,
+  wrapWithTimeout,
   isTimeoutError,
 } from './loadBalancing/streamTimeout.js';
 import { buildExtendedStats } from './loadBalancing/statsBuilder.js';
 import { buildRoundRobinResolvedOptions as buildRoundRobinResolvedOptionsExternal } from './loadBalancing/resolvedOptionsBuilder.js';
 import { cloneContentsForCompression } from './loadBalancing/contentClone.js';
+import {
+  getRequestSignal,
+  rethrowIfAborted,
+} from './loadBalancing/requestAbort.js';
+import { hasTransportAttemptRemaining } from './transportAttemptBudget.js';
+import {
+  createDelegateAttempt,
+  requireTransportAttempt,
+} from './loadBalancing/delegateAttempt.js';
+import {
+  observeDelegateFailure,
+  recordBackendFailure,
+  shouldSkipBackend,
+  validateNotAllUnhealthy,
+} from './loadBalancing/backendRuntime.js';
 import {
   LoadBalancerAllContextLimitsExceededError,
   LoadBalancerCompressionCallbackError,
@@ -70,6 +87,7 @@ export type {
   LoadBalancingProviderConfig,
   ResolvedSubProfile,
 } from './loadBalancing/loadBalancerTypes.js';
+
 export { isResolvedSubProfile } from './loadBalancing/loadBalancerTypes.js';
 export type { TokenAccountingDiagnostics } from './loadBalancing/tokenAccountingDiagnostics.js';
 export { isLoadBalancerProfileFormat } from './loadBalancing/loadBalancerProfileFormat.js';
@@ -334,6 +352,7 @@ export class LoadBalancingProvider implements IProvider {
       subProfile,
       enforcedOptions,
     );
+    requireTransportAttempt(resolvedOptions);
 
     yield* this.yieldWithMetrics(
       delegateProvider,
@@ -623,19 +642,6 @@ export class LoadBalancingProvider implements IProvider {
   private readonly tpmTracker: TPMTracker;
   private readonly metricsCollector: BackendMetricsCollector;
 
-  private async *wrapWithTimeout(
-    iterator: AsyncIterableIterator<IContent>,
-    timeoutMs: number | undefined,
-    profileName: string,
-  ): AsyncGenerator<IContent> {
-    yield* wrapWithFirstChunkTimeout(
-      iterator,
-      timeoutMs,
-      profileName,
-      this.logger,
-    );
-  }
-
   private updateTPM(profileName: string, tokensUsed: number): void {
     this.tpmTracker.updateTPM(profileName, tokensUsed);
   }
@@ -689,18 +695,35 @@ export class LoadBalancingProvider implements IProvider {
     );
 
     // Check if all backends are unhealthy (circuit breakers open)
-    this.validateNotAllUnhealthy(settings, numProfiles);
+    validateNotAllUnhealthy(
+      settings.circuitBreakerEnabled,
+      this.config.subProfiles
+        .slice(0, numProfiles)
+        .map((profile) => profile.name),
+      (name) => this.circuitBreaker.canAttemptBackend(name),
+    );
 
     // Start from currentFailoverIndex and iterate through all backends (Issue #902)
     let visitedCount = 0;
     let currentIndex = startIndex;
 
-    while (visitedCount < numProfiles) {
+    while (
+      visitedCount < numProfiles &&
+      hasTransportAttemptRemaining(options)
+    ) {
       const subProfile = this.config.subProfiles[currentIndex];
       visitedCount++;
 
       // Skip unhealthy backends (circuit breaker + TPM checks)
-      if (this.shouldSkipBackend(subProfile.name, settings)) {
+      if (
+        shouldSkipBackend(
+          subProfile.name,
+          settings.tpmThreshold,
+          (name) => this.circuitBreaker.isBackendHealthy(name),
+          (name, threshold) => this.tpmTracker.shouldSkipOnTPM(name, threshold),
+          this.logger,
+        )
+      ) {
         currentIndex = (currentIndex + 1) % numProfiles;
         continue;
       }
@@ -731,58 +754,23 @@ export class LoadBalancingProvider implements IProvider {
     this.failoverState.setIfOwner(requestOwner, 0);
 
     if (errors.length === 0 && contextLimitErrors.length > 0) {
-      throw new LoadBalancerAllContextLimitsExceededError({
+      const aggregate = new LoadBalancerAllContextLimitsExceededError({
         profileName: this.config.profileName,
         failures: contextLimitErrors.map(({ profile, error }) => ({
           profile,
           error,
         })),
       });
+      markProviderErrorObservationHandled(options, aggregate);
+      throw aggregate;
     }
 
-    throw new LoadBalancerFailoverError(this.config.profileName, [
+    const aggregate = new LoadBalancerFailoverError(this.config.profileName, [
       ...errors,
       ...contextLimitErrors,
     ]);
-  }
-
-  private shouldSkipBackend(
-    profileName: string,
-    settings: FailoverSettings,
-  ): boolean {
-    if (!this.circuitBreaker.isBackendHealthy(profileName)) {
-      this.logger.debug(
-        () =>
-          `[LB:failover] Skipping unhealthy backend: ${profileName} (circuit breaker open)`,
-      );
-      return true;
-    }
-
-    if (this.tpmTracker.shouldSkipOnTPM(profileName, settings.tpmThreshold)) {
-      this.logger.debug(
-        () =>
-          `[LB:failover] Skipping backend: ${profileName} (TPM below threshold)`,
-      );
-      return true;
-    }
-
-    return false;
-  }
-
-  private validateNotAllUnhealthy(
-    settings: FailoverSettings,
-    numProfiles: number,
-  ): void {
-    if (settings.circuitBreakerEnabled) {
-      const allUnhealthy = this.config.subProfiles
-        .slice(0, numProfiles)
-        .every((sp) => !this.circuitBreaker.canAttemptBackend(sp.name));
-      if (allUnhealthy) {
-        throw new Error(
-          'All backends are currently unhealthy (circuit breakers open). Please wait for recovery or check backend configurations.',
-        );
-      }
-    }
+    markProviderErrorObservationHandled(options, aggregate);
+    throw aggregate;
   }
 
   private async *tryBackendWithRetries(
@@ -797,7 +785,7 @@ export class LoadBalancingProvider implements IProvider {
   ): AsyncGenerator<IContent, boolean> {
     let attempts = 0;
     const maxAttempts = Math.max(1, settings.retryCount);
-    while (attempts < maxAttempts) {
+    while (attempts < maxAttempts && hasTransportAttemptRemaining(options)) {
       attempts++;
       let startTime = 0;
       let requestStarted = false;
@@ -819,6 +807,10 @@ export class LoadBalancingProvider implements IProvider {
         this.failoverState.setIfOwner(requestOwner, currentIndex);
         return true;
       } catch (error) {
+        rethrowIfAborted(error, options);
+        if (!chunksYielded.value) {
+          observeDelegateFailure(options, error, this.logger);
+        }
         if (
           error instanceof LoadBalancerCompressionCallbackError ||
           error instanceof LoadBalancerContextLimitError
@@ -831,10 +823,7 @@ export class LoadBalancingProvider implements IProvider {
           );
         }
         if (!requestStarted) {
-          errors.push({
-            profile: subProfile.name,
-            error: error instanceof Error ? error : new Error(String(error)),
-          });
+          recordBackendFailure(errors, subProfile.name, error);
           return this.failoverState.advanceFrom(
             requestOwner,
             currentIndex,
@@ -853,13 +842,12 @@ export class LoadBalancingProvider implements IProvider {
           currentIndex,
           numProfiles,
           requestOwner,
+          hasTransportAttemptRemaining(options),
         );
         if (handled === 'immediate-throw') throw error;
         if (handled === 'break') break;
         if (settings.retryDelayMs > 0) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, settings.retryDelayMs),
-          );
+          await delay(settings.retryDelayMs, getRequestSignal(options));
         }
       }
     }
@@ -891,20 +879,29 @@ export class LoadBalancingProvider implements IProvider {
     if (!delegateProvider) {
       throw new Error(`Provider "${subProfile.providerName}" not found`);
     }
+    requireTransportAttempt(resolvedOptions);
 
-    const rawIterator =
-      delegateProvider.generateChatCompletion(resolvedOptions);
-    const iterator = this.wrapWithTimeout(
-      rawIterator,
-      settings.timeoutMs,
-      subProfile.name,
-    );
-
+    const attempt = createDelegateAttempt(resolvedOptions);
     const chunks: IContent[] = [];
-    for await (const chunk of iterator) {
-      chunksYielded.value = true;
-      chunks.push(chunk);
-      yield chunk;
+    try {
+      const rawIterator = delegateProvider.generateChatCompletion(
+        attempt.options,
+      );
+      const iterator = wrapWithTimeout(
+        rawIterator,
+        settings.timeoutMs,
+        subProfile.name,
+        this.logger,
+        attempt.linked.controller,
+      );
+      for await (const chunk of iterator) {
+        chunksYielded.value = true;
+        chunks.push(chunk);
+        yield chunk;
+      }
+    } finally {
+      attempt.linked.controller.abort();
+      attempt.linked.dispose();
     }
 
     const tokensUsed = BackendMetricsCollector.extractTokenCount(chunks);
@@ -932,6 +929,7 @@ export class LoadBalancingProvider implements IProvider {
     currentIndex: number,
     numProfiles: number,
     requestOwner: symbol,
+    transportAttemptRemaining: boolean,
   ): 'immediate-throw' | 'break' | 'retry' {
     if (this.isImmediateFailoverError(error)) {
       if (chunksYielded) {
@@ -959,7 +957,10 @@ export class LoadBalancingProvider implements IProvider {
     }
 
     const isLastAttempt = attempts >= maxAttempts;
-    const shouldRetry = !isLastAttempt && this.shouldFailover(error, settings);
+    const shouldRetry =
+      !isLastAttempt &&
+      transportAttemptRemaining &&
+      this.shouldFailover(error, settings);
 
     if (shouldRetry) {
       if (settings.retryDelayMs > 0) {

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -16,7 +16,7 @@ import { coreEvents } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { getErrorStatus } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
-import { LoadBalancerFailoverError } from './errors.js';
+import { LoadBalancerFailoverError, permitsBucketFailover } from './errors.js';
 import { markProviderErrorObservationHandled } from './providerErrorObservation.js';
 import { CircuitBreakerManager } from './loadBalancing/circuitBreakerManager.js';
 import { TPMTracker } from './loadBalancing/tpmTracker.js';
@@ -933,6 +933,7 @@ export class LoadBalancingProvider implements IProvider {
     requestOwner: symbol,
     transportAttemptRemaining: boolean,
   ): 'immediate-throw' | 'break' | 'retry' {
+    if (!permitsBucketFailover(error)) return 'immediate-throw';
     if (this.isImmediateFailoverError(error)) {
       if (chunksYielded) {
         this.logger.debug(

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -16,8 +16,11 @@ import { coreEvents } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { getErrorStatus } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
-import { LoadBalancerFailoverError, permitsBucketFailover } from './errors.js';
-import { markProviderErrorObservationHandled } from './providerErrorObservation.js';
+import { LoadBalancerFailoverError } from './errors.js';
+import {
+  markProviderErrorObservationHandled,
+  withProviderErrorObservationContext,
+} from './providerErrorObservation.js';
 import { CircuitBreakerManager } from './loadBalancing/circuitBreakerManager.js';
 import { TPMTracker } from './loadBalancing/tpmTracker.js';
 import { BackendMetricsCollector } from './loadBalancing/backendMetrics.js';
@@ -25,6 +28,7 @@ import {
   extractFailoverSettings as extractFailoverSettingsFromEphemeral,
   shouldFailover as shouldFailoverOnError,
   isImmediateFailoverError as isImmediateFailover,
+  permitsLoadBalancerFailover,
 } from './loadBalancing/failoverSettings.js';
 import {
   wrapWithTimeout,
@@ -39,6 +43,7 @@ import {
 } from './loadBalancing/requestAbort.js';
 import { hasTransportAttemptRemaining } from './transportAttemptBudget.js';
 import {
+  cleanupDelegateAttempt,
   createDelegateAttempt,
   requireTransportAttempt,
 } from './loadBalancing/delegateAttempt.js';
@@ -684,6 +689,14 @@ export class LoadBalancingProvider implements IProvider {
   private async *executeWithFailover(
     options: GenerateChatOptions,
   ): AsyncGenerator<IContent> {
+    yield* withProviderErrorObservationContext(options, (observedOptions) =>
+      this.executeObservedFailover(observedOptions),
+    );
+  }
+
+  private async *executeObservedFailover(
+    options: GenerateChatOptions,
+  ): AsyncGenerator<IContent> {
     const { owner: requestOwner, startIndex } = this.failoverState.claim();
     const settings = this.extractFailoverSettings();
     const errors: Array<{ profile: string; error: Error }> = [];
@@ -882,28 +895,23 @@ export class LoadBalancingProvider implements IProvider {
 
     const attempt = createDelegateAttempt(resolvedOptions);
     const chunks: IContent[] = [];
-    try {
-      const rawIterator = delegateProvider.generateChatCompletion(
-        attempt.options,
-      );
-      const iterator = wrapWithTimeout(
-        rawIterator,
-        settings.timeoutMs,
-        subProfile.name,
-        this.logger,
-        {
-          signal: attempt.linked.controller.signal,
-          cancel: () => attempt.linked.controller.abort(),
-        },
-      );
-      for await (const chunk of iterator) {
-        chunksYielded.value = true;
-        chunks.push(chunk);
-        yield chunk;
-      }
-    } finally {
-      attempt.linked.controller.abort();
-      attempt.linked.dispose();
+    const rawIterator = delegateProvider.generateChatCompletion(
+      attempt.options,
+    );
+    const iterator = wrapWithTimeout(
+      rawIterator,
+      settings.timeoutMs,
+      subProfile.name,
+      this.logger,
+      {
+        signal: attempt.linked.controller.signal,
+        cancel: () => attempt.linked.controller.abort(),
+      },
+    );
+    for await (const chunk of cleanupDelegateAttempt(attempt, iterator)) {
+      chunksYielded.value = true;
+      chunks.push(chunk);
+      yield chunk;
     }
 
     const tokensUsed = BackendMetricsCollector.extractTokenCount(chunks);
@@ -933,21 +941,17 @@ export class LoadBalancingProvider implements IProvider {
     requestOwner: symbol,
     transportAttemptRemaining: boolean,
   ): 'immediate-throw' | 'break' | 'retry' {
-    if (!permitsBucketFailover(error)) return 'immediate-throw';
+    if (chunksYielded) {
+      this.logger.debug(
+        () =>
+          `[LB:failover] ${subProfile.name} failed after yielding chunks, aborting stream`,
+      );
+      this.recordRequestFailure(subProfile.name, startTime, error as Error);
+      this.circuitBreaker.recordBackendFailure(subProfile.name, error as Error);
+      return 'immediate-throw';
+    }
+    if (!permitsLoadBalancerFailover(error)) return 'immediate-throw';
     if (this.isImmediateFailoverError(error)) {
-      if (chunksYielded) {
-        this.logger.debug(
-          () =>
-            `[LB:failover] ${subProfile.name} returned immediate failover error after yielding chunks, aborting stream`,
-        );
-        this.recordRequestFailure(subProfile.name, startTime, error as Error);
-        this.circuitBreaker.recordBackendFailure(
-          subProfile.name,
-          error as Error,
-        );
-        return 'immediate-throw';
-      }
-
       this.logger.debug(
         () =>
           `[LB:failover] ${subProfile.name} returned immediate failover error (${getErrorStatus(error)}), skipping retries`,

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -808,9 +808,7 @@ export class LoadBalancingProvider implements IProvider {
         return true;
       } catch (error) {
         rethrowIfAborted(error, options);
-        if (!chunksYielded.value) {
-          observeDelegateFailure(options, error, this.logger);
-        }
+        observeDelegateFailure(options, error, this.logger);
         if (
           error instanceof LoadBalancerCompressionCallbackError ||
           error instanceof LoadBalancerContextLimitError
@@ -892,7 +890,10 @@ export class LoadBalancingProvider implements IProvider {
         settings.timeoutMs,
         subProfile.name,
         this.logger,
-        attempt.linked.controller,
+        {
+          signal: attempt.linked.controller.signal,
+          cancel: () => attempt.linked.controller.abort(),
+        },
       );
       for await (const chunk of iterator) {
         chunksYielded.value = true;

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -97,6 +97,7 @@ export { isLoadBalancerProfileFormat } from './loadBalancing/loadBalancerProfile
  */
 export class LoadBalancingProvider implements IProvider {
   readonly name = 'load-balancer';
+  readonly transportAttemptOwnership = 'provider' as const;
   private roundRobinIndex = 0;
   private readonly logger = new DebugLogger('llxprt:providers:load-balancer');
   private stats: Map<string, number> = new Map();

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -38,28 +38,43 @@ import {
   getErrorStatus,
   isNetworkTransientError,
   isOverloadError,
+  isRetryableError,
 } from '@vybestack/llxprt-code-core/utils/retry.js';
 import {
   delay,
   createAbortError,
 } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
-import { AllBucketsExhaustedError } from './errors.js';
+import { AllBucketsExhaustedError, permitsBucketFailover } from './errors.js';
+import type { StructuredErrorCategory } from '@vybestack/llxprt-code-core/core/turn.js';
+import {
+  claimProviderErrorObservation,
+  toObservedProviderError,
+} from './providerErrorObservation.js';
 import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/configTypes.js';
 import {
   delegateGetStats,
   delegateGetLoadBalancerConfig,
 } from './loadBalancing/wrappedProviderDelegation.js';
-
-/**
- * Internal shape used to carry an AbortSignal through retry orchestration when
- * no full RuntimeInvocationContext is available (e.g. legacy signal signature).
- * BaseProvider normalization detects this shape and replaces it with a real
- * RuntimeInvocationContext while preserving the signal via extractLegacySignal.
- */
-interface SignalOnlyInvocation {
-  readonly signal?: AbortSignal;
-}
+import {
+  createLinkedAbortController,
+  getRequestSignal,
+  raceWithAbort,
+  withRequestSignal,
+} from './utils/abortSignal.js';
+import { consumeTransportAttempt } from './transportAttemptBudget.js';
+import { resolveRetryRequestContext } from './retryRequestContext.js';
+import { closeIteratorBeforeContinuing } from './utils/streamCleanup.js';
+import {
+  classifyRetryError,
+  isTerminalRetryError,
+  resetRetryErrorCounters,
+  updateRetryErrorCounters,
+} from './retryErrorClassification.js';
+import {
+  createRetriesExhaustedError,
+  throwIfEmptyStreamExhaustsBudget,
+} from './retryExhaustion.js';
 
 function withLegacySignal(
   signal: AbortSignal | undefined,
@@ -86,13 +101,8 @@ function withSignal(
   } as GenerateChatOptions['invocation'];
 }
 
-function extractSignal(
-  invocation: GenerateChatOptions['invocation'],
-): AbortSignal | undefined {
-  if (!invocation) {
-    return undefined;
-  }
-  return (invocation as unknown as SignalOnlyInvocation).signal;
+function extractSignal(options: GenerateChatOptions): AbortSignal | undefined {
+  return getRequestSignal(options);
 }
 
 function isSignalAborted(signal: AbortSignal | undefined): boolean {
@@ -164,21 +174,8 @@ export class RetryOrchestrator implements IProvider {
     };
   }
 
-  /**
-   * Check if the wrapped provider is a LoadBalancingProvider
-   * LoadBalancingProvider has its own retry/failover logic, so we should
-   * pass through without adding retry orchestration
-   */
-  private isLoadBalancer(): boolean {
-    // Check by name pattern rather than importing LoadBalancingProvider
-    // to avoid circular dependency
-    return this.wrappedProvider.name === 'load-balancer';
-  }
-
   private shouldBypassRetry(options: GenerateChatOptions): boolean {
-    return (
-      this.isLoadBalancer() || options.metadata?.loadBalancerDelegate === true
-    );
+    return options.metadata?.loadBalancerDelegate === true;
   }
 
   // Delegate all IProvider methods to wrapped provider
@@ -296,40 +293,18 @@ export class RetryOrchestrator implements IProvider {
   private async *generateChatCompletionWithRetry(
     options: GenerateChatOptions,
   ): AsyncIterableIterator<IContent> {
-    // If the wrapped provider is a LoadBalancingProvider, pass through without retry logic
-    // because LoadBalancingProvider already has its own failover and retry mechanisms.
-    // Don't buffer chunks for LoadBalancingProvider to avoid timeout issues.
     if (this.shouldBypassRetry(options)) {
-      for await (const chunk of this.wrappedProvider.generateChatCompletion(
-        options,
-      )) {
-        yield chunk;
-      }
+      yield* this.wrappedProvider.generateChatCompletion(options);
       return;
     }
 
-    // Extract signal - it may be on invocation or in options directly
-    const signal = extractSignal(options.invocation);
-
-    // Check for abort before starting
-    if (isSignalAborted(signal)) {
-      throw createAbortError();
-    }
-
-    // Read ephemeral settings for retry configuration
-    const invocationEphemerals = options.invocation?.ephemerals;
-    const maxAttempts =
-      (invocationEphemerals?.['retries'] as number | undefined) ??
-      this.config.maxAttempts;
-    const initialDelayMs =
-      (invocationEphemerals?.['retrywait'] as number | undefined) ??
-      this.config.initialDelayMs;
-    const authRetryTimeoutMs =
-      (invocationEphemerals?.['auth-retry-timeout'] as number | undefined) ??
-      this.config.authRetryTimeoutMs;
-
-    const bucketFailoverHandler = this.getBucketFailoverHandler(options);
-
+    const signal = extractSignal(options);
+    if (isSignalAborted(signal)) throw createAbortError();
+    const request = resolveRetryRequestContext(options, this.config);
+    const { maxAttempts, initialDelayMs, authRetryTimeoutMs, budget } = request;
+    const requestOptions = request.options;
+    const bucketFailoverHandler = this.getBucketFailoverHandler(requestOptions);
+    let lastError: unknown;
     const retryState = {
       attempt: 0,
       currentDelay: initialDelayMs,
@@ -337,59 +312,65 @@ export class RetryOrchestrator implements IProvider {
       consecutiveAuthErrors: 0,
       consecutiveNetworkErrors: 0,
     };
-    const failoverThreshold = 1;
-
-    while (retryState.attempt < maxAttempts) {
-      if (isSignalAborted(signal)) {
-        throw createAbortError();
-      }
-
-      retryState.attempt++;
-
+    while (budget.used < budget.limit) {
+      if (isSignalAborted(signal)) throw createAbortError();
+      const linked = createLinkedAbortController(signal);
+      const attemptOptions = withRequestSignal(
+        requestOptions,
+        linked.controller.signal,
+      );
+      let attemptError: unknown;
       try {
-        if (isSignalAborted(signal)) {
-          throw createAbortError();
+        if (
+          this.wrappedProvider.name !== 'load-balancer' &&
+          !consumeTransportAttempt(attemptOptions)
+        ) {
+          break;
         }
-
-        const stream = this.wrappedProvider.generateChatCompletion(options);
-
-        if (this.config.streamingTimeoutMs > 0) {
-          yield* this.streamWithTimeout(
-            stream,
-            this.config.streamingTimeoutMs,
-            signal,
-          );
-        } else {
-          yield* this.yieldStreamUnprotected(stream);
-        }
-
-        // Success - reset error counters and bucket failover tracking
-        retryState.consecutive429s = 0;
-        retryState.consecutiveAuthErrors = 0;
-        retryState.consecutiveNetworkErrors = 0;
+        const stream =
+          this.wrappedProvider.generateChatCompletion(attemptOptions);
+        const producedContent =
+          this.config.streamingTimeoutMs > 0
+            ? yield* this.streamWithTimeout(
+                stream,
+                this.config.streamingTimeoutMs,
+                linked.controller,
+              )
+            : yield* this.yieldStreamUnprotected(stream, linked.controller);
+        throwIfEmptyStreamExhaustsBudget(
+          producedContent,
+          budget.used,
+          budget.limit,
+        );
+        resetRetryErrorCounters(retryState);
         bucketFailoverHandler?.resetSession?.();
         return;
       } catch (error) {
-        const action = await this.handleRetryError(
-          error,
-          options,
-          retryState,
-          maxAttempts,
-          initialDelayMs,
-          failoverThreshold,
-          bucketFailoverHandler,
-          signal,
-          authRetryTimeoutMs,
-        );
-        if (action.type === 'throw') {
-          throw action.error;
-        }
-        // action.type === 'continue' — loop again
+        attemptError = error;
+        lastError = error;
+      } finally {
+        linked.controller.abort();
+        linked.dispose();
       }
+      retryState.attempt = budget.used;
+      const action = await this.handleRetryError(
+        attemptError,
+        requestOptions,
+        retryState,
+        maxAttempts,
+        initialDelayMs,
+        1,
+        bucketFailoverHandler,
+        signal,
+        authRetryTimeoutMs,
+      );
+      if (action.type === 'throw') throw action.error;
     }
 
-    // Exhausted all retries
-    throw new Error('Retry attempts exhausted');
+    throw createRetriesExhaustedError(
+      lastError ?? new Error('Shared transport attempt budget exhausted'),
+      budget.used,
+    );
   }
 
   /**
@@ -398,14 +379,20 @@ export class RetryOrchestrator implements IProvider {
    */
   private async *yieldStreamUnprotected(
     stream: AsyncIterableIterator<IContent>,
-  ): AsyncGenerator<IContent> {
+    attemptController: AbortController,
+  ): AsyncGenerator<IContent, boolean> {
     let chunksYielded = false;
+    let completed = false;
+    let failure: unknown;
     try {
       for await (const chunk of stream) {
         chunksYielded = true;
         yield chunk;
       }
+      completed = true;
+      return chunksYielded;
     } catch (streamError) {
+      failure = streamError;
       if (chunksYielded) {
         this.logger.debug(
           () =>
@@ -416,6 +403,11 @@ export class RetryOrchestrator implements IProvider {
         )._chunksYieldedBeforeError = true;
       }
       throw streamError;
+    } finally {
+      if (!completed) {
+        attemptController.abort();
+        await closeIteratorBeforeContinuing(stream, failure);
+      }
     }
   }
 
@@ -423,6 +415,24 @@ export class RetryOrchestrator implements IProvider {
    * Classifies the error, updates consecutive counters, runs auth/failover
    * handlers, and returns either a throw action or continue action.
    */
+  private observeProviderError(
+    options: GenerateChatOptions,
+    error: unknown,
+    status: number | undefined,
+    category: StructuredErrorCategory | undefined,
+  ): void {
+    if (!claimProviderErrorObservation(options, error)) return;
+    try {
+      options.onProviderError?.(
+        toObservedProviderError(error, status, category),
+      );
+    } catch (observerError) {
+      this.logger.debug(
+        () => `Provider error observer failed: ${String(observerError)}`,
+      );
+    }
+  }
+
   private async handleRetryError(
     error: unknown,
     options: GenerateChatOptions,
@@ -440,47 +450,47 @@ export class RetryOrchestrator implements IProvider {
     signal: AbortSignal | undefined,
     authRetryTimeoutMs: number,
   ): Promise<{ type: 'throw'; error: unknown } | { type: 'continue' }> {
-    if (error instanceof Error && error.name === 'AbortError') {
-      return { type: 'throw', error };
-    }
+    if (isTerminalRetryError(error)) return { type: 'throw', error };
 
-    if (
-      (error as Error & { _chunksYieldedBeforeError?: boolean })
-        ._chunksYieldedBeforeError === true
-    ) {
-      return { type: 'throw', error };
-    }
-
-    const errorStatus = getErrorStatus(error);
-    const isOverload = isOverloadError(error);
-    const is429 = errorStatus === 429 || isOverload;
-    const is402 = errorStatus === 402;
-    const isAuthError = errorStatus === 401 || errorStatus === 403;
-    const isNetworkError = isNetworkTransientError(error);
+    const classification = classifyRetryError(error);
+    const {
+      status: errorStatus,
+      category,
+      is429,
+      is402,
+      isAuthError,
+      isNetworkError,
+    } = classification;
+    this.observeProviderError(options, error, errorStatus, category);
 
     this.logger.debug(
       () =>
         `[attempt ${state.attempt}/${maxAttempts}] Error: status=${errorStatus}, is429=${is429}, is402=${is402}, isAuth=${isAuthError}, isNetwork=${isNetworkError}`,
     );
 
-    this.updateConsecutiveCounters(state, is429, isAuthError, isNetworkError);
+    updateRetryErrorCounters(state, classification);
 
     const shouldAttemptRefreshRetry =
-      isAuthError && state.consecutiveAuthErrors === 1;
+      isAuthError &&
+      state.consecutiveAuthErrors === 1 &&
+      state.attempt < maxAttempts;
 
     if (shouldAttemptRefreshRetry) {
-      await this.invokeAuthErrorHandler(error, options, errorStatus);
+      await this.invokeAuthErrorHandler(error, options, errorStatus, signal);
     }
 
-    const shouldAttemptFailover = this.shouldAttemptFailover(
-      bucketFailoverHandler,
-      is429,
-      is402,
-      isAuthError,
-      isNetworkError,
-      state,
-      failoverThreshold,
-    );
+    const shouldAttemptFailover =
+      state.attempt < maxAttempts &&
+      permitsBucketFailover(error) &&
+      this.shouldAttemptFailover(
+        bucketFailoverHandler,
+        is429,
+        is402,
+        isAuthError,
+        isNetworkError,
+        state,
+        failoverThreshold,
+      );
 
     if (shouldAttemptFailover && bucketFailoverHandler) {
       return this.handleFailoverDecision(
@@ -492,6 +502,7 @@ export class RetryOrchestrator implements IProvider {
         bucketFailoverHandler,
         error,
         authRetryTimeoutMs,
+        signal,
       );
     }
 
@@ -502,6 +513,8 @@ export class RetryOrchestrator implements IProvider {
       initialDelayMs,
       shouldAttemptRefreshRetry,
       signal,
+      category,
+      errorStatus,
     );
   }
 
@@ -533,33 +546,6 @@ export class RetryOrchestrator implements IProvider {
     return isNetworkError && state.consecutiveNetworkErrors > failoverThreshold;
   }
 
-  private updateConsecutiveCounters(
-    state: {
-      consecutive429s: number;
-      consecutiveAuthErrors: number;
-      consecutiveNetworkErrors: number;
-    },
-    is429: boolean,
-    isAuthError: boolean,
-    isNetworkError: boolean,
-  ): void {
-    if (is429) {
-      state.consecutive429s++;
-    } else {
-      state.consecutive429s = 0;
-    }
-    if (isAuthError) {
-      state.consecutiveAuthErrors++;
-    } else {
-      state.consecutiveAuthErrors = 0;
-    }
-    if (isNetworkError && !is429 && !isAuthError) {
-      state.consecutiveNetworkErrors++;
-    } else {
-      state.consecutiveNetworkErrors = 0;
-    }
-  }
-
   private async handleFailoverDecision(
     errorStatus: number | undefined,
     is429: boolean,
@@ -575,6 +561,7 @@ export class RetryOrchestrator implements IProvider {
     bucketFailoverHandler: BucketFailoverHandler,
     error: unknown,
     authRetryTimeoutMs: number,
+    signal: AbortSignal | undefined,
   ): Promise<{ type: 'throw'; error: unknown } | { type: 'continue' }> {
     const failoverResult = await this.attemptBucketFailover(
       errorStatus,
@@ -583,6 +570,7 @@ export class RetryOrchestrator implements IProvider {
       state,
       bucketFailoverHandler,
       authRetryTimeoutMs,
+      signal,
     );
     if (failoverResult === 'continue') {
       state.currentDelay = initialDelayMs;
@@ -607,16 +595,23 @@ export class RetryOrchestrator implements IProvider {
     initialDelayMs: number,
     shouldAttemptRefreshRetry: boolean,
     signal: AbortSignal | undefined,
+    category: StructuredErrorCategory | undefined,
+    status: number | undefined,
   ): Promise<{ type: 'throw'; error: unknown } | { type: 'continue' }> {
     const shouldRetry = this.shouldRetryError(error);
     if (!shouldRetry && !shouldAttemptRefreshRetry) {
       return { type: 'throw', error };
     }
-    if (state.attempt >= maxAttempts && !shouldAttemptRefreshRetry) {
-      return { type: 'throw', error };
-    }
-    if (state.attempt >= maxAttempts && shouldAttemptRefreshRetry) {
-      state.attempt--;
+    if (state.attempt >= maxAttempts) {
+      return {
+        type: 'throw',
+        error: createRetriesExhaustedError(
+          error,
+          state.attempt,
+          category,
+          status,
+        ),
+      };
     }
 
     const delayMs = this.getDelayDuration(error, state.currentDelay);
@@ -647,18 +642,27 @@ export class RetryOrchestrator implements IProvider {
     error: unknown,
     options: GenerateChatOptions,
     errorStatus: number | undefined,
+    signal: AbortSignal | undefined,
   ): Promise<void> {
     const authErrorHandler = this.getOnAuthErrorHandler(options);
     if (authErrorHandler) {
       try {
-        const failedAccessToken = await this.resolveAuthToken(options);
+        const failedAccessToken = await raceWithAbort(
+          this.resolveAuthToken(options),
+          signal,
+        );
         const providerId = this.name;
-        await authErrorHandler.handleAuthError({
-          failedAccessToken,
-          providerId,
-          errorStatus: errorStatus ?? 401,
-        });
+        await raceWithAbort(
+          authErrorHandler.handleAuthError({
+            failedAccessToken,
+            providerId,
+            errorStatus: errorStatus ?? 401,
+            signal,
+          }),
+          signal,
+        );
       } catch (handlerError) {
+        if (signal?.aborted === true) throw handlerError;
         this.logger.debug(
           () =>
             `Auth error handler failed, continuing with retry: ${handlerError}`,
@@ -683,6 +687,7 @@ export class RetryOrchestrator implements IProvider {
     },
     bucketFailoverHandler: BucketFailoverHandler,
     authRetryTimeoutMs: number,
+    signal: AbortSignal | undefined,
   ): Promise<'continue' | 'exhausted'> {
     const failoverReason = resolveFailoverReason(
       is429,
@@ -698,19 +703,19 @@ export class RetryOrchestrator implements IProvider {
     const failoverContext: FailoverContext = {
       triggeringStatus: errorStatus,
       authRetryTimeoutMs,
+      signal,
     };
 
-    const failoverResult =
-      await bucketFailoverHandler.tryFailover(failoverContext);
+    const failoverResult = await raceWithAbort(
+      bucketFailoverHandler.tryFailover(failoverContext),
+      signal,
+    );
 
     if (failoverResult) {
       this.logger.debug(
         () => `Bucket failover successful, resetting retry state`,
       );
-      state.consecutive429s = 0;
-      state.consecutiveAuthErrors = 0;
-      state.consecutiveNetworkErrors = 0;
-      state.attempt--;
+      resetRetryErrorCounters(state);
       return 'continue';
     }
 
@@ -726,34 +731,36 @@ export class RetryOrchestrator implements IProvider {
   private async *streamWithTimeout(
     stream: AsyncIterableIterator<IContent>,
     timeoutMs: number,
-    signal?: AbortSignal,
-  ): AsyncIterableIterator<IContent> {
+    attemptController: AbortController,
+  ): AsyncGenerator<IContent, boolean> {
     const iterator = stream[Symbol.asyncIterator]();
     let firstChunk = true;
+    let chunksYielded = false;
+    let completed = false;
+    let failure: unknown;
 
-    for (;;) {
-      if (isSignalAborted(signal)) {
-        throw createAbortError();
-      }
-
-      const nextPromise = iterator.next();
-
-      // Apply timeout only for first chunk
-      if (firstChunk && timeoutMs > 0) {
-        const outcome = await raceFirstChunkWithTimeout(nextPromise, timeoutMs);
-        if (outcome.done === true) {
-          return;
-        }
+    try {
+      for (;;) {
+        if (attemptController.signal.aborted) throw createAbortError();
+        const nextPromise = iterator.next();
+        const result = firstChunk
+          ? await raceFirstChunkWithTimeout(nextPromise, timeoutMs)
+          : await nextPromise;
         firstChunk = false;
-        yield outcome.value;
-      } else {
-        const result = await nextPromise;
-
         if (result.done === true) {
-          return;
+          completed = true;
+          return chunksYielded;
         }
-
+        chunksYielded = true;
         yield result.value;
+      }
+    } catch (error) {
+      failure = error;
+      throw error;
+    } finally {
+      if (!completed) {
+        attemptController.abort();
+        await closeIteratorBeforeContinuing(iterator, failure);
       }
     }
   }
@@ -762,6 +769,14 @@ export class RetryOrchestrator implements IProvider {
    * Determines if an error should trigger a retry
    */
   private shouldRetryError(error: unknown): boolean {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      Array.isArray((error as { failures?: unknown }).failures) &&
+      typeof (error as { isRetryable?: unknown }).isRetryable === 'boolean'
+    ) {
+      return isRetryableError(error);
+    }
     const status = getErrorStatus(error);
 
     // Don't retry client errors (4xx except 429)
@@ -973,19 +988,15 @@ async function raceFirstChunkWithTimeout<T>(
   nextPromise: Promise<IteratorResult<T>>,
   timeoutMs: number,
 ): Promise<IteratorResult<T>> {
-  let timeoutId: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(
-      () => reject(new Error('Stream timeout: first chunk not received')),
-      timeoutMs,
-    );
-  });
-
+  const timeoutController = new AbortController();
   try {
+    const timeoutPromise = delay(timeoutMs, timeoutController.signal).then(
+      () => {
+        throw new Error('Stream timeout: first chunk not received');
+      },
+    );
     return await Promise.race([nextPromise, timeoutPromise]);
   } finally {
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-    }
+    timeoutController.abort();
   }
 }

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -49,6 +49,7 @@ import { AllBucketsExhaustedError, permitsBucketFailover } from './errors.js';
 import type { StructuredErrorCategory } from '@vybestack/llxprt-code-core/core/turn.js';
 import {
   claimProviderErrorObservation,
+  invokeProviderErrorObserver,
   toObservedProviderError,
 } from './providerErrorObservation.js';
 import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/configTypes.js';
@@ -423,15 +424,15 @@ export class RetryOrchestrator implements IProvider {
     category: StructuredErrorCategory | undefined,
   ): void {
     if (!claimProviderErrorObservation(options, error)) return;
-    try {
-      options.onProviderError?.(
-        toObservedProviderError(error, status, category),
-      );
-    } catch (observerError) {
-      this.logger.debug(
-        () => `Provider error observer failed: ${String(observerError)}`,
-      );
-    }
+    invokeProviderErrorObserver(
+      options.onProviderError,
+      toObservedProviderError(error, status, category),
+      (observerError) => {
+        this.logger.debug(
+          () => `Provider error observer failed: ${String(observerError)}`,
+        );
+      },
+    );
   }
 
   private async handleRetryError(

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -358,9 +358,14 @@ export class RetryOrchestrator implements IProvider {
       if (action.type === 'throw') throw action.error;
     }
 
+    const finalError =
+      lastError ?? new Error('Shared transport attempt budget exhausted');
+    const { category, status } = classifyRetryError(finalError);
     throw createRetriesExhaustedError(
-      lastError ?? new Error('Shared transport attempt budget exhausted'),
+      finalError,
       budget.used,
+      category,
+      status,
     );
   }
 

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -61,10 +61,20 @@ import {
   createLinkedAbortController,
   getRequestSignal,
   raceWithAbort,
+  withLegacyRequestSignal,
+  withOptionalRequestSignal,
   withRequestSignal,
 } from './utils/abortSignal.js';
-import { consumeTransportAttempt } from './transportAttemptBudget.js';
-import { resolveRetryRequestContext } from './retryRequestContext.js';
+import {
+  resolveRetryRequestContext,
+  type RetryRequestContext,
+} from './retryRequestContext.js';
+import {
+  accountProviderAttempt,
+  beginProviderTransportAttempt,
+  createInitialRetryState,
+  providerOwnsTransportAttempts,
+} from './retryTransportOwnership.js';
 import { closeIteratorBeforeContinuing } from './utils/streamCleanup.js';
 import {
   classifyRetryError,
@@ -77,31 +87,6 @@ import {
   createRetriesExhaustedError,
   throwIfEmptyStreamExhaustsBudget,
 } from './retryExhaustion.js';
-
-function withLegacySignal(
-  signal: AbortSignal | undefined,
-): GenerateChatOptions['invocation'] | undefined {
-  if (!signal) {
-    return undefined;
-  }
-  return { signal } as unknown as GenerateChatOptions['invocation'];
-}
-
-function withSignal(
-  invocation: GenerateChatOptions['invocation'],
-  signal: AbortSignal | undefined,
-): GenerateChatOptions['invocation'] | undefined {
-  if (!signal) {
-    return invocation;
-  }
-  if (!invocation) {
-    return withLegacySignal(signal);
-  }
-  return {
-    ...invocation,
-    signal,
-  } as GenerateChatOptions['invocation'];
-}
 
 function extractSignal(options: GenerateChatOptions): AbortSignal | undefined {
   return getRequestSignal(options);
@@ -276,13 +261,16 @@ export class RetryOrchestrator implements IProvider {
       options = {
         contents: optionsOrContents,
         tools,
-        invocation: withLegacySignal(signal),
+        invocation: withLegacyRequestSignal(signal),
       } as GenerateChatOptions;
     } else {
       // Modern signature: (options)
       options = {
         ...optionsOrContents,
-        invocation: withSignal(optionsOrContents.invocation, signal),
+        invocation: withOptionalRequestSignal(
+          optionsOrContents.invocation,
+          signal,
+        ),
       };
     }
 
@@ -299,23 +287,29 @@ export class RetryOrchestrator implements IProvider {
       yield* this.wrappedProvider.generateChatCompletion(options);
       return;
     }
-
     const signal = extractSignal(options);
-    if (isSignalAborted(signal)) throw createAbortError();
+    if (isSignalAborted(signal)) throw createAbortError(signal?.reason);
     const request = resolveRetryRequestContext(options, this.config);
+    try {
+      yield* this.runRetryRequest(request, signal);
+    } finally {
+      request.releaseBudget();
+    }
+  }
+
+  private async *runRetryRequest(
+    request: RetryRequestContext,
+    signal: AbortSignal | undefined,
+  ): AsyncIterableIterator<IContent> {
     const { maxAttempts, initialDelayMs, authRetryTimeoutMs, budget } = request;
     const requestOptions = request.options;
     const bucketFailoverHandler = this.getBucketFailoverHandler(requestOptions);
+    const ownsAttempts = providerOwnsTransportAttempts(this.wrappedProvider);
     let lastError: unknown;
-    const retryState = {
-      attempt: 0,
-      currentDelay: initialDelayMs,
-      consecutive429s: 0,
-      consecutiveAuthErrors: 0,
-      consecutiveNetworkErrors: 0,
-    };
+    const retryState = createInitialRetryState(initialDelayMs);
     while (budget.used < budget.limit) {
-      if (isSignalAborted(signal)) throw createAbortError();
+      if (isSignalAborted(signal)) throw createAbortError(signal?.reason);
+      const usedBefore = budget.used;
       const linked = createLinkedAbortController(signal);
       const attemptOptions = withRequestSignal(
         requestOptions,
@@ -323,12 +317,7 @@ export class RetryOrchestrator implements IProvider {
       );
       let attemptError: unknown;
       try {
-        if (
-          this.wrappedProvider.name !== 'load-balancer' &&
-          !consumeTransportAttempt(attemptOptions)
-        ) {
-          break;
-        }
+        beginProviderTransportAttempt(ownsAttempts, attemptOptions);
         const stream =
           this.wrappedProvider.generateChatCompletion(attemptOptions);
         const producedContent =
@@ -354,6 +343,12 @@ export class RetryOrchestrator implements IProvider {
         linked.controller.abort();
         linked.dispose();
       }
+      accountProviderAttempt(
+        this.wrappedProvider,
+        requestOptions,
+        budget,
+        usedBefore,
+      );
       retryState.attempt = budget.used;
       const action = await this.handleRetryError(
         attemptError,
@@ -744,7 +739,9 @@ export class RetryOrchestrator implements IProvider {
 
     try {
       for (;;) {
-        if (attemptController.signal.aborted) throw createAbortError();
+        if (attemptController.signal.aborted) {
+          throw createAbortError(attemptController.signal.reason);
+        }
         const nextPromise = iterator.next();
         const result = firstChunk
           ? await raceFirstChunkWithTimeout(nextPromise, timeoutMs)

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -756,8 +756,11 @@ export class RetryOrchestrator implements IProvider {
       }
     } catch (error) {
       failed = true;
-      failure = error;
-      throw error;
+      const propagatedFailure = chunksYielded
+        ? markErrorAfterStreamOutput(error)
+        : error;
+      failure = propagatedFailure;
+      throw propagatedFailure;
     } finally {
       if (!completed) {
         attemptController.abort();

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -68,6 +68,7 @@ import { closeIteratorBeforeContinuing } from './utils/streamCleanup.js';
 import {
   classifyRetryError,
   isTerminalRetryError,
+  markErrorAfterStreamOutput,
   resetRetryErrorCounters,
   updateRetryErrorCounters,
 } from './retryErrorClassification.js';
@@ -383,6 +384,7 @@ export class RetryOrchestrator implements IProvider {
   ): AsyncGenerator<IContent, boolean> {
     let chunksYielded = false;
     let completed = false;
+    let failed = false;
     let failure: unknown;
     try {
       for await (const chunk of stream) {
@@ -392,21 +394,20 @@ export class RetryOrchestrator implements IProvider {
       completed = true;
       return chunksYielded;
     } catch (streamError) {
+      failed = true;
       failure = streamError;
       if (chunksYielded) {
         this.logger.debug(
           () =>
             `Error after yielding chunks - cannot retry (would produce mixed response)`,
         );
-        (
-          streamError as Error & { _chunksYieldedBeforeError: boolean }
-        )._chunksYieldedBeforeError = true;
+        throw markErrorAfterStreamOutput(streamError);
       }
       throw streamError;
     } finally {
       if (!completed) {
         attemptController.abort();
-        await closeIteratorBeforeContinuing(stream, failure);
+        await closeIteratorBeforeContinuing(stream, failure, failed);
       }
     }
   }
@@ -737,6 +738,7 @@ export class RetryOrchestrator implements IProvider {
     let firstChunk = true;
     let chunksYielded = false;
     let completed = false;
+    let failed = false;
     let failure: unknown;
 
     try {
@@ -755,12 +757,13 @@ export class RetryOrchestrator implements IProvider {
         yield result.value;
       }
     } catch (error) {
+      failed = true;
       failure = error;
       throw error;
     } finally {
       if (!completed) {
         attemptController.abort();
-        await closeIteratorBeforeContinuing(iterator, failure);
+        await closeIteratorBeforeContinuing(iterator, failure, failed);
       }
     }
   }

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -50,6 +50,7 @@ import type { StructuredErrorCategory } from '@vybestack/llxprt-code-core/core/t
 import {
   claimProviderErrorObservation,
   invokeProviderErrorObserver,
+  isStreamTimeoutError,
   toObservedProviderError,
 } from './providerErrorObservation.js';
 import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/configTypes.js';
@@ -61,8 +62,6 @@ import {
   createLinkedAbortController,
   getRequestSignal,
   raceWithAbort,
-  withLegacyRequestSignal,
-  withOptionalRequestSignal,
   withRequestSignal,
 } from './utils/abortSignal.js';
 import {
@@ -254,24 +253,19 @@ export class RetryOrchestrator implements IProvider {
     let options: GenerateChatOptions;
 
     if (Array.isArray(optionsOrContents)) {
-      // Legacy signature: (contents, tools?, signal?)
-      // The signal is carried on invocation so retry logic and the wrapped
-      // provider can read it; BaseProvider normalization replaces this stub
-      // with a real RuntimeInvocationContext (preserving the signal).
-      options = {
+      const legacyOptions: GenerateChatOptions = {
         contents: optionsOrContents,
         tools,
-        invocation: withLegacyRequestSignal(signal),
-      } as GenerateChatOptions;
-    } else {
-      // Modern signature: (options)
-      options = {
-        ...optionsOrContents,
-        invocation: withOptionalRequestSignal(
-          optionsOrContents.invocation,
-          signal,
-        ),
       };
+      options =
+        signal === undefined
+          ? legacyOptions
+          : withRequestSignal(legacyOptions, signal);
+    } else {
+      options =
+        signal === undefined
+          ? optionsOrContents
+          : withRequestSignal(optionsOrContents, signal);
     }
 
     return this.generateChatCompletionWithRetry(options);
@@ -809,9 +803,7 @@ export class RetryOrchestrator implements IProvider {
     }
 
     // Retry stream timeouts
-    if (error instanceof Error && error.message.includes('Stream timeout')) {
-      return true;
-    }
+    if (isStreamTimeoutError(error)) return true;
 
     return false;
   }

--- a/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
+++ b/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
@@ -168,6 +168,33 @@ describe('BaseProvider normalization invocation safety', () => {
     ).toBe(true);
   });
 
+  it('inherits a metadata signal when a valid invocation has no signal', async () => {
+    const { createProviderCallOptions } = await import(
+      '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js'
+    );
+    const provider = new InvocationSafetyProvider();
+    wireProviderWithAuth(provider);
+    const settings = createSettings(provider);
+    const controller = new AbortController();
+    const validOptions = createProviderCallOptions({
+      providerName: PROVIDER_NAME,
+      settings,
+      ephemerals: {},
+    });
+
+    await provider
+      .generateChatCompletion({
+        ...validOptions,
+        contents: [prompt],
+        metadata: { abortSignal: controller.signal },
+      })
+      .next();
+
+    expect(provider.lastNormalizedOptions?.invocation.signal).toBe(
+      controller.signal,
+    );
+  });
+
   it('keeps a valid RuntimeInvocationContext coherent while refreshing current ephemerals', async () => {
     const { createProviderCallOptions } = await import(
       '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js'

--- a/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
+++ b/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
@@ -18,7 +18,10 @@ import {
 } from '../BaseProvider.js';
 import type { GenerateChatOptions } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
-import type { RuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import {
+  createRuntimeInvocationContext,
+  type RuntimeInvocationContext,
+} from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import {
   clearActiveProviderRuntimeContext,
@@ -168,7 +171,7 @@ describe('BaseProvider normalization invocation safety', () => {
     ).toBe(true);
   });
 
-  it('inherits a metadata signal when a valid invocation has no signal', async () => {
+  it('uses a metadata signal when a valid invocation has no signal', async () => {
     const { createProviderCallOptions } = await import(
       '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js'
     );
@@ -192,6 +195,43 @@ describe('BaseProvider normalization invocation safety', () => {
 
     expect(provider.lastNormalizedOptions?.invocation.signal).toBe(
       controller.signal,
+    );
+  });
+
+  it('uses an invocation signal ahead of a metadata signal', async () => {
+    const { createProviderCallOptions } = await import(
+      '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js'
+    );
+    const provider = new InvocationSafetyProvider();
+    wireProviderWithAuth(provider);
+    const settings = createSettings(provider);
+    const invocationController = new AbortController();
+    const metadataController = new AbortController();
+    const validOptions = createProviderCallOptions({
+      providerName: PROVIDER_NAME,
+      settings,
+      ephemerals: {},
+    });
+    const invocation = createRuntimeInvocationContext({
+      runtime: validOptions.runtime,
+      settings,
+      providerName: PROVIDER_NAME,
+      ephemeralsSnapshot: {},
+      signal: invocationController.signal,
+      fallbackRuntimeId: validOptions.runtime.runtimeId,
+    });
+
+    await provider
+      .generateChatCompletion({
+        ...validOptions,
+        contents: [prompt],
+        invocation,
+        metadata: { abortSignal: metadataController.signal },
+      })
+      .next();
+
+    expect(provider.lastNormalizedOptions?.invocation.signal).toBe(
+      invocationController.signal,
     );
   });
 

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
@@ -14,6 +14,7 @@ import {
   type LoadBalancingProviderConfig,
 } from '../LoadBalancingProvider.js';
 import { LoadBalancerFailoverError } from '../errors.js';
+import { MAX_PUBLIC_PROVIDER_MESSAGE_LENGTH } from '../providerErrorObservation.js';
 import type { IProvider } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { GenerateChatOptions } from '../GenerateChatOptions.js';
@@ -325,6 +326,22 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
 
       expect(error.message).toContain('no backend attempts were recorded');
       expect(error.message).toContain('(tried: none)');
+    });
+
+    it('keeps public summaries bounded while preserving every structured failure', () => {
+      const failures = Array.from({ length: 5 }, (_, index) => ({
+        profile: `backend-${index + 1}`,
+        error: new Error(`private failure ${index + 1}`),
+      }));
+
+      const error = new LoadBalancerFailoverError('test-profile', failures);
+
+      expect(error.message.length).toBeLessThanOrEqual(
+        MAX_PUBLIC_PROVIDER_MESSAGE_LENGTH,
+      );
+      expect(error.message).toContain('+2 more');
+      expect(error.message).not.toContain('private failure 4');
+      expect(error.failures).toStrictEqual(failures);
     });
   });
   describe('ResolvedSubProfile settings propagation', () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
@@ -315,7 +315,7 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
       ]);
 
       expect(error.message).toContain('only backend failed');
-      expect(error.message).not.toContain('sole:');
+      expect(error.message).toContain('sole: only backend failed');
       expect(error.message).toContain('test-profile');
       expect(error.message).toContain('sole');
     });

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.errors.test.ts
@@ -13,7 +13,7 @@ import {
   LoadBalancingProvider,
   type LoadBalancingProviderConfig,
 } from '../LoadBalancingProvider.js';
-import { LoadBalancerFailoverError } from '../errors.js';
+import { LoadBalancerFailoverError, RetriesExhaustedError } from '../errors.js';
 import { MAX_PUBLIC_PROVIDER_MESSAGE_LENGTH } from '../providerErrorObservation.js';
 import type { IProvider } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
@@ -31,6 +31,271 @@ describe('LoadBalancingProvider - Failover Strategy', () => {
   });
 
   describe('Aggregated Error When All Backends Fail', () => {
+    it('fails over to the next backend after a retryable nested load balancer failure', async () => {
+      const transientFailure = Object.assign(new Error('nested unavailable'), {
+        status: 503,
+      });
+      const nestedFailure = new LoadBalancerFailoverError('nested-profile', [
+        { profile: 'nested-backend', error: transientFailure },
+      ]);
+      const noContent: IContent[] = [];
+      let calls = 0;
+      const delegate: IProvider = {
+        name: 'test-provider',
+        async *generateChatCompletion(): AsyncGenerator<IContent> {
+          calls++;
+          if (calls === 1) {
+            yield* noContent;
+            throw nestedFailure;
+          }
+          yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'test-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => null,
+      };
+      providerManager.registerProvider(delegate);
+      const provider = new LoadBalancingProvider(
+        {
+          profileName: 'outer-profile',
+          strategy: 'failover',
+          subProfiles: [
+            {
+              name: 'primary',
+              providerName: 'test-provider',
+              modelId: 'model-1',
+              baseURL: 'https://primary.test',
+              authToken: 'token-1',
+            },
+            {
+              name: 'secondary',
+              providerName: 'test-provider',
+              modelId: 'model-2',
+              baseURL: 'https://secondary.test',
+              authToken: 'token-2',
+            },
+          ],
+        },
+        providerManager,
+      );
+      const chunks: IContent[] = [];
+
+      for await (const chunk of provider.generateChatCompletion({
+        contents: [],
+      })) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toStrictEqual([
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] },
+      ]);
+      expect(calls).toBe(2);
+    });
+
+    it('propagates a retryable nested load balancer failure after yielding content', async () => {
+      const nestedFailure = new LoadBalancerFailoverError('nested-profile', [
+        {
+          profile: 'nested-primary',
+          error: Object.assign(new Error('nested primary unavailable'), {
+            status: 503,
+          }),
+        },
+        {
+          profile: 'nested-secondary',
+          error: Object.assign(new Error('nested secondary unavailable'), {
+            status: 503,
+          }),
+        },
+      ]);
+      const content: IContent = {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'partial response' }],
+      };
+      let primaryCalls = 0;
+      let secondaryCalls = 0;
+      const primary: IProvider = {
+        name: 'primary-provider',
+        async *generateChatCompletion(): AsyncGenerator<IContent> {
+          primaryCalls++;
+          yield content;
+          throw nestedFailure;
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'primary-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => null,
+      };
+      const secondary: IProvider = {
+        name: 'secondary-provider',
+        async *generateChatCompletion(): AsyncGenerator<IContent> {
+          secondaryCalls++;
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'unexpected' }],
+          };
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'secondary-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => null,
+      };
+      providerManager.registerProvider(primary);
+      providerManager.registerProvider(secondary);
+      const provider = new LoadBalancingProvider(
+        {
+          profileName: 'outer-profile',
+          strategy: 'failover',
+          subProfiles: [
+            {
+              name: 'primary',
+              providerName: 'primary-provider',
+              modelId: 'primary-model',
+              baseURL: 'https://primary.test',
+              authToken: 'primary-token',
+            },
+            {
+              name: 'secondary',
+              providerName: 'secondary-provider',
+              modelId: 'secondary-model',
+              baseURL: 'https://secondary.test',
+              authToken: 'secondary-token',
+            },
+          ],
+        },
+        providerManager,
+      );
+      const chunks: IContent[] = [];
+      let thrown: unknown;
+
+      try {
+        for await (const chunk of provider.generateChatCompletion({
+          contents: [],
+        })) {
+          chunks.push(chunk);
+        }
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(chunks).toStrictEqual([content]);
+      expect(thrown).toBe(nestedFailure);
+      expect(primaryCalls).toBe(1);
+      expect(secondaryCalls).toBe(0);
+    });
+
+    it('does not fail over after a terminal retries-exhausted failure', async () => {
+      const terminalFailure = new RetriesExhaustedError(
+        'transport retries exhausted',
+        'server_error',
+        { cause: new Error('last transport failure') },
+      );
+      let calls = 0;
+      const delegate: IProvider = {
+        name: 'test-provider',
+        async *generateChatCompletion(): AsyncGenerator<IContent> {
+          calls++;
+          if (calls === 1) throw terminalFailure;
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'unexpected' }],
+          };
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'test-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => null,
+      };
+      providerManager.registerProvider(delegate);
+      const provider = new LoadBalancingProvider(
+        {
+          profileName: 'outer-profile',
+          strategy: 'failover',
+          subProfiles: [
+            {
+              name: 'primary',
+              providerName: 'test-provider',
+              modelId: 'model-1',
+              baseURL: 'https://primary.test',
+              authToken: 'token-1',
+            },
+            {
+              name: 'secondary',
+              providerName: 'test-provider',
+              modelId: 'model-2',
+              baseURL: 'https://secondary.test',
+              authToken: 'token-2',
+            },
+          ],
+        },
+        providerManager,
+      );
+
+      await expect(async () => {
+        for await (const _chunk of provider.generateChatCompletion({
+          contents: [],
+        })) {
+          await Promise.resolve();
+        }
+      }).rejects.toBe(terminalFailure);
+      expect(calls).toBe(1);
+    });
+
+    it('observes the same backend error once per reused request lifecycle', async () => {
+      const sharedFailure = new Error('shared backend failure');
+      const noContent: IContent[] = [];
+      const delegate: IProvider = {
+        name: 'test-provider',
+        async *generateChatCompletion(): AsyncGenerator<IContent> {
+          yield* noContent;
+          throw sharedFailure;
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'test-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => null,
+      };
+      providerManager.registerProvider(delegate);
+      const provider = new LoadBalancingProvider(
+        {
+          profileName: 'observation-profile',
+          strategy: 'failover',
+          subProfiles: [
+            {
+              name: 'primary',
+              providerName: 'test-provider',
+              modelId: 'model-1',
+              baseURL: 'https://primary.test',
+              authToken: 'token-1',
+            },
+            {
+              name: 'secondary',
+              providerName: 'test-provider',
+              modelId: 'model-2',
+              baseURL: 'https://secondary.test',
+              authToken: 'token-2',
+            },
+          ],
+        },
+        providerManager,
+      );
+      const observed: unknown[] = [];
+      const options: GenerateChatOptions = {
+        contents: [],
+        onProviderError: (error) => observed.push(error),
+      };
+
+      for (let request = 0; request < 2; request++) {
+        await expect(async () => {
+          for await (const _chunk of provider.generateChatCompletion(options)) {
+            await Promise.resolve();
+          }
+        }).rejects.toBeInstanceOf(LoadBalancerFailoverError);
+      }
+
+      expect(observed).toHaveLength(2);
+    });
+
     it('should throw LoadBalancerFailoverError when all backends fail', async () => {
       const mockProvider: IProvider = {
         name: 'test-provider',

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -175,12 +175,13 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
         },
         providerManager,
       );
-      const requestContext: Record<string, unknown> = {};
+      const requestContext: Record<string, unknown> = {
+        transportAttemptBudget: { limit: 1, used: 0 },
+      };
       const options = {
         ...makeOptions(),
         metadata: { _retryRequestContext: requestContext },
       };
-      requestContext.transportAttemptBudget = { limit: 1, used: 0 };
 
       let thrown: unknown;
       try {
@@ -461,9 +462,17 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
     );
 
     const received: IContent[] = [];
+    const observedErrors: Array<{
+      message: string;
+      status?: number;
+      category?: string;
+    }> = [];
     let thrown: unknown;
     try {
-      for await (const chunk of lb.generateChatCompletion(makeOptions())) {
+      for await (const chunk of lb.generateChatCompletion({
+        ...makeOptions(),
+        onProviderError: (error) => observedErrors.push(error),
+      })) {
         received.push(chunk);
       }
     } catch (e) {
@@ -476,6 +485,13 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
     // instead of being collected into an aggregate.
     expect(thrown).not.toBeInstanceOf(LoadBalancerFailoverError);
     expect(getErrorStatus(thrown)).toBe(429);
+    expect(observedErrors).toStrictEqual([
+      {
+        message: 'rate limited',
+        status: 429,
+        category: 'rate_limit',
+      },
+    ]);
     // Only the first backend was ever invoked; no silent cross-backend retry.
     expect(counter.value).toBe(1);
   });

--- a/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.failover.retryable.test.ts
@@ -154,6 +154,52 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
     return { error: thrown as LoadBalancerFailoverError, counter };
   }
 
+  it.each([
+    ['server', statusError('service unavailable', 503), 'server_error'],
+    ['network', new Error('socket hang up'), 'network'],
+  ])(
+    'records a %s failure when the global budget ends after one transport',
+    async (_label, failure, category) => {
+      const { provider, counter } = makeFakeProvider(async function* () {
+        throw failure;
+        yield undefined as unknown as IContent;
+      });
+      providerManager.registerProvider(provider);
+      const lb = new LoadBalancingProvider(
+        {
+          ...makeFailoverConfig('budget-one'),
+          lbProfileEphemeralSettings: {
+            failover_retry_count: 3,
+            failover_retry_delay_ms: 10_000,
+          },
+        },
+        providerManager,
+      );
+      const requestContext: Record<string, unknown> = {};
+      const options = {
+        ...makeOptions(),
+        metadata: { _retryRequestContext: requestContext },
+      };
+      requestContext.transportAttemptBudget = { limit: 1, used: 0 };
+
+      let thrown: unknown;
+      try {
+        for await (const _chunk of lb.generateChatCompletion(options)) {
+          // consume
+        }
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toMatchObject({
+        category,
+        reason: 'retries_exhausted',
+        failures: [{ error: failure }],
+      });
+      expect(counter.value).toBe(1);
+    },
+  );
+
   it('classifies an all-429 aggregate as retryable and does not masquerade as an HTTP 429', async () => {
     const { error, counter } = await captureFailoverError(
       function* (): AsyncGenerator<IContent> {
@@ -177,13 +223,14 @@ describe('LoadBalancingProvider - Failover aggregate retryability (issue #2450)'
    * to bucket state. Recovery is driven solely by the isRetryable marker via
    * normal bounded retry.
    */
-  it('does not expose an HTTP status on an all-429 aggregate (getErrorStatus === undefined)', () => {
+  it('exposes the safe homogeneous status on an all-429 aggregate', () => {
     const error = new LoadBalancerFailoverError('glm', [
       { profile: 'zai', error: statusError('rate limited', 429) },
       { profile: 'makoraglm51', error: statusError('rate limited', 429) },
       { profile: 'ollamaglm51', error: statusError('rate limited', 429) },
     ]);
-    expect(getErrorStatus(error)).toBeUndefined();
+    expect(getErrorStatus(error)).toBe(429);
+    expect(error.category).toBe('rate_limit');
   });
 
   it('classifies an all-5xx aggregate as retryable', async () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.retryBoundary.integration.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.retryBoundary.integration.test.ts
@@ -10,7 +10,7 @@
  * (driven solely by the aggregate's `isRetryable` marker), NOT thrown fatally
  * via the bucket-failover / `onPersistent429` path.
  *
- * These tests use the REAL `retryWithBackoff` from core wrapping a REAL
+ * These tests use the real `RetryOrchestrator` wrapping a real
  * `LoadBalancingProvider` (real `ProviderManager`, fake delegate providers).
  * No mock theater — the unit under test is never mocked.
  */
@@ -27,6 +27,7 @@ import {
 import type { IProvider } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { GenerateChatOptions } from '../GenerateChatOptions.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
 import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
 
 /** A mutable handle onto the fake delegate's behavior. */
@@ -214,17 +215,14 @@ describe('LoadBalancingProvider retry boundary integration (issue #2450)', () =>
     const { provider, counter } = makeFakeProvider(behavior);
     providerManager.registerProvider(provider);
 
-    providerManager.registerProvider(
+    const maxAttempts = 3;
+    const providerChain = new RetryOrchestrator(
       new LoadBalancingProvider(
         makeFailoverConfig('glm-always-429'),
         providerManager,
       ),
+      { maxAttempts, initialDelayMs: 0 },
     );
-    const providerChain = requireProvider(
-      providerManager.getProviderByName('load-balancer'),
-    );
-
-    const maxAttempts = 3;
     const observed: Array<{
       message: string;
       status?: number;

--- a/packages/providers/src/__tests__/LoadBalancingProvider.retryBoundary.integration.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.retryBoundary.integration.test.ts
@@ -15,7 +15,7 @@
  * No mock theater — the unit under test is never mocked.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ProviderManager } from '../ProviderManager.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
@@ -24,14 +24,10 @@ import {
   LoadBalancingProvider,
   type LoadBalancingProviderConfig,
 } from '../LoadBalancingProvider.js';
-import { LoadBalancerFailoverError } from '../errors.js';
 import type { IProvider } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { GenerateChatOptions } from '../GenerateChatOptions.js';
-import {
-  retryWithBackoff,
-  isRetryableError,
-} from '@vybestack/llxprt-code-core/utils/retry.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
 
 /** A mutable handle onto the fake delegate's behavior. */
 interface FakeBehavior {
@@ -69,11 +65,12 @@ function statusError(message: string, status: number): Error {
   return error;
 }
 
-function makeOptions(): GenerateChatOptions {
-  return {
-    prompt: 'test prompt',
-    messages: [{ role: 'user' as const, content: 'test' }],
-  };
+function makeOptions(retries: number): GenerateChatOptions {
+  return createProviderCallOptions({
+    providerName: 'load-balancer',
+    contents: [{ speaker: 'human', blocks: [{ type: 'text', text: 'test' }] }],
+    ephemerals: { retries, retrywait: 0 },
+  });
 }
 
 function makeFailoverConfig(profileName: string): LoadBalancingProviderConfig {
@@ -125,12 +122,17 @@ function* successChunk(): AsyncGenerator<IContent> {
  * On success it returns the first chunk so the caller can assert on it; on
  * failure the LB aggregate error propagates out to retryWithBackoff.
  */
+function requireProvider(provider: IProvider | undefined): IProvider {
+  if (provider === undefined) throw new Error('load balancer not registered');
+  return provider;
+}
+
 async function pullFirstChunk(
-  lb: LoadBalancingProvider,
+  provider: IProvider,
   options: GenerateChatOptions,
 ): Promise<IContent> {
-  const it = lb.generateChatCompletion(options);
-  const first = await it.next();
+  const iterator = provider.generateChatCompletion(options);
+  const first = await iterator.next();
   if (first.done === true) {
     throw new Error('stream ended immediately');
   }
@@ -171,19 +173,19 @@ describe('LoadBalancingProvider retry boundary integration (issue #2450)', () =>
     const { provider, counter } = makeFakeProvider(behavior);
     providerManager.registerProvider(provider);
 
-    const lb = new LoadBalancingProvider(
-      makeFailoverConfig('glm-retry-then-success'),
-      providerManager,
+    providerManager.registerProvider(
+      new LoadBalancingProvider(
+        makeFailoverConfig('glm-retry-then-success'),
+        providerManager,
+      ),
+    );
+    const providerChain = requireProvider(
+      providerManager.getProviderByName('load-balancer'),
     );
 
-    const firstChunk = await retryWithBackoff(
-      () => pullFirstChunk(lb, makeOptions()),
-      {
-        shouldRetryOnError: (e) => isRetryableError(e),
-        maxAttempts: 3,
-        initialDelayMs: 0,
-        maxDelayMs: 0,
-      },
+    const firstChunk = await pullFirstChunk(
+      providerChain,
+      makeOptions(NUM_BACKENDS + 1),
     );
 
     expect(firstChunk).toStrictEqual({ type: 'text', content: 'ok' });
@@ -193,34 +195,17 @@ describe('LoadBalancingProvider retry boundary integration (issue #2450)', () =>
   });
 
   /**
-   * Scenario B (bounded + bucket-failover-path guard): ALL rotations always
-   * 429. The call must:
-   *   - reject with LoadBalancerFailoverError (the underlying aggregate), and
-   *   - do so after EXACTLY `maxAttempts` full rotations
-   *     (= maxAttempts × NUM_BACKENDS delegate invocations).
+   * Scenario B (bounded + bucket-failover-path guard): every backend returns
+   * 429. Each transport failure must be observed before aggregation so a
+   * pre-request timeout can retain the provider's classified rate-limit error.
+   * The aggregate adds no new provider failure and must not be observed again.
    *
-   * Why the aggregate must NOT expose an HTTP `status` (the actual fix), and
-   * what this test guards:
-   *
-   * Inside retryWithBackoff, `classifyError` derives `is429` purely from the
-   * error's HTTP status (or an Anthropic overload body). The fixed aggregate
-   * has NO status, so `is429` is false, `attemptFailover` returns 'proceed'
-   * WITHOUT ever invoking `onPersistent429`, and recovery is driven solely by
-   * `isRetryableError` (the structural marker) under normal bounded retry —
-   * hence exactly maxAttempts × NUM_BACKENDS invocations.
-   *
-   * We deliberately wire `onPersistent429: async () => false` as a SAFETY NET
-   * to prove the negative: even with a bucket-failover callback present, the
-   * status-less aggregate never routes into it. Under the REJECTED `status =
-   * 429` design the aggregate WOULD reach `onPersistent429`; a `false` return
-   * there throws it fatally on attempt 1 (only NUM_BACKENDS invocations),
-   * whereas a `true` return decrements the attempt counter and loops
-   * unbounded. Asserting exactly maxAttempts × NUM_BACKENDS therefore fails
-   * under that design in both directions and passes only for the status-less
-   * fix. The callback is asserted to have been NEVER called to make the
-   * "bucket failover is not on the active path" guarantee explicit.
+   * The shared transport budget bounds the request to `maxAttempts` delegate
+   * invocations. Although the homogeneous aggregate safely retains status 429,
+   * its explicit bucket-failover policy keeps the profile's internal backend
+   * failures out of credential-bucket failover.
    */
-  it('Scenario B: bounded by maxAttempts and never routes a status-less aggregate into bucket failover', async () => {
+  it('Scenario B: observes each bounded backend 429 once without bucket failover or aggregate duplication', async () => {
     const behavior: FakeBehavior = {
       respond(): AsyncGenerator<IContent> {
         return always429();
@@ -229,38 +214,59 @@ describe('LoadBalancingProvider retry boundary integration (issue #2450)', () =>
     const { provider, counter } = makeFakeProvider(behavior);
     providerManager.registerProvider(provider);
 
-    const lb = new LoadBalancingProvider(
-      makeFailoverConfig('glm-always-429'),
-      providerManager,
+    providerManager.registerProvider(
+      new LoadBalancingProvider(
+        makeFailoverConfig('glm-always-429'),
+        providerManager,
+      ),
+    );
+    const providerChain = requireProvider(
+      providerManager.getProviderByName('load-balancer'),
     );
 
     const maxAttempts = 3;
-    let onPersistent429Calls = 0;
-    const failoverCallback = async (): Promise<boolean> => {
-      onPersistent429Calls++;
-      return false;
+    const observed: Array<{
+      message: string;
+      status?: number;
+      category?: string;
+    }> = [];
+    const tryFailover = vi.fn(async () => true);
+    const bucketHandler = {
+      tryFailover,
+      getProviderName: () => 'test-provider',
+      getAttemptedBuckets: () => [],
+      getBucketFailureReasons: () => ({}),
+    };
+    const configWithBucketHandler = {
+      ...config,
+      getBucketFailoverHandler: () => bucketHandler,
+    } as Config;
+    const options = {
+      ...makeOptions(maxAttempts),
+      config: configWithBucketHandler,
+      onProviderError: (error: {
+        message: string;
+        status?: number;
+        category?: string;
+      }) => {
+        observed.push(error);
+      },
     };
 
-    let thrown: unknown;
-    try {
-      await retryWithBackoff(() => pullFirstChunk(lb, makeOptions()), {
-        shouldRetryOnError: (e) => isRetryableError(e),
-        maxAttempts,
-        initialDelayMs: 0,
-        maxDelayMs: 0,
-        onPersistent429: failoverCallback,
-      });
-    } catch (e) {
-      thrown = e;
-    }
-
-    expect(thrown).toBeInstanceOf(LoadBalancerFailoverError);
-    // Exactly maxAttempts full rotations × NUM_BACKENDS invocations. Not 1
-    // rotation (which a status-bearing aggregate would produce by routing into
-    // onPersistent429), and not unbounded.
-    expect(counter.value).toBe(maxAttempts * NUM_BACKENDS);
-    // The status-less aggregate is never classified as a 429, so the
-    // bucket-failover callback is never reached.
-    expect(onPersistent429Calls).toBe(0);
+    await expect(pullFirstChunk(providerChain, options)).rejects.toMatchObject({
+      status: 429,
+      category: 'rate_limit',
+      reason: 'retries_exhausted',
+      isRetryable: false,
+    });
+    expect(counter.value).toBe(maxAttempts);
+    expect(observed).toStrictEqual(
+      Array.from({ length: maxAttempts }, () => ({
+        message: 'rate limited',
+        status: 429,
+        category: 'rate_limit',
+      })),
+    );
+    expect(tryFailover).not.toHaveBeenCalled();
   });
 });

--- a/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { GenerateChatOptions, IProvider } from '../IProvider.js';
 import { ProviderManager } from '../ProviderManager.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
@@ -440,6 +440,14 @@ describe('LoadBalancingProvider', () => {
           name: 'anthropic',
           async *generateChatCompletion(options: GenerateChatOptions) {
             capturedSignal = options.invocation?.signal;
+            if (capturedSignal === undefined) {
+              throw new Error('Delegate invocation signal is required');
+            }
+            await new Promise<void>((resolve) => {
+              capturedSignal.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
             yield { role: 'model', parts: [{ text: 'response' }] };
           },
           getModels: async () => [],
@@ -452,20 +460,26 @@ describe('LoadBalancingProvider', () => {
         providerManager.getProviderByName = () => delegate;
 
         try {
-          for await (const _chunk of provider.generateChatCompletion({
-            contents: [{ role: 'user', parts: [{ text: 'test' }] }],
-            settings: settingsService,
-            config,
-            runtime: { settingsService, config },
-            metadata: { abortSignal: controller.signal },
-          })) {
-            // Consume
-          }
+          const completion = (async () => {
+            for await (const _chunk of provider.generateChatCompletion({
+              contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+              settings: settingsService,
+              config,
+              runtime: { settingsService, config },
+              metadata: { abortSignal: controller.signal },
+            })) {
+              void _chunk;
+            }
+          })();
+          await vi.waitFor(() => expect(capturedSignal).toBeDefined());
+          expect(capturedSignal?.aborted).toBe(false);
+          controller.abort();
+          await completion;
         } finally {
           providerManager.getProviderByName = originalGetProvider;
         }
 
-        expect(capturedSignal).toBe(controller.signal);
+        expect(capturedSignal?.aborted).toBe(true);
       });
     });
     describe('ephemeralSettings merge (dumb merge)', () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
@@ -415,6 +415,58 @@ describe('LoadBalancingProvider', () => {
           providerManager.getProviderByName = originalGetProvider;
         }
       });
+
+      it('preserves the request signal in a resolved delegate invocation', async () => {
+        const controller = new AbortController();
+        const resolvedSubProfiles: ResolvedSubProfile[] = [
+          {
+            name: 'resolved',
+            providerName: 'anthropic',
+            model: 'claude-test',
+            ephemeralSettings: {},
+            modelParams: {},
+          },
+        ];
+        const provider = new LoadBalancingProvider(
+          {
+            profileName: 'signal-lb',
+            strategy: 'round-robin',
+            subProfiles: resolvedSubProfiles,
+          },
+          providerManager,
+        );
+        let capturedSignal: AbortSignal | undefined;
+        const delegate: IProvider = {
+          name: 'anthropic',
+          async *generateChatCompletion(options: GenerateChatOptions) {
+            capturedSignal = options.invocation?.signal;
+            yield { role: 'model', parts: [{ text: 'response' }] };
+          },
+          getModels: async () => [],
+          getDefaultModel: () => 'claude-test',
+          getServerTools: () => [],
+          invokeServerTool: async () => ({}),
+        };
+        const originalGetProvider =
+          providerManager.getProviderByName.bind(providerManager);
+        providerManager.getProviderByName = () => delegate;
+
+        try {
+          for await (const _chunk of provider.generateChatCompletion({
+            contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+            settings: settingsService,
+            config,
+            runtime: { settingsService, config },
+            metadata: { abortSignal: controller.signal },
+          })) {
+            // Consume
+          }
+        } finally {
+          providerManager.getProviderByName = originalGetProvider;
+        }
+
+        expect(capturedSignal).toBe(controller.signal);
+      });
     });
     describe('ephemeralSettings merge (dumb merge)', () => {
       it('should merge LB profile ephemeralSettings over sub-profile ephemeralSettings', async () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
@@ -19,6 +19,7 @@ import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { IProvider } from '../IProvider.js';
+import { LoadBalancerFailoverError } from '../errors.js';
 
 describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
   let settingsService: SettingsService;
@@ -502,6 +503,63 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
     expect(add).toHaveBeenCalledTimes(1);
     expect(remove).toHaveBeenCalledTimes(1);
     expect(remove.mock.calls[0][1]).toBe(add.mock.calls[0][1]);
+  });
+
+  it('preserves transport failures when linked listener removal throws', async () => {
+    const parent = new AbortController();
+    const cleanupError = new Error('listener removal failed');
+    vi.spyOn(parent.signal, 'removeEventListener').mockImplementation(() => {
+      throw cleanupError;
+    });
+    const primaryError = new Error('primary transport failed');
+    const secondaryError = new Error('secondary transport failed');
+    const failures = [primaryError, secondaryError];
+    let calls = 0;
+    const noContent: IContent[] = [];
+    const throwingProvider: IProvider = {
+      name: 'test-provider-1',
+      async *generateChatCompletion(): AsyncGenerator<IContent> {
+        const failure = calls === 0 ? primaryError : secondaryError;
+        calls++;
+        yield* noContent;
+        throw failure;
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => null,
+    };
+    providerManager.registerProvider(throwingProvider);
+    providerManager.registerProvider({
+      ...throwingProvider,
+      name: 'test-provider-2',
+    });
+    const lb = new LoadBalancingProvider(
+      {
+        ...config,
+        subProfiles,
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
+      },
+      providerManager,
+    );
+
+    let thrown: unknown;
+    try {
+      for await (const _chunk of lb.generateChatCompletion({
+        contents: [],
+        metadata: { abortSignal: parent.signal },
+      })) {
+        await Promise.resolve();
+      }
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(LoadBalancerFailoverError);
+    const loadBalancerFailure =
+      thrown instanceof LoadBalancerFailoverError ? thrown : undefined;
+    expect(
+      loadBalancerFailure?.failures.map((failure) => failure.error),
+    ).toStrictEqual(failures);
   });
 
   describe('No timeout after first chunk', () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
@@ -453,7 +453,9 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
     }
 
     expect(chunks).toHaveLength(1);
-    expect(remove.mock.calls.length).toBe(add.mock.calls.length);
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0][1]).toBe(add.mock.calls[0][1]);
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -489,7 +491,9 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
         // consume
       }
     }).rejects.toThrow('synchronous construction failure');
-    expect(remove.mock.calls.length).toBe(add.mock.calls.length);
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0][1]).toBe(add.mock.calls[0][1]);
   });
 
   describe('No timeout after first chunk', () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
@@ -404,9 +404,7 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
       return chunks;
     })();
 
-    while (calls === 0) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await vi.waitFor(() => expect(calls).toBe(1), { timeout: 1_000 });
     controller.abort();
 
     await expect(promise).rejects.toThrow(/abort/i);

--- a/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
@@ -142,8 +142,10 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
       providerManager.registerProvider(mockProvider2);
 
       const chunks: IContent[] = [];
+      const observedErrors: unknown[] = [];
       const gen = lb.generateChatCompletion({
         contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+        onProviderError: (error) => observedErrors.push(error),
       });
 
       for await (const chunk of gen) {
@@ -152,6 +154,12 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
 
       // Should have failed over to backend2 after timeout
       expect(chunks).toHaveLength(1);
+      expect(observedErrors).toStrictEqual([
+        {
+          message: 'Request timeout after 100ms',
+          category: 'network',
+        },
+      ]);
       const text = chunks[0].parts?.[0];
       expect(
         text != null && typeof text === 'object' && 'text' in text
@@ -368,6 +376,7 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
     vi.useRealTimers();
     const controller = new AbortController();
     let calls = 0;
+    const observedErrors: unknown[] = [];
     const stalledProvider: IProvider = {
       name: 'test-provider-1',
       async *generateChatCompletion(options): AsyncGenerator<IContent> {
@@ -398,6 +407,7 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
       for await (const chunk of lb.generateChatCompletion({
         contents: [{ role: 'user', parts: [{ text: 'test' }] }],
         metadata: { abortSignal: controller.signal },
+        onProviderError: (error) => observedErrors.push(error),
       })) {
         chunks.push(chunk);
       }
@@ -409,6 +419,7 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
 
     await expect(promise).rejects.toThrow(/abort/i);
     expect(calls).toBe(1);
+    expect(observedErrors).toStrictEqual([]);
   });
   it('releases abort listeners and timeout timers after a successful first chunk', async () => {
     const parent = new AbortController();
@@ -425,9 +436,12 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
     providerManager.registerProvider({
       name: 'test-provider-1',
       async *generateChatCompletion(): AsyncGenerator<IContent> {
-        yield { role: 'assistant', parts: [{ text: 'ok' }] } as IContent;
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
       },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
       getServerTools: () => [],
+      invokeServerTool: async () => null,
     });
 
     const chunks: IContent[] = [];
@@ -447,13 +461,17 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
     const parent = new AbortController();
     const add = vi.spyOn(parent.signal, 'addEventListener');
     const remove = vi.spyOn(parent.signal, 'removeEventListener');
-    providerManager.registerProvider({
+    const throwingProvider: IProvider = {
       name: 'test-provider-1',
       generateChatCompletion() {
         throw new Error('synchronous construction failure');
       },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
       getServerTools: () => [],
-    } as unknown as IProvider);
+      invokeServerTool: async () => null,
+    };
+    providerManager.registerProvider(throwingProvider);
     const lb = new LoadBalancingProvider(
       {
         ...config,

--- a/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
@@ -144,7 +144,9 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
       const chunks: IContent[] = [];
       const observedErrors: unknown[] = [];
       const gen = lb.generateChatCompletion({
-        contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
         onProviderError: (error) => observedErrors.push(error),
       });
 
@@ -405,7 +407,9 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
     const promise = (async () => {
       const chunks: IContent[] = [];
       for await (const chunk of lb.generateChatCompletion({
-        contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
         metadata: { abortSignal: controller.signal },
         onProviderError: (error) => observedErrors.push(error),
       })) {
@@ -446,7 +450,9 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
 
     const chunks: IContent[] = [];
     for await (const chunk of lb.generateChatCompletion({
-      contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+      contents: [
+        { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+      ],
       metadata: { abortSignal: parent.signal },
     })) {
       chunks.push(chunk);
@@ -485,7 +491,9 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
 
     await expect(async () => {
       for await (const _chunk of lb.generateChatCompletion({
-        contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
         metadata: { abortSignal: parent.signal },
       })) {
         // consume

--- a/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
@@ -18,6 +18,7 @@ import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IProvider } from '../IProvider.js';
 
 describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
   let settingsService: SettingsService;
@@ -361,6 +362,118 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
       // Verify the request was made and failover occurred
       expect(stats.totalRequests).toBe(1);
     });
+  });
+
+  it('aborts a stalled first chunk without attempting another backend', async () => {
+    vi.useRealTimers();
+    const controller = new AbortController();
+    let calls = 0;
+    const stalledProvider: IProvider = {
+      name: 'test-provider-1',
+      async *generateChatCompletion(options): AsyncGenerator<IContent> {
+        calls++;
+        const signal = options.invocation?.signal;
+        await new Promise<void>((resolve, reject) => {
+          const onAbort = () => reject(new Error('provider observed abort'));
+          signal?.addEventListener('abort', onAbort, { once: true });
+          if (signal?.aborted === true) onAbort();
+        });
+        yield { speaker: 'ai', blocks: [] };
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => null,
+    };
+    providerManager.registerProvider(stalledProvider);
+    const lb = new LoadBalancingProvider(
+      {
+        ...config,
+        lbProfileEphemeralSettings: { timeout_ms: 60_000 },
+      },
+      providerManager,
+    );
+    const promise = (async () => {
+      const chunks: IContent[] = [];
+      for await (const chunk of lb.generateChatCompletion({
+        contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+        metadata: { abortSignal: controller.signal },
+      })) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    })();
+
+    while (calls === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    controller.abort();
+
+    await expect(promise).rejects.toThrow(/abort/i);
+    expect(calls).toBe(1);
+  });
+  it('releases abort listeners and timeout timers after a successful first chunk', async () => {
+    const parent = new AbortController();
+    const add = vi.spyOn(parent.signal, 'addEventListener');
+    const remove = vi.spyOn(parent.signal, 'removeEventListener');
+    const lb = new LoadBalancingProvider(
+      {
+        ...config,
+        subProfiles,
+        lbProfileEphemeralSettings: { timeout_ms: 60_000 },
+      },
+      providerManager,
+    );
+    providerManager.registerProvider({
+      name: 'test-provider-1',
+      async *generateChatCompletion(): AsyncGenerator<IContent> {
+        yield { role: 'assistant', parts: [{ text: 'ok' }] } as IContent;
+      },
+      getServerTools: () => [],
+    });
+
+    const chunks: IContent[] = [];
+    for await (const chunk of lb.generateChatCompletion({
+      contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+      metadata: { abortSignal: parent.signal },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(remove.mock.calls.length).toBe(add.mock.calls.length);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('disposes the linked controller when delegate construction throws synchronously', async () => {
+    const parent = new AbortController();
+    const add = vi.spyOn(parent.signal, 'addEventListener');
+    const remove = vi.spyOn(parent.signal, 'removeEventListener');
+    providerManager.registerProvider({
+      name: 'test-provider-1',
+      generateChatCompletion() {
+        throw new Error('synchronous construction failure');
+      },
+      getServerTools: () => [],
+    } as unknown as IProvider);
+    const lb = new LoadBalancingProvider(
+      {
+        ...config,
+        subProfiles,
+        lbProfileEphemeralSettings: { failover_retry_count: 1 },
+      },
+      providerManager,
+    );
+
+    await expect(async () => {
+      for await (const _chunk of lb.generateChatCompletion({
+        contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+        metadata: { abortSignal: parent.signal },
+      })) {
+        // consume
+      }
+    }).rejects.toThrow('synchronous construction failure');
+    expect(remove.mock.calls.length).toBe(add.mock.calls.length);
   });
 
   describe('No timeout after first chunk', () => {

--- a/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.timeout.test.ts
@@ -421,7 +421,7 @@ describe('LoadBalancingProvider Timeout Wrapper - Phase 3', () => {
     await vi.waitFor(() => expect(calls).toBe(1), { timeout: 1_000 });
     controller.abort();
 
-    await expect(promise).rejects.toThrow(/abort/i);
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
     expect(calls).toBe(1);
     expect(observedErrors).toStrictEqual([]);
   });

--- a/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
@@ -914,7 +914,7 @@ describe('RetryOrchestrator', () => {
           await delay(50);
 
           if (options.invocation?.signal?.aborted === true) {
-            throw new Error('Aborted');
+            throw new DOMException('Aborted', 'AbortError');
           }
 
           yield {
@@ -955,12 +955,45 @@ describe('RetryOrchestrator', () => {
       // Abort after a short delay
       setTimeout(() => abortController.abort(), 25);
 
-      await expect(streamPromise).rejects.toThrow(/abort/i);
+      await expect(streamPromise).rejects.toMatchObject({
+        name: 'AbortError',
+      });
 
       // Provider should have been called and received the signal
       expect(providerCalls).toBeGreaterThan(0);
       expect(providerReceivedOptions?.invocation?.signal).toBeDefined();
       expect(providerReceivedOptions?.invocation?.signal?.aborted).toBe(true);
     });
+  });
+
+  it('bounds a provider named load-balancer without relying on its name', async () => {
+    let calls = 0;
+    const provider = createTestProvider({
+      name: 'load-balancer',
+      responses: [
+        { error: createServerError(503) },
+        { error: createServerError(503) },
+        { error: createServerError(503) },
+        { error: createBadRequestError() },
+      ],
+      onTransportCall: () => {
+        calls++;
+      },
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 3,
+      initialDelayMs: 0,
+    });
+
+    await expect(
+      consumeStream(
+        orchestrator.generateChatCompletion({
+          contents: [],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      name: 'RetriesExhaustedError',
+    });
+    expect(calls).toBe(3);
   });
 });

--- a/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
@@ -202,7 +202,9 @@ describe('RetryOrchestrator', () => {
         category?: string;
       }> = [];
       const options: GenerateChatOptions = {
-        contents: [{ role: 'user', blocks: [{ type: 'text', text: 'test' }] }],
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
         onProviderError: (error) => observedErrors.push(error),
       };
 
@@ -238,7 +240,7 @@ describe('RetryOrchestrator', () => {
       const result = consumeStream(
         orchestrator.generateChatCompletion({
           contents: [
-            { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+            { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
           ],
         }),
       );
@@ -415,7 +417,7 @@ describe('RetryOrchestrator', () => {
       const result = await consumeStream(
         orchestrator.generateChatCompletion({
           contents: [
-            { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+            { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
           ],
           onProviderError: () => {
             throw new Error('observer failed');
@@ -445,7 +447,7 @@ describe('RetryOrchestrator', () => {
         consumeStream(
           orchestrator.generateChatCompletion({
             contents: [
-              { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+              { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
             ],
             metadata: { abortSignal: controller.signal },
           }),

--- a/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
@@ -426,7 +426,7 @@ describe('RetryOrchestrator', () => {
       expect(result).toHaveLength(1);
     });
 
-    it('does not issue a later transport request after metadata aborts during backoff', async () => {
+    it('does not issue a later transport request when metadata aborts before retry transport', async () => {
       const controller = new AbortController();
       let transportCalls = 0;
       const provider = createTestProvider({

--- a/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.basic.test.ts
@@ -10,6 +10,7 @@ import type { IProvider, GenerateChatOptions } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { IModel } from '../IModel.js';
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
 
 /**
  * Test helper: Creates a fake provider that behaves according to provided scenarios
@@ -18,6 +19,7 @@ function createTestProvider(config: {
   name?: string;
   responses?: Array<'success' | 'error' | { error: Error }>;
   streamChunks?: IContent[][];
+  onTransportCall?: (options: GenerateChatOptions) => void;
 }): IProvider {
   let callCount = 0;
 
@@ -28,7 +30,8 @@ function createTestProvider(config: {
 
   return {
     name: config.name ?? 'test-provider',
-    async *generateChatCompletion(_options: GenerateChatOptions) {
+    async *generateChatCompletion(options: GenerateChatOptions) {
+      config.onTransportCall?.(options);
       const responseIndex = Math.min(
         callCount,
         (config.responses?.length ?? 1) - 1,
@@ -193,18 +196,59 @@ describe('RetryOrchestrator', () => {
         initialDelayMs: 10, // Fast for testing
       });
 
+      const observedErrors: Array<{
+        message: string;
+        status?: number;
+        category?: string;
+      }> = [];
       const options: GenerateChatOptions = {
         contents: [{ role: 'user', blocks: [{ type: 'text', text: 'test' }] }],
+        onProviderError: (error) => observedErrors.push(error),
       };
 
       const result = await consumeStream(
         orchestrator.generateChatCompletion(options),
       );
 
-      expect(result).toHaveLength(1);
-      expect(result[0].blocks[0]).toMatchObject({
-        type: 'text',
-        text: 'test response',
+      expect({ result, observedErrors }).toMatchObject({
+        result: [
+          {
+            blocks: [{ type: 'text', text: 'test response' }],
+          },
+        ],
+        observedErrors: [
+          {
+            message: 'Rate limit exceeded',
+            status: 429,
+            category: 'rate_limit',
+          },
+        ],
+      });
+    });
+
+    it('surfaces an immediate 429 as a classified retries-exhausted error', async () => {
+      const provider = createTestProvider({
+        responses: [{ error: createRateLimitError() }],
+      });
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 1,
+        initialDelayMs: 1,
+      });
+
+      const result = consumeStream(
+        orchestrator.generateChatCompletion({
+          contents: [
+            { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+          ],
+        }),
+      );
+
+      await expect(result).rejects.toMatchObject({
+        category: 'rate_limit',
+        status: 429,
+        message: expect.stringMatching(
+          /retries exhausted.*Rate limit exceeded/i,
+        ),
       });
     });
 
@@ -298,7 +342,7 @@ describe('RetryOrchestrator', () => {
       });
     });
 
-    it('should respect maxAttempts configuration', async () => {
+    it('preserves the final 429 classification when retries are exhausted', async () => {
       const rateLimitError = createRateLimitError();
       const provider = createTestProvider({
         responses: [
@@ -319,7 +363,95 @@ describe('RetryOrchestrator', () => {
 
       await expect(
         consumeStream(orchestrator.generateChatCompletion(options)),
-      ).rejects.toThrow('Rate limit exceeded');
+      ).rejects.toMatchObject({
+        category: 'rate_limit',
+        status: 429,
+        message: expect.stringMatching(
+          /retries exhausted.*Rate limit exceeded/i,
+        ),
+      });
+    });
+
+    it('uses invocation ephemerals as the single transport retry budget', async () => {
+      let transportCalls = 0;
+      const provider = createTestProvider({
+        responses: [{ error: createRateLimitError() }],
+        onTransportCall: () => {
+          transportCalls++;
+        },
+      });
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 6,
+        initialDelayMs: 1000,
+      });
+      const options = createProviderCallOptions({
+        providerName: provider.name,
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
+        ephemerals: { retries: 2, retrywait: 1 },
+      });
+
+      await expect(
+        consumeStream(orchestrator.generateChatCompletion(options)),
+      ).rejects.toMatchObject({
+        status: 429,
+        category: 'rate_limit',
+        reason: 'retries_exhausted',
+        isRetryable: false,
+      });
+      expect(transportCalls).toBe(2);
+    });
+
+    it('continues retries when the provider-error observer throws', async () => {
+      const provider = createTestProvider({
+        responses: [{ error: createRateLimitError() }, 'success'],
+      });
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 2,
+        initialDelayMs: 1,
+      });
+
+      const result = await consumeStream(
+        orchestrator.generateChatCompletion({
+          contents: [
+            { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+          ],
+          onProviderError: () => {
+            throw new Error('observer failed');
+          },
+        }),
+      );
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not issue a later transport request after metadata aborts during backoff', async () => {
+      const controller = new AbortController();
+      let transportCalls = 0;
+      const provider = createTestProvider({
+        responses: [{ error: createRateLimitError() }, 'success'],
+        onTransportCall: () => {
+          transportCalls++;
+          controller.abort();
+        },
+      });
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 3,
+        initialDelayMs: 25,
+      });
+
+      await expect(
+        consumeStream(
+          orchestrator.generateChatCompletion({
+            contents: [
+              { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+            ],
+            metadata: { abortSignal: controller.signal },
+          }),
+        ),
+      ).rejects.toThrow(/abort/i);
+      expect(transportCalls).toBe(1);
     });
 
     it('should apply exponential backoff with jitter', async () => {

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover-budget.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover-budget.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { GenerateChatOptions, IProvider } from '../IProvider.js';
 import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import { attachTransportAttemptBudget } from '../transportAttemptBudget.js';
 
 function rateLimitError(): Error {
   return Object.assign(new Error('Rate limit exceeded'), { status: 429 });
@@ -72,6 +73,39 @@ describe('RetryOrchestrator failover transport budget', () => {
       transportCalls: 3,
       failoverCalls: 1,
     });
+  });
+
+  it('preserves the final 429 classification when a shared request budget exhausts before nested retries', async () => {
+    let transportCalls = 0;
+    const orchestrator = new RetryOrchestrator(
+      failingProvider(() => transportCalls++),
+      { maxAttempts: 4, initialDelayMs: 0 },
+    );
+    const request = attachTransportAttemptBudget({ contents: [] }, 2);
+
+    try {
+      const failure = await consume(
+        orchestrator.generateChatCompletion(request.options),
+      ).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      expect({ failure, transportCalls, budget: request.budget }).toMatchObject(
+        {
+          failure: {
+            category: 'rate_limit',
+            status: 429,
+            reason: 'retries_exhausted',
+            isRetryable: false,
+          },
+          transportCalls: 2,
+          budget: { limit: 2, used: 2 },
+        },
+      );
+    } finally {
+      request.release();
+    }
   });
 
   it('does not start a transport after aborting a never-resolving bucket failover', async () => {

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover-budget.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover-budget.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+
+function rateLimitError(): Error {
+  return Object.assign(new Error('Rate limit exceeded'), { status: 429 });
+}
+
+function failingProvider(onCall: () => void): IProvider {
+  return {
+    name: 'test-provider',
+    async *generateChatCompletion(): AsyncGenerator<IContent> {
+      onCall();
+      yield* [];
+      throw rateLimitError();
+    },
+    async getModels() {
+      return [];
+    },
+    getDefaultModel() {
+      return 'test-model';
+    },
+    getServerTools() {
+      return [];
+    },
+    async invokeServerTool() {
+      return null;
+    },
+  };
+}
+
+async function consume(stream: AsyncIterableIterator<IContent>): Promise<void> {
+  for await (const _chunk of stream) {
+    // Consume the real retry stream.
+  }
+}
+
+describe('RetryOrchestrator failover transport budget', () => {
+  it('never exceeds the global transport budget when a bucket switch succeeds', async () => {
+    let transportCalls = 0;
+    let failoverCalls = 0;
+    const orchestrator = new RetryOrchestrator(
+      failingProvider(() => transportCalls++),
+      { maxAttempts: 3, initialDelayMs: 0 },
+    );
+    const options: GenerateChatOptions = {
+      contents: [],
+      config: {
+        getBucketFailoverHandler: () => ({
+          getBuckets: () => ['bucket1', 'bucket2'],
+          getCurrentBucket: () => 'bucket1',
+          tryFailover: async () => {
+            failoverCalls++;
+            return true;
+          },
+          isEnabled: () => true,
+        }),
+      } as GenerateChatOptions['config'],
+    };
+
+    await expect(
+      consume(orchestrator.generateChatCompletion(options)),
+    ).rejects.toMatchObject({ reason: 'retries_exhausted' });
+    expect({ transportCalls, failoverCalls }).toStrictEqual({
+      transportCalls: 3,
+      failoverCalls: 1,
+    });
+  });
+
+  it('aborts a never-resolving bucket failover without another transport', async () => {
+    const controller = new AbortController();
+    let transports = 0;
+    let notifyStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      notifyStarted = resolve;
+    });
+    const orchestrator = new RetryOrchestrator(
+      failingProvider(() => transports++),
+      { maxAttempts: 3, initialDelayMs: 0 },
+    );
+    const consumption = consume(
+      orchestrator.generateChatCompletion({
+        contents: [],
+        config: {
+          getBucketFailoverHandler: () => ({
+            getBuckets: () => ['bucket1', 'bucket2'],
+            getCurrentBucket: () => 'bucket1',
+            tryFailover: async () => {
+              notifyStarted();
+              return new Promise<boolean>(() => {});
+            },
+            isEnabled: () => true,
+          }),
+        } as GenerateChatOptions['config'],
+        invocation: {
+          signal: controller.signal,
+        } as GenerateChatOptions['invocation'],
+      }),
+    );
+
+    await started;
+    controller.abort();
+
+    await expect(consumption).rejects.toThrow(/abort/i);
+    expect(transports).toBe(2);
+  });
+});

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover-budget.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover-budget.test.ts
@@ -74,9 +74,10 @@ describe('RetryOrchestrator failover transport budget', () => {
     });
   });
 
-  it('aborts a never-resolving bucket failover without another transport', async () => {
+  it('does not start a transport after aborting a never-resolving bucket failover', async () => {
     const controller = new AbortController();
     let transports = 0;
+    let transportsWhenFailoverStarted = 0;
     let notifyStarted!: () => void;
     const started = new Promise<void>((resolve) => {
       notifyStarted = resolve;
@@ -93,6 +94,7 @@ describe('RetryOrchestrator failover transport budget', () => {
             getBuckets: () => ['bucket1', 'bucket2'],
             getCurrentBucket: () => 'bucket1',
             tryFailover: async () => {
+              transportsWhenFailoverStarted = transports;
               notifyStarted();
               return new Promise<boolean>(() => {});
             },
@@ -109,6 +111,6 @@ describe('RetryOrchestrator failover transport budget', () => {
     controller.abort();
 
     await expect(consumption).rejects.toThrow(/abort/i);
-    expect(transports).toBe(2);
+    expect(transports).toBe(transportsWhenFailoverStarted);
   });
 });

--- a/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.failover.test.ts
@@ -17,6 +17,7 @@ function createTestProvider(config: {
   name?: string;
   responses?: Array<'success' | 'error' | { error: Error }>;
   streamChunks?: IContent[][];
+  onCall?: () => void;
 }): IProvider {
   let callCount = 0;
 
@@ -28,6 +29,7 @@ function createTestProvider(config: {
   return {
     name: config.name ?? 'test-provider',
     async *generateChatCompletion(_options: GenerateChatOptions) {
+      config.onCall?.();
       const responseIndex = Math.min(
         callCount,
         (config.responses?.length ?? 1) - 1,

--- a/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
@@ -123,7 +123,8 @@ describe('RetryOrchestrator invocation safety', () => {
     const normalized = baseProvider.lastNormalized;
     expect(normalized).toBeDefined();
     expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
-    expect(normalized!.invocation.signal).toBe(abortController.signal);
+    expect(normalized!.invocation.signal).not.toBe(abortController.signal);
+    expect(normalized!.invocation.signal?.aborted).toBe(true);
   });
 
   it('does not crash a wrapped BaseProvider when only options + signal are provided', async () => {
@@ -149,7 +150,8 @@ describe('RetryOrchestrator invocation safety', () => {
     const normalized = baseProvider.lastNormalized;
     expect(normalized).toBeDefined();
     expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
-    expect(normalized!.invocation.signal).toBe(abortController.signal);
+    expect(normalized!.invocation.signal).not.toBe(abortController.signal);
+    expect(normalized!.invocation.signal?.aborted).toBe(true);
   });
 
   it('adds an explicit signal to an existing invocation object', async () => {
@@ -177,7 +179,8 @@ describe('RetryOrchestrator invocation safety', () => {
     const normalized = baseProvider.lastNormalized;
     expect(normalized).toBeDefined();
     expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
-    expect(normalized!.invocation.signal).toBe(abortController.signal);
+    expect(normalized!.invocation.signal).not.toBe(abortController.signal);
+    expect(normalized!.invocation.signal?.aborted).toBe(true);
   });
 
   it('preserves abort propagation through the legacy signal signature', async () => {
@@ -264,6 +267,7 @@ describe('RetryOrchestrator invocation safety', () => {
       ),
     );
 
-    expect(receivedSignal).toBe(abortController.signal);
+    expect(receivedSignal).not.toBe(abortController.signal);
+    expect(receivedSignal?.aborted).toBe(true);
   });
 });

--- a/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
@@ -26,6 +26,7 @@ import {
   setActiveProviderRuntimeContext,
 } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { getRequestSignal } from '../utils/abortSignal.js';
 
 async function consumeStream(
   stream: AsyncIterableIterator<IContent>,
@@ -228,13 +229,13 @@ describe('RetryOrchestrator invocation safety', () => {
     expect(providerCalls).toBeGreaterThanOrEqual(1);
   });
 
-  it('propagates signal to the wrapped provider via invocation', async () => {
+  it('propagates signal to the wrapped provider through request options', async () => {
     let receivedSignal: AbortSignal | undefined;
 
     const provider: IProvider = {
       name: 'signal-receiver-provider',
       async *generateChatCompletion(options: GenerateChatOptions) {
-        receivedSignal = options.invocation?.signal;
+        receivedSignal = getRequestSignal(options);
         yield {
           speaker: 'ai',
           blocks: [{ type: 'text', text: 'ok' }],

--- a/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
@@ -123,8 +123,7 @@ describe('RetryOrchestrator invocation safety', () => {
     const normalized = baseProvider.lastNormalized;
     expect(normalized).toBeDefined();
     expect(typeof normalized!.invocation.getModelBehavior).toBe('function');
-    expect(normalized!.invocation.signal).not.toBe(abortController.signal);
-    expect(normalized!.invocation.signal?.aborted).toBe(true);
+    expect(normalized!.invocation.signal).toBeInstanceOf(AbortSignal);
   });
 
   it('does not crash a wrapped BaseProvider when only options + signal are provided', async () => {

--- a/packages/providers/src/__tests__/RetryOrchestrator.onAuthError.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.onAuthError.test.ts
@@ -142,7 +142,7 @@ describe('RetryOrchestrator onAuthError handler', () => {
       consumeStream(
         orchestrator.generateChatCompletion({
           contents: [
-            { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+            { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
           ],
           runtime: {
             config: {

--- a/packages/providers/src/__tests__/RetryOrchestrator.onAuthError.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.onAuthError.test.ts
@@ -321,8 +321,12 @@ describe('RetryOrchestrator onAuthError handler', () => {
     const controller = new AbortController();
     let transports = 0;
     let refreshStarted!: () => void;
+    let refreshSettled!: () => void;
     const started = new Promise<void>((resolve) => {
       refreshStarted = resolve;
+    });
+    const settled = new Promise<void>((resolve) => {
+      refreshSettled = resolve;
     });
     const provider = createTestProvider({
       responses: [{ error: createAuthError(401, 'unauthorized') }, 'success'],
@@ -338,9 +342,16 @@ describe('RetryOrchestrator onAuthError handler', () => {
     });
     const config = {
       getOnAuthErrorHandler: () => ({
-        handleAuthError: async () => {
+        handleAuthError: async ({ signal }) => {
           refreshStarted();
-          await new Promise<void>(() => {});
+          await new Promise<void>((_resolve, reject) => {
+            const onAbort = () => {
+              refreshSettled();
+              reject(new DOMException('Aborted', 'AbortError'));
+            };
+            signal?.addEventListener('abort', onAbort, { once: true });
+            if (signal?.aborted === true) onAbort();
+          });
         },
       }),
     } as GenerateChatOptions['config'];
@@ -357,7 +368,8 @@ describe('RetryOrchestrator onAuthError handler', () => {
     await started;
     controller.abort();
 
-    await expect(consumption).rejects.toThrow(/abort/i);
+    await expect(consumption).rejects.toMatchObject({ name: 'AbortError' });
+    await settled;
     expect(transports).toBe(1);
   });
   /**

--- a/packages/providers/src/__tests__/RetryOrchestrator.onAuthError.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.onAuthError.test.ts
@@ -129,6 +129,32 @@ describe('RetryOrchestrator onAuthError handler', () => {
     );
   });
 
+  it('does not refresh authentication when the only transport attempt is exhausted', async () => {
+    const authError = createAuthError(401, 'authentication failed');
+    const handleAuthError = vi.fn().mockResolvedValue(undefined);
+    const provider = createTestProvider({ responses: [{ error: authError }] });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 1,
+      initialDelayMs: 1,
+    });
+
+    await expect(
+      consumeStream(
+        orchestrator.generateChatCompletion({
+          contents: [
+            { role: 'user', blocks: [{ type: 'text', text: 'test' }] },
+          ],
+          runtime: {
+            config: {
+              getOnAuthErrorHandler: () => ({ handleAuthError }),
+            },
+          } as GenerateChatOptions['runtime'],
+        }),
+      ),
+    ).rejects.toMatchObject({ isRetryable: false });
+    expect(handleAuthError).not.toHaveBeenCalled();
+  });
+
   /**
    * @fix issue1861
    * Test that RetryOrchestrator calls onAuthError handler on 403 error before retry
@@ -291,6 +317,49 @@ describe('RetryOrchestrator onAuthError handler', () => {
     expect(result).toHaveLength(1);
   });
 
+  it('aborts a never-resolving auth refresh without another transport', async () => {
+    const controller = new AbortController();
+    let transports = 0;
+    let refreshStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      refreshStarted = resolve;
+    });
+    const provider = createTestProvider({
+      responses: [{ error: createAuthError(401, 'unauthorized') }, 'success'],
+    });
+    const originalGenerate = provider.generateChatCompletion.bind(provider);
+    provider.generateChatCompletion = ((options: GenerateChatOptions) => {
+      transports++;
+      return originalGenerate(options);
+    }) as IProvider['generateChatCompletion'];
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+    const config = {
+      getOnAuthErrorHandler: () => ({
+        handleAuthError: async () => {
+          refreshStarted();
+          await new Promise<void>(() => {});
+        },
+      }),
+    } as GenerateChatOptions['config'];
+    const consumption = consumeStream(
+      orchestrator.generateChatCompletion({
+        contents: [],
+        config,
+        invocation: {
+          signal: controller.signal,
+        } as GenerateChatOptions['invocation'],
+      }),
+    );
+
+    await started;
+    controller.abort();
+
+    await expect(consumption).rejects.toThrow(/abort/i);
+    expect(transports).toBe(1);
+  });
   /**
    * @fix issue1861
    * Test that onAuthError handler is called on consecutive auth errors before failover

--- a/packages/providers/src/__tests__/RetryOrchestrator.timeoutCleanup.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.timeoutCleanup.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import type { IModel } from '../IModel.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+
+async function collect(stream: AsyncIterable<IContent>): Promise<IContent[]> {
+  const chunks: IContent[] = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return chunks;
+}
+
+describe('RetryOrchestrator timeout cleanup', () => {
+  it('aborts and closes a timed-out attempt before starting the retry', async () => {
+    let attempts = 0;
+    let activeStreams = 0;
+    let maximumActiveStreams = 0;
+    let observedAborts = 0;
+    let finalizedStreams = 0;
+    const provider: IProvider = {
+      name: 'abort-aware-timeout-provider',
+      async *generateChatCompletion(options: GenerateChatOptions) {
+        attempts++;
+        activeStreams++;
+        maximumActiveStreams = Math.max(maximumActiveStreams, activeStreams);
+        try {
+          if (attempts === 1) {
+            const signal = options.invocation?.signal;
+            await new Promise<void>((resolve, reject) => {
+              const onAbort = () => {
+                observedAborts++;
+                reject(new Error('transport aborted'));
+              };
+              signal?.addEventListener('abort', onAbort, { once: true });
+              if (signal?.aborted === true) onAbort();
+            });
+          }
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'success' }],
+          } as IContent;
+        } finally {
+          activeStreams--;
+          finalizedStreams++;
+        }
+      },
+      async getModels(): Promise<IModel[]> {
+        return [];
+      },
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => null,
+    };
+    const orchestrator = new RetryOrchestrator(provider, {
+      streamingTimeoutMs: 10,
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const chunks = await collect(
+      orchestrator.generateChatCompletion({
+        contents: [{ role: 'user', blocks: [{ type: 'text', text: 'test' }] }],
+      }),
+    );
+
+    expect(chunks).toHaveLength(1);
+    expect({
+      attempts,
+      maximumActiveStreams,
+      observedAborts,
+      finalizedStreams,
+    }).toStrictEqual({
+      attempts: 2,
+      maximumActiveStreams: 1,
+      observedAborts: 1,
+      finalizedStreams: 2,
+    });
+  });
+});

--- a/packages/providers/src/__tests__/RetryOrchestrator.timeoutCleanup.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.timeoutCleanup.test.ts
@@ -82,4 +82,64 @@ describe('RetryOrchestrator timeout cleanup', () => {
       finalizedStreams: 2,
     });
   });
+
+  it('does not retry a timeout-wrapped stream after yielding content', async () => {
+    let attemptCount = 0;
+    const streamFailure = Object.assign(new Error('Connection reset'), {
+      code: 'STREAM_INTERRUPTED',
+    });
+    const provider: IProvider = {
+      name: 'timeout-wrapped-streaming-provider',
+      async *generateChatCompletion() {
+        attemptCount++;
+        if (attemptCount === 1) {
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'partial' }],
+          };
+          throw streamFailure;
+        }
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'appended retry' }],
+        };
+      },
+      async getModels(): Promise<IModel[]> {
+        return [];
+      },
+      getDefaultModel: () => 'test-model',
+      getServerTools: () => [],
+      invokeServerTool: async () => null,
+    };
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 3,
+      initialDelayMs: 0,
+      streamingTimeoutMs: 1_000,
+    });
+    const chunks: IContent[] = [];
+    let thrown: unknown;
+
+    try {
+      for await (const chunk of orchestrator.generateChatCompletion({
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
+      })) {
+        chunks.push(chunk);
+      }
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect({ attemptCount, chunks, thrown }).toStrictEqual({
+      attemptCount: 1,
+      chunks: [
+        {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'partial' }],
+        },
+      ],
+      thrown: streamFailure,
+    });
+  });
 });

--- a/packages/providers/src/__tests__/RetryOrchestrator.timeoutCleanup.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.timeoutCleanup.test.ts
@@ -9,6 +9,7 @@ import type { IContent } from '@vybestack/llxprt-code-core/services/history/ICon
 import type { GenerateChatOptions, IProvider } from '../IProvider.js';
 import type { IModel } from '../IModel.js';
 import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import { getRequestSignal } from '../utils/abortSignal.js';
 
 async function collect(stream: AsyncIterable<IContent>): Promise<IContent[]> {
   const chunks: IContent[] = [];
@@ -31,14 +32,17 @@ describe('RetryOrchestrator timeout cleanup', () => {
         maximumActiveStreams = Math.max(maximumActiveStreams, activeStreams);
         try {
           if (attempts === 1) {
-            const signal = options.invocation?.signal;
+            const signal = getRequestSignal(options);
+            if (signal === undefined) {
+              throw new Error('Retry attempt signal is required');
+            }
             await new Promise<void>((resolve, reject) => {
               const onAbort = () => {
                 observedAborts++;
                 reject(new Error('transport aborted'));
               };
-              signal?.addEventListener('abort', onAbort, { once: true });
-              if (signal?.aborted === true) onAbort();
+              signal.addEventListener('abort', onAbort, { once: true });
+              if (signal.aborted) onAbort();
             });
           }
           yield {
@@ -58,7 +62,7 @@ describe('RetryOrchestrator timeout cleanup', () => {
       invokeServerTool: async () => null,
     };
     const orchestrator = new RetryOrchestrator(provider, {
-      streamingTimeoutMs: 10,
+      streamingTimeoutMs: 50,
       maxAttempts: 2,
       initialDelayMs: 0,
     });
@@ -69,7 +73,12 @@ describe('RetryOrchestrator timeout cleanup', () => {
       }),
     );
 
-    expect(chunks).toHaveLength(1);
+    expect(chunks).toStrictEqual([
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'success' }],
+      },
+    ]);
     expect({
       attempts,
       maximumActiveStreams,

--- a/packages/providers/src/__tests__/errors.test.ts
+++ b/packages/providers/src/__tests__/errors.test.ts
@@ -96,7 +96,7 @@ describe('AllBucketsExhaustedError @plan:PLAN-20260223-ISSUE1598.P07', () => {
     expect(error.message).toContain('bucket-beta');
     expect(error.message).toContain('bucket-gamma');
     expect(error.message).toMatch(
-      /All buckets exhausted for provider 'google': bucket-alpha, bucket-beta, bucket-gamma/,
+      /All buckets exhausted for provider 'google' after 3 attempts \(buckets: bucket-alpha, bucket-beta, bucket-gamma\)/,
     );
   });
 

--- a/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
+++ b/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
@@ -22,6 +22,7 @@ import { CircuitBreakerManager } from '../loadBalancing/circuitBreakerManager.js
 import { buildExtendedStats } from '../loadBalancing/statsBuilder.js';
 import {
   isTimeoutError,
+  RequestTimeoutError,
   wrapWithTimeout,
 } from '../loadBalancing/streamTimeout.js';
 import { getBaseUrlFromProvider } from '../baseUrlResolver.js';
@@ -153,9 +154,11 @@ describe('extracted provider helper behavior', () => {
         ),
       ),
     ).rejects.toThrow('Request timeout after 1ms');
-    await new Promise((resolve) => setTimeout(resolve, 25));
     expect(closed).toBe(true);
     expect(isTimeoutError(new Error('Request timeout after 1ms'))).toBe(true);
+    const typedTimeout = new RequestTimeoutError(1);
+    typedTimeout.message = 'localized timeout text';
+    expect(isTimeoutError(typedTimeout)).toBe(true);
   });
 
   it('uses the attempt cancellation capability supplied by its owner', async () => {

--- a/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
+++ b/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
@@ -38,6 +38,7 @@ import {
 import { extractSimpleContent } from '../logging/streamChunkUtils.js';
 import { accumulateTokenUsage } from '../logging/tokenAccumulator.js';
 import { extractTokenCountsFromResponse } from '../logging/tokenCounts.js';
+import { getBackendSkipReasons } from '../loadBalancing/backendRuntime.js';
 
 function debugLoggerStub(): DebugLogger {
   return {
@@ -74,6 +75,17 @@ async function collectChunks(
 }
 
 describe('extracted provider helper behavior', () => {
+  it('reports every reason that makes a backend ineligible', () => {
+    expect(
+      getBackendSkipReasons(
+        'primary',
+        100,
+        () => false,
+        () => true,
+      ),
+    ).toStrictEqual(['unhealthy', 'tpm_below_threshold']);
+  });
+
   it('preserves load-balancer failover defaults and status classification', () => {
     const defaults = extractFailoverSettings(undefined);
 

--- a/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
+++ b/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
@@ -12,6 +12,7 @@ import type { GenerateChatOptions, IProvider } from '../IProvider.js';
 import type { CircuitBreakerState } from '../LoadBalancingProvider.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
 import {
   extractFailoverSettings,
   isImmediateFailoverError,
@@ -152,6 +153,7 @@ describe('extracted provider helper behavior', () => {
         ),
       ),
     ).rejects.toThrow('Request timeout after 1ms');
+    await new Promise((resolve) => setTimeout(resolve, 25));
     expect(closed).toBe(true);
     expect(isTimeoutError(new Error('Request timeout after 1ms'))).toBe(true);
   });
@@ -386,6 +388,43 @@ describe('extracted provider helper behavior', () => {
         'base-url': 'https://settings.example.test',
       },
     });
+  });
+
+  it('adds a metadata signal to an existing valid invocation', () => {
+    const settingsService = new SettingsService();
+    settingsService.set('activeProvider', 'provider-a');
+    settingsService.setProviderSetting('provider-a', 'model', 'model-a');
+    settingsService.setProviderSetting(
+      'provider-a',
+      'base-url',
+      'https://provider-a.example.test',
+    );
+    settingsService.setProviderSetting('provider-a', 'auth-key', 'test-token');
+    const config = createRuntimeConfigStub(settingsService);
+    const controller = new AbortController();
+    const rawOptions = createProviderCallOptions({
+      providerName: 'provider-a',
+      settings: settingsService,
+      ephemerals: {},
+    });
+
+    const normalized = normalizeRuntimeInputs(
+      {
+        ...rawOptions,
+        runtime: {
+          settingsService,
+          config,
+          runtimeId: 'runtime-signal',
+        },
+        metadata: { abortSignal: controller.signal },
+      },
+      {
+        getActiveProviderName: () => 'provider-a',
+        getProvider: () => providerStub(),
+      },
+    );
+
+    expect(normalized.invocation?.signal).toBe(controller.signal);
   });
 
   it('does not apply global ephemeral settings when config owns a different SettingsService', () => {

--- a/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
+++ b/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
@@ -158,6 +158,28 @@ describe('extracted provider helper behavior', () => {
     expect(isTimeoutError(new Error('Request timeout after 1ms'))).toBe(true);
   });
 
+  it('uses the attempt cancellation capability supplied by its owner', async () => {
+    const controller = new AbortController();
+    const cancel = vi.fn(() => controller.abort());
+    async function* delayedFirstChunk(): AsyncIterableIterator<IContent> {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      yield { speaker: 'ai', blocks: [{ type: 'text', text: 'late' }] };
+    }
+
+    await expect(
+      collectChunks(
+        wrapWithTimeout(
+          delayedFirstChunk(),
+          1,
+          'owned-attempt',
+          debugLoggerStub(),
+          { signal: controller.signal, cancel },
+        ),
+      ),
+    ).rejects.toThrow('Request timeout after 1ms');
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it('preserves backend token extraction and request metrics accumulation', () => {
     const metrics = new Map();
     const collector = new BackendMetricsCollector(metrics);

--- a/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
+++ b/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
@@ -66,6 +66,25 @@ describe('request-scoped retry infrastructure', () => {
     expect(independentRequest.budget.used).toBe(0);
     expect(callerContext).toStrictEqual({ requestLabel: 'caller' });
     expect(originalOptions.metadata?._retryRequestContext).toBe(callerContext);
+
+    nestedWrapper.release();
+    firstRequest.release();
+    const reusedOptions = attachTransportAttemptBudget(firstRequest.options, 2);
+    expect(reusedOptions.budget).not.toBe(firstRequest.budget);
+    expect(reusedOptions.budget.used).toBe(0);
+  });
+
+  it('rejects array-shaped request contexts and attaches an isolated budget', () => {
+    const originalOptions: GenerateChatOptions = {
+      contents: [],
+      metadata: { _retryRequestContext: [] },
+    };
+
+    const request = attachTransportAttemptBudget(originalOptions, 2);
+
+    expect(request.options).not.toBe(originalOptions);
+    expect(request.budget).toStrictEqual({ limit: 2, used: 0 });
+    expect(originalOptions.metadata?._retryRequestContext).toStrictEqual([]);
   });
 
   it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(

--- a/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
+++ b/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
@@ -10,16 +10,20 @@ import type { GenerateChatOptions } from '../IProvider.js';
 import { permitsBucketFailover, RetriesExhaustedError } from '../errors.js';
 import { requireTransportAttempt } from '../loadBalancing/delegateAttempt.js';
 import { rethrowIfAborted } from '../loadBalancing/requestAbort.js';
-import { claimProviderErrorObservation } from '../providerErrorObservation.js';
+import {
+  attachProviderErrorObservationContext,
+  claimProviderErrorObservation,
+} from '../providerErrorObservation.js';
 import {
   classifyRetryError,
   isTerminalRetryError,
   markErrorAfterStreamOutput,
 } from '../retryErrorClassification.js';
+import { throwIfEmptyStreamExhaustsBudget } from '../retryExhaustion.js';
 import { resolveRetryRequestContext } from '../retryRequestContext.js';
 import {
   attachTransportAttemptBudget,
-  consumeTransportAttempt,
+  tryConsumeTransportAttempt,
 } from '../transportAttemptBudget.js';
 import {
   createLinkedAbortController,
@@ -55,7 +59,7 @@ describe('request-scoped retry infrastructure', () => {
     };
 
     const firstRequest = attachTransportAttemptBudget(originalOptions, 2);
-    expect(consumeTransportAttempt(firstRequest.options)).toBe(true);
+    expect(tryConsumeTransportAttempt(firstRequest.options)).toBe(true);
     const nestedWrapper = attachTransportAttemptBudget(
       firstRequest.options,
       99,
@@ -89,19 +93,38 @@ describe('request-scoped retry infrastructure', () => {
     expect(originalOptions.metadata?._retryRequestContext).toStrictEqual([]);
   });
 
-  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
-    'bounds non-finite transport limit %s to one attempt',
-    (limit) => {
-      const { options, budget } = attachTransportAttemptBudget(
-        { contents: [] },
-        limit,
-      );
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    0,
+    -1,
+  ])('bounds invalid transport limit %s to one attempt', (limit) => {
+    const { options, budget } = attachTransportAttemptBudget(
+      { contents: [] },
+      limit,
+    );
 
-      expect(budget).toStrictEqual({ limit: 1, used: 0 });
-      expect(consumeTransportAttempt(options)).toBe(true);
-      expect(consumeTransportAttempt(options)).toBe(false);
-    },
-  );
+    expect(budget).toStrictEqual({ limit: 1, used: 0 });
+    expect(tryConsumeTransportAttempt(options)).toBe(true);
+    expect(tryConsumeTransportAttempt(options)).toBe(false);
+  });
+
+  it('replaces a malformed budget whose used count exceeds its limit', () => {
+    const malformed = { limit: 2, used: 3 };
+    const request = attachTransportAttemptBudget(
+      {
+        contents: [],
+        metadata: {
+          _retryRequestContext: { transportAttemptBudget: malformed },
+        },
+      },
+      4,
+    );
+
+    expect(request.budget).not.toBe(malformed);
+    expect(request.budget).toStrictEqual({ limit: 4, used: 0 });
+  });
 
   it('admits no more concurrent consumers than the shared budget limit', async () => {
     const { options, budget } = attachTransportAttemptBudget(
@@ -110,7 +133,9 @@ describe('request-scoped retry infrastructure', () => {
     );
 
     const admitted = await Promise.all(
-      Array.from({ length: 8 }, async () => consumeTransportAttempt(options)),
+      Array.from({ length: 8 }, async () =>
+        tryConsumeTransportAttempt(options),
+      ),
     );
 
     expect(admitted.filter(Boolean)).toHaveLength(2);
@@ -205,6 +230,18 @@ describe('request-scoped retry infrastructure', () => {
       failoverEligible: false,
     });
   });
+  it('preserves EmptyStreamError as the terminal exhaustion cause', () => {
+    expect(() => throwIfEmptyStreamExhaustsBudget(false, 2, 2)).toThrowError(
+      expect.objectContaining({
+        name: 'RetriesExhaustedError',
+        cause: expect.objectContaining({
+          name: 'EmptyStreamError',
+          message: 'Model stream ended immediately with no content.',
+        }),
+      }),
+    );
+  });
+
   it('classifies primitive retry errors safely and preserves object error identity', () => {
     expect(isTerminalRetryError(null)).toBe(false);
     expect(isTerminalRetryError('provider failed')).toBe(false);
@@ -253,6 +290,37 @@ describe('request-scoped retry infrastructure', () => {
     expect(claimProviderErrorObservation(options, error)).toBe(false);
   });
 
+  it('preserves detached claims when observation context is attached', () => {
+    const options: GenerateChatOptions = {
+      contents: [],
+      onProviderError: () => undefined,
+    };
+    const error = new Error('delegate failure');
+
+    expect(claimProviderErrorObservation(options, error)).toBe(true);
+    expect(
+      claimProviderErrorObservation(
+        attachProviderErrorObservationContext(options),
+        error,
+      ),
+    ).toBe(false);
+  });
+
+  it('bounds detached primitive error deduplication', () => {
+    const options: GenerateChatOptions = {
+      contents: [],
+      onProviderError: () => undefined,
+    };
+
+    for (let index = 0; index < 64; index++) {
+      expect(claimProviderErrorObservation(options, `failure-${index}`)).toBe(
+        true,
+      );
+    }
+
+    expect(claimProviderErrorObservation(options, 'failure-0')).toBe(true);
+  });
+
   it('retains the abort reason when racing an operation', async () => {
     const controller = new AbortController();
     const reason = new Error('request deadline expired');
@@ -292,7 +360,7 @@ describe('request-scoped retry infrastructure', () => {
     );
   });
 
-  it('contains synchronous iterator return failures', async () => {
+  it('suppresses synchronous iterator return failures during cleanup', async () => {
     const iterator: AsyncIterator<unknown> = {
       next: async () => ({ done: true, value: undefined }),
       return: () => {

--- a/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
+++ b/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
@@ -6,7 +6,9 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { GenerateChatOptions } from '../IProvider.js';
+import { permitsBucketFailover, RetriesExhaustedError } from '../errors.js';
 import { rethrowIfAborted } from '../loadBalancing/requestAbort.js';
+import { claimProviderErrorObservation } from '../providerErrorObservation.js';
 import {
   classifyRetryError,
   isTerminalRetryError,
@@ -17,6 +19,7 @@ import {
   attachTransportAttemptBudget,
   consumeTransportAttempt,
 } from '../transportAttemptBudget.js';
+import { raceWithAbort } from '../utils/abortSignal.js';
 import { closeIteratorBeforeContinuing } from '../utils/streamCleanup.js';
 
 const defaults = {
@@ -76,6 +79,20 @@ describe('request-scoped retry infrastructure', () => {
     },
   );
 
+  it('admits no more concurrent consumers than the shared budget limit', async () => {
+    const { options, budget } = attachTransportAttemptBudget(
+      { contents: [] },
+      2,
+    );
+
+    const admitted = await Promise.all(
+      Array.from({ length: 8 }, async () => consumeTransportAttempt(options)),
+    );
+
+    expect(admitted.filter(Boolean)).toHaveLength(2);
+    expect(budget.used).toBe(2);
+  });
+
   it('falls back from invalid retry counts and delay settings', () => {
     const request = resolveRetryRequestContext(
       optionsWithEphemerals({
@@ -130,6 +147,38 @@ describe('request-scoped retry infrastructure', () => {
     const wrappedPrimitive = markErrorAfterStreamOutput('primitive failure');
     expect(wrappedPrimitive).toMatchObject({ cause: 'primitive failure' });
     expect(isTerminalRetryError(wrappedPrimitive)).toBe(true);
+  });
+
+  it('prevents bucket failover after retry exhaustion', () => {
+    const cause = new Error('last transport failed');
+    const error = new RetriesExhaustedError(
+      'transport budget exhausted',
+      'server_error',
+      { cause },
+    );
+
+    expect(permitsBucketFailover(error)).toBe(false);
+  });
+
+  it('claims the same unscoped error only once', () => {
+    const options: GenerateChatOptions = {
+      contents: [],
+      onProviderError: () => undefined,
+    };
+    const error = new Error('delegate failure');
+
+    expect(claimProviderErrorObservation(options, error)).toBe(true);
+    expect(claimProviderErrorObservation(options, error)).toBe(false);
+  });
+
+  it('retains the abort reason when racing an operation', async () => {
+    const controller = new AbortController();
+    const reason = new Error('request deadline expired');
+    controller.abort(reason);
+
+    await expect(
+      raceWithAbort(new Promise<void>(() => {}), controller.signal),
+    ).rejects.toMatchObject({ name: 'AbortError', cause: reason });
   });
 
   it('converts request cancellation to AbortError while retaining the provider failure', () => {

--- a/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
+++ b/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
@@ -5,8 +5,10 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JsonFormatter } from '@vybestack/llxprt-code-core';
 import type { GenerateChatOptions } from '../IProvider.js';
 import { permitsBucketFailover, RetriesExhaustedError } from '../errors.js';
+import { requireTransportAttempt } from '../loadBalancing/delegateAttempt.js';
 import { rethrowIfAborted } from '../loadBalancing/requestAbort.js';
 import { claimProviderErrorObservation } from '../providerErrorObservation.js';
 import {
@@ -168,6 +170,41 @@ describe('request-scoped retry infrastructure', () => {
     });
   });
 
+  it('reports transport budget exhaustion as a classified terminal JSON error', () => {
+    const { options } = attachTransportAttemptBudget({ contents: [] }, 1);
+    requireTransportAttempt(options);
+    const captureFailure = (): Error => {
+      try {
+        requireTransportAttempt(options);
+      } catch (error) {
+        return error instanceof Error ? error : new Error(String(error));
+      }
+      throw new Error('Expected transport budget exhaustion');
+    };
+    const failure = captureFailure();
+
+    expect({
+      json: new JsonFormatter().formatError(failure),
+      terminal:
+        failure instanceof RetriesExhaustedError && !failure.isRetryable,
+      failoverEligible: permitsBucketFailover(failure),
+    }).toStrictEqual({
+      json: JSON.stringify(
+        {
+          error: {
+            type: 'RetriesExhaustedError',
+            message: 'Transport attempt budget exhausted',
+            category: 'server_error',
+            reason: 'retries_exhausted',
+          },
+        },
+        null,
+        2,
+      ),
+      terminal: true,
+      failoverEligible: false,
+    });
+  });
   it('classifies primitive retry errors safely and preserves object error identity', () => {
     expect(isTerminalRetryError(null)).toBe(false);
     expect(isTerminalRetryError('provider failed')).toBe(false);
@@ -178,9 +215,22 @@ describe('request-scoped retry infrastructure', () => {
 
     const wrappedPrimitive = markErrorAfterStreamOutput('primitive failure');
     expect(wrappedPrimitive).toMatchObject({ cause: 'primitive failure' });
+
     expect(isTerminalRetryError(wrappedPrimitive)).toBe(true);
   });
 
+  it('recognizes DOMException AbortErrors without assuming safe properties', () => {
+    const throwingName = Object.defineProperty({}, 'name', {
+      get(): never {
+        throw new Error('name is inaccessible');
+      },
+    });
+
+    expect(
+      isTerminalRetryError(new DOMException('request aborted', 'AbortError')),
+    ).toBe(true);
+    expect(isTerminalRetryError(throwingName)).toBe(false);
+  });
   it('prevents bucket failover after retry exhaustion', () => {
     const cause = new Error('last transport failed');
     const error = new RetriesExhaustedError(

--- a/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
+++ b/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GenerateChatOptions } from '../IProvider.js';
+import { rethrowIfAborted } from '../loadBalancing/requestAbort.js';
+import {
+  classifyRetryError,
+  isTerminalRetryError,
+  markErrorAfterStreamOutput,
+} from '../retryErrorClassification.js';
+import { resolveRetryRequestContext } from '../retryRequestContext.js';
+import {
+  attachTransportAttemptBudget,
+  consumeTransportAttempt,
+} from '../transportAttemptBudget.js';
+import { closeIteratorBeforeContinuing } from '../utils/streamCleanup.js';
+
+const defaults = {
+  maxAttempts: 4,
+  initialDelayMs: 25,
+  authRetryTimeoutMs: 500,
+};
+
+function optionsWithEphemerals(
+  ephemerals: Record<string, unknown>,
+): GenerateChatOptions {
+  return {
+    contents: [],
+    invocation: { ephemerals } as GenerateChatOptions['invocation'],
+  };
+}
+
+describe('request-scoped retry infrastructure', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shares a budget through nested wrappers without mutating reusable caller context', () => {
+    const callerContext: Record<string, unknown> = { requestLabel: 'caller' };
+    const originalOptions: GenerateChatOptions = {
+      contents: [],
+      metadata: { _retryRequestContext: callerContext },
+    };
+
+    const firstRequest = attachTransportAttemptBudget(originalOptions, 2);
+    expect(consumeTransportAttempt(firstRequest.options)).toBe(true);
+    const nestedWrapper = attachTransportAttemptBudget(
+      firstRequest.options,
+      99,
+    );
+    const independentRequest = attachTransportAttemptBudget(originalOptions, 2);
+
+    expect(nestedWrapper.budget).toBe(firstRequest.budget);
+    expect(nestedWrapper.budget.used).toBe(1);
+    expect(independentRequest.budget).not.toBe(firstRequest.budget);
+    expect(independentRequest.budget.used).toBe(0);
+    expect(callerContext).toStrictEqual({ requestLabel: 'caller' });
+    expect(originalOptions.metadata?._retryRequestContext).toBe(callerContext);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'bounds non-finite transport limit %s to one attempt',
+    (limit) => {
+      const { options, budget } = attachTransportAttemptBudget(
+        { contents: [] },
+        limit,
+      );
+
+      expect(budget).toStrictEqual({ limit: 1, used: 0 });
+      expect(consumeTransportAttempt(options)).toBe(true);
+      expect(consumeTransportAttempt(options)).toBe(false);
+    },
+  );
+
+  it('falls back from invalid retry counts and delay settings', () => {
+    const request = resolveRetryRequestContext(
+      optionsWithEphemerals({
+        retries: Number.POSITIVE_INFINITY,
+        retrywait: Number.NaN,
+        'auth-retry-timeout': -1,
+      }),
+      defaults,
+    );
+
+    expect(request.maxAttempts).toBe(defaults.maxAttempts);
+    expect(request.initialDelayMs).toBe(defaults.initialDelayMs);
+    expect(request.authRetryTimeoutMs).toBe(defaults.authRetryTimeoutMs);
+    expect(request.budget.limit).toBe(defaults.maxAttempts);
+  });
+
+  it('accepts zero for delay settings while normalizing fractional attempts', () => {
+    const request = resolveRetryRequestContext(
+      optionsWithEphemerals({
+        retries: 2.9,
+        retrywait: 0,
+        'auth-retry-timeout': 0,
+      }),
+      defaults,
+    );
+
+    expect(request.maxAttempts).toBe(2);
+    expect(request.initialDelayMs).toBe(0);
+    expect(request.authRetryTimeoutMs).toBe(0);
+  });
+
+  it('treats an explicit client status as authoritative for retry classification', () => {
+    const error = Object.assign(new Error('socket hang up'), {
+      status: 400,
+      code: 'ECONNRESET',
+    });
+
+    expect(classifyRetryError(error)).toMatchObject({
+      category: 'client_error',
+      isNetworkError: false,
+    });
+  });
+
+  it('classifies primitive retry errors safely and preserves object error identity', () => {
+    expect(isTerminalRetryError(null)).toBe(false);
+    expect(isTerminalRetryError('provider failed')).toBe(false);
+
+    const frozenError = Object.freeze(new Error('midstream failure'));
+    expect(markErrorAfterStreamOutput(frozenError)).toBe(frozenError);
+    expect(isTerminalRetryError(frozenError)).toBe(true);
+
+    const wrappedPrimitive = markErrorAfterStreamOutput('primitive failure');
+    expect(wrappedPrimitive).toMatchObject({ cause: 'primitive failure' });
+    expect(isTerminalRetryError(wrappedPrimitive)).toBe(true);
+  });
+
+  it('converts request cancellation to AbortError while retaining the provider failure', () => {
+    const controller = new AbortController();
+    const providerFailure = new Error('provider observed cancellation');
+    controller.abort();
+
+    expect(() =>
+      rethrowIfAborted(providerFailure, {
+        contents: [],
+        metadata: { abortSignal: controller.signal },
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'AbortError',
+        cause: providerFailure,
+      }),
+    );
+  });
+
+  it('contains synchronous iterator return failures', async () => {
+    const iterator: AsyncIterator<unknown> = {
+      next: async () => ({ done: true, value: undefined }),
+      return: () => {
+        throw new Error('synchronous return failure');
+      },
+    };
+
+    await expect(
+      closeIteratorBeforeContinuing(iterator, new Error('provider failure')),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([new Error('original provider failure'), null, undefined])(
+    'does not replace an existing provider failure %s when cleanup times out',
+    async (failure) => {
+      vi.useFakeTimers();
+      const iterator: AsyncIterator<unknown> = {
+        next: async () => ({ done: true, value: undefined }),
+        return: () => new Promise(() => {}),
+      };
+      const cleanup = closeIteratorBeforeContinuing(iterator, failure, true);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(cleanup).resolves.toBeUndefined();
+    },
+  );
+});

--- a/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
+++ b/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
@@ -19,7 +19,10 @@ import {
   attachTransportAttemptBudget,
   consumeTransportAttempt,
 } from '../transportAttemptBudget.js';
-import { raceWithAbort } from '../utils/abortSignal.js';
+import {
+  createLinkedAbortController,
+  raceWithAbort,
+} from '../utils/abortSignal.js';
 import { closeIteratorBeforeContinuing } from '../utils/streamCleanup.js';
 
 const defaults = {
@@ -124,6 +127,16 @@ describe('request-scoped retry infrastructure', () => {
     expect(request.authRetryTimeoutMs).toBe(0);
   });
 
+  it('normalizes a fractional default attempt count to a whole transport budget', () => {
+    const request = resolveRetryRequestContext(optionsWithEphemerals({}), {
+      ...defaults,
+      maxAttempts: 3.9,
+    });
+
+    expect(request.maxAttempts).toBe(3);
+    expect(request.budget.limit).toBe(3);
+  });
+
   it('treats an explicit client status as authoritative for retry classification', () => {
     const error = Object.assign(new Error('socket hang up'), {
       status: 400,
@@ -179,6 +192,17 @@ describe('request-scoped retry infrastructure', () => {
     await expect(
       raceWithAbort(new Promise<void>(() => {}), controller.signal),
     ).rejects.toMatchObject({ name: 'AbortError', cause: reason });
+  });
+
+  it('allows linked attempt cleanup to be repeated and detaches from its parent', () => {
+    const parent = new AbortController();
+    const linked = createLinkedAbortController(parent.signal);
+
+    linked.dispose();
+    linked.dispose();
+    parent.abort(new Error('parent stopped'));
+
+    expect(linked.controller.signal.aborted).toBe(false);
   });
 
   it('converts request cancellation to AbortError while retaining the provider failure', () => {

--- a/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
+++ b/packages/providers/src/__tests__/retryInfrastructure.behavior.test.ts
@@ -298,12 +298,32 @@ describe('request-scoped retry infrastructure', () => {
     const error = new Error('delegate failure');
 
     expect(claimProviderErrorObservation(options, error)).toBe(true);
-    expect(
-      claimProviderErrorObservation(
-        attachProviderErrorObservationContext(options),
-        error,
-      ),
-    ).toBe(false);
+    const attached = attachProviderErrorObservationContext(options);
+    expect(claimProviderErrorObservation(attached.options, error)).toBe(false);
+    attached.release();
+  });
+
+  it('starts fresh observation deduplication after a request lifecycle ends', () => {
+    const options: GenerateChatOptions = {
+      contents: [],
+      onProviderError: () => undefined,
+    };
+    const error = new Error('delegate failure');
+    const firstRequest = attachProviderErrorObservationContext(options);
+
+    expect(claimProviderErrorObservation(firstRequest.options, error)).toBe(
+      true,
+    );
+    expect(claimProviderErrorObservation(firstRequest.options, error)).toBe(
+      false,
+    );
+    firstRequest.release();
+
+    const secondRequest = attachProviderErrorObservationContext(options);
+    expect(claimProviderErrorObservation(secondRequest.options, error)).toBe(
+      true,
+    );
+    secondRequest.release();
   });
 
   it('bounds detached primitive error deduplication', () => {
@@ -340,6 +360,21 @@ describe('request-scoped retry infrastructure', () => {
     parent.abort(new Error('parent stopped'));
 
     expect(linked.controller.signal.aborted).toBe(false);
+  });
+
+  it('does not repeat linked cleanup after listener removal throws', () => {
+    const parent = new AbortController();
+    const cleanupError = new Error('listener removal failed');
+    const remove = vi
+      .spyOn(parent.signal, 'removeEventListener')
+      .mockImplementation(() => {
+        throw cleanupError;
+      });
+    const linked = createLinkedAbortController(parent.signal);
+
+    expect(() => linked.dispose()).toThrow(cleanupError);
+    expect(() => linked.dispose()).not.toThrow();
+    expect(remove).toHaveBeenCalledTimes(1);
   });
 
   it('converts request cancellation to AbortError while retaining the provider failure', () => {

--- a/packages/providers/src/anthropic/AnthropicApiExecution.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.ts
@@ -127,18 +127,23 @@ export function createAnthropicApiCall(
   client: Anthropic,
   requestBody: Record<string, unknown>,
   customHeaders: Record<string, string>,
+  signal?: AbortSignal,
 ): () => Promise<{
   data: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>;
   response: Response | undefined;
 }> {
   const params = asMessageCreateParams(requestBody);
   return async () => {
-    const apiCall = () =>
-      Object.keys(customHeaders).length > 0
-        ? client.messages.create(params, { headers: customHeaders })
+    const requestOptions = {
+      ...(Object.keys(customHeaders).length > 0
+        ? { headers: customHeaders }
+        : {}),
+      ...(signal !== undefined ? { signal } : {}),
+    };
+    const promise =
+      Object.keys(requestOptions).length > 0
+        ? client.messages.create(params, requestOptions)
         : client.messages.create(params);
-
-    const promise = apiCall();
     // The promise has a withResponse() method we can call
     if (typeof promise === 'object' && 'withResponse' in promise) {
       return (

--- a/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
@@ -500,21 +500,27 @@ describe('AnthropicProvider', () => {
           .next();
 
         const controller = new AbortController();
+        const reason = new Error('request cancelled during throttle');
         const baseOptions = buildCallOptions(messages);
         const throttledCall = provider.generateChatCompletion({
           ...baseOptions,
           invocation: { ...baseOptions.invocation, signal: controller.signal },
         });
         vi.useFakeTimers();
-        const nextPromise = throttledCall.next();
-        await vi.waitFor(() => expect(vi.getTimerCount()).toBeGreaterThan(0), {
-          interval: 1,
-          timeout: 20,
-        });
-        controller.abort();
+        try {
+          const nextPromise = throttledCall.next();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
 
-        await expect(nextPromise).rejects.toThrow(/abort/i);
-        expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+          controller.abort(reason);
+
+          await expect(nextPromise).rejects.toMatchObject({
+            name: 'AbortError',
+          });
+          expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+        } finally {
+          vi.useRealTimers();
+        }
       });
 
       it('should handle partial rate limit headers', async () => {

--- a/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
@@ -505,7 +505,12 @@ describe('AnthropicProvider', () => {
           ...baseOptions,
           invocation: { ...baseOptions.invocation, signal: controller.signal },
         });
+        vi.useFakeTimers();
         const nextPromise = throttledCall.next();
+        await vi.waitFor(() => expect(vi.getTimerCount()).toBeGreaterThan(0), {
+          interval: 1,
+          timeout: 20,
+        });
         controller.abort();
 
         await expect(nextPromise).rejects.toThrow(/abort/i);

--- a/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
@@ -516,8 +516,12 @@ describe('AnthropicProvider', () => {
 
           await expect(nextPromise).rejects.toMatchObject({
             name: 'AbortError',
+            cause: reason,
           });
+          await vi.runAllTimersAsync();
           expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+          expect(vi.getTimerCount()).toBe(0);
+          await throttledCall.return?.();
         } finally {
           vi.useRealTimers();
         }

--- a/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ratelimits.test.ts
@@ -461,6 +461,57 @@ describe('AnthropicProvider', () => {
         sleepSpy.mockRestore();
       });
 
+      it('aborts proactive throttling before issuing the next transport call', async () => {
+        settingsService.setProviderSetting('anthropic', 'streaming', 'enabled');
+        settingsService.setProviderSetting(
+          'anthropic',
+          'rate-limit-throttle',
+          'on',
+        );
+        const headers = new Headers({
+          'anthropic-ratelimit-requests-limit': '1000',
+          'anthropic-ratelimit-requests-remaining': '1',
+          'anthropic-ratelimit-requests-reset': new Date(
+            Date.now() + 60_000,
+          ).toISOString(),
+        });
+        const stream = {
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: 'content_block_delta',
+              delta: { type: 'text_delta', text: 'First' },
+            };
+          },
+        };
+        mockMessagesCreate.mockReturnValueOnce({
+          withResponse: vi.fn().mockResolvedValue({
+            data: stream,
+            response: { headers },
+          }),
+        } as unknown as Promise<Anthropic.Message>);
+        const messages: IContent[] = [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'First request' }],
+          },
+        ];
+        await provider
+          .generateChatCompletion(buildCallOptions(messages))
+          .next();
+
+        const controller = new AbortController();
+        const baseOptions = buildCallOptions(messages);
+        const throttledCall = provider.generateChatCompletion({
+          ...baseOptions,
+          invocation: { ...baseOptions.invocation, signal: controller.signal },
+        });
+        const nextPromise = throttledCall.next();
+        controller.abort();
+
+        await expect(nextPromise).rejects.toThrow(/abort/i);
+        expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+      });
+
       it('should handle partial rate limit headers', async () => {
         const mockResponse = {
           content: [{ type: 'text', text: 'response' }],

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -7,6 +7,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { ClientOptions } from '@anthropic-ai/sdk';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { type IModel } from '../IModel.js';
 import type { ToolFormat } from '@vybestack/llxprt-code-tools/IToolFormatter.js';
 import { TOOL_PREFIX } from './schemaConverter.js';
@@ -140,6 +141,7 @@ export class AnthropicProvider extends BaseProvider {
     const isOAuthToken = this.classifyOAuthToken(authToken);
     const clientConfig: Record<string, unknown> = {
       dangerouslyAllowBrowser: true,
+      maxRetries: 0,
     };
 
     if (isOAuthToken) {
@@ -578,12 +580,17 @@ export class AnthropicProvider extends BaseProvider {
     const customHeaders = this.buildCustomHeaders(requestContext, isOAuth);
 
     const rateLimitLogger = this.getRateLimitLogger();
-    await this.applyRateLimitThrottling(requestContext, rateLimitLogger);
+    await this.applyRateLimitThrottling(
+      requestContext,
+      rateLimitLogger,
+      options.invocation.signal,
+    );
 
     const apiCallWithResponse = createAnthropicApiCall(
       initialClient,
       requestContext.requestBody,
       customHeaders,
+      options.invocation.signal,
     );
 
     const { response, rateLimitInfo } = await this.executeApiCall(
@@ -602,7 +609,6 @@ export class AnthropicProvider extends BaseProvider {
       requestContext,
       options,
       isOAuth,
-      apiCallWithResponse,
       rateLimitLogger,
     );
   }
@@ -643,6 +649,7 @@ export class AnthropicProvider extends BaseProvider {
   private async applyRateLimitThrottling(
     requestContext: Awaited<ReturnType<typeof prepareAnthropicRequest>>,
     rateLimitLogger: { debug: (fn: () => string) => void },
+    signal?: AbortSignal,
   ): Promise<void> {
     const waitDecision = calculateWaitTime(this.lastRateLimitInfo ?? {}, {
       throttleEnabled:
@@ -660,7 +667,7 @@ export class AnthropicProvider extends BaseProvider {
     });
     if (waitDecision.shouldWait) {
       rateLimitLogger.debug(() => waitDecision.reason);
-      await this.sleep(waitDecision.waitMs);
+      await this.sleep(waitDecision.waitMs, signal);
     }
   }
 
@@ -697,10 +704,6 @@ export class AnthropicProvider extends BaseProvider {
     requestContext: Awaited<ReturnType<typeof prepareAnthropicRequest>>,
     options: NormalizedGenerateChatOptions,
     isOAuth: boolean,
-    apiCallWithResponse: () => Promise<{
-      data: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>;
-      response?: Response;
-    }>,
     rateLimitLogger: { debug: (fn: () => string) => void },
   ): AsyncGenerator<IContent> {
     if (requestContext.streamingEnabled) {
@@ -712,9 +715,6 @@ export class AnthropicProvider extends BaseProvider {
           unprefixToolName: (name, oauth) => this.unprefixToolName(name, oauth),
           findToolSchema: (t, name, oauth) =>
             this.findToolSchema(t, name, oauth),
-          maxAttempts: requestContext.maxAttempts,
-          initialDelayMs: requestContext.initialDelayMs,
-          apiCallWithResponse,
           logger: this.getStreamingLogger(),
           cacheLogger: requestContext.cacheLogger,
           rateLimitLogger,
@@ -731,12 +731,8 @@ export class AnthropicProvider extends BaseProvider {
     }
   }
 
-  /**
-   * Mockable sleep for rate-limit throttling.
-   * Tests spy on this method to avoid real delays.
-   */
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  private sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return delay(ms, signal);
   }
 }
 

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import { describe, expect, it } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import {
+  processAnthropicStream,
+  type StreamProcessorOptions,
+} from './AnthropicStreamProcessor.js';
+
+const streamOptions: StreamProcessorOptions = {
+  isOAuth: false,
+  tools: undefined,
+  unprefixToolName: (name) => name,
+  findToolSchema: () => undefined,
+  logger: { debug: () => undefined },
+  cacheLogger: { debug: () => undefined },
+  rateLimitLogger: { debug: () => undefined },
+};
+
+async function* failingAnthropicStream(): AsyncGenerator<Anthropic.MessageStreamEvent> {
+  await Promise.resolve();
+  throw new Error('fetch failed');
+  yield { type: 'ping' } as Anthropic.MessageStreamEvent;
+}
+
+async function collect(stream: AsyncIterable<IContent>): Promise<IContent[]> {
+  const chunks: IContent[] = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return chunks;
+}
+
+describe('Anthropic stream retry ownership', () => {
+  it('uses only the central transport attempt budget for stream network failures', async () => {
+    let transportCalls = 0;
+    const transport: IProvider = {
+      name: 'anthropic',
+      async *generateChatCompletion() {
+        transportCalls++;
+        if (transportCalls < 3) {
+          yield* processAnthropicStream(
+            failingAnthropicStream(),
+            streamOptions,
+          );
+          return;
+        }
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'claude-test',
+      getServerTools: () => [],
+      invokeServerTool: async () => null,
+    };
+    const provider = new RetryOrchestrator(transport, {
+      maxAttempts: 3,
+      initialDelayMs: 0,
+    });
+
+    const chunks = await collect(
+      provider.generateChatCompletion({
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
+      }),
+    );
+
+    expect(transportCalls).toBe(3);
+    expect(chunks).toStrictEqual([
+      { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] },
+    ]);
+  });
+
+  it('does not start another Anthropic transport after abort during backoff', async () => {
+    const controller = new AbortController();
+    let transportCalls = 0;
+    const transport: IProvider = {
+      name: 'anthropic',
+      async *generateChatCompletion(_options: GenerateChatOptions) {
+        transportCalls++;
+        yield* processAnthropicStream(failingAnthropicStream(), streamOptions);
+      },
+      getModels: async () => [],
+      getDefaultModel: () => 'claude-test',
+      getServerTools: () => [],
+      invokeServerTool: async () => null,
+    };
+    const provider = new RetryOrchestrator(transport, {
+      maxAttempts: 3,
+      initialDelayMs: 100,
+    });
+    const result = collect(
+      provider.generateChatCompletion({
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+        ],
+        metadata: { abortSignal: controller.signal },
+      }),
+    );
+    setTimeout(() => controller.abort(), 10);
+
+    await expect(result).rejects.toThrow(/abort/i);
+    expect(transportCalls).toBe(1);
+  });
+});

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
@@ -113,7 +113,7 @@ describe('Anthropic stream retry ownership', () => {
     });
     controller.abort();
 
-    await expect(result).rejects.toThrow(/abort/i);
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
     expect(transportCalls).toBe(1);
   });
 });

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type Anthropic from '@anthropic-ai/sdk';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { GenerateChatOptions, IProvider } from '../IProvider.js';
 import { RetryOrchestrator } from '../RetryOrchestrator.js';
@@ -37,6 +37,10 @@ async function collect(stream: AsyncIterable<IContent>): Promise<IContent[]> {
 }
 
 describe('Anthropic stream retry ownership', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('uses only the central transport attempt budget for stream network failures', async () => {
     let transportCalls = 0;
     const transport: IProvider = {
@@ -77,6 +81,7 @@ describe('Anthropic stream retry ownership', () => {
   });
 
   it('does not start another Anthropic transport after abort during backoff', async () => {
+    vi.useFakeTimers();
     const controller = new AbortController();
     let transportCalls = 0;
     const transport: IProvider = {
@@ -102,7 +107,11 @@ describe('Anthropic stream retry ownership', () => {
         metadata: { abortSignal: controller.signal },
       }),
     );
-    setTimeout(() => controller.abort(), 10);
+    await vi.waitFor(() => expect(vi.getTimerCount()).toBeGreaterThan(0), {
+      interval: 1,
+      timeout: 20,
+    });
+    controller.abort();
 
     await expect(result).rejects.toThrow(/abort/i);
     expect(transportCalls).toBe(1);

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
@@ -25,9 +25,9 @@ const streamOptions: StreamProcessorOptions = {
 };
 
 async function* failingAnthropicStream(): AsyncGenerator<Anthropic.MessageStreamEvent> {
-  await Promise.resolve();
-  throw new Error('fetch failed');
-  yield { type: 'ping' } as Anthropic.MessageStreamEvent;
+  yield await Promise.reject<Anthropic.MessageStreamEvent>(
+    new Error('fetch failed'),
+  );
 }
 
 async function collect(stream: AsyncIterable<IContent>): Promise<IContent[]> {

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.retryOwnership.test.ts
@@ -107,10 +107,8 @@ describe('Anthropic stream retry ownership', () => {
         metadata: { abortSignal: controller.signal },
       }),
     );
-    await vi.waitFor(() => expect(vi.getTimerCount()).toBeGreaterThan(0), {
-      interval: 1,
-      timeout: 20,
-    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
     controller.abort();
 
     await expect(result).rejects.toMatchObject({ name: 'AbortError' });

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
@@ -37,8 +37,6 @@ export type StreamProcessorOptions = {
   rateLimitLogger: { debug: (fn: () => string) => void };
 };
 
-type StreamState = { hasYieldedContent: boolean };
-
 // Global counter appended to tool call IDs so providers that reset indices per
 // API call (e.g. Kimi on Fireworks) never produce duplicates across turns.
 let toolCallSequence = 0;
@@ -46,7 +44,6 @@ let toolCallSequence = 0;
 async function* processStreamEvents(
   stream: AsyncIterable<Anthropic.MessageStreamEvent>,
   options: StreamProcessorOptions,
-  state: StreamState,
 ): AsyncGenerator<IContent> {
   const {
     isOAuth,
@@ -79,7 +76,6 @@ async function* processStreamEvents(
         currentThinkingBlock = blockResult.currentThinkingBlock;
       }
       if (blockResult.content) {
-        state.hasYieldedContent = true;
         yield blockResult.content;
       }
     } else if (chunk.type === 'content_block_delta') {
@@ -90,7 +86,6 @@ async function* processStreamEvents(
         logger,
       );
       if (deltaResult.textDelta) {
-        state.hasYieldedContent = true;
         yield {
           speaker: 'ai',
           blocks: [{ type: 'text', text: deltaResult.textDelta }],
@@ -107,13 +102,12 @@ async function* processStreamEvents(
         logger,
       );
       if (stopResult.content) {
-        state.hasYieldedContent = true;
         yield stopResult.content;
       }
       currentToolCall = stopResult.currentToolCall;
       currentThinkingBlock = stopResult.currentThinkingBlock;
     } else if (chunk.type === 'message_delta') {
-      yield* handleMessageDelta(chunk, logger, state);
+      yield* handleMessageDelta(chunk, logger);
     }
   }
 }
@@ -127,8 +121,7 @@ export async function* processAnthropicStream(
   options: StreamProcessorOptions,
 ): AsyncGenerator<IContent> {
   options.logger.debug(() => 'Processing streaming response');
-  const state: StreamState = { hasYieldedContent: false };
-  yield* processStreamEvents(response, options, state);
+  yield* processStreamEvents(response, options);
 }
 
 function* handleMessageStart(
@@ -439,7 +432,6 @@ function readMessageDeltaStopReason(
 function* handleMessageDelta(
   chunk: Anthropic.MessageStreamEvent & { type: 'message_delta' },
   logger: { debug: (fn: () => string) => void },
-  state: StreamState,
 ): Generator<IContent> {
   const usage = chunk.usage as
     | {
@@ -459,7 +451,6 @@ function* handleMessageDelta(
     );
 
     if (stopReason) {
-      state.hasYieldedContent = true;
       yield {
         speaker: 'ai',
         blocks: [],

--- a/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
+++ b/packages/providers/src/anthropic/AnthropicStreamProcessor.ts
@@ -22,8 +22,6 @@ import {
   logDoubleEscapingInChunk,
 } from '@vybestack/llxprt-code-tools/doubleEscapeUtils.js';
 import { coerceParametersToSchema } from '@vybestack/llxprt-code-core/utils/parameterCoercion.js';
-import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
-import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
 
 export type StreamProcessorOptions = {
   isOAuth: boolean;
@@ -34,12 +32,6 @@ export type StreamProcessorOptions = {
     name: string,
     isOAuth: boolean,
   ) => unknown;
-  maxAttempts: number;
-  initialDelayMs: number;
-  apiCallWithResponse: () => Promise<{
-    data: Anthropic.Message | AsyncIterable<Anthropic.MessageStreamEvent>;
-    response?: Response;
-  }>;
   logger: { debug: (fn: () => string) => void };
   cacheLogger: { debug: (fn: () => string) => void };
   rateLimitLogger: { debug: (fn: () => string) => void };
@@ -127,72 +119,16 @@ async function* processStreamEvents(
 }
 
 /**
- * Processes an Anthropic streaming response with retry logic for network errors
- * Yields IContent blocks as they arrive from the stream
+ * Processes one Anthropic streaming response. Retry ownership belongs to the
+ * central RetryOrchestrator so every API request consumes the same budget.
  */
 export async function* processAnthropicStream(
   response: AsyncIterable<Anthropic.MessageStreamEvent>,
   options: StreamProcessorOptions,
 ): AsyncGenerator<IContent> {
-  const { maxAttempts, initialDelayMs, apiCallWithResponse, logger } = options;
-
-  const streamRetryMaxDelayMs = 30000;
-  let streamingAttempt = 0;
-  let currentDelay = initialDelayMs;
-  let currentResponse = response;
-
-  while (streamingAttempt < maxAttempts) {
-    streamingAttempt++;
-
-    const state: StreamState = { hasYieldedContent: false };
-
-    try {
-      if (streamingAttempt > 1) {
-        logger.debug(
-          () =>
-            `Stream retry attempt ${streamingAttempt}/${maxAttempts}: Making fresh API call`,
-        );
-        const retryResult = await apiCallWithResponse();
-        currentResponse =
-          retryResult.data as AsyncIterable<Anthropic.MessageStreamEvent>;
-      }
-
-      logger.debug(() => 'Processing streaming response');
-      yield* processStreamEvents(currentResponse, options, state);
-      return;
-    } catch (error) {
-      const canRetryStream = isNetworkTransientError(error);
-      logger.debug(
-        () =>
-          `Stream attempt ${streamingAttempt}/${maxAttempts} error: ${error}`,
-      );
-
-      if (state.hasYieldedContent) {
-        logger.debug(
-          () =>
-            `Stream error after content was already yielded to consumer, cannot safely retry: ${error}`,
-        );
-        throw error;
-      }
-
-      if (!canRetryStream || streamingAttempt >= maxAttempts) {
-        logger.debug(
-          () =>
-            `Stream error not retryable or max attempts reached, throwing: ${error}`,
-        );
-        throw error;
-      }
-
-      const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
-      const delayWithJitter = Math.max(0, currentDelay + jitter);
-      logger.debug(
-        () =>
-          `Stream retry attempt ${streamingAttempt}/${maxAttempts}: Transient error detected, waiting ${Math.round(delayWithJitter)}ms before retry`,
-      );
-      await delay(delayWithJitter);
-      currentDelay = Math.min(streamRetryMaxDelayMs, currentDelay * 2);
-    }
-  }
+  options.logger.debug(() => 'Processing streaming response');
+  const state: StreamState = { hasYieldedContent: false };
+  yield* processStreamEvents(response, options, state);
 }
 
 function* handleMessageStart(

--- a/packages/providers/src/auth/BucketFailoverHandlerImpl.case-50.spec.ts
+++ b/packages/providers/src/auth/BucketFailoverHandlerImpl.case-50.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { OAuthToken } from '@vybestack/llxprt-code-auth';
+import { BucketFailoverHandlerImpl } from './BucketFailoverHandlerImpl.js';
+import {
+  makeToken,
+  MemoryTokenStore,
+} from './BucketFailoverHandlerImpl.test-helpers.js';
+import type { BucketFailoverOAuthManagerLike } from './types.js';
+
+class PendingLookupTokenStore extends MemoryTokenStore {
+  constructor(
+    private readonly pendingLookup: Promise<OAuthToken | null>,
+    private readonly lookupStarted: () => void,
+  ) {
+    super();
+  }
+
+  override async getToken(
+    provider: string,
+    bucket?: string,
+  ): Promise<OAuthToken | null> {
+    if (bucket === 'bucket-b') {
+      this.lookupStarted();
+      return this.pendingLookup;
+    }
+    return super.getToken(provider, bucket);
+  }
+}
+
+describe('BucketFailoverHandlerImpl #50', () => {
+  it('does not switch the active bucket when an aborted token lookup later resolves', async () => {
+    let resolveLookup: ((token: OAuthToken | null) => void) | undefined;
+    const pendingLookup = new Promise<OAuthToken | null>((resolve) => {
+      resolveLookup = resolve;
+    });
+    let notifyLookupStarted: (() => void) | undefined;
+    const lookupStarted = new Promise<void>((resolve) => {
+      notifyLookupStarted = resolve;
+    });
+    const tokenStore = new PendingLookupTokenStore(pendingLookup, () =>
+      notifyLookupStarted?.(),
+    );
+    let sessionBucket = 'bucket-a';
+    let sessionWriteCount = 0;
+    const oauthManager: BucketFailoverOAuthManagerLike = {
+      getSessionBucket: () => sessionBucket,
+      setSessionBucket: (_provider, bucket) => {
+        sessionWriteCount++;
+        sessionBucket = bucket;
+      },
+      getOAuthToken: (_provider, bucket) =>
+        tokenStore.getToken('anthropic', bucket),
+      authenticate: async () => undefined,
+      authenticateMultipleBuckets: async () => undefined,
+      getTokenStore: () => tokenStore,
+      forceRefreshToken: async () => null,
+    };
+    const handler = new BucketFailoverHandlerImpl(
+      ['bucket-a', 'bucket-b'],
+      'anthropic',
+      oauthManager,
+    );
+    const controller = new AbortController();
+    const failover = handler.tryFailover({
+      triggeringStatus: 429,
+      signal: controller.signal,
+    });
+
+    await lookupStarted;
+    controller.abort();
+    await expect(failover).rejects.toMatchObject({ name: 'AbortError' });
+    expect(resolveLookup).toBeTypeOf('function');
+    resolveLookup?.(makeToken('late-token'));
+    await pendingLookup;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect({
+      handlerBucket: handler.getCurrentBucket(),
+      sessionBucket,
+      sessionWriteCount,
+    }).toStrictEqual({
+      handlerBucket: 'bucket-a',
+      sessionBucket: 'bucket-a',
+      sessionWriteCount: 0,
+    });
+  });
+});

--- a/packages/providers/src/auth/BucketFailoverHandlerImpl.ts
+++ b/packages/providers/src/auth/BucketFailoverHandlerImpl.ts
@@ -22,6 +22,7 @@ import type {
 } from '@vybestack/llxprt-code-core/config/configTypes.js';
 import type { BucketFailureReason } from '@vybestack/llxprt-code-core/runtime/contracts/index.js';
 import type { BucketFailoverOAuthManagerLike } from './types.js';
+import { raceWithAbort } from '../utils/abortSignal.js';
 
 const logger = new DebugLogger('llxprt:bucket:failover:handler');
 
@@ -146,6 +147,12 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
    * Pass 3: Attempt foreground reauth for expired/missing tokens
    */
   async tryFailover(context?: FailoverContext): Promise<boolean> {
+    return raceWithAbort(this.tryFailoverInternal(context), context?.signal);
+  }
+
+  private async tryFailoverInternal(
+    context?: FailoverContext,
+  ): Promise<boolean> {
     this.lastFailoverReasons = {};
     const authRetryTimeoutMs =
       context?.authRetryTimeoutMs ?? this.configuredAuthRetryTimeoutMs;

--- a/packages/providers/src/auth/BucketFailoverHandlerImpl.ts
+++ b/packages/providers/src/auth/BucketFailoverHandlerImpl.ts
@@ -38,6 +38,10 @@ type TriggerClassificationResult = {
   completed: boolean;
 };
 
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
 /**
  * CLI implementation of BucketFailoverHandler
  *
@@ -147,7 +151,11 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
    * Pass 3: Attempt foreground reauth for expired/missing tokens
    */
   async tryFailover(context?: FailoverContext): Promise<boolean> {
-    return raceWithAbort(this.tryFailoverInternal(context), context?.signal);
+    const signal = context?.signal;
+    if (isAborted(signal)) {
+      return raceWithAbort(Promise.resolve(false), signal);
+    }
+    return raceWithAbort(this.tryFailoverInternal(context), signal);
   }
 
   private async tryFailoverInternal(
@@ -156,7 +164,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     this.lastFailoverReasons = {};
     const authRetryTimeoutMs =
       context?.authRetryTimeoutMs ?? this.configuredAuthRetryTimeoutMs;
-    this.syncCursorFromSession();
+    this.syncCursorFromSession(context?.signal);
 
     const currentBucket = this.getCurrentBucket();
     if (!currentBucket) {
@@ -168,10 +176,15 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       currentBucket,
       context,
     );
+    const signal = context?.signal;
+    if (isAborted(signal)) return false;
     if (classification.completed) return true;
     this.recordTriggeringBucket(currentBucket, classification.reason);
 
-    if (await this.tryPassTwoFailover(currentBucket)) return true;
+    if (await this.tryPassTwoFailover(currentBucket, signal)) {
+      return true;
+    }
+    if (isAborted(signal)) return false;
 
     const candidateBucket = this.findPassThreeCandidate(currentBucket);
     if (candidateBucket !== undefined) {
@@ -179,6 +192,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
         currentBucket,
         candidateBucket,
         authRetryTimeoutMs,
+        signal,
       );
     }
 
@@ -186,14 +200,14 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     return false;
   }
 
-  private syncCursorFromSession(): void {
+  private syncCursorFromSession(signal: AbortSignal | undefined): void {
     const sessionBucket = this.oauthManager.getSessionBucket(
       this.provider,
       this.metadata,
     );
     if (sessionBucket) {
       const idx = this.buckets.indexOf(sessionBucket);
-      if (idx >= 0) {
+      if (idx >= 0 && !isAborted(signal)) {
         this.currentBucketIndex = idx;
       }
     }
@@ -300,9 +314,14 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
    * @pseudocode failover-handler.md lines 60-121
    */
 
-  private async tryPassTwoFailover(currentBucket: string): Promise<boolean> {
+  private async tryPassTwoFailover(
+    currentBucket: string,
+    signal: AbortSignal | undefined,
+  ): Promise<boolean> {
     for (const bucket of this.buckets) {
-      if (await this.tryPassTwoBucket(bucket, currentBucket)) return true;
+      if (isAborted(signal)) return false;
+      if (await this.tryPassTwoBucket(bucket, currentBucket, signal))
+        return true;
     }
     return false;
   }
@@ -310,25 +329,29 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
   private async tryPassTwoBucket(
     bucket: string,
     currentBucket: string,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     if (this.triedBucketsThisSession.has(bucket)) {
       this.lastFailoverReasons[bucket] ??= 'skipped';
       return false;
     }
 
-    const storedToken = await this.readPassTwoToken(bucket);
-    if (storedToken === null) return false;
+    const storedToken = await this.readPassTwoToken(bucket, signal);
+    if (isAborted(signal) || storedToken === null) return false;
 
     const nowSec = Math.floor(Date.now() / 1000);
     if (storedToken.expiry - nowSec <= 0) {
-      return this.tryRefreshCandidate(bucket, currentBucket, nowSec);
+      return this.tryRefreshCandidate(bucket, currentBucket, nowSec, signal);
     }
-    return this.tryValidCandidate(bucket, currentBucket);
+    return this.tryValidCandidate(bucket, currentBucket, signal);
   }
 
-  private async readPassTwoToken(bucket: string): Promise<OAuthToken | null> {
+  private async readPassTwoToken(
+    bucket: string,
+    signal: AbortSignal | undefined,
+  ): Promise<OAuthToken | null> {
     const storedToken = await this.readStoredToken(bucket);
-    if (storedToken === null) {
+    if (storedToken === null && !isAborted(signal)) {
       this.lastFailoverReasons[bucket] = 'no-token';
     }
     return storedToken;
@@ -338,14 +361,18 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     bucket: string,
     currentBucket: string,
     nowSec: number,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     try {
       const refreshedToken = await this.oauthManager.getOAuthToken(
         this.provider,
         bucket,
       );
-      if (refreshedToken && refreshedToken.expiry > nowSec) {
-        this.switchToBucket(bucket, 'pass-2 refresh');
+      if (
+        refreshedToken &&
+        refreshedToken.expiry > nowSec &&
+        this.switchToBucket(bucket, 'pass-2 refresh', signal)
+      ) {
         logger.warn(
           () =>
             `Bucket failover: switched to ${bucket} after refresh from ${currentBucket}`,
@@ -355,6 +382,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     } catch (refreshError) {
       logger.debug(`Refresh failed for ${bucket}:`, refreshError);
     }
+    if (isAborted(signal)) return false;
     this.lastFailoverReasons[bucket] = 'expired-refresh-failed';
     return false;
   }
@@ -362,29 +390,39 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
   private async tryValidCandidate(
     bucket: string,
     currentBucket: string,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     let token: OAuthToken | null = null;
     try {
       token = await this.oauthManager.getOAuthToken(this.provider, bucket);
     } catch (error) {
       logger.warn(`Failed to get token for ${this.provider}/${bucket}:`, error);
-      this.lastFailoverReasons[bucket] = 'no-token';
+      if (!isAborted(signal)) {
+        this.lastFailoverReasons[bucket] = 'no-token';
+      }
       return false;
     }
 
     if (token === null) {
-      this.lastFailoverReasons[bucket] = 'no-token';
+      if (!isAborted(signal)) {
+        this.lastFailoverReasons[bucket] = 'no-token';
+      }
       return false;
     }
 
-    this.switchToBucket(bucket, 'pass-2 switch');
+    if (!this.switchToBucket(bucket, 'pass-2 switch', signal)) return false;
     logger.warn(
       () => `Bucket failover: switched from ${currentBucket} to ${bucket}`,
     );
     return true;
   }
 
-  private switchToBucket(bucket: string, stage: BucketSwitchStage): void {
+  private switchToBucket(
+    bucket: string,
+    stage: BucketSwitchStage,
+    signal: AbortSignal | undefined,
+  ): boolean {
+    if (isAborted(signal)) return false;
     const bucketIndex = this.buckets.indexOf(bucket);
     if (bucketIndex >= 0) {
       this.currentBucketIndex = bucketIndex;
@@ -395,6 +433,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     } catch (setError) {
       logger.warn(`Failed to set session bucket during ${stage}: ${setError}`);
     }
+    return true;
   }
 
   private findPassThreeCandidate(currentBucket: string): string | undefined {
@@ -421,6 +460,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     currentBucket: string,
     candidateBucket: string,
     authRetryTimeoutMs: number,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     const existingForegroundReauth =
       this.foregroundReauthInFlightByBucket.get(candidateBucket);
@@ -430,6 +470,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       authRetryTimeoutMs,
       currentBucket,
       candidateBucket,
+      signal,
     );
     this.foregroundReauthInFlightByBucket.set(candidateBucket, pass3Promise);
     try {
@@ -453,13 +494,21 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     authRetryTimeoutMs: number,
     currentBucket: string,
     candidateBucket: string,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     await this.waitForEagerAuth(
       candidateBucket,
       'Foreground reauth waiting for in-flight eager auth',
       'In-flight eager auth failed before pass-3 reauth',
     );
-    if (await this.tryPassThreeTokenRecheck(currentBucket, candidateBucket)) {
+    if (isAborted(signal)) return false;
+    if (
+      await this.tryPassThreeTokenRecheck(
+        currentBucket,
+        candidateBucket,
+        signal,
+      )
+    ) {
       return true;
     }
 
@@ -468,8 +517,13 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       'Foreground reauth detected late in-flight eager auth',
       'Late in-flight eager auth failed before pass-3 reauth',
     );
+    if (isAborted(signal)) return false;
     if (
-      await this.tryFinalPassThreeTokenRecheck(currentBucket, candidateBucket)
+      await this.tryFinalPassThreeTokenRecheck(
+        currentBucket,
+        candidateBucket,
+        signal,
+      )
     ) {
       return true;
     }
@@ -478,6 +532,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       authRetryTimeoutMs,
       currentBucket,
       candidateBucket,
+      signal,
     );
   }
 
@@ -502,6 +557,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
   private async tryPassThreeTokenRecheck(
     currentBucket: string,
     candidateBucket: string,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     return this.tryTokenRecheckSwitch(
       currentBucket,
@@ -509,12 +565,14 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       'pass-3 token re-check switch',
       `Token re-check failed before pass-3 reauth for ${candidateBucket}:`,
       `Bucket failover: switched from ${currentBucket} to ${candidateBucket} after token became available`,
+      signal,
     );
   }
 
   private async tryFinalPassThreeTokenRecheck(
     currentBucket: string,
     candidateBucket: string,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     return this.tryTokenRecheckSwitch(
       currentBucket,
@@ -522,6 +580,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       'final pass-3 token re-check switch',
       `Final token re-check failed before pass-3 reauth for ${candidateBucket}:`,
       `Bucket failover: switched from ${currentBucket} to ${candidateBucket} after final token re-check`,
+      signal,
     );
   }
 
@@ -531,6 +590,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     stage: BucketSwitchStage,
     failureMessage: string,
     successMessage: string,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     let token: OAuthToken | null = null;
     try {
@@ -543,7 +603,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     }
     if (token === null) return false;
 
-    this.switchToBucket(candidateBucket, stage);
+    if (!this.switchToBucket(candidateBucket, stage, signal)) return false;
     logger.warn(() => successMessage);
     return true;
   }
@@ -552,6 +612,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     authRetryTimeoutMs: number,
     currentBucket: string,
     candidateBucket: string,
+    signal: AbortSignal | undefined,
   ): Promise<boolean> {
     try {
       logger.debug(
@@ -561,6 +622,7 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
         candidateBucket,
         authRetryTimeoutMs,
       );
+      if (isAborted(signal)) return false;
       if (authResult === 'timeout') {
         logger.debug(
           `Foreground reauth timed out after ${authRetryTimeoutMs}ms for bucket: ${candidateBucket}`,
@@ -574,12 +636,15 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
         this.provider,
         candidateBucket,
       );
+      if (isAborted(signal)) return false;
       if (token === null) {
         this.recordReauthFailure(candidateBucket);
         return false;
       }
 
-      this.switchToBucket(candidateBucket, 'pass-3 reauth');
+      if (!this.switchToBucket(candidateBucket, 'pass-3 reauth', signal)) {
+        return false;
+      }
       logger.warn(
         () =>
           `Bucket failover: switched from ${currentBucket} to ${candidateBucket} after reauth`,
@@ -605,8 +670,10 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
         `Foreground reauth failed for bucket ${candidateBucket}:`,
         reauthError,
       );
-      this.lastFailoverReasons[candidateBucket] = 'reauth-failed';
-      this.triedBucketsThisSession.add(candidateBucket);
+      if (!isAborted(signal)) {
+        this.lastFailoverReasons[candidateBucket] = 'reauth-failed';
+        this.triedBucketsThisSession.add(candidateBucket);
+      }
       return false;
     }
   }

--- a/packages/providers/src/auth/OnAuthErrorHandlerImpl.ts
+++ b/packages/providers/src/auth/OnAuthErrorHandlerImpl.ts
@@ -15,6 +15,7 @@ import type { OnAuthErrorHandler } from '@vybestack/llxprt-code-core/config/conf
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 import { createHash } from 'node:crypto';
 import type { BucketFailoverOAuthManagerLike } from './types.js';
+import { raceWithAbort } from '../utils/abortSignal.js';
 
 const logger = new DebugLogger('llxprt:auth:error-handler');
 
@@ -48,8 +49,10 @@ export class OnAuthErrorHandlerImpl implements OnAuthErrorHandler {
     providerId: string;
     profileId?: string;
     errorStatus: number;
+    signal?: AbortSignal;
   }): Promise<void> {
-    const { failedAccessToken, providerId, profileId, errorStatus } = context;
+    const { failedAccessToken, providerId, profileId, errorStatus, signal } =
+      context;
 
     logger.debug(
       () =>
@@ -64,9 +67,9 @@ export class OnAuthErrorHandlerImpl implements OnAuthErrorHandler {
     );
 
     try {
-      const refreshedToken = await this.oauthManager.forceRefreshToken(
-        providerId,
-        failedAccessToken,
+      const refreshedToken = await raceWithAbort(
+        this.oauthManager.forceRefreshToken(providerId, failedAccessToken),
+        signal,
       );
 
       if (refreshedToken) {
@@ -81,6 +84,7 @@ export class OnAuthErrorHandlerImpl implements OnAuthErrorHandler {
         );
       }
     } catch (error) {
+      if (signal?.aborted === true) throw error;
       // Log but don't throw - the retry should still proceed
       logger.debug(
         () =>

--- a/packages/providers/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
+++ b/packages/providers/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
@@ -21,6 +21,34 @@ import { BucketFailoverHandlerImpl } from '../BucketFailoverHandlerImpl.js';
 import type { BucketFailoverOAuthManagerLike } from '../types.js';
 
 describe('BucketFailoverHandlerImpl.invalidateAuthCache', () => {
+  it('rejects with cancellation when failover is pending and the request aborts', async () => {
+    const oauthManager: BucketFailoverOAuthManagerLike = {
+      getSessionBucket: vi.fn().mockReturnValue(undefined),
+      setSessionBucket: vi.fn(),
+      getTokenStore: vi.fn().mockReturnValue({
+        getToken: () => new Promise<never>(() => {}),
+      }),
+      getOAuthToken: vi.fn(),
+      authenticate: vi.fn(),
+      authenticateMultipleBuckets: vi.fn(),
+      forceRefreshToken: vi.fn(),
+    };
+    const controller = new AbortController();
+    const handler = new BucketFailoverHandlerImpl(
+      ['default'],
+      'anthropic',
+      oauthManager,
+    );
+
+    const failover = handler.tryFailover({
+      triggeringStatus: 500,
+      signal: controller.signal,
+    });
+    controller.abort(new Error('request deadline expired'));
+
+    await expect(failover).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
   it('flushes the runtime auth scope for unbucketed profiles', () => {
     const oauthManager: BucketFailoverOAuthManagerLike = {
       getSessionBucket: vi.fn().mockReturnValue(undefined),

--- a/packages/providers/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
+++ b/packages/providers/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
@@ -17,10 +17,84 @@ vi.mock('@vybestack/llxprt-code-auth', async (importOriginal) => {
 
 import { flushRuntimeAuthScope } from '@vybestack/llxprt-code-auth';
 import type { OAuthTokenRequestMetadata } from '@vybestack/llxprt-code-auth';
+import { retryWithBackoff } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { BucketFailoverHandlerImpl } from '../BucketFailoverHandlerImpl.js';
 import type { BucketFailoverOAuthManagerLike } from '../types.js';
 
+class RateLimitTestError extends Error {
+  readonly status = 429;
+}
+
 describe('BucketFailoverHandlerImpl.invalidateAuthCache', () => {
+  it('rejects with canonical cancellation without changing failover state when already aborted', async () => {
+    const oauthManager: BucketFailoverOAuthManagerLike = {
+      getSessionBucket: vi.fn().mockReturnValue(undefined),
+      setSessionBucket: vi.fn(),
+      getTokenStore: vi.fn(),
+      getOAuthToken: vi.fn(),
+      authenticate: vi.fn(),
+      authenticateMultipleBuckets: vi.fn(),
+      forceRefreshToken: vi.fn(),
+    };
+    const controller = new AbortController();
+    const reason = new Error('request already cancelled');
+    controller.abort(reason);
+    const handler = new BucketFailoverHandlerImpl(
+      ['default', 'backup'],
+      'anthropic',
+      oauthManager,
+    );
+    const bucketBeforeFailover = handler.getCurrentBucket();
+
+    await expect(
+      handler.tryFailover({ triggeringStatus: 500, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError', cause: reason });
+    expect(handler.getCurrentBucket()).toBe(bucketBeforeFailover);
+    expect(oauthManager.getTokenStore).not.toHaveBeenCalled();
+  });
+
+  it('rejects cancellation between a failed transport and persistent-rate-limit failover', async () => {
+    const oauthManager: BucketFailoverOAuthManagerLike = {
+      getSessionBucket: vi.fn().mockReturnValue(undefined),
+      setSessionBucket: vi.fn(),
+      getTokenStore: vi.fn(),
+      getOAuthToken: vi.fn(),
+      authenticate: vi.fn(),
+      authenticateMultipleBuckets: vi.fn(),
+      forceRefreshToken: vi.fn(),
+    };
+    const handler = new BucketFailoverHandlerImpl(
+      ['default', 'backup'],
+      'anthropic',
+      oauthManager,
+    );
+    const controller = new AbortController();
+    const reason = new Error('cancelled after transport failure');
+    let transports = 0;
+
+    await expect(
+      retryWithBackoff(
+        async () => {
+          transports++;
+          queueMicrotask(() => controller.abort(reason));
+          throw new RateLimitTestError('rate limited');
+        },
+        {
+          initialDelayMs: 0,
+          maxAttempts: 2,
+          signal: controller.signal,
+          onPersistent429: () =>
+            handler.tryFailover({
+              triggeringStatus: 429,
+              signal: controller.signal,
+            }),
+        },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError', cause: reason });
+    expect(transports).toBe(1);
+    expect(oauthManager.getTokenStore).not.toHaveBeenCalled();
+  });
+
   it('rejects with cancellation when failover is pending and the request aborts', async () => {
     const oauthManager: BucketFailoverOAuthManagerLike = {
       getSessionBucket: vi.fn().mockReturnValue(undefined),

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -14,6 +14,14 @@ import {
   getErrorStatus,
   isRetryableError,
 } from '@vybestack/llxprt-code-core/utils/retry.js';
+import type { StructuredErrorCategory } from '@vybestack/llxprt-code-core/core/turn.js';
+import {
+  classifyProviderError,
+  formatPublicProviderMessage,
+  getEffectiveProviderStatus,
+  getSafeProviderMessage,
+  summarizeProviderLabels,
+} from './providerErrorObservation.js';
 
 /**
  * Error thrown when authentication is required but not available
@@ -185,41 +193,67 @@ export class ProviderRuntimeScopeError extends Error {
  * Error thrown when all backends in a load balancer failover policy have failed
  * @plan PLAN-20251212issue488
  */
+export type BucketFailoverPolicy = 'eligible' | 'ineligible';
+
+export interface BucketFailoverPolicyError {
+  readonly bucketFailoverPolicy: BucketFailoverPolicy;
+}
+
+export function permitsBucketFailover(error: unknown): boolean {
+  return !(
+    typeof error === 'object' &&
+    error !== null &&
+    'bucketFailoverPolicy' in error &&
+    error.bucketFailoverPolicy === 'ineligible'
+  );
+}
+
 export class LoadBalancerFailoverError extends Error {
   readonly profileName: string;
   readonly failures: ReadonlyArray<{
     readonly profile: string;
     readonly error: Error;
   }>;
-  /**
-   * Whether the aggregate failure is retryable by the upstream backoff layer.
-   * True only when EVERY recorded failure is transient/retryable (429, 5xx,
-   * network-transient, or overload). Mixed or client-error failures → false.
-   * (issue #2450)
-   *
-   * Note: the aggregate deliberately does NOT expose an HTTP `status`. An
-   * aggregate-of-failures is not itself an HTTP 429 response, and exposing a
-   * status would cause `retryWithBackoff` to mis-route the aggregate into the
-   * bucket-failover / `onPersistent429` path (which either throws it fatally
-   * before this marker is consulted, or binds its retry count to bucket
-   * state). Recovery is driven SOLELY by this `isRetryable` marker via normal
-   * bounded retry.
-   */
   readonly isRetryable: boolean;
+  readonly bucketFailoverPolicy = 'ineligible' as const;
+  readonly status?: number;
+  readonly category?: StructuredErrorCategory;
+  readonly reason = 'retries_exhausted' as const;
 
   constructor(
     profileName: string,
     failures: Array<{ profile: string; error: Error }>,
   ) {
-    const profileNames = failures.map((f) => f.profile).join(', ') || 'none';
-    const errorSummary = summarizeFailures(failures);
+    const categories = failures.map(({ error }) =>
+      classifyProviderError(error, getErrorStatus(error)),
+    );
+    const statuses = failures.map(({ error }, index) =>
+      getEffectiveProviderStatus(
+        error,
+        getErrorStatus(error),
+        categories[index],
+      ),
+    );
+    const category = getHomogeneousValue(categories);
+    const status = getHomogeneousValue(statuses);
+    const safeProfileName = summarizeProviderLabels([profileName]);
+    const safeFailureProfiles = summarizeProviderLabels(
+      failures.map(({ profile }) => profile),
+    );
+    const failureSummary = summarizeFailures(failures);
     super(
-      `Load balancer "${profileName}" failover exhausted: ${errorSummary} (tried: ${profileNames})`,
+      formatPublicProviderMessage(
+        `Load balancer "${safeProfileName}" failover exhausted after ${failures.length} backend failures (tried: ${safeFailureProfiles})`,
+        failureSummary,
+      ),
+      { cause: failures[failures.length - 1]?.error },
     );
     this.name = 'LoadBalancerFailoverError';
     this.profileName = profileName;
     this.failures = failures;
     this.isRetryable = computeAggregateRetryable(failures);
+    this.status = status;
+    this.category = category;
   }
 }
 
@@ -258,6 +292,16 @@ function computeAggregateRetryable(
   return failures.every((f) => isTransientBackendFailure(f.error));
 }
 
+function getHomogeneousValue<T>(
+  values: ReadonlyArray<T | undefined>,
+): T | undefined {
+  const first = values[0];
+  if (first === undefined || !values.every((value) => value === first)) {
+    return undefined;
+  }
+  return first;
+}
+
 /**
  * Build a human-readable summary of per-backend failures. For a single failure
  * the underlying message is used; for multiple failures each backend name,
@@ -267,21 +311,14 @@ function computeAggregateRetryable(
 function summarizeFailures(
   failures: Array<{ profile: string; error: Error }>,
 ): string {
-  if (failures.length === 0) {
-    return 'no backend attempts were recorded';
-  }
-
-  if (failures.length === 1) {
-    return failures[0].error.message;
-  }
-
-  return failures
-    .map((failure) => {
-      const status = getErrorStatus(failure.error);
-      const statusSuffix = status !== undefined ? ` (status: ${status})` : '';
-      return `${failure.profile}: ${failure.error.message}${statusSuffix}`;
-    })
-    .join('; ');
+  if (failures.length === 0) return 'no backend attempts were recorded';
+  const displayed = failures.slice(0, 3).map(({ profile, error }) => {
+    const status = getErrorStatus(error);
+    const statusSuffix = status !== undefined ? ` (status: ${status})` : '';
+    return `${summarizeProviderLabels([profile])}: ${getSafeProviderMessage(error)}${statusSuffix}`;
+  });
+  const omitted = failures.length - displayed.length;
+  return `${displayed.join('; ')}${omitted > 0 ? `; +${omitted} more` : ''}`;
 }
 
 /**
@@ -291,13 +328,7 @@ function summarizeFailures(
  * Base class for all provider errors with consistent retry/failover behavior
  */
 export abstract class ProviderError extends Error {
-  abstract readonly category:
-    | 'rate_limit'
-    | 'quota'
-    | 'authentication'
-    | 'server_error'
-    | 'network'
-    | 'client_error';
+  abstract readonly category: StructuredErrorCategory;
   abstract readonly isRetryable: boolean;
   abstract readonly shouldFailover: boolean;
   readonly status?: number;
@@ -323,6 +354,34 @@ export class RateLimitError extends ProviderError {
   readonly category = 'rate_limit' as const;
   readonly isRetryable = true;
   readonly shouldFailover = true;
+}
+
+export class StreamCleanupTimeoutError extends ProviderError {
+  readonly category = 'server_error' as const;
+  readonly isRetryable = false;
+  readonly shouldFailover = false;
+  readonly failures: readonly Error[];
+
+  constructor(cause: Error) {
+    super('Provider stream did not stop after cancellation', { cause });
+    this.failures = [cause];
+  }
+}
+
+export class RetriesExhaustedError extends ProviderError {
+  readonly isRetryable = false;
+  readonly shouldFailover = false;
+  readonly reason = 'retries_exhausted' as const;
+  readonly failures: readonly Error[];
+
+  constructor(
+    message: string,
+    readonly category: StructuredErrorCategory,
+    options: { status?: number; cause: Error },
+  ) {
+    super(message, options);
+    this.failures = [options.cause];
+  }
 }
 
 /**
@@ -416,6 +475,10 @@ export class AllBucketsExhaustedError extends Error {
   readonly lastError: Error;
   readonly bucketFailureReasons: Record<string, BucketFailureReason>;
   readonly status?: number;
+  readonly category: StructuredErrorCategory;
+  readonly reason = 'all_buckets_exhausted' as const;
+  readonly isRetryable = false;
+  readonly failures: readonly Error[];
 
   constructor(
     providerName: string,
@@ -449,16 +512,25 @@ export class AllBucketsExhaustedError extends Error {
       : '';
 
     super(
-      `All buckets exhausted for provider '${providerName}': ${attemptedBuckets.join(', ')}` +
-        (bucketDetails ? `\n${bucketDetails}` : '') +
-        `\nLast error: ${cleanedLastErrorMsg}` +
-        reauthenticateSuffix,
+      formatPublicProviderMessage(
+        `All buckets exhausted for provider '${summarizeProviderLabels([providerName])}' after ${attemptedBuckets.length} attempts (buckets: ${summarizeProviderLabels(attemptedBuckets)})`,
+        `${bucketDetails} Last error: ${cleanedLastErrorMsg}${reauthenticateSuffix}`,
+      ),
+      { cause: lastError },
     );
     this.name = 'AllBucketsExhaustedError';
     this.attemptedBuckets = [...attemptedBuckets];
     this.lastError = lastError;
     this.bucketFailureReasons = storedReasons;
-    this.status = (lastError as { status?: number }).status;
+    const rawStatus = getErrorStatus(lastError);
+    this.category =
+      classifyProviderError(lastError, rawStatus) ?? 'client_error';
+    this.status = getEffectiveProviderStatus(
+      lastError,
+      rawStatus,
+      this.category,
+    );
+    this.failures = [lastError];
   }
 
   /**
@@ -467,17 +539,6 @@ export class AllBucketsExhaustedError extends Error {
    *      → 'Rate limited'
    */
   private static extractHumanReadableMessage(raw: string): string {
-    const jsonStart = raw.indexOf('{');
-    if (jsonStart === -1) return raw;
-    try {
-      const parsed = JSON.parse(raw.substring(jsonStart)) as {
-        error?: { message?: string; type?: string };
-        type?: string;
-      };
-      if (parsed.error?.message) return parsed.error.message;
-    } catch {
-      // Not valid JSON — use as-is
-    }
-    return raw;
+    return getSafeProviderMessage(new Error(raw));
   }
 }

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -371,6 +371,7 @@ export class StreamCleanupTimeoutError extends ProviderError {
 export class RetriesExhaustedError extends ProviderError {
   readonly isRetryable = false;
   readonly shouldFailover = false;
+  readonly bucketFailoverPolicy = 'ineligible' as const;
   readonly reason = 'retries_exhausted' as const;
   readonly failures: readonly Error[];
 

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -308,15 +308,19 @@ function getHomogeneousValue<T>(
  * message, and HTTP status (when available) are included so callers can diagnose
  * auth, rate-limit, and server issues without inspecting structured fields.
  */
+const MAX_DISPLAYED_FAILURES = 3;
+
 function summarizeFailures(
   failures: Array<{ profile: string; error: Error }>,
 ): string {
   if (failures.length === 0) return 'no backend attempts were recorded';
-  const displayed = failures.slice(0, 3).map(({ profile, error }) => {
-    const status = getErrorStatus(error);
-    const statusSuffix = status !== undefined ? ` (status: ${status})` : '';
-    return `${summarizeProviderLabels([profile])}: ${getSafeProviderMessage(error)}${statusSuffix}`;
-  });
+  const displayed = failures
+    .slice(0, MAX_DISPLAYED_FAILURES)
+    .map(({ profile, error }) => {
+      const status = getErrorStatus(error);
+      const statusSuffix = status !== undefined ? ` (status: ${status})` : '';
+      return `${summarizeProviderLabels([profile])}: ${getSafeProviderMessage(error)}${statusSuffix}`;
+    });
   const omitted = failures.length - displayed.length;
   return `${displayed.join('; ')}${omitted > 0 ? `; +${omitted} more` : ''}`;
 }
@@ -540,6 +544,6 @@ export class AllBucketsExhaustedError extends Error {
    *      → 'Rate limited'
    */
   private static extractHumanReadableMessage(raw: string): string {
-    return getSafeProviderMessage(new Error(raw));
+    return getSafeProviderMessage(raw);
   }
 }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -56,6 +56,10 @@ export {
   type TokenAccountingDiagnostics,
   type ResolvedSubProfile,
 } from './LoadBalancingProvider.js';
+export {
+  RetryOrchestrator,
+  type RetryOrchestratorConfig,
+} from './RetryOrchestrator.js';
 
 // --- Content generation ---
 export { ProviderContentGenerator } from './ProviderContentGenerator.js';

--- a/packages/providers/src/loadBalancing/backendRuntime.ts
+++ b/packages/providers/src/loadBalancing/backendRuntime.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { getErrorStatus } from '@vybestack/llxprt-code-core/utils/retry.js';
+import type { GenerateChatOptions } from '../IProvider.js';
+import {
+  claimProviderErrorObservation,
+  classifyProviderError,
+  toObservedProviderError,
+} from '../providerErrorObservation.js';
+
+export function shouldSkipBackend(
+  profileName: string,
+  tpmThreshold: number | undefined,
+  isHealthy: (name: string) => boolean,
+  shouldSkipOnTPM: (name: string, threshold: number | undefined) => boolean,
+  logger: DebugLogger,
+): boolean {
+  if (!isHealthy(profileName)) {
+    logger.debug(
+      () =>
+        `[LB:failover] Skipping unhealthy backend: ${profileName} (circuit breaker open)`,
+    );
+    return true;
+  }
+  if (shouldSkipOnTPM(profileName, tpmThreshold)) {
+    logger.debug(
+      () =>
+        `[LB:failover] Skipping backend: ${profileName} (TPM below threshold)`,
+    );
+    return true;
+  }
+  return false;
+}
+
+export function validateNotAllUnhealthy(
+  circuitBreakerEnabled: boolean,
+  profileNames: readonly string[],
+  canAttemptBackend: (name: string) => boolean,
+): void {
+  if (
+    circuitBreakerEnabled &&
+    profileNames.every((name) => !canAttemptBackend(name))
+  ) {
+    throw new Error(
+      'All backends are currently unhealthy (circuit breakers open). Please wait for recovery or check backend configurations.',
+    );
+  }
+}
+
+export function recordBackendFailure(
+  errors: Array<{ profile: string; error: Error }>,
+  profile: string,
+  error: unknown,
+): void {
+  errors.push({
+    profile,
+    error: error instanceof Error ? error : new Error(String(error)),
+  });
+}
+
+export function observeDelegateFailure(
+  options: GenerateChatOptions,
+  error: unknown,
+  logger: DebugLogger,
+): void {
+  if (!claimProviderErrorObservation(options, error)) return;
+  const status = getErrorStatus(error);
+  try {
+    options.onProviderError?.(
+      toObservedProviderError(
+        error,
+        status,
+        classifyProviderError(error, status),
+      ),
+    );
+  } catch (observerError) {
+    logger.debug(
+      () => `Provider error observer failed: ${String(observerError)}`,
+    );
+  }
+}

--- a/packages/providers/src/loadBalancing/backendRuntime.ts
+++ b/packages/providers/src/loadBalancing/backendRuntime.ts
@@ -14,6 +14,24 @@ import {
   toObservedProviderError,
 } from '../providerErrorObservation.js';
 
+export type BackendSkipReason = 'unhealthy' | 'tpm_below_threshold';
+
+export function getBackendSkipReasons(
+  profileName: string,
+  tpmThreshold: number | undefined,
+  isHealthy: (name: string) => boolean,
+  shouldSkipOnTPM: (name: string, threshold: number | undefined) => boolean,
+): BackendSkipReason[] {
+  const unhealthy = !isHealthy(profileName);
+  const belowTpmThreshold = shouldSkipOnTPM(profileName, tpmThreshold);
+  if (unhealthy && belowTpmThreshold) {
+    return ['unhealthy', 'tpm_below_threshold'];
+  }
+  if (unhealthy) return ['unhealthy'];
+  if (belowTpmThreshold) return ['tpm_below_threshold'];
+  return [];
+}
+
 export function shouldSkipBackend(
   profileName: string,
   tpmThreshold: number | undefined,
@@ -21,21 +39,20 @@ export function shouldSkipBackend(
   shouldSkipOnTPM: (name: string, threshold: number | undefined) => boolean,
   logger: DebugLogger,
 ): boolean {
-  if (!isHealthy(profileName)) {
-    logger.debug(
-      () =>
-        `[LB:failover] Skipping unhealthy backend: ${profileName} (circuit breaker open)`,
+  const reasons = getBackendSkipReasons(
+    profileName,
+    tpmThreshold,
+    isHealthy,
+    shouldSkipOnTPM,
+  );
+  for (const reason of reasons) {
+    logger.debug(() =>
+      reason === 'unhealthy'
+        ? `[LB:failover] Skipping unhealthy backend: ${profileName} (circuit breaker open)`
+        : `[LB:failover] Skipping backend: ${profileName} (TPM below threshold)`,
     );
-    return true;
   }
-  if (shouldSkipOnTPM(profileName, tpmThreshold)) {
-    logger.debug(
-      () =>
-        `[LB:failover] Skipping backend: ${profileName} (TPM below threshold)`,
-    );
-    return true;
-  }
-  return false;
+  return reasons.length > 0;
 }
 
 export function validateNotAllUnhealthy(

--- a/packages/providers/src/loadBalancing/backendRuntime.ts
+++ b/packages/providers/src/loadBalancing/backendRuntime.ts
@@ -10,6 +10,7 @@ import type { GenerateChatOptions } from '../IProvider.js';
 import {
   claimProviderErrorObservation,
   classifyProviderError,
+  invokeProviderErrorObserver,
   toObservedProviderError,
 } from '../providerErrorObservation.js';
 
@@ -70,17 +71,17 @@ export function observeDelegateFailure(
 ): void {
   if (!claimProviderErrorObservation(options, error)) return;
   const status = getErrorStatus(error);
-  try {
-    options.onProviderError?.(
-      toObservedProviderError(
-        error,
-        status,
-        classifyProviderError(error, status),
-      ),
-    );
-  } catch (observerError) {
-    logger.debug(
-      () => `Provider error observer failed: ${String(observerError)}`,
-    );
-  }
+  invokeProviderErrorObserver(
+    options.onProviderError,
+    toObservedProviderError(
+      error,
+      status,
+      classifyProviderError(error, status),
+    ),
+    (observerError) => {
+      logger.debug(
+        () => `Provider error observer failed: ${String(observerError)}`,
+      );
+    },
+  );
 }

--- a/packages/providers/src/loadBalancing/delegateAttempt.ts
+++ b/packages/providers/src/loadBalancing/delegateAttempt.ts
@@ -23,13 +23,41 @@ export function requireTransportAttempt(options: GenerateChatOptions): void {
   }
 }
 
-export function createDelegateAttempt(options: GenerateChatOptions): {
+export interface DelegateAttempt {
   readonly linked: LinkedAbortController;
   readonly options: GenerateChatOptions;
-} {
+}
+
+export function createDelegateAttempt(
+  options: GenerateChatOptions,
+): DelegateAttempt {
   const linked = createLinkedAbortController(getRequestSignal(options));
   return {
     linked,
     options: withRequestSignal(options, linked.controller.signal),
   };
+}
+
+export async function* cleanupDelegateAttempt<T>(
+  attempt: DelegateAttempt,
+  stream: AsyncIterable<T>,
+): AsyncGenerator<T> {
+  let requestFailed = false;
+  let requestFailure: unknown;
+  let cleanupFailure: unknown;
+  try {
+    yield* stream;
+  } catch (error) {
+    requestFailed = true;
+    requestFailure = error;
+  } finally {
+    attempt.linked.controller.abort();
+    try {
+      attempt.linked.dispose();
+    } catch (error) {
+      cleanupFailure = error;
+    }
+  }
+  if (requestFailed) throw requestFailure;
+  if (cleanupFailure !== undefined) throw cleanupFailure;
 }

--- a/packages/providers/src/loadBalancing/delegateAttempt.ts
+++ b/packages/providers/src/loadBalancing/delegateAttempt.ts
@@ -6,7 +6,7 @@
 
 import type { GenerateChatOptions } from '../IProvider.js';
 import { RetriesExhaustedError } from '../errors.js';
-import { consumeTransportAttempt } from '../transportAttemptBudget.js';
+import { tryConsumeTransportAttempt } from '../transportAttemptBudget.js';
 import {
   createLinkedAbortController,
   getRequestSignal,
@@ -15,7 +15,7 @@ import {
 } from '../utils/abortSignal.js';
 
 export function requireTransportAttempt(options: GenerateChatOptions): void {
-  if (!consumeTransportAttempt(options)) {
+  if (!tryConsumeTransportAttempt(options)) {
     const message = 'Transport attempt budget exhausted';
     throw new RetriesExhaustedError(message, 'server_error', {
       cause: new Error(message),

--- a/packages/providers/src/loadBalancing/delegateAttempt.ts
+++ b/packages/providers/src/loadBalancing/delegateAttempt.ts
@@ -5,6 +5,7 @@
  */
 
 import type { GenerateChatOptions } from '../IProvider.js';
+import { RetriesExhaustedError } from '../errors.js';
 import { consumeTransportAttempt } from '../transportAttemptBudget.js';
 import {
   createLinkedAbortController,
@@ -15,7 +16,10 @@ import {
 
 export function requireTransportAttempt(options: GenerateChatOptions): void {
   if (!consumeTransportAttempt(options)) {
-    throw new Error('Transport attempt budget exhausted');
+    const message = 'Transport attempt budget exhausted';
+    throw new RetriesExhaustedError(message, 'server_error', {
+      cause: new Error(message),
+    });
   }
 }
 

--- a/packages/providers/src/loadBalancing/delegateAttempt.ts
+++ b/packages/providers/src/loadBalancing/delegateAttempt.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GenerateChatOptions } from '../IProvider.js';
+import { consumeTransportAttempt } from '../transportAttemptBudget.js';
+import {
+  createLinkedAbortController,
+  getRequestSignal,
+  withRequestSignal,
+  type LinkedAbortController,
+} from '../utils/abortSignal.js';
+
+export function requireTransportAttempt(options: GenerateChatOptions): void {
+  if (!consumeTransportAttempt(options)) {
+    throw new Error('Transport attempt budget exhausted');
+  }
+}
+
+export function createDelegateAttempt(options: GenerateChatOptions): {
+  readonly linked: LinkedAbortController;
+  readonly options: GenerateChatOptions;
+} {
+  const linked = createLinkedAbortController(getRequestSignal(options));
+  return {
+    linked,
+    options: withRequestSignal(options, linked.controller.signal),
+  };
+}

--- a/packages/providers/src/loadBalancing/failoverSettings.ts
+++ b/packages/providers/src/loadBalancing/failoverSettings.ts
@@ -67,6 +67,18 @@ export function extractFailoverSettings(
 /**
  * Determine if an error should trigger failover to the next backend.
  */
+export function permitsLoadBalancerFailover(error: unknown): boolean {
+  if (
+    typeof error !== 'object' ||
+    error === null ||
+    !('reason' in error) ||
+    error.reason !== 'retries_exhausted'
+  ) {
+    return true;
+  }
+  return 'isRetryable' in error && error.isRetryable === true;
+}
+
 export function shouldFailover(
   error: unknown,
   settings: FailoverSettings,

--- a/packages/providers/src/loadBalancing/requestAbort.ts
+++ b/packages/providers/src/loadBalancing/requestAbort.ts
@@ -9,5 +9,9 @@ export function rethrowIfAborted(
   options: GenerateChatOptions,
 ): void {
   if (error instanceof Error && error.name === 'AbortError') throw error;
-  if (getRequestSignal(options)?.aborted === true) throw createAbortError();
+  if (getRequestSignal(options)?.aborted === true) {
+    const abortError = createAbortError() as Error & { cause?: unknown };
+    abortError.cause = error;
+    throw abortError;
+  }
 }

--- a/packages/providers/src/loadBalancing/requestAbort.ts
+++ b/packages/providers/src/loadBalancing/requestAbort.ts
@@ -1,0 +1,13 @@
+import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import type { GenerateChatOptions } from '../IProvider.js';
+import { getRequestSignal } from '../utils/abortSignal.js';
+
+export { getRequestSignal } from '../utils/abortSignal.js';
+
+export function rethrowIfAborted(
+  error: unknown,
+  options: GenerateChatOptions,
+): void {
+  if (error instanceof Error && error.name === 'AbortError') throw error;
+  if (getRequestSignal(options)?.aborted === true) throw createAbortError();
+}

--- a/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
+++ b/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
@@ -19,6 +19,7 @@ import type {
   LoadBalancerSubProfile,
 } from '../LoadBalancingProvider.js';
 import { isResolvedSubProfile } from '../LoadBalancingProvider.js';
+import { getRequestSignal } from '../utils/abortSignal.js';
 
 export interface OptionsBuildContext {
   lbProfileEphemeralSettings: Record<string, unknown> | undefined;
@@ -184,6 +185,7 @@ function createDelegateInvocation(
     ephemeralsSnapshot,
     telemetry: options.resolved?.telemetry,
     metadata: options.metadata,
+    signal: getRequestSignal(options),
     fallbackRuntimeId: `${ctx.providerName}:${subProfile.name}`,
   });
 }

--- a/packages/providers/src/loadBalancing/streamTimeout.ts
+++ b/packages/providers/src/loadBalancing/streamTimeout.ts
@@ -20,6 +20,17 @@ export interface AttemptCancellation {
   cancel(): void;
 }
 
+const REQUEST_TIMEOUT_ERROR_CODE = 'LLXPRT_REQUEST_TIMEOUT';
+
+export class RequestTimeoutError extends Error {
+  readonly code = REQUEST_TIMEOUT_ERROR_CODE;
+
+  constructor(readonly timeoutMs: number) {
+    super(`Request timeout after ${timeoutMs}ms`);
+    this.name = 'RequestTimeoutError';
+  }
+}
+
 function createAttemptCancellation(): AttemptCancellation {
   const controller = new AbortController();
   return {
@@ -40,7 +51,7 @@ async function waitForFirstChunk(
       return await raceWithAbort(next, signal);
     }
     const timeout = delay(timeoutMs, waitController.signal).then(() => {
-      throw new Error(`Request timeout after ${timeoutMs}ms`);
+      throw new RequestTimeoutError(timeoutMs);
     });
     return await raceWithAbort(Promise.race([next, timeout]), signal);
   } finally {
@@ -97,5 +108,14 @@ export async function* wrapWithTimeout(
 }
 
 export function isTimeoutError(error: unknown): boolean {
+  if (error instanceof RequestTimeoutError) return true;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === REQUEST_TIMEOUT_ERROR_CODE
+  ) {
+    return true;
+  }
   return error instanceof Error && error.message.includes('Request timeout');
 }

--- a/packages/providers/src/loadBalancing/streamTimeout.ts
+++ b/packages/providers/src/loadBalancing/streamTimeout.ts
@@ -15,6 +15,19 @@ import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { raceWithAbort } from '../utils/abortSignal.js';
 import { closeIteratorBeforeContinuing } from '../utils/streamCleanup.js';
 
+export interface AttemptCancellation {
+  readonly signal: AbortSignal;
+  cancel(): void;
+}
+
+function createAttemptCancellation(): AttemptCancellation {
+  const controller = new AbortController();
+  return {
+    signal: controller.signal,
+    cancel: () => controller.abort(),
+  };
+}
+
 async function waitForFirstChunk(
   iterator: AsyncIterableIterator<IContent>,
   timeoutMs: number | undefined,
@@ -40,15 +53,16 @@ export async function* wrapWithTimeout(
   timeoutMs: number | undefined,
   profileName: string,
   logger: DebugLogger,
-  attemptController: AbortController = new AbortController(),
+  attemptCancellation: AttemptCancellation = createAttemptCancellation(),
 ): AsyncGenerator<IContent> {
   let completed = false;
+  let failed = false;
   let failure: unknown;
   try {
     const firstResult = await waitForFirstChunk(
       iterator,
       timeoutMs,
-      attemptController.signal,
+      attemptCancellation.signal,
     );
     if (firstResult.done !== true) yield firstResult.value;
     for await (const chunk of { [Symbol.asyncIterator]: () => iterator }) {
@@ -56,6 +70,7 @@ export async function* wrapWithTimeout(
     }
     completed = true;
   } catch (error) {
+    failed = true;
     failure = error;
     if (isTimeoutError(error)) {
       logger.debug(
@@ -66,8 +81,17 @@ export async function* wrapWithTimeout(
     throw error;
   } finally {
     if (!completed) {
-      attemptController.abort();
-      await closeIteratorBeforeContinuing(iterator, failure);
+      let cancellationFailure: unknown;
+      try {
+        attemptCancellation.cancel();
+      } catch (error) {
+        cancellationFailure = error;
+      }
+      await closeIteratorBeforeContinuing(
+        iterator,
+        failed ? failure : cancellationFailure,
+        failed || cancellationFailure !== undefined,
+      );
     }
   }
 }

--- a/packages/providers/src/loadBalancing/streamTimeout.ts
+++ b/packages/providers/src/loadBalancing/streamTimeout.ts
@@ -7,75 +7,71 @@
 /**
  * @plan PLAN-20251212issue489 - Phase 3
  * Stream timeout wrapping for load-balancer first-chunk timeouts.
- * Extracted from LoadBalancingProvider.
  */
 
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
+import { raceWithAbort } from '../utils/abortSignal.js';
+import { closeIteratorBeforeContinuing } from '../utils/streamCleanup.js';
 
-/**
- * Wrap an async iterator with a first-chunk timeout. After the first chunk
- * arrives the timeout is cleared and the remaining chunks stream without
- * timeout.
- */
+async function waitForFirstChunk(
+  iterator: AsyncIterableIterator<IContent>,
+  timeoutMs: number | undefined,
+  signal: AbortSignal,
+): Promise<IteratorResult<IContent>> {
+  const waitController = new AbortController();
+  try {
+    const next = iterator.next();
+    if (timeoutMs === undefined || timeoutMs <= 0) {
+      return await raceWithAbort(next, signal);
+    }
+    const timeout = delay(timeoutMs, waitController.signal).then(() => {
+      throw new Error(`Request timeout after ${timeoutMs}ms`);
+    });
+    return await raceWithAbort(Promise.race([next, timeout]), signal);
+  } finally {
+    waitController.abort();
+  }
+}
+
 export async function* wrapWithTimeout(
   iterator: AsyncIterableIterator<IContent>,
   timeoutMs: number | undefined,
   profileName: string,
   logger: DebugLogger,
+  attemptController: AbortController = new AbortController(),
 ): AsyncGenerator<IContent> {
-  // Use explicit undefined check to avoid different-types-comparison
-  if (timeoutMs === undefined || timeoutMs <= 0) {
-    // Use for-await instead of yield* to ensure proper error propagation
-    // yield* can have subtle issues with error propagation in async generators
-    for await (const chunk of iterator) {
-      yield chunk;
-    }
-    return;
-  }
-
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutHandle = setTimeout(() => {
-      reject(new Error(`Request timeout after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-
+  let completed = false;
+  let failure: unknown;
   try {
-    // Race first chunk against timeout
-    const iteratorResult = iterator.next();
-    const firstResult = await Promise.race([iteratorResult, timeoutPromise]);
-
-    // Got first chunk, clear timeout
-    if (timeoutHandle !== undefined) {
-      clearTimeout(timeoutHandle);
-    }
-
-    if (firstResult.done !== true) {
-      yield firstResult.value;
-    }
-
-    // Yield remaining chunks (no timeout after first chunk)
+    const firstResult = await waitForFirstChunk(
+      iterator,
+      timeoutMs,
+      attemptController.signal,
+    );
+    if (firstResult.done !== true) yield firstResult.value;
     for await (const chunk of { [Symbol.asyncIterator]: () => iterator }) {
       yield chunk;
     }
+    completed = true;
   } catch (error) {
-    if (timeoutHandle !== undefined) {
-      clearTimeout(timeoutHandle);
+    failure = error;
+    if (isTimeoutError(error)) {
+      logger.debug(
+        () =>
+          `[LB:timeout] ${profileName}: Request timed out after ${timeoutMs}ms`,
+      );
     }
-    await iterator.return?.();
-    logger.debug(
-      () =>
-        `[LB:timeout] ${profileName}: Request timed out after ${timeoutMs}ms`,
-    );
     throw error;
+  } finally {
+    if (!completed) {
+      attemptController.abort();
+      await closeIteratorBeforeContinuing(iterator, failure);
+    }
   }
 }
 
-/**
- * Check if an error is a timeout error (message contains "Request timeout").
- */
 export function isTimeoutError(error: unknown): boolean {
   return error instanceof Error && error.message.includes('Request timeout');
 }

--- a/packages/providers/src/loadBalancing/streamTimeout.ts
+++ b/packages/providers/src/loadBalancing/streamTimeout.ts
@@ -44,12 +44,12 @@ async function waitForFirstChunk(
   timeoutMs: number | undefined,
   signal: AbortSignal,
 ): Promise<IteratorResult<IContent>> {
+  const next = iterator.next();
+  if (timeoutMs === undefined || timeoutMs <= 0) {
+    return raceWithAbort(next, signal);
+  }
   const waitController = new AbortController();
   try {
-    const next = iterator.next();
-    if (timeoutMs === undefined || timeoutMs <= 0) {
-      return await raceWithAbort(next, signal);
-    }
     const timeout = delay(timeoutMs, waitController.signal).then(() => {
       throw new RequestTimeoutError(timeoutMs);
     });

--- a/packages/providers/src/providerErrorObservation.test.ts
+++ b/packages/providers/src/providerErrorObservation.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyProviderError,
+  getEffectiveProviderStatus,
+  getSafeProviderMessage,
+  normalizePublicProviderText,
+  toObservedProviderError,
+} from './providerErrorObservation.js';
+
+describe('provider error observation', () => {
+  it('uses the provider envelope message and removes unsafe control characters', () => {
+    const observed = toObservedProviderError(
+      {
+        message: 'raw private diagnostics',
+        error: {
+          type: 'error',
+          error: {
+            type: 'rate_limit_error',
+            message: 'Safe\u0000 provider message',
+          },
+        },
+      },
+      429,
+      'rate_limit',
+    );
+
+    expect(observed).toStrictEqual({
+      message: 'Safe provider message',
+      status: 429,
+      category: 'rate_limit',
+    });
+  });
+
+  it('bounds oversized messages and safely handles malformed payloads', () => {
+    const oversized = getSafeProviderMessage(new Error('x'.repeat(2000)));
+
+    expect({
+      oversized,
+      malformed: getSafeProviderMessage({ error: { message: null } }),
+    }).toMatchObject({
+      malformed: 'Provider request failed',
+    });
+    expect(oversized.length).toBe(512);
+    expect(oversized.endsWith('…')).toBe(true);
+  });
+
+  it('truncates by Unicode code point without splitting an astral character', () => {
+    const astral = '\u{1F600}';
+    expect(normalizePublicProviderText(`ab${astral}c`, 4)).toBe(`ab${astral}c`);
+    expect(normalizePublicProviderText(`ab${astral}cd`, 4)).toBe(
+      `ab${astral}…`,
+    );
+  });
+
+  it('classifies a body-level statusless rate_limit_error and normalizes whitespace', () => {
+    const error = {
+      type: 'rate_limit_error',
+      message: '  limited\n\tby\u0000 provider  ',
+    };
+    const category = classifyProviderError(error, undefined);
+
+    expect({
+      category,
+      status: getEffectiveProviderStatus(error, undefined, category),
+      message: getSafeProviderMessage(error),
+    }).toStrictEqual({
+      category: 'rate_limit',
+      status: 429,
+      message: 'limited by provider',
+    });
+  });
+
+  it('preserves an existing structured category before status classification', () => {
+    expect(classifyProviderError({ category: 'quota' }, 429)).toBe('quota');
+  });
+
+  it('classifies status 429 as rate_limit', () => {
+    expect(classifyProviderError({}, 429)).toBe('rate_limit');
+  });
+
+  it('classifies status 402 as quota', () => {
+    expect(classifyProviderError({}, 402)).toBe('quota');
+  });
+
+  it.each([401, 403])('classifies status %i as authentication', (status) => {
+    expect(classifyProviderError({}, status)).toBe('authentication');
+  });
+
+  it.each(['overloaded_error', 'api_error'])(
+    'classifies body-level %s as server_error',
+    (type) => {
+      expect(classifyProviderError({ error: { type } }, undefined)).toBe(
+        'server_error',
+      );
+    },
+  );
+
+  it.each([500, 599])('classifies status %i as server_error', (status) => {
+    expect(classifyProviderError({}, status)).toBe('server_error');
+  });
+
+  it('classifies a transient network error as network', () => {
+    const error = Object.assign(new Error('DNS lookup failed'), {
+      code: 'ENOTFOUND',
+    });
+
+    expect(classifyProviderError(error, undefined)).toBe('network');
+  });
+
+  it.each([400, 404, 499])(
+    'classifies other status %i as client_error',
+    (status) => {
+      expect(classifyProviderError({}, status)).toBe('client_error');
+    },
+  );
+
+  it('classifies a statusless stream timeout as server_error, not rate_limit', () => {
+    expect(
+      classifyProviderError(new Error('Stream timeout occurred'), undefined),
+    ).toBe('server_error');
+  });
+
+  it('returns undefined for an unclassifiable statusless error', () => {
+    expect(
+      classifyProviderError(new Error('Unknown provider failure'), undefined),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    'authentication',
+    'server_error',
+    'network',
+    'client_error',
+  ] as const)('omits status for a statusless %s observation', (category) => {
+    const observed = toObservedProviderError(
+      { message: 'Provider failed' },
+      undefined,
+      category,
+    );
+
+    expect(observed).toStrictEqual({
+      message: 'Provider failed',
+      category,
+    });
+    expect('status' in observed).toBe(false);
+  });
+});

--- a/packages/providers/src/providerErrorObservation.test.ts
+++ b/packages/providers/src/providerErrorObservation.test.ts
@@ -9,6 +9,21 @@ import {
 } from './providerErrorObservation.js';
 
 describe('provider error observation', () => {
+  it('contains synchronous observer failure', () => {
+    const observerFailure = new Error('observer failed synchronously');
+    const onFailure = vi.fn();
+
+    invokeProviderErrorObserver(
+      () => {
+        throw observerFailure;
+      },
+      { message: 'provider failed' },
+      onFailure,
+    );
+
+    expect(onFailure).toHaveBeenCalledWith(observerFailure);
+  });
+
   it('contains asynchronous observer rejection', async () => {
     const observerFailure = new Error('observer failed asynchronously');
     const onFailure = vi.fn();

--- a/packages/providers/src/providerErrorObservation.test.ts
+++ b/packages/providers/src/providerErrorObservation.test.ts
@@ -1,13 +1,31 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   classifyProviderError,
   getEffectiveProviderStatus,
   getSafeProviderMessage,
+  invokeProviderErrorObserver,
   normalizePublicProviderText,
   toObservedProviderError,
 } from './providerErrorObservation.js';
 
 describe('provider error observation', () => {
+  it('contains asynchronous observer rejection', async () => {
+    const observerFailure = new Error('observer failed asynchronously');
+    const onFailure = vi.fn();
+
+    invokeProviderErrorObserver(
+      async () => {
+        throw observerFailure;
+      },
+      { message: 'provider failed' },
+      onFailure,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onFailure).toHaveBeenCalledWith(observerFailure);
+  });
+
   it('uses the provider envelope message and removes unsafe control characters', () => {
     const observed = toObservedProviderError(
       {

--- a/packages/providers/src/providerErrorObservation.test.ts
+++ b/packages/providers/src/providerErrorObservation.test.ts
@@ -36,7 +36,6 @@ describe('provider error observation', () => {
       onFailure,
     );
     await Promise.resolve();
-    await Promise.resolve();
 
     expect(onFailure).toHaveBeenCalledWith(observerFailure);
   });
@@ -62,6 +61,14 @@ describe('provider error observation', () => {
       status: 429,
       category: 'rate_limit',
     });
+  });
+
+  it('extracts a safe provider message directly from a string payload', () => {
+    expect(
+      getSafeProviderMessage(
+        '429 {"error":{"message":"Rate limited by provider"}}',
+      ),
+    ).toBe('Rate limited by provider');
   });
 
   it('bounds oversized messages and safely handles malformed payloads', () => {

--- a/packages/providers/src/providerErrorObservation.test.ts
+++ b/packages/providers/src/providerErrorObservation.test.ts
@@ -114,6 +114,15 @@ describe('provider error observation', () => {
     },
   );
 
+  it('treats an explicit client status as authoritative over network heuristics', () => {
+    const error = Object.assign(new Error('socket hang up'), {
+      status: 400,
+      code: 'ECONNRESET',
+    });
+
+    expect(classifyProviderError(error, 400)).toBe('client_error');
+  });
+
   it('classifies a statusless stream timeout as server_error, not rate_limit', () => {
     expect(
       classifyProviderError(new Error('Stream timeout occurred'), undefined),

--- a/packages/providers/src/providerErrorObservation.ts
+++ b/packages/providers/src/providerErrorObservation.ts
@@ -8,9 +8,11 @@ import type { GenerateChatOptions } from './IProvider.js';
 
 const PROVIDER_ERROR_OBSERVATION_CONTEXT_KEY =
   '_providerErrorObservationContext';
+const MAX_HANDLED_PRIMITIVE_ERRORS = 32;
 
 interface ProviderErrorObservationContext {
-  readonly handledErrors: Set<unknown>;
+  readonly handledObjects: WeakSet<object>;
+  readonly handledPrimitives: Set<unknown>;
 }
 
 const detachedObservationContexts = new WeakMap<
@@ -23,19 +25,75 @@ function getProviderErrorObservationContext(
 ): ProviderErrorObservationContext | undefined {
   const context = options.metadata?.[PROVIDER_ERROR_OBSERVATION_CONTEXT_KEY];
   if (typeof context !== 'object' || context === null) return undefined;
-  if (!('handledErrors' in context)) return undefined;
-  return context.handledErrors instanceof Set
-    ? { handledErrors: context.handledErrors }
-    : undefined;
+  if (!('handledObjects' in context) || !('handledPrimitives' in context)) {
+    return undefined;
+  }
+  if (
+    !(context.handledObjects instanceof WeakSet) ||
+    !(context.handledPrimitives instanceof Set)
+  ) {
+    return undefined;
+  }
+  return {
+    handledObjects: context.handledObjects,
+    handledPrimitives: context.handledPrimitives,
+  };
+}
+
+function createProviderErrorObservationContext(): ProviderErrorObservationContext {
+  return {
+    handledObjects: new WeakSet<object>(),
+    handledPrimitives: new Set<unknown>(),
+  };
+}
+
+function getOrCreateProviderErrorObservationContext(
+  options: GenerateChatOptions,
+): ProviderErrorObservationContext {
+  const attached = getProviderErrorObservationContext(options);
+  if (attached !== undefined) return attached;
+  const detached = detachedObservationContexts.get(options);
+  if (detached !== undefined) return detached;
+  const context = createProviderErrorObservationContext();
+  detachedObservationContexts.set(options, context);
+  return context;
+}
+
+function isObjectError(error: unknown): error is object {
+  return (
+    (typeof error === 'object' && error !== null) || typeof error === 'function'
+  );
+}
+
+function hasHandledError(
+  context: ProviderErrorObservationContext,
+  error: unknown,
+): boolean {
+  return isObjectError(error)
+    ? context.handledObjects.has(error)
+    : context.handledPrimitives.has(error);
+}
+
+function markHandledError(
+  context: ProviderErrorObservationContext,
+  error: unknown,
+): void {
+  if (isObjectError(error)) {
+    context.handledObjects.add(error);
+  } else {
+    if (context.handledPrimitives.size >= MAX_HANDLED_PRIMITIVE_ERRORS) {
+      const oldest = context.handledPrimitives.values().next();
+      if (oldest.done !== true) context.handledPrimitives.delete(oldest.value);
+    }
+    context.handledPrimitives.add(error);
+  }
 }
 
 export function attachProviderErrorObservationContext(
   options: GenerateChatOptions,
 ): GenerateChatOptions {
   if (getProviderErrorObservationContext(options) !== undefined) return options;
-  const context: ProviderErrorObservationContext = {
-    handledErrors: new Set<unknown>(),
-  };
+  const context = getOrCreateProviderErrorObservationContext(options);
   return {
     ...options,
     metadata: {
@@ -50,13 +108,9 @@ export function claimProviderErrorObservation(
   error: unknown,
 ): boolean {
   if (options.onProviderError === undefined) return false;
-  const context = getProviderErrorObservationContext(options) ??
-    detachedObservationContexts.get(options) ?? {
-      handledErrors: new Set<unknown>(),
-    };
-  detachedObservationContexts.set(options, context);
-  if (context.handledErrors.has(error)) return false;
-  context.handledErrors.add(error);
+  const context = getOrCreateProviderErrorObservationContext(options);
+  if (hasHandledError(context, error)) return false;
+  markHandledError(context, error);
   return true;
 }
 
@@ -65,12 +119,7 @@ export function markProviderErrorObservationHandled(
   error: unknown,
 ): void {
   if (options.onProviderError === undefined) return;
-  const context = getProviderErrorObservationContext(options) ??
-    detachedObservationContexts.get(options) ?? {
-      handledErrors: new Set<unknown>(),
-    };
-  detachedObservationContexts.set(options, context);
-  context.handledErrors.add(error);
+  markHandledError(getOrCreateProviderErrorObservationContext(options), error);
 }
 
 export function invokeProviderErrorObserver(
@@ -181,6 +230,11 @@ export function summarizeProviderLabels(values: readonly string[]): string {
 }
 
 export function getSafeProviderMessage(error: unknown): string {
+  if (typeof error === 'string') {
+    const jsonDetail = getJsonDetail(error);
+    const jsonMessage = readStringProperty(jsonDetail, 'message');
+    return normalizePublicProviderText(jsonMessage ?? error);
+  }
   const detail = unwrapTwoLevelProviderErrorEnvelope(error);
   const detailMessage =
     detail === error ? undefined : readStringProperty(detail, 'message');
@@ -219,6 +273,10 @@ function isStructuredErrorCategory(
   );
 }
 
+export function isStreamTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('Stream timeout');
+}
+
 export function classifyProviderError(
   error: unknown,
   status: number | undefined,
@@ -246,9 +304,7 @@ export function classifyProviderError(
     return 'client_error';
   }
   if (isNetworkTransientError(error)) return 'network';
-  if (error instanceof Error && error.message.includes('Stream timeout')) {
-    return 'server_error';
-  }
+  if (isStreamTimeoutError(error)) return 'server_error';
   return undefined;
 }
 

--- a/packages/providers/src/providerErrorObservation.ts
+++ b/packages/providers/src/providerErrorObservation.ts
@@ -15,9 +15,19 @@ interface ProviderErrorObservationContext {
   readonly handledPrimitives: Set<unknown>;
 }
 
+interface DetachedProviderErrorObservationContext {
+  readonly context: ProviderErrorObservationContext;
+  readonly active: boolean;
+}
+
+export interface AttachedProviderErrorObservationContext {
+  readonly options: GenerateChatOptions;
+  release(): void;
+}
+
 const detachedObservationContexts = new WeakMap<
   GenerateChatOptions,
-  ProviderErrorObservationContext
+  DetachedProviderErrorObservationContext
 >();
 
 function getProviderErrorObservationContext(
@@ -53,9 +63,9 @@ function getOrCreateProviderErrorObservationContext(
   const attached = getProviderErrorObservationContext(options);
   if (attached !== undefined) return attached;
   const detached = detachedObservationContexts.get(options);
-  if (detached !== undefined) return detached;
+  if (detached !== undefined) return detached.context;
   const context = createProviderErrorObservationContext();
-  detachedObservationContexts.set(options, context);
+  detachedObservationContexts.set(options, { context, active: false });
   return context;
 }
 
@@ -91,16 +101,46 @@ function markHandledError(
 
 export function attachProviderErrorObservationContext(
   options: GenerateChatOptions,
-): GenerateChatOptions {
-  if (getProviderErrorObservationContext(options) !== undefined) return options;
-  const context = getOrCreateProviderErrorObservationContext(options);
+): AttachedProviderErrorObservationContext {
+  if (getProviderErrorObservationContext(options) !== undefined) {
+    return { options, release: () => undefined };
+  }
+  const detached = detachedObservationContexts.get(options);
+  const context =
+    detached === undefined || detached.active
+      ? createProviderErrorObservationContext()
+      : detached.context;
+  const lifecycle = { context, active: true };
+  detachedObservationContexts.set(options, lifecycle);
+  let released = false;
   return {
-    ...options,
-    metadata: {
-      ...options.metadata,
-      [PROVIDER_ERROR_OBSERVATION_CONTEXT_KEY]: context,
+    options: {
+      ...options,
+      metadata: {
+        ...options.metadata,
+        [PROVIDER_ERROR_OBSERVATION_CONTEXT_KEY]: context,
+      },
+    },
+    release: () => {
+      if (released) return;
+      released = true;
+      if (detachedObservationContexts.get(options) === lifecycle) {
+        detachedObservationContexts.delete(options);
+      }
     },
   };
+}
+
+export async function* withProviderErrorObservationContext<T>(
+  options: GenerateChatOptions,
+  generate: (options: GenerateChatOptions) => AsyncIterableIterator<T>,
+): AsyncGenerator<T> {
+  const observation = attachProviderErrorObservationContext(options);
+  try {
+    yield* generate(observation.options);
+  } finally {
+    observation.release();
+  }
 }
 
 export function claimProviderErrorObservation(

--- a/packages/providers/src/providerErrorObservation.ts
+++ b/packages/providers/src/providerErrorObservation.ts
@@ -210,10 +210,10 @@ export function classifyProviderError(
   if (status !== undefined && status >= 500 && status < 600) {
     return 'server_error';
   }
-  if (isNetworkTransientError(error)) return 'network';
   if (status !== undefined && status >= 400 && status < 500) {
     return 'client_error';
   }
+  if (isNetworkTransientError(error)) return 'network';
   if (error instanceof Error && error.message.includes('Stream timeout')) {
     return 'server_error';
   }

--- a/packages/providers/src/providerErrorObservation.ts
+++ b/packages/providers/src/providerErrorObservation.ts
@@ -12,6 +12,11 @@ interface ProviderErrorObservationContext {
   readonly handledErrors: Set<unknown>;
 }
 
+const detachedObservationContexts = new WeakMap<
+  GenerateChatOptions,
+  ProviderErrorObservationContext
+>();
+
 function getProviderErrorObservationContext(
   options: GenerateChatOptions,
 ): ProviderErrorObservationContext | undefined {
@@ -44,8 +49,11 @@ export function claimProviderErrorObservation(
   error: unknown,
 ): boolean {
   if (options.onProviderError === undefined) return false;
-  const context = getProviderErrorObservationContext(options);
-  if (context === undefined) return true;
+  const context = getProviderErrorObservationContext(options) ??
+    detachedObservationContexts.get(options) ?? {
+      handledErrors: new Set<unknown>(),
+    };
+  detachedObservationContexts.set(options, context);
   if (context.handledErrors.has(error)) return false;
   context.handledErrors.add(error);
   return true;
@@ -56,13 +64,35 @@ export function markProviderErrorObservationHandled(
   error: unknown,
 ): void {
   if (options.onProviderError === undefined) return;
-  getProviderErrorObservationContext(options)?.handledErrors.add(error);
+  const context = getProviderErrorObservationContext(options) ??
+    detachedObservationContexts.get(options) ?? {
+      handledErrors: new Set<unknown>(),
+    };
+  detachedObservationContexts.set(options, context);
+  context.handledErrors.add(error);
+}
+
+export function invokeProviderErrorObserver(
+  observer: ((error: StructuredError) => unknown) | undefined,
+  error: StructuredError,
+  onFailure: (failure: unknown) => void,
+): void {
+  if (observer === undefined) return;
+  try {
+    const result = observer(error);
+    void Promise.resolve(result).catch(onFailure);
+  } catch (failure) {
+    onFailure(failure);
+  }
 }
 
 export const MAX_PUBLIC_PROVIDER_MESSAGE_LENGTH = 512;
 export const MAX_PUBLIC_PROVIDER_LABEL_LENGTH = 64;
 export const MAX_PUBLIC_PROVIDER_LABELS = 8;
 const FALLBACK_PROVIDER_MESSAGE = 'Provider request failed';
+const MAX_ASCII_CONTROL_CHARACTER_CODE = 31;
+const MIN_C1_CONTROL_CHARACTER_CODE = 127;
+const MAX_C1_CONTROL_CHARACTER_CODE = 159;
 
 function readStringProperty(
   value: unknown,
@@ -75,7 +105,7 @@ function readStringProperty(
   return typeof propertyValue === 'string' ? propertyValue : undefined;
 }
 
-function getProviderDetail(error: unknown): unknown {
+function unwrapTwoLevelProviderErrorEnvelope(error: unknown): unknown {
   if (typeof error !== 'object' || error === null || !('error' in error)) {
     return error;
   }
@@ -89,7 +119,9 @@ function getJsonDetail(message: string): unknown {
   const jsonStart = message.indexOf('{');
   if (jsonStart < 0) return undefined;
   try {
-    return getProviderDetail(JSON.parse(message.slice(jsonStart)));
+    return unwrapTwoLevelProviderErrorEnvelope(
+      JSON.parse(message.slice(jsonStart)),
+    );
   } catch {
     return undefined;
   }
@@ -103,7 +135,13 @@ export function normalizePublicProviderText(
   const normalized = Array.from(value)
     .map((character) => {
       const code = character.charCodeAt(0);
-      if (code <= 31 || (code >= 127 && code <= 159)) return ' ';
+      if (
+        code <= MAX_ASCII_CONTROL_CHARACTER_CODE ||
+        (code >= MIN_C1_CONTROL_CHARACTER_CODE &&
+          code <= MAX_C1_CONTROL_CHARACTER_CODE)
+      ) {
+        return ' ';
+      }
       return character;
     })
     .join('')
@@ -142,7 +180,7 @@ export function summarizeProviderLabels(values: readonly string[]): string {
 }
 
 export function getSafeProviderMessage(error: unknown): string {
-  const detail = getProviderDetail(error);
+  const detail = unwrapTwoLevelProviderErrorEnvelope(error);
   const detailMessage =
     detail === error ? undefined : readStringProperty(detail, 'message');
   if (detailMessage !== undefined)
@@ -166,7 +204,7 @@ export function getSafeProviderMessage(error: unknown): string {
 
 function getProviderType(error: unknown): string | undefined {
   return (
-    readStringProperty(getProviderDetail(error), 'type') ??
+    readStringProperty(unwrapTwoLevelProviderErrorEnvelope(error), 'type') ??
     readStringProperty(error, 'type')
   );
 }

--- a/packages/providers/src/providerErrorObservation.ts
+++ b/packages/providers/src/providerErrorObservation.ts
@@ -1,0 +1,245 @@
+import type {
+  StructuredError,
+  StructuredErrorCategory,
+} from '@vybestack/llxprt-code-core/core/turn.js';
+import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
+import type { GenerateChatOptions } from './IProvider.js';
+
+const PROVIDER_ERROR_OBSERVATION_CONTEXT_KEY =
+  '_providerErrorObservationContext';
+
+interface ProviderErrorObservationContext {
+  readonly handledErrors: Set<unknown>;
+}
+
+function getProviderErrorObservationContext(
+  options: GenerateChatOptions,
+): ProviderErrorObservationContext | undefined {
+  const context = options.metadata?.[PROVIDER_ERROR_OBSERVATION_CONTEXT_KEY];
+  if (typeof context !== 'object' || context === null) return undefined;
+  if (!('handledErrors' in context)) return undefined;
+  return context.handledErrors instanceof Set
+    ? { handledErrors: context.handledErrors }
+    : undefined;
+}
+
+export function attachProviderErrorObservationContext(
+  options: GenerateChatOptions,
+): GenerateChatOptions {
+  if (getProviderErrorObservationContext(options) !== undefined) return options;
+  const context: ProviderErrorObservationContext = {
+    handledErrors: new Set<unknown>(),
+  };
+  return {
+    ...options,
+    metadata: {
+      ...options.metadata,
+      [PROVIDER_ERROR_OBSERVATION_CONTEXT_KEY]: context,
+    },
+  };
+}
+
+export function claimProviderErrorObservation(
+  options: GenerateChatOptions,
+  error: unknown,
+): boolean {
+  if (options.onProviderError === undefined) return false;
+  const context = getProviderErrorObservationContext(options);
+  if (context === undefined) return true;
+  if (context.handledErrors.has(error)) return false;
+  context.handledErrors.add(error);
+  return true;
+}
+
+export function markProviderErrorObservationHandled(
+  options: GenerateChatOptions,
+  error: unknown,
+): void {
+  if (options.onProviderError === undefined) return;
+  getProviderErrorObservationContext(options)?.handledErrors.add(error);
+}
+
+export const MAX_PUBLIC_PROVIDER_MESSAGE_LENGTH = 512;
+export const MAX_PUBLIC_PROVIDER_LABEL_LENGTH = 64;
+export const MAX_PUBLIC_PROVIDER_LABELS = 8;
+const FALLBACK_PROVIDER_MESSAGE = 'Provider request failed';
+
+function readStringProperty(
+  value: unknown,
+  property: string,
+): string | undefined {
+  if (typeof value !== 'object' || value === null || !(property in value)) {
+    return undefined;
+  }
+  const propertyValue = (value as Record<string, unknown>)[property];
+  return typeof propertyValue === 'string' ? propertyValue : undefined;
+}
+
+function getProviderDetail(error: unknown): unknown {
+  if (typeof error !== 'object' || error === null || !('error' in error)) {
+    return error;
+  }
+  const envelope = error.error;
+  if (typeof envelope !== 'object' || envelope === null) return error;
+  if ('error' in envelope) return envelope.error;
+  return envelope;
+}
+
+function getJsonDetail(message: string): unknown {
+  const jsonStart = message.indexOf('{');
+  if (jsonStart < 0) return undefined;
+  try {
+    return getProviderDetail(JSON.parse(message.slice(jsonStart)));
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizePublicProviderText(
+  value: string,
+  maximumLength = MAX_PUBLIC_PROVIDER_MESSAGE_LENGTH,
+  fallback = FALLBACK_PROVIDER_MESSAGE,
+): string {
+  const normalized = Array.from(value)
+    .map((character) => {
+      const code = character.charCodeAt(0);
+      if (code <= 31 || (code >= 127 && code <= 159)) return ' ';
+      return character;
+    })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const safeValue = normalized === '' ? fallback : normalized;
+  const codePoints = Array.from(safeValue);
+  if (codePoints.length <= maximumLength) return safeValue;
+  return `${codePoints.slice(0, Math.max(0, maximumLength - 1)).join('')}…`;
+}
+
+export function formatPublicProviderMessage(
+  prefix: string,
+  detail?: string,
+): string {
+  const normalizedPrefix = normalizePublicProviderText(prefix);
+  const combined =
+    detail === undefined ? normalizedPrefix : `${normalizedPrefix}: ${detail}`;
+  return normalizePublicProviderText(combined);
+}
+
+export function getSafeProviderLabel(value: string): string {
+  return normalizePublicProviderText(
+    value,
+    MAX_PUBLIC_PROVIDER_LABEL_LENGTH,
+    'unknown',
+  );
+}
+
+export function summarizeProviderLabels(values: readonly string[]): string {
+  const displayed = values
+    .slice(0, MAX_PUBLIC_PROVIDER_LABELS)
+    .map(getSafeProviderLabel);
+  const omitted = values.length - displayed.length;
+  return `${displayed.join(', ') || 'none'}${omitted > 0 ? ` (+${omitted} more)` : ''}`;
+}
+
+export function getSafeProviderMessage(error: unknown): string {
+  const detail = getProviderDetail(error);
+  const detailMessage =
+    detail === error ? undefined : readStringProperty(detail, 'message');
+  if (detailMessage !== undefined)
+    return normalizePublicProviderText(detailMessage);
+
+  const directMessage = readStringProperty(error, 'message');
+  if (directMessage !== undefined) {
+    const jsonDetail = getJsonDetail(directMessage);
+    const jsonMessage = readStringProperty(jsonDetail, 'message');
+    return normalizePublicProviderText(jsonMessage ?? directMessage);
+  }
+  if (error instanceof Error) {
+    const jsonMessage = readStringProperty(
+      getJsonDetail(error.message),
+      'message',
+    );
+    return normalizePublicProviderText(jsonMessage ?? error.message);
+  }
+  return FALLBACK_PROVIDER_MESSAGE;
+}
+
+function getProviderType(error: unknown): string | undefined {
+  return (
+    readStringProperty(getProviderDetail(error), 'type') ??
+    readStringProperty(error, 'type')
+  );
+}
+
+function isStructuredErrorCategory(
+  value: unknown,
+): value is StructuredErrorCategory {
+  switch (value) {
+    case 'rate_limit':
+    case 'quota':
+    case 'authentication':
+    case 'server_error':
+    case 'network':
+    case 'client_error':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function classifyProviderError(
+  error: unknown,
+  status: number | undefined,
+): StructuredErrorCategory | undefined {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'category' in error &&
+    isStructuredErrorCategory(error.category)
+  ) {
+    return error.category;
+  }
+  const providerType = getProviderType(error);
+  if (status === 429 || providerType === 'rate_limit_error')
+    return 'rate_limit';
+  if (status === 402) return 'quota';
+  if (status === 401 || status === 403) return 'authentication';
+  if (providerType === 'overloaded_error' || providerType === 'api_error') {
+    return 'server_error';
+  }
+  if (status !== undefined && status >= 500 && status < 600) {
+    return 'server_error';
+  }
+  if (isNetworkTransientError(error)) return 'network';
+  if (status !== undefined && status >= 400 && status < 500) {
+    return 'client_error';
+  }
+  if (error instanceof Error && error.message.includes('Stream timeout')) {
+    return 'server_error';
+  }
+  return undefined;
+}
+
+export function getEffectiveProviderStatus(
+  _error: unknown,
+  status: number | undefined,
+  category: StructuredErrorCategory | undefined,
+): number | undefined {
+  if (status !== undefined) return status;
+  if (category === 'rate_limit') return 429;
+  if (category === 'quota') return 402;
+  return undefined;
+}
+
+export function toObservedProviderError(
+  error: unknown,
+  status: number | undefined,
+  category: StructuredErrorCategory | undefined,
+): StructuredError {
+  const effectiveStatus = getEffectiveProviderStatus(error, status, category);
+  return {
+    message: getSafeProviderMessage(error),
+    ...(effectiveStatus !== undefined ? { status: effectiveStatus } : {}),
+    ...(category !== undefined ? { category } : {}),
+  };
+}

--- a/packages/providers/src/providerErrorObservation.ts
+++ b/packages/providers/src/providerErrorObservation.ts
@@ -1,6 +1,7 @@
-import type {
-  StructuredError,
-  StructuredErrorCategory,
+import {
+  STRUCTURED_ERROR_CATEGORIES,
+  type StructuredError,
+  type StructuredErrorCategory,
 } from '@vybestack/llxprt-code-core/core/turn.js';
 import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import type { GenerateChatOptions } from './IProvider.js';
@@ -212,17 +213,10 @@ function getProviderType(error: unknown): string | undefined {
 function isStructuredErrorCategory(
   value: unknown,
 ): value is StructuredErrorCategory {
-  switch (value) {
-    case 'rate_limit':
-    case 'quota':
-    case 'authentication':
-    case 'server_error':
-    case 'network':
-    case 'client_error':
-      return true;
-    default:
-      return false;
-  }
+  return (
+    typeof value === 'string' &&
+    STRUCTURED_ERROR_CATEGORIES.some((category) => category === value)
+  );
 }
 
 export function classifyProviderError(

--- a/packages/providers/src/retryErrorClassification.ts
+++ b/packages/providers/src/retryErrorClassification.ts
@@ -7,7 +7,6 @@
 import type { StructuredErrorCategory } from '@vybestack/llxprt-code-core/core/turn.js';
 import {
   getErrorStatus,
-  isNetworkTransientError,
   isOverloadError,
 } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { classifyProviderError } from './providerErrorObservation.js';
@@ -27,23 +26,40 @@ export interface RetryErrorClassification {
   readonly isNetworkError: boolean;
 }
 
-export function isTerminalRetryError(error: unknown): boolean {
+const errorsAfterStreamOutput = new WeakSet<object>();
+
+function isObjectLike(value: unknown): value is object {
   return (
-    (error instanceof Error && error.name === 'AbortError') ||
-    (error as Error & { _chunksYieldedBeforeError?: boolean })
-      ._chunksYieldedBeforeError === true
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
   );
+}
+
+export function markErrorAfterStreamOutput(error: unknown): unknown {
+  if (isObjectLike(error)) {
+    errorsAfterStreamOutput.add(error);
+    return error;
+  }
+  const wrappedError = new Error(String(error)) as Error & { cause: unknown };
+  wrappedError.cause = error;
+  errorsAfterStreamOutput.add(wrappedError);
+  return wrappedError;
+}
+
+export function isTerminalRetryError(error: unknown): boolean {
+  if (error instanceof Error && error.name === 'AbortError') return true;
+  return isObjectLike(error) && errorsAfterStreamOutput.has(error);
 }
 
 export function classifyRetryError(error: unknown): RetryErrorClassification {
   const status = getErrorStatus(error);
+  const category = classifyProviderError(error, status);
   return {
     status,
-    category: classifyProviderError(error, status),
+    category,
     is429: status === 429 || isOverloadError(error),
     is402: status === 402,
     isAuthError: status === 401 || status === 403,
-    isNetworkError: isNetworkTransientError(error),
+    isNetworkError: category === 'network',
   };
 }
 

--- a/packages/providers/src/retryErrorClassification.ts
+++ b/packages/providers/src/retryErrorClassification.ts
@@ -34,6 +34,15 @@ function isObjectLike(value: unknown): value is object {
   );
 }
 
+function hasErrorName(error: unknown, expectedName: string): boolean {
+  if (!isObjectLike(error)) return false;
+  try {
+    return 'name' in error && error.name === expectedName;
+  } catch {
+    return false;
+  }
+}
+
 export function markErrorAfterStreamOutput(error: unknown): unknown {
   if (isObjectLike(error)) {
     errorsAfterStreamOutput.add(error);
@@ -46,7 +55,7 @@ export function markErrorAfterStreamOutput(error: unknown): unknown {
 }
 
 export function isTerminalRetryError(error: unknown): boolean {
-  if (error instanceof Error && error.name === 'AbortError') return true;
+  if (hasErrorName(error, 'AbortError')) return true;
   return isObjectLike(error) && errorsAfterStreamOutput.has(error);
 }
 

--- a/packages/providers/src/retryErrorClassification.ts
+++ b/packages/providers/src/retryErrorClassification.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { StructuredErrorCategory } from '@vybestack/llxprt-code-core/core/turn.js';
+import {
+  getErrorStatus,
+  isNetworkTransientError,
+  isOverloadError,
+} from '@vybestack/llxprt-code-core/utils/retry.js';
+import { classifyProviderError } from './providerErrorObservation.js';
+
+export interface RetryErrorCounters {
+  consecutive429s: number;
+  consecutiveAuthErrors: number;
+  consecutiveNetworkErrors: number;
+}
+
+export interface RetryErrorClassification {
+  readonly status: number | undefined;
+  readonly category: StructuredErrorCategory | undefined;
+  readonly is429: boolean;
+  readonly is402: boolean;
+  readonly isAuthError: boolean;
+  readonly isNetworkError: boolean;
+}
+
+export function isTerminalRetryError(error: unknown): boolean {
+  return (
+    (error instanceof Error && error.name === 'AbortError') ||
+    (error as Error & { _chunksYieldedBeforeError?: boolean })
+      ._chunksYieldedBeforeError === true
+  );
+}
+
+export function classifyRetryError(error: unknown): RetryErrorClassification {
+  const status = getErrorStatus(error);
+  return {
+    status,
+    category: classifyProviderError(error, status),
+    is429: status === 429 || isOverloadError(error),
+    is402: status === 402,
+    isAuthError: status === 401 || status === 403,
+    isNetworkError: isNetworkTransientError(error),
+  };
+}
+
+export function updateRetryErrorCounters(
+  state: RetryErrorCounters,
+  classification: RetryErrorClassification,
+): void {
+  const { is429, isAuthError, isNetworkError } = classification;
+  state.consecutive429s = is429 ? state.consecutive429s + 1 : 0;
+  state.consecutiveAuthErrors = isAuthError
+    ? state.consecutiveAuthErrors + 1
+    : 0;
+  state.consecutiveNetworkErrors =
+    isNetworkError && !is429 && !isAuthError
+      ? state.consecutiveNetworkErrors + 1
+      : 0;
+}
+
+export function resetRetryErrorCounters(state: RetryErrorCounters): void {
+  state.consecutive429s = 0;
+  state.consecutiveAuthErrors = 0;
+  state.consecutiveNetworkErrors = 0;
+}

--- a/packages/providers/src/retryExhaustion.ts
+++ b/packages/providers/src/retryExhaustion.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EmptyStreamError } from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+import type { StructuredErrorCategory } from '@vybestack/llxprt-code-core/core/turn.js';
+import { RetriesExhaustedError } from './errors.js';
+import {
+  formatPublicProviderMessage,
+  getEffectiveProviderStatus,
+  getSafeProviderMessage,
+} from './providerErrorObservation.js';
+
+export function createRetriesExhaustedError(
+  error: unknown,
+  attempts: number,
+  category: StructuredErrorCategory = 'server_error',
+  status?: number,
+): RetriesExhaustedError {
+  const effectiveStatus = getEffectiveProviderStatus(error, status, category);
+  const cause =
+    error instanceof Error ? error : new Error(getSafeProviderMessage(error));
+  return new RetriesExhaustedError(
+    formatPublicProviderMessage(
+      `Provider retries exhausted after ${attempts} transport attempts`,
+      getSafeProviderMessage(error),
+    ),
+    category,
+    { status: effectiveStatus, cause },
+  );
+}
+
+export function throwIfEmptyStreamExhaustsBudget(
+  producedContent: boolean,
+  used: number,
+  limit: number,
+): void {
+  if (producedContent || used < limit) return;
+  throw createRetriesExhaustedError(
+    new EmptyStreamError('Model stream ended immediately with no content.'),
+    used,
+  );
+}

--- a/packages/providers/src/retryRequestContext.ts
+++ b/packages/providers/src/retryRequestContext.ts
@@ -19,6 +19,24 @@ export interface RetryRequestContext {
   readonly authRetryTimeoutMs: number;
 }
 
+function positiveInteger(value: unknown, fallback: number): number {
+  const defaultValue =
+    Number.isFinite(fallback) && fallback > 0
+      ? Math.max(1, Math.floor(fallback))
+      : 1;
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.max(1, Math.floor(value))
+    : defaultValue;
+}
+
+function nonNegativeFiniteNumber(value: unknown, fallback: number): number {
+  const defaultValue =
+    Number.isFinite(fallback) && fallback >= 0 ? fallback : 0;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : defaultValue;
+}
+
 export function resolveRetryRequestContext(
   options: GenerateChatOptions,
   defaults: {
@@ -28,9 +46,10 @@ export function resolveRetryRequestContext(
   },
 ): RetryRequestContext {
   const ephemerals = options.invocation?.ephemerals;
-  const configuredAttempts =
-    (ephemerals?.['retries'] as number | undefined) ?? defaults.maxAttempts;
-  const maxAttempts = Math.max(1, Math.floor(configuredAttempts));
+  const maxAttempts = positiveInteger(
+    ephemerals?.['retries'],
+    defaults.maxAttempts,
+  );
   const budgetContext = attachTransportAttemptBudget(options, maxAttempts);
   const requestOptions = attachProviderErrorObservationContext(
     budgetContext.options,
@@ -39,11 +58,13 @@ export function resolveRetryRequestContext(
     options: requestOptions,
     budget: budgetContext.budget,
     maxAttempts,
-    initialDelayMs:
-      (ephemerals?.['retrywait'] as number | undefined) ??
+    initialDelayMs: nonNegativeFiniteNumber(
+      ephemerals?.['retrywait'],
       defaults.initialDelayMs,
-    authRetryTimeoutMs:
-      (ephemerals?.['auth-retry-timeout'] as number | undefined) ??
+    ),
+    authRetryTimeoutMs: nonNegativeFiniteNumber(
+      ephemerals?.['auth-retry-timeout'],
       defaults.authRetryTimeoutMs,
+    ),
   };
 }

--- a/packages/providers/src/retryRequestContext.ts
+++ b/packages/providers/src/retryRequestContext.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GenerateChatOptions } from './IProvider.js';
+import { attachProviderErrorObservationContext } from './providerErrorObservation.js';
+import {
+  attachTransportAttemptBudget,
+  type TransportAttemptBudget,
+} from './transportAttemptBudget.js';
+
+export interface RetryRequestContext {
+  readonly options: GenerateChatOptions;
+  readonly budget: TransportAttemptBudget;
+  readonly maxAttempts: number;
+  readonly initialDelayMs: number;
+  readonly authRetryTimeoutMs: number;
+}
+
+export function resolveRetryRequestContext(
+  options: GenerateChatOptions,
+  defaults: {
+    readonly maxAttempts: number;
+    readonly initialDelayMs: number;
+    readonly authRetryTimeoutMs: number;
+  },
+): RetryRequestContext {
+  const ephemerals = options.invocation?.ephemerals;
+  const configuredAttempts =
+    (ephemerals?.['retries'] as number | undefined) ?? defaults.maxAttempts;
+  const maxAttempts = Math.max(1, Math.floor(configuredAttempts));
+  const budgetContext = attachTransportAttemptBudget(options, maxAttempts);
+  const requestOptions = attachProviderErrorObservationContext(
+    budgetContext.options,
+  );
+  return {
+    options: requestOptions,
+    budget: budgetContext.budget,
+    maxAttempts,
+    initialDelayMs:
+      (ephemerals?.['retrywait'] as number | undefined) ??
+      defaults.initialDelayMs,
+    authRetryTimeoutMs:
+      (ephemerals?.['auth-retry-timeout'] as number | undefined) ??
+      defaults.authRetryTimeoutMs,
+  };
+}

--- a/packages/providers/src/retryRequestContext.ts
+++ b/packages/providers/src/retryRequestContext.ts
@@ -14,6 +14,7 @@ import {
 export interface RetryRequestContext {
   readonly options: GenerateChatOptions;
   readonly budget: TransportAttemptBudget;
+  readonly releaseBudget: () => void;
   readonly maxAttempts: number;
   readonly initialDelayMs: number;
   readonly authRetryTimeoutMs: number;
@@ -63,6 +64,7 @@ export function resolveRetryRequestContext(
   return {
     options: requestOptions,
     budget: budgetContext.budget,
+    releaseBudget: budgetContext.release,
     maxAttempts,
     initialDelayMs: nonNegativeFiniteNumber(
       ephemerals?.[RETRY_EPHEMERAL_KEYS.initialDelayMs],

--- a/packages/providers/src/retryRequestContext.ts
+++ b/packages/providers/src/retryRequestContext.ts
@@ -19,6 +19,12 @@ export interface RetryRequestContext {
   readonly authRetryTimeoutMs: number;
 }
 
+const RETRY_EPHEMERAL_KEYS = {
+  maxAttempts: 'retries',
+  initialDelayMs: 'retrywait',
+  authRetryTimeoutMs: 'auth-retry-timeout',
+};
+
 function positiveInteger(value: unknown, fallback: number): number {
   const defaultValue =
     Number.isFinite(fallback) && fallback > 0
@@ -47,7 +53,7 @@ export function resolveRetryRequestContext(
 ): RetryRequestContext {
   const ephemerals = options.invocation?.ephemerals;
   const maxAttempts = positiveInteger(
-    ephemerals?.['retries'],
+    ephemerals?.[RETRY_EPHEMERAL_KEYS.maxAttempts],
     defaults.maxAttempts,
   );
   const budgetContext = attachTransportAttemptBudget(options, maxAttempts);
@@ -59,11 +65,11 @@ export function resolveRetryRequestContext(
     budget: budgetContext.budget,
     maxAttempts,
     initialDelayMs: nonNegativeFiniteNumber(
-      ephemerals?.['retrywait'],
+      ephemerals?.[RETRY_EPHEMERAL_KEYS.initialDelayMs],
       defaults.initialDelayMs,
     ),
     authRetryTimeoutMs: nonNegativeFiniteNumber(
-      ephemerals?.['auth-retry-timeout'],
+      ephemerals?.[RETRY_EPHEMERAL_KEYS.authRetryTimeoutMs],
       defaults.authRetryTimeoutMs,
     ),
   };

--- a/packages/providers/src/retryRequestContext.ts
+++ b/packages/providers/src/retryRequestContext.ts
@@ -58,13 +58,16 @@ export function resolveRetryRequestContext(
     defaults.maxAttempts,
   );
   const budgetContext = attachTransportAttemptBudget(options, maxAttempts);
-  const requestOptions = attachProviderErrorObservationContext(
+  const observationContext = attachProviderErrorObservationContext(
     budgetContext.options,
   );
   return {
-    options: requestOptions,
+    options: observationContext.options,
     budget: budgetContext.budget,
-    releaseBudget: budgetContext.release,
+    releaseBudget: () => {
+      observationContext.release();
+      budgetContext.release();
+    },
     maxAttempts,
     initialDelayMs: nonNegativeFiniteNumber(
       ephemerals?.[RETRY_EPHEMERAL_KEYS.initialDelayMs],

--- a/packages/providers/src/retryTransportOwnership.ts
+++ b/packages/providers/src/retryTransportOwnership.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GenerateChatOptions, IProvider } from './IProvider.js';
+import {
+  consumeTransportAttempt,
+  type TransportAttemptBudget,
+} from './transportAttemptBudget.js';
+
+export function providerOwnsTransportAttempts(provider: IProvider): boolean {
+  return provider.transportAttemptOwnership === 'provider';
+}
+
+export function beginProviderTransportAttempt(
+  providerOwnsAttempts: boolean,
+  options: GenerateChatOptions,
+): void {
+  if (!providerOwnsAttempts) consumeTransportAttempt(options);
+}
+
+export function accountProviderAttempt(
+  provider: IProvider,
+  options: GenerateChatOptions,
+  budget: TransportAttemptBudget,
+  usedBefore: number,
+): void {
+  if (providerOwnsTransportAttempts(provider) && budget.used === usedBefore) {
+    consumeTransportAttempt(options);
+  }
+}
+
+export function createInitialRetryState(initialDelayMs: number): {
+  attempt: number;
+  currentDelay: number;
+  consecutive429s: number;
+  consecutiveAuthErrors: number;
+  consecutiveNetworkErrors: number;
+} {
+  return {
+    attempt: 0,
+    currentDelay: initialDelayMs,
+    consecutive429s: 0,
+    consecutiveAuthErrors: 0,
+    consecutiveNetworkErrors: 0,
+  };
+}

--- a/packages/providers/src/retryTransportOwnership.ts
+++ b/packages/providers/src/retryTransportOwnership.ts
@@ -6,7 +6,7 @@
 
 import type { GenerateChatOptions, IProvider } from './IProvider.js';
 import {
-  consumeTransportAttempt,
+  tryConsumeTransportAttempt,
   type TransportAttemptBudget,
 } from './transportAttemptBudget.js';
 
@@ -18,7 +18,7 @@ export function beginProviderTransportAttempt(
   providerOwnsAttempts: boolean,
   options: GenerateChatOptions,
 ): void {
-  if (!providerOwnsAttempts) consumeTransportAttempt(options);
+  if (!providerOwnsAttempts) tryConsumeTransportAttempt(options);
 }
 
 export function accountProviderAttempt(
@@ -28,7 +28,7 @@ export function accountProviderAttempt(
   usedBefore: number,
 ): void {
   if (providerOwnsTransportAttempts(provider) && budget.used === usedBefore) {
-    consumeTransportAttempt(options);
+    tryConsumeTransportAttempt(options);
   }
 }
 

--- a/packages/providers/src/runtimeNormalizer.ts
+++ b/packages/providers/src/runtimeNormalizer.ts
@@ -20,6 +20,7 @@ import { isContainerSandbox } from './utils/containerSandbox.js';
 import { PROVIDER_CONFIG_KEYS } from './providerConfigKeys.js';
 import { ProviderRuntimeNormalizationError } from './errors.js';
 import { getBaseUrlFromProvider } from './baseUrlResolver.js';
+import { isAbortSignal } from './utils/abortSignal.js';
 
 const logger = new DebugLogger('llxprt:provider:manager');
 
@@ -440,6 +441,13 @@ function readConfigUserMemory(config: Config): string | undefined {
   return configWithOptionalMemory.getUserMemory?.() ?? undefined;
 }
 
+function getAbortSignal(
+  metadata: Record<string, unknown>,
+): AbortSignal | undefined {
+  const value = metadata.abortSignal;
+  return isAbortSignal(value) ? value : undefined;
+}
+
 /** REQ-SP4-005: Build final normalized options with runtime context. */
 function buildNormalizedOptions(
   rawOptions: GenerateChatOptions,
@@ -471,23 +479,30 @@ function buildNormalizedOptions(
   const userMemorySnapshot =
     typeof userMemory === 'string' ? userMemory : configUserMemory;
 
+  const metadataSignal = getAbortSignal(metadata);
+  const existingInvocation = rawOptions.invocation;
   const invocation =
-    rawOptions.invocation ??
-    createRuntimeInvocationContext({
-      runtime: normalizedRuntime,
-      settings: settingsService,
-      providerName: targetProvider,
-      ephemeralsSnapshot: buildEphemeralsSnapshot(
-        settingsService,
-        targetProvider,
-      ),
-      telemetry: resolved.telemetry as
-        | { runtimeId: string; normalizedAt: string; provider: string }
-        | undefined,
-      metadata,
-      userMemory: userMemorySnapshot,
-      fallbackRuntimeId: runtimeId,
-    });
+    existingInvocation === undefined ||
+    (existingInvocation.signal === undefined && metadataSignal !== undefined)
+      ? createRuntimeInvocationContext({
+          runtime: normalizedRuntime,
+          settings: settingsService,
+          providerName: targetProvider,
+          ephemeralsSnapshot:
+            existingInvocation?.ephemerals ??
+            buildEphemeralsSnapshot(settingsService, targetProvider),
+          telemetry:
+            existingInvocation?.telemetry ??
+            (resolved.telemetry as
+              | { runtimeId: string; normalizedAt: string; provider: string }
+              | undefined),
+          metadata: existingInvocation?.metadata ?? metadata,
+          userMemory: existingInvocation?.userMemory ?? userMemorySnapshot,
+          redaction: existingInvocation?.redaction,
+          signal: existingInvocation?.signal ?? metadataSignal,
+          fallbackRuntimeId: existingInvocation?.runtimeId ?? runtimeId,
+        })
+      : existingInvocation;
 
   return {
     ...rawOptions,

--- a/packages/providers/src/transportAttemptBudget.ts
+++ b/packages/providers/src/transportAttemptBudget.ts
@@ -35,7 +35,9 @@ function isTransportAttemptBudget(
   if (typeof value.limit !== 'number') return false;
   if (!Number.isInteger(value.limit) || value.limit <= 0) return false;
   if (typeof value.used !== 'number') return false;
-  return Number.isInteger(value.used) && value.used >= 0;
+  return (
+    Number.isInteger(value.used) && value.used >= 0 && value.used <= value.limit
+  );
 }
 
 function getRequestContext(
@@ -130,7 +132,9 @@ export function hasTransportAttemptRemaining(
   return budget === undefined || budget.used < budget.limit;
 }
 
-export function consumeTransportAttempt(options: GenerateChatOptions): boolean {
+export function tryConsumeTransportAttempt(
+  options: GenerateChatOptions,
+): boolean {
   const budget = getTransportAttemptBudget(options);
   if (budget === undefined) return true;
   if (budget.used >= budget.limit) return false;

--- a/packages/providers/src/transportAttemptBudget.ts
+++ b/packages/providers/src/transportAttemptBudget.ts
@@ -14,6 +14,10 @@ export interface TransportAttemptBudget {
   used: number;
 }
 
+function normalizeTransportAttemptLimit(limit: number): number {
+  return Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 1;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -45,11 +49,13 @@ export function attachTransportAttemptBudget(
     return { options, budget: existing };
   }
   const budget: TransportAttemptBudget = {
-    limit: Math.max(1, Math.floor(limit)),
+    limit: normalizeTransportAttemptLimit(limit),
     used: 0,
   };
-  const requestContext = existingContext ?? {};
-  requestContext[TRANSPORT_ATTEMPT_BUDGET_KEY] = budget;
+  const requestContext = {
+    ...existingContext,
+    [TRANSPORT_ATTEMPT_BUDGET_KEY]: budget,
+  };
   return {
     options: {
       ...options,

--- a/packages/providers/src/transportAttemptBudget.ts
+++ b/packages/providers/src/transportAttemptBudget.ts
@@ -14,12 +14,18 @@ export interface TransportAttemptBudget {
   used: number;
 }
 
+interface BudgetLifecycle {
+  readonly leases: number;
+}
+
+const budgetLifecycles = new WeakMap<TransportAttemptBudget, BudgetLifecycle>();
+
 function normalizeTransportAttemptLimit(limit: number): number {
   return Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 1;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function isTransportAttemptBudget(
@@ -39,19 +45,60 @@ function getRequestContext(
   return isRecord(value) ? value : undefined;
 }
 
+export interface AttachedTransportAttemptBudget {
+  readonly options: GenerateChatOptions;
+  readonly budget: TransportAttemptBudget;
+  release(): void;
+}
+
+function acquireBudgetLifecycle(
+  budget: TransportAttemptBudget,
+): BudgetLifecycle | undefined {
+  const lifecycle = budgetLifecycles.get(budget);
+  if (lifecycle === undefined || lifecycle.leases === 0) return undefined;
+  const acquired = { leases: lifecycle.leases + 1 };
+  budgetLifecycles.set(budget, acquired);
+  return acquired;
+}
+
+function createBudgetLifecycle(budget: TransportAttemptBudget): void {
+  budgetLifecycles.set(budget, { leases: 1 });
+}
+
+function releaseBudgetLifecycle(budget: TransportAttemptBudget): () => void {
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const lifecycle = budgetLifecycles.get(budget);
+    if (lifecycle === undefined) return;
+    budgetLifecycles.set(budget, {
+      leases: Math.max(0, lifecycle.leases - 1),
+    });
+  };
+}
+
 export function attachTransportAttemptBudget(
   options: GenerateChatOptions,
   limit: number,
-): { options: GenerateChatOptions; budget: TransportAttemptBudget } {
+): AttachedTransportAttemptBudget {
   const existingContext = getRequestContext(options);
   const existing = existingContext?.[TRANSPORT_ATTEMPT_BUDGET_KEY];
   if (isTransportAttemptBudget(existing)) {
-    return { options, budget: existing };
+    const lifecycle = acquireBudgetLifecycle(existing);
+    if (lifecycle !== undefined) {
+      return {
+        options,
+        budget: existing,
+        release: releaseBudgetLifecycle(existing),
+      };
+    }
   }
   const budget: TransportAttemptBudget = {
     limit: normalizeTransportAttemptLimit(limit),
     used: 0,
   };
+  createBudgetLifecycle(budget);
   const requestContext = {
     ...existingContext,
     [TRANSPORT_ATTEMPT_BUDGET_KEY]: budget,
@@ -65,6 +112,7 @@ export function attachTransportAttemptBudget(
       },
     },
     budget,
+    release: releaseBudgetLifecycle(budget),
   };
 }
 

--- a/packages/providers/src/transportAttemptBudget.ts
+++ b/packages/providers/src/transportAttemptBudget.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GenerateChatOptions } from './IProvider.js';
+
+const RETRY_REQUEST_CONTEXT_KEY = '_retryRequestContext';
+const TRANSPORT_ATTEMPT_BUDGET_KEY = 'transportAttemptBudget';
+
+export interface TransportAttemptBudget {
+  readonly limit: number;
+  used: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isTransportAttemptBudget(
+  value: unknown,
+): value is TransportAttemptBudget {
+  if (!isRecord(value)) return false;
+  if (typeof value.limit !== 'number') return false;
+  if (!Number.isInteger(value.limit) || value.limit <= 0) return false;
+  if (typeof value.used !== 'number') return false;
+  return Number.isInteger(value.used) && value.used >= 0;
+}
+
+function getRequestContext(
+  options: GenerateChatOptions,
+): Record<string, unknown> | undefined {
+  const value = options.metadata?.[RETRY_REQUEST_CONTEXT_KEY];
+  return isRecord(value) ? value : undefined;
+}
+
+export function attachTransportAttemptBudget(
+  options: GenerateChatOptions,
+  limit: number,
+): { options: GenerateChatOptions; budget: TransportAttemptBudget } {
+  const existingContext = getRequestContext(options);
+  const existing = existingContext?.[TRANSPORT_ATTEMPT_BUDGET_KEY];
+  if (isTransportAttemptBudget(existing)) {
+    return { options, budget: existing };
+  }
+  const budget: TransportAttemptBudget = {
+    limit: Math.max(1, Math.floor(limit)),
+    used: 0,
+  };
+  const requestContext = existingContext ?? {};
+  requestContext[TRANSPORT_ATTEMPT_BUDGET_KEY] = budget;
+  return {
+    options: {
+      ...options,
+      metadata: {
+        ...options.metadata,
+        [RETRY_REQUEST_CONTEXT_KEY]: requestContext,
+      },
+    },
+    budget,
+  };
+}
+
+export function getTransportAttemptBudget(
+  options: GenerateChatOptions,
+): TransportAttemptBudget | undefined {
+  const value = getRequestContext(options)?.[TRANSPORT_ATTEMPT_BUDGET_KEY];
+  return isTransportAttemptBudget(value) ? value : undefined;
+}
+
+export function hasTransportAttemptRemaining(
+  options: GenerateChatOptions,
+): boolean {
+  const budget = getTransportAttemptBudget(options);
+  return budget === undefined || budget.used < budget.limit;
+}
+
+export function consumeTransportAttempt(options: GenerateChatOptions): boolean {
+  const budget = getTransportAttemptBudget(options);
+  if (budget === undefined) return true;
+  if (budget.used >= budget.limit) return false;
+  budget.used++;
+  return true;
+}

--- a/packages/providers/src/utils/abortSignal.ts
+++ b/packages/providers/src/utils/abortSignal.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import type { GenerateChatOptions } from '../IProvider.js';
+
+export function isAbortSignal(value: unknown): value is AbortSignal {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('aborted' in value) || typeof value.aborted !== 'boolean') return false;
+  if (
+    !('addEventListener' in value) ||
+    typeof value.addEventListener !== 'function'
+  ) {
+    return false;
+  }
+  return (
+    'removeEventListener' in value &&
+    typeof value.removeEventListener === 'function'
+  );
+}
+
+export function getRequestSignal(
+  options: Pick<GenerateChatOptions, 'invocation' | 'metadata'>,
+): AbortSignal | undefined {
+  const invocationSignal = options.invocation?.signal;
+  if (isAbortSignal(invocationSignal)) return invocationSignal;
+  const metadataSignal = options.metadata?.abortSignal;
+  return isAbortSignal(metadataSignal) ? metadataSignal : undefined;
+}
+
+export interface LinkedAbortController {
+  readonly controller: AbortController;
+  dispose(): void;
+}
+
+export function createLinkedAbortController(
+  parent?: AbortSignal,
+): LinkedAbortController {
+  const controller = new AbortController();
+  const onAbort = () => controller.abort(parent?.reason);
+  if (parent?.aborted === true) {
+    onAbort();
+  } else {
+    parent?.addEventListener('abort', onAbort, { once: true });
+  }
+  return {
+    controller,
+    dispose() {
+      parent?.removeEventListener('abort', onAbort);
+    },
+  };
+}
+
+export function withRequestSignal(
+  options: GenerateChatOptions,
+  signal: AbortSignal,
+): GenerateChatOptions {
+  return {
+    ...options,
+    invocation:
+      options.invocation === undefined
+        ? ({ signal } as GenerateChatOptions['invocation'])
+        : ({
+            ...options.invocation,
+            signal,
+          } as GenerateChatOptions['invocation']),
+    metadata: { ...options.metadata, abortSignal: signal },
+  };
+}
+
+export function raceWithAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (signal === undefined) return operation;
+  if (signal.aborted) return Promise.reject(createAbortError());
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    const dispose = () => signal.removeEventListener('abort', onAbort);
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      (value) => {
+        dispose();
+        resolve(value);
+      },
+      (error: unknown) => {
+        dispose();
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/providers/src/utils/abortSignal.ts
+++ b/packages/providers/src/utils/abortSignal.ts
@@ -76,10 +76,10 @@ export function raceWithAbort<T>(
   signal: AbortSignal | undefined,
 ): Promise<T> {
   if (signal === undefined) return operation;
-  if (signal.aborted) return Promise.reject(createAbortError());
+  if (signal.aborted) return Promise.reject(createAbortError(signal.reason));
 
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(createAbortError());
+    const onAbort = () => reject(createAbortError(signal.reason));
     const dispose = () => signal.removeEventListener('abort', onAbort);
     signal.addEventListener('abort', onAbort, { once: true });
     operation.then(

--- a/packages/providers/src/utils/abortSignal.ts
+++ b/packages/providers/src/utils/abortSignal.ts
@@ -57,6 +57,24 @@ export function createLinkedAbortController(
   };
 }
 
+export function withLegacyRequestSignal(
+  signal: AbortSignal | undefined,
+): GenerateChatOptions['invocation'] | undefined {
+  return signal === undefined
+    ? undefined
+    : ({ signal } as GenerateChatOptions['invocation']);
+}
+
+export function withOptionalRequestSignal(
+  invocation: GenerateChatOptions['invocation'],
+  signal: AbortSignal | undefined,
+): GenerateChatOptions['invocation'] | undefined {
+  if (signal === undefined) return invocation;
+  return invocation === undefined
+    ? withLegacyRequestSignal(signal)
+    : ({ ...invocation, signal } as GenerateChatOptions['invocation']);
+}
+
 export function withRequestSignal(
   options: GenerateChatOptions,
   signal: AbortSignal,

--- a/packages/providers/src/utils/abortSignal.ts
+++ b/packages/providers/src/utils/abortSignal.ts
@@ -46,9 +46,12 @@ export function createLinkedAbortController(
   } else {
     parent?.addEventListener('abort', onAbort, { once: true });
   }
+  let disposed = false;
   return {
     controller,
     dispose() {
+      if (disposed) return;
+      disposed = true;
       parent?.removeEventListener('abort', onAbort);
     },
   };

--- a/packages/providers/src/utils/abortSignal.ts
+++ b/packages/providers/src/utils/abortSignal.ts
@@ -57,37 +57,15 @@ export function createLinkedAbortController(
   };
 }
 
-export function withLegacyRequestSignal(
-  signal: AbortSignal | undefined,
-): GenerateChatOptions['invocation'] | undefined {
-  return signal === undefined
-    ? undefined
-    : ({ signal } as GenerateChatOptions['invocation']);
-}
-
-export function withOptionalRequestSignal(
-  invocation: GenerateChatOptions['invocation'],
-  signal: AbortSignal | undefined,
-): GenerateChatOptions['invocation'] | undefined {
-  if (signal === undefined) return invocation;
-  return invocation === undefined
-    ? withLegacyRequestSignal(signal)
-    : ({ ...invocation, signal } as GenerateChatOptions['invocation']);
-}
-
 export function withRequestSignal(
   options: GenerateChatOptions,
   signal: AbortSignal,
 ): GenerateChatOptions {
   return {
     ...options,
-    invocation:
-      options.invocation === undefined
-        ? ({ signal } as GenerateChatOptions['invocation'])
-        : ({
-            ...options.invocation,
-            signal,
-          } as GenerateChatOptions['invocation']),
+    ...(options.invocation === undefined
+      ? {}
+      : { invocation: { ...options.invocation, signal } }),
     metadata: { ...options.metadata, abortSignal: signal },
   };
 }
@@ -97,7 +75,10 @@ export function raceWithAbort<T>(
   signal: AbortSignal | undefined,
 ): Promise<T> {
   if (signal === undefined) return operation;
-  if (signal.aborted) return Promise.reject(createAbortError(signal.reason));
+  if (signal.aborted) {
+    void operation.catch(() => undefined);
+    return Promise.reject(createAbortError(signal.reason));
+  }
 
   return new Promise<T>((resolve, reject) => {
     const onAbort = () => reject(createAbortError(signal.reason));

--- a/packages/providers/src/utils/streamCleanup.ts
+++ b/packages/providers/src/utils/streamCleanup.ts
@@ -11,20 +11,25 @@ const STREAM_CLEANUP_TIMEOUT_MS = 1_000;
 export async function closeIteratorBeforeContinuing<T>(
   iterator: AsyncIterator<T>,
   cause: unknown,
+  preserveExistingFailure = cause !== undefined,
 ): Promise<void> {
   if (iterator.return === undefined) return;
 
   let timeoutId: NodeJS.Timeout | undefined;
-  const cleanup = Promise.resolve(iterator.return())
+  const cleanup = Promise.resolve()
+    .then(() => iterator.return?.())
     .then(() => 'closed' as const)
     .catch(() => 'closed' as const);
   const timeout = new Promise<'timeout'>((resolve) => {
     timeoutId = setTimeout(() => resolve('timeout'), STREAM_CLEANUP_TIMEOUT_MS);
   });
   try {
-    if ((await Promise.race([cleanup, timeout])) === 'timeout') {
+    if (
+      (await Promise.race([cleanup, timeout])) === 'timeout' &&
+      !preserveExistingFailure
+    ) {
       throw new StreamCleanupTimeoutError(
-        cause instanceof Error ? cause : new Error(String(cause)),
+        new Error('Stream cleanup timed out'),
       );
     }
   } finally {

--- a/packages/providers/src/utils/streamCleanup.ts
+++ b/packages/providers/src/utils/streamCleanup.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StreamCleanupTimeoutError } from '../errors.js';
+
+const STREAM_CLEANUP_TIMEOUT_MS = 1_000;
+
+export async function closeIteratorBeforeContinuing<T>(
+  iterator: AsyncIterator<T>,
+  cause: unknown,
+): Promise<void> {
+  if (iterator.return === undefined) return;
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  const cleanup = Promise.resolve(iterator.return())
+    .then(() => 'closed' as const)
+    .catch(() => 'closed' as const);
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timeoutId = setTimeout(() => resolve('timeout'), STREAM_CLEANUP_TIMEOUT_MS);
+  });
+  try {
+    if ((await Promise.race([cleanup, timeout])) === 'timeout') {
+      throw new StreamCleanupTimeoutError(
+        cause instanceof Error ? cause : new Error(String(cause)),
+      );
+    }
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}

--- a/packages/providers/src/utils/streamCleanup.ts
+++ b/packages/providers/src/utils/streamCleanup.ts
@@ -15,7 +15,7 @@ export async function closeIteratorBeforeContinuing<T>(
 ): Promise<void> {
   if (iterator.return === undefined) return;
 
-  let timeoutId: NodeJS.Timeout | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const cleanup = Promise.resolve()
     .then(() => iterator.return?.())
     .then(() => 'closed' as const)


### PR DESCRIPTION
## Summary

- preserve provider 429/quota failures when the first-response watchdog races configured retries
- enforce one transport-attempt budget across direct providers, OAuth bucket failover, load-balancer delegates, empty-stream retries, and Anthropic streaming
- propagate cancellation through retry delays, authentication/failover work, delegate requests, throttling, and iterator cleanup
- expose bounded structured status, category, and retry-exhaustion reason in JSON and stream-JSON without duplicate terminal records
- keep genuine silent-stream idle timeouts distinct and clear recovered provider observations after stream progress

## Root cause

The non-interactive streaming path had several independent retry and timeout owners. A provider could report HTTP 429 while nested SDK, provider, load-balancer, agent, or bucket retry loops continued. The 300-second first-response watchdog could then abort the stream and emit a generic idle timeout, replacing the specific provider failure. Retry budgets and abort signals were also reconstructed at several boundaries, allowing extra transport attempts and background work after cancellation.

## Implementation

- add a shared transport-attempt budget and retry-exhaustion contract
- disable Anthropic SDK/internal stream retries in favor of the central orchestrator
- classify and safely bound provider errors, including rate limit, quota, auth, network, server, and client failures
- observe load-balancer delegate failures before failover so a known 429 survives a later stall
- propagate AbortSignal through normalized invocation contexts, Anthropic requests, load-balancer delegates, auth refresh, bucket failover, and backoff
- make timeout/iterator cleanup bounded without masking the original provider error
- extend public event schemas and machine-output contracts with status/category/reason
- prevent duplicate stream-JSON terminal records and preserve canonical idle-timeout messages

## Behavioral coverage

- immediate 429
- repeated 429 through configured exhaustion
- 429 followed by success
- 429 followed by recovered content and a later genuine idle timeout
- load-balancer 429 followed by a stalled delegate
- exact transport budgets across direct, bucket, load-balancer, and empty-stream paths
- cancellation during backoff, auth refresh, bucket failover, throttling, first-chunk waits, and iterator cleanup
- JSON and stream-JSON structured error fields and single-record behavior
- genuine silent idle timeout
- safe bounded provider messages and complete category classification

## Verification

- full repository test suite passed
- npm run typecheck passed
- npm run format passed
- focused lint for all changed production/test areas passed; full lint previously passed before later reviewed additions, and all subsequent changed paths were linted
- npm run build passed
- Open Code Review ran twice with tests included; valid findings were remediated (the external review provider returned overload errors for some file subtasks)
- independent concurrency/retry review findings were remediated
- ollamakimi smoke reached the real provider and returned the new structured terminal 429 after exactly six configured transport attempts; the external account rejected the request because its monthly extra-usage limit was reached

Fixes #2559


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured error details (status, category, reason) to agent error events and machine-readable CLI output.
  * Added request-scoped hooks for provider error reporting and request context, plus abort-aware handling across streaming, retries, authentication refresh, rate-limit throttling, and failover.
* **Bug Fixes**
  * Stopped retries on terminal failures and enforced shared transport retry/failover budgets.
  * Preserved provider rate-limit/failure classification in final errors.
  * Improved cleanup when iterators/timeouts are aborted or stall, preventing deadlocks and leaked timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->