### PR TITLE
test(providers): tighten profile fallback regression coverage

### DIFF
--- a/packages/providers/src/runtime/__tests__/profileApplication.unavailableProvider.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.unavailableProvider.test.ts
@@ -85,9 +85,17 @@ describe('selectAvailableProvider (issue #2479)', () => {
     expect(result.requestedProvider).toBeNull();
   });
 
-  it('keeps the silent fallback for empty-string provider', () => {
+  it('keeps the silent fallback for whitespace-only provider', () => {
     const result = selectAvailableProvider('   ', ['openai']);
     expect(result.providerName).toBe('openai');
+    expect(result.didFallback).toBe(false);
+    expect(result.requestedProvider).toBeNull();
+  });
+
+  it('keeps the silent fallback for empty-string provider', () => {
+    const result = selectAvailableProvider('', ['openai']);
+    expect(result.providerName).toBe('openai');
+    expect(result.didFallback).toBe(false);
     expect(result.requestedProvider).toBeNull();
   });
 

--- a/packages/providers/src/runtime/__tests__/profileSnapshot.loadBalancerSave.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileSnapshot.loadBalancerSave.test.ts
@@ -55,7 +55,13 @@ vi.mock('../runtimeAccessors.js', () => ({
       () => runtimeServicesState.activeProviderName,
     ),
     getProviderSettingsSnapshot: vi.fn(() => ({})),
-    getActiveProviderOrThrow: vi.fn(),
+    // Not exercised by these save-path tests; throw if accidentally called so
+    // an empty mock cannot hide a future dependency (issue #2482).
+    getActiveProviderOrThrow: vi.fn(() => {
+      throw new Error(
+        'getActiveProviderOrThrow should not be called during profile save snapshot tests',
+      );
+    }),
     extractModelParams: vi.fn(() => ({})),
   },
 }));


### PR DESCRIPTION
## Summary
- Make the unused `getActiveProviderOrThrow` mock throw if called so empty mocks cannot hide future dependencies.
- Split whitespace-only vs empty-string provider fallback cases and assert `didFallback: false` on both.

Fixes #2482.

## Test plan
- [x] `bunx vitest run packages/providers/src/runtime/__tests__/profileSnapshot.loadBalancerSave.test.ts packages/providers/src/runtime/__tests__/profileApplication.unavailableProvider.test.ts` (16/16 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for whitespace-only and truly empty provider values.
  * Verified that empty provider requests continue to fall back silently.
  * Strengthened load-balancer profile snapshot tests to detect unintended provider lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->