### PR TITLE
Honor manual versions for nightly releases (Fixes #2589)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,11 @@ on:
         type: boolean
         default: true
       create_nightly_release:
-        description: 'Auto apply the nightly release tag, input version is ignored.'
+        description: >-
+          Create a nightly release. For scheduled runs the version is derived
+          from package.json. For manual dispatch the version input is used as
+          the nightly base version when provided, otherwise package.json is
+          used.
         required: false
         type: boolean
         default: false

--- a/dev-docs/npm.md
+++ b/dev-docs/npm.md
@@ -44,13 +44,13 @@ Every night at midnight UTC, the [Release workflow](https://github.com/acoliver/
 1.  Checks out the latest code from the `main` branch.
 2.  Installs all dependencies.
 3.  Runs the full suite of `preflight` checks and integration tests.
-4.  If all tests succeed, it calculates the next nightly version number (e.g., `v0.2.1-nightly.20230101`).
+4.  If all tests succeed, it calculates the next nightly version number. The base version is taken from `package.json` for scheduled runs. For manual nightly dispatch (`create_nightly_release`), the optional `version` input is used as the nightly base when provided as a stable `X.Y.Z` or `vX.Y.Z`; otherwise `package.json` is used. The resulting tag has the shape `vX.Y.Z-nightly.YYMMDD.shortsha` (e.g., `v0.1.0-nightly.250720.abcdef`), where `YYMMDD` is the UTC date and `shortsha` is the short commit SHA.
 5.  It then builds and publishes the packages to npm with the `nightly` dist-tag.
 6.  Finally, it creates a GitHub Release for the nightly version.
 
 ### Failure Handling
 
-If any step in the nightly workflow fails, it will automatically create a new issue in the repository with the labels `bug` and `nightly-failure`. The issue will contain a link to the failed workflow run for easy debugging.
+If the nightly workflow fails, the `notify_failure` job creates (or comments on) a GitHub issue labeled `ci/cd` linking to the failed workflow run. (Release workflow failures create an issue labeled `ci/cd` as well.) These issues are tracked for debugging rather than being filed as generic bugs.
 
 ### How to Use the Nightly Build
 

--- a/scripts/get-release-version.ts
+++ b/scripts/get-release-version.ts
@@ -31,8 +31,31 @@ function getShortSha(): string {
   return execSync('git rev-parse --short HEAD').toString().trim();
 }
 
-export function getNightlyTagName(): string {
-  const version = getPackageVersion();
+const STABLE_SEMVER_RE = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+
+function stripLeadingV(version: string): string {
+  return version.startsWith('v') ? version.slice(1) : version;
+}
+
+function assertStableManualNightlyBase(manualVersion: string): void {
+  const base = stripLeadingV(manualVersion);
+  if (!STABLE_SEMVER_RE.test(base)) {
+    throw new Error(
+      'Error: Nightly manual version must be a stable numeric semver (X.Y.Z). Pre-release, build metadata, and other formats are not supported for nightly bases.',
+    );
+  }
+}
+
+function getNightlyBaseVersion(manualVersion?: string): string {
+  if (manualVersion === undefined || manualVersion === '') {
+    return getPackageVersion();
+  }
+  assertStableManualNightlyBase(manualVersion);
+  return stripLeadingV(manualVersion);
+}
+
+export function getNightlyTagName(manualVersion?: string): string {
+  const version = getNightlyBaseVersion(manualVersion);
   const now = new Date();
   const year = now.getUTCFullYear().toString().slice(-2);
   const month = (now.getUTCMonth() + 1).toString().padStart(2, '0');
@@ -59,7 +82,7 @@ export function getReleaseVersion(): ReleaseVersionInfo {
 
   if (isNightly) {
     console.error('Calculating next nightly version...');
-    releaseTag = getNightlyTagName();
+    releaseTag = getNightlyTagName(manualVersion);
   } else if (isPreview) {
     console.error('Calculating next beta version...');
     const betaVersion = getBetaVersion();

--- a/scripts/tests/get-release-version.test.js
+++ b/scripts/tests/get-release-version.test.js
@@ -38,12 +38,19 @@ describe('getReleaseVersion', () => {
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
+    delete process.env.IS_NIGHTLY;
+    delete process.env.IS_PREVIEW;
+    delete process.env.MANUAL_VERSION;
     vi.useFakeTimers();
+    vi.mocked(fs.default.readFileSync).mockReturnValue(
+      JSON.stringify({ version: '0.1.0' }),
+    );
+    vi.mocked(execSync).mockReturnValue('abcdef');
   });
 
   afterEach(() => {
     process.env = originalEnv;
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     vi.useRealTimers();
   });
 
@@ -51,14 +58,122 @@ describe('getReleaseVersion', () => {
     process.env.IS_NIGHTLY = 'true';
     const knownDate = new Date('2025-07-20T10:00:00.000Z');
     vi.setSystemTime(knownDate);
-    vi.mocked(fs.default.readFileSync).mockReturnValue(
-      JSON.stringify({ version: '0.1.0' }),
-    );
-    vi.mocked(execSync).mockReturnValue('abcdef');
     const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
     expect(releaseTag).toBe('v0.1.0-nightly.250720.abcdef');
     expect(releaseVersion).toBe('0.1.0-nightly.250720.abcdef');
     expect(npmTag).toBe('nightly');
+  });
+
+  it('should use MANUAL_VERSION as nightly base when IS_NIGHTLY and MANUAL_VERSION are set', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '0.11.0';
+    const knownDate = new Date('2025-07-20T10:00:00.000Z');
+    vi.setSystemTime(knownDate);
+    const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
+    expect(releaseTag).toBe('v0.11.0-nightly.250720.abcdef');
+    expect(releaseVersion).toBe('0.11.0-nightly.250720.abcdef');
+    expect(npmTag).toBe('nightly');
+  });
+
+  it('should support v-prefixed MANUAL_VERSION as nightly base', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = 'v0.11.0';
+    const knownDate = new Date('2025-07-20T10:00:00.000Z');
+    vi.setSystemTime(knownDate);
+    const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
+    expect(releaseTag).toBe('v0.11.0-nightly.250720.abcdef');
+    expect(releaseVersion).toBe('0.11.0-nightly.250720.abcdef');
+    expect(npmTag).toBe('nightly');
+  });
+
+  it('should fall back to package.json when MANUAL_VERSION is absent for nightly', () => {
+    process.env.IS_NIGHTLY = 'true';
+    delete process.env.MANUAL_VERSION;
+    const knownDate = new Date('2025-07-20T10:00:00.000Z');
+    vi.setSystemTime(knownDate);
+    const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
+    expect(releaseTag).toBe('v0.1.0-nightly.250720.abcdef');
+    expect(releaseVersion).toBe('0.1.0-nightly.250720.abcdef');
+    expect(npmTag).toBe('nightly');
+  });
+
+  it('should fall back to package.json when MANUAL_VERSION is empty for nightly', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '';
+    const knownDate = new Date('2025-07-20T10:00:00.000Z');
+    vi.setSystemTime(knownDate);
+    const { releaseTag, releaseVersion, npmTag } = getReleaseVersion();
+    expect(releaseTag).toBe('v0.1.0-nightly.250720.abcdef');
+    expect(releaseVersion).toBe('0.1.0-nightly.250720.abcdef');
+    expect(npmTag).toBe('nightly');
+  });
+
+  it('should throw for prerelease MANUAL_VERSION base under nightly', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = 'v0.11.0-beta.1';
+    expect(() => getReleaseVersion()).toThrow(
+      'Error: Nightly manual version must be a stable numeric semver',
+    );
+  });
+
+  it('should throw for build-metadata MANUAL_VERSION base under nightly', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '0.11.0+build1';
+    expect(() => getReleaseVersion()).toThrow(
+      'Error: Nightly manual version must be a stable numeric semver',
+    );
+  });
+
+  it('should throw for malformed MANUAL_VERSION base under nightly', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '0.11';
+    expect(() => getReleaseVersion()).toThrow(
+      'Error: Nightly manual version must be a stable numeric semver',
+    );
+  });
+
+  it('should reject leading-zero major component in nightly base (01.2.3)', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '01.2.3';
+    expect(() => getReleaseVersion()).toThrow(
+      'Error: Nightly manual version must be a stable numeric semver',
+    );
+  });
+
+  it('should reject leading-zero minor component in nightly base (1.02.3)', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '1.02.3';
+    expect(() => getReleaseVersion()).toThrow(
+      'Error: Nightly manual version must be a stable numeric semver',
+    );
+  });
+
+  it('should reject leading-zero patch component in nightly base (1.2.03)', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '1.2.03';
+    expect(() => getReleaseVersion()).toThrow(
+      'Error: Nightly manual version must be a stable numeric semver',
+    );
+  });
+
+  it('should reject v-prefixed leading-zero nightly base (v01.2.3)', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = 'v01.2.3';
+    expect(() => getReleaseVersion()).toThrow(
+      'Error: Nightly manual version must be a stable numeric semver',
+    );
+  });
+
+  it('should accept zero-valued components in nightly base (0.0.0, 0.10.0)', () => {
+    process.env.IS_NIGHTLY = 'true';
+    process.env.MANUAL_VERSION = '0.0.0';
+    vi.setSystemTime(new Date('2025-07-20T10:00:00.000Z'));
+    expect(getReleaseVersion().releaseTag).toBe('v0.0.0-nightly.250720.abcdef');
+
+    process.env.MANUAL_VERSION = '0.10.0';
+    expect(getReleaseVersion().releaseTag).toBe(
+      'v0.10.0-nightly.250720.abcdef',
+    );
   });
 
   it('should use manual version when provided', () => {
@@ -247,6 +362,177 @@ describe('get-release-version script CLI contract', () => {
     expect(parsed.releaseTag).toMatch(
       /^v\d+\.\d+\.\d+-nightly\.\d{6}\.[0-9a-f]+$/,
     );
+  });
+
+  it('uses MANUAL_VERSION as nightly base for manual nightly dispatch', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    if (!gitAvailable()) {
+      if (process.env.CI === 'true') {
+        throw new Error(
+          'git is required for nightly get-release-version CLI contract tests in CI.',
+        );
+      }
+      ctx.skip();
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: '0.11.0',
+    });
+    expectCleanJsonStdout(result);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.npmTag).toBe('nightly');
+    expect(parsed.releaseTag).toMatch(/^v0\.11\.0-nightly\.\d{6}\.[0-9a-f]+$/);
+    expect(parsed.releaseVersion).toMatch(
+      /^0\.11\.0-nightly\.\d{6}\.[0-9a-f]+$/,
+    );
+  });
+
+  it('supports v-prefixed MANUAL_VERSION for manual nightly dispatch', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    if (!gitAvailable()) {
+      if (process.env.CI === 'true') {
+        throw new Error(
+          'git is required for nightly get-release-version CLI contract tests in CI.',
+        );
+      }
+      ctx.skip();
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: 'v0.11.0',
+    });
+    expectCleanJsonStdout(result);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.npmTag).toBe('nightly');
+    expect(parsed.releaseTag).toMatch(/^v0\.11\.0-nightly\.\d{6}\.[0-9a-f]+$/);
+  });
+
+  it('rejects malformed MANUAL_VERSION base under nightly dispatch', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: '0.11',
+    });
+    expect(result.status).not.toBeNull();
+    expect(result.status, `stderr: ${result.stderr}`).toBeGreaterThan(0);
+    expect(result.stderr).toMatch(
+      /Error: Nightly manual version must be a stable numeric semver/,
+    );
+    const trimmed = result.stdout.trim();
+    if (trimmed.startsWith('{')) {
+      throw new Error(`Unexpected JSON on stdout for error case: ${trimmed}`);
+    }
+  });
+
+  it('rejects prerelease MANUAL_VERSION base under nightly dispatch', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: 'v0.11.0-beta.1',
+    });
+    expect(result.status).not.toBeNull();
+    expect(result.status, `stderr: ${result.stderr}`).toBeGreaterThan(0);
+    expect(result.stderr).toMatch(
+      /Error: Nightly manual version must be a stable numeric semver/,
+    );
+    const trimmed = result.stdout.trim();
+    if (trimmed.startsWith('{')) {
+      throw new Error(`Unexpected JSON on stdout for error case: ${trimmed}`);
+    }
+  });
+
+  it('rejects build-metadata MANUAL_VERSION base under nightly dispatch', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: '0.11.0+build1',
+    });
+    expect(result.status).not.toBeNull();
+    expect(result.status, `stderr: ${result.stderr}`).toBeGreaterThan(0);
+    expect(result.stderr).toMatch(
+      /Error: Nightly manual version must be a stable numeric semver/,
+    );
+    const trimmed = result.stdout.trim();
+    if (trimmed.startsWith('{')) {
+      throw new Error(`Unexpected JSON on stdout for error case: ${trimmed}`);
+    }
+  });
+
+  it('rejects leading-zero major in MANUAL_VERSION nightly base before tag creation', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: '01.2.3',
+    });
+    expect(result.status).not.toBeNull();
+    expect(result.status, `stderr: ${result.stderr}`).toBeGreaterThan(0);
+    expect(result.stderr).toMatch(
+      /Error: Nightly manual version must be a stable numeric semver/,
+    );
+    const trimmed = result.stdout.trim();
+    if (trimmed.startsWith('{')) {
+      throw new Error(`Unexpected JSON on stdout for error case: ${trimmed}`);
+    }
+  });
+
+  it('rejects leading-zero minor in MANUAL_VERSION nightly base before tag creation', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: '1.02.3',
+    });
+    expect(result.status).not.toBeNull();
+    expect(result.status, `stderr: ${result.stderr}`).toBeGreaterThan(0);
+    expect(result.stderr).toMatch(
+      /Error: Nightly manual version must be a stable numeric semver/,
+    );
+    const trimmed = result.stdout.trim();
+    if (trimmed.startsWith('{')) {
+      throw new Error(`Unexpected JSON on stdout for error case: ${trimmed}`);
+    }
+  });
+
+  it('rejects leading-zero patch in MANUAL_VERSION nightly base before tag creation', (ctx) => {
+    if (skipWhenBunUnavailable(ctx)) {
+      return;
+    }
+    const result = runScript({
+      IS_NIGHTLY: 'true',
+      IS_PREVIEW: '',
+      MANUAL_VERSION: '1.2.03',
+    });
+    expect(result.status).not.toBeNull();
+    expect(result.status, `stderr: ${result.stderr}`).toBeGreaterThan(0);
+    expect(result.stderr).toMatch(
+      /Error: Nightly manual version must be a stable numeric semver/,
+    );
+    const trimmed = result.stdout.trim();
+    if (trimmed.startsWith('{')) {
+      throw new Error(`Unexpected JSON on stdout for error case: ${trimmed}`);
+    }
   });
 
   it('keeps manual-version diagnostic text off stdout', (ctx) => {

--- a/scripts/tests/release-process.test.js
+++ b/scripts/tests/release-process.test.js
@@ -257,6 +257,20 @@ describe('.github/workflows/release.yml', () => {
     );
     expect(releaseYml).toContain('npm pack -w @vybestack/llxprt-code-agents');
   });
+
+  it('does not claim create_nightly_release ignores the version input', () => {
+    expect(releaseYml).not.toContain('input version is ignored');
+  });
+
+  it('documents that create_nightly_release distinguishes manual from scheduled dispatch', () => {
+    expect(releaseYml).toContain('create_nightly_release');
+    const nightlyInput = releaseYml.slice(
+      releaseYml.indexOf('create_nightly_release'),
+      releaseYml.indexOf('force_skip_tests'),
+    );
+    expect(nightlyInput).toContain('manual');
+    expect(nightlyInput).toContain('scheduled');
+  });
 });
 
 describe('scripts/build_sandbox.ts', () => {


### PR DESCRIPTION
## Summary

- use the manually supplied stable version as the base for manually dispatched nightly releases
- preserve the package.json fallback for scheduled nightlies and manual nightlies without a version input
- validate manual nightly bases as stable numeric semantic versions before constructing a tag
- update workflow guidance and npm release documentation to describe the actual behavior

## Root cause

The failed release run was dispatched from dev/0.11.0 with version 0.11.0 and nightly release enabled. Nightly version calculation ignored the manual version and always read the root package version, which was 0.10.0. That produced v0.10.0-nightly.260716.7183b03ab and caused the failure issue to carry the wrong version.

The release itself stopped during preflight lint because the source commit exceeded the 800-line limit in packages/agents/src/core/turn.ts and packages/agents/src/tools/task.ts. Those files have already been refactored on main, and the exact focused eslint check passes on this branch; this PR does not alter those unrelated files.

## Behavior

- version 0.11.0 or v0.11.0 with nightly enabled produces v0.11.0-nightly.YYMMDD.shortsha
- absent or empty manual version continues to derive the nightly base from package.json
- malformed, prerelease, build-metadata, and leading-zero manual nightly bases fail before tag construction
- non-nightly manual and preview behavior remains unchanged

## Verification

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- focused shuffled release-version and workflow tests
- ambient release-environment regression test
- focused eslint on the historical turn.ts and task.ts failure paths
- OpenCodeReview completed and its actionable mock-isolation finding was addressed

The required stepfun-37 CLI smoke was attempted and reached the provider, but the provider returned HTTP 429 because the weekly step-plan quota is exhausted until 2026-07-17T00:00:00Z.

Fixes #2589
