### PR TITLE
Add Windows Bun native-module nightly smoke (Fixes #2301)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -309,6 +309,77 @@ jobs:
           RUN_EVALS: '1'
         run: 'npm run test:all_evals'
 
+  windows_bun_native_smoke:
+    name: 'Windows Bun native-modules smoke (Nightly)'
+    runs-on: 'windows-latest'
+    timeout-minutes: 15
+    permissions:
+      contents: 'read'
+    outputs:
+      smoke_output: '${{ steps.capture_smoke.outputs.smoke_output }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # ratchet:actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'npm'
+
+      - name: 'Setup Bun'
+        uses: 'oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76' # ratchet:oven-sh/setup-bun@v2
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: 'Install dependencies'
+        run: 'npm ci'
+
+      - name: 'Run Bun native-modules smoke'
+        shell: 'bash'
+        run: |
+          SMOKE_OUTPUT_FILE=smoke_output.txt
+          set +e
+          bun scripts/bun-native-modules-smoke.mjs > "${SMOKE_OUTPUT_FILE}" 2>&1
+          SMOKE_EXIT=$?
+          set -e
+          cat "${SMOKE_OUTPUT_FILE}"
+          exit "${SMOKE_EXIT}"
+
+      - name: 'Capture smoke output'
+        if: always()
+        shell: 'bash'
+        id: capture_smoke
+        run: |
+          set -euo pipefail
+          SMOKE_OUTPUT_FILE=smoke_output.txt
+          TRIMMED_OUTPUT_FILE=smoke_output_trimmed.txt
+          # Reserve space below GitHub's 65,536-character issue-body limit for
+          # the affected-job summary, run URL, and Markdown wrapper.
+          MAX_OUTPUT_BYTES=60000
+          HEAD_BYTES=29000
+          TAIL_BYTES=29000
+
+          if [[ ! -f "${SMOKE_OUTPUT_FILE}" ]]; then
+            printf 'smoke_output=\n' >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          BYTE_COUNT="$(wc -c < "${SMOKE_OUTPUT_FILE}" | tr -d '[:space:]')"
+          if [[ "${BYTE_COUNT}" -gt "${MAX_OUTPUT_BYTES}" ]]; then
+            head -c "${HEAD_BYTES}" "${SMOKE_OUTPUT_FILE}" > "${TRIMMED_OUTPUT_FILE}"
+            printf '\n[output truncated: original output was %s bytes; showing first and final %s bytes]\n' \
+              "${BYTE_COUNT}" "${HEAD_BYTES}" >> "${TRIMMED_OUTPUT_FILE}"
+            tail -c "${TAIL_BYTES}" "${SMOKE_OUTPUT_FILE}" >> "${TRIMMED_OUTPUT_FILE}"
+          else
+            cp "${SMOKE_OUTPUT_FILE}" "${TRIMMED_OUTPUT_FILE}"
+          fi
+
+          ENCODED="$(base64 < "${TRIMMED_OUTPUT_FILE}" | tr -d '\r\n')"
+          printf 'smoke_output=%s\n' "${ENCODED}" >> "${GITHUB_OUTPUT}"
+
   notify_failure:
     name: 'Create Issue on Failure'
     runs-on: 'ubuntu-latest'
@@ -317,6 +388,7 @@ jobs:
       - 'windows_ci'
       - 'e2e_full'
       - 'behavioral_evals'
+      - 'windows_bun_native_smoke'
     if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     permissions:
       issues: 'write'
@@ -328,10 +400,36 @@ jobs:
           WINDOWS_CI_RESULT: '${{ needs.windows_ci.result }}'
           E2E_FULL_RESULT: '${{ needs.e2e_full.result }}'
           BEHAVIORAL_EVALS_RESULT: '${{ needs.behavioral_evals.result }}'
+          WINDOWS_BUN_NATIVE_SMOKE_RESULT: '${{ needs.windows_bun_native_smoke.result }}'
+          SMOKE_OUTPUT_B64: '${{ needs.windows_bun_native_smoke.outputs.smoke_output }}'
         shell: 'bash'
         run: |
           set -euo pipefail
           ISSUE_TITLE="Nightly workflow failed"
+
+          FAILED_JOBS=()
+          [[ "${WINDOWS_CI_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("windows_ci=${WINDOWS_CI_RESULT}")
+          [[ "${E2E_FULL_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("e2e_full=${E2E_FULL_RESULT}")
+          [[ "${BEHAVIORAL_EVALS_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("behavioral_evals=${BEHAVIORAL_EVALS_RESULT}")
+
+          INCLUDE_SMOKE_OUTPUT=false
+          SMOKE_OUTPUT_FILE=smoke_output_decoded.txt
+          : > "${SMOKE_OUTPUT_FILE}"
+          if [[ "${WINDOWS_BUN_NATIVE_SMOKE_RESULT}" =~ ^(failure|cancelled)$ ]]; then
+            FAILED_JOBS+=("windows_bun_native_smoke=${WINDOWS_BUN_NATIVE_SMOKE_RESULT}")
+            INCLUDE_SMOKE_OUTPUT=true
+          fi
+          if [[ "${INCLUDE_SMOKE_OUTPUT}" == true && -n "${SMOKE_OUTPUT_B64}" ]] && \
+            ! printf '%s' "${SMOKE_OUTPUT_B64}" | base64 --decode > "${SMOKE_OUTPUT_FILE}"; then
+            echo "ERROR: Failed to decode Windows Bun smoke output; the transferred job output is malformed." >&2
+            exit 1
+          fi
+
+          if [[ ${#FAILED_JOBS[@]} -eq 0 ]]; then
+            echo "No failed or cancelled jobs detected; nothing to report."
+            exit 0
+          fi
+          FAILED_JOBS_TEXT="${FAILED_JOBS[*]}"
 
           ensure_label() {
             local name="$1"
@@ -363,16 +461,6 @@ jobs:
             echo "Warning: continuing without ci/cd label" >&2
           fi
 
-          FAILED_JOBS=()
-          [[ "${WINDOWS_CI_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("windows_ci=${WINDOWS_CI_RESULT}")
-          [[ "${E2E_FULL_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("e2e_full=${E2E_FULL_RESULT}")
-          [[ "${BEHAVIORAL_EVALS_RESULT}" =~ ^(failure|cancelled)$ ]] && FAILED_JOBS+=("behavioral_evals=${BEHAVIORAL_EVALS_RESULT}")
-          if [[ ${#FAILED_JOBS[@]} -eq 0 ]]; then
-            echo "No failed or cancelled jobs detected; nothing to report."
-            exit 0
-          fi
-          FAILED_JOBS_TEXT="${FAILED_JOBS[*]}"
-
           retry_gh() {
             local attempt
             for attempt in 1 2 3 4; do
@@ -388,6 +476,24 @@ jobs:
             return 1
           }
 
+          build_body_file() {
+            local body_file="$1"
+            local introduction="$2"
+            {
+              printf '%s\n\n' "${introduction}"
+              printf 'Full run: %s\n' "${RUN_URL}"
+              if [[ "${INCLUDE_SMOKE_OUTPUT}" == true ]]; then
+                printf '\n<details><summary>Windows Bun native-modules smoke output</summary>\n\n```text\n'
+                if [[ -s "${SMOKE_OUTPUT_FILE}" ]]; then
+                  cat "${SMOKE_OUTPUT_FILE}"
+                else
+                  printf '(No smoke output was captured.)'
+                fi
+                printf '\n```\n\n</details>\n'
+              fi
+            } > "${body_file}"
+          }
+
           if ! EXISTING_ISSUE="$(
             retry_gh gh issue list \
               --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
@@ -399,25 +505,22 @@ jobs:
             exit 1
           fi
 
+          BODY_FILE=issue_body.md
           if [[ -n "${EXISTING_ISSUE}" ]]; then
+            INTRODUCTION="Nightly workflow failed again on $(date +'%Y-%m-%d'). Affected jobs: ${FAILED_JOBS_TEXT}."
+            build_body_file "${BODY_FILE}" "${INTRODUCTION}"
             retry_gh gh issue comment "${EXISTING_ISSUE}" \
-              --body "Nightly workflow failed again on $(date +'%Y-%m-%d'). Affected jobs: ${FAILED_JOBS_TEXT}. Full run: ${RUN_URL}" || {
+              --body-file "${BODY_FILE}" || {
               echo "ERROR: Failed to comment on existing issue #${EXISTING_ISSUE}" >&2
               exit 1
             }
-          elif [[ ${#LABEL_ARGS[@]} -gt 0 ]]; then
-            retry_gh gh issue create \
-              --title "${ISSUE_TITLE}" \
-              --body "The nightly test workflow failed. Affected jobs: ${FAILED_JOBS_TEXT}. Full run: ${RUN_URL}" \
-              "${LABEL_ARGS[@]}" || {
-              echo "ERROR: Failed to create issue with labels" >&2
-              exit 1
-            }
           else
-            retry_gh gh issue create \
-              --title "${ISSUE_TITLE}" \
-              --body "The nightly test workflow failed. Affected jobs: ${FAILED_JOBS_TEXT}. Full run: ${RUN_URL}" || {
-              echo "ERROR: Failed to create issue without labels" >&2
+            INTRODUCTION="The nightly test workflow failed. Affected jobs: ${FAILED_JOBS_TEXT}."
+            build_body_file "${BODY_FILE}" "${INTRODUCTION}"
+            CREATE_ARGS=(--title "${ISSUE_TITLE}" --body-file "${BODY_FILE}")
+            CREATE_ARGS+=("${LABEL_ARGS[@]}")
+            retry_gh gh issue create "${CREATE_ARGS[@]}" || {
+              echo "ERROR: Failed to create nightly failure issue" >&2
               exit 1
             }
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -369,10 +369,8 @@ jobs:
 
           BYTE_COUNT="$(wc -c < "${SMOKE_OUTPUT_FILE}" | tr -d '[:space:]')"
           if [[ "${BYTE_COUNT}" -gt "${MAX_OUTPUT_BYTES}" ]]; then
-            head -c "${HEAD_BYTES}" "${SMOKE_OUTPUT_FILE}" > "${TRIMMED_OUTPUT_FILE}"
-            printf '\n[output truncated: original output was %s bytes; showing first and final %s bytes]\n' \
-              "${BYTE_COUNT}" "${HEAD_BYTES}" >> "${TRIMMED_OUTPUT_FILE}"
-            tail -c "${TAIL_BYTES}" "${SMOKE_OUTPUT_FILE}" >> "${TRIMMED_OUTPUT_FILE}"
+            node -e "const fs=require('fs');const b=fs.readFileSync(process.argv[1]);const hn=Number(process.argv[3]);const tn=Number(process.argv[4]);const h=b.subarray(0,hn).toString('utf8');const t=b.subarray(-tn).toString('utf8');fs.writeFileSync(process.argv[2],h+'\\n[output truncated: original output was '+b.length+' bytes; showing first '+hn+' and final '+tn+' bytes]\\n'+t)" \
+              "${SMOKE_OUTPUT_FILE}" "${TRIMMED_OUTPUT_FILE}" "${HEAD_BYTES}" "${TAIL_BYTES}"
           else
             cp "${SMOKE_OUTPUT_FILE}" "${TRIMMED_OUTPUT_FILE}"
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -396,6 +396,7 @@ jobs:
       - name: 'Create Issue on Failure'
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_REPO: '${{ github.repository }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           WINDOWS_CI_RESULT: '${{ needs.windows_ci.result }}'
           E2E_FULL_RESULT: '${{ needs.e2e_full.result }}'
@@ -438,10 +439,10 @@ jobs:
             local existing=""
             local create_err=""
             # Capture stderr in create_err while discarding stdout; redirect order matters.
-            if create_err="$(gh label create "${name}" --color "${color}" --description "${description}" 2>&1 >/dev/null)"; then
+            if create_err="$(gh label create "${name}" --repo "${GH_REPO}" --color "${color}" --description "${description}" 2>&1 >/dev/null)"; then
               return
             fi
-            if ! existing="$(gh label list --search "${name}" --json name --jq ".[] | select(.name == \"${name}\") | .name" 2>&1)"; then
+            if ! existing="$(gh label list --repo "${GH_REPO}" --search "${name}" --json name --jq ".[] | select(.name == \"${name}\") | .name" 2>&1)"; then
               echo "Failed to check for label: ${name}" >&2
               echo "  create error: ${create_err}" >&2
               echo "  list error: ${existing}" >&2
@@ -496,6 +497,7 @@ jobs:
 
           if ! EXISTING_ISSUE="$(
             retry_gh gh issue list \
+              --repo "${GH_REPO}" \
               --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
               --limit 30 \
               --json number,title \
@@ -510,6 +512,7 @@ jobs:
             INTRODUCTION="Nightly workflow failed again on $(date +'%Y-%m-%d'). Affected jobs: ${FAILED_JOBS_TEXT}."
             build_body_file "${BODY_FILE}" "${INTRODUCTION}"
             retry_gh gh issue comment "${EXISTING_ISSUE}" \
+              --repo "${GH_REPO}" \
               --body-file "${BODY_FILE}" || {
               echo "ERROR: Failed to comment on existing issue #${EXISTING_ISSUE}" >&2
               exit 1
@@ -517,7 +520,7 @@ jobs:
           else
             INTRODUCTION="The nightly test workflow failed. Affected jobs: ${FAILED_JOBS_TEXT}."
             build_body_file "${BODY_FILE}" "${INTRODUCTION}"
-            CREATE_ARGS=(--title "${ISSUE_TITLE}" --body-file "${BODY_FILE}")
+            CREATE_ARGS=(--repo "${GH_REPO}" --title "${ISSUE_TITLE}" --body-file "${BODY_FILE}")
             CREATE_ARGS+=("${LABEL_ARGS[@]}")
             retry_gh gh issue create "${CREATE_ARGS[@]}" || {
               echo "ERROR: Failed to create nightly failure issue" >&2

--- a/dev-docs/bun.md
+++ b/dev-docs/bun.md
@@ -134,6 +134,21 @@ names; introducing a native package outside those known families is a deliberate
 decision that must also update the allowlist (which the exact-match assertion
 forces).
 
+## Windows native-module smoke
+
+The nightly workflow runs `scripts/bun-native-modules-smoke.mjs` in a dedicated
+`windows-latest` job. The harness exercises `@ast-grep/napi`, constructs an
+`@napi-rs/keyring` entry without credential I/O, parses Bash with
+`web-tree-sitter` and `tree-sitter-bash`, and spawns a real ConPTY process with
+`@lydell/node-pty`. `Bun.Terminal` remains POSIX-only and is explicitly skipped
+on Windows.
+
+A hosted Windows Server 2025 run on 2026-07-16 verified the complete smoke with
+Bun 1.3.14, including streamed output and a real zero exit callback from the
+`@lydell/node-pty` ConPTY process. The Windows runtime therefore keeps using
+`@lydell/node-pty`; no JavaScript compile fallback is needed. The evidence is in
+[nightly run 29534151672](https://github.com/vybestack/llxprt-code/actions/runs/29534151672/job/87741315456).
+
 ## Dual Lockfile Policy
 
 During the migration, **two lockfiles coexist side-by-side** at the repository

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -306,6 +306,8 @@ bun run typecheck
 
 On Windows, the `node-pty` module has a known terminal resize race condition (`Cannot resize a pty that has already exited`). The CLI silences this specific error at the process level and uses `@lydell/node-pty` (with `node-pty` as fallback) — **not** the Bun adapter. The `bun-pty` adapter (`packages/core/src/utils/bunPtyAdapter.ts`) is POSIX-only and is not used on Windows. If you encounter terminal sizing or resize issues on Windows, use a compatible terminal emulator; the resize race is in `node-pty` itself, not the Bun runtime.
 
+The `@lydell/node-pty` ConPTY path is verified under Bun on Windows by the nightly native-module smoke. A hosted Windows Server 2025 run passed with Bun 1.3.14, including streamed PTY data and a real zero exit callback, so Bun on Windows continues to use this path. See the [hosted smoke result](https://github.com/vybestack/llxprt-code/actions/runs/29534151672/job/87741315456).
+
 ## See Also
 
 - [Authentication](./cli/authentication.md) — key management, keyring, OAuth

--- a/scripts/bun-native-modules-smoke.mjs
+++ b/scripts/bun-native-modules-smoke.mjs
@@ -161,13 +161,17 @@ async function checkNodePty() {
     return;
   }
   let ptyProcess;
+  let exitPromise;
   let didExit = false;
   try {
     const nodePty = await import('@lydell/node-pty');
     const spawn = nodePty.default?.spawn ?? nodePty.spawn;
+    if (typeof spawn !== 'function') {
+      throw new Error('@lydell/node-pty is missing its spawn() export');
+    }
 
     let output = '';
-    const exitPromise = createExitPromise(NODE_PTY_TIMEOUT_MS);
+    exitPromise = createExitPromise(NODE_PTY_TIMEOUT_MS);
 
     ptyProcess = spawn(
       process.env.COMSPEC ?? 'cmd.exe',
@@ -181,6 +185,11 @@ async function checkNodePty() {
 
     if (typeof ptyProcess.pid !== 'number' || ptyProcess.pid <= 0) {
       throw new Error(`invalid pid: ${ptyProcess.pid}`);
+    }
+    for (const methodName of ['onData', 'onExit', 'kill']) {
+      if (typeof ptyProcess[methodName] !== 'function') {
+        throw new Error(`@lydell/node-pty process is missing ${methodName}()`);
+      }
     }
 
     ptyProcess.onData((data) => {
@@ -212,6 +221,7 @@ async function checkNodePty() {
   } catch (e) {
     fail('@lydell/node-pty ConPTY', e);
   } finally {
+    exitPromise?.resolve(null);
     if (ptyProcess && !didExit) {
       try {
         ptyProcess.kill();

--- a/scripts/bun-native-modules-smoke.mjs
+++ b/scripts/bun-native-modules-smoke.mjs
@@ -44,7 +44,7 @@ if (!isPosix) {
 if (!isWindows) {
   skippedChecks += 1;
   console.log(
-    '[SKIP] @lydell/node-pty ConPTY check is Windows-only; native module checks still run on POSIX.',
+    '[SKIP] @lydell/node-pty ConPTY check is Windows-only; other native-module checks still run on POSIX.',
   );
 }
 
@@ -316,4 +316,3 @@ if (skippedChecks > 0) {
 } else {
   console.log('\nAll native-module smoke checks passed under Bun.');
 }
-process.exit(0);

--- a/scripts/bun-native-modules-smoke.mjs
+++ b/scripts/bun-native-modules-smoke.mjs
@@ -306,3 +306,4 @@ if (skippedChecks > 0) {
 } else {
   console.log('\nAll native-module smoke checks passed under Bun.');
 }
+process.exit(0);

--- a/scripts/bun-native-modules-smoke.mjs
+++ b/scripts/bun-native-modules-smoke.mjs
@@ -1,15 +1,20 @@
 /**
- * Bun native-module smoke harness (issue 2239, S2).
+ * Bun native-module smoke harness (issue 2239, S2; issue 2301 Windows).
  *
  * Verifies that the native modules the CLI depends on load and operate under
- * the Bun runtime on POSIX:
+ * the Bun runtime on the current platform:
  *
  * - @ast-grep/napi — native AST engine (parse a TS snippet)
  * - @napi-rs/keyring — native OS credential store (construct-only; no I/O)
  * - web-tree-sitter + tree-sitter-bash WASM — shell parser (parse a command)
- * - Bun.Terminal PTY adapter — the bun-pty seam (spawn, stream data, real exit)
+ * - @lydell/node-pty — Windows ConPTY spawn/data/exit (Windows-only)
+ * - Bun.Terminal PTY adapter — the bun-pty seam (spawn, stream data, real exit;
+ *   POSIX-only — skipped on Windows)
  *
- * Each check prints [PASS] or [FAIL]. Exits non-zero if any check fails.
+ * Each check prints [PASS], [FAIL], or [SKIP]. Exits non-zero if any check
+ * fails. Platform-inappropriate checks are skipped:
+ * - On Windows, the Bun.Terminal PTY adapter is skipped (POSIX-only).
+ * - On POSIX, the @lydell/node-pty ConPTY check is skipped (Windows-only).
  *
  * Usage: bun scripts/bun-native-modules-smoke.mjs
  */
@@ -28,11 +33,18 @@ if (!isBun) {
 }
 
 const isPosix = process.platform !== 'win32';
+const isWindows = process.platform === 'win32';
 let skippedChecks = 0;
 if (!isPosix) {
   skippedChecks += 1;
   console.log(
     '[SKIP] Bun.Terminal PTY adapter is POSIX-only; native module checks still run on Windows.',
+  );
+}
+if (!isWindows) {
+  skippedChecks += 1;
+  console.log(
+    '[SKIP] @lydell/node-pty ConPTY check is Windows-only; native module checks still run on POSIX.',
   );
 }
 
@@ -140,7 +152,76 @@ async function checkTreeSitter() {
 }
 
 // ---------------------------------------------------------------------------
-// 4. Bun.Terminal PTY adapter (the bun-pty seam)
+// 4. @lydell/node-pty (Windows ConPTY path; Windows-only)
+// ---------------------------------------------------------------------------
+const NODE_PTY_TIMEOUT_MS = 10000;
+
+async function checkNodePty() {
+  if (!isWindows) {
+    return;
+  }
+  let ptyProcess;
+  try {
+    const nodePty = await import('@lydell/node-pty');
+    const spawn = nodePty.default?.spawn ?? nodePty.spawn;
+
+    let output = '';
+    const exitPromise = createExitPromise(NODE_PTY_TIMEOUT_MS);
+
+    ptyProcess = spawn(
+      process.env.COMSPEC ?? 'cmd.exe',
+      ['/c', 'echo node-pty-conpty-smoke-ok'],
+      {
+        cols: 80,
+        rows: 24,
+        name: 'xterm-256color',
+      },
+    );
+
+    if (typeof ptyProcess.pid !== 'number' || ptyProcess.pid <= 0) {
+      throw new Error(`invalid pid: ${ptyProcess.pid}`);
+    }
+
+    ptyProcess.onData((data) => {
+      output += data;
+    });
+
+    ptyProcess.onExit((exitInfo) => {
+      exitPromise.resolve(exitInfo);
+    });
+
+    const exitInfo = await exitPromise.promise;
+
+    if (!exitInfo) {
+      throw new Error('timeout waiting for ConPTY exit');
+    }
+
+    if (exitInfo.exitCode !== 0) {
+      throw new Error(`expected exit code 0, got ${exitInfo.exitCode}`);
+    }
+
+    if (!output.includes('node-pty-conpty-smoke-ok')) {
+      throw new Error(
+        `expected output to contain "node-pty-conpty-smoke-ok", got: ${JSON.stringify(output)}`,
+      );
+    }
+
+    pass('@lydell/node-pty ConPTY: spawn, stream data, real exit code');
+  } catch (e) {
+    fail('@lydell/node-pty ConPTY', e);
+  } finally {
+    if (ptyProcess) {
+      try {
+        ptyProcess.kill();
+      } catch {
+        // Process may already have exited.
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Bun.Terminal PTY adapter (the bun-pty seam; POSIX-only)
 // ---------------------------------------------------------------------------
 async function checkBunPty() {
   if (!isPosix) {
@@ -209,6 +290,7 @@ async function checkBunPty() {
 await checkAstGrep();
 await checkKeyring();
 await checkTreeSitter();
+await checkNodePty();
 await checkBunPty();
 
 if (failures > 0) {
@@ -217,7 +299,7 @@ if (failures > 0) {
 }
 if (skippedChecks > 0) {
   console.log(
-    `\nAll native-module smoke checks passed under Bun (${skippedChecks} POSIX-only check skipped).`,
+    `\nAll native-module smoke checks passed under Bun (${skippedChecks} platform-specific check(s) skipped).`,
   );
 } else {
   console.log('\nAll native-module smoke checks passed under Bun.');

--- a/scripts/bun-native-modules-smoke.mjs
+++ b/scripts/bun-native-modules-smoke.mjs
@@ -161,6 +161,7 @@ async function checkNodePty() {
     return;
   }
   let ptyProcess;
+  let didExit = false;
   try {
     const nodePty = await import('@lydell/node-pty');
     const spawn = nodePty.default?.spawn ?? nodePty.spawn;
@@ -187,6 +188,7 @@ async function checkNodePty() {
     });
 
     ptyProcess.onExit((exitInfo) => {
+      didExit = true;
       exitPromise.resolve(exitInfo);
     });
 
@@ -210,7 +212,7 @@ async function checkNodePty() {
   } catch (e) {
     fail('@lydell/node-pty ConPTY', e);
   } finally {
-    if (ptyProcess) {
+    if (ptyProcess && !didExit) {
       try {
         ptyProcess.kill();
       } catch {

--- a/scripts/tests/cli-import-boundary.test.js
+++ b/scripts/tests/cli-import-boundary.test.js
@@ -871,7 +871,7 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
       const { code, stdout } = runScript(null, 0, { useRealRepo: true });
       expect(stdout).toContain('allowlist is fresh');
       expect(code).toBe(0);
-    });
+    }, 15_000);
 
     // ── public subpath treatment (#2204 burn-down) ──────────────────────────
     //

--- a/scripts/tests/nightly-bun-native-smoke.test.js
+++ b/scripts/tests/nightly-bun-native-smoke.test.js
@@ -117,6 +117,7 @@ describe('nightly Windows Bun native-module smoke', () => {
     expect(needs).toContain('windows_bun_native_smoke');
     expect(notifyJob.permissions).toEqual({ issues: 'write' });
     expect(notifyStep.env?.GH_TOKEN).toBe('${{ secrets.GITHUB_TOKEN }}');
+    expect(notifyStep.env?.GH_REPO).toBe('${{ github.repository }}');
     expect(notifyStep.env?.WINDOWS_BUN_NATIVE_SMOKE_RESULT).toBe(
       '${{ needs.windows_bun_native_smoke.result }}',
     );
@@ -125,6 +126,7 @@ describe('nightly Windows Bun native-module smoke', () => {
     );
 
     const run = String(notifyStep.run).replace(/\s+/g, ' ').trim();
+    expect(run).toContain('--repo "${GH_REPO}"');
     expect(run).toContain(
       'if [[ "${WINDOWS_BUN_NATIVE_SMOKE_RESULT}" =~ ^(failure|cancelled)$ ]]',
     );

--- a/scripts/tests/nightly-bun-native-smoke.test.js
+++ b/scripts/tests/nightly-bun-native-smoke.test.js
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+const execFileAsync = promisify(execFile);
+
+function stepNamed(job, name) {
+  expect(
+    job,
+    `workflow should define the job containing step: ${name}`,
+  ).toBeDefined();
+  expect(job.steps, 'job should have a steps array').toBeDefined();
+  const step = job.steps.find((candidate) => candidate.name === name);
+  expect(step, `job should contain step: ${name}`).toBeTruthy();
+  return step;
+}
+
+describe('nightly Windows Bun native-module smoke', () => {
+  let smokeJob;
+  let notifyJob;
+  let notifyStep;
+
+  beforeAll(() => {
+    try {
+      const workflowPath = path.join(ROOT, '.github/workflows/nightly.yml');
+      const workflow = yaml.load(fs.readFileSync(workflowPath, 'utf8'));
+      smokeJob = workflow.jobs?.windows_bun_native_smoke;
+      notifyJob = workflow.jobs?.notify_failure;
+      expect(
+        smokeJob,
+        'workflow should define windows_bun_native_smoke',
+      ).toBeDefined();
+      expect(notifyJob, 'workflow should define notify_failure').toBeDefined();
+      notifyStep = stepNamed(notifyJob, 'Create Issue on Failure');
+    } catch (error) {
+      throw new Error(`Failed to load nightly workflow: ${error.message}`, {
+        cause: error,
+      });
+    }
+  });
+
+  it('runs the committed native-module harness in a bounded least-privilege Windows job', () => {
+    expect(smokeJob['runs-on']).toBe('windows-latest');
+    expect(smokeJob.permissions).toEqual({ contents: 'read' });
+    expect(smokeJob['timeout-minutes']).toBe(15);
+    expect(stepNamed(smokeJob, 'Checkout').with?.['persist-credentials']).toBe(
+      false,
+    );
+    expect(stepNamed(smokeJob, 'Setup Bun').with?.['bun-version-file']).toBe(
+      '.bun-version',
+    );
+    expect(String(stepNamed(smokeJob, 'Install dependencies').run).trim()).toBe(
+      'npm ci',
+    );
+
+    const smokeStep = stepNamed(smokeJob, 'Run Bun native-modules smoke');
+    expect(smokeStep.shell).toBe('bash');
+    expect(String(smokeStep.run)).toContain(
+      'bun scripts/bun-native-modules-smoke.mjs',
+    );
+    expect(String(smokeStep.run)).toContain('exit "${SMOKE_EXIT}"');
+  });
+
+  it('retains both ends of oversized diagnostics within the issue-body budget', async () => {
+    const captureStep = stepNamed(smokeJob, 'Capture smoke output');
+    expect(captureStep.if).toBe('always()');
+    expect(smokeJob.outputs?.smoke_output).toBe(
+      '${{ steps.capture_smoke.outputs.smoke_output }}',
+    );
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'llxprt-smoke-output-'),
+    );
+    const githubOutput = path.join(tempDir, 'github-output.txt');
+    const oversizedLog = `BEGIN-DIAGNOSTIC\n${'x'.repeat(70_000)}\nEND-DIAGNOSTIC\n`;
+
+    try {
+      fs.writeFileSync(path.join(tempDir, 'smoke_output.txt'), oversizedLog);
+      await execFileAsync('bash', ['-c', String(captureStep.run)], {
+        cwd: tempDir,
+        env: { ...process.env, GITHUB_OUTPUT: githubOutput },
+      });
+
+      const outputLine = fs
+        .readFileSync(githubOutput, 'utf8')
+        .split('\n')
+        .find((line) => line.startsWith('smoke_output='));
+      expect(outputLine).toBeDefined();
+      const decoded = Buffer.from(
+        outputLine.slice('smoke_output='.length),
+        'base64',
+      );
+      expect(decoded.byteLength).toBeLessThanOrEqual(60_000);
+      expect(decoded.toString('utf8')).toContain('BEGIN-DIAGNOSTIC');
+      expect(decoded.toString('utf8')).toContain('output truncated:');
+      expect(decoded.toString('utf8')).toContain('END-DIAGNOSTIC');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports smoke failures with captured output and the workflow run URL', () => {
+    const needs = Array.isArray(notifyJob.needs)
+      ? notifyJob.needs
+      : [notifyJob.needs];
+    expect(needs).toContain('windows_bun_native_smoke');
+    expect(notifyJob.permissions).toEqual({ issues: 'write' });
+    expect(notifyStep.env?.GH_TOKEN).toBe('${{ secrets.GITHUB_TOKEN }}');
+    expect(notifyStep.env?.WINDOWS_BUN_NATIVE_SMOKE_RESULT).toBe(
+      '${{ needs.windows_bun_native_smoke.result }}',
+    );
+    expect(notifyStep.env?.SMOKE_OUTPUT_B64).toBe(
+      '${{ needs.windows_bun_native_smoke.outputs.smoke_output }}',
+    );
+
+    const run = String(notifyStep.run).replace(/\s+/g, ' ').trim();
+    expect(run).toContain(
+      'if [[ "${WINDOWS_BUN_NATIVE_SMOKE_RESULT}" =~ ^(failure|cancelled)$ ]]',
+    );
+    expect(run).toContain(
+      'if [[ "${INCLUDE_SMOKE_OUTPUT}" == true && -n "${SMOKE_OUTPUT_B64}" ]]',
+    );
+    expect(run).toContain('Failed to decode Windows Bun smoke output');
+    expect(run).toContain('Windows Bun native-modules smoke output');
+    expect(run).toContain('--body-file "${BODY_FILE}"');
+    expect(notifyStep.env?.RUN_URL).toBe(
+      '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+    );
+  });
+});
+
+describe('Bun native-module smoke harness', () => {
+  it('passes its real checks for the current platform', async () => {
+    const { stdout } = await execFileAsync(
+      'bun',
+      ['scripts/bun-native-modules-smoke.mjs'],
+      {
+        cwd: ROOT,
+        encoding: 'utf8',
+        timeout: 60_000,
+      },
+    );
+
+    expect(stdout).toContain('All native-module smoke checks passed under Bun');
+  }, 70_000);
+});

--- a/scripts/tests/nightly-bun-native-smoke.test.js
+++ b/scripts/tests/nightly-bun-native-smoke.test.js
@@ -14,6 +14,15 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 const ROOT = path.resolve(import.meta.dirname, '../..');
 const execFileAsync = promisify(execFile);
+const HARNESS_TIMEOUT_MS = 60_000;
+const TEST_TIMEOUT_MS = 70_000;
+
+function collectProcessDiagnostics(error) {
+  return [error.stdout, error.stderr]
+    .filter((output) => typeof output === 'string' && output.trim())
+    .join('\n')
+    .trim();
+}
 
 function stepNamed(job, name) {
   expect(
@@ -143,17 +152,57 @@ describe('nightly Windows Bun native-module smoke', () => {
 });
 
 describe('Bun native-module smoke harness', () => {
-  it('passes its real checks for the current platform', async () => {
-    const { stdout } = await execFileAsync(
-      'bun',
-      ['scripts/bun-native-modules-smoke.mjs'],
-      {
-        cwd: ROOT,
-        encoding: 'utf8',
-        timeout: 60_000,
-      },
-    );
+  it(
+    'passes its real checks for the current platform',
+    async () => {
+      let stdout;
+      try {
+        ({ stdout } = await execFileAsync(
+          'bun',
+          ['scripts/bun-native-modules-smoke.mjs'],
+          {
+            cwd: ROOT,
+            encoding: 'utf8',
+            signal: AbortSignal.timeout(HARNESS_TIMEOUT_MS),
+          },
+        ));
+      } catch (error) {
+        if (error && typeof error === 'object') {
+          if (error.code === 'ENOENT') {
+            throw new Error(
+              'Bun is required to run the native-module smoke harness; install the version pinned in .bun-version and ensure bun is on PATH.',
+              { cause: error },
+            );
+          }
+          const diagnostics = collectProcessDiagnostics(error);
+          if (error.code === 'ABORT_ERR' && error.name === 'AbortError') {
+            throw new Error(
+              `Bun native-module smoke harness exceeded its ${HARNESS_TIMEOUT_MS}ms subprocess timeout${diagnostics ? `:\n${diagnostics}` : '.'}`,
+              { cause: error },
+            );
+          }
+          if (typeof error.code === 'number') {
+            throw new Error(
+              `Bun native-module smoke harness failed with exit code ${error.code}${diagnostics ? `:\n${diagnostics}` : '.'}`,
+              { cause: error },
+            );
+          }
+          const detail =
+            typeof error.message === 'string' && error.message.trim()
+              ? error.message.trim()
+              : `system error ${String(error.code)}`;
+          throw new Error(
+            `Bun native-module smoke harness could not execute: ${detail}${diagnostics ? `\n${diagnostics}` : ''}`,
+            { cause: error },
+          );
+        }
+        throw error;
+      }
 
-    expect(stdout).toContain('All native-module smoke checks passed under Bun');
-  }, 70_000);
+      expect(stdout).toContain(
+        'All native-module smoke checks passed under Bun',
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/scripts/tests/release-process.test.js
+++ b/scripts/tests/release-process.test.js
@@ -813,11 +813,10 @@ describe('.github/workflows/nightly.yml', () => {
     expect(normalizedRun).toContain('No failed or cancelled jobs detected');
     expect(normalizedRun).toContain('retry_gh gh issue create');
     expect(normalizedRun).toContain('--title "${ISSUE_TITLE}"');
-    expect(normalizedRun).toContain('--body');
+    expect(normalizedRun).toContain('--body-file "${BODY_FILE}"');
     expect(normalizedRun).toContain('${FAILED_JOBS_TEXT}');
     expect(normalizedRun).toContain('${RUN_URL}');
-    expect(normalizedRun).toContain('elif [[ ${#LABEL_ARGS[@]} -gt 0 ]]');
-    expect(normalizedRun).toContain('"${LABEL_ARGS[@]}"');
+    expect(normalizedRun).toContain('CREATE_ARGS+=("${LABEL_ARGS[@]}")');
   });
 
   it('updates an existing open nightly failure issue instead of duplicating it', () => {
@@ -854,7 +853,7 @@ describe('.github/workflows/nightly.yml', () => {
       'retry_gh gh issue comment "${EXISTING_ISSUE}"',
     );
     expect(normalizedRun).toContain("$(date +'%Y-%m-%d')");
-    expect(normalizedRun).toContain('Full run: ${RUN_URL}');
+    expect(normalizedRun).toContain('printf \'Full run: %s\\n\' "${RUN_URL}"');
   });
 
   it('runs the failure notification job when a dependency fails or is cancelled', () => {
@@ -870,7 +869,12 @@ describe('.github/workflows/nightly.yml', () => {
   it('makes the failure notification job depend on all nightly test jobs', () => {
     // Keep in sync with .github/workflows/nightly.yml — every non-notify job
     // MUST be listed here, otherwise notify_failure won't fire on its failure.
-    const expectedNeeds = ['windows_ci', 'e2e_full', 'behavioral_evals'];
+    const expectedNeeds = [
+      'windows_ci',
+      'e2e_full',
+      'behavioral_evals',
+      'windows_bun_native_smoke',
+    ];
     const actualNeeds = Array.isArray(notifyFailureJob.needs)
       ? notifyFailureJob.needs
       : [notifyFailureJob.needs];


### PR DESCRIPTION
## Summary

- adds a dedicated least-privilege Windows nightly job that runs the real Bun native-module smoke harness
- exercises ast-grep, construct-only keyring, tree-sitter Bash WASM, and the node-pty ConPTY path while explicitly skipping the POSIX-only Bun.Terminal adapter
- captures bounded head-and-tail smoke diagnostics and includes them in the deduplicated nightly failure issue
- fixes the notifier to work without a checkout by passing the repository explicitly to every gh command
- documents the empirical hosted Windows result

## Hosted Windows result

The dedicated smoke passed on Windows Server 2025 with Bun 1.3.14. The node-pty ConPTY check spawned cmd.exe, streamed the expected output, and received a real zero exit callback. Bun.Terminal was skipped as POSIX-only. The Windows runtime path remains node-pty; no JavaScript compile fallback is introduced.

Evidence: https://github.com/vybestack/llxprt-code/actions/runs/29534151672/job/87741315456

A follow-up hosted run verified the smoke process terminates cleanly after validation: https://github.com/vybestack/llxprt-code/actions/runs/29537852255

The failure notifier was also exercised by unrelated existing nightly failures and successfully created/updated https://github.com/vybestack/llxprt-code/issues/2595.

## Verification

Passed locally:

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- npm run test:scripts
- focused nightly/release workflow tests: 39 passed
- ESLint for the new workflow tests
- actionlint with repository-standard ignores
- direct Bun native-module smoke
- git diff --check
- detached OpenCodeReview; no actionable findings remained in issue-2301 files

The required live StepFun profile smoke was attempted again but remains externally blocked by HTTP 429 weekly quota exhaustion, with the provider reporting reset at 2026-07-17T00:00:00Z.

fixes #2301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows nightly smoke test for Bun native modules (including ConPTY) and surfaced captured diagnostics in failure reports.
* **Documentation**
  * Updated Windows troubleshooting notes to reflect verified Bun ConPTY behavior, with an example nightly run reference.
* **Bug Fixes**
  * Improved nightly failure detection to include cancelled/failed smoke runs and enhanced issue/comment content generation (with truncation safeguards and a direct run link).
* **Tests**
  * Strengthened nightly workflow contract and harness coverage for output truncation and platform-specific checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->