### PR TITLE
Harden subagent review follow-ups (Fixes #2472)

### DIFF
--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -122,6 +122,7 @@ export class StreamProcessor {
     private readonly flushAuthScope: typeof flushRuntimeAuthScope = flushRuntimeAuthScope,
   ) {}
 
+  /** Tracks tool responses already recorded during eager client streaming. */
   markToolResponsesRecorded(callIds: readonly string[]): void {
     for (const callId of callIds) {
       if (typeof callId === 'string' && callId.length > 0) {

--- a/packages/agents/src/core/subagentSettingsAccess.test.ts
+++ b/packages/agents/src/core/subagentSettingsAccess.test.ts
@@ -7,7 +7,12 @@
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { expandTilde } from './subagentSettingsAccess.js';
+import {
+  expandTilde,
+  getNumberSetting,
+  getStringSetting,
+  getStringArraySetting,
+} from './subagentSettingsAccess.js';
 
 describe('subagentSettingsAccess expandTilde', () => {
   it('expands leading tilde followed by a Windows separator', () => {
@@ -41,5 +46,33 @@ describe('subagentSettingsAccess expandTilde', () => {
 
   it('returns an empty string unchanged', () => {
     expect(expandTilde('')).toBe('');
+  });
+});
+
+describe('getSetting helpers with undefined settings (Issue #2472)', () => {
+  it('getNumberSetting returns undefined', () => {
+    expect(getNumberSetting(undefined, ['temperature'])).toBeUndefined();
+  });
+
+  it('getStringSetting returns undefined', () => {
+    expect(getStringSetting(undefined, ['auth-key'])).toBeUndefined();
+  });
+
+  it('getStringArraySetting returns undefined', () => {
+    expect(getStringArraySetting(undefined, ['tools.allowed'])).toBeUndefined();
+  });
+});
+
+describe('getSetting helpers with null settings (Issue #2472)', () => {
+  it('getNumberSetting returns undefined for null', () => {
+    expect(getNumberSetting(null, ['temperature'])).toBeUndefined();
+  });
+
+  it('getStringSetting returns undefined for null', () => {
+    expect(getStringSetting(null, ['auth-key'])).toBeUndefined();
+  });
+
+  it('getStringArraySetting returns undefined for null', () => {
+    expect(getStringArraySetting(null, ['tools.allowed'])).toBeUndefined();
   });
 });

--- a/packages/agents/src/core/subagentSettingsAccess.ts
+++ b/packages/agents/src/core/subagentSettingsAccess.ts
@@ -7,10 +7,13 @@
 import { expandTildePath } from '@vybestack/llxprt-code-core';
 import type { Profile } from '@vybestack/llxprt-code-settings';
 
-type EphemeralSettings = Profile['ephemeralSettings'];
+type EphemeralSettings = Profile['ephemeralSettings'] | null | undefined;
 
 /** Reads a raw ephemeral setting value by key. */
 function getSetting(settings: EphemeralSettings, key: string): unknown {
+  if (settings === null || settings === undefined) {
+    return undefined;
+  }
   const values = settings as unknown as Record<string, unknown>;
   return values[key];
 }

--- a/packages/agents/src/core/subagentSettingsPopulation.test.ts
+++ b/packages/agents/src/core/subagentSettingsPopulation.test.ts
@@ -160,6 +160,67 @@ describe('populatePreActivationSettings and populatePostActivationSettings', () 
     }
   });
 
+  it('logs the resolved path (not the raw relative path) when keyfile is missing', () => {
+    const service = createRuntimeSettingsService();
+    const warn = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'subagent-keyfile-'));
+    const missingKeyfile = path.join(tempDir, 'nonexistent-key.txt');
+    const relativeKeyfile = path.relative(process.cwd(), missingKeyfile);
+    const profile = createProfile({ 'auth-keyfile': relativeKeyfile });
+
+    try {
+      populatePreActivationSettings(
+        service,
+        profile,
+        'relative-missing-keyfile-profile',
+      );
+      populatePostActivationSettings(
+        service,
+        profile,
+        'relative-missing-keyfile-profile',
+        new Set(),
+      );
+
+      expect(warn).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(missingKeyfile),
+      );
+    } finally {
+      warn.mockRestore();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('logs the resolved path when keyfile exists but is empty', () => {
+    const warn = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'subagent-keyfile-'));
+
+    try {
+      const emptyKeyfile = path.join(tempDir, 'empty-key.txt');
+      fs.writeFileSync(emptyKeyfile, '', 'utf8');
+      const relativeKeyfile = path.relative(process.cwd(), emptyKeyfile);
+      const profile = createProfile({ 'auth-keyfile': relativeKeyfile });
+      const service = createRuntimeSettingsService();
+      populatePreActivationSettings(
+        service,
+        profile,
+        'relative-empty-keyfile-profile',
+      );
+      populatePostActivationSettings(
+        service,
+        profile,
+        'relative-empty-keyfile-profile',
+        new Set(),
+      );
+
+      expect(warn).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(emptyKeyfile),
+      );
+    } finally {
+      warn.mockRestore();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('populates auth-key-name in both generic and provider-scoped settings', () => {
     const service = createRuntimeSettingsService();
     const profile = createProfile({ 'auth-key-name': 'MY_API_KEY' });

--- a/packages/agents/src/core/subagentSettingsPopulation.ts
+++ b/packages/agents/src/core/subagentSettingsPopulation.ts
@@ -198,8 +198,8 @@ function tryLoadApiKeyFromKeyfile(
   expandedKeyfile: string,
   service: SettingsService,
 ): void {
+  const resolvedPath = path.resolve(expandedKeyfile);
   try {
-    const resolvedPath = path.resolve(expandedKeyfile);
     // This stays synchronous because subagent settings population runs inside a
     // synchronous runtime-initialization path; main provider activation uses the
     // same warning/fallback keyfile semantics before this isolated settings copy
@@ -210,12 +210,12 @@ function tryLoadApiKeyFromKeyfile(
       service.set(`providers.${provider}.auth-key`, content);
     } else {
       debugLogger.warn(
-        `SubagentOrchestrator: auth key file '${expandedKeyfile}' is empty`,
+        `SubagentOrchestrator: auth key file '${resolvedPath}' is empty`,
       );
     }
   } catch (error) {
     debugLogger.warn(
-      `SubagentOrchestrator: unable to read auth key file '${expandedKeyfile}': ${
+      `SubagentOrchestrator: unable to read auth key file '${resolvedPath}': ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
@@ -351,8 +351,9 @@ function populateGeneralEphemerals(
 ): void {
   const ephemerals = profile.ephemeralSettings as
     | Record<string, unknown>
+    | null
     | undefined;
-  if (ephemerals === undefined) {
+  if (ephemerals === null || ephemerals === undefined) {
     return;
   }
   for (const [key, value] of Object.entries(ephemerals)) {

--- a/packages/agents/src/core/subagentToolProcessing.test.ts
+++ b/packages/agents/src/core/subagentToolProcessing.test.ts
@@ -268,7 +268,7 @@ describe('subagentToolProcessing', () => {
       expect(output.final_message.trim().toLowerCase()).not.toBe('none');
     });
 
-    it('should preserve literal "None" as a meaningful goal answer without emitted vars', () => {
+    it('should preserve literal "None" as a meaningful goal answer without emitted vars (Issue #2410)', () => {
       const output: OutputObject = {
         emitted_vars: {},
         terminate_reason: SubagentTerminateMode.GOAL,

--- a/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
+++ b/packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts
@@ -37,6 +37,10 @@ const agentState = vi.hoisted(() => ({
   events: [] as AgentEvent[],
 }));
 
+// Activation params (_profileModelParams, _cliModelParams, _bootstrapArgs) have
+// no public setter API on Config — production code reads/writes them via the
+// same underscore-prefixed casts. This local non-readonly intersection mirrors
+// those casts so the test can stage activation state.
 type ConfigWithActivationParams = Config & {
   _profileModelParams?: Record<string, unknown>;
   _cliModelParams?: Record<string, unknown>;

--- a/packages/cli/src/ui/commands/diagnosticsCommand.edges.spec.ts
+++ b/packages/cli/src/ui/commands/diagnosticsCommand.edges.spec.ts
@@ -382,8 +382,7 @@ describe('diagnosticsCommand OAuth token display (edges)', () => {
 
       expect(content).toContain('auth-key:');
       expect(content).not.toContain('sk-abcdefghijklmnop');
-      // Should show first 4 + masked middle + last 4
-      expect(content).toContain('sk-a***********mnop');
+      expect(content).toContain('[REDACTED]');
     });
 
     it('does not mask auth-keyfile value (just a file path)', async () => {

--- a/packages/cli/src/ui/commands/diagnosticsCommand.ts
+++ b/packages/cli/src/ui/commands/diagnosticsCommand.ts
@@ -18,7 +18,10 @@ import { DebugLogger } from '@vybestack/llxprt-code-telemetry';
 import type { Agent } from '@vybestack/llxprt-code-agents';
 import path from 'node:path';
 import process from 'node:process';
-import { Storage } from '@vybestack/llxprt-code-settings';
+import {
+  Storage,
+  redactSensitiveValues,
+} from '@vybestack/llxprt-code-settings';
 import type {
   ExtendedLoadBalancerStats,
   TokenAccountingDiagnostics,
@@ -127,17 +130,6 @@ function isSessionTokenUsage(
   return tokenFields.every(
     (field) =>
       typeof candidate[field] === 'number' && Number.isFinite(candidate[field]),
-  );
-}
-
-function maskSensitive(value: string): string {
-  if (value.length < 8) {
-    return '*'.repeat(value.length);
-  }
-  return (
-    value.substring(0, 4) +
-    '*'.repeat(value.length - 8) +
-    value.substring(value.length - 4)
   );
 }
 
@@ -302,31 +294,26 @@ function appendEphemeralSettings(
   ephemeralSettings: Record<string, unknown>,
   logger: DebugLogger,
 ): void {
+  const redactedSettings = redactSensitiveValues(ephemeralSettings);
   diagnostics.push('\n## Ephemeral Settings');
   logger.debug(
     () =>
-      `[diagnostics] ephemeral settings ${JSON.stringify(ephemeralSettings)}`,
+      `[diagnostics] ephemeral settings ${JSON.stringify(redactedSettings)}`,
   );
-  if (Object.keys(ephemeralSettings).length === 0) {
+  if (Object.keys(redactedSettings).length === 0) {
     diagnostics.push('- No ephemeral settings configured');
     return;
   }
 
-  const sensitiveKeys = new Set(['auth-key', 'apiKey', 'api-key']);
-
-  const formatSettingValue = (key: string, value: unknown): string => {
-    if (typeof value === 'string' && sensitiveKeys.has(key)) {
-      return maskSensitive(value);
-    }
-    return typeof value === 'object' ? JSON.stringify(value) : String(value);
-  };
+  const formatSettingValue = (value: unknown): string =>
+    typeof value === 'object' ? JSON.stringify(value) : String(value);
 
   const authSettings: Array<[string, unknown]> = [];
   const toolSettings: Array<[string, unknown]> = [];
   const compressionSettings: Array<[string, unknown]> = [];
   const otherSettings: Array<[string, unknown]> = [];
 
-  for (const [key, value] of Object.entries(ephemeralSettings)) {
+  for (const [key, value] of Object.entries(redactedSettings)) {
     if (value === undefined || value === null) {
       continue;
     }
@@ -345,7 +332,7 @@ function appendEphemeralSettings(
   if (authSettings.length > 0) {
     diagnostics.push('- Authentication:');
     for (const [key, value] of authSettings) {
-      diagnostics.push(`  - ${key}: ${formatSettingValue(key, value)}`);
+      diagnostics.push(`  - ${key}: ${formatSettingValue(value)}`);
     }
   }
 
@@ -366,7 +353,7 @@ function appendEphemeralSettings(
   if (otherSettings.length > 0) {
     diagnostics.push('- Other Settings:');
     for (const [key, value] of otherSettings) {
-      diagnostics.push(`  - ${key}: ${formatSettingValue(key, value)}`);
+      diagnostics.push(`  - ${key}: ${formatSettingValue(value)}`);
     }
   }
 }

--- a/packages/core/src/integration-tests/settings-remediation.test.ts
+++ b/packages/core/src/integration-tests/settings-remediation.test.ts
@@ -499,12 +499,12 @@ describe('Settings Remediation Integration', () => {
       const diagnostics = await settingsService.getDiagnosticsData();
 
       expect(diagnostics.provider).toBe('openai');
-      expect(diagnostics.providerSettings['auth-key']).toBe('test-key');
+      expect(diagnostics.providerSettings['auth-key']).toBe('[REDACTED]');
       expect(diagnostics.providerSettings.model).toBe('gpt-4');
       expect(diagnostics.ephemeralSettings.model).toBe('test-model');
       expect(diagnostics.ephemeralSettings.temperature).toBe(0.8);
       expect(diagnostics.allSettings.providers.openai['auth-key']).toBe(
-        'test-key',
+        '[REDACTED]',
       );
     });
   });

--- a/packages/providers/src/anthropic/AnthropicMessageValidator.stripEmptyTextBlocks.test.ts
+++ b/packages/providers/src/anthropic/AnthropicMessageValidator.stripEmptyTextBlocks.test.ts
@@ -16,10 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type {
-  AnthropicMessage,
-  AnthropicMessageBlock,
-} from './AnthropicMessageNormalizer.js';
+import type { AnthropicMessage } from './AnthropicMessageNormalizer.js';
 import { stripEmptyTextBlocks } from './AnthropicMessageValidator.js';
 
 const noopLogger = { debug: (_fn: () => string) => {} };
@@ -42,14 +39,13 @@ describe('stripEmptyTextBlocks (Issue #2410)', () => {
 
     const result = stripEmptyTextBlocks(messages, noopLogger);
 
-    expect(Array.isArray(result[0].content)).toBe(true);
-    const content = result[0].content as AnthropicMessageBlock[];
-    expect(content).toHaveLength(1);
-    expect(content[0]).toMatchObject({
-      type: 'tool_result',
-      tool_use_id: 'toolu_1',
-      content: 'file contents here',
-    });
+    expect(result[0].content).toStrictEqual([
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: 'file contents here',
+      },
+    ]);
   });
 
   it('removes whitespace-only text blocks', () => {
@@ -64,9 +60,26 @@ describe('stripEmptyTextBlocks (Issue #2410)', () => {
     ];
 
     const result = stripEmptyTextBlocks(messages, noopLogger);
-    const content = result[0].content as AnthropicMessageBlock[];
-    expect(content).toHaveLength(1);
-    expect(content[0]).toMatchObject({ type: 'text', text: 'real question' });
+    expect(result[0].content).toStrictEqual([
+      { type: 'text', text: 'real question' },
+    ]);
+  });
+
+  it('removes Unicode-whitespace-only text blocks (NBSP, em space)', () => {
+    const messages: AnthropicMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'real question' },
+          { type: 'text', text: '\u00A0\u2003\u00A0' },
+        ],
+      },
+    ];
+
+    const result = stripEmptyTextBlocks(messages, noopLogger);
+    expect(result[0].content).toStrictEqual([
+      { type: 'text', text: 'real question' },
+    ]);
   });
 
   it('preserves non-empty text blocks unchanged', () => {
@@ -130,7 +143,74 @@ describe('stripEmptyTextBlocks (Issue #2410)', () => {
     ];
 
     const result = stripEmptyTextBlocks(messages, noopLogger);
-    expect((result[0].content as AnthropicMessageBlock[]).length).toBe(1);
-    expect((result[1].content as AnthropicMessageBlock[]).length).toBe(1);
+    expect(result.map((message) => message.content)).toStrictEqual([
+      [{ type: 'text', text: 'keep me' }],
+      [{ type: 'text', text: 'answer' }],
+    ]);
+  });
+
+  it('replaces empty content array (content: []) with the role placeholder', () => {
+    const messages: AnthropicMessage[] = [
+      { role: 'user', content: [] },
+      { role: 'assistant', content: [] },
+    ];
+
+    const result = stripEmptyTextBlocks(messages, noopLogger);
+
+    expect(result[0].content).toBe('[Empty message]');
+    expect(result[1].content).toBe('[No content generated]');
+  });
+
+  it('leaves non-text-only content arrays unchanged (e.g. tool_use only)', () => {
+    const original: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'toolu_1', name: 'read_file', input: {} },
+        ],
+      },
+    ];
+
+    const result = stripEmptyTextBlocks(original, noopLogger);
+
+    expect(result[0].content).toBe(original[0].content);
+  });
+
+  it('leaves arrays with a mix of tool_result and non-text blocks unchanged', () => {
+    const original: AnthropicMessage[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_1',
+            content: 'result data',
+          },
+        ],
+      },
+    ];
+
+    const result = stripEmptyTextBlocks(original, noopLogger);
+
+    expect(result[0].content).toBe(original[0].content);
+  });
+
+  it('preserves a thinking block when it is the only block', () => {
+    const original: AnthropicMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'internal thought',
+            signature: 'sig',
+          },
+        ],
+      },
+    ];
+
+    const result = stripEmptyTextBlocks(original, noopLogger);
+
+    expect(result[0].content).toBe(original[0].content);
   });
 });

--- a/packages/providers/src/anthropic/AnthropicMessageValidator.ts
+++ b/packages/providers/src/anthropic/AnthropicMessageValidator.ts
@@ -506,6 +506,15 @@ export function stripEmptyTextBlocks(
         content: getEmptyMessagePlaceholder(message.role),
       };
     }
+    // An empty content array is invalid for strict endpoints; replace it
+    // with the role placeholder before the equality short-circuit below.
+    if (message.content.length === 0) {
+      strippedCount += 1;
+      return {
+        ...message,
+        content: getEmptyMessagePlaceholder(message.role),
+      };
+    }
     const filtered = message.content.filter((block: AnthropicMessageBlock) => {
       if (block.type === 'text') {
         return block.text.trim() !== '';

--- a/packages/providers/src/gemini/GeminiProvider.auth.test.ts
+++ b/packages/providers/src/gemini/GeminiProvider.auth.test.ts
@@ -12,7 +12,6 @@ const googleGenAIConstructor = vi.hoisted(() => vi.fn());
 
 vi.mock('@google/genai', () => ({
   GoogleGenAI: googleGenAIConstructor,
-  Type: { OBJECT: 'object' },
 }));
 
 vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
@@ -24,11 +23,8 @@ vi.mock('@vybestack/llxprt-code-core/code_assist/codeAssist.js', () => ({
 }));
 
 const mockSettingsService = vi.hoisted(() => ({
-  set: vi.fn(),
   get: vi.fn(),
   getProviderSettings: vi.fn().mockReturnValue({}),
-  updateSettings: vi.fn(),
-  getAllGlobalSettings: vi.fn().mockReturnValue({}),
 }));
 
 type GeminiProviderInternals = {
@@ -80,7 +76,6 @@ describe('GeminiProvider Authentication', () => {
     vi.clearAllMocks();
     mockSettingsService.get.mockReset();
     mockSettingsService.getProviderSettings.mockReturnValue({});
-    mockSettingsService.getAllGlobalSettings.mockReturnValue({});
     delete process.env.GEMINI_API_KEY;
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
     delete process.env.GOOGLE_API_KEY;
@@ -325,5 +320,28 @@ describe('GeminiProvider Authentication', () => {
       settingsService: mockSettingsService,
       includeOAuth: false,
     });
+  });
+
+  it('rejects whitespace-only Vertex AI project settings', async () => {
+    mockVertexAISettings('   ', 'europe-west4');
+    const provider = createProviderWithRuntimeSettings();
+
+    await expect(
+      createGenAIClientViaProvider(provider, 'USE_VERTEX_AI', 'vertex-ai'),
+    ).rejects.toThrow(
+      'Vertex AI mode is active but project/location are not configured',
+    );
+  });
+
+  it('rejects whitespace-only Vertex AI location from the environment', async () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'env-project';
+    process.env.GOOGLE_CLOUD_LOCATION = '   ';
+    const provider = createProviderWithRuntimeSettings();
+
+    await expect(
+      createGenAIClientViaProvider(provider, 'USE_VERTEX_AI', 'vertex-ai'),
+    ).rejects.toThrow(
+      'Vertex AI mode is active but project/location are not configured',
+    );
   });
 });

--- a/packages/providers/src/gemini/GeminiProvider.ts
+++ b/packages/providers/src/gemini/GeminiProvider.ts
@@ -331,9 +331,7 @@ export class GeminiProvider extends BaseProvider {
   private hasCompleteVertexProjectConfig(
     vertexConfig: VertexAIAuthConfig,
   ): boolean {
-    return (
-      vertexConfig.project !== undefined && vertexConfig.location !== undefined
-    );
+    return Boolean(vertexConfig.project) && Boolean(vertexConfig.location);
   }
 
   private buildVertexAIOptions(

--- a/packages/settings/src/__tests__/SettingsService.test.ts
+++ b/packages/settings/src/__tests__/SettingsService.test.ts
@@ -441,3 +441,159 @@ describe('SettingsService — provider trust boundary', () => {
     expect(exported.providers).not.toHaveProperty('openai');
   });
 });
+
+describe('SettingsService — diagnostics redacts sensitive auth-key (Issue #2472)', () => {
+  function setupServiceWithSecret(): SettingsService {
+    const svc = new SettingsService();
+    svc.set('auth-key', 'sk-real-secret-value');
+    svc.setProviderSetting('openai', 'auth-key', 'sk-provider-secret');
+    svc.set('providers.openai.model', 'gpt-4');
+    svc.set('temperature', 0.7);
+    svc.set('base-url', 'https://api.example.com');
+    return svc;
+  }
+
+  it('redacts auth-key in ephemeralSettings', async () => {
+    const diag = await setupServiceWithSecret().getDiagnosticsData();
+    expect(diag.ephemeralSettings['auth-key']).toBe('[REDACTED]');
+  });
+
+  it('redacts auth-key in providerSettings', async () => {
+    const diag = await setupServiceWithSecret().getDiagnosticsData();
+    expect(diag.providerSettings['auth-key']).toBe('[REDACTED]');
+  });
+
+  it('redacts auth-key in modelParams', async () => {
+    const diag = await setupServiceWithSecret().getDiagnosticsData();
+    expect(diag.modelParams['auth-key']).toBe('[REDACTED]');
+  });
+
+  it('redacts auth-key inside allSettings.providers', async () => {
+    const diag = await setupServiceWithSecret().getDiagnosticsData();
+    expect(diag.allSettings.providers['openai']['auth-key']).toBe('[REDACTED]');
+  });
+
+  it('preserves non-sensitive values in diagnostics', async () => {
+    const diag = await setupServiceWithSecret().getDiagnosticsData();
+    expect(diag).toMatchObject({
+      model: 'gpt-4',
+      ephemeralSettings: {
+        temperature: 0.7,
+        'base-url': 'https://api.example.com',
+      },
+      providerSettings: { model: 'gpt-4' },
+    });
+  });
+
+  it('does not leak raw secrets in serialized diagnostics JSON', async () => {
+    const serialized = JSON.stringify(
+      await setupServiceWithSecret().getDiagnosticsData(),
+    );
+    expect(
+      ['sk-real-secret-value', 'sk-provider-secret'].every(
+        (secret) => !serialized.includes(secret),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('SettingsService — exportForProfile preserves auth-key (Issue #2472)', () => {
+  it('does not redact auth-key in exported provider settings', async () => {
+    const svc = new SettingsService();
+    svc.setProviderSetting('openai', 'auth-key', 'sk-persist-me');
+    svc.setProviderSetting('openai', 'model', 'gpt-4');
+
+    const exported = await svc.exportForProfile();
+
+    expect(exported.providers['openai']).toMatchObject({
+      'auth-key': 'sk-persist-me',
+      model: 'gpt-4',
+    });
+  });
+});
+
+describe('SettingsService — change event redacts sensitive values (Issue #2472)', () => {
+  it('redacts oldValue and newValue for auth-key in change events', () => {
+    const svc = new SettingsService();
+    svc.set('auth-key', 'sk-original');
+    let evt: { key: string; oldValue: unknown; newValue: unknown } | undefined;
+    svc.on('change', (e) => {
+      evt = e;
+    });
+    svc.set('auth-key', 'sk-rotated');
+
+    expect(evt?.key).toBe('auth-key');
+    expect(evt?.oldValue).toBe('[REDACTED]');
+    expect(evt?.newValue).toBe('[REDACTED]');
+  });
+
+  it('redacts oldValue and newValue for apiKey alias in change events', () => {
+    const svc = new SettingsService();
+    svc.set('apiKey', 'sk-original');
+    let evt: { key: string; oldValue: unknown; newValue: unknown } | undefined;
+    svc.on('change', (e) => {
+      evt = e;
+    });
+    svc.set('apiKey', 'sk-rotated');
+
+    expect(evt?.key).toBe('apiKey');
+    expect(evt?.oldValue).toBe('[REDACTED]');
+    expect(evt?.newValue).toBe('[REDACTED]');
+  });
+
+  it('preserves non-sensitive newValue in change events', () => {
+    const svc = new SettingsService();
+    let evt: { key: string; oldValue: unknown; newValue: unknown } | undefined;
+    svc.on('change', (e) => {
+      evt = e;
+    });
+    svc.set('temperature', 0.9);
+
+    expect(evt?.key).toBe('temperature');
+    expect(evt?.newValue).toBe(0.9);
+  });
+
+  it('redacts oldValue and newValue for auth-key in provider-change events', () => {
+    const svc = new SettingsService();
+    svc.setProviderSetting('openai', 'auth-key', 'sk-original');
+    let evt:
+      | { provider: string; key: string; oldValue: unknown; newValue: unknown }
+      | undefined;
+    svc.on('provider-change', (e) => {
+      evt = e;
+    });
+    svc.setProviderSetting('openai', 'auth-key', 'sk-rotated');
+
+    expect(evt?.provider).toBe('openai');
+    expect(evt?.key).toBe('auth-key');
+    expect(evt?.oldValue).toBe('[REDACTED]');
+    expect(evt?.newValue).toBe('[REDACTED]');
+  });
+
+  it('preserves provider and key metadata in provider-change events for sensitive keys', () => {
+    const svc = new SettingsService();
+    svc.setProviderSetting('anthropic', 'apiKey', 'sk-original');
+    let evt:
+      | { provider: string; key: string; oldValue: unknown; newValue: unknown }
+      | undefined;
+    svc.on('provider-change', (e) => {
+      evt = e;
+    });
+    svc.setProviderSetting('anthropic', 'apiKey', 'sk-rotated');
+
+    expect(evt?.provider).toBe('anthropic');
+    expect(evt?.key).toBe('apiKey');
+  });
+
+  it('preserves non-sensitive newValue in provider-change events', () => {
+    const svc = new SettingsService();
+    let evt: { key: string; newValue: unknown } | undefined;
+    svc.on('provider-change', (e) => {
+      evt = e;
+    });
+    svc.setProviderSetting('openai', 'model', 'gpt-4');
+
+    expect(evt?.key).toBe('model');
+    expect(evt?.newValue).toBe('gpt-4');
+  });
+});

--- a/packages/settings/src/__tests__/settingsRegistry.redaction.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.redaction.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  redactSensitiveValues,
+  REDACTED_VALUE,
+} from '../settings/settingsRegistry.js';
+
+describe('redactSensitiveValues', () => {
+  it('redacts the canonical auth-key setting', () => {
+    expect(redactSensitiveValues({ 'auth-key': 'secret' })).toStrictEqual({
+      'auth-key': REDACTED_VALUE,
+    });
+  });
+
+  it('redacts auth-key aliases', () => {
+    expect(
+      redactSensitiveValues({ apiKey: 'first', 'api-key': 'second' }),
+    ).toStrictEqual({
+      apiKey: REDACTED_VALUE,
+      'api-key': REDACTED_VALUE,
+    });
+  });
+
+  it('redacts a dotted provider auth-key event path', () => {
+    expect(
+      redactSensitiveValues({ 'providers.openai.auth-key': 'secret' }),
+    ).toStrictEqual({
+      'providers.openai.auth-key': REDACTED_VALUE,
+    });
+  });
+
+  it('preserves non-sensitive values without mutating the input', () => {
+    const input = { model: 'gpt-4', 'base-url': 'https://example.com' };
+    const result = redactSensitiveValues(input);
+
+    expect({ input, result }).toStrictEqual({
+      input: { model: 'gpt-4', 'base-url': 'https://example.com' },
+      result: { model: 'gpt-4', 'base-url': 'https://example.com' },
+    });
+  });
+});

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -25,6 +25,9 @@ export {
   getDirectSettingSpecs,
   getInternalSettingKeys,
   isInternalSettingKey,
+  redactSensitiveValues,
+  isSensitiveSettingKey,
+  REDACTED_VALUE,
   SETTINGS_REGISTRY,
 } from './settings/settingsRegistry.js';
 export type {

--- a/packages/settings/src/settings/SettingsService.ts
+++ b/packages/settings/src/settings/SettingsService.ts
@@ -15,6 +15,15 @@ import {
   type TrustedProviderRecord,
   type TrustedProvidersMap,
 } from './validation.js';
+import {
+  redactSensitiveValues,
+  isSensitiveSettingKey,
+  REDACTED_VALUE,
+} from './settingsRegistry.js';
+
+function redactEventValue(key: string, value: unknown): unknown {
+  return isSensitiveSettingKey(key) ? REDACTED_VALUE : value;
+}
 
 interface EphemeralSettings {
   providers: TrustedProvidersMap;
@@ -43,6 +52,23 @@ type SettingsEventListener =
   | ((event: ProviderSettingsChangeEvent) => void)
   | (() => void)
   | ((...args: unknown[]) => void);
+
+/**
+ * Snapshot returned by {@link SettingsService.getDiagnosticsData}.
+ * Sensitive setting values (e.g. `auth-key`) are replaced with
+ * `[REDACTED]`; all other values are preserved verbatim.
+ */
+export interface DiagnosticsData {
+  provider: string;
+  model: string;
+  profile: string | null;
+  providerSettings: Record<string, unknown>;
+  ephemeralSettings: Record<string, unknown>;
+  modelParams: Record<string, unknown>;
+  allSettings: {
+    providers: Record<string, Record<string, unknown>>;
+  };
+}
 
 function copyStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.map((name) => String(name)) : [];
@@ -80,8 +106,8 @@ export class SettingsService extends EventEmitter {
 
     this.eventEmitter.emit('change', {
       key,
-      oldValue,
-      newValue: value,
+      oldValue: redactEventValue(key, oldValue),
+      newValue: redactEventValue(key, value),
     });
   }
 
@@ -103,8 +129,8 @@ export class SettingsService extends EventEmitter {
     this.eventEmitter.emit('provider-change', {
       provider,
       key,
-      oldValue,
-      newValue: value,
+      oldValue: redactEventValue(key, oldValue),
+      newValue: redactEventValue(key, value),
     });
   }
 
@@ -411,7 +437,7 @@ export class SettingsService extends EventEmitter {
     return typeof value === 'string' ? value : null;
   }
 
-  getDiagnosticsData(): Promise<Record<string, unknown>> {
+  getDiagnosticsData(): Promise<DiagnosticsData> {
     const globalActiveProvider = this.settings.global.activeProvider;
     const fallbackActiveProvider =
       typeof this.settings.activeProvider === 'string' &&
@@ -433,15 +459,24 @@ export class SettingsService extends EventEmitter {
       }
     }
 
+    const redactedProviders: Record<string, Record<string, unknown>> = {};
+    for (const [provider, settings] of Object.entries(
+      this.settings.providers,
+    )) {
+      if (settings !== undefined) {
+        redactedProviders[provider] = redactSensitiveValues(settings);
+      }
+    }
+
     return Promise.resolve({
       provider: activeProvider,
       model,
       profile: this.getCurrentProfileName(),
-      providerSettings,
-      ephemeralSettings: this.settings.global,
-      modelParams,
+      providerSettings: redactSensitiveValues(providerSettings),
+      ephemeralSettings: redactSensitiveValues(this.settings.global),
+      modelParams: redactSensitiveValues(modelParams),
       allSettings: {
-        providers: this.settings.providers,
+        providers: redactedProviders,
       },
     });
   }

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -14,6 +14,7 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
     description: 'Provider API authentication key',
     type: 'string',
     persistToProfile: true,
+    sensitive: true,
   },
   {
     key: 'auth-keyfile',

--- a/packages/settings/src/settings/registry/registry-types.ts
+++ b/packages/settings/src/settings/registry/registry-types.ts
@@ -32,6 +32,8 @@ export interface SettingSpec {
   default?: unknown;
   persistToProfile: boolean;
   completionOptions?: ReadonlyArray<{ value: string; description?: string }>;
+  /** When true, the value is secret and must be masked in diagnostics. */
+  sensitive?: boolean;
 }
 
 export interface SeparatedSettings {

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -524,6 +524,34 @@ export function getProtectedSettingKeys(): string[] {
   return keys;
 }
 
+const SENSITIVE_SETTING_KEYS: ReadonlySet<string> = new Set(
+  SETTINGS_REGISTRY.filter((s) => s.sensitive === true).flatMap((s) => [
+    s.key,
+    ...(s.aliases ?? []),
+  ]),
+);
+
+export const REDACTED_VALUE = '[REDACTED]';
+
+export function isSensitiveSettingKey(key: string): boolean {
+  if (SENSITIVE_SETTING_KEYS.has(key)) {
+    return true;
+  }
+  const lastDot = key.lastIndexOf('.');
+  return lastDot >= 0 && SENSITIVE_SETTING_KEYS.has(key.slice(lastDot + 1));
+}
+
+/** Returns a shallow copy with sensitive top-level setting values redacted. */
+export function redactSensitiveValues(
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    result[key] = isSensitiveSettingKey(key) ? REDACTED_VALUE : value;
+  }
+  return result;
+}
+
 export function getProviderConfigKeys(): string[] {
   return collectProviderConfigKeys();
 }


### PR DESCRIPTION
## TLDR

Remediates the actionable, issue-scoped follow-ups from the subagent runtime isolation review. This hardens auth-key diagnostics boundaries, resolves path/error and null-safety edge cases, improves Anthropic empty-content handling, and cleans up the related tests without expanding into generalized secret serialization.

## Dive Deeper

- documents eager tool-response tracking and the unavoidable private-state test seam
- reports the fully resolved auth keyfile path for missing and empty files
- makes subagent setting access null-safe and keeps Vertex auth completeness checks consistent for blank values
- renames the Anthropic strip-empty-text test to match the function and covers non-empty strings, Unicode whitespace, true empty arrays, and non-text-only blocks
- removes unused Gemini auth-test mocks and keeps tests on public client-creation behavior
- marks only auth-key and its existing aliases as sensitive in registry metadata
- redacts auth-key values at SettingsService diagnostics/change-event and CLI diagnostics boundaries while preserving profile export values
- deliberately does not add recursive serialization, cycle handling, tool-key sensitivity, keyfile sensitivity, or new warning-channel architecture
- leaves StreamProcessor implicit-public because the repository ESLint configuration forbids explicit public accessibility
- retains the existing structured-clone warning layer because this synchronous settings-copy code has no established user-facing warning channel

## Reviewer Test Plan

1. Run the focused issue tests:

       npx vitest run packages/settings/src/__tests__/SettingsService.test.ts packages/settings/src/__tests__/settingsRegistry.redaction.test.ts packages/cli/src/ui/commands/diagnosticsCommand.edges.spec.ts packages/providers/src/anthropic/AnthropicMessageValidator.stripEmptyTextBlocks.test.ts packages/providers/src/gemini/GeminiProvider.auth.test.ts packages/agents/src/core/subagentSettingsAccess.test.ts packages/agents/src/core/subagentSettingsPopulation.test.ts packages/agents/src/core/subagentToolProcessing.test.ts packages/cli/src/nonInteractiveCli.slashCommandsAndThinking.test.ts

2. Confirm diagnostics replace auth-key/apiKey/api-key values with [REDACTED], while auth-keyfile and profile export remain unchanged.
3. Confirm relative missing/empty keyfile warnings show the absolute path actually used for I/O.
4. Confirm whitespace-only Vertex project/location values fail configuration and Anthropic empty content arrays receive the existing placeholder.
5. Run full verification:

       npm run test
       npm run lint
       npm run typecheck
       npm run format
       npm run build
       bun scripts/start.ts --profile-load ollamakimi "write me a haiku and nothing else"

All commands above passed on macOS. Open Code Review inspected all 20 changed files; its actionable strict-equality and assertion-strength findings were addressed.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2472
