### PR TITLE
Harden provider context overflow recovery (Fixes #2588)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -67,6 +67,7 @@ import {
  * @requirement Module 3 specification
  */
 export class CompressionHandler {
+  // Preserve the existing public static constants while centralizing the policy.
   static readonly TOKEN_SAFETY_MARGIN = TOKEN_SAFETY_MARGIN;
   static readonly CONTEXT_LIMIT_FUDGE_FACTOR = CONTEXT_LIMIT_FUDGE_FACTOR;
   static readonly DEFAULT_COMPLETION_BUDGET = 65_536;

--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -820,7 +820,18 @@ export class CompressionHandler {
           'Provider truncation fallback failed during hard-limit enforcement',
           { primaryError, fallbackError },
         );
-        throw fallbackError;
+        const primaryMessage =
+          primaryError instanceof Error
+            ? primaryError.message
+            : String(primaryError);
+        const fallbackMessage =
+          fallbackError instanceof Error
+            ? fallbackError.message
+            : String(fallbackError);
+        throw new AggregateError(
+          [primaryError, fallbackError],
+          `Provider truncation fallback failed during hard-limit enforcement. Primary failure: ${primaryMessage}. Fallback failure: ${fallbackMessage}`,
+        );
       }
       this.logger.error(
         'Fallback compression also failed — continuing without compression',

--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -815,13 +815,17 @@ export class CompressionHandler {
       // Both strategies failed — track the failure
       this.compressionFailureCount++;
       this.lastCompressionFailureTime = Date.now();
+      if (!swallowErrors) {
+        this.logger.error(
+          'Provider truncation fallback failed during hard-limit enforcement',
+          { primaryError, fallbackError },
+        );
+        throw fallbackError;
+      }
       this.logger.error(
         'Fallback compression also failed — continuing without compression',
         { primaryError, fallbackError },
       );
-      if (!swallowErrors) {
-        throw fallbackError;
-      }
       return false;
     }
   }

--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -52,6 +52,12 @@ import {
   getCompletionBudget,
 } from './compressionBudgeting.js';
 import { ProviderContentEnforcer } from './providerContentEnforcement.js';
+import {
+  TOKEN_SAFETY_MARGIN,
+  CONTEXT_LIMIT_FUDGE_FACTOR,
+  INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD,
+  computeMarginAdjustedLimit,
+} from './contextLimitPolicy.js';
 
 /**
  * CompressionHandler orchestrates all compression logic for ChatSession.
@@ -61,18 +67,13 @@ import { ProviderContentEnforcer } from './providerContentEnforcement.js';
  * @requirement Module 3 specification
  */
 export class CompressionHandler {
-  static readonly TOKEN_SAFETY_MARGIN = 1000;
-  /**
-   * Estimation cushion (0.5%) applied on top of TOKEN_SAFETY_MARGIN so that
-   * marginally-over requests (e.g. a few tokens) are allowed through instead of
-   * blocking the turn. Interim solution for #2067; a targeted truncation
-   * strategy is planned for a future release.
-   */
-  static readonly CONTEXT_LIMIT_FUDGE_FACTOR = 0.005;
+  static readonly TOKEN_SAFETY_MARGIN = TOKEN_SAFETY_MARGIN;
+  static readonly CONTEXT_LIMIT_FUDGE_FACTOR = CONTEXT_LIMIT_FUDGE_FACTOR;
   static readonly DEFAULT_COMPLETION_BUDGET = 65_536;
   static readonly COMPRESSION_COOLDOWN_MS = 60_000;
   static readonly COMPRESSION_FAILURE_THRESHOLD = 3;
-  static readonly INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD = 0.05;
+  static readonly INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD =
+    INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD;
   static readonly RECENT_COMPRESSION_WINDOW_MS =
     CompressionHandler.COMPRESSION_COOLDOWN_MS;
 
@@ -399,17 +400,7 @@ export class CompressionHandler {
     );
     const userContextLimit = this.runtimeContext.ephemerals.contextLimit();
     const limit = tokenLimit(this.runtimeContext.state.model, userContextLimit);
-    const safetyAdjustedLimit = Math.max(
-      0,
-      limit - CompressionHandler.TOKEN_SAFETY_MARGIN,
-    );
-    const marginAdjustedLimit = Math.min(
-      limit,
-      Math.floor(
-        safetyAdjustedLimit +
-          safetyAdjustedLimit * CompressionHandler.CONTEXT_LIMIT_FUDGE_FACTOR,
-      ),
-    );
+    const marginAdjustedLimit = computeMarginAdjustedLimit(limit);
     return { completionBudget, limit, marginAdjustedLimit };
   }
 
@@ -521,14 +512,8 @@ export class CompressionHandler {
             context,
             new Error('Provider content fallback truncation triggered'),
             applyAndResetPromptCount,
+            { swallowErrors: false },
           );
-        } catch (error) {
-          this.logger.warn(
-            () =>
-              '[CompressionHandler] Provider truncation fallback failed during hard-limit enforcement',
-            error,
-          );
-          return false;
         } finally {
           this.popSuppressDensityDirty();
         }
@@ -574,7 +559,7 @@ export class CompressionHandler {
       historyService: this.historyService,
       logger: this.logger,
       ineffectiveCompressionReductionThreshold:
-        CompressionHandler.INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD,
+        INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD,
       getContextLimits: (activeProvider) =>
         this.computeContextLimits(activeProvider),
       computeProjectedTokens: (tokens, completionBudget) =>
@@ -804,12 +789,19 @@ export class CompressionHandler {
    *
    * @plan PLAN-20260218-COMPRESSION-RETRY.P01
    * @requirement REQ-CR-004-005
+   *
+   * When `swallowErrors` is true (default), errors are caught and false is
+   * returned to avoid blocking the conversation turn. When false (provider
+   * hard-limit enforcement), errors propagate so the enforcer can capture
+   * them as truncationFailure for actionable overflow diagnostics.
    */
   private async performFallbackCompression(
     context: CompressionContext,
     primaryError: unknown,
     applyResult: (newHistory: IContent[]) => void,
+    options?: { swallowErrors?: boolean },
   ): Promise<boolean> {
+    const swallowErrors = options?.swallowErrors ?? true;
     try {
       // Use the strategy factory so tests can intercept
       const result = await this.compressWithFallbackStrategy(context);
@@ -819,14 +811,16 @@ export class CompressionHandler {
       );
       return true;
     } catch (fallbackError) {
-      // Both strategies failed — track the failure and continue without compression
+      // Both strategies failed — track the failure
       this.compressionFailureCount++;
       this.lastCompressionFailureTime = Date.now();
       this.logger.error(
         'Fallback compression also failed — continuing without compression',
         { primaryError, fallbackError },
       );
-      // Swallow error to avoid blocking the conversation turn
+      if (!swallowErrors) {
+        throw fallbackError;
+      }
       return false;
     }
   }

--- a/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
@@ -39,6 +39,11 @@ import * as compressionFactory from '../compressionStrategyFactory.js';
 import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+import type {
+  CompressionProviderResult,
+  CompressionStrategy,
+} from '@vybestack/llxprt-code-core/core/compression/types.js';
+import type { RuntimeProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ProviderContentEnvelope } from '@vybestack/llxprt-code-core/services/history/historyProviderPipeline.js';
 
@@ -81,16 +86,16 @@ describe('Finding 1: provider fallback failure propagation through real Compress
       compressionThreshold: 0.8,
     });
 
+    const provider = {
+      name: 'test',
+      generateChatCompletion: vi.fn(),
+    } as unknown as RuntimeProvider;
+    const providerResult: CompressionProviderResult = { provider };
     handler = new CompressionHandler(
       runtimeContext,
       historyService,
       {},
-      vi.fn().mockResolvedValue({
-        provider: {
-          name: 'test',
-          generateChatCompletion: vi.fn(),
-        } as never,
-      }),
+      vi.fn().mockResolvedValue(providerResult),
       vi.fn().mockResolvedValue(undefined),
     );
   });
@@ -121,14 +126,17 @@ describe('Finding 1: provider fallback failure propagation through real Compress
       PerformCompressionResult.COMPRESSED,
     );
 
-    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue({
+    const strategy: CompressionStrategy = {
       name: 'top-down-truncation',
       requiresLLM: false,
       trigger: { mode: 'threshold', defaultThreshold: 0.8 },
       compress: vi
         .fn()
         .mockRejectedValue(new Error('truncation engine blew up')),
-    } as never);
+    };
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue(
+      strategy,
+    );
 
     let thrownError: Error | undefined;
     try {
@@ -227,16 +235,23 @@ describe('Finding 1: provider fallback failure propagation through real Compress
     );
 
     const fallbackHistory = [makeUserMessage('truncated summary')];
-    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue({
+    const strategy: CompressionStrategy = {
       name: 'top-down-truncation',
       requiresLLM: false,
       trigger: { mode: 'threshold', defaultThreshold: 0.8 },
       compress: vi.fn().mockResolvedValue({
         newHistory: fallbackHistory,
-        strategy: 'top-down-truncation',
-        summary: undefined,
+        metadata: {
+          originalMessageCount: 1,
+          compressedMessageCount: 1,
+          strategyUsed: 'top-down-truncation',
+          llmCallMade: false,
+        },
       }),
-    } as never);
+    };
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue(
+      strategy,
+    );
 
     const result = await handler.enforceProviderContents(
       envelope,
@@ -340,7 +355,7 @@ describe('Finding 2: stage-aware projection errors in ProviderContentEnforcer (I
 
     expect(thrownError).toBeInstanceOf(Error);
     expect(thrownError!.message).toContain('estimation infrastructure down');
-    expect(thrownError!.message.toLowerCase()).toContain('compression');
+    expect(thrownError!.message).toContain('post-compression stage');
   });
 
   /**

--- a/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
@@ -194,12 +194,12 @@ describe('Finding 1: provider fallback failure propagation through real Compress
   /**
    * When the fallback strategy succeeds, the normal happy path should work.
    *
-   * The projections are scripted so that the real fallback stage is provably
-   * reached: initial, post-density, and post-first-compression projections are
-   * all over-limit, and only the post-truncation projection fits. The effective
-   * first compression intentionally bypasses retry. This ensures the test
-   * exercises the actual fallback path rather
-   * than returning early from an earlier stage. The returned contents must
+   * Compression is simulated at the handler boundary. Scripted projections
+   * keep the initial, post-density, and post-first-compression payloads over
+   * limit while making the simulated first compression effective enough to
+   * bypass retry. Only the post-truncation projection fits, proving that the
+   * real handler-to-fallback wiring applied the strategy result instead of
+   * returning early from an earlier stage. The returned contents must
    * contain the truncated summary and preserve the pending message.
    */
   it('still succeeds when fallback truncation works correctly', async () => {

--- a/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright 2025 Vybestack LLC
- * SPDX-License: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Behavioral tests for CompressionHandler provider fallback failure
  * propagation and stage-aware projection errors (Issue #2588 findings).
@@ -184,8 +184,14 @@ describe('Finding 1: provider fallback failure propagation through real Compress
   });
 
   /**
-   * When the fallback strategy succeeds, the normal happy path should work
-   * (no regression).
+   * When the fallback strategy succeeds, the normal happy path should work.
+   *
+   * The projections are scripted so that the real fallback stage is provably
+   * reached: initial, post-density, post-first-compression, and post-retry
+   * projections are all over-limit, and only the post-truncation projection
+   * fits. This ensures the test exercises the actual fallback path rather
+   * than returning early from an earlier stage. The returned contents must
+   * contain the truncated summary and preserve the pending message.
    */
   it('still succeeds when fallback truncation works correctly', async () => {
     historyService.add(makeUserMessage('established history'));
@@ -196,32 +202,57 @@ describe('Finding 1: provider fallback failure propagation through real Compress
       pendingContents: [pending],
     };
 
-    const estimateSpy = vi
-      .spyOn(historyService, 'estimateTokensForContents')
-      .mockResolvedValue(150_000);
+    // contextLimit = 200_000, completionBudget = 65_536
+    // marginAdjustedLimit = 199_995 → over-limit when projected > 199_995
+    // estimate + 65_536 > 199_995 → estimate > 134_459
+    const OVER_LIMIT_ESTIMATE = 150_000; // 150_000 + 65_536 = 215_536 > 199_995
+    const TRUNCATED_SUMMARY_ESTIMATE = 50_000; // 50_000 + 65_536 = 115_536 < 199_995
+
+    const estimateSpy = vi.spyOn(historyService, 'estimateTokensForContents');
+    // 1. Initial projection — over-limit
+    estimateSpy.mockResolvedValueOnce(OVER_LIMIT_ESTIMATE);
+    // 2. Post-density-optimization — over-limit
+    estimateSpy.mockResolvedValueOnce(OVER_LIMIT_ESTIMATE);
+    // 3. Post-first-compression — still over-limit, but effective enough to
+    //    avoid retry (reduction >= 5% of pre-compression projection).
+    //    pre-compression projected = 215_536, need reduction >= ~10_777,
+    //    so post-compression estimate <= 139_223 keeps ratio >= 5%.
+    //    135_000 + 65_536 = 200_536 > 199_995 (still over margin limit).
+    estimateSpy.mockResolvedValueOnce(135_000);
+    // 4. Post-truncation — under-limit (fallback succeeded)
+    estimateSpy.mockResolvedValueOnce(TRUNCATED_SUMMARY_ESTIMATE);
 
     vi.spyOn(handler, 'performCompression').mockResolvedValue(
       PerformCompressionResult.COMPRESSED,
     );
 
+    const fallbackHistory = [makeUserMessage('truncated summary')];
     vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue({
       name: 'top-down-truncation',
       requiresLLM: false,
       trigger: { mode: 'threshold', defaultThreshold: 0.8 },
       compress: vi.fn().mockResolvedValue({
-        newHistory: [makeUserMessage('truncated summary')],
+        newHistory: fallbackHistory,
         strategy: 'top-down-truncation',
         summary: undefined,
       }),
     } as never);
-
-    estimateSpy.mockResolvedValue(50_000);
 
     const result = await handler.enforceProviderContents(
       envelope,
       'test-prompt',
     );
 
+    // The truncated summary content must appear in the returned provider
+    // contents, proving the fallback path applied its result.
+    const resultText = result
+      .flatMap((c) => c.blocks)
+      .filter((b) => b.type === 'text')
+      .map((b) => (b as { text: string }).text)
+      .join(' ');
+    expect(resultText).toContain('truncated summary');
+
+    // The pending request must be preserved in the returned contents.
     expect(result).toContainEqual(pending);
   });
 });
@@ -437,5 +468,61 @@ describe('Finding 2: stage-aware projection errors in ProviderContentEnforcer (I
     expect(thrownError).toBeInstanceOf(Error);
     expect(thrownError!.message).toContain('estimation infrastructure down');
     expect(thrownError!.message.toLowerCase()).toContain('projection');
+  });
+
+  /**
+   * Finding 4 (CodeRabbit PR #2598): Projection rejection must not be caught
+   * as a compression failure.
+   *
+   * When the first post-compression projection rejects, the stage-aware
+   * projection error must propagate directly — not be caught by the
+   * compression try/catch and re-projected as a compression failure. If the
+   * second estimate would succeed, enforcement must NOT proceed to truncation
+   * or fallback; it must surface the original projection error.
+   */
+  it('throws the stage-aware projection error when post-compression projection rejects, even if a subsequent estimate would succeed (CodeRabbit PR #2598)', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const pending = makeUserMessage('pending request');
+    const contents: IContent[] = historyService.getCuratedForProvider([
+      pending,
+    ]);
+    const envelope: ProviderContentEnvelope = {
+      contents,
+      pendingContents: [pending],
+    };
+
+    const harness = buildEnforcerHarness();
+    const estimateSpy = vi.spyOn(historyService, 'estimateTokensForContents');
+
+    // 1. Initial — over-limit (succeeds)
+    estimateSpy.mockResolvedValueOnce(200_000);
+    // 2. Post-density — over-limit (succeeds)
+    estimateSpy.mockResolvedValueOnce(200_000);
+    // 3. Post-first-compression — REJECTS with a specific stage error
+    estimateSpy.mockRejectedValueOnce(
+      new Error('estimation infrastructure down'),
+    );
+    // 4+. Any subsequent call would succeed (never reached)
+    estimateSpy.mockResolvedValueOnce(50_000);
+
+    harness.deps.performCompression.mockResolvedValue(
+      PerformCompressionResult.COMPRESSED,
+    );
+
+    let thrownError: Error | undefined;
+    try {
+      await harness.enforcer.enforce(envelope, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    // The original stage-aware projection error must propagate directly.
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError!.message).toContain('estimation infrastructure down');
+    expect(thrownError!.message.toLowerCase()).toContain('post-compression');
+
+    // Fallback must NOT be reached — the projection error surfaced before
+    // truncation.
+    expect(harness.deps.performFallbackCompression).not.toHaveBeenCalled();
   });
 });

--- a/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
@@ -279,7 +279,6 @@ describe('Finding 1: provider fallback failure propagation through real Compress
 
 describe('Finding 2: stage-aware projection errors in ProviderContentEnforcer (Issue #2588)', () => {
   let historyService: HistoryService;
-  let runtimeContext: AgentRuntimeContext;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -298,7 +297,7 @@ describe('Finding 2: stage-aware projection errors in ProviderContentEnforcer (I
   function buildEnforcerHarness(
     overrides: Partial<ProviderContentEnforcementDeps> = {},
   ): EnforcerHarness {
-    runtimeContext = buildRuntimeContext(historyService, {
+    const runtimeContext = buildRuntimeContext(historyService, {
       contextLimit: 200_000,
       compressionThreshold: 0.8,
     });

--- a/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
@@ -195,9 +195,10 @@ describe('Finding 1: provider fallback failure propagation through real Compress
    * When the fallback strategy succeeds, the normal happy path should work.
    *
    * The projections are scripted so that the real fallback stage is provably
-   * reached: initial, post-density, post-first-compression, and post-retry
-   * projections are all over-limit, and only the post-truncation projection
-   * fits. This ensures the test exercises the actual fallback path rather
+   * reached: initial, post-density, and post-first-compression projections are
+   * all over-limit, and only the post-truncation projection fits. The effective
+   * first compression intentionally bypasses retry. This ensures the test
+   * exercises the actual fallback path rather
    * than returning early from an earlier stage. The returned contents must
    * contain the truncated summary and preserve the pending message.
    */

--- a/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-provider-fallback-propagation.test.ts
@@ -1,0 +1,441 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License: Apache-2.0
+ *
+ * Behavioral tests for CompressionHandler provider fallback failure
+ * propagation and stage-aware projection errors (Issue #2588 findings).
+ *
+ * Finding 1: When the real provider fallback path (top-down truncation or
+ * buildCompressionContext) fails during hard-limit enforcement, the failure
+ * cause must propagate to the final overflow diagnostics. Previously the
+ * error was swallowed at two layers (the createProviderContentEnforcer lambda
+ * catches and returns false; CompressionHandler.performFallbackCompression
+ * also catches and returns false), so truncationFailure was never set and the
+ * final overflow error lost the cause.
+ *
+ * Finding 2: When estimateTokensForContents rejects after compression, retry,
+ * or truncation mutations, the error must include stage/action context so the
+ * caller can diagnose which stage failed. Previously the raw projection error
+ * bubbled up ambiguously.
+ *
+ * These tests follow dev-docs/RULES.md: they assert observable behavior
+ * (error messages, content preservation) and NEVER assert that mock functions
+ * were called with specific arguments.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import {
+  makeUserMessage,
+  buildRuntimeContext,
+} from '../../core/__tests__/chatSession-density-helpers.js';
+import {
+  ProviderContentEnforcer,
+  type ProviderContentEnforcementDeps,
+} from '../providerContentEnforcement.js';
+import { CompressionHandler } from '../CompressionHandler.js';
+import * as compressionFactory from '../compressionStrategyFactory.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { ProviderContentEnvelope } from '@vybestack/llxprt-code-core/services/history/historyProviderPipeline.js';
+
+function makeLogger(): DebugLogger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as DebugLogger;
+}
+
+vi.mock('@vybestack/llxprt-code-settings', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@vybestack/llxprt-code-settings')>();
+  return {
+    ...original,
+    Storage: {
+      ...original.Storage,
+      getGlobalConfigDir: vi.fn(() => '/tmp/llxprt-test-config'),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Finding 1: Provider fallback failure propagation through real wiring
+// ---------------------------------------------------------------------------
+
+describe('Finding 1: provider fallback failure propagation through real CompressionHandler (Issue #2588)', () => {
+  let historyService: HistoryService;
+  let runtimeContext: AgentRuntimeContext;
+  let handler: CompressionHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    historyService = new HistoryService();
+    runtimeContext = buildRuntimeContext(historyService, {
+      contextLimit: 200_000,
+      compressionThreshold: 0.8,
+    });
+
+    handler = new CompressionHandler(
+      runtimeContext,
+      historyService,
+      {},
+      vi.fn().mockResolvedValue({
+        provider: {
+          name: 'test',
+          generateChatCompletion: vi.fn(),
+        } as never,
+      }),
+      vi.fn().mockResolvedValue(undefined),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * When the top-down-truncation fallback strategy throws during
+   * enforceProviderContents hard-limit enforcement, the error must propagate
+   * as truncationFailure in the final overflow diagnostics.
+   */
+  it('propagates fallback truncation failure cause into the final overflow error', async () => {
+    historyService.add(makeUserMessage('established history'));
+
+    const pending = makeUserMessage('pending request');
+    const envelope: ProviderContentEnvelope = {
+      contents: historyService.getCuratedForProvider([pending]),
+      pendingContents: [pending],
+    };
+
+    vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+      150_000,
+    );
+
+    vi.spyOn(handler, 'performCompression').mockResolvedValue(
+      PerformCompressionResult.COMPRESSED,
+    );
+
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue({
+      name: 'top-down-truncation',
+      requiresLLM: false,
+      trigger: { mode: 'threshold', defaultThreshold: 0.8 },
+      compress: vi
+        .fn()
+        .mockRejectedValue(new Error('truncation engine blew up')),
+    } as never);
+
+    let thrownError: Error | undefined;
+    try {
+      await handler.enforceProviderContents(envelope, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError!.message).toContain(
+      'Truncation fallback failed during hard-limit enforcement',
+    );
+    expect(thrownError!.message).toContain('truncation engine blew up');
+  });
+
+  /**
+   * When buildCompressionContext fails during the provider fallback path,
+   * the error must also propagate as truncationFailure.
+   */
+  it('propagates buildCompressionContext failure cause into the final overflow error', async () => {
+    historyService.add(makeUserMessage('established history'));
+
+    const pending = makeUserMessage('pending request');
+    const envelope: ProviderContentEnvelope = {
+      contents: historyService.getCuratedForProvider([pending]),
+      pendingContents: [pending],
+    };
+
+    vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+      150_000,
+    );
+
+    vi.spyOn(handler, 'performCompression').mockResolvedValue(
+      PerformCompressionResult.COMPRESSED,
+    );
+
+    vi.spyOn(handler, 'buildCompressionContext').mockRejectedValue(
+      new Error('context build exploded'),
+    );
+
+    let thrownError: Error | undefined;
+    try {
+      await handler.enforceProviderContents(envelope, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError!.message).toContain(
+      'Truncation fallback failed during hard-limit enforcement',
+    );
+    expect(thrownError!.message).toContain('context build exploded');
+  });
+
+  /**
+   * When the fallback strategy succeeds, the normal happy path should work
+   * (no regression).
+   */
+  it('still succeeds when fallback truncation works correctly', async () => {
+    historyService.add(makeUserMessage('established history'));
+
+    const pending = makeUserMessage('pending request');
+    const envelope: ProviderContentEnvelope = {
+      contents: historyService.getCuratedForProvider([pending]),
+      pendingContents: [pending],
+    };
+
+    const estimateSpy = vi
+      .spyOn(historyService, 'estimateTokensForContents')
+      .mockResolvedValue(150_000);
+
+    vi.spyOn(handler, 'performCompression').mockResolvedValue(
+      PerformCompressionResult.COMPRESSED,
+    );
+
+    vi.spyOn(compressionFactory, 'getCompressionStrategy').mockReturnValue({
+      name: 'top-down-truncation',
+      requiresLLM: false,
+      trigger: { mode: 'threshold', defaultThreshold: 0.8 },
+      compress: vi.fn().mockResolvedValue({
+        newHistory: [makeUserMessage('truncated summary')],
+        strategy: 'top-down-truncation',
+        summary: undefined,
+      }),
+    } as never);
+
+    estimateSpy.mockResolvedValue(50_000);
+
+    const result = await handler.enforceProviderContents(
+      envelope,
+      'test-prompt',
+    );
+
+    expect(result).toContainEqual(pending);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 2: Stage-aware projection errors in ProviderContentEnforcer
+// ---------------------------------------------------------------------------
+
+describe('Finding 2: stage-aware projection errors in ProviderContentEnforcer (Issue #2588)', () => {
+  let historyService: HistoryService;
+  let runtimeContext: AgentRuntimeContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    historyService = new HistoryService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  interface EnforcerHarness {
+    enforcer: ProviderContentEnforcer;
+    deps: ProviderContentEnforcementDeps;
+  }
+
+  function buildEnforcerHarness(
+    overrides: Partial<ProviderContentEnforcementDeps> = {},
+  ): EnforcerHarness {
+    runtimeContext = buildRuntimeContext(historyService, {
+      contextLimit: 200_000,
+      compressionThreshold: 0.8,
+    });
+    const deps: ProviderContentEnforcementDeps = {
+      historyService,
+      runtimeContext,
+      generationConfig: {},
+      providerRuntimeNullable: undefined,
+      logger: makeLogger(),
+      ensureDensityOptimized: vi.fn().mockResolvedValue(undefined),
+      performCompression: vi.fn(),
+      performFallbackCompression: vi.fn().mockResolvedValue(false),
+      ...overrides,
+    };
+    return { enforcer: new ProviderContentEnforcer(deps), deps };
+  }
+
+  /**
+   * Post-first-compression projection failure.
+   *
+   * enforce() projection call sequence:
+   * 1. Initial projection (enforce)
+   * 2. Post-density-optimization (optimizeAndProject)
+   * 3. Post-compression (projectSuccess) — ALL subsequent calls reject
+   */
+  it('includes stage context when projection fails after first compression', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const pending = makeUserMessage('pending request');
+    const contents: IContent[] = historyService.getCuratedForProvider([
+      pending,
+    ]);
+    const envelope: ProviderContentEnvelope = {
+      contents,
+      pendingContents: [pending],
+    };
+
+    const harness = buildEnforcerHarness();
+    const estimateSpy = vi.spyOn(historyService, 'estimateTokensForContents');
+
+    estimateSpy
+      .mockResolvedValueOnce(200_000)
+      .mockResolvedValueOnce(200_000)
+      .mockRejectedValue(new Error('estimation infrastructure down'));
+
+    harness.deps.performCompression.mockResolvedValue(
+      PerformCompressionResult.COMPRESSED,
+    );
+
+    let thrownError: Error | undefined;
+    try {
+      await harness.enforcer.enforce(envelope, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError!.message).toContain('estimation infrastructure down');
+    expect(thrownError!.message.toLowerCase()).toContain('compression');
+  });
+
+  /**
+   * Post-retry projection failure.
+   *
+   * enforce() projection call sequence:
+   * 1. Initial projection
+   * 2. Post-density-optimization
+   * 3. Post-first-compression (reduction < 5%, triggers retry)
+   * 4. Post-retry-compression — ALL subsequent calls reject
+   */
+  it('includes stage context when projection fails after retry compression', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const pending = makeUserMessage('pending request');
+    const contents: IContent[] = historyService.getCuratedForProvider([
+      pending,
+    ]);
+    const envelope: ProviderContentEnvelope = {
+      contents,
+      pendingContents: [pending],
+    };
+
+    const harness = buildEnforcerHarness();
+    const estimateSpy = vi.spyOn(historyService, 'estimateTokensForContents');
+
+    estimateSpy
+      .mockResolvedValueOnce(200_000)
+      .mockResolvedValueOnce(200_000)
+      .mockResolvedValueOnce(199_000)
+      .mockRejectedValue(new Error('estimation infrastructure down'));
+
+    harness.deps.performCompression.mockResolvedValue(
+      PerformCompressionResult.COMPRESSED,
+    );
+
+    let thrownError: Error | undefined;
+    try {
+      await harness.enforcer.enforce(envelope, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError!.message).toContain('estimation infrastructure down');
+    expect(thrownError!.message.toLowerCase()).toContain('retry');
+  });
+
+  /**
+   * Post-truncation projection failure.
+   *
+   * enforce() projection call sequence:
+   * 1. Initial projection
+   * 2. Post-density-optimization
+   * 3. Post-first-compression (reduction < 5%, triggers retry)
+   * 4. Post-retry-compression (still over, triggers truncation)
+   * 5. Post-truncation — ALL subsequent calls reject
+   */
+  it('includes stage context when projection fails after truncation', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const pending = makeUserMessage('pending request');
+    const contents: IContent[] = historyService.getCuratedForProvider([
+      pending,
+    ]);
+    const envelope: ProviderContentEnvelope = {
+      contents,
+      pendingContents: [pending],
+    };
+
+    const harness = buildEnforcerHarness();
+    const estimateSpy = vi.spyOn(historyService, 'estimateTokensForContents');
+
+    estimateSpy
+      .mockResolvedValueOnce(200_000)
+      .mockResolvedValueOnce(200_000)
+      .mockResolvedValueOnce(199_000)
+      .mockResolvedValueOnce(199_000)
+      .mockRejectedValue(new Error('estimation infrastructure down'));
+
+    harness.deps.performCompression.mockResolvedValue(
+      PerformCompressionResult.COMPRESSED,
+    );
+
+    harness.deps.performFallbackCompression.mockImplementation(
+      async (_promptId, applyResult) => {
+        applyResult([makeUserMessage('truncated history')]);
+        return true;
+      },
+    );
+
+    let thrownError: Error | undefined;
+    try {
+      await harness.enforcer.enforce(envelope, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError!.message).toContain('estimation infrastructure down');
+    expect(thrownError!.message.toLowerCase()).toContain('truncation');
+  });
+
+  /**
+   * Initial projection failure should propagate with a stage label.
+   */
+  it('propagates initial projection error with explicit stage label', async () => {
+    historyService.add(makeUserMessage('established history'));
+    const contents: IContent[] = historyService.getCuratedForProvider();
+    const envelope: ProviderContentEnvelope = {
+      contents,
+      pendingContents: undefined,
+    };
+
+    const harness = buildEnforcerHarness();
+    vi.spyOn(historyService, 'estimateTokensForContents').mockRejectedValue(
+      new Error('estimation infrastructure down'),
+    );
+
+    let thrownError: Error | undefined;
+    try {
+      await harness.enforcer.enforce(envelope, 'test-prompt');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError!.message).toContain('estimation infrastructure down');
+    expect(thrownError!.message.toLowerCase()).toContain('projection');
+  });
+});

--- a/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
@@ -145,6 +145,7 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
       // No overflow error thrown — the capped cushion prevents the needless
       // error that the user saw in the issue (tokensStillNeeded=202, reduced 0)
       expect(result).toContainEqual(pending);
+      expect(harness.deps.performCompression).toHaveBeenCalledOnce();
     });
 
     it('still triggers compression when projected exceeds the capped cushion limit', async () => {

--- a/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
@@ -35,6 +35,10 @@ import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/Ag
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
 
+const ISSUE_CONTEXT_LIMIT = 262_144;
+const STANDARD_CONTEXT_LIMIT = 200_000;
+const COMPRESSION_THRESHOLD = 0.8;
+
 function makeLogger(): DebugLogger {
   return {
     debug: vi.fn(),
@@ -114,8 +118,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
       // is triggered, but even with zero reduction the capped margin keeps the
       // payload under the hard limit — no overflow error is thrown.
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 262_144,
-        compressionThreshold: 0.8,
+        contextLimit: ISSUE_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -146,8 +150,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
     it('still triggers compression when projected exceeds the capped cushion limit', async () => {
       // projected = 263000 > 262144 (capped limit) → compression needed
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 262_144,
-        compressionThreshold: 0.8,
+        contextLimit: ISSUE_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -182,8 +186,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   describe('one-retry-before-truncation: ineffective first compression', () => {
     it('makes exactly one additional full compression attempt when first compression is ineffective (<5%) and second fits', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -247,8 +251,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   describe('retry remains insufficient, truncation fits', () => {
     it('falls through to truncation when both compression attempts remain over limit, and preserves pending', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -307,8 +311,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   describe('failure diagnostics', () => {
     it('does not redundantly retry full compression when first compression FAILED, proceeds to truncation', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -353,8 +357,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
     it('does not redundantly retry full compression when first compression THREW, proceeds to truncation', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -399,8 +403,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
     it('proceeds to truncation when the retry compression attempt fails, and includes compression failure diagnostics', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -454,8 +458,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
     it('includes truncation failure details when truncation also fails', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -503,8 +507,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   describe('unrecoverable boundary preservation (issues #2304/#2306)', () => {
     it('returns contents as-is when pendingContents is undefined but under capped hard limit', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 262_144,
-        compressionThreshold: 0.8,
+        contextLimit: ISSUE_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -526,8 +530,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
     it('throws unrecoverable-boundary error when pendingContents is undefined and over capped hard limit', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 262_144,
-        compressionThreshold: 0.8,
+        contextLimit: ISSUE_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -556,8 +560,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   describe('non-COMPRESSED skipped results (SKIPPED_EMPTY / SKIPPED_COOLDOWN)', () => {
     it('does not make an additional full retry when first compression returns SKIPPED_EMPTY, proceeds to truncation', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -603,8 +607,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
     it('does not make an additional full retry when first compression returns SKIPPED_COOLDOWN, proceeds to truncation', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -644,8 +648,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
     it('retains actionable diagnostics identifying the skipped result when overflow remains after truncation', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -690,8 +694,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   describe('retry-failure cause preservation', () => {
     it('preserves the underlying retry error message in final diagnostics (not just generic message)', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -752,8 +756,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   describe('compressAndRecompose callback contract (rethrow compressionFailure)', () => {
     it('throws when performCompression throws during callback compression', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -775,8 +779,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
     it('throws when performCompression returns a non-COMPRESSED result during callback compression', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));
@@ -804,8 +808,8 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
       // proceeds to truncation. This proves the rethrow is isolated to
       // the compressAndRecompose callback entry point, not enforced globally.
       runtimeContext = buildRuntimeContext(historyService, {
-        contextLimit: 200_000,
-        compressionThreshold: 0.8,
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
       });
 
       historyService.add(makeUserMessage('established history'));

--- a/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
@@ -277,8 +277,6 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
       // Truncation fits
       harness.deps.performFallbackCompression.mockImplementation(
         async (_promptId, applyResult) => {
-          historyService.clear();
-          historyService.add(makeUserMessage('truncated history'));
           estimateSpy.mockResolvedValue(50_000); // fits
           applyResult([makeUserMessage('truncated history')]);
           return true;
@@ -583,8 +581,6 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
       // Truncation fits so we observe the final return value.
       harness.deps.performFallbackCompression.mockImplementation(
         async (_promptId, applyResult) => {
-          historyService.clear();
-          historyService.add(makeUserMessage('truncated history'));
           estimateSpy.mockResolvedValue(50_000);
           applyResult([makeUserMessage('truncated history')]);
           return true;
@@ -628,8 +624,6 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
       harness.deps.performFallbackCompression.mockImplementation(
         async (_promptId, applyResult) => {
-          historyService.clear();
-          historyService.add(makeUserMessage('truncated history'));
           estimateSpy.mockResolvedValue(50_000);
           applyResult([makeUserMessage('truncated history')]);
           return true;

--- a/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
@@ -1,0 +1,847 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for ProviderContentEnforcer hard-limit enforcement retry
+ * policy (Issue #2588).
+ *
+ * The provider-content enforcement path must use the SAME margin policy and
+ * one-retry-before-truncation retry policy as the pending enforcement path
+ * (Issue #2067). Previously the provider path had its own divergent margin
+ * calculation (missing the 0.5% cushion) and skipped the retry attempt,
+ * causing needless compression at the near-limit boundary and premature
+ * truncation.
+ *
+ * These tests follow dev-docs/RULES.md: their primary assertions cover
+ * observable behavior (returned provider contents, error messages, pending
+ * preservation). Call-state assertions additionally pin whether retry and
+ * fallback boundaries were reached. The ProviderContentEnforcer and
+ * HistoryService are real; only infrastructure boundaries (token estimation,
+ * compression execution) are mocked.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import {
+  makeUserMessage,
+  buildRuntimeContext,
+} from '../../core/__tests__/chatSession-density-helpers.js';
+import {
+  ProviderContentEnforcer,
+  type ProviderContentEnforcementDeps,
+} from '../providerContentEnforcement.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+
+function makeLogger(): DebugLogger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as DebugLogger;
+}
+
+interface EnforcerHarness {
+  enforcer: ProviderContentEnforcer;
+  deps: ProviderContentEnforcementDeps;
+  historyService: HistoryService;
+  runtimeContext: AgentRuntimeContext;
+}
+
+function buildEnforcerHarness(
+  historyService: HistoryService,
+  runtimeContext: AgentRuntimeContext,
+  overrides: Partial<ProviderContentEnforcementDeps> = {},
+): EnforcerHarness {
+  const performCompression = vi.fn();
+  const performFallbackCompression = vi.fn().mockResolvedValue(false);
+  const ensureDensityOptimized = vi.fn().mockResolvedValue(undefined);
+  const deps: ProviderContentEnforcementDeps = {
+    historyService,
+    runtimeContext,
+    generationConfig: {},
+    providerRuntimeNullable: undefined,
+    logger: makeLogger(),
+    ensureDensityOptimized,
+    performCompression,
+    performFallbackCompression,
+    ...overrides,
+  };
+  return {
+    enforcer: new ProviderContentEnforcer(deps),
+    deps,
+    historyService,
+    runtimeContext,
+  };
+}
+
+describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => {
+  let historyService: HistoryService;
+  let runtimeContext: AgentRuntimeContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    historyService = new HistoryService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // Test A: Near-limit shape returns original contents (no needless compression)
+  // -----------------------------------------------------------------------
+  describe('near-limit 0.5% capped cushion', () => {
+    it('returns contents without overflow error for the exact issue-2588 near-limit shape', async () => {
+      // Exact scenario from the issue:
+      //   context limit   = 262144
+      //   completionBudget = 65536
+      //   projected        = 261346
+      //   old safety-adjusted limit (no cushion) = 262144 - 1000 = 261144
+      //   tokensStillNeeded with old code = 261346 - 261144 = 202
+      //
+      // With the shared 0.5% cushion policy (same as pending #2067):
+      //   safetyAdjusted = 262144 - 1000 = 261144
+      //   cushion         = floor(261144 * 0.005) = 1305
+      //   marginAdjusted  = min(262144, 261144 + 1305) = 262144
+      //   projected 261346 <= 262144 → no overflow, no needless error
+      //
+      // The projected IS over the compression threshold (222822) so compression
+      // is triggered, but even with zero reduction the capped margin keeps the
+      // payload under the hard limit — no overflow error is thrown.
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 262_144,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      // estimate = projected - completionBudget = 261346 - 65536 = 195810
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        195_810,
+      );
+
+      // Compression does zero reduction (simulating the issue scenario)
+      harness.deps.performCompression.mockImplementation(
+        async () => PerformCompressionResult.COMPRESSED,
+      );
+
+      const result = await harness.enforcer.enforce(
+        { contents, pendingContents: [pending] },
+        'test-prompt',
+      );
+
+      // No overflow error thrown — the capped cushion prevents the needless
+      // error that the user saw in the issue (tokensStillNeeded=202, reduced 0)
+      expect(result).toContainEqual(pending);
+    });
+
+    it('still triggers compression when projected exceeds the capped cushion limit', async () => {
+      // projected = 263000 > 262144 (capped limit) → compression needed
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 262_144,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(197_464); // 197464 + 65536 = 263000 > 262144
+
+      harness.deps.performCompression.mockImplementation(async () => {
+        historyService.clear();
+        historyService.add(makeUserMessage('compressed summary'));
+        estimateSpy.mockResolvedValue(1_000);
+        return PerformCompressionResult.COMPRESSED;
+      });
+
+      const result = await harness.enforcer.enforce(
+        { contents, pendingContents: [pending] },
+        'test-prompt',
+      );
+
+      expect(result).not.toStrictEqual(contents);
+      expect(result).toContainEqual(pending);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test B: First compression ineffective, second compression fits
+  // -----------------------------------------------------------------------
+  describe('one-retry-before-truncation: ineffective first compression', () => {
+    it('makes exactly one additional full compression attempt when first compression is ineffective (<5%) and second fits', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      // marginAdjustedLimit with 0.5% cushion:
+      //   safetyAdjusted = 199000
+      //   cushion = floor(199000 * 0.005) = 995
+      //   marginAdjusted = min(200000, 199995) = 199995
+      // First estimate: 150000 + 65536 = 215536 > 199995
+      // After 1st compression: 148000 + 65536 = 213536 (reduction <5%, ineffective)
+      // After 2nd compression: 100000 + 65536 = 165536 < 199995 → fits!
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(150_000);
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        historyService.clear();
+        if (compressionCallCount === 1) {
+          historyService.add(makeUserMessage('first compressed summary'));
+          estimateSpy.mockResolvedValue(148_000); // <5% reduction, still over
+        } else {
+          historyService.add(makeUserMessage('second compressed summary'));
+          estimateSpy.mockResolvedValue(100_000); // fits now
+        }
+        return PerformCompressionResult.COMPRESSED;
+      });
+
+      const result = await harness.enforcer.enforce(
+        { contents, pendingContents: [pending] },
+        'test-prompt',
+      );
+
+      // Two full compression attempts were made (not truncation)
+      expect(compressionCallCount).toBe(2);
+
+      // Result contains the SECOND summary, not the first, and not a fallback
+      const allText = result
+        .flatMap((c) => c.blocks)
+        .filter((b) => b.type === 'text')
+        .map((b) => (b as { text: string }).text)
+        .join(' ');
+      expect(allText).toContain('second compressed summary');
+      expect(allText).not.toContain('first compressed summary');
+
+      // Pending is preserved
+      expect(result).toContainEqual(pending);
+
+      // Truncation was NOT invoked
+      expect(harness.deps.performFallbackCompression).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test C: Retry insufficient, truncation fits
+  // -----------------------------------------------------------------------
+  describe('retry remains insufficient, truncation fits', () => {
+    it('falls through to truncation when both compression attempts remain over limit, and preserves pending', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(150_000);
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        historyService.clear();
+        historyService.add(makeUserMessage('compressed still large'));
+        // Both compressions remain over limit
+        estimateSpy.mockResolvedValue(148_000);
+        return PerformCompressionResult.COMPRESSED;
+      });
+
+      // Truncation fits
+      harness.deps.performFallbackCompression.mockImplementation(
+        async (_promptId, applyResult) => {
+          historyService.clear();
+          historyService.add(makeUserMessage('truncated history'));
+          estimateSpy.mockResolvedValue(50_000); // fits
+          applyResult([makeUserMessage('truncated history')]);
+          return true;
+        },
+      );
+
+      const result = await harness.enforcer.enforce(
+        { contents, pendingContents: [pending] },
+        'test-prompt',
+      );
+
+      // Two compression attempts were made, then truncation
+      expect(compressionCallCount).toBe(2);
+      expect(harness.deps.performFallbackCompression).toHaveBeenCalled();
+
+      // Result contains truncated history and pending is preserved
+      const allText = result
+        .flatMap((c) => c.blocks)
+        .filter((b) => b.type === 'text')
+        .map((b) => (b as { text: string }).text)
+        .join(' ');
+      expect(allText).toContain('truncated history');
+      expect(result).toContainEqual(pending);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test D: Diagnostics for compression/truncation failures
+  // -----------------------------------------------------------------------
+  describe('failure diagnostics', () => {
+    it('does not redundantly retry full compression when first compression FAILED, proceeds to truncation', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        150_000,
+      );
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        historyService.clear();
+        historyService.add(makeUserMessage('attempted compression'));
+        // First compression FAILED (non-throwing)
+        return PerformCompressionResult.FAILED;
+      });
+
+      // Truncation also fails to bring it under limit
+      harness.deps.performFallbackCompression.mockResolvedValue(false);
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      // Only ONE compression attempt (no redundant retry on FAILED)
+      expect(compressionCallCount).toBe(1);
+
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError!.message).toContain(
+        'Automatic compression failed before fallback',
+      );
+    });
+
+    it('does not redundantly retry full compression when first compression THREW, proceeds to truncation', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        150_000,
+      );
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        throw new Error('network error during compression');
+      });
+
+      // Truncation also fails
+      harness.deps.performFallbackCompression.mockResolvedValue(false);
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      // Only ONE compression attempt (no redundant retry on thrown error)
+      expect(compressionCallCount).toBe(1);
+
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError!.message).toContain(
+        'Automatic compression failed before fallback',
+      );
+      expect(thrownError!.message).toContain(
+        'network error during compression',
+      );
+    });
+
+    it('proceeds to truncation when the retry compression attempt fails, and includes compression failure diagnostics', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(150_000);
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        historyService.clear();
+        if (compressionCallCount === 1) {
+          // First compression succeeds but is ineffective
+          historyService.add(makeUserMessage('ineffective compression'));
+          estimateSpy.mockResolvedValue(148_000);
+          return PerformCompressionResult.COMPRESSED;
+        }
+        // Second (retry) compression fails
+        throw new Error('retry compression failed');
+      });
+
+      // Truncation also fails
+      harness.deps.performFallbackCompression.mockResolvedValue(false);
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      // Two compression attempts (first succeeded, retry failed)
+      expect(compressionCallCount).toBe(2);
+
+      expect(thrownError).toBeInstanceOf(Error);
+      // Compression failure diagnostics surfaced
+      expect(thrownError!.message).toContain(
+        'Automatic compression failed before fallback',
+      );
+      expect(thrownError!.message).toContain(
+        'Additional hard-limit compression attempt failed',
+      );
+    });
+
+    it('includes truncation failure details when truncation also fails', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(150_000);
+
+      harness.deps.performCompression.mockImplementation(async () => {
+        historyService.clear();
+        historyService.add(makeUserMessage('ineffective compression'));
+        estimateSpy.mockResolvedValue(148_000);
+        return PerformCompressionResult.COMPRESSED;
+      });
+
+      // Truncation rejects (throws)
+      harness.deps.performFallbackCompression.mockRejectedValue(
+        new Error('truncation broke'),
+      );
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError!.message).toContain(
+        'Truncation fallback failed during hard-limit enforcement',
+      );
+      expect(thrownError!.message).toContain('truncation broke');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test E: Unrecoverable boundary regression + pending preservation
+  // -----------------------------------------------------------------------
+  describe('unrecoverable boundary preservation (issues #2304/#2306)', () => {
+    it('returns contents as-is when pendingContents is undefined but under capped hard limit', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 262_144,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const contents = historyService.getCuratedForProvider();
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      // projected = 195810 + 65536 = 261346 <= 262144 (capped limit) → as-is
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        195_810,
+      );
+
+      const result = await harness.enforcer.enforce(
+        { contents, pendingContents: undefined },
+        'test-prompt',
+      );
+
+      expect(result).toStrictEqual(contents);
+    });
+
+    it('throws unrecoverable-boundary error when pendingContents is undefined and over capped hard limit', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 262_144,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const contents = historyService.getCuratedForProvider();
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      // projected = 300000 + 65536 = 365536 > 262144 → unrecoverable
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        300_000,
+      );
+
+      await expect(
+        harness.enforcer.enforce(
+          { contents, pendingContents: undefined },
+          'test-prompt',
+        ),
+      ).rejects.toThrow(/unrecoverable/i);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test F: Non-COMPRESSED (skipped) outcomes are treated as ineffective
+  // consistently — no redundant retry, proceeds to truncation, diagnostics
+  // identify the skipped result.
+  // -----------------------------------------------------------------------
+  describe('non-COMPRESSED skipped results (SKIPPED_EMPTY / SKIPPED_COOLDOWN)', () => {
+    it('does not make an additional full retry when first compression returns SKIPPED_EMPTY, proceeds to truncation', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(150_000);
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        // First compression returns a skipped result, not FAILED.
+        return PerformCompressionResult.SKIPPED_EMPTY;
+      });
+
+      // Truncation fits so we observe the final return value.
+      harness.deps.performFallbackCompression.mockImplementation(
+        async (_promptId, applyResult) => {
+          historyService.clear();
+          historyService.add(makeUserMessage('truncated history'));
+          estimateSpy.mockResolvedValue(50_000);
+          applyResult([makeUserMessage('truncated history')]);
+          return true;
+        },
+      );
+
+      const result = await harness.enforcer.enforce(
+        { contents, pendingContents: [pending] },
+        'test-prompt',
+      );
+
+      // Only ONE compression attempt — a skipped result must NOT trigger a
+      // redundant full retry (treating it as "successful" like COMPRESSED).
+      expect(compressionCallCount).toBe(1);
+
+      // Truncation was reached.
+      expect(harness.deps.performFallbackCompression).toHaveBeenCalled();
+      expect(result).toContainEqual(pending);
+    });
+
+    it('does not make an additional full retry when first compression returns SKIPPED_COOLDOWN, proceeds to truncation', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(150_000);
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        return PerformCompressionResult.SKIPPED_COOLDOWN;
+      });
+
+      harness.deps.performFallbackCompression.mockImplementation(
+        async (_promptId, applyResult) => {
+          historyService.clear();
+          historyService.add(makeUserMessage('truncated history'));
+          estimateSpy.mockResolvedValue(50_000);
+          applyResult([makeUserMessage('truncated history')]);
+          return true;
+        },
+      );
+
+      const result = await harness.enforcer.enforce(
+        { contents, pendingContents: [pending] },
+        'test-prompt',
+      );
+
+      expect(compressionCallCount).toBe(1);
+      expect(harness.deps.performFallbackCompression).toHaveBeenCalled();
+      expect(result).toContainEqual(pending);
+    });
+
+    it('retains actionable diagnostics identifying the skipped result when overflow remains after truncation', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        150_000,
+      );
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        return PerformCompressionResult.SKIPPED_EMPTY;
+      });
+
+      // Truncation does NOT bring it under limit → overflow error.
+      harness.deps.performFallbackCompression.mockResolvedValue(false);
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      expect(compressionCallCount).toBe(1);
+      expect(thrownError).toBeInstanceOf(Error);
+      // The diagnostics should identify the skipped compression result so the
+      // error is actionable.
+      expect(thrownError!.message).toContain('skipped_empty');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test G: Additional compression retry failure preserves the underlying cause
+  // -----------------------------------------------------------------------
+  describe('retry-failure cause preservation', () => {
+    it('preserves the underlying retry error message in final diagnostics (not just generic message)', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      const estimateSpy = vi
+        .spyOn(historyService, 'estimateTokensForContents')
+        .mockResolvedValue(150_000);
+
+      let compressionCallCount = 0;
+      harness.deps.performCompression.mockImplementation(async () => {
+        compressionCallCount++;
+        historyService.clear();
+        if (compressionCallCount === 1) {
+          historyService.add(makeUserMessage('ineffective compression'));
+          estimateSpy.mockResolvedValue(148_000);
+          return PerformCompressionResult.COMPRESSED;
+        }
+        // Second (retry) compression throws a specific underlying error.
+        throw new Error('underlying retry cause: network timeout');
+      });
+
+      harness.deps.performFallbackCompression.mockResolvedValue(false);
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      expect(compressionCallCount).toBe(2);
+      expect(thrownError).toBeInstanceOf(Error);
+      // The underlying cause must be preserved in actionable diagnostics.
+      expect(thrownError!.message).toContain(
+        'underlying retry cause: network timeout',
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Test H: compressAndRecompose callback contract (Issue #2588 OCR finding)
+  //
+  // compressAndRecompose is invoked from the provider compression callback
+  // (CompressionHandler.attachCompressionCallback). That callback's try/catch
+  // expects failure to THROW so the provider can reject the request.
+  // runCompressionAndRecompose catches errors/non-COMPRESSED results and
+  // returns them as structured compressionFailure — compressAndRecompose must
+  // rethrow that failure so the callback contract is honored, while the
+  // enforcement orchestration (enforce) continues to consume structured
+  // failures for its own retry/truncation/overflow diagnostics.
+  // -----------------------------------------------------------------------
+  describe('compressAndRecompose callback contract (rethrow compressionFailure)', () => {
+    it('throws when performCompression throws during callback compression', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        10_000,
+      );
+
+      harness.deps.performCompression.mockRejectedValue(
+        new Error('callback compression network failure'),
+      );
+
+      await expect(
+        harness.enforcer.compressAndRecompose([pending], 'test-prompt'),
+      ).rejects.toThrow('callback compression network failure');
+    });
+
+    it('throws when performCompression returns a non-COMPRESSED result during callback compression', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        10_000,
+      );
+
+      harness.deps.performCompression.mockResolvedValue(
+        PerformCompressionResult.FAILED,
+      );
+
+      // A non-COMPRESSED result is a failure in the callback context; it must
+      // throw (not silently return unprojected contents).
+      await expect(
+        harness.enforcer.compressAndRecompose([pending], 'test-prompt'),
+      ).rejects.toThrow(/Auto compression did not complete/);
+    });
+
+    it('still consumes structured failures in enforce orchestration when compression fails (no rethrow from enforce)', async () => {
+      // The enforcement orchestration path (enforce) must NOT rethrow on a
+      // single compression failure; it consumes the structured failure and
+      // proceeds to truncation. This proves the rethrow is isolated to
+      // the compressAndRecompose callback entry point, not enforced globally.
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: 200_000,
+        compressionThreshold: 0.8,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+      vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
+        150_000,
+      );
+
+      harness.deps.performCompression.mockRejectedValue(
+        new Error('enforce compression failed'),
+      );
+
+      // Truncation also fails, so we observe the final overflow error.
+      harness.deps.performFallbackCompression.mockResolvedValue(false);
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      }
+
+      // enforce consumed the structured failure and proceeded to truncation;
+      // it did NOT rethrow the raw compression error. The diagnostics surface
+      // the compression failure as a structured field, not a raw throw.
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError!.message).toContain(
+        'Automatic compression failed before fallback',
+      );
+      expect(thrownError!.message).toContain('enforce compression failed');
+    });
+  });
+});

--- a/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
@@ -848,4 +848,83 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
       expect(thrownError!.message).toContain('enforce compression failed');
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Finding 3 (CodeRabbit PR #2598): Data integrity bug — silent history loss
+  //
+  // If performFallbackCompression rejects AND restoring the original history
+  // fails, forceTruncation can leave historyService empty. A low projection
+  // against that empty history would then fit under the margin-adjusted limit,
+  // and enforce() would return "successfully" despite having lost all
+  // established history. This must be rejected, not silently accepted.
+  // -----------------------------------------------------------------------
+  describe('data integrity: rejects instead of silently accepting lost history (CodeRabbit PR #2598)', () => {
+    it('throws when fallback rejects, history restoration fails, and empty-history projection fits', async () => {
+      runtimeContext = buildRuntimeContext(historyService, {
+        contextLimit: STANDARD_CONTEXT_LIMIT,
+        compressionThreshold: COMPRESSION_THRESHOLD,
+      });
+
+      historyService.add(makeUserMessage('established history'));
+      const pending = makeUserMessage('pending request');
+      const contents = historyService.getCuratedForProvider([pending]);
+
+      const harness = buildEnforcerHarness(historyService, runtimeContext);
+
+      // Script the projection sequence so the real fallback stage is
+      // provably reached:
+      // 1. Initial — over-limit
+      // 2. Post-density — over-limit
+      // 3. Post-first-compression — over-limit, effective (>=5%) to avoid retry
+      // 4. Post-truncation — under-limit BUT history was lost
+      const estimateSpy = vi.spyOn(historyService, 'estimateTokensForContents');
+      // completionBudget = 65_536, marginAdjustedLimit = 199_995
+      // estimate > 134_459 → over-limit
+      estimateSpy.mockResolvedValueOnce(150_000); // initial
+      estimateSpy.mockResolvedValueOnce(150_000); // post-density
+      // 150_000 + 65_536 = 215_536, need >=5% reduction: <= 139_223
+      // 135_000 + 65_536 = 200_536 > 199_995 (still over)
+      estimateSpy.mockResolvedValueOnce(135_000); // post-compression (effective, still over)
+      // Post-truncation: empty history fits, but history was lost
+      estimateSpy.mockResolvedValueOnce(50_000); // post-truncation
+
+      harness.deps.performCompression.mockImplementation(async () => {
+        historyService.clear();
+        historyService.add(makeUserMessage('compressed'));
+        return PerformCompressionResult.COMPRESSED;
+      });
+
+      // Make addAll fail during fallback, so restoreHistory cannot apply
+      // either the new or backup history — leaving historyService empty.
+      const addAllSpy = vi
+        .spyOn(historyService, 'addAll')
+        .mockImplementation(() => {
+          throw new Error('history persistence layer down');
+        });
+
+      // The fallback rejects because restoreHistory throws when addAll fails
+      // for both new and backup history.
+      harness.deps.performFallbackCompression.mockImplementation(
+        async (_promptId, applyResult) => {
+          applyResult([makeUserMessage('truncated history')]);
+          return true;
+        },
+      );
+
+      let thrownError: Error | undefined;
+      try {
+        await harness.enforcer.enforce(
+          { contents, pendingContents: [pending] },
+          'test-prompt',
+        );
+      } catch (error) {
+        thrownError = error as Error;
+      } finally {
+        addAllSpy.mockRestore();
+      }
+
+      // Enforcement MUST reject rather than silently accept lost history.
+      expect(thrownError).toBeInstanceOf(Error);
+    });
+  });
 });

--- a/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
@@ -346,6 +346,7 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
       // Only ONE compression attempt (no redundant retry on FAILED)
       expect(compressionCallCount).toBe(1);
+      expect(harness.deps.performFallbackCompression).toHaveBeenCalled();
 
       expect(thrownError).toBeInstanceOf(Error);
       expect(thrownError!.message).toContain(
@@ -389,6 +390,7 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
       // Only ONE compression attempt (no redundant retry on thrown error)
       expect(compressionCallCount).toBe(1);
+      expect(harness.deps.performFallbackCompression).toHaveBeenCalled();
 
       expect(thrownError).toBeInstanceOf(Error);
       expect(thrownError!.message).toContain(
@@ -443,6 +445,7 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
       // Two compression attempts (first succeeded, retry failed)
       expect(compressionCallCount).toBe(2);
+      expect(harness.deps.performFallbackCompression).toHaveBeenCalled();
 
       expect(thrownError).toBeInstanceOf(Error);
       // Compression failure diagnostics surfaced
@@ -919,6 +922,10 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
       // Enforcement MUST reject rather than silently accept lost history.
       expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError!.message).toContain(
+        'Truncation fallback failed during hard-limit enforcement',
+      );
+      expect(thrownError!.message).toContain('history persistence layer down');
     });
   });
 });

--- a/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
@@ -79,7 +79,7 @@ function buildEnforcerHarness(
  * overflow/compression path.
  *
  * With contextLimit=200_000 and the default completion budget (65_536):
- *   compressionThreshold = min(199_995, 0.8 * 134_464 + 65_536) = 172_107
+ *   compressionThreshold = min(199_995, 0.8 * 134_464 + 65_536) = 173_107.2
  *   marginAdjustedLimit   = min(200_000, floor(199_000 + 199_000*0.005)) = 199_995
  *   initialProjected      = OVERFLOW_TOKENS + 65_536 = 200_536 > 199_995
  */

--- a/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
@@ -79,11 +79,11 @@ function buildEnforcerHarness(
  * overflow/compression path.
  *
  * With contextLimit=200_000 and the default completion budget (65_536):
- *   compressionThreshold = min(199_000, 0.8 * 134_464 + 65_536) = 172_107
- *   marginAdjustedLimit   = 199_000
- *   initialProjected      = OVERFLOW_TOKENS + 65_536 = 199_536 > 199_000
+ *   compressionThreshold = min(199_995, 0.8 * 134_464 + 65_536) = 172_107
+ *   marginAdjustedLimit   = min(200_000, floor(199_000 + 199_000*0.005)) = 199_995
+ *   initialProjected      = OVERFLOW_TOKENS + 65_536 = 200_536 > 199_995
  */
-const OVERFLOW_TOKENS = 134_000;
+const OVERFLOW_TOKENS = 135_000;
 
 describe('ProviderContentEnforcer envelope-based enforcement (issue #2304)', () => {
   let historyService: HistoryService;

--- a/packages/agents/src/compression/__tests__/contextLimitPolicy.test.ts
+++ b/packages/agents/src/compression/__tests__/contextLimitPolicy.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the centralized context-limit margin policy
+ * (contextLimitPolicy.ts).
+ *
+ * The shared helper is used by BOTH the pending-token enforcement path and the
+ * provider-content enforcement path. The pending path historically produced a
+ * marginAdjustedLimit of 0 for limits at or below TOKEN_SAFETY_MARGIN (the
+ * safety-adjusted value floors to 0, and the cushion adds nothing). The
+ * provider-only path previously clamped to at least 1, but that provider-only
+ * drift must NOT silently alter the shared pending policy. Therefore the shared
+ * helper preserves the pending semantics: positive limits <= safety margin
+ * produce 0, not 1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  TOKEN_SAFETY_MARGIN,
+  CONTEXT_LIMIT_FUDGE_FACTOR,
+  INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD,
+  computeMarginAdjustedLimit,
+} from '../contextLimitPolicy.js';
+
+describe('contextLimitPolicy constants', () => {
+  it('exports the expected safety margin', () => {
+    expect(TOKEN_SAFETY_MARGIN).toBe(1000);
+  });
+
+  it('exports the expected fudge factor', () => {
+    expect(CONTEXT_LIMIT_FUDGE_FACTOR).toBe(0.005);
+  });
+
+  it('exports the expected ineffective threshold', () => {
+    expect(INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD).toBe(0.05);
+  });
+});
+
+describe('computeMarginAdjustedLimit — realistic windows', () => {
+  it('applies the visible 0.5% cushion for a 200000-token window (cushion not capped)', () => {
+    // For 200000 the cushion does NOT hit the cap, so the arithmetic is
+    // directly observable: the adjusted value is strictly less than the limit.
+    const limit = 200_000;
+    const safetyAdjusted = limit - TOKEN_SAFETY_MARGIN; // 199000
+    const cushion = Math.floor(safetyAdjusted * CONTEXT_LIMIT_FUDGE_FACTOR); // 995
+    const expected = safetyAdjusted + cushion; // 199995 (< 200000, not capped)
+    const adjustedLimit = computeMarginAdjustedLimit(limit);
+    expect(adjustedLimit).toBe(expected);
+    expect(adjustedLimit).toBeLessThan(limit);
+  });
+
+  it('caps the adjusted limit at the original limit when the cushion would exceed it (262144 window)', () => {
+    // For 262144 the safety-adjusted + cushion (262449) exceeds the limit, so
+    // the result is capped at the original limit (262144).
+    const limit = 262_144;
+    expect(computeMarginAdjustedLimit(limit)).toBe(limit);
+  });
+});
+
+describe('computeMarginAdjustedLimit — tiny / degenerate limits (pending semantics preserved)', () => {
+  it('returns 0 for positive limits at or below TOKEN_SAFETY_MARGIN (preserves pending policy)', () => {
+    // The shared helper must NOT apply the old provider-only Math.max(1, ...)
+    // floor. Positive limits <= safety margin produce 0 because the
+    // safety-adjusted value floors to 0 and the cushion adds nothing.
+    for (const limit of [1, 100, 500, 999, 1_000]) {
+      const result = computeMarginAdjustedLimit(limit);
+      expect(
+        result,
+        `expected marginAdjustedLimit 0 for limit=${limit}, got ${result}`,
+      ).toBe(0);
+    }
+  });
+
+  it('returns 0 for a limit of exactly TOKEN_SAFETY_MARGIN', () => {
+    expect(computeMarginAdjustedLimit(TOKEN_SAFETY_MARGIN)).toBe(0);
+  });
+
+  it('returns a positive adjusted value once the limit exceeds TOKEN_SAFETY_MARGIN', () => {
+    // limit=1001: safetyAdjusted=1, cushion=floor(1*0.005)=0, adjusted=1
+    expect(computeMarginAdjustedLimit(1_001)).toBe(1);
+    // limit=2000: safetyAdjusted=1000, cushion=floor(1000*0.005)=5, adjusted=1005
+    expect(computeMarginAdjustedLimit(2_000)).toBe(1_005);
+  });
+
+  it('returns 0 for a zero limit', () => {
+    expect(computeMarginAdjustedLimit(0)).toBe(0);
+  });
+
+  it('returns 0 for negative limits (defensive nonnegative clamp)', () => {
+    expect(computeMarginAdjustedLimit(-500)).toBe(0);
+    expect(computeMarginAdjustedLimit(-1)).toBe(0);
+  });
+});

--- a/packages/agents/src/compression/contextLimitPolicy.ts
+++ b/packages/agents/src/compression/contextLimitPolicy.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const TOKEN_SAFETY_MARGIN = 1000;
+export const CONTEXT_LIMIT_FUDGE_FACTOR = 0.005;
+export const INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD = 0.05;
+
+export function computeMarginAdjustedLimit(limit: number): number {
+  const safetyAdjustedLimit = Math.max(0, limit - TOKEN_SAFETY_MARGIN);
+  return Math.max(
+    0,
+    Math.min(
+      limit,
+      Math.floor(
+        safetyAdjustedLimit + safetyAdjustedLimit * CONTEXT_LIMIT_FUDGE_FACTOR,
+      ),
+    ),
+  );
+}

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -483,29 +483,43 @@ export class ProviderContentEnforcer {
     };
   }
 
-  private async projectSuccess(
+  private projectSuccess(
     pendingContents: IContent[],
     completionBudget: number,
     model: string,
     stage: string,
   ): Promise<ProjectionResult> {
-    const contents = this.recomposeProviderContents(pendingContents);
-    const projected = await this.estimateProviderProjection(
-      contents,
+    return this.projectContents(
+      pendingContents,
       completionBudget,
       model,
       stage,
     );
-    return { contents, projected };
   }
 
-  private async projectWithFailure(
+  private projectWithFailure(
     pendingContents: IContent[],
     completionBudget: number,
     model: string,
     compressionFailure: Error,
     stage: string,
   ): Promise<ProjectionResult> {
+    return this.projectContents(
+      pendingContents,
+      completionBudget,
+      model,
+      stage,
+      compressionFailure,
+    );
+  }
+
+  private async projectContents(
+    pendingContents: IContent[],
+    completionBudget: number,
+    model: string,
+    stage: string,
+    compressionFailure?: Error,
+  ): Promise<ProjectionResult> {
     const contents = this.recomposeProviderContents(pendingContents);
     const projected = await this.estimateProviderProjection(
       contents,
@@ -513,7 +527,9 @@ export class ProviderContentEnforcer {
       model,
       stage,
     );
-    return { contents, projected, compressionFailure };
+    return compressionFailure === undefined
+      ? { contents, projected }
+      : { contents, projected, compressionFailure };
   }
 
   private restoreHistory(history: IContent[]): void {

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -61,6 +61,7 @@ interface OverflowReductionResult {
   projected: number;
   compressionFailure?: Error;
   truncationFailure?: Error;
+  truncationApplied: boolean;
 }
 
 export class ProviderContentEnforcer {
@@ -73,77 +74,126 @@ export class ProviderContentEnforcer {
   ): Promise<IContent[]> {
     await this.deps.historyService.waitForTokenUpdates();
     const model = this.resolveModel(provider);
-    const {
-      completionBudget,
-      limit,
-      marginAdjustedLimit,
-      compressionThreshold,
-    } = this.computeContextLimits(provider, model);
+    const limits = this.computeContextLimits(provider, model);
     const initialProjected = await this.estimateProviderProjection(
       envelope.contents,
-      completionBudget,
+      limits.completionBudget,
       model,
       'initial',
     );
 
-    if (initialProjected <= compressionThreshold) {
-      return envelope.contents;
+    const earlyReturn = this.checkEarlyReturn(
+      envelope,
+      limits,
+      initialProjected,
+    );
+    if (earlyReturn !== undefined) {
+      return earlyReturn;
     }
-
     if (envelope.pendingContents === undefined) {
-      if (initialProjected <= marginAdjustedLimit) {
-        return envelope.contents;
-      }
       throw this.buildUnrecoverableBoundaryError(
         initialProjected,
-        marginAdjustedLimit,
+        limits.marginAdjustedLimit,
       );
     }
 
     const postOpt = await this.optimizeAndProject(
       envelope.pendingContents,
-      completionBudget,
+      limits.completionBudget,
       model,
     );
-    if (postOpt.projected <= compressionThreshold) {
+    if (postOpt.projected <= limits.compressionThreshold) {
       return postOpt.contents;
     }
 
     const firstResult = await this.runCompressionAndRecompose(
       promptId,
       envelope.pendingContents,
-      completionBudget,
+      limits.completionBudget,
       model,
     );
-    if (firstResult.projected <= marginAdjustedLimit) {
+    if (firstResult.projected <= limits.marginAdjustedLimit) {
       return firstResult.contents;
     }
 
     const retryResult = await this.retryCompressionIfIneffective(
       promptId,
       envelope.pendingContents,
-      completionBudget,
+      limits.completionBudget,
       model,
-      marginAdjustedLimit,
+      limits.marginAdjustedLimit,
       postOpt.projected,
       firstResult,
     );
-    if (retryResult.projected <= marginAdjustedLimit) {
+    if (retryResult.projected <= limits.marginAdjustedLimit) {
       return retryResult.contents;
     }
 
-    const truncationResult = await this.forceTruncation(
+    return this.enforceTruncation(
       promptId,
       envelope.pendingContents,
-      completionBudget,
+      limits,
       model,
+      initialProjected,
       retryResult.compressionFailure,
     );
-    if (truncationResult.projected <= marginAdjustedLimit) {
+  }
+
+  private checkEarlyReturn(
+    envelope: ProviderContentEnvelope,
+    limits: ContextLimits,
+    initialProjected: number,
+  ): IContent[] | undefined {
+    if (initialProjected <= limits.compressionThreshold) {
+      return envelope.contents;
+    }
+    if (
+      envelope.pendingContents === undefined &&
+      initialProjected <= limits.marginAdjustedLimit
+    ) {
+      return envelope.contents;
+    }
+    return undefined;
+  }
+
+  private async enforceTruncation(
+    promptId: string,
+    pendingContents: IContent[],
+    limits: ContextLimits,
+    model: string,
+    initialProjected: number,
+    compressionFailure: Error | undefined,
+  ): Promise<IContent[]> {
+    const truncationResult = await this.forceTruncation(
+      promptId,
+      pendingContents,
+      limits.completionBudget,
+      model,
+      compressionFailure,
+    );
+    if (
+      truncationResult.truncationApplied &&
+      truncationResult.projected <= limits.marginAdjustedLimit
+    ) {
       return truncationResult.contents;
     }
+    throw this.buildOverflowError(
+      limits.limit,
+      limits.completionBudget,
+      limits.marginAdjustedLimit,
+      initialProjected,
+      truncationResult,
+    );
+  }
 
-    throw buildContextOverflowError({
+  private buildOverflowError(
+    limit: number,
+    completionBudget: number,
+    marginAdjustedLimit: number,
+    initialProjected: number,
+    truncationResult: OverflowReductionResult,
+  ): Error {
+    return buildContextOverflowError({
       limit,
       initialProjected,
       finalProjected: truncationResult.projected,
@@ -231,40 +281,29 @@ export class ProviderContentEnforcer {
     model: string,
     stage: string = 'post-compression',
   ): Promise<ProjectionResult> {
+    // The try/catch covers ONLY performCompression, the token-update wait,
+    // and compression-result handling. Projection calls (projectSuccess /
+    // projectWithFailure) are executed OUTSIDE the catch so that a projection
+    // rejection surfaces as a stage-aware error rather than being swallowed
+    // and re-projected as a compression failure.
+    let compressionResult: PerformCompressionResult;
+    let compressionError: Error | undefined;
     try {
-      const result = await this.deps.performCompression(promptId, {
+      compressionResult = await this.deps.performCompression(promptId, {
         bypassCooldown: true,
         trigger: 'auto',
       });
       await this.deps.historyService.waitForTokenUpdates();
-      if (result !== PerformCompressionResult.COMPRESSED) {
-        this.deps.logger.debug(
-          () =>
-            `[CompressionHandler] Provider-content compression finished without COMPRESSED result: ${result}`,
-        );
-        return await this.projectWithFailure(
-          pendingContents,
-          completionBudget,
-          model,
-          new Error(
-            `Auto compression did not complete during hard-limit enforcement (result: ${result})`,
-          ),
-          stage,
-        );
-      }
-      return await this.projectSuccess(
-        pendingContents,
-        completionBudget,
-        model,
-        stage,
-      );
     } catch (error) {
-      const compressionError = this.normalizeError(error);
+      compressionResult = PerformCompressionResult.FAILED;
+      compressionError = this.normalizeError(error);
       this.deps.logger.warn(
         () =>
           '[CompressionHandler] Auto compression failed during hard-limit enforcement',
         compressionError,
       );
+    }
+    if (compressionError !== undefined) {
       return this.projectWithFailure(
         pendingContents,
         completionBudget,
@@ -273,6 +312,22 @@ export class ProviderContentEnforcer {
         stage,
       );
     }
+    if (compressionResult !== PerformCompressionResult.COMPRESSED) {
+      this.deps.logger.debug(
+        () =>
+          `[CompressionHandler] Provider-content compression finished without COMPRESSED result: ${compressionResult}`,
+      );
+      return this.projectWithFailure(
+        pendingContents,
+        completionBudget,
+        model,
+        new Error(
+          `Auto compression did not complete during hard-limit enforcement (result: ${compressionResult})`,
+        ),
+        stage,
+      );
+    }
+    return this.projectSuccess(pendingContents, completionBudget, model, stage);
   }
 
   private async retryCompressionIfIneffective(
@@ -337,6 +392,38 @@ export class ProviderContentEnforcer {
     model: string,
     compressionFailure: Error | undefined,
   ): Promise<OverflowReductionResult> {
+    const fallbackOutcome = await this.executeFallbackTruncation(promptId);
+    await this.deps.historyService.waitForTokenUpdates();
+    const contents = this.recomposeProviderContents(pendingContents);
+    const projected = await this.estimateProviderProjection(
+      contents,
+      completionBudget,
+      model,
+      'post-truncation',
+    );
+    const result: OverflowReductionResult = {
+      contents,
+      projected,
+      truncationApplied: fallbackOutcome.truncationApplied,
+    };
+    if (compressionFailure !== undefined) {
+      result.compressionFailure = compressionFailure;
+    }
+    if (fallbackOutcome.truncationFailure !== undefined) {
+      result.truncationFailure = fallbackOutcome.truncationFailure;
+    }
+    return result;
+  }
+
+  /**
+   * Executes the fallback truncation strategy and manages history restoration.
+   * Truncation is only considered successfully applied when the fallback
+   * reported success AND history was restored into historyService.
+   */
+  private async executeFallbackTruncation(promptId: string): Promise<{
+    truncationApplied: boolean;
+    truncationFailure?: Error;
+  }> {
     const originalHistory = this.deps.historyService.getCurated();
     const fallbackState = { historyRestored: false };
     let truncationFailure: Error | undefined;
@@ -376,7 +463,7 @@ export class ProviderContentEnforcer {
         () =>
           '[CompressionHandler] Fallback compression returned false; restoring original history',
       );
-      this.tryRestoreHistory(
+      fallbackState.historyRestored = this.tryRestoreHistory(
         originalHistory,
         '[CompressionHandler] Failed to restore history after fallback returned false',
       );
@@ -385,27 +472,15 @@ export class ProviderContentEnforcer {
         () =>
           '[CompressionHandler] Fallback compression succeeded without applying history; restoring original history',
       );
-      this.tryRestoreHistory(
+      fallbackState.historyRestored = this.tryRestoreHistory(
         originalHistory,
         '[CompressionHandler] Failed to restore history after fallback succeeded without applying history',
       );
     }
-    await this.deps.historyService.waitForTokenUpdates();
-    const contents = this.recomposeProviderContents(pendingContents);
-    const projected = await this.estimateProviderProjection(
-      contents,
-      completionBudget,
-      model,
-      'post-truncation',
-    );
-    const result: OverflowReductionResult = { contents, projected };
-    if (compressionFailure !== undefined) {
-      result.compressionFailure = compressionFailure;
-    }
-    if (truncationFailure !== undefined) {
-      result.truncationFailure = truncationFailure;
-    }
-    return result;
+    return {
+      truncationApplied: fallbackSucceeded && fallbackState.historyRestored,
+      truncationFailure,
+    };
   }
 
   private async projectSuccess(

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -370,6 +370,7 @@ export class ProviderContentEnforcer {
     if (retryResult.compressionFailure !== undefined) {
       const retryError = new Error(
         `Additional hard-limit compression attempt failed: ${retryResult.compressionFailure.message}`,
+        { cause: retryResult.compressionFailure },
       );
       this.deps.logger.warn(
         () =>
@@ -603,9 +604,10 @@ export class ProviderContentEnforcer {
         );
       return requestTokens + completionBudget;
     } catch (error) {
-      const cause = error instanceof Error ? error.message : String(error);
+      const projectionError = this.normalizeError(error);
       throw new Error(
-        `Token projection failed at ${stage} stage during provider-content hard-limit enforcement: ${cause}`,
+        `Token projection failed at ${stage} stage during provider-content hard-limit enforcement: ${projectionError.message}`,
+        { cause: projectionError },
       );
     }
   }

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -154,6 +154,11 @@ export class ProviderContentEnforcer {
     });
   }
 
+  /**
+   * Compresses history and recomposes it with pending content.
+   *
+   * @throws When compression throws or returns a non-COMPRESSED result.
+   */
   async compressAndRecompose(
     pendingContents: IContent[],
     promptId: string,

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -15,10 +15,12 @@ import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.
 import { getCompletionBudget } from './compressionBudgeting.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
 import { buildProviderContent } from '@vybestack/llxprt-code-core/services/history/historyProviderPipeline.js';
+import { buildContextOverflowError } from './contextOverflowError.js';
+import {
+  INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD,
+  computeMarginAdjustedLimit,
+} from './contextLimitPolicy.js';
 
-const TOKEN_SAFETY_MARGIN = 1000;
-const INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD = 0.05;
-const COMPLETION_BUDGET_WARNING_RATIO = 0.8;
 type CompletionSettingsService = { get: (key: string) => unknown };
 
 export interface ProviderContentEnforcementDeps {
@@ -48,6 +50,19 @@ interface ContextLimits {
   compressionThreshold: number;
 }
 
+interface ProjectionResult {
+  contents: IContent[];
+  projected: number;
+  compressionFailure?: Error;
+}
+
+interface OverflowReductionResult {
+  contents: IContent[];
+  projected: number;
+  compressionFailure?: Error;
+  truncationFailure?: Error;
+}
+
 export class ProviderContentEnforcer {
   constructor(private readonly deps: ProviderContentEnforcementDeps) {}
 
@@ -68,6 +83,7 @@ export class ProviderContentEnforcer {
       envelope.contents,
       completionBudget,
       model,
+      'initial',
     );
 
     if (initialProjected <= compressionThreshold) {
@@ -75,74 +91,67 @@ export class ProviderContentEnforcer {
     }
 
     if (envelope.pendingContents === undefined) {
-      // marginAdjustedLimit (limit minus TOKEN_SAFETY_MARGIN) is this enforcer's
-      // effective hard limit — the same acceptance criterion used for compressed
-      // contents later in enforce() — so the unrecoverable-boundary policy
-      // ("send as-is under the hard limit / throw over it", issue #2306)
-      // intentionally uses it for consistency and to protect against
-      // token-estimate error.
       if (initialProjected <= marginAdjustedLimit) {
         return envelope.contents;
       }
-      throw new Error(
-        'Context overflow requires compression, but the pending-content boundary is unrecoverable: ' +
-          'a BeforeModel hook replaced or restructured the conversation contents, and no usable ' +
-          'llm_request_boundary metadata was available, so compression cannot safely recompose the pending region. ' +
-          'Consider reducing the context size, or have the hook supply valid llm_request_boundary metadata. ' +
-          `Projected ${initialProjected} exceeds safety-adjusted limit ${marginAdjustedLimit}.`,
+      throw this.buildUnrecoverableBoundaryError(
+        initialProjected,
+        marginAdjustedLimit,
       );
     }
 
-    await this.deps.ensureDensityOptimized();
-    await this.deps.historyService.waitForTokenUpdates();
-
-    const optimizedContents = this.recomposeProviderContents(
+    const postOpt = await this.optimizeAndProject(
       envelope.pendingContents,
-    );
-    const postOptProjected = await this.estimateProviderProjection(
-      optimizedContents,
       completionBudget,
       model,
     );
-    if (postOptProjected <= compressionThreshold) {
-      return optimizedContents;
+    if (postOpt.projected <= compressionThreshold) {
+      return postOpt.contents;
     }
 
-    const compressedContents = await this.runCompressionAndRecompose(
+    const firstResult = await this.runCompressionAndRecompose(
       promptId,
       envelope.pendingContents,
-    );
-    let recomputed = await this.estimateProviderProjection(
-      compressedContents,
       completionBudget,
       model,
     );
-    if (recomputed <= marginAdjustedLimit) {
-      return compressedContents;
+    if (firstResult.projected <= marginAdjustedLimit) {
+      return firstResult.contents;
     }
 
-    const fallbackContents = await this.forceTruncationIfIneffective(
+    const retryResult = await this.retryCompressionIfIneffective(
       promptId,
-      postOptProjected,
-      recomputed,
       envelope.pendingContents,
-    );
-    recomputed = await this.estimateProviderProjection(
-      fallbackContents,
       completionBudget,
       model,
+      marginAdjustedLimit,
+      postOpt.projected,
+      firstResult,
     );
-    if (recomputed <= marginAdjustedLimit) {
-      return fallbackContents;
+    if (retryResult.projected <= marginAdjustedLimit) {
+      return retryResult.contents;
     }
 
-    throw this.buildContextOverflowError(
+    const truncationResult = await this.forceTruncation(
+      promptId,
+      envelope.pendingContents,
+      completionBudget,
+      model,
+      retryResult.compressionFailure,
+    );
+    if (truncationResult.projected <= marginAdjustedLimit) {
+      return truncationResult.contents;
+    }
+
+    throw buildContextOverflowError({
       limit,
       initialProjected,
-      recomputed,
+      finalProjected: truncationResult.projected,
       marginAdjustedLimit,
       completionBudget,
-    );
+      truncationFailure: truncationResult.truncationFailure,
+      compressionFailure: truncationResult.compressionFailure,
+    });
   }
 
   async compressAndRecompose(
@@ -152,7 +161,22 @@ export class ProviderContentEnforcer {
     if (pendingContents.length === 0) {
       return [];
     }
-    return this.runCompressionAndRecompose(promptId, pendingContents);
+    const result = await this.runCompressionAndRecompose(
+      promptId,
+      pendingContents,
+      0,
+      this.deps.runtimeContext.state.model,
+    );
+    // runCompressionAndRecompose catches errors/non-COMPRESSED results and
+    // returns them as a structured compressionFailure. The provider compression
+    // callback contract (attachCompressionCallback) expects failure to throw
+    // so the provider can reject the request. Rethrow here honors that contract;
+    // the enforcement orchestration (enforce) consumes the structured failure
+    // directly via runCompressionAndRecompose and is unaffected.
+    if (result.compressionFailure !== undefined) {
+      throw result.compressionFailure;
+    }
+    return result.contents;
   }
 
   private resolveModel(provider?: IProvider): string {
@@ -165,70 +189,152 @@ export class ProviderContentEnforcer {
     return this.deps.runtimeContext.state.model;
   }
 
+  private buildUnrecoverableBoundaryError(
+    projected: number,
+    marginAdjustedLimit: number,
+  ): Error {
+    return new Error(
+      'Context overflow requires compression, but the pending-content boundary is unrecoverable: ' +
+        'a BeforeModel hook replaced or restructured the conversation contents, and no usable ' +
+        'llm_request_boundary metadata was available, so compression cannot safely recompose the pending region. ' +
+        'Consider reducing the context size, or have the hook supply valid llm_request_boundary metadata. ' +
+        `Projected ${projected} exceeds safety-adjusted limit ${marginAdjustedLimit}.`,
+    );
+  }
+
+  private async optimizeAndProject(
+    pendingContents: IContent[],
+    completionBudget: number,
+    model: string,
+  ): Promise<ProjectionResult> {
+    await this.deps.ensureDensityOptimized();
+    await this.deps.historyService.waitForTokenUpdates();
+    const optimizedContents = this.recomposeProviderContents(pendingContents);
+    const postOptProjected = await this.estimateProviderProjection(
+      optimizedContents,
+      completionBudget,
+      model,
+      'post-density-optimization',
+    );
+    return { contents: optimizedContents, projected: postOptProjected };
+  }
+
   private async runCompressionAndRecompose(
     promptId: string,
     pendingContents: IContent[],
-  ): Promise<IContent[]> {
-    const result = await this.deps.performCompression(promptId, {
-      bypassCooldown: true,
-      trigger: 'auto',
-    });
-    await this.deps.historyService.waitForTokenUpdates();
-    if (result !== PerformCompressionResult.COMPRESSED) {
-      this.deps.logger.debug(
-        () =>
-          `[CompressionHandler] Provider-content compression finished without COMPRESSED result: ${result}`,
-      );
-    }
-    return this.recomposeProviderContents(pendingContents);
-  }
-
-  private recomposeProviderContents(pendingContents: IContent[]): IContent[] {
-    return buildProviderContent(
-      this.deps.historyService.getCurated(),
-      pendingContents,
-      this.deps.logger,
-    );
-  }
-
-  private async estimateProviderProjection(
-    contents: IContent[],
     completionBudget: number,
     model: string,
-  ): Promise<number> {
-    const requestTokens =
-      await this.deps.historyService.estimateTokensForContents(contents, model);
-    return requestTokens + completionBudget;
+    stage: string = 'post-compression',
+  ): Promise<ProjectionResult> {
+    try {
+      const result = await this.deps.performCompression(promptId, {
+        bypassCooldown: true,
+        trigger: 'auto',
+      });
+      await this.deps.historyService.waitForTokenUpdates();
+      if (result !== PerformCompressionResult.COMPRESSED) {
+        this.deps.logger.debug(
+          () =>
+            `[CompressionHandler] Provider-content compression finished without COMPRESSED result: ${result}`,
+        );
+        return await this.projectWithFailure(
+          pendingContents,
+          completionBudget,
+          model,
+          new Error(
+            `Auto compression did not complete during hard-limit enforcement (result: ${result})`,
+          ),
+          stage,
+        );
+      }
+      return await this.projectSuccess(
+        pendingContents,
+        completionBudget,
+        model,
+        stage,
+      );
+    } catch (error) {
+      const compressionError = this.normalizeError(error);
+      this.deps.logger.warn(
+        () =>
+          '[CompressionHandler] Auto compression failed during hard-limit enforcement',
+        compressionError,
+      );
+      return this.projectWithFailure(
+        pendingContents,
+        completionBudget,
+        model,
+        compressionError,
+        stage,
+      );
+    }
   }
 
-  private async forceTruncationIfIneffective(
+  private async retryCompressionIfIneffective(
     promptId: string,
-    preCompressionProjected: number,
-    postCompressionProjected: number,
     pendingContents: IContent[],
-  ): Promise<IContent[]> {
-    const reduction = preCompressionProjected - postCompressionProjected;
+    completionBudget: number,
+    model: string,
+    marginAdjustedLimit: number,
+    preCompressionProjected: number,
+    firstResult: ProjectionResult,
+  ): Promise<ProjectionResult> {
+    const reduction = preCompressionProjected - firstResult.projected;
     const reductionRatio =
       preCompressionProjected > 0 ? reduction / preCompressionProjected : 0;
-    // Issue #2207 requires a last-resort truncation pass after compression when
-    // the fully assembled provider payload still cannot fit. Unlike the older
-    // pending-token projection path, this path already has the exact provider
-    // payload and must keep trying older-history truncation before overflowing.
-    const fallbackReason =
+    if (
+      firstResult.compressionFailure !== undefined ||
       reductionRatio >= INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD
-        ? 'Primary compression reduced tokens but the provider payload still exceeds the hard limit'
-        : 'Primary compression was ineffective';
+    ) {
+      return firstResult;
+    }
+
     this.deps.logger.warn(
       () =>
-        `[CompressionHandler] ${fallbackReason}, forcing provider truncation fallback`,
+        '[CompressionHandler] Auto compression remained ineffective, retrying full compression before truncation',
       {
         preCompressionProjected,
-        postCompressionProjected,
+        postCompressionProjected: firstResult.projected,
         reductionRatio,
+        tokensStillNeeded: firstResult.projected - marginAdjustedLimit,
       },
     );
+
+    const retryResult = await this.runCompressionAndRecompose(
+      promptId,
+      pendingContents,
+      completionBudget,
+      model,
+      'post-retry-compression',
+    );
+    if (retryResult.compressionFailure !== undefined) {
+      const retryError = new Error(
+        `Additional hard-limit compression attempt failed: ${retryResult.compressionFailure.message}`,
+      );
+      this.deps.logger.warn(
+        () =>
+          '[CompressionHandler] Additional hard-limit compression attempt failed',
+        retryResult.compressionFailure,
+      );
+      return {
+        contents: retryResult.contents,
+        projected: retryResult.projected,
+        compressionFailure: retryError,
+      };
+    }
+    return retryResult;
+  }
+
+  private async forceTruncation(
+    promptId: string,
+    pendingContents: IContent[],
+    completionBudget: number,
+    model: string,
+    compressionFailure: Error | undefined,
+  ): Promise<OverflowReductionResult> {
     const originalHistory = this.deps.historyService.getCurated();
     const fallbackState = { historyRestored: false };
+    let truncationFailure: Error | undefined;
     let fallbackSucceeded = false;
     try {
       fallbackSucceeded = await this.deps.performFallbackCompression(
@@ -247,8 +353,7 @@ export class ProviderContentEnforcer {
         },
       );
     } catch (fallbackError) {
-      // Defensive guard for future fallback implementations that may reject;
-      // the current CompressionHandler-backed dependency returns false instead.
+      truncationFailure = this.normalizeError(fallbackError);
       this.deps.logger.warn(
         () =>
           '[CompressionHandler] Provider truncation fallback rejected during hard-limit enforcement',
@@ -281,7 +386,54 @@ export class ProviderContentEnforcer {
       );
     }
     await this.deps.historyService.waitForTokenUpdates();
-    return this.recomposeProviderContents(pendingContents);
+    const contents = this.recomposeProviderContents(pendingContents);
+    const projected = await this.estimateProviderProjection(
+      contents,
+      completionBudget,
+      model,
+      'post-truncation',
+    );
+    const result: OverflowReductionResult = { contents, projected };
+    if (compressionFailure !== undefined) {
+      result.compressionFailure = compressionFailure;
+    }
+    if (truncationFailure !== undefined) {
+      result.truncationFailure = truncationFailure;
+    }
+    return result;
+  }
+
+  private async projectSuccess(
+    pendingContents: IContent[],
+    completionBudget: number,
+    model: string,
+    stage: string,
+  ): Promise<ProjectionResult> {
+    const contents = this.recomposeProviderContents(pendingContents);
+    const projected = await this.estimateProviderProjection(
+      contents,
+      completionBudget,
+      model,
+      stage,
+    );
+    return { contents, projected };
+  }
+
+  private async projectWithFailure(
+    pendingContents: IContent[],
+    completionBudget: number,
+    model: string,
+    compressionFailure: Error,
+    stage: string,
+  ): Promise<ProjectionResult> {
+    const contents = this.recomposeProviderContents(pendingContents);
+    const projected = await this.estimateProviderProjection(
+      contents,
+      completionBudget,
+      model,
+      stage,
+    );
+    return { contents, projected, compressionFailure };
   }
 
   private restoreHistory(history: IContent[]): void {
@@ -302,7 +454,6 @@ export class ProviderContentEnforcer {
         try {
           this.deps.historyService.clear();
           this.addHistoryEntries(history);
-          // Final retry restored the requested history, so the original restore error no longer applies.
           return;
         } catch (finalError) {
           this.deps.historyService.clear();
@@ -334,9 +485,33 @@ export class ProviderContentEnforcer {
     }
   }
 
-  private computeMarginAdjustedLimit(limit: number): number {
-    const safetyAdjustedLimit = Math.max(0, limit - TOKEN_SAFETY_MARGIN);
-    return Math.max(1, safetyAdjustedLimit);
+  private recomposeProviderContents(pendingContents: IContent[]): IContent[] {
+    return buildProviderContent(
+      this.deps.historyService.getCurated(),
+      pendingContents,
+      this.deps.logger,
+    );
+  }
+
+  private async estimateProviderProjection(
+    contents: IContent[],
+    completionBudget: number,
+    model: string,
+    stage: string = 'initial',
+  ): Promise<number> {
+    try {
+      const requestTokens =
+        await this.deps.historyService.estimateTokensForContents(
+          contents,
+          model,
+        );
+      return requestTokens + completionBudget;
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Token projection failed at ${stage} stage during provider-content hard-limit enforcement: ${cause}`,
+      );
+    }
   }
 
   private computeCompressionThreshold(
@@ -368,7 +543,7 @@ export class ProviderContentEnforcer {
     );
     const userContextLimit = this.deps.runtimeContext.ephemerals.contextLimit();
     const limit = tokenLimit(model, userContextLimit);
-    const marginAdjustedLimit = this.computeMarginAdjustedLimit(limit);
+    const marginAdjustedLimit = computeMarginAdjustedLimit(limit);
     return {
       completionBudget,
       limit,
@@ -381,25 +556,10 @@ export class ProviderContentEnforcer {
     };
   }
 
-  private buildContextOverflowError(
-    limit: number,
-    initialProjected: number,
-    finalProjected: number,
-    marginAdjustedLimit: number,
-    completionBudget: number,
-  ): Error {
-    const totalReduction = Math.max(0, initialProjected - finalProjected);
-    const tokensStillNeeded = finalProjected - marginAdjustedLimit;
-    const parts: string[] = [
-      `Request still exceeds the safety-adjusted context limit (${marginAdjustedLimit} tokens).`,
-      `Density optimization and compression reduced ${totalReduction} tokens (from ${initialProjected} to ${finalProjected} projected).`,
-      `completionBudget=${completionBudget}, tokensStillNeeded=${tokensStillNeeded}.`,
-    ];
-    if (completionBudget > COMPLETION_BUDGET_WARNING_RATIO * limit) {
-      parts.push(
-        `The completion budget (${completionBudget}) consumes more than ${COMPLETION_BUDGET_WARNING_RATIO * 100}% of the context window (${limit}). Consider lowering maxOutputTokens.`,
-      );
+  private normalizeError(error: unknown): Error {
+    if (error instanceof Error) {
+      return error;
     }
-    return new Error(parts.join(' '));
+    return new Error(String(error));
   }
 }


### PR DESCRIPTION
## Summary

- share the pending and provider-content context-limit safety policy, including the capped 0.5%% cushion
- retry one completed but ineffective provider compression before truncation
- preserve provider payload recomposition, pending boundaries, callback failure propagation, and history restoration
- surface stage-aware projection errors and underlying compression/truncation failures

## Behavioral coverage

- exact 202-token near-limit reproduction
- ineffective first compression followed by successful retry
- retry followed by truncation with pending-content preservation
- failed, skipped, and thrown compression outcomes
- real CompressionHandler fallback failure propagation
- projection failures after compression, retry, and truncation
- context-limit arithmetic and unrecoverable-boundary regressions

## Verification

- npm run test
- npm run lint (changed files; full command was watchdog-terminated without diagnostics)
- npm run typecheck
- npm run format
- npm run build
- bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
- OpenCodeReview and independent deep review, with all actionable findings addressed

Fixes #2588


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of content near provider context limits using shared safety-threshold logic.
  - Added a more reliable retry-before-truncation flow when compression reduction is ineffective.
  - Preserved pending content more consistently during hard-limit enforcement.
  - Ensured compression/truncation failures propagate correctly, with clearer stage-labeled diagnostics.
  - Strengthened overflow error handling for unrecoverable and boundary scenarios.
- **Tests**
  - Added extensive end-to-end and policy-focused coverage to prevent regressions in fallback and stage-aware error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->