### PR TITLE
Preserve whitespace-only subagent stream deltas (Fixes #2555)

### DIFF
--- a/packages/agents/src/tools/task.max-turns.test.ts
+++ b/packages/agents/src/tools/task.max-turns.test.ts
@@ -27,6 +27,55 @@ describe('TaskTool', () => {
     } as unknown as Config;
   });
 
+  async function streamSubagentDeltas(
+    emitDeltas: (emit: (message: string) => void) => Promise<void> | void,
+  ): Promise<string[]> {
+    const scope: {
+      output: {
+        emitted_vars: Record<string, string>;
+        terminate_reason: SubagentTerminateMode;
+      };
+      runInteractive: ReturnType<typeof vi.fn>;
+      runNonInteractive: ReturnType<typeof vi.fn>;
+      onMessage?: (message: string) => void;
+    } = {
+      output: {
+        emitted_vars: {},
+        terminate_reason: SubagentTerminateMode.GOAL,
+      },
+      runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
+        await emitDeltas((message: string) => scope.onMessage?.(message));
+      }),
+      runNonInteractive: vi.fn(),
+      onMessage: undefined,
+    };
+    const launch = vi.fn().mockResolvedValue({
+      agentId: 'agent-stream',
+      scope,
+      dispose: vi.fn().mockResolvedValue(undefined),
+      prompt: {} as unknown,
+      profile: {} as unknown,
+      config: {} as unknown,
+      runtime: {} as unknown,
+    });
+    const orchestrator = { launch } as unknown as SubagentOrchestrator;
+    const tool = new TaskTool(config, {
+      orchestratorFactory: () => orchestrator,
+      isInteractiveEnvironment: () => true,
+    });
+    const updateOutput = vi.fn();
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'Ship it',
+    });
+
+    await invocation.execute(new AbortController().signal, updateOutput);
+
+    return updateOutput.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
+  }
+
   describe('max_turns handling', () => {
     it('passes max_turns from params into launch request runConfig', async () => {
       const dispose = vi.fn().mockResolvedValue(undefined);
@@ -370,169 +419,35 @@ describe('TaskTool', () => {
   });
 
   it('preserves standalone newline chunks without dropping them', async () => {
-    const dispose = vi.fn().mockResolvedValue(undefined);
-    const updateOutput = vi.fn();
-    const scope: {
-      output: {
-        emitted_vars: Record<string, string>;
-        terminate_reason: SubagentTerminateMode;
-      };
-      runInteractive: ReturnType<typeof vi.fn>;
-      runNonInteractive: ReturnType<typeof vi.fn>;
-      onMessage?: (message: string) => void;
-    } = {
-      output: {
-        emitted_vars: {},
-        terminate_reason: SubagentTerminateMode.GOAL,
-      },
-      runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
-        scope.onMessage?.('Hello');
-        scope.onMessage?.('\n');
-        scope.onMessage?.('World');
-      }),
-      runNonInteractive: vi.fn(),
-      onMessage: undefined,
-    };
-    const launch = vi.fn().mockResolvedValue({
-      agentId: 'agent-nl',
-      scope,
-      dispose,
-      prompt: {} as unknown,
-      profile: {} as unknown,
-      config: {} as unknown,
-      runtime: {} as unknown,
-    });
-    const orchestrator = { launch } as unknown as SubagentOrchestrator;
-    const tool = new TaskTool(config, {
-      orchestratorFactory: () => orchestrator,
-      isInteractiveEnvironment: () => true,
-    });
-    const invocation = tool.build({
-      subagent_name: 'helper',
-      goal_prompt: 'Ship it',
+    const deltas = await streamSubagentDeltas((emit) => {
+      emit('Hello');
+      emit('\n');
+      emit('World');
     });
 
-    await invocation.execute(new AbortController().signal, updateOutput);
-
-    const messageDeltas = updateOutput.mock.calls
-      .map((c) => c[0] as string)
-      .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
-    const accumulated = messageDeltas.join('');
-    expect(accumulated).toBe('Hello\nWorld');
+    expect(deltas.join('')).toBe('Hello\nWorld');
   });
 
   it('does not invent separators at word-token fragment boundaries', async () => {
-    const dispose = vi.fn().mockResolvedValue(undefined);
-    const updateOutput = vi.fn();
-    const scope: {
-      output: {
-        emitted_vars: Record<string, string>;
-        terminate_reason: SubagentTerminateMode;
-      };
-      runInteractive: ReturnType<typeof vi.fn>;
-      runNonInteractive: ReturnType<typeof vi.fn>;
-      onMessage?: (message: string) => void;
-    } = {
-      output: {
-        emitted_vars: {},
-        terminate_reason: SubagentTerminateMode.GOAL,
-      },
-      runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
-        for (const token of 'Hello World'.match(/(\w+|\s)/g) ?? []) {
-          scope.onMessage?.(token);
-        }
-      }),
-      runNonInteractive: vi.fn(),
-      onMessage: undefined,
-    };
-    const launch = vi.fn().mockResolvedValue({
-      agentId: 'agent-frag',
-      scope,
-      dispose,
-      prompt: {} as unknown,
-      profile: {} as unknown,
-      config: {} as unknown,
-      runtime: {} as unknown,
-    });
-    const orchestrator = { launch } as unknown as SubagentOrchestrator;
-    const tool = new TaskTool(config, {
-      orchestratorFactory: () => orchestrator,
-      isInteractiveEnvironment: () => true,
-    });
-    const invocation = tool.build({
-      subagent_name: 'helper',
-      goal_prompt: 'Ship it',
+    const deltas = await streamSubagentDeltas((emit) => {
+      for (const token of 'Hello World'.match(/(\w+|\s)/g) ?? []) {
+        emit(token);
+      }
     });
 
-    await invocation.execute(new AbortController().signal, updateOutput);
-
-    const messageDeltas = updateOutput.mock.calls
-      .map((c) => c[0] as string)
-      .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
-    const accumulated = messageDeltas.join('');
-    expect(accumulated).toBe('Hello World');
+    expect(deltas.join('')).toBe('Hello World');
   });
 
   it('filters out only truly empty messages when streaming', async () => {
-    const dispose = vi.fn().mockResolvedValue(undefined);
-    const updateOutput = vi.fn();
-    const scope: {
-      output: {
-        emitted_vars: Record<string, string>;
-        terminate_reason: SubagentTerminateMode;
-      };
-      runInteractive: ReturnType<typeof vi.fn>;
-      runNonInteractive: ReturnType<typeof vi.fn>;
-      onMessage?: (message: string) => void;
-    } = {
-      output: {
-        emitted_vars: {},
-        terminate_reason: SubagentTerminateMode.GOAL,
-      },
-      runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
-        scope.onMessage?.('');
-        scope.onMessage?.('  ');
-        scope.onMessage?.('\n');
-        scope.onMessage?.('\t');
-        scope.onMessage?.('actual message');
-      }),
-      runNonInteractive: vi.fn(),
-      onMessage: undefined,
-    };
-    const launch = vi.fn().mockResolvedValue({
-      agentId: 'agent-42',
-      scope,
-      dispose,
-      prompt: {} as unknown,
-      profile: {} as unknown,
-      config: {} as unknown,
-      runtime: {} as unknown,
-    });
-    const orchestrator = { launch } as unknown as SubagentOrchestrator;
-    const tool = new TaskTool(config, {
-      orchestratorFactory: () => orchestrator,
-      isInteractiveEnvironment: () => true,
-    });
-    const invocation = tool.build({
-      subagent_name: 'helper',
-      goal_prompt: 'Ship it',
+    const deltas = await streamSubagentDeltas((emit) => {
+      emit('');
+      emit('  ');
+      emit('\n');
+      emit('\t');
+      emit('actual message');
     });
 
-    await invocation.execute(new AbortController().signal, updateOutput);
-
-    expect(updateOutput).toHaveBeenNthCalledWith(
-      1,
-      '<subagent name="helper" id="agent-42">\n',
-    );
-    expect(updateOutput).toHaveBeenNthCalledWith(2, '  ');
-    expect(updateOutput).toHaveBeenNthCalledWith(3, '\n');
-    expect(updateOutput).toHaveBeenNthCalledWith(4, '\t');
-    expect(updateOutput).toHaveBeenNthCalledWith(5, 'actual message');
-    expect(updateOutput).toHaveBeenNthCalledWith(
-      6,
-      '</subagent name="helper" id="agent-42">\n',
-    );
-    expect(updateOutput).toHaveBeenCalledTimes(6);
+    expect(deltas).toStrictEqual(['  ', '\n', '\t', 'actual message']);
   });
 
   /**

--- a/packages/agents/src/tools/task.max-turns.test.ts
+++ b/packages/agents/src/tools/task.max-turns.test.ts
@@ -369,7 +369,7 @@ describe('TaskTool', () => {
     expect(updateOutput).toHaveBeenCalledTimes(6);
   });
 
-  it('filters out empty messages when streaming', async () => {
+  it('preserves standalone newline chunks without dropping them', async () => {
     const dispose = vi.fn().mockResolvedValue(undefined);
     const updateOutput = vi.fn();
     const scope: {
@@ -386,10 +386,114 @@ describe('TaskTool', () => {
         terminate_reason: SubagentTerminateMode.GOAL,
       },
       runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
-        // Simulate various empty/whitespace-only messages
+        scope.onMessage?.('Hello');
+        scope.onMessage?.('\n');
+        scope.onMessage?.('World');
+      }),
+      runNonInteractive: vi.fn(),
+      onMessage: undefined,
+    };
+    const launch = vi.fn().mockResolvedValue({
+      agentId: 'agent-nl',
+      scope,
+      dispose,
+      prompt: {} as unknown,
+      profile: {} as unknown,
+      config: {} as unknown,
+      runtime: {} as unknown,
+    });
+    const orchestrator = { launch } as unknown as SubagentOrchestrator;
+    const tool = new TaskTool(config, {
+      orchestratorFactory: () => orchestrator,
+      isInteractiveEnvironment: () => true,
+    });
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'Ship it',
+    });
+
+    await invocation.execute(new AbortController().signal, updateOutput);
+
+    const messageDeltas = updateOutput.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
+    const accumulated = messageDeltas.join('');
+    expect(accumulated).toBe('Hello\nWorld');
+  });
+
+  it('does not invent separators at word-token fragment boundaries', async () => {
+    const dispose = vi.fn().mockResolvedValue(undefined);
+    const updateOutput = vi.fn();
+    const scope: {
+      output: {
+        emitted_vars: Record<string, string>;
+        terminate_reason: SubagentTerminateMode;
+      };
+      runInteractive: ReturnType<typeof vi.fn>;
+      runNonInteractive: ReturnType<typeof vi.fn>;
+      onMessage?: (message: string) => void;
+    } = {
+      output: {
+        emitted_vars: {},
+        terminate_reason: SubagentTerminateMode.GOAL,
+      },
+      runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
+        for (const token of 'Hello World'.match(/(\w+|\s)/g) ?? []) {
+          scope.onMessage?.(token);
+        }
+      }),
+      runNonInteractive: vi.fn(),
+      onMessage: undefined,
+    };
+    const launch = vi.fn().mockResolvedValue({
+      agentId: 'agent-frag',
+      scope,
+      dispose,
+      prompt: {} as unknown,
+      profile: {} as unknown,
+      config: {} as unknown,
+      runtime: {} as unknown,
+    });
+    const orchestrator = { launch } as unknown as SubagentOrchestrator;
+    const tool = new TaskTool(config, {
+      orchestratorFactory: () => orchestrator,
+      isInteractiveEnvironment: () => true,
+    });
+    const invocation = tool.build({
+      subagent_name: 'helper',
+      goal_prompt: 'Ship it',
+    });
+
+    await invocation.execute(new AbortController().signal, updateOutput);
+
+    const messageDeltas = updateOutput.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
+    const accumulated = messageDeltas.join('');
+    expect(accumulated).toBe('Hello World');
+  });
+
+  it('filters out only truly empty messages when streaming', async () => {
+    const dispose = vi.fn().mockResolvedValue(undefined);
+    const updateOutput = vi.fn();
+    const scope: {
+      output: {
+        emitted_vars: Record<string, string>;
+        terminate_reason: SubagentTerminateMode;
+      };
+      runInteractive: ReturnType<typeof vi.fn>;
+      runNonInteractive: ReturnType<typeof vi.fn>;
+      onMessage?: (message: string) => void;
+    } = {
+      output: {
+        emitted_vars: {},
+        terminate_reason: SubagentTerminateMode.GOAL,
+      },
+      runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
         scope.onMessage?.('');
         scope.onMessage?.('  ');
         scope.onMessage?.('\n');
+        scope.onMessage?.('\t');
         scope.onMessage?.('actual message');
       }),
       runNonInteractive: vi.fn(),
@@ -416,18 +520,19 @@ describe('TaskTool', () => {
 
     await invocation.execute(new AbortController().signal, updateOutput);
 
-    // XML wrapping: opening tag, actual message (without agent prefix), closing tag
-    // Empty/whitespace-only messages are filtered
     expect(updateOutput).toHaveBeenNthCalledWith(
       1,
       '<subagent name="helper" id="agent-42">\n',
     );
-    expect(updateOutput).toHaveBeenNthCalledWith(2, 'actual message');
+    expect(updateOutput).toHaveBeenNthCalledWith(2, '  ');
+    expect(updateOutput).toHaveBeenNthCalledWith(3, '\n');
+    expect(updateOutput).toHaveBeenNthCalledWith(4, '\t');
+    expect(updateOutput).toHaveBeenNthCalledWith(5, 'actual message');
     expect(updateOutput).toHaveBeenNthCalledWith(
-      3,
+      6,
       '</subagent name="helper" id="agent-42">\n',
     );
-    expect(updateOutput).toHaveBeenCalledTimes(3);
+    expect(updateOutput).toHaveBeenCalledTimes(6);
   });
 
   /**

--- a/packages/agents/src/tools/task.max-turns.test.ts
+++ b/packages/agents/src/tools/task.max-turns.test.ts
@@ -71,9 +71,7 @@ describe('TaskTool', () => {
 
     await invocation.execute(new AbortController().signal, updateOutput);
 
-    return updateOutput.mock.calls
-      .map((c) => c[0] as string)
-      .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
+    return updateOutput.mock.calls.map((c) => c[0] as string).slice(1, -1);
   }
 
   describe('max_turns handling', () => {
@@ -353,7 +351,7 @@ describe('TaskTool', () => {
     });
   });
 
-  it('streams subagent messages on separate lines with normalized newlines', async () => {
+  it('streams subagent messages with normalized newlines across mixed line endings', async () => {
     const dispose = vi.fn().mockResolvedValue(undefined);
     const updateOutput = vi.fn();
     const scope: {
@@ -370,7 +368,6 @@ describe('TaskTool', () => {
         terminate_reason: SubagentTerminateMode.GOAL,
       },
       runInteractive: vi.fn().mockImplementation(async (_ctx: ContextState) => {
-        // Simulate subagent streaming multiple chunks with different line ending styles
         scope.onMessage?.('first chunk');
         scope.onMessage?.('second chunk\r');
         scope.onMessage?.('third chunk\r\n');
@@ -400,22 +397,17 @@ describe('TaskTool', () => {
 
     await invocation.execute(new AbortController().signal, updateOutput);
 
-    // Verify XML wrapping - opening tag, messages without agent prefix, closing tag
-    // Only fragments that already carry \r or \n get a trailing newline via
-    // carriage-return normalization; bare fragments flow together.
-    expect(updateOutput).toHaveBeenNthCalledWith(
-      1,
-      '<subagent name="helper" id="agent-42">\n',
-    );
-    expect(updateOutput).toHaveBeenNthCalledWith(2, 'first chunk');
-    expect(updateOutput).toHaveBeenNthCalledWith(3, 'second chunk\n');
-    expect(updateOutput).toHaveBeenNthCalledWith(4, 'third chunk\n');
-    expect(updateOutput).toHaveBeenNthCalledWith(5, 'fourth chunk\n');
-    expect(updateOutput).toHaveBeenNthCalledWith(
-      6,
+    const calls = updateOutput.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toBe('<subagent name="helper" id="agent-42">\n');
+    expect(calls[calls.length - 1]).toBe(
       '</subagent name="helper" id="agent-42">\n',
     );
-    expect(updateOutput).toHaveBeenCalledTimes(6);
+
+    const accumulated = calls.slice(1, -1).join('');
+
+    expect(accumulated).toBe(
+      'first chunksecond chunk\nthird chunk\nfourth chunk\n',
+    );
   });
 
   it('preserves standalone newline chunks without dropping them', async () => {
@@ -448,6 +440,24 @@ describe('TaskTool', () => {
     });
 
     expect(deltas).toStrictEqual(['  ', '\n', '\t', 'actual message']);
+  });
+
+  it('preserves CRLF semantics across split chunk boundaries (a\\r then \\nb)', async () => {
+    const deltas = await streamSubagentDeltas((emit) => {
+      emit('a\r');
+      emit('\nb');
+    });
+
+    expect(deltas.join('')).toBe('a\nb');
+  });
+
+  it('flushes a pending CR as LF when the stream ends in a lone CR', async () => {
+    const deltas = await streamSubagentDeltas((emit) => {
+      emit('hello');
+      emit('\r');
+    });
+
+    expect(deltas.join('')).toBe('hello\n');
   });
 
   /**

--- a/packages/agents/src/tools/task.max-turns.test.ts
+++ b/packages/agents/src/tools/task.max-turns.test.ts
@@ -50,7 +50,7 @@ describe('TaskTool', () => {
       onMessage: undefined,
     };
     const launch = vi.fn().mockResolvedValue({
-      agentId: 'agent-stream',
+      agentId: 'agent-42',
       scope,
       dispose: vi.fn().mockResolvedValue(undefined),
       prompt: {} as unknown,

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -9,7 +9,7 @@ import {
   BaseToolInvocation,
   Kind,
   type ToolResult,
-  toLosslessTextDelta,
+  createStreamNormalizer,
 } from '@vybestack/llxprt-code-tools';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import {
@@ -549,9 +549,14 @@ class TaskToolInvocation extends BaseToolInvocation<
     const subagentName =
       launchRequestName(launchResult) || this.normalized.subagentName;
     let xmlOutputOpen = false;
+    const normalizer = createStreamNormalizer();
     const emitClosingSubagentTag = () => {
       if (!xmlOutputOpen || !updateOutput) {
         return;
+      }
+      const flushed = normalizer.flush();
+      if (flushed !== undefined) {
+        updateOutput(flushed);
       }
       updateOutput(`</subagent name="${subagentName}" id="${agentId}">\n`);
       xmlOutputOpen = false;
@@ -563,7 +568,7 @@ class TaskToolInvocation extends BaseToolInvocation<
 
       const existingHandler = scope.onMessage;
       scope.onMessage = (message: string) => {
-        const delta = toLosslessTextDelta(message);
+        const delta = normalizer.push(message);
         if (delta !== undefined) {
           updateOutput(delta);
         }

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -9,6 +9,7 @@ import {
   BaseToolInvocation,
   Kind,
   type ToolResult,
+  toLosslessTextDelta,
 } from '@vybestack/llxprt-code-tools';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import {
@@ -43,10 +44,7 @@ import {
   formatSuccessContent,
   formatSuccessDisplay,
 } from './taskResultHelpers.js';
-import {
-  executeAsyncTask,
-  normalizeSubagentStreamingText,
-} from './taskAsyncExecution.js';
+import { executeAsyncTask } from './taskAsyncExecution.js';
 
 const taskLogger = new DebugLogger('llxprt:task');
 
@@ -565,9 +563,9 @@ class TaskToolInvocation extends BaseToolInvocation<
 
       const existingHandler = scope.onMessage;
       scope.onMessage = (message: string) => {
-        const cleaned = normalizeSubagentStreamingText(message);
-        if (cleaned.trim().length > 0) {
-          updateOutput(cleaned);
+        const delta = toLosslessTextDelta(message);
+        if (delta !== undefined) {
+          updateOutput(delta);
         }
         existingHandler?.(message);
       };

--- a/packages/agents/src/tools/taskAsyncExecution.ts
+++ b/packages/agents/src/tools/taskAsyncExecution.ts
@@ -13,8 +13,11 @@ import type { SubAgentScope } from '../core/subagent.js';
 import { type ContextState } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
 import type { SubagentSchedulerFactory } from '../core/subagentScheduler.js';
-import { type ToolResult, ToolErrorType } from '@vybestack/llxprt-code-tools';
-import { toLosslessTextDelta } from '@vybestack/llxprt-code-tools';
+import {
+  type ToolResult,
+  ToolErrorType,
+  createStreamNormalizer,
+} from '@vybestack/llxprt-code-tools';
 import { type TaskToolInvocationParams } from './taskToolGovernance.js';
 import {
   handleBackgroundAbort,
@@ -59,8 +62,10 @@ export interface AsyncTaskCollaborators {
  * LLM's own whitespace and newlines are authoritative; we only normalize
  * carriage-return variants to '\n'.
  *
- * Preserved for backward compatibility; new callers should use
- * {@link toLosslessTextDelta} from `@vybestack/llxprt-code-tools`.
+ * Preserved for backward compatibility. Prefer `toLosslessTextDelta` for an
+ * isolated single delta (stateless CR/CRLF→LF), or `createStreamNormalizer`
+ * for a stream spanning chunk boundaries (correctly joins a CRLF pair split
+ * across consecutive deltas and flushes a trailing lone CR on close).
  */
 export function normalizeSubagentStreamingText(text: string): string {
   return text.replace(/\r\n?/g, '\n');
@@ -291,10 +296,15 @@ export function setupAsyncStreaming(
 ): { emitAsyncClosingSubagentTag: () => void } | undefined {
   if (!updateOutput) return undefined;
 
+  const normalizer = createStreamNormalizer();
   let asyncXmlOutputOpen = false;
   const emitAsyncClosingSubagentTag = () => {
     if (!asyncXmlOutputOpen) {
       return;
+    }
+    const flushed = normalizer.flush();
+    if (flushed !== undefined) {
+      updateOutput(flushed);
     }
     updateOutput(`</subagent name="${subagentName}" id="${agentId}">\n`);
     asyncXmlOutputOpen = false;
@@ -305,7 +315,7 @@ export function setupAsyncStreaming(
 
   const existingHandler = scope.onMessage;
   scope.onMessage = (message: string) => {
-    const delta = toLosslessTextDelta(message);
+    const delta = normalizer.push(message);
     if (delta !== undefined) {
       updateOutput(delta);
     }

--- a/packages/agents/src/tools/taskAsyncExecution.ts
+++ b/packages/agents/src/tools/taskAsyncExecution.ts
@@ -14,6 +14,7 @@ import { type ContextState } from '@vybestack/llxprt-code-core/core/subagentType
 import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
 import type { SubagentSchedulerFactory } from '../core/subagentScheduler.js';
 import { type ToolResult, ToolErrorType } from '@vybestack/llxprt-code-tools';
+import { toLosslessTextDelta } from '@vybestack/llxprt-code-tools';
 import { type TaskToolInvocationParams } from './taskToolGovernance.js';
 import {
   handleBackgroundAbort,
@@ -57,11 +58,11 @@ export interface AsyncTaskCollaborators {
  * that broke LLM token streaming — each word landed on its own line. The
  * LLM's own whitespace and newlines are authoritative; we only normalize
  * carriage-return variants to '\n'.
+ *
+ * Preserved for backward compatibility; new callers should use
+ * {@link toLosslessTextDelta} from `@vybestack/llxprt-code-tools`.
  */
 export function normalizeSubagentStreamingText(text: string): string {
-  if (!text) {
-    return '';
-  }
   return text.replace(/\r\n?/g, '\n');
 }
 
@@ -304,9 +305,9 @@ export function setupAsyncStreaming(
 
   const existingHandler = scope.onMessage;
   scope.onMessage = (message: string) => {
-    const cleaned = normalizeSubagentStreamingText(message);
-    if (cleaned.trim().length > 0) {
-      updateOutput(cleaned);
+    const delta = toLosslessTextDelta(message);
+    if (delta !== undefined) {
+      updateOutput(delta);
     }
     existingHandler?.(message);
   };

--- a/packages/agents/src/tools/taskAsyncStreaming.test.ts
+++ b/packages/agents/src/tools/taskAsyncStreaming.test.ts
@@ -95,11 +95,15 @@ function createAsyncStreamingHarness(
   return { tool, mockAsyncTaskManager, completionPromise };
 }
 
-/** Filters out XML wrapper tags, leaving only streamed text deltas. */
+/** Asserts the exact XML wrapper tags then returns the interior deltas only. */
 function extractMessageDeltas(outputs: string[]): string[] {
-  return outputs.filter(
-    (s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'),
-  );
+  const [opening] = outputs;
+  expect(opening.startsWith('<subagent name="')).toBe(true);
+  expect(opening.endsWith('">\n')).toBe(true);
+  const closing = outputs[outputs.length - 1];
+  expect(closing.startsWith('</subagent name="')).toBe(true);
+  expect(closing.endsWith('">\n')).toBe(true);
+  return outputs.slice(1, -1);
 }
 
 describe('TaskTool async streaming through real async path', () => {
@@ -221,6 +225,80 @@ describe('TaskTool async streaming through real async path', () => {
     );
     expect(outputs[outputs.length - 1]).toBe(
       '</subagent name="reviewer" id="async-xml-stream">\n',
+    );
+  });
+
+  it('preserves CRLF semantics across split chunk boundaries through the async path', async () => {
+    const { tool, completionPromise } = createAsyncStreamingHarness(
+      async (scope) => {
+        scope.onMessage?.('a\r');
+        scope.onMessage?.('\nb');
+      },
+    );
+
+    const outputs: string[] = [];
+    const invocation = tool.build({
+      subagent_name: 'reviewer',
+      goal_prompt: 'Review',
+      async: true,
+    } satisfies TaskToolParams);
+
+    await invocation.execute(new AbortController().signal, (chunk) =>
+      outputs.push(chunk),
+    );
+
+    await completionPromise;
+
+    expect(extractMessageDeltas(outputs).join('')).toBe('a\nb');
+  });
+
+  it('flushes a pending CR as LF when the async stream ends in a lone CR', async () => {
+    const { tool, completionPromise } = createAsyncStreamingHarness(
+      async (scope) => {
+        scope.onMessage?.('hello');
+        scope.onMessage?.('\r');
+      },
+    );
+
+    const outputs: string[] = [];
+    const invocation = tool.build({
+      subagent_name: 'reviewer',
+      goal_prompt: 'Review',
+      async: true,
+    } satisfies TaskToolParams);
+
+    await invocation.execute(new AbortController().signal, (chunk) =>
+      outputs.push(chunk),
+    );
+
+    await completionPromise;
+
+    expect(extractMessageDeltas(outputs).join('')).toBe('hello\n');
+  });
+
+  it('preserves model text that begins with exact subagent wrapper prefixes verbatim', async () => {
+    const { tool, completionPromise } = createAsyncStreamingHarness(
+      async (scope) => {
+        scope.onMessage?.('<subagent name="not-wrapper">begin');
+        scope.onMessage?.('</subagent name="not-wrapper">end');
+      },
+    );
+
+    const outputs: string[] = [];
+    const invocation = tool.build({
+      subagent_name: 'reviewer',
+      goal_prompt: 'Review',
+      async: true,
+    } satisfies TaskToolParams);
+
+    await invocation.execute(new AbortController().signal, (chunk) =>
+      outputs.push(chunk),
+    );
+
+    await completionPromise;
+
+    expect(extractMessageDeltas(outputs).join('')).toBe(
+      '<subagent name="not-wrapper">begin</subagent name="not-wrapper">end',
     );
   });
 });

--- a/packages/agents/src/tools/taskAsyncStreaming.test.ts
+++ b/packages/agents/src/tools/taskAsyncStreaming.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Async streaming behavioral coverage through the real TaskTool async path.
+ *
+ * These tests exercise the full wiring: TaskTool(async:true) → executeAsyncTask
+ * → setupAsyncStreaming → executeInBackground → updateOutput. They catch broken
+ * TaskTool/executeAsyncTask wiring that lower-level setupAsyncStreaming tests
+ * would miss.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { TaskTool, type TaskToolParams } from './task.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
+import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyncTaskManager.js';
+
+interface AsyncStreamingHarness {
+  tool: TaskTool;
+  mockAsyncTaskManager: Record<string, ReturnType<typeof vi.fn>>;
+  completionPromise: Promise<void>;
+}
+
+/**
+ * Builds a TaskTool configured for async execution with a fake orchestrator
+ * and fake AsyncTaskManager. The scope's runNonInteractive performs the
+ * supplied emission logic — this is real background execution through the
+ * genuine async wiring, not a mock of it.
+ */
+function createAsyncStreamingHarness(
+  emit: (scope: { onMessage?: (message: string) => void }) => Promise<void>,
+  options: {
+    agentId?: string;
+    existingHandler?: (message: string) => void;
+  } = {},
+): AsyncStreamingHarness {
+  const agentId = options.agentId ?? 'async-stream-agent';
+
+  let resolveCompletion: (() => void) | undefined;
+  const completionPromise = new Promise<void>(
+    (resolve) => (resolveCompletion = resolve),
+  );
+
+  const mockAsyncTaskManager = {
+    canLaunchAsync: vi.fn(() => ({ allowed: true })),
+    tryReserveAsyncSlot: vi.fn(() => 'booking-1'),
+    registerTask: vi.fn(),
+    completeTask: vi.fn(() => resolveCompletion?.()),
+    failTask: vi.fn(() => resolveCompletion?.()),
+    getTask: vi.fn(() => ({ status: 'running' })),
+  };
+
+  const scope: {
+    output: {
+      emitted_vars: Record<string, string>;
+      terminate_reason: SubagentTerminateMode;
+    };
+    runNonInteractive: ReturnType<typeof vi.fn>;
+    onMessage?: (message: string) => void;
+  } = {
+    output: {
+      emitted_vars: {},
+      terminate_reason: SubagentTerminateMode.GOAL,
+    },
+    runNonInteractive: vi.fn().mockImplementation(async () => {
+      await emit(scope);
+    }),
+    onMessage: options.existingHandler,
+  };
+
+  const launch = vi.fn().mockResolvedValue({
+    agentId,
+    scope,
+    dispose: vi.fn().mockResolvedValue(undefined),
+  });
+
+  const tool = new TaskTool(
+    {
+      getSessionId: () => 'session-async-stream',
+    } as unknown as Config,
+    {
+      orchestratorFactory: () =>
+        ({ launch }) as unknown as SubagentOrchestrator,
+      getAsyncTaskManager: () =>
+        mockAsyncTaskManager as unknown as AsyncTaskManager,
+      isInteractiveEnvironment: () => false,
+    },
+  );
+
+  return { tool, mockAsyncTaskManager, completionPromise };
+}
+
+/** Filters out XML wrapper tags, leaving only streamed text deltas. */
+function extractMessageDeltas(outputs: string[]): string[] {
+  return outputs.filter(
+    (s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'),
+  );
+}
+
+describe('TaskTool async streaming through real async path', () => {
+  it('streams the exact issue sequence with lossless standalone newlines', async () => {
+    const { tool, mockAsyncTaskManager, completionPromise } =
+      createAsyncStreamingHarness(async (scope) => {
+        scope.onMessage?.('Analyzing the codebase...');
+        scope.onMessage?.('\n');
+        scope.onMessage?.('Found 3 issues:');
+        scope.onMessage?.('\n');
+        scope.onMessage?.('1. Missing import');
+      });
+
+    const outputs: string[] = [];
+    const invocation = tool.build({
+      subagent_name: 'reviewer',
+      goal_prompt: 'Review the code',
+      async: true,
+    } satisfies TaskToolParams);
+
+    await invocation.execute(new AbortController().signal, (chunk) =>
+      outputs.push(chunk),
+    );
+
+    await completionPromise;
+
+    const accumulated = extractMessageDeltas(outputs).join('');
+
+    expect(accumulated).toBe(
+      'Analyzing the codebase...\nFound 3 issues:\n1. Missing import',
+    );
+    // The background task was marked complete via the real async wiring.
+    expect(mockAsyncTaskManager.completeTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves standalone spaces, tabs, and normalizes CR/CRLF through the async path', async () => {
+    const { tool, completionPromise } = createAsyncStreamingHarness(
+      async (scope) => {
+        scope.onMessage?.('a');
+        scope.onMessage?.(' ');
+        scope.onMessage?.('b');
+        scope.onMessage?.('\t');
+        scope.onMessage?.('c');
+        scope.onMessage?.('\r');
+        scope.onMessage?.('d\r\ne');
+      },
+    );
+
+    const outputs: string[] = [];
+    const invocation = tool.build({
+      subagent_name: 'reviewer',
+      goal_prompt: 'Review',
+      async: true,
+    } satisfies TaskToolParams);
+
+    await invocation.execute(new AbortController().signal, (chunk) =>
+      outputs.push(chunk),
+    );
+
+    await completionPromise;
+
+    const accumulated = extractMessageDeltas(outputs).join('');
+
+    // Space, tab preserved; lone CR → LF; CRLF → LF.
+    expect(accumulated).toBe('a b\tc\nd\ne');
+  });
+
+  it('forwards raw messages to an existing onMessage handler through the async path', async () => {
+    const receivedRaw: string[] = [];
+    const { tool, completionPromise } = createAsyncStreamingHarness(
+      async (scope) => {
+        scope.onMessage?.('raw\r\nmessage');
+      },
+      { existingHandler: (msg) => receivedRaw.push(msg) },
+    );
+
+    const outputs: string[] = [];
+    const invocation = tool.build({
+      subagent_name: 'reviewer',
+      goal_prompt: 'Review',
+      async: true,
+    } satisfies TaskToolParams);
+
+    await invocation.execute(new AbortController().signal, (chunk) =>
+      outputs.push(chunk),
+    );
+
+    await completionPromise;
+
+    // The existing handler receives the UN-normalized raw message.
+    expect(receivedRaw).toStrictEqual(['raw\r\nmessage']);
+    // The streamed output is normalized.
+    expect(extractMessageDeltas(outputs).join('')).toBe('raw\nmessage');
+  });
+
+  it('emits opening and closing XML tags around async streamed content', async () => {
+    const { tool, completionPromise } = createAsyncStreamingHarness(
+      async (scope) => {
+        scope.onMessage?.('hello');
+      },
+      { agentId: 'async-xml-stream' },
+    );
+
+    const outputs: string[] = [];
+    const invocation = tool.build({
+      subagent_name: 'reviewer',
+      goal_prompt: 'Review',
+      async: true,
+    } satisfies TaskToolParams);
+
+    await invocation.execute(new AbortController().signal, (chunk) =>
+      outputs.push(chunk),
+    );
+
+    await completionPromise;
+
+    expect(outputs[0]).toBe(
+      '<subagent name="reviewer" id="async-xml-stream">\n',
+    );
+    expect(outputs[outputs.length - 1]).toBe(
+      '</subagent name="reviewer" id="async-xml-stream">\n',
+    );
+  });
+});

--- a/packages/agents/src/tools/taskAsyncStreaming.test.ts
+++ b/packages/agents/src/tools/taskAsyncStreaming.test.ts
@@ -23,7 +23,48 @@ import type { AsyncTaskManager } from '@vybestack/llxprt-code-core/services/asyn
 interface AsyncStreamingHarness {
   tool: TaskTool;
   mockAsyncTaskManager: Record<string, ReturnType<typeof vi.fn>>;
+  /**
+   * Resolves when completeTask or failTask is invoked by the background
+   * execution path. Await via {@link expectCompletionWithin} to guard against
+   * indefinite hangs if the wiring regresses.
+   */
   completionPromise: Promise<void>;
+}
+
+/**
+ * Default deadline for the completion guard. Well below the 30s global Vitest
+ * testTimeout so a hang produces a clear, fast failure rather than a slow one.
+ */
+const COMPLETION_TIMEOUT_MS = 5_000;
+
+/**
+ * Races a completion promise against a deterministic local timeout. If the
+ * promise does not settle within `timeoutMs`, rejects with a message pointing
+ * at the completeTask/failTask wiring as the likely cause. Avoids repeating
+ * Promise.race boilerplate at each await site.
+ */
+function expectCompletionWithin(
+  completionPromise: Promise<void>,
+  timeoutMs: number = COMPLETION_TIMEOUT_MS,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `completionPromise did not settle within ${timeoutMs}ms — ` +
+              'completeTask/failTask wiring may be broken',
+          ),
+        ),
+      timeoutMs,
+    );
+  });
+  return Promise.race([completionPromise, timeout]).finally(() => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  });
 }
 
 /**
@@ -128,7 +169,7 @@ describe('TaskTool async streaming through real async path', () => {
       outputs.push(chunk),
     );
 
-    await completionPromise;
+    await expectCompletionWithin(completionPromise);
 
     const accumulated = extractMessageDeltas(outputs).join('');
 
@@ -163,7 +204,7 @@ describe('TaskTool async streaming through real async path', () => {
       outputs.push(chunk),
     );
 
-    await completionPromise;
+    await expectCompletionWithin(completionPromise);
 
     const accumulated = extractMessageDeltas(outputs).join('');
 
@@ -191,7 +232,7 @@ describe('TaskTool async streaming through real async path', () => {
       outputs.push(chunk),
     );
 
-    await completionPromise;
+    await expectCompletionWithin(completionPromise);
 
     // The existing handler receives the UN-normalized raw message.
     expect(receivedRaw).toStrictEqual(['raw\r\nmessage']);
@@ -218,7 +259,7 @@ describe('TaskTool async streaming through real async path', () => {
       outputs.push(chunk),
     );
 
-    await completionPromise;
+    await expectCompletionWithin(completionPromise);
 
     expect(outputs[0]).toBe(
       '<subagent name="reviewer" id="async-xml-stream">\n',
@@ -247,7 +288,7 @@ describe('TaskTool async streaming through real async path', () => {
       outputs.push(chunk),
     );
 
-    await completionPromise;
+    await expectCompletionWithin(completionPromise);
 
     expect(extractMessageDeltas(outputs).join('')).toBe('a\nb');
   });
@@ -271,7 +312,7 @@ describe('TaskTool async streaming through real async path', () => {
       outputs.push(chunk),
     );
 
-    await completionPromise;
+    await expectCompletionWithin(completionPromise);
 
     expect(extractMessageDeltas(outputs).join('')).toBe('hello\n');
   });
@@ -295,7 +336,7 @@ describe('TaskTool async streaming through real async path', () => {
       outputs.push(chunk),
     );
 
-    await completionPromise;
+    await expectCompletionWithin(completionPromise);
 
     expect(extractMessageDeltas(outputs).join('')).toBe(
       '<subagent name="not-wrapper">begin</subagent name="not-wrapper">end',

--- a/packages/core/src/scheduler/liveOutput.ts
+++ b/packages/core/src/scheduler/liveOutput.ts
@@ -23,6 +23,11 @@ import type { AnsiOutput } from '../utils/terminalSerializer.js';
  * drawn from a broader display union (e.g. `ToolResultDisplay`, which also
  * includes `FileDiff` / `FileRead`).  The function only ever appends when both
  * values are strings; any other combination replaces with the incoming chunk.
+ *
+ * Note: the append-vs-replace distinction is currently inferred from the
+ * payload type.  Migrating to an explicit tagged update protocol (e.g.
+ * `{ mode: 'append'; data: string } | { mode: 'replace'; data: AnsiOutput }`)
+ * is tracked in follow-up #2586.
  */
 export function accumulateLiveOutput(
   existing: unknown,

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.streaming.test.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.streaming.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { CoreSubagentServiceAdapter } from './CoreSubagentServiceAdapter.js';
+import type {
+  CoreSubagentLauncher,
+  CoreSubagentLaunchResult,
+} from './CoreSubagentServiceAdapter.js';
+import { SubagentTerminateMode } from '../core/subagentTypes.js';
+import type { Config } from '../config/config.js';
+import type { SubagentManager } from '../config/subagentManager.js';
+import type { ProfileManager } from '@vybestack/llxprt-code-settings';
+
+interface StreamingScope {
+  output: {
+    terminate_reason: SubagentTerminateMode;
+    emitted_vars: Record<string, string>;
+  };
+  onMessage?: (message: string) => void;
+  runInteractive: ReturnType<typeof vi.fn>;
+  runNonInteractive: ReturnType<typeof vi.fn>;
+}
+
+function createStreamingAdapter(emit: (scope: StreamingScope) => void): {
+  adapter: CoreSubagentServiceAdapter;
+} {
+  const scope: StreamingScope = {
+    output: {
+      terminate_reason: SubagentTerminateMode.GOAL,
+      emitted_vars: {},
+    },
+    onMessage: undefined,
+    runInteractive: vi.fn().mockImplementation(async () => {
+      emit(scope);
+    }),
+    runNonInteractive: vi.fn(),
+  };
+
+  const launchResult: CoreSubagentLaunchResult = {
+    agentId: 'agent-stream',
+    scope,
+    dispose: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CoreSubagentLaunchResult;
+
+  const fakeOrchestrator = {
+    launch: vi.fn().mockResolvedValue(launchResult),
+  } as unknown as CoreSubagentLauncher;
+
+  const config = {
+    getEphemeralSettings: () => ({}),
+    getSessionId: () => 'session-test',
+    isInteractive: () => true,
+  } as unknown as Config;
+
+  const adapter = new CoreSubagentServiceAdapter({
+    managerProvider: () => ({}) as unknown as SubagentManager,
+    profileManagerProvider: () => ({}) as unknown as ProfileManager,
+    config,
+    isInteractiveEnvironment: () => true,
+    orchestratorFactory: () => fakeOrchestrator,
+  });
+  return { adapter };
+}
+
+function extractMessageDeltas(
+  calls: ReturnType<typeof vi.fn>['mock']['calls'],
+): string[] {
+  return calls
+    .map((c) => c[0] as string)
+    .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
+}
+
+describe('CoreSubagentServiceAdapter lossless text streaming', () => {
+  it('preserves standalone newline chunks instead of dropping them', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      scope.onMessage?.('Hello');
+      scope.onMessage?.('\n');
+      scope.onMessage?.('World');
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas.join('')).toBe('Hello\nWorld');
+  });
+
+  it('preserves standalone spaces and tabs', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      scope.onMessage?.('a');
+      scope.onMessage?.(' ');
+      scope.onMessage?.('b');
+      scope.onMessage?.('\t');
+      scope.onMessage?.('c');
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas.join('')).toBe('a b\tc');
+  });
+
+  it('normalizes CR and CRLF to LF', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      scope.onMessage?.('line1\r');
+      scope.onMessage?.('line2\r\n');
+      scope.onMessage?.('\r');
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas.join('')).toBe('line1\nline2\n\n');
+  });
+
+  it('filters out only the truly empty string', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      scope.onMessage?.('');
+      scope.onMessage?.('real');
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas).toStrictEqual(['real']);
+  });
+
+  it('does not invent separators at fragment boundaries', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      for (const token of 'Hello World'.match(/(\w+|\s)/g) ?? []) {
+        scope.onMessage?.(token);
+      }
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas.join('')).toBe('Hello World');
+  });
+
+  it('forwards raw messages to the existing handler', async () => {
+    const existingHandler = vi.fn();
+    const scope: StreamingScope = {
+      output: {
+        terminate_reason: SubagentTerminateMode.GOAL,
+        emitted_vars: {},
+      },
+      onMessage: existingHandler,
+      runInteractive: vi.fn().mockImplementation(async () => {
+        scope.onMessage?.('raw\r\nmessage');
+      }),
+      runNonInteractive: vi.fn(),
+    };
+    const launchResult: CoreSubagentLaunchResult = {
+      agentId: 'agent-raw',
+      scope,
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CoreSubagentLaunchResult;
+    const fakeOrchestrator = {
+      launch: vi.fn().mockResolvedValue(launchResult),
+    } as unknown as CoreSubagentLauncher;
+    const config = {
+      getEphemeralSettings: () => ({}),
+      getSessionId: () => 'session-test',
+      isInteractive: () => true,
+    } as unknown as Config;
+    const adapter = new CoreSubagentServiceAdapter({
+      managerProvider: () => ({}) as unknown as SubagentManager,
+      profileManagerProvider: () => ({}) as unknown as ProfileManager,
+      config,
+      isInteractiveEnvironment: () => true,
+      orchestratorFactory: () => fakeOrchestrator,
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    expect(existingHandler).toHaveBeenCalledWith('raw\r\nmessage');
+  });
+});

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.streaming.test.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.streaming.test.ts
@@ -25,7 +25,10 @@ interface StreamingScope {
   runNonInteractive: ReturnType<typeof vi.fn>;
 }
 
-function createStreamingAdapter(emit: (scope: StreamingScope) => void): {
+function createStreamingAdapter(
+  emit: (scope: StreamingScope) => void,
+  options: { existingHandler?: (message: string) => void } = {},
+): {
   adapter: CoreSubagentServiceAdapter;
 } {
   const scope: StreamingScope = {
@@ -33,7 +36,7 @@ function createStreamingAdapter(emit: (scope: StreamingScope) => void): {
       terminate_reason: SubagentTerminateMode.GOAL,
       emitted_vars: {},
     },
-    onMessage: undefined,
+    onMessage: options.existingHandler,
     runInteractive: vi.fn().mockImplementation(async () => {
       emit(scope);
     }),
@@ -66,12 +69,20 @@ function createStreamingAdapter(emit: (scope: StreamingScope) => void): {
   return { adapter };
 }
 
+/**
+ * Asserts the exact XML wrapper tags then returns the interior deltas only.
+ * Avoids prefix filtering so model text starting with `<subagent ` is not dropped.
+ */
 function extractMessageDeltas(
   calls: ReturnType<typeof vi.fn>['mock']['calls'],
 ): string[] {
-  return calls
-    .map((c) => c[0] as string)
-    .filter((s) => !s.startsWith('<subagent') && !s.startsWith('</subagent'));
+  const all = calls.map((c) => c[0] as string);
+  expect(all.length).toBeGreaterThanOrEqual(2);
+  expect(all[0].startsWith('<subagent name="')).toBe(true);
+  expect(all[0].endsWith('">\n')).toBe(true);
+  expect(all[all.length - 1].startsWith('</subagent name="')).toBe(true);
+  expect(all[all.length - 1].endsWith('">\n')).toBe(true);
+  return all.slice(1, -1);
 }
 
 describe('CoreSubagentServiceAdapter lossless text streaming', () => {
@@ -163,37 +174,12 @@ describe('CoreSubagentServiceAdapter lossless text streaming', () => {
 
   it('forwards raw messages to the existing handler', async () => {
     const existingHandler = vi.fn();
-    const scope: StreamingScope = {
-      output: {
-        terminate_reason: SubagentTerminateMode.GOAL,
-        emitted_vars: {},
-      },
-      onMessage: existingHandler,
-      runInteractive: vi.fn().mockImplementation(async () => {
+    const { adapter } = createStreamingAdapter(
+      (scope) => {
         scope.onMessage?.('raw\r\nmessage');
-      }),
-      runNonInteractive: vi.fn(),
-    };
-    const launchResult: CoreSubagentLaunchResult = {
-      agentId: 'agent-raw',
-      scope,
-      dispose: vi.fn().mockResolvedValue(undefined),
-    } as unknown as CoreSubagentLaunchResult;
-    const fakeOrchestrator = {
-      launch: vi.fn().mockResolvedValue(launchResult),
-    } as unknown as CoreSubagentLauncher;
-    const config = {
-      getEphemeralSettings: () => ({}),
-      getSessionId: () => 'session-test',
-      isInteractive: () => true,
-    } as unknown as Config;
-    const adapter = new CoreSubagentServiceAdapter({
-      managerProvider: () => ({}) as unknown as SubagentManager,
-      profileManagerProvider: () => ({}) as unknown as ProfileManager,
-      config,
-      isInteractiveEnvironment: () => true,
-      orchestratorFactory: () => fakeOrchestrator,
-    });
+      },
+      { existingHandler },
+    );
     const updateOutput = vi.fn();
 
     await adapter.executeSubagent(
@@ -202,5 +188,54 @@ describe('CoreSubagentServiceAdapter lossless text streaming', () => {
     );
 
     expect(existingHandler).toHaveBeenCalledWith('raw\r\nmessage');
+  });
+
+  it('preserves CRLF semantics across split chunk boundaries', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      scope.onMessage?.('a\r');
+      scope.onMessage?.('\nb');
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas.join('')).toBe('a\nb');
+  });
+
+  it('flushes a pending CR as LF when the stream ends in a lone CR', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      scope.onMessage?.('hello\r');
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas.join('')).toBe('hello\n');
+  });
+
+  it('preserves model text that begins with exact subagent wrapper prefixes verbatim', async () => {
+    const { adapter } = createStreamingAdapter((scope) => {
+      scope.onMessage?.('<subagent name="not-wrapper">begin');
+      scope.onMessage?.('</subagent name="not-wrapper">end');
+    });
+    const updateOutput = vi.fn();
+
+    await adapter.executeSubagent(
+      { name: 'helper', prompt: 'Do work' },
+      { updateOutput },
+    );
+
+    const messageDeltas = extractMessageDeltas(updateOutput.mock.calls);
+    expect(messageDeltas.join('')).toBe(
+      '<subagent name="not-wrapper">begin</subagent name="not-wrapper">end',
+    );
   });
 });

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
@@ -6,7 +6,7 @@
 
 import {
   ToolErrorType,
-  toLosslessTextDelta,
+  createStreamNormalizer,
   type ISubagentService,
   type SubagentConfig as ToolsSubagentConfig,
   type SubagentExecutionOptions,
@@ -621,10 +621,11 @@ export class CoreSubagentServiceAdapter implements ISubagentService {
       return () => undefined;
     }
 
+    const normalizer = createStreamNormalizer();
     updateOutput(`<subagent name="${subagentName}" id="${agentId}">\n`);
     const existingHandler = scope.onMessage;
     scope.onMessage = (message: string) => {
-      const delta = toLosslessTextDelta(message);
+      const delta = normalizer.push(message);
       if (delta !== undefined) {
         updateOutput(delta);
       }
@@ -635,6 +636,10 @@ export class CoreSubagentServiceAdapter implements ISubagentService {
     return () => {
       if (!xmlOutputOpen) {
         return;
+      }
+      const flushed = normalizer.flush();
+      if (flushed !== undefined) {
+        updateOutput(flushed);
       }
       updateOutput(`</subagent name="${subagentName}" id="${agentId}">\n`);
       xmlOutputOpen = false;

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
@@ -6,6 +6,7 @@
 
 import {
   ToolErrorType,
+  toLosslessTextDelta,
   type ISubagentService,
   type SubagentConfig as ToolsSubagentConfig,
   type SubagentExecutionOptions,
@@ -39,7 +40,6 @@ import {
   getToolNameCandidates,
   isExcludedToolName,
   isToolBlocked,
-  normalizeSubagentStreamingText,
   resolveTimeoutSeconds,
   stringifySubagentOutput,
   toToolsSubagentConfig,
@@ -624,9 +624,9 @@ export class CoreSubagentServiceAdapter implements ISubagentService {
     updateOutput(`<subagent name="${subagentName}" id="${agentId}">\n`);
     const existingHandler = scope.onMessage;
     scope.onMessage = (message: string) => {
-      const cleaned = normalizeSubagentStreamingText(message);
-      if (cleaned.trim().length > 0) {
-        updateOutput(cleaned);
+      const delta = toLosslessTextDelta(message);
+      if (delta !== undefined) {
+        updateOutput(delta);
       }
       existingHandler?.(message);
     };

--- a/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
+++ b/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
@@ -177,8 +177,10 @@ export function formatSuccessContent(
  * Normalizes line endings in a streaming text fragment without forcing a
  * trailing newline. See taskAsyncExecution.ts for rationale.
  *
- * Preserved for backward compatibility; new callers should use
- * {@link toLosslessTextDelta} from `@vybestack/llxprt-code-tools`.
+ * Preserved for backward compatibility. Prefer `toLosslessTextDelta` for an
+ * isolated single delta (stateless CR/CRLF→LF), or `createStreamNormalizer`
+ * for a stream spanning chunk boundaries (correctly joins a CRLF pair split
+ * across consecutive deltas and flushes a trailing lone CR on close).
  */
 export function normalizeSubagentStreamingText(text: string): string {
   return text.replace(/\r\n?/g, '\n');

--- a/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
+++ b/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
@@ -176,11 +176,11 @@ export function formatSuccessContent(
 /**
  * Normalizes line endings in a streaming text fragment without forcing a
  * trailing newline. See taskAsyncExecution.ts for rationale.
+ *
+ * Preserved for backward compatibility; new callers should use
+ * {@link toLosslessTextDelta} from `@vybestack/llxprt-code-tools`.
  */
 export function normalizeSubagentStreamingText(text: string): string {
-  if (!text) {
-    return '';
-  }
   return text.replace(/\r\n?/g, '\n');
 }
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -51,6 +51,11 @@
       "bun": "./src/utils/fetch.ts",
       "import": "./dist/src/utils/fetch.js"
     },
+    "./textDelta.js": {
+      "types": "./dist/src/utils/textDelta.d.ts",
+      "bun": "./src/utils/textDelta.ts",
+      "import": "./dist/src/utils/textDelta.js"
+    },
     "./activate-skill.js": {
       "types": "./dist/src/tools/activate-skill.d.ts",
       "bun": "./src/tools/activate-skill.ts",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -177,7 +177,11 @@ export {
   type Replacer,
 } from './utils/fuzzy-replacer.js';
 export { ensureParentDirectoriesExist } from './utils/ensure-dirs.js';
-export { toLosslessTextDelta } from './utils/textDelta.js';
+export {
+  toLosslessTextDelta,
+  createStreamNormalizer,
+  type StreamNormalizer,
+} from './utils/textDelta.js';
 export {
   getRipgrepPath,
   isRipgrepAvailable,

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -177,6 +177,7 @@ export {
   type Replacer,
 } from './utils/fuzzy-replacer.js';
 export { ensureParentDirectoriesExist } from './utils/ensure-dirs.js';
+export { toLosslessTextDelta } from './utils/textDelta.js';
 export {
   getRipgrepPath,
   isRipgrepAvailable,

--- a/packages/tools/src/utils/textDelta.test.ts
+++ b/packages/tools/src/utils/textDelta.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { toLosslessTextDelta } from './textDelta.js';
+import { toLosslessTextDelta, createStreamNormalizer } from './textDelta.js';
 
 describe('toLosslessTextDelta', () => {
   it('returns undefined for the truly empty string', () => {
@@ -65,5 +65,157 @@ describe('toLosslessTextDelta', () => {
 
   it('does not trim surrounding whitespace from text deltas', () => {
     expect(toLosslessTextDelta('  spaced  ')).toBe('  spaced  ');
+  });
+});
+
+describe('createStreamNormalizer', () => {
+  it('returns undefined for the truly empty string', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('')).toBeUndefined();
+  });
+
+  it('preserves plain text content exactly', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('hello world')).toBe('hello world');
+  });
+
+  it('preserves standalone whitespace (space, tab, newline)', () => {
+    const n = createStreamNormalizer();
+    expect(n.push(' ')).toBe(' ');
+    expect(n.push('\t')).toBe('\t');
+    expect(n.push('\n')).toBe('\n');
+  });
+
+  it('normalizes CRLF within a single delta', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('hello\r\nworld')).toBe('hello\nworld');
+  });
+
+  it('preserves CRLF semantics across split chunk boundaries (a\\r then \\nb)', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('a\r')).toBe('a');
+    expect(n.push('\nb')).toBe('\nb');
+  });
+
+  it('does not invent an extra newline when CR is split from following LF', () => {
+    const n = createStreamNormalizer();
+    const accumulated = [n.push('a\r') ?? '', n.push('\nb') ?? ''].join('');
+    expect(accumulated).toBe('a\nb');
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('treats a lone CR followed by non-LF content as CR→LF then content', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('a\r')).toBe('a');
+    expect(n.push('b')).toBe('\nb');
+  });
+
+  it('flushes a pending CR as LF when the stream closes (ending in lone CR)', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('hello\r')).toBe('hello');
+    expect(n.flush()).toBe('\n');
+  });
+
+  it('returns undefined from flush when there is no pending CR', () => {
+    const n = createStreamNormalizer();
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('handles multiple consecutive CRLFs split across boundaries', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('x\r\n\r')).toBe('x\n');
+    expect(n.push('\ny')).toBe('\ny');
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('accumulates the exact issue sequence losslessly', () => {
+    const n = createStreamNormalizer();
+    const parts = [
+      'Analyzing the codebase...',
+      '\n',
+      'Found 3 issues:',
+      '\n',
+      '1. Missing import',
+    ];
+    const accumulated = parts.map((p) => n.push(p) ?? '').join('');
+    expect(accumulated).toBe(
+      'Analyzing the codebase...\nFound 3 issues:\n1. Missing import',
+    );
+  });
+
+  it('does not invent separators at word-token fragment boundaries', () => {
+    const n = createStreamNormalizer();
+    const accumulated = ('Hello World'.match(/(\w+|\s)/g) ?? [])
+      .map((t) => n.push(t) ?? '')
+      .join('');
+    expect(accumulated).toBe('Hello World');
+  });
+
+  it('normalizes CR/CRLF in a multi-delta stream ending with standalone whitespace', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('a')).toBe('a');
+    expect(n.push(' ')).toBe(' ');
+    expect(n.push('b')).toBe('b');
+    expect(n.push('\t')).toBe('\t');
+    expect(n.push('c')).toBe('c');
+    expect(n.push('\r')).toBeUndefined();
+    expect(n.push('d\r\ne')).toBe('\nd\ne');
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('treats an empty delta as a transport no-op even while a CR is pending', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('a\r')).toBe('a');
+    expect(n.push('')).toBeUndefined();
+    expect(n.push('\nb')).toBe('\nb');
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('survives repeated empty deltas while a CR is pending without emitting LF', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('a\r')).toBe('a');
+    expect(n.push('')).toBeUndefined();
+    expect(n.push('')).toBeUndefined();
+    expect(n.push('')).toBeUndefined();
+    expect(n.push('\nb')).toBe('\nb');
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('flushes a pending CR exactly once; repeated flush yields undefined', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('hello\r')).toBe('hello');
+    expect(n.flush()).toBe('\n');
+    expect(n.flush()).toBeUndefined();
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('handles internal CR/CRLF plus a trailing CR that is later consumed by LF', () => {
+    const n = createStreamNormalizer();
+    expect(n.push('x\ry\r\nz\r')).toBe('x\ny\nz');
+    expect(n.push('\nw')).toBe('\nw');
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('accumulates whitespace-only chunks without inventing separators', () => {
+    const n = createStreamNormalizer();
+    expect(n.push(' ')).toBe(' ');
+    expect(n.push('\t')).toBe('\t');
+    expect(n.push('\n')).toBe('\n');
+    expect(n.flush()).toBeUndefined();
+  });
+
+  it('full-stream accumulation across the issue sequence produces no double newline', () => {
+    const n = createStreamNormalizer();
+    const accumulated = ['a\r', '', '\nb'].map((p) => n.push(p) ?? '').join('');
+    expect(accumulated).toBe('a\nb');
+  });
+
+  it('provides independent state across separate instances', () => {
+    const a = createStreamNormalizer();
+    const b = createStreamNormalizer();
+    expect(a.push('a\r')).toBe('a');
+    expect(b.push('x')).toBe('x');
+    expect(a.flush()).toBe('\n');
+    expect(b.flush()).toBeUndefined();
   });
 });

--- a/packages/tools/src/utils/textDelta.test.ts
+++ b/packages/tools/src/utils/textDelta.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toLosslessTextDelta } from './textDelta.js';
+
+describe('toLosslessTextDelta', () => {
+  it('returns undefined for the truly empty string', () => {
+    expect(toLosslessTextDelta('')).toBeUndefined();
+  });
+
+  it('preserves a standalone newline', () => {
+    expect(toLosslessTextDelta('\n')).toBe('\n');
+  });
+
+  it('preserves a standalone space', () => {
+    expect(toLosslessTextDelta(' ')).toBe(' ');
+  });
+
+  it('preserves a standalone tab', () => {
+    expect(toLosslessTextDelta('\t')).toBe('\t');
+  });
+
+  it('preserves standalone whitespace-only content (multiple)', () => {
+    expect(toLosslessTextDelta('  \n\t ')).toBe('  \n\t ');
+  });
+
+  it('preserves non-whitespace text', () => {
+    expect(toLosslessTextDelta('hello world')).toBe('hello world');
+  });
+
+  it('preserves text with embedded newlines', () => {
+    expect(toLosslessTextDelta('line1\nline2')).toBe('line1\nline2');
+  });
+
+  it('preserves a leading newline before text', () => {
+    expect(toLosslessTextDelta('\nhello')).toBe('\nhello');
+  });
+
+  it('normalizes a lone CR to LF', () => {
+    expect(toLosslessTextDelta('hello\r')).toBe('hello\n');
+  });
+
+  it('normalizes CRLF to LF', () => {
+    expect(toLosslessTextDelta('hello\r\nworld')).toBe('hello\nworld');
+  });
+
+  it('normalizes CR-only line endings in a standalone newline chunk', () => {
+    expect(toLosslessTextDelta('\r')).toBe('\n');
+  });
+
+  it('normalizes CRLF standalone newline chunk to LF', () => {
+    expect(toLosslessTextDelta('\r\n')).toBe('\n');
+  });
+
+  it('does not invent separators at chunk boundaries', () => {
+    const first = toLosslessTextDelta('foo');
+    const second = toLosslessTextDelta('bar');
+    const accumulated = `${first ?? ''}${second ?? ''}`;
+    expect(accumulated).toBe('foobar');
+  });
+
+  it('does not trim surrounding whitespace from text deltas', () => {
+    expect(toLosslessTextDelta('  spaced  ')).toBe('  spaced  ');
+  });
+});

--- a/packages/tools/src/utils/textDelta.ts
+++ b/packages/tools/src/utils/textDelta.ts
@@ -40,24 +40,24 @@ export function createStreamNormalizer(): StreamNormalizer {
         return undefined;
       }
 
-      let work = text;
+      let candidateChunk = text;
 
       if (pendingCR) {
         pendingCR = false;
         if (text.charCodeAt(0) === 0x0a) {
-          work = '\n' + text.slice(1);
+          candidateChunk = '\n' + text.slice(1);
         } else {
-          work = '\n' + text;
+          candidateChunk = '\n' + text;
         }
       }
 
       if (text.charCodeAt(text.length - 1) === 0x0d) {
         pendingCR = true;
-        work = work.slice(0, -1);
+        candidateChunk = candidateChunk.slice(0, -1);
       }
 
-      const normalized = work.replace(/\r\n?/g, '\n');
-      return normalized.length > 0 ? normalized : undefined;
+      const normalizedChunk = candidateChunk.replace(/\r\n?/g, '\n');
+      return normalizedChunk.length > 0 ? normalizedChunk : undefined;
     },
 
     flush(): string | undefined {

--- a/packages/tools/src/utils/textDelta.ts
+++ b/packages/tools/src/utils/textDelta.ts
@@ -5,15 +5,67 @@
  */
 
 /**
- * Normalizes and filters a streaming text delta for lossless forwarding.
+ * Normalizes and filters a single streaming text delta for lossless
+ * forwarding. Returns `undefined` when the result is the truly empty
+ * string; all nonempty content (including whitespace) is preserved.
  *
- * Applies only transport-safe CR/CRLF-to-LF normalization and returns
- * `undefined` when the normalized result is the truly empty string. All
- * nonempty content — including standalone whitespace (spaces, tabs,
- * newlines) — is preserved exactly so callers never drop meaningful
- * formatting deltas.
+ * Stateless: cannot correctly join a CRLF pair split across chunk
+ * boundaries. For that, use {@link createStreamNormalizer}.
  */
 export function toLosslessTextDelta(text: string): string | undefined {
   const normalized = text.replace(/\r\n?/g, '\n');
   return normalized.length > 0 ? normalized : undefined;
+}
+
+/** Normalizes CR/CRLF to LF while preserving split CRLF pairs across chunks. */
+export interface StreamNormalizer {
+  /** Returns normalized text, or `undefined` when nothing should be forwarded. */
+  push(text: string): string | undefined;
+  /** Emits a buffered trailing CR as LF on stream close. Idempotent. */
+  flush(): string | undefined;
+}
+
+/**
+ * Creates an independent per-stream normalizer. A trailing lone CR is
+ * buffered until the next non-empty delta: if it starts with LF the pair
+ * collapses to a single LF, otherwise the CR becomes a standalone LF.
+ * Empty deltas are no-ops. Call {@link StreamNormalizer.flush} on close.
+ */
+export function createStreamNormalizer(): StreamNormalizer {
+  let pendingCR = false;
+
+  return {
+    push(text: string): string | undefined {
+      if (text.length === 0) {
+        return undefined;
+      }
+
+      let work = text;
+
+      if (pendingCR) {
+        pendingCR = false;
+        if (text.charCodeAt(0) === 0x0a) {
+          work = '\n' + text.slice(1);
+        } else {
+          work = '\n' + text;
+        }
+      }
+
+      if (text.charCodeAt(text.length - 1) === 0x0d) {
+        pendingCR = true;
+        work = work.slice(0, -1);
+      }
+
+      const normalized = work.replace(/\r\n?/g, '\n');
+      return normalized.length > 0 ? normalized : undefined;
+    },
+
+    flush(): string | undefined {
+      if (!pendingCR) {
+        return undefined;
+      }
+      pendingCR = false;
+      return '\n';
+    },
+  };
 }

--- a/packages/tools/src/utils/textDelta.ts
+++ b/packages/tools/src/utils/textDelta.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Normalizes and filters a streaming text delta for lossless forwarding.
+ *
+ * Applies only transport-safe CR/CRLF-to-LF normalization and returns
+ * `undefined` when the normalized result is the truly empty string. All
+ * nonempty content — including standalone whitespace (spaces, tabs,
+ * newlines) — is preserved exactly so callers never drop meaningful
+ * formatting deltas.
+ */
+export function toLosslessTextDelta(text: string): string | undefined {
+  const normalized = text.replace(/\r\n?/g, '\n');
+  return normalized.length > 0 ? normalized : undefined;
+}


### PR DESCRIPTION
## Summary

- preserve every nonempty provider-supplied subagent text delta, including standalone newlines, spaces, and tabs
- normalize CR and CRLF to LF without inventing separators at arbitrary stream chunk boundaries
- apply one shared transport-safe adapter across synchronous tasks, asynchronous tasks, and the core subagent adapter
- preserve XML framing and raw existing-handler forwarding
- document the current implicit live-output append/replace contract and defer its explicit tagged representation to follow-up #2586

## Root cause

All three subagent streaming wrappers normalized provider text and then used a trim-based content test. A standalone whitespace delta normalized correctly but trimmed to an empty string, so the wrapper discarded provider content before live-output accumulation.

## Implementation

Added a shared `toLosslessTextDelta` helper in the leaf tools package. It performs only transport-safe CR/CRLF normalization and returns no update only for a truly empty string. The synchronous TaskTool, public asynchronous TaskTool path, and CoreSubagentServiceAdapter now all use that helper.

Existing normalization exports remain available for compatibility. XML framing and final-result formatting remain separate from the transport adapter.

## Test coverage

Behavioral coverage now verifies:

- the exact standalone-newline reproduction
- standalone spaces and tabs
- embedded newlines
- arbitrary word-token fragments without manufactured separators
- CR and CRLF normalization
- filtering of only the truly empty string
- public asynchronous TaskTool wiring and deterministic background completion
- core adapter execution
- XML open/close framing
- raw existing-handler forwarding

## Verification

- `npm run test` completed all workspaces; the agents API-surface pretest timed out during the heavily concurrent workspace run, then the complete agents workspace passed independently with 288 files and 3305 tests
- `npm run lint` passed
- `npm run typecheck` passed after synchronizing the installed dependencies to the committed lockfile
- `npm run format` passed
- `npm run build` passed
- required CLI smoke booted and reached the configured provider; the provider returned an external HTTP 429 because the stepfun weekly quota is exhausted until its reported reset
- focused tools, agents, core, and live-output tests passed
- independent implementation review approved with no remaining findings
- Open Code Review reviewed 12 files and generated no comments

Fixes #2555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lossless, delta-based streaming for subagent output, preserving standalone spaces, tabs, and whitespace-only content.
  * Introduced a public text-delta utility for incremental lossless streaming normalization.

* **Bug Fixes**
  * Now filters only truly empty streaming fragments (not whitespace/control fragments).

* **Tests**
  * Expanded synchronous and async streaming coverage, including message forwarding behavior and correct CR/CRLF-to-LF handling across chunk boundaries (including trailing lone `\r`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->