### PR TITLE
Make stream watchdogs provider-liveness aware (Fixes #2607)

### DIFF
--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -121,23 +121,24 @@ returns a ready-to-use `Agent`. It is `async` — always `await` it.
 
 ### Commonly used optional fields
 
-| Field                 | Type                                | Description                                                         |
-| --------------------- | ----------------------------------- | ------------------------------------------------------------------- |
-| `modelParams`         | `Readonly<Record<string, unknown>>` | Provider/model knobs (temperature, etc.).                           |
-| `auth`                | `AgentAuth`                         | Credentials — see [Authentication](#authentication-and-precedence). |
-| `tools`               | `readonly string[]`                 | Allow-list of tool names to enable.                                 |
-| `excludeTools`        | `readonly string[]`                 | Tools to exclude.                                                   |
-| `mcpServers`          | `Record<string, MCPServerConfig>`   | MCP servers to wire at startup.                                     |
-| `approvalMode`        | `ApprovalMode`                      | Tool-confirmation policy.                                           |
-| `systemPrompt`        | `string`                            | System instruction.                                                 |
-| `workingDir`          | `string`                            | Workspace root for file tools.                                      |
-| `sessionId`           | `string`                            | Stable runtime id (defaults to a generated one).                    |
-| `sandbox`             | `SandboxConfig`                     | Sandbox configuration (see below).                                  |
-| `hooks`               | `AgentHooks`                        | Lifecycle hooks keyed by event name.                                |
-| `streamIdleTimeoutMs` | `number`                            | Idle-timeout for a stream turn.                                     |
-| `onApproval`          | `ApprovalHandler`                   | Callback invoked for tool confirmations.                            |
-| `onOAuthPrompt`       | `OAuthPromptHandler`                | Callback invoked when an OAuth flow needs the user.                 |
-| `editorCallbacks`     | `EditorCallbacks`                   | Hooks for opening/closing an external editor.                       |
+| Field                          | Type                                | Description                                                                                                                                                      |
+| ------------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `modelParams`                  | `Readonly<Record<string, unknown>>` | Provider/model knobs (temperature, etc.).                                                                                                                        |
+| `auth`                         | `AgentAuth`                         | Credentials — see [Authentication](#authentication-and-precedence).                                                                                              |
+| `tools`                        | `readonly string[]`                 | Allow-list of tool names to enable.                                                                                                                              |
+| `excludeTools`                 | `readonly string[]`                 | Tools to exclude.                                                                                                                                                |
+| `mcpServers`                   | `Record<string, MCPServerConfig>`   | MCP servers to wire at startup.                                                                                                                                  |
+| `approvalMode`                 | `ApprovalMode`                      | Tool-confirmation policy.                                                                                                                                        |
+| `systemPrompt`                 | `string`                            | System instruction.                                                                                                                                              |
+| `workingDir`                   | `string`                            | Workspace root for file tools.                                                                                                                                   |
+| `sessionId`                    | `string`                            | Stable runtime id (defaults to a generated one).                                                                                                                 |
+| `sandbox`                      | `SandboxConfig`                     | Sandbox configuration (see below).                                                                                                                               |
+| `hooks`                        | `AgentHooks`                        | Lifecycle hooks keyed by event name.                                                                                                                             |
+| `streamIdleTimeoutMs`          | `number`                            | Idle-timeout for a stream turn.                                                                                                                                  |
+| `streamFirstResponseTimeoutMs` | `number`                            | First-response (time-to-first-content) watchdog in ms. Default `300000`; `0`/negative disables. A provider liveness signal (e.g. `response.created`) disarms it. |
+| `onApproval`                   | `ApprovalHandler`                   | Callback invoked for tool confirmations.                                                                                                                         |
+| `onOAuthPrompt`                | `OAuthPromptHandler`                | Callback invoked when an OAuth flow needs the user.                                                                                                              |
+| `editorCallbacks`              | `EditorCallbacks`                   | Hooks for opening/closing an external editor.                                                                                                                    |
 
 `AgentConfig` carries many more long-tail fields (telemetry, compression,
 recording, file filtering, policy, extensions, skills, IDE mode, etc.). See the

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -149,6 +149,13 @@ In addition to a project settings file, a project's `.llxprt` directory can cont
   - **Default:** `0`
   - **Requires restart:** No
 
+#### `streamFirstResponseTimeoutMs`
+
+- **`streamFirstResponseTimeoutMs`** (number):
+  - **Description:** First-response (time-to-first-content) watchdog in milliseconds. Enabled by default (300000 = 5 minutes). A provider liveness signal (e.g. response.created) disarms it even before semantic content arrives. Set to 0 or a negative number to disable.
+  - **Default:** `300000`
+  - **Requires restart:** No
+
 #### `useExternalAuth`
 
 - **`useExternalAuth`** (boolean):

--- a/packages/agents/src/api/__tests__/config-adapter.spec.ts
+++ b/packages/agents/src/api/__tests__/config-adapter.spec.ts
@@ -25,6 +25,11 @@ import {
   toConfigParameters,
   AdapterError,
 } from '@vybestack/llxprt-code-agents';
+import { applyRuntimeEphemerals } from '../agentConfig.adapter.js';
+
+const STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY = 'streamIdleTimeoutMs';
+const STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY =
+  'streamFirstResponseTimeoutMs';
 
 /** Reads a ConfigParameters field by name without leaking a cast into asserts. */
 function read(params: Readonly<Record<string, unknown>>, key: string): unknown {
@@ -474,5 +479,106 @@ describe('toConfigParameters adapter @plan:PLAN-20260617-COREAPI.P14 @requiremen
         expect(config.coreTools).toStrictEqual(inputSnapshot);
       }),
     );
+  });
+});
+
+/**
+ * Records ephemeral writes so behavioral tests can assert the exact
+ * (camelCase key → value) tuples applied to the runtime Config, without a
+ * real Config or mock theater.
+ */
+interface EphemeralSink {
+  readonly entries: ReadonlyArray<readonly [string, unknown]>;
+  setEphemeralSetting(key: string, value: unknown): void;
+}
+
+function createEphemeralSink(): EphemeralSink {
+  const entries: Array<readonly [string, unknown]> = [];
+  return {
+    entries,
+    setEphemeralSetting(key: string, value: unknown): void {
+      entries.push([key, value]);
+    },
+  };
+}
+
+describe('applyRuntimeEphemerals (typed stream timeouts) @issue:2607', () => {
+  it('sets streamIdleTimeoutMs under its camelCase key when provided', () => {
+    const sink = createEphemeralSink();
+    applyRuntimeEphemerals(sink, {
+      streamIdleTimeoutMs: 12_000,
+      streamFirstResponseTimeoutMs: undefined,
+    });
+    expect(sink.entries).toStrictEqual([
+      [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY, 12_000],
+    ]);
+  });
+
+  it('sets streamFirstResponseTimeoutMs under its camelCase key when provided', () => {
+    const sink = createEphemeralSink();
+    applyRuntimeEphemerals(sink, {
+      streamIdleTimeoutMs: undefined,
+      streamFirstResponseTimeoutMs: 300_000,
+    });
+    expect(sink.entries).toStrictEqual([
+      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, 300_000],
+    ]);
+  });
+
+  it('applies both timeout fields when both are provided', () => {
+    const sink = createEphemeralSink();
+    applyRuntimeEphemerals(sink, {
+      streamIdleTimeoutMs: 5_000,
+      streamFirstResponseTimeoutMs: 300_000,
+    });
+    expect(sink.entries).toStrictEqual([
+      [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY, 5_000],
+      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, 300_000],
+    ]);
+  });
+
+  it('writes nothing when both timeout fields are undefined', () => {
+    const sink = createEphemeralSink();
+    applyRuntimeEphemerals(sink, {
+      streamIdleTimeoutMs: undefined,
+      streamFirstResponseTimeoutMs: undefined,
+    });
+    expect(sink.entries).toStrictEqual([]);
+  });
+
+  it('preserves 0 (disabled) for streamFirstResponseTimeoutMs — does not drop falsy value', () => {
+    const sink = createEphemeralSink();
+    applyRuntimeEphemerals(sink, {
+      streamIdleTimeoutMs: undefined,
+      streamFirstResponseTimeoutMs: 0,
+    });
+    expect(sink.entries).toStrictEqual([
+      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, 0],
+    ]);
+  });
+
+  it('preserves negative values (also disable the watchdog) verbatim', () => {
+    const sink = createEphemeralSink();
+    applyRuntimeEphemerals(sink, {
+      streamIdleTimeoutMs: undefined,
+      streamFirstResponseTimeoutMs: -1,
+    });
+    expect(sink.entries).toStrictEqual([
+      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, -1],
+    ]);
+  });
+
+  it('an explicit 300000 is distinguishable from absent (always written, not defaulted)', () => {
+    const sink = createEphemeralSink();
+    applyRuntimeEphemerals(sink, {
+      streamIdleTimeoutMs: undefined,
+      streamFirstResponseTimeoutMs: 300_000,
+    });
+    // A single explicit write at 300000; absent would have written nothing.
+    expect(sink.entries).toHaveLength(1);
+    expect(sink.entries[0]?.[0]).toBe(
+      STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+    );
+    expect(sink.entries[0]?.[1]).toBe(300_000);
   });
 });

--- a/packages/agents/src/api/__tests__/streamTimeouts.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/streamTimeouts.behavior.test.ts
@@ -11,10 +11,10 @@
  * (streamFirstResponseTimeoutMs, streamIdleTimeoutMs) are wired into runtime
  * Config ephemerals through the public createAgent path.
  *
- * These tests build a REAL public Agent over a REAL FakeProvider and assert on
- * PUBLIC runtime behavior via the Agent's Config — they do NOT assert on private
- * adapter implementation calls. The camelCase typed API keys are used so
- * diagnostics report the actual source field the caller set.
+ * These integration tests build a real public Agent over a FakeProvider, then
+ * inspect its internal Config to verify the typed-to-runtime wiring without
+ * asserting on adapter implementation calls. The camelCase typed API keys are
+ * used so diagnostics report the actual source field the caller set.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/agents/src/api/__tests__/streamTimeouts.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/streamTimeouts.behavior.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue:2607 Finding 2
+ *
+ * BEHAVIORAL tests proving typed AgentConfig stream-timeout fields
+ * (streamFirstResponseTimeoutMs, streamIdleTimeoutMs) are wired into runtime
+ * Config ephemerals through the public createAgent path.
+ *
+ * These tests build a REAL public Agent over a REAL FakeProvider and assert on
+ * PUBLIC runtime behavior via the Agent's Config — they do NOT assert on private
+ * adapter implementation calls. The camelCase typed API keys are used so
+ * diagnostics report the actual source field the caller set.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAgent, internalConfig } from './helpers/agentHarness.js';
+import {
+  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+} from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+
+describe('createAgent typed stream timeouts @issue:2607', () => {
+  it('applies a positive streamFirstResponseTimeoutMs to the runtime Config under its camelCase key', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      streamFirstResponseTimeoutMs: 180_000,
+    });
+    try {
+      const config = internalConfig(agent);
+      expect(
+        config.getEphemeralSetting(
+          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+        ),
+      ).toBe(180_000);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('resolves streamFirstResponseTimeoutMs 0 (disables the watchdog) verbatim to the Config', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      streamFirstResponseTimeoutMs: 0,
+    });
+    try {
+      const config = internalConfig(agent);
+      expect(
+        config.getEphemeralSetting(
+          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+        ),
+      ).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('an explicit 300000 is distinguishable from absent/default (written verbatim, not defaulted)', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      streamFirstResponseTimeoutMs: 300_000,
+    });
+    try {
+      const config = internalConfig(agent);
+      // Absent would have been undefined (no ephemeral materialized); an
+      // explicit 300000 is written through as a concrete value.
+      expect(
+        config.getEphemeralSetting(
+          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+        ),
+      ).toBe(300_000);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('does NOT materialize a streamFirstResponseTimeoutMs ephemeral when the field is absent', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl');
+    try {
+      const config = internalConfig(agent);
+      expect(
+        config.getEphemeralSetting(
+          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+        ),
+      ).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('applies an existing streamIdleTimeoutMs to the runtime Config under its camelCase key', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      streamIdleTimeoutMs: 7_500,
+    });
+    try {
+      const config = internalConfig(agent);
+      expect(
+        config.getEphemeralSetting(STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY),
+      ).toBe(7_500);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('applies both timeout fields together when both are provided', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      streamIdleTimeoutMs: 5_000,
+      streamFirstResponseTimeoutMs: 240_000,
+    });
+    try {
+      const config = internalConfig(agent);
+      expect(
+        config.getEphemeralSetting(STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY),
+      ).toBe(5_000);
+      expect(
+        config.getEphemeralSetting(
+          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+        ),
+      ).toBe(240_000);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/agents/src/api/agentConfig.adapter.ts
+++ b/packages/agents/src/api/agentConfig.adapter.ts
@@ -9,6 +9,10 @@
  */
 
 import type { ConfigParameters } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+} from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import type { AgentConfig } from './config-types.js';
 import { CONFIG_FIELD_CLASSIFICATION } from './config-classification.js';
 
@@ -60,8 +64,9 @@ interface SimpleMapping {
  * @pseudocode config-adapter.md steps 61-71: typed-field → ConfigParameters map.
  * Each entry maps an AgentConfig field to its ConfigParameters target. Only
  * fields whose target genuinely exists on ConfigParameters are present.
- * modelParams and streamIdleTimeoutMs drive runtime behavior (not a
- * ConfigParameters field), so they are absent.
+ * streamIdleTimeoutMs and streamFirstResponseTimeoutMs drive runtime behavior
+ * via Config ephemerals (not ConfigParameters fields); see
+ * {@link applyRuntimeEphemerals}.
  */
 const SIMPLE_MAPPINGS: readonly SimpleMapping[] = [
   { configField: 'fileFiltering', paramField: 'fileFiltering', kind: 'clone' },
@@ -312,4 +317,47 @@ export function toConfigParameters(
 
   // @pseudocode config-adapter.md step 100: return frozen params
   return Object.freeze(params);
+}
+
+/**
+ * Minimal Config surface needed to push ephemerals after construction.
+ * Kept structural so the function is testable without a full Config.
+ */
+type EphemeralCapableConfig = {
+  setEphemeralSetting(key: string, value: unknown): void;
+};
+
+/**
+ * Applies the typed stream-timeout AgentConfig fields onto the runtime Config
+ * as ephemerals. These fields drive runtime behavior (the idle/first-response
+ * watchdogs) but are NOT ConfigParameters fields, so they cannot flow through
+ * {@link toConfigParameters}. They must be pushed after Config construction.
+ *
+ * The camelCase typed API keys are used directly so diagnostics report the
+ * actual source field the caller set (not a hyphenated alias). This mirrors
+ * the CLI's `postConfigRuntime.applyStreamIdleTimeoutSettings` /
+ * `applyStreamFirstResponseTimeoutSettings`, which use the same camelCase keys.
+ *
+ * @param config the runtime Config (or structural equivalent for tests).
+ * @param agentConfig the validated typed AgentConfig.
+ */
+export function applyRuntimeEphemerals(
+  config: EphemeralCapableConfig,
+  agentConfig: Pick<
+    AgentConfig,
+    'streamIdleTimeoutMs' | 'streamFirstResponseTimeoutMs'
+  >,
+): void {
+  if (agentConfig.streamIdleTimeoutMs !== undefined) {
+    config.setEphemeralSetting(
+      STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+      agentConfig.streamIdleTimeoutMs,
+    );
+  }
+  if (agentConfig.streamFirstResponseTimeoutMs !== undefined) {
+    config.setEphemeralSetting(
+      STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+      agentConfig.streamFirstResponseTimeoutMs,
+    );
+  }
 }

--- a/packages/agents/src/api/config-classification.ts
+++ b/packages/agents/src/api/config-classification.ts
@@ -149,6 +149,12 @@ export const CONFIG_FIELD_CLASSIFICATION: readonly ClassificationEntry[] = [
     rationale: 'Drives the terminal idle-timeout stream event (REQ-003).',
   },
   {
+    field: 'streamFirstResponseTimeoutMs',
+    classification: 'typed',
+    rationale:
+      'Drives the first-response watchdog (issue #2607); a CLI-behavior setting, not a model param.',
+  },
+  {
     field: 'toolOutputLimits',
     classification: 'typed',
     rationale: 'Maps to ConfigParameters.truncateToolOutputThreshold/Lines.',

--- a/packages/agents/src/api/createAgent.ts
+++ b/packages/agents/src/api/createAgent.ts
@@ -43,7 +43,10 @@ import type {
 import type { AgentAuth } from './config-types.js';
 import type { Agent } from './agent.js';
 import { AgentConfigSchema } from './config-schema.js';
-import { toConfigParameters } from './agentConfig.adapter.js';
+import {
+  toConfigParameters,
+  applyRuntimeEphemerals,
+} from './agentConfig.adapter.js';
 import { AgenticLoop } from '../core/agenticLoop/AgenticLoop.js';
 import type { DisplayCallbacks } from '../core/agenticLoop/types.js';
 import { CoreToolScheduler } from '../core/coreToolScheduler.js';
@@ -118,6 +121,10 @@ export async function createAgent(rawConfig: AgentConfig): Promise<Agent> {
     parsed,
     forceConfirmations,
   );
+  // Apply typed stream-timeout AgentConfig fields as runtime Config ephemerals.
+  // These drive the idle/first-response watchdogs but are not ConfigParameters
+  // fields, so they are pushed after Config construction (issue #2607 Finding 2).
+  applyRuntimeEphemerals(config, parsed);
   const settingsService = config.getSettingsService();
 
   // @pseudocode createAgent.md steps 41-58

--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -449,6 +449,7 @@ export class StreamProcessor {
         config: runtimeContext.config,
         runtime: runtimeContext,
         onProviderError: params.config?.onProviderError,
+        onStreamLiveness: params.config?.onStreamLiveness,
         settings:
           runtimeContext.settingsService as GenerateChatOptions['settings'],
         metadata: {

--- a/packages/agents/src/core/chatSession.ts
+++ b/packages/agents/src/core/chatSession.ts
@@ -15,6 +15,7 @@ import type {
 import type { ToolGroupArray } from './streamRequestHelpers.js';
 import type { ContentBlock } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { StructuredError } from '@vybestack/llxprt-code-core/core/turn.js';
+import type { StreamLivenessEvent } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 
 /**
  * Neutral generation config carried by ChatSession. Extends the neutral
@@ -27,6 +28,13 @@ import type { StructuredError } from '@vybestack/llxprt-code-core/core/turn.js';
 export interface ChatSessionConfig extends ModelGenerationSettings {
   abortSignal?: AbortSignal;
   onProviderError?: (error: StructuredError) => void;
+  /**
+   * Optional provider-neutral transport-liveness listener (issue #2607).
+   * Threaded down to the provider stream parser so a raw lifecycle SSE event
+   * (e.g. response.created) can satisfy the first-response watchdog without
+   * requiring visible semantic content.
+   */
+  onStreamLiveness?: (event: StreamLivenessEvent) => void;
   providerRequestContext?: Record<string, unknown>;
   tools?: ToolGroupArray;
   toolConfig?: unknown;

--- a/packages/agents/src/core/turn.abort-timeout.test.ts
+++ b/packages/agents/src/core/turn.abort-timeout.test.ts
@@ -362,7 +362,7 @@ describe('Turn run - abort and idle timeout', () => {
           value: {
             error: {
               message:
-                'Stream idle timeout: no response received within the allowed time.',
+                'Inter-chunk stream-idle timeout: no response received within the allowed time (threshold 30000ms) from stream-idle-timeout-ms.',
               status: undefined,
             },
           },

--- a/packages/agents/src/core/turn.liveness.test.ts
+++ b/packages/agents/src/core/turn.liveness.test.ts
@@ -1,0 +1,673 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the two-phase first-response watchdog driven by
+ * provider liveness (issue #2607). A raw lifecycle SSE signal (e.g.
+ * response.created) proves the provider/transport is alive even before any
+ * semantic IContent; observing it must disarm the default-on first-response
+ * guard so a healthy reasoning stream is not killed for lacking first
+ * semantic content.
+ *
+ * Modeled on turn.preRequestTimeout.test.ts (fake-timer + hoisted-mock
+ * patterns). No mock theater: real Turn + real timers where feasible.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type {
+  ServerAgentStreamEvent,
+  ServerStreamIdleTimeoutEvent,
+} from './turn.js';
+import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import { StreamEventType } from './chatSession.js';
+import { type MockedChatInstance, mockChunk } from './turn-test-helpers.js';
+
+const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
+  mockSendMessageStream: vi.fn(),
+  mockGetHistory: vi.fn(),
+}));
+
+vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn(),
+}));
+
+vi.mock(
+  '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js')
+      >();
+    return {
+      analyzeResponseOutcome: actual.analyzeResponseOutcome,
+    };
+  },
+);
+
+type Part = { text: string };
+
+function buildTurn(
+  firstResponseMs?: number,
+  idleMs?: number,
+): {
+  turn: Turn;
+  mockChatInstance: MockedChatInstance;
+} {
+  const mockGetConfig = vi.fn().mockReturnValue({
+    getEphemeralSetting: (key: string) => {
+      if (key === 'stream-first-response-timeout-ms') {
+        return firstResponseMs;
+      }
+      if (key === 'stream-idle-timeout-ms') {
+        return idleMs;
+      }
+      return undefined;
+    },
+  });
+
+  const mockChatInstance = {
+    sendMessageStream: mockSendMessageStream,
+    getHistory: mockGetHistory,
+    getConfig: mockGetConfig,
+  } as unknown as MockedChatInstance;
+
+  const turn = new Turn(
+    mockChatInstance as unknown as ChatSession,
+    'prompt-id-liveness',
+    DEFAULT_AGENT_ID,
+    'test',
+  );
+  mockGetHistory.mockReturnValue([]);
+  return { turn, mockChatInstance };
+}
+
+function failsafe(ms: number): { promise: Promise<never>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Test exceeded failsafe deadline of ${ms}ms`)),
+      ms,
+    );
+  });
+  promise.catch(() => {});
+  return { promise, cancel: () => clearTimeout(timer) };
+}
+
+describe('Turn - provider-liveness two-phase watchdog (issue #2607)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    process.env = { ...originalEnv };
+    delete process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS;
+    delete process.env.LLXPRT_STREAM_IDLE_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('a provider liveness ping before the first-response threshold disarms phase A when inter-chunk idle is disabled (0)', async () => {
+    // first-response guard is small (30ms); a liveness ping arrives at 10ms;
+    // then semantic content arrives at 60ms (AFTER the 30ms first-response
+    // bound would have fired). Because liveness disarmed phase A and idle=0
+    // means phase B is unbounded, NO timeout fires.
+    vi.useRealTimers();
+    const { turn } = buildTurn(30, 0);
+
+    let releaseLiveness!: () => void;
+    const livenessGate = new Promise<void>((resolve) => {
+      releaseLiveness = resolve;
+    });
+    let releaseContent!: () => void;
+    const contentGate = new Promise<void>((resolve) => {
+      releaseContent = resolve;
+    });
+
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          releaseLiveness();
+          await contentGate;
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'Hello' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    const guard = failsafe(2000);
+    await Promise.race([livenessGate, guard.promise]);
+    // Liveness observed at ~10ms. Wait until AFTER the 30ms first-response
+    // bound would have fired, then release content.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    releaseContent();
+
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    expect(events.some((e) => e.type === AgentEventType.Content)).toBe(true);
+  });
+
+  it('no liveness: a stalled first .next() still fires the default first-response timeout', async () => {
+    // Confirms the default-on bound still fires when NO liveness and NO content
+    // arrive (genuinely absent provider response stays bounded).
+    const { turn } = buildTurn(20);
+
+    mockSendMessageStream.mockResolvedValue(
+      (async function* () {
+        await new Promise<void>(() => {});
+        yield {
+          type: StreamEventType.CHUNK,
+          value: mockChunk({ text: 'never' }),
+        };
+      })(),
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeDefined();
+  });
+
+  it('liveness observed then semantic content after DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS does NOT fire', async () => {
+    // The headline issue-2607 scenario: liveness disarms phase A; the model
+    // thinks for a long time (longer than the original 300000ms bound) then
+    // emits content. With idle=0 (default), this must NOT time out.
+    vi.useRealTimers();
+    // Use a tiny first-response env so the test is fast, but assert the
+    // content arrives well after that bound thanks to liveness.
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '50';
+
+    const { turn } = buildTurn(undefined, 0);
+
+    let releaseContent!: () => void;
+    const contentGate = new Promise<void>((resolve) => {
+      releaseContent = resolve;
+    });
+
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          await contentGate;
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'Finally' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    // Wait well past the 50ms first-response bound, then release content.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    releaseContent();
+
+    const guard = failsafe(2000);
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    expect(events.some((e) => e.type === AgentEventType.Content)).toBe(true);
+  });
+
+  it('opt-in post-liveness inter-chunk idle timeout DOES fire precisely after a liveness ping then silence', async () => {
+    // Liveness disarms phase A, then phase B (inter-chunk idle) governs. With
+    // a small idle timeout, a silence after liveness (no content) must fire.
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '50';
+    const { turn } = buildTurn(undefined, 40);
+
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          await new Promise<void>(() => {});
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'never' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    const guard = failsafe(2000);
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    const timeoutEvents = events.filter(
+      (event): event is ServerStreamIdleTimeoutEvent =>
+        event.type === AgentEventType.StreamIdleTimeout,
+    );
+    expect(timeoutEvents).toHaveLength(1);
+    expect(timeoutEvents[0].value.error.message).toContain(
+      'Inter-chunk stream-idle',
+    );
+  });
+
+  it('a second liveness ping rearms the phase B inter-chunk idle timer (rearm)', async () => {
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '50';
+    const { turn } = buildTurn(undefined, 60);
+
+    let releaseContent!: () => void;
+    const contentGate = new Promise<void>((resolve) => {
+      releaseContent = resolve;
+    });
+
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          // Wait 40ms (under the 60ms idle bound), then ping again (rearm).
+          await new Promise((resolve) => setTimeout(resolve, 40));
+          listener?.({
+            sourceEvent: 'response.in_progress',
+            sseObserved: true,
+          });
+          // Now wait for content release.
+          await contentGate;
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'Hello' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    // After both pings (5 + 40 = 45ms), wait 50ms more (total 95ms). Without
+    // rearm, the idle timer (armed at ~5ms, 60ms bound) would have fired at
+    // ~65ms. With rearm at ~45ms, it would fire at ~105ms. Release content at
+    // 80ms so it arrives before the rearmed bound.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    releaseContent();
+
+    const guard = failsafe(2000);
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    expect(events.some((e) => e.type === AgentEventType.Content)).toBe(true);
+  });
+
+  it('parent abort during a post-liveness wait yields UserCancelled, not a timeout', async () => {
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '50';
+    const { turn } = buildTurn(undefined, 60_000);
+
+    const abortController = new AbortController();
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config?: {
+          abortSignal?: AbortSignal;
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const providerSignal = params.config?.abortSignal;
+        const listener = params.config?.onStreamLiveness;
+        if (!(providerSignal instanceof AbortSignal)) {
+          throw new Error('Test setup error: missing abortSignal');
+        }
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          // Now block until the provider signal aborts.
+          await new Promise<void>((_resolve, reject) => {
+            if (providerSignal.aborted) {
+              reject(new Error('aborted'));
+              return;
+            }
+            providerSignal.addEventListener(
+              'abort',
+              () => reject(new Error('aborted')),
+              { once: true },
+            );
+          });
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'never' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        abortController.signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    abortController.abort();
+
+    const guard = failsafe(2000);
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    expect(
+      events.find((e) => e.type === AgentEventType.UserCancelled),
+    ).toBeDefined();
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+  });
+
+  it('a completed first turn does not leak its watchdog into a second turn (fresh timer per turn)', async () => {
+    // The tool-continuation lifecycle invariant: each Turn.run arms a fresh
+    // watchdog; a prior turn's liveness/timer state never carries over.
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '50';
+
+    const { turn } = buildTurn(undefined, 0);
+
+    // A mock that emits a liveness ping after livenessDelay, then content after
+    // an additional contentDelay. The listener is captured from the
+    // sendMessageStream params so the Turn's onStreamLiveness callback is
+    // actually invoked.
+    const makeStreamImpl =
+      (livenessDelay: number, contentDelay: number, text: string) =>
+      (
+        params: {
+          config?: {
+            onStreamLiveness?: (event: {
+              sourceEvent: string;
+              sseObserved: boolean;
+            }) => void;
+          };
+        } | null,
+      ) => {
+        const listener = params?.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, livenessDelay));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          await new Promise((resolve) => setTimeout(resolve, contentDelay));
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text }),
+          };
+        })();
+        return Promise.resolve(stream);
+      };
+
+    // First turn: liveness at 5ms, content at 20ms.
+    mockSendMessageStream.mockImplementationOnce(
+      makeStreamImpl(5, 15, 'first'),
+    );
+    const firstEvents: ServerAgentStreamEvent[] = [];
+    const firstRun = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        firstEvents.push(event);
+      }
+    })();
+    const guard1 = failsafe(2000);
+    await Promise.race([firstRun, guard1.promise]);
+    guard1.cancel();
+    expect(firstEvents.some((e) => e.type === AgentEventType.Content)).toBe(
+      true,
+    );
+
+    // Second turn (continuation): liveness at 5ms, content at 200ms (AFTER the
+    // 50ms first-response bound). If the first turn's watchdog leaked, this
+    // would erroneously fire. A fresh watchdog armed at run-start, disarmed by
+    // liveness at 5ms, allows the 200ms content.
+    mockSendMessageStream.mockImplementationOnce(
+      makeStreamImpl(5, 195, 'second'),
+    );
+    const secondEvents: ServerAgentStreamEvent[] = [];
+    const secondRun = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'again' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        secondEvents.push(event);
+      }
+    })();
+    const guard2 = failsafe(3000);
+    await Promise.race([secondRun, guard2.promise]);
+    guard2.cancel();
+
+    expect(
+      secondEvents.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    expect(secondEvents.some((e) => e.type === AgentEventType.Content)).toBe(
+      true,
+    );
+  });
+
+  it('disabled path (first-response=0): liveness is never needed and content flows unbounded', async () => {
+    vi.useRealTimers();
+    const { turn } = buildTurn(0, 0);
+
+    let releaseContent!: () => void;
+    const contentGate = new Promise<void>((resolve) => {
+      releaseContent = resolve;
+    });
+
+    mockSendMessageStream.mockImplementation(() => {
+      const stream = (async function* () {
+        await contentGate;
+        yield {
+          type: StreamEventType.CHUNK,
+          value: mockChunk({ text: 'Finally' }),
+        };
+      })();
+      return Promise.resolve(stream);
+    });
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    releaseContent();
+
+    const guard = failsafe(2000);
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    expect(events.some((e) => e.type === AgentEventType.Content)).toBe(true);
+  });
+
+  it('diagnostics: a first-response timeout message identifies the guard, threshold, and config source', async () => {
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '20';
+    const { turn } = buildTurn();
+
+    mockSendMessageStream.mockReturnValue(new Promise(() => {}));
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    const timeoutEvent = events.find(
+      (e) => e.type === AgentEventType.StreamIdleTimeout,
+    ) as { value: { error: { message: string } } } | undefined;
+
+    expect(timeoutEvent).toBeDefined();
+    expect(timeoutEvent?.value.error.message).toContain('First-response');
+    expect(timeoutEvent?.value.error.message).toContain('threshold 20ms');
+    expect(timeoutEvent?.value.error.message).toContain('from env');
+  });
+
+  it('diagnostics: an inter-chunk timeout message identifies the guard, threshold, and config source', async () => {
+    const { turn } = buildTurn(0, 20);
+
+    mockSendMessageStream.mockResolvedValue(
+      (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: mockChunk({ text: 'progress' }),
+        };
+        await new Promise<void>(() => {});
+      })(),
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    const timeoutEvent = events.find(
+      (e) => e.type === AgentEventType.StreamIdleTimeout,
+    ) as { value: { error: { message: string } } } | undefined;
+
+    expect(timeoutEvent).toBeDefined();
+    expect(timeoutEvent?.value.error.message).toContain(
+      'Inter-chunk stream-idle',
+    );
+    expect(timeoutEvent?.value.error.message).toContain('threshold 20ms');
+  });
+});

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -362,7 +362,7 @@ describe('Turn - first-response timeout (issue #2379)', () => {
           value: {
             error: {
               message:
-                'Stream idle timeout: no response received within the allowed time.',
+                'First-response timeout: no response received within the allowed time (threshold 20ms) from stream-first-response-timeout-ms.',
               status: undefined,
             },
           },

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -7,9 +7,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ServerAgentStreamEvent, StructuredError } from './turn.js';
 import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
-import type { ChatSession } from './chatSession.js';
+import type { ChatSession, StreamEvent } from './chatSession.js';
 import { StreamEventType } from './chatSession.js';
-import type { ModelStreamChunk } from '@vybestack/llxprt-code-core/llm-types/index.js';
 import { type MockedChatInstance, mockChunk } from './turn-test-helpers.js';
 import { DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
@@ -104,6 +103,8 @@ function failsafe(ms: number): { promise: Promise<never>; cancel: () => void } {
   return { promise, cancel: () => clearTimeout(timer) };
 }
 
+type TurnStreamIterator = AsyncIterator<StreamEvent>;
+
 /** A stream whose first .next() never resolves (acquisition resolves fine). */
 function createStreamWithStalledFirstNext(): AsyncGenerator<{
   type: StreamEventType;
@@ -111,10 +112,7 @@ function createStreamWithStalledFirstNext(): AsyncGenerator<{
 }> {
   return (async function* () {
     await new Promise<void>(() => {});
-    yield {
-      type: StreamEventType.CHUNK,
-      value: mockChunk({ text: 'never' }),
-    };
+    yield { type: StreamEventType.CHUNK, value: mockChunk({ text: 'never' }) };
   })();
 }
 
@@ -136,36 +134,25 @@ describe('Turn - first-response timeout (issue #2379)', () => {
   });
 
   it('DEFAULT-ON regression: with NO first-response setting/env, a stream whose first .next() never resolves yields terminal StreamIdleTimeout after DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS', async () => {
-    // buildTurn() with NO args: first-response returns undefined → resolver falls to default 300000
     const { turn } = buildTurn();
-
     mockSendMessageStream.mockResolvedValue(createStreamWithStalledFirstNext());
-
     const events: ServerAgentStreamEvent[] = [];
     const reqParts: Part[] = [{ text: 'Hi' }];
     const signal = new AbortController().signal;
-
     const iterator = turn.run(reqParts, signal);
     const runPromise = (async () => {
       for await (const event of iterator) {
         events.push(event);
       }
     })();
-
-    // Before the default timeout: no events, generator still pending.
     await vi.advanceTimersByTimeAsync(
       DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS - 1,
     );
     await Promise.resolve();
     expect(events).toHaveLength(0);
-
-    // Advance past the default first-response timeout (300000ms). Drain all
-    // pending timers/microtasks so the rejection deterministically propagates
-    // through handleRunError before we await the consumer loop.
     await vi.advanceTimersByTimeAsync(2);
     await vi.runAllTimersAsync();
     await runPromise;
-
     const timeoutEvent = events.find(
       (e) => e.type === AgentEventType.StreamIdleTimeout,
     );
@@ -175,8 +162,6 @@ describe('Turn - first-response timeout (issue #2379)', () => {
 
   it('DEFAULT-ON regression (real-timer failsafe): never-resolving first .next() surfaces StreamIdleTimeout under the failsafe deadline', async () => {
     vi.useRealTimers();
-    // Use a tiny env override so the real-timer test finishes quickly while
-    // still proving the DEFAULT-ON path fires (no ephemeral setting needed).
     process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '50';
     const { turn } = buildTurn();
 
@@ -196,7 +181,6 @@ describe('Turn - first-response timeout (issue #2379)', () => {
       guard.promise,
     ]);
     guard.cancel();
-
     const timeoutEvent = events.find(
       (e) => e.type === AgentEventType.StreamIdleTimeout,
     );
@@ -205,24 +189,19 @@ describe('Turn - first-response timeout (issue #2379)', () => {
 
   it('never-resolving ACQUISITION (sendMessageStream promise never resolves) with a small explicit first-response timeout → terminal StreamIdleTimeout', async () => {
     const { turn } = buildTurn(20);
-
     mockSendMessageStream.mockReturnValue(new Promise(() => {}));
-
     const events: ServerAgentStreamEvent[] = [];
     const reqParts: Part[] = [{ text: 'Hi' }];
     const signal = new AbortController().signal;
-
     const iterator = turn.run(reqParts, signal);
     const runPromise = (async () => {
       for await (const event of iterator) {
         events.push(event);
       }
     })();
-
     await vi.advanceTimersByTimeAsync(25);
     await vi.runAllTimersAsync();
     await runPromise;
-
     expect(
       events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
     ).toBeDefined();
@@ -230,26 +209,20 @@ describe('Turn - first-response timeout (issue #2379)', () => {
   });
 
   it('never-resolving FIRST .next() (acquisition resolves, first chunk never arrives) with a small explicit first-response timeout → terminal StreamIdleTimeout', async () => {
-    // This proves the first-response bound covers the first .next(), not just acquisition.
     const { turn } = buildTurn(20);
-
     mockSendMessageStream.mockResolvedValue(createStreamWithStalledFirstNext());
-
     const events: ServerAgentStreamEvent[] = [];
     const reqParts: Part[] = [{ text: 'Hi' }];
     const signal = new AbortController().signal;
-
     const iterator = turn.run(reqParts, signal);
     const runPromise = (async () => {
       for await (const event of iterator) {
         events.push(event);
       }
     })();
-
     await vi.advanceTimersByTimeAsync(25);
     await vi.runAllTimersAsync();
     await runPromise;
-
     expect(
       events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
     ).toBeDefined();
@@ -531,29 +504,17 @@ describe('Turn - first-response timeout (issue #2379)', () => {
   });
 
   it('resource cleanup: when the timeout wins but the first .next() resolves LATE, the acquired iterator is closed (no provider connection leak)', async () => {
-    // Race edge case: timeoutController.abort() is asynchronous, so the
-    // in-flight first .next() can still resolve successfully a moment AFTER the
-    // timeout has already won the race. The losing (late-resolving) iterator
-    // must be closed via return() so the provider connection is not leaked.
     const { turn } = buildTurn(20);
-
     let releaseFirstNext!: () => void;
     const firstNextGate = new Promise<void>((resolve) => {
       releaseFirstNext = resolve;
     });
-    // Deterministic sync point: the mock's return() resolves this promise, so
-    // the test can await the exact moment cleanup fires instead of polling an
-    // arbitrary number of microtask hops.
     let signalReturnCalled!: () => void;
     const returnCalledPromise = new Promise<void>((resolve) => {
       signalReturnCalled = resolve;
     });
     const cleanup = { returnCalled: false };
-
-    const leakyIterator: AsyncIterator<{
-      type: StreamEventType;
-      value: ModelStreamChunk;
-    }> = {
+    const leakyIterator: TurnStreamIterator = {
       async next() {
         await firstNextGate;
         return {
@@ -573,31 +534,21 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     mockSendMessageStream.mockResolvedValue({
       [Symbol.asyncIterator]: () => leakyIterator,
     });
-
     const events: ServerAgentStreamEvent[] = [];
     const reqParts: Part[] = [{ text: 'Hi' }];
     const signal = new AbortController().signal;
-
     const runPromise = (async () => {
       for await (const event of turn.run(reqParts, signal)) {
         events.push(event);
       }
     })();
-
-    // Let the timeout win the race first.
     await vi.advanceTimersByTimeAsync(25);
     await vi.runAllTimersAsync();
     await runPromise;
-
-    // Release the late first .next() so the losing promise resolves AFTER the
-    // timeout already settled the race, then await the deterministic sync point
-    // (bounded by the suite failsafe) so a regression that never closes the
-    // iterator fails loudly instead of passing.
     releaseFirstNext();
     const guard = failsafe(2000);
     await Promise.race([returnCalledPromise, guard.promise]);
     guard.cancel();
-
     expect(
       events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
     ).toBeDefined();
@@ -641,6 +592,88 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     expect(events.at(-1)?.type).toBe(AgentEventType.StreamIdleTimeout);
   });
 
+  it('late acquisition cleanup: timeout wins BEFORE acquisition completes and iterator hangs in next() → return() called on acquisition (issue #2607 finding A)', async () => {
+    const { turn } = buildTurn(20);
+    let releaseAcquisition!: () => void;
+    const acquisitionGate = new Promise<void>((resolve) => {
+      releaseAcquisition = resolve;
+    });
+    let signalReturnCalled!: () => void;
+    const returnCalledPromise = new Promise<void>((resolve) => {
+      signalReturnCalled = resolve;
+    });
+    const cleanup = { returnCalled: false };
+    const iterator: TurnStreamIterator = {
+      next: () => new Promise<IteratorResult<never>>(() => {}),
+      async return() {
+        cleanup.returnCalled = true;
+        signalReturnCalled();
+        return { done: true, value: undefined };
+      },
+    };
+    mockSendMessageStream.mockImplementation(() =>
+      acquisitionGate.then(() => ({ [Symbol.asyncIterator]: () => iterator })),
+    );
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+    releaseAcquisition();
+    const guard = failsafe(2000);
+    await Promise.race([returnCalledPromise, guard.promise]);
+    guard.cancel();
+    expect(cleanup.returnCalled).toBe(true);
+    expect(events.at(-1)?.type).toBe(AgentEventType.StreamIdleTimeout);
+  });
+
+  it('first non-semantic RETRY does not disarm first-response guard: never-resolving next() still emits First-response StreamIdleTimeout (issue #2607 finding B)', async () => {
+    const { turn } = buildTurn(20, 0);
+    let firstNextTaken = false;
+    const iterator: TurnStreamIterator = {
+      next: () => {
+        if (!firstNextTaken) {
+          firstNextTaken = true;
+          return Promise.resolve({
+            done: false,
+            value: { type: StreamEventType.RETRY },
+          });
+        }
+        return new Promise<IteratorResult<never>>(() => {});
+      },
+      async return() {
+        return { done: true, value: undefined };
+      },
+    };
+    mockSendMessageStream.mockResolvedValue({
+      [Symbol.asyncIterator]: () => iterator,
+    });
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.runAllTimersAsync();
+    await runPromise;
+    const timeoutEvent = events.find(
+      (e) => e.type === AgentEventType.StreamIdleTimeout,
+    );
+    expect(timeoutEvent).toBeDefined();
+    expect(timeoutEvent?.value.error.message).toContain('First-response');
+  });
+
   it('resource cleanup (disabled path): when first-response is DISABLED (0) and the first .next() throws, the acquired iterator is closed (no leak)', async () => {
     const { turn } = buildTurn(0);
 
@@ -668,17 +701,12 @@ describe('Turn - first-response timeout (issue #2379)', () => {
     mockSendMessageStream.mockResolvedValue({
       [Symbol.asyncIterator]: () => throwingIterator,
     });
-
     const events: ServerAgentStreamEvent[] = [];
     const reqParts: Part[] = [{ text: 'Hi' }];
     const signal = new AbortController().signal;
-
     for await (const event of turn.run(reqParts, signal)) {
       events.push(event);
     }
-
-    // The failing iterator MUST have been closed to release the provider
-    // connection, and the provider error surfaces instead of the cleanup error.
     expect(returnCalled).toBe(true);
     expect(events).toContainEqual({
       type: AgentEventType.Error,
@@ -724,25 +752,13 @@ describe('Turn - first-response timeout (issue #2379)', () => {
   });
 
   it('regression: a HEALTHY stream where the first chunk arrives quickly, then a LATER inter-chunk gap LARGER than the first-response timeout does NOT trip anything (inter-chunk idle is default-off)', async () => {
-    // first-response timeout is tiny (30ms), first chunk arrives at 10ms (before it),
-    // then a later inter-chunk gap of 60ms (> first-response) must NOT trip anything
-    // because the first-response timer is cancelled after the first chunk and the
-    // inter-chunk idle watchdog is default-off (0). This is the key proof that
-    // first-response ≠ inter-chunk.
     vi.useRealTimers();
     const { turn } = buildTurn(30);
-
     const mockResponseStream = (async function* () {
       await new Promise((resolve) => setTimeout(resolve, 10));
-      yield {
-        type: StreamEventType.CHUNK,
-        value: mockChunk({ text: 'Hel' }),
-      };
+      yield { type: StreamEventType.CHUNK, value: mockChunk({ text: 'Hel' }) };
       await new Promise((resolve) => setTimeout(resolve, 60));
-      yield {
-        type: StreamEventType.CHUNK,
-        value: mockChunk({ text: 'lo' }),
-      };
+      yield { type: StreamEventType.CHUNK, value: mockChunk({ text: 'lo' }) };
     })();
     mockSendMessageStream.mockResolvedValue(mockResponseStream);
 
@@ -760,7 +776,6 @@ describe('Turn - first-response timeout (issue #2379)', () => {
       guard.promise,
     ]);
     guard.cancel();
-
     expect(
       events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
     ).toBeUndefined();
@@ -771,25 +786,16 @@ describe('Turn - first-response timeout (issue #2379)', () => {
   });
 
   it('abort: parent signal abort during first-response wait → UserCancelled, not a timeout', async () => {
-    // Use REAL timers with a LARGE first-response timeout (60s) that cannot fire
-    // within this test, so the ONLY mechanism that can unblock the wait is the
-    // parent-abort propagating through the provider's abortSignal. This gives
-    // the test teeth: if the parent-abort wiring (run() -> timeoutController ->
-    // provider abortSignal) breaks, the wait never settles and the failsafe
-    // trips instead of a spurious pass from the timeout firing.
+    // REAL timers + LARGE first-response timeout (60s) so only parent-abort can
+    // unblock the wait via the provider abortSignal.
     vi.useRealTimers();
     const { turn } = buildTurn(60_000);
 
-    // Acquisition resolves; the first .next() only settles when the provided
-    // abortSignal aborts, at which point it rejects with an AbortError — exactly
-    // how a provider reacts to abortSignal cancellation mid-first-response.
     mockSendMessageStream.mockImplementation(
       (params: { config: { abortSignal: AbortSignal } }) => {
         const providerSignal = params.config.abortSignal;
         if (!(providerSignal instanceof AbortSignal)) {
-          throw new Error(
-            'Test setup error: sendMessageStream did not receive config.abortSignal',
-          );
+          throw new Error('sendMessageStream missing config.abortSignal');
         }
         const stream = (async function* () {
           await new Promise<void>((_resolve, reject) => {
@@ -800,7 +806,9 @@ describe('Turn - first-response timeout (issue #2379)', () => {
             providerSignal.addEventListener(
               'abort',
               () => reject(new Error('aborted')),
-              { once: true },
+              {
+                once: true,
+              },
             );
           });
           yield {
@@ -823,9 +831,7 @@ describe('Turn - first-response timeout (issue #2379)', () => {
       }
     })();
 
-    // Let the generator body start and reach the first-response wait (past the
-    // pre-flight signal.aborted check) BEFORE aborting, so the abort is
-    // genuinely observed DURING the wait.
+    // Let the generator reach the first-response wait before aborting.
     await new Promise((resolve) => setTimeout(resolve, 10));
     abortController.abort();
 

--- a/packages/agents/src/core/turn.preRequestTimeout.test.ts
+++ b/packages/agents/src/core/turn.preRequestTimeout.test.ts
@@ -106,10 +106,7 @@ function failsafe(ms: number): { promise: Promise<never>; cancel: () => void } {
 type TurnStreamIterator = AsyncIterator<StreamEvent>;
 
 /** A stream whose first .next() never resolves (acquisition resolves fine). */
-function createStreamWithStalledFirstNext(): AsyncGenerator<{
-  type: StreamEventType;
-  value: ModelStreamChunk;
-}> {
+function createStreamWithStalledFirstNext(): AsyncGenerator<StreamEvent> {
   return (async function* () {
     await new Promise<void>(() => {});
     yield { type: StreamEventType.CHUNK, value: mockChunk({ text: 'never' }) };
@@ -560,10 +557,7 @@ describe('Turn - first-response timeout (issue #2379)', () => {
   it('invokes iterator return promptly when first next never settles', async () => {
     const { turn } = buildTurn(20);
     let returnCalls = 0;
-    const iterator: AsyncIterator<{
-      type: StreamEventType;
-      value: ModelStreamChunk;
-    }> = {
+    const iterator: TurnStreamIterator = {
       next: () => new Promise(() => {}),
       async return() {
         returnCalls++;
@@ -686,10 +680,7 @@ describe('Turn - first-response timeout (issue #2379)', () => {
       status: 504,
       category: 'network',
     });
-    const throwingIterator: AsyncIterator<{
-      type: StreamEventType;
-      value: ModelStreamChunk;
-    }> = {
+    const throwingIterator: TurnStreamIterator = {
       async next(): Promise<never> {
         throw firstNextFailure;
       },

--- a/packages/agents/src/core/turn.test.ts
+++ b/packages/agents/src/core/turn.test.ts
@@ -86,6 +86,7 @@ describe('Turn', () => {
           config: {
             abortSignal: expect.any(AbortSignal),
             onProviderError: expect.any(Function),
+            onStreamLiveness: expect.any(Function),
           },
         },
         'prompt-id-1',

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -453,11 +453,8 @@ export class Turn {
         return;
       }
       if (dispatch.action === 'process' && dispatch.chunk != null) {
-        // A semantic event rearms the inter-chunk guard (issue #2607 finding 2)
-        // so liveness-aware idle behavior is preserved across the whole stream.
-        if (idleMs > 0) {
-          watchdog.onSemanticEvent();
-        }
+        // Only a real model chunk advances the semantic-output watchdog.
+        watchdog.onSemanticEvent();
         onStreamProgress();
         cumulativeOutcome = this.mergeResponseOutcome(
           cumulativeOutcome,
@@ -768,17 +765,22 @@ export class Turn {
     }
 
     let acquiredIterator: AsyncIterator<StreamEvent> | undefined;
-    const firstEventPromise = (async () => {
-      const iterator = await this.openResponseStreamIterator(
-        req,
-        timeoutSignal,
-        onProviderError,
-        onStreamLiveness,
-      );
-      acquiredIterator = iterator;
+    const acquisitionPromise = this.openResponseStreamIterator(
+      req,
+      timeoutSignal,
+      onProviderError,
+      onStreamLiveness,
+    );
+    acquisitionPromise
+      .then((iterator) => {
+        acquiredIterator = iterator;
+        return iterator;
+      })
+      .catch(() => undefined);
+    const firstEventPromise = acquisitionPromise.then(async (iterator) => {
       const firstResult = await iterator.next();
       return { iterator, firstResult };
-    })();
+    });
     firstEventPromise.catch(() => {});
 
     try {
@@ -786,20 +788,18 @@ export class Turn {
         firstEventPromise,
         watchdog.timeoutPromise,
       ]);
-      // Disarm phase A (first-response) via the semantic event so phase B
-      // (inter-chunk) stays armed for the rest of the stream. Do NOT cancel —
-      // the whole-stream watchdog must remain active (issue #2607 finding 2).
-      watchdog.onSemanticEvent();
       return result;
     } catch (error) {
       watchdog.cancel();
-      await closeIteratorBounded(acquiredIterator, timeoutSignal);
-      firstEventPromise
-        .then(async (late) => {
-          if (late.iterator !== acquiredIterator) {
-            await closeIteratorBounded(late.iterator, timeoutSignal);
-          }
-        })
+      const iteratorAtCatch = acquiredIterator;
+      await closeIteratorBounded(iteratorAtCatch, timeoutSignal);
+      // Close a late-acquired iterator without waiting for its first next().
+      acquisitionPromise
+        .then((lateIterator) =>
+          lateIterator === iteratorAtCatch
+            ? undefined
+            : closeIteratorBounded(lateIterator, timeoutSignal),
+        )
         .catch(() => undefined);
       if (idleFlag.fire !== undefined) {
         throw new Error(

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -26,7 +26,6 @@ import {
 } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 import { reportError } from '@vybestack/llxprt-code-core/utils/errorReporting.js';
 import {
-  getErrorMessage,
   UnauthorizedError,
   toFriendlyError,
 } from '@vybestack/llxprt-code-core/utils/errors.js';
@@ -44,12 +43,21 @@ import { getCodeAssistServer } from '@vybestack/llxprt-code-core/code_assist/cod
 import { UserTierId } from '@vybestack/llxprt-code-core/code_assist/types.js';
 import { parseThought } from '@vybestack/llxprt-code-core/utils/thoughtUtils.js';
 import {
-  nextStreamEventWithIdleTimeout,
-  resolveStreamIdleTimeoutMs,
-  resolveStreamFirstResponseTimeoutMs,
+  resolveStreamIdleTimeoutMsSource,
+  resolveStreamFirstResponseTimeoutMsSource,
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+  type StreamLivenessListener,
 } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
-import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
+import {
+  createStreamWatchdog,
+  type StreamWatchdog,
+  type StreamWatchdogFire,
+} from '@vybestack/llxprt-code-core/utils/streamWatchdog.js';
+import {
+  buildStructuredError,
+  isAbortSignalActive,
+  safeJsonStringify,
+} from './turnJsonUtils.js';
 import {
   DEFAULT_AGENT_ID,
   AgentEventType,
@@ -59,19 +67,29 @@ import {
   type StructuredError,
 } from '@vybestack/llxprt-code-core/core/turn.js';
 
-/**
- * Transitional turn-request type — avoids importing a provider SDK PartListUnion.
- * Accepts strings and arrays of part-shaped objects that the chatSession's
- * normalizeToolInteractionInput can handle. Narrows to AgentMessageInput at P21.
- *
- * @plan:PLAN-20260707-AGENTNEUTRAL.P08
- */
 type TurnRequest = string | object | readonly unknown[];
 /** @deprecated Use DEFAULT_STREAM_IDLE_TIMEOUT_MS from streamIdleTimeout.js instead */
 export const TURN_STREAM_IDLE_TIMEOUT_MS = DEFAULT_STREAM_IDLE_TIMEOUT_MS;
 
-const TURN_STREAM_IDLE_TIMEOUT_ERROR_MESSAGE =
-  'Stream idle timeout: no response received within the allowed time.';
+function formatStreamIdleTimeoutMessage(
+  fire: StreamWatchdogFire,
+  livenessObserved: boolean,
+): string {
+  const guardLabel =
+    fire.guard === 'first-response'
+      ? 'First-response'
+      : 'Inter-chunk stream-idle';
+  const livenessPart = livenessObserved
+    ? '; provider liveness was observed before the timeout'
+    : '';
+  return `${guardLabel} timeout: no response received within the allowed time (threshold ${fire.thresholdMs}ms) from ${fire.configSource}${livenessPart}.`;
+}
+
+interface IdleFlag {
+  timedOut: boolean;
+  fire: StreamWatchdogFire | undefined;
+  livenessObserved: boolean;
+}
 
 /**
  * Filters ContentBlocks by hook-restricted allowed tool names.
@@ -116,56 +134,6 @@ interface EmitFinishReasonOptions {
   stopReason: string | undefined;
 }
 
-/**
- * Safely checks if an AbortSignal (or runtime-nullish value) has been aborted.
- * Runtime payloads can pass null/undefined despite declared types.
- */
-function isAbortSignalActive(signal: unknown): boolean {
-  return (
-    signal != null &&
-    typeof signal === 'object' &&
-    (signal as { aborted?: unknown }).aborted === true
-  );
-}
-
-function createSafeJsonReplacer(): (key: string, value: unknown) => unknown {
-  const seen = new WeakSet<object>();
-  return (_key: string, value: unknown): unknown => {
-    if (typeof value === 'bigint') {
-      return value.toString();
-    }
-
-    if (typeof value !== 'object' || value === null) {
-      return value;
-    }
-
-    if (seen.has(value)) {
-      return '[Circular]';
-    }
-    seen.add(value);
-
-    if (Array.isArray(value)) {
-      return value;
-    }
-
-    const record = value as Record<string, unknown>;
-    return Object.keys(record)
-      .sort()
-      .reduce<Record<string, unknown>>((sorted, key) => {
-        sorted[key] = record[key];
-        return sorted;
-      }, {});
-  };
-}
-
-function safeJsonStringify(value: unknown, space?: number): string {
-  try {
-    return JSON.stringify(value, createSafeJsonReplacer(), space);
-  } catch (error) {
-    return `[Unserializable request: ${getErrorMessage(error)}]`;
-  }
-}
-
 // Re-export types that consumers need from this module
 export {
   DEFAULT_AGENT_ID,
@@ -204,6 +172,11 @@ export type {
   StructuredError,
   ServerTool,
 } from '@vybestack/llxprt-code-core/core/turn.js';
+
+interface TurnWatchdogBundle {
+  readonly watchdog: StreamWatchdog;
+  readonly idleMs: number;
+}
 
 // A turn manages the agentic loop turn within the server context.
 export class Turn {
@@ -434,36 +407,29 @@ export class Turn {
     streamIterator: AsyncIterator<StreamEvent>,
     timeoutController: AbortController,
     signal: AbortSignal,
-    effectiveTimeoutMs: number,
-    idleFlag: { timedOut: boolean },
+    watchdog: StreamWatchdog,
+    idleMs: number,
+    idleFlag: IdleFlag,
     onStreamProgress: () => void,
     firstResult?: IteratorResult<StreamEvent>,
   ): AsyncGenerator<ServerAgentStreamEvent> {
     let cumulativeOutcome = this.createEmptyResponseOutcome();
     let pendingResult: IteratorResult<StreamEvent> | undefined = firstResult;
     for (;;) {
-      // Use watchdog if timeout > 0, otherwise call iterator.next() directly
       let result: IteratorResult<StreamEvent>;
       if (pendingResult !== undefined) {
         // First event was already fetched (and bounded by the first-response
         // watchdog in run()); consume it directly, then clear the pending slot.
         result = pendingResult;
         pendingResult = undefined;
-      } else if (effectiveTimeoutMs > 0) {
-        result = await nextStreamEventWithIdleTimeout({
-          iterator: streamIterator,
-          timeoutMs: effectiveTimeoutMs,
-          signal: timeoutController.signal,
-          onTimeout: () => {
-            if (signal.aborted) {
-              return;
-            }
-            idleFlag.timedOut = true;
-            timeoutController.abort();
-          },
-          createTimeoutError: () =>
-            new Error(TURN_STREAM_IDLE_TIMEOUT_ERROR_MESSAGE),
-        });
+      } else if (watchdog.isActive) {
+        // The watchdog governs the whole stream: its inter-chunk guard is
+        // rearmed by both provider liveness pings and semantic events, so a
+        // healthy stream never false-trips regardless of chunk cadence.
+        result = await Promise.race([
+          streamIterator.next(),
+          watchdog.timeoutPromise,
+        ]);
       } else {
         // Watchdog disabled: call iterator.next() directly
         result = await streamIterator.next();
@@ -487,6 +453,11 @@ export class Turn {
         return;
       }
       if (dispatch.action === 'process' && dispatch.chunk != null) {
+        // A semantic event rearms the inter-chunk guard (issue #2607 finding 2)
+        // so liveness-aware idle behavior is preserved across the whole stream.
+        if (idleMs > 0) {
+          watchdog.onSemanticEvent();
+        }
         onStreamProgress();
         cumulativeOutcome = this.mergeResponseOutcome(
           cumulativeOutcome,
@@ -566,53 +537,11 @@ export class Turn {
     };
   }
 
-  private extractErrorStatus(error: unknown): number | undefined {
-    if (typeof error !== 'object' || error === null || !('status' in error)) {
-      return undefined;
-    }
-    return typeof error.status === 'number' ? error.status : undefined;
-  }
-
-  private extractErrorCategory(
-    error: unknown,
-  ): StructuredError['category'] | undefined {
-    if (typeof error !== 'object' || error === null || !('category' in error)) {
-      return undefined;
-    }
-    const category = error.category;
-    switch (category) {
-      case 'rate_limit':
-      case 'quota':
-      case 'authentication':
-      case 'server_error':
-      case 'network':
-      case 'client_error':
-        return category;
-      default:
-        return undefined;
-    }
-  }
-
-  private extractErrorReason(
-    error: unknown,
-  ): StructuredError['reason'] | undefined {
-    if (typeof error !== 'object' || error === null || !('reason' in error)) {
-      return undefined;
-    }
-    switch (error.reason) {
-      case 'retries_exhausted':
-      case 'all_buckets_exhausted':
-        return error.reason;
-      default:
-        return undefined;
-    }
-  }
-
   private async *handleRunError(
     e: unknown,
     req: TurnRequest,
     signal: AbortSignal,
-    idleFlag: { timedOut: boolean },
+    idleFlag: IdleFlag,
     observedProviderError: StructuredError | undefined,
   ): AsyncGenerator<ServerAgentStreamEvent> {
     if (signal.aborted) {
@@ -629,11 +558,19 @@ export class Turn {
     }
 
     if (idleFlag.timedOut) {
+      const fire = idleFlag.fire ?? {
+        guard: 'first-response' as const,
+        thresholdMs: 0,
+        configSource: 'default',
+      };
       yield {
         type: AgentEventType.StreamIdleTimeout,
         value: {
           error: {
-            message: TURN_STREAM_IDLE_TIMEOUT_ERROR_MESSAGE,
+            message: formatStreamIdleTimeoutMessage(
+              fire,
+              idleFlag.livenessObserved,
+            ),
             status: undefined,
           },
         },
@@ -658,24 +595,44 @@ export class Turn {
       contextForReport,
       'Turn.run-sendMessageStream',
     );
-    const status = this.extractErrorStatus(error);
-    const category = this.extractErrorCategory(error);
-    const reason = this.extractErrorReason(error);
-    const structuredError: StructuredError = {
-      message: getErrorMessage(error),
-      ...(status !== undefined ? { status } : {}),
-      ...(category !== undefined ? { category } : {}),
-      ...(reason !== undefined ? { reason } : {}),
-    };
+    const structuredError = buildStructuredError(error);
     yield { type: AgentEventType.Error, value: { error: structuredError } };
   }
 
   // The run method yields simpler events suitable for server logic
+  private createTurnWatchdog(
+    timeoutController: AbortController,
+    idleFlag: IdleFlag,
+  ): TurnWatchdogBundle {
+    const idleResolution = resolveStreamIdleTimeoutMsSource(
+      this.chat.getConfig(),
+    );
+    const firstResponseResolution = resolveStreamFirstResponseTimeoutMsSource(
+      this.chat.getConfig(),
+    );
+    const watchdog = createStreamWatchdog({
+      firstResponseMs: firstResponseResolution.ms,
+      firstResponseSource: firstResponseResolution.source,
+      idleMs: idleResolution.ms,
+      idleSource: idleResolution.source,
+      onFire: (fire) => {
+        idleFlag.timedOut = true;
+        idleFlag.fire = fire;
+        timeoutController.abort();
+      },
+    });
+    return { watchdog, idleMs: idleResolution.ms };
+  }
+
   async *run(
     req: TurnRequest,
     signal: AbortSignal,
   ): AsyncGenerator<ServerAgentStreamEvent> {
-    const idleFlag: { timedOut: boolean } = { timedOut: false };
+    const idleFlag: IdleFlag = {
+      timedOut: false,
+      fire: undefined,
+      livenessObserved: false,
+    };
     let observedProviderError: StructuredError | undefined;
     const onProviderError = (error: StructuredError): void => {
       observedProviderError = error;
@@ -699,26 +656,24 @@ export class Turn {
 
       let streamIterator: AsyncIterator<StreamEvent> | undefined;
 
-      const effectiveTimeoutMs = resolveStreamIdleTimeoutMs(
-        this.chat.getConfig(),
-      );
-      const firstResponseTimeoutMs = resolveStreamFirstResponseTimeoutMs(
-        this.chat.getConfig(),
+      const { watchdog, idleMs } = this.createTurnWatchdog(
+        timeoutController,
+        idleFlag,
       );
 
+      const onStreamLiveness: StreamLivenessListener = (event) => {
+        idleFlag.livenessObserved = true;
+        watchdog.onLiveness(event);
+      };
+
       try {
-        // Acquire the stream AND await the FIRST event, bounding the entire
-        // window (activation + connect + first token) by the first-response
-        // watchdog. After the first event arrives the first-response timer is
-        // cancelled and inter-chunk gaps are governed solely by the existing
-        // (default-off) effectiveTimeoutMs watchdog in consumeStreamEvents.
         const { iterator, firstResult } = await this.acquireFirstStreamEvent(
           req,
           timeoutSignal,
-          timeoutController,
-          firstResponseTimeoutMs,
+          watchdog,
           idleFlag,
           onProviderError,
+          onStreamLiveness,
         );
         streamIterator = iterator;
 
@@ -726,7 +681,8 @@ export class Turn {
           streamIterator,
           timeoutController,
           signal,
-          effectiveTimeoutMs,
+          watchdog,
+          idleMs,
           idleFlag,
           () => {
             observedProviderError = undefined;
@@ -734,9 +690,14 @@ export class Turn {
           firstResult,
         );
       } finally {
-        timeoutController.abort();
-        await closeIteratorBounded(streamIterator, timeoutSignal);
-        signal.removeEventListener('abort', onParentAbort);
+        await this.cleanupStreamResources(
+          watchdog,
+          timeoutController,
+          streamIterator,
+          timeoutSignal,
+          signal,
+          onParentAbort,
+        );
       }
     } catch (e) {
       yield* this.handleRunError(
@@ -750,109 +711,88 @@ export class Turn {
   }
 
   /**
-   * Acquire the response stream and await its FIRST event, bounding the whole
-   * time-to-first-response window (both the sendMessageStream() acquisition and
-   * the first .next(), since the network work happens on that first .next()) by
-   * the first-response watchdog. A dedicated AbortController drives the timer
-   * and is aborted in `finally` once the first event resolves or throws, so it
-   * can never fire mid-stream. On timeout it sets idleFlag.timedOut, aborts the
-   * turn's timeoutController, and throws the canonical idle-timeout error so
-   * handleRunError yields StreamIdleTimeout; a parent-signal abort during the
-   * wait yields UserCancelled instead (guarded by `!timeoutSignal.aborted`).
-   * When disabled (<=0) the behavior is the pre-existing direct acquire-then-
-   * next with no bound. Mirrors the first-chunk-timeout pattern in
-   * loadBalancing/streamTimeout.ts and RetryOrchestrator.ts.
+   * Tears down watchdog, timeout controller, and stream iterator without
+   * letting a cleanup failure mask the original stream result. Iterator
+   * cleanup rejections are logged as warnings but never rethrown.
    */
+  private async cleanupStreamResources(
+    watchdog: StreamWatchdog,
+    timeoutController: AbortController,
+    streamIterator: AsyncIterator<StreamEvent> | undefined,
+    timeoutSignal: AbortSignal,
+    signal: AbortSignal,
+    onParentAbort: () => void,
+  ): Promise<void> {
+    watchdog.cancel();
+    timeoutController.abort();
+    try {
+      await closeIteratorBounded(streamIterator, timeoutSignal);
+    } catch (cleanupError) {
+      this.logger.warn(
+        () =>
+          `[stream:turn] iterator cleanup failed: ${
+            cleanupError instanceof Error
+              ? cleanupError.message
+              : String(cleanupError)
+          }`,
+      );
+    }
+    signal.removeEventListener('abort', onParentAbort);
+  }
+
   private async acquireFirstStreamEvent(
     req: TurnRequest,
     timeoutSignal: AbortSignal,
-    timeoutController: AbortController,
-    firstResponseTimeoutMs: number,
-    idleFlag: { timedOut: boolean },
+    watchdog: StreamWatchdog,
+    idleFlag: IdleFlag,
     onProviderError: (error: StructuredError) => void,
+    onStreamLiveness: StreamLivenessListener,
   ): Promise<{
     iterator: AsyncIterator<StreamEvent>;
     firstResult: IteratorResult<StreamEvent>;
   }> {
-    if (firstResponseTimeoutMs <= 0) {
-      // First-response watchdog explicitly disabled: direct acquire + first next.
+    if (!watchdog.isActive) {
       const iterator = await this.openResponseStreamIterator(
         req,
         timeoutSignal,
         onProviderError,
+        onStreamLiveness,
       );
       try {
         const firstResult = await iterator.next();
         return { iterator, firstResult };
       } catch (error) {
-        // On a first-next failure the iterator has not yet been handed to
-        // run() (streamIterator is still unassigned there), so close it here to
-        // avoid leaking the provider connection before rethrowing.
         await closeIteratorBounded(iterator, timeoutSignal);
         throw error;
       }
     }
 
-    // Dedicated timer cancelled in `finally` so it can never fire mid-stream.
-    const firstResponseTimer = new AbortController();
-    const timeoutPromise = delay(
-      firstResponseTimeoutMs,
-      firstResponseTimer.signal,
-    ).then(() => {
-      // If the parent already aborted, do NOT mask that with a timeout error:
-      // surface an AbortError so the race settles with the accurate cause.
-      // handleRunError yields UserCancelled either way, but the thrown error is
-      // then correct for any upstream diagnostics.
-      if (timeoutSignal.aborted) {
-        throw new DOMException('Aborted', 'AbortError');
-      }
-      idleFlag.timedOut = true;
-      timeoutController.abort();
-      throw new Error(TURN_STREAM_IDLE_TIMEOUT_ERROR_MESSAGE);
-    });
-    // Aborting the timer (in `finally`, once the event wins) rejects the
-    // delay() with an AbortError. Suppress it: the timeout losing the race is
-    // expected, and an unhandled rejection could otherwise crash under strict
-    // Node --unhandled-rejections modes.
-    timeoutPromise.catch(() => {});
-
-    // Race the ENTIRE first-response window: acquisition (sendMessageStream)
-    // AND the first .next(), because in production the network work happens on
-    // the first .next(), not necessarily during acquisition. The
-    // firstEventPromise chains acquisition then first-next; whichever of it or
-    // the timeout settles first wins.
     let acquiredIterator: AsyncIterator<StreamEvent> | undefined;
     const firstEventPromise = (async () => {
       const iterator = await this.openResponseStreamIterator(
         req,
         timeoutSignal,
         onProviderError,
+        onStreamLiveness,
       );
       acquiredIterator = iterator;
       const firstResult = await iterator.next();
       return { iterator, firstResult };
     })();
-    // Attach a no-op rejection handler immediately (mirroring timeoutPromise
-    // above) so that if firstEventPromise rejects in the brief window before
-    // the catch block below attaches the real cleanup handler, it cannot
-    // surface as an unhandled rejection under strict Node modes. Promise.race
-    // still delivers the rejection to the caller.
     firstEventPromise.catch(() => {});
 
     try {
-      const result = await Promise.race([firstEventPromise, timeoutPromise]);
-      // firstEventPromise won: the caller owns and later closes this iterator.
+      const result = await Promise.race([
+        firstEventPromise,
+        watchdog.timeoutPromise,
+      ]);
+      // Disarm phase A (first-response) via the semantic event so phase B
+      // (inter-chunk) stays armed for the rest of the stream. Do NOT cancel —
+      // the whole-stream watchdog must remain active (issue #2607 finding 2).
+      watchdog.onSemanticEvent();
       return result;
     } catch (error) {
-      // The timeout won (or acquisition/first-next threw). firstEventPromise is
-      // the loser, so its result is discarded and must be cleaned up. Attaching
-      // the cleanup HERE — only once we know firstEvent lost — makes correctness
-      // independent of microtask ordering: on the winning path above we return
-      // without ever attaching cleanup, so the returned iterator is never closed
-      // underneath the caller. On the losing path, close the iterator whether it
-      // resolves LATE (first event arrived just after the abort) or REJECTS (the
-      // aborted provider throws), and swallow the rejection to avoid an
-      // unhandled rejection under strict Node modes.
+      watchdog.cancel();
       await closeIteratorBounded(acquiredIterator, timeoutSignal);
       firstEventPromise
         .then(async (late) => {
@@ -861,9 +801,18 @@ export class Turn {
           }
         })
         .catch(() => undefined);
+      if (idleFlag.fire !== undefined) {
+        throw new Error(
+          formatStreamIdleTimeoutMessage(
+            idleFlag.fire,
+            idleFlag.livenessObserved,
+          ),
+        );
+      }
+      if (timeoutSignal.aborted) {
+        throw new DOMException('Aborted', 'AbortError');
+      }
       throw error;
-    } finally {
-      firstResponseTimer.abort();
     }
   }
 
@@ -876,6 +825,7 @@ export class Turn {
     req: TurnRequest,
     timeoutSignal: AbortSignal,
     onProviderError: (error: StructuredError) => void,
+    onStreamLiveness?: StreamLivenessListener,
   ): Promise<AsyncIterator<StreamEvent>> {
     // Bridge: chatSession.sendMessageStream still expects Google-shaped
     // SendMessageParameters (until P21). The value is structurally compatible;
@@ -888,6 +838,7 @@ export class Turn {
         config: {
           abortSignal: timeoutSignal,
           onProviderError,
+          ...(onStreamLiveness !== undefined ? { onStreamLiveness } : {}),
         },
       },
       this.prompt_id,

--- a/packages/agents/src/core/turn.watchdog.test.ts
+++ b/packages/agents/src/core/turn.watchdog.test.ts
@@ -1,0 +1,406 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the whole-stream watchdog and run-scoped isolation
+ * (issue #2607 findings 2, 3, 5). Extracted from turn.liveness.test.ts to
+ * stay under the max-lines lint limit. These tests exercise real Turn + real
+ * timers against mocked sendMessageStream boundaries — no mock interaction
+ * assertions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ServerAgentStreamEvent } from './turn.js';
+import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
+import type { ChatSession } from './chatSession.js';
+import { StreamEventType } from './chatSession.js';
+import { type MockedChatInstance, mockChunk } from './turn-test-helpers.js';
+
+const { mockSendMessageStream, mockGetHistory } = vi.hoisted(() => ({
+  mockSendMessageStream: vi.fn(),
+  mockGetHistory: vi.fn(),
+}));
+
+vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn(),
+}));
+
+vi.mock(
+  '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js')
+      >();
+    return {
+      analyzeResponseOutcome: actual.analyzeResponseOutcome,
+    };
+  },
+);
+
+type Part = { text: string };
+
+function buildTurn(
+  firstResponseMs?: number,
+  idleMs?: number,
+): {
+  turn: Turn;
+  mockChatInstance: MockedChatInstance;
+} {
+  const mockGetConfig = vi.fn().mockReturnValue({
+    getEphemeralSetting: (key: string) => {
+      if (key === 'stream-first-response-timeout-ms') {
+        return firstResponseMs;
+      }
+      if (key === 'stream-idle-timeout-ms') {
+        return idleMs;
+      }
+      return undefined;
+    },
+  });
+
+  const mockChatInstance = {
+    sendMessageStream: mockSendMessageStream,
+    getHistory: mockGetHistory,
+    getConfig: mockGetConfig,
+  } as unknown as MockedChatInstance;
+
+  const turn = new Turn(
+    mockChatInstance as unknown as ChatSession,
+    'prompt-id-watchdog',
+    DEFAULT_AGENT_ID,
+    'test',
+  );
+  mockGetHistory.mockReturnValue([]);
+  return { turn, mockChatInstance };
+}
+
+function failsafe(ms: number): { promise: Promise<never>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Test exceeded failsafe deadline of ${ms}ms`)),
+      ms,
+    );
+  });
+  promise.catch(() => {});
+  return { promise, cancel: () => clearTimeout(timer) };
+}
+
+describe('Turn - whole-stream watchdog & run-scoped isolation (issue #2607)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS;
+    delete process.env.LLXPRT_STREAM_IDLE_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('whole-stream liveness: first content, repeated liveness pings spanning longer than idle threshold, then more content => NO timeout', async () => {
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '200';
+    const { turn } = buildTurn(undefined, 30);
+
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'first' }),
+          };
+          for (let i = 0; i < 8; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            listener?.({
+              sourceEvent: 'response.in_progress',
+              sseObserved: true,
+            });
+          }
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'second' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    const guard = failsafe(3000);
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    const contentEvents = events.filter(
+      (e) => e.type === AgentEventType.Content,
+    );
+    expect(contentEvents.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('whole-stream liveness: after pings stop for the idle threshold => precise inter-chunk timeout', async () => {
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '200';
+    const { turn } = buildTurn(undefined, 40);
+
+    mockSendMessageStream.mockImplementation(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'first' }),
+          };
+          for (let i = 0; i < 3; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            listener?.({
+              sourceEvent: 'response.in_progress',
+              sseObserved: true,
+            });
+          }
+          await new Promise<void>(() => {});
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const events: ServerAgentStreamEvent[] = [];
+    const runPromise = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'Hi' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+    })();
+
+    const guard = failsafe(3000);
+    await Promise.race([runPromise, guard.promise]);
+    guard.cancel();
+
+    expect(
+      events.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeDefined();
+  });
+
+  it('two overlapping run calls cannot cross-contaminate timeout/source values (run-scoped isolation)', async () => {
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '500';
+    const { turn } = buildTurn(undefined, 60);
+
+    let releaseB!: () => void;
+    const gateB = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+    const gateA = new Promise<void>(() => {});
+
+    mockSendMessageStream.mockImplementationOnce(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          await gateA;
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'A' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    mockSendMessageStream.mockImplementationOnce(
+      (params: {
+        config?: {
+          onStreamLiveness?: (event: {
+            sourceEvent: string;
+            sseObserved: boolean;
+          }) => void;
+        };
+      }) => {
+        const listener = params.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          await gateB;
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'B' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const eventsA: ServerAgentStreamEvent[] = [];
+    const eventsB: ServerAgentStreamEvent[] = [];
+
+    const runA = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'A' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        eventsA.push(event);
+      }
+    })();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const runB = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'B' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        eventsB.push(event);
+      }
+    })();
+
+    const guard = failsafe(3000);
+    await Promise.race([runA, guard.promise]);
+    guard.cancel();
+
+    expect(
+      eventsA.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeDefined();
+
+    releaseB();
+    const guard2 = failsafe(3000);
+    await Promise.race([runB, guard2.promise]);
+    guard2.cancel();
+
+    expect(
+      eventsB.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    expect(eventsB.some((e) => e.type === AgentEventType.Content)).toBe(true);
+  });
+
+  it('tool lifecycle: tool call → completed result → continuation with liveness before delayed content does NOT false-timeout (issue #2607 finding 5)', async () => {
+    vi.useRealTimers();
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '50';
+    const { turn } = buildTurn(undefined, 0);
+
+    mockSendMessageStream.mockImplementationOnce(() => {
+      const stream = (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: mockChunk({
+            toolCalls: [
+              {
+                id: 'call_1',
+                name: 'run_shell_command',
+                args: { command: 'echo hi' },
+              },
+            ],
+            finishReason: 'tool_calls',
+          }),
+        };
+      })();
+      return Promise.resolve(stream);
+    });
+
+    mockSendMessageStream.mockImplementationOnce(
+      (
+        params: {
+          config?: {
+            onStreamLiveness?: (event: {
+              sourceEvent: string;
+              sseObserved: boolean;
+            }) => void;
+          };
+        } | null,
+      ) => {
+        const listener = params?.config?.onStreamLiveness;
+        const stream = (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          listener?.({ sourceEvent: 'response.created', sseObserved: true });
+          await new Promise((resolve) => setTimeout(resolve, 195));
+          yield {
+            type: StreamEventType.CHUNK,
+            value: mockChunk({ text: 'continuation result' }),
+          };
+        })();
+        return Promise.resolve(stream);
+      },
+    );
+
+    const firstEvents: ServerAgentStreamEvent[] = [];
+    const firstRun = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'do something' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        firstEvents.push(event);
+      }
+    })();
+    const guard1 = failsafe(2000);
+    await Promise.race([firstRun, guard1.promise]);
+    guard1.cancel();
+
+    expect(
+      firstEvents.some((e) => e.type === AgentEventType.ToolCallRequest),
+    ).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const secondEvents: ServerAgentStreamEvent[] = [];
+    const secondRun = (async () => {
+      for await (const event of turn.run(
+        [{ text: 'tool result' }] as unknown as Part[],
+        new AbortController().signal,
+      )) {
+        secondEvents.push(event);
+      }
+    })();
+    const guard2 = failsafe(3000);
+    await Promise.race([secondRun, guard2.promise]);
+    guard2.cancel();
+
+    expect(
+      secondEvents.find((e) => e.type === AgentEventType.StreamIdleTimeout),
+    ).toBeUndefined();
+    expect(secondEvents.some((e) => e.type === AgentEventType.Content)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/agents/src/core/turn.watchdog.test.ts
+++ b/packages/agents/src/core/turn.watchdog.test.ts
@@ -166,8 +166,8 @@ describe('Turn - whole-stream watchdog & run-scoped isolation (issue #2607)', ()
 
   it('whole-stream liveness: after pings stop for the idle threshold => precise inter-chunk timeout', async () => {
     vi.useRealTimers();
-    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '200';
-    const { turn } = buildTurn(undefined, 40);
+    process.env.LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS = '1000';
+    const { turn } = buildTurn(undefined, 200);
 
     mockSendMessageStream.mockImplementation(
       (params: {

--- a/packages/agents/src/core/turnJsonUtils.test.ts
+++ b/packages/agents/src/core/turnJsonUtils.test.ts
@@ -57,6 +57,10 @@ describe('safeJsonStringify', () => {
     const parsed = JSON.parse(result) as Record<string, unknown>;
     expect(Object.keys(parsed)).toStrictEqual(['a', 'b']);
   });
+
+  it('serializes BigInt values as JSON strings', () => {
+    expect(safeJsonStringify(1n)).toBe('"1"');
+  });
 });
 
 describe('isAbortSignalActive', () => {

--- a/packages/agents/src/core/turnJsonUtils.test.ts
+++ b/packages/agents/src/core/turnJsonUtils.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for turnJsonUtils helpers (issue #2607 OCR finding 5).
+ * Focuses on edge cases: safeJsonStringify must always return a string, and
+ * isAbortSignalActive must use strict checks without type assertions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { safeJsonStringify, isAbortSignalActive } from './turnJsonUtils.js';
+
+describe('safeJsonStringify', () => {
+  it('returns a string for a normal object', () => {
+    const result = safeJsonStringify({ a: 1 });
+    expect(typeof result).toBe('string');
+    expect(JSON.parse(result)).toStrictEqual({ a: 1 });
+  });
+
+  it('always returns a string for undefined (JSON.stringify returns undefined)', () => {
+    const result = safeJsonStringify(undefined);
+    expect(typeof result).toBe('string');
+    // JSON.stringify(undefined) === undefined, so we must synthesize a string.
+    expect(result).toBe('undefined');
+  });
+
+  it('always returns a string for a function (JSON.stringify returns undefined)', () => {
+    const result = safeJsonStringify(() => 42);
+    expect(typeof result).toBe('string');
+    expect(result).toBe('undefined');
+  });
+
+  it('always returns a string for a symbol (JSON.stringify returns undefined)', () => {
+    const result = safeJsonStringify(Symbol('s'));
+    expect(typeof result).toBe('string');
+    expect(result).toBe('undefined');
+  });
+
+  it('returns a string for null', () => {
+    const result = safeJsonStringify(null);
+    expect(result).toBe('null');
+  });
+
+  it('handles circular references without throwing', () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    const result = safeJsonStringify(obj);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('[Circular]');
+  });
+
+  it('sorts object keys deterministically', () => {
+    const result = safeJsonStringify({ b: 2, a: 1 });
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    expect(Object.keys(parsed)).toStrictEqual(['a', 'b']);
+  });
+});
+
+describe('isAbortSignalActive', () => {
+  it('returns false for undefined', () => {
+    expect(isAbortSignalActive(undefined)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isAbortSignalActive(null)).toBe(false);
+  });
+
+  it('returns false for a non-aborted AbortSignal', () => {
+    expect(isAbortSignalActive(new AbortController().signal)).toBe(false);
+  });
+
+  it('returns true for an aborted AbortSignal', () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(isAbortSignalActive(controller.signal)).toBe(true);
+  });
+
+  it('returns false for a plain object without aborted property', () => {
+    expect(isAbortSignalActive({})).toBe(false);
+  });
+
+  it('returns false for an object whose aborted is not exactly true', () => {
+    expect(isAbortSignalActive({ aborted: 'true' })).toBe(false);
+    expect(isAbortSignalActive({ aborted: 1 })).toBe(false);
+    expect(isAbortSignalActive({ aborted: undefined })).toBe(false);
+  });
+
+  it('returns true for an AbortSignal-like object with aborted === true', () => {
+    expect(isAbortSignalActive({ aborted: true })).toBe(true);
+  });
+});

--- a/packages/agents/src/core/turnJsonUtils.ts
+++ b/packages/agents/src/core/turnJsonUtils.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getErrorMessage } from '@vybestack/llxprt-code-core/utils/errors.js';
+import type {
+  StructuredError,
+  StructuredErrorCategory,
+  StructuredErrorReason,
+} from '@vybestack/llxprt-code-core/core/turn.js';
+
+const STRUCTURED_ERROR_CATEGORIES: ReadonlySet<string> = new Set([
+  'rate_limit',
+  'quota',
+  'authentication',
+  'server_error',
+  'network',
+  'client_error',
+]);
+
+function isStructuredErrorCategory(
+  value: unknown,
+): value is StructuredErrorCategory {
+  return typeof value === 'string' && STRUCTURED_ERROR_CATEGORIES.has(value);
+}
+
+function isStructuredErrorReason(
+  value: unknown,
+): value is StructuredErrorReason {
+  return value === 'retries_exhausted' || value === 'all_buckets_exhausted';
+}
+
+export function buildStructuredError(error: unknown): StructuredError {
+  if (typeof error !== 'object' || error === null) {
+    return { message: getErrorMessage(error) };
+  }
+
+  const status =
+    'status' in error && typeof error.status === 'number'
+      ? error.status
+      : undefined;
+  const category =
+    'category' in error && isStructuredErrorCategory(error.category)
+      ? error.category
+      : undefined;
+  const reason =
+    'reason' in error && isStructuredErrorReason(error.reason)
+      ? error.reason
+      : undefined;
+
+  return {
+    message: getErrorMessage(error),
+    ...(status !== undefined ? { status } : {}),
+    ...(category !== undefined ? { category } : {}),
+    ...(reason !== undefined ? { reason } : {}),
+  };
+}
+
+export function createSafeJsonReplacer(): (
+  key: string,
+  value: unknown,
+) => unknown {
+  const seen = new WeakSet<object>();
+  return (_key: string, value: unknown): unknown => {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+
+    if (typeof value !== 'object' || value === null) {
+      return value;
+    }
+
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    const record = value as Record<string, unknown>;
+    return Object.keys(record)
+      .sort()
+      .reduce<Record<string, unknown>>((sorted, key) => {
+        sorted[key] = record[key];
+        return sorted;
+      }, {});
+  };
+}
+
+export function safeJsonStringify(value: unknown, space?: number): string {
+  // JSON.stringify returns undefined for top-level undefined/functions/symbols.
+  // The contract is "always return string", so handle those cases explicitly.
+  if (
+    value === undefined ||
+    typeof value === 'function' ||
+    typeof value === 'symbol'
+  ) {
+    return 'undefined';
+  }
+  try {
+    return JSON.stringify(value, createSafeJsonReplacer(), space);
+  } catch (error) {
+    return `[Unserializable request: ${getErrorMessage(error)}]`;
+  }
+}
+
+export function isAbortSignalActive(signal: unknown): boolean {
+  if (signal === null || signal === undefined) return false;
+  if (typeof signal !== 'object') return false;
+  if ('aborted' in signal) {
+    return signal.aborted === true;
+  }
+  return false;
+}

--- a/packages/cli/src/config/postConfigRuntime.test.ts
+++ b/packages/cli/src/config/postConfigRuntime.test.ts
@@ -6,13 +6,18 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV,
   LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV,
+  resolveStreamFirstResponseTimeoutMs,
+  resolveStreamFirstResponseTimeoutMsSource,
   resolveStreamIdleTimeoutMs,
 } from '@vybestack/llxprt-code-core';
 import type { Settings } from './settings.js';
 import {
   applyGlobalAndProfileEphemeralSettings,
+  applyStreamFirstResponseTimeoutSettings,
   applyStreamIdleTimeoutSettings,
+  type StreamTimeoutSettingsInput,
 } from './postConfigRuntime.js';
 
 interface CapturingConfig {
@@ -54,7 +59,7 @@ describe('applyStreamIdleTimeoutSettings', () => {
 
   it('preserves hyphenated stream-idle-timeout-ms priority over streamIdleTimeoutMs', () => {
     const config = createCapturingConfig();
-    const settings: Settings & Record<string, unknown> = {
+    const settings: StreamTimeoutSettingsInput = {
       streamIdleTimeoutMs: 120_000,
       'stream-idle-timeout-ms': 60_000,
     };
@@ -92,12 +97,12 @@ describe('applyStreamIdleTimeoutSettings', () => {
     const stringConfig = createCapturingConfig();
     applyStreamIdleTimeoutSettings(stringConfig, {
       streamIdleTimeoutMs: '120000',
-    } as unknown as Settings & Record<string, unknown>);
+    } as unknown as StreamTimeoutSettingsInput);
 
     const invalidConfig = createCapturingConfig();
     applyStreamIdleTimeoutSettings(invalidConfig, {
       streamIdleTimeoutMs: 'abc',
-    } as unknown as Settings & Record<string, unknown>);
+    } as unknown as StreamTimeoutSettingsInput);
 
     const nanConfig = createCapturingConfig();
     applyStreamIdleTimeoutSettings(nanConfig, {
@@ -110,12 +115,78 @@ describe('applyStreamIdleTimeoutSettings', () => {
   });
 });
 
+describe('applyStreamFirstResponseTimeoutSettings @issue:2607', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('wires streamFirstResponseTimeoutMs settings into runtime timeout resolution', () => {
+    const config = createCapturingConfig();
+    const settings: Settings = { streamFirstResponseTimeoutMs: 200_000 };
+
+    applyStreamFirstResponseTimeoutSettings(config, settings);
+
+    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(
+      200_000,
+    );
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
+  });
+
+  it('preserves hyphenated stream-first-response-timeout-ms priority over camelCase', () => {
+    const config = createCapturingConfig();
+    const settings: StreamTimeoutSettingsInput = {
+      streamFirstResponseTimeoutMs: 200_000,
+      'stream-first-response-timeout-ms': 100_000,
+    };
+
+    applyStreamFirstResponseTimeoutSettings(config, settings);
+
+    expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
+      100_000,
+    );
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(100_000);
+  });
+
+  it('keeps the environment variable as the highest priority after settings are wired', () => {
+    process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV] = '420000';
+    const config = createCapturingConfig();
+    const settings: Settings = { streamFirstResponseTimeoutMs: 200_000 };
+
+    applyStreamFirstResponseTimeoutSettings(config, settings);
+
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(420_000);
+  });
+
+  it('preserves zero and negative settings as watchdog disable values', () => {
+    const zeroConfig = createCapturingConfig();
+    applyStreamFirstResponseTimeoutSettings(zeroConfig, {
+      streamFirstResponseTimeoutMs: 0,
+    });
+
+    const negativeConfig = createCapturingConfig();
+    applyStreamFirstResponseTimeoutSettings(negativeConfig, {
+      streamFirstResponseTimeoutMs: -1,
+    });
+
+    expect(resolveStreamFirstResponseTimeoutMs(zeroConfig)).toBe(0);
+    expect(resolveStreamFirstResponseTimeoutMs(negativeConfig)).toBe(0);
+  });
+});
+
 describe('applyGlobalAndProfileEphemeralSettings', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV];
+    delete process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV];
   });
 
   afterEach(() => {
@@ -261,5 +332,164 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
     });
 
     expect(resolveStreamIdleTimeoutMs(config)).toBe(120_000);
+  });
+
+  it('applies stream first-response timeout from profile ephemerals when profile settings are active @issue:2607', () => {
+    const config = createCapturingConfig();
+
+    applyGlobalAndProfileEphemeralSettings({
+      config,
+      bootstrapArgs: { profileJson: null },
+      argv: { provider: undefined },
+      settings: {},
+      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 200_000 },
+      profileLoadResult: { profileToLoad: 'work' },
+    });
+
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
+  });
+
+  it('skips stream first-response timeout profile ephemerals when provider is explicit @issue:2607', () => {
+    const config = createCapturingConfig();
+
+    applyGlobalAndProfileEphemeralSettings({
+      config,
+      bootstrapArgs: { profileJson: null },
+      argv: { provider: 'openai' },
+      settings: { streamFirstResponseTimeoutMs: 180_000 },
+      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 200_000 },
+      profileLoadResult: { profileToLoad: 'work' },
+    });
+
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(180_000);
+  });
+
+  it('profile stream first-response timeout overrides global when profile is active @issue:2607', () => {
+    const config = createCapturingConfig();
+
+    applyGlobalAndProfileEphemeralSettings({
+      config,
+      bootstrapArgs: { profileJson: null },
+      argv: { provider: undefined },
+      settings: { streamFirstResponseTimeoutMs: 180_000 },
+      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 200_000 },
+      profileLoadResult: { profileToLoad: 'work' },
+    });
+
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
+  });
+
+  it('zero disables the first-response watchdog via profile @issue:2607', () => {
+    const config = createCapturingConfig();
+
+    applyGlobalAndProfileEphemeralSettings({
+      config,
+      bootstrapArgs: { profileJson: null },
+      argv: { provider: undefined },
+      settings: {},
+      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 0 },
+      profileLoadResult: { profileToLoad: 'work' },
+    });
+
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(0);
+  });
+});
+
+describe('applyStreamFirstResponseTimeoutSettings — default-source provenance (issue #2607 finding 4)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('reports the built-in fallback as the default when no setting is present', () => {
+    const config = createCapturingConfig();
+
+    applyStreamFirstResponseTimeoutSettings(config, {});
+
+    expect(
+      config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+    ).toBeUndefined();
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(300_000);
+    expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
+      'default',
+    );
+  });
+
+  it('preserves an explicit value equal to the built-in fallback', () => {
+    const config = createCapturingConfig();
+
+    applyStreamFirstResponseTimeoutSettings(config, {
+      streamFirstResponseTimeoutMs: 300_000,
+    });
+
+    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(
+      300_000,
+    );
+    expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
+      'streamFirstResponseTimeoutMs',
+    );
+  });
+
+  it('writes an explicit non-default value as an ephemeral (source=setting key)', () => {
+    const config = createCapturingConfig();
+    applyStreamFirstResponseTimeoutSettings(config, {
+      streamFirstResponseTimeoutMs: 200_000,
+    });
+
+    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(
+      200_000,
+    );
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
+    expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
+      'streamFirstResponseTimeoutMs',
+    );
+  });
+
+  it('writes 0 (disable) as an explicit ephemeral even though it is not the built-in default', () => {
+    const config = createCapturingConfig();
+    applyStreamFirstResponseTimeoutSettings(config, {
+      streamFirstResponseTimeoutMs: 0,
+    });
+
+    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(0);
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(0);
+    expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
+      'streamFirstResponseTimeoutMs',
+    );
+  });
+
+  it('writes the hyphenated canonical key when it is NOT the built-in default', () => {
+    const config = createCapturingConfig();
+    applyStreamFirstResponseTimeoutSettings(config, {
+      'stream-first-response-timeout-ms': 120_000,
+    });
+
+    expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
+      120_000,
+    );
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(120_000);
+    expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
+      'stream-first-response-timeout-ms',
+    );
+  });
+
+  it('preserves an explicit canonical value equal to the built-in fallback', () => {
+    const config = createCapturingConfig();
+    applyStreamFirstResponseTimeoutSettings(config, {
+      'stream-first-response-timeout-ms': 300_000,
+    });
+
+    expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
+      300_000,
+    );
+    expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
+      'stream-first-response-timeout-ms',
+    );
   });
 });

--- a/packages/cli/src/config/postConfigRuntime.test.ts
+++ b/packages/cli/src/config/postConfigRuntime.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
   LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV,
   LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV,
   resolveStreamFirstResponseTimeoutMs,
@@ -415,7 +416,9 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
     expect(
       config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
     ).toBeUndefined();
-    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(300_000);
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(
+      DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
+    );
     expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
       'default',
     );
@@ -425,11 +428,11 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
     const config = createCapturingConfig();
 
     applyStreamFirstResponseTimeoutSettings(config, {
-      streamFirstResponseTimeoutMs: 300_000,
+      streamFirstResponseTimeoutMs: DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
     });
 
     expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(
-      300_000,
+      DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
     );
     expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
       'streamFirstResponseTimeoutMs',
@@ -482,11 +485,12 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
   it('preserves an explicit canonical value equal to the built-in fallback', () => {
     const config = createCapturingConfig();
     applyStreamFirstResponseTimeoutSettings(config, {
-      'stream-first-response-timeout-ms': 300_000,
+      'stream-first-response-timeout-ms':
+        DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
     });
 
     expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
-      300_000,
+      DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
     );
     expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
       'stream-first-response-timeout-ms',

--- a/packages/cli/src/config/postConfigRuntime.ts
+++ b/packages/cli/src/config/postConfigRuntime.ts
@@ -6,6 +6,8 @@
 
 import {
   ApprovalMode,
+  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+  STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
   STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
   STREAM_IDLE_TIMEOUT_SETTING_KEY,
   type Config,
@@ -84,33 +86,73 @@ type ApplyToolPoliciesInput = Pick<
 
 // ─── Sub-functions ────────────────────────────────────────────────────────────
 
+// ─── Stream timeout settings application ───────────────────────────────────
+
+/**
+ * Profile/runtime settings input that may carry either the camelCase Settings
+ * key or the canonical hyphenated ephemeral key. The hyphenated keys are NOT
+ * part of the public JSON Settings schema (they would falsely advertise
+ * themselves as JSON properties); they are modeled locally here because
+ * profiles and runtime code historically set them as ephemerals directly.
+ */
+export type StreamTimeoutSettingsInput = Settings & {
+  readonly 'stream-idle-timeout-ms'?: unknown;
+  readonly 'stream-first-response-timeout-ms'?: unknown;
+};
+
+/**
+ * Generic applicator for a camel/hyphenated timeout setting pair. Reads both
+ * the camelCase Settings key and the canonical hyphenated ephemeral key from
+ * the supplied settings object and pushes whichever are defined onto Config
+ * ephemerals. The hyphenated key is applied second so it wins the resolver's
+ * priority order (canonical before alias).
+ */
+function applyStreamTimeoutSettingPair(
+  config: Pick<Config, 'setEphemeralSetting'>,
+  settings: StreamTimeoutSettingsInput,
+  camelKey: keyof Settings,
+  canonicalKey: 'stream-idle-timeout-ms' | 'stream-first-response-timeout-ms',
+): void {
+  const camelValue = settings[camelKey];
+  if (camelValue !== undefined) {
+    config.setEphemeralSetting(camelKey, camelValue);
+  }
+  const canonicalValue = settings[canonicalKey];
+  if (canonicalValue !== undefined) {
+    config.setEphemeralSetting(canonicalKey, canonicalValue);
+  }
+}
+
 export function applyStreamIdleTimeoutSettings(
   config: Pick<Config, 'setEphemeralSetting'>,
-  settings: Settings,
+  settings: StreamTimeoutSettingsInput,
 ): void {
-  const camelCaseValue = settings.streamIdleTimeoutMs;
-  if (camelCaseValue !== undefined) {
-    config.setEphemeralSetting(
-      STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
-      camelCaseValue,
-    );
-  }
-  const settingsRecord = settings as Record<string, unknown>;
-  const hyphenatedValue = settingsRecord[STREAM_IDLE_TIMEOUT_SETTING_KEY];
-  if (hyphenatedValue !== undefined) {
-    config.setEphemeralSetting(
-      STREAM_IDLE_TIMEOUT_SETTING_KEY,
-      hyphenatedValue,
-    );
-  }
+  applyStreamTimeoutSettingPair(
+    config,
+    settings,
+    STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+    STREAM_IDLE_TIMEOUT_SETTING_KEY,
+  );
+}
+
+export function applyStreamFirstResponseTimeoutSettings(
+  config: Pick<Config, 'setEphemeralSetting'>,
+  settings: StreamTimeoutSettingsInput,
+): void {
+  applyStreamTimeoutSettingPair(
+    config,
+    settings,
+    STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+    STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
+  );
 }
 
 interface ProfileEphemeralSettingsInput {
   readonly config: Pick<Config, 'setEphemeralSetting'>;
   readonly bootstrapArgs: Pick<BootstrapProfileArgs, 'profileJson'>;
   readonly argv: Pick<CliArgs, 'provider'>;
-  readonly settings: Settings;
-  readonly profileSettingsWithTools: Settings;
+  readonly settings: StreamTimeoutSettingsInput;
+  readonly profileSettingsWithTools: StreamTimeoutSettingsInput;
   readonly profileLoadResult: Pick<ProfileLoadResult, 'profileToLoad'>;
 }
 
@@ -128,6 +170,7 @@ export function applyGlobalAndProfileEphemeralSettings(
 
   // Global settings must apply even when --provider suppresses profile values.
   applyStreamIdleTimeoutSettings(config, settings);
+  applyStreamFirstResponseTimeoutSettings(config, settings);
 
   const profileToLoad = profileLoadResult.profileToLoad;
   const shouldApplyProfileSettings =
@@ -138,6 +181,7 @@ export function applyGlobalAndProfileEphemeralSettings(
   }
 
   applyStreamIdleTimeoutSettings(config, profileSettingsWithTools);
+  applyStreamFirstResponseTimeoutSettings(config, profileSettingsWithTools);
 
   const ephemeralKeys = [
     'auth-key',

--- a/packages/cli/src/config/settings-schema/schema-core.ts
+++ b/packages/cli/src/config/settings-schema/schema-core.ts
@@ -193,6 +193,18 @@ export const CORE_SETTINGS_SCHEMA = {
     showInDialog: false,
   },
 
+  streamFirstResponseTimeoutMs: {
+    type: 'number',
+    label: 'Stream First-Response Timeout (ms)',
+    category: 'Streaming',
+    requiresRestart: false,
+    default: undefined as number | undefined,
+    documentedDefault: 300000,
+    description:
+      'First-response (time-to-first-content) watchdog in milliseconds. Enabled by default (300000 = 5 minutes). A provider liveness signal (e.g. response.created) disarms it even before semantic content arrives. Set to 0 or a negative number to disable.',
+    showInDialog: false,
+  },
+
   useExternalAuth: {
     type: 'boolean',
     label: 'Use External Auth',

--- a/packages/cli/src/config/settings-schema/types.ts
+++ b/packages/cli/src/config/settings-schema/types.ts
@@ -111,6 +111,20 @@ export interface SettingDefinition {
    * (e.g. multipleOf 1 restricts to integers).
    */
   multipleOf?: number;
+  /**
+   * Documented/schema default shown to users in generated JSON schema and docs
+   * when it differs from the runtime merge default (`default`).
+   *
+   * Use this when a setting's advertised public default must NOT be materialized
+   * by settingsMerge — for example, a watchdog whose runtime default is
+   * `undefined` (disabled at the settings layer) but whose documented contract
+   * is a concrete value applied later by runtime logic (e.g. ephemeral
+   * resolution with a built-in fallback). Generators prefer `documentedDefault`
+   * over `default` for the emitted `default`/markdown; settingsMerge continues
+   * to use only `default`, so the runtime value stays `undefined` unless a user
+   * sets it explicitly.
+   */
+  documentedDefault?: SettingsValue;
 }
 
 export interface SettingsSchema {

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -43,6 +43,12 @@ type GeneratedSettingsSchema = {
       minimum?: number;
       maximum?: number;
     };
+    streamFirstResponseTimeoutMs?: {
+      type?: string;
+      default?: number;
+      minimum?: number;
+      maximum?: number;
+    };
   };
   $defs: {
     ModelConfig: {
@@ -424,6 +430,78 @@ describe('SettingsSchema', () => {
         expect(setting).toBeDefined();
         expect(setting?.type).toBe('number');
         expect(setting?.default).toBe(0);
+        expect(setting?.minimum).toBeUndefined();
+        expect(setting?.maximum).toBeUndefined();
+      });
+    });
+
+    describe('streamFirstResponseTimeoutMs', () => {
+      it('should be defined as a top-level setting in SETTINGS_SCHEMA', () => {
+        expect(SETTINGS_SCHEMA.streamFirstResponseTimeoutMs).toBeDefined();
+      });
+
+      it('should be a number type in SETTINGS_SCHEMA', () => {
+        expect(SETTINGS_SCHEMA.streamFirstResponseTimeoutMs.type).toBe(
+          'number',
+        );
+      });
+
+      it('should not define minimum or maximum constraints (permissive finite-number intent)', () => {
+        expect('minimum' in SETTINGS_SCHEMA.streamFirstResponseTimeoutMs).toBe(
+          false,
+        );
+        expect('maximum' in SETTINGS_SCHEMA.streamFirstResponseTimeoutMs).toBe(
+          false,
+        );
+      });
+
+      it('should keep runtime default undefined so settings merge does not materialize an unconfigured ephemeral', () => {
+        expect(
+          SETTINGS_SCHEMA.streamFirstResponseTimeoutMs.default,
+        ).toBeUndefined();
+      });
+
+      it('should advertise a documented/schema default of 300000 via documentedDefault', () => {
+        expect(
+          SETTINGS_SCHEMA.streamFirstResponseTimeoutMs.documentedDefault,
+        ).toBe(300000);
+      });
+
+      it('should accept a positive integer value via validation', () => {
+        const result = validateSettings({ streamFirstResponseTimeoutMs: 5000 });
+        expect(result.success).toBe(true);
+      });
+
+      it('should accept zero (watchdog disabled) via validation', () => {
+        const result = validateSettings({ streamFirstResponseTimeoutMs: 0 });
+        expect(result.success).toBe(true);
+      });
+
+      it('should accept a negative value via validation (no minimum constraint)', () => {
+        const result = validateSettings({ streamFirstResponseTimeoutMs: -1 });
+        expect(result.success).toBe(true);
+      });
+
+      it('should accept a fractional value via validation (no multipleOf constraint)', () => {
+        const result = validateSettings({
+          streamFirstResponseTimeoutMs: 0.5,
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should accept the documented default 300000 via validation (explicit setting still applied)', () => {
+        const result = validateSettings({
+          streamFirstResponseTimeoutMs: 300000,
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should advertise default 300000 in the generated settings.schema.json (documentedDefault precedence over undefined runtime default)', () => {
+        const setting =
+          parsedGeneratedSchema.properties.streamFirstResponseTimeoutMs;
+        expect(setting).toBeDefined();
+        expect(setting?.type).toBe('number');
+        expect(setting?.default).toBe(300000);
         expect(setting?.minimum).toBeUndefined();
         expect(setting?.maximum).toBeUndefined();
       });

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -104,6 +104,7 @@ describe('SettingsSchema', () => {
         'allowPtyThemeOverride',
         'ptyScrollbackLimit',
         'streamIdleTimeoutMs',
+        'streamFirstResponseTimeoutMs',
       ];
 
       expectedSettings.forEach((setting) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -471,6 +471,10 @@
       "bun": "./src/utils/streamIdleTimeout.ts",
       "import": "./dist/src/utils/streamIdleTimeout.js"
     },
+    "./utils/streamWatchdog.js": {
+      "bun": "./src/utils/streamWatchdog.ts",
+      "import": "./dist/src/utils/streamWatchdog.js"
+    },
     "./utils/terminalSerializer.js": {
       "bun": "./src/utils/terminalSerializer.ts",
       "import": "./dist/src/utils/terminalSerializer.js"

--- a/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
+++ b/packages/core/src/runtime/contracts/RuntimeProviderChat.ts
@@ -23,6 +23,7 @@ import type { ProviderRuntimeContext } from '../providerRuntimeContext.js';
 import type { RuntimeInvocationContext } from '../RuntimeInvocationContext.js';
 import type { TelemetryContext } from './TelemetryContext.js';
 import type { StructuredError } from '../../core/turn.js';
+import type { StreamLivenessListener } from '../../utils/streamIdleTimeout.js';
 
 export interface RuntimeProviderTool {
   type: 'function';
@@ -63,6 +64,15 @@ export interface RuntimeGenerateChatOptions {
   runtime?: ProviderRuntimeContext;
   invocation?: RuntimeInvocationContext;
   onProviderError?: (error: StructuredError) => void;
+  /**
+   * Optional provider-neutral transport-liveness listener (issue #2607).
+   * Providers that observe raw lifecycle evidence (e.g. an OpenAI Responses
+   * `response.created` SSE event) should invoke this to signal the connection
+   * is alive even before any semantic IContent is produced. The Turn-level
+   * first-response watchdog uses this to avoid false timeouts on healthy
+   * reasoning-model streams.
+   */
+  onStreamLiveness?: StreamLivenessListener;
   metadata?: Record<string, unknown>;
   resolved?: {
     model?: string;

--- a/packages/core/src/utils/streamIdleTimeout.liveness.test.ts
+++ b/packages/core/src/utils/streamIdleTimeout.liveness.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type StreamLivenessEvent,
+  resolveStreamIdleTimeoutMs,
+  resolveStreamFirstResponseTimeoutMs,
+  resolveStreamIdleTimeoutMsSource,
+  resolveStreamFirstResponseTimeoutMsSource,
+  DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+  DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
+  LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV,
+  LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV,
+  STREAM_IDLE_TIMEOUT_SETTING_KEY,
+  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+  STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
+  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+} from './streamIdleTimeout.js';
+
+describe('StreamLivenessEvent', () => {
+  it('accepts a source event name and sseObserved flag', () => {
+    const event: StreamLivenessEvent = {
+      sourceEvent: 'response.created',
+      sseObserved: true,
+    };
+    expect(event.sourceEvent).toBe('response.created');
+    expect(event.sseObserved).toBe(true);
+  });
+
+  it('allows sseObserved to be false for a non-sse liveness source', () => {
+    const event: StreamLivenessEvent = {
+      sourceEvent: 'http-headers',
+      sseObserved: false,
+    };
+    expect(event.sseObserved).toBe(false);
+  });
+});
+
+describe('resolveStreamIdleTimeoutMsSource', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('reports source "default" when nothing is configured', () => {
+    const { ms, source } = resolveStreamIdleTimeoutMsSource();
+    expect(ms).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
+    expect(source).toBe('default');
+  });
+
+  it('reports source "env" when the env var is set', () => {
+    process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV] = '120000';
+    const { ms, source } = resolveStreamIdleTimeoutMsSource();
+    expect(ms).toBe(120_000);
+    expect(source).toBe('env');
+  });
+
+  it('reports the hyphenated setting key when it is set', () => {
+    const mockConfig = {
+      getEphemeralSetting: (key: string) =>
+        key === STREAM_IDLE_TIMEOUT_SETTING_KEY ? 180_000 : undefined,
+    };
+    const { ms, source } = resolveStreamIdleTimeoutMsSource(mockConfig);
+    expect(ms).toBe(180_000);
+    expect(source).toBe(STREAM_IDLE_TIMEOUT_SETTING_KEY);
+  });
+
+  it('reports the camelCase alias when only it is set', () => {
+    const mockConfig = {
+      getEphemeralSetting: (key: string) =>
+        key === STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY ? 90_000 : undefined,
+    };
+    const { ms, source } = resolveStreamIdleTimeoutMsSource(mockConfig);
+    expect(ms).toBe(90_000);
+    expect(source).toBe(STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY);
+  });
+
+  it('env var takes precedence over both setting keys for source', () => {
+    process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV] = '5000';
+    const mockConfig = {
+      getEphemeralSetting: () => 60_000,
+    };
+    const { ms, source } = resolveStreamIdleTimeoutMsSource(mockConfig);
+    expect(ms).toBe(5_000);
+    expect(source).toBe('env');
+  });
+
+  it('matches the legacy numeric resolver exactly', () => {
+    process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV] = '42000';
+    const mockConfig = {
+      getEphemeralSetting: (key: string) =>
+        key === STREAM_IDLE_TIMEOUT_SETTING_KEY ? 100_000 : undefined,
+    };
+    expect(resolveStreamIdleTimeoutMsSource(mockConfig).ms).toBe(
+      resolveStreamIdleTimeoutMs(mockConfig),
+    );
+  });
+});
+
+describe('resolveStreamFirstResponseTimeoutMsSource', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('reports source "default" when nothing is configured', () => {
+    const { ms, source } = resolveStreamFirstResponseTimeoutMsSource();
+    expect(ms).toBe(DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS);
+    expect(source).toBe('default');
+  });
+
+  it('reports source "env" when the env var is set', () => {
+    process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV] = '60000';
+    const { ms, source } = resolveStreamFirstResponseTimeoutMsSource();
+    expect(ms).toBe(60_000);
+    expect(source).toBe('env');
+  });
+
+  it('reports the hyphenated setting key when it is set', () => {
+    const mockConfig = {
+      getEphemeralSetting: (key: string) =>
+        key === STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY ? 180_000 : undefined,
+    };
+    const { ms, source } =
+      resolveStreamFirstResponseTimeoutMsSource(mockConfig);
+    expect(ms).toBe(180_000);
+    expect(source).toBe(STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY);
+  });
+
+  it('reports the camelCase alias when only it is set', () => {
+    const mockConfig = {
+      getEphemeralSetting: (key: string) =>
+        key === STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY
+          ? 150_000
+          : undefined,
+    };
+    const { ms, source } =
+      resolveStreamFirstResponseTimeoutMsSource(mockConfig);
+    expect(ms).toBe(150_000);
+    expect(source).toBe(STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY);
+  });
+
+  it('env var takes precedence over both canonical and camelCase ephemerals for source', () => {
+    process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV] = '7000';
+    const mockConfig = {
+      getEphemeralSetting: () => 100_000,
+    };
+    const { ms, source } =
+      resolveStreamFirstResponseTimeoutMsSource(mockConfig);
+    expect(ms).toBe(7_000);
+    expect(source).toBe('env');
+  });
+
+  it('matches the legacy numeric resolver exactly', () => {
+    process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV] = '42000';
+    const mockConfig = {
+      getEphemeralSetting: () => 100_000,
+    };
+    expect(resolveStreamFirstResponseTimeoutMsSource(mockConfig).ms).toBe(
+      resolveStreamFirstResponseTimeoutMs(mockConfig),
+    );
+  });
+});

--- a/packages/core/src/utils/streamIdleTimeout.ts
+++ b/packages/core/src/utils/streamIdleTimeout.ts
@@ -14,6 +14,36 @@ export class StreamIdleTimeoutError extends Error {
 }
 
 /**
+ * A provider-neutral transport/provider liveness signal (issue #2607).
+ *
+ * Emitted by a provider SSE parser when a raw lifecycle event (e.g. OpenAI
+ * Responses `response.created` / `response.in_progress`) proves the HTTP
+ * response and SSE stream are alive, even when no semantic IContent has been
+ * yielded yet. This satisfies the first-response watchdog without requiring
+ * visible model output, preventing false timeouts on healthy reasoning-model
+ * continuations.
+ */
+export interface StreamLivenessEvent {
+  /**
+   * The provider event name that established liveness (e.g.
+   * 'response.created', 'response.in_progress', 'http-headers').
+   */
+  readonly sourceEvent: string;
+  /**
+   * Whether the liveness was observed at the SSE layer (a parsed SSE data
+   * event) versus a coarser signal (e.g. HTTP response headers received).
+   */
+  readonly sseObserved: boolean;
+}
+
+/**
+ * Listener invoked by a provider stream parser when a liveness signal is
+ * observed. Listener failures MUST NOT break stream parsing; parsers wrap
+ * invocations in try/catch.
+ */
+export type StreamLivenessListener = (event: StreamLivenessEvent) => void;
+
+/**
  * Default stream idle timeout in milliseconds.
  * Disabled by default (0). Set to a positive number via
  * LLXPRT_STREAM_IDLE_TIMEOUT_MS env var or 'stream-idle-timeout-ms'
@@ -124,15 +154,34 @@ function normalizeTimeoutConfigValue(value: unknown): number | undefined {
  * Values <= 0 are normalized to 0 (disabled sentinel).
  * Invalid/empty string values fall through to the next priority level.
  */
-function resolveTimeout(
+
+/**
+ * The provenance of a resolved timeout value, for diagnostics. 'default' means
+ * the fallback default was used; 'env' means the environment variable won;
+ * otherwise the value is the specific ephemeral setting key (hyphenated or
+ * camelCase alias) that supplied the value.
+ */
+export type StreamTimeoutSource = 'default' | 'env' | (string & {});
+
+export interface ResolvedStreamTimeout {
+  readonly ms: number;
+  readonly source: StreamTimeoutSource;
+}
+
+/**
+ * Like {@link resolveTimeout} but also reports which input supplied the value
+ * (issue #2607 diagnostics). Mirrors the exact priority/normalization rules so
+ * callers can rely on `.ms` being identical to the numeric resolver.
+ */
+function resolveTimeoutSource(
   envName: string,
   configKeys: readonly string[],
   fallbackDefault: number,
   config?: { getEphemeralSetting?: (key: string) => unknown },
-): number {
+): ResolvedStreamTimeout {
   const envValue = normalizeTimeoutConfigValue(process.env[envName]);
   if (envValue !== undefined) {
-    return envValue;
+    return { ms: envValue, source: 'env' };
   }
 
   for (const settingKey of configKeys) {
@@ -140,11 +189,11 @@ function resolveTimeout(
       config?.getEphemeralSetting?.(settingKey),
     );
     if (configValue !== undefined) {
-      return configValue;
+      return { ms: configValue, source: settingKey };
     }
   }
 
-  return fallbackDefault;
+  return { ms: fallbackDefault, source: 'default' };
 }
 
 /**
@@ -169,7 +218,23 @@ function resolveTimeout(
 export function resolveStreamIdleTimeoutMs(config?: {
   getEphemeralSetting?: (key: string) => unknown;
 }): number {
-  return resolveTimeout(
+  return resolveTimeoutSource(
+    LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV,
+    STREAM_IDLE_TIMEOUT_CONFIG_KEYS,
+    DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+    config,
+  ).ms;
+}
+
+/**
+ * Source-aware variant of {@link resolveStreamIdleTimeoutMs}. Returns both the
+ * resolved ms value and the provenance ('env', a setting key, or 'default').
+ * The `.ms` field is identical to {@link resolveStreamIdleTimeoutMs}.
+ */
+export function resolveStreamIdleTimeoutMsSource(config?: {
+  getEphemeralSetting?: (key: string) => unknown;
+}): ResolvedStreamTimeout {
+  return resolveTimeoutSource(
     LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV,
     STREAM_IDLE_TIMEOUT_CONFIG_KEYS,
     DEFAULT_STREAM_IDLE_TIMEOUT_MS,
@@ -201,7 +266,24 @@ export function resolveStreamIdleTimeoutMs(config?: {
 export function resolveStreamFirstResponseTimeoutMs(config?: {
   getEphemeralSetting?: (key: string) => unknown;
 }): number {
-  return resolveTimeout(
+  return resolveTimeoutSource(
+    LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV,
+    STREAM_FIRST_RESPONSE_CONFIG_KEYS,
+    DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
+    config,
+  ).ms;
+}
+
+/**
+ * Source-aware variant of {@link resolveStreamFirstResponseTimeoutMs}. Returns
+ * both the resolved ms value and the provenance ('env', a setting key, or
+ * 'default'). The `.ms` field is identical to
+ * {@link resolveStreamFirstResponseTimeoutMs}.
+ */
+export function resolveStreamFirstResponseTimeoutMsSource(config?: {
+  getEphemeralSetting?: (key: string) => unknown;
+}): ResolvedStreamTimeout {
+  return resolveTimeoutSource(
     LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV,
     STREAM_FIRST_RESPONSE_CONFIG_KEYS,
     DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,

--- a/packages/core/src/utils/streamWatchdog.test.ts
+++ b/packages/core/src/utils/streamWatchdog.test.ts
@@ -337,6 +337,15 @@ describe('createStreamWatchdog', () => {
       wd.cancel();
       expect(wd.isActive).toBe(false);
     });
+
+    it('ignores liveness after cancellation', () => {
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 100, idleMs: 30 }),
+      );
+      wd.cancel();
+      wd.onLiveness(livenessPing());
+      expect(wd.isActive).toBe(false);
+    });
   });
 
   describe('whole-stream liveness-aware idle (issue #2607 finding 2)', () => {

--- a/packages/core/src/utils/streamWatchdog.test.ts
+++ b/packages/core/src/utils/streamWatchdog.test.ts
@@ -1,0 +1,549 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral unit tests for the two-phase stream watchdog (issue #2607).
+ *
+ * The watchdog bounds the time-to-first-response window with two phases:
+ * - Phase A (first-response): fires after firstResponseMs unless disarmed by
+ *   a provider liveness signal.
+ * - Phase B (post-liveness idle): armed/rearmed on each liveness ping when
+ *   idleMs > 0; covers silence after liveness but before first content.
+ *
+ * Tests use fake timers for deterministic verification. "Does not fire"
+ * assertions advance fake timers past the deadline and inspect state directly
+ * rather than racing with setTimeout.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createStreamWatchdog,
+  type StreamWatchdogOptions,
+} from './streamWatchdog.js';
+import type { StreamLivenessEvent } from './streamIdleTimeout.js';
+
+function defaultOpts(
+  overrides: Partial<StreamWatchdogOptions> = {},
+): StreamWatchdogOptions {
+  return {
+    firstResponseMs: 100,
+    firstResponseSource: 'stream-first-response-timeout-ms',
+    idleMs: 0,
+    idleSource: 'stream-idle-timeout-ms',
+    ...overrides,
+  };
+}
+
+const livenessPing = (
+  sourceEvent = 'response.created',
+): StreamLivenessEvent => ({
+  sourceEvent,
+  sseObserved: true,
+});
+
+describe('createStreamWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('disabled state (firstResponseMs <= 0)', () => {
+    it('is not active and never fires', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 0 }));
+      expect(wd.isActive).toBe(false);
+
+      vi.advanceTimersByTime(10_000);
+      expect(wd.getFire()).toBeUndefined();
+    });
+
+    it('onLiveness is a no-op that does not throw', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 0 }));
+      expect(() => wd.onLiveness(livenessPing())).not.toThrow();
+    });
+
+    it('cancel does not throw', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 0 }));
+      expect(() => wd.cancel()).not.toThrow();
+    });
+
+    it('getFire returns undefined', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 0 }));
+      expect(wd.getFire()).toBeUndefined();
+    });
+  });
+
+  describe('phase A (first-response)', () => {
+    it('fires after firstResponseMs when no liveness arrives', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, onFire }),
+      );
+      expect(wd.isActive).toBe(true);
+
+      const promise = wd.timeoutPromise;
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expect(promise).rejects.toThrow('Stream watchdog timeout');
+      expect(onFire).toHaveBeenCalledTimes(1);
+      expect(wd.getFire()).toStrictEqual({
+        guard: 'first-response',
+        thresholdMs: 50,
+        configSource: 'stream-first-response-timeout-ms',
+      });
+    });
+
+    it('does not fire before firstResponseMs', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 100, onFire }),
+      );
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.getFire()).toBeUndefined();
+    });
+  });
+
+  describe('liveness disarm (phase A → phase B)', () => {
+    it('a liveness ping before the deadline disarms phase A', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, idleMs: 0, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.getFire()).toBeUndefined();
+    });
+
+    it('arms phase B (idleMs > 0) after liveness, fires on idle silence', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 100, idleMs: 30, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      await vi.advanceTimersByTimeAsync(30);
+
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(onFire).toHaveBeenCalledTimes(1);
+      expect(wd.getFire()).toStrictEqual({
+        guard: 'inter-chunk',
+        thresholdMs: 30,
+        configSource: 'stream-idle-timeout-ms',
+      });
+    });
+
+    it('idleMs=0 means phase B is unbounded after liveness', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, idleMs: 0, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.getFire()).toBeUndefined();
+    });
+
+    it('a second liveness ping rearms phase B (resets the idle timer)', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 100, idleMs: 60, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+
+      wd.onLiveness(livenessPing('response.in_progress'));
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(wd.getFire()?.guard).toBe('inter-chunk');
+    });
+  });
+
+  describe('cancel', () => {
+    it('prevents the watchdog from firing after cancel', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, onFire }),
+      );
+
+      wd.cancel();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.getFire()).toBeUndefined();
+    });
+
+    it('cancel after liveness disarmed prevents phase B from firing', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 100, idleMs: 30, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      wd.cancel();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onFire).not.toHaveBeenCalled();
+    });
+
+    it('cancel is idempotent', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 50 }));
+      expect(() => {
+        wd.cancel();
+        wd.cancel();
+        wd.cancel();
+      }).not.toThrow();
+    });
+  });
+
+  describe('onFire callback', () => {
+    it('is invoked exactly once when the watchdog fires', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 30, onFire }),
+      );
+
+      await vi.advanceTimersByTimeAsync(30);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+
+      expect(onFire).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not invoked when cancelled before firing', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 30, onFire }),
+      );
+      wd.cancel();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onFire).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('timeoutPromise unhandled-rejection safety', () => {
+    it('does not produce an unhandled rejection when cancelled without awaiting', async () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 30 }));
+      wd.cancel();
+      await vi.advanceTimersByTimeAsync(100);
+      // If timeoutPromise had an unhandled rejection, Node/vitest would surface
+      // it. Reaching here cleanly is the assertion.
+      expect(wd.getFire()).toBeUndefined();
+    });
+  });
+
+  describe('onFire callback failure isolation (issue #2607 finding 1)', () => {
+    it('timeoutPromise rejects even when onFire throws', async () => {
+      const onFire = vi.fn(() => {
+        throw new Error('callback blew up');
+      });
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 30, onFire }),
+      );
+
+      await vi.advanceTimersByTimeAsync(30);
+
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(onFire).toHaveBeenCalledTimes(1);
+      // getFire must still be populated regardless of callback success
+      expect(wd.getFire()?.guard).toBe('first-response');
+    });
+
+    it('a throwing onFire on the inter-chunk guard still rejects timeoutPromise', async () => {
+      const onFire = vi.fn(() => {
+        throw new Error('callback blew up');
+      });
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 100, idleMs: 30, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      await vi.advanceTimersByTimeAsync(30);
+
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(wd.getFire()?.guard).toBe('inter-chunk');
+    });
+
+    it('a throwing onFire produces no unhandled rejection', async () => {
+      const wd = createStreamWatchdog(
+        defaultOpts({
+          firstResponseMs: 30,
+          onFire: () => {
+            throw new Error('callback blew up');
+          },
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(30);
+      // Drain microtasks so any stray rejection would surface
+      await vi.runAllTimersAsync();
+      // Reaching here without vitest surfacing an unhandled rejection is the
+      // assertion. Additionally verify state is consistent.
+      expect(wd.getFire()).toBeDefined();
+    });
+  });
+
+  describe('isActive truthfulness (issue #2607 finding 1)', () => {
+    it('isActive is true while the first-response guard is armed', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 100 }));
+      expect(wd.isActive).toBe(true);
+    });
+
+    it('isActive becomes false after fire', async () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 30 }));
+      await vi.advanceTimersByTimeAsync(30);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('isActive becomes false after cancel', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 30 }));
+      wd.cancel();
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('isActive becomes false after cancel following liveness disarm', async () => {
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 100, idleMs: 30 }),
+      );
+      wd.onLiveness(livenessPing());
+      expect(wd.isActive).toBe(true);
+      wd.cancel();
+      expect(wd.isActive).toBe(false);
+    });
+  });
+
+  describe('whole-stream liveness-aware idle (issue #2607 finding 2)', () => {
+    it('a semantic event disarms phase A just like a liveness ping', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, idleMs: 0, onFire }),
+      );
+
+      wd.onSemanticEvent();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.getFire()).toBeUndefined();
+    });
+
+    it('first semantic content, repeated liveness pings spanning longer than idle threshold, then semantic content => no timeout', async () => {
+      // idle threshold = 100ms. content arrives, then 3 liveness pings each
+      // 40ms apart (total 120ms > 100ms), then more content. Each ping rearms
+      // the inter-chunk guard, so no single silent window exceeds 100ms.
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 200, idleMs: 100, onFire }),
+      );
+
+      wd.onSemanticEvent();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(onFire).not.toHaveBeenCalled();
+
+      wd.onLiveness(livenessPing('response.in_progress'));
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+
+      wd.onLiveness(livenessPing('response.in_progress'));
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+
+      wd.onLiveness(livenessPing('response.in_progress'));
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+
+      wd.onSemanticEvent();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.getFire()).toBeUndefined();
+    });
+
+    it('after pings stop for the idle threshold => precise inter-chunk timeout', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 200, idleMs: 100, onFire }),
+      );
+
+      wd.onSemanticEvent();
+      wd.onLiveness(livenessPing());
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+
+      // Pings stop. Exactly at 100ms after the last ping, it should fire.
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(onFire).toHaveBeenCalledTimes(1);
+      expect(wd.getFire()?.guard).toBe('inter-chunk');
+      expect(wd.getFire()?.thresholdMs).toBe(100);
+    });
+
+    it('default idle=0 behavior preserved: semantic content disarms phase A, phase B unbounded', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, idleMs: 0, onFire }),
+      );
+
+      wd.onSemanticEvent();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.getFire()).toBeUndefined();
+    });
+  });
+
+  describe('isActive means an actual armed guard (issue #2607 OCR finding 1)', () => {
+    it('firstResponse=0/idle>0: initially inactive (no timer armed) then active after progress arms phase B', () => {
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 0, idleMs: 30 }),
+      );
+      expect(wd.isActive).toBe(false);
+
+      wd.onLiveness(livenessPing());
+      expect(wd.isActive).toBe(true);
+
+      wd.onSemanticEvent();
+      expect(wd.isActive).toBe(true);
+    });
+
+    it('firstResponse=0/idle>0: fires inter-chunk after progress then silence', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 0, idleMs: 30, onFire }),
+      );
+      expect(wd.isActive).toBe(false);
+
+      wd.onLiveness(livenessPing());
+      expect(wd.isActive).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(30);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(wd.getFire()?.guard).toBe('inter-chunk');
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('firstResponse>0/idle=0: becomes inactive after liveness disarms phase A (no phase B to arm)', () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, idleMs: 0, onFire }),
+      );
+      expect(wd.isActive).toBe(true);
+
+      wd.onLiveness(livenessPing());
+      expect(wd.isActive).toBe(false);
+
+      wd.onSemanticEvent();
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('firstResponse>0/idle=0: becomes inactive after semantic event disarms phase A', () => {
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 50, idleMs: 0 }),
+      );
+      expect(wd.isActive).toBe(true);
+
+      wd.onSemanticEvent();
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('after fire, isActive is false', async () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 30 }));
+      await vi.advanceTimersByTimeAsync(30);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('after cancel, isActive is false', () => {
+      const wd = createStreamWatchdog(defaultOpts({ firstResponseMs: 30 }));
+      wd.cancel();
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('cancel after liveness-armed phase B makes it inactive', () => {
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 0, idleMs: 30 }),
+      );
+      expect(wd.isActive).toBe(false);
+      wd.onLiveness(livenessPing());
+      expect(wd.isActive).toBe(true);
+      wd.cancel();
+      expect(wd.isActive).toBe(false);
+    });
+
+    it('rearm: second liveness ping keeps phase B active and resets the timer', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 0, idleMs: 60, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      expect(wd.isActive).toBe(true);
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+      expect(wd.isActive).toBe(true);
+
+      wd.onLiveness(livenessPing('response.in_progress'));
+      expect(wd.isActive).toBe(true);
+      await vi.advanceTimersByTimeAsync(40);
+      expect(onFire).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+      expect(wd.getFire()?.guard).toBe('inter-chunk');
+    });
+
+    it('timer-abort race: aborting a phase B timer via rearm does not fire the old guard', async () => {
+      const onFire = vi.fn();
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 0, idleMs: 30, onFire }),
+      );
+
+      wd.onLiveness(livenessPing());
+      await vi.advanceTimersByTimeAsync(20);
+      // Rearm before the 30ms deadline — the first timer must be aborted.
+      wd.onLiveness(livenessPing('response.in_progress'));
+      await vi.advanceTimersByTimeAsync(20);
+      // 40ms total since first arm, but only 20ms since rearm; must not fire.
+      expect(onFire).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(10);
+      await expect(wd.timeoutPromise).rejects.toThrow(
+        'Stream watchdog timeout',
+      );
+    });
+  });
+});

--- a/packages/core/src/utils/streamWatchdog.test.ts
+++ b/packages/core/src/utils/streamWatchdog.test.ts
@@ -300,8 +300,7 @@ describe('createStreamWatchdog', () => {
       );
 
       await vi.advanceTimersByTimeAsync(30);
-      // Drain microtasks so any stray rejection would surface
-      await vi.runAllTimersAsync();
+      await Promise.resolve();
       // Reaching here without vitest surfacing an unhandled rejection is the
       // assertion. Additionally verify state is consistent.
       expect(wd.getFire()).toBeDefined();
@@ -434,6 +433,14 @@ describe('createStreamWatchdog', () => {
       expect(wd.isActive).toBe(true);
     });
 
+    it('firstResponse=0/idle>0 creates no active first-response timer', () => {
+      const wd = createStreamWatchdog(
+        defaultOpts({ firstResponseMs: 0, idleMs: 30 }),
+      );
+
+      expect(wd.isActive).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
     it('firstResponse=0/idle>0: fires inter-chunk after progress then silence', async () => {
       const onFire = vi.fn();
       const wd = createStreamWatchdog(

--- a/packages/core/src/utils/streamWatchdog.ts
+++ b/packages/core/src/utils/streamWatchdog.ts
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { delay } from './delay.js';
+import type {
+  StreamLivenessEvent,
+  StreamTimeoutSource,
+} from './streamIdleTimeout.js';
+
+export type StreamTimeoutGuard = 'first-response' | 'inter-chunk';
+
+export interface StreamWatchdogFire {
+  readonly guard: StreamTimeoutGuard;
+  readonly thresholdMs: number;
+  readonly configSource: StreamTimeoutSource;
+}
+
+export type StreamWatchdogFireCallback = (fire: StreamWatchdogFire) => void;
+
+export interface StreamWatchdogOptions {
+  readonly firstResponseMs: number;
+  readonly firstResponseSource: StreamTimeoutSource;
+  readonly idleMs: number;
+  readonly idleSource: StreamTimeoutSource;
+  readonly onFire?: StreamWatchdogFireCallback;
+}
+
+export interface StreamWatchdog {
+  /**
+   * Whether a real guard timer is currently armed (first-response or
+   * inter-chunk). False when no timer is pending — either disabled from the
+   * start, disarmed after progress without phase B arming, fired, or
+   * cancelled. When false, the timeoutPromise is guaranteed never to settle,
+   * so callers must not race against it.
+   */
+  readonly isActive: boolean;
+  readonly timeoutPromise: Promise<never>;
+  onLiveness: (event: StreamLivenessEvent) => void;
+  /**
+   * Notifies the watchdog that a semantic stream event (IContent-bearing
+   * chunk) was consumed. When idleMs > 0, this rearms the inter-chunk guard
+   * exactly like a provider liveness ping, so the watchdog stays alive across
+   * the entire stream rather than disarming after the first event.
+   */
+  onSemanticEvent: () => void;
+  getFire: () => StreamWatchdogFire | undefined;
+  cancel: () => void;
+}
+
+const NEVER: Promise<never> = new Promise<never>(() => {});
+
+function createDisabledWatchdog(): StreamWatchdog {
+  return {
+    isActive: false,
+    timeoutPromise: NEVER,
+    onLiveness: () => {},
+    onSemanticEvent: () => {},
+    getFire: () => undefined,
+    cancel: () => {},
+  };
+}
+
+interface WatchdogState {
+  readonly timeoutPromise: Promise<never>;
+  readonly fireGuard: (
+    guard: StreamTimeoutGuard,
+    thresholdMs: number,
+    configSource: StreamTimeoutSource,
+  ) => void;
+  readonly armInterChunk: () => void;
+  readonly disarmFirstResponse: () => void;
+  readonly cancel: () => void;
+  readonly isActive: () => boolean;
+  readonly getFire: () => StreamWatchdogFire | undefined;
+}
+
+function createState(
+  firstResponseTimer: AbortController,
+  opts: StreamWatchdogOptions,
+): WatchdogState {
+  let phaseBTimer: AbortController | undefined;
+  let livenessDisarmed = false;
+  let settled = false;
+  // Track whether a real guard timer is currently armed. isActive must mean an
+  // actual guard is pending so callers do not race a never-settling promise.
+  let phaseAArmed = opts.firstResponseMs > 0;
+  let phaseBArmed = false;
+  let fire: StreamWatchdogFire | undefined;
+
+  let rejectTimeout: (error: Error) => void = () => {};
+  const timeoutPromise: Promise<never> = new Promise<never>(
+    (_resolve, reject) => {
+      rejectTimeout = reject;
+    },
+  );
+  timeoutPromise.catch(() => {});
+
+  const fireGuard = (
+    guard: StreamTimeoutGuard,
+    thresholdMs: number,
+    configSource: StreamTimeoutSource,
+  ): void => {
+    if (settled) return;
+    settled = true;
+    phaseAArmed = false;
+    phaseBArmed = false;
+    fire = { guard, thresholdMs, configSource };
+    rejectTimeout(new Error('Stream watchdog timeout'));
+    try {
+      opts.onFire?.(fire);
+    } catch {
+      // Listener failures cannot change watchdog settlement.
+    }
+  };
+
+  const armInterChunk = (): void => {
+    if (settled) return;
+    if (opts.idleMs <= 0) return;
+    phaseBTimer?.abort();
+    phaseBTimer = new AbortController();
+    phaseBArmed = true;
+    const timer = phaseBTimer;
+    delay(opts.idleMs, timer.signal).then(
+      () => fireGuard('inter-chunk', opts.idleMs, opts.idleSource),
+      () => {},
+    );
+  };
+
+  const disarmFirstResponse = (): void => {
+    if (livenessDisarmed) return;
+    livenessDisarmed = true;
+    phaseAArmed = false;
+    firstResponseTimer.abort();
+  };
+
+  const cancel = (): void => {
+    if (settled) return;
+    settled = true;
+    phaseAArmed = false;
+    phaseBArmed = false;
+    firstResponseTimer.abort();
+    phaseBTimer?.abort();
+  };
+
+  return {
+    timeoutPromise,
+    fireGuard,
+    armInterChunk,
+    disarmFirstResponse,
+    cancel,
+    isActive: () => !settled && (phaseAArmed || phaseBArmed),
+    getFire: () => fire,
+  };
+}
+
+export function createStreamWatchdog(
+  opts: StreamWatchdogOptions,
+): StreamWatchdog {
+  // When neither guard can ever arm, return the disabled (never-active)
+  // watchdog whose timeoutPromise never settles.
+  if (opts.firstResponseMs <= 0 && opts.idleMs <= 0) {
+    return createDisabledWatchdog();
+  }
+
+  const phaseATimer = new AbortController();
+  const state = createState(phaseATimer, opts);
+
+  if (opts.firstResponseMs > 0) {
+    delay(opts.firstResponseMs, phaseATimer.signal).then(
+      () =>
+        state.fireGuard(
+          'first-response',
+          opts.firstResponseMs,
+          opts.firstResponseSource,
+        ),
+      () => {},
+    );
+  }
+
+  // Liveness/progress disarms phase A (if armed) and arms phase B (when
+  // idleMs > 0). We must NOT short-circuit on isActive here: when
+  // firstResponseMs <= 0 phase A is never armed (so isActive starts false),
+  // yet phase B still needs to arm on the first liveness ping. armInterChunk
+  // and disarmFirstResponse are internally idempotent/settled-safe.
+  const recordProgress = (): void => {
+    state.disarmFirstResponse();
+    state.armInterChunk();
+  };
+
+  const onLiveness = (_event: StreamLivenessEvent): void => {
+    recordProgress();
+  };
+
+  return {
+    get isActive() {
+      return state.isActive();
+    },
+    timeoutPromise: state.timeoutPromise,
+    onLiveness,
+    onSemanticEvent: recordProgress,
+    getFire: state.getFire,
+    cancel: state.cancel,
+  };
+}

--- a/packages/core/src/utils/streamWatchdog.ts
+++ b/packages/core/src/utils/streamWatchdog.ts
@@ -130,7 +130,7 @@ function createState(
   };
 
   const disarmFirstResponse = (): void => {
-    if (livenessDisarmed) return;
+    if (settled || livenessDisarmed) return;
     livenessDisarmed = true;
     phaseAArmed = false;
     firstResponseTimer?.abort();

--- a/packages/core/src/utils/streamWatchdog.ts
+++ b/packages/core/src/utils/streamWatchdog.ts
@@ -78,7 +78,7 @@ interface WatchdogState {
 }
 
 function createState(
-  firstResponseTimer: AbortController,
+  firstResponseTimer: AbortController | undefined,
   opts: StreamWatchdogOptions,
 ): WatchdogState {
   let phaseBTimer: AbortController | undefined;
@@ -133,7 +133,7 @@ function createState(
     if (livenessDisarmed) return;
     livenessDisarmed = true;
     phaseAArmed = false;
-    firstResponseTimer.abort();
+    firstResponseTimer?.abort();
   };
 
   const cancel = (): void => {
@@ -141,7 +141,7 @@ function createState(
     settled = true;
     phaseAArmed = false;
     phaseBArmed = false;
-    firstResponseTimer.abort();
+    firstResponseTimer?.abort();
     phaseBTimer?.abort();
   };
 
@@ -165,10 +165,11 @@ export function createStreamWatchdog(
     return createDisabledWatchdog();
   }
 
-  const phaseATimer = new AbortController();
+  const phaseATimer =
+    opts.firstResponseMs > 0 ? new AbortController() : undefined;
   const state = createState(phaseATimer, opts);
 
-  if (opts.firstResponseMs > 0) {
+  if (phaseATimer !== undefined) {
     delay(opts.firstResponseMs, phaseATimer.signal).then(
       () =>
         state.fireGuard(

--- a/packages/providers/src/IProvider.ts
+++ b/packages/providers/src/IProvider.ts
@@ -22,6 +22,7 @@ import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import type { RuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
 import type { StructuredError } from '@vybestack/llxprt-code-core/core/turn.js';
+import type { StreamLivenessEvent } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import type {
   ProviderTelemetryContext,
   ResolvedAuthToken,
@@ -54,6 +55,13 @@ export interface GenerateChatOptions {
   runtime?: ProviderRuntimeContext;
   invocation?: RuntimeInvocationContext;
   onProviderError?: (error: StructuredError) => void;
+  /**
+   * Optional provider-neutral transport-liveness listener (issue #2607).
+   * Providers that observe raw lifecycle evidence (e.g. an OpenAI Responses
+   * `response.created` SSE event) invoke this to signal the connection is
+   * alive even before any semantic IContent is produced.
+   */
+  onStreamLiveness?: (event: StreamLivenessEvent) => void;
   metadata?: Record<string, unknown>;
   resolved?: {
     model?: string;

--- a/packages/providers/src/__tests__/LoadBalancingProvider.liveness.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.liveness.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral test pinning that onStreamLiveness survives the resolved-options
+ * building/delegation in LoadBalancingProvider (issue #2607 finding 6). The
+ * spread logic in resolvedOptionsBuilder.ts preserves onStreamLiveness via
+ * `...options`, so invoking it at the delegate must reach the original
+ * observable callback supplied by the caller. No mock interaction assertions —
+ * only the real delegation path with a boundary delegate provider.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { StreamLivenessEvent } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import {
+  LoadBalancingProvider,
+  type LoadBalancingProviderConfig,
+} from '../LoadBalancingProvider.js';
+
+describe('LoadBalancingProvider — onStreamLiveness propagation (issue #2607 finding 6)', () => {
+  let settingsService: SettingsService;
+  let providerManager: ProviderManager;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    const config = createRuntimeConfigStub(settingsService);
+    providerManager = new ProviderManager({ settingsService, config });
+  });
+
+  it('onStreamLiveness invoked at the delegate reaches the original caller callback', async () => {
+    const captured: StreamLivenessEvent[] = [];
+
+    function createLivenessDelegate(name: string): IProvider {
+      return {
+        name,
+        async *generateChatCompletion(
+          optionsOrContents: GenerateChatOptions | IContent[],
+        ): AsyncIterableIterator<IContent> {
+          const opts = Array.isArray(optionsOrContents)
+            ? undefined
+            : optionsOrContents;
+          opts?.onStreamLiveness?.({
+            sourceEvent: 'response.created',
+            sseObserved: true,
+          });
+          yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+        },
+        getModels: async () => [],
+        getDefaultModel: () => 'delegate-model',
+        getServerTools: () => [],
+        invokeServerTool: async () => ({}),
+      } as unknown as IProvider;
+    }
+
+    const lbConfig: LoadBalancingProviderConfig = {
+      profileName: 'lb',
+      strategy: 'round-robin',
+      subProfiles: [{ name: 's1', providerName: 'gemini', modelId: 'gpt-4' }],
+    };
+
+    const provider = new LoadBalancingProvider(lbConfig, providerManager);
+
+    const originalGetProvider =
+      providerManager.getProviderByName.bind(providerManager);
+    providerManager.getProviderByName = (name: string) => {
+      if (name === 'gemini') return createLivenessDelegate('gemini');
+      return originalGetProvider(name);
+    };
+
+    try {
+      const iterator = provider.generateChatCompletion({
+        contents: [
+          { speaker: 'human', blocks: [{ type: 'text', text: 'hi' }] },
+        ],
+        onStreamLiveness: (event) => captured.push(event),
+      } as GenerateChatOptions);
+
+      for await (const _chunk of iterator) {
+        // drain
+      }
+    } finally {
+      providerManager.getProviderByName = originalGetProvider;
+    }
+
+    expect(captured).toContainEqual({
+      sourceEvent: 'response.created',
+      sseObserved: true,
+    });
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue:2607 Finding 3
+ *
+ * Behavioral tests for abort-signal propagation and retry-backoff abort in the
+ * OpenAI Responses executor.
+ *
+ * The executor uses the established `getRequestSignal(options)` utility, which
+ * prefers the normalized `invocation.signal` while preserving the legacy
+ * `metadata.abortSignal` fallback. The resulting signal drives fetch, the
+ * parser/retry path, and retry backoff (via `delay(backoff, signal)`), so an
+ * abort during backoff rejects promptly with an AbortError and does not issue
+ * another fetch/retry.
+ *
+ * Uses fake timers/signals deterministically — no wall-clock sleeps.
+ */
+
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  executeOpenAIResponsesRequest,
+  type ResponsesExecutorDeps,
+} from './openAIResponsesExecutor.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+
+const getCoreSystemPromptAsyncSpy = vi.hoisted(() =>
+  vi.fn().mockResolvedValue('system prompt'),
+);
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: getCoreSystemPromptAsyncSpy,
+}));
+
+function buildNormalizedOptions(
+  overrides: Partial<NormalizedGenerateChatOptions> & {
+    invocationSignal?: AbortSignal;
+    metadataAbortSignal?: AbortSignal;
+  } = {},
+): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: 'test-runtime',
+  });
+  const config = createRuntimeConfigStub(settings, {});
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'openai-responses',
+    ephemeralsSnapshot: overrides.ephemerals ?? {},
+    fallbackRuntimeId: 'test-runtime',
+    ...(overrides.invocationSignal !== undefined
+      ? { signal: overrides.invocationSignal }
+      : {}),
+  });
+
+  const base = {
+    contents: [
+      {
+        speaker: 'human' as const,
+        blocks: [{ type: 'text' as const, text: 'Hello' }],
+      },
+    ],
+    settings,
+    config,
+    runtime,
+    invocation,
+    userMemory: undefined,
+    tools: undefined,
+    metadata:
+      overrides.metadataAbortSignal !== undefined
+        ? { abortSignal: overrides.metadataAbortSignal }
+        : {},
+    resolved: {
+      model: 'gpt-5',
+      baseURL: 'https://api.openai.com/v1',
+      authToken: 'test-token',
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+
+  return { ...base, ...overrides };
+}
+
+function buildDeps(
+  overrides: Partial<ResponsesExecutorDeps> = {},
+): ResponsesExecutorDeps {
+  return {
+    providerName: 'openai-responses',
+    logger: { debug: vi.fn() } as unknown as ResponsesExecutorDeps['logger'],
+    getProviderBaseURL: () => 'https://api.openai.com/v1',
+    getCustomHeaders: () => undefined,
+    isCodexBaseURL: () => false,
+    getCodexAccountId: async () => 'codex-account',
+    resolveAuthTokenForPrompt: async () => '',
+    generateSyntheticCallId: () => 'call_synthetic_test',
+    shouldRetryOnError: () => true,
+    getDefaultModel: () => 'gpt-5',
+    getGlobalConfig: () => undefined,
+    ...overrides,
+  };
+}
+
+function encodeSse(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function drain(
+  iterator: AsyncIterableIterator<IContent>,
+): Promise<readonly IContent[]> {
+  const messages: IContent[] = [];
+  for await (const chunk of iterator) {
+    messages.push(chunk);
+  }
+  return messages;
+}
+
+/**
+ * Safe predicate checking that a thrown value is an Error whose `name` matches
+ * the expected value, without relying on `instanceof` cross-realm pitfalls.
+ */
+function isNamedError(value: unknown, expectedName: string): boolean {
+  return value instanceof Error && value.name === expectedName;
+}
+
+describe('executeOpenAIResponsesRequest abort-signal propagation @issue:2607', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCoreSystemPromptAsyncSpy.mockResolvedValue('system prompt');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('passes the invocation-only signal to fetch (preferred over absent metadata signal)', async () => {
+    const controller = new AbortController();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      body: encodeSse([
+        'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const options = buildNormalizedOptions({
+      invocationSignal: controller.signal,
+    });
+    await drain(executeOpenAIResponsesRequest(options, buildDeps()));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const fetchCallInit = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(fetchCallInit.signal).toBe(controller.signal);
+  });
+
+  it('still passes the legacy metadata.abortSignal to fetch when invocation.signal is absent', async () => {
+    const controller = new AbortController();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      body: encodeSse([
+        'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const options = buildNormalizedOptions({
+      metadataAbortSignal: controller.signal,
+    });
+    await drain(executeOpenAIResponsesRequest(options, buildDeps()));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const fetchCallInit = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(fetchCallInit.signal).toBe(controller.signal);
+  });
+
+  it('prefers invocation.signal over metadata.abortSignal when both are present', async () => {
+    const invocationController = new AbortController();
+    const metadataController = new AbortController();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      body: encodeSse([
+        'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const options = buildNormalizedOptions({
+      invocationSignal: invocationController.signal,
+      metadataAbortSignal: metadataController.signal,
+    });
+    await drain(executeOpenAIResponsesRequest(options, buildDeps()));
+
+    const fetchCallInit = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(fetchCallInit.signal).toBe(invocationController.signal);
+  });
+
+  it('aborts during retry backoff promptly with AbortError and issues no further fetch/retry', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const fetchSpy = vi
+      .fn()
+      // First attempt: transient network error (retryable).
+      .mockRejectedValueOnce(new TypeError('network error'))
+      // Any subsequent attempt must NEVER be reached — abort during backoff.
+      .mockResolvedValue({
+        ok: true,
+        body: encodeSse([
+          'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const options = buildNormalizedOptions({
+      invocationSignal: controller.signal,
+      ephemerals: { retrywait: 10_000, retries: 5 },
+    });
+    const iterator = executeOpenAIResponsesRequest(options, buildDeps());
+
+    // Drain into a promise we can assert rejects. Attach a no-op catch now so
+    // the delayed rejection (after abort) never becomes an unhandled rejection.
+    const drainPromise = drain(iterator);
+    const caughtPromise = drainPromise.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    // Wait for the first fetch to be called (transient failure), then the
+    // retry backoff delay begins.
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1), {
+      interval: 1,
+      timeout: 200,
+    });
+
+    // Abort DURING the backoff delay (before it elapses).
+    controller.abort();
+
+    // Advance fake timers to let the aborted delay reject promptly.
+    await vi.advanceTimersByTimeAsync(1);
+
+    const result = await caughtPromise;
+    expect(isNamedError(result, 'AbortError')).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies an AbortError as an AbortError (no retry) even on a retryable transient failure', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    // First attempt: aborted fetch rejects with an AbortError (not retried).
+    const abortError = new DOMException('aborted', 'AbortError');
+    const fetchSpy = vi.fn().mockRejectedValueOnce(abortError);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const options = buildNormalizedOptions({
+      invocationSignal: controller.signal,
+      ephemerals: { retrywait: 1_000, retries: 5 },
+    });
+    const iterator = executeOpenAIResponsesRequest(options, buildDeps());
+    controller.abort();
+
+    await expect(drain(iterator)).rejects.toBe(abortError);
+    // AbortError must NOT trigger a retry — only one fetch call.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
@@ -131,10 +131,7 @@ async function drain(
   return messages;
 }
 
-/**
- * Safe predicate checking that a thrown value is an Error whose `name` matches
- * the expected value, without relying on `instanceof` cross-realm pitfalls.
- */
+/** Checks that a thrown Error has the expected name. */
 function isNamedError(value: unknown, expectedName: string): boolean {
   return value instanceof Error && value.name === expectedName;
 }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral test: the OpenAI Responses executor threads the provider-neutral
+ * onStreamLiveness listener from NormalizedGenerateChatOptions down through
+ * fetchStreamWithRetries into parseResponsesStream, so a raw lifecycle SSE
+ * event (response.created) reaches the listener (issue #2607).
+ *
+ * Only the fetch boundary is intercepted (legitimate I/O edge); the real
+ * executor and real SSE parser run.
+ */
+
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  executeOpenAIResponsesRequest,
+  type ResponsesExecutorDeps,
+} from './openAIResponsesExecutor.js';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import type { StreamLivenessEvent } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+
+const getCoreSystemPromptAsyncSpy = vi.hoisted(() =>
+  vi.fn().mockResolvedValue('system prompt'),
+);
+
+vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: getCoreSystemPromptAsyncSpy,
+}));
+
+function buildNormalizedOptions(
+  overrides: Partial<NormalizedGenerateChatOptions> = {},
+): NormalizedGenerateChatOptions {
+  const settings = new SettingsService();
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: 'test-runtime',
+  });
+  const config = createRuntimeConfigStub(settings, {});
+  const invocation = createRuntimeInvocationContext({
+    runtime,
+    settings,
+    providerName: 'openai-responses',
+    ephemeralsSnapshot: {},
+    fallbackRuntimeId: 'test-runtime',
+  });
+
+  const base = {
+    contents: [
+      {
+        speaker: 'human' as const,
+        blocks: [{ type: 'text' as const, text: 'Hello' }],
+      },
+    ],
+    settings,
+    config,
+    runtime,
+    invocation,
+    userMemory: undefined,
+    tools: undefined,
+    metadata: {},
+    resolved: {
+      model: 'gpt-5',
+      baseURL: 'https://api.openai.com/v1',
+      authToken: 'test-token',
+    },
+  } as unknown as NormalizedGenerateChatOptions;
+
+  return { ...base, ...overrides };
+}
+
+function buildDeps(
+  overrides: Partial<ResponsesExecutorDeps> = {},
+): ResponsesExecutorDeps {
+  return {
+    providerName: 'openai-responses',
+    logger: { debug: vi.fn() } as unknown as ResponsesExecutorDeps['logger'],
+    getProviderBaseURL: () => 'https://api.openai.com/v1',
+    getCustomHeaders: () => undefined,
+    isCodexBaseURL: () => false,
+    getCodexAccountId: async () => 'codex-account',
+    resolveAuthTokenForPrompt: async () => '',
+    generateSyntheticCallId: () => 'call_synthetic_test',
+    shouldRetryOnError: () => false,
+    getDefaultModel: () => 'gpt-5',
+    getGlobalConfig: () => undefined,
+    ...overrides,
+  };
+}
+
+function encodeSse(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('executeOpenAIResponsesRequest onStreamLiveness threading @issue:2607', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCoreSystemPromptAsyncSpy.mockResolvedValue('system prompt');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('invokes onStreamLiveness for a response.created lifecycle event', async () => {
+    const sseBody = encodeSse([
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: {"type":"response.output_text.delta","delta":"Hello"}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, body: sseBody }),
+    );
+
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const options = buildNormalizedOptions({
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    });
+
+    const iterator = executeOpenAIResponsesRequest(options, buildDeps());
+    for await (const _chunk of iterator) {
+      void _chunk;
+    }
+
+    expect(livenessEvents).toContainEqual({
+      sourceEvent: 'response.created',
+      sseObserved: true,
+    });
+  });
+
+  it('does not invoke onStreamLiveness when not provided (no crash)', async () => {
+    const sseBody = encodeSse([
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, body: sseBody }),
+    );
+
+    const options = buildNormalizedOptions();
+    const iterator = executeOpenAIResponsesRequest(options, buildDeps());
+    const messages: IContent[] = [];
+    for await (const chunk of iterator) {
+      messages.push(chunk);
+    }
+    expect(messages).toStrictEqual([
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Hi' }],
+      },
+    ]);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -38,6 +38,7 @@ import {
   type ParseResponsesStreamOptions,
 } from '../openai/parseResponsesStream.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import type { StreamLivenessListener } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import { convertToolsToOpenAIResponses } from './schemaConverter.js';
 import { getCoreSystemPromptAsync } from '@vybestack/llxprt-code-core/core/prompts.js';
 import { shouldIncludeSubagentDelegation } from '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js';
@@ -46,6 +47,7 @@ import { mergeSystemInstruction } from '../utils/systemInstructionMerge.js';
 import { resolveRuntimeAuthToken } from '../utils/authToken.js';
 import { isNetworkTransientError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { delay } from '@vybestack/llxprt-code-core/utils/delay.js';
+import { getRequestSignal } from '../utils/abortSignal.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import {
   toOpenAIResponsesWireEffort,
@@ -110,8 +112,9 @@ export async function* executeOpenAIResponsesRequest(
   options: NormalizedGenerateChatOptions,
   deps: ResponsesExecutorDeps,
 ): AsyncIterableIterator<IContent> {
-  const metadata = (options as { metadata?: Record<string, unknown> }).metadata;
-  const abortSignal = metadata?.['abortSignal'] as AbortSignal | undefined;
+  // Prefer the normalized invocation.signal (via getRequestSignal) while
+  // preserving the legacy metadata.abortSignal fallback (issue #2607 Finding 3).
+  const abortSignal = getRequestSignal(options);
   const patchedContent = SyntheticToolResponseHandler.patchMessageHistory(
     options.contents,
   );
@@ -696,10 +699,14 @@ async function* streamResponses(
   );
   yield* fetchStreamWithRetries(
     {
-      ...params,
       responsesURL: `${params.baseURL}/responses`,
       headers,
       bodyBlob,
+      abortSignal: params.abortSignal,
+      includeThinkingInResponse: params.includeThinkingInResponse,
+      maxStreamingAttempts: params.maxStreamingAttempts,
+      streamRetryInitialDelayMs: params.streamRetryInitialDelayMs,
+      onStreamLiveness: params.normalizedOptions.onStreamLiveness,
     },
     deps,
   );
@@ -713,6 +720,7 @@ interface FetchStreamParams {
   includeThinkingInResponse: boolean;
   maxStreamingAttempts: number;
   streamRetryInitialDelayMs: number;
+  onStreamLiveness?: StreamLivenessListener;
 }
 
 async function* fetchStreamWithRetries(
@@ -736,6 +744,7 @@ async function* fetchStreamWithRetries(
           maxStreamingAttempts: params.maxStreamingAttempts,
           currentDelay,
         },
+        params.abortSignal,
         deps,
       );
     }
@@ -764,6 +773,7 @@ async function* parseSuccessfulResponse(
     bodyBlob: Blob;
     abortSignal?: AbortSignal;
     includeThinkingInResponse: boolean;
+    onStreamLiveness?: StreamLivenessListener;
   },
   deps: ResponsesExecutorDeps,
 ): AsyncIterableIterator<IContent> {
@@ -775,6 +785,7 @@ async function* parseSuccessfulResponse(
 
   const streamOptions: ParseResponsesStreamOptions = {
     includeThinkingInResponse: params.includeThinkingInResponse,
+    onStreamLiveness: params.onStreamLiveness,
   };
   for await (const message of parseResponsesStream(
     response.body,
@@ -802,6 +813,7 @@ async function handleStreamRetry(
     maxStreamingAttempts: number;
     currentDelay: number;
   },
+  abortSignal: AbortSignal | undefined,
   deps: ResponsesExecutorDeps,
 ): Promise<number> {
   if (error instanceof Error && error.name === 'AbortError') {
@@ -822,7 +834,9 @@ async function handleStreamRetry(
       `Stream retry attempt ${state.streamingAttempt}/${state.maxStreamingAttempts}: Transient error detected, delay ${state.currentDelay}ms before retry. Error: ${String(error)}`,
   );
   const jitter = state.currentDelay * 0.3 * (Math.random() * 2 - 1);
-  await delay(Math.max(0, state.currentDelay + jitter));
+  // Pass the abort signal so an abort during backoff rejects promptly with an
+  // AbortError instead of waiting out the full delay (issue #2607 Finding 3).
+  await delay(Math.max(0, state.currentDelay + jitter), abortSignal);
   return Math.min(30000, state.currentDelay * 2);
 }
 

--- a/packages/providers/src/openai/parseResponsesStream.liveness.test.ts
+++ b/packages/providers/src/openai/parseResponsesStream.liveness.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the OpenAI Responses SSE parser's stream-liveness
+ * callback (issue #2607). A successfully parsed lifecycle SSE event such as
+ * response.created or response.in_progress evidences transport/provider
+ * liveness even though it yields no semantic IContent, and must be reported
+ * via the onStreamLiveness callback so the first-response watchdog can be
+ * disarmed.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { StreamLivenessEvent } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
+import { parseResponsesStream } from './parseResponsesStream.js';
+
+function createSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let index = 0;
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (index < chunks.length) {
+        const chunk = chunks[index++];
+        controller.enqueue(encoder.encode(chunk));
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+describe('parseResponsesStream - stream liveness (issue #2607)', () => {
+  it('reports liveness for response.created with sseObserved true and yields no IContent', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const chunks = [
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const messages: IContent[] = [];
+    for await (const message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    })) {
+      messages.push(message);
+    }
+
+    expect(livenessEvents).toContainEqual({
+      sourceEvent: 'response.created',
+      sseObserved: true,
+    });
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('reports liveness for response.in_progress', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const chunks = [
+      'data: {"type":"response.in_progress","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    for await (const _message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    })) {
+      void _message;
+    }
+
+    expect(livenessEvents).toContainEqual({
+      sourceEvent: 'response.in_progress',
+      sseObserved: true,
+    });
+  });
+
+  it('every parsed lifecycle event emits liveness, including duplicates of the same event type', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const chunks = [
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: {"type":"response.in_progress","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    for await (const _message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    })) {
+      void _message;
+    }
+
+    const createdEvents = livenessEvents.filter(
+      (e) => e.sourceEvent === 'response.created',
+    );
+    const inProgressEvents = livenessEvents.filter(
+      (e) => e.sourceEvent === 'response.in_progress',
+    );
+    expect(createdEvents).toHaveLength(2);
+    expect(inProgressEvents).toHaveLength(1);
+  });
+
+  it('semantic output is unchanged when a liveness callback is provided for a mixed lifecycle + content stream', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const chunks = [
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: {"type":"response.output_text.delta","delta":"Hello"}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const messagesWith: IContent[] = [];
+    for await (const message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    })) {
+      messagesWith.push(message);
+    }
+
+    const messagesWithout: IContent[] = [];
+    for await (const message of parseResponsesStream(createSSEStream(chunks))) {
+      messagesWithout.push(message);
+    }
+
+    expect(messagesWith).toStrictEqual(messagesWithout);
+    expect(messagesWith).toStrictEqual([
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Hello' }],
+      },
+    ]);
+    expect(livenessEvents).toContainEqual({
+      sourceEvent: 'response.created',
+      sseObserved: true,
+    });
+  });
+
+  it('malformed JSON does not count as liveness', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const chunks = ['data: {not valid json\n\n', 'data: [DONE]\n\n'];
+
+    for await (const _message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    })) {
+      void _message;
+    }
+
+    expect(livenessEvents).toStrictEqual([]);
+  });
+
+  it('[DONE] does not count as liveness', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const chunks = ['data: [DONE]\n\n'];
+
+    for await (const _message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    })) {
+      void _message;
+    }
+
+    expect(livenessEvents).toStrictEqual([]);
+  });
+
+  it('a throwing liveness listener does not break parsing', async () => {
+    const chunks = [
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: {"type":"response.output_text.delta","delta":"Hello"}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const messages: IContent[] = [];
+    for await (const message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: () => {
+        throw new Error('listener blew up');
+      },
+    })) {
+      messages.push(message);
+    }
+
+    expect(messages).toStrictEqual([
+      {
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Hello' }],
+      },
+    ]);
+  });
+
+  it('reports liveness for content-bearing events too (every parsed event)', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const chunks = [
+      'data: {"type":"response.output_text.delta","delta":"Hello"}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    for await (const _message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: (event) => livenessEvents.push(event),
+    })) {
+      void _message;
+    }
+
+    expect(livenessEvents).toContainEqual({
+      sourceEvent: 'response.output_text.delta',
+      sseObserved: true,
+    });
+  });
+
+  it('does not report liveness when no callback is supplied (no crash)', async () => {
+    const chunks = [
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const messages: IContent[] = [];
+    for await (const message of parseResponsesStream(createSSEStream(chunks))) {
+      messages.push(message);
+    }
+
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('reports liveness for each response.created event in the stream', async () => {
+    const livenessEvents: StreamLivenessEvent[] = [];
+    const listener = vi.fn((event: StreamLivenessEvent) =>
+      livenessEvents.push(event),
+    );
+    const chunks = [
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: {"type":"response.created","response":{"id":"r1","object":"response","model":"gpt-5","status":"in_progress"}}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    for await (const _message of parseResponsesStream(createSSEStream(chunks), {
+      onStreamLiveness: listener,
+    })) {
+      void _message;
+    }
+
+    // The parser reports every successfully parsed lifecycle event; the
+    // consumer (Turn) decides how to act on repeated pings.
+    expect(livenessEvents).toHaveLength(2);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/providers/src/openai/parseResponsesStream.ts
+++ b/packages/providers/src/openai/parseResponsesStream.ts
@@ -12,6 +12,7 @@ import {
 } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { createStreamInterruptionError } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import type { StreamLivenessListener } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import { mapFinishReasonToStopReason } from './finishReasonMapping.js';
 
 const logger = new DebugLogger('llxprt:providers:openai-responses:sse');
@@ -108,6 +109,14 @@ export interface ParseResponsesStreamOptions {
    * Defaults to true.
    */
   includeThinkingInResponse?: boolean;
+  /**
+   * Optional provider-neutral liveness listener (issue #2607). Invoked for
+   * successfully parsed lifecycle SSE events (e.g. response.created,
+   * response.in_progress) that evidence transport/provider activation even
+   * when they yield no semantic IContent. Malformed data and [DONE] do not
+   * count. Listener failures are swallowed so parsing is never broken.
+   */
+  onStreamLiveness?: StreamLivenessListener;
 }
 
 /**
@@ -674,6 +683,25 @@ function* dispatchEventCases(
 }
 
 /**
+ * Notifies the optional liveness listener for any successfully parsed SSE
+ * event. Every successfully JSON-parsed event proves the transport is alive.
+ * Listener failures are swallowed so parsing is never broken.
+ */
+function notifyStreamLiveness(
+  listener: StreamLivenessListener | undefined,
+  event: ResponsesEvent,
+): void {
+  if (listener === undefined) {
+    return;
+  }
+  try {
+    listener({ sourceEvent: event.type, sseObserved: true });
+  } catch {
+    // A throwing listener must never break stream parsing.
+  }
+}
+
+/**
  * Dispatch a single SSE event to the appropriate handler.
  */
 function* dispatchEvent(
@@ -718,6 +746,7 @@ async function* tryDispatchEvent(
   hasEmittedVisibleThinking: boolean,
   emittedThoughts: Map<string, { hasEncrypted: boolean }>,
   lastLoggedType: string | undefined,
+  onStreamLiveness: StreamLivenessListener | undefined,
 ): AsyncGenerator<IContent, DispatchResult> {
   let event: ResponsesEvent;
   try {
@@ -731,6 +760,8 @@ async function* tryDispatchEvent(
       lastLoggedType,
     };
   }
+
+  notifyStreamLiveness(onStreamLiveness, event);
 
   return yield* dispatchEvent(
     event,
@@ -748,7 +779,7 @@ export async function* parseResponsesStream(
   stream: ReadableStream<Uint8Array>,
   options: ParseResponsesStreamOptions = {},
 ): AsyncIterableIterator<IContent> {
-  const { includeThinkingInResponse = true } = options;
+  const { includeThinkingInResponse = true, onStreamLiveness } = options;
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
@@ -795,6 +826,7 @@ export async function* parseResponsesStream(
           hasEmittedVisibleThinking,
           emittedThoughts,
           lastLoggedType,
+          onStreamLiveness,
         );
         hasEmittedVisibleThinking = dispatchState.hasEmittedVisibleThinking;
         reasoningText = dispatchState.reasoningText;

--- a/packages/settings/src/__tests__/settingsRegistry.issue2607.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2607.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2607 - The first-response watchdog configuration
+ * (stream-first-response-timeout-ms / streamFirstResponseTimeoutMs) must be a
+ * first-class CLI setting just like stream-idle-timeout-ms, so /set, --set,
+ * profile save/load, validation, completion, and help all recognize it, and it
+ * is NEVER leaked into modelParams (API request bodies).
+ *
+ * These tests mirror settingsRegistry.issue2182.test.ts to pin the settings
+ * surface for the first-response watchdog.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAlias,
+  getSettingSpec,
+  separateSettings,
+} from '../settings/settingsRegistry.js';
+
+describe('issue #2607: streamFirstResponseTimeoutMs camelCase alias', () => {
+  it('resolves streamFirstResponseTimeoutMs to the canonical stream-first-response-timeout-ms', () => {
+    expect(resolveAlias('streamFirstResponseTimeoutMs')).toBe(
+      'stream-first-response-timeout-ms',
+    );
+  });
+
+  it('finds the cli-behavior spec for streamFirstResponseTimeoutMs via the alias', () => {
+    const spec = getSettingSpec('streamFirstResponseTimeoutMs');
+    expect(spec?.key).toBe('stream-first-response-timeout-ms');
+    expect(spec?.category).toBe('cli-behavior');
+  });
+
+  it('classifies streamFirstResponseTimeoutMs into cliSettings (not modelParams) for every provider', () => {
+    for (const provider of ['anthropic', 'codex', 'openai', 'gemini']) {
+      const result = separateSettings(
+        { streamFirstResponseTimeoutMs: 300_000 },
+        provider,
+      );
+      expect(result.cliSettings['stream-first-response-timeout-ms']).toBe(
+        300_000,
+      );
+      expect(
+        result.modelParams['streamFirstResponseTimeoutMs'],
+      ).toBeUndefined();
+      expect(
+        result.modelParams['stream-first-response-timeout-ms'],
+      ).toBeUndefined();
+    }
+  });
+
+  it('treats the canonical hyphenated key identically', () => {
+    const canonical = separateSettings(
+      { 'stream-first-response-timeout-ms': 300_000 },
+      'anthropic',
+    );
+    const camel = separateSettings(
+      { streamFirstResponseTimeoutMs: 300_000 },
+      'anthropic',
+    );
+    expect(camel.cliSettings['stream-first-response-timeout-ms']).toBe(
+      canonical.cliSettings['stream-first-response-timeout-ms'],
+    );
+  });
+
+  it('the setting spec is persistToProfile and type number', () => {
+    const spec = getSettingSpec('stream-first-response-timeout-ms');
+    expect(spec?.persistToProfile).toBe(true);
+    expect(spec?.type).toBe('number');
+  });
+
+  it('validates a finite number successfully', () => {
+    const spec = getSettingSpec('stream-first-response-timeout-ms');
+    expect(spec?.validate?.(300_000)).toStrictEqual({
+      success: true,
+      value: 300_000,
+    });
+  });
+
+  it('rejects a non-number value with a helpful message', () => {
+    const spec = getSettingSpec('stream-first-response-timeout-ms');
+    const result = spec?.validate?.('not-a-number');
+    expect(result?.success).toBe(false);
+    expect(typeof result?.message).toBe('string');
+  });
+
+  it('accepts 0 (disabled) and negative values as valid', () => {
+    const spec = getSettingSpec('stream-first-response-timeout-ms');
+    expect(spec).toBeDefined();
+    expect(spec!.validate!(0).success).toBe(true);
+    expect(spec!.validate!(-1).success).toBe(true);
+  });
+});

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -131,6 +131,10 @@ export interface EphemeralSettings {
   'compression.density.recencyPruning'?: boolean;
   'compression.density.recencyRetention'?: number;
   'compression.density.compressHeadroom'?: number;
+  'stream-first-response-timeout-ms'?: number;
+  streamFirstResponseTimeoutMs?: number;
+  'stream-idle-timeout-ms'?: number;
+  streamIdleTimeoutMs?: number;
 }
 
 /**

--- a/packages/settings/src/settings/registry/registry-entries-3.ts
+++ b/packages/settings/src/settings/registry/registry-entries-3.ts
@@ -409,7 +409,7 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'stream-first-response-timeout-ms',
-    // Mirrors stream-idle-timeout-ms: the alias keeps the camelCase form a
+    // Mirrors stream-idle-timeout-ms: the alias keeps the camelCase form as a
     // recognized CLI setting so it is not leaked into API request bodies
     // (modelParams). @issue #2607
     aliases: ['streamFirstResponseTimeoutMs'],

--- a/packages/settings/src/settings/registry/registry-entries-3.ts
+++ b/packages/settings/src/settings/registry/registry-entries-3.ts
@@ -407,4 +407,26 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
       };
     },
   },
+  {
+    key: 'stream-first-response-timeout-ms',
+    // Mirrors stream-idle-timeout-ms: the alias keeps the camelCase form a
+    // recognized CLI setting so it is not leaked into API request bodies
+    // (modelParams). @issue #2607
+    aliases: ['streamFirstResponseTimeoutMs'],
+    category: 'cli-behavior',
+    description:
+      'First-response (time-to-first-content) watchdog in milliseconds. Enabled by default (300000 = 5 minutes). Set to 0 or a negative number to disable; a provider liveness signal (e.g. response.created) disarms it even before semantic content arrives.',
+    type: 'number',
+    persistToProfile: true,
+    validate: (value: unknown): ValidationResult => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return { success: true, value };
+      }
+      return {
+        success: false,
+        message:
+          'stream-first-response-timeout-ms must be a finite number (use 0 or negative to disable)',
+      };
+    },
+  },
 ];

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -154,6 +154,13 @@
       "default": 0,
       "type": "number"
     },
+    "streamFirstResponseTimeoutMs": {
+      "title": "Stream First-Response Timeout (ms)",
+      "description": "First-response (time-to-first-content) watchdog in milliseconds. Enabled by default (300000 = 5 minutes). A provider liveness signal (e.g. response.created) disarms it even before semantic content arrives. Set to 0 or a negative number to disable.",
+      "markdownDescription": "First-response (time-to-first-content) watchdog in milliseconds. Enabled by default (300000 = 5 minutes). A provider liveness signal (e.g. response.created) disarms it even before semantic content arrives. Set to 0 or a negative number to disable.\n\n- Category: `Streaming`\n- Requires restart: `no`\n- Default: `300000`",
+      "default": 300000,
+      "type": "number"
+    },
     "useExternalAuth": {
       "title": "Use External Auth",
       "description": "Whether to use an external authentication flow.",

--- a/scripts/generate-settings-doc.ts
+++ b/scripts/generate-settings-doc.ts
@@ -151,9 +151,12 @@ function collectEntries(
           label: definition.label,
           category: definition.category,
           description: formatDescription(definition),
-          defaultValue: formatDefaultValue(definition.default, {
-            quoteStrings: true,
-          }),
+          defaultValue: formatDefaultValue(
+            resolveDocumentedDefault(definition),
+            {
+              quoteStrings: true,
+            },
+          ),
           requiresRestart: Boolean(definition.requiresRestart),
           enumValues: definition.options?.map((option) =>
             formatDefaultValue(option.value, { quoteStrings: true }),
@@ -176,6 +179,18 @@ function formatDescription(definition: SettingDefinition) {
     return definition.description.trim();
   }
   return 'Description not provided.';
+}
+
+/**
+ * Resolves the default value advertised in generated documentation.
+ *
+ * Mirrors the schema generator: `documentedDefault` takes precedence so a
+ * setting can advertise a public default that differs from its runtime merge
+ * default (e.g. `streamFirstResponseTimeoutMs` documents 300000 while its
+ * runtime `default` stays `undefined`).
+ */
+function resolveDocumentedDefault(definition: SettingDefinition): unknown {
+  return definition.documentedDefault ?? definition.default;
 }
 
 function formatType(definition: SettingDefinition): string {

--- a/scripts/generate-settings-schema.ts
+++ b/scripts/generate-settings-schema.ts
@@ -139,7 +139,7 @@ function buildSchemaObject(schema: SettingsSchemaType): JsonSchema {
   return root;
 }
 
-function buildSettingSchema(
+export function buildSettingSchema(
   definition: SettingDefinition,
   pathSegments: string[],
   defs: Map<string, JsonSchema>,
@@ -150,13 +150,30 @@ function buildSettingSchema(
     markdownDescription: buildMarkdownDescription(definition),
   };
 
-  if (definition.default !== undefined) {
-    base.default = definition.default as JsonValue;
+  const effectiveDefault = resolveDocumentedDefault(definition);
+  if (effectiveDefault !== undefined) {
+    base.default = effectiveDefault as JsonValue;
   }
 
   const schemaShape = resolveSchemaShape(definition, pathSegments, defs);
 
   return { ...base, ...schemaShape };
+}
+
+/**
+ * Resolves the default value emitted into the generated JSON schema.
+ *
+ * Generators advertise the documented/schema contract, which may intentionally
+ * differ from the runtime merge default. `documentedDefault` takes precedence
+ * so a setting like `streamFirstResponseTimeoutMs` can advertise a public
+ * default (300000) while keeping its runtime `default: undefined` so
+ * settingsMerge does not materialize an unconfigured ephemeral. When
+ * `documentedDefault` is absent, the runtime `default` is used.
+ */
+export function resolveDocumentedDefault(
+  definition: SettingDefinition,
+): unknown {
+  return definition.documentedDefault ?? definition.default;
 }
 
 function resolveSchemaShape(
@@ -343,7 +360,9 @@ function isSettingDefinition(
   return 'label' in source;
 }
 
-function buildMarkdownDescription(definition: SettingDefinition): string {
+export function buildMarkdownDescription(
+  definition: SettingDefinition,
+): string {
   const lines: string[] = [];
 
   if (definition.description?.trim()) {
@@ -358,8 +377,9 @@ function buildMarkdownDescription(definition: SettingDefinition): string {
     `- Requires restart: \`${definition.requiresRestart ? 'yes' : 'no'}\``,
   );
 
-  if (definition.default !== undefined) {
-    lines.push(`- Default: \`${formatDefaultValue(definition.default)}\``);
+  const effectiveDefault = resolveDocumentedDefault(definition);
+  if (effectiveDefault !== undefined) {
+    lines.push(`- Default: \`${formatDefaultValue(effectiveDefault)}\``);
   }
 
   return lines.join('\n');

--- a/scripts/tests/generate-settings-schema.test.ts
+++ b/scripts/tests/generate-settings-schema.test.ts
@@ -4,34 +4,114 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
-import { readFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-import { main as generateSchema } from '../generate-settings-schema.ts';
+/**
+ * Behavioral tests for the settings schema/doc generator's `documentedDefault`
+ * metadata mechanism (issue #2607 Finding 1).
+ *
+ * The mechanism separates a documented/schema default (advertised to users)
+ * from a merge-applied runtime settings default (materialized by settingsMerge).
+ * This keeps `streamFirstResponseTimeoutMs`'s runtime default `undefined`
+ * (no unconfigured ephemeral) while generators advertise the public 300000.
+ */
 
-describe('generate-settings-schema', () => {
-  it('keeps schema in sync in check mode', async () => {
-    const previousExitCode = process.exitCode;
-    await expect(generateSchema(['--check'])).resolves.toBeUndefined();
-    expect(process.exitCode).toBe(previousExitCode);
+import { describe, it, expect } from 'vitest';
+import {
+  buildSettingSchema,
+  buildMarkdownDescription,
+  resolveDocumentedDefault,
+} from '../generate-settings-schema.js';
+import type { SettingDefinition } from '../packages/cli/src/config/settingsSchema.js';
+
+function numberSetting(
+  overrides: Partial<SettingDefinition> = {},
+): SettingDefinition {
+  return {
+    type: 'number',
+    label: 'Test Setting',
+    category: 'Test',
+    requiresRestart: false,
+    default: 0,
+    ...overrides,
+  };
+}
+
+describe('resolveDocumentedDefault', () => {
+  it('returns the runtime default when documentedDefault is absent', () => {
+    const def = numberSetting({ default: 42 });
+    expect(resolveDocumentedDefault(def)).toBe(42);
   });
 
-  it('includes $schema property in generated schema', async () => {
-    const __dirname = dirname(fileURLToPath(import.meta.url));
-    const schemaPath = join(__dirname, '../../schemas/settings.schema.json');
-    const schemaContent = await readFile(schemaPath, 'utf-8');
-    const schema = JSON.parse(schemaContent);
-
-    // Verify $schema property exists in the schema's properties
-    expect(schema.properties).toHaveProperty('$schema');
-    expect(schema.properties.$schema).toEqual({
-      type: 'string',
-      title: 'Schema',
-      description:
-        'The URL of the JSON schema for this settings file. Used by editors for validation and autocompletion.',
-      default:
-        'https://raw.githubusercontent.com/vybestack/llxprt-code/main/schemas/settings.schema.json',
+  it('prefers documentedDefault over the runtime default', () => {
+    const def = numberSetting({
+      default: undefined,
+      documentedDefault: 300000,
     });
+    expect(resolveDocumentedDefault(def)).toBe(300000);
+  });
+
+  it('prefers documentedDefault even when default is a concrete value', () => {
+    const def = numberSetting({ default: 1, documentedDefault: 99 });
+    expect(resolveDocumentedDefault(def)).toBe(99);
+  });
+
+  it('returns undefined when neither default is defined', () => {
+    const def = numberSetting({ default: undefined });
+    expect(resolveDocumentedDefault(def)).toBeUndefined();
+  });
+});
+
+describe('buildSettingSchema documentedDefault precedence', () => {
+  const emptyDefs = new Map<string, unknown>();
+
+  it('emits the documentedDefault as the JSON schema default when runtime default is undefined', () => {
+    const def = numberSetting({
+      default: undefined,
+      documentedDefault: 300000,
+    });
+    const schema = buildSettingSchema(def, ['k'], emptyDefs as never);
+    expect(schema.default).toBe(300000);
+    expect(schema.type).toBe('number');
+  });
+
+  it('emits the runtime default when documentedDefault is absent', () => {
+    const def = numberSetting({ default: 0 });
+    const schema = buildSettingSchema(def, ['k'], emptyDefs as never);
+    expect(schema.default).toBe(0);
+  });
+
+  it('emits documentedDefault when both are present (documented wins)', () => {
+    const def = numberSetting({ default: 1, documentedDefault: 99 });
+    const schema = buildSettingSchema(def, ['k'], emptyDefs as never);
+    expect(schema.default).toBe(99);
+  });
+
+  it('omits the default key entirely when neither is defined', () => {
+    const def = numberSetting({ default: undefined });
+    const schema = buildSettingSchema(def, ['k'], emptyDefs as never);
+    expect(schema.default).toBeUndefined();
+    expect('default' in schema).toBe(false);
+  });
+});
+
+describe('buildMarkdownDescription documentedDefault precedence', () => {
+  it('renders the documentedDefault in the markdown Default line', () => {
+    const def = numberSetting({
+      default: undefined,
+      documentedDefault: 300000,
+    });
+    const md = buildMarkdownDescription(def);
+    expect(md).toContain('- Default: `300000`');
+  });
+
+  it('renders the runtime default when documentedDefault is absent', () => {
+    const def = numberSetting({ default: 0 });
+    const md = buildMarkdownDescription(def);
+    expect(md).toContain('- Default: `0`');
+  });
+
+  it('omits the Default line when neither default is defined', () => {
+    const def = numberSetting({ default: undefined });
+    const md = buildMarkdownDescription(def);
+    expect(md).not.toContain('- Default:');
   });
 });

--- a/scripts/tests/generate-settings-schema.test.ts
+++ b/scripts/tests/generate-settings-schema.test.ts
@@ -20,7 +20,7 @@ import {
   buildMarkdownDescription,
   resolveDocumentedDefault,
 } from '../generate-settings-schema.js';
-import type { SettingDefinition } from '../packages/cli/src/config/settingsSchema.js';
+import type { SettingDefinition } from '../../packages/cli/src/config/settingsSchema.js';
 
 function numberSetting(
   overrides: Partial<SettingDefinition> = {},


### PR DESCRIPTION
## Summary

- distinguish provider transport activity from semantic model output in stream watchdog handling
- propagate provider-neutral stream liveness through Turn, runtime, load-balancer, and OpenAI Responses paths
- keep genuinely silent providers bounded while allowing active high-reasoning streams to continue
- register the first-response timeout across typed agent config, CLI settings, profiles, schema generation, and documentation
- preserve timeout source provenance and emit precise guard, threshold, source, and liveness diagnostics
- make OpenAI Responses retry backoff abortable and honor normalized invocation signals

## Behavioral coverage

- provider lifecycle SSE disarms the first-response guard before semantic content
- semantic content and provider liveness rearm an enabled inter-chunk guard across the full stream
- malformed SSE JSON and DONE markers do not report liveness; listener failures are isolated
- post-tool continuations receive a fresh watchdog and tool execution does not consume the next model timer
- overlapping Turn runs keep timeout state isolated
- typed API, settings.json, profile, alias, environment-precedence, load-balancer, cleanup, retry-abort, and diagnostics paths are covered

## Verification

- full workspace tests completed successfully after package build
- full workspace typecheck passed
- full workspace build passed
- formatting and generated settings schema/docs checks passed
- changed-file and integration-test lint passed; full-tree lint was also exercised but the shell watchdog terminated that long foreground invocation
- required live profile smoke passed with stepfun-37
- two DeepThinker review cycles completed with findings remediated
- two detached Open Code Review cycles completed; all valid findings were remediated and the final-cycle findings were evaluated

fixes #2607


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `streamFirstResponseTimeoutMs` (time-to-first-content watchdog), defaulting to 5 minutes, with per-run runtime wiring for stream timeouts.
  * Added transport liveness callbacks (`onStreamLiveness`) to reduce false first-response/idle timeouts while the provider is actively streaming.
* **Bug Fixes**
  * Improved `StreamIdleTimeout` diagnostics to clearly identify watchdog phase (first-response vs inter-chunk), thresholds, and timeout source.
* **Documentation**
  * Updated Agent API, CLI configuration, and generated settings/schema docs to include `streamFirstResponseTimeoutMs` (including disable semantics via `0`/negative values and documented default behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->