### PR TITLE
Harden OCR provider budgeting, redaction, and notification-write idempotency (Fixes #2576)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1367,6 +1367,7 @@ jobs:
                   --json number,title \
                   --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number]"
               )"; then
+                echo "::warning::Failed to list duplicate tracking issues for convergence; duplicates may accumulate."
                 return 0
               fi
               local dup_count

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -42,6 +42,8 @@ env:
   # Disable colorized CLI output so text parsers (e.g. the changed-test
   # scope guard) always see plain text.
   NO_COLOR: '1'
+  OCR_VERSION: '1.7.9'
+  OCR_CONCURRENCY: '2'
 
 jobs:
   code-review:
@@ -214,7 +216,7 @@ jobs:
             exit 0
           fi
           OCR_PREFIX="${RUNNER_TEMP}/ocr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          if ! npm install --prefix "$OCR_PREFIX" --ignore-scripts @alibaba-group/open-code-review@1.6.1 2>> ocr-stderr.log; then
+          if ! npm install --prefix "$OCR_PREFIX" --ignore-scripts @alibaba-group/open-code-review@${OCR_VERSION} 2>> ocr-stderr.log; then
             echo "::warning::OpenCodeReview installation failed."
             echo "70" > ocr-exit-code.txt
             mark_infrastructure_failure "install" "OpenCodeReview installation failed"
@@ -509,6 +511,7 @@ jobs:
             --format json \
             --audience agent \
             --timeout 30 \
+            --concurrency "$OCR_CONCURRENCY" \
             > ocr-stdout.raw 2> ocr-stderr.log
           status=$?
           if ! cp ocr-stdout.raw ocr-result.json; then
@@ -516,7 +519,15 @@ jobs:
           fi
           echo "$status" > ocr-exit-code.txt
           if [ "$status" -ne 0 ]; then
-            if grep -Eqi "all [0-9]+ file review(\(s\)|s)? failed" ocr-stderr.log; then
+            if grep -Eqi "429|rate limit" ocr-stderr.log; then
+              mark_infrastructure_failure "review" "OCR review failed: HTTP 429 rate limit"
+            elif grep -Eqi "529|overloaded" ocr-stderr.log; then
+              mark_infrastructure_failure "review" "OCR review failed: HTTP 529 provider overloaded"
+            elif grep -Eqi "401|403|auth|unauthorized|forbidden|invalid api key|invalid_api_key|api key" ocr-stderr.log; then
+              mark_infrastructure_failure "review" "OCR review failed: authentication or configuration error"
+            elif grep -Eqi "timeout|timed out" ocr-stderr.log; then
+              mark_infrastructure_failure "review" "OCR review failed: timeout"
+            elif grep -Eqi "all [0-9]+ file review(\(s\)|s)? failed" ocr-stderr.log; then
               mark_infrastructure_failure "review" "all OCR per-file reviews failed; likely LLM provider/config/auth failure"
             else
               mark_infrastructure_failure "review" "OCR review command failed"
@@ -720,6 +731,31 @@ jobs:
               return `${comment.path}\u0000${comment.line}\u0000${startLine}\u0000${unrenderFindingText(comment.body)}`;
             }
 
+            function deduplicationKey(finding) {
+              if (!finding || typeof finding !== 'object') return String(finding || '');
+              const path = finding.path || '';
+              const startLine = finding.start_line || '';
+              const endLine = finding.end_line || '';
+              const body = finding.content || finding.comment || finding.message || finding.body || '';
+              return `${path}\u0000${startLine}\u0000${endLine}\u0000${redactSecretDiagnostics(String(body))}`;
+            }
+
+            function deduplicateFindings(findings) {
+              const seen = new Map();
+              const deduped = [];
+              let suppressed = 0;
+              for (const finding of findings) {
+                const key = deduplicationKey(finding);
+                if (seen.has(key)) {
+                  suppressed += 1;
+                } else {
+                  seen.set(key, true);
+                  deduped.push(finding);
+                }
+              }
+              return { deduped, suppressed };
+            }
+
             async function existingInlineCommentKeys() {
               const comments = await github.paginate(github.rest.pulls.listReviewComments, {
                 owner, repo, pull_number: number, per_page: 100,
@@ -755,6 +791,11 @@ jobs:
             } else {
               core.warning(`Skipping OCR output parsing because phase ${phase} already recorded exit code ${exitCode}.`);
             }
+
+            const dedupedFindings = deduplicateFindings(findings);
+            let suppressedDuplicateCount = 0;
+            suppressedDuplicateCount = dedupedFindings.suppressed;
+            findings = dedupedFindings.deduped;
 
             // Split findings into inline (resolvable file/line) vs. lineless.
             const inline = [];
@@ -891,6 +932,9 @@ jobs:
               `- ${statusLine}`,
               `- ${artifactLine}`,
             ];
+            if (suppressedDuplicateCount > 0) {
+              body.push(`- Suppressed ${suppressedDuplicateCount} exact duplicate finding(s).`);
+            }
             if (!ran || infrastructureFailure) {
               body.push(
                 '',
@@ -921,13 +965,12 @@ jobs:
             }
             const summary = body.join('\n');
 
-            // Sticky summary: update in place if the marker exists, else create.
-            try {
+            async function reconcileMarkerComment() {
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: number, per_page: 100,
               });
-              const markerComments = comments.filter((c) =>
-                c.body && c.body.includes(MARKER));
+              const markerComments = comments.filter((comment) =>
+                comment.body && comment.body.includes(MARKER));
               const existing = markerComments[0];
               for (const duplicate of markerComments.slice(1)) {
                 try {
@@ -939,15 +982,35 @@ jobs:
                   core.warning(redactSecretDiagnostics(`Failed to delete duplicate OCR marker comment ${duplicate.id}: ${duplicateError.message || duplicateError}`));
                 }
               }
+              return existing || null;
+            }
+
+            async function createOrUpdateMarkerComment(summary) {
+              const existing = await reconcileMarkerComment();
               if (existing) {
                 await github.rest.issues.updateComment({
                   owner, repo, comment_id: existing.id, body: summary,
                 });
-              } else {
+                return;
+              }
+              try {
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: number, body: summary,
                 });
+              } catch (createErr) {
+                const reconciled = await reconcileMarkerComment();
+                if (reconciled) {
+                  await github.rest.issues.updateComment({
+                    owner, repo, comment_id: reconciled.id, body: summary,
+                  });
+                } else {
+                  throw createErr;
+                }
               }
+            }
+
+            try {
+              await createOrUpdateMarkerComment(summary);
             } catch (summaryError) {
               core.warning(redactSecretDiagnostics(`Failed to post OCR sticky summary; continuing without failing the workflow: ${summaryError.message || summaryError}`));
             }
@@ -1031,9 +1094,13 @@ jobs:
               }
             }
           };
+          const REDACTED_PENDING = '[REDACTED-PENDING]';
           for (const fileName of diagnosticArtifacts) {
             try {
-              fs.writeFileSync(fileName, redact(fs.readFileSync(fileName, 'utf8')));
+              const originalContent = fs.readFileSync(fileName, 'utf8');
+              fs.writeFileSync(fileName, REDACTED_PENDING);
+              const redactedContent = redact(originalContent);
+              fs.writeFileSync(fileName, redactedContent);
             } catch (error) {
               if (error && error.code !== 'ENOENT') {
                 replaceWithRedactionFailure(fileName, error);
@@ -1272,17 +1339,47 @@ jobs:
             }
             create_infrastructure_issue() {
               local issue_body_file
+              local create_stderr
               issue_body_file="$1"
               shift
-              if retry_gh gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd"; then
+              create_stderr="$(mktemp)"
+              if gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"; then
+                rm -f "${create_stderr}"
                 return 0
               fi
-              echo "::warning::Failed to create OCR infrastructure issue with ci/cd label; retrying without labels."
-              if retry_gh gh issue create "$@" --body-file "$issue_body_file"; then
-                return 0
+              if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then
+                echo "::warning::OCR infrastructure issue label was unavailable; retrying without labels."
+                if gh issue create "$@" --body-file "$issue_body_file"; then
+                  rm -f "${create_stderr}"
+                  return 0
+                fi
               fi
+              rm -f "${create_stderr}"
               echo "::warning::Failed to create OCR infrastructure issue."
               return 1
+            }
+            converge_duplicate_tracking_issues() {
+              local dup_issues
+              if ! dup_issues="$(
+                gh issue list \
+                  --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-asc" \
+                  --limit 30 \
+                  --json number,title \
+                  --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number]"
+              )"; then
+                return 0
+              fi
+              local dup_count
+              dup_count="$(printf '%s' "$dup_issues" | jq 'length')"
+              if [ "$dup_count" -le 1 ]; then
+                return 0
+              fi
+              local KEEP_ISSUE
+              KEEP_ISSUE="$(printf '%s' "$dup_issues" | jq -r '.[0]')"
+              for dup in $(printf '%s' "$dup_issues" | jq -r '.[1:][]'); do
+                gh issue comment "${KEEP_ISSUE}" --body "Consolidated duplicate tracking issue #${dup} into this issue." || true
+                gh issue close "${dup}" || true
+              done
             }
             if ! EXISTING_ISSUE="$(
               retry_gh gh issue list \
@@ -1307,7 +1404,8 @@ jobs:
               return 1
             fi
             if [ -n "$EXISTING_ISSUE" ]; then
-              retry_gh gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue."
+              gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue."
+              converge_duplicate_tracking_issues
               return 0
             fi
             if ! EXISTING_ISSUE="$(
@@ -1321,11 +1419,13 @@ jobs:
               return 0
             fi
             if [ -n "$EXISTING_ISSUE" ]; then
-              retry_gh gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue after recheck."
+              gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue after recheck."
+              converge_duplicate_tracking_issues
               return 0
             fi
             create_infrastructure_issue "$body_file" \
               --title "${ISSUE_TITLE}"
+            converge_duplicate_tracking_issues
             return 0
           }
           notify_ocr_infrastructure_failure || echo "::warning::OCR infrastructure issue notification failed; continuing."

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -986,7 +986,12 @@ jobs:
             }
 
             async function createOrUpdateMarkerComment(summary) {
-              const existing = await reconcileMarkerComment();
+              let existing = null;
+              try {
+                existing = await reconcileMarkerComment();
+              } catch (reconcileErr) {
+                core.warning(redactSecretDiagnostics(`Reconciliation failed before summary posting; attempting create: ${reconcileErr.message || reconcileErr}`));
+              }
               if (existing) {
                 await github.rest.issues.updateComment({
                   owner, repo, comment_id: existing.id, body: summary,
@@ -1100,7 +1105,9 @@ jobs:
               const originalContent = fs.readFileSync(fileName, 'utf8');
               fs.writeFileSync(fileName, REDACTED_PENDING);
               const redactedContent = redact(originalContent);
-              fs.writeFileSync(fileName, redactedContent);
+              const tempFile = `${fileName}.redacting`;
+              fs.writeFileSync(tempFile, redactedContent);
+              fs.renameSync(tempFile, fileName);
             } catch (error) {
               if (error && error.code !== 'ENOENT') {
                 replaceWithRedactionFailure(fileName, error);

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -216,7 +216,7 @@ jobs:
             exit 0
           fi
           OCR_PREFIX="${RUNNER_TEMP}/ocr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          if ! npm install --prefix "$OCR_PREFIX" --ignore-scripts @alibaba-group/open-code-review@${OCR_VERSION} 2>> ocr-stderr.log; then
+          if ! npm install --prefix "$OCR_PREFIX" --ignore-scripts "@alibaba-group/open-code-review@${OCR_VERSION}" 2>> ocr-stderr.log; then
             echo "::warning::OpenCodeReview installation failed."
             echo "70" > ocr-exit-code.txt
             mark_infrastructure_failure "install" "OpenCodeReview installation failed"

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -112,16 +112,16 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
     );
     expectContainsAll(redactRun, [
       'fs.writeFileSync(fileName, REDACTED_PENDING)',
-      'fs.writeFileSync(fileName, redactedContent)',
+      'const tempFile = `${fileName}.redacting`',
+      'fs.writeFileSync(tempFile, redactedContent)',
+      'fs.renameSync(tempFile, fileName)',
     ]);
     expect(redactRun).toContain('[REDACTED-PENDING]');
     const placeholderIndex = redactRun.indexOf(
       'fs.writeFileSync(fileName, REDACTED_PENDING)',
     );
-    const redactedIndex = redactRun.indexOf(
-      'fs.writeFileSync(fileName, redactedContent)',
-    );
-    expect(redactedIndex).toBeGreaterThan(placeholderIndex);
+    const renameIndex = redactRun.indexOf('fs.renameSync(tempFile, fileName)');
+    expect(renameIndex).toBeGreaterThan(placeholderIndex);
   });
 
   it('does not retry non-idempotent gh issue writes (Behavior 5)', () => {
@@ -147,7 +147,7 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
       'createOrUpdateMarkerComment',
     );
     expectContainsAll(postFunctionSource, [
-      'const existing = await reconcileMarkerComment()',
+      'existing = await reconcileMarkerComment()',
       'github.rest.issues.updateComment({',
       'github.rest.issues.createComment({',
       'const reconciled = await reconcileMarkerComment()',

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -87,6 +87,9 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
       'all OCR per-file reviews failed; likely LLM provider/config/auth failure',
       'OCR review command failed',
     ]);
+    // The ordering assertions verify the first-match-wins priority of the
+    // classifier: if branches are reordered, a message matching multiple
+    // patterns (e.g. "429" and "timeout") would be classified differently.
     const http429Index = reviewRun.indexOf('HTTP 429 rate limit');
     const http529Index = reviewRun.indexOf('HTTP 529 provider overloaded');
     const authIndex = reviewRun.indexOf(
@@ -173,6 +176,7 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
       'gh issue list',
       'gh issue comment "${KEEP_ISSUE}"',
       'gh issue close "${dup}"',
+      'Failed to list duplicate tracking issues for convergence; duplicates may accumulate.',
     ]);
   });
 

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  expectContainsAll,
+  extractFunctionSource,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.js';
+
+describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors', () => {
+  let workflowYml;
+  let workflow;
+  let codeReviewJob;
+  let postStep;
+  let postScript;
+  let notifyJob;
+  let notifyStep;
+  let notifyRun;
+
+  beforeAll(() => {
+    workflowYml = readRootFile(WORKFLOW_PATH);
+    try {
+      workflow = yaml.load(workflowYml);
+    } catch (error) {
+      throw new Error(`Failed to parse ${WORKFLOW_PATH}: ${error.message}`, {
+        cause: error,
+      });
+    }
+    codeReviewJob = workflow.jobs?.['code-review'];
+    notifyJob = workflow.jobs?.['notify-ocr-infrastructure-failure'];
+    postStep = stepNamed(codeReviewJob, 'Post OCR results');
+    postScript = commandText(postStep);
+    notifyStep = stepNamed(
+      notifyJob,
+      'Notify OCR infrastructure failure issue',
+    );
+    notifyRun = commandText(notifyStep);
+  });
+
+  it('exposes a single OCR_VERSION env var set to 1.7.9 (Behavior 1)', () => {
+    expect(workflow.env?.OCR_VERSION).toBe('1.7.9');
+  });
+
+  it('installs OpenCodeReview using the OCR_VERSION env var (Behavior 1)', () => {
+    const installRun = commandText(
+      stepNamed(codeReviewJob, 'Install OpenCodeReview'),
+    );
+    expect(installRun).toContain(
+      '@alibaba-group/open-code-review@${OCR_VERSION}',
+    );
+    expect(installRun).not.toContain('1.6.1');
+    expect(installRun).not.toContain('@alibaba-group/open-code-review@1.7.9');
+  });
+
+  it('exposes a configurable OCR_CONCURRENCY env var set to 2 (Behavior 2)', () => {
+    expect(workflow.env?.OCR_CONCURRENCY).toBe('2');
+  });
+
+  it('passes --concurrency to the ocr review command (Behavior 2)', () => {
+    const reviewRun = commandText(
+      stepNamed(codeReviewJob, 'Run OpenCodeReview'),
+    );
+    expect(reviewRun).toContain('--concurrency "$OCR_CONCURRENCY"');
+  });
+
+  it('classifies provider failures into distinct categories (Behavior 3)', () => {
+    const reviewRun = commandText(
+      stepNamed(codeReviewJob, 'Run OpenCodeReview'),
+    );
+    expectContainsAll(reviewRun, [
+      'grep -Eqi "429|rate limit" ocr-stderr.log',
+      'OCR review failed: HTTP 429 rate limit',
+      'grep -Eqi "529|overloaded" ocr-stderr.log',
+      'OCR review failed: HTTP 529 provider overloaded',
+      'grep -Eqi "401|403|auth|unauthorized|forbidden|invalid api key|invalid_api_key|api key" ocr-stderr.log',
+      'OCR review failed: authentication or configuration error',
+      'grep -Eqi "timeout|timed out" ocr-stderr.log',
+      'OCR review failed: timeout',
+      'all OCR per-file reviews failed; likely LLM provider/config/auth failure',
+      'OCR review command failed',
+    ]);
+    const http429Index = reviewRun.indexOf('HTTP 429 rate limit');
+    const http529Index = reviewRun.indexOf('HTTP 529 provider overloaded');
+    const authIndex = reviewRun.indexOf(
+      'authentication or configuration error',
+    );
+    const timeoutIndex = reviewRun.indexOf('OCR review failed: timeout');
+    const allFileIndex = reviewRun.indexOf('all OCR per-file reviews failed');
+    const genericIndex = reviewRun.indexOf('OCR review command failed');
+    expect(http429Index).toBeGreaterThan(-1);
+    expect(http529Index).toBeGreaterThan(http429Index);
+    expect(authIndex).toBeGreaterThan(http529Index);
+    expect(timeoutIndex).toBeGreaterThan(authIndex);
+    expect(allFileIndex).toBeGreaterThan(timeoutIndex);
+    expect(genericIndex).toBeGreaterThan(allFileIndex);
+  });
+
+  it('writes a safe placeholder before redacting artifacts (Behavior 4)', () => {
+    const redactRun = commandText(
+      stepNamed(codeReviewJob, 'Redact OCR diagnostic artifacts'),
+    );
+    expectContainsAll(redactRun, [
+      'fs.writeFileSync(fileName, REDACTED_PENDING)',
+      'fs.writeFileSync(fileName, redactedContent)',
+    ]);
+    expect(redactRun).toContain('[REDACTED-PENDING]');
+    const placeholderIndex = redactRun.indexOf(
+      'fs.writeFileSync(fileName, REDACTED_PENDING)',
+    );
+    const redactedIndex = redactRun.indexOf(
+      'fs.writeFileSync(fileName, redactedContent)',
+    );
+    expect(redactedIndex).toBeGreaterThan(placeholderIndex);
+  });
+
+  it('does not retry non-idempotent gh issue writes (Behavior 5)', () => {
+    expectContainsAll(notifyRun, [
+      'gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd"',
+      'gh issue create "$@" --body-file "$issue_body_file"',
+      'gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file"',
+    ]);
+    const createWithLabelPattern = /retry_gh\s+gh\s+issue\s+create/;
+    expect(notifyRun).not.toMatch(createWithLabelPattern);
+    const commentRetryPattern = /retry_gh\s+gh\s+issue\s+comment/;
+    expect(notifyRun).not.toMatch(commentRetryPattern);
+  });
+
+  it('reconciles ambiguous createComment by marker (Behavior 6)', () => {
+    expectContainsAll(postScript, [
+      'async function createOrUpdateMarkerComment(summary)',
+      'async function reconcileMarkerComment()',
+      'comment.body && comment.body.includes(MARKER)',
+    ]);
+    const postFunctionSource = extractFunctionSource(
+      postScript,
+      'createOrUpdateMarkerComment',
+    );
+    expectContainsAll(postFunctionSource, [
+      'const existing = await reconcileMarkerComment()',
+      'github.rest.issues.updateComment({',
+      'github.rest.issues.createComment({',
+      'const reconciled = await reconcileMarkerComment()',
+      'if (reconciled)',
+    ]);
+  });
+
+  it('retries issue creation without labels only for label errors (Behavior 7)', () => {
+    expectContainsAll(notifyRun, [
+      'create_infrastructure_issue() {',
+      'issue_body_file="$1"',
+      'gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"',
+      'local create_stderr',
+      'if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then',
+      'gh issue create "$@" --body-file "$issue_body_file"',
+      'Failed to create OCR infrastructure issue.',
+    ]);
+    expect(notifyRun).not.toContain(
+      'Failed to create OCR infrastructure issue with ci/cd label; retrying without labels.',
+    );
+  });
+
+  it('converges duplicate tracking issues after create (Behavior 8)', () => {
+    expectContainsAll(notifyRun, [
+      'converge_duplicate_tracking_issues() {',
+      'gh issue list',
+      'gh issue comment "${KEEP_ISSUE}"',
+      'gh issue close "${dup}"',
+    ]);
+  });
+
+  it('deduplicates exact candidates before posting (Behavior 9)', () => {
+    expectContainsAll(postScript, [
+      'function deduplicationKey(finding)',
+      'deduplicationKey(finding)',
+      'const dedupedFindings = deduplicateFindings(findings)',
+      'let suppressedDuplicateCount = 0',
+      'Suppressed ${suppressedDuplicateCount} exact duplicate finding(s).',
+    ]);
+  });
+
+  it('records suppression count in the summary comment (Behavior 10)', () => {
+    expect(postScript).toContain(
+      'Suppressed ${suppressedDuplicateCount} exact duplicate finding(s).',
+    );
+    const dedupFunctionSource = extractFunctionSource(
+      postScript,
+      'deduplicateFindings',
+    );
+    expectContainsAll(dedupFunctionSource, [
+      'const seen = new Map()',
+      'seen.has(key)',
+      'suppressed += 1',
+      'seen.set(key, true)',
+      'return { deduped, suppressed }',
+    ]);
+  });
+});

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -54,7 +54,7 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
       stepNamed(codeReviewJob, 'Install OpenCodeReview'),
     );
     expect(installRun).toContain(
-      '@alibaba-group/open-code-review@${OCR_VERSION}',
+      '"@alibaba-group/open-code-review@${OCR_VERSION}"',
     );
     expect(installRun).not.toContain('1.6.1');
     expect(installRun).not.toContain('@alibaba-group/open-code-review@1.7.9');

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -230,7 +230,7 @@ describe('.github/workflows/ocr-review.yml', () => {
 
     expectContainsAll(installRun, [
       'OCR_PREFIX="${RUNNER_TEMP}/ocr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
-      'npm install --prefix "$OCR_PREFIX" --ignore-scripts @alibaba-group/open-code-review@${OCR_VERSION}',
+      'npm install --prefix "$OCR_PREFIX" --ignore-scripts "@alibaba-group/open-code-review@${OCR_VERSION}"',
       'echo "70" > ocr-exit-code.txt',
       'OCR_BIN="${OCR_PREFIX}/node_modules/.bin"',
       'echo "$OCR_BIN" >> "$GITHUB_PATH"',

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -230,7 +230,7 @@ describe('.github/workflows/ocr-review.yml', () => {
 
     expectContainsAll(installRun, [
       'OCR_PREFIX="${RUNNER_TEMP}/ocr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
-      'npm install --prefix "$OCR_PREFIX" --ignore-scripts @alibaba-group/open-code-review@1.6.1',
+      'npm install --prefix "$OCR_PREFIX" --ignore-scripts @alibaba-group/open-code-review@${OCR_VERSION}',
       'echo "70" > ocr-exit-code.txt',
       'OCR_BIN="${OCR_PREFIX}/node_modules/.bin"',
       'echo "$OCR_BIN" >> "$GITHUB_PATH"',
@@ -240,6 +240,8 @@ describe('.github/workflows/ocr-review.yml', () => {
     ]);
     expect(installRun).not.toContain('${OCR_PREFIX}/bin');
     expect(installRun).not.toContain('npm install -g');
+    expect(installRun).not.toContain('@alibaba-group/open-code-review@1.6.1');
+    expect(installRun).not.toContain('@alibaba-group/open-code-review@latest');
   });
 
   it('records OCR phases and keeps provider/runtime failures non-blocking', () => {
@@ -803,14 +805,16 @@ describe('.github/workflows/ocr-review.yml', () => {
       "$(TZ=UTC date +'%Y-%m-%d')",
       'create_infrastructure_issue() {',
       'local issue_body_file',
+      'local create_stderr',
       'issue_body_file="$1"',
       'shift',
-      'retry_gh gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd"',
-      'Failed to create OCR infrastructure issue with ci/cd label; retrying without labels.',
-      'retry_gh gh issue create "$@" --body-file "$issue_body_file"',
+      'gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"',
+      'if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then',
+      'gh issue create "$@" --body-file "$issue_body_file"',
       'Failed to create OCR infrastructure issue.',
       'return 1',
       'create_infrastructure_issue "$body_file"',
+      'converge_duplicate_tracking_issues',
     ]);
     expect(normalizedNotifyRun).not.toContain('sleep 5');
     expect(normalizedNotifyRun).not.toContain("$(date +'%Y-%m-%d')");


### PR DESCRIPTION
## Summary

Harden the OCR review workflow (`.github/workflows/ocr-review.yml`) with 10 operational controls from issue #2576, referencing Luther PR 130 patterns.

## Changes

### Workflow (`.github/workflows/ocr-review.yml`)

1. **Single OCR version source (1.6.1 → 1.7.9)** — Added `OCR_VERSION: '1.7.9'` workflow-level env var; install step uses `@alibaba-group/open-code-review@${OCR_VERSION}` instead of a hardcoded version.

2. **Configurable provider concurrency** — Added `OCR_CONCURRENCY: '2'` workflow-level env var; review command gets `--concurrency "$OCR_CONCURRENCY"`.

3. **Provider failure classification** — Multi-branch classifier in the review step now distinguishes HTTP 429 (rate limit), HTTP 529 (overloaded), authentication/configuration errors, timeout, all-file failure, and generic failure — each with a distinct `mark_infrastructure_failure` reason.

4. **Fail-closed redaction** — Artifact redaction now writes a `[REDACTED-PENDING]` placeholder immediately after reading original content, before attempting the redacted write. If the final write fails, the file contains only the safe placeholder, never original bytes.

5. **Retry only idempotent operations** — Removed `retry_gh` wrapper from `gh issue create` and `gh issue comment` (non-idempotent). Only `gh issue list` (read) retains retry.

6. **Reconcile ambiguous writes** — Sticky summary posting now uses `createOrUpdateMarkerComment()` / `reconcileMarkerComment()` functions. On `createComment` failure, it re-lists comments to check if the comment was actually created before retrying, preventing duplicates from ambiguous responses.

7. **Label-verified issue creation** — `create_infrastructure_issue` captures stderr from the labeled create, checks for label-related errors (`label|labels|not found|does not exist`), and only retries without labels if the failure was specifically label-related.

8. **Tracking issue convergence** — Added `converge_duplicate_tracking_issues()` that lists open issues with the tracking title, keeps the oldest (`created-asc`), comments on it, and closes duplicates. Runs on both comment-on-existing and create paths.

9. **Candidate deduplication** — Added `deduplicationKey()` / `deduplicateFindings()` to the Post OCR results step. Exact duplicate findings (same path, start_line, end_line, body) are deduplicated before inline/lineless split.

10. **Suppression recording** — The summary comment includes `Suppressed N exact duplicate finding(s).` when duplicates were removed.

### Tests

- **`scripts/tests/ocr-review-workflow.test.js`** — Updated existing tests for the new retry/label behavior.
- **`scripts/tests/ocr-review-workflow-behaviors.test.js`** (new) — 12 dedicated contract tests for all 10 behaviors, split out to stay under the 800-line max-lines rule.

## Test plan

- [x] `npm run test:scripts` — all OCR workflow tests pass (44 total)
- [x] `npx eslint` — no errors in changed files
- [x] `npx prettier --check` — all files formatted
- [x] YAML parsed and validated with js-yaml
- [x] OCR local review completed (3 findings addressed: beforeAll error handling added; contract test pattern dismissed as established convention)

## Closes

Closes #2576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Pinned OpenCodeReview to version **1.7.9** and added **review concurrency (2)**.
  - Enhanced provider failure classification (HTTP **429/529**, auth/config issues, and timeouts).
  - Deduplicates identical findings and includes a suppressed-duplicates count in the published summary.
  - Improves diagnostic redaction with a **[REDACTED-PENDING]** placeholder.
  - Refines marker comment updates and strengthens infrastructure issue handling, including label-error recovery and consolidation of duplicate tracking issues.
- **Tests**
  - Updated CI workflow behavior tests to match the revised install, error-handling, and posting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->