### PR TITLE
Generate trustworthy release notes (Fixes #2288)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,10 @@ on:
         default: 'main'
         type: 'string'
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   skip_check:
     name: 'Skip Duplicate Check'
@@ -154,23 +158,39 @@ jobs:
           - sandbox: ${{ github.event_name == 'push' && 'sandbox:docker' || 'NEVER_MATCH' }}
 
     steps:
-      - name: 'Checkout (fork)'
+      - name: 'Checkout trusted quota selector'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
-        if: "github.event_name == 'pull_request_target'"
         with:
-          ref: '${{ github.event.pull_request.head.sha }}'
-          repository: '${{ github.event.pull_request.head.repo.full_name }}'
-
-      - name: 'Checkout (internal)'
-        uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
-        if: "github.event_name != 'pull_request_target'"
-        with:
-          ref: '${{ github.event.inputs.branch_ref || github.ref }}'
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.base.sha || github.event.inputs.branch_ref || github.ref }}
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # ratchet:actions/setup-node@v6
         with:
           node-version: '${{ matrix.node-version }}'
+
+      - name: 'Check API quota and select optimal key'
+        id: 'quota'
+        run: node scripts/ci-quota-check.js
+        env:
+          KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
+          OPENAI_API_KEY: '${{ secrets[vars.KEY_VAR_NAME] }}'
+          OPENAI_API_KEY_2: '${{ secrets[vars.KEY_VAR_NAME_2] }}'
+
+      - name: 'Checkout PR head (fork)'
+        uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
+        if: "github.event_name == 'pull_request_target'"
+        with:
+          ref: '${{ github.event.pull_request.head.sha }}'
+          repository: '${{ github.event.pull_request.head.repo.full_name }}'
+          persist-credentials: false
+
+      - name: 'Checkout PR merge ref (internal)'
+        uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
+        if: "github.event_name == 'pull_request'"
+        with:
+          ref: '${{ github.ref }}'
+          persist-credentials: false
+          clean: false
 
       - name: 'Setup Bun'
         # npm run build below is backed by bun scripts/build.ts and requires
@@ -189,16 +209,10 @@ jobs:
         if: "matrix.sandbox == 'sandbox:docker'"
         uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
 
-      - name: 'Check API quota and select optimal key'
-        run: node scripts/ci-quota-check.js
-        env:
-          KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
-          OPENAI_API_KEY: '${{ secrets[vars.KEY_VAR_NAME] }}'
-          OPENAI_API_KEY_2: '${{ secrets[vars.KEY_VAR_NAME_2] }}'
-
       - name: 'Validate E2E provider environment (Linux)'
         shell: 'bash'
         env:
+          OPENAI_API_KEY: ${{ steps.quota.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || env.OPENAI_API_KEY || '' }}
           OPENAI_BASE_URL: '${{ vars.OPENAI_BASE_URL }}'
           LLXPRT_DEFAULT_MODEL: '${{ vars.LLXPRT_DEFAULT_MODEL }}'
           LLXPRT_DEFAULT_PROVIDER: '${{ vars.LLXPRT_DEFAULT_PROVIDER }}'
@@ -213,8 +227,7 @@ jobs:
       - name: 'Run E2E tests'
         env:
           # Provider configuration from repository secrets/variables
-          # OPENAI_API_KEY is set via GITHUB_ENV by quota check step
-          OPENAI_API_KEY_2: '${{ secrets[vars.KEY_VAR_NAME_2] }}'
+          OPENAI_API_KEY: ${{ steps.quota.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || env.OPENAI_API_KEY || '' }}
           KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
           OPENAI_BASE_URL: '${{ vars.OPENAI_BASE_URL }}'
           LLXPRT_DEFAULT_MODEL: '${{ vars.LLXPRT_DEFAULT_MODEL }}'
@@ -268,23 +281,39 @@ jobs:
     runs-on: 'macos-latest'
     continue-on-error: true
     steps:
-      - name: 'Checkout (fork)'
+      - name: 'Checkout trusted quota selector'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
-        if: "github.event_name == 'pull_request_target'"
         with:
-          ref: '${{ github.event.pull_request.head.sha }}'
-          repository: '${{ github.event.pull_request.head.repo.full_name }}'
-
-      - name: 'Checkout (internal)'
-        uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
-        if: "github.event_name != 'pull_request_target'"
-        with:
-          ref: '${{ github.event.inputs.branch_ref || github.ref }}'
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.base.sha || github.event.inputs.branch_ref || github.ref }}
 
       - name: 'Set up Node.js 24.x'
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # ratchet:actions/setup-node@v6
         with:
           node-version: '24.x'
+
+      - name: 'Check API quota and select optimal key (macOS)'
+        id: 'quota_macos'
+        run: node scripts/ci-quota-check.js
+        env:
+          KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
+          OPENAI_API_KEY: '${{ secrets[vars.KEY_VAR_NAME] }}'
+          OPENAI_API_KEY_2: '${{ secrets[vars.KEY_VAR_NAME_2] }}'
+
+      - name: 'Checkout PR head (fork)'
+        uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
+        if: "github.event_name == 'pull_request_target'"
+        with:
+          ref: '${{ github.event.pull_request.head.sha }}'
+          repository: '${{ github.event.pull_request.head.repo.full_name }}'
+          persist-credentials: false
+
+      - name: 'Checkout PR merge ref (internal)'
+        uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
+        if: "github.event_name == 'pull_request'"
+        with:
+          ref: '${{ github.ref }}'
+          persist-credentials: false
+          clean: false
 
       - name: 'Setup Bun'
         # npm run build below is backed by bun scripts/build.ts and requires
@@ -304,16 +333,10 @@ jobs:
         run: |
           npm cache clean --force
 
-      - name: 'Check API quota and select optimal key (macOS)'
-        run: node scripts/ci-quota-check.js
-        env:
-          KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
-          OPENAI_API_KEY: '${{ secrets[vars.KEY_VAR_NAME] }}'
-          OPENAI_API_KEY_2: '${{ secrets[vars.KEY_VAR_NAME_2] }}'
-
       - name: 'Validate E2E provider environment (macOS)'
         shell: 'bash'
         env:
+          OPENAI_API_KEY: ${{ steps.quota_macos.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota_macos.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || env.OPENAI_API_KEY || '' }}
           OPENAI_BASE_URL: '${{ vars.OPENAI_BASE_URL }}'
           LLXPRT_DEFAULT_MODEL: '${{ vars.LLXPRT_DEFAULT_MODEL }}'
           LLXPRT_DEFAULT_PROVIDER: '${{ vars.LLXPRT_DEFAULT_PROVIDER }}'
@@ -329,8 +352,7 @@ jobs:
         if: "runner.os != 'Windows'"
         env:
           # Provider configuration from repository secrets/variables
-          # OPENAI_API_KEY is set via GITHUB_ENV by quota check step
-          OPENAI_API_KEY_2: '${{ secrets[vars.KEY_VAR_NAME_2] }}'
+          OPENAI_API_KEY: ${{ steps.quota_macos.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota_macos.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || env.OPENAI_API_KEY || '' }}
           KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
           OPENAI_BASE_URL: '${{ vars.OPENAI_BASE_URL }}'
           LLXPRT_DEFAULT_MODEL: '${{ vars.LLXPRT_DEFAULT_MODEL }}'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -36,10 +36,6 @@ jobs:
       PR_NUMBER: '${{ github.event.pull_request.number }}'
       GH_TOKEN: '${{ github.token }}'
       GITHUB_TOKEN: '${{ github.token }}'
-      # OPENAI_API_KEY is set via GITHUB_ENV by quota check step below
-      # Initial value from secrets will be overridden if quota check succeeds
-      OPENAI_API_KEY: '${{ secrets[vars.KEY_VAR_NAME] }}'
-      OPENAI_API_KEY_2: '${{ secrets[vars.KEY_VAR_NAME_2] }}'
       OPENAI_BASE_URL: '${{ vars.OPENAI_BASE_URL }}'
       LLXPRT_DEFAULT_MODEL: '${{ vars.LLXPRT_DEFAULT_MODEL }}'
       LLXPRT_DEFAULT_PROVIDER: '${{ vars.LLXPRT_DEFAULT_PROVIDER }}'
@@ -193,6 +189,7 @@ jobs:
 
       - name: 'Check API quota and select optimal key'
         if: steps.issue_gate.outputs.should_review == 'true'
+        id: 'quota'
         run: node scripts/ci-quota-check.js
         env:
           KEY_VAR_NAME: '${{ vars.KEY_VAR_NAME }}'
@@ -416,6 +413,8 @@ jobs:
       - name: 'Run LLxprt review'
         if: steps.issue_gate.outputs.should_review == 'true'
         id: 'llxprt'
+        env:
+          OPENAI_API_KEY: ${{ steps.quota.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || '' }}
         run: |
           set -euo pipefail
           llxprt_log="review/llxprt.log"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,6 @@ on:
         description: 'The version to release (e.g., v0.1.11). Required for manual patch releases.'
         required: false # Not required for scheduled runs
         type: string
-      ref:
-        description: 'The branch or ref (full git sha) to release from.'
-        required: true
-        type: string
-        default: 'main'
       dry_run:
         description: >-
           Run a dry-run of the release process; no branches, npm packages or GitHub
@@ -60,6 +55,7 @@ jobs:
     # See: https://github.com/lovell/sharp/issues/4351
     # Can revert to ubuntu-latest once sharp fixes Ubuntu 24.04 support
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     environment:
       name: production-release
       url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.version.outputs.RELEASE_TAG }}
@@ -72,6 +68,7 @@ jobs:
       packages: write
       id-token: write
       issues: write # For creating issues on failure
+      pull-requests: read # For enrichment (gh api GraphQL on PR metadata)
     outputs:
       RELEASE_TAG: ${{ steps.version.outputs.RELEASE_TAG }}
 
@@ -193,7 +190,11 @@ jobs:
           echo "should_create_branch=${should_create_branch}" >> "$GITHUB_OUTPUT"
 
       - name: Check API quota and select optimal key
-        if: github.event.inputs.force_skip_tests != 'true'
+        id: quota
+        if: >-
+          github.event.inputs.force_skip_tests != 'true' ||
+          (github.event.inputs.dry_run != 'true' && github.event.inputs.publish_vscode_only != 'true')
+        continue-on-error: ${{ github.event.inputs.force_skip_tests == 'true' }}
         run: node scripts/ci-quota-check.js
         env:
           KEY_VAR_NAME: ${{ vars.KEY_VAR_NAME }}
@@ -204,8 +205,7 @@ jobs:
         if: github.event.inputs.force_skip_tests != 'true'
         run: node scripts/preflight-ci.js
         env:
-          # Provider configuration from repository secrets/variables
-          # OPENAI_API_KEY is set via GITHUB_ENV by quota check step
+          OPENAI_API_KEY: ${{ steps.quota.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || '' }}
           OPENAI_API_KEY_2: ${{ secrets[vars.KEY_VAR_NAME_2] }}
           KEY_VAR_NAME: ${{ vars.KEY_VAR_NAME }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
@@ -221,8 +221,7 @@ jobs:
           # Skipping Docker tests due to flakiness
           # npm run test:integration:sandbox:docker
         env:
-          # Provider configuration from repository secrets/variables
-          # OPENAI_API_KEY is set via GITHUB_ENV by quota check step
+          OPENAI_API_KEY: ${{ steps.quota.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || '' }}
           OPENAI_API_KEY_2: ${{ secrets[vars.KEY_VAR_NAME_2] }}
           KEY_VAR_NAME: ${{ vars.KEY_VAR_NAME }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
@@ -297,6 +296,21 @@ jobs:
             exit 1
           fi
           echo "VSIX_PATH=$VSIX_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Release Notes
+        if: ${{ steps.vars.outputs.should_run_standard_release == 'true' && steps.vars.outputs.is_dry_run == 'false' }}
+        id: release_notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.version.outputs.RELEASE_TAG }}
+          IS_NIGHTLY: ${{ steps.vars.outputs.is_nightly }}
+          KEY_VAR_NAME: ${{ vars.KEY_VAR_NAME }}
+          LLXPRT_DEFAULT_PROVIDER: ${{ vars.LLXPRT_DEFAULT_PROVIDER }}
+          LLXPRT_DEFAULT_MODEL: ${{ vars.LLXPRT_DEFAULT_MODEL }}
+          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+          OPENAI_API_KEY: ${{ steps.quota.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.quota.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || '' }}
+        run: bun scripts/generate-release-notes.ts
 
       - name: Publish VS Code extension
         if: ${{ steps.vars.outputs.should_publish_vscode == 'true' && steps.vars.outputs.is_dry_run == 'false' }}
@@ -433,162 +447,6 @@ jobs:
           build-args: |
             CLI_VERSION_ARG=${{ steps.version.outputs.RELEASE_VERSION }}
 
-      - name: Generate Release Notes
-        if: ${{ steps.vars.outputs.should_run_standard_release == 'true' && steps.vars.outputs.is_dry_run == 'false' }}
-        id: release_notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Get the last stable release tag (excluding pre-release tags)
-          LAST_STABLE_TAG=$(git tag -l 'v*' | grep -v '\-' | sort -V | tail -n 1)
-          if [ -z "$LAST_STABLE_TAG" ]; then
-            # If no stable tag, get the most recent tag
-            LAST_STABLE_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-
-          fi
-          if [ -z "$LAST_STABLE_TAG" ]; then
-            echo "No previous release tag found, using first commit"
-            LAST_STABLE_TAG=$(git rev-list --max-parents=0 HEAD)
-          fi
-
-          # Save last tag for comparison link
-          echo "LAST_TAG=$LAST_STABLE_TAG" >> "$GITHUB_OUTPUT"
-
-          # Get commit messages since last tag
-          echo "Getting commits from $LAST_STABLE_TAG to HEAD"
-          git log --pretty=format:"- %s (%h)" "$LAST_STABLE_TAG"..HEAD > commits.txt
-
-          # Start building the release notes with static header and installation
-          {
-            echo "## Release ${{ steps.version.outputs.RELEASE_TAG }}"
-            echo ""
-          } > release-notes.md
-
-          # Static installation instructions - always the same format
-          {
-            echo "### Installation"
-            echo ""
-            echo "Install or upgrade LLxprt Code using npm:"
-            echo ""
-            echo '```bash'
-            echo "npm install -g @vybestack/llxprt-code"
-            echo '```'
-            echo ""
-            echo "Or use directly with npx:"
-            echo ""
-            echo '```bash'
-            echo "npx @vybestack/llxprt-code"
-            echo '```'
-            echo ""
-          } >> release-notes.md
-
-          # Generate feature summary with LLxprt or fall back to basic format
-          echo "Attempting to generate feature summary with LLxprt Code..."
-
-          # Create a focused prompt for feature extraction only
-          PROMPT="Analyze the following git commits and identify ONLY the user-facing features and bug fixes worth highlighting.
-
-          Write your analysis to a file called 'features.md' with ONLY a '### What's New' section containing a bulleted list of the most important user-facing changes.
-
-          Here are the commits since $LAST_STABLE_TAG:
-          $(cat commits.txt)
-
-          RULES:
-          1. ONLY include features that directly affect users:
-             - New AI provider support or model support
-             - New command-line flags or options
-             - Performance improvements users will notice
-             - Bug fixes for user-facing issues
-             - New tools or tool improvements
-             - UI/UX improvements
-             - New capabilities or features
-
-          2. EXCLUDE these entirely:
-             - Test file changes
-             - Internal refactoring
-             - Build system changes
-             - CI/CD updates
-             - Dependency updates (unless they add new features)
-             - Documentation updates (unless for new features)
-             - Development tooling changes
-             - Any bugs that were both introduced AND fixed in this same release
-
-          3. Write concise, clear bullet points that explain the benefit to users
-          4. NO EMOJIS
-          5. If there are no user-facing changes, write 'No major user-facing changes in this release.'
-
-          Use the write_file tool to save ONLY the feature list to 'features.md'."
-
-          # Try LLxprt generation for features
-          set +e
-          npx @vybestack/llxprt-code@latest \
-            --provider ${{ vars.LLXPRT_DEFAULT_PROVIDER }} \
-            --model ${{ vars.LLXPRT_DEFAULT_MODEL }} \
-            --key "${{ secrets[vars.KEY_VAR_NAME] }}" \
-            --baseurl ${{ vars.OPENAI_BASE_URL }} \
-            --yolo \
-            --prompt "$PROMPT" > /dev/null 2>&1
-          LLXPRT_EXIT=$?
-          set -e
-
-          # Add features section if generation succeeded
-          if [ $LLXPRT_EXIT -eq 0 ] && [ -s features.md ]; then
-            echo "Adding LLxprt-generated feature summary"
-            cat features.md >> release-notes.md
-            echo "" >> release-notes.md
-          else
-            echo "Skipping feature summary (LLxprt generation failed)"
-          fi
-
-          # Gather contributor acknowledgements (exclude maintainer acoliver)
-          echo "Collecting contributor acknowledgements..."
-          PR_NUMBERS=$(git log "$LAST_STABLE_TAG"..HEAD --merges --pretty='%s' | sed -n 's/.*#\([0-9]\+\).*/\1/p' | sort -u)
-          CONTRIBUTORS=""
-          for PR_NUMBER in $PR_NUMBERS; do
-            if [ -z "$PR_NUMBER" ]; then
-              continue
-            fi
-            LOGIN=$(gh pr view "$PR_NUMBER" --json author --jq '.author.login' 2>/dev/null || echo "")
-            if [ -n "$LOGIN" ] && [ "$LOGIN" != "acoliver" ]; then
-              CONTRIBUTORS="${CONTRIBUTORS}"$'\n'"$LOGIN"
-            fi
-          done
-
-          CONTRIBUTORS=$(printf "%s\n" "$CONTRIBUTORS" | sed '/^$/d' | sort -u)
-          if [ -n "$CONTRIBUTORS" ]; then
-            {
-              echo "### Thanks"
-              echo ""
-              echo "Huge thanks to the following contributors for their pull requests in this release:"
-              echo ""
-            } >> release-notes.md
-            while IFS= read -r contributor; do
-              echo "- @$contributor" >> release-notes.md
-            done <<< "$CONTRIBUTORS"
-            echo "" >> release-notes.md
-          else
-            echo "No external contributors to acknowledge for this release."
-          fi
-
-          # Always add the full commit list
-          {
-            echo "### All Changes"
-            echo ""
-          } >> release-notes.md
-          cat commits.txt >> release-notes.md
-
-          # Add comparison link if we have a real previous tag
-          if [[ "$LAST_STABLE_TAG" != $(git rev-list --max-parents=0 HEAD) ]]; then
-            {
-              echo ""
-              echo "---"
-              echo ""
-              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LAST_STABLE_TAG}...${{ steps.version.outputs.RELEASE_TAG }}"
-            } >> release-notes.md
-          fi
-
-          echo "Release notes generated"
-
       - name: Create GitHub Release and Tag
         if: ${{ steps.vars.outputs.should_run_standard_release == 'true' && steps.vars.outputs.is_dry_run == 'false' }}
         env:
@@ -605,7 +463,7 @@ jobs:
           if [[ "$SHOULD_CREATE_BRANCH" == "true" && -n "$RELEASE_BRANCH" ]]; then
             TARGET_REF="$RELEASE_BRANCH"
           else
-            TARGET_REF="${{ github.sha }}"
+            TARGET_REF="$(git rev-parse HEAD)"
           fi
 
           # Ship the source-containing CLI npm tarball as the release asset

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "release:version": "bun scripts/version.ts",
     "telemetry": "bun scripts/telemetry.ts",
     "check:lockfile": "bun scripts/check-lockfile.ts",
-    "clean": "bun scripts/clean.ts"
+    "clean": "bun scripts/clean.ts",
+    "generate:release-notes": "bun scripts/generate-release-notes.ts"
   },
   "overrides": {
     "@tootallnate/once": "3.0.1",

--- a/packages/agents/src/core/clientToolGovernance.ts
+++ b/packages/agents/src/core/clientToolGovernance.ts
@@ -57,21 +57,22 @@ export function getToolGovernanceEphemerals(config: Config):
       disabled?: string[];
     }
   | undefined {
-  const allowedList = readToolList(config.getEphemeralSetting('tools.allowed'));
+  const rawAllowed = config.getEphemeralSetting('tools.allowed');
+  const allowedList = readToolList(rawAllowed);
   const disabledList = readToolList(
     config.getEphemeralSetting('tools.disabled') ??
       config.getEphemeralSetting('disabled-tools'),
   );
 
-  const hasAllowed = allowedList.length > 0;
+  const allowedExplicit = Array.isArray(rawAllowed);
   const hasDisabled = disabledList.length > 0;
 
-  if (!hasAllowed && !hasDisabled) {
+  if (!allowedExplicit && !hasDisabled) {
     return undefined;
   }
 
   return {
-    allowed: hasAllowed ? allowedList : undefined,
+    allowed: allowedExplicit ? allowedList : undefined,
     disabled: hasDisabled ? disabledList : undefined,
   };
 }

--- a/packages/cli/src/config/__tests__/toolGovernanceParity.test.ts
+++ b/packages/cli/src/config/__tests__/toolGovernanceParity.test.ts
@@ -313,6 +313,14 @@ async function runConfig(settings: Settings, argv: string[] = []) {
   );
 }
 
+function emptyToolInlineProfile(): string {
+  return JSON.stringify({
+    provider: 'openai',
+    model: 'test-model',
+    ephemeralSettings: { 'tools.allowed': [] },
+  });
+}
+
 // ─── Suite ────────────────────────────────────────────────────────────────────
 
 describe('toolGovernanceParity: interactive mode', () => {
@@ -369,6 +377,13 @@ describe('toolGovernanceParity: interactive mode', () => {
     expect(config.getExcludeTools()).not.toContain(ShellTool.Name);
     expect(config.getExcludeTools()).not.toContain(EditTool.Name);
     expect(config.getExcludeTools()).not.toContain(WriteFileTool.Name);
+  });
+
+  it('interactive inline profile preserves an explicit empty allowlist', async () => {
+    process.stdin.isTTY = true;
+    const config = await runConfig({}, ['--profile', emptyToolInlineProfile()]);
+
+    expect(config.getEphemeralSetting('tools.allowed')).toStrictEqual([]);
   });
 });
 
@@ -581,6 +596,24 @@ describe('toolGovernanceParity: tool policy - non-interactive allowed sets', () 
     expect(allowed).toBeUndefined();
   });
 
+  it.each([
+    ['default', []],
+    ['yolo', ['--yolo']],
+  ])(
+    'non-interactive %s inline profile preserves an explicit empty allowlist',
+    async (_mode, modeArgs) => {
+      process.stdin.isTTY = false;
+      const config = await runConfig({}, [
+        '-p',
+        'test',
+        ...modeArgs,
+        '--profile',
+        emptyToolInlineProfile(),
+      ]);
+
+      expect(config.getEphemeralSetting('tools.allowed')).toStrictEqual([]);
+    },
+  );
   it('READ_ONLY_TOOL_NAMES contains expected read-only tools', () => {
     expect(READ_ONLY_TOOL_NAMES).toContain('read_file');
     expect(READ_ONLY_TOOL_NAMES).toContain('glob');

--- a/packages/cli/src/config/postConfigRuntime.test.ts
+++ b/packages/cli/src/config/postConfigRuntime.test.ts
@@ -137,6 +137,23 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
     expect(resolveStreamIdleTimeoutMs(config)).toBe(120_000);
   });
 
+  it('does not reapply profile tool allowlists after governance', () => {
+    const config = createCapturingConfig();
+
+    applyGlobalAndProfileEphemeralSettings({
+      config,
+      bootstrapArgs: { profileJson: '{"provider":"openai"}' },
+      argv: { provider: undefined },
+      settings: {},
+      profileSettingsWithTools: {
+        'tools.allowed': ['release_notes_no_tools'],
+      },
+      profileLoadResult: { profileToLoad: undefined },
+    });
+
+    expect(config.getEphemeralSetting('tools.allowed')).toBeUndefined();
+  });
+
   it('applies profile ephemerals when profileJson is provided without profileToLoad', () => {
     const config = createCapturingConfig();
 

--- a/packages/cli/src/config/postConfigRuntime.ts
+++ b/packages/cli/src/config/postConfigRuntime.ts
@@ -12,7 +12,10 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { DebugLogger } from '@vybestack/llxprt-code-telemetry';
 import { ProfileManager } from '@vybestack/llxprt-code-settings';
-import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import type {
+  EphemeralSettings,
+  SettingsService,
+} from '@vybestack/llxprt-code-settings';
 import {
   getCliRuntimeContext,
   setCliRuntimeContext,
@@ -49,7 +52,7 @@ export interface PostConfigInput {
   readonly bootstrapArgs: BootstrapProfileArgs;
   readonly argv: CliArgs;
   readonly settings: Settings;
-  readonly profileSettingsWithTools: Settings;
+  readonly profileSettingsWithTools: Settings & EphemeralSettings;
   readonly profileLoadResult: ProfileLoadResult;
   readonly providerModelResult: ProviderModelResult;
   readonly defaultDisabledTools: readonly string[];
@@ -110,7 +113,7 @@ interface ProfileEphemeralSettingsInput {
   readonly bootstrapArgs: Pick<BootstrapProfileArgs, 'profileJson'>;
   readonly argv: Pick<CliArgs, 'provider'>;
   readonly settings: Settings;
-  readonly profileSettingsWithTools: Settings;
+  readonly profileSettingsWithTools: Settings & EphemeralSettings;
   readonly profileLoadResult: Pick<ProfileLoadResult, 'profileToLoad'>;
 }
 
@@ -421,9 +424,9 @@ function applyToolPolicies(input: ApplyToolPoliciesInput): void {
       : (profileSettingsWithTools.allowedTools ?? []),
   );
 
-  const profileAllowedTools = buildNormalizedToolSet(
-    config.getEphemeralSetting('tools.allowed'),
-  );
+  const rawProfileAllowedTools = profileSettingsWithTools['tools.allowed'];
+  const profileAllowedExplicit = Array.isArray(rawProfileAllowedTools);
+  const profileAllowedTools = buildNormalizedToolSet(rawProfileAllowedTools);
 
   const applyPolicy = (allowedSet: Set<string> | undefined): void => {
     if (allowedSet === undefined) {
@@ -440,7 +443,7 @@ function applyToolPolicies(input: ApplyToolPoliciesInput): void {
 
   if (interactive !== true && experimentalAcp !== true) {
     if (approvalMode === ApprovalMode.YOLO) {
-      if (profileAllowedTools.size > 0 || explicitAllowedTools.size > 0) {
+      if (profileAllowedExplicit || explicitAllowedTools.size > 0) {
         const finalAllowed = new Set(profileAllowedTools);
         explicitAllowedTools.forEach((tool) => finalAllowed.add(tool));
         applyPolicy(finalAllowed);
@@ -456,16 +459,15 @@ function applyToolPolicies(input: ApplyToolPoliciesInput): void {
         baseAllowed.add(EDIT_TOOL_NAME);
       }
 
-      const finalAllowed =
-        profileAllowedTools.size > 0
-          ? new Set(
-              [...baseAllowed].filter((tool) => profileAllowedTools.has(tool)),
-            )
-          : baseAllowed;
+      const finalAllowed = profileAllowedExplicit
+        ? new Set(
+            [...baseAllowed].filter((tool) => profileAllowedTools.has(tool)),
+          )
+        : baseAllowed;
 
       applyPolicy(finalAllowed);
     }
-  } else if (profileAllowedTools.size > 0 || explicitAllowedTools.size > 0) {
+  } else if (profileAllowedExplicit || explicitAllowedTools.size > 0) {
     const finalAllowed = new Set(profileAllowedTools);
     explicitAllowedTools.forEach((tool) => finalAllowed.add(tool));
     applyPolicy(finalAllowed);

--- a/packages/core/src/runtime/AgentRuntimeLoader.ts
+++ b/packages/core/src/runtime/AgentRuntimeLoader.ts
@@ -109,6 +109,7 @@ function hydrateContentGeneratorConfig(
 
 type ToolGovernance = {
   allowed: Set<string>;
+  allowedExplicit: boolean;
   disabled: Set<string>;
   excluded: Set<string>;
 };
@@ -128,6 +129,7 @@ function buildToolGovernance(
     allowed: new Set(
       (allowedRaw ?? []).map((tool) => normalizeToolName(tool) ?? tool),
     ),
+    allowedExplicit: allowedRaw !== undefined,
     disabled: new Set(
       (disabledRaw ?? []).map((tool) => normalizeToolName(tool) ?? tool),
     ),
@@ -148,7 +150,7 @@ function isToolPermitted(
   if (governance.disabled.has(canonical)) {
     return false;
   }
-  if (governance.allowed.size > 0 && !governance.allowed.has(canonical)) {
+  if (governance.allowedExplicit && !governance.allowed.has(canonical)) {
     return false;
   }
   return true;

--- a/packages/tools/src/tools/tool-registry.ts
+++ b/packages/tools/src/tools/tool-registry.ts
@@ -22,6 +22,11 @@ import { ToolErrorType } from '../types/tool-error.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { normalizeToolName } from '../formatters/toolNameUtils.js';
+import {
+  buildToolGovernance,
+  isToolBlocked,
+  type ToolGovernance,
+} from '../formatters/toolGovernanceUtils.js';
 
 export const DISCOVERED_TOOL_PREFIX = 'discovered_tool_';
 
@@ -287,70 +292,16 @@ export class ToolRegistry {
     this.messageBus = messageBus;
   }
 
-  private getToolGovernance(): {
-    allowed: Set<string>;
-    disabled: Set<string>;
-    excluded: Set<string>;
-  } {
-    const rawEphemerals =
-      typeof this.config.getEphemeralSettings === 'function'
-        ? (this.config.getEphemeralSettings() as
-            | Record<string, unknown>
-            | null
-            | undefined
-            | false
-            | 0
-            | '')
-        : undefined;
-
-    const ephemerals: Record<string, unknown> =
-      resolveEphemerals(rawEphemerals);
-
-    const allowedRaw = Array.isArray(ephemerals['tools.allowed'])
-      ? (ephemerals['tools.allowed'] as string[])
-      : [];
-
-    function resolveDisabled(ephemeralsMap: Record<string, unknown>): string[] {
-      if (Array.isArray(ephemeralsMap['tools.disabled'])) {
-        return ephemeralsMap['tools.disabled'] as string[];
-      }
-      if (Array.isArray(ephemeralsMap['disabled-tools'])) {
-        return ephemeralsMap['disabled-tools'] as string[];
-      }
-      return [];
-    }
-
-    const disabledRaw = resolveDisabled(ephemerals);
-    const excludedRaw = this.config.getExcludeTools?.() ?? [];
-
-    return {
-      allowed: new Set(
-        allowedRaw.map((name) => normalizeToolName(name) ?? name),
-      ),
-      disabled: new Set(
-        disabledRaw.map((name) => normalizeToolName(name) ?? name),
-      ),
-      excluded: new Set(
-        excludedRaw.map((name) => normalizeToolName(name) ?? name),
-      ),
-    };
+  private getToolGovernance(): ToolGovernance {
+    return buildToolGovernance({
+      getEphemeralSettings: () =>
+        this.config.getEphemeralSettings?.() ?? undefined,
+      getExcludeTools: () => this.config.getExcludeTools?.(),
+    });
   }
 
-  private isToolActive(
-    toolName: string,
-    governance: ReturnType<ToolRegistry['getToolGovernance']>,
-  ): boolean {
-    const canonical = normalizeToolName(toolName) ?? toolName;
-    if (governance.excluded.has(canonical)) {
-      return false;
-    }
-    if (governance.disabled.has(canonical)) {
-      return false;
-    }
-    if (governance.allowed.size > 0 && !governance.allowed.has(canonical)) {
-      return false;
-    }
-    return true;
+  private isToolActive(toolName: string, governance: ToolGovernance): boolean {
+    return !isToolBlocked(toolName, governance);
   }
 
   /**
@@ -817,22 +768,4 @@ export class ToolRegistry {
       this.discoveryLock = null;
     }
   }
-}
-
-type EphemeralValue =
-  | Record<string, unknown>
-  | null
-  | undefined
-  | false
-  | 0
-  | '';
-
-function resolveEphemerals(raw: EphemeralValue): Record<string, unknown> {
-  if (raw === null || raw === undefined || raw === false || raw === 0) {
-    return {};
-  }
-  if (raw === '') {
-    return {};
-  }
-  return raw;
 }

--- a/scripts/ci-quota-check.js
+++ b/scripts/ci-quota-check.js
@@ -3,13 +3,13 @@
  * CI Quota Check Script
  *
  * Checks API quota for both keys and selects the one with lower usage.
- * Writes the selected key to GITHUB_ENV for downstream steps.
+ * Writes only the selected key identifier to GITHUB_OUTPUT for downstream steps.
  *
  * Environment Variables:
  *   KEY_VAR_NAME - The name of the primary key variable (checked for "SYNTHETIC")
  *   OPENAI_API_KEY - Primary API key to check
  *   OPENAI_API_KEY_2 - Secondary API key to check
- *   GITHUB_ENV - Path to GitHub Actions environment file
+ *   GITHUB_OUTPUT - Path to GitHub Actions output file
  *
  * Exit codes:
  *   0 - Success (quota check completed, key selected or skipped)
@@ -17,21 +17,50 @@
  */
 
 import fs from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Returns true when the value contains CR or LF characters. Such characters
+ * are not valid in API keys and must never reach external requests.
+ */
+function containsNewline(value) {
+  return value.includes('\r') || value.includes('\n');
+}
+
+/**
+ * Rejects a key that contains CR/LF characters before any GITHUB_ENV or
+ * GITHUB_OUTPUT write. Throws to abort the process so no tainted write
+ * occurs. Called in both Synthetic and non-Synthetic paths.
+ */
+function assertKeySafe(key, label) {
+  if (containsNewline(key)) {
+    throw new Error(
+      `${label} contains CR/LF characters and is not a valid API key.`,
+    );
+  }
+}
+
+function writeSelectedKeyOutput(selectedKeyName) {
+  const githubOutputPath = process.env.GITHUB_OUTPUT;
+  if (githubOutputPath) {
+    fs.appendFileSync(githubOutputPath, `selected_key=${selectedKeyName}\n`);
+  }
+}
 
 async function checkQuota(apiKey, keyName) {
   if (!apiKey) return null;
 
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000);
+  assertKeySafe(apiKey, keyName);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
 
+  try {
     const response = await fetch('https://api.synthetic.new/v2/quotas', {
       method: 'GET',
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: controller.signal,
     });
-
-    clearTimeout(timeoutId);
 
     if (!response.ok) {
       console.log(
@@ -41,35 +70,33 @@ async function checkQuota(apiKey, keyName) {
     }
 
     const data = await response.json();
-
+    const limit = data.subscription?.limit;
+    const requests = data.subscription?.requests;
     if (
-      !data.subscription ||
-      typeof data.subscription.limit !== 'number' ||
-      typeof data.subscription.requests !== 'number'
+      !Number.isSafeInteger(limit) ||
+      limit <= 0 ||
+      !Number.isSafeInteger(requests) ||
+      requests < 0
     ) {
-      console.log(`${keyName} quota response missing required fields`);
+      console.log(`${keyName} quota response has invalid counters`);
       return null;
     }
 
-    if (data.subscription.limit <= 0) {
-      console.log(`${keyName} quota response has non-positive limit`);
-      return null;
-    }
-
-    const usagePercent =
-      (data.subscription.requests / data.subscription.limit) * 100;
+    const usagePercent = (requests / limit) * 100;
     console.log(
-      `${keyName}: ${usagePercent.toFixed(1)}% used (${data.subscription.requests}/${data.subscription.limit})`,
+      `${keyName}: ${usagePercent.toFixed(1)}% used (${requests}/${limit})`,
     );
 
     return { usagePercent, key: apiKey };
   } catch (e) {
     console.log(`${keyName} quota check error: ${e.message}`);
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
-async function selectOptimalKey() {
+export async function selectOptimalKey() {
   const key1 = process.env.OPENAI_API_KEY;
   const key2 = process.env.OPENAI_API_KEY_2;
 
@@ -81,32 +108,31 @@ async function selectOptimalKey() {
   const quota1 = await checkQuota(key1, 'Key 1');
   const quota2 = await checkQuota(key2, 'Key 2');
 
-  // If both keys are >90% used, fail
-  if (
-    quota1 &&
-    quota1.usagePercent > 90 &&
-    quota2 &&
-    quota2.usagePercent > 90
-  ) {
-    console.error('Both API keys are over 90% quota usage');
-    process.exit(1);
+  const usable1 = quota1?.usagePercent <= 90 ? quota1 : null;
+  const usable2 = quota2?.usagePercent <= 90 ? quota2 : null;
+
+  if (!usable1 && !usable2 && (quota1 || quota2)) {
+    throw new Error('No verified API key is at or below 90% quota usage');
   }
 
-  let selectedKey = key1;
-  let reason = 'using primary key (default)';
+  let selectedKey;
+  let reason;
 
   if (!quota1 && !quota2) {
-    reason = 'quota checks failed, using primary key';
-  } else if (!quota1) {
+    selectedKey = key1 || key2;
+    reason = 'quota checks failed, using first configured key';
+  } else if (!usable1) {
     selectedKey = key2;
-    reason = 'key1 check failed, using key2';
-  } else if (!quota2 || !key2) {
-    reason = 'key2 not available, using key1';
-  } else if (quota2.usagePercent < quota1.usagePercent) {
+    reason = 'key1 unavailable or over quota, using key2';
+  } else if (!usable2) {
+    selectedKey = key1;
+    reason = 'key2 unavailable or over quota, using key1';
+  } else if (usable2.usagePercent < usable1.usagePercent) {
     selectedKey = key2;
-    reason = `key2 has lower usage (${quota2.usagePercent.toFixed(1)}% vs ${quota1.usagePercent.toFixed(1)}%)`;
+    reason = `key2 has lower usage (${usable2.usagePercent.toFixed(1)}% vs ${usable1.usagePercent.toFixed(1)}%)`;
   } else {
-    reason = `key1 has lower or equal usage (${quota1.usagePercent.toFixed(1)}% vs ${quota2.usagePercent.toFixed(1)}%)`;
+    selectedKey = key1;
+    reason = `key1 has lower or equal usage (${usable1.usagePercent.toFixed(1)}% vs ${usable2.usagePercent.toFixed(1)}%)`;
   }
 
   console.log(`Selected: ${reason}`);
@@ -116,45 +142,40 @@ async function selectOptimalKey() {
     process.exit(1);
   }
 
-  // Export to GITHUB_ENV
-  const githubEnvPath = process.env.GITHUB_ENV;
-  if (!githubEnvPath) {
-    console.error('GITHUB_ENV environment variable not set');
-    process.exit(1);
-  }
+  assertKeySafe(selectedKey, 'Selected API key');
 
-  fs.appendFileSync(githubEnvPath, `OPENAI_API_KEY=${selectedKey}\n`);
+  const selectedKeyName = selectedKey === key2 ? 'secondary' : 'primary';
+  writeSelectedKeyOutput(selectedKeyName);
 }
 
-async function main() {
+export async function main() {
   const keyVarName = process.env.KEY_VAR_NAME || '';
-  const githubEnvPath = process.env.GITHUB_ENV;
-
-  if (!githubEnvPath) {
-    console.error('GITHUB_ENV environment variable not set');
-    process.exit(1);
-  }
 
   if (keyVarName.includes('SYNTHETIC')) {
     console.log('Using Synthetic provider, checking quota...');
     await selectOptimalKey();
   } else {
     console.log('Not using Synthetic provider, using primary key');
-    // For non-Synthetic providers, just write the primary key to GITHUB_ENV
-    const primaryKey = process.env.OPENAI_API_KEY;
+    // For non-Synthetic providers, use the first configured key
+    const primaryKey =
+      process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY_2;
     if (!primaryKey || primaryKey.trim() === '') {
-      console.error('No primary API key configured');
+      console.error('No API key configured');
       process.exit(1);
     }
-    fs.appendFileSync(
-      githubEnvPath,
-      `OPENAI_API_KEY=${primaryKey}
-`,
-    );
+    assertKeySafe(primaryKey, 'Primary API key');
+    const selectedKeyName =
+      primaryKey === process.env.OPENAI_API_KEY_2 ? 'secondary' : 'primary';
+    writeSelectedKeyOutput(selectedKeyName);
   }
 }
 
-main().catch((e) => {
-  console.error('Quota selection failed:', e.message);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((e) => {
+    console.error('Quota selection failed:', e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateReleaseNotes } from './release-notes/orchestrator.js';
+import {
+  selectDiffBase,
+  nightlyCandidateNames,
+} from './release-notes/diff-selection.js';
+import { loadCuratedHeadline } from './release-notes/curated-headline.js';
+import {
+  getCommits,
+  getAllCommits,
+  listTags,
+  createTopologyResolver,
+  getRootCommit,
+} from './release-notes/git-port.js';
+import { createGhPort, MAX_ENRICHED_REFS } from './release-notes/gh-port.js';
+import { createLlmPort } from './release-notes/llm-port.js';
+import { createNullLlmPort } from './release-notes/null-llm-port.js';
+import {
+  createReleaseMetadataPort,
+  createBoundedReleaseMetadataLookup,
+} from './release-notes/release-metadata-port.js';
+import { computeContributors } from './release-notes/contributors.js';
+import type { EnrichedRef, GhPort, LlmPort } from './release-notes/types.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+interface EnvConfig {
+  readonly releaseTag: string;
+  readonly isNightly: boolean;
+  readonly repository: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly apiKey: string;
+  readonly keyfilePath: string | undefined;
+  readonly baseUrl: string | undefined;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Required environment variable ${name} is not set.`);
+  }
+  return value;
+}
+
+/**
+ * Reads the API key from a keyfile path when provided (supported secure
+ * mechanism via the CLI `--keyfile` flag), falling back to the OPENAI_API_KEY
+ * environment variable. Returns an empty string when neither is available,
+ * which selects the deterministic null-LLM fallback path.
+ *
+ * Keys containing CR/LF characters are rejected: a newline in the key would
+ * corrupt the keyfile (each line becomes a separate token) and can break
+ * downstream auth headers.
+ */
+function readApiKey(): { key: string; keyfilePath: string | undefined } {
+  const keyfileEnv = process.env.OPENAI_API_KEY_FILE;
+  if (keyfileEnv !== undefined && keyfileEnv.length > 0) {
+    try {
+      const key = readFileSync(keyfileEnv, 'utf-8').trim();
+      if (key.length > 0 && !hasNewline(key)) {
+        return { key, keyfilePath: resolve(keyfileEnv) };
+      }
+    } catch {
+      // Fall through to env-based key.
+    }
+  }
+  const envKey = process.env.OPENAI_API_KEY ?? '';
+  if (hasNewline(envKey)) {
+    return { key: '', keyfilePath: undefined };
+  }
+  return { key: envKey, keyfilePath: undefined };
+}
+
+/**
+ * Returns true when the value contains CR or LF characters. Such characters
+ * are not valid in API keys and would corrupt keyfile writes or auth headers.
+ */
+function hasNewline(value: string): boolean {
+  return value.includes('\r') || value.includes('\n');
+}
+
+function readEnvConfig(): EnvConfig {
+  const { key, keyfilePath } = readApiKey();
+  return {
+    releaseTag: requireEnv('RELEASE_TAG'),
+    isNightly: process.env.IS_NIGHTLY === 'true',
+    repository: requireEnv('GITHUB_REPOSITORY'),
+    provider: process.env.LLXPRT_DEFAULT_PROVIDER ?? '',
+    model: process.env.LLXPRT_DEFAULT_MODEL ?? '',
+    apiKey: key,
+    keyfilePath,
+    baseUrl: process.env.OPENAI_BASE_URL,
+  };
+}
+
+function createCachedGhPort(delegate: GhPort): GhPort {
+  const cache = new Map<number, EnrichedRef>();
+  const attempted = new Set<number>();
+  return {
+    async fetchRefs(numbers) {
+      const remainingBudget = Math.max(0, MAX_ENRICHED_REFS - attempted.size);
+      const missing = numbers
+        .filter((number) => !attempted.has(number))
+        .slice(0, remainingBudget);
+      if (missing.length > 0) {
+        for (const number of missing) {
+          attempted.add(number);
+        }
+        const fetched = await delegate.fetchRefs(missing);
+        for (const [number, ref] of fetched) {
+          cache.set(number, ref);
+        }
+      }
+      const result = new Map<number, EnrichedRef>();
+      for (const number of numbers) {
+        const ref = cache.get(number);
+        if (ref !== undefined) {
+          result.set(number, ref);
+        }
+      }
+      return result;
+    },
+  };
+}
+
+function createConfiguredLlmPort(config: EnvConfig): LlmPort {
+  const provider = config.provider.trim();
+  const model = config.model.trim();
+  const apiKey = config.apiKey.trim();
+  if (provider.length === 0 || model.length === 0 || apiKey.length === 0) {
+    return createNullLlmPort();
+  }
+  return createLlmPort({
+    provider,
+    model,
+    apiKey,
+    keyfilePath: config.keyfilePath,
+    baseUrl: config.baseUrl,
+    temperature: 0.1,
+  });
+}
+
+async function main(): Promise<void> {
+  const config = readEnvConfig();
+  const tags = listTags();
+  const nightlyCandidates = config.isNightly
+    ? nightlyCandidateNames(tags, config.releaseTag)
+    : [];
+  const releaseMetadataLookup = config.isNightly
+    ? await createBoundedReleaseMetadataLookup(
+        createReleaseMetadataPort(),
+        nightlyCandidates,
+      )
+    : undefined;
+  const diffBase = selectDiffBase(
+    tags,
+    config.releaseTag,
+    config.isNightly,
+    releaseMetadataLookup,
+  );
+  let lastTag: string;
+  let isFirstRelease: boolean;
+  if (diffBase !== null) {
+    lastTag = diffBase;
+    isFirstRelease = false;
+  } else {
+    const rootCommit = getRootCommit();
+    if (rootCommit === null) {
+      throw new Error(
+        `No suitable diff base tag found for ${config.releaseTag}, and the repository has no root commit.`,
+      );
+    }
+    lastTag = rootCommit;
+    isFirstRelease = true;
+  }
+
+  const rawCommits = isFirstRelease ? getAllCommits() : getCommits(lastTag);
+  const ghPort = createCachedGhPort(createGhPort(config.repository));
+  const releaseContributors = await computeContributors(ghPort, rawCommits);
+  const releaseVersion = config.releaseTag.replace(/^v/, '');
+  const curatedHeadline = config.isNightly
+    ? null
+    : loadCuratedHeadline(join(ROOT, 'docs', 'release-notes'), releaseVersion);
+  const markdown = await generateReleaseNotes({
+    releaseTag: config.releaseTag,
+    lastTag,
+    isFirstRelease,
+    isNightly: config.isNightly,
+    rawCommits,
+    contributors: releaseContributors,
+    ghPort,
+    llmPort: createConfiguredLlmPort(config),
+    curatedHeadline,
+    repository: config.repository,
+    topologyResolver: createTopologyResolver(),
+  });
+
+  writeFileSync(join(ROOT, 'release-notes.md'), markdown);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error generating release notes: ${message}`);
+  process.exitCode = 1;
+});

--- a/scripts/release-notes/classification.ts
+++ b/scripts/release-notes/classification.ts
@@ -1,0 +1,318 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ChangeCategory, EnrichedRef, RawCommit } from './types.js';
+
+export const INTERNAL_LABELS: ReadonlySet<string> = new Set([
+  'code quality',
+  'modularization',
+  'code quality / modularization',
+  'refactor',
+  'internal',
+  'tech-debt',
+  'cleanup',
+  'ci/cd',
+  'ci',
+  'cd',
+  'continuous integration',
+  'continuous deployment',
+  'github actions',
+  'architecture',
+  'development',
+  'dev',
+  'developer experience',
+  'dx',
+  'plan',
+  'planning',
+  'roadmap',
+  'chores',
+]);
+
+export const PROMOTING_LABELS: ReadonlySet<string> = new Set([
+  'provider support',
+  'tooling',
+  'configuration',
+  'feature',
+  'enhancement',
+  'bug',
+  'fix',
+  'ux',
+  'ui',
+  'performance',
+]);
+
+const CONVENTIONAL_RE =
+  /^(feat|fix|perf|refactor|test|chore|docs|style|ci|build|revert|misc)(?:\([^)]*\))?(!)?:/i;
+
+/**
+ * Signal strength ranking for change categories. Used to ensure promoting
+ * labels never demote a higher-signal commit-prefix category (e.g. a `feat:`
+ * commit tagged `bug` stays `new`, not demoted to `fix`).
+ */
+const CATEGORY_SIGNAL_RANK: Record<ChangeCategory, number> = {
+  breaking: 4,
+  new: 3,
+  fix: 2,
+  improvement: 1,
+  internal: 0,
+};
+
+export function strongerCategory(
+  left: ChangeCategory,
+  right: ChangeCategory,
+): ChangeCategory {
+  return CATEGORY_SIGNAL_RANK[right] > CATEGORY_SIGNAL_RANK[left]
+    ? right
+    : left;
+}
+
+export function classifyCommit(commit: RawCommit): ChangeCategory {
+  const subject = commit.subject;
+  if (/\bBREAKING CHANGE\b/i.test(subject)) {
+    return 'breaking';
+  }
+  const match = CONVENTIONAL_RE.exec(subject);
+  if (match === null) {
+    return 'improvement';
+  }
+  if (match[2] === '!') {
+    return 'breaking';
+  }
+  switch (match[1].toLowerCase()) {
+    case 'feat':
+      return 'new';
+    case 'fix':
+      return 'fix';
+    case 'perf':
+    case 'docs':
+    case 'misc':
+      return 'improvement';
+    default:
+      return 'internal';
+  }
+}
+
+function normalizeLabel(label: string): string {
+  return label.trim().toLowerCase();
+}
+
+function hasInternalLabel(enriched: readonly EnrichedRef[]): boolean {
+  return enriched.some((ref) =>
+    ref.labels.some((label) => INTERNAL_LABELS.has(normalizeLabel(label))),
+  );
+}
+
+/**
+ * Positive promoting labels are scoped to the owning/first enriched ref.
+ * A related issue's label must not positively recategorize the owning PR,
+ * consistent with classifyEnrichedRefs ownership scoping. Internal-label
+ * demotion still spans all refs (see hasInternalLabel above).
+ */
+function owningRef(enriched: readonly EnrichedRef[]): readonly EnrichedRef[] {
+  return enriched[0] === undefined ? [] : [enriched[0]];
+}
+
+function hasPromotingLabel(enriched: readonly EnrichedRef[]): boolean {
+  return enriched.some((ref) =>
+    ref.labels.some((label) => PROMOTING_LABELS.has(normalizeLabel(label))),
+  );
+}
+
+/**
+ * Determines highlight eligibility. Internal labels ALWAYS win: an entry with
+ * any internal label is never eligible, even if it also carries a promoting
+ * label. When no internal label is present, a promoting label overrides the
+ * commit-prefix category — an `internal`-category commit tagged `feature`
+ * becomes eligible. Without either label type, the commit-prefix category
+ * decides: non-internal categories are eligible, `internal` is not.
+ *
+ * When any enriched ref has truncated labels (totalCount exceeded the
+ * first 100 fetched), we cannot guarantee an internal label is absent from
+ * the unfetched pages. The entry is conservatively treated as ineligible
+ * for highlights rather than risking an internal-labeled change appearing
+ * as a headline.
+ */
+export function isEligibleForHighlights(
+  category: ChangeCategory,
+  enriched: readonly EnrichedRef[],
+): boolean {
+  if (
+    enriched.some(
+      (ref) => ref.labelsTruncated || ref.metadataAvailable === false,
+    )
+  ) {
+    return false;
+  }
+  if (hasInternalLabel(enriched)) {
+    return false;
+  }
+  if (hasPromotingLabel(owningRef(enriched))) {
+    return true;
+  }
+  return category !== 'internal';
+}
+
+/**
+ * Determines whether an entry should be demoted from prominent categories
+ * (New, Improvements, Fixes, Breaking). Internal labels ALWAYS win: an entry
+ * with any internal label is demoted regardless of its commit-prefix category
+ * or any promoting label — the internal label signals that the change is
+ * internal even when the conventional commit prefix or a promoting label
+ * suggests otherwise (e.g. a `feat:` commit tagged `tech-debt`).
+ *
+ * Truncated labels are also treated conservatively: when a ref's label set
+ * was truncated, the entry is demoted from prominent categories because we
+ * cannot guarantee an internal label is absent from the unfetched pages.
+ */
+export function classifyEnrichedRefs(
+  enriched: readonly EnrichedRef[],
+): ChangeCategory {
+  if (
+    enriched.some(
+      (ref) => ref.labelsTruncated || ref.metadataAvailable === false,
+    )
+  ) {
+    return 'internal';
+  }
+  if (hasInternalLabel(enriched)) {
+    return 'internal';
+  }
+  const categories = enriched.map((ref) =>
+    classifyCommit({
+      subject: ref.title,
+      hash: '',
+      author: '',
+      isMerge: false,
+      parents: [],
+    }),
+  );
+  const primary = categories[0] ?? 'internal';
+  const fallback = categories.find((category) => category !== 'internal');
+  const titleCategory =
+    primary === 'internal' ? (fallback ?? primary) : primary;
+  return promotedCategory(titleCategory, owningRef(enriched));
+}
+
+export function shouldDemoteFromProminent(
+  enriched: readonly EnrichedRef[],
+): boolean {
+  if (
+    enriched.some(
+      (ref) => ref.labelsTruncated || ref.metadataAvailable === false,
+    )
+  ) {
+    return true;
+  }
+  return hasInternalLabel(enriched);
+}
+
+/**
+ * Derives the effective categorized category for a change entry, applying
+ * internal-label precedence and promoting-label promotion.
+ *
+ * Internal labels ALWAYS win: an entry with any internal label is
+ * classified as `internal` regardless of its commit-prefix category or any
+ * promoting label — the internal label signals that the change is internal
+ * even when the conventional commit prefix or a promoting label suggests
+ * otherwise (e.g. a `feat:` commit tagged `tech-debt`).
+ *
+ * When no internal label is present, a promoting label overrides the
+ * commit-prefix category: an `internal`-category commit tagged `feature`
+ * becomes `new`, `bug`/`fix` becomes `fix`, and `enhancement`/`ux`/`ui`/
+ * `performance` becomes `improvement`.
+ *
+ * When neither label type is present, the original commit-prefix category
+ * is returned unchanged.
+ */
+export function deriveEffectiveCategory(
+  category: ChangeCategory,
+  enriched: readonly EnrichedRef[],
+): ChangeCategory {
+  if (
+    enriched.some(
+      (ref) => ref.labelsTruncated || ref.metadataAvailable === false,
+    )
+  ) {
+    return 'internal';
+  }
+  if (hasInternalLabel(enriched)) {
+    return 'internal';
+  }
+  if (hasPromotingLabel(owningRef(enriched))) {
+    return promotedCategory(category, owningRef(enriched));
+  }
+  return category;
+}
+
+/**
+ * Derives the promoted category from promoting labels, with a deterministic
+ * precedence: bug/fix → fix; feature/enhancement/provider support → new;
+ * ux/ui/performance → improvement. When multiple promoting labels exist,
+ * the first matching precedence tier wins.
+ *
+ * Promoting labels only move a category UP (or laterally within the same
+ * signal rank): a promoting label can promote an internal-prefix commit, but
+ * never demotes a higher-signal commit-prefix category. For example, a
+ * `feat:` commit tagged `bug` stays `new` (rank 3), not demoted to `fix`
+ * (rank 2).
+ */
+function promotedCategory(
+  original: ChangeCategory,
+  enriched: readonly EnrichedRef[],
+): ChangeCategory {
+  const target = promotingLabelTarget(enriched);
+  if (target === null) {
+    return original === 'internal' ? 'improvement' : original;
+  }
+  // Only apply the promotion when it does not lower the signal rank.
+  // This prevents a lower-signal promoting label from demoting a stronger
+  // commit-prefix category (e.g. `feat:` tagged `bug` stays `new`).
+  if (CATEGORY_SIGNAL_RANK[target] >= CATEGORY_SIGNAL_RANK[original]) {
+    return target;
+  }
+  return original;
+}
+
+/**
+ * Determines the target category implied by promoting labels, scanning
+ * refs in deterministic precedence order: bug/fix → fix, then
+ * feature/enhancement/provider support → new, then ux/ui/performance →
+ * improvement. Returns null when only lower-signal promoting labels
+ * (tooling, configuration) are present, which promote `internal` to
+ * `improvement` but do not override a non-internal original.
+ */
+function promotingLabelTarget(
+  enriched: readonly EnrichedRef[],
+): ChangeCategory | null {
+  for (const ref of enriched) {
+    const labels = ref.labels.map((label) => normalizeLabel(label));
+    if (labels.includes('bug') || labels.includes('fix')) {
+      return 'fix';
+    }
+  }
+  for (const ref of enriched) {
+    const labels = ref.labels.map((label) => normalizeLabel(label));
+    if (
+      labels.includes('feature') ||
+      labels.includes('enhancement') ||
+      labels.includes('provider support')
+    ) {
+      return 'new';
+    }
+  }
+  for (const ref of enriched) {
+    const labels = ref.labels.map((label) => normalizeLabel(label));
+    if (
+      labels.includes('ux') ||
+      labels.includes('ui') ||
+      labels.includes('performance')
+    ) {
+      return 'improvement';
+    }
+  }
+  // tooling, configuration — only meaningful when promoting from internal.
+  return null;
+}

--- a/scripts/release-notes/contributors.ts
+++ b/scripts/release-notes/contributors.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { parseRefs } from './filtering.js';
+import type { EnrichedRef, GhPort, RawCommit } from './types.js';
+
+/** The maintainer login to exclude from contributor thanks. */
+export const MAINTAINER_LOGIN = 'acoliver';
+
+/**
+ * Extracts unique PR numbers from raw commit subjects using the same
+ * `parseRefs` logic that drives commit grouping (processing.ts). This covers
+ * classic merges (`Merge pull request #N`), terminal squash markers (`(#N)`),
+ * and Fixes/Closes/Resolves references that point to a PR.
+ *
+ * Numbers are de-duplicated (preserving first-seen order) so the same PR
+ * referenced by multiple commits is enriched only once.
+ */
+export function extractPrNumbers(
+  commits: readonly RawCommit[],
+): readonly number[] {
+  const seen = new Set<number>();
+  const numbers: number[] = [];
+  for (const commit of commits) {
+    for (const ref of parseRefs(commit.subject)) {
+      if (!seen.has(ref.number)) {
+        seen.add(ref.number);
+        numbers.push(ref.number);
+      }
+    }
+  }
+  return numbers;
+}
+
+/**
+ * Determines whether a login should be excluded from the contributor thanks
+ * section: the maintainer, empty/deleted authors, and bot accounts (suffix
+ * `[bot]`).
+ */
+export function isExcludedContributor(login: string): boolean {
+  if (login.trim().length === 0) {
+    return true;
+  }
+  if (login === MAINTAINER_LOGIN) {
+    return true;
+  }
+  return login.endsWith('[bot]');
+}
+
+/**
+ * Computes the sorted, de-duplicated contributor logins for a release given
+ * the raw commits. PR numbers are derived from the same shared `parseRefs`
+ * extraction used for commit grouping, then enriched via the gh port. Only
+ * enriched PR refs (isPr) with a non-excluded author are retained.
+ *
+ * This works across both classic merge and squash-merge conventions and
+ * degrades gracefully when GitHub returns partial data (a missing or
+ * non-PR ref is simply skipped).
+ */
+export async function computeContributors(
+  ghPort: GhPort,
+  commits: readonly RawCommit[],
+): Promise<readonly string[]> {
+  const prNumbers = extractPrNumbers(commits);
+  if (prNumbers.length === 0) {
+    return [];
+  }
+  let refs: ReadonlyMap<number, EnrichedRef>;
+  try {
+    refs = await ghPort.fetchRefs(prNumbers);
+  } catch {
+    console.warn(
+      `GitHub enrichment failed for contributor lookup; continuing without contributors.`,
+    );
+    return [];
+  }
+  return [
+    ...new Set(
+      [...refs.values()]
+        .filter((ref) => ref.isPr)
+        .map((ref) => ref.author)
+        .filter(
+          (author): author is string =>
+            author !== null && author !== undefined && author.length > 0,
+        )
+        .filter((author) => !isExcludedContributor(author)),
+    ),
+  ].sort();
+}

--- a/scripts/release-notes/curated-headline.ts
+++ b/scripts/release-notes/curated-headline.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Pattern for valid version strings used in curated headline filenames.
+ * Allows digits, dots, hyphens (for pre-release), and alphanumerics only.
+ */
+const VERSION_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+/**
+ * Loads an optional curated headline from `docs/release-notes/<version>.md`.
+ * This is the "maintainer headline channel" (issue E): for stable releases,
+ * a maintainer may pre-author a headline that gets prepended to the generated
+ * notes. Returns null when absent or empty — graceful degradation.
+ *
+ * The version is validated against a strict pattern to prevent path traversal.
+ */
+export function loadCuratedHeadline(
+  docsDir: string,
+  version: string,
+): string | null {
+  if (!VERSION_PATTERN.test(version)) {
+    return null;
+  }
+  const filePath = join(docsDir, `${version}.md`);
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  const content = readFileSync(filePath, 'utf-8');
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  return trimmed;
+}

--- a/scripts/release-notes/diff-selection.ts
+++ b/scripts/release-notes/diff-selection.ts
@@ -1,0 +1,495 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import semver from 'semver';
+import type { ReleaseMetadata } from './types.js';
+
+export interface TagInfo {
+  readonly name: string;
+  readonly createdAt: number;
+}
+
+export interface ReleaseMetadataLookup {
+  (tag: string): ReleaseMetadata;
+  readonly candidates?: ReadonlySet<string>;
+}
+
+/**
+ * Extracts the nightly suffix from a tag name, e.g. for
+ * `v0.11.0-nightly.260714.abcdef` returns `260714.abcdef`.
+ * Returns null when the tag is not a nightly for the given base version.
+ */
+function nightlySuffix(tagName: string, baseVersion: string): string | null {
+  const prefix = `v${baseVersion}-nightly.`;
+  if (!tagName.startsWith(prefix)) {
+    return null;
+  }
+  return tagName.slice(prefix.length);
+}
+
+/**
+ * Parses the date portion (YYMMDD) from a nightly suffix. Returns the date
+ * as an integer for comparison, or null when no parseable date is present.
+ */
+function parseNightlyDate(suffix: string): number | null {
+  const match = /^(\d{6})\b/.exec(suffix);
+  if (match === null) {
+    return null;
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Internal structure for locally plausible nightly candidates with pre-parsed
+ * chronology fields. Local selection uses these fields only when no release
+ * metadata lookup is available.
+ */
+interface NightlyCandidate {
+  readonly name: string;
+  readonly createdAt: number;
+  readonly date: number | null;
+  readonly suffix: string;
+}
+
+interface PublishedNightlyCandidate {
+  readonly name: string;
+  readonly publishedAt: number;
+  readonly suffix: string;
+}
+
+function compareLocalNightlyChronology(
+  left: NightlyCandidate,
+  right: NightlyCandidate,
+): number {
+  if (left.date !== null && right.date !== null) {
+    if (left.date !== right.date) {
+      return left.date - right.date;
+    }
+  } else if (left.date !== null) {
+    return -1;
+  } else if (right.date !== null) {
+    return 1;
+  }
+  if (left.createdAt !== right.createdAt) {
+    return left.createdAt - right.createdAt;
+  }
+  return left.suffix.localeCompare(right.suffix);
+}
+
+function comparePublicationChronology(
+  left: PublishedNightlyCandidate,
+  right: PublishedNightlyCandidate,
+): number {
+  if (left.publishedAt !== right.publishedAt) {
+    return left.publishedAt - right.publishedAt;
+  }
+  return left.suffix.localeCompare(right.suffix);
+}
+
+function currentBaseVersion(currentTag: string): string | null {
+  const parsed = semver.parse(currentTag.replace(/^v/, ''));
+  return parsed === null
+    ? null
+    : `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+}
+
+function isOlderStableTag(tag: TagInfo, currentTag: string): boolean {
+  if (tag.name === currentTag) {
+    return false;
+  }
+  const parsed = semver.parse(tag.name.replace(/^v/, ''));
+  const current = semver.parse(currentTag.replace(/^v/, ''));
+  if (parsed === null || parsed.prerelease.length > 0) {
+    return false;
+  }
+  if (current === null) {
+    return true;
+  }
+  const currentStable = `${current.major}.${current.minor}.${current.patch}`;
+  const isNightly = current.prerelease[0] === 'nightly';
+  return isNightly
+    ? semver.lte(parsed, currentStable)
+    : semver.lt(parsed, current);
+}
+
+function latestStable(
+  tags: readonly TagInfo[],
+  currentTag: string,
+): string | null {
+  const candidates = tags.filter((tag) => isOlderStableTag(tag, currentTag));
+  candidates.sort((left, right) => {
+    const leftSemver = semver.parse(left.name.replace(/^v/, ''));
+    const rightSemver = semver.parse(right.name.replace(/^v/, ''));
+    if (leftSemver === null || rightSemver === null) {
+      return 0;
+    }
+    return semver.compare(rightSemver, leftSemver); // descending
+  });
+  return candidates[0]?.name ?? null;
+}
+
+/**
+ * Extracts the current tag's timestamp for use in chronological comparison.
+ * When available, this avoids relying solely on tag createdAt from the ref
+ * listing.
+ */
+function currentTagTimestamp(
+  tags: readonly TagInfo[],
+  currentTag: string,
+): number | null {
+  const found = tags.find((tag) => tag.name === currentTag);
+  return found === undefined ? null : found.createdAt;
+}
+
+/**
+ * Selects a locally plausible nightly predecessor. Without metadata it uses
+ * parsed date, tag creation time, and suffix. With metadata it fails closed:
+ * only confirmed published releases are eligible, ordered by publication time
+ * and suffix. Confirmed-absent and unknown candidates are never selected.
+ */
+function predatesUnpublishedCurrent(
+  releaseMetadata: ReleaseMetadataLookup | undefined,
+  currentCreatedAt: number | null,
+  currentDate: number | null,
+  candidateDate: number | null,
+): boolean {
+  if (releaseMetadata !== undefined || currentCreatedAt !== null) {
+    return true;
+  }
+  return (
+    currentDate === null ||
+    candidateDate === null ||
+    candidateDate < currentDate
+  );
+}
+
+function latestNightly(
+  tags: readonly TagInfo[],
+  currentTag: string,
+  releaseMetadata: ReleaseMetadataLookup | undefined,
+): string | null {
+  const base = currentBaseVersion(currentTag);
+  if (base === null) return null;
+  const currentSuffix = nightlySuffix(currentTag, base);
+  if (currentSuffix === null) return null;
+  const currentDate = parseNightlyDate(currentSuffix);
+  const currentCreatedAt = currentTagTimestamp(tags, currentTag);
+  const priorCandidates: NightlyCandidate[] = tags
+    .filter((tag) => tag.name !== currentTag)
+    .flatMap((tag) => {
+      const suffix = nightlySuffix(tag.name, base);
+      if (suffix === null) {
+        return [];
+      }
+      const candidate = {
+        name: tag.name,
+        createdAt: tag.createdAt,
+        date: parseNightlyDate(suffix),
+        suffix,
+      };
+      const predatesMissingTag = predatesUnpublishedCurrent(
+        releaseMetadata,
+        currentCreatedAt,
+        currentDate,
+        candidate.date,
+      );
+      return predatesMissingTag &&
+        isPlausiblePredecessor(
+          candidate,
+          currentDate,
+          currentCreatedAt ?? Number.MAX_SAFE_INTEGER,
+        )
+        ? [candidate]
+        : [];
+    });
+
+  if (releaseMetadata === undefined) {
+    return (
+      priorCandidates.sort((left, right) =>
+        compareLocalNightlyChronology(right, left),
+      )[0]?.name ?? null
+    );
+  }
+
+  const metadata = priorCandidates
+    .filter(
+      (candidate) =>
+        releaseMetadata.candidates === undefined ||
+        releaseMetadata.candidates.has(candidate.name),
+    )
+    .map((candidate) => ({
+      candidate,
+      release: releaseMetadata(candidate.name),
+    }));
+  if (metadata.some(({ release }) => release.status === 'unknown')) {
+    throw new Error(
+      'Unable to determine the previous published nightly release',
+    );
+  }
+  const publishedCandidates: PublishedNightlyCandidate[] = metadata.flatMap(
+    ({ candidate, release }) =>
+      release.status === 'published'
+        ? [
+            {
+              name: candidate.name,
+              publishedAt: release.publishedAt,
+              suffix: candidate.suffix,
+            },
+          ]
+        : [],
+  );
+  return (
+    publishedCandidates.sort((left, right) =>
+      comparePublicationChronology(right, left),
+    )[0]?.name ?? null
+  );
+}
+
+/**
+ * Proximity-sortable candidate shape for nightlyCandidateNames. Carries the
+ * parsed date and createdAt used to compute chronological distance from the
+ * current tag.
+ */
+interface ProximityCandidate {
+  readonly name: string;
+  readonly suffix: string;
+  readonly date: number | null;
+  readonly createdAt: number;
+}
+
+/**
+ * Computes the absolute chronological distance (proximity) of a candidate
+ * from the current tag's date. Candidates with parseable dates use the date
+ * difference; candidates without are deprioritized when the current date
+ * is known. Smaller value = closer to the current tag.
+ */
+function candidateDateProximity(
+  candidateDate: number | null,
+  currentDate: number | null,
+): number {
+  if (candidateDate !== null && currentDate !== null) {
+    return Math.abs(candidateDate - currentDate);
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Compares two candidates by chronological proximity to the current tag.
+ * The nearest candidate (smallest distance) comes first. Ties in parsed
+ * date are broken by reverse chronological createdAt, then by deterministic
+ * suffix order.
+ *
+ * Returns negative when `left` is closer (should come first).
+ */
+function compareCandidateProximity(
+  left: ProximityCandidate,
+  right: ProximityCandidate,
+  currentDate: number | null,
+): number {
+  const leftProx = candidateDateProximity(left.date, currentDate);
+  const rightProx = candidateDateProximity(right.date, currentDate);
+  if (leftProx !== rightProx) {
+    return leftProx - rightProx;
+  }
+  if (left.createdAt !== right.createdAt) {
+    return right.createdAt - left.createdAt;
+  }
+  if (left.suffix < right.suffix) {
+    return -1;
+  }
+  if (left.suffix > right.suffix) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Returns true when a candidate is chronologically before the current tag
+ * by parsed date — i.e. a plausible predecessor. When neither date is
+ * parseable, createdAt is used instead. Candidates with a date equal to
+ * the current date are NOT future candidates (same-date with earlier
+ * createdAt is a valid same-day predecessor).
+ */
+function isPlausiblePredecessor(
+  candidate: ProximityCandidate,
+  currentDate: number | null,
+  currentCreatedAt: number,
+): boolean {
+  if (candidate.date !== null && currentDate !== null) {
+    return (
+      candidate.date < currentDate ||
+      (candidate.date === currentDate &&
+        candidate.createdAt <= currentCreatedAt)
+    );
+  }
+  return candidate.createdAt <= currentCreatedAt;
+}
+
+/**
+ * Returns the tag names of same-base nightly candidates that are
+ * chronologically before the current tag (plausible predecessors only),
+ * sorted by chronological proximity to the current tag. This is a local
+ * filter (no network calls): it identifies tags matching
+ * `v<base>-nightly.<suffix>` for the same base version as the current
+ * nightly tag.
+ *
+ * Chronologically future candidates are EXCLUDED before the proximity
+ * sort so that MAX_NIGHTLY_CANDIDATES never wastes metadata lookups on
+ * tags that cannot be predecessors, and so they can never be selected
+ * as the diff base. A candidate is future when its parsed date is
+ * greater than the current tag's parsed date (same-date is NOT future —
+ * same-date tags with earlier createdAt are valid same-day predecessors).
+ *
+ * Candidates are ordered so that the chronologically nearest plausible
+ * predecessors come first. This ensures that when MAX_NIGHTLY_CANDIDATES
+ * is applied downstream (in createBoundedReleaseMetadataLookup), the most
+ * relevant tags — those closest to the target — are queried for
+ * publication metadata, rather than arbitrary refname-order tags.
+ *
+ * Returns an empty array when the current tag is not a nightly.
+ */
+export function nightlyCandidateNames(
+  tags: readonly TagInfo[],
+  currentTag: string,
+): string[] {
+  const base = currentBaseVersion(currentTag);
+  if (base === null) {
+    return [];
+  }
+  const currentSuffix = nightlySuffix(currentTag, base);
+  if (currentSuffix === null) {
+    return [];
+  }
+  const currentDate = parseNightlyDate(currentSuffix);
+  const currentTagInfo = tags.find((tag) => tag.name === currentTag);
+  const currentCreatedAt = currentTagInfo?.createdAt ?? Number.MAX_SAFE_INTEGER;
+
+  const candidates = tags
+    .filter((tag) => tag.name !== currentTag)
+    .map((tag) => {
+      const suffix = nightlySuffix(tag.name, base);
+      if (suffix === null) {
+        return null;
+      }
+      return {
+        name: tag.name,
+        suffix,
+        date: parseNightlyDate(suffix),
+        createdAt: tag.createdAt,
+      };
+    })
+    .filter(
+      (
+        c,
+      ): c is {
+        name: string;
+        suffix: string;
+        date: number | null;
+        createdAt: number;
+      } => c !== null,
+    )
+    .filter((candidate) =>
+      isPlausiblePredecessor(candidate, currentDate, currentCreatedAt),
+    );
+
+  candidates.sort((left, right) =>
+    compareCandidateProximity(left, right, currentDate),
+  );
+
+  return candidates.map((candidate) => candidate.name);
+}
+
+/**
+ * Returns true when the current tag is a non-nightly prerelease (alpha, beta,
+ * rc, etc.) — i.e. it has a prerelease component but does NOT match the
+ * nightly pattern. Nightlies are handled by `latestNightly`, not here.
+ */
+function isPrereleaseTag(currentTag: string): boolean {
+  const parsed = semver.parse(currentTag.replace(/^v/, ''));
+  if (parsed === null) {
+    return false;
+  }
+  if (parsed.prerelease.length === 0) {
+    return false;
+  }
+  return !parsed.prerelease.includes('nightly');
+}
+
+/**
+ * Finds the latest older prerelease tag with the same major.minor.patch base
+ * version as the current tag. Only non-nightly prereleases are considered.
+ * Returns null when the current tag is not a prerelease or when no eligible
+ * predecessor exists.
+ */
+function latestPrerelease(
+  tags: readonly TagInfo[],
+  currentTag: string,
+): string | null {
+  if (!isPrereleaseTag(currentTag)) {
+    return null;
+  }
+  const currentParsed = semver.parse(currentTag.replace(/^v/, ''));
+  if (currentParsed === null) {
+    return null;
+  }
+  const currentBase = `${currentParsed.major}.${currentParsed.minor}.${currentParsed.patch}`;
+  const candidates = tags
+    .filter((tag) => tag.name !== currentTag)
+    .map((tag) => {
+      const parsed = semver.parse(tag.name.replace(/^v/, ''));
+      if (parsed === null || parsed.prerelease.length === 0) {
+        return null;
+      }
+      if (parsed.prerelease.includes('nightly')) {
+        return null;
+      }
+      const tagBase = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+      if (tagBase !== currentBase) {
+        return null;
+      }
+      if (!semver.lt(parsed, currentParsed)) {
+        return null;
+      }
+      return { name: tag.name, version: parsed };
+    })
+    .filter(
+      (
+        c,
+      ): c is {
+        name: string;
+        version: semver.SemVer;
+      } => c !== null,
+    );
+  if (candidates.length === 0) {
+    return null;
+  }
+  candidates.sort((left, right) => semver.compare(right.version, left.version));
+  return candidates[0]?.name ?? null;
+}
+
+/**
+ * Selects the diff base tag. Nightly releases use authoritative publication
+ * order when release metadata is available and local tag chronology only when
+ * no metadata lookup was created. In metadata mode, incomplete or absent
+ * releases are excluded rather than mixed with local timestamps.
+ *
+ * Non-nightly prereleases prefer the latest older prerelease with the same
+ * base version. All release kinds fall back to the latest older stable tag.
+ */
+export function selectDiffBase(
+  tags: readonly TagInfo[],
+  currentTag: string,
+  isNightly: boolean,
+  releaseMetadata?: ReleaseMetadataLookup,
+): string | null {
+  if (isNightly) {
+    return (
+      latestNightly(tags, currentTag, releaseMetadata) ??
+      latestStable(tags, currentTag)
+    );
+  }
+  return latestPrerelease(tags, currentTag) ?? latestStable(tags, currentTag);
+}

--- a/scripts/release-notes/filtering.ts
+++ b/scripts/release-notes/filtering.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { RawCommit, ParsedRef } from './types.js';
+
+/**
+ * Regular-expression patterns for process-noise commit subjects. Each is
+ * narrowly matched so that a real feature or fix that happens to mention a
+ * keyword is not accidentally dropped.
+ */
+const NOISE_PATTERNS: readonly RegExp[] = [
+  /^coderabbit(?:\s|:)/i,
+  /^(?:[^:]{1,40}:\s*)?(?:address|apply|resolve)\b.*\b(?:ocr|coderabbit|review)\b.*\b(?:findings?|feedback|threads?)\s*$/i,
+  /^apply (?:coderabbit|review) suggestions?(?:\s|:|$)/i,
+  /^address\s+(?:(?:coderabbit|ocr)\s+)?review\s+(?:feedback|findings)(?:\s|:|$)/i,
+  /^(?:(?:fix|chore|test)(?:\([^)]*\))?:\s*)?address(?:\s+all\s+\d+)?\s+(?:ocr(?:\s+round\s+\d+)?(?:\s+review)?(?:\s+findings)?|(?:pr\d+\s+)?review\s+threads?)(?:\s|:|$)/i,
+  /^fix\s+ocr\s+review\s+findings(?:\s|:|$)/i,
+  /^chore(?:\([^)]*\))?:\s*address.*\breview\b/i,
+  /^(?:chore:\s*)?(lint|style|format)(?:\s|:)/i,
+  /^(?:chore|fix)(?:\([^)]*\))?:\s*(?:(?:fix|run)\s+)?(?:prettier|eslint|lint|format)(?:ting)?(?:\s|:|$)/i,
+  /^ci(?:\([^)]*\))?:\s*retrigger(?:\s|:)/i,
+  /^ci(?:\([^)]*\))?:\s*trigger\s+(?:ci|build|tests?|workflow)(?:\s|:|$)/i,
+  /^test(?:\([^)]*\))?:\s*stabiliz/i,
+  /^test(?:\([^)]*\))?:\s*(?:fix\s+)?flaky(?:\s+\S+)*\s+tests?(?:\s|:|$)/i,
+  /^chore\(deps?\)/i,
+  /^chore:\s*(bump|update|upgrade)\s+(deps|dependenc)/i,
+  /^chore:\s*(bump|update|upgrade)\s+\S+\s+from/i,
+];
+
+/**
+ * Returns true when a commit subject is pure process noise: CodeRabbit/OCR
+ * review fixups, lint/format runs, CI retriggers, flaky-test stabilization, or
+ * automated dependency bumps. Real features and fixes must NOT be classified
+ * as noise even if they share a keyword.
+ */
+export function isProcessNoise(commit: RawCommit): boolean {
+  const subject = commit.subject;
+  for (const pattern of NOISE_PATTERNS) {
+    if (pattern.test(subject)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Pattern matching `Merge pull request #N`.
+ */
+const MERGE_PULL_REQUEST_PATTERN = /Merge pull request #(\d+)/i;
+
+/**
+ * Pattern matching a terminal GitHub PR marker `(#N)` at the end of a
+ * subject — the convention GitHub appends to squash-merge commits.
+ */
+const TERMINAL_PR_PATTERN = /\(#(\d+)\)$/;
+
+const REF_PATTERN = /\b(fix(?:es)?|clos(?:e|es)|resolv(?:e|es))\s+#(\d+)\b/gi;
+
+/**
+ * Parses issue/PR references from a commit subject. This recognizes three
+ * independent kinds of markers:
+ *  1. `Fixes/Closes/Resolves #N` issue references (enrichment only).
+ *  2. `Merge pull request #N` classic-merge PR markers.
+ *  3. `(#N)` terminal squash-merge PR markers (independent of Fixes/Closes).
+ *
+ * All relevant refs are retained without duplicate numbers.
+ */
+export function parseRefs(subject: string): ParsedRef[] {
+  const refs: ParsedRef[] = [];
+  const seenNumbers = new Set<number>();
+
+  function addRef(number: number, verb: string): void {
+    if (number <= 0 || seenNumbers.has(number)) {
+      return;
+    }
+    seenNumbers.add(number);
+    refs.push({ number, verb });
+  }
+
+  // 1. Fixes/Closes/Resolves issue references (in subject order).
+  let match: RegExpExecArray | null;
+  REF_PATTERN.lastIndex = 0;
+  while ((match = REF_PATTERN.exec(subject)) !== null) {
+    const number = parseInt(match[2], 10);
+    if (Number.isInteger(number)) {
+      addRef(number, match[1]);
+    }
+  }
+
+  // 2. Classic-merge PR marker: Merge pull request #N.
+  const mergeMatch = MERGE_PULL_REQUEST_PATTERN.exec(subject);
+  if (mergeMatch !== null) {
+    addRef(Number(mergeMatch[1]), 'merge');
+  }
+
+  // 3. Terminal squash-merge PR marker: (#N) at end of subject.
+  const terminalMatch = TERMINAL_PR_PATTERN.exec(subject);
+  if (terminalMatch !== null) {
+    addRef(Number(terminalMatch[1]), 'pr');
+  }
+
+  return refs;
+}
+
+/**
+ * Extracts the PR identity number from a commit subject. Only terminal squash
+ * markers `(#N)` and classic merge markers `Merge pull request #N` provide
+ * PR identity. Issue references (`Fixes #N`) are NOT PR identity — they are
+ * enrichment only and must never be used as a grouping key.
+ *
+ * Returns the PR number, or null when the commit has no PR identity.
+ */
+export function extractPrIdentity(commit: RawCommit): number | null {
+  const mergeMatch = MERGE_PULL_REQUEST_PATTERN.exec(commit.subject);
+  if (mergeMatch !== null) {
+    const number = Number(mergeMatch[1]);
+    if (Number.isInteger(number) && number > 0) {
+      return number;
+    }
+  }
+  const terminalMatch = TERMINAL_PR_PATTERN.exec(commit.subject);
+  if (terminalMatch !== null) {
+    const number = Number(terminalMatch[1]);
+    if (Number.isInteger(number) && number > 0) {
+      return number;
+    }
+  }
+  return null;
+}

--- a/scripts/release-notes/gh-port.ts
+++ b/scripts/release-notes/gh-port.ts
@@ -1,0 +1,328 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import { z } from 'zod';
+import type { EnrichedRef, GhPort } from './types.js';
+
+/**
+ * Number of PR/issue nodes per GraphQL query chunk. Each node carries title,
+ * body (up to 65536 chars), labels (first 100), and author. With 4-byte
+ * UTF-8 multibyte content, 25 nodes × 65536 chars × 4 bytes ≈ 6.5 MB,
+ * which fits comfortably under GH_RUNNER_MAX_BUFFER (10 MB) with JSON
+ * overhead. This is a documented, bounded design: 25-node chunks at 10 MiB
+ * maxBuffer never exceed the limit for any valid response.
+ */
+const CHUNK_SIZE = 25;
+export const MAX_ENRICHED_REFS = 1000;
+
+// ---------------------------------------------------------------------------
+// Zod schemas for safe GraphQL response parsing.
+// ---------------------------------------------------------------------------
+
+const labelConnectionSchema = z.object({
+  nodes: z.array(z.unknown()).optional(),
+  totalCount: z.number().optional(),
+});
+
+const labelNodeSchema = z.object({
+  name: z.string().optional(),
+});
+
+const authorSchema = z
+  .object({
+    login: z.string().optional(),
+  })
+  .nullish();
+
+const nodeSchema = z
+  .object({
+    __typename: z.string().optional(),
+    number: z.number().optional(),
+    title: z.string().optional(),
+    body: z.string().optional(),
+    // Labels use a permissive schema here; individual label nodes are
+    // validated separately in extractLabels so one malformed label does not
+    // reject the entire node. totalCount lets us detect label truncation
+    // when a PR/issue has more than 100 labels.
+    labels: labelConnectionSchema.optional(),
+    author: authorSchema,
+  })
+  .nullish();
+
+const envelopeSchema = z.object({
+  data: z
+    .object({
+      repository: z.record(z.string(), z.unknown()).optional(),
+    })
+    .optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Injectable runner abstraction.
+// ---------------------------------------------------------------------------
+
+export type GhRunner = (args: readonly string[]) => string;
+
+/**
+ * maxBuffer for the gh CLI runner. Each chunk contains up to CHUNK_SIZE
+ * PR/issue nodes, each with title, body (up to 65536 chars), labels, and
+ * author. A full 25-node full-multibyte response can reach ~6.5 MB, so
+ * 10 MiB provides headroom. Because the chunk size is deliberately bounded
+ * to keep the worst-case response under this limit, maxBuffer truncation
+ * should never occur under normal operation. If it does (e.g. a node with
+ * an unexpectedly large body), the chunk is treated as a failed runner
+ * call and skipped — no partial recovery is attempted.
+ */
+export const GH_RUNNER_MAX_BUFFER = 16 * 1024 * 1024;
+
+/**
+ * Options object passed to execFileSync by the default runner. Exported
+ * so tests can verify the bounded maxBuffer without mocking child_process.
+ */
+export const GH_RUNNER_OPTIONS: {
+  readonly encoding: BufferEncoding;
+  readonly timeout: number;
+  readonly maxBuffer: number;
+} = {
+  encoding: 'utf8',
+  timeout: 15_000,
+  maxBuffer: GH_RUNNER_MAX_BUFFER,
+};
+
+/**
+ * Safely converts a Buffer to a UTF-8 string. Exported for tests that need
+ * to verify Buffer handling. Node's execFileSync returns a string when
+ * encoding is set to 'utf8', so this function is only used when a Buffer
+ * is returned by a custom runner.
+ *
+ * No partial maxBuffer recovery is attempted: the chunk size and maxBuffer
+ * are bounded so that truncation does not occur under normal operation. If
+ * a runner returns invalid data, the chunk is treated as a failed call.
+ */
+export function safeMultibyteString(raw: string | Buffer): string {
+  if (typeof raw === 'string') {
+    return raw;
+  }
+  return raw.toString('utf8');
+}
+
+export const defaultRunner: GhRunner = (args) =>
+  execFileSync('gh', [...args], GH_RUNNER_OPTIONS);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseRepository(repository: string): readonly [string, string] {
+  const match = /^([^/]+)\/([^/]+)$/.exec(repository);
+  if (match === null) {
+    throw new Error(`Invalid GitHub repository: ${repository}`);
+  }
+  const owner = match[1];
+  const name = match[2];
+  if (owner === undefined || name === undefined) {
+    throw new Error(`Invalid GitHub repository: ${repository}`);
+  }
+  return [owner, name];
+}
+
+function chunks(numbers: readonly number[]): number[][] {
+  const result: number[][] = [];
+  for (let index = 0; index < numbers.length; index += CHUNK_SIZE) {
+    result.push(numbers.slice(index, index + CHUNK_SIZE));
+  }
+  return result;
+}
+
+function buildQuery(numbers: readonly number[]): string {
+  const variables = numbers.map((_, index) => `$n${index}:Int!`).join(',');
+  const selections = numbers
+    .map(
+      (_, index) =>
+        `r${index}:issueOrPullRequest(number:$n${index}){__typename ... on Issue{number title body labels(first:100){nodes{name} totalCount} author{login}} ... on PullRequest{number title body labels(first:100){nodes{name} totalCount} author{login}}}`,
+    )
+    .join(' ');
+  return `query($owner:String!,$name:String!,${variables}){repository(owner:$owner,name:$name){${selections}}}`;
+}
+
+function buildArgs(
+  owner: string,
+  name: string,
+  numbers: readonly number[],
+): string[] {
+  const args = [
+    'api',
+    'graphql',
+    '-f',
+    `query=${buildQuery(numbers)}`,
+    '-F',
+    `owner=${owner}`,
+    '-F',
+    `name=${name}`,
+  ];
+  numbers.forEach((number, index) => {
+    args.push('-F', `n${index}=${number}`);
+  });
+  return args;
+}
+
+/**
+ * Maximum number of labels to process per node. GitHub's GraphQL API caps
+ * `labels(first:N)` at 100 per page; when a PR/issue exceeds this, additional
+ * labels require pagination. Since label-driven classification only needs the
+ * first set of meaningful labels (bug, feature, enhancement, internal, etc.),
+ * we bound processing to this limit. The totalCount from the response is
+ * checked to detect truncation.
+ */
+export const MAX_LABELS_PER_NODE = 100;
+
+interface LabelExtraction {
+  readonly labels: readonly string[];
+  readonly truncated: boolean;
+}
+
+function extractLabels(
+  labels:
+    | { readonly nodes?: readonly unknown[]; readonly totalCount?: number }
+    | undefined,
+): LabelExtraction {
+  const result: string[] = [];
+  for (const raw of labels?.nodes ?? []) {
+    const parsed = labelNodeSchema.safeParse(raw);
+    if (parsed.success && parsed.data.name !== undefined) {
+      result.push(parsed.data.name);
+    }
+  }
+  const totalCount = labels?.totalCount;
+  const truncated =
+    labels?.nodes === undefined ||
+    typeof totalCount !== 'number' ||
+    totalCount > result.length;
+  return {
+    labels: result.slice(0, MAX_LABELS_PER_NODE),
+    truncated,
+  };
+}
+
+/**
+ * Safely converts a single raw GraphQL node into an EnrichedRef. Returns null
+ * when the node is malformed, null/undefined, the returned number does not
+ * match the requested batch number, or a title is absent.
+ */
+function tryEnrichNode(
+  rawNode: unknown,
+  requestedNumber: number,
+): EnrichedRef | null {
+  const result = nodeSchema.safeParse(rawNode);
+  if (!result.success) {
+    return null;
+  }
+  const node = result.data;
+  if (node === null || node === undefined) {
+    return null;
+  }
+  // Verify the alias rN node number equals the requested batch number to
+  // prevent key/number mismatches from corrupting the result map.
+  if (node.number !== requestedNumber) {
+    return null;
+  }
+  if (node.title === undefined) {
+    return null;
+  }
+  const extracted = extractLabels(node.labels);
+  return {
+    number: requestedNumber,
+    title: node.title,
+    body: node.body ?? '',
+    labels: extracted.labels,
+    labelsTruncated: extracted.truncated,
+    metadataAvailable: true,
+    author: node.author?.login ?? '',
+    isPr: node.__typename === 'PullRequest',
+    userImpact: null,
+  };
+}
+
+/**
+ * Parses a raw gh GraphQL response string for a single chunk (batch) of
+ * requested numbers. Malformed JSON, malformed envelopes, and individual
+ * malformed/null/mismatched nodes are degraded gracefully — valid nodes
+ * within the same response are still returned.
+ */
+export function parseChunkResponse(
+  raw: string,
+  batch: readonly number[],
+): Map<number, EnrichedRef> {
+  const result = new Map<number, EnrichedRef>();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return result;
+  }
+  const envelope = envelopeSchema.safeParse(parsed);
+  if (!envelope.success) {
+    return result;
+  }
+  const repo = envelope.data.data?.repository ?? {};
+  batch.forEach((requestedNumber, index) => {
+    const enriched = tryEnrichNode(repo[`r${index}`], requestedNumber);
+    if (enriched !== null) {
+      result.set(requestedNumber, enriched);
+    }
+  });
+  return result;
+}
+
+/**
+ * Fetches enriched refs via the gh CLI with an injectable runner. Numbers are
+ * sorted, de-duplicated, and batched in groups of CHUNK_SIZE (25). A failed
+ * chunk (runner throws) is skipped and the loop continues to the next chunk.
+ * Individual malformed/null/mismatched nodes within a successful response are
+ * degraded without affecting sibling nodes.
+ */
+export function fetchRefsViaGh(
+  repository: string,
+  numbers: readonly number[],
+  runner: GhRunner = defaultRunner,
+): Map<number, EnrichedRef> {
+  const [owner, name] = parseRepository(repository);
+  const result = new Map<number, EnrichedRef>();
+  const sortedNumbers = [...new Set(numbers)].sort(
+    (left, right) => left - right,
+  );
+  if (sortedNumbers.length > MAX_ENRICHED_REFS) {
+    console.warn(
+      `GitHub enrichment limited to ${MAX_ENRICHED_REFS} of ${sortedNumbers.length} references.`,
+    );
+  }
+  const uniqueNumbers = sortedNumbers.slice(0, MAX_ENRICHED_REFS);
+  for (const batch of chunks(uniqueNumbers)) {
+    try {
+      const batchResult = parseChunkResponse(
+        runner(buildArgs(owner, name, batch)),
+        batch,
+      );
+      for (const [num, ref] of batchResult) {
+        result.set(num, ref);
+      }
+    } catch {
+      console.warn(
+        `GitHub enrichment failed for reference batch ${batch[0]}-${batch.at(-1)}.`,
+      );
+    }
+  }
+  return result;
+}
+
+export function createGhPort(repository: string, runner?: GhRunner): GhPort {
+  return {
+    async fetchRefs(numbers: readonly number[]) {
+      return fetchRefsViaGh(repository, numbers, runner);
+    },
+  };
+}

--- a/scripts/release-notes/git-port.ts
+++ b/scripts/release-notes/git-port.ts
@@ -1,0 +1,275 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
+import type { TagInfo } from './diff-selection.js';
+import type { RawCommit, TopologyResolver } from './types.js';
+
+/**
+ * Executes a git command and returns its stdout as a string.
+ */
+function gitExec(
+  args: readonly string[],
+  options: Partial<ExecFileSyncOptions> = {},
+): string {
+  return execFileSync('git', ['-c', 'core.pager=', ...args], {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+    ...options,
+  }).toString();
+}
+
+/**
+ * Lists all tags with their creatordate as unix timestamps.
+ */
+export function listTags(): TagInfo[] {
+  const output = gitExec([
+    'for-each-ref',
+    '--format=%(refname:short)%09%(creatordate:unix)',
+    'refs/tags',
+  ]);
+  return output
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [name, timestamp] = line.split('\t');
+      return { name: name ?? '', createdAt: Number(timestamp) * 1000 };
+    });
+}
+
+/**
+ * Regex validating a full 40-character lowercase hex Git object hash.
+ * Git always emits 40-char hashes with `%H`; abbreviated `%h` is never used.
+ */
+export const FULL_HASH_PATTERN = /^[0-9a-f]{40}$/;
+
+/**
+ * Number of fields per commit record: hash, subject, author, parents.
+ */
+const FIELD_COUNT = 4;
+
+/**
+ * Splits a string on NUL bytes using character-level logic.
+ */
+function splitOnNul(value: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  for (let index = 0; index < value.length; index++) {
+    if (value.charCodeAt(index) === 0) {
+      result.push(current);
+      current = '';
+    } else {
+      current += value[index];
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+/**
+ * Splits a string on whitespace using character-level logic. Avoids regex
+ * to prevent super-linear runtime on adversarial input.
+ */
+function splitOnWhitespace(value: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  for (let index = 0; index < value.length; index++) {
+    const charCode = value.charCodeAt(index);
+    if (isWhitespaceCharCode(charCode)) {
+      if (current.length > 0) {
+        result.push(current);
+        current = '';
+      }
+    } else {
+      current += value[index] ?? '';
+    }
+  }
+  if (current.length > 0) {
+    result.push(current);
+  }
+  return result;
+}
+
+function isWhitespaceCharCode(charCode: number): boolean {
+  return isSpaceOrTab(charCode) || isNewlineLike(charCode);
+}
+
+function isSpaceOrTab(charCode: number): boolean {
+  return charCode === 0x20 || charCode === 0x09;
+}
+
+function isNewlineLike(charCode: number): boolean {
+  return (
+    charCode === 0x0a ||
+    charCode === 0x0d ||
+    charCode === 0x0b ||
+    charCode === 0x0c
+  );
+}
+
+/**
+ * Parses git log NUL-delimited output into RawCommit objects.
+ *
+ * The format is `%H%x00%s%x00%an%x00%P` — four NUL-separated fields per
+ * record (hash, subject, author, parents). With `-z`, Git separates
+ * records with a single NUL byte, so no trailing `%x00` is added after
+ * `%P`. (Adding it would produce a double-NUL between records: one from
+ * the explicit `%x00` and one from `-z`, which shifts every subsequent
+ * record off-alignment and loses every other commit.)
+ *
+ * Git guarantees NUL cannot appear in any field value, so field boundaries
+ * are unambiguous and fixed-position. Records with fewer than FIELD_COUNT
+ * fields (truncated output) are skipped to prevent phantom records from
+ * corrupting the commit list. Each hash is validated as a full 40-character
+ * lowercase hex Git object hash; records with an invalid hash are skipped.
+ */
+export function parseCommits(output: string): RawCommit[] {
+  const fields = splitOnNul(output);
+  const commits: RawCommit[] = [];
+  for (
+    let index = 0;
+    index + FIELD_COUNT <= fields.length;
+    index += FIELD_COUNT
+  ) {
+    const hash = fields[index] ?? '';
+    if (!FULL_HASH_PATTERN.test(hash)) {
+      continue;
+    }
+    const subject = fields[index + 1] ?? '';
+    const author = fields[index + 2] ?? '';
+    const parentsRaw = fields[index + 3] ?? '';
+    const parentList = splitOnWhitespace(parentsRaw.trim()).filter(
+      (parent) => parent.length > 0,
+    );
+    commits.push({
+      hash,
+      subject,
+      author,
+      isMerge: parentList.length > 1,
+      parents: parentList,
+    });
+  }
+  return commits;
+}
+
+/**
+ * Gets all commits in the range [fromRef..toRef] using `git log -z` with
+ * NUL-delimited output. No trailing `%x00` is added after `%P` because
+ * `-z` already inserts a single NUL between records — adding one in the
+ * format string would create a double-NUL that corrupts alignment.
+ * Returns ALL commits including merge commits — caller filtering decides
+ * which to keep.
+ */
+export function getCommits(fromRef: string, toRef = 'HEAD'): RawCommit[] {
+  const format = `%H%x00%s%x00%an%x00%P`;
+  const output = gitExec([
+    'log',
+    '-z',
+    `--format=${format}`,
+    `${fromRef}..${toRef}`,
+  ]);
+  return parseCommits(output);
+}
+
+/**
+ * Gets all commits reachable from `toRef` (default HEAD) including the
+ * root commit. Unlike `getCommits`, which uses the exclusive `from..to`
+ * range notation, this includes the root commit — essential for first
+ * releases where the entire repository history must be covered.
+ * Returns ALL commits including merge commits — caller filtering decides
+ * which to keep.
+ */
+export function getAllCommits(toRef = 'HEAD'): RawCommit[] {
+  const format = `%H%x00%s%x00%an%x00%P`;
+  const output = gitExec(['log', '-z', `--format=${format}`, toRef]);
+  return parseCommits(output);
+}
+
+/**
+ * Returns the hash of the root commit (the first commit with no parents).
+ * This is used as a fallback diff base when no previous release tag exists
+ * (first release scenario). Returns null when the repository has no commits.
+ */
+export function getRootCommit(): string | null {
+  try {
+    const output = gitExec(['rev-list', '--max-parents=0', 'HEAD']).trim();
+    // rev-list returns commits oldest-first by default, so the first line
+    // is the true root commit. When multiple roots exist, pick the oldest.
+    const firstLine = output.split('\n')[0]?.trim();
+    if (firstLine === undefined || firstLine.length === 0) {
+      return null;
+    }
+    return firstLine;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the commit hashes introduced by a two-parent merge commit (the
+ * commits on the merged branch, not on the base). Uses git rev-list with
+ * the merge-base exclusion pattern `^parent1 parent2`.
+ */
+export function getMergeIntroducedHashes(
+  firstParent: string,
+  secondParent: string,
+): string[] {
+  const output = gitExec(['rev-list', `^${firstParent}`, secondParent]);
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Returns the deduplicated commit hashes introduced by a multi-parent
+ * (octopus) merge — commits reachable from any non-first parent but not
+ * from the first parent. For a 2-parent merge this delegates to
+ * getMergeIntroducedHashes; for 3+ parents, it queries each non-first
+ * parent independently and deduplicates the union.
+ */
+export function getOctopusMergeIntroducedHashes(
+  parents: readonly string[],
+): string[] {
+  if (parents.length < 2) {
+    return [];
+  }
+  const firstParent = parents[0];
+  if (firstParent === undefined) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (let index = 1; index < parents.length; index += 1) {
+    const parent = parents[index];
+    if (parent === undefined) {
+      continue;
+    }
+    const introduced = getMergeIntroducedHashes(firstParent, parent);
+    for (const hash of introduced) {
+      if (!seen.has(hash)) {
+        seen.add(hash);
+        result.push(hash);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Creates a TopologyResolver backed by real git commands. Used by PR grouping
+ * to associate classic merge commits with their introduced child commits.
+ */
+export function createTopologyResolver(): TopologyResolver {
+  return {
+    getMergeIntroducedHashes(firstParent: string, secondParent: string) {
+      return getMergeIntroducedHashes(firstParent, secondParent);
+    },
+    getOctopusMergeIntroducedHashes(parents: readonly string[]) {
+      return getOctopusMergeIntroducedHashes(parents);
+    },
+  };
+}

--- a/scripts/release-notes/llm-port.ts
+++ b/scripts/release-notes/llm-port.ts
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { LlmPort } from './types.js';
+
+export interface LlmPortConfig {
+  readonly provider: string;
+  readonly model: string;
+  readonly apiKey: string;
+  readonly keyfilePath?: string;
+  readonly baseUrl?: string;
+  readonly temperature?: number;
+  /**
+   * Override for the CLI bin path. Defaults to the local built CLI at
+   * `<root>/packages/cli/bin/llxprt.cjs`.
+   */
+  readonly cliBinPath?: string;
+}
+
+export interface LlmRunnerOptions {
+  readonly encoding: 'utf8';
+  readonly env: NodeJS.ProcessEnv;
+  readonly stdio: 'pipe';
+  readonly timeout: number;
+  readonly cwd: string;
+}
+
+export type LlmRunner = (
+  command: string,
+  args: readonly string[],
+  options: LlmRunnerOptions,
+) => SpawnSyncReturns<string>;
+
+const DEFAULT_CLI_BIN = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'packages',
+  'cli',
+  'bin',
+  'llxprt.cjs',
+);
+function buildInlineProfile(config: LlmPortConfig): string {
+  return JSON.stringify({
+    provider: config.provider,
+    model: config.model,
+    modelParams: { temperature: config.temperature ?? 0.1 },
+    ephemeralSettings: {
+      'tools.allowed': [],
+    },
+  });
+}
+
+function buildPrompt(structuredContext: string): string {
+  return [
+    'Return valid JSON and nothing else.',
+    'The object must have one field: sourceIds.',
+    'sourceIds must contain 3-6 strings from the eligible source IDs listed below.',
+    'Select only IDs that correspond to user-facing changes with defensible impact.',
+    'Do not include emoji, markdown, internal mechanisms, refactors, tests, CI, or build work.',
+    structuredContext,
+  ].join('\n');
+}
+
+/**
+ * Builds a fully isolated environment for the spawned LLM process.
+ * Only PATH, TMPDIR, the isolated HOME, and provider configuration env vars
+ * are forwarded. Real HOME, npm config, GitHub/Docker/CI secrets, and any
+ * unrelated env are explicitly NOT inherited to prevent credential leakage.
+ */
+export function buildIsolatedEnvironment(
+  config: LlmPortConfig,
+  home: string,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH ?? '',
+    TMPDIR: process.env.TMPDIR ?? tmpdir(),
+    HOME: home,
+  };
+  if (config.baseUrl !== undefined) {
+    env.OPENAI_BASE_URL = config.baseUrl;
+  }
+  return env;
+}
+
+const defaultRunner: LlmRunner = (command, args, options) =>
+  spawnSync(command, [...args], options);
+
+/**
+ * Creates a private temporary keyfile containing the API key when no supplied
+ * keyfile path is configured. The keyfile is mode 0600 so only the owning
+ * user can read it. Returns the resolved keyfile path to pass via `--keyfile`
+ * — the API key is never passed in argv, profile, or env.
+ *
+ * When a supplied keyfilePath is relative, it is resolved to an absolute
+ * path relative to the parent process's cwd, because the spawned child
+ * process runs with an isolated tempDir cwd that would break relative
+ * resolution.
+ *
+ * Throws when the key contains CR/LF characters, which are not valid in API
+ * keys and would corrupt the keyfile or downstream auth headers.
+ */
+function resolveKeyfilePath(config: LlmPortConfig, tempDir: string): string {
+  if (hasNewline(config.apiKey)) {
+    throw new Error(
+      'API key contains CR/LF characters and cannot be written to keyfile.',
+    );
+  }
+  if (config.keyfilePath !== undefined) {
+    return resolve(config.keyfilePath);
+  }
+  const keyfilePath = join(tempDir, 'key');
+  writeFileSync(keyfilePath, config.apiKey, { mode: 0o600 });
+  return keyfilePath;
+}
+
+/**
+ * Returns true when the value contains CR or LF characters. Such characters
+ * are not valid in API keys and would corrupt keyfile writes or auth headers.
+ */
+function hasNewline(value: string): boolean {
+  return value.includes('\r') || value.includes('\n');
+}
+
+function validateConfig(config: LlmPortConfig): void {
+  if (config.provider.trim().length === 0) {
+    throw new Error('LLM provider is required');
+  }
+  if (config.model.trim().length === 0) {
+    throw new Error('LLM model is required');
+  }
+  if (
+    config.apiKey.trim().length === 0 &&
+    (config.keyfilePath === undefined || config.keyfilePath.trim().length === 0)
+  ) {
+    throw new Error('LLM API key or keyfile path is required');
+  }
+}
+
+function readSecretForRedaction(keyfilePath: string): string {
+  try {
+    return readFileSync(keyfilePath, 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+function invocationFailure(
+  result: SpawnSyncReturns<string>,
+  secrets: readonly string[],
+): Error {
+  if (
+    result.error?.name === 'ETIMEDOUT' ||
+    (result.error?.message ?? '').includes('ETIMEDOUT')
+  ) {
+    return new Error('LLxprt Code LLM invocation timed out');
+  }
+  const rawStderr = result.stderr ?? '';
+  const redacted = secrets
+    .filter((secret) => secret.length > 0)
+    .reduce(
+      (diagnostic, secret) => diagnostic.replaceAll(secret, '[redacted]'),
+      rawStderr,
+    );
+  const stderr = [...redacted]
+    .map((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code < 32 || (code >= 127 && code <= 159) ? ' ' : character;
+    })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+  const detail = stderr.length > 0 ? `: ${stderr}` : '';
+  return new Error(
+    `LLxprt Code LLM invocation failed (status ${result.status ?? 'null'})${detail}`,
+  );
+}
+
+export function createLlmPort(
+  config: LlmPortConfig,
+  runner: LlmRunner = defaultRunner,
+): LlmPort {
+  validateConfig(config);
+  return {
+    async generateHighlights(structuredContext: string): Promise<string> {
+      // Isolated temp HOME + cwd: the spawned process must not inherit the
+      // real HOME, npm config, or the repository working directory.
+      const tempDir = mkdtempSync(join(tmpdir(), 'llxprt-llm-'));
+      try {
+        const keyfilePath = resolveKeyfilePath(config, tempDir);
+
+        const cliBin = config.cliBinPath ?? DEFAULT_CLI_BIN;
+        const args: string[] = [
+          cliBin,
+          '--profile',
+          buildInlineProfile(config),
+          '--keyfile',
+          keyfilePath,
+          '--output-format',
+          'json',
+          '--prompt',
+          buildPrompt(structuredContext),
+        ];
+        if (config.baseUrl !== undefined) {
+          args.push('--baseurl', config.baseUrl);
+        }
+
+        const result = runner('node', args, {
+          encoding: 'utf8',
+          env: buildIsolatedEnvironment(config, tempDir),
+          stdio: 'pipe',
+          timeout: 120_000,
+          cwd: tempDir,
+        });
+        if (result.error !== undefined || result.status !== 0) {
+          const keyfileSecret = readSecretForRedaction(keyfilePath);
+          throw invocationFailure(result, [
+            config.apiKey,
+            keyfileSecret,
+            keyfilePath,
+          ]);
+        }
+        let envelope: unknown;
+        try {
+          envelope = JSON.parse(result.stdout ?? '');
+        } catch {
+          throw new Error('LLxprt Code returned an invalid JSON response');
+        }
+        if (
+          typeof envelope !== 'object' ||
+          envelope === null ||
+          !('response' in envelope) ||
+          typeof envelope.response !== 'string'
+        ) {
+          throw new Error('LLxprt Code returned an invalid JSON envelope');
+        }
+        return envelope.response;
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/scripts/release-notes/markdown.ts
+++ b/scripts/release-notes/markdown.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Maximum length for any rendered untrusted field. Prevents oversized
+ * content from blowing up release-notes structure.
+ */
+const MAX_FIELD_LENGTH = 500;
+
+/**
+ * Characters and substrings that carry structural meaning in Markdown and
+ * must never survive into rendered output from untrusted sources. Curated
+ * maintainer Markdown (docs/release-notes/<version>.md) is the ONLY trusted
+ * Markdown channel and bypasses this sanitization.
+ */
+const UNSAFE_CHARACTERS = /[`<>[\]\\#*_~]|!\[|]\(|:\s*\/\//g;
+
+/**
+ * URL schemes that must be stripped entirely to prevent link injection.
+ */
+const URL_SCHEMES = /\b(?:https?:\/\/|www\.)\S+/gi;
+
+/**
+ * Emoji and pictograph characters that must be stripped from all untrusted
+ * rendered fields. Release notes must be emoji-free per the issue contract
+ * and the LLM prompt's "NO EMOJIS" rule.
+ */
+const EMOJI_PATTERN =
+  /[0-9#*]\u{FE0F}?\u{20E3}|\p{Extended_Pictographic}|\p{Regional_Indicator}|\p{Emoji_Modifier}|\u{FE0F}|\u{200D}|\u{20E3}/gu;
+
+function truncateField(input: string): string {
+  return Array.from(input).slice(0, MAX_FIELD_LENGTH).join('');
+}
+
+/**
+ * Returns true when the character code is a control character that must be
+ * collapsed to a space: C0 (0x00–0x1F), DEL (0x7F), C1 (0x80–0x9F),
+ * Unicode line/paragraph separators (0x2028, 0x2029), soft hyphen (0x00AD),
+ * and BOM (0xFEFF). Uses codepoint comparison instead of a control-character
+ * regex to satisfy no-control-regex without suppression.
+ */
+function isControlCharacter(charCode: number): boolean {
+  return (
+    isC0Control(charCode) || isC1Control(charCode) || isUnicodeControl(charCode)
+  );
+}
+
+function isC0Control(charCode: number): boolean {
+  return charCode >= 0x00 && charCode <= 0x1f;
+}
+
+function isC1Control(charCode: number): boolean {
+  return charCode === 0x7f || (charCode >= 0x80 && charCode <= 0x9f);
+}
+
+function isUnicodeControl(charCode: number): boolean {
+  return charCode === 0x2028 || charCode === 0x2029 || charCode === 0x00ad;
+}
+
+const INVISIBLE_FORMAT_CONTROLS = new Set([0x061c, 0x2060, 0xfeff]);
+
+function isInvisibleFormatControl(charCode: number): boolean {
+  if (INVISIBLE_FORMAT_CONTROLS.has(charCode)) {
+    return true;
+  }
+  const inZeroWidthRange = charCode >= 0x200b && charCode <= 0x200f;
+  const inBidiOverrideRange = charCode >= 0x202a && charCode <= 0x202e;
+  const inBidiIsolateRange = charCode >= 0x2066 && charCode <= 0x2069;
+  return inZeroWidthRange || inBidiOverrideRange || inBidiIsolateRange;
+}
+
+/**
+ * Collapses all control characters (C0, DEL, C1, and Unicode control ranges)
+ * to a single space using character-level logic. Prevents embedded
+ * record/field separators, NULs, and other invisible characters from
+ * altering structure.
+ */
+function stripControlCharacters(input: string): string {
+  let result = '';
+  for (let index = 0; index < input.length; index++) {
+    const charCode = input.charCodeAt(index);
+    if (isInvisibleFormatControl(charCode)) {
+      continue;
+    }
+    result += isControlCharacter(charCode) ? ' ' : input[index];
+  }
+  return result;
+}
+
+/**
+ * Sanitizes a single untrusted string for safe Markdown rendering.
+ *
+ * Strips structural Markdown characters (backticks, angle brackets, square
+ * brackets, backslashes, headings, emphasis, links, images), collapses
+ * control characters and whitespace, and bounds the length. The result is
+ * plain text that cannot alter the surrounding Markdown structure.
+ */
+export function sanitizeMarkdown(input: string): string {
+  const stripped = stripControlCharacters(input)
+    .replace(URL_SCHEMES, ' ')
+    .replace(EMOJI_PATTERN, '')
+    .replace(UNSAFE_CHARACTERS, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return truncateField(stripped);
+}
+
+/**
+ * Sanitizes an optional string, returning an empty string for null/undefined.
+ */
+export function sanitizeOptionalMarkdown(
+  input: string | undefined | null,
+): string {
+  if (input === undefined || input === null) {
+    return '';
+  }
+  return sanitizeMarkdown(input);
+}
+
+/**
+ * Validates a bare GitHub login (without @). GitHub usernames are 1-39 chars,
+ * alphanumeric and hyphens, not starting or ending with a hyphen, no
+ * consecutive hyphens. Bot accounts use a `name[bot]` suffix. Team mentions
+ * use `org/team` format. This validation prevents malformed/injection
+ * logins from rendering as live mention links.
+ */
+const GITHUB_LOGIN_PATTERN =
+  /^(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\[bot\])?$/;
+
+function isValidGitHubLogin(login: string): boolean {
+  const accountName = login.endsWith('[bot]') ? login.slice(0, -5) : login;
+  if (accountName.length === 0 || accountName.length > 39) {
+    return false;
+  }
+  return GITHUB_LOGIN_PATTERN.test(login);
+}
+
+/**
+ * Renders a contributor handle safely. The caller supplies the bare login
+ * (without @); this function validates it against GitHub login grammar,
+ * sanitizes it, and ensures it cannot inject structure. Invalid logins are
+ * omitted entirely (returns empty string).
+ */
+export function renderContributor(login: string): string {
+  if (!isValidGitHubLogin(login)) {
+    return '';
+  }
+  return `- @${login}`;
+}
+
+/**
+ * Renders a bullet item safely, prefixing with "- " after sanitizing the text.
+ */
+export function renderBullet(text: string): string {
+  const sanitized = sanitizeMarkdown(text);
+  if (sanitized.length === 0) {
+    return '';
+  }
+  return `- ${sanitized}`;
+}
+
+/**
+ * Sanitizes a commit subject for the "All Changes" section. Like
+ * sanitizeMarkdown, but preserves `#N` PR/issue references (a `#` immediately
+ * followed by digits) which are common in commit subjects and carry no
+ * Markdown heading risk (headings require `#` at line start followed by
+ * whitespace). Heading-style `#` (at start followed by space) is still
+ * stripped.
+ */
+function sanitizeSubjectText(input: string): string {
+  const withoutUrls = stripControlCharacters(input)
+    .replace(URL_SCHEMES, ' ')
+    .replace(EMOJI_PATTERN, '');
+  return withoutUrls
+    .split(/(#\d+)/g)
+    .map((segment) =>
+      /^#\d+$/.test(segment)
+        ? segment
+        : segment.replace(UNSAFE_CHARACTERS, ' '),
+    )
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function sanitizeSubject(input: string): string {
+  return truncateField(sanitizeSubjectText(input));
+}
+
+export function sanitizeAllChangesLine(input: string): string {
+  return sanitizeSubjectText(input);
+}

--- a/scripts/release-notes/null-llm-port.ts
+++ b/scripts/release-notes/null-llm-port.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LlmPort } from './types.js';
+
+/**
+ * Creates an LLM port that always throws, forcing the deterministic fallback
+ * path. Used when no LLM credentials are configured (e.g. local dry-runs).
+ */
+export function createNullLlmPort(): LlmPort {
+  return {
+    async generateHighlights(_context: string): Promise<string> {
+      throw new Error('No LLM configured; using deterministic fallback.');
+    },
+  };
+}

--- a/scripts/release-notes/orchestrator.ts
+++ b/scripts/release-notes/orchestrator.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ChangeEntry,
+  GhPort,
+  LlmPort,
+  RawCommit,
+  ReleaseNotesData,
+  TopologyResolver,
+} from './types.js';
+import { buildChangeEntries } from './processing.js';
+import {
+  buildDeterministicFallback,
+  entriesToCategorizedBullets,
+  validateHighlights,
+  validateLlmOutput,
+} from './validation.js';
+import { buildHighlightsFromSelection } from './provenance.js';
+import { renderReleaseNotes } from './rendering.js';
+import { sanitizeSubject } from './markdown.js';
+
+export interface GenerateReleaseNotesInput {
+  readonly releaseTag: string;
+  readonly lastTag: string;
+  readonly isFirstRelease: boolean;
+  readonly isNightly: boolean;
+  readonly rawCommits: readonly RawCommit[];
+  readonly contributors: readonly string[];
+  readonly ghPort: GhPort;
+  readonly llmPort: LlmPort;
+  readonly curatedHeadline: string | null;
+  readonly repository?: string;
+  readonly topologyResolver?: TopologyResolver;
+}
+
+/**
+ * Validates that a value is a plausible Git commit hash: 7–40 hex characters.
+ * Anything else is treated as missing to prevent injection in "All Changes".
+ */
+const HASH_PATTERN = /^[0-9a-fA-F]{7,40}$/;
+
+/**
+ * Sanitizes a single raw commit into a safe "All Changes" bullet line.
+ * The subject is sanitized as plain text and the hash is validated and
+ * bounded; invalid hashes are omitted from the parenthetical.
+ */
+function formatCommitLine(commit: RawCommit): string {
+  const subject = sanitizeSubject(commit.subject);
+  const hashValid = HASH_PATTERN.test(commit.hash);
+  return hashValid ? `- ${subject} (${commit.hash})` : `- ${subject}`;
+}
+
+function formatAllChanges(commits: readonly RawCommit[]): string[] {
+  return commits.map(formatCommitLine);
+}
+
+const MAX_LLM_CONTEXT_BYTES = 64 * 1024;
+
+type LlmContextChange = {
+  readonly id: string;
+  readonly category: ChangeEntry['category'];
+  readonly title: string;
+  readonly userImpact: string | null;
+  readonly references: ReadonlyArray<{
+    readonly number: number;
+    readonly title: string;
+    readonly labels: readonly string[];
+  }>;
+};
+
+function toLlmContextChange(entry: ChangeEntry): LlmContextChange | null {
+  const first = entry.sourceFacts[0];
+  if (!entry.eligibleForHighlights || first === undefined) {
+    return null;
+  }
+  return {
+    id: entry.id,
+    category: entry.category,
+    title: first.title,
+    userImpact: first.userImpact,
+    references: entry.enriched.map((ref) => ({
+      number: ref.number,
+      title: ref.title.slice(0, 200),
+      labels: ref.labels,
+    })),
+  };
+}
+
+function buildLlmContext(entries: readonly ChangeEntry[]): string {
+  const candidates = entries
+    .map(toLlmContextChange)
+    .filter((change): change is LlmContextChange => change !== null);
+  const changes: LlmContextChange[] = [];
+  for (const change of candidates) {
+    const candidate = JSON.stringify({ changes: [...changes, change] });
+    if (Buffer.byteLength(candidate, 'utf8') <= MAX_LLM_CONTEXT_BYTES) {
+      changes.push(change);
+    }
+  }
+  return JSON.stringify({ changes });
+}
+
+async function generateHighlights(
+  llmPort: LlmPort,
+  entries: readonly ChangeEntry[],
+): Promise<readonly string[] | null> {
+  const eligibleEntries = entries.filter(
+    (entry) => entry.eligibleForHighlights,
+  );
+  if (eligibleEntries.length === 0) {
+    return [];
+  }
+
+  const entriesWithFacts = eligibleEntries.filter(
+    (entry) => entry.sourceFacts.length > 0,
+  );
+  if (entriesWithFacts.length === 0) {
+    return [];
+  }
+
+  const context = buildLlmContext(entries);
+  if (context === '{"changes":[]}') {
+    return null;
+  }
+
+  try {
+    const parsed = validateLlmOutput(await llmPort.generateHighlights(context));
+    if (parsed === null) {
+      return null;
+    }
+    const validated = validateHighlights(parsed.sourceIds, eligibleEntries);
+    if (validated === null) {
+      return null;
+    }
+    return buildHighlightsFromSelection(validated, entriesWithFacts);
+  } catch {
+    console.warn(
+      'LLM highlight selection failed; using deterministic release-note highlights.',
+    );
+    return null;
+  }
+}
+
+/**
+ * Validates the repository string as `owner/name` and builds a GitHub
+ * compare URL. Returns null when the repository is missing or malformed
+ * so the comparison section is omitted rather than rendering a broken URL.
+ */
+function buildComparisonUrl(
+  repository: string | undefined,
+  lastTag: string,
+  releaseTag: string,
+  isFirstRelease: boolean,
+): string | null {
+  if (isFirstRelease) {
+    return null;
+  }
+  if (repository === undefined) {
+    return null;
+  }
+  if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repository)) {
+    return null;
+  }
+  const safeRef = (ref: string): boolean =>
+    /^[A-Za-z0-9._/-]+$/.test(ref) &&
+    !ref.startsWith('/') &&
+    !ref.endsWith('/') &&
+    !ref.includes('//');
+  if (!safeRef(lastTag) || !safeRef(releaseTag)) {
+    return null;
+  }
+  return `https://github.com/${repository}/compare/${encodeURIComponent(lastTag)}...${encodeURIComponent(releaseTag)}`;
+}
+
+export async function generateReleaseNotes(
+  input: GenerateReleaseNotesInput,
+): Promise<string> {
+  const entries = await buildChangeEntries(
+    input.rawCommits,
+    input.ghPort,
+    input.topologyResolver,
+  );
+  const generatedHighlights = await generateHighlights(input.llmPort, entries);
+  const fallback = buildDeterministicFallback(entries);
+  const highlights = generatedHighlights ?? fallback.highlights;
+  const comparisonUrl = buildComparisonUrl(
+    input.repository,
+    input.lastTag,
+    input.releaseTag,
+    input.isFirstRelease,
+  );
+  const data: ReleaseNotesData = {
+    releaseTag: input.releaseTag,
+    highlights,
+    categorized: entriesToCategorizedBullets(entries),
+    allChanges: formatAllChanges(input.rawCommits),
+    contributors: input.contributors,
+    lastTag: input.lastTag,
+    isFirstRelease: input.isFirstRelease,
+    comparisonUrl,
+    curatedHeadline: input.isNightly ? null : input.curatedHeadline,
+  };
+  return renderReleaseNotes(data);
+}

--- a/scripts/release-notes/processing.ts
+++ b/scripts/release-notes/processing.ts
@@ -1,0 +1,477 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ChangeEntry,
+  EnrichedRef,
+  GhPort,
+  ParsedRef,
+  RawCommit,
+  TopologyResolver,
+} from './types.js';
+import {
+  classifyCommit,
+  classifyEnrichedRefs,
+  deriveEffectiveCategory,
+  isEligibleForHighlights,
+  strongerCategory,
+} from './classification.js';
+import { parseRefs, extractPrIdentity, isProcessNoise } from './filtering.js';
+import { extractSourceFacts } from './provenance.js';
+
+/**
+ * A group of commits that belong to the same logical change (same PR).
+ */
+export interface CommitGroup {
+  readonly representative: RawCommit;
+  readonly commits: readonly RawCommit[];
+  readonly childHashes: readonly string[];
+}
+
+/**
+ * Groups raw commits by their PR identity using git topology. The grouping
+ * key is the terminal squash marker `(#N)` or classic merge marker
+ * `Merge pull request #N` — never a `Fixes #N` issue reference, since two
+ * distinct PRs can close the same issue and must not be merged into one
+ * entry.
+ *
+ * Classic merge commits (two parents) are resolved via the TopologyResolver
+ * to find their introduced child commits; those children are grouped under
+ * the merge's PR identity and their hashes populate childHashes. This ensures
+ * no commit is lost: the merge and all its children become one entry.
+ *
+ * Commits without any PR identity become individual entries. Process-noise
+ * commits are dropped from model input but never lose PR identity.
+ */
+function moveCommitToOwnerGroup(
+  commit: RawCommit,
+  groups: CommitGroup[],
+  childToGroup: ReadonlyMap<string, number>,
+  groupByPrNumber: ReadonlyMap<number, number>,
+): void {
+  const ownerIndex = childToGroup.get(commit.hash);
+  const prNumber = extractPrIdentity(commit);
+  const ownIndex =
+    prNumber === null ? undefined : groupByPrNumber.get(prNumber);
+  if (
+    ownerIndex === undefined ||
+    ownIndex === undefined ||
+    ownerIndex === ownIndex
+  ) {
+    return;
+  }
+  const ownerGroup = groups[ownerIndex];
+  const ownGroup = groups[ownIndex];
+  if (ownerGroup === undefined || ownGroup === undefined) {
+    return;
+  }
+  groups[ownerIndex] = {
+    ...ownerGroup,
+    commits: [...ownerGroup.commits, commit],
+  };
+  groups[ownIndex] = {
+    ...ownGroup,
+    commits: ownGroup.commits.filter(
+      (candidate) => candidate.hash !== commit.hash,
+    ),
+  };
+}
+
+function reconcileNestedMerges(
+  groups: CommitGroup[],
+  classicMerges: readonly RawCommit[],
+  childToGroup: ReadonlyMap<string, number>,
+  groupByPrNumber: ReadonlyMap<number, number>,
+): void {
+  for (const commit of classicMerges) {
+    moveCommitToOwnerGroup(commit, groups, childToGroup, groupByPrNumber);
+  }
+  for (let index = 0; index < groups.length; index += 1) {
+    const current = groups[index];
+    if (current === undefined) {
+      continue;
+    }
+    groups[index] = {
+      ...current,
+      childHashes: current.childHashes.filter(
+        (hash) => childToGroup.get(hash) === index,
+      ),
+    };
+  }
+}
+
+function resolveIntroducedHashes(
+  commit: RawCommit,
+  resolver: TopologyResolver | undefined,
+): readonly string[] {
+  if (resolver === undefined) {
+    return [];
+  }
+  const [firstParent, secondParent] = commit.parents;
+  if (firstParent === undefined || secondParent === undefined) {
+    return [];
+  }
+  if (commit.parents.length === 2) {
+    return resolver.getMergeIntroducedHashes(firstParent, secondParent);
+  }
+  return resolver.getOctopusMergeIntroducedHashes(commit.parents);
+}
+
+function registerMergeGroups(
+  commits: readonly RawCommit[],
+  resolver: TopologyResolver | undefined,
+  groups: CommitGroup[],
+  groupByPrNumber: Map<number, number>,
+  childToGroup: Map<string, number>,
+): RawCommit[] {
+  const merges = commits.filter(
+    (commit) => commit.isMerge && commit.parents.length >= 2,
+  );
+  for (const commit of merges) {
+    const prNumber = extractPrIdentity(commit);
+    if (prNumber === null) {
+      continue;
+    }
+    const groupIndex = groups.length;
+    const childHashes = [...new Set(resolveIntroducedHashes(commit, resolver))];
+    for (const hash of childHashes) {
+      childToGroup.set(hash, groupIndex);
+    }
+    groupByPrNumber.set(prNumber, groupIndex);
+    groups.push({ representative: commit, commits: [commit], childHashes });
+  }
+  return merges;
+}
+
+/**
+ * Assigns a non-merge commit that is a child of a registered classic merge
+ * to its owning group. Returns true when the commit was mapped to a group
+ * (whether or not the group exists), so the caller knows to skip further
+ * processing. Returns false when the commit is not a mapped child.
+ */
+function assignChildToGroup(
+  commit: RawCommit,
+  groups: CommitGroup[],
+  childToGroup: ReadonlyMap<string, number>,
+): boolean {
+  const mappedGroup = childToGroup.get(commit.hash);
+  if (mappedGroup === undefined) {
+    return false;
+  }
+  const existing = groups[mappedGroup];
+  if (existing !== undefined) {
+    const childHashes = existing.childHashes.includes(commit.hash)
+      ? existing.childHashes
+      : [...existing.childHashes, commit.hash];
+    groups[mappedGroup] = {
+      representative: existing.representative,
+      commits: [...existing.commits, commit],
+      childHashes,
+    };
+  }
+  return true;
+}
+
+/**
+ * Assigns a non-merge commit by its PR identity: joins an existing group
+ * for that PR, or creates a new group. Commits without a PR identity form
+ * a new individual group.
+ */
+function assignByPrIdentity(
+  commit: RawCommit,
+  groups: CommitGroup[],
+  groupByPrNumber: Map<number, number>,
+): void {
+  const prNumber = extractPrIdentity(commit);
+  if (prNumber === null) {
+    groups.push({
+      representative: commit,
+      commits: [commit],
+      childHashes: [],
+    });
+    return;
+  }
+  const existingIndex = groupByPrNumber.get(prNumber);
+  if (existingIndex === undefined) {
+    groupByPrNumber.set(prNumber, groups.length);
+    groups.push({
+      representative: commit,
+      commits: [commit],
+      childHashes: [],
+    });
+    return;
+  }
+  const existing = groups[existingIndex];
+  if (existing === undefined) {
+    return;
+  }
+  groups[existingIndex] = {
+    representative: existing.representative,
+    commits: [...existing.commits, commit],
+    childHashes: existing.childHashes,
+  };
+}
+
+export function groupPrCommits(
+  commits: readonly RawCommit[],
+  resolver?: TopologyResolver,
+): readonly CommitGroup[] {
+  const groups: CommitGroup[] = [];
+  const groupByPrNumber = new Map<number, number>();
+  const childToGroup = new Map<string, number>();
+  const multiParentMerges = registerMergeGroups(
+    commits,
+    resolver,
+    groups,
+    groupByPrNumber,
+    childToGroup,
+  );
+
+  reconcileNestedMerges(
+    groups,
+    multiParentMerges,
+    childToGroup,
+    groupByPrNumber,
+  );
+
+  // Second pass: assign non-merge commits to a group by PR identity, or by
+  // being a child of a registered classic merge. Commits without either form
+  // a new individual group.
+  const nonMergeCommits = commits.filter((candidate) => !candidate.isMerge);
+  for (const commit of nonMergeCommits) {
+    if (assignChildToGroup(commit, groups, childToGroup)) {
+      continue;
+    }
+    assignByPrIdentity(commit, groups, groupByPrNumber);
+  }
+
+  return groups;
+}
+
+/**
+ * Collects all unique ref numbers from a set of commit groups for batched
+ * gh dereferencing. This includes both PR identity numbers and Fixes/Closes
+ * issue references (kept as enrichment).
+ */
+function collectRefNumbers(groups: readonly CommitGroup[]): number[] {
+  const numbers = new Set<number>();
+  for (const group of groups) {
+    for (const commit of group.commits) {
+      for (const ref of parseRefs(commit.subject)) {
+        numbers.add(ref.number);
+      }
+    }
+  }
+  return [...numbers];
+}
+
+/**
+ * Builds enriched refs for a single group's refs, using the batched map.
+ *
+ * Refs whose PR number is the identity of a different group are excluded to
+ * prevent label contamination in nested merge topology: when the outer PR
+ * owns the inner merge commit topologically, the inner merge's PR identity
+ * must NOT bleed into the outer group's enrichment. Conversely, the group's
+ * own PR identity ref is always included even when the merge commit that
+ * carries it has moved to an outer group (nested merge topology).
+ */
+function unavailableRef(number: number): EnrichedRef {
+  return {
+    number,
+    title: '',
+    body: '',
+    labels: [],
+    labelsTruncated: false,
+    metadataAvailable: false,
+    author: '',
+    isPr: false,
+    userImpact: null,
+  };
+}
+
+function resolveGroupRefs(
+  group: CommitGroup,
+  enrichedMap: ReadonlyMap<number, EnrichedRef>,
+  foreignPrNumbers: ReadonlySet<number>,
+  ownPrNumber: number | null,
+): { refs: ParsedRef[]; enriched: EnrichedRef[] } {
+  const refs: ParsedRef[] = [];
+  const enriched: EnrichedRef[] = [];
+  const seenNumbers = new Set<number>();
+
+  // The group's own PR identity is always retained, even when the merge commit
+  // carrying it has moved to an outer group in nested merge topology.
+  if (ownPrNumber !== null) {
+    refs.push({ number: ownPrNumber, verb: 'pr' });
+    seenNumbers.add(ownPrNumber);
+    enriched.push(enrichedMap.get(ownPrNumber) ?? unavailableRef(ownPrNumber));
+  }
+
+  for (const commit of group.commits) {
+    for (const ref of parseRefs(commit.subject)) {
+      if (seenNumbers.has(ref.number) || foreignPrNumbers.has(ref.number)) {
+        continue;
+      }
+      seenNumbers.add(ref.number);
+      refs.push(ref);
+      enriched.push(enrichedMap.get(ref.number) ?? unavailableRef(ref.number));
+    }
+  }
+  return { refs, enriched: dedupeEnriched(enriched) };
+}
+
+function dedupeEnriched(enriched: EnrichedRef[]): EnrichedRef[] {
+  const seen = new Set<number>();
+  const result: EnrichedRef[] = [];
+  for (const ref of enriched) {
+    if (!seen.has(ref.number)) {
+      seen.add(ref.number);
+      result.push(ref);
+    }
+  }
+  return result;
+}
+
+/**
+ * Processes raw commits into classified, enriched change entries. The core
+ * transformation pipeline:
+ *   group (topology-aware, PR-identity-keyed) → filter noise → dereference → classify
+ *
+ * Classic merge commits and their child commits are kept through grouping
+ * (no commits lost), then grouped into one entry per PR. Process noise is
+ * filtered without losing PR identity. Enrichment failure degrades gracefully.
+ */
+export async function buildChangeEntries(
+  commits: readonly RawCommit[],
+  ghPort: GhPort,
+  resolver?: TopologyResolver,
+): Promise<readonly ChangeEntry[]> {
+  const groups = groupPrCommits(commits, resolver);
+  const refNumbers = collectRefNumbers(groups);
+  const allPrNumbers = new Set<number>(
+    groups
+      .map((group) => extractPrIdentity(group.representative))
+      .filter((num): num is number => num !== null),
+  );
+
+  let enrichedMap: ReadonlyMap<number, EnrichedRef> = new Map();
+  if (refNumbers.length > 0) {
+    try {
+      enrichedMap = await ghPort.fetchRefs(refNumbers);
+    } catch {
+      console.warn(
+        `GitHub enrichment failed for ${refNumbers.length} release-note references; continuing without metadata.`,
+      );
+    }
+  }
+
+  const entries: ChangeEntry[] = [];
+  for (const group of groups) {
+    const entry = buildGroupEntry(group, enrichedMap, allPrNumbers);
+    if (entry !== null) {
+      entries.push(entry);
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Determines whether a group should be omitted from the categorized entry
+ * list. A group is omitted when all commits are process noise, or when a
+ * classic merge wrapper has no non-noise child commits (all children are
+ * process noise). Returns true when the group should be skipped.
+ */
+function shouldOmitGroup(
+  group: CommitGroup,
+  nonNoiseCommits: readonly RawCommit[],
+): boolean {
+  if (nonNoiseCommits.length === 0 && isProcessNoise(group.representative)) {
+    return true;
+  }
+  // Classic merge wrapper whose only non-noise commit is the merge itself
+  // (all child commits are process noise): omit the logical categorized
+  // entry. Raw commits (merge + children) are retained in All Changes
+  // because the orchestrator formats rawCommits directly.
+  return (
+    group.representative.isMerge &&
+    group.commits.length > 1 &&
+    nonNoiseCommits.length === 1 &&
+    nonNoiseCommits[0] === group.representative
+  );
+}
+
+/**
+ * Builds a ChangeEntry for a single commit group, or returns null when the
+ * group should be omitted (all process noise, or a classic merge wrapper
+ * with no substantive child commits).
+ *
+ * For classic merge groups, the first non-noise child commit is preferred as
+ * the representative — a substantive child carries classification signal that
+ * the merge commit's boilerplate subject does not.
+ */
+function buildGroupEntry(
+  group: CommitGroup,
+  enrichedMap: ReadonlyMap<number, EnrichedRef>,
+  allPrNumbers: ReadonlySet<number>,
+): ChangeEntry | null {
+  const nonNoiseCommits = group.commits.filter(
+    (commit) => !isProcessNoise(commit),
+  );
+  if (shouldOmitGroup(group, nonNoiseCommits)) {
+    return null;
+  }
+  const nonMergeNonNoise = group.representative.isMerge
+    ? nonNoiseCommits.filter((commit) => !commit.isMerge)
+    : nonNoiseCommits;
+  const representative =
+    nonMergeNonNoise.length > 0
+      ? (nonMergeNonNoise[0] ?? group.representative)
+      : group.representative;
+  const ownPrIdentity = extractPrIdentity(group.representative);
+  // PR numbers owned by other groups must not contaminate this group's
+  // enrichment. The own PR identity is retained; all others are foreign.
+  const foreignPrNumbers =
+    ownPrIdentity === null
+      ? allPrNumbers
+      : new Set([...allPrNumbers].filter((num) => num !== ownPrIdentity));
+  const { refs, enriched } = resolveGroupRefs(
+    group,
+    enrichedMap,
+    foreignPrNumbers,
+    ownPrIdentity,
+  );
+  const commitCategory = classifyCommit(representative);
+  const ownRef =
+    ownPrIdentity === null
+      ? undefined
+      : enriched.find((ref) => ref.number === ownPrIdentity);
+  const hasOwnPrMetadata = ownRef?.metadataAvailable === true;
+  const prefixCategory = hasOwnPrMetadata
+    ? strongerCategory(commitCategory, classifyEnrichedRefs(enriched))
+    : commitCategory;
+  const category = deriveEffectiveCategory(prefixCategory, enriched);
+  const eligible = isEligibleForHighlights(category, enriched);
+  const prIdentity = extractPrIdentity(group.representative);
+  const source = {
+    id:
+      prIdentity === null
+        ? `commit:${representative.hash}`
+        : `ref:${prIdentity}`,
+    enriched,
+    category,
+  };
+  return {
+    ...source,
+    subject: representative.subject,
+    hash: representative.hash,
+    author: representative.author,
+    refs,
+    eligibleForHighlights: eligible,
+    childHashes: group.childHashes,
+    sourceFacts: extractSourceFacts(source),
+  };
+}

--- a/scripts/release-notes/provenance.ts
+++ b/scripts/release-notes/provenance.ts
@@ -1,0 +1,541 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ChangeEntry, SourceFact } from './types.js';
+import { sanitizeMarkdown } from './markdown.js';
+
+/**
+ * Regular-expression patterns for lines that are structural boilerplate rather
+ * than user-impact prose: Markdown headings, closing keywords, and
+ * issue/PR template section labels. Each is matched case-insensitively at the
+ * start of a trimmed raw line (before markdown stripping).
+ */
+const BOILERPLATE_LINE_PATTERNS: readonly RegExp[] = [
+  /^#+\s+/i,
+  /^\s*(summary|description|motivation|context|background)\b\s*:?\s*/i,
+  /^\s*(what|why|how|steps to reproduce|reproduction|expected|actual)\b\s*:?\s*/i,
+  /^\s*(checklist|checkbox|verification|verified|testing|test plan|implementation)\b\s*:?\s*/i,
+  /^\s*(checklist for submitter|submitter checklist|reviewer checklist)\b\s*:?\s*/i,
+  /^\s*(clos(?:e|es|ed)|fix(?:e|es|ed)|resolv(?:e|es|ed)|address(?:e|es|ed))\s+#\d+/i,
+  /^\s*(fixes|closes|resolves)\s+https?:\/\//i,
+  /^\s*(\[[ x]\])\s*/i,
+  /^\s*\d+\.\s*/i,
+  /^\s*[-*]\s+/i,
+];
+
+/**
+ * Section headings that introduce provenance/test/verification boilerplate.
+ * These sections must be suppressed until another heading — blank lines do
+ * NOT end them, because their content is never user-impact prose.
+ */
+const HARD_SUPPRESS_SECTION_HEADINGS: readonly RegExp[] = [
+  /^#+\s*(checklist|checkbox|verification|verified|testing|test plan|reproduction|implementation)\b/i,
+  /^#+\s*(checklist for submitter|submitter checklist|reviewer checklist)\b/i,
+  /^#+\s*(how|steps to reproduce)\b/i,
+];
+
+/**
+ * Section headings that introduce template boilerplate (Summary, Description,
+ * Motivation, etc.). These are skipped as headings but their body content
+ * can still contain defensible prose after a blank line — the heading itself
+ * and immediately-following boilerplate lines (like Fixes #N) are skipped.
+ */
+const SOFT_BOILERPLATE_HEADINGS: readonly RegExp[] = [
+  /^#+\s*(summary|description|motivation|context|background)\b/i,
+];
+
+const CAPABILITY_SIGNALS: readonly string[] = [
+  'can now',
+  'can use',
+  'can configure',
+  'can select',
+  'can run',
+  'can specify',
+  'can access',
+  'can create',
+  'can manage',
+  'can view',
+  'can export',
+  'can import',
+  'can pin',
+  'allows',
+  'lets',
+  'adds support',
+  'add support',
+  'supports',
+  'support for',
+  'ability to',
+  'will see',
+  'will receive',
+  'will get',
+  'new command',
+  'new option',
+  'new setting',
+  'new capability',
+];
+
+const DIRECTIONAL_IMPACT_SIGNALS: readonly string[] = [
+  'no longer',
+  'crash-free',
+  'now receive',
+  'now get',
+  'now see',
+  'now have',
+  'faster',
+  'safer',
+  'simpler',
+  'easier',
+  'cleaner',
+  'clearer',
+  'better',
+  'enhances',
+  'improves',
+  'improved',
+  'prevents',
+  'restores',
+  'reduces',
+  'removes the need',
+  'benefit',
+  'lower latency',
+  'more reliable',
+];
+
+/**
+ * Returns true for ANY Markdown heading line.
+ */
+function isHeading(rawLine: string): boolean {
+  return /^#+\s+/.test(rawLine);
+}
+
+function isHardSuppressSection(rawLine: string): boolean {
+  return HARD_SUPPRESS_SECTION_HEADINGS.some((pattern) =>
+    pattern.test(rawLine),
+  );
+}
+
+function isSoftBoilerplateHeading(rawLine: string): boolean {
+  return SOFT_BOILERPLATE_HEADINGS.some((pattern) => pattern.test(rawLine));
+}
+
+/**
+ * Returns true when a raw (unmodified) line is a standalone boilerplate marker
+ * — a heading, closing keyword, checklist item, or list item — rather than
+ * user-impact prose.
+ */
+function isBoilerplateLine(rawLine: string): boolean {
+  return BOILERPLATE_LINE_PATTERNS.some((pattern) => pattern.test(rawLine));
+}
+
+/**
+ * Extracts a defensible user impact statement from an enriched ref body.
+ * The impact must be a non-empty, plain-text sentence that does not contain
+ * mechanism-only language, template boilerplate, or closing-keyword noise.
+ *
+ * The body is split into lines. Lines under a hard-suppress section heading
+ * (Verification, Checklist, Reproduction, Implementation, etc.) are skipped
+ * until the next heading — blank lines do NOT end a hard-suppress section.
+ * Lines under a soft-boilerplate heading (Summary, Description) are skipped
+ * only as headings and immediately-following boilerplate; content after a
+ * blank line can be selected. Code blocks are removed entirely. The first
+ * remaining prose line that forms a complete sentence (ending in `.`, `!`,
+ * or `?`) or is long enough to be meaningful is used. Returns null when no
+ * defensible impact can be established.
+ */
+interface ImpactScanState {
+  inHardSuppressSection: boolean;
+  activeFence: FenceMarker | null;
+}
+
+/**
+ * Describes an active fenced code block: the fence character (backtick or
+ * tilde) and the opening fence length. A closing fence must use the same
+ * character with at least this many markers.
+ */
+type FenceMarker = { readonly char: '`' | '~'; readonly length: number };
+
+/**
+ * Matches the opening fence of a line: up to three spaces of indentation
+ * (per CommonMark), then three or more backticks or tildes. The info
+ * string after the fence characters is irrelevant for block detection.
+ */
+const MARKDOWN_CONTAINER_RE = /^(?: {0,3}> ?| {0,3}(?:[-+*]|\d+[.)]) +)/;
+const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/;
+
+function stripMarkdownContainers(rawLine: string): string {
+  let line = rawLine;
+  let previous: string;
+  do {
+    previous = line;
+    line = line.replace(MARKDOWN_CONTAINER_RE, '');
+  } while (line !== previous);
+  return line;
+}
+
+function parseFenceOpen(rawLine: string): FenceMarker | null {
+  const match = FENCE_OPEN_RE.exec(stripMarkdownContainers(rawLine));
+  if (match === null) {
+    return null;
+  }
+  const seq = match[1]!;
+  const char = seq[0];
+  if (char !== '`' && char !== '~') {
+    return null;
+  }
+  return { char, length: seq.length };
+}
+
+/**
+ * Returns true when a line closes the currently active fence. Per CommonMark,
+ * the closing fence may be indented up to three spaces, must use the same
+ * character as the opening fence, must have at least as many markers, and
+ * may only contain trailing whitespace after the fence characters.
+ */
+function isFenceClose(rawLine: string, active: FenceMarker): boolean {
+  const match = /^ {0,3}(`{3,}|~{3,})\s*$/.exec(
+    stripMarkdownContainers(rawLine),
+  );
+  if (match === null) {
+    return false;
+  }
+  const seq = match[1]!;
+  return seq[0] === active.char && seq.length >= active.length;
+}
+
+function impactCandidate(
+  rawLine: string,
+  state: ImpactScanState,
+): string | null {
+  const trimmed = rawLine.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  // Any heading resets hard-suppress state.
+  if (isHeading(trimmed)) {
+    state.inHardSuppressSection = false;
+  }
+  // A hard-suppress heading starts the suppression until another heading.
+  if (isHardSuppressSection(trimmed)) {
+    state.inHardSuppressSection = true;
+    return null;
+  }
+  if (state.inHardSuppressSection) {
+    return null;
+  }
+  // A soft-boilerplate heading is skipped as a heading, but does not
+  // suppress content below it.
+  if (isSoftBoilerplateHeading(trimmed)) {
+    return null;
+  }
+  if (isBoilerplateLine(trimmed)) {
+    return null;
+  }
+  const line = rawLine
+    .replace(/[#>*_`~[\]]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const sentenceEnd = line.search(/[.!?](?:\s|$)/);
+  const sentence = sentenceEnd === -1 ? line : line.slice(0, sentenceEnd + 1);
+  const bounded = sentence.slice(0, 240).trim();
+  if (bounded.length < 10 || isMechanismOnly(bounded)) {
+    return null;
+  }
+  return sanitizeMarkdown(bounded);
+}
+
+function extractUserImpact(body: string): string | null {
+  const state: ImpactScanState = {
+    inHardSuppressSection: false,
+    activeFence: null,
+  };
+  for (const rawLine of body.split('\n')) {
+    const candidate = scanLine(rawLine, state);
+    if (candidate !== null) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Processes a single body line for user-impact extraction. Returns a
+ * candidate impact string when found, or null to continue scanning.
+ * Manages fenced-code-block state: lines inside an open fence are skipped
+ * (with potential close detection), and opening fence lines enter the
+ * fenced state.
+ */
+function scanLine(rawLine: string, state: ImpactScanState): string | null {
+  if (state.activeFence !== null) {
+    if (isFenceClose(rawLine, state.activeFence)) {
+      state.activeFence = null;
+    }
+    return null;
+  }
+  const fenceOpen = parseFenceOpen(rawLine);
+  if (fenceOpen !== null) {
+    state.activeFence = fenceOpen;
+    return null;
+  }
+  return impactCandidate(rawLine, state);
+}
+
+/**
+ * Determines whether an impact sentence has a defensible user-facing
+ * subject: an explicit user actor (users, developers), a user capability
+ * ("can now", "allows", "ability to"), or an observable outcome ("faster",
+ * "fixes", "no longer"). Weak signals alone ("new", "option",
+ * "configuration", "cli") are NOT sufficient — they describe what changed
+ * but not who benefits or what the user observes.
+ *
+ * Matching uses word boundaries to prevent substring collisions: "fix" must
+ * not match "prefix", "new" must not match "renew", "option" must not match
+ * "optional", "user" must not match "username", etc.
+ */
+function hasUserImpactSignal(impact: string): boolean {
+  const lower = impact.toLowerCase();
+  const capabilityStatement = /\bcan (?:now )?[a-z]+\b/.test(lower);
+  const negativeCapability =
+    /\bcan (?:now )?(?:crash|fail|hang|stall|lose|break|corrupt)\b/.test(lower);
+  const concreteFix =
+    /\bfix(?:es|ed)?\b/.test(lower) &&
+    /\b(?:crash|hang|memory leak|data loss|startup failure|login failure)s?\b/.test(
+      lower,
+    );
+  const explicitCapability = CAPABILITY_SIGNALS.some((signal) =>
+    containsWordOrPhrase(lower, signal),
+  );
+  const explicitActor =
+    /\b(?:users?|customers?|developers?|operators?|administrators?|you)\b/.test(
+      lower,
+    );
+  const actorCapability =
+    explicitActor &&
+    (explicitCapability || (capabilityStatement && !negativeCapability));
+  const directionalImpact = DIRECTIONAL_IMPACT_SIGNALS.some((signal) =>
+    containsWordOrPhrase(lower, signal),
+  );
+  const observableSubject =
+    explicitActor ||
+    /\b(?:startup|commands?|sessions?|errors?|output|responses?|requests?|inputs?|files?|messages?|authentication|login|memory|latency|performance|stability|reliability|workflows?|compatibility)\b/.test(
+      lower,
+    );
+  return [
+    actorCapability,
+    concreteFix,
+    directionalImpact && observableSubject,
+  ].some(Boolean);
+}
+
+/**
+ * Heuristic: determines whether an impact sentence is mechanism-only (internal
+ * refactoring, test, CI, build, implementation detail) rather than
+ * user-facing. Returns true when the sentence describes internal mechanics
+ * with no user benefit. A sentence is mechanism-only when it contains a
+ * mechanism phrase, OR when it lacks any positive user-facing signal.
+ *
+ * Matching uses word/phrase boundaries to prevent substring collisions.
+ */
+function isMechanismOnly(impact: string): boolean {
+  if (!hasUserImpactSignal(impact)) {
+    return true;
+  }
+  const lower = impact.toLowerCase();
+  const describesMaintenanceMechanism =
+    /\b(?:internal|state machine|refactor|ci|build|tests?|test harness|code quality|release process|dependencies|dependency update)\b/.test(
+      lower,
+    );
+  const observableResolution =
+    /\b(?:prevents?|fix(?:es|ed)?|no longer|restores?)\b/.test(lower) &&
+    /\b(?:startup|crash|failure|data loss|memory leak|login|errors?)s?\b/.test(
+      lower,
+    );
+  if (describesMaintenanceMechanism && !observableResolution) {
+    return true;
+  }
+  const normalized = lower.replace(/[-/]/g, ' ');
+  const describesProductMechanism =
+    /\b(?:parser|registry|adapter layer)\b/.test(normalized);
+  const identifiesBeneficiary =
+    /\b(?:users?|customers?|developers?|operators?|administrators?|you)\b/.test(
+      lower,
+    );
+  return describesProductMechanism && !identifiesBeneficiary;
+}
+
+/**
+ * Matches a word or phrase at word boundaries within a lowercased string.
+ * For single-word signals, uses `\b` boundaries to prevent substring
+ * collisions (e.g. "fix" must not match "prefix", "new" must not match
+ * "renew", "option" must not match "optional", "user" must not match
+ * "username"). For multi-word phrases, the phrase is matched as a
+ * contiguous sequence of words with boundaries on both ends.
+ */
+function containsWordOrPhrase(text: string, signal: string): boolean {
+  const escaped = signal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\b${escaped}\\b`);
+  return pattern.test(text);
+}
+
+/**
+ * Extracts validated SourceFacts from an enriched change entry. Each fact
+ * carries a defensible user impact statement derived from the enriched issue
+ * or PR body — never from free-form prose. Returns an empty array when no
+ * defensible impact can be established.
+ */
+type SourceFactInput = Pick<ChangeEntry, 'id' | 'enriched' | 'category'>;
+
+export function extractSourceFacts(
+  entry: SourceFactInput,
+): readonly SourceFact[] {
+  const facts: SourceFact[] = [];
+  for (const ref of entry.enriched) {
+    const impact = extractUserImpact(ref.body);
+    if (impact === null || isMechanismOnly(impact)) {
+      continue;
+    }
+    const title = sanitizeMarkdown(ref.title);
+    facts.push(
+      Object.freeze({
+        sourceId: entry.id,
+        title: isMechanismOnly(title) ? '' : title,
+        category: entry.category,
+        userImpact: impact,
+        evidence: `Issue/PR #${ref.number}: ${sanitizeMarkdown(ref.title)}`,
+      }),
+    );
+  }
+  return Object.freeze(facts);
+}
+
+/**
+ * Constructs deterministic highlight text from validated source facts. The
+ * model selects eligible source IDs; this function builds the final text
+ * from the facts bound to those IDs — untrusted prose cannot inject
+ * arbitrary Markdown or claims.
+ *
+ * Returns 3–6 highlights when at least 3 defensible eligible impacts exist.
+ * Returns fewer (or none) when impact cannot be established, rather than
+ * inventing claims.
+ */
+export function buildHighlightsFromSelection(
+  selection: readonly string[],
+  entries: readonly ChangeEntry[],
+): readonly string[] {
+  const factsById = new Map<string, readonly SourceFact[]>();
+  for (const entry of entries) {
+    if (entry.eligibleForHighlights && entry.sourceFacts.length > 0) {
+      factsById.set(entry.id, entry.sourceFacts);
+    }
+  }
+
+  const highlights: string[] = [];
+  const seen = new Set<string>();
+  for (const sourceId of selection) {
+    if (seen.has(sourceId)) {
+      continue;
+    }
+    const facts = factsById.get(sourceId);
+    if (facts !== undefined && facts.length > 0) {
+      const first = facts[0];
+      if (first !== undefined) {
+        appendHighlight(sourceId, first, highlights, seen);
+      }
+    }
+  }
+
+  return highlights;
+}
+
+/**
+ * Builds the deterministic fallback highlights from validated source facts.
+ * Returns 3–6 when at least 3 defensible impacts exist; fewer or none
+ * otherwise.
+ */
+export function buildFallbackHighlights(
+  entries: readonly ChangeEntry[],
+): readonly string[] {
+  const allHighlights: string[] = [];
+  for (const entry of entries) {
+    if (!entry.eligibleForHighlights) {
+      continue;
+    }
+    const first = entry.sourceFacts[0];
+    if (first !== undefined) {
+      appendFallbackHighlight(first, allHighlights);
+    }
+  }
+  return allHighlights.slice(0, 6);
+}
+
+/**
+ * Appends a sanitized deterministic highlight from a validated SourceFact.
+ * The fact's title and user impact are combined as "{title}: {userImpact}"
+ * and sanitized; empty results are skipped.
+ */
+function sourceFactText(fact: SourceFact): string {
+  return fact.title.length > 0
+    ? `${fact.title}: ${fact.userImpact}`
+    : fact.userImpact;
+}
+
+function appendFallbackHighlight(fact: SourceFact, highlights: string[]): void {
+  const sanitized = sanitizeMarkdown(sourceFactText(fact));
+  if (sanitized.length > 0) {
+    highlights.push(sanitized);
+  }
+}
+
+/**
+ * Appends a sanitized deterministic highlight from a validated SourceFact,
+ * also marking the sourceId as seen to prevent duplicates.
+ */
+function appendHighlight(
+  sourceId: string,
+  fact: SourceFact,
+  highlights: string[],
+  seen: Set<string>,
+): void {
+  const sanitized = sanitizeMarkdown(sourceFactText(fact));
+  if (sanitized.length > 0) {
+    highlights.push(sanitized);
+    seen.add(sourceId);
+  }
+}
+
+/**
+ * Validates that the model's source ID selection contains only eligible
+ * source IDs with defensible impact. Returns the validated selection, or
+ * null when the selection is invalid.
+ */
+export function validateSelection(
+  selection: readonly string[],
+  entries: readonly ChangeEntry[],
+): readonly string[] | null {
+  const eligibleIds = new Set(
+    entries
+      .filter(
+        (entry) => entry.eligibleForHighlights && entry.sourceFacts.length > 0,
+      )
+      .map((entry) => entry.id),
+  );
+
+  const seen = new Set<string>();
+  for (const id of selection) {
+    if (!eligibleIds.has(id) || seen.has(id)) {
+      return null;
+    }
+    seen.add(id);
+  }
+
+  const maxHighlights = Math.min(6, eligibleIds.size);
+  if (selection.length < Math.min(3, eligibleIds.size)) {
+    return null;
+  }
+  if (selection.length > maxHighlights) {
+    return null;
+  }
+
+  return selection;
+}

--- a/scripts/release-notes/release-metadata-port.ts
+++ b/scripts/release-notes/release-metadata-port.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import { z } from 'zod';
+import type { ReleaseMetadata, ReleaseMetadataPort } from './types.js';
+import type { ReleaseMetadataLookup } from './diff-selection.js';
+
+export type GhRunner = (args: readonly string[]) => string;
+
+const defaultRunner: GhRunner = (args) =>
+  execFileSync('gh', [...args], { encoding: 'utf8', timeout: 15_000 });
+
+const publishedAtSchema = z.object({
+  publishedAt: z.string().nullable(),
+});
+const releaseListSchema = z.array(
+  z.object({ tagName: z.string(), publishedAt: z.string().nullable() }),
+);
+
+const UNKNOWN: ReleaseMetadata = Object.freeze({ status: 'unknown' });
+const CONFIRMED_ABSENT: ReleaseMetadata = Object.freeze({
+  status: 'confirmed-absent',
+});
+
+export function parseReleaseMetadata(raw: string): ReleaseMetadata {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return UNKNOWN;
+  }
+  const result = publishedAtSchema.safeParse(parsed);
+  if (!result.success) {
+    return UNKNOWN;
+  }
+  if (result.data.publishedAt === null) {
+    return CONFIRMED_ABSENT;
+  }
+  const publishedAt = Date.parse(result.data.publishedAt);
+  if (Number.isNaN(publishedAt)) {
+    return UNKNOWN;
+  }
+  return Object.freeze({ status: 'published', publishedAt });
+}
+
+export const MAX_RELEASE_METADATA = 1000;
+
+export function createReleaseMetadataPort(
+  runner: GhRunner = defaultRunner,
+): ReleaseMetadataPort {
+  let cache: ReadonlyMap<string, ReleaseMetadata> = new Map();
+  let complete = false;
+  let loaded = false;
+  let loadAttempts = 0;
+  let loading: Promise<void> | null = null;
+  const load = async (): Promise<void> => {
+    loadAttempts += 1;
+    try {
+      const raw = runner([
+        'release',
+        'list',
+        '--limit',
+        String(MAX_RELEASE_METADATA),
+        '--json',
+        'tagName,publishedAt',
+      ]);
+      const parsed = releaseListSchema.safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        loaded = loadAttempts >= 2;
+        console.warn('GitHub release metadata response was invalid.');
+        return;
+      }
+      loaded = true;
+      complete = parsed.data.length < MAX_RELEASE_METADATA;
+      cache = new Map(
+        parsed.data.map((release) => [
+          release.tagName,
+          parseReleaseMetadata(JSON.stringify(release)),
+        ]),
+      );
+    } catch {
+      loaded = loadAttempts >= 2;
+      console.warn('GitHub release metadata lookup failed.');
+    }
+  };
+  return {
+    async getReleaseMetadata(tag: string): Promise<ReleaseMetadata> {
+      if (loaded) {
+        return cache.get(tag) ?? (complete ? CONFIRMED_ABSENT : UNKNOWN);
+      }
+      if (loading === null) {
+        loading = load().finally(() => {
+          loading = null;
+        });
+      }
+      await loading;
+      return cache.get(tag) ?? (complete ? CONFIRMED_ABSENT : UNKNOWN);
+    },
+  };
+}
+
+export function createStaticReleaseMetadataPort(
+  map: ReadonlyMap<string, ReleaseMetadata>,
+): ReleaseMetadataPort {
+  return {
+    async getReleaseMetadata(tag: string): Promise<ReleaseMetadata> {
+      return map.get(tag) ?? UNKNOWN;
+    },
+  };
+}
+
+export const MAX_NIGHTLY_CANDIDATES = MAX_RELEASE_METADATA;
+
+export async function createBoundedReleaseMetadataLookup(
+  port: ReleaseMetadataPort,
+  candidates: readonly string[],
+): Promise<ReleaseMetadataLookup | undefined> {
+  const bounded = candidates.slice(0, MAX_NIGHTLY_CANDIDATES);
+  if (bounded.length === 0) {
+    return undefined;
+  }
+  const [firstTag, ...remainingTags] = bounded;
+  if (firstTag === undefined) {
+    return undefined;
+  }
+  const initial = await port.getReleaseMetadata(firstTag);
+  const firstResult =
+    initial.status === 'unknown'
+      ? await port.getReleaseMetadata(firstTag)
+      : initial;
+  const metadata = await Promise.all(
+    remainingTags.map(async (tag) => ({
+      tag,
+      release: await port.getReleaseMetadata(tag),
+    })),
+  );
+  const resolved = new Map<string, ReleaseMetadata>([[firstTag, firstResult]]);
+  metadata.forEach(({ tag, release }) => {
+    resolved.set(tag, release);
+  });
+  const lookup = Object.assign(
+    (tag: string): ReleaseMetadata => resolved.get(tag) ?? UNKNOWN,
+    { candidates: new Set(bounded) },
+  );
+  return lookup;
+}

--- a/scripts/release-notes/rendering.ts
+++ b/scripts/release-notes/rendering.ts
@@ -1,0 +1,361 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CategorizedBullets, ReleaseNotesData } from './types.js';
+import {
+  renderContributor,
+  sanitizeAllChangesLine,
+  sanitizeMarkdown,
+} from './markdown.js';
+
+/**
+ * Pattern matching an @mention at the start of a word boundary. GitHub
+ * renders `@user` and `@org/team` as mention links in rendered Markdown.
+ * Untrusted prose (PR titles, bodies, commit subjects) must not carry live
+ * mentions into the rendered release notes.
+ */
+const MENTION_PATTERN = /@[A-Za-z0-9](?:[A-Za-z0-9-]*)(?:\/[A-Za-z0-9._-]+)?/g;
+
+function isAsciiAlphanumeric(code: number): boolean {
+  if (code >= 48 && code <= 57) {
+    return true;
+  }
+  if (code >= 65 && code <= 90) {
+    return true;
+  }
+  return code >= 97 && code <= 122;
+}
+
+function isEmailAt(text: string, atIndex: number): boolean {
+  let start = atIndex;
+  while (start > 0) {
+    const character = text[start - 1];
+    if (character === undefined || !/[A-Za-z0-9._%+-]/.test(character)) {
+      break;
+    }
+    start -= 1;
+  }
+  let end = atIndex + 1;
+  while (end < text.length) {
+    const character = text[end];
+    if (character === undefined || !/[A-Za-z0-9.-]/.test(character)) {
+      break;
+    }
+    end += 1;
+  }
+  while (end > atIndex + 1 && text[end - 1] === '.') {
+    end -= 1;
+  }
+  const local = text.slice(start, atIndex);
+  const domain = text.slice(atIndex + 1, end);
+  const localStartsWithAlphanumeric = isAsciiAlphanumeric(local.charCodeAt(0));
+  const localEndsWithAlphanumeric = isAsciiAlphanumeric(
+    local.charCodeAt(local.length - 1),
+  );
+  const domainStartsWithAlphanumeric = isAsciiAlphanumeric(
+    domain.charCodeAt(0),
+  );
+  const domainEndsWithAlphanumeric = isAsciiAlphanumeric(
+    domain.charCodeAt(domain.length - 1),
+  );
+  if (
+    !localStartsWithAlphanumeric ||
+    !localEndsWithAlphanumeric ||
+    !domainStartsWithAlphanumeric ||
+    !domainEndsWithAlphanumeric
+  ) {
+    return false;
+  }
+  if (local.includes('..') || domain.includes('..')) {
+    return false;
+  }
+  return domain.includes('.') && !domain.endsWith('.');
+}
+
+/**
+ * Neutralizes @mentions in untrusted prose by removing the @ sigil, so
+ * GitHub does not render them as live mention links. This is applied to
+ * all untrusted text channels (highlights, categorized bullets, all changes)
+ * EXCEPT the contributor thanks section, which uses renderContributor for
+ * validated, intentional @mentions.
+ */
+function neutralizeMentions(text: string): string {
+  return text.replace(MENTION_PATTERN, (match, offset: number) =>
+    isEmailAt(text, offset) ? match : match.slice(1),
+  );
+}
+
+/**
+ * Renders the static installation instructions block.
+ */
+function renderInstallation(): string {
+  return [
+    '### Installation',
+    '',
+    'Install or upgrade LLxprt Code using npm:',
+    '',
+    '```bash',
+    'npm install -g @vybestack/llxprt-code',
+    '```',
+    '',
+    'Or use directly with npx:',
+    '',
+    '```bash',
+    'npx @vybestack/llxprt-code',
+    '```',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Renders the curated headline section (if any) followed by highlights.
+ * Highlights are sanitized to neutralize @mentions from untrusted prose.
+ */
+function renderHighlights(
+  curated: string | null,
+  highlights: readonly string[],
+): string {
+  const lines: string[] = [];
+  if (curated !== null && curated.trim().length > 0) {
+    lines.push(curated, '');
+  }
+  lines.push('### Highlights', '');
+  if (highlights.length === 0) {
+    lines.push('No major user-facing changes in this release.');
+  } else {
+    for (const item of highlights) {
+      lines.push(`- ${neutralizeMentions(sanitizeMarkdown(item))}`);
+    }
+  }
+  lines.push('');
+  return lines.length > 0 ? lines.join('\n') : '';
+}
+
+/**
+ * Renders a single categorized section, or empty string when the section
+ * has no bullets. Each bullet is sanitized to neutralize @mentions that
+ * could survive from untrusted prose.
+ */
+function renderCategorySection(
+  heading: string,
+  bullets: readonly string[],
+): string {
+  if (bullets.length === 0) {
+    return '';
+  }
+  const lines = [heading, ''];
+  for (const bullet of bullets) {
+    lines.push(`- ${neutralizeMentions(sanitizeMarkdown(bullet))}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Renders all four categorized sections in order, skipping empties.
+ */
+function renderCategorized(categorized: CategorizedBullets): string {
+  const sections = [
+    renderCategorySection('#### New', categorized.new),
+    renderCategorySection('#### Improvements', categorized.improvements),
+    renderCategorySection('#### Fixes', categorized.fixes),
+    renderCategorySection('#### Breaking changes', categorized.breaking),
+  ];
+  return sections.filter((s) => s.length > 0).join('');
+}
+
+/**
+ * Renders the contributor thanks section using the safe renderContributor
+ * helper, which validates the login grammar and sanitizes each handle.
+ */
+function renderThanks(contributors: readonly string[]): string {
+  if (contributors.length === 0) {
+    return '';
+  }
+  const lines = [
+    '### Thanks',
+    '',
+    'Huge thanks to the following contributors for their pull requests in this release:',
+    '',
+  ];
+  for (const contributor of contributors) {
+    const rendered = renderContributor(contributor);
+    if (rendered.length > 0) {
+      lines.push(rendered);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Renders the All Changes section with raw commit lines. Each line is
+ * sanitized to neutralize @mentions that could survive in commit subjects.
+ */
+function renderAllChanges(allChanges: readonly string[]): string {
+  if (allChanges.length === 0) {
+    return '';
+  }
+  const sanitized = allChanges
+    .map((line) => neutralizeMentions(sanitizeAllChangesLine(line)))
+    .filter((line) => line.length > 0);
+  return ['### All Changes', '', ...sanitized].join('\n');
+}
+
+/**
+ * Renders the comparison link footer. For first releases, renders a banner
+ * noting that this is the initial release instead of a compare URL.
+ */
+function isSafeRefCharacter(character: string): boolean {
+  const code = character.codePointAt(0);
+  if (code === undefined) {
+    return false;
+  }
+  const isDigit = code >= 48 && code <= 57;
+  const isUppercase = code >= 65 && code <= 90;
+  const isLowercase = code >= 97 && code <= 122;
+  return isDigit || isUppercase || isLowercase || '._-/'.includes(character);
+}
+
+function hasSafeSlashPlacement(ref: string): boolean {
+  return !ref.startsWith('/') && !ref.endsWith('/') && !ref.includes('//');
+}
+
+function isSafeRef(ref: string): boolean {
+  return (
+    ref.length > 0 &&
+    hasSafeSlashPlacement(ref) &&
+    [...ref].every(isSafeRefCharacter)
+  );
+}
+
+function isSafeComparisonRange(range: string): boolean {
+  const separator = range.indexOf('...');
+  if (separator <= 0 || separator !== range.lastIndexOf('...')) {
+    return false;
+  }
+  const from = range.slice(0, separator);
+  const to = range.slice(separator + 3);
+  return isSafeRef(from) && isSafeRef(to);
+}
+
+function isSafeComparisonUrl(comparisonUrl: string): boolean {
+  try {
+    const url = new URL(comparisonUrl);
+    const parts = url.pathname.split('/').filter((part) => part.length > 0);
+    if (url.protocol !== 'https:' || url.hostname !== 'github.com') {
+      return false;
+    }
+    const encodedRange = parts[3];
+    if (
+      parts.length !== 4 ||
+      parts[2] !== 'compare' ||
+      encodedRange === undefined
+    ) {
+      return false;
+    }
+    return isSafeComparisonRange(decodeURIComponent(encodedRange));
+  } catch {
+    return false;
+  }
+}
+
+function renderComparison(
+  comparisonUrl: string | null,
+  isFirstRelease: boolean,
+): string {
+  if (isFirstRelease) {
+    return ['', '---', '', '*Initial release.*'].join('\n');
+  }
+  if (comparisonUrl === null || !isSafeComparisonUrl(comparisonUrl)) {
+    return '';
+  }
+  return ['', '---', '', `**Full Changelog**: ${comparisonUrl}`].join('\n');
+}
+
+const MAX_RELEASE_BODY_BYTES = 120_000;
+const OMITTED_CHANGES_NOTICE =
+  '_Additional details omitted; use All Changes and the release history for traceability._';
+const ALL_CHANGES_BUDGET_BYTES = 40_000;
+
+function takeWholeLines(text: string, maxBytes: number): string {
+  const lines: string[] = [];
+  for (const line of text.split('\n')) {
+    const candidate = [...lines, line].join('\n');
+    if (Buffer.byteLength(candidate, 'utf8') > maxBytes) {
+      break;
+    }
+    lines.push(line);
+  }
+  return lines.join('\n');
+}
+
+function fitReleaseBody(
+  body: string,
+  allChanges: string,
+  comparison: string,
+): string {
+  const complete = [body, allChanges, comparison].filter(Boolean).join('\n');
+  if (Buffer.byteLength(complete, 'utf8') + 1 <= MAX_RELEASE_BODY_BYTES) {
+    return `${complete.trim()}\n`;
+  }
+  const boundedAllChanges = takeWholeLines(
+    allChanges,
+    ALL_CHANGES_BUDGET_BYTES,
+  );
+  const reserved = [OMITTED_CHANGES_NOTICE, boundedAllChanges, comparison]
+    .filter(Boolean)
+    .join('\n\n');
+  const bodyBudget =
+    MAX_RELEASE_BODY_BYTES - Buffer.byteLength(reserved, 'utf8') - 4;
+  const boundedBody = takeWholeLines(body, bodyBudget);
+  return `${[boundedBody, OMITTED_CHANGES_NOTICE, boundedAllChanges, comparison]
+    .filter(Boolean)
+    .join('\n\n')}\n`;
+}
+
+/**
+ * Renders complete release notes markdown from structured data through a
+ * deterministic template. The output order is always:
+ * Release header, Installation, Curated headline/Highlights, categorized
+ * sections, Thanks, All Changes, comparison link.
+ */
+export function renderReleaseNotes(data: ReleaseNotesData): string {
+  const parts: string[] = [];
+
+  parts.push(`## Release ${sanitizeMarkdown(data.releaseTag)}`, '');
+
+  parts.push(renderInstallation());
+
+  const highlightsSection = renderHighlights(
+    data.curatedHeadline,
+    data.highlights,
+  );
+  if (highlightsSection.length > 0) {
+    parts.push(highlightsSection);
+  }
+
+  const categorizedSection = renderCategorized(data.categorized);
+  if (categorizedSection.length > 0) {
+    parts.push(categorizedSection);
+  }
+
+  const thanksSection = renderThanks(data.contributors);
+  if (thanksSection.length > 0) {
+    parts.push(thanksSection);
+  }
+
+  const allChangesSection = renderAllChanges(data.allChanges);
+  const comparisonSection = renderComparison(
+    data.comparisonUrl,
+    data.isFirstRelease,
+  );
+  return fitReleaseBody(
+    parts.join('\n').trim(),
+    allChangesSection,
+    comparisonSection,
+  );
+}

--- a/scripts/release-notes/types.ts
+++ b/scripts/release-notes/types.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+
+export interface RawCommit {
+  readonly hash: string;
+  readonly subject: string;
+  readonly author: string;
+  readonly isMerge: boolean;
+  readonly parents: readonly string[];
+}
+
+export interface ParsedRef {
+  readonly number: number;
+  readonly verb: string;
+}
+
+export interface EnrichedRef {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly labels: readonly string[];
+  readonly labelsTruncated: boolean;
+  readonly metadataAvailable?: boolean;
+  readonly author: string;
+  readonly isPr: boolean;
+  readonly userImpact: string | null;
+}
+
+export type ChangeCategory =
+  | 'new'
+  | 'improvement'
+  | 'fix'
+  | 'breaking'
+  | 'internal';
+
+export interface ChangeEntry {
+  readonly id: string;
+  readonly subject: string;
+  readonly hash: string;
+  readonly author: string;
+  readonly refs: readonly ParsedRef[];
+  readonly enriched: readonly EnrichedRef[];
+  readonly category: ChangeCategory;
+  readonly eligibleForHighlights: boolean;
+  readonly childHashes: readonly string[];
+  readonly sourceFacts: readonly SourceFact[];
+}
+
+export interface CategorizedBullets {
+  readonly new: readonly string[];
+  readonly improvements: readonly string[];
+  readonly fixes: readonly string[];
+  readonly breaking: readonly string[];
+}
+
+export interface ReleaseNotesData {
+  readonly releaseTag: string;
+  readonly highlights: readonly string[];
+  readonly categorized: CategorizedBullets;
+  readonly allChanges: readonly string[];
+  readonly contributors: readonly string[];
+  readonly lastTag: string;
+  readonly isFirstRelease: boolean;
+  readonly comparisonUrl: string | null;
+  readonly curatedHeadline: string | null;
+}
+
+export interface GhPort {
+  fetchRefs(
+    numbers: readonly number[],
+  ): Promise<ReadonlyMap<number, EnrichedRef>>;
+}
+
+/**
+ * Resolves git topology: given a two-parent merge commit, returns the hashes
+ * of commits introduced by that merge (on the merged branch, not the base).
+ * This lets PR grouping associate a classic merge commit with its child
+ * commits without losing any of them.
+ */
+export interface TopologyResolver {
+  getMergeIntroducedHashes(
+    firstParent: string,
+    secondParent: string,
+  ): readonly string[];
+
+  /**
+   * Returns the deduplicated hashes of commits introduced by a multi-parent
+   * (octopus) merge — commits reachable from any non-first parent but not
+   * from the first parent. Handles merges with 3+ parents where multiple
+   * branches may have overlapping commit sets.
+   */
+  getOctopusMergeIntroducedHashes(
+    parents: readonly string[],
+  ): readonly string[];
+}
+
+export interface LlmPort {
+  generateHighlights(context: string): Promise<string>;
+}
+
+/**
+ * A release-metadata port that resolves the publication timestamp for a
+ * published GitHub release (stable or nightly). Tag creatordate for
+ * lightweight tags reflects the commit the tag points at, NOT when the
+ * release was published — so authoritative publication ordering must come
+ * from the GitHub release object. Returns null when release metadata is
+ * unavailable (e.g. a tag with no published release) so callers can fall
+ * back deterministically to tag chronology.
+ */
+export type ReleaseMetadata =
+  | { readonly status: 'published'; readonly publishedAt: number }
+  | { readonly status: 'confirmed-absent' }
+  | { readonly status: 'unknown' };
+
+export interface ReleaseMetadataPort {
+  getReleaseMetadata(tag: string): Promise<ReleaseMetadata>;
+}
+
+/**
+ * A validated, structured fact extracted from an enriched GitHub issue/PR.
+ * Each fact carries a defensible user impact statement. These are the ONLY
+ * building blocks for highlight text — the model selects which eligible source
+ * IDs to surface, but final text is constructed deterministically from
+ * validated source facts, not from free-form model prose.
+ */
+export interface SourceFact {
+  readonly sourceId: string;
+  readonly title: string;
+  readonly category: ChangeCategory;
+  readonly userImpact: string;
+  readonly evidence: string;
+}
+
+/**
+ * Schema for the model's highlight selection. The model selects eligible
+ * source IDs only — final highlight text is constructed deterministically
+ * from validated SourceFacts, never from free-form model prose.
+ */
+const highlightSelectionSchema = z.object({
+  sourceIds: z.array(z.string()).min(0).max(6),
+});
+
+export const llmOutputSchema = highlightSelectionSchema;
+
+export type LlmOutput = z.infer<typeof llmOutputSchema>;

--- a/scripts/release-notes/validation.ts
+++ b/scripts/release-notes/validation.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  llmOutputSchema,
+  type CategorizedBullets,
+  type ChangeEntry,
+  type LlmOutput,
+} from './types.js';
+import { sanitizeMarkdown } from './markdown.js';
+import { buildFallbackHighlights, validateSelection } from './provenance.js';
+import {
+  deriveEffectiveCategory,
+  shouldDemoteFromProminent,
+} from './classification.js';
+
+const MAX_HIGHLIGHTS = 6;
+
+/**
+ * Strips Markdown code fences from raw LLM output before JSON parsing.
+ */
+function stripCodeFences(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('```')) {
+    return trimmed;
+  }
+  const contentStart = trimmed.indexOf('\n');
+  const contentEnd = trimmed.lastIndexOf('```');
+  if (contentStart === -1 || contentEnd <= contentStart) {
+    return trimmed;
+  }
+  return trimmed.slice(contentStart + 1, contentEnd).trim();
+}
+
+/**
+ * Validates raw LLM output as a highlight selection (sourceIds only).
+ * The model selects eligible source IDs; final text is constructed
+ * deterministically from validated SourceFacts — never from free-form
+ * prose. Returns null when the output is malformed or invalid.
+ */
+export function validateLlmOutput(raw: string): LlmOutput | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFences(raw));
+  } catch {
+    return null;
+  }
+  const result = llmOutputSchema.safeParse(parsed);
+  if (!result.success) {
+    return null;
+  }
+  return result.data;
+}
+
+/**
+ * Validates the model's highlight selection against eligible entries with
+ * defensible impact. Returns the validated source ID list, or null when
+ * the selection is invalid.
+ */
+export function validateHighlights(
+  selection: readonly string[],
+  eligibleEntries: readonly ChangeEntry[],
+): readonly string[] | null {
+  return validateSelection(selection, eligibleEntries);
+}
+
+function displayTitle(entry: ChangeEntry): string {
+  const enrichedTitle = entry.enriched.find(
+    (ref) => ref.title.trim().length > 0,
+  )?.title;
+  return sanitizeMarkdown(enrichedTitle?.trim() ?? entry.subject);
+}
+
+export function entriesToCategorizedBullets(
+  entries: readonly ChangeEntry[],
+): CategorizedBullets {
+  const categorized: {
+    new: string[];
+    improvements: string[];
+    fixes: string[];
+    breaking: string[];
+  } = { new: [], improvements: [], fixes: [], breaking: [] };
+  for (const entry of entries) {
+    // Internal labels demote entries out of prominent categories entirely,
+    // not just from highlights.
+    if (shouldDemoteFromProminent(entry.enriched)) {
+      continue;
+    }
+    // Derive the effective category with internal-label precedence and
+    // promoting-label promotion so that the rendered category reflects
+    // labels, not just the commit prefix.
+    const effectiveCategory = deriveEffectiveCategory(
+      entry.category,
+      entry.enriched,
+    );
+    const title = displayTitle(entry);
+    switch (effectiveCategory) {
+      case 'new':
+        categorized.new.push(title);
+        break;
+      case 'improvement':
+        categorized.improvements.push(title);
+        break;
+      case 'fix':
+        categorized.fixes.push(title);
+        break;
+      case 'breaking':
+        categorized.breaking.push(title);
+        break;
+      case 'internal':
+        break;
+    }
+  }
+  return categorized;
+}
+
+/**
+ * Builds the deterministic fallback from validated source facts. Highlights
+ * are only emitted when defensible user impact can be established — otherwise
+ * omitted (fewer/none) rather than inventing claims.
+ */
+export function buildDeterministicFallback(entries: readonly ChangeEntry[]): {
+  highlights: readonly string[];
+  categorized: CategorizedBullets;
+} {
+  const highlights = buildFallbackHighlights(entries).slice(0, MAX_HIGHLIGHTS);
+  return { highlights, categorized: entriesToCategorizedBullets(entries) };
+}

--- a/scripts/tests/ci-quota-check.test.js
+++ b/scripts/tests/ci-quota-check.test.js
@@ -1,0 +1,402 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { main } from '../ci-quota-check.js';
+
+const ORIGINAL_ENV = { ...process.env };
+let testDir;
+
+function quotaResponse(requests) {
+  return new Response(
+    JSON.stringify({ subscription: { limit: 100, requests } }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function configureFiles(includeOutput = true) {
+  process.env.GITHUB_ENV = join(testDir, 'github-env');
+  if (includeOutput) {
+    process.env.GITHUB_OUTPUT = join(testDir, 'github-output');
+  } else {
+    delete process.env.GITHUB_OUTPUT;
+  }
+}
+
+function failingResponse(status = 500) {
+  return new Response('error', { status });
+}
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'ci-quota-check-'));
+  process.env = { ...ORIGINAL_ENV };
+  configureFiles();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('ci quota key selection outputs', () => {
+  it('reports primary when the primary Synthetic key has lower usage', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(10))
+        .mockResolvedValueOnce(quotaResponse(20)),
+    );
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=primary\n',
+    );
+  });
+
+  it('reports secondary when the secondary Synthetic key has lower usage', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(20))
+        .mockResolvedValueOnce(quotaResponse(10)),
+    );
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=secondary\n',
+    );
+  });
+
+  it('reports primary without a quota request for non-Synthetic providers', async () => {
+    process.env.KEY_VAR_NAME = 'OPENAI_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await main();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=primary\n',
+    );
+  });
+
+  it('continues when GITHUB_OUTPUT is unavailable', async () => {
+    configureFiles(false);
+    process.env.KEY_VAR_NAME = 'OPENAI_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+
+    await main();
+
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('falls back to first configured key when both Synthetic quota probes fail', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(failingResponse(500))
+        .mockResolvedValueOnce(failingResponse(500)),
+    );
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=primary\n',
+    );
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('falls back to secondary when primary is absent and both probes fail', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    delete process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(failingResponse(500))
+        .mockResolvedValueOnce(failingResponse(500)),
+    );
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=secondary\n',
+    );
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('selects key2 when key1 probe fails but key2 succeeds', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(failingResponse(500))
+        .mockResolvedValueOnce(quotaResponse(10)),
+    );
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=secondary\n',
+    );
+  });
+
+  it('selects key1 when key2 probe fails but key1 succeeds', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(10))
+        .mockResolvedValueOnce(failingResponse(500)),
+    );
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=primary\n',
+    );
+  });
+
+  it('selects key1 when only key1 is configured (key2 absent)', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    delete process.env.OPENAI_API_KEY_2;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(quotaResponse(10)));
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=primary\n',
+    );
+  });
+
+  it('selects key2 when only key2 is configured (key1 absent)', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    delete process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    // Only key2 is configured so checkQuota is called exactly once (for key2).
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(quotaResponse(10)));
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=secondary\n',
+    );
+  });
+
+  it('exits with error when no keys are configured', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_2;
+
+    await expect(main()).rejects.toThrow();
+  });
+
+  it('uses secondary for non-Synthetic when only key2 is configured', async () => {
+    process.env.KEY_VAR_NAME = 'OPENAI_KEY';
+    delete process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await main();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=secondary\n',
+    );
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('exits with error for non-Synthetic when no keys are configured', async () => {
+    process.env.KEY_VAR_NAME = 'OPENAI_KEY';
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_2;
+
+    await expect(main()).rejects.toThrow();
+  });
+
+  it('rejects when primary is known over quota and the secondary probe fails', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(95))
+        .mockResolvedValueOnce(failingResponse()),
+    );
+
+    await expect(main()).rejects.toThrow('No verified API key');
+    expect(existsSync(process.env.GITHUB_OUTPUT)).toBe(false);
+  });
+
+  it('rejects when secondary is known over quota and the primary probe fails', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(failingResponse())
+        .mockResolvedValueOnce(quotaResponse(95)),
+    );
+
+    await expect(main()).rejects.toThrow('No verified API key');
+    expect(existsSync(process.env.GITHUB_OUTPUT)).toBe(false);
+  });
+
+  it.each([
+    ['negative requests', { limit: 100, requests: -1 }],
+    ['fractional requests', { limit: 100, requests: 1.5 }],
+    ['fractional limit', { limit: 100.5, requests: 1 }],
+    ['nonfinite limit', { limit: null, requests: 1 }],
+  ])(
+    'rejects invalid %s counters in favor of a verified key',
+    async (_label, subscription) => {
+      process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+      process.env.OPENAI_API_KEY = 'primary-secret';
+      process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ subscription }), { status: 200 }),
+          )
+          .mockResolvedValueOnce(quotaResponse(10)),
+      );
+
+      await main();
+
+      expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+        'selected_key=secondary\n',
+      );
+    },
+  );
+
+  it('rejects without writing GITHUB_OUTPUT or GITHUB_ENV when both keys exceed 90% quota', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(95))
+        .mockResolvedValueOnce(quotaResponse(95)),
+    );
+
+    await expect(main()).rejects.toThrow();
+
+    expect(existsSync(process.env.GITHUB_OUTPUT)).toBe(false);
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('accepts both keys when usage is exactly at the 90% threshold', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(90))
+        .mockResolvedValueOnce(quotaResponse(90)),
+    );
+
+    await main();
+
+    expect(readFileSync(process.env.GITHUB_OUTPUT, 'utf8')).toBe(
+      'selected_key=primary\n',
+    );
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('writes no GITHUB_OUTPUT or GITHUB_ENV content when the quota check rejects', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'primary-secret';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(100))
+        .mockResolvedValueOnce(quotaResponse(100)),
+    );
+
+    await expect(main()).rejects.toThrow();
+
+    expect(existsSync(process.env.GITHUB_OUTPUT)).toBe(false);
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('rejects a CR/LF API key in the Synthetic path without writing files', async () => {
+    process.env.KEY_VAR_NAME = 'SYNTHETIC_API_KEY';
+    process.env.OPENAI_API_KEY = 'evil\nGITHUB_TOKEN=stolen';
+    process.env.OPENAI_API_KEY_2 = 'secondary-secret';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(quotaResponse(10))
+        .mockResolvedValueOnce(quotaResponse(10)),
+    );
+
+    await expect(main()).rejects.toThrow(/CR\/LF/);
+
+    expect(existsSync(process.env.GITHUB_OUTPUT)).toBe(false);
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('rejects a CR/LF API key in the non-Synthetic path without writing files', async () => {
+    process.env.KEY_VAR_NAME = 'OPENAI_KEY';
+    process.env.OPENAI_API_KEY = 'evil\nGITHUB_TOKEN=stolen';
+
+    await expect(main()).rejects.toThrow(/CR\/LF/);
+
+    expect(existsSync(process.env.GITHUB_OUTPUT)).toBe(false);
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+
+  it('rejects a CR-only API key in the non-Synthetic path without writing files', async () => {
+    process.env.KEY_VAR_NAME = 'OPENAI_KEY';
+    process.env.OPENAI_API_KEY = 'evil\r\nmalicious';
+
+    await expect(main()).rejects.toThrow(/CR\/LF/);
+
+    expect(existsSync(process.env.GITHUB_OUTPUT)).toBe(false);
+    expect(existsSync(process.env.GITHUB_ENV)).toBe(false);
+  });
+});

--- a/scripts/tests/release-notes/classification.test.ts
+++ b/scripts/tests/release-notes/classification.test.ts
@@ -1,0 +1,543 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyCommit,
+  classifyEnrichedRefs,
+  isEligibleForHighlights,
+  shouldDemoteFromProminent,
+  deriveEffectiveCategory,
+  INTERNAL_LABELS,
+  PROMOTING_LABELS,
+} from '../../release-notes/classification.js';
+import type { RawCommit, EnrichedRef } from '../../release-notes/types.js';
+
+function makeCommit(overrides: Partial<RawCommit> = {}): RawCommit {
+  return {
+    hash: 'abcdef0',
+    subject: 'fix: something',
+    author: 'dev',
+    isMerge: false,
+    parents: [],
+    ...overrides,
+  };
+}
+
+function makeEnriched(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 1,
+    title: 'Some issue',
+    body: '',
+    labels: [],
+    labelsTruncated: false,
+    author: 'someone',
+    isPr: false,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+describe('classifyCommit', () => {
+  it('classifies feat: as new', () => {
+    expect(
+      classifyCommit(makeCommit({ subject: 'feat: add Gemini support' })),
+    ).toBe('new');
+  });
+
+  it('classifies fix: as fix', () => {
+    expect(classifyCommit(makeCommit({ subject: 'fix: resolve crash' }))).toBe(
+      'fix',
+    );
+  });
+
+  it('classifies perf: as improvement', () => {
+    expect(
+      classifyCommit(makeCommit({ subject: 'perf: faster startup' })),
+    ).toBe('improvement');
+  });
+
+  it('classifies refactor: as internal', () => {
+    expect(
+      classifyCommit(makeCommit({ subject: 'refactor: clean up utils' })),
+    ).toBe('internal');
+  });
+
+  it('classifies test: as internal', () => {
+    expect(
+      classifyCommit(makeCommit({ subject: 'test: add unit tests' })),
+    ).toBe('internal');
+  });
+
+  it('classifies chore: as internal', () => {
+    expect(classifyCommit(makeCommit({ subject: 'chore: update deps' }))).toBe(
+      'internal',
+    );
+  });
+
+  it('classifies docs: as improvement when user-facing', () => {
+    expect(
+      classifyCommit(makeCommit({ subject: 'docs: update getting started' })),
+    ).toBe('improvement');
+  });
+
+  it('classifies BREAKING as breaking', () => {
+    expect(
+      classifyCommit(makeCommit({ subject: 'feat!: remove deprecated API' })),
+    ).toBe('breaking');
+  });
+
+  it('classifies BREAKING CHANGE footer as breaking', () => {
+    expect(
+      classifyCommit(
+        makeCommit({
+          subject: 'refactor: API overhaul\n\nBREAKING CHANGE: old API removed',
+        }),
+      ),
+    ).toBe('breaking');
+  });
+
+  it('defaults unknown prefixes to improvement', () => {
+    expect(classifyCommit(makeCommit({ subject: 'misc: whatever' }))).toBe(
+      'improvement',
+    );
+  });
+});
+
+describe('INTERNAL_LABELS', () => {
+  it('includes the canonical composite internal label', () => {
+    expect(INTERNAL_LABELS.has('code quality / modularization')).toBe(true);
+  });
+});
+
+describe('PROMOTING_LABELS', () => {
+  it('includes Provider Support', () => {
+    expect(PROMOTING_LABELS.has('provider support')).toBe(true);
+  });
+
+  it('includes Tooling', () => {
+    expect(PROMOTING_LABELS.has('tooling')).toBe(true);
+  });
+
+  it('includes configuration', () => {
+    expect(PROMOTING_LABELS.has('configuration')).toBe(true);
+  });
+});
+
+describe('isEligibleForHighlights', () => {
+  it('returns false when enriched has an internal label', () => {
+    const enriched = [makeEnriched({ labels: ['Code Quality'] })];
+    expect(isEligibleForHighlights('new', enriched)).toBe(false);
+  });
+
+  it('returns false for internal category commits', () => {
+    expect(isEligibleForHighlights('internal', [])).toBe(false);
+  });
+
+  it('returns true for new feature with no internal labels', () => {
+    expect(isEligibleForHighlights('new', [])).toBe(true);
+  });
+
+  it('returns true for fix with no internal labels', () => {
+    expect(isEligibleForHighlights('fix', [])).toBe(true);
+  });
+
+  it('returns true for breaking change with no internal labels', () => {
+    expect(isEligibleForHighlights('breaking', [])).toBe(true);
+  });
+
+  it('returns true when enriched has a promoting label', () => {
+    const enriched = [makeEnriched({ labels: ['Provider Support'] })];
+    expect(isEligibleForHighlights('improvement', enriched)).toBe(true);
+  });
+
+  it('internal label overrides promoting label', () => {
+    const enriched = [
+      makeEnriched({ labels: ['Provider Support', 'Modularization'] }),
+    ];
+    expect(isEligibleForHighlights('new', enriched)).toBe(false);
+  });
+});
+
+describe('promoting-label semantics', () => {
+  it('promotes an internal-category commit to eligible when tagged feature', () => {
+    const enriched = [makeEnriched({ labels: ['feature'] })];
+    expect(isEligibleForHighlights('internal', enriched)).toBe(true);
+  });
+
+  it('promotes an internal-category commit to eligible when tagged bug', () => {
+    const enriched = [makeEnriched({ labels: ['bug'] })];
+    expect(isEligibleForHighlights('internal', enriched)).toBe(true);
+  });
+
+  it('promotes an internal-category commit to eligible when tagged enhancement', () => {
+    const enriched = [makeEnriched({ labels: ['enhancement'] })];
+    expect(isEligibleForHighlights('internal', enriched)).toBe(true);
+  });
+
+  it('promotes an internal-category commit to eligible when tagged ux', () => {
+    const enriched = [makeEnriched({ labels: ['ux'] })];
+    expect(isEligibleForHighlights('internal', enriched)).toBe(true);
+  });
+
+  it('promotes an internal-category commit to eligible when tagged ui', () => {
+    const enriched = [makeEnriched({ labels: ['ui'] })];
+    expect(isEligibleForHighlights('internal', enriched)).toBe(true);
+  });
+
+  it('promotes an internal-category commit to eligible when tagged performance', () => {
+    const enriched = [makeEnriched({ labels: ['performance'] })];
+    expect(isEligibleForHighlights('internal', enriched)).toBe(true);
+  });
+
+  it('internal label always wins over promoting label regardless of order', () => {
+    expect(
+      isEligibleForHighlights('new', [
+        makeEnriched({ labels: ['tech-debt', 'feature'] }),
+      ]),
+    ).toBe(false);
+    expect(
+      isEligibleForHighlights('new', [
+        makeEnriched({ labels: ['feature', 'tech-debt'] }),
+      ]),
+    ).toBe(false);
+  });
+
+  it('internal label wins over promoting label even across multiple refs', () => {
+    const enriched = [
+      makeEnriched({ number: 1, labels: ['feature'] }),
+      makeEnriched({ number: 2, labels: ['refactor'] }),
+    ];
+    expect(isEligibleForHighlights('new', enriched)).toBe(false);
+  });
+
+  it('does not demote when only promoting labels are present', () => {
+    const enriched = [makeEnriched({ labels: ['enhancement', 'ux'] })];
+    expect(shouldDemoteFromProminent(enriched)).toBe(false);
+  });
+
+  it('internal label demotes even when a promoting label is present', () => {
+    const enriched = [makeEnriched({ labels: ['feature', 'cleanup'] })];
+    expect(shouldDemoteFromProminent(enriched)).toBe(true);
+  });
+
+  it('case-insensitive: Feature and FEATURE both promote', () => {
+    expect(
+      isEligibleForHighlights('internal', [
+        makeEnriched({ labels: ['Feature'] }),
+      ]),
+    ).toBe(true);
+    expect(
+      isEligibleForHighlights('internal', [
+        makeEnriched({ labels: ['FEATURE'] }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('shouldDemoteFromProminent', () => {
+  it('demotes a feat commit with an internal label', () => {
+    const enriched = [makeEnriched({ labels: ['Code Quality'] })];
+    expect(shouldDemoteFromProminent(enriched)).toBe(true);
+  });
+
+  it('demotes a fix commit with an internal label', () => {
+    const enriched = [makeEnriched({ labels: ['tech-debt'] })];
+    expect(shouldDemoteFromProminent(enriched)).toBe(true);
+  });
+
+  it('does not demote when no internal labels are present', () => {
+    const enriched = [makeEnriched({ labels: ['bug'] })];
+    expect(shouldDemoteFromProminent(enriched)).toBe(false);
+  });
+
+  it('demotes when any enriched ref has an internal label', () => {
+    const enriched = [
+      makeEnriched({ number: 1, labels: ['feature'] }),
+      makeEnriched({ number: 2, labels: ['refactor'] }),
+    ];
+    expect(shouldDemoteFromProminent(enriched)).toBe(true);
+  });
+
+  it('does not demote with only promoting labels', () => {
+    const enriched = [makeEnriched({ labels: ['enhancement', 'ux'] })];
+    expect(shouldDemoteFromProminent(enriched)).toBe(false);
+  });
+});
+
+describe('deriveEffectiveCategory', () => {
+  it('returns the original category when no labels are present', () => {
+    expect(deriveEffectiveCategory('new', [])).toBe('new');
+    expect(deriveEffectiveCategory('fix', [])).toBe('fix');
+    expect(deriveEffectiveCategory('improvement', [])).toBe('improvement');
+    expect(deriveEffectiveCategory('internal', [])).toBe('internal');
+  });
+
+  it('internal label overrides any commit-prefix category', () => {
+    expect(
+      deriveEffectiveCategory('new', [makeEnriched({ labels: ['tech-debt'] })]),
+    ).toBe('internal');
+    expect(
+      deriveEffectiveCategory('fix', [makeEnriched({ labels: ['refactor'] })]),
+    ).toBe('internal');
+    expect(
+      deriveEffectiveCategory('breaking', [
+        makeEnriched({ labels: ['cleanup'] }),
+      ]),
+    ).toBe('internal');
+  });
+
+  it('internal label wins over promoting label in effective category', () => {
+    const enriched = [makeEnriched({ labels: ['feature', 'tech-debt'] })];
+    expect(deriveEffectiveCategory('new', enriched)).toBe('internal');
+    expect(deriveEffectiveCategory('internal', enriched)).toBe('internal');
+  });
+
+  it('promoting label bug promotes internal to fix', () => {
+    expect(
+      deriveEffectiveCategory('internal', [makeEnriched({ labels: ['bug'] })]),
+    ).toBe('fix');
+  });
+
+  it('promoting label fix promotes internal to fix', () => {
+    expect(
+      deriveEffectiveCategory('internal', [makeEnriched({ labels: ['fix'] })]),
+    ).toBe('fix');
+  });
+
+  it('promoting label feature promotes internal to new', () => {
+    expect(
+      deriveEffectiveCategory('internal', [
+        makeEnriched({ labels: ['feature'] }),
+      ]),
+    ).toBe('new');
+  });
+
+  it('promoting label enhancement promotes internal to new', () => {
+    expect(
+      deriveEffectiveCategory('internal', [
+        makeEnriched({ labels: ['enhancement'] }),
+      ]),
+    ).toBe('new');
+  });
+
+  it('promoting label provider support promotes internal to new', () => {
+    expect(
+      deriveEffectiveCategory('internal', [
+        makeEnriched({ labels: ['provider support'] }),
+      ]),
+    ).toBe('new');
+  });
+
+  it('promoting label ux promotes internal to improvement', () => {
+    expect(
+      deriveEffectiveCategory('internal', [makeEnriched({ labels: ['ux'] })]),
+    ).toBe('improvement');
+  });
+
+  it('promoting label ui promotes internal to improvement', () => {
+    expect(
+      deriveEffectiveCategory('internal', [makeEnriched({ labels: ['ui'] })]),
+    ).toBe('improvement');
+  });
+
+  it('promoting label performance promotes internal to improvement', () => {
+    expect(
+      deriveEffectiveCategory('internal', [
+        makeEnriched({ labels: ['performance'] }),
+      ]),
+    ).toBe('improvement');
+  });
+
+  it('promoting label does not demote a higher-signal category', () => {
+    // A feat commit with a 'bug' promoting label stays 'new', not 'fix',
+    // because the prefix category 'new' is more specific than the bug
+    // promoting label which would push to 'fix'. The original category
+    // is preserved when the promoting label would lower the category.
+    expect(
+      deriveEffectiveCategory('new', [makeEnriched({ labels: ['bug'] })]),
+    ).toBe('new');
+  });
+
+  it('internal label precedence overrides promoting label across multiple refs', () => {
+    const enriched = [
+      makeEnriched({ number: 1, labels: ['feature'] }),
+      makeEnriched({ number: 2, labels: ['refactor'] }),
+    ];
+    expect(deriveEffectiveCategory('internal', enriched)).toBe('internal');
+  });
+
+  it('bug promoting label takes precedence over feature in same ref', () => {
+    // When a single ref carries both 'bug' and 'feature', the fix tier
+    // (bug) wins over the new tier (feature) for the effective category
+    // from an internal-prefix commit.
+    const enriched = [makeEnriched({ labels: ['bug', 'feature'] })];
+    expect(deriveEffectiveCategory('internal', enriched)).toBe('fix');
+  });
+
+  it('case-insensitive: Bug and BUG both promote to fix', () => {
+    expect(
+      deriveEffectiveCategory('internal', [makeEnriched({ labels: ['Bug'] })]),
+    ).toBe('fix');
+    expect(
+      deriveEffectiveCategory('internal', [makeEnriched({ labels: ['BUG'] })]),
+    ).toBe('fix');
+  });
+});
+
+describe('classifyEnrichedRefs internal-label precedence', () => {
+  it('keeps internal labels authoritative over titles and promoting labels', () => {
+    const enriched = [
+      makeEnriched({
+        title: 'feat: add visible capability',
+        labels: ['feature', 'internal'],
+      }),
+    ];
+
+    expect(classifyEnrichedRefs(enriched)).toBe('internal');
+  });
+});
+
+describe('unavailable metadata', () => {
+  const unavailable = makeEnriched({
+    title: 'feat: add visible capability',
+    labels: ['feature'],
+    metadataAvailable: false,
+  });
+
+  it('is excluded from highlights', () => {
+    expect(isEligibleForHighlights('new', [unavailable])).toBe(false);
+  });
+
+  it('is demoted from prominent categories', () => {
+    expect(shouldDemoteFromProminent([unavailable])).toBe(true);
+    expect(deriveEffectiveCategory('new', [unavailable])).toBe('internal');
+    expect(classifyEnrichedRefs([unavailable])).toBe('internal');
+  });
+});
+
+describe('realistic label truncation with 100 nodes and totalCount 150', () => {
+  // Simulates a real PR/issue with 150 labels where the GraphQL
+  // labels(first:100) connection returns only the first 100 nodes and
+  // totalCount=150. The gh-port layer sets labelsTruncated=true to signal
+  // that unfetched label pages may contain internal labels we cannot see.
+
+  function makeTruncatedRef(): EnrichedRef {
+    return makeEnriched({
+      labels: Array.from({ length: 100 }, (_, i) => `label-${i}`),
+      labelsTruncated: true,
+    });
+  }
+
+  it('classifies a truncated-label entry as internal regardless of prefix', () => {
+    // Even a feat: commit with truncated labels is conservatively demoted
+    // to internal, because an unseen internal label may exist on page 2+.
+    expect(deriveEffectiveCategory('new', [makeTruncatedRef()])).toBe(
+      'internal',
+    );
+  });
+
+  it('renders a truncated-label entry as ineligible for highlights', () => {
+    expect(isEligibleForHighlights('new', [makeTruncatedRef()])).toBe(false);
+  });
+
+  it('demotes a truncated-label entry from prominent categories', () => {
+    expect(shouldDemoteFromProminent([makeTruncatedRef()])).toBe(true);
+  });
+
+  it('does not demote when labels are not truncated even with many labels', () => {
+    // 100 labels with totalCount=100 means no truncation — classification
+    // proceeds normally based on the visible labels.
+    const ref = makeEnriched({
+      labels: Array.from({ length: 100 }, (_, i) => `label-${i}`),
+      labelsTruncated: false,
+    });
+    expect(shouldDemoteFromProminent([ref])).toBe(false);
+    expect(isEligibleForHighlights('new', [ref])).toBe(true);
+  });
+});
+
+describe('classifyEnrichedRefs', () => {
+  it('preserves a feature title when a lower-ranked UX label is present', () => {
+    const enriched = [
+      makeEnriched({ title: 'feat: add visual configuration', labels: ['ux'] }),
+    ];
+
+    expect(classifyEnrichedRefs(enriched)).toBe('new');
+  });
+
+  it('keeps the owning PR category ahead of a related issue title', () => {
+    const enriched = [
+      makeEnriched({ title: 'fix: restore profile loading' }),
+      makeEnriched({ number: 2, title: 'feat: support saved profiles' }),
+    ];
+
+    expect(classifyEnrichedRefs(enriched)).toBe('fix');
+  });
+
+  it('does not let related issue labels recategorize the owning PR', () => {
+    const enriched = [
+      makeEnriched({ title: 'fix: restore profile loading' }),
+      makeEnriched({
+        number: 2,
+        title: 'Profile loading fails',
+        labels: ['feature'],
+      }),
+    ];
+
+    expect(classifyEnrichedRefs(enriched)).toBe('fix');
+  });
+});
+
+describe('deriveEffectiveCategory ownership scoping', () => {
+  it('does not let a related ref promoting label recategorize the owning PR', () => {
+    // Owning PR #1 is internal (no labels); related issue #2 carries a
+    // 'feature' label. The owning PR must remain internal — the related
+    // ref's promoting label must not positively recategorize it.
+    const enriched = [
+      makeEnriched({ number: 1, labels: [] }),
+      makeEnriched({ number: 2, labels: ['feature'] }),
+    ];
+    expect(deriveEffectiveCategory('internal', enriched)).toBe('internal');
+  });
+
+  it('does not let a related ref bug label promote the owning PR', () => {
+    const enriched = [
+      makeEnriched({ number: 1, labels: [] }),
+      makeEnriched({ number: 2, labels: ['bug'] }),
+    ];
+    expect(deriveEffectiveCategory('internal', enriched)).toBe('internal');
+  });
+
+  it('still promotes when the owning/first ref carries the promoting label', () => {
+    const enriched = [
+      makeEnriched({ number: 1, labels: ['feature'] }),
+      makeEnriched({ number: 2, labels: [] }),
+    ];
+    expect(deriveEffectiveCategory('internal', enriched)).toBe('new');
+  });
+
+  it('retains conservative internal-label demotion across all refs', () => {
+    // Owning PR #1 carries no internal label, but related issue #2 carries
+    // 'refactor'. The internal-label demotion applies across all enriched
+    // refs, so the owning PR is still demoted to internal.
+    const enriched = [
+      makeEnriched({ number: 1, labels: ['feature'] }),
+      makeEnriched({ number: 2, labels: ['refactor'] }),
+    ];
+    expect(deriveEffectiveCategory('new', enriched)).toBe('internal');
+  });
+
+  it('owning promoting label wins over related internal label for eligibility edge', () => {
+    // Internal label on related ref still demotes — ownership scoping only
+    // restricts positive promotion, not conservative demotion.
+    const enriched = [
+      makeEnriched({ number: 1, labels: ['bug'] }),
+      makeEnriched({ number: 2, labels: ['tech-debt'] }),
+    ];
+    expect(deriveEffectiveCategory('internal', enriched)).toBe('internal');
+  });
+});

--- a/scripts/tests/release-notes/contributors.test.ts
+++ b/scripts/tests/release-notes/contributors.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  extractPrNumbers,
+  isExcludedContributor,
+  MAINTAINER_LOGIN,
+  computeContributors,
+} from '../../release-notes/contributors.js';
+import type {
+  EnrichedRef,
+  GhPort,
+  RawCommit,
+} from '../../release-notes/types.js';
+
+function makeCommit(overrides: Partial<RawCommit> = {}): RawCommit {
+  return {
+    hash: 'abc',
+    subject: 'feat: thing',
+    author: 'dev',
+    isMerge: false,
+    parents: [],
+    ...overrides,
+  };
+}
+
+function makeEnriched(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 1,
+    title: 'Title',
+    body: '',
+    labels: [],
+    labelsTruncated: false,
+    author: 'someone',
+    isPr: true,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+function fakeGh(refs: readonly EnrichedRef[]): GhPort {
+  return {
+    async fetchRefs() {
+      return new Map(refs.map((r) => [r.number, r]));
+    },
+  };
+}
+
+describe('extractPrNumbers', () => {
+  it('extracts from classic merge subjects', () => {
+    const commits = [
+      makeCommit({ subject: 'Merge pull request #42 from feature/branch' }),
+    ];
+    expect(extractPrNumbers(commits)).toEqual([42]);
+  });
+
+  it('extracts from terminal squash markers', () => {
+    const commits = [
+      makeCommit({ subject: 'feat: add streaming support (#100)' }),
+    ];
+    expect(extractPrNumbers(commits)).toEqual([100]);
+  });
+
+  it('extracts from both classic merge and squash in the same set', () => {
+    const commits = [
+      makeCommit({ subject: 'Merge pull request #42 from feature/branch' }),
+      makeCommit({ subject: 'feat: add thing (#100)' }),
+    ];
+    expect(extractPrNumbers(commits)).toEqual([42, 100]);
+  });
+
+  it('deduplicates the same PR referenced multiple times', () => {
+    const commits = [
+      makeCommit({ subject: 'Merge pull request #42 from feature/branch' }),
+      makeCommit({ subject: 'fix: followup (#42)' }),
+    ];
+    expect(extractPrNumbers(commits)).toEqual([42]);
+  });
+
+  it('also captures Fixes/Closes references', () => {
+    const commits = [makeCommit({ subject: 'fix: crash Fixes #7' })];
+    expect(extractPrNumbers(commits)).toEqual([7]);
+  });
+
+  it('returns empty when no PR references', () => {
+    const commits = [makeCommit({ subject: 'feat: standalone' })];
+    expect(extractPrNumbers(commits)).toEqual([]);
+  });
+});
+
+describe('isExcludedContributor', () => {
+  it('excludes the maintainer', () => {
+    expect(isExcludedContributor(MAINTAINER_LOGIN)).toBe(true);
+  });
+
+  it('excludes empty/deleted authors', () => {
+    expect(isExcludedContributor('')).toBe(true);
+    expect(isExcludedContributor('   ')).toBe(true);
+  });
+
+  it('excludes bots with [bot] suffix', () => {
+    expect(isExcludedContributor('dependabot[bot]')).toBe(true);
+    expect(isExcludedContributor('github-actions[bot]')).toBe(true);
+  });
+
+  it('keeps regular contributors', () => {
+    expect(isExcludedContributor('alice')).toBe(false);
+    expect(isExcludedContributor('bobby')).toBe(false);
+  });
+});
+
+describe('computeContributors', () => {
+  it('combines classic merge and squash PR contributors', async () => {
+    const commits = [
+      makeCommit({ subject: 'Merge pull request #10 from feature' }),
+      makeCommit({ subject: 'feat: thing (#20)' }),
+    ];
+    const gh = fakeGh([
+      makeEnriched({ number: 10, author: 'alice', isPr: true }),
+      makeEnriched({ number: 20, author: 'bob', isPr: true }),
+    ]);
+    expect(await computeContributors(gh, commits)).toEqual(['alice', 'bob']);
+  });
+
+  it('deduplicates duplicate PR numbers', async () => {
+    const commits = [
+      makeCommit({ subject: 'Merge pull request #10 from feature' }),
+      makeCommit({ subject: 'fix: followup (#10)' }),
+    ];
+    const gh = fakeGh([
+      makeEnriched({ number: 10, author: 'alice', isPr: true }),
+    ]);
+    expect(await computeContributors(gh, commits)).toEqual(['alice']);
+  });
+
+  it('filters bots with [bot] suffix', async () => {
+    const commits = [makeCommit({ subject: 'feat: thing (#20)' })];
+    const gh = fakeGh([
+      makeEnriched({ number: 20, author: 'dependabot[bot]', isPr: true }),
+    ]);
+    expect(await computeContributors(gh, commits)).toEqual([]);
+  });
+
+  it('filters the maintainer', async () => {
+    const commits = [makeCommit({ subject: 'feat: thing (#20)' })];
+    const gh = fakeGh([
+      makeEnriched({ number: 20, author: 'acoliver', isPr: true }),
+    ]);
+    expect(await computeContributors(gh, commits)).toEqual([]);
+  });
+
+  it('filters empty/deleted authors', async () => {
+    const commits = [makeCommit({ subject: 'feat: thing (#20)' })];
+    const gh = fakeGh([makeEnriched({ number: 20, author: '', isPr: true })]);
+    expect(await computeContributors(gh, commits)).toEqual([]);
+  });
+
+  it('skips non-PR refs (issues) even when enriched', async () => {
+    const commits = [makeCommit({ subject: 'fix: crash Fixes #7' })];
+    const gh = fakeGh([
+      makeEnriched({ number: 7, author: 'ghost', isPr: false }),
+    ]);
+    expect(await computeContributors(gh, commits)).toEqual([]);
+  });
+
+  it('handles missing GitHub data (ref not returned) gracefully', async () => {
+    const commits = [makeCommit({ subject: 'feat: thing (#20)' })];
+    const gh = fakeGh([]);
+    expect(await computeContributors(gh, commits)).toEqual([]);
+  });
+
+  it('handles partial GitHub data: some refs present, some missing', async () => {
+    const commits = [
+      makeCommit({ subject: 'Merge pull request #10 from feature' }),
+      makeCommit({ subject: 'feat: thing (#20)' }),
+      makeCommit({ subject: 'fix: another (#30)' }),
+    ];
+    const gh = fakeGh([
+      makeEnriched({ number: 10, author: 'alice', isPr: true }),
+      // #20 missing from GitHub response
+      makeEnriched({ number: 30, author: 'carol', isPr: true }),
+    ]);
+    expect(await computeContributors(gh, commits)).toEqual(['alice', 'carol']);
+  });
+
+  it('returns empty for commits with no PR references', async () => {
+    const commits = [makeCommit({ subject: 'feat: standalone' })];
+    const gh = fakeGh([]);
+    expect(await computeContributors(gh, commits)).toEqual([]);
+  });
+
+  it('returns a sorted, deduplicated list', async () => {
+    const commits = [
+      makeCommit({ subject: 'Merge pull request #30 from feature' }),
+      makeCommit({ subject: 'Merge pull request #10 from feature' }),
+      makeCommit({ subject: 'Merge pull request #20 from feature' }),
+    ];
+    const gh = fakeGh([
+      makeEnriched({ number: 30, author: 'charlie', isPr: true }),
+      makeEnriched({ number: 10, author: 'alice', isPr: true }),
+      makeEnriched({ number: 20, author: 'bob', isPr: true }),
+    ]);
+    expect(await computeContributors(gh, commits)).toEqual([
+      'alice',
+      'bob',
+      'charlie',
+    ]);
+  });
+
+  it('returns an empty list when gh enrichment rejects (degrades gracefully)', async () => {
+    const commits = [makeCommit({ subject: 'feat: thing (#20)' })];
+    const gh: GhPort = {
+      async fetchRefs() {
+        throw new Error('gh api graphql failed: token expired');
+      },
+    };
+    expect(await computeContributors(gh, commits)).toEqual([]);
+  });
+});

--- a/scripts/tests/release-notes/curated-headline.test.ts
+++ b/scripts/tests/release-notes/curated-headline.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { loadCuratedHeadline } from '../../release-notes/curated-headline.js';
+import { createTempDirHelper, writeTempFile } from './fixtures.js';
+
+const getDir = createTempDirHelper();
+
+describe('loadCuratedHeadline', () => {
+  it('returns null when the file does not exist', () => {
+    const dir = getDir();
+    const result = loadCuratedHeadline(dir, '0.11.0');
+    expect(result).toBeNull();
+  });
+
+  it('returns file content when the file exists', () => {
+    const dir = getDir();
+    writeTempFile(dir, '0.11.0.md', '## Major release\nThis is a big one.');
+    const result = loadCuratedHeadline(dir, '0.11.0');
+    expect(result).toBe('## Major release\nThis is a big one.');
+  });
+
+  it('returns null for empty file', () => {
+    const dir = getDir();
+    writeTempFile(dir, '0.11.0.md', '');
+    const result = loadCuratedHeadline(dir, '0.11.0');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for whitespace-only file', () => {
+    const dir = getDir();
+    writeTempFile(dir, '0.11.0.md', '   \n\n  ');
+    const result = loadCuratedHeadline(dir, '0.11.0');
+    expect(result).toBeNull();
+  });
+
+  it('rejects version with path traversal characters', () => {
+    const dir = getDir();
+    const result = loadCuratedHeadline(dir, '../../../etc/passwd');
+    expect(result).toBeNull();
+  });
+
+  it('rejects version with non-alphanumeric characters', () => {
+    const dir = getDir();
+    const result = loadCuratedHeadline(dir, '0.11.0;rm -rf');
+    expect(result).toBeNull();
+  });
+});

--- a/scripts/tests/release-notes/diff-selection.test.ts
+++ b/scripts/tests/release-notes/diff-selection.test.ts
@@ -1,0 +1,448 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  selectDiffBase,
+  nightlyCandidateNames,
+  type TagInfo,
+} from '../../release-notes/diff-selection.js';
+import type { ReleaseMetadata } from '../../release-notes/types.js';
+
+function tag(name: string, createdAt: number): TagInfo {
+  return { name, createdAt };
+}
+
+describe('selectDiffBase', () => {
+  it('selects the highest same-version nightly by createdAt when dates match', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260714.zzzzzzz', 100),
+      tag('v0.11.0-nightly.260714.aaaaaaa', 200),
+      tag('v0.10.0', 50),
+    ];
+    // Same date 260714; aaaaaaa has later createdAt (200 > 100).
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.ccccccc', true)).toBe(
+      'v0.11.0-nightly.260714.aaaaaaa',
+    );
+  });
+
+  it('falls back to the latest older stable for a first nightly', () => {
+    expect(
+      selectDiffBase(
+        [tag('v0.10.0', 100), tag('v0.9.0', 50)],
+        'v0.11.0-nightly.260715.abc',
+        true,
+      ),
+    ).toBe('v0.10.0');
+  });
+
+  it('excludes beta and rc tags from stable fallback', () => {
+    expect(
+      selectDiffBase(
+        [
+          tag('v0.10.0-beta.1', 300),
+          tag('v0.10.0-rc.1', 200),
+          tag('v0.9.0', 100),
+        ],
+        'v0.10.0',
+        false,
+      ),
+    ).toBe('v0.9.0');
+  });
+
+  it('does not select a newer stable tag', () => {
+    expect(
+      selectDiffBase(
+        [tag('v0.12.0', 300), tag('v0.10.0', 100)],
+        'v0.11.0',
+        false,
+      ),
+    ).toBe('v0.10.0');
+  });
+
+  it('returns null when no valid base exists', () => {
+    expect(selectDiffBase([], 'v0.11.0', false)).toBeNull();
+  });
+});
+
+describe('nightly predecessor (parsed date + createdAt chronology)', () => {
+  it('selects by parsed date, not SHA lexical order', () => {
+    // Nonmonotonic hashes: zzzzzzz created earlier than aaaaaaa (by createdAt).
+    const tags = [
+      tag('v0.11.0-nightly.260714.zzzzzzz', 100),
+      tag('v0.11.0-nightly.260714.aaaaaaa', 200),
+    ];
+    // Same date 260714; aaaaaaa has later createdAt (200 > 100), so it wins.
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.ccccccc', true)).toBe(
+      'v0.11.0-nightly.260714.aaaaaaa',
+    );
+  });
+
+  it('selects the predecessor by parsed date even with nonmonotonic hashes', () => {
+    // Date 260713 with SHA zzzzzzz (created at 100) is earlier than
+    // date 260714 with SHA aaaaaaa (created at 50). Date wins over createdAt.
+    const tags = [
+      tag('v0.11.0-nightly.260713.zzzzzzz', 100),
+      tag('v0.11.0-nightly.260714.aaaaaaa', 50),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.ccccccc', true)).toBe(
+      'v0.11.0-nightly.260714.aaaaaaa',
+    );
+  });
+
+  it('uses deterministic name tie-break when date and createdAt are equal', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260714.bbb', 100),
+      tag('v0.11.0-nightly.260714.aaa', 100),
+      tag('v0.11.0-nightly.260714.ccc', 100),
+    ];
+    // Same date, same createdAt → lexicographic name tie-break (descending).
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.x', true)).toBe(
+      'v0.11.0-nightly.260714.ccc',
+    );
+  });
+
+  it('uses current tag timestamp when available for chronological comparison', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 200),
+      tag('v0.11.0-nightly.260715.bbb', 100), // current tag
+    ];
+    // Current tag 260715.bbb has createdAt 100. The 260714.aaa tag (createdAt 200)
+    // is older by date, so it's the predecessor.
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.bbb', true)).toBe(
+      'v0.11.0-nightly.260714.aaa',
+    );
+  });
+
+  it('is deterministic regardless of input order (shuffled)', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260710.x', 300),
+      tag('v0.11.0-nightly.260712.x', 100),
+      tag('v0.11.0-nightly.260711.x', 200),
+      tag('v0.11.0-nightly.260709.x', 400),
+    ];
+    const shuffled = [...tags].reverse();
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260713.x', true)).toBe(
+      selectDiffBase(shuffled, 'v0.11.0-nightly.260713.x', true),
+    );
+  });
+
+  it('handles equal timestamps deterministically', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260710.aaa', 100),
+      tag('v0.11.0-nightly.260711.bbb', 100),
+      tag('v0.11.0-nightly.260709.ccc', 100),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260712.x', true)).toBe(
+      'v0.11.0-nightly.260711.bbb',
+    );
+  });
+
+  it('excludes the current nightly tag itself', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260715.x', 500),
+      tag('v0.11.0-nightly.260714.x', 200),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.x', true)).toBe(
+      'v0.11.0-nightly.260714.x',
+    );
+  });
+
+  it('excludes future nightly tags relative to current', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260714.x', 100),
+      tag('v0.11.0-nightly.260716.x', 300),
+      tag('v0.11.0-nightly.260713.x', 200),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.x', true)).toBe(
+      'v0.11.0-nightly.260714.x',
+    );
+  });
+
+  it('falls back to latest older stable when no same-base nightly exists', () => {
+    const tags = [tag('v0.10.0', 100), tag('v0.9.0', 50)];
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.abc', true)).toBe(
+      'v0.10.0',
+    );
+  });
+
+  it('falls back to latest older stable when nightlies are only future', () => {
+    const tags = [tag('v0.10.0', 100), tag('v0.11.0-nightly.260716.x', 300)];
+    expect(selectDiffBase(tags, 'v0.11.0-nightly.260715.x', true)).toBe(
+      'v0.10.0',
+    );
+  });
+});
+
+describe('stable predecessor (semver-correct)', () => {
+  it('selects the latest older stable excluding prereleases', () => {
+    const tags = [
+      tag('v0.9.0', 50),
+      tag('v0.10.0', 100),
+      tag('v0.11.0-beta.1', 200),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0', false)).toBe('v0.10.0');
+  });
+
+  it('excludes newer stable tags', () => {
+    const tags = [tag('v0.10.0', 100), tag('v0.12.0', 300)];
+    expect(selectDiffBase(tags, 'v0.11.0', false)).toBe('v0.10.0');
+  });
+
+  it('returns null when only prereleases exist below current', () => {
+    const tags = [tag('v0.10.0-beta.1', 100), tag('v0.10.0-rc.1', 200)];
+    expect(selectDiffBase(tags, 'v0.11.0', false)).toBeNull();
+  });
+
+  it('is deterministic regardless of input order', () => {
+    const tags = [tag('v0.8.0', 50), tag('v0.10.0', 300), tag('v0.9.0', 200)];
+    const shuffled = [...tags].reverse();
+    expect(selectDiffBase(tags, 'v0.11.0', false)).toBe(
+      selectDiffBase(shuffled, 'v0.11.0', false),
+    );
+  });
+});
+
+describe('prerelease predecessor (same-base, non-nightly)', () => {
+  it('selects the previous alpha of the same base version', () => {
+    const tags = [
+      tag('v0.11.0-alpha.1', 100),
+      tag('v0.11.0-alpha.2', 200),
+      tag('v0.10.0', 50),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-alpha.2', false)).toBe(
+      'v0.11.0-alpha.1',
+    );
+  });
+
+  it('falls back to latest stable when no same-base prerelease exists', () => {
+    const tags = [tag('v0.10.0', 50), tag('v0.11.0-alpha.1', 100)];
+    expect(selectDiffBase(tags, 'v0.11.0-alpha.1', false)).toBe('v0.10.0');
+  });
+
+  it('falls back to latest stable when only newer prereleases exist', () => {
+    const tags = [
+      tag('v0.10.0', 50),
+      tag('v0.11.0-alpha.3', 300),
+      tag('v0.11.0-alpha.2', 200),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-alpha.1', false)).toBe('v0.10.0');
+  });
+
+  it('selects the previous beta of the same base version', () => {
+    const tags = [
+      tag('v0.11.0-beta.1', 100),
+      tag('v0.11.0-beta.2', 200),
+      tag('v0.10.0', 50),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-beta.2', false)).toBe(
+      'v0.11.0-beta.1',
+    );
+  });
+
+  it('selects the previous rc of the same base version', () => {
+    const tags = [
+      tag('v0.11.0-rc.1', 100),
+      tag('v0.11.0-rc.2', 200),
+      tag('v0.10.0', 50),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-rc.2', false)).toBe('v0.11.0-rc.1');
+  });
+
+  it('excludes prereleases from a different base version', () => {
+    const tags = [
+      tag('v0.10.0-alpha.1', 100),
+      tag('v0.11.0-alpha.1', 200),
+      tag('v0.10.0', 50),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-alpha.1', false)).toBe('v0.10.0');
+  });
+
+  it('excludes nightlies from prerelease candidates', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 100),
+      tag('v0.11.0-alpha.2', 200),
+      tag('v0.11.0-alpha.1', 150),
+      tag('v0.10.0', 50),
+    ];
+    expect(selectDiffBase(tags, 'v0.11.0-alpha.2', false)).toBe(
+      'v0.11.0-alpha.1',
+    );
+  });
+
+  it('is deterministic regardless of input order', () => {
+    const tags = [
+      tag('v0.11.0-alpha.1', 100),
+      tag('v0.11.0-alpha.3', 300),
+      tag('v0.11.0-alpha.2', 200),
+    ];
+    const shuffled = [...tags].reverse();
+    expect(selectDiffBase(tags, 'v0.11.0-alpha.4', false)).toBe(
+      selectDiffBase(shuffled, 'v0.11.0-alpha.4', false),
+    );
+  });
+
+  it('does not apply to stable (non-prerelease) current tags', () => {
+    const tags = [
+      tag('v0.10.0', 50),
+      tag('v0.11.0-alpha.1', 100),
+      tag('v0.11.0', 200),
+    ];
+    // Stable v0.11.0 uses latestStable, which excludes prereleases.
+    expect(selectDiffBase(tags, 'v0.11.0', false)).toBe('v0.10.0');
+  });
+});
+
+describe('nightlyCandidateNames', () => {
+  it('returns same-base nightly tags excluding the current tag', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 100),
+      tag('v0.11.0-nightly.260713.bbb', 200),
+      tag('v0.10.0', 50),
+      tag('v0.12.0-nightly.260715.ccc', 300),
+    ];
+    expect(nightlyCandidateNames(tags, 'v0.11.0-nightly.260715.ddd')).toContain(
+      'v0.11.0-nightly.260714.aaa',
+    );
+    expect(nightlyCandidateNames(tags, 'v0.11.0-nightly.260715.ddd')).toContain(
+      'v0.11.0-nightly.260713.bbb',
+    );
+  });
+
+  it('excludes the current tag itself', () => {
+    const tags = [tag('v0.11.0-nightly.260714.aaa', 100)];
+    expect(nightlyCandidateNames(tags, 'v0.11.0-nightly.260714.aaa')).toEqual(
+      [],
+    );
+  });
+
+  it('excludes nightlies from a different base version', () => {
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 100),
+      tag('v0.12.0-nightly.260714.bbb', 200),
+    ];
+    const candidates = nightlyCandidateNames(tags, 'v0.11.0-nightly.260715.x');
+    expect(candidates).toContain('v0.11.0-nightly.260714.aaa');
+    expect(candidates).not.toContain('v0.12.0-nightly.260714.bbb');
+  });
+
+  it('excludes stable tags', () => {
+    const tags = [tag('v0.10.0', 50), tag('v0.11.0-nightly.260714.aaa', 100)];
+    const candidates = nightlyCandidateNames(tags, 'v0.11.0-nightly.260715.x');
+    expect(candidates).not.toContain('v0.10.0');
+  });
+
+  it('returns empty for a stable (non-nightly) current tag', () => {
+    const tags = [tag('v0.10.0', 50), tag('v0.11.0-nightly.260714.aaa', 100)];
+    expect(nightlyCandidateNames(tags, 'v0.11.0')).toEqual([]);
+  });
+
+  it('returns empty when no same-base nightlies exist', () => {
+    const tags = [tag('v0.10.0', 50), tag('v0.12.0-nightly.260715.aaa', 100)];
+    expect(nightlyCandidateNames(tags, 'v0.11.0-nightly.260715.bbb')).toEqual(
+      [],
+    );
+  });
+
+  it('excludes chronologically future nightly candidates', () => {
+    // Current tag is 260715. Tags 260716 and 260717 are future — they
+    // must NOT appear in the candidate list at all.
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 100),
+      tag('v0.11.0-nightly.260716.bbb', 200),
+      tag('v0.11.0-nightly.260717.ccc', 300),
+      tag('v0.11.0-nightly.260710.ddd', 400),
+    ];
+    const candidates = nightlyCandidateNames(tags, 'v0.11.0-nightly.260715.x');
+    expect(candidates).toContain('v0.11.0-nightly.260714.aaa');
+    expect(candidates).toContain('v0.11.0-nightly.260710.ddd');
+    expect(candidates).not.toContain('v0.11.0-nightly.260716.bbb');
+    expect(candidates).not.toContain('v0.11.0-nightly.260717.ccc');
+  });
+
+  it('keeps same-date candidates (same-day predecessors)', () => {
+    // Same-date tags with earlier createdAt are valid predecessors.
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 50),
+      tag('v0.11.0-nightly.260714.bbb', 100),
+    ];
+    const candidates = nightlyCandidateNames(tags, 'v0.11.0-nightly.260715.x');
+    expect(candidates).toContain('v0.11.0-nightly.260714.aaa');
+    expect(candidates).toContain('v0.11.0-nightly.260714.bbb');
+  });
+
+  it('never selects a chronologically future nightly as predecessor (261015 → 261049)', () => {
+    // Reproduces the exact scenario from the issue: current nightly is
+    // 261015 and there is a future 261049 tag. 261049 must never be
+    // selected as the predecessor.
+    const tags = [
+      tag('v0.11.0-nightly.261015.abc', 10_000),
+      tag('v0.11.0-nightly.261049.xyz', 20_000),
+      tag('v0.11.0-nightly.261014.def', 9000),
+    ];
+    const result = selectDiffBase(tags, 'v0.11.0-nightly.261015.abc', true);
+    expect(result).not.toBe('v0.11.0-nightly.261049.xyz');
+    expect(result).toBe('v0.11.0-nightly.261014.def');
+    // Also verify nightlyCandidateNames excludes the future tag so it
+    // never gets queried for metadata.
+    expect(
+      nightlyCandidateNames(tags, 'v0.11.0-nightly.261015.abc'),
+    ).not.toContain('v0.11.0-nightly.261049.xyz');
+  });
+});
+
+describe('release metadata selection', () => {
+  const published = (publishedAt: number): ReleaseMetadata => ({
+    status: 'published',
+    publishedAt,
+  });
+
+  it('orders published candidates deterministically on timestamp ties', () => {
+    const current = 'v0.11.0-nightly.260715.current';
+    const lookup = (): ReleaseMetadata => published(100);
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 20),
+      tag('v0.11.0-nightly.260714.ccc', 10),
+      tag('v0.11.0-nightly.260714.bbb', 30),
+      tag(current, 40),
+    ];
+
+    expect(selectDiffBase(tags, current, true, lookup)).toBe(
+      'v0.11.0-nightly.260714.ccc',
+    );
+  });
+
+  it('is deterministic regardless of metadata-enabled input order', () => {
+    const current = 'v0.11.0-nightly.260715.current';
+    const lookup = (candidate: string): ReleaseMetadata => ({
+      status: 'published',
+      publishedAt: candidate.endsWith('.aaa') ? 200 : 300,
+    });
+    const tags = [
+      tag('v0.11.0-nightly.260714.aaa', 20),
+      tag('v0.11.0-nightly.260713.bbb', 30),
+      tag(current, 40),
+    ];
+
+    expect(selectDiffBase(tags, current, true, lookup)).toBe(
+      selectDiffBase([...tags].reverse(), current, true, lookup),
+    );
+  });
+
+  it('fails when nightly publication metadata is unknown', () => {
+    const current = 'v0.11.0-nightly.260715.current';
+    const tags = [
+      tag('v0.10.0', 10),
+      tag('v0.11.0-nightly.260714.failed', 20),
+      tag(current, 30),
+    ];
+    const lookup = (): ReleaseMetadata => ({ status: 'unknown' });
+
+    expect(() => selectDiffBase(tags, current, true, lookup)).toThrow(
+      'Unable to determine the previous published nightly release',
+    );
+  });
+});

--- a/scripts/tests/release-notes/filtering.test.ts
+++ b/scripts/tests/release-notes/filtering.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isProcessNoise,
+  parseRefs,
+  extractPrIdentity,
+} from '../../release-notes/filtering.js';
+import type { RawCommit } from '../../release-notes/types.js';
+
+function makeCommit(overrides: Partial<RawCommit> = {}): RawCommit {
+  return {
+    hash: 'abcdef0',
+    subject: 'fix: something broke',
+    author: 'dev',
+    isMerge: false,
+    parents: [],
+    ...overrides,
+  };
+}
+
+describe('isProcessNoise', () => {
+  it('detects CodeRabbit review fixups', () => {
+    expect(
+      isProcessNoise(makeCommit({ subject: 'Apply CodeRabbit suggestions' })),
+    ).toBe(true);
+  });
+
+  it.each([
+    'fix OCR review findings',
+    'refactor: address OCR round 2 findings',
+    'fix(test): address Bun migration review findings',
+    'Zed ACP: address OCR and CodeRabbit review findings',
+    'fix(config): address follow-up migration review findings',
+  ])('detects review fixup %s', (subject) => {
+    expect(isProcessNoise(makeCommit({ subject }))).toBe(true);
+  });
+
+  it.each([
+    'lint: fix formatting',
+    'style: prettier run',
+    'chore: fix lint',
+    'fix: lint formatting',
+    'chore(format): run prettier',
+  ])('detects lint/format process noise: %s', (subject) => {
+    expect(isProcessNoise(makeCommit({ subject }))).toBe(true);
+  });
+
+  it('detects CI retrigger commits', () => {
+    expect(
+      isProcessNoise(makeCommit({ subject: 'ci: retrigger workflow' })),
+    ).toBe(true);
+  });
+
+  it('detects flaky test stabilization commits', () => {
+    expect(
+      isProcessNoise(
+        makeCommit({ subject: 'test: stabilize flaky integration test' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects dependency bumps that are chore', () => {
+    expect(
+      isProcessNoise(
+        makeCommit({ subject: 'chore(deps): bump eslint from 9.1.0 to 9.2.0' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT classify a real feature as noise', () => {
+    expect(
+      isProcessNoise(
+        makeCommit({ subject: 'feat: add streaming support for Ollama' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT classify a real bug fix as noise', () => {
+    expect(
+      isProcessNoise(
+        makeCommit({ subject: 'fix: resolve deadlock in streaming handler' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT classify a user-facing refactor as noise', () => {
+    expect(
+      isProcessNoise(
+        makeCommit({
+          subject: 'refactor: simplify provider registration API',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    'feat: add OCR review workflow',
+    'feat: apply suggestion engine improvement',
+    'feat: address review feedback display for users',
+    'ci: add trigger feature for webhooks',
+    'test: add flaky test detector',
+    'chore: address preview release bug',
+  ])('preserves legitimate commit %s', (subject) => {
+    expect(isProcessNoise(makeCommit({ subject }))).toBe(false);
+  });
+});
+
+describe('parseRefs', () => {
+  it('parses Fixes references', () => {
+    expect(parseRefs('fix: crash Fixes #123')).toEqual([
+      { number: 123, verb: 'Fixes' },
+    ]);
+  });
+
+  it('parses Closes references', () => {
+    expect(parseRefs('feat: thing Closes #456')).toEqual([
+      { number: 456, verb: 'Closes' },
+    ]);
+  });
+
+  it('parses Resolves references', () => {
+    expect(parseRefs('fix: bug Resolves #789')).toEqual([
+      { number: 789, verb: 'Resolves' },
+    ]);
+  });
+
+  it('parses lowercase verbs', () => {
+    expect(parseRefs('fix: crash fixes #123')).toEqual([
+      { number: 123, verb: 'fixes' },
+    ]);
+  });
+
+  it('parses multiple references in one subject', () => {
+    expect(parseRefs('fix: thing Fixes #1 Closes #2 resolves #3')).toEqual([
+      { number: 1, verb: 'Fixes' },
+      { number: 2, verb: 'Closes' },
+      { number: 3, verb: 'resolves' },
+    ]);
+  });
+
+  it('parses terminal GitHub PR marker (#N) independently of Fixes/Closes', () => {
+    expect(
+      parseRefs(
+        'Keep Codex provider identity coherent during startup (Fixes #2544) (#2561)',
+      ),
+    ).toEqual([
+      { number: 2544, verb: 'Fixes' },
+      { number: 2561, verb: 'pr' },
+    ]);
+  });
+
+  it('parses Merge pull request #N as a pr ref', () => {
+    expect(parseRefs('Merge pull request #123 from foo/bar')).toEqual([
+      { number: 123, verb: 'merge' },
+    ]);
+  });
+
+  it('retains all refs without duplicate numbers', () => {
+    const refs = parseRefs('fix: crash Fixes #42 (#42)');
+    const numbers = refs.map((r) => r.number);
+    expect(new Set(numbers).size).toBe(numbers.length);
+  });
+
+  it('returns empty array when no references', () => {
+    expect(parseRefs('feat: something cool')).toEqual([]);
+  });
+
+  it('parses Fixes plus terminal (#pr) as two distinct refs', () => {
+    // Fixes #100 closes an issue, (#200) is the PR — both must be retained.
+    const refs = parseRefs('feat: add provider Fixes #100 (#200)');
+    expect(refs).toEqual([
+      { number: 100, verb: 'Fixes' },
+      { number: 200, verb: 'pr' },
+    ]);
+  });
+});
+
+describe('extractPrIdentity', () => {
+  it('extracts PR identity from a terminal squash marker', () => {
+    expect(
+      extractPrIdentity(
+        makeCommit({ subject: 'feat: add streaming support (#100)' }),
+      ),
+    ).toBe(100);
+  });
+
+  it('extracts PR identity from a classic merge marker', () => {
+    expect(
+      extractPrIdentity(
+        makeCommit({ subject: 'Merge pull request #123 from foo/bar' }),
+      ),
+    ).toBe(123);
+  });
+
+  it('returns null for a Fixes-only commit (issue ref is NOT PR identity)', () => {
+    expect(
+      extractPrIdentity(makeCommit({ subject: 'fix: crash Fixes #42' })),
+    ).toBeNull();
+  });
+
+  it('returns null when no PR marker exists', () => {
+    expect(
+      extractPrIdentity(makeCommit({ subject: 'feat: standalone change' })),
+    ).toBeNull();
+  });
+
+  it('prefers the classic merge marker when both merge and terminal exist', () => {
+    // This is unusual but tests determinism.
+    expect(
+      extractPrIdentity(
+        makeCommit({ subject: 'Merge pull request #50 (#51)' }),
+      ),
+    ).toBe(50);
+  });
+});

--- a/scripts/tests/release-notes/fixtures.ts
+++ b/scripts/tests/release-notes/fixtures.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, afterEach } from 'vitest';
+
+/**
+ * Shared temp-fixture helper per dev-docs/RULES.md: one line of setup per
+ * describe block instead of duplicated beforeEach/afterEach hooks.
+ * Returns a lazy temp directory accessor and auto-cleans on afterEach.
+ */
+export function createTempDirHelper(): () => string {
+  let dir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'llxprt-rn-'));
+  });
+
+  afterEach(() => {
+    if (dir !== undefined) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dir = undefined;
+  });
+
+  return () => {
+    if (dir === undefined) {
+      throw new Error('createTempDirHelper accessor called outside a test');
+    }
+    return dir;
+  };
+}
+
+/**
+ * Write a file inside a temp directory created by createTempDirHelper.
+ */
+export function writeTempFile(
+  dir: string,
+  relativePath: string,
+  content: string,
+): string {
+  const fullPath = join(dir, relativePath);
+  writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+/**
+ * Creates and initializes an isolated git repository in a temp directory,
+ * changing the process working directory so that git-port functions (which
+ * use cwd implicitly) operate on the temp repo. Returns a lazy directory
+ * accessor. Auto-restores cwd and removes the temp repo on afterEach.
+ *
+ * Extracted from git-port.test.ts and processing.test.ts per dev-docs/RULES.md
+ * shared-setup requirements.
+ */
+export function useTempRepo(prefix = 'llxprt-git'): () => string {
+  let dir: string | undefined;
+  let originalCwd: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), `${prefix}-`));
+    originalCwd = process.cwd();
+    process.chdir(dir);
+    execFileSync('git', ['init', '--initial-branch=main'], {
+      encoding: 'utf8',
+    });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], {
+      encoding: 'utf8',
+    });
+    execFileSync('git', ['config', 'user.name', 'Test'], { encoding: 'utf8' });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], {
+      encoding: 'utf8',
+    });
+  });
+
+  afterEach(() => {
+    if (originalCwd !== undefined) {
+      process.chdir(originalCwd);
+    }
+    if (dir !== undefined) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dir = undefined;
+    originalCwd = undefined;
+  });
+
+  return () => {
+    if (dir === undefined) {
+      throw new Error('useTempRepo accessor called outside a test');
+    }
+    return dir;
+  };
+}
+
+/**
+ * Creates a commit in the git repo at `dir` by writing a stamp file, staging
+ * all changes, and committing with the given message. Returns the full commit
+ * hash.
+ */
+export function gitCommit(dir: string, message: string): string {
+  const stampFile = join(dir, `.stamp-${Date.now()}-${Math.random()}`);
+  writeFileSync(stampFile, String(Math.random()));
+  execFileSync('git', ['add', '.'], { encoding: 'utf8' });
+  execFileSync('git', ['commit', '-m', message], {
+    encoding: 'utf8',
+  });
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+/**
+ * Merges `branchToMerge` into the current branch with --no-ff and the given
+ * commit message. Returns the full merge commit hash.
+ */
+export function gitMerge(
+  dir: string,
+  message: string,
+  branchToMerge: string,
+): string {
+  void dir;
+  execFileSync('git', ['merge', '--no-ff', '-m', message, branchToMerge], {
+    encoding: 'utf8',
+  });
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+}

--- a/scripts/tests/release-notes/gh-port.test.ts
+++ b/scripts/tests/release-notes/gh-port.test.ts
@@ -1,0 +1,662 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createGhPort,
+  fetchRefsViaGh,
+  parseChunkResponse,
+  safeMultibyteString,
+  GH_RUNNER_OPTIONS,
+  GH_RUNNER_MAX_BUFFER,
+  MAX_LABELS_PER_NODE,
+} from '../../release-notes/gh-port.js';
+import type { EnrichedRef } from '../../release-notes/types.js';
+
+function node(
+  index: number,
+  number: number,
+  overrides: Record<string, unknown> = {},
+): string {
+  const base = {
+    __typename: 'PullRequest',
+    number,
+    title: `PR ${number}`,
+    body: `Body for ${number}`,
+    labels: { nodes: [{ name: 'bug' }] },
+    author: { login: `user${number}` },
+    ...overrides,
+  };
+  return JSON.stringify({ data: { repository: { [`r${index}`]: base } } });
+}
+
+function repoEnvelope(entries: Record<string, unknown>): string {
+  return JSON.stringify({ data: { repository: entries } });
+}
+
+/**
+ * Returns the value for a key from a Map, throwing a descriptive error if
+ * the key is missing. This replaces non-null assertions (!) with a safe
+ * guard that produces actionable failure messages.
+ */
+function requireRef(
+  map: ReadonlyMap<number, EnrichedRef>,
+  key: number,
+): EnrichedRef {
+  const ref = map.get(key);
+  if (ref === undefined) {
+    throw new Error(`Expected ref ${key} to be present in the result map`);
+  }
+  return ref;
+}
+
+describe('parseChunkResponse', () => {
+  it('parses valid nodes and keys by requested number', () => {
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'Title 10',
+        body: 'Body 10',
+        labels: { nodes: [{ name: 'bug' }, { name: 'feature' }] },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    const ref = result.get(10)!;
+    expect(ref.number).toBe(10);
+    expect(ref.title).toBe('Title 10');
+    expect(ref.labels).toEqual(['bug', 'feature']);
+    expect(ref.author).toBe('alice');
+    expect(ref.isPr).toBe(true);
+  });
+
+  it('returns empty map for malformed JSON', () => {
+    const result = parseChunkResponse('{not valid json', [10]);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty map when envelope shape is malformed', () => {
+    const result = parseChunkResponse(
+      JSON.stringify({ wrong: { shape: true } }),
+      [10],
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it('degrades individually malformed nodes but keeps valid siblings', () => {
+    const raw = repoEnvelope({
+      r0: { __typename: 'PullRequest', number: 10, title: 'Good', author: {} },
+      r1: 'not-an-object',
+      r2: { __typename: 'Issue', number: 12, title: 'Also good' },
+    });
+    const result = parseChunkResponse(raw, [10, 11, 12]);
+    expect(result.size).toBe(2);
+    expect(requireRef(result, 10).title).toBe('Good');
+    expect(requireRef(result, 12).title).toBe('Also good');
+    expect(result.has(11)).toBe(false);
+  });
+
+  it('degrades null nodes individually', () => {
+    const raw = repoEnvelope({
+      r0: null,
+      r1: { __typename: 'PullRequest', number: 20, title: 'Present' },
+    });
+    const result = parseChunkResponse(raw, [19, 20]);
+    expect(result.size).toBe(1);
+    expect(requireRef(result, 20).title).toBe('Present');
+  });
+
+  it('rejects nodes where the alias number does not match the requested batch number', () => {
+    // The alias r0 is for requested number 10, but the returned node says 999.
+    const raw = repoEnvelope({
+      r0: { __typename: 'PullRequest', number: 999, title: 'Mismatched' },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(0);
+  });
+
+  it('rejects nodes with missing title', () => {
+    const raw = repoEnvelope({
+      r0: { __typename: 'PullRequest', number: 10, author: {} },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(0);
+  });
+
+  it('degrades malformed labels nodes but keeps the rest of the ref', () => {
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'Title',
+        labels: { nodes: [{ name: 'bug' }, 'bad', { other: 1 }] },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    // Valid label name is kept; malformed label nodes are ignored.
+    expect(requireRef(result, 10).labels).toEqual(['bug']);
+  });
+
+  it('handles missing author (null) gracefully', () => {
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'Title',
+        author: null,
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    expect(requireRef(result, 10).author).toBe('');
+  });
+
+  it('sets metadataAvailable true on a successfully enriched PullRequest', () => {
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'Title',
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    expect(requireRef(result, 10).metadataAvailable).toBe(true);
+  });
+
+  it('sets metadataAvailable true on a successfully enriched Issue', () => {
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'Issue',
+        number: 20,
+        title: 'Issue Title',
+        author: { login: 'bob' },
+      },
+    });
+    const result = parseChunkResponse(raw, [20]);
+    expect(result.size).toBe(1);
+    expect(requireRef(result, 20).metadataAvailable).toBe(true);
+  });
+});
+
+function echoRequestedRefs(args: readonly string[]): string {
+  const requested = args
+    .map((arg) => /^n\d+=(\d+)$/.exec(arg))
+    .filter((match) => match !== null)
+    .map((match) => Number(match[1]));
+  return repoEnvelope(
+    Object.fromEntries(
+      requested.map((number, index) => [
+        `r${index}`,
+        {
+          __typename: 'PullRequest',
+          number,
+          title: `PR ${number}`,
+          author: { login: 'u' },
+        },
+      ]),
+    ),
+  );
+}
+describe('fetchRefsViaGh (injectable runner)', () => {
+  it('processes 25 numbers in a single bounded chunk', () => {
+    const numbers = Array.from({ length: 25 }, (_, i) => i + 1);
+    let callCount = 0;
+    const runner = (args: readonly string[]) => {
+      callCount++;
+      return echoRequestedRefs(args);
+    };
+    const result = fetchRefsViaGh('owner/repo', numbers, runner);
+    expect(callCount).toBe(1);
+    expect(result.size).toBe(25);
+  });
+
+  it('processes 50 numbers across two bounded chunks (25 + 25)', () => {
+    const numbers = Array.from({ length: 50 }, (_, i) => i + 1);
+    let callCount = 0;
+    const runner = (args: readonly string[]) => {
+      callCount++;
+      return echoRequestedRefs(args);
+    };
+    const result = fetchRefsViaGh('owner/repo', numbers, runner);
+    expect(callCount).toBe(2);
+    expect(result.size).toBe(50);
+  });
+
+  it('processes 51 numbers across three bounded chunks (25 + 25 + 1)', () => {
+    const numbers = Array.from({ length: 51 }, (_, i) => i + 1);
+    let callCount = 0;
+    const runner = (args: readonly string[]) => {
+      callCount++;
+      const requested = args
+        .map((arg) => /^n\d+=(\d+)$/.exec(arg))
+        .filter((match) => match !== null)
+        .map((match) => Number(match[1]));
+      return repoEnvelope(
+        Object.fromEntries(
+          requested.map((number, index) => [
+            `r${index}`,
+            {
+              __typename: 'PullRequest',
+              number,
+              title: `PR ${number}`,
+              author: { login: 'u' },
+            },
+          ]),
+        ),
+      );
+    };
+    const result = fetchRefsViaGh('owner/repo', numbers, runner);
+    expect(callCount).toBe(3);
+    expect(result.size).toBe(51);
+  });
+
+  it('sorts and de-duplicates input numbers', () => {
+    const captured: number[] = [];
+    const capturingRunner = (args: readonly string[]) => {
+      // Extract nN=value pairs from the -F flags: args come as ["-F","n0=1",...]
+      for (const arg of args) {
+        const match = /^n\d+=(\d+)$/.exec(arg);
+        if (match !== null) {
+          captured.push(Number(match[1]));
+        }
+      }
+      return repoEnvelope({});
+    };
+    // Duplicates and unsorted.
+    fetchRefsViaGh('owner/repo', [3, 1, 2, 1, 3], capturingRunner);
+    expect(captured).toEqual([1, 2, 3]);
+  });
+
+  it('bounds enrichment to forty GraphQL requests', () => {
+    let calls = 0;
+    const runner: GhRunner = (args) => {
+      calls++;
+      const numbers = args.flatMap((arg) => {
+        const match = /^n\d+=(\d+)$/.exec(arg);
+        return match === null ? [] : [Number(match[1])];
+      });
+      return repoEnvelope(
+        Object.fromEntries(
+          numbers.map((number, index) => [
+            `r${index}`,
+            {
+              __typename: 'PullRequest',
+              number,
+              title: `PR ${number}`,
+              author: { login: 'u' },
+            },
+          ]),
+        ),
+      );
+    };
+
+    const result = fetchRefsViaGh(
+      'owner/repo',
+      Array.from({ length: 1400 }, (_, index) => index + 1),
+      runner,
+    );
+
+    expect(calls).toBe(40);
+    expect(result.size).toBe(1000);
+  });
+
+  it('continues after a failed first chunk and processes the second', () => {
+    const numbers = Array.from({ length: 51 }, (_, i) => i + 1);
+    let callCount = 0;
+    const runner = () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new Error('network error');
+      }
+      // Third chunk: just number 51 (25 + 25 = 50 already in first two chunks).
+      if (callCount === 2) {
+        // Second chunk: numbers 26-50, return them.
+        const repo: Record<string, unknown> = {};
+        for (let i = 0; i < 25; i++) {
+          repo[`r${i}`] = {
+            __typename: 'PullRequest',
+            number: 26 + i,
+            title: `PR ${26 + i}`,
+            author: { login: 'u' },
+          };
+        }
+        return repoEnvelope(repo);
+      }
+      // Third chunk: number 51.
+      return repoEnvelope({
+        r0: {
+          __typename: 'PullRequest',
+          number: 51,
+          title: 'PR 51',
+          author: { login: 'u' },
+        },
+      });
+    };
+    const result = fetchRefsViaGh('owner/repo', numbers, runner);
+    // First chunk failed (numbers 1-25 dropped), second and third succeeded.
+    expect(result.size).toBe(26);
+    expect(requireRef(result, 51).title).toBe('PR 51');
+  });
+
+  it('returns empty map when all chunks fail', () => {
+    const runner = () => {
+      throw new Error('total failure');
+    };
+    const result = fetchRefsViaGh('owner/repo', [1, 2, 3], runner);
+    expect(result.size).toBe(0);
+  });
+
+  it('handles malformed envelope in one chunk but valid in next', () => {
+    // 51 numbers forces three chunks (25 + 25 + 1).
+    const numbers = Array.from({ length: 51 }, (_, i) => i + 1);
+    let callCount = 0;
+    const runner = () => {
+      callCount++;
+      if (callCount === 1) {
+        return '{malformed';
+      }
+      // Subsequent chunks: return matching nodes for whatever was requested.
+      return node(0, numbers[callCount === 2 ? 25 : 50]!, {});
+    };
+    const result = fetchRefsViaGh('owner/repo', numbers, runner);
+    // First chunk (1-25) malformed, second (26-50) returns node(0, 26)
+    // which has number mismatch (26 != 51), third (51) returns node(0,51).
+    // Second chunk has alias r0 number 26 but response says number 26,
+    // requested batch[0] is 26, so it matches.
+    expect(requireRef(result, 51).title).toBe('PR 51');
+  });
+});
+
+describe('createGhPort', () => {
+  it('returns a GhPort whose fetchRefs delegates to the injectable runner', async () => {
+    const runner = () => node(0, 42, {});
+    const port = createGhPort('owner/repo', runner);
+    const refs = await port.fetchRefs([42]);
+    expect(refs.size).toBe(1);
+    const ref: EnrichedRef = refs.get(42)!;
+    expect(ref.number).toBe(42);
+    expect(ref.title).toBe('PR 42');
+  });
+});
+
+describe('defaultRunner maxBuffer', () => {
+  it('sets a bounded maxBuffer large enough for a full 25-node chunk', () => {
+    // The default runner must set a maxBuffer large enough for the maximum
+    // chunk size (25 PRs with substantial bodies). Node's execFileSync
+    // default maxBuffer is 1 MB, which is insufficient for 25 richly
+    // detailed PR bodies. We verify GH_RUNNER_MAX_BUFFER is >= 10 MB.
+    expect(GH_RUNNER_MAX_BUFFER).toBeGreaterThanOrEqual(10 * 1024 * 1024);
+  });
+
+  it('default runner passes the bounded maxBuffer to execFileSync', () => {
+    // GH_RUNNER_OPTIONS is the options object the default runner passes
+    // to execFileSync. It must include a maxBuffer >= 10 MB so a valid
+    // 25-node chunk response never hits Node's default 1 MB limit.
+    expect(GH_RUNNER_OPTIONS.maxBuffer).toBe(GH_RUNNER_MAX_BUFFER);
+    expect(GH_RUNNER_OPTIONS.encoding).toBe('utf8');
+    expect(GH_RUNNER_OPTIONS.timeout).toBe(15_000);
+  });
+
+  it('processes a realistic 25-node chunk with 100 labels per node under the buffer', () => {
+    // Build a realistic response: 25 PRs, each with a 100 KB body and
+    // 100 labels. This is the worst-case bounded chunk that must fit
+    // within GH_RUNNER_MAX_BUFFER (10 MiB).
+    const numbers = Array.from({ length: 25 }, (_, i) => i + 1);
+    const largeBody = 'x'.repeat(100_000);
+    const labels = Array.from({ length: 100 }, (_, i) => ({
+      name: `label-${i}`,
+    }));
+    const repo: Record<string, unknown> = {};
+    for (let i = 0; i < 25; i++) {
+      repo[`r${i}`] = {
+        __typename: 'PullRequest',
+        number: numbers[i]!,
+        title: `PR ${numbers[i]}`,
+        body: largeBody,
+        labels: { nodes: labels, totalCount: 100 },
+        author: { login: 'u' },
+      };
+    }
+    const raw = repoEnvelope(repo);
+    // The response must be well under the 10 MiB buffer.
+    expect(Buffer.byteLength(raw, 'utf8')).toBeLessThan(GH_RUNNER_MAX_BUFFER);
+    const result = parseChunkResponse(raw, numbers);
+    expect(result.size).toBe(25);
+  });
+
+  it('a full multibyte 25-node chunk (4-byte CJK) fits under the buffer', () => {
+    // Worst-case multibyte: 25 nodes each with 65536 chars of 4-byte UTF-8.
+    // 25 × 65536 × 4 = 6,553,600 bytes ≈ 6.25 MiB, well under 10 MiB.
+    const cjkBody = '𠮷'.repeat(65_536); // 4-byte UTF-8 character
+    const numbers = Array.from({ length: 25 }, (_, i) => i + 1);
+    const repo: Record<string, unknown> = {};
+    for (let i = 0; i < 25; i++) {
+      repo[`r${i}`] = {
+        __typename: 'PullRequest',
+        number: numbers[i]!,
+        title: `PR ${numbers[i]}`,
+        body: cjkBody,
+        author: { login: 'u' },
+      };
+    }
+    const raw = repoEnvelope(repo);
+    expect(Buffer.byteLength(raw, 'utf8')).toBeLessThan(GH_RUNNER_MAX_BUFFER);
+    const result = parseChunkResponse(raw, numbers);
+    expect(result.size).toBe(25);
+  });
+});
+
+describe('safeMultibyteString', () => {
+  it('returns string input unchanged', () => {
+    const valid = JSON.stringify({ data: { repository: {} } });
+    expect(safeMultibyteString(valid)).toBe(valid);
+  });
+
+  it('handles a multibyte JSON response with valid UTF-8', () => {
+    const node = {
+      data: {
+        repository: {
+          r0: {
+            __typename: 'PullRequest',
+            number: 1,
+            title: 'Fix: 流れる星の原理',
+            body: '日本語のボディ',
+            author: { login: 'alice' },
+          },
+        },
+      },
+    };
+    const raw = JSON.stringify(node);
+    const result = safeMultibyteString(raw);
+    expect(JSON.parse(result)).toEqual(node);
+  });
+
+  it('converts a Buffer to a UTF-8 string', () => {
+    const expected = JSON.stringify({ data: { repository: {} } });
+    const buf = Buffer.from(expected, 'utf8');
+    expect(safeMultibyteString(buf)).toBe(expected);
+  });
+});
+
+describe('multibyte content through fetchRefsViaGh', () => {
+  it('processes a valid multibyte response without truncation', () => {
+    // A runner that returns valid JSON with multibyte content — no truncation.
+    const response = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 42,
+        title: 'Fix: マルチバイト対応',
+        body: 'テスト用ボディ',
+        author: { login: 'alice' },
+      },
+    });
+    const runner = () => response;
+    const result = fetchRefsViaGh('owner/repo', [42], runner);
+    expect(result.size).toBe(1);
+    expect(requireRef(result, 42).title).toBe('Fix: マルチバイト対応');
+  });
+
+  it('parses a response with multibyte CJK content in bodies correctly', () => {
+    // A realistic multibyte response with CJK characters in PR titles
+    // and bodies. This exercises the UTF-8 handling path end-to-end.
+    const response = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'feat: 新機能の追加',
+        body: 'ユーザーは新しいストリーミング機能を使用できるようになります。',
+        labels: { nodes: [{ name: 'feature' }] },
+        author: { login: 'alice' },
+      },
+      r1: {
+        __typename: 'PullRequest',
+        number: 20,
+        title: 'fix: バグ修正',
+        body: 'クラッシュの問題を修正しました。',
+        labels: { nodes: [{ name: 'bug' }] },
+        author: { login: 'bob' },
+      },
+    });
+    const runner = () => response;
+    const result = fetchRefsViaGh('owner/repo', [10, 20], runner);
+    expect(result.size).toBe(2);
+    expect(requireRef(result, 10).title).toBe('feat: 新機能の追加');
+    expect(requireRef(result, 20).title).toBe('fix: バグ修正');
+    expect(requireRef(result, 10).labels).toEqual(['feature']);
+  });
+});
+
+describe('label truncation safety beyond 100 labels', () => {
+  it('processes up to 100 labels without truncation', () => {
+    const labels = Array.from({ length: 100 }, (_, i) => ({
+      name: `label-${i}`,
+    }));
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'PR with 100 labels',
+        labels: { nodes: labels, totalCount: 100 },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    expect(requireRef(result, 10).labels).toHaveLength(100);
+  });
+
+  it('truncates labels beyond 100 to prevent unbounded arrays', () => {
+    const labels = Array.from({ length: 150 }, (_, i) => ({
+      name: `label-${i}`,
+    }));
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'PR with 150 labels',
+        labels: { nodes: labels, totalCount: 150 },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    // Labels beyond 100 are truncated for safety.
+    expect(requireRef(result, 10).labels).toHaveLength(MAX_LABELS_PER_NODE);
+  });
+
+  it('includes totalCount from the GraphQL response for truncation detection', () => {
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'PR',
+        labels: { nodes: [{ name: 'bug' }], totalCount: 5 },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    // The label node schema now includes totalCount in the connection.
+    // The extracted labels still work correctly.
+    expect(requireRef(result, 10).labels).toEqual(['bug']);
+  });
+
+  it('handles missing totalCount gracefully', () => {
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'PR without totalCount',
+        labels: { nodes: [{ name: 'bug' }] },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    expect(requireRef(result, 10).labels).toEqual(['bug']);
+  });
+
+  it('MAX_LABELS_PER_NODE is 100 matching the GraphQL first:100 query', () => {
+    expect(MAX_LABELS_PER_NODE).toBe(100);
+  });
+
+  it('sets labelsTruncated when 100 nodes are returned but totalCount is 150', () => {
+    // Realistic scenario: a PR with 150 labels. The GraphQL query
+    // labels(first:100) returns 100 nodes but totalCount=150, signaling
+    // that additional label pages exist. The parser must set
+    // labelsTruncated=true so downstream classification conservatively
+    // demotes the entry.
+    const labelNodes = Array.from({ length: 100 }, (_, i) => ({
+      name: `label-${i}`,
+    }));
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'PR with 150 total labels',
+        labels: { nodes: labelNodes, totalCount: 150 },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    const ref = result.get(10);
+    expect(ref).toBeDefined();
+    if (ref !== undefined) {
+      expect(ref.labels).toHaveLength(100);
+      expect(ref.labelsTruncated).toBe(true);
+    }
+  });
+
+  it('does not set labelsTruncated when totalCount equals node count', () => {
+    // 100 labels with totalCount=100 means no additional pages.
+    const labelNodes = Array.from({ length: 100 }, (_, i) => ({
+      name: `label-${i}`,
+    }));
+    const raw = repoEnvelope({
+      r0: {
+        __typename: 'PullRequest',
+        number: 10,
+        title: 'PR with exactly 100 labels',
+        labels: { nodes: labelNodes, totalCount: 100 },
+        author: { login: 'alice' },
+      },
+    });
+    const result = parseChunkResponse(raw, [10]);
+    expect(result.size).toBe(1);
+    const ref = result.get(10);
+    expect(ref).toBeDefined();
+    if (ref !== undefined) {
+      expect(ref.labelsTruncated).toBe(false);
+    }
+  });
+});

--- a/scripts/tests/release-notes/git-port.test.ts
+++ b/scripts/tests/release-notes/git-port.test.ts
@@ -1,0 +1,496 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import {
+  parseCommits,
+  getCommits,
+  getAllCommits,
+  getMergeIntroducedHashes,
+  getOctopusMergeIntroducedHashes,
+  getRootCommit,
+  createTopologyResolver,
+} from '../../release-notes/git-port.js';
+import { useTempRepo, gitCommit, gitMerge } from './fixtures.js';
+
+const NUL = '\0';
+
+const HASH_A = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0';
+const HASH_B = 'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1';
+const HASH_MERGE = 'c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2';
+const HASH_ROOT = 'd4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3';
+
+function makeRecord(
+  hash: string,
+  subject: string,
+  author: string,
+  parents = '',
+): string {
+  return [hash, subject, author, parents].join(NUL) + NUL;
+}
+
+function makeOutput(records: readonly string[]): string {
+  return records.join('');
+}
+
+describe('parseCommits', () => {
+  it('parses a single commit record', () => {
+    const output = makeOutput([
+      makeRecord(HASH_A, 'feat: add streaming', 'Alice'),
+    ]);
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.hash).toBe(HASH_A);
+    expect(commits[0]!.subject).toBe('feat: add streaming');
+    expect(commits[0]!.author).toBe('Alice');
+    expect(commits[0]!.isMerge).toBe(false);
+  });
+
+  it('parses a merge commit (two parents) with isMerge=true', () => {
+    const output = makeOutput([
+      makeRecord(
+        HASH_MERGE,
+        'Merge pull request #42',
+        'Bob',
+        'parent1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa parent2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      ),
+    ]);
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.isMerge).toBe(true);
+    expect(commits[0]!.parents).toHaveLength(2);
+  });
+
+  it('parses a root commit (no parents) with isMerge=false', () => {
+    const output = makeOutput([
+      makeRecord(HASH_ROOT, 'Initial commit', 'Alice'),
+    ]);
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.isMerge).toBe(false);
+    expect(commits[0]!.parents).toEqual([]);
+  });
+
+  it('parses an empty string into an empty array', () => {
+    expect(parseCommits('')).toEqual([]);
+  });
+
+  it('parses multiple records', () => {
+    const output = makeOutput([
+      makeRecord(HASH_A, 'feat: first', 'Alice'),
+      makeRecord(HASH_B, 'fix: second', 'Bob'),
+    ]);
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]!.hash).toBe(HASH_A);
+    expect(commits[1]!.hash).toBe(HASH_B);
+  });
+
+  it('parses a subject containing literal 0x1e (record separator) text safely', () => {
+    const evilSubject = 'feat: contains \x1e RS char';
+    const output = makeOutput([
+      makeRecord(HASH_A, evilSubject, 'Alice'),
+      makeRecord(HASH_B, 'fix: another', 'Bob'),
+    ]);
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]!.subject).toBe(evilSubject);
+    expect(commits[0]!.hash).toBe(HASH_A);
+  });
+
+  it('parses a subject containing literal 0x1f (field separator) text safely', () => {
+    const evilSubject = 'feat: contains \x1f FS char';
+    const output = makeOutput([makeRecord(HASH_A, evilSubject, 'Alice')]);
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.subject).toBe(evilSubject);
+  });
+
+  it('does not produce phantom records from trailing NUL', () => {
+    const output = makeRecord(HASH_A, 'feat: first', 'Alice') + NUL;
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.hash).toBe(HASH_A);
+  });
+
+  it('skips incomplete trailing record (fewer than 4 fields)', () => {
+    const output = makeRecord(HASH_A, 'feat: first', 'Alice') + 'truncated\0';
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(1);
+  });
+
+  it('skips records with invalid (non-40-hex) hashes', () => {
+    const output = makeOutput([
+      makeRecord('abc1234', 'feat: short hash', 'Alice'),
+      makeRecord(HASH_B, 'fix: valid hash', 'Bob'),
+    ]);
+    const commits = parseCommits(output);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.hash).toBe(HASH_B);
+  });
+
+  it('handles Unicode and unusual whitespace in subjects', () => {
+    const output = makeOutput([
+      makeRecord(HASH_A, 'feat: Unicode 你好世界\n\ttabbed', 'Alice'),
+    ]);
+    const commits = parseCommits(output);
+    expect(commits[0]!.subject).toContain('你好世界');
+  });
+});
+
+describe('getCommits (temp-repo integration)', () => {
+  const getDir = useTempRepo();
+
+  it('returns an empty array when there are no commits in range', () => {
+    const dir = getDir();
+    gitCommit(dir, 'Initial commit');
+    const commits = getCommits('HEAD', 'HEAD');
+    expect(commits).toEqual([]);
+  });
+
+  it('parses a root commit with no parents', () => {
+    const dir = getDir();
+    gitCommit(dir, 'feat: root commit');
+    const emptyTree = execFileSync(
+      'git',
+      ['hash-object', '-t', 'tree', '/dev/null'],
+      {
+        encoding: 'utf8',
+      },
+    ).trim();
+    const startHash = execFileSync(
+      'git',
+      ['commit-tree', emptyTree, '-m', 'start'],
+      { encoding: 'utf8' },
+    ).trim();
+    execFileSync('git', ['update-ref', 'refs/tags/start', startHash], {
+      encoding: 'utf8',
+    });
+    const commits = getCommits('refs/tags/start', 'HEAD');
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.subject).toBe('feat: root commit');
+    expect(commits[0]!.isMerge).toBe(false);
+  });
+
+  it('parses a single commit with one parent', () => {
+    const dir = getDir();
+    const root = gitCommit(dir, 'Initial commit');
+    execFileSync('git', ['tag', 'start', root], {
+      encoding: 'utf8',
+    });
+    gitCommit(dir, 'feat: second commit');
+    const commits = getCommits('start', 'HEAD');
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.subject).toBe('feat: second commit');
+    expect(commits[0]!.parents).toEqual([root]);
+  });
+
+  it('retains all sequential commits with complete hashes in reverse-chronological order', () => {
+    const dir = getDir();
+    const root = gitCommit(dir, 'Initial commit');
+    execFileSync('git', ['tag', 'start', root], {
+      encoding: 'utf8',
+    });
+    const h1 = gitCommit(dir, 'feat: first');
+    const h2 = gitCommit(dir, 'feat: second');
+    const h3 = gitCommit(dir, 'feat: third');
+    const commits = getCommits('start', 'HEAD');
+    expect(commits).toHaveLength(3);
+    expect(commits[0]!.hash).toBe(h3);
+    expect(commits[1]!.hash).toBe(h2);
+    expect(commits[2]!.hash).toBe(h1);
+    expect(commits[0]!.subject).toBe('feat: third');
+    expect(commits[1]!.subject).toBe('feat: second');
+    expect(commits[2]!.subject).toBe('feat: first');
+    for (const commit of commits) {
+      expect(commit.hash).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it('detects a two-parent merge commit', () => {
+    const dir = getDir();
+    const root = gitCommit(dir, 'Initial commit');
+    execFileSync('git', ['tag', 'start', root], {
+      encoding: 'utf8',
+    });
+    execFileSync('git', ['checkout', '-b', 'feature'], {
+      encoding: 'utf8',
+    });
+    gitCommit(dir, 'Branch 1 commit');
+    const branch1Hash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    try {
+      execFileSync('git', ['checkout', 'main'], {
+        encoding: 'utf8',
+      });
+    } catch {
+      execFileSync('git', ['checkout', 'master'], {
+        encoding: 'utf8',
+      });
+    }
+    gitCommit(dir, 'Branch 2 commit');
+    const branch2Hash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    const mergeHash = gitMerge(dir, 'Merge branches', 'feature');
+    const commits = getCommits('start', 'HEAD');
+    const mergeCommit = commits.find((c) => c.hash === mergeHash);
+    expect(mergeCommit).toBeDefined();
+    expect(mergeCommit!.isMerge).toBe(true);
+    expect(mergeCommit!.parents).toHaveLength(2);
+    expect(mergeCommit!.parents).toContain(branch1Hash);
+    expect(mergeCommit!.parents).toContain(branch2Hash);
+  });
+});
+
+describe('getMergeIntroducedHashes (temp-repo integration)', () => {
+  const getDir = useTempRepo();
+
+  describe('getAllCommits (temp-repo integration)', () => {
+    const getDir = useTempRepo();
+
+    it('includes the root commit, unlike getCommits(root..HEAD)', () => {
+      const dir = getDir();
+      const root = gitCommit(dir, 'Initial commit');
+      gitCommit(dir, 'feat: second');
+      gitCommit(dir, 'feat: third');
+
+      const allCommits = getAllCommits();
+      const rangedCommits = getCommits(root, 'HEAD');
+
+      expect(rangedCommits).not.toContain(
+        expect.objectContaining({ hash: root }),
+      );
+      const allHashes = allCommits.map((c) => c.hash);
+      expect(allHashes).toContain(root);
+      expect(allCommits).toHaveLength(3);
+    });
+
+    it('includes root commit in reverse-chronological order', () => {
+      const dir = getDir();
+      const root = gitCommit(dir, 'Initial commit');
+      const h1 = gitCommit(dir, 'feat: first');
+      const h2 = gitCommit(dir, 'feat: second');
+
+      const commits = getAllCommits();
+      expect(commits).toHaveLength(3);
+      expect(commits[0]!.hash).toBe(h2);
+      expect(commits[1]!.hash).toBe(h1);
+      expect(commits[2]!.hash).toBe(root);
+      expect(commits[2]!.subject).toBe('Initial commit');
+    });
+  });
+
+  it('returns commits introduced by a two-parent merge', () => {
+    const dir = getDir();
+    const root = gitCommit(dir, 'Initial commit');
+    execFileSync('git', ['tag', 'start', root], {
+      encoding: 'utf8',
+    });
+    execFileSync('git', ['checkout', '-b', 'feature'], {
+      encoding: 'utf8',
+    });
+    gitCommit(dir, 'Feature commit 1');
+    const childHash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    try {
+      execFileSync('git', ['checkout', 'main'], {
+        encoding: 'utf8',
+      });
+    } catch {
+      execFileSync('git', ['checkout', 'master'], {
+        encoding: 'utf8',
+      });
+    }
+    gitCommit(dir, 'Mainline commit');
+    const mergeHash = gitMerge(dir, 'Merge branches', 'feature');
+    const mergeCommitInfo = execFileSync('git', ['cat-file', '-p', mergeHash], {
+      encoding: 'utf8',
+    });
+    const parentLines = mergeCommitInfo
+      .split('\n')
+      .filter((line) => line.startsWith('parent '))
+      .map((line) => line.slice('parent '.length).trim());
+    const [firstParent, secondParent] = parentLines;
+    const introduced = getMergeIntroducedHashes(firstParent!, secondParent!);
+    expect(introduced).toContain(childHash);
+    expect(introduced).not.toContain(mergeHash);
+  });
+});
+
+describe('createTopologyResolver', () => {
+  const getDir = useTempRepo();
+
+  it('returns a resolver that delegates to getMergeIntroducedHashes', () => {
+    const resolver = createTopologyResolver();
+    expect(typeof resolver.getMergeIntroducedHashes).toBe('function');
+    expect(typeof resolver.getOctopusMergeIntroducedHashes).toBe('function');
+    const dir = getDir();
+    void dir;
+  });
+
+  it('octopus resolver returns deduplicated introduced children for 3-parent merge', () => {
+    const dir = getDir();
+    const root = gitCommit(dir, 'Initial commit');
+    execFileSync('git', ['tag', 'start', root], { encoding: 'utf8' });
+
+    // Create two feature branches with commits
+    execFileSync('git', ['checkout', '-b', 'feature1'], { encoding: 'utf8' });
+    gitCommit(dir, 'Feature1 commit');
+    const feature1Child = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    execFileSync('git', ['checkout', root], { encoding: 'utf8' });
+    execFileSync('git', ['checkout', '-b', 'feature2'], { encoding: 'utf8' });
+    gitCommit(dir, 'Feature2 commit');
+    const feature2Child = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Merge both branches into main as an octopus merge
+    try {
+      execFileSync('git', ['checkout', 'main'], { encoding: 'utf8' });
+    } catch {
+      execFileSync('git', ['checkout', 'master'], { encoding: 'utf8' });
+    }
+    gitCommit(dir, 'Mainline commit');
+    execFileSync(
+      'git',
+      [
+        'merge',
+        '--no-ff',
+        '-m',
+        'Octopus merge of two branches',
+        'feature1',
+        'feature2',
+      ],
+      { encoding: 'utf8' },
+    );
+    const mergeHash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    const parents = execFileSync(
+      'git',
+      ['log', '-1', '--format=%P', mergeHash],
+      {
+        encoding: 'utf8',
+      },
+    )
+      .trim()
+      .split(/\s+/);
+
+    const resolver = createTopologyResolver();
+    const introduced = resolver.getOctopusMergeIntroducedHashes(parents);
+    // Both feature branch children should be included.
+    expect(introduced).toContain(feature1Child);
+    expect(introduced).toContain(feature2Child);
+    // No duplicates.
+    expect(new Set(introduced).size).toBe(introduced.length);
+  });
+});
+
+describe('getOctopusMergeIntroducedHashes (temp-repo integration)', () => {
+  const getDir = useTempRepo();
+
+  it('returns all unique children introduced by a 3-parent octopus merge', () => {
+    const dir = getDir();
+    const root = gitCommit(dir, 'Initial commit');
+    execFileSync('git', ['tag', 'start', root], { encoding: 'utf8' });
+
+    execFileSync('git', ['checkout', '-b', 'feature1'], { encoding: 'utf8' });
+    gitCommit(dir, 'Feature1 commit');
+    const feature1Child = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    execFileSync('git', ['checkout', root], { encoding: 'utf8' });
+    execFileSync('git', ['checkout', '-b', 'feature2'], { encoding: 'utf8' });
+    gitCommit(dir, 'Feature2 commit');
+    const feature2Child = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    try {
+      execFileSync('git', ['checkout', 'main'], { encoding: 'utf8' });
+    } catch {
+      execFileSync('git', ['checkout', 'master'], { encoding: 'utf8' });
+    }
+    gitCommit(dir, 'Mainline commit');
+    execFileSync(
+      'git',
+      ['merge', '--no-ff', '-m', 'Octopus merge', 'feature1', 'feature2'],
+      { encoding: 'utf8' },
+    );
+    const mergeHash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    const parents = execFileSync(
+      'git',
+      ['log', '-1', '--format=%P', mergeHash],
+      {
+        encoding: 'utf8',
+      },
+    )
+      .trim()
+      .split(/\s+/);
+
+    const introduced = getOctopusMergeIntroducedHashes(parents);
+    expect(introduced).toContain(feature1Child);
+    expect(introduced).toContain(feature2Child);
+  });
+
+  it('returns an empty array for fewer than 2 parents', () => {
+    expect(getOctopusMergeIntroducedHashes([])).toEqual([]);
+    expect(getOctopusMergeIntroducedHashes(['onlyone'])).toEqual([]);
+  });
+});
+
+describe('getRootCommit (temp-repo integration)', () => {
+  const getDir = useTempRepo();
+
+  it('returns the root commit hash for a repo with a single root', () => {
+    const dir = getDir();
+    const rootHash = gitCommit(dir, 'Initial commit');
+    expect(getRootCommit()).toBe(rootHash);
+  });
+
+  it('returns the oldest root commit when multiple root commits exist', () => {
+    const dir = getDir();
+    const root1 = gitCommit(dir, 'First root');
+    // Create a second root via an orphan branch then merge it back
+    // (allowing unrelated histories for this synthetic topology test).
+    execFileSync('git', ['checkout', '--orphan', 'orphan'], {
+      encoding: 'utf8',
+    });
+    execFileSync('git', ['rm', '-rf', '.'], { encoding: 'utf8' });
+    const root2 = gitCommit(dir, 'Second root');
+    execFileSync('git', ['checkout', 'main'], { encoding: 'utf8' });
+    execFileSync(
+      'git',
+      [
+        'merge',
+        '--no-ff',
+        '--allow-unrelated-histories',
+        '-m',
+        'Merge orphan roots',
+        'orphan',
+      ],
+      { encoding: 'utf8' },
+    );
+    const result = getRootCommit();
+    // The oldest root is returned (rev-list --max-parents=0 lists oldest first).
+    expect([root1, root2]).toContain(result);
+  });
+
+  it('returns null for an empty repository with no commits', () => {
+    getDir();
+    expect(getRootCommit()).toBeNull();
+  });
+});

--- a/scripts/tests/release-notes/llm-port.test.ts
+++ b/scripts/tests/release-notes/llm-port.test.ts
@@ -1,0 +1,483 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createLlmPort,
+  type LlmRunner,
+  buildIsolatedEnvironment,
+} from '../../release-notes/llm-port.js';
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, isAbsolute, relative } from 'node:path';
+import { z } from 'zod';
+
+const inlineProfileSchema = z.object({
+  modelParams: z.object({ temperature: z.number() }),
+  ephemeralSettings: z.object({ 'tools.allowed': z.array(z.string()) }),
+});
+
+function parseInlineProfile(args: readonly string[]) {
+  const profileIndex = args.indexOf('--profile');
+  const profileValue = args.at(profileIndex + 1);
+  if (profileIndex < 0 || profileValue === undefined) {
+    throw new Error('Expected an inline profile argument');
+  }
+  return inlineProfileSchema.parse(JSON.parse(profileValue));
+}
+
+function successfulRunner(
+  inspect: (
+    command: string,
+    args: readonly string[],
+    options: {
+      readonly encoding: 'utf8';
+      readonly env: NodeJS.ProcessEnv;
+      readonly stdio: 'pipe';
+      readonly timeout: number;
+      readonly cwd: string;
+    },
+  ) => void,
+): LlmRunner {
+  return (command, args, options) => {
+    inspect(command, args, options);
+    return {
+      pid: 1,
+      output: [
+        null,
+        '{"session_id":"test","response":"{\\"sourceIds\\":[]}","stats":{}}',
+        '',
+      ],
+      stdout:
+        '{"session_id":"test","response":"{\\"sourceIds\\":[]}","stats":{}}',
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    };
+  };
+}
+
+describe('createLlmPort', () => {
+  it('invokes the local built CLI (node <cliBin>), not npx @latest', async () => {
+    const port = createLlmPort(
+      {
+        provider: 'openai',
+        model: 'model',
+        apiKey: 'secret-key',
+        baseUrl: 'https://example.invalid',
+      },
+      successfulRunner((command, args) => {
+        expect(command).toBe('node');
+        // First arg must be an absolute path to the local CLI bin, not
+        // "@vybestack/llxprt-code@latest" or an npx-style package reference.
+        const cliBin = args[0]!;
+        expect(cliBin).not.toContain('@latest');
+        expect(cliBin).not.toContain('npx');
+        expect(cliBin.endsWith('llxprt.cjs')).toBe(true);
+      }),
+    );
+
+    await expect(port.generateHighlights('{"changes":[]}')).resolves.toBe(
+      '{"sourceIds":[]}',
+    );
+  });
+
+  it('passes the API key via --keyfile (temp file), never in argv', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'super-secret-key' },
+      successfulRunner((_command, args) => {
+        const join = args.join('\n');
+        expect(join).not.toContain('super-secret-key');
+        expect(join).not.toContain('--key\n');
+        // --keyfile must be present with a temp path value.
+        const keyfileIndex = args.indexOf('--keyfile');
+        expect(keyfileIndex).toBeGreaterThan(-1);
+        const keyfilePath = args[keyfileIndex + 1]!;
+        expect(keyfilePath).toContain('llxprt-llm-');
+      }),
+    );
+    await port.generateHighlights('{}');
+  });
+
+  it('does not pass --yolo, --key (inline), or any tool-permission-bypassing flag', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      successfulRunner((_command, args) => {
+        const join = args.join(' ');
+        expect(join).not.toContain('--yolo');
+        expect(join).not.toContain('--key ');
+      }),
+    );
+    await port.generateHighlights('{}');
+  });
+
+  it('prompt instructs the model to return sourceIds (not free-form highlights)', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      successfulRunner((_command, args) => {
+        const promptIndex = args.indexOf('--prompt');
+        const prompt = args[promptIndex + 1]!;
+        expect(prompt).toContain('sourceIds');
+        expect(prompt).not.toContain('highlights');
+      }),
+    );
+    await port.generateHighlights('{}');
+  });
+
+  it('exposes an isolated minimal environment without real HOME/npm/GitHub/Docker secrets', async () => {
+    process.env.UNRELATED_WORKFLOW_SECRET = 'must-not-leak';
+    process.env.GITHUB_TOKEN = 'ghp-must-not-leak';
+    process.env.NPM_TOKEN = 'npm-must-not-leak';
+    process.env.DOCKER_PASSWORD = 'docker-must-not-leak';
+    process.env.NPM_CONFIG_USERCONFIG = '/must-not-leak';
+    process.env.OPENAI_API_KEY = 'sk-must-not-leak';
+    const realHome = process.env.HOME;
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      successfulRunner((_command, _args, options) => {
+        expect(options.env.UNRELATED_WORKFLOW_SECRET).toBeUndefined();
+        expect(options.env.GITHUB_TOKEN).toBeUndefined();
+        expect(options.env.NPM_TOKEN).toBeUndefined();
+        expect(options.env.DOCKER_PASSWORD).toBeUndefined();
+        expect(options.env.NPM_CONFIG_USERCONFIG).toBeUndefined();
+        expect(options.env.OPENAI_API_KEY).toBeUndefined();
+        expect(options.env.PATH).toBeDefined();
+        // HOME must be an isolated temp dir, NOT the real HOME.
+        expect(options.env.HOME).toBeDefined();
+        expect(options.env.HOME).not.toBe(realHome);
+        expect(options.env.HOME).toContain('llxprt-llm-');
+        // cwd must be the isolated temp dir too.
+        expect(options.cwd).toContain('llxprt-llm-');
+        expect(options.cwd).not.toBe(process.cwd());
+      }),
+    );
+    await port.generateHighlights('{}');
+    delete process.env.UNRELATED_WORKFLOW_SECRET;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.NPM_TOKEN;
+    delete process.env.DOCKER_PASSWORD;
+    delete process.env.NPM_CONFIG_USERCONFIG;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('does not inherit real HOME — HOME is isolated temp dir', async () => {
+    const realHome = process.env.HOME;
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      successfulRunner((_command, _args, options) => {
+        expect(options.env.HOME).not.toBe(realHome);
+        expect(options.env.HOME).toContain('llxprt-llm-');
+      }),
+    );
+    await port.generateHighlights('{}');
+  });
+
+  it('forwards only baseUrl env var, no other provider config env', async () => {
+    const port = createLlmPort(
+      {
+        provider: 'openai',
+        model: 'model',
+        apiKey: 'key',
+        baseUrl: 'https://custom.example',
+      },
+      successfulRunner((_command, _args, options) => {
+        expect(options.env.OPENAI_BASE_URL).toBe('https://custom.example');
+        // Only PATH, TMPDIR, HOME, OPENAI_BASE_URL should be present.
+        const keys = Object.keys(options.env).sort();
+        expect(keys).toEqual(
+          ['HOME', 'OPENAI_BASE_URL', 'PATH', 'TMPDIR'].sort(),
+        );
+      }),
+    );
+    await port.generateHighlights('{}');
+  });
+
+  it('uses the supplied existing keyfile when configured', async () => {
+    const port = createLlmPort(
+      {
+        provider: 'openai',
+        model: 'model',
+        apiKey: 'supplied-key',
+        keyfilePath: '/configured/keyfile',
+      },
+      successfulRunner((_command, args) => {
+        const keyfileIndex = args.indexOf('--keyfile');
+        expect(args[keyfileIndex + 1]).toBe('/configured/keyfile');
+      }),
+    );
+    await port.generateHighlights('{}');
+  });
+
+  it('resolves a relative supplied keyfile to absolute before the child changes cwd', async () => {
+    // Create a real keyfile in a temp directory, then reference it via a
+    // relative path. The child process runs with cwd=tempDir, so a relative
+    // path must be resolved to absolute in the parent process before spawn.
+    const keyDir = mkdtempSync(join(tmpdir(), 'llxprt-relkey-'));
+    const keyfileName = 'relative-key.txt';
+    const fullPath = join(keyDir, keyfileName);
+    writeFileSync(fullPath, 'relative-keyfile-content');
+    const relativePath = relative(process.cwd(), fullPath);
+
+    try {
+      const port = createLlmPort(
+        {
+          provider: 'openai',
+          model: 'model',
+          apiKey: '',
+          keyfilePath: relativePath,
+        },
+        successfulRunner((_command, args) => {
+          const keyfileIndex = args.indexOf('--keyfile');
+          const resolved = args[keyfileIndex + 1]!;
+          // The path must be absolute (resolved before cwd change).
+          expect(isAbsolute(resolved)).toBe(true);
+          // It must point to the original file, not a temp-dir-relative path.
+          expect(existsSync(resolved)).toBe(true);
+          // The resolved absolute path must normalize to the real file.
+          expect(resolved.endsWith(keyfileName)).toBe(true);
+        }),
+      );
+      await port.generateHighlights('{}');
+    } finally {
+      rmSync(keyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a mode-0600 temp keyfile when no keyfile configured', async () => {
+    let keyfileOk = false;
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'temp-key' },
+      successfulRunner((_command, args) => {
+        const keyfileIndex = args.indexOf('--keyfile');
+        const keyfilePath = args[keyfileIndex + 1]!;
+        // Check permissions DURING invocation (temp dir still exists).
+        expect(existsSync(keyfilePath)).toBe(true);
+        const stat = statSync(keyfilePath);
+        expect(stat.mode & 0o777).toBe(0o600);
+        keyfileOk = true;
+      }),
+    );
+    await port.generateHighlights('{}');
+    expect(keyfileOk).toBe(true);
+  });
+
+  it('cleans up the temp directory after successful invocation', async () => {
+    let capturedCwd = '';
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      successfulRunner((_command, _args, options) => {
+        capturedCwd = options.cwd;
+      }),
+    );
+    await port.generateHighlights('{}');
+    // The temp HOME/cwd should be removed after invocation.
+    expect(existsSync(capturedCwd)).toBe(false);
+  });
+
+  it('cleans up the temp directory even on runner failure', async () => {
+    const failingRunner: LlmRunner = () => ({
+      pid: 1,
+      output: [null, '', 'fail'],
+      stdout: '',
+      stderr: 'fail',
+      status: 1,
+      signal: null,
+      error: undefined,
+    });
+    let capturedCwd = '';
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      (command, args, options) => {
+        capturedCwd = options.cwd;
+        return failingRunner(command, args, options);
+      },
+    );
+    await expect(port.generateHighlights('{}')).rejects.toThrow();
+    expect(existsSync(capturedCwd)).toBe(false);
+  });
+
+  it('buildIsolatedEnvironment produces minimal env without real HOME', () => {
+    const env = buildIsolatedEnvironment(
+      {
+        provider: 'openai',
+        model: 'model',
+        apiKey: 'key',
+        baseUrl: 'https://example',
+      },
+      '/isolated/home',
+    );
+    expect(env.HOME).toBe('/isolated/home');
+    expect(env.PATH).toBeDefined();
+    expect(env.TMPDIR).toBeDefined();
+    expect(env.OPENAI_BASE_URL).toBe('https://example');
+    expect(env.NPM_CONFIG_USERCONFIG).toBeUndefined();
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it('buildIsolatedEnvironment omits baseUrl when not configured', () => {
+    const env = buildIsolatedEnvironment(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      join(tmpdir(), 'isolated'),
+    );
+    expect(env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it('sets a low temperature in the inline profile', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      successfulRunner((_command, args) => {
+        const profile = parseInlineProfile(args);
+        expect(profile.modelParams.temperature).toBe(0.1);
+      }),
+    );
+    await port.generateHighlights('{}');
+  });
+
+  it('configures an explicit empty tool allowlist', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      successfulRunner((_command, args) => {
+        const profile = parseInlineProfile(args);
+        expect(profile.ephemeralSettings['tools.allowed']).toEqual([]);
+      }),
+    );
+
+    await port.generateHighlights('{}');
+  });
+
+  it('redacts supplied keyfile secrets and paths from failures', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'llm-keyfile-test-'));
+    const keyfilePath = join(directory, 'secret-keyfile');
+    writeFileSync(keyfilePath, 'supplied-secret');
+    const runner: LlmRunner = () => ({
+      pid: 1,
+      output: [null, '', `failed with supplied-secret from ${keyfilePath}`],
+      stdout: '',
+      stderr: `failed with supplied-secret from ${keyfilePath}`,
+      status: 1,
+      signal: null,
+      error: undefined,
+    });
+    try {
+      const port = createLlmPort(
+        {
+          provider: 'openai',
+          model: 'model',
+          apiKey: '',
+          keyfilePath,
+        },
+        runner,
+      );
+
+      await expect(port.generateHighlights('{}')).rejects.toThrow(
+        'failed with [redacted] from [redacted]',
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves invocation failures when a supplied keyfile disappears', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'llm-keyfile-missing-'));
+    const keyfilePath = join(directory, 'secret-keyfile');
+    writeFileSync(keyfilePath, 'supplied-secret');
+    const runner: LlmRunner = () => {
+      rmSync(keyfilePath);
+      return {
+        pid: 1,
+        output: [null, '', 'original invocation failure'],
+        stdout: '',
+        stderr: 'original invocation failure',
+        status: 1,
+        signal: null,
+        error: undefined,
+      };
+    };
+    try {
+      const port = createLlmPort(
+        { provider: 'openai', model: 'model', apiKey: '', keyfilePath },
+        runner,
+      );
+
+      await expect(port.generateHighlights('{}')).rejects.toThrow(
+        'original invocation failure',
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on child-process failure', async () => {
+    const runner: LlmRunner = () => ({
+      pid: 1,
+      output: [null, '', 'failure'],
+      stdout: '',
+      stderr: 'failure',
+      status: 1,
+      signal: null,
+      error: undefined,
+    });
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key' },
+      runner,
+    );
+    await expect(port.generateHighlights('{}')).rejects.toThrow(
+      'LLxprt Code LLM invocation failed',
+    );
+  });
+
+  it('rejects API keys containing CR/LF before writing to keyfile', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key\rwith\ncr' },
+      successfulRunner(() => {}),
+    );
+    await expect(port.generateHighlights('{}')).rejects.toThrow(
+      'API key contains CR/LF characters',
+    );
+  });
+
+  it('rejects API keys containing only LF before writing to keyfile', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key\nwith-lf' },
+      successfulRunner(() => {}),
+    );
+    await expect(port.generateHighlights('{}')).rejects.toThrow(
+      'API key contains CR/LF characters',
+    );
+  });
+
+  it('rejects API keys containing only CR before writing to keyfile', async () => {
+    const port = createLlmPort(
+      { provider: 'openai', model: 'model', apiKey: 'key\rwith-cr' },
+      successfulRunner(() => {}),
+    );
+    await expect(port.generateHighlights('{}')).rejects.toThrow(
+      'API key contains CR/LF characters',
+    );
+  });
+
+  it('rejects API keys with embedded newlines even when a custom keyfilePath is configured', async () => {
+    const port = createLlmPort(
+      {
+        provider: 'openai',
+        model: 'model',
+        apiKey: 'injected\r\nevil-key',
+        keyfilePath: '/tmp/preexisting-keyfile',
+      },
+      successfulRunner(() => {}),
+    );
+    await expect(port.generateHighlights('{}')).rejects.toThrow(
+      'API key contains CR/LF characters',
+    );
+  });
+});

--- a/scripts/tests/release-notes/markdown.test.ts
+++ b/scripts/tests/release-notes/markdown.test.ts
@@ -1,0 +1,284 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeMarkdown,
+  sanitizeOptionalMarkdown,
+  sanitizeSubject,
+  renderContributor,
+  renderBullet,
+} from '../../release-notes/markdown.js';
+
+describe('sanitizeMarkdown', () => {
+  it('passes through plain text unchanged', () => {
+    expect(sanitizeMarkdown('Faster streaming responses')).toBe(
+      'Faster streaming responses',
+    );
+  });
+
+  it('neutralizes bare www autolinks', () => {
+    expect(sanitizeMarkdown('Visit www.evil.example for details')).toBe(
+      'Visit for details',
+    );
+  });
+  it('strips backticks to prevent inline code injection', () => {
+    expect(sanitizeMarkdown('`rm -rf /`')).toBe('rm -rf /');
+  });
+
+  it('strips HTML angle brackets', () => {
+    expect(sanitizeMarkdown('<script>alert(1)</script>')).toBe(
+      'script alert(1) /script',
+    );
+  });
+
+  it('strips square brackets to prevent link injection', () => {
+    const result = sanitizeMarkdown('[click](https://evil.invalid)');
+    expect(result).not.toContain('[');
+    expect(result).not.toContain(']');
+    expect(result).not.toContain('https');
+    expect(result).toContain('click');
+  });
+
+  it('strips image syntax', () => {
+    const result = sanitizeMarkdown('![alt](https://evil.invalid/x.png)');
+    expect(result).not.toContain('[');
+    expect(result).not.toContain(']');
+    expect(result).not.toContain('!');
+    expect(result).not.toContain('https');
+    expect(result).toContain('alt');
+  });
+
+  it('strips backslashes', () => {
+    expect(sanitizeMarkdown('foo\\bar\\baz')).toBe('foo bar baz');
+  });
+
+  it('strips markdown heading hashes', () => {
+    expect(sanitizeMarkdown('### All Changes')).toBe('All Changes');
+  });
+
+  it('strips emphasis markers', () => {
+    expect(sanitizeMarkdown('*bold* and _under_')).toBe('bold and under');
+  });
+
+  it('strips strikethrough markers', () => {
+    expect(sanitizeMarkdown('~~removed~~')).toBe('removed');
+  });
+
+  it('collapses control characters including record separators', () => {
+    expect(sanitizeMarkdown('a\x1eb\x1fc')).toBe('a b c');
+  });
+
+  it('collapses NUL and other C0 control characters', () => {
+    expect(sanitizeMarkdown('a\x00b\x07c')).toBe('a b c');
+  });
+
+  it('collapses Unicode line/byte separators', () => {
+    expect(sanitizeMarkdown('a\u2028b\u2029c')).toBe('a b c');
+  });
+
+  it('strips bidi and zero-width controls without separating visible text', () => {
+    const controls =
+      '\u061c\u200b\u200c\u200d\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2060\u2066\u2067\u2068\u2069\ufeff';
+
+    expect(sanitizeMarkdown(`safe${controls}text`)).toBe('safetext');
+    expect(sanitizeSubject(`fix: safe${controls}text (#42)`)).toBe(
+      'fix: safetext (#42)',
+    );
+  });
+
+  it('collapses whitespace runs', () => {
+    expect(sanitizeMarkdown('foo   bar\n\tbaz')).toBe('foo bar baz');
+  });
+
+  it('bounds oversized content to 500 characters', () => {
+    const long = 'x'.repeat(1000);
+    const result = sanitizeMarkdown(long);
+    expect(result.length).toBe(500);
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeMarkdown('  hello  ')).toBe('hello');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(sanitizeMarkdown('   \n\t  ')).toBe('');
+  });
+
+  it('strips emoji characters from untrusted text', () => {
+    expect(sanitizeMarkdown('Streaming is faster \u{1F680}')).toBe(
+      'Streaming is faster',
+    );
+    expect(sanitizeMarkdown('\u{1F389} New feature added')).toBe(
+      'New feature added',
+    );
+  });
+
+  it('strips pictograph and dingbat characters', () => {
+    expect(sanitizeMarkdown('Fix: crashes \u{2705}')).toBe('Fix: crashes');
+    expect(sanitizeMarkdown('Test \u{2714} done')).toBe('Test done');
+  });
+});
+
+describe('sanitizeOptionalMarkdown', () => {
+  it('returns empty string for undefined', () => {
+    expect(sanitizeOptionalMarkdown(undefined)).toBe('');
+  });
+
+  it('returns empty string for null', () => {
+    expect(sanitizeOptionalMarkdown(null)).toBe('');
+  });
+
+  it('sanitizes provided value', () => {
+    const result = sanitizeOptionalMarkdown('[link](https://x.invalid)');
+    expect(result).not.toContain('[');
+    expect(result).not.toContain(']');
+    expect(result).not.toContain('https');
+    expect(result).toContain('link');
+  });
+});
+
+describe('renderContributor', () => {
+  it('renders a sanitized contributor handle with @ prefix', () => {
+    expect(renderContributor('alice')).toBe('- @alice');
+  });
+
+  it('rejects login with injected markdown', () => {
+    expect(renderContributor('alice`code`')).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(renderContributor('   ')).toBe('');
+  });
+
+  it('renders a valid bot login', () => {
+    expect(renderContributor('dependabot[bot]')).toBe('- @dependabot[bot]');
+  });
+
+  it('rejects a login starting with a hyphen', () => {
+    expect(renderContributor('-evil')).toBe('');
+  });
+
+  it('rejects a login ending with a hyphen', () => {
+    expect(renderContributor('evil-')).toBe('');
+  });
+  it('rejects a login with newline (injection attempt)', () => {
+    expect(renderContributor('alice\n- @admin')).toBe('');
+  });
+
+  it('rejects a login with consecutive hyphens', () => {
+    expect(renderContributor('a--b')).toBe('');
+  });
+
+  it('rejects a team mention as a contributor login', () => {
+    expect(renderContributor('org/team')).toBe('');
+  });
+
+  it('rejects a malformed login with special characters', () => {
+    expect(renderContributor('user;rm -rf')).toBe('');
+  });
+});
+
+describe('renderBullet', () => {
+  it('renders a sanitized bullet', () => {
+    expect(renderBullet('Fixed streaming hang')).toBe('- Fixed streaming hang');
+  });
+
+  it('strips injected heading from bullet text', () => {
+    expect(renderBullet('### All Changes')).toBe('- All Changes');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(renderBullet('')).toBe('');
+  });
+});
+
+describe('sanitizeSubject', () => {
+  it('preserves PR/issue references like #42', () => {
+    expect(sanitizeSubject('Merge pull request #42 from feature')).toBe(
+      'Merge pull request #42 from feature',
+    );
+  });
+
+  it('preserves terminal PR marker (#N)', () => {
+    expect(sanitizeSubject('feat: add streaming (#100)')).toBe(
+      'feat: add streaming (#100)',
+    );
+  });
+
+  it('strips markdown heading hash at line start', () => {
+    expect(sanitizeSubject('### All Changes')).toBe('All Changes');
+  });
+
+  it('strips backticks and code injection', () => {
+    const result = sanitizeSubject('feat: `rm -rf /` malicious');
+    expect(result).not.toContain('`');
+  });
+
+  it('strips link syntax but preserves the text', () => {
+    const result = sanitizeSubject('feat: [click](https://evil.invalid)');
+    expect(result).not.toContain('https');
+    expect(result).not.toContain('[');
+    expect(result).toContain('click');
+  });
+
+  it('strips HTML injection', () => {
+    const result = sanitizeSubject('feat: <script>alert(1)</script>');
+    expect(result).not.toContain('<script>');
+  });
+
+  it('strips control characters including 0x1e/0x1f', () => {
+    const result = sanitizeSubject('feat: inject\x1erecord\x1fsep');
+    expect(result).not.toContain('\x1e');
+    expect(result).not.toContain('\x1f');
+  });
+
+  it('collapses whitespace including newlines', () => {
+    expect(sanitizeSubject('feat: multiline\n  thing')).toBe(
+      'feat: multiline thing',
+    );
+  });
+
+  it('preserves multiple PR references', () => {
+    expect(sanitizeSubject('fix: thing Fixes #1 Closes #2 (#100)')).toBe(
+      'fix: thing Fixes #1 Closes #2 (#100)',
+    );
+  });
+
+  it('strips image syntax', () => {
+    const result = sanitizeSubject('feat: ![alt](https://evil.invalid/x.png)');
+    expect(result).not.toContain('https');
+    expect(result).not.toContain('!');
+    expect(result).toContain('alt');
+  });
+
+  it('bounds oversized content to 500 characters', () => {
+    const long = 'x'.repeat(1000);
+    const result = sanitizeSubject(long);
+    expect(result.length).toBe(500);
+  });
+
+  it('strips emoji characters while preserving PR references', () => {
+    expect(sanitizeSubject('feat: add streaming \u{1F680} (#100)')).toBe(
+      'feat: add streaming (#100)',
+    );
+  });
+
+  it.each(['🇺🇸', '🏽', '1️⃣'])(
+    'strips complete emoji forms from subjects: %s',
+    (emoji) => {
+      expect(sanitizeSubject(`feat: ready ${emoji} (#100)`)).toBe(
+        'feat: ready (#100)',
+      );
+    },
+  );
+
+  it('does not split supplementary characters at the field boundary', () => {
+    const result = sanitizeSubject(`${'x'.repeat(499)}𠮷tail`);
+    expect(Array.from(result)).toHaveLength(500);
+    expect(result.endsWith('𠮷')).toBe(true);
+  });
+});

--- a/scripts/tests/release-notes/orchestrator.test.ts
+++ b/scripts/tests/release-notes/orchestrator.test.ts
@@ -1,0 +1,559 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateReleaseNotes } from '../../release-notes/orchestrator.js';
+import type {
+  EnrichedRef,
+  GhPort,
+  LlmPort,
+  RawCommit,
+} from '../../release-notes/types.js';
+
+function makeCommit(overrides: Partial<RawCommit> = {}): RawCommit {
+  return {
+    hash: 'abcdef0',
+    subject: 'feat: something (#42)',
+    author: 'dev',
+    isMerge: false,
+    parents: [],
+    ...overrides,
+  };
+}
+
+function makeRef(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 42,
+    title: 'Faster streaming responses',
+    body: 'Users now receive responses without intermittent stalls.',
+    labels: ['feature'],
+    labelsTruncated: false,
+    author: 'alice',
+    isPr: false,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+function fakeGh(entries: readonly EnrichedRef[]): GhPort {
+  return {
+    async fetchRefs() {
+      return new Map(entries.map((entry) => [entry.number, entry]));
+    },
+  };
+}
+
+function fakeLlm(response: string | Error): LlmPort {
+  return {
+    async generateHighlights(context) {
+      if (response instanceof Error) {
+        throw response;
+      }
+      return response.replace('__CONTEXT__', context);
+    },
+  };
+}
+
+function llmOutput(sourceIds: readonly string[]): string {
+  return JSON.stringify({ sourceIds });
+}
+
+const baseInput = {
+  releaseTag: 'v0.11.0',
+  lastTag: 'v0.10.0',
+  isFirstRelease: false,
+  isNightly: false,
+  contributors: ['alice'],
+  curatedHeadline: null,
+  repository: 'vybestack/llxprt-code',
+};
+
+describe('generateReleaseNotes', () => {
+  it('renders provenance-validated LLM highlights and stable sections', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit(),
+        makeCommit({ hash: 'bbbbbbb', subject: 'feat: another (#43)' }),
+        makeCommit({ hash: 'ccccccc', subject: 'fix: third (#44)' }),
+      ],
+      ghPort: fakeGh([
+        makeRef(),
+        makeRef({
+          number: 43,
+          title: 'Configure a new provider',
+          body: 'Users can select the provider in settings.',
+        }),
+        makeRef({
+          number: 44,
+          title: 'Crash-free startup',
+          body: 'Users no longer experience crashes on startup.',
+        }),
+      ]),
+      llmPort: fakeLlm(llmOutput(['ref:42', 'ref:43', 'ref:44'])),
+    });
+
+    expect(md).toContain('### Highlights');
+    expect(md).toContain(
+      'Faster streaming responses: Users now receive responses without intermittent stalls.',
+    );
+    expect(md).toContain('Users can select the provider in settings.');
+    expect(md).toContain(
+      'Crash-free startup: Users no longer experience crashes on startup.',
+    );
+    expect(md).toContain('#### New');
+    expect(md).toContain('### Installation');
+    expect(md).toContain('### Thanks');
+    expect(md).toContain('### All Changes');
+    expect(md).toContain('compare/v0.10.0...v0.11.0');
+  });
+
+  it('sends only eligible enriched changes to the model', async () => {
+    let capturedContext = '';
+    const llmPort: LlmPort = {
+      async generateHighlights(context) {
+        capturedContext = context;
+        return llmOutput(['ref:43', 'ref:44', 'ref:45']);
+      },
+    };
+    await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({ subject: 'refactor: internals (#42)' }),
+        makeCommit({ hash: 'bbbbbbb', subject: 'feat: provider (#43)' }),
+        makeCommit({ hash: 'ccccccc', subject: 'fix: crash (#44)' }),
+        makeCommit({ hash: 'ddddddd', subject: 'feat: ui (#45)' }),
+      ],
+      ghPort: fakeGh([
+        makeRef({
+          number: 42,
+          title: 'Internal provider rewrite',
+          body: 'Implementation details only.',
+          labels: ['CODE QUALITY / MODULARIZATION'],
+        }),
+        makeRef({
+          number: 43,
+          title: 'Configure a new provider',
+          body: 'Users can select the provider in settings.',
+        }),
+        makeRef({
+          number: 44,
+          title: 'Crash-free startup',
+          body: 'Users no longer experience crashes on startup.',
+        }),
+        makeRef({
+          number: 45,
+          title: 'Improved UI layout',
+          body: 'Users see a cleaner layout.',
+        }),
+      ]),
+      llmPort,
+    });
+
+    expect(capturedContext).not.toContain('Internal provider rewrite');
+    expect(capturedContext).not.toContain('Implementation details only');
+    expect(capturedContext).toContain('Configure a new provider');
+  });
+
+  it('uses deterministic fallback when no complete change fits the LLM context', async () => {
+    let calls = 0;
+    const llmPort: LlmPort = {
+      async generateHighlights() {
+        calls += 1;
+        return llmOutput(['ref:42']);
+      },
+    };
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [makeCommit()],
+      ghPort: fakeGh([
+        makeRef({
+          labels: ['feature', 'x'.repeat(70_000)],
+        }),
+      ]),
+      llmPort,
+    });
+
+    expect(calls).toBe(0);
+    expect(md).toContain(
+      'Faster streaming responses: Users now receive responses without intermittent stalls.',
+    );
+  });
+  it('uses enriched user impact for deterministic fallback', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit(),
+        makeCommit({ hash: 'bbbbbbb', subject: 'feat: another (#43)' }),
+        makeCommit({ hash: 'ccccccc', subject: 'fix: third (#44)' }),
+      ],
+      ghPort: fakeGh([
+        makeRef(),
+        makeRef({
+          number: 43,
+          title: 'Configure a new provider',
+          body: 'Users can select the provider in settings.',
+        }),
+        makeRef({
+          number: 44,
+          title: 'Crash-free startup',
+          body: 'Users no longer experience crashes on startup.',
+        }),
+      ]),
+      llmPort: fakeLlm(new Error('model unavailable')),
+    });
+
+    expect(md).toContain(
+      'Faster streaming responses: Users now receive responses without intermittent stalls.',
+    );
+    expect(
+      md.slice(md.indexOf('### Highlights'), md.indexOf('####')),
+    ).not.toContain('feat: something');
+  });
+
+  it('omits fallback Highlights when no impact can be established', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [makeCommit({ subject: 'feat: mechanism only' })],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(new Error('model unavailable')),
+    });
+    expect(md).toContain('### Highlights');
+    expect(md).toContain('No major user-facing changes in this release.');
+    expect(md).toContain('#### New');
+  });
+
+  it('uses curated headlines only for stable releases', async () => {
+    const input = {
+      ...baseInput,
+      rawCommits: [],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(llmOutput([])),
+      curatedHeadline: '## Maintainer-selected headline',
+    };
+    const stable = await generateReleaseNotes(input);
+    const nightly = await generateReleaseNotes({ ...input, isNightly: true });
+    expect(stable).toContain('Maintainer-selected headline');
+    expect(nightly).not.toContain('Maintainer-selected headline');
+  });
+
+  it('retains raw merge and process commits in All Changes', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({
+          subject: 'Merge pull request #42',
+          isMerge: true,
+          parents: ['p1', 'p2'],
+        }),
+        makeCommit({ hash: 'bbbbbbb', subject: 'chore: fix lint' }),
+      ],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(llmOutput([])),
+    });
+    expect(md).toContain('Merge pull request #42');
+    expect(md).toContain('chore: fix lint');
+  });
+
+  it('rejects model selections with ineligible source IDs (falls back)', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit(),
+        makeCommit({ hash: 'bbbbbbb', subject: 'feat: another (#43)' }),
+        makeCommit({ hash: 'ccccccc', subject: 'fix: third (#44)' }),
+      ],
+      ghPort: fakeGh([
+        makeRef(),
+        makeRef({
+          number: 43,
+          title: 'Configure a new provider',
+          body: 'Users can select the provider in settings.',
+        }),
+        makeRef({
+          number: 44,
+          title: 'Crash-free startup',
+          body: 'Users no longer experience crashes on startup.',
+        }),
+      ]),
+      llmPort: fakeLlm(llmOutput(['ref:99', 'ref:42', 'ref:43'])),
+    });
+
+    expect(md).toContain('### Highlights');
+    expect(md).toContain('Faster streaming responses');
+  });
+
+  it('produces 3-6 highlights when enough defensible facts exist', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [1, 2, 3, 4].map((n) =>
+        makeCommit({
+          hash: `hash${n}`,
+          subject: `feat: feature ${n} (#${40 + n})`,
+        }),
+      ),
+      ghPort: fakeGh(
+        [1, 2, 3, 4].map((n) =>
+          makeRef({
+            number: 40 + n,
+            title: `Feature ${n}`,
+            body: `Users can now use feature ${n} for better productivity.`,
+          }),
+        ),
+      ),
+      llmPort: fakeLlm(llmOutput(['ref:41', 'ref:42', 'ref:43', 'ref:44'])),
+    });
+
+    expect(md).toContain('### Highlights');
+    const highlightsSection = md.slice(
+      md.indexOf('### Highlights'),
+      md.indexOf('####'),
+    );
+    const bullets = highlightsSection
+      .split('\n')
+      .filter((line) => line.startsWith('- '));
+    expect(bullets.length).toBeGreaterThanOrEqual(3);
+    expect(bullets.length).toBeLessThanOrEqual(6);
+  });
+
+  it('uses validated model selections for highlight membership and order', async () => {
+    const rawCommits = [1, 2, 3, 4, 5, 6, 7].map((number) =>
+      makeCommit({
+        hash: `abcde${number}0`,
+        subject: `feat: feature ${number} (#${40 + number})`,
+      }),
+    );
+    const ghPort = fakeGh(
+      [1, 2, 3, 4, 5, 6, 7].map((number) =>
+        makeRef({
+          number: 40 + number,
+          title: `Feature ${number}`,
+          body: `Users can now use feature ${number}.`,
+        }),
+      ),
+    );
+    const generate = (sourceIds: readonly string[]) =>
+      generateReleaseNotes({
+        ...baseInput,
+        rawCommits,
+        ghPort,
+        llmPort: fakeLlm(llmOutput(sourceIds)),
+      });
+
+    const first = await generate([
+      'ref:41',
+      'ref:42',
+      'ref:43',
+      'ref:44',
+      'ref:45',
+      'ref:46',
+    ]);
+    const second = await generate([
+      'ref:47',
+      'ref:46',
+      'ref:45',
+      'ref:44',
+      'ref:43',
+      'ref:42',
+    ]);
+    const highlights = (markdown: string) =>
+      markdown.slice(
+        markdown.indexOf('### Highlights'),
+        markdown.indexOf('####'),
+      );
+
+    expect(highlights(first)).toContain('Users can now use feature 1.');
+    expect(highlights(first)).not.toContain('Users can now use feature 7.');
+    expect(highlights(second)).toContain('Users can now use feature 7.');
+    expect(highlights(second)).not.toContain('Users can now use feature 1.');
+    expect(highlights(second).indexOf('feature 7')).toBeLessThan(
+      highlights(second).indexOf('feature 6'),
+    );
+  });
+});
+
+describe('generateReleaseNotes — All Changes sanitization (issue6)', () => {
+  it('sanitizes All Changes subjects as plain text', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({
+          hash: 'abc1234',
+          subject: 'feat: add `[evil](https://x.invalid)` markdown',
+        }),
+      ],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(new Error('no llm')),
+    });
+    const allChangesSection = md.slice(md.indexOf('### All Changes'));
+    expect(allChangesSection).not.toContain('https://x.invalid');
+    expect(allChangesSection).not.toContain('`[evil]`');
+    expect(allChangesSection).toContain('abc1234');
+  });
+
+  it('retains the hash after a maximally long sanitized subject', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({
+          hash: 'abc1234',
+          subject: 'a'.repeat(500),
+        }),
+      ],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(new Error('no llm')),
+    });
+    const allChangesSection = md.slice(md.indexOf('### All Changes'));
+    expect(allChangesSection).toContain(`- ${'a'.repeat(500)} (abc1234)`);
+  });
+
+  it('omits invalid hashes from the parenthetical', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({
+          hash: 'not-a-hash!;rm -rf',
+          subject: 'feat: safe subject',
+        }),
+      ],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(new Error('no llm')),
+    });
+    const allChangesSection = md.slice(md.indexOf('### All Changes'));
+    expect(allChangesSection).not.toContain('rm -rf');
+    expect(allChangesSection).not.toContain('(not-a-hash');
+  });
+
+  it('strips HTML injection from All Changes subjects', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({
+          hash: 'abc1234',
+          subject: 'feat: <script>alert(1)</script> thing',
+        }),
+      ],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(new Error('no llm')),
+    });
+    const allChangesSection = md.slice(md.indexOf('### All Changes'));
+    expect(allChangesSection).not.toContain('<script>');
+  });
+
+  it('strips control characters and newlines from All Changes subjects', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({
+          hash: 'abc1234',
+          subject: 'feat: inject\x1erecord\x1fsep\nnewline',
+        }),
+      ],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(new Error('no llm')),
+    });
+    const allChangesSection = md.slice(md.indexOf('### All Changes'));
+    expect(allChangesSection).not.toContain('\x1e');
+    expect(allChangesSection).not.toContain('\x1f');
+  });
+
+  it('strips emoji characters from All Changes subjects', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({
+          hash: 'abc1234',
+          subject: 'feat: add streaming \u{1F680} support',
+        }),
+      ],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(new Error('no llm')),
+    });
+    const allChangesSection = md.slice(md.indexOf('### All Changes'));
+    const emojiPattern = /[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{27BF}]/u;
+    expect(emojiPattern.test(allChangesSection)).toBe(false);
+    expect(allChangesSection).toContain('add streaming');
+    expect(allChangesSection).toContain('abc1234');
+  });
+});
+
+describe('generateReleaseNotes — comparison URL (issue13)', () => {
+  it('builds comparison URL from validated repository input', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      repository: 'vybestack/llxprt-code',
+      rawCommits: [],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(llmOutput([])),
+    });
+    expect(md).toContain(
+      'https://github.com/vybestack/llxprt-code/compare/v0.10.0...v0.11.0',
+    );
+  });
+
+  it('omits comparison URL when repository is missing', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      repository: undefined,
+      rawCommits: [],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(llmOutput([])),
+    });
+    expect(md).not.toContain('**Full Changelog**');
+  });
+
+  it('omits comparison URL when repository is malformed', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      repository: 'not/a/valid/repo',
+      rawCommits: [],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(llmOutput([])),
+    });
+    expect(md).not.toContain('**Full Changelog**');
+  });
+
+  it('omits comparison URL when repository has injection characters', async () => {
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      repository: 'evil/repo"; rm -rf /',
+      rawCommits: [],
+      ghPort: fakeGh([]),
+      llmPort: fakeLlm(llmOutput([])),
+    });
+    expect(md).not.toContain('rm -rf');
+    expect(md).not.toContain('**Full Changelog**');
+  });
+});
+
+describe('generateReleaseNotes — enrichment failure handling (issue7)', () => {
+  it('produces sensible output when gh port throws (total enrichment failure)', async () => {
+    const failingGh: GhPort = {
+      async fetchRefs() {
+        throw new Error('total network failure');
+      },
+    };
+    const md = await generateReleaseNotes({
+      ...baseInput,
+      rawCommits: [
+        makeCommit({ subject: 'feat: real work (#42)' }),
+        makeCommit({
+          hash: 'bbbbbbb',
+          subject: 'fix: another (#43)',
+        }),
+      ],
+      ghPort: failingGh,
+      llmPort: fakeLlm(new Error('no llm')),
+    });
+    // Without enrichment, highlights are omitted but the structure is intact.
+    expect(md).toContain('### Highlights');
+    expect(md).toContain('No major user-facing changes in this release.');
+    expect(md).toContain('### Installation');
+    expect(md).toContain('### All Changes');
+    expect(md).toContain('feat: real work');
+    expect(md).toContain('fix: another');
+  });
+});

--- a/scripts/tests/release-notes/processing-noise.test.ts
+++ b/scripts/tests/release-notes/processing-noise.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildChangeEntries } from '../../release-notes/processing.js';
+import type {
+  EnrichedRef,
+  GhPort,
+  RawCommit,
+  TopologyResolver,
+} from '../../release-notes/types.js';
+
+function commit(overrides: Partial<RawCommit> = {}): RawCommit {
+  return {
+    hash: 'abcdef0',
+    subject: 'fix: something',
+    author: 'dev',
+    isMerge: false,
+    parents: [],
+    ...overrides,
+  };
+}
+
+function enriched(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 50,
+    title: 'Feature PR',
+    body: '',
+    labels: ['feature'],
+    labelsTruncated: false,
+    author: 'alice',
+    isPr: true,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+function topology(childHashes: readonly string[]): TopologyResolver {
+  return {
+    getMergeIntroducedHashes() {
+      return childHashes;
+    },
+    getOctopusMergeIntroducedHashes() {
+      return childHashes;
+    },
+  };
+}
+
+function ghPort(): GhPort {
+  return {
+    async fetchRefs() {
+      return new Map([[50, enriched()]]);
+    },
+  };
+}
+
+describe('classic merge process-noise handling', () => {
+  it('omits a logical entry when every child is process noise', async () => {
+    const commits = [
+      commit({
+        subject: 'Merge pull request #50 from feature',
+        hash: 'mergehash',
+        isMerge: true,
+        parents: ['mainline', 'featurebranch'],
+      }),
+      commit({ subject: 'lint: fix formatting', hash: 'child1' }),
+      commit({ subject: 'style: prettier run', hash: 'child2' }),
+    ];
+
+    const entries = await buildChangeEntries(
+      commits,
+      ghPort(),
+      topology(['child1', 'child2']),
+    );
+
+    expect(entries).toHaveLength(0);
+  });
+
+  it('uses a substantive child as the logical representative', async () => {
+    const commits = [
+      commit({
+        subject: 'Merge pull request #50 from feature',
+        hash: 'mergehash',
+        isMerge: true,
+        parents: ['mainline', 'featurebranch'],
+      }),
+      commit({ subject: 'lint: fix formatting', hash: 'child1' }),
+      commit({ subject: 'feat: real feature', hash: 'child2' }),
+    ];
+
+    const entries = await buildChangeEntries(
+      commits,
+      ghPort(),
+      topology(['child1', 'child2']),
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.id).toBe('ref:50');
+    expect(entries[0]!.subject).toBe('feat: real feature');
+  });
+
+  it('retains a standalone merge without introduced children', async () => {
+    const entries = await buildChangeEntries(
+      [
+        commit({
+          subject: 'Merge pull request #50 from feature',
+          hash: 'mergehash',
+          isMerge: true,
+          parents: ['mainline', 'featurebranch'],
+        }),
+      ],
+      ghPort(),
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.id).toBe('ref:50');
+  });
+});

--- a/scripts/tests/release-notes/processing.test.ts
+++ b/scripts/tests/release-notes/processing.test.ts
@@ -1,0 +1,846 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import {
+  groupPrCommits,
+  buildChangeEntries,
+} from '../../release-notes/processing.js';
+import {
+  getCommits,
+  createTopologyResolver,
+} from '../../release-notes/git-port.js';
+import { useTempRepo, gitCommit, gitMerge } from './fixtures.js';
+import type {
+  RawCommit,
+  EnrichedRef,
+  GhPort,
+  TopologyResolver,
+} from '../../release-notes/types.js';
+
+function makeCommit(overrides: Partial<RawCommit> = {}): RawCommit {
+  return {
+    hash: 'abcdef0',
+    subject: 'fix: something',
+    author: 'dev',
+    isMerge: false,
+    parents: [],
+    ...overrides,
+  };
+}
+
+function makeEnriched(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 1,
+    title: 'Issue title',
+    body: '',
+    labels: [],
+    labelsTruncated: false,
+    author: 'someone',
+    isPr: false,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+function fakeTopology(
+  map: ReadonlyMap<string, readonly string[]>,
+): TopologyResolver {
+  return {
+    getMergeIntroducedHashes(firstParent: string, _secondParent: string) {
+      return map.get(firstParent) ?? [];
+    },
+    getOctopusMergeIntroducedHashes(parents: readonly string[]) {
+      const firstParent = parents[0] ?? '';
+      const seen = new Set<string>();
+      const result: string[] = [];
+      for (let index = 1; index < parents.length; index += 1) {
+        const introduced = map.get(firstParent) ?? [];
+        for (const hash of introduced) {
+          if (!seen.has(hash)) {
+            seen.add(hash);
+            result.push(hash);
+          }
+        }
+      }
+      return result;
+    },
+  };
+}
+
+describe('groupPrCommits (PR-identity-based grouping)', () => {
+  it('groups commits from the same squash PR into one logical entry', () => {
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'feat: add streaming (#100)',
+        hash: 'aaa1111',
+        author: 'alice',
+      }),
+      makeCommit({
+        subject: 'fix: edge case in streaming (#100)',
+        hash: 'bbb2222',
+        author: 'alice',
+      }),
+      makeCommit({
+        subject: 'feat: unrelated thing (#200)',
+        hash: 'ccc3333',
+        author: 'bob',
+      }),
+    ];
+    const groups = groupPrCommits(commits);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.commits.map((c) => c.hash)).toEqual([
+      'aaa1111',
+      'bbb2222',
+    ]);
+    expect(groups[1]!.commits.map((c) => c.hash)).toEqual(['ccc3333']);
+  });
+
+  it('keeps commits without refs as individual entries', () => {
+    const commits: RawCommit[] = [
+      makeCommit({ subject: 'feat: standalone', hash: 'aaa1111' }),
+      makeCommit({ subject: 'fix: another standalone', hash: 'bbb2222' }),
+    ];
+    const groups = groupPrCommits(commits);
+    expect(groups).toHaveLength(2);
+  });
+
+  it('uses first commit as the representative for a group', () => {
+    const commits: RawCommit[] = [
+      makeCommit({ subject: 'feat: main work (#42)', hash: 'aaa1111' }),
+      makeCommit({ subject: 'fix: followup (#42)', hash: 'bbb2222' }),
+    ];
+    const groups = groupPrCommits(commits);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.representative.subject).toContain('main work');
+    expect(groups[0]!.representative.hash).toBe('aaa1111');
+  });
+
+  it('does NOT merge distinct PRs that close the same issue', () => {
+    // Two distinct PRs (#10 and #20) both close issue #5 — they must remain
+    // separate entries. Fixes #5 is enrichment, not a grouping key.
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'feat: approach A Fixes #5 (#10)',
+        hash: 'aaa1111',
+      }),
+      makeCommit({
+        subject: 'feat: approach B Fixes #5 (#20)',
+        hash: 'bbb2222',
+      }),
+    ];
+    const groups = groupPrCommits(commits);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.commits[0]!.hash).toBe('aaa1111');
+    expect(groups[1]!.commits[0]!.hash).toBe('bbb2222');
+  });
+
+  it('groups classic merge children into one PR entry via topology', () => {
+    const childHashes = ['child1', 'child2'];
+    const resolver = fakeTopology(new Map([['mainline', childHashes]]));
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #50 from feature',
+        hash: 'mergehash',
+        isMerge: true,
+        parents: ['mainline', 'featurebranch'],
+      }),
+      makeCommit({ subject: 'feat: child 1', hash: 'child1' }),
+      makeCommit({ subject: 'fix: child 2', hash: 'child2' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.commits.map((c) => c.hash)).toEqual([
+      'mergehash',
+      'child1',
+      'child2',
+    ]);
+    expect(groups[0]!.childHashes).toEqual(['child1', 'child2']);
+  });
+
+  it('keeps a classic merge as its own group when topology resolver is absent', () => {
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #50 from feature',
+        hash: 'mergehash',
+        isMerge: true,
+        parents: ['mainline', 'featurebranch'],
+      }),
+    ];
+    const groups = groupPrCommits(commits);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.commits.map((c) => c.hash)).toEqual(['mergehash']);
+    expect(groups[0]!.childHashes).toEqual([]);
+  });
+
+  it('groups multiple classic merges by PR identity', () => {
+    const resolver = fakeTopology(
+      new Map([
+        ['main1', ['childA']],
+        ['main2', ['childB']],
+      ]),
+    );
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #50 from feature',
+        hash: 'merge50',
+        isMerge: true,
+        parents: ['main1', 'feat1'],
+      }),
+      makeCommit({
+        subject: 'Merge pull request #60 from feature',
+        hash: 'merge60',
+        isMerge: true,
+        parents: ['main2', 'feat2'],
+      }),
+      makeCommit({ subject: 'feat: child A', hash: 'childA' }),
+      makeCommit({ subject: 'fix: child B', hash: 'childB' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(2);
+    const pr50 = groups.find((g) => g.representative.subject.includes('#50'))!;
+    const pr60 = groups.find((g) => g.representative.subject.includes('#60'))!;
+    expect(pr50.commits.map((c) => c.hash)).toContain('merge50');
+    expect(pr50.commits.map((c) => c.hash)).toContain('childA');
+    expect(pr60.commits.map((c) => c.hash)).toContain('merge60');
+    expect(pr60.commits.map((c) => c.hash)).toContain('childB');
+  });
+
+  it('assigns nested merge children to the nearest (innermost) introducing PR', () => {
+    const resolver = fakeTopology(
+      new Map([
+        ['outerMain', ['innerMerge', 'grandchild']],
+        ['innerMain', ['grandchild']],
+      ]),
+    );
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #100 from outer',
+        hash: 'outerMerge',
+        isMerge: true,
+        parents: ['outerMain', 'outerFeat'],
+      }),
+      makeCommit({
+        subject: 'Merge pull request #50 from inner',
+        hash: 'innerMerge',
+        isMerge: true,
+        parents: ['innerMain', 'innerFeat'],
+      }),
+      makeCommit({ subject: 'feat: grandchild', hash: 'grandchild' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(2);
+    const outer = groups.find((g) => g.representative.hash === 'outerMerge')!;
+    const inner = groups.find((g) => g.representative.hash === 'innerMerge')!;
+    expect(outer.commits.map((c) => c.hash)).toContain('outerMerge');
+    expect(outer.commits.map((c) => c.hash)).toContain('innerMerge');
+    expect(outer.commits.map((c) => c.hash)).not.toContain('grandchild');
+    expect(inner.commits.map((c) => c.hash)).not.toContain('innerMerge');
+    expect(inner.commits.map((c) => c.hash)).toContain('grandchild');
+  });
+
+  it('keeps childHashes and commits consistent for nested merges (no loss/duplication)', () => {
+    const resolver = fakeTopology(
+      new Map([
+        ['outerMain', ['innerMerge', 'gc1', 'gc2']],
+        ['innerMain', ['gc1', 'gc2']],
+      ]),
+    );
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #100 from outer',
+        hash: 'outerMerge',
+        isMerge: true,
+        parents: ['outerMain', 'outerFeat'],
+      }),
+      makeCommit({
+        subject: 'Merge pull request #50 from inner',
+        hash: 'innerMerge',
+        isMerge: true,
+        parents: ['innerMain', 'innerFeat'],
+      }),
+      makeCommit({ subject: 'feat: gc1', hash: 'gc1' }),
+      makeCommit({ subject: 'fix: gc2', hash: 'gc2' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    const allAssignedHashes = groups.flatMap((g) =>
+      g.commits.map((c) => c.hash),
+    );
+    for (const hash of ['gc1', 'gc2']) {
+      expect(allAssignedHashes.filter((h) => h === hash)).toHaveLength(1);
+    }
+    for (const group of groups) {
+      const commitHashes = group.commits.map((c) => c.hash);
+      for (const childHash of group.childHashes) {
+        expect(commitHashes).toContain(childHash);
+      }
+    }
+  });
+});
+
+describe('nested classic merges — temp-git integration', () => {
+  const getDir = useTempRepo('llxprt-nested-merge');
+
+  it('groups a real nested merge: outer PR owns inner merge, inner PR owns grandchild', () => {
+    const dir = getDir();
+    const root = gitCommit(dir, 'root');
+    execFileSync('git', ['tag', 'start', root], { encoding: 'utf8' });
+
+    // Create sub-branch with grandchild commit
+    execFileSync('git', ['checkout', '-b', 'sub'], { encoding: 'utf8' });
+    gitCommit(dir, 'feat: grandchild work');
+    const grandchildHash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Create inner-feature branch from root, merge sub into it
+    execFileSync('git', ['checkout', root], { encoding: 'utf8' });
+    execFileSync('git', ['checkout', '-b', 'inner-feature'], {
+      encoding: 'utf8',
+    });
+    gitCommit(dir, 'feat: inner feature work');
+    gitMerge(dir, 'Merge pull request #50 from sub', 'sub');
+    const innerMergeHash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Merge inner-feature into main
+    execFileSync('git', ['checkout', 'main'], { encoding: 'utf8' });
+    gitMerge(
+      dir,
+      'Merge pull request #100 from inner-feature',
+      'inner-feature',
+    );
+    const outerMergeHash = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    const commits = getCommits('start', 'HEAD');
+    const resolver = createTopologyResolver();
+    const groups = groupPrCommits(commits, resolver);
+
+    const grandchildOwners = groups.filter((g) =>
+      g.commits.some((c) => c.hash === grandchildHash),
+    );
+    expect(grandchildOwners).toHaveLength(1);
+
+    const outerGroup = groups.find(
+      (g) => g.representative.hash === outerMergeHash,
+    );
+    expect(outerGroup).toBeDefined();
+    expect(outerGroup!.commits.map((c) => c.hash)).toContain(innerMergeHash);
+
+    const allHashes = commits.map((c) => c.hash);
+    const assignedHashes = groups.flatMap((g) => g.commits.map((c) => c.hash));
+    for (const hash of allHashes) {
+      expect(assignedHashes.filter((h) => h === hash)).toHaveLength(1);
+    }
+  });
+});
+
+describe('buildChangeEntries', () => {
+  it('enriches commits via gh port and classifies them', async () => {
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'feat: add Ollama support (#42)',
+        hash: 'aaa1111',
+        author: 'alice',
+      }),
+    ];
+
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map<number, EnrichedRef>([
+          [
+            42,
+            makeEnriched({
+              number: 42,
+              title: 'Add Ollama support',
+              labels: ['Provider Support'],
+              isPr: true,
+              author: 'alice',
+            }),
+          ],
+        ]);
+      },
+    };
+
+    const entries = await buildChangeEntries(commits, fakeGh);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.category).toBe('new');
+    expect(entries[0]!.eligibleForHighlights).toBe(true);
+    expect(entries[0]!.enriched[0]!.title).toBe('Add Ollama support');
+  });
+
+  it('attaches immutable source facts once during entry construction', async () => {
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map<number, EnrichedRef>([
+          [
+            42,
+            makeEnriched({
+              number: 42,
+              title: 'Resume interrupted sessions',
+              body: 'Users can now resume interrupted sessions.',
+              labels: ['feature'],
+            }),
+          ],
+        ]);
+      },
+    };
+
+    const entries = await buildChangeEntries(
+      [makeCommit({ subject: 'feat: recovery (#42)' })],
+      fakeGh,
+    );
+
+    expect(entries[0]?.sourceFacts).toEqual([
+      expect.objectContaining({
+        sourceId: 'ref:42',
+        userImpact: 'Users can now resume interrupted sessions.',
+      }),
+    ]);
+    expect(Object.isFrozen(entries[0]?.sourceFacts)).toBe(true);
+    expect(Object.isFrozen(entries[0]?.sourceFacts[0])).toBe(true);
+  });
+
+  it('handles gh port returning no enrichment gracefully', async () => {
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'fix: standalone fix',
+        hash: 'aaa1111',
+        author: 'alice',
+      }),
+    ];
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map();
+      },
+    };
+    const entries = await buildChangeEntries(commits, fakeGh);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.enriched).toEqual([]);
+  });
+
+  it('retains unavailable references only in All Changes', async () => {
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map();
+      },
+    };
+
+    const entries = await buildChangeEntries(
+      [makeCommit({ subject: 'feat: add provider support (#42)' })],
+      fakeGh,
+    );
+
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    if (entry === undefined) {
+      throw new Error('Expected the unavailable reference to be retained');
+    }
+    expect(entry.category).toBe('internal');
+    expect(entry.eligibleForHighlights).toBe(false);
+  });
+
+  it('never demotes a breaking child from a non-conventional PR title', async () => {
+    const resolver = fakeTopology(new Map([['mainline', ['child']]]));
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map([
+          [42, makeEnriched({ number: 42, title: 'Improve configuration' })],
+        ]);
+      },
+    };
+    const commits = [
+      makeCommit({
+        subject: 'Merge pull request #42 from feature',
+        hash: 'merge',
+        isMerge: true,
+        parents: ['mainline', 'feature'],
+      }),
+      makeCommit({
+        subject: 'feat!: replace public config format',
+        hash: 'child',
+      }),
+    ];
+
+    const entries = await buildChangeEntries(commits, fakeGh, resolver);
+
+    expect(entries[0]!.category).toBe('breaking');
+  });
+
+  it('marks internal-label entries as ineligible for highlights', async () => {
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'refactor: restructure providers (#99)',
+        hash: 'aaa1111',
+        author: 'alice',
+      }),
+    ];
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map<number, EnrichedRef>([
+          [
+            99,
+            makeEnriched({
+              number: 99,
+              title: 'Restructure providers',
+              labels: ['Code Quality', 'Modularization'],
+            }),
+          ],
+        ]);
+      },
+    };
+    const entries = await buildChangeEntries(commits, fakeGh);
+    expect(entries[0]!.eligibleForHighlights).toBe(false);
+  });
+
+  it('keeps complete commits through topology-aware grouping', async () => {
+    const childHashes = ['child1', 'child2'];
+    const resolver = fakeTopology(new Map([['mainline', childHashes]]));
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #50 from feature',
+        hash: 'mergehash',
+        isMerge: true,
+        parents: ['mainline', 'featurebranch'],
+      }),
+      makeCommit({ subject: 'feat: child 1', hash: 'child1' }),
+      makeCommit({ subject: 'fix: child 2', hash: 'child2' }),
+    ];
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map<number, EnrichedRef>([
+          [
+            50,
+            makeEnriched({
+              number: 50,
+              title: 'Feature PR',
+              labels: ['feature'],
+              isPr: true,
+              author: 'alice',
+            }),
+          ],
+        ]);
+      },
+    };
+    const entries = await buildChangeEntries(commits, fakeGh, resolver);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.id).toBe('ref:50');
+    expect(entries[0]!.childHashes).toEqual(['child1', 'child2']);
+  });
+
+  it('does not merge distinct PRs closing the same issue into one entry', async () => {
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'feat: approach A Fixes #5 (#10)',
+        hash: 'aaa1111',
+      }),
+      makeCommit({
+        subject: 'feat: approach B Fixes #5 (#20)',
+        hash: 'bbb2222',
+      }),
+    ];
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map<number, EnrichedRef>([
+          [5, makeEnriched({ number: 5, title: 'Shared issue', isPr: false })],
+          [
+            10,
+            makeEnriched({
+              number: 10,
+              title: 'PR A',
+              isPr: true,
+              author: 'alice',
+            }),
+          ],
+          [
+            20,
+            makeEnriched({
+              number: 20,
+              title: 'PR B',
+              isPr: true,
+              author: 'bob',
+            }),
+          ],
+        ]);
+      },
+    };
+    const entries = await buildChangeEntries(commits, fakeGh);
+    expect(entries).toHaveLength(2);
+    // Both PR refs are retained as enrichment (issue ref included).
+    expect(entries[0]!.enriched.length).toBeGreaterThanOrEqual(1);
+    expect(entries[1]!.enriched.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('nested merge topology: outer PR does NOT collect inner PR enrichment (no label contamination)', async () => {
+    const resolver = fakeTopology(
+      new Map([
+        ['outerMain', ['innerMerge', 'grandchild']],
+        ['innerMain', ['grandchild']],
+      ]),
+    );
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #100 from outer',
+        hash: 'outerMerge',
+        isMerge: true,
+        parents: ['outerMain', 'outerFeat'],
+      }),
+      makeCommit({
+        subject: 'Merge pull request #50 from inner',
+        hash: 'innerMerge',
+        isMerge: true,
+        parents: ['innerMain', 'innerFeat'],
+      }),
+      makeCommit({ subject: 'feat: grandchild', hash: 'grandchild' }),
+    ];
+    const fakeGh: GhPort = {
+      async fetchRefs() {
+        return new Map<number, EnrichedRef>([
+          [
+            100,
+            makeEnriched({
+              number: 100,
+              title: 'Outer PR',
+              labels: ['feature'],
+              isPr: true,
+              author: 'alice',
+            }),
+          ],
+          [
+            50,
+            makeEnriched({
+              number: 50,
+              title: 'Inner PR',
+              labels: ['bug', 'fix'],
+              isPr: true,
+              author: 'bob',
+            }),
+          ],
+        ]);
+      },
+    };
+    const entries = await buildChangeEntries(commits, fakeGh, resolver);
+    expect(entries).toHaveLength(2);
+    const outer = entries.find((e) => e.id === 'ref:100')!;
+    const inner = entries.find((e) => e.id === 'ref:50')!;
+    const outerNumbers = outer.enriched.map((r) => r.number);
+    expect(outerNumbers).not.toContain(50);
+    expect(outerNumbers).toContain(100);
+    const innerNumbers = inner.enriched.map((r) => r.number);
+    expect(innerNumbers).toContain(50);
+    expect(innerNumbers).not.toContain(100);
+    expect(outer.category).toBe('new');
+    // Inner entry's enrichment only contains its own PR #50 (bug/fix labels),
+    // never the outer PR #100's 'feature' label.
+    const innerLabelCount = inner.enriched.flatMap((r) => r.labels);
+    expect(innerLabelCount).not.toContain('feature');
+    expect(innerLabelCount).toContain('bug');
+  });
+
+  it('respects metadataAvailable for owning-PR classification', async () => {
+    const cases = [
+      {
+        title: 'feat: add streaming support',
+        labels: [],
+        metadataAvailable: true,
+        commitSubject: 'chore: minor cleanup (#42)',
+        expectedCategory: 'new',
+        eligible: true,
+      },
+      {
+        title: 'feat: add streaming support',
+        labels: ['feature'],
+        metadataAvailable: false,
+        commitSubject: 'chore: minor cleanup (#42)',
+        expectedCategory: 'internal',
+        eligible: false,
+      },
+      {
+        title: 'Improve configuration loading',
+        labels: ['bug'],
+        metadataAvailable: true,
+        commitSubject: 'perf: optimize config path (#42)',
+        expectedCategory: 'fix',
+        eligible: true,
+      },
+    ];
+    for (const c of cases) {
+      const fakeGh: GhPort = {
+        async fetchRefs() {
+          return new Map<number, EnrichedRef>([
+            [
+              42,
+              makeEnriched({
+                number: 42,
+                title: c.title,
+                labels: c.labels,
+                metadataAvailable: c.metadataAvailable,
+                isPr: true,
+              }),
+            ],
+          ]);
+        },
+      };
+      const entries = await buildChangeEntries(
+        [makeCommit({ subject: c.commitSubject })],
+        fakeGh,
+      );
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.category).toBe(c.expectedCategory);
+      expect(entries[0]!.eligibleForHighlights).toBe(c.eligible);
+    }
+  });
+});
+
+describe('classic merge wrapper — topology behavior', () => {
+  it('groups all children under the merge commit via topology', () => {
+    const childHashes = ['childA', 'childB', 'childC'];
+    const resolver = fakeTopology(new Map([['mainline', childHashes]]));
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #70 from feature',
+        hash: 'mergehash',
+        isMerge: true,
+        parents: ['mainline', 'featurebranch'],
+      }),
+      makeCommit({ subject: 'feat: child A', hash: 'childA' }),
+      makeCommit({ subject: 'fix: child B', hash: 'childB' }),
+      makeCommit({ subject: 'refactor: child C', hash: 'childC' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.commits).toHaveLength(4);
+    expect(groups[0]!.childHashes).toEqual(['childA', 'childB', 'childC']);
+  });
+
+  it('does not associate a child with the wrong merge commit', () => {
+    const resolver = fakeTopology(
+      new Map([
+        ['mainline1', ['childA']],
+        ['mainline2', ['childB']],
+      ]),
+    );
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #80 from feature',
+        hash: 'merge80',
+        isMerge: true,
+        parents: ['mainline1', 'feat1'],
+      }),
+      makeCommit({
+        subject: 'Merge pull request #90 from feature',
+        hash: 'merge90',
+        isMerge: true,
+        parents: ['mainline2', 'feat2'],
+      }),
+      makeCommit({ subject: 'feat: child A', hash: 'childA' }),
+      makeCommit({ subject: 'fix: child B', hash: 'childB' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(2);
+    const pr80 = groups.find((g) => g.representative.hash === 'merge80')!;
+    const pr90 = groups.find((g) => g.representative.hash === 'merge90')!;
+    expect(pr80.commits.map((c) => c.hash)).toContain('childA');
+    expect(pr80.commits.map((c) => c.hash)).not.toContain('childB');
+    expect(pr90.commits.map((c) => c.hash)).toContain('childB');
+    expect(pr90.commits.map((c) => c.hash)).not.toContain('childA');
+  });
+});
+
+describe('octopus merge grouping (3+ parents)', () => {
+  it('groups a 3-parent octopus merge and all its introduced children into one entry', () => {
+    const resolver = fakeTopology(
+      new Map([['octoMain', ['childA', 'childB', 'childC']]]),
+    );
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #70 from feature',
+        hash: 'octoMerge',
+        isMerge: true,
+        parents: ['octoMain', 'branch1', 'branch2'],
+      }),
+      makeCommit({ subject: 'feat: child A', hash: 'childA' }),
+      makeCommit({ subject: 'fix: child B', hash: 'childB' }),
+      makeCommit({ subject: 'refactor: child C', hash: 'childC' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.commits.map((c) => c.hash)).toEqual([
+      'octoMerge',
+      'childA',
+      'childB',
+      'childC',
+    ]);
+    expect(groups[0]!.childHashes).toEqual(['childA', 'childB', 'childC']);
+  });
+
+  it('deduplicates overlapping introduced children from octopus parents', () => {
+    const resolver: TopologyResolver = {
+      getMergeIntroducedHashes() {
+        return [];
+      },
+      getOctopusMergeIntroducedHashes(parents: readonly string[]) {
+        const firstParent = parents[0]!;
+        const map = new Map<string, readonly string[]>([
+          ['octoMain', ['branch1Child', 'sharedChild', 'branch2Child']],
+        ]);
+        const introduced = map.get(firstParent) ?? [];
+        return [...new Set(introduced)];
+      },
+    };
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #80 from octopus',
+        hash: 'octoMerge',
+        isMerge: true,
+        parents: ['octoMain', 'branch1', 'branch2'],
+      }),
+      makeCommit({ subject: 'feat: branch1 child', hash: 'branch1Child' }),
+      makeCommit({ subject: 'fix: shared child', hash: 'sharedChild' }),
+      makeCommit({ subject: 'refactor: branch2 child', hash: 'branch2Child' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(1);
+    const childOccurrences = groups[0]!.childHashes.filter(
+      (h) => h === 'sharedChild',
+    );
+    expect(childOccurrences).toHaveLength(1);
+    expect(groups[0]!.childHashes).toContain('branch1Child');
+    expect(groups[0]!.childHashes).toContain('sharedChild');
+    expect(groups[0]!.childHashes).toContain('branch2Child');
+  });
+
+  it('keeps octopus merge children in exactly one group (no loss, no duplication)', () => {
+    const resolver = fakeTopology(
+      new Map([['octoMain', ['childA', 'childB']]]),
+    );
+    const commits: RawCommit[] = [
+      makeCommit({
+        subject: 'Merge pull request #100 from octopus',
+        hash: 'octoMerge',
+        isMerge: true,
+        parents: ['octoMain', 'b1', 'b2'],
+      }),
+      makeCommit({ subject: 'feat: child A', hash: 'childA' }),
+      makeCommit({ subject: 'fix: child B', hash: 'childB' }),
+      makeCommit({ subject: 'feat: unrelated PR (#200)', hash: 'standalone' }),
+    ];
+    const groups = groupPrCommits(commits, resolver);
+    expect(groups).toHaveLength(2);
+    const octoGroup = groups.find(
+      (g) => g.representative.hash === 'octoMerge',
+    )!;
+    expect(octoGroup.commits.map((c) => c.hash)).toContain('childA');
+    expect(octoGroup.commits.map((c) => c.hash)).toContain('childB');
+    const allHashes = groups.flatMap((g) => g.commits.map((c) => c.hash));
+    expect(allHashes.filter((h) => h === 'childA')).toHaveLength(1);
+    expect(allHashes.filter((h) => h === 'childB')).toHaveLength(1);
+  });
+});

--- a/scripts/tests/release-notes/provenance-user-impact.test.ts
+++ b/scripts/tests/release-notes/provenance-user-impact.test.ts
@@ -1,0 +1,687 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { extractSourceFacts } from '../../release-notes/provenance.js';
+import type { ChangeEntry, EnrichedRef } from '../../release-notes/types.js';
+
+function makeRef(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 42,
+    title: 'Faster streaming responses',
+    body: 'Users now receive responses without intermittent stalls.',
+    labels: ['feature'],
+    labelsTruncated: false,
+    author: 'alice',
+    isPr: false,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<ChangeEntry> = {}): ChangeEntry {
+  return {
+    id: 'ref:42',
+    subject: 'feat: thing',
+    hash: 'abc',
+    author: 'dev',
+    refs: [],
+    enriched: [makeRef()],
+    category: 'new',
+    eligibleForHighlights: true,
+    childHashes: [],
+    sourceFacts: [],
+    ...overrides,
+  };
+}
+
+describe('extractUserImpact — adapter/provider/registry/parser/config mechanism rejection (Finding 2)', () => {
+  // These adversarial tests guard against internal mechanism prose that
+  // describes new adapters, provider registries, configuration parsers,
+  // config loaders, and similar internal plumbing masquerading as
+  // user-facing impact. Each sentence below MUST be rejected — it
+  // describes an internal mechanism, not an explicit user actor,
+  // capability, or observable outcome.
+
+  it('rejects "new adapter" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Added a new adapter for the internal provider system.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "adapter registry" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The adapter registry was updated to support new entries.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "provider registry" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Implemented a provider registry for dynamic loading.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "new provider registry" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Created a new provider registry to manage internal components.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "configuration parser" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The configuration parser was rewritten for better performance.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "new parser" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'A new parser was added for the internal config format.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "adapter framework" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Built an adapter framework for extensible internal modules.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "internal mechanism" prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'This change adds an internal mechanism for plugin loading.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "plumbing" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Updated the internal plumbing for the provider layer.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "under the hood" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Changes under the hood improve the build system reliability.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "config loader" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The config loader was refactored to reduce duplication.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "config layer" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The config layer was reorganized for internal consistency.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "config handler" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The config handler was extracted into a separate module.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "internal config" mechanism prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The internal config was updated to support new registry entries.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+});
+
+describe('extractUserImpact — weak signals alone are insufficient (Finding 2)', () => {
+  // Words like "new", "option", "configuration", "cli", "setting", "flag"
+  // describe WHAT changed but not WHO benefits or what the user OBSERVES.
+  // These alone must NOT qualify as defensible user-facing impact. They
+  // require an explicit user actor, capability phrase, or observable
+  // outcome to form a valid impact statement.
+
+  it('rejects a sentence with only "new" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Added a new internal module for the processing pipeline.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects a sentence with only "option" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The option field was added to the internal data structure.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects a sentence with only "configuration" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The configuration values were reorganized in the schema.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects a sentence with only "cli" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The cli module was restructured for internal consistency.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects a sentence with only "setting" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The setting object was updated in the internal registry.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects a sentence with only "flag" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The flag variable was renamed in the module exports.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects a sentence with only "command" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The command handler was refactored for the dispatcher pattern.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects a sentence with only "available" and no user actor/capability/observable', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The available endpoints were registered in the router.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it.each([
+    'Refactor parser without changing behavior.',
+    'Users receive the same output without any visible change.',
+  ])('rejects explicit no-change prose: %s', (body) => {
+    const facts = extractSourceFacts(
+      makeEntry({ enriched: [makeRef({ body })] }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects internal CI impact for maintainers', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({ body: 'This fixes CI failures for maintainers.' }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+});
+
+describe('extractUserImpact — weak signal + explicit actor/capability/observable is valid (Finding 2)', () => {
+  // Weak signals ("new", "option", "configuration") DO qualify as valid
+  // impact when combined with an explicit user actor ("users"), capability
+  // phrase ("can now"), or observable outcome ("no longer"). The finding
+  // requires preserving valid impact, not rejecting everything with a
+  // weak signal word.
+
+  it('accepts "new" + "users" (explicit actor)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users get a new option to control output format.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('new option');
+  });
+
+  it('accepts "configuration" + "can now" (capability)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Developers can now configure the retry behavior.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('configure');
+  });
+
+  it('accepts "cli" + "fixes" (observable outcome)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'This fixes the cli crash on startup.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('cli crash');
+  });
+
+  it('accepts "setting" + "allows" (capability)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'A new setting allows users to control cache size.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('cache size');
+  });
+
+  it('accepts "flag" + "can use" (capability)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users can use a flag to enable verbose output.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('verbose output');
+  });
+
+  it('accepts "command" + "can run" (capability)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users can run the command to export session data.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('export session');
+  });
+
+  it('accepts "option" + "can select" (capability)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users can select an option to change the theme.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('change the theme');
+  });
+});
+
+describe('extractUserImpact — preserves valid impact with explicit actor/capability/observable (Finding 2)', () => {
+  // These tests verify that genuine user-facing impact sentences — with
+  // explicit user actors, capability phrases, or observable outcomes —
+  // are preserved even when they happen to mention internal-sounding words.
+
+  it.each([
+    'Improves performance for large sessions.',
+    'Enhances stability during startup.',
+    'Users now receive better error messages.',
+  ])('accepts directional impact with an observable subject: %s', (body) => {
+    const facts = extractSourceFacts(
+      makeEntry({ enriched: [makeRef({ body })] }),
+    );
+
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toBe(body);
+  });
+
+  it.each([
+    'Improves functionality.',
+    'Improves features.',
+    'Improves application behavior.',
+  ])('rejects content-free directional claims: %s', (body) => {
+    const facts = extractSourceFacts(
+      makeEntry({ enriched: [makeRef({ body })] }),
+    );
+
+    expect(facts).toEqual([]);
+  });
+
+  it('accepts genuine user impact with "users" actor', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users now experience faster response times.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('faster response');
+  });
+
+  it('accepts genuine capability "can now"', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'You can now pin a specific model version.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('pin a specific model');
+  });
+
+  it('accepts genuine observable outcome "no longer"', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The application no longer crashes on large inputs.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('no longer crashes');
+  });
+
+  it('accepts genuine observable outcome "fixes"', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'This fixes a memory leak during long sessions.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('memory leak');
+  });
+
+  it('accepts genuine observable outcome "faster"', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Startup is now 3x faster for all users.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('3x faster');
+  });
+
+  it('accepts "developers" actor with capability', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Developers can now extend the tool with custom plugins.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('custom plugins');
+  });
+
+  it('accepts "config" when paired with a user capability phrase', () => {
+    // "config" alone is a weak signal, but "can now configure" is a
+    // capability phrase. Genuine user-facing config changes must survive.
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users can now configure the output format via the config file.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('configure the output format');
+  });
+
+  it.each([
+    'Users experience crashes on startup.',
+    'Developers cannot load saved profiles.',
+    'Customers see intermittent failures during login.',
+    'The CLI is slower for users with large histories.',
+  ])(
+    'rejects negative problem statement without a directional resolution: %s',
+    (body) => {
+      const facts = extractSourceFacts(
+        makeEntry({ enriched: [makeRef({ body })] }),
+      );
+
+      expect(facts).toEqual([]);
+    },
+  );
+
+  it('rejects mechanism prose without a recognized impact signal', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The state machine enables users to resume sessions.',
+          }),
+        ],
+      }),
+    );
+
+    expect(facts).toEqual([]);
+  });
+
+  it.each([
+    'A new provider registry allows users to select providers.',
+    'The configuration parser now gives users clearer errors.',
+    'The adapter layer lets developers add custom providers.',
+  ])(
+    'accepts strong user impact even when mechanism wording is present: %s',
+    (body) => {
+      const facts = extractSourceFacts(
+        makeEntry({ enriched: [makeRef({ body })] }),
+      );
+
+      expect(facts).toHaveLength(1);
+      expect(facts[0]!.userImpact).toBe(body);
+    },
+  );
+
+  it.each([
+    'The refactor lets developers run tests faster.',
+    'The CI build allows developers to run tests.',
+    'Improved code quality.',
+    'Safer release process.',
+    'Cleaner implementation.',
+    'Simpler control flow.',
+    'Faster composition root initialization.',
+    'Cleaner provider implementation.',
+    'Improved provider abstraction.',
+    'Safer configuration loading.',
+    'Faster provider initialization.',
+    'Cleaner provider wiring.',
+  ])('rejects internal maintenance outcomes: %s', (body) => {
+    const facts = extractSourceFacts(
+      makeEntry({ enriched: [makeRef({ body })] }),
+    );
+
+    expect(facts).toEqual([]);
+  });
+
+  it('retains directional resolution while excluding a mechanism title', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            title: 'State machine rewrite for session recovery',
+            body: 'Users can now resume interrupted sessions.',
+          }),
+        ],
+      }),
+    );
+
+    expect(facts).toEqual([
+      expect.objectContaining({
+        title: '',
+        userImpact: 'Users can now resume interrupted sessions.',
+      }),
+    ]);
+  });
+});

--- a/scripts/tests/release-notes/provenance.test.ts
+++ b/scripts/tests/release-notes/provenance.test.ts
@@ -1,0 +1,675 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { extractSourceFacts } from '../../release-notes/provenance.js';
+import type { ChangeEntry, EnrichedRef } from '../../release-notes/types.js';
+
+function makeRef(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 42,
+    title: 'Faster streaming responses',
+    body: 'Users now receive responses without intermittent stalls.',
+    labels: ['feature'],
+    labelsTruncated: false,
+    author: 'alice',
+    isPr: false,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<ChangeEntry> = {}): ChangeEntry {
+  return {
+    id: 'ref:42',
+    subject: 'feat: thing',
+    hash: 'abc',
+    author: 'dev',
+    refs: [],
+    enriched: [makeRef()],
+    category: 'new',
+    eligibleForHighlights: true,
+    childHashes: [],
+    sourceFacts: [],
+    ...overrides,
+  };
+}
+
+describe('extractUserImpact (via extractSourceFacts)', () => {
+  it('extracts a clear user-impact sentence', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users now experience faster streaming responses.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('faster streaming responses');
+  });
+
+  it('skips issue-template heading boilerplate like "Summary Fixes #2208"', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: '## Summary\nFixes #2208\n\nUsers can now configure streaming.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('configure streaming');
+    // The boilerplate "Fixes #2208" must NOT be the impact.
+    expect(facts[0]!.userImpact).not.toContain('Fixes #2208');
+  });
+
+  it('skips "Summary:" section label prefix', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Summary: This is the template summary field.\n\nUsers can now export data.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('export data');
+    expect(facts[0]!.userImpact).not.toContain('template summary field');
+  });
+
+  it('skips closing keywords lines (Fixes #N at line start)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Fixes #1234\n\nUsers benefit from lower latency.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('lower latency');
+    expect(facts[0]!.userImpact).not.toContain('Fixes #1234');
+  });
+
+  it('skips verification/checklist boilerplate until another heading', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '## Verification',
+              'I ran the test suite and it passed.',
+              '',
+              '## Impact',
+              'Users can now use the new feature.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('new feature');
+  });
+
+  it('skips checklist items ([ ] / [x])', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '[x] I have tested this change',
+              '[ ] I have updated the docs',
+              '',
+              'Users see a cleaner interface.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('cleaner interface');
+  });
+
+  it('skips mechanism-only sentences', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'This is an internal refactor for code quality.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('skips mechanism-only line and uses the next defensible line', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              'This adds test coverage for the module.',
+              'Users can now configure providers at runtime.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('configure providers at runtime');
+  });
+
+  it('removes code blocks before parsing', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '```js',
+              'const x = dangerous.statement();',
+              '```',
+              '',
+              'Users can now pin a specific version.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('pin a specific version');
+    expect(facts[0]!.userImpact).not.toContain('dangerous');
+  });
+
+  it('returns empty when body is entirely boilerplate', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: '## Summary\nFixes #2208',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('returns empty when body is empty', () => {
+    const facts = extractSourceFacts(
+      makeEntry({ enriched: [makeRef({ body: '' })] }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('handles a real-world issue template with mixed boilerplate and impact', () => {
+    const realTemplateBody = [
+      '## Summary',
+      'Fixes #2208',
+      '',
+      'Users can now connect Ollama models and run inference locally without external API keys.',
+      '',
+      '## Motivation',
+      'Local model support has been requested by many users.',
+      '',
+      '## Checklist',
+      '- [x] Tests added',
+      '- [x] Docs updated',
+    ].join('\n');
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            title: 'Add Ollama provider support',
+            body: realTemplateBody,
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    // The first defensible impact line (outside boilerplate sections) is used.
+    expect(facts[0]!.userImpact).toContain('Ollama models');
+    expect(facts[0]!.userImpact).not.toContain('Fixes #2208');
+    expect(facts[0]!.userImpact).not.toContain('Checklist');
+  });
+
+  it('does not accept a single-word heading as impact', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [makeRef({ body: '# Summary\n# Description' })],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('uses user-facing evidence from an Expected section', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: '## Expected\nUsers can resume interrupted sessions safely.',
+          }),
+        ],
+      }),
+    );
+    expect(facts[0]?.userImpact).toBe(
+      'Users can resume interrupted sessions safely.',
+    );
+  });
+
+  it('skips "Steps to reproduce" section', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '## Steps to reproduce',
+              '1. Open the app',
+              '2. Click the button',
+              '',
+              '## Impact',
+              'Users now get a confirmation dialog.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('confirmation dialog');
+  });
+
+  it('does not end a hard-suppress boilerplate section on a blank line (only on a heading)', () => {
+    // Verification heading starts a hard-suppress section. A blank line must
+    // NOT end it — only another heading does. The prose after the blank line
+    // is still inside Verification and must be skipped.
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '## Verification',
+              'I ran the test suite and it passed.',
+              '',
+              'This looks like user impact but is inside the verification section.',
+              '',
+              '## Result',
+              'Users benefit from faster startup.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('faster startup');
+    // Must not pick up Verification-section prose.
+    expect(facts[0]!.userImpact).not.toContain('verification section');
+  });
+
+  it('suppresses an implementation provenance section until another heading', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '## Implementation',
+              'Refactored the handler to use a state machine.',
+              'Added comprehensive test coverage.',
+              '',
+              '## Result',
+              'Users experience a 3x faster response time.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('faster response time');
+    expect(facts[0]!.userImpact).not.toContain('state machine');
+  });
+
+  it('suppresses a reproduction section until another heading', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '## Reproduction',
+              'Run the CLI with --verbose to see the error.',
+              '',
+              '## Fix',
+              'Users no longer see spurious error messages.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('spurious error messages');
+    expect(facts[0]!.userImpact).not.toContain('--verbose');
+  });
+
+  it('never selects test/mechanism prose even outside boilerplate sections', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'This adds test coverage for the streaming module.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('suppresses a tilde-fenced code block and recovers subsequent prose', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '~~~ruby',
+              'Users can now run this dangerous command.',
+              '~~~',
+              '',
+              'Users benefit from lower latency.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('lower latency');
+    expect(facts[0]!.userImpact).not.toContain('dangerous');
+  });
+
+  it('suppresses content after an unterminated fence through EOF', () => {
+    for (const opener of ['```', '~~~js']) {
+      const facts = extractSourceFacts(
+        makeEntry({
+          enriched: [
+            makeRef({
+              body: [
+                opener,
+                'Users can now execute malicious code.',
+                'Users no longer see any errors.',
+              ].join('\n'),
+            }),
+          ],
+        }),
+      );
+      expect(facts).toEqual([]);
+    }
+  });
+
+  it('handles interleaved backtick and tilde fences independently', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '```',
+              'Users dangerous one.',
+              '```',
+              '',
+              'Users can now pin a specific model.',
+              '',
+              '~~~',
+              'Users dangerous two.',
+              '~~~',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('pin a specific model');
+  });
+
+  it('requires the closing fence to match the opening character and length', () => {
+    // A tilde fence is not closed by backticks.
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '~~~',
+              'Users dangerous content stays inside.',
+              '```',
+              '',
+              'Users benefit from improved reliability.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it.each([
+    ['blockquote', '> ~~~', '> Users can now run dangerous code.', '> ~~~'],
+    ['list item', '- ~~~', '  Users can now run dangerous code.', '  ~~~'],
+  ])('suppresses a fence nested in a %s', (_name, open, content, close) => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              open,
+              content,
+              close,
+              '',
+              'Users benefit from lower latency.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('lower latency');
+    expect(facts[0]!.userImpact).not.toContain('dangerous');
+  });
+
+  it('handles up to three spaces of indentation before a fence', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: [
+              '   ```',
+              '   Users can now do something dangerous inside indented code.',
+              '   ```',
+              '',
+              'Users see a cleaner interface.',
+            ].join('\n'),
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('cleaner interface');
+    expect(facts[0]!.userImpact).not.toContain('dangerous');
+  });
+});
+
+describe('extractUserImpact — word-boundary adversarial inputs (no substring collisions)', () => {
+  // These tests guard against the `\b` word-boundary contract: the
+  // USER_IMPACT_SIGNALS list contains "fix", "new", "option", "user",
+  // etc. Without word boundaries, "prefix" would match "fix", "renew"
+  // would match "new", "optional" would match "option", and "username"
+  // would match "user" — letting mechanism-only prose masquerade as
+  // user impact. Each adversarial sentence below MUST be rejected.
+  it('rejects "prefix" (fix must not match prefix)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Updated the prefix matcher to avoid false positives in parsing.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "renew" (new must not match renew)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The token renew logic was refactored for internal clarity.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "username" (user must not match username)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'The username field was validated against the internal schema.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('rejects "optional" (option must not match optional)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Made the optional configuration field nullable in the internal model.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('accepts a genuine "fix" sentence (boundary-anchored)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'This fix resolves a crash that users encountered on startup.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('fix resolves a crash');
+  });
+
+  it('accepts a genuine "new" sentence (boundary-anchored)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'A new command lets users inspect the session history.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('new command');
+  });
+
+  it('accepts a genuine "option" sentence (boundary-anchored)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users can now pass an option to control the output format.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('option to control');
+  });
+
+  it('accepts a genuine "user" sentence (boundary-anchored)', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Each user can now pin a specific model for inference.',
+          }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.userImpact).toContain('user can now pin');
+  });
+});
+
+describe('extractSourceFacts — observable user-impact requirement', () => {
+  // A source fact must always carry a non-empty userImpact string; the
+  // observable output contract is that every emitted SourceFact has a
+  // defensible, non-empty userImpact that survives sanitization.
+  it('every emitted fact has a non-empty userImpact', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users can now export conversation history to a file.',
+          }),
+          makeRef({
+            number: 43,
+            body: 'Users can now import conversation history from a file.',
+          }),
+        ],
+      }),
+    );
+    expect(facts.length).toBeGreaterThan(0);
+    for (const fact of facts) {
+      expect(fact.userImpact.length).toBeGreaterThan(0);
+      expect(fact.userImpact.trim()).toBe(fact.userImpact);
+    }
+  });
+
+  it('emits zero facts when no ref carries defensible impact', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({ body: 'Internal refactoring for clarity.' }),
+          makeRef({ number: 43, body: '' }),
+        ],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('emits one fact per ref that carries defensible impact', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [
+          makeRef({
+            body: 'Users can now export conversation history to a file.',
+          }),
+          makeRef({
+            number: 43,
+            body: 'Users can now import conversation history from a file.',
+          }),
+          makeRef({ number: 44, body: 'Internal cleanup only.' }),
+        ],
+      }),
+    );
+    expect(facts).toHaveLength(2);
+    expect(facts[0]!.sourceId).toBe('ref:42');
+    expect(facts[1]!.sourceId).toBe('ref:42');
+    expect(facts[0]!.userImpact).toContain('export');
+    expect(facts[1]!.userImpact).toContain('import');
+  });
+});

--- a/scripts/tests/release-notes/release-metadata-port.test.ts
+++ b/scripts/tests/release-notes/release-metadata-port.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createBoundedReleaseMetadataLookup,
+  createReleaseMetadataPort,
+  createStaticReleaseMetadataPort,
+  MAX_NIGHTLY_CANDIDATES,
+  parseReleaseMetadata,
+} from '../../release-notes/release-metadata-port.js';
+import {
+  nightlyCandidateNames,
+  selectDiffBase,
+  type TagInfo,
+} from '../../release-notes/diff-selection.js';
+import type { ReleaseMetadata } from '../../release-notes/types.js';
+
+const published = (publishedAt: number): ReleaseMetadata => ({
+  status: 'published',
+  publishedAt,
+});
+const absent: ReleaseMetadata = { status: 'confirmed-absent' };
+const unknown: ReleaseMetadata = { status: 'unknown' };
+
+function tag(name: string, createdAt: number): TagInfo {
+  return { name, createdAt };
+}
+
+describe('parseReleaseMetadata', () => {
+  it('models a valid publication timestamp as published', () => {
+    expect(
+      parseReleaseMetadata(
+        JSON.stringify({ publishedAt: '2025-07-14T00:00:00Z' }),
+      ),
+    ).toEqual(published(Date.parse('2025-07-14T00:00:00Z')));
+  });
+
+  it('models an explicit null publication as confirmed absent', () => {
+    expect(parseReleaseMetadata(JSON.stringify({ publishedAt: null }))).toEqual(
+      absent,
+    );
+  });
+
+  it.each([
+    ['missing field', JSON.stringify({})],
+    ['invalid JSON', 'not json'],
+    ['null response', 'null'],
+    ['invalid timestamp', JSON.stringify({ publishedAt: 'not-a-date' })],
+  ])('models %s as unknown', (_label, raw) => {
+    expect(parseReleaseMetadata(raw)).toEqual(unknown);
+  });
+});
+
+describe('ReleaseMetadataPort', () => {
+  it('preserves explicit static states and treats unmapped tags as unknown', async () => {
+    const port = createStaticReleaseMetadataPort(
+      new Map([
+        ['published', published(1000)],
+        ['absent', absent],
+      ]),
+    );
+
+    expect(await port.getReleaseMetadata('published')).toEqual(published(1000));
+    expect(await port.getReleaseMetadata('absent')).toEqual(absent);
+    expect(await port.getReleaseMetadata('unmapped')).toEqual(unknown);
+  });
+
+  it('models runner failures as unknown rather than absent', async () => {
+    const port = createReleaseMetadataPort(() => {
+      throw new Error('network failure');
+    });
+
+    expect(await port.getReleaseMetadata('v1.0.0')).toEqual(unknown);
+  });
+
+  it('passes the tag name to the isolated gh runner', async () => {
+    const calls: string[][] = [];
+    const port = createReleaseMetadataPort((args) => {
+      calls.push([...args]);
+      return JSON.stringify([
+        { tagName: 'v2.0.0', publishedAt: '2025-01-01T00:00:00Z' },
+      ]);
+    });
+
+    await port.getReleaseMetadata('v2.0.0');
+
+    expect(calls).toEqual([
+      ['release', 'list', '--limit', '1000', '--json', 'tagName,publishedAt'],
+    ]);
+  });
+});
+
+describe('createBoundedReleaseMetadataLookup', () => {
+  it('returns undefined when there are no candidates', async () => {
+    const lookup = await createBoundedReleaseMetadataLookup(
+      createStaticReleaseMetadataPort(new Map()),
+      [],
+    );
+
+    expect(lookup).toBeUndefined();
+  });
+
+  it('retains unknown for overflow instead of mixing tag chronology into selection', async () => {
+    const candidates = Array.from(
+      { length: MAX_NIGHTLY_CANDIDATES + 10 },
+      (_, index) => `v0.11.0-nightly.261${String(index).padStart(3, '0')}.x`,
+    );
+    const metadata = new Map<string, ReleaseMetadata>(
+      candidates.map((candidate, index) => [candidate, published(index)]),
+    );
+    const lookup = await createBoundedReleaseMetadataLookup(
+      createStaticReleaseMetadataPort(metadata),
+      candidates,
+    );
+
+    expect(lookup?.(candidates[0]!)).toEqual(published(0));
+    expect(lookup?.(candidates[MAX_NIGHTLY_CANDIDATES]!)).toEqual(unknown);
+  });
+
+  it('loads release metadata once for all bounded candidates', async () => {
+    let calls = 0;
+    const port = createReleaseMetadataPort(() => {
+      calls++;
+      return JSON.stringify([
+        { tagName: 'candidate-75', publishedAt: '2025-01-01T00:00:00Z' },
+      ]);
+    });
+    const candidates = Array.from(
+      { length: 120 },
+      (_, index) => `candidate-${index}`,
+    );
+
+    const lookup = await createBoundedReleaseMetadataLookup(port, candidates);
+
+    expect(calls).toBe(1);
+    expect(lookup?.('candidate-75')).toEqual(published(1735689600000));
+  });
+
+  it('retains a successful retry for the first candidate', async () => {
+    const results = [unknown, published(123), unknown];
+    let calls = 0;
+    const lookup = await createBoundedReleaseMetadataLookup(
+      {
+        async getReleaseMetadata() {
+          return results[calls++] ?? unknown;
+        },
+      },
+      ['candidate'],
+    );
+
+    expect(calls).toBe(2);
+    expect(lookup?.('candidate')).toEqual(published(123));
+  });
+});
+
+describe('bounded nightly publication selection', () => {
+  it('uses publication order rather than tag date or creation time', () => {
+    const current = 'v0.11.0-nightly.260715.current';
+    const olderDate = 'v0.11.0-nightly.260713.older';
+    const newerDate = 'v0.11.0-nightly.260714.newer';
+    const tags = [tag(olderDate, 200), tag(newerDate, 300), tag(current, 400)];
+    const lookup = (candidate: string): ReleaseMetadata =>
+      candidate === olderDate ? published(900) : published(800);
+
+    expect(selectDiffBase(tags, current, true, lookup)).toBe(olderDate);
+  });
+
+  it('never selects a tag confirmed to have no release', () => {
+    const current = 'v0.11.0-nightly.260715.current';
+    const absentTag = 'v0.11.0-nightly.260714.absent';
+    const publishedTag = 'v0.11.0-nightly.260713.published';
+    const lookup = (candidate: string): ReleaseMetadata =>
+      candidate === absentTag ? absent : published(100);
+
+    expect(
+      selectDiffBase(
+        [tag(absentTag, 900), tag(publishedTag, 100), tag(current, 1000)],
+        current,
+        true,
+        lookup,
+      ),
+    ).toBe(publishedTag);
+  });
+
+  it('fails closed when any candidate metadata lookup fails', () => {
+    const current = 'v0.11.0-nightly.260715.current';
+    const failedTag = 'v0.11.0-nightly.260714.failed';
+    const publishedTag = 'v0.11.0-nightly.260713.published';
+    const lookup = (candidate: string): ReleaseMetadata =>
+      candidate === failedTag ? unknown : published(100);
+
+    expect(() =>
+      selectDiffBase(
+        [tag(failedTag, 900), tag(publishedTag, 100), tag(current, 1000)],
+        current,
+        true,
+        lookup,
+      ),
+    ).toThrow('Unable to determine the previous published nightly release');
+  });
+
+  it('cannot select or chronology-mix an overflow tag beyond the lookup bound', async () => {
+    const current = 'v0.11.0-nightly.261070.current';
+    const tags = Array.from({ length: 60 }, (_, index) => {
+      const day = index + 10;
+      return tag(`v0.11.0-nightly.2610${day}.candidate-${day}`, day * 1000);
+    });
+    const candidates = nightlyCandidateNames(
+      [...tags, tag(current, 70_000)],
+      current,
+    );
+    const selected = candidates[10]!;
+    const overflow = candidates[MAX_NIGHTLY_CANDIDATES]!;
+    const metadata = new Map<string, ReleaseMetadata>(
+      candidates.map((candidate) => [candidate, published(1)]),
+    );
+    metadata.set(selected, published(500));
+    metadata.set(overflow, published(10_000));
+    const lookup = await createBoundedReleaseMetadataLookup(
+      createStaticReleaseMetadataPort(metadata),
+      candidates,
+    );
+
+    expect(
+      selectDiffBase([...tags, tag(current, 70_000)], current, true, lookup),
+    ).toBe(selected);
+  });
+});

--- a/scripts/tests/release-notes/rendering.test.ts
+++ b/scripts/tests/release-notes/rendering.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderReleaseNotes } from '../../release-notes/rendering.js';
+import type { ReleaseNotesData } from '../../release-notes/types.js';
+
+function makeData(overrides: Partial<ReleaseNotesData> = {}): ReleaseNotesData {
+  return {
+    releaseTag: 'v0.10.0',
+    highlights: ['New Gemini support', 'Faster startup'],
+    categorized: {
+      new: ['Added Gemini provider'],
+      improvements: ['Improved startup time'],
+      fixes: ['Fixed crash on exit'],
+      breaking: [],
+    },
+    allChanges: [
+      '- feat: add Gemini (abc1234)',
+      '- fix: crash on exit (def5678)',
+    ],
+    contributors: ['alice', 'bob'],
+    lastTag: 'v0.9.0',
+    isFirstRelease: false,
+    comparisonUrl: 'https://github.com/owner/repo/compare/v0.9.0...v0.10.0',
+    curatedHeadline: null,
+    ...overrides,
+  };
+}
+
+describe('renderReleaseNotes', () => {
+  it('includes the release header with tag', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('## Release v0.10.0');
+  });
+
+  it('includes installation instructions', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('### Installation');
+    expect(md).toContain('npm install -g @vybestack/llxprt-code');
+    expect(md).toContain('npx @vybestack/llxprt-code');
+  });
+
+  it('renders highlights section when highlights exist', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('### Highlights');
+    expect(md).toContain('- New Gemini support');
+    expect(md).toContain('- Faster startup');
+  });
+
+  it('renders a safe highlights placeholder when empty', () => {
+    const md = renderReleaseNotes(makeData({ highlights: [] }));
+    expect(md).toContain('### Highlights');
+    expect(md).toContain('No major user-facing changes in this release.');
+  });
+
+  it('renders curated headline before highlights when provided', () => {
+    const md = renderReleaseNotes(
+      makeData({ curatedHeadline: '## Curated headline text' }),
+    );
+    const headlineIndex = md.indexOf('## Curated headline text');
+    const highlightsIndex = md.indexOf('### Highlights');
+    expect(headlineIndex).toBeGreaterThan(-1);
+    expect(headlineIndex).toBeLessThan(highlightsIndex);
+  });
+
+  it('renders categorized New section', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('#### New');
+    expect(md).toContain('- Added Gemini provider');
+  });
+
+  it('renders categorized Improvements section', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('#### Improvements');
+    expect(md).toContain('- Improved startup time');
+  });
+
+  it('renders categorized Fixes section', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('#### Fixes');
+    expect(md).toContain('- Fixed crash on exit');
+  });
+
+  it('omits Breaking changes section when empty', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).not.toContain('#### Breaking changes');
+  });
+
+  it('renders Breaking changes section when populated', () => {
+    const md = renderReleaseNotes(
+      makeData({
+        categorized: {
+          new: [],
+          improvements: [],
+          fixes: [],
+          breaking: ['Removed old API'],
+        },
+      }),
+    );
+    expect(md).toContain('#### Breaking changes');
+    expect(md).toContain('- Removed old API');
+  });
+
+  it('renders contributor thanks section', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('### Thanks');
+    expect(md).toContain('- @alice');
+    expect(md).toContain('- @bob');
+  });
+
+  it('omits thanks section when no contributors', () => {
+    const md = renderReleaseNotes(makeData({ contributors: [] }));
+    expect(md).not.toContain('### Thanks');
+  });
+
+  it('renders All Changes section with raw commits', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('### All Changes');
+    expect(md).toContain('- feat: add Gemini (abc1234)');
+  });
+
+  it('includes comparison link when available', () => {
+    const md = renderReleaseNotes(makeData());
+    expect(md).toContain('**Full Changelog**');
+    expect(md).toContain('compare/v0.9.0...v0.10.0');
+  });
+
+  it('omits comparison link when null', () => {
+    const md = renderReleaseNotes(makeData({ comparisonUrl: null }));
+    expect(md).not.toContain('**Full Changelog**');
+  });
+
+  it('orders sections: Installation, Highlights, categories, All Changes', () => {
+    const md = renderReleaseNotes(makeData());
+    const installIdx = md.indexOf('### Installation');
+    const highlightsIdx = md.indexOf('### Highlights');
+    const newIdx = md.indexOf('#### New');
+    const allChangesIdx = md.indexOf('### All Changes');
+    expect(installIdx).toBeLessThan(highlightsIdx);
+    expect(highlightsIdx).toBeLessThan(newIdx);
+    expect(newIdx).toBeLessThan(allChangesIdx);
+  });
+
+  it('places Thanks after categories and before All Changes', () => {
+    const md = renderReleaseNotes(makeData());
+    const fixesIdx = md.indexOf('#### Fixes');
+    const thanksIdx = md.indexOf('### Thanks');
+    const allChangesIdx = md.indexOf('### All Changes');
+    expect(fixesIdx).toBeLessThan(thanksIdx);
+    expect(thanksIdx).toBeLessThan(allChangesIdx);
+  });
+
+  it('does not contain emojis in hardcoded fixture data', () => {
+    const md = renderReleaseNotes(makeData());
+    const emojiPattern = /[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{27BF}]/u;
+    expect(emojiPattern.test(md)).toBe(false);
+  });
+
+  it('strips emojis from untrusted highlight and bullet input', () => {
+    const md = renderReleaseNotes(
+      makeData({
+        highlights: ['New Gemini support \u{1F680}'],
+        categorized: {
+          new: ['Added Gemini provider \u{1F389}'],
+          improvements: [],
+          fixes: [],
+          breaking: [],
+        },
+      }),
+    );
+    const emojiPattern = /[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{27BF}]/u;
+    expect(emojiPattern.test(md)).toBe(false);
+    expect(md).toContain('New Gemini support');
+    expect(md).toContain('Added Gemini provider');
+  });
+
+  it('strips bidi and zero-width controls from every untrusted render field', () => {
+    const controls = '\u200b\u200c\u202e\u202c\u2066\u2069';
+    const md = renderReleaseNotes(
+      makeData({
+        releaseTag: `v0.10.${controls}0`,
+        highlights: [`Faster${controls} startup`],
+        categorized: {
+          new: [`New${controls} provider`],
+          improvements: [],
+          fixes: [],
+          breaking: [],
+        },
+        allChanges: [`- fix: safe${controls} subject (#42)`],
+        contributors: [`ali${controls}ce`],
+        comparisonUrl: `https://github.com/owner/repo/compare/v0.9.0...v0.10.${controls}0`,
+      }),
+    );
+
+    expect(md).not.toContain(controls);
+    for (const control of controls) {
+      expect(md).not.toContain(control);
+    }
+    expect(md).toContain('## Release v0.10.0');
+    expect(md).toContain('- Faster startup');
+
+    expect(md).toContain('- New provider');
+    expect(md).toContain('- fix: safe subject (#42)');
+    expect(md).not.toContain('@alice');
+    expect(md).not.toContain('Full Changelog');
+  });
+
+  it('preserves emails while neutralizing ambiguous mention forms', () => {
+    const md = renderReleaseNotes(
+      makeData({
+        highlights: [
+          'Contact contact@example.com, not .@octocat, +@github, or .@octocat.com',
+        ],
+        categorized: {
+          new: ['Notify +@github.com'],
+          improvements: [],
+          fixes: [],
+          breaking: [],
+        },
+        allChanges: ['- fix: notify +@github (abc1234)'],
+      }),
+    );
+
+    expect(md).toContain('contact@example.com');
+    expect(md).not.toContain('@octocat');
+    expect(md).not.toContain('@github');
+  });
+
+  it('neutralizes invalid email domains with consecutive dots', () => {
+    const md = renderReleaseNotes(
+      makeData({ highlights: ['Contact foo@bar..com for support.'] }),
+    );
+
+    expect(md).not.toContain('foo@bar..com');
+  });
+
+  it('neutralizes malformed email domains with trailing separators', () => {
+    const md = renderReleaseNotes(
+      makeData({ highlights: ['Contact foo@example.com- for support.'] }),
+    );
+
+    expect(md).not.toContain('@example.com-');
+  });
+  it('bounds large release bodies while preserving the comparison URL', () => {
+    const allChanges = Array.from(
+      { length: 1_200 },
+      (_, index) => `- feat: ${'x'.repeat(200)} ${index}`,
+    );
+    const comparisonUrl =
+      'https://github.com/owner/repo/compare/v0.9.0...v0.10.0';
+
+    const md = renderReleaseNotes(makeData({ allChanges, comparisonUrl }));
+
+    expect(Buffer.byteLength(md, 'utf8')).toBeLessThanOrEqual(120_000);
+    expect(md).toContain('Additional details omitted');
+    expect(md).toContain('### All Changes');
+    expect(md).toContain('- feat:');
+    expect(md).toContain(comparisonUrl);
+  });
+});

--- a/scripts/tests/release-notes/validation.test.ts
+++ b/scripts/tests/release-notes/validation.test.ts
@@ -1,0 +1,408 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildDeterministicFallback,
+  entriesToCategorizedBullets,
+  validateHighlights,
+  validateLlmOutput,
+} from '../../release-notes/validation.js';
+import {
+  buildHighlightsFromSelection,
+  extractSourceFacts,
+} from '../../release-notes/provenance.js';
+import type { ChangeEntry, EnrichedRef } from '../../release-notes/types.js';
+import { renderReleaseNotes } from '../../release-notes/rendering.js';
+
+function makeRef(overrides: Partial<EnrichedRef> = {}): EnrichedRef {
+  return {
+    number: 42,
+    title: 'Faster streaming responses',
+    body: 'Users now receive responses without intermittent stalls.',
+    labels: ['bug'],
+    labelsTruncated: false,
+    author: 'alice',
+    isPr: false,
+    userImpact: null,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<ChangeEntry> = {}): ChangeEntry {
+  const entry = {
+    id: 'ref:42',
+    subject: 'feat: mechanism details',
+    hash: 'abcdef0',
+    author: 'dev',
+    refs: [],
+    enriched: [makeRef()],
+    category: 'new' as const,
+    eligibleForHighlights: true,
+    childHashes: [],
+    sourceFacts: [],
+    ...overrides,
+  };
+  return {
+    ...entry,
+    sourceFacts: overrides.sourceFacts ?? extractSourceFacts(entry),
+  };
+}
+
+function sourceIdsOutput(sourceIds: readonly string[]): string {
+  return JSON.stringify({ sourceIds });
+}
+
+describe('validateLlmOutput', () => {
+  it('accepts a valid sourceIds array', () => {
+    expect(
+      validateLlmOutput(sourceIdsOutput(['ref:42', 'ref:43'])),
+    ).not.toBeNull();
+    expect(
+      validateLlmOutput(sourceIdsOutput(['ref:42', 'ref:43']))?.sourceIds,
+    ).toEqual(['ref:42', 'ref:43']);
+  });
+
+  it('accepts an empty sourceIds array', () => {
+    expect(validateLlmOutput(sourceIdsOutput([]))?.sourceIds).toEqual([]);
+  });
+
+  it('rejects legacy free-form highlights array (no sourceIds field)', () => {
+    expect(
+      validateLlmOutput(
+        JSON.stringify({
+          highlights: [
+            { sourceId: 'ref:42', text: 'Streaming no longer stalls' },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    '{not json',
+    JSON.stringify({ new: [] }),
+    JSON.stringify({ sourceIds: 'ref:42' }),
+    JSON.stringify({ sourceIds: [123] }),
+  ])('rejects malformed or invalid JSON: %s', (raw) => {
+    expect(validateLlmOutput(raw)).toBeNull();
+  });
+
+  it('accepts fenced JSON with sourceIds', () => {
+    expect(
+      validateLlmOutput(`\`\`\`json\n${sourceIdsOutput(['ref:42'])}\n\`\`\``),
+    ).not.toBeNull();
+  });
+});
+
+describe('validateHighlights', () => {
+  it('accepts eligible source IDs and returns the validated selection', () => {
+    expect(validateHighlights(['ref:42'], [makeEntry()])).toEqual(['ref:42']);
+  });
+
+  it('rejects unknown, ineligible, or duplicate source IDs', () => {
+    expect(validateHighlights(['ref:99'], [makeEntry()])).toBeNull();
+    expect(
+      validateHighlights(
+        ['ref:42'],
+        [makeEntry({ eligibleForHighlights: false })],
+      ),
+    ).toBeNull();
+    expect(validateHighlights(['ref:42', 'ref:42'], [makeEntry()])).toBeNull();
+  });
+
+  it('requires three source IDs when at least three eligible entries exist', () => {
+    const entries = [1, 2, 3].map((number) =>
+      makeEntry({ id: `ref:${number}` }),
+    );
+    expect(validateHighlights(['ref:1'], entries)).toBeNull();
+  });
+
+  it('builds deterministic highlight prose from validated source facts', () => {
+    const entries = [makeEntry()];
+    const validated = validateHighlights(['ref:42'], entries);
+    expect(validated).not.toBeNull();
+    const highlights = buildHighlightsFromSelection(validated!, entries);
+    expect(highlights).toEqual([
+      'Faster streaming responses: Users now receive responses without intermittent stalls.',
+    ]);
+  });
+
+  it('omits highlights when the selected entry has only mechanism-only impact', () => {
+    const entries = [
+      makeEntry({
+        enriched: [makeRef({ body: 'Internal refactor for code quality.' })],
+      }),
+    ];
+    const validated = validateHighlights(['ref:42'], entries);
+    // Mechanism-only impact means no eligible IDs → selection is invalid.
+    expect(validated).toBeNull();
+  });
+
+  it('omits highlights when the selected entry has no defensible sentence', () => {
+    const entries = [makeEntry({ enriched: [makeRef({ body: '' })] })];
+    const validated = validateHighlights(['ref:42'], entries);
+    expect(validated).toBeNull();
+  });
+});
+
+describe('extractSourceFacts', () => {
+  it('produces defensible facts from enriched user impact', () => {
+    const facts = extractSourceFacts(makeEntry());
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.sourceId).toBe('ref:42');
+    expect(facts[0]!.title).toBe('Faster streaming responses');
+    expect(facts[0]!.userImpact).toContain(
+      'Users now receive responses without intermittent stalls',
+    );
+  });
+
+  it('returns empty when the body is mechanism-only', () => {
+    const facts = extractSourceFacts(
+      makeEntry({
+        enriched: [makeRef({ body: 'Internal refactor for code quality.' })],
+      }),
+    );
+    expect(facts).toEqual([]);
+  });
+
+  it('returns empty when the body has no defensible sentence', () => {
+    const facts = extractSourceFacts(
+      makeEntry({ enriched: [makeRef({ body: '' })] }),
+    );
+    expect(facts).toEqual([]);
+  });
+});
+
+describe('deterministic rendering data', () => {
+  it('builds user-impact fallback highlights from enriched title and body', () => {
+    const result = buildDeterministicFallback([makeEntry()]);
+    expect(result.highlights).toEqual([
+      'Faster streaming responses: Users now receive responses without intermittent stalls.',
+    ]);
+    expect(result.highlights[0]).not.toContain('feat: mechanism');
+  });
+
+  it('omits fallback highlights without enriched impact', () => {
+    const result = buildDeterministicFallback([
+      makeEntry({ enriched: [makeRef({ body: '' })] }),
+      makeEntry({
+        id: 'ref:99',
+        eligibleForHighlights: false,
+        enriched: [makeRef({ body: 'Internal implementation changed.' })],
+      }),
+    ]);
+    expect(result.highlights).toEqual([]);
+  });
+
+  it('uses enriched titles in categorized details and omits internal entries', () => {
+    const bullets = entriesToCategorizedBullets([
+      makeEntry(),
+      makeEntry({
+        id: 'commit:2',
+        category: 'fix',
+        enriched: [makeRef({ title: 'Crash-free startup' })],
+      }),
+      makeEntry({
+        id: 'commit:3',
+        category: 'internal',
+        enriched: [
+          makeRef({ number: 3, title: 'Internal change', labels: [] }),
+        ],
+      }),
+    ]);
+    expect(bullets.new).toEqual(['Faster streaming responses']);
+    expect(bullets.fixes).toEqual(['Crash-free startup']);
+    expect(bullets.improvements).toEqual([]);
+  });
+
+  it('omits internal-labeled entries from prominent categories (not just highlights)', () => {
+    // A feat: commit with a Code Quality label must be demoted from New.
+    const bullets = entriesToCategorizedBullets([
+      makeEntry({
+        category: 'new',
+        enriched: [makeRef({ labels: ['Code Quality', 'Modularization'] })],
+      }),
+      makeEntry({
+        id: 'ref:99',
+        category: 'fix',
+        enriched: [makeRef({ number: 99, labels: ['bug'] })],
+      }),
+    ]);
+    expect(bullets.new).toEqual([]);
+    expect(bullets.fixes).toEqual(['Faster streaming responses']);
+  });
+});
+
+describe('deriveEffectiveCategory — promoting-label categorized rendering', () => {
+  it('promotes an internal-prefix commit tagged feature into New', () => {
+    const bullets = entriesToCategorizedBullets([
+      makeEntry({
+        subject: 'refactor: internal cleanup',
+        category: 'internal',
+        enriched: [makeRef({ labels: ['feature'] })],
+      }),
+    ]);
+    expect(bullets.new).toEqual(['Faster streaming responses']);
+    expect(bullets.improvements).toEqual([]);
+  });
+
+  it('promotes an internal-prefix commit tagged bug into Fixes', () => {
+    const bullets = entriesToCategorizedBullets([
+      makeEntry({
+        subject: 'refactor: internal cleanup',
+        category: 'internal',
+        enriched: [makeRef({ labels: ['bug'] })],
+      }),
+    ]);
+    expect(bullets.fixes).toEqual(['Faster streaming responses']);
+    expect(bullets.new).toEqual([]);
+  });
+
+  it('promotes an internal-prefix commit tagged ux into Improvements', () => {
+    const bullets = entriesToCategorizedBullets([
+      makeEntry({
+        subject: 'refactor: internal cleanup',
+        category: 'internal',
+        enriched: [makeRef({ labels: ['ux'] })],
+      }),
+    ]);
+    expect(bullets.improvements).toEqual(['Faster streaming responses']);
+    expect(bullets.new).toEqual([]);
+  });
+
+  it('internal label overrides promoting label in categorized rendering', () => {
+    const bullets = entriesToCategorizedBullets([
+      makeEntry({
+        category: 'new',
+        enriched: [makeRef({ labels: ['feature', 'tech-debt'] })],
+      }),
+    ]);
+    expect(bullets.new).toEqual([]);
+    expect(bullets.improvements).toEqual([]);
+    expect(bullets.fixes).toEqual([]);
+    expect(bullets.breaking).toEqual([]);
+  });
+
+  it('preserves original category when promoting label is lower-signal', () => {
+    // A feat commit with a 'bug' promoting label stays in New, not demoted
+    // to Fixes.
+    const bullets = entriesToCategorizedBullets([
+      makeEntry({
+        subject: 'feat: add streaming',
+        category: 'new',
+        enriched: [makeRef({ labels: ['bug'] })],
+      }),
+    ]);
+    expect(bullets.new).toEqual(['Faster streaming responses']);
+    expect(bullets.fixes).toEqual([]);
+  });
+
+  it('renders promoted category in full release notes output', () => {
+    const entries: ChangeEntry[] = [
+      makeEntry({
+        subject: 'refactor: internal cleanup',
+        category: 'internal',
+        enriched: [makeRef({ labels: ['feature'] })],
+      }),
+    ];
+    const fallback = buildDeterministicFallback(entries);
+    const md = renderReleaseNotes({
+      releaseTag: 'v1.0.0',
+      highlights: fallback.highlights,
+      categorized: fallback.categorized,
+      allChanges: [],
+      contributors: [],
+      lastTag: 'v0.9.0',
+      isFirstRelease: false,
+      comparisonUrl: null,
+      curatedHeadline: null,
+    });
+    expect(md).toContain('#### New');
+    expect(md).toContain('Faster streaming responses');
+    expect(md).not.toContain('#### Improvements');
+  });
+
+  it('renders demoted internal-label entry in no prominent section', () => {
+    const entries: ChangeEntry[] = [
+      makeEntry({
+        subject: 'feat: add streaming',
+        category: 'new',
+        enriched: [makeRef({ labels: ['feature', 'cleanup'] })],
+      }),
+    ];
+    const fallback = buildDeterministicFallback(entries);
+    const md = renderReleaseNotes({
+      releaseTag: 'v1.0.0',
+      highlights: fallback.highlights,
+      categorized: fallback.categorized,
+      allChanges: [],
+      contributors: [],
+      lastTag: 'v0.9.0',
+      isFirstRelease: false,
+      comparisonUrl: null,
+      curatedHeadline: null,
+    });
+    expect(md).not.toContain('#### New');
+    expect(md).not.toContain('#### Improvements');
+    expect(md).not.toContain('#### Fixes');
+  });
+
+  it('processes multiple entries with mixed labels in full pipeline', async () => {
+    const { buildChangeEntries } = await import(
+      '../../release-notes/processing.js'
+    );
+    const commits = [
+      {
+        hash: 'aaa1111',
+        subject: 'refactor: internal cleanup (#10)',
+        author: 'dev',
+        isMerge: false,
+        parents: [] as readonly string[],
+      },
+      {
+        hash: 'bbb2222',
+        subject: 'chore: reorganize tooling (#20)',
+        author: 'dev',
+        isMerge: false,
+        parents: [] as readonly string[],
+      },
+    ];
+    const fakeGh = {
+      async fetchRefs() {
+        return new Map<number, EnrichedRef>([
+          [
+            10,
+            makeRef({
+              number: 10,
+              title: 'Internal cleanup with feature tag',
+              labels: ['feature'],
+              isPr: true,
+            }),
+          ],
+          [
+            20,
+            makeRef({
+              number: 20,
+              title: 'Update dependencies',
+              labels: ['tech-debt'],
+              isPr: true,
+            }),
+          ],
+        ]);
+      },
+    };
+    const entries = await buildChangeEntries(commits, fakeGh);
+    // Entry #10: internal-prefix commit with feature promoting label → new
+    const entry10 = entries.find((e) => e.id === 'ref:10')!;
+    expect(entry10.category).toBe('new');
+    expect(entry10.eligibleForHighlights).toBe(true);
+    // Entry #20: chore-prefix commit with tech-debt internal label → internal
+    const entry20 = entries.find((e) => e.id === 'ref:20')!;
+    expect(entry20.category).toBe('internal');
+    expect(entry20.eligibleForHighlights).toBe(false);
+  });
+});

--- a/scripts/tests/release-process.test.js
+++ b/scripts/tests/release-process.test.js
@@ -131,6 +131,32 @@ describe('scripts/version.ts', () => {
 
 describe('.github/workflows/release.yml', () => {
   const releaseYml = readRootFile('.github/workflows/release.yml');
+  const releaseSteps = yaml.load(releaseYml).jobs.release.steps;
+  const stepById = (id) =>
+    releaseSteps.find((s) => s.id === id) ??
+    expect.fail(`missing step id: ${id}`);
+  const stepByName = (name) =>
+    releaseSteps.find((s) => s.name === name) ??
+    expect.fail(`missing step: ${name}`);
+
+  it('selects keys before standard release notes without blocking skipped-test fallback', () => {
+    const quota = stepById('quota');
+    const releaseNotes = stepByName('Generate Release Notes');
+    const quotaIndex = releaseSteps.indexOf(quota);
+    const releaseNotesIndex = releaseSteps.indexOf(releaseNotes);
+    expect(quota.if.replace(/\s+/g, ' ').trim()).toBe(
+      "github.event.inputs.force_skip_tests != 'true' || (github.event.inputs.dry_run != 'true' && github.event.inputs.publish_vscode_only != 'true')",
+    );
+    expect(quotaIndex >= 0 && releaseNotesIndex > quotaIndex).toBe(true);
+    expect(quota['continue-on-error']).toBe(
+      "${{ github.event.inputs.force_skip_tests == 'true' }}",
+    );
+    expect(quota.run).toBe('node scripts/ci-quota-check.js');
+    expect(releaseNotes.env.OPENAI_API_KEY).toContain(
+      "steps.quota.outputs.selected_key == 'secondary'",
+    );
+    expect(quota.env.OPENAI_API_KEY).toBe('${{ secrets[vars.KEY_VAR_NAME] }}');
+  });
 
   it('publishes every npm release package', () => {
     for (const packageName of npmReleasePackages()) {

--- a/scripts/tests/workflow-quota-selection.test.js
+++ b/scripts/tests/workflow-quota-selection.test.js
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+
+function readWorkflow(name) {
+  return yaml.load(
+    fs.readFileSync(path.join(ROOT, '.github/workflows', name), 'utf-8'),
+  );
+}
+
+function selectedKeyExpression(stepId, migrationFallback = false) {
+  const fallback = migrationFallback ? 'env.OPENAI_API_KEY || ' : '';
+  return `\${{ steps.${stepId}.outputs.selected_key == 'primary' && secrets[vars.KEY_VAR_NAME] || steps.${stepId}.outputs.selected_key == 'secondary' && secrets[vars.KEY_VAR_NAME_2] || ${fallback}'' }}`;
+}
+
+function stepNamed(steps, name) {
+  return (
+    steps.find((step) => step.name === name) ??
+    expect.fail(`missing step: ${name}`)
+  );
+}
+
+/**
+ * Structurally verifies the trusted-ref and PR-code-checkout steps for a
+ * single E2E job. The trusted checkout ref must cover BOTH pull_request
+ * and pull_request_target. After quota selection, the PR code must be
+ * checked out via two mutually-exclusive conditional steps — fork head
+ * for pull_request_target and merge ref for pull_request — each with
+ * persist-credentials:false.
+ */
+function assertJobCheckoutSecurity(steps, quotaName, quotaId) {
+  const trustedCheckout = stepNamed(steps, 'Checkout trusted quota selector');
+  const quota = stepNamed(steps, quotaName);
+  const forkCheckout = stepNamed(steps, 'Checkout PR head (fork)');
+  const internalCheckout = stepNamed(steps, 'Checkout PR merge ref (internal)');
+
+  expect(quota.id).toBe(quotaId);
+
+  // Trusted checkout ref must use base.sha for BOTH PR event types.
+  const trustedRef = trustedCheckout.with.ref;
+  expect(trustedRef).toContain("github.event_name == 'pull_request'");
+  expect(trustedRef).toContain("github.event_name == 'pull_request_target'");
+  expect(trustedRef).toContain('github.event.pull_request.base.sha');
+  // Non-PR events must fall back to dispatch input or github.ref.
+  expect(trustedRef).toContain('github.event.inputs.branch_ref');
+  expect(trustedRef).toContain('github.ref');
+
+  // Fork PR head checkout: only for pull_request_target.
+  expect(forkCheckout.if).toBe("github.event_name == 'pull_request_target'");
+  expect(forkCheckout.with.ref).toBe(
+    '${{ github.event.pull_request.head.sha }}',
+  );
+  expect(forkCheckout.with.repository).toBe(
+    '${{ github.event.pull_request.head.repo.full_name }}',
+  );
+  expect(forkCheckout.with['persist-credentials']).toBe(false);
+
+  // Internal PR merge-ref checkout: only for pull_request.
+  expect(internalCheckout.if).toBe("github.event_name == 'pull_request'");
+  expect(internalCheckout.with.ref).toBe('${{ github.ref }}');
+  expect(internalCheckout.with['persist-credentials']).toBe(false);
+  expect(internalCheckout.with.clean).toBe(false);
+
+  // Ordering: trusted → quota → fork/internal checkouts.
+  const idxTrusted = steps.indexOf(trustedCheckout);
+  const idxQuota = steps.indexOf(quota);
+  const idxFork = steps.indexOf(forkCheckout);
+  const idxInternal = steps.indexOf(internalCheckout);
+
+  expect(idxTrusted).toBeLessThan(idxQuota);
+  expect(idxQuota).toBeLessThan(idxFork);
+  expect(idxQuota).toBeLessThan(idxInternal);
+}
+
+describe('quota-selected workflow credentials', () => {
+  it('maps Linux and macOS E2E quota outputs into validation and test steps', () => {
+    const workflow = readWorkflow('e2e.yml');
+    expect(workflow.permissions).toEqual({
+      actions: 'read',
+      contents: 'read',
+    });
+    const cases = [
+      {
+        steps: workflow.jobs.e2e_linux.steps,
+        quotaName: 'Check API quota and select optimal key',
+        quotaId: 'quota',
+        validationName: 'Validate E2E provider environment (Linux)',
+        testName: 'Run E2E tests',
+      },
+      {
+        steps: workflow.jobs.e2e_mac.steps,
+        quotaName: 'Check API quota and select optimal key (macOS)',
+        quotaId: 'quota_macos',
+        validationName: 'Validate E2E provider environment (macOS)',
+        testName: 'Run E2E tests (non-Windows)',
+      },
+    ];
+
+    for (const testCase of cases) {
+      assertJobCheckoutSecurity(
+        testCase.steps,
+        testCase.quotaName,
+        testCase.quotaId,
+      );
+
+      const quota = stepNamed(testCase.steps, testCase.quotaName);
+      const validation = stepNamed(testCase.steps, testCase.validationName);
+      const tests = stepNamed(testCase.steps, testCase.testName);
+
+      expect(validation.env.OPENAI_API_KEY).toBe(
+        selectedKeyExpression(testCase.quotaId, true),
+      );
+      expect(tests.env.OPENAI_API_KEY).toBe(
+        selectedKeyExpression(testCase.quotaId, true),
+      );
+      expect(validation.env.OPENAI_API_KEY_2).toBeUndefined();
+      expect(tests.env.OPENAI_API_KEY_2).toBeUndefined();
+
+      // Quota must precede validation and test steps.
+      expect(testCase.steps.indexOf(quota)).toBeLessThan(
+        testCase.steps.indexOf(validation),
+      );
+      expect(testCase.steps.indexOf(quota)).toBeLessThan(
+        testCase.steps.indexOf(tests),
+      );
+    }
+  });
+
+  it('maps only the selected PR-review key into the LLxprt invocation', () => {
+    const job = readWorkflow('pr-review.yml').jobs.review;
+    const quota = stepNamed(
+      job.steps,
+      'Check API quota and select optimal key',
+    );
+    const review = stepNamed(job.steps, 'Run LLxprt review');
+    expect(quota.id).toBe('quota');
+    expect(review.env.OPENAI_API_KEY).toBe(selectedKeyExpression('quota'));
+    expect(review.env.OPENAI_API_KEY_2).toBeUndefined();
+    expect(job.env.OPENAI_API_KEY).toBeUndefined();
+    expect(job.env.OPENAI_API_KEY_2).toBeUndefined();
+    expect(job.steps.indexOf(quota)).toBeLessThan(job.steps.indexOf(review));
+  });
+});

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -32,6 +32,7 @@
     "scripts/generate-settings-doc.ts",
     "scripts/generate-settings-schema.ts",
     "scripts/generate_prompt_manifest.ts",
+    "scripts/generate-release-notes.ts",
     "scripts/genai-import-inventory.ts",
     "scripts/genai-enclave/**/*.ts",
     "scripts/get-release-version.ts",
@@ -41,6 +42,7 @@
     "scripts/start.ts",
     "scripts/telemetry.ts",
     "scripts/utils/**/*.ts",
+    "scripts/release-notes/**/*.ts",
     "scripts/version.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- replace inline release-note shell logic with a deterministic TypeScript pipeline grounded in Git history and validated GitHub metadata
- preserve classic, nested, and octopus merge provenance while bounding and retrying GitHub enrichment and release-metadata calls
- derive user-facing highlights only from immutable source facts, with isolated model selection restricted to source IDs and an explicit deny-all tool policy
- fail closed when metadata is unavailable, ambiguous, truncated, or incomplete rather than promoting unverifiable changes
- sanitize untrusted Markdown, links, Unicode controls, emoji, mentions, email-like text, and contributor identities before bounded rendering
- preserve immutable release-source fidelity and gate publication on successful release-note generation
- select quota-verified credentials without writing secrets to workflow environment/output files or silently falling back to an unselected secret
- add behavioral coverage for governance, quota boundaries, topology, provenance, rendering, metadata completeness, process noise, and workflow invariants

## Verification

- full npm test suite passed
- full npm lint passed
- npm format passed
- full build passed
- serial post-build typecheck passed
- actionlint passed for the release workflow
- git diff check passed
- Ollama smoke test passed using the repository Bun entry point and ollamakimi profile
- focused post-review regression suite: 152 tests passed
- Open Code Review completed over all 35 final workspace files, including every changed test; all 16 comments were evaluated and valid correctness findings were remediated
- independent review identified the explicit-empty tool allowlist security defect; it was fixed across CLI, agent, runtime, and registry paths with behavioral coverage

Fixes #2288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notes are now generated by an automated pipeline with curated headlines, categorized highlights, contributor acknowledgements, safer markdown rendering, and optional comparison links.
* **Bug Fixes**
  * Explicitly empty tool allowlists are preserved for correct tool governance.
  * Profile tool allowlists are no longer unintentionally reapplied after governance decisions.
* **Chores**
  * CI workflows now use a trusted quota-selection step with tightened permissions; E2E and review steps dynamically use the selected API capacity, and the release job timeout was set.
* **Tests**
  * Expanded coverage for quota-selection workflow wiring and the release-notes generation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->