### PR TITLE
Consolidate release guard regression coverage (Fixes #2597)

### DIFF
--- a/scripts/tests/genai-enclave-guard-maxbuffer.test.ts
+++ b/scripts/tests/genai-enclave-guard-maxbuffer.test.ts
@@ -7,6 +7,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   bunAvailable,
+  GEMINI_IMPORT,
   runScriptWithMaxBuffer,
   withFixture,
 } from './genai-enclave-guard-helpers.ts';
@@ -22,38 +23,21 @@ describe.skipIf(process.env.CI !== 'true' && !bunAvailable())(
       }
     });
 
-    it('rejects on maxBuffer overflow rather than satisfying expectedCode 1 (ERR_CHILD_PROCESS_STDIO_MAXBUFFER at 256 bytes)', async () => {
-      const tinyMaxBuffer = 256;
-      await expect(
-        withFixture(({ root, write }) => {
-          for (let i = 0; i < 12; i++) {
-            write(
-              `packages/cli/src/violation${i}.ts`,
-              "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
-            );
-          }
-          return runScriptWithMaxBuffer(root, tinyMaxBuffer, 1);
-        }),
-      ).rejects.toThrow(
-        'Guard script exceeded maxBuffer (256 bytes) and was killed (ERR_CHILD_PROCESS_STDIO_MAXBUFFER)',
-      );
-    }, 60_000);
-
-    it('diagnostic for 128-byte maxBuffer names both the buffer value and ERR_CHILD_PROCESS_STDIO_MAXBUFFER', async () => {
-      const tinyMaxBuffer = 128;
-      await expect(
-        withFixture(({ root, write }) => {
-          for (let i = 0; i < 12; i++) {
-            write(
-              `packages/cli/src/violation${i}.ts`,
-              "import { GoogleGenAI } from '@google/genai';\nexport const x = 1;\n",
-            );
-          }
-          return runScriptWithMaxBuffer(root, tinyMaxBuffer, 1);
-        }),
-      ).rejects.toThrow(
-        'Guard script exceeded maxBuffer (128 bytes) and was killed (ERR_CHILD_PROCESS_STDIO_MAXBUFFER)',
-      );
-    }, 60_000);
+    it.each([256, 128])(
+      'rejects on maxBuffer overflow at %i bytes rather than satisfying expectedCode 1',
+      async (tinyMaxBuffer) => {
+        await expect(
+          withFixture(({ root, write }) => {
+            for (let i = 0; i < 12; i++) {
+              write(`packages/cli/src/violation${i}.ts`, GEMINI_IMPORT);
+            }
+            return runScriptWithMaxBuffer(root, tinyMaxBuffer, 1);
+          }),
+        ).rejects.toThrow(
+          `Guard script exceeded maxBuffer (${tinyMaxBuffer} bytes) and was killed (ERR_CHILD_PROCESS_STDIO_MAXBUFFER)`,
+        );
+      },
+      60_000,
+    );
   },
 );


### PR DESCRIPTION
## Summary

- confirms that the release failure in issue 2597 was the same Vitest worker-RPC starvation previously reported in issue 2584
- carries the already-merged asynchronous guard execution fix from PR 2593 because this branch starts from current main
- consolidates the maxBuffer operational-failure regression cases without weakening expected-exit or diagnostic assertions
- reuses the shared GenAI violation fixture so maxBuffer coverage cannot drift from the main guard fixtures

## Root cause and fix

Release run 29548287874 executed at commit cf296c4c0 before PR 2593 merged. Its scripts assertions all passed, but repeated synchronous guard subprocesses blocked the Vitest worker event loop long enough for the internal onTaskUpdate RPC to exceed its 60-second timeout.

PR 2593 subsequently changed real guard invocations to asynchronous child processes, made fixture cleanup await completion, and added a behavioral event-loop-responsiveness regression. The current issue2597 branch includes that fix from main. This PR preserves the follow-up maxBuffer behavior while removing duplicated test bodies and fixture content.

## Verification

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- focused GenAI guard and maxBuffer tests: 55 passed
- scripts TypeScript and touched-file lint/format checks
- bun scripts/start.ts --profile-load stepfun-37 with a successful haiku response
- Open Code Review completed; every finding was evaluated and valid maintainability findings were addressed
- independent compliance and release-readiness review completed with no issue-2597 correctness blockers

## Release validation

After PR checks are green, a real non-dry-run 0.10.0 nightly will be dispatched from the pushed issue2597 workflow ref and monitored to completion.

Fixes #2597


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated max-buffer guard coverage into a parameterized test.
  * Verified that exceeding configured buffer limits terminates the guard process and reports the corresponding error details.
  * Reused a shared import definition to keep test scenarios consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->