### PR TITLE
Keep release guard tests responsive (Fixes #2584)

### DIFF
--- a/scripts/tests/genai-enclave-guard-helpers.ts
+++ b/scripts/tests/genai-enclave-guard-helpers.ts
@@ -7,15 +7,18 @@
 /**
  * Shared test helpers for the genai-enclave guard behavioral tests.
  *
- * These helpers invoke the real guard script via execFileSync (no mock
- * theater) and manage temp-fixture creation/cleanup.
+ * These helpers invoke the real guard script via an async child process
+ * (no mock theater) and manage temp-fixture creation/cleanup.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
+import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
 
 export const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = join(SCRIPT_DIR, '..', '..');
@@ -52,12 +55,12 @@ export interface ScriptResult {
 }
 
 interface ExecErrorLike {
-  readonly status?: number | null;
+  readonly exitCode?: number | null;
+  readonly systemCode?: string;
   readonly signal?: string;
-  readonly code?: string;
   readonly message: string;
-  readonly stdout?: string | Buffer;
-  readonly stderr?: string | Buffer;
+  readonly stdout?: string;
+  readonly stderr?: string;
 }
 
 function toExecError(error: unknown): ExecErrorLike {
@@ -65,29 +68,26 @@ function toExecError(error: unknown): ExecErrorLike {
     return { message: String(error) };
   }
   const candidate = error as Record<string, unknown>;
+  const rawCode = candidate.code;
   return {
-    status:
-      typeof candidate.status === 'number' || candidate.status === null
-        ? candidate.status
-        : undefined,
+    exitCode: typeof rawCode === 'number' ? rawCode : null,
+    systemCode: typeof rawCode === 'string' ? rawCode : undefined,
     signal: typeof candidate.signal === 'string' ? candidate.signal : undefined,
-    code: typeof candidate.code === 'string' ? candidate.code : undefined,
     message:
       typeof candidate.message === 'string' ? candidate.message : String(error),
-    stdout: isOutput(candidate.stdout) ? candidate.stdout : undefined,
-    stderr: isOutput(candidate.stderr) ? candidate.stderr : undefined,
+    stdout: typeof candidate.stdout === 'string' ? candidate.stdout : undefined,
+    stderr: typeof candidate.stderr === 'string' ? candidate.stderr : undefined,
   };
-}
-
-function isOutput(value: unknown): value is string | Buffer {
-  return typeof value === 'string' || Buffer.isBuffer(value);
 }
 
 /**
  * Run the guard script against `root` (a temp fixture root). Returns exit
  * code, stdout, stderr.
  */
-export function runScript(root: string, expectedCode?: number): ScriptResult {
+export function runScript(
+  root: string,
+  expectedCode?: number,
+): Promise<ScriptResult> {
   const env = { ...process.env, GENAI_ENCLAVE_ROOT: root };
   return runGuard(env, 30_000, 10 * 1024 * 1024, expectedCode);
 }
@@ -95,48 +95,68 @@ export function runScript(root: string, expectedCode?: number): ScriptResult {
 /**
  * Run the guard script against the real repository (no GENAI_ENCLAVE_ROOT).
  */
-export function runScriptRealRepo(expectedCode?: number): ScriptResult {
+export function runScriptRealRepo(
+  expectedCode?: number,
+): Promise<ScriptResult> {
   const env = { ...process.env };
   delete env.GENAI_ENCLAVE_ROOT;
   return runGuard(env, 60_000, 20 * 1024 * 1024, expectedCode);
 }
-function runGuard(
+
+export function runScriptWithMaxBuffer(
+  root: string,
+  maxBuffer: number,
+  expectedCode?: number,
+): Promise<ScriptResult> {
+  const env = { ...process.env, GENAI_ENCLAVE_ROOT: root };
+  return runGuard(env, 30_000, maxBuffer, expectedCode);
+}
+
+async function runGuard(
   env: NodeJS.ProcessEnv,
   timeout: number,
   maxBuffer: number,
   expectedCode?: number,
-): ScriptResult {
+): Promise<ScriptResult> {
   let stdout = '';
   let stderr = '';
   let exitCode = 0;
   try {
-    stdout = execFileSync(RUNTIME, [SCRIPT], {
+    const result = await execFileAsync(RUNTIME, [SCRIPT], {
       cwd: REPO_ROOT,
       env,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
       timeout,
       maxBuffer,
     });
+    stdout = result.stdout;
+    stderr = result.stderr;
   } catch (error) {
     const err = toExecError(error);
-    const isTimeout =
-      err.status === null &&
-      (err.signal === 'SIGTERM' || err.code === 'ETIMEDOUT');
-    if (isTimeout) {
+    if (
+      err.systemCode === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' ||
+      err.systemCode === 'ENOBUFS'
+    ) {
+      throw new Error(
+        `Guard script exceeded maxBuffer (${maxBuffer} bytes) and was killed ` +
+          `(${err.systemCode}). This is an operational harness failure, not a ` +
+          `guard exit — output was truncated. Original: ${err.message}`,
+      );
+    }
+    if (err.signal === 'SIGTERM' || err.systemCode === 'ETIMEDOUT') {
       throw new Error(
         `Guard script timed out after ${timeout / 1000}s (SIGTERM/ETIMEDOUT).`,
       );
     }
-    if (err.code === 'ENOENT') {
+    if (err.systemCode === 'ENOENT') {
       throw new Error(
         `Guard script failed with ENOENT. Runtime "${RUNTIME}" not on PATH ` +
           `or script missing: ${SCRIPT}. Original: ${err.message}`,
       );
     }
-    stdout = err.stdout ? err.stdout.toString() : '';
-    stderr = err.stderr ? err.stderr.toString() : '';
-    exitCode = err.status ?? 1;
+    stdout = err.stdout ?? '';
+    stderr = err.stderr ?? '';
+    exitCode = err.exitCode ?? 1;
   }
   if (expectedCode !== undefined && exitCode !== expectedCode) {
     throw new Error(
@@ -186,9 +206,9 @@ export function writeRequiredManifests(write: FixtureHelpers['write']): void {
  * Create a temp fixture directory, run `fn` with write helpers, and clean up.
  * Cleanup errors are emitted as warnings rather than thrown.
  */
-export function withFixture(
-  fn: (helpers: FixtureHelpers) => ScriptResult,
-): ScriptResult {
+export async function withFixture(
+  fn: (helpers: FixtureHelpers) => Promise<ScriptResult>,
+): Promise<ScriptResult> {
   const root = mkdtempSync(join(tmpdir(), 'genai-enclave-'));
   let result: ScriptResult;
   try {
@@ -197,7 +217,7 @@ export function withFixture(
       mkdirSync(dirname(full), { recursive: true });
       writeFileSync(full, content);
     };
-    result = fn({ root, write });
+    result = await fn({ root, write });
   } finally {
     try {
       rmSync(root, { recursive: true, force: true });

--- a/scripts/tests/genai-enclave-guard-manifest.test.ts
+++ b/scripts/tests/genai-enclave-guard-manifest.test.ts
@@ -13,7 +13,7 @@
  * (package.json dependency declarations) and operational fail-closed
  * behavior.
  *
- * Tests invoke the real guard script via execFileSync (no mock theater).
+ * Tests invoke the real guard script via an async child process (no mock theater).
  *
  * Per RULES.md: positive tests ISOLATE the enclave under test; negative
  * tests verify the exact file that should be flagged.
@@ -47,8 +47,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
     // reaches the manifest check and fails specifically on the manifest
     // violation (not on "no scannable files found").
     describe('manifest violations', () => {
-      it('allows the root packaging bridge at the sanctioned version', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows the root packaging bridge at the sanctioned version', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           write(
             'package.json',
             JSON.stringify({
@@ -77,8 +77,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('FAILS when packages/cli declares @google/genai', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when packages/cli declares @google/genai', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/package.json',
@@ -95,8 +95,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('@google/genai');
       });
 
-      it('FAILS when a nested package manifest declares @google/genai', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when a nested package manifest declares @google/genai', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/examples/server/package.json',
@@ -113,8 +113,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('@google/genai');
       });
 
-      it('FAILS when packages/core declares wrong version of @google/genai', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when packages/core declares wrong version of @google/genai', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite packages/core with the wrong version
           write(
@@ -132,8 +132,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('1.30.0');
       });
 
-      it('FAILS when packages/cli declares @google/genai in optionalDependencies', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when packages/cli declares @google/genai in optionalDependencies', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/package.json',
@@ -150,8 +150,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('@google/genai');
       });
 
-      it('FAILS when root package.json is malformed JSON (fail-closed)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when root package.json is malformed JSON (fail-closed)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite root with broken JSON
           write(
@@ -165,8 +165,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('fail-closed');
       });
 
-      it('allows packages/core to declare @google/genai at 1.30.0', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows packages/core to declare @google/genai at 1.30.0', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           write(
             'package.json',
             JSON.stringify({
@@ -194,8 +194,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('allows packages/providers to declare @google/genai at 1.30.0', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows packages/providers to declare @google/genai at 1.30.0', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           write(
             'package.json',
             JSON.stringify({
@@ -223,8 +223,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('FAILS when a dependency section is an array instead of an object (fail-closed)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when a dependency section is an array instead of an object (fail-closed)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite root with array deps
           write(
@@ -242,8 +242,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('dependencies');
       });
 
-      it('FAILS when a dependency section is a string instead of an object (fail-closed)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when a dependency section is a string instead of an object (fail-closed)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite core with string deps
           write(
@@ -260,8 +260,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('fail-closed');
       });
 
-      it('FAILS when a dependency section is null instead of an object (fail-closed)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when a dependency section is null instead of an object (fail-closed)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/package.json',
@@ -277,8 +277,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('fail-closed');
       });
 
-      it('FAILS when an npm alias targets @google/genai (F1)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when an npm alias targets @google/genai (F1)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/package.json',
@@ -297,8 +297,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('@google/genai');
       });
 
-      it('FAILS when an npm alias targets a @google/genai subpath (F1)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when an npm alias targets a @google/genai subpath (F1)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/agents/package.json',
@@ -316,8 +316,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('npm alias');
       });
 
-      it('FAILS when SDK declared in both dependencies and devDependencies (F9)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when SDK declared in both dependencies and devDependencies (F9)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite core with duplicate sections
           write(
@@ -335,8 +335,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('duplicate');
       });
 
-      it('FAILS when SDK declared in both dependencies and peerDependencies (F9)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when SDK declared in both dependencies and peerDependencies (F9)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite providers with duplicate sections
           write(
@@ -354,8 +354,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('duplicate');
       });
 
-      it('FAILS when SDK declared in dependencies and optionalDependencies (F9)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when SDK declared in dependencies and optionalDependencies (F9)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite core with duplicate deps + optionalDependencies
           write(
@@ -374,8 +374,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('optionalDependencies');
       });
 
-      it('FAILS when a sanctioned workspace omits the SDK from dependencies (F10)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when a sanctioned workspace omits the SDK from dependencies (F10)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           // Overwrite core with a manifest that omits the SDK
           write(
@@ -392,8 +392,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('missing');
       });
 
-      it('FAILS when a dependency value is not a string (F6 fail-closed)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when a dependency value is not a string (F6 fail-closed)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/package.json',
@@ -409,10 +409,10 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('fail-closed');
       });
 
-      it('FAILS when a required root manifest is absent (F4 fail-closed)', () => {
+      it('FAILS when a required root manifest is absent (F4 fail-closed)', async () => {
         // Root package.json is missing entirely — the packaging bridge
         // must be checked, so its absence is an operational failure.
-        const { code, stdout } = withFixture(({ root, write }) => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write('packages/cli/src/index.ts', 'export const x = 1;\n');
           return runScript(root, 1);
         });
@@ -421,8 +421,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('package.json');
       });
 
-      it('FAILS when packages/core manifest is absent (F4 fail-closed)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when packages/core manifest is absent (F4 fail-closed)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'package.json',
             JSON.stringify({
@@ -446,8 +446,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('packages/core');
       });
 
-      it('FAILS when packages/providers manifest is absent (F4 fail-closed)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS when packages/providers manifest is absent (F4 fail-closed)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'package.json',
             JSON.stringify({
@@ -473,15 +473,17 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
 
     // ── Operational failures (fail-closed) ─────────────────────────────
     describe('operational failures (fail-closed)', () => {
-      it('FAILS when zero TypeScript files are found (temp root with no packages)', () => {
+      it('FAILS when zero TypeScript files are found (temp root with no packages)', async () => {
         // No files written — packages/ dir does not exist
-        const { code, stdout } = withFixture(({ root }) => runScript(root));
+        const { code, stdout } = await withFixture(({ root }) =>
+          runScript(root),
+        );
         expect(code).toBe(1);
         expect(stdout).toContain('no scannable files found');
       });
 
-      it('FAILS on source with parse diagnostics (invalid syntax)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS on source with parse diagnostics (invalid syntax)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/broken-syntax.ts',
             'export const x = ((((;\n',

--- a/scripts/tests/genai-enclave-guard-maxbuffer.test.ts
+++ b/scripts/tests/genai-enclave-guard-maxbuffer.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  bunAvailable,
+  runScriptWithMaxBuffer,
+  withFixture,
+} from './genai-enclave-guard-helpers.ts';
+
+describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
+  'check-genai-enclave (maxBuffer overflow)',
+  () => {
+    beforeAll(() => {
+      if (process.env.CI === 'true' && !bunAvailable()) {
+        throw new Error(
+          '[genai-enclave] Bun runtime not found — install Bun or set BUN_EXECUTABLE.',
+        );
+      }
+    });
+
+    it('rejects on maxBuffer overflow rather than satisfying expectedCode 1 (ERR_CHILD_PROCESS_STDIO_MAXBUFFER at 256 bytes)', async () => {
+      const tinyMaxBuffer = 256;
+      await expect(
+        withFixture(({ root, write }) => {
+          for (let i = 0; i < 12; i++) {
+            write(
+              `packages/cli/src/violation${i}.ts`,
+              "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
+            );
+          }
+          return runScriptWithMaxBuffer(root, tinyMaxBuffer, 1);
+        }),
+      ).rejects.toThrow(
+        'Guard script exceeded maxBuffer (256 bytes) and was killed (ERR_CHILD_PROCESS_STDIO_MAXBUFFER)',
+      );
+    }, 60_000);
+
+    it('diagnostic for 128-byte maxBuffer names both the buffer value and ERR_CHILD_PROCESS_STDIO_MAXBUFFER', async () => {
+      const tinyMaxBuffer = 128;
+      await expect(
+        withFixture(({ root, write }) => {
+          for (let i = 0; i < 12; i++) {
+            write(
+              `packages/cli/src/violation${i}.ts`,
+              "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
+            );
+          }
+          return runScriptWithMaxBuffer(root, tinyMaxBuffer, 1);
+        }),
+      ).rejects.toThrow(
+        'Guard script exceeded maxBuffer (128 bytes) and was killed (ERR_CHILD_PROCESS_STDIO_MAXBUFFER)',
+      );
+    }, 60_000);
+  },
+);

--- a/scripts/tests/genai-enclave-guard.test.ts
+++ b/scripts/tests/genai-enclave-guard.test.ts
@@ -18,7 +18,8 @@
  *    paths FAIL, computed imports FAIL, manifest violations FAIL, operational
  *    errors FAIL (closed).
  *
- * Tests invoke the real guard script via execFileSync (no mock theater).
+ * Tests invoke the real guard script via a non-blocking async child process
+ * (no mock theater).
  *
  * Per RULES.md: positive tests ISOLATE the enclave under test — they do NOT
  * write filler files from the other enclave. Negative tests verify the exact
@@ -47,10 +48,42 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
       }
     });
 
+    // ── Non-blocking execution ──────────────────────────────────────────
+    describe('non-blocking execution', () => {
+      it('keeps the worker event loop responsive during a guard invocation', async () => {
+        const guardPromise = withFixture(({ root, write }) => {
+          writeRequiredManifests(write);
+          write(
+            'packages/providers/src/gemini/geminiProvider.ts',
+            GEMINI_IMPORT,
+          );
+          for (let i = 0; i < 200; i++) {
+            write(
+              `packages/cli/src/workload/module${i}.ts`,
+              `import { randomBytes } from 'node:crypto';\n` +
+                `export const token${i}: string = randomBytes(16).toString('hex');\n` +
+                `export interface Config${i} { id: number; label: string; }\n` +
+                `export class Service${i} {\n` +
+                `  private data: Config${i}[] = [];\n` +
+                `  add(c: Config${i}): void { this.data.push(c); }\n` +
+                `  count(): number { return this.data.length; }\n` +
+                `}\n`,
+            );
+          }
+          return runScript(root, 0);
+        });
+        const timerPromise = new Promise<string>((resolve) =>
+          setImmediate(() => resolve('timer')),
+        );
+        expect(await Promise.race([guardPromise, timerPromise])).toBe('timer');
+        await guardPromise;
+      }, 60_000);
+    });
+
     // ── Real repo must be clean ─────────────────────────────────────────
     describe('real repo (current state must be clean)', () => {
-      it('passes against the real repository', () => {
-        const { code, stdout } = runScriptRealRepo(0);
+      it('passes against the real repository', async () => {
+        const { code, stdout } = await runScriptRealRepo(0);
         expect(code).toBe(0);
         expect(stdout).toContain('genai-enclave guard PASSED');
       }, 90000);
@@ -61,8 +94,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
     // from the other enclave — so the test proves the guard allows that
     // specific enclave path, not that it was masked by the other.
     describe('allowed enclaves (isolated positive cases)', () => {
-      it('allows @google/genai import in packages/providers/src/gemini/', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows @google/genai import in packages/providers/src/gemini/', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/providers/src/gemini/geminiProvider.ts',
@@ -73,8 +106,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('allows @google/genai import in packages/core/src/code_assist/', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows @google/genai import in packages/core/src/code_assist/', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write('packages/core/src/code_assist/codeAssist.ts', GEMINI_IMPORT);
           return runScript(root, 0);
@@ -82,8 +115,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('allows a Gemini-named export inside the gemini enclave', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows a Gemini-named export inside the gemini enclave', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/providers/src/gemini/GeminiProvider.ts',
@@ -94,8 +127,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('allows a Gemini-named export in code_assist enclave', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows a Gemini-named export in code_assist enclave', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/core/src/code_assist/GeminiCredentialHelper.ts',
@@ -111,8 +144,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
     // The enclave prefix has a trailing slash. A sibling directory that
     // shares the prefix stem but NOT the slash boundary must be flagged.
     describe('sibling-prefix negatives', () => {
-      it('FAILS @google/genai in packages/providers/src/gemini-backup/', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS @google/genai in packages/providers/src/gemini-backup/', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/providers/src/gemini-backup/converter.ts',
             "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
@@ -123,8 +156,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('converter.ts');
       });
 
-      it('FAILS @google/genai in packages/providers/src/geminiprovider/', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS @google/genai in packages/providers/src/geminiprovider/', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/providers/src/geminiprovider/handler.ts',
             "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
@@ -135,8 +168,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('handler.ts');
       });
 
-      it('FAILS @google/genai in packages/core/src/code_assist-old/', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS @google/genai in packages/core/src/code_assist-old/', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/core/src/code_assist-old/legacy.ts',
             "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
@@ -147,8 +180,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('legacy.ts');
       });
 
-      it('FAILS a Gemini-named export in packages/providers/src/gemini-backup/', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a Gemini-named export in packages/providers/src/gemini-backup/', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/providers/src/gemini-backup/GeminiHelper.ts',
             'export class GeminiHelper {}\n',
@@ -159,10 +192,10 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiHelper');
       });
 
-      it('does NOT match the gemini directory path without trailing slash', () => {
+      it('does NOT match the gemini directory path without trailing slash', async () => {
         // A file literally at 'packages/providers/src/gemini' (no trailing
         // slash) does NOT match the enclave prefix.
-        const { code, stdout } = withFixture(({ root, write }) => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/providers/src/gemini.ts',
             "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
@@ -176,8 +209,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
 
     // ── Disallowed @google/genai imports ───────────────────────────────
     describe('disallowed @google/genai imports (negative cases)', () => {
-      it('FAILS a static import in packages/cli', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a static import in packages/cli', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/rogue.ts',
             "import { Part } from '@google/genai';\nexport const p: Part | null = null;\n",
@@ -189,8 +222,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout.toLowerCase()).toContain('@google/genai');
       });
 
-      it('FAILS a type-only import in packages/cli', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a type-only import in packages/cli', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/type-only.ts',
             "import type { Content } from '@google/genai';\nexport type T = Content;\n",
@@ -201,8 +234,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('type-only.ts');
       });
 
-      it('FAILS a dynamic import() in packages/agents', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a dynamic import() in packages/agents', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/agents/src/dynamic.ts',
             "export async function f() { return await import('@google/genai'); }\n",
@@ -213,8 +246,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('dynamic.ts');
       });
 
-      it('FAILS an import-equals (require) in packages/tools', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS an import-equals (require) in packages/tools', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/tools/src/legacy.ts',
             "import genai = require('@google/genai');\nexport { genai };\n",
@@ -225,8 +258,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('legacy.ts');
       });
 
-      it('FAILS a re-export from @google/genai outside enclaves', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a re-export from @google/genai outside enclaves', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/re-export.ts',
             "export { Part } from '@google/genai';\n",
@@ -237,8 +270,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('re-export.ts');
       });
 
-      it('FAILS export * from @google/genai outside enclaves', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS export * from @google/genai outside enclaves', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/star-export.ts',
             "export * from '@google/genai';\n",
@@ -249,8 +282,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('star-export.ts');
       });
 
-      it('FAILS a subpath import from @google/genai in packages/mcp', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a subpath import from @google/genai in packages/mcp', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/mcp/src/sub.ts',
             "import { x } from '@google/genai/sub';\nexport { x };\n",
@@ -261,8 +294,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('sub.ts');
       });
 
-      it('does NOT match @google/genai-utils (different package)', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('does NOT match @google/genai-utils (different package)', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/src/utils-import.ts',
@@ -273,8 +306,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('FAILS a @google/genai import in a .js file', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a @google/genai import in a .js file', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/rogue.js',
             "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
@@ -286,8 +319,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout.toLowerCase()).toContain('@google/genai');
       });
 
-      it('FAILS a @google/genai import in a .mjs file', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a @google/genai import in a .mjs file', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/rogue.mjs',
             "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
@@ -298,8 +331,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('rogue.mjs');
       });
 
-      it('FAILS a @google/genai import in a .cjs file', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a @google/genai import in a .cjs file', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/rogue.cjs',
             "const { GoogleGenAI } = require('@google/genai');\nmodule.exports = { x: 1 };\n",
@@ -313,8 +346,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
 
     // ── Computed dynamic imports ───────────────────────────────────────
     describe('computed dynamic imports (negative cases)', () => {
-      it('FAILS a variable-specifier dynamic import() outside enclaves', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a variable-specifier dynamic import() outside enclaves', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/computed.ts',
             "const pkg = 'anything'; export async function f() { return await import(pkg); }\n",
@@ -326,8 +359,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('computed');
       });
 
-      it('FAILS a variable-specifier require() outside enclaves', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a variable-specifier require() outside enclaves', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/agents/src/computed-require.ts',
             "const pkg = 'anything'; require(pkg);\nexport const x = 1;\n",
@@ -338,8 +371,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('computed-require.ts');
       });
 
-      it('FAILS a GenAI load through a bound createRequire alias', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a GenAI load through a bound createRequire alias', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/bound-require.ts',
             "import { createRequire as makeRequire } from 'node:module';\nconst load = makeRequire(import.meta.url);\nexport const sdk = load('@google/genai');\n",
@@ -351,8 +384,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('@google/genai');
       });
 
-      it('FAILS a computed load through a bound createRequire alias', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a computed load through a bound createRequire alias', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/computed-bound-require.ts',
             "import { createRequire } from 'node:module';\nconst load = createRequire(import.meta.url);\nconst specifier = 'anything';\nexport const value = load(specifier);\n",
@@ -364,8 +397,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('computed');
       });
 
-      it('FAILS a template-literal dynamic import() outside enclaves', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a template-literal dynamic import() outside enclaves', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/core/src/utils/template-import.ts',
             'export async function f() { return await import(`pkg/${sub}`); }\n',
@@ -376,8 +409,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('template-import.ts');
       });
 
-      it('FAILS computed imports in test files (no exemption)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS computed imports in test files (no exemption)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/module.test.ts',
             "const mod = await import('./mod?t=' + Date.now());\nexport { mod };\n",
@@ -389,8 +422,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('computed');
       });
 
-      it('FAILS computed imports in .mts test files (no exemption)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS computed imports in .mts test files (no exemption)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/module.test.mts',
             "const mod = await import('./mod?t=' + Date.now());\nexport { mod };\n",
@@ -401,8 +434,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('module.test.mts');
       });
 
-      it('FAILS computed imports in .cts spec files (no exemption)', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS computed imports in .cts spec files (no exemption)', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/module.spec.cts',
             "const mod = await import('./mod?t=' + Date.now());\nexport { mod };\n",
@@ -413,8 +446,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('module.spec.cts');
       });
 
-      it('does NOT flag computed imports in enclave files', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('does NOT flag computed imports in enclave files', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/providers/src/gemini/dynamic-loader.ts',
@@ -425,8 +458,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('does NOT flag string-literal dynamic imports of non-genai packages', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('does NOT flag string-literal dynamic imports of non-genai packages', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/src/safe-dynamic.ts',
@@ -440,8 +473,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
 
     // ── Disallowed Gemini-named exports ────────────────────────────────
     describe('disallowed Gemini-named exports (negative cases)', () => {
-      it('FAILS a new Gemini-named class export in packages/cli', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a new Gemini-named class export in packages/cli', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write('packages/cli/src/hook.ts', 'export class useGeminiFoo {}\n');
           return runScript(root, 1);
         });
@@ -450,8 +483,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('useGeminiFoo');
       });
 
-      it('FAILS a Gemini-named function export in packages/agents', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a Gemini-named function export in packages/agents', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/agents/src/util.ts',
             'export function geminiHelper(): void {}\n',
@@ -462,8 +495,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('util.ts');
       });
 
-      it('FAILS a Gemini-named re-export alias outside enclaves', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a Gemini-named re-export alias outside enclaves', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/alias.ts',
             "export { Foo as GeminiBar } from './local';\n",
@@ -475,8 +508,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiBar');
       });
 
-      it('FAILS a CommonJS defineProperty Gemini export', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a CommonJS defineProperty Gemini export', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/legacy.cjs',
             "Object.defineProperty(exports, 'GeminiLegacy', { value: 1 });\n",
@@ -488,8 +521,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiLegacy');
       });
 
-      it('FAILS a CommonJS Object.assign Gemini export', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a CommonJS Object.assign Gemini export', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/assigned.cjs',
             "Object.assign(module['exports'], { GeminiAssigned: 1 });\n",
@@ -501,8 +534,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiAssigned');
       });
 
-      it('FAILS a TypeScript export = object literal with a Gemini name', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a TypeScript export = object literal with a Gemini name', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/export-equals.ts',
             'export = { GeminiTs: 1 };\n',
@@ -514,8 +547,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiTs');
       });
 
-      it('FAILS a chained CJS export assignment with a Gemini name', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a chained CJS export assignment with a Gemini name', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/chained-exports.cjs',
             'exports = module.exports = { GeminiCjs: 1 };\n',
@@ -527,8 +560,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiCjs');
       });
 
-      it('FAILS an inline spread with a Gemini name in module.exports', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS an inline spread with a Gemini name in module.exports', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/spread-export.cjs',
             'module.exports = { ...{ GeminiLeak: 1 } };\n',
@@ -540,8 +573,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiLeak');
       });
 
-      it('FAILS an inline spread with a Gemini name in TS export-equals', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS an inline spread with a Gemini name in TS export-equals', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/spread-export-equals.ts',
             'export = { ...{ GeminiLeak: 1 } };\n',
@@ -553,8 +586,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiLeak');
       });
 
-      it('FAILS a logical-assignment (||=) Gemini export', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a logical-assignment (||=) Gemini export', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/logical-or.cjs',
             'exports.GeminiLeak ||= 1;\n',
@@ -566,8 +599,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiLeak');
       });
 
-      it('FAILS a logical-assignment (??=) Gemini export', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a logical-assignment (??=) Gemini export', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/logical-coalesce.cjs',
             'exports.GeminiLeak ??= 1;\n',
@@ -579,8 +612,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiLeak');
       });
 
-      it('FAILS a logical-assignment (&&=) Gemini export', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a logical-assignment (&&=) Gemini export', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/logical-and.cjs',
             'exports.GeminiLeak &&= 1;\n',
@@ -592,8 +625,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiLeak');
       });
 
-      it('FAILS a bracket-access Object[defineProperty] Gemini export', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a bracket-access Object[defineProperty] Gemini export', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/bracket-odp.cjs',
             "Object['defineProperty'](exports, 'GeminiLeak', { value: 1 });\n",
@@ -605,8 +638,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiLeak');
       });
 
-      it('FAILS a bracket-access Object[assign] Gemini export', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a bracket-access Object[assign] Gemini export', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/bracket-assign.cjs',
             "Object['assign'](exports, { GeminiStatic: 1 });\n",
@@ -618,8 +651,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('GeminiStatic');
       });
 
-      it('allows non-Gemini-named exports outside enclaves', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows non-Gemini-named exports outside enclaves', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write('packages/cli/src/normal.ts', 'export class NormalClass {}\n');
           return runScript(root, 0);
@@ -627,8 +660,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('FAILS export default of a Gemini-named identifier in packages/cli', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS export default of a Gemini-named identifier in packages/cli', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           write(
             'packages/cli/src/default-export.ts',
             'class GeminiConfig {}\nexport default GeminiConfig;\n',
@@ -646,8 +679,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
     // even when the detail string does NOT contain "Gemini". The guard must
     // NOT silently drop these — they could smuggle a Gemini-named export.
     describe('fail-closed export violations (no guard filtering)', () => {
-      it('FAILS a computed-key module.exports assignment even without "Gemini"', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS a computed-key module.exports assignment even without "Gemini"', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/src/computed-key.cjs',
@@ -660,8 +693,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('fail-closed');
       });
 
-      it('FAILS Object.assign with a non-literal source even without "Gemini"', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS Object.assign with a non-literal source even without "Gemini"', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/src/assign-src.cjs',
@@ -674,8 +707,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('fail-closed');
       });
 
-      it('allows export default with a non-literal spread and no Gemini name', () => {
-        const { code } = withFixture(({ root, write }) => {
+      it('allows export default with a non-literal spread and no Gemini name', async () => {
+        const { code } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/src/spread-default.ts',
@@ -686,8 +719,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(code).toBe(0);
       });
 
-      it('FAILS Object.defineProperty with computed key even without "Gemini"', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS Object.defineProperty with computed key even without "Gemini"', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/src/odp-computed.cjs',
@@ -700,8 +733,8 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
         expect(stdout).toContain('fail-closed');
       });
 
-      it('FAILS export = with non-literal spread even without "Gemini"', () => {
-        const { code, stdout } = withFixture(({ root, write }) => {
+      it('FAILS export = with non-literal spread even without "Gemini"', async () => {
+        const { code, stdout } = await withFixture(({ root, write }) => {
           writeRequiredManifests(write);
           write(
             'packages/cli/src/spread-export-equals.ts',


### PR DESCRIPTION
## TLDR

Fix the nightly release preflight failure by keeping Vitest's script-test worker responsive while the GenAI enclave guard runs real child processes.

The guard behavioral tests now use awaited asynchronous child execution instead of blocking the worker with execFileSync. A regression test verifies that the worker event loop advances during a substantial real guard invocation, and maxBuffer failures remain explicit harness failures rather than being mistaken for expected guard exit code 1.

## Dive Deeper

Release run 29464807281 completed all script tests but failed after the long GenAI enclave guard suite with a Vitest worker RPC timeout while calling onTaskUpdate. The suite spent more than the RPC timeout in synchronous child-process work, including a long real-repository guard scan, so the worker could not service Vitest's progress messages.

This change:

- converts guard invocations to promisified execFile while retaining the short cached Bun availability probe
- makes fixture helpers await child completion before cleanup
- updates every guard and manifest test call site to await the real process result
- verifies event-loop responsiveness with a substantial real TypeScript fixture and no child-process mocks
- preserves cwd, environment, timeout, maxBuffer, stdout/stderr, numeric exit-code, ENOENT, and expected-code behavior
- fails closed on ERR_CHILD_PROCESS_STDIO_MAXBUFFER and ENOBUFS before expected exit-code handling
- adds behavioral coverage for maxBuffer classification and diagnostics

Review focus:

- async child error translation in scripts/tests/genai-enclave-guard-helpers.ts
- event-loop responsiveness coverage in scripts/tests/genai-enclave-guard.test.ts
- fail-closed maxBuffer coverage in scripts/tests/genai-enclave-guard-maxbuffer.test.ts

## Reviewer Test Plan

1. Run the complete script suite:

       npm run test:scripts

   Confirm all script test files pass without an unhandled Vitest onTaskUpdate timeout.

2. Run the focused behavioral suites:

       npm run test:scripts -- scripts/tests/genai-enclave-guard.test.ts scripts/tests/genai-enclave-guard-manifest.test.ts scripts/tests/genai-enclave-guard-maxbuffer.test.ts

3. Run static verification:

       npm run typecheck
       npm run lint
       npm run format
       npm run build

4. Inspect the non-blocking regression and confirm it starts the real guard child, observes a timer event first, and still awaits child completion for deterministic cleanup.

Local verification completed:

- npm run test passed; a later full rerun encountered one unrelated 30-second timeout in capabilityGaps.integration.spec.ts, and the same file immediately passed 18/18 in 3.73 seconds when retried
- npm run test:scripts passed with 51 files passed, 5 skipped, 1749 tests passed, and 8 skipped
- affected guard suites passed 83/83
- npm run typecheck passed
- npm run format passed
- npm run build passed
- full ESLint targets passed under Node 24 with a 16 GB local heap; the repository's fixed 8 GB npm run lint command exhausted local memory before diagnostics, so PR CI is authoritative for that exact heap path
- CLI smoke reached the provider but was externally blocked by HTTP 429 weekly step-plan quota
- independent full review approved with no findings
- detached Open Code Review findings were evaluated and remediated or rejected with runtime evidence where factually incorrect

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2584
