### PR TITLE
Prevent OAuth browser launch from hiding Windows terminals

### DIFF
--- a/packages/core/src/utils/secure-browser-launcher.test.ts
+++ b/packages/core/src/utils/secure-browser-launcher.test.ts
@@ -51,6 +51,16 @@ describe('secure-browser-launcher', () => {
     });
   }
 
+  function requireWindowsDirectory(
+    windowsDirectory: string | undefined,
+  ): asserts windowsDirectory is string {
+    if (windowsDirectory === undefined) {
+      throw new Error(
+        'Windows integration test requires SystemRoot or windir to locate System32\\where.exe.',
+      );
+    }
+  }
+
   describe('URL validation', () => {
     it('should allow valid HTTP URLs', async () => {
       setPlatform('darwin');
@@ -140,15 +150,13 @@ describe('secure-browser-launcher', () => {
     it.runIf(process.platform === 'win32')(
       'executes the production PowerShell launch with where.exe and remains usable afterward',
       async () => {
+        const windowsDirectory = process.env.SystemRoot ?? process.env.windir;
+        requireWindowsDirectory(windowsDirectory);
+        const harmlessTarget = join(windowsDirectory, 'System32', 'where.exe');
         const directory = await mkdtemp(
           join(tmpdir(), 'llxprt-browser-launch-'),
         );
         const sentinelPath = join(directory, 'parent-sentinel.txt');
-        const harmlessTarget = join(
-          process.env.SystemRoot ?? 'C:\\Windows',
-          'System32',
-          'where.exe',
-        );
         const { execFile: executeFile } =
           await vi.importActual<typeof import('node:child_process')>(
             'node:child_process',

--- a/packages/core/src/utils/secure-browser-launcher.test.ts
+++ b/packages/core/src/utils/secure-browser-launcher.test.ts
@@ -5,13 +5,23 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ExecFileOptions } from 'node:child_process';
 import {
   openBrowserSecurely,
   shouldLaunchBrowser,
 } from './secure-browser-launcher.js';
 
+type ExecFilePromise = (
+  command: string,
+  args: string[],
+  options: ExecFileOptions,
+) => Promise<{ stdout: string; stderr: string }>;
+
 // Create mock function using vi.hoisted
-const mockExecFile = vi.hoisted(() => vi.fn());
+const mockExecFile = vi.hoisted(() => vi.fn<ExecFilePromise>());
 
 // Mock modules
 vi.mock('node:child_process');
@@ -95,29 +105,93 @@ describe('secure-browser-launcher', () => {
   });
 
   describe('Command injection prevention', () => {
-    it('should prevent PowerShell command injection on Windows', async () => {
+    it('keeps the exact Windows URL in the environment and out of constant PowerShell source', async () => {
       setPlatform('win32');
+      const url =
+        'https://example.com/callback path?name=O\'Brien&quote="double quotes"&state=$(whoami);pipe|tick`&redirect=>out#fragment';
 
-      // The POC from the vulnerability report
-      const maliciousUrl =
-        "http://127.0.0.1:8080/?param=example#$(Invoke-Expression([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('Y2FsYy5leGU='))))";
+      await openBrowserSecurely(url);
 
-      await openBrowserSecurely(maliciousUrl);
-
-      // Verify that execFile was called (not exec) and the URL is passed safely
       expect(mockExecFile).toHaveBeenCalledWith(
         'powershell.exe',
         [
           '-NoProfile',
           '-NonInteractive',
-          '-WindowStyle',
-          'Hidden',
           '-Command',
-          `Start-Process '${maliciousUrl.replace(/'/g, "''")}'`,
+          '$browserUrl = $env:LLXPRT_BROWSER_URL; Remove-Item Env:LLXPRT_BROWSER_URL; Start-Process -FilePath $browserUrl',
         ],
-        expect.any(Object),
+        {
+          env: {
+            ...process.env,
+            SHELL: undefined,
+            LLXPRT_BROWSER_URL: url,
+          },
+          shell: false,
+          windowsHide: true,
+        },
       );
+
+      const args = mockExecFile.mock.calls[0]?.[1] ?? [];
+      expect(args.join(' ')).not.toContain(url);
+      expect(args.join(' ')).not.toContain('-WindowStyle');
+      expect(args.join(' ')).not.toContain('Hidden');
     });
+
+    it.runIf(process.platform === 'win32')(
+      'executes the production PowerShell launch with where.exe and remains usable afterward',
+      async () => {
+        const directory = await mkdtemp(
+          join(tmpdir(), 'llxprt-browser-launch-'),
+        );
+        const sentinelPath = join(directory, 'parent-sentinel.txt');
+        const harmlessTarget = join(
+          process.env.SystemRoot ?? 'C:\\Windows',
+          'System32',
+          'where.exe',
+        );
+        const { execFile: executeFile } =
+          await vi.importActual<typeof import('node:child_process')>(
+            'node:child_process',
+          );
+
+        mockExecFile.mockImplementationOnce(async (command, args, options) => {
+          await new Promise<void>((resolve, reject) => {
+            executeFile(
+              command,
+              args,
+              {
+                ...options,
+                env: {
+                  ...options.env,
+                  LLXPRT_BROWSER_URL: harmlessTarget,
+                },
+              },
+              (error) => {
+                if (error) {
+                  reject(error);
+                  return;
+                }
+                resolve();
+              },
+            );
+          });
+          return { stdout: '', stderr: '' };
+        });
+
+        try {
+          setPlatform('win32');
+          await openBrowserSecurely('https://example.com/safe-integration');
+          await writeFile(sentinelPath, 'parent remains usable', 'utf8');
+
+          await expect(readFile(sentinelPath, 'utf8')).resolves.toBe(
+            'parent remains usable',
+          );
+        } finally {
+          await rm(directory, { recursive: true, force: true });
+        }
+      },
+      10_000,
+    );
 
     it('should handle URLs with special shell characters safely', async () => {
       setPlatform('darwin');
@@ -141,28 +215,6 @@ describe('secure-browser-launcher', () => {
         );
       }
     });
-
-    it('should properly escape single quotes in URLs on Windows', async () => {
-      setPlatform('win32');
-
-      const urlWithSingleQuotes =
-        "http://example.com/path?name=O'Brien&test='value'";
-      await openBrowserSecurely(urlWithSingleQuotes);
-
-      // Verify that single quotes are escaped by doubling them
-      expect(mockExecFile).toHaveBeenCalledWith(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-WindowStyle',
-          'Hidden',
-          '-Command',
-          `Start-Process 'http://example.com/path?name=O''Brien&test=''value'''`,
-        ],
-        expect.any(Object),
-      );
-    });
   });
 
   describe('Platform-specific behavior', () => {
@@ -172,19 +224,6 @@ describe('secure-browser-launcher', () => {
       expect(mockExecFile).toHaveBeenCalledWith(
         'open',
         ['https://example.com'],
-        expect.any(Object),
-      );
-    });
-
-    it('should use PowerShell on Windows', async () => {
-      setPlatform('win32');
-      await openBrowserSecurely('https://example.com');
-      expect(mockExecFile).toHaveBeenCalledWith(
-        'powershell.exe',
-        expect.arrayContaining([
-          '-Command',
-          `Start-Process 'https://example.com'`,
-        ]),
         expect.any(Object),
       );
     });

--- a/packages/core/src/utils/secure-browser-launcher.test.ts
+++ b/packages/core/src/utils/secure-browser-launcher.test.ts
@@ -181,6 +181,7 @@ describe('secure-browser-launcher', () => {
         try {
           setPlatform('win32');
           await openBrowserSecurely('https://example.com/safe-integration');
+          expect(mockExecFile).toHaveBeenCalledTimes(1);
           await writeFile(sentinelPath, 'parent remains usable', 'utf8');
 
           await expect(readFile(sentinelPath, 'utf8')).resolves.toBe(

--- a/packages/core/src/utils/secure-browser-launcher.ts
+++ b/packages/core/src/utils/secure-browser-launcher.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execFile } from 'node:child_process';
+import { execFile, type ExecFileOptions } from 'node:child_process';
 import { promisify } from 'node:util';
 import { platform } from 'node:os';
 import { URL } from 'node:url';
@@ -44,79 +44,84 @@ function validateUrl(url: string): void {
   }
 }
 
+interface BrowserLaunchPlan {
+  readonly command: string;
+  readonly args: string[];
+  readonly options: ExecFileOptions;
+}
+
+function createBrowserLaunchPlan(
+  platformName: NodeJS.Platform,
+  url: string,
+): BrowserLaunchPlan {
+  const env = {
+    ...process.env,
+    SHELL: undefined,
+  };
+
+  switch (platformName) {
+    case 'darwin':
+      return {
+        command: 'open',
+        args: [url],
+        options: { env, shell: false },
+      };
+    case 'win32':
+      return {
+        command: 'powershell.exe',
+        args: [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          '$browserUrl = $env:LLXPRT_BROWSER_URL; Remove-Item Env:LLXPRT_BROWSER_URL; Start-Process -FilePath $browserUrl',
+        ],
+        options: {
+          env: { ...env, LLXPRT_BROWSER_URL: url },
+          shell: false,
+          windowsHide: true,
+        },
+      };
+    case 'linux':
+    case 'freebsd':
+    case 'openbsd':
+      return {
+        command: 'xdg-open',
+        args: [url],
+        options: { env, shell: false },
+      };
+    default:
+      throw new Error(`Unsupported platform: ${platformName}`);
+  }
+}
+
 /**
  * Opens a URL in the default browser using platform-specific commands.
  * This implementation avoids shell injection vulnerabilities by:
  * 1. Validating the URL to ensure it's HTTP/HTTPS only
  * 2. Using execFile instead of exec to avoid shell interpretation
- * 3. Passing the URL as an argument rather than constructing a command string
+ * 3. Keeping URL data out of PowerShell command source
  *
  * @param url The URL to open
  * @throws Error if the URL is invalid or if opening the browser fails
  */
 export async function openBrowserSecurely(url: string): Promise<void> {
-  // Validate the URL first
   validateUrl(url);
 
   const platformName = platform();
-  let command: string;
-  let args: string[];
-
-  switch (platformName) {
-    case 'darwin':
-      // macOS
-      command = 'open';
-      args = [url];
-      break;
-
-    case 'win32':
-      // Windows - use PowerShell with Start-Process
-      // This avoids the cmd.exe shell which is vulnerable to injection
-      command = 'powershell.exe';
-      args = [
-        '-NoProfile',
-        '-NonInteractive',
-        '-WindowStyle',
-        'Hidden',
-        '-Command',
-        `Start-Process '${url.replace(/'/g, "''")}'`,
-      ];
-      break;
-
-    case 'linux':
-    case 'freebsd':
-    case 'openbsd':
-      // Linux and BSD variants
-      // Try xdg-open first, fall back to other options
-      command = 'xdg-open';
-      args = [url];
-      break;
-
-    default:
-      throw new Error(`Unsupported platform: ${platformName}`);
-  }
-
-  const options: Record<string, unknown> = {
-    // Don't inherit parent's environment to avoid potential issues
-    env: {
-      ...process.env,
-      // Ensure we're not in a shell that might interpret special characters
-      SHELL: undefined,
-    },
-    // Detach the browser process so it doesn't block
-    detached: true,
-    stdio: 'ignore',
-  };
+  const launchPlan = createBrowserLaunchPlan(platformName, url);
 
   try {
-    await execFileAsync(command, args, options);
+    await execFileAsync(
+      launchPlan.command,
+      launchPlan.args,
+      launchPlan.options,
+    );
   } catch (error) {
-    // For Linux, try fallback commands if xdg-open fails
     if (
       (platformName === 'linux' ||
         platformName === 'freebsd' ||
         platformName === 'openbsd') &&
-      command === 'xdg-open'
+      launchPlan.command === 'xdg-open'
     ) {
       const fallbackCommands = [
         'gnome-open',
@@ -129,14 +134,13 @@ export async function openBrowserSecurely(url: string): Promise<void> {
       const succeeded = await tryFallbackBrowserCommands(
         fallbackCommands,
         url,
-        options,
+        launchPlan.options,
       );
       if (succeeded) {
         return;
       }
     }
 
-    // Re-throw the error if all attempts failed
     throw new Error(
       `Failed to open browser: ${error instanceof Error ? error.message : 'Unknown error'}`,
     );
@@ -197,9 +201,9 @@ export function shouldLaunchBrowser(
 }
 
 async function tryFallbackBrowserCommands(
-  fallbackCommands: string[],
+  fallbackCommands: readonly string[],
   url: string,
-  options: Record<string, unknown>,
+  options: ExecFileOptions,
 ): Promise<boolean> {
   for (const fallbackCommand of fallbackCommands) {
     try {

--- a/packages/core/src/utils/secure-browser-launcher.ts
+++ b/packages/core/src/utils/secure-browser-launcher.ts
@@ -10,6 +10,7 @@ import { platform } from 'node:os';
 import { URL } from 'node:url';
 
 const execFileAsync = promisify(execFile);
+const WINDOWS_BROWSER_URL_ENV_VAR = 'LLXPRT_BROWSER_URL';
 
 /**
  * Validates that a URL is safe to open in a browser.
@@ -73,10 +74,10 @@ function createBrowserLaunchPlan(
           '-NoProfile',
           '-NonInteractive',
           '-Command',
-          '$browserUrl = $env:LLXPRT_BROWSER_URL; Remove-Item Env:LLXPRT_BROWSER_URL; Start-Process -FilePath $browserUrl',
+          `$browserUrl = $env:${WINDOWS_BROWSER_URL_ENV_VAR}; Remove-Item Env:${WINDOWS_BROWSER_URL_ENV_VAR}; Start-Process -FilePath $browserUrl`,
         ],
         options: {
-          env: { ...env, LLXPRT_BROWSER_URL: url },
+          env: { ...env, [WINDOWS_BROWSER_URL_ENV_VAR]: url },
           shell: false,
           windowsHide: true,
         },

--- a/project-plans/issue2512/plan.md
+++ b/project-plans/issue2512/plan.md
@@ -79,7 +79,7 @@ npm run test --workspace @vybestack/llxprt-code-core -- src/utils/secure-browser
 
 ## Safe real-process regression
 
-The Windows-only test calls the public `openBrowserSecurely` function. At the existing infrastructure mock boundary, it replaces only the `LLXPRT_BROWSER_URL` target with `%SystemRoot%\System32\where.exe`, then delegates the unchanged production executable, argument vector, and remaining options to native Node `child_process.execFile`.
+The Windows-only test calls the public `openBrowserSecurely` function. Before creating its temporary fixture, the test derives the installed Windows directory from `process.env.SystemRoot ?? process.env.windir` and fails with an actionable fixture error if neither variable is defined. It uses that directory only to locate the built-in `System32\where.exe` test target; this fixture resolution does not exercise or claim production fallback behavior. At the existing infrastructure mock boundary, it replaces only the `LLXPRT_BROWSER_URL` target, then delegates the unchanged production executable, argument vector, and remaining options to native Node `child_process.execFile`.
 
 The real `powershell.exe` therefore executes the production bind/remove/`Start-Process` source. `where.exe` is a short-lived built-in target and does not open a browser or authentication flow. After the helper returns, the test writes and reads a temporary sentinel, proving the parent test process remains operational. A ten-second test timeout bounds the test without introducing process-killing behavior.
 

--- a/project-plans/issue2512/plan.md
+++ b/project-plans/issue2512/plan.md
@@ -1,0 +1,127 @@
+# Issue #2512 — Prevent Windows browser launch from hiding the parent console
+
+Plan ID: PLAN-20260722-ISSUE2512
+Issue: https://github.com/vybestack/llxprt-code/issues/2512
+Branch: `issue2512`
+Baseline: `c28806b8cc4db1898efe514c4aa501c30a2c16c8`
+
+## Goal
+
+Keep the existing `openBrowserSecurely(url)` API and the shared Codex, Anthropic, and MCP call path while ensuring Windows default-browser launch cannot hide or manipulate the caller's shared console. Preserve URL validation, injection resistance, non-Windows command/fallback behavior, and contextual errors.
+
+## Grounded findings
+
+- The baseline Windows implementation launched `powershell.exe -WindowStyle Hidden`, which can affect a console shared with the parent PowerShell session.
+- Explicit `/auth codex login` and lazy Codex authentication converge on `openBrowserSecurely`; Anthropic and MCP OAuth use the same helper.
+- The baseline interpolated an escaped URL into PowerShell source. The remediated design keeps URL data out of source entirely.
+- `windowsHide: true` is already an established process-creation option in this repository and suppresses the child window without asking PowerShell to hide a potentially shared console.
+- `execFile` supports `windowsHide` and `shell`, but its option type does not support the previous `detached` and `stdio` fields. Those fields were removed rather than represented by a test-only abstraction.
+- The public function must remain one-argument. Tests use the existing mocked child-process infrastructure boundary and do not expose a production test seam.
+
+## Behavioral requirements
+
+### REQ-2512-001 — Never manipulate the shared console
+
+For Windows browser launch, PowerShell arguments contain no `-WindowStyle`, `Hidden`, or other console-window manipulation command.
+
+### REQ-2512-002 — Suppress only the helper window
+
+The Windows PowerShell helper is created with `windowsHide: true` and `shell: false`. It does not use `cmd.exe`, `shell: true`, or Windows detachment.
+
+### REQ-2512-003 — Keep URL data out of PowerShell source
+
+The exact validated URL is supplied through `LLXPRT_BROWSER_URL`. Constant PowerShell source copies it into a scalar, removes the environment entry, and only then launches the associated application:
+
+```powershell
+$browserUrl = $env:LLXPRT_BROWSER_URL; Remove-Item Env:LLXPRT_BROWSER_URL; Start-Process -FilePath $browserUrl
+```
+
+This keeps apostrophes, double quotes, spaces, dollar expressions, semicolons, pipes, backticks, ampersands, redirects, and fragments as data. Removing the environment entry before `Start-Process` prevents the launched browser or association process from inheriting it.
+
+### REQ-2512-004 — Preserve validation
+
+Valid HTTP and HTTPS URLs launch. Invalid URLs, non-HTTP(S) protocols, and URLs containing control characters fail before process execution.
+
+### REQ-2512-005 — Preserve other platforms
+
+macOS continues to execute `open <URL>`. Linux, FreeBSD, and OpenBSD continue to execute `xdg-open <URL>` and retain the existing fallback order. Unsupported platforms and launch failures retain contextual errors.
+
+### REQ-2512-006 — Preserve callers and API
+
+`openBrowserSecurely` remains `(url: string) => Promise<void>`. Codex, Anthropic, and MCP call sites require no edits.
+
+## Test-first implementation
+
+### Initial RED
+
+Before the first production change, the Windows harmless-child test failed with one failed and seventeen passed tests because the baseline ignored the attempted runner injection and retained the old `-WindowStyle Hidden`/interpolated command. That failure established missing behavior but did not directly exercise the console hazard, so the test design was strengthened during review.
+
+### Review RED
+
+Before the final remediation, the strengthened all-host Windows contract test failed with one failed and nineteen passed tests. It expected the bind/remove/launch command but received `Start-Process -FilePath $env:LLXPRT_BROWSER_URL`, proving that the launched association process would inherit the OAuth URL environment entry. Compiler inspection also showed the rejected public signature `(url: string, processRunner?: BrowserProcessRunner) => Promise<void>`.
+
+Focused RED command:
+
+```powershell
+npm run test --workspace @vybestack/llxprt-code-core -- src/utils/secure-browser-launcher.test.ts
+```
+
+### GREEN
+
+- Restored the one-argument public API and removed the test-only process-runner abstraction.
+- Typed internal launch data with Node's actual `ExecFileOptions`.
+- Replaced `-WindowStyle Hidden` with `windowsHide: true` at process creation.
+- Added explicit `shell: false`.
+- Kept the PowerShell source constant and removed the URL environment entry before `Start-Process`.
+- Removed unsupported `detached`/`stdio` claims without changing effective macOS/Linux/BSD commands or fallback behavior.
+- Added an all-host Windows contract test so non-Windows CI catches a return of `-WindowStyle Hidden`, URL interpolation, or unsafe process options.
+- Added a Windows-only real-process test through the existing mocked `execFile` infrastructure boundary.
+
+## Safe real-process regression
+
+The Windows-only test calls the public `openBrowserSecurely` function. At the existing infrastructure mock boundary, it replaces only the `LLXPRT_BROWSER_URL` target with `%SystemRoot%\System32\where.exe`, then delegates the unchanged production executable, argument vector, and remaining options to native Node `child_process.execFile`.
+
+The real `powershell.exe` therefore executes the production bind/remove/`Start-Process` source. `where.exe` is a short-lived built-in target and does not open a browser or authentication flow. After the helper returns, the test writes and reads a temporary sentinel, proving the parent test process remains operational. A ten-second test timeout bounds the test without introducing process-killing behavior.
+
+The automated test does not prove taskbar visibility, exercise a registered browser association, directly inspect the target's inherited environment, or execute under Bun. Two Bun-hosted Vitest attempts failed before collection with `TypeError: File URL path must be an absolute path`; zero Bun-hosted tests executed. Manual Windows OAuth validation remains required.
+
+## Verification record
+
+Focused and caller verification passed:
+
+- Browser launcher: 1 file, 19 tests passed.
+- Core: 284 files passed; 5,212 tests passed and 50 skipped.
+- Provider callers: 4 files, 21 tests passed.
+- MCP callers: 2 files, 28 tests passed.
+- Core, providers, and MCP typechecks passed.
+- Focused ESLint and Prettier checks passed.
+- `git diff --check` passed.
+
+Mandatory repository verification passed:
+
+- `npm run test`: 509 files; 10,320 tests passed and 100 skipped.
+- `npm run lint`.
+- `npm run typecheck`.
+- `npm run format`.
+- `npm run build`.
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` returned a valid haiku.
+
+Non-fatal existing Windows diagnostics concerning `locale`, provider-reference parsing, and node-pty fallback appeared during verification, but every required command exited successfully.
+
+## Safety constraints
+
+- Never launch a real browser or authentication flow during automated verification.
+- Never hide, close, or terminate the developer terminal or another process.
+- Do not use `cmd.exe`, `shell: true`, or interpolate URL data into PowerShell source.
+- Do not add dependencies, modify `.llxprt/`, run `git clean`, or edit OAuth callers needlessly.
+
+## Remaining manual validation
+
+After the PR and review cycle, manually run `/auth codex login` on Windows and confirm:
+
+1. The registered browser opens.
+2. The existing PowerShell window remains visible, accessible from the taskbar, and usable.
+3. The callback and authentication complete successfully.
+4. Lazy authentication has the same safe behavior.
+
+That manual validation is intentionally deferred to the user because it opens a real browser and exercises live OAuth.


### PR DESCRIPTION
﻿## TLDR

Prevents Windows OAuth browser launch from hiding or making the parent PowerShell session inaccessible.

The Windows browser helper no longer invokes PowerShell with `-WindowStyle Hidden`. Instead, the helper window is suppressed at process creation with `windowsHide: true`, while the validated URL is transported as data rather than interpolated into PowerShell source.

## Dive Deeper

Both explicit `/auth codex login` and lazy Codex authentication converge on `openBrowserSecurely`. Anthropic and MCP OAuth also share this helper.

Previously, Windows launched:

```text
powershell.exe -WindowStyle Hidden -Command "Start-Process '<URL>'"
```

When the child PowerShell remained associated with the caller's console, `-WindowStyle Hidden` could affect the shared console containing the interactive PowerShell, Node launcher, Bun, and LLxprt. The auth path contains no intentional upward process-tree kill; the problematic behavior is the runtime window-style operation against a potentially shared console.

This change:

- removes `-WindowStyle Hidden` completely;
- creates the helper with `windowsHide: true` and `shell: false`;
- preserves the one-argument `openBrowserSecurely(url)` public API;
- keeps URL data out of PowerShell source;
- copies the URL into a scalar and removes `LLXPRT_BROWSER_URL` before `Start-Process`, preventing inheritance by the browser/association process;
- preserves macOS, Linux, BSD, validation, fallback, and error behavior.

Security-sensitive PowerShell source is constant:

```powershell
$browserUrl = $env:LLXPRT_BROWSER_URL; Remove-Item Env:LLXPRT_BROWSER_URL; Start-Process -FilePath $browserUrl
```

The implementation remains shell-free and safely transports quotes, spaces, `$()`, semicolons, pipes, backticks, ampersands, redirects, and fragments as scalar data.

Review remediation removed a proposed test-only public process-runner seam and added stronger cross-platform contract coverage plus a safe Windows real-process regression.

## Reviewer Test Plan

Automated validation:

1. Run the focused suite:
   ```text
   npm run test --workspace @vybestack/llxprt-code-core -- src/utils/secure-browser-launcher.test.ts
   ```
2. Confirm the all-host Windows contract requires:
   - no `-WindowStyle` or `Hidden` arguments;
   - `windowsHide: true`;
   - `shell: false`;
   - exact URL only in `LLXPRT_BROWSER_URL`;
   - environment removal before `Start-Process`.
3. On Windows, the safe integration launches the real production PowerShell command with `where.exe` substituted as the harmless target. It proves the helper returns and the parent process remains usable without opening a browser or running OAuth.
4. Run `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build`.

Manual validation is intentionally deferred until after the PR/remediation cycle. On Windows:

1. Launch LLxprt from PowerShell.
2. Run `/auth codex login`.
3. Confirm the browser opens and the original PowerShell window remains visible, taskbar-accessible, and usable.
4. Complete authentication and verify callback success.
5. Repeat with lazy authentication.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | CI  | ✅  | CI  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | CI  | -   | CI  |
| Podman   | ❓  | -   | -   |
| Seatbelt | CI  | -   | -   |

Local Windows verification passed:

- Focused launcher: 19/19 tests.
- Core: 5,212 passed, 50 skipped.
- Provider callers: 21/21.
- MCP callers: 28/28.
- Root tests: 10,320 passed, 100 skipped.
- `npm run lint`.
- `npm run typecheck`.
- `npm run format`.
- `npm run build`.
- StepFun profile smoke returned a valid haiku.
- Deep review: PASS.
- Detached local OCR completed; its inaccurate `execFile` option and coverage suggestions were evaluated and rejected with runtime/type evidence.

Bun-hosted Vitest on Windows could not collect tests because of the existing `File URL path must be an absolute path` vite-node failure. Actual Bun-hosted OAuth/browser behavior is therefore part of the requested manual validation.

## Linked issues / bugs

Fixes #2512


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows browser launching security by passing the target URL through an environment variable instead of embedding it in PowerShell command text.
  * Preserved Linux/BSD fallback behavior and improved cross-platform launch consistency when the primary launcher isn’t available.
* **Tests**
  * Expanded Windows-only coverage to validate secure PowerShell launching and verify real execution behavior remains usable after hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->