### PR TITLE
Fix IDE companion session reconnects (Fixes #2650)

### DIFF
--- a/packages/ide-integration/src/ide/ide-client-lifecycle.test.ts
+++ b/packages/ide-integration/src/ide/ide-client-lifecycle.test.ts
@@ -1,0 +1,749 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mocked,
+} from 'vitest';
+import { IdeClient, IDEConnectionStatus } from './ide-client.js';
+import { ideContext, IdeContextNotificationSchema } from './ideContext.js';
+import * as fs from 'node:fs';
+import { getIdeProcessInfo } from './process-utils.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { detectIde, IDE_DEFINITIONS } from './detect-ide.js';
+import * as os from 'node:os';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    promises: {
+      readFile: vi.fn(),
+      readdir: vi.fn(),
+    },
+    realpathSync: (p: string) => p,
+    existsSync: () => false,
+  };
+});
+vi.mock('./process-utils.js');
+vi.mock('@modelcontextprotocol/sdk/client/index.js');
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js');
+vi.mock('./detect-ide.js');
+vi.mock('node:os');
+
+/**
+ * A controllable fake MCP Client that lets tests drive connect/ping and fire
+ * notification/onclose/onerror events on demand. This tests lifecycle
+ * concurrency behavior (stale attempt isolation, supersession) rather than
+ * verifying private method calls.
+ */
+interface FakeClientController {
+  client: Mocked<Client>;
+  contextHandler:
+    | ((notification: { params: Record<string, unknown> }) => void)
+    | undefined;
+  /** Resolve the client.connect() promise. */
+  resolveConnect: () => void;
+  /** Reject the client.connect() promise. */
+  rejectConnect: (error: Error) => void;
+  /** Resolve the client.ping() promise. */
+  resolvePing: () => void;
+  /** Reject the client.ping() promise. */
+  rejectPing: (error: Error) => void;
+  /** Fire the ide/contextUpdate notification handler. */
+  fireContextNotification: (params?: Record<string, unknown>) => void;
+  /** Fire the client.onclose handler. */
+  fireClose: () => void;
+  /** Fire the client.onerror handler. */
+  fireError: (error?: unknown) => void;
+}
+
+function createFakeClient(): FakeClientController {
+  let connectResolve!: () => void;
+  let connectReject!: (error: Error) => void;
+  let pingResolve!: () => void;
+  let pingReject!: (error: Error) => void;
+  let contextHandler:
+    | ((notification: { params: Record<string, unknown> }) => void)
+    | undefined;
+
+  const connectPromise = new Promise<void>((resolve, reject) => {
+    connectResolve = resolve;
+    connectReject = reject;
+  });
+  const pingPromise = new Promise<void>((resolve, reject) => {
+    pingResolve = resolve;
+    pingReject = reject;
+  });
+
+  const client = {
+    connect: vi.fn().mockReturnValue(connectPromise),
+    ping: vi.fn().mockReturnValue(pingPromise),
+    close: vi.fn().mockResolvedValue(undefined),
+    setNotificationHandler: vi.fn((schema, handler) => {
+      if (schema === IdeContextNotificationSchema) {
+        contextHandler = handler as typeof contextHandler;
+      }
+    }),
+    callTool: vi.fn(),
+    set onerror(handler: (error: unknown) => void) {
+      (client as unknown as { _onerror: unknown })._onerror = handler;
+    },
+    get onerror() {
+      return (client as unknown as { _onerror: unknown })._onerror as (
+        error: unknown,
+      ) => void;
+    },
+    set onclose(handler: () => void) {
+      (client as unknown as { _onclose: unknown })._onclose = handler;
+    },
+    get onclose() {
+      return (client as unknown as { _onclose: unknown })
+        ._onclose as () => void;
+    },
+  } as unknown as Mocked<Client>;
+
+  return {
+    client,
+    get contextHandler() {
+      return contextHandler;
+    },
+    resolveConnect: () => connectResolve(),
+    rejectConnect: (error: Error) => connectReject(error),
+    resolvePing: () => pingResolve(),
+    rejectPing: (error: Error) => pingReject(error),
+    fireContextNotification: (params: Record<string, unknown> = {}) => {
+      contextHandler?.({ params });
+    },
+    fireClose: () => {
+      const handler = (client as unknown as { _onclose?: () => void })._onclose;
+      handler?.();
+    },
+    fireError: (error: unknown = new Error('test error')) => {
+      const handler = (client as unknown as { _onerror?: (e: unknown) => void })
+        ._onerror;
+      handler?.(error);
+    },
+  };
+}
+
+/**
+ * Yields control to the event loop for a short macrotask interval. This lets
+ * all pending microtasks and timer callbacks drain, which is necessary because
+ * IdeClient.connect() has multiple async gaps (config file reads, supersede
+ * awaits, establishConnection awaits). Single-microtask yields are insufficient
+ * to let a connect() invocation progress through all its awaits.
+ */
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('IdeClient connection lifecycle isolation', () => {
+  let transportMock: { close: ReturnType<typeof vi.fn> };
+  let ideClient: IdeClient;
+
+  /**
+   * All fake clients created by the mocked Client constructor, in creation
+   * order. The last element is always the most recent — the one the active
+   * attempt is using.
+   */
+  let createdFakes: FakeClientController[];
+
+  beforeEach(async () => {
+    (IdeClient as unknown as { instance: IdeClient | undefined }).instance =
+      undefined;
+    process.env['LLXPRT_CODE_IDE_WORKSPACE_PATH'] = '/test/workspace';
+    delete process.env['LLXPRT_CODE_IDE_SERVER_PORT'];
+    delete process.env['LLXPRT_CODE_IDE_AUTH_TOKEN'];
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/test/workspace/sub-dir');
+    vi.mocked(detectIde).mockReturnValue(IDE_DEFINITIONS.vscode);
+    vi.mocked(getIdeProcessInfo).mockResolvedValue({
+      pid: 12345,
+      command: 'test-ide',
+    });
+    vi.mocked(os.tmpdir).mockReturnValue('/tmp');
+
+    createdFakes = [];
+    vi.mocked(Client).mockImplementation(() => {
+      const controller = createFakeClient();
+      createdFakes.push(controller);
+      return controller.client;
+    });
+
+    transportMock = { close: vi.fn().mockResolvedValue(undefined) };
+    vi.mocked(StreamableHTTPClientTransport).mockReturnValue(
+      transportMock as unknown as Mocked<StreamableHTTPClientTransport>,
+    );
+
+    vi.mocked(fs.promises.readFile).mockResolvedValue(
+      JSON.stringify({ port: '8080' }),
+    );
+    (
+      vi.mocked(fs.promises.readdir) as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([]);
+
+    ideClient = await IdeClient.getInstance();
+    ideContext.clearIdeContext();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    ideContext.clearIdeContext();
+  });
+
+  /**
+   * Drives the most recently created fake client through a full successful
+   * handshake: resolve connect, resolve ping, fire context notification.
+   * Call after flushing async to ensure the attempt has created its client.
+   */
+  async function driveSuccess(
+    fake: FakeClientController,
+    params: Record<string, unknown> = { workspaceState: { isTrusted: true } },
+  ): Promise<void> {
+    fake.resolveConnect();
+    await flushAsync();
+    fake.resolvePing();
+    await flushAsync();
+    fake.fireContextNotification(params);
+    await flushAsync();
+  }
+
+  it('superseded attempt A context notification does not satisfy attempt B', async () => {
+    // Start attempt A and let it fully create its client (register handlers).
+    const connectA = ideClient.connect();
+    await flushAsync();
+
+    // Attempt A must have created exactly one fake client.
+    expect(createdFakes).toHaveLength(1);
+    const fakeA = createdFakes[0];
+
+    // Drive A through connect + ping so it reaches the context-receipt wait.
+    // But do NOT fire the context notification yet.
+    fakeA.resolveConnect();
+    await flushAsync();
+    fakeA.resolvePing();
+    await flushAsync();
+
+    // Start attempt B which supersedes A.
+    const connectB = ideClient.connect();
+    await flushAsync();
+
+    // B must have created its own fake client.
+    expect(createdFakes).toHaveLength(2);
+    const fakeB = createdFakes[1];
+
+    // Drive B to success.
+    await driveSuccess(fakeB);
+    await connectB;
+
+    // Fire A's stale context notification — must be ignored (A was superseded).
+    fakeA.fireContextNotification({
+      workspaceState: { isTrusted: false },
+      openFiles: [{ path: '/stale-from-A.js' }],
+    });
+
+    // Resolve A's pending connect promise so it can settle.
+    // (A was already past connect, so this is a no-op in practice, but
+    // ensures no dangling promise.)
+    await connectA;
+
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+    // B's context is visible, not A's.
+    expect(ideContext.getIdeContext()?.workspaceState?.isTrusted).toBe(true);
+  });
+
+  it('stale attempt A onclose does not disconnect attempt B', async () => {
+    const connectA = ideClient.connect();
+    await flushAsync();
+    const fakeA = createdFakes[0];
+    fakeA.resolveConnect();
+    await flushAsync();
+    fakeA.resolvePing();
+    await flushAsync();
+
+    const connectB = ideClient.connect();
+    await flushAsync();
+    const fakeB = createdFakes[1];
+    await driveSuccess(fakeB);
+    await connectB;
+
+    // A is now stale. Firing A's onclose must NOT disconnect B.
+    fakeA.fireClose();
+
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    await connectA;
+  });
+
+  it('stale attempt A onerror does not disconnect attempt B', async () => {
+    const connectA = ideClient.connect();
+    await flushAsync();
+    const fakeA = createdFakes[0];
+    fakeA.resolveConnect();
+    await flushAsync();
+    fakeA.resolvePing();
+    await flushAsync();
+
+    const connectB = ideClient.connect();
+    await flushAsync();
+    const fakeB = createdFakes[1];
+    await driveSuccess(fakeB);
+    await connectB;
+
+    // A is stale. Firing A's onerror must NOT disconnect B.
+    fakeA.fireError(new Error('stale A error'));
+
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    await connectA;
+  });
+
+  it('disconnect during connect settles promptly and does not hang', async () => {
+    const connectPromise = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake = createdFakes[0];
+
+    // Disconnect while connect is in-flight (after connect, before ping).
+    fake.resolveConnect();
+    await flushAsync();
+
+    const disconnectPromise = ideClient.disconnect();
+
+    // Disconnect must settle promptly.
+    await expect(disconnectPromise).resolves.toBeUndefined();
+
+    // Allow the in-flight connect to settle without hanging.
+    fake.resolvePing();
+    await expect(connectPromise).resolves.toBeUndefined();
+
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+  });
+
+  it('reconnect after disconnect establishes a fresh connection', async () => {
+    // First connect.
+    const connect1 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake1 = createdFakes[0];
+    await driveSuccess(fake1);
+
+    await connect1;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    await ideClient.disconnect();
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+
+    // Second connect (reconnect) creates a fresh fake client.
+    const connect2 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(2);
+    const fake2 = createdFakes[1];
+    await driveSuccess(fake2);
+
+    await connect2;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+  });
+
+  it('failed attempt whose ping rejects leaves no visible context (no supersession needed)', async () => {
+    const connectPromise = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake = createdFakes[0];
+    fake.resolveConnect();
+    await flushAsync();
+    fake.rejectPing(new Error('ping failed'));
+
+    await connectPromise;
+
+    expect(ideContext.getIdeContext()).toBeUndefined();
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+  });
+
+  it('immediate connect then disconnect with no intervening flush ends Disconnected and no late attempt connects', async () => {
+    // The critical interleaving for finding #1: connect() must claim lifecycle
+    // ownership synchronously (before its first await) so that a disconnect
+    // issued immediately after — without any flush — invalidates it. The older
+    // connect must NOT resume and claim a newer generation afterward.
+    const connectPromise = ideClient.connect();
+
+    // Disconnect immediately, with NO flush in between. disconnect must
+    // invalidate the in-flight connect's ownership before connect resumes.
+    await ideClient.disconnect();
+
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+
+    // Now allow the in-flight connect to settle. It must not have installed an
+    // attempt (no fake client created) and must not become Connected.
+    await flushAsync();
+
+    expect(createdFakes).toHaveLength(0);
+
+    // Even if a late fake were somehow created, driving it to success must not
+    // flip the state to Connected.
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+
+    // Settle the connect promise without hanging.
+    await expect(connectPromise).resolves.toBeUndefined();
+  });
+
+  it('overlapping connect calls with delayed prior-attempt close: latest invocation wins', async () => {
+    // Establish an initial connected attempt whose close is deliberately
+    // delayed so that a subsequent connect() invocation stalls inside its
+    // supersede await. This reproduces finding #2: an older connect invocation
+    // must not resume after a newer one and claim newest ownership.
+    const connect1 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake1 = createdFakes[0];
+    await driveSuccess(fake1);
+    await connect1;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // Make fake1's close (invoked during supersession) block on a deferred so
+    // the older connect's supersede await cannot complete promptly.
+    let resolveClose!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      resolveClose = resolve;
+    });
+    fake1.client.close = vi
+      .fn()
+      .mockReturnValue(closeGate) as unknown as typeof fake1.client.close;
+
+    // Start connect A. It will await supersedeActiveAttempt() which now blocks
+    // on fake1.close(). A has claimed its lifecycle epoch but cannot proceed
+    // past this await.
+    const connectA = ideClient.connect();
+    await flushAsync();
+
+    // While A is blocked superseding fake1, start connect B. B claims a newer
+    // lifecycle epoch and must be able to proceed to a successful connection,
+    // winning the lifecycle regardless of when A resumes.
+    const connectB = ideClient.connect();
+    await flushAsync();
+    await flushAsync();
+
+    // B is the latest invocation. It must have created its own fake client
+    // (fake1 is index 0; B's is index 1). A is still blocked and has NOT
+    // created a client.
+    expect(createdFakes).toHaveLength(2);
+    const fakeB = createdFakes[1];
+
+    // Release the delayed close so A can eventually resume.
+    resolveClose();
+    await flushAsync();
+
+    // Drive B to success — B is the latest invocation and must own the
+    // lifecycle regardless of when A resumes.
+    await driveSuccess(fakeB);
+    await connectB;
+
+    // Allow A to settle fully. A must abort (its epoch was superseded by B)
+    // without creating a client or clobbering B's connection.
+    await connectA;
+
+    // A must not have created an additional client beyond fake1 and fakeB.
+    expect(createdFakes).toHaveLength(2);
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+    // The visible context must be B's, not A's.
+    expect(ideContext.getIdeContext()?.workspaceState?.isTrusted).toBe(true);
+  });
+
+  it('reconnect while disconnect is blocked in closeDiff is not clobbered by the stale disconnect', async () => {
+    // Finding #3: disconnect() awaits closeDiff() for pending diffs and then
+    // unconditionally clears shared diff/client/context/state. A reconnect that
+    // starts and completes during that await must survive the stale
+    // disconnect's post-await mutations.
+    const connect1 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake1 = createdFakes[0];
+    await driveSuccess(fake1);
+    await connect1;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // Open a diff so disconnect has a pending closeDiff to await, and make that
+    // closeDiff (client.callTool) block on a deferred so disconnect stalls
+    // AFTER issuing closeDiff but BEFORE its post-await clear/setState.
+    let resolveCloseDiff!: (value: unknown) => void;
+    const closeDiffGate = new Promise<unknown>((resolve) => {
+      resolveCloseDiff = resolve;
+    });
+    fake1.client.callTool = vi
+      .fn()
+      .mockReturnValue(
+        closeDiffGate,
+      ) as unknown as typeof fake1.client.callTool;
+    // openDiff registers a pending resolver keyed by filePath.
+    void ideClient.openDiff('/test/workspace/file.ts', 'new');
+
+    // Start disconnect; it will stall awaiting closeDiff for the pending diff.
+    const disconnectPromise = ideClient.disconnect();
+    await flushAsync();
+
+    // While disconnect is stalled in closeDiff, reconnect. This new connection
+    // must win and must NOT be cleared by the still-pending stale disconnect.
+    const connect2 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes.length).toBeGreaterThanOrEqual(2);
+    const fake2 = createdFakes[createdFakes.length - 1];
+    // Restore normal callTool behavior for the new client so driveSuccess works.
+    fake2.client.callTool = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'closed' }],
+    }) as unknown as typeof fake2.client.callTool;
+    await driveSuccess(fake2);
+    await connect2;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // Now release the stale disconnect's blocked closeDiff. It must not clobber
+    // the fresh connection: state must remain Connected and the active context
+    // must be the reconnect's.
+    resolveCloseDiff({ content: [{ type: 'text', text: 'closed' }] });
+    await disconnectPromise;
+    await flushAsync();
+
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+    expect(ideContext.getIdeContext()?.workspaceState?.isTrusted).toBe(true);
+  });
+
+  it('throwing trust change listener does not prevent context receipt and connection success', async () => {
+    // Register a trust change listener that throws. The initial context
+    // notification carries workspaceState.isTrusted, which invokes trust
+    // listeners before the receipt deferred is resolved. If a listener throws,
+    // receipt acknowledgment must still happen so establishConnection does not
+    // time out and report initial context missing despite having received it.
+    const throwingListener = vi.fn(() => {
+      throw new Error('trust listener exploded');
+    });
+    ideClient.addTrustChangeListener(throwingListener);
+
+    const connectPromise = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake = createdFakes[0];
+
+    await driveSuccess(fake, {
+      workspaceState: { isTrusted: true },
+    });
+    await connectPromise;
+
+    // The throwing listener must have been invoked.
+    expect(throwingListener).toHaveBeenCalledWith(true);
+    // The connection must still succeed despite the listener throwing.
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+    // The context must have been received and stored.
+    expect(ideContext.getIdeContext()?.workspaceState?.isTrusted).toBe(true);
+
+    ideClient.removeTrustChangeListener(throwingListener);
+  });
+
+  it('stale disconnect with multiple old diffs does not closeDiff a new-lifecycle diff through the new client', async () => {
+    // Blocking defect: disconnect() iterates the live shared diffResponses Map
+    // and each closeDiff() dereferences mutable this.client. If disconnect
+    // blocks closing an old diff, a reconnect installs a new client and opens
+    // a new diff, then the stale disconnect resumes: it must NOT observe the
+    // new map entry and send closeDiff(new) through the reconnected client.
+    const connect1 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake1 = createdFakes[0];
+    await driveSuccess(fake1);
+    await connect1;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // Open two old diffs so disconnect has two pending closeDiff calls to
+    // iterate. Make the FIRST closeDiff block on a deferred so disconnect
+    // stalls after issuing it but before subsequent cleanup.
+    let resolveFirstCloseDiff!: (value: unknown) => void;
+    const firstCloseDiffGate = new Promise<unknown>((resolve) => {
+      resolveFirstCloseDiff = resolve;
+    });
+    let closeDiffCallCount = 0;
+    fake1.client.callTool = vi.fn().mockImplementation((request) => {
+      const name = request?.name;
+      if (name === 'closeDiff') {
+        closeDiffCallCount++;
+        if (closeDiffCallCount === 1) {
+          return firstCloseDiffGate;
+        }
+        return Promise.resolve({
+          content: [{ type: 'text', text: 'closed' }],
+        });
+      }
+      // Non-closeDiff calls (e.g. openDiff) resolve normally.
+      return Promise.resolve({
+        content: [{ type: 'text', text: 'closed' }],
+      });
+    }) as unknown as typeof fake1.client.callTool;
+
+    // openDiff registers pending resolvers keyed by filePath.
+    const diffA = ideClient.openDiff('/test/workspace/oldA.ts', 'newA');
+    const diffB = ideClient.openDiff('/test/workspace/oldB.ts', 'newB');
+    await flushAsync();
+
+    // Start disconnect; it will stall awaiting the first closeDiff.
+    const disconnectPromise = ideClient.disconnect();
+    await flushAsync();
+
+    // While disconnect is stalled, reconnect. This new connection wins the
+    // lifecycle epoch.
+    const connect2 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes.length).toBeGreaterThanOrEqual(2);
+    const fake2 = createdFakes[createdFakes.length - 1];
+    fake2.client.callTool = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'closed' }],
+    }) as unknown as typeof fake2.client.callTool;
+    await driveSuccess(fake2);
+    await connect2;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // Open a NEW diff on the fresh lifecycle AFTER reconnect. The stale
+    // disconnect must never closeDiff this path.
+    const newDiffPath = '/test/workspace/new.ts';
+    const newDiff = ideClient.openDiff(newDiffPath, 'newContent');
+    await flushAsync();
+
+    // Track all closeDiff calls on fake2 (the new client). None should occur.
+    const fake2CloseDiffCalls = () =>
+      fake2.client.callTool.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { name?: string }).name === 'closeDiff',
+      );
+
+    // Now release the stale disconnect's blocked first closeDiff. The stale
+    // disconnect resumes but must detect it is stale and stop: no further
+    // closeDiff calls (neither oldB nor new) and no clearing of shared state.
+    resolveFirstCloseDiff({
+      content: [{ type: 'text', text: 'closed' }],
+    });
+    await disconnectPromise;
+    await flushAsync();
+
+    // The stale disconnect must not have sent closeDiff through the new client.
+    expect(fake2CloseDiffCalls()).toHaveLength(0);
+
+    // The new diff must remain pending/usable (still registered, not cleared).
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // The new diff resolver must not have been settled/cleared by the stale
+    // disconnect. We verify by ensuring it is still pending.
+    const newDiffSettled = await Promise.race([
+      newDiff.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+    ]);
+    expect(newDiffSettled).toBe(false);
+
+    // old diffs should have been left unsettled too (stale disconnect stopped).
+    const diffASettled = await Promise.race([
+      diffA.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+    ]);
+    expect(diffASettled).toBe(false);
+
+    // Suppress unhandled rejection warnings for unsettled promises in test.
+    void diffA.catch(() => {});
+    void diffB.catch(() => {});
+    void newDiff.catch(() => {});
+  });
+
+  it('current disconnect tolerates a rejecting closeDiff and still completes cleanup', async () => {
+    // Genuine OCR finding: if a disconnect-owned closeDiff call throws, the
+    // sequential loop can abort cleanup and skip remaining disconnect-owned
+    // diffs/resources/state cleanup. When the disconnect remains current, it
+    // must continue cleanup and end Disconnected with resources closed.
+    const connect1 = ideClient.connect();
+    await flushAsync();
+    expect(createdFakes).toHaveLength(1);
+    const fake1 = createdFakes[0];
+    await driveSuccess(fake1);
+    await connect1;
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // Open two diffs. Make the first closeDiff reject and the second resolve.
+    let closeDiffCallCount = 0;
+    fake1.client.callTool = vi.fn().mockImplementation((request) => {
+      const name = request?.name;
+      if (name === 'closeDiff') {
+        closeDiffCallCount++;
+        if (closeDiffCallCount === 1) {
+          return Promise.reject(new Error('closeDiff exploded'));
+        }
+        return Promise.resolve({
+          content: [{ type: 'text', text: 'closed' }],
+        });
+      }
+      return Promise.resolve({
+        content: [{ type: 'text', text: 'closed' }],
+      });
+    }) as unknown as typeof fake1.client.callTool;
+
+    void ideClient.openDiff('/test/workspace/first.ts', 'first');
+    void ideClient.openDiff('/test/workspace/second.ts', 'second');
+    await flushAsync();
+
+    // Disconnect must not reject and must complete cleanup despite the
+    // throwing closeDiff. Both closeDiff calls should have been attempted.
+    await ideClient.disconnect();
+
+    expect(closeDiffCallCount).toBe(2);
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+  });
+});

--- a/packages/ide-integration/src/ide/ide-client-lifecycle.test.ts
+++ b/packages/ide-integration/src/ide/ide-client-lifecycle.test.ts
@@ -684,15 +684,24 @@ describe('IdeClient connection lifecycle isolation', () => {
     ]);
     expect(newDiffSettled).toBe(false);
 
-    // old diffs should have been left unsettled too (stale disconnect stopped).
-    const diffASettled = await Promise.race([
+    // old diffs are settled as 'rejected' by the stale disconnect so their
+    // awaiters never hang (closeDiffViaClient uses suppressNotification, so no
+    // IDE notification would ever settle them). The stale disconnect must NOT
+    // delete the new lifecycle's diff entry, but it unconditionally settles
+    // its OWN captured resolvers.
+    const diffAResult = await Promise.race([
       diffA.then(
-        () => true,
-        () => true,
+        (r) => r as unknown,
+        () => 'rejected-error' as const,
       ),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+      new Promise<unknown>((resolve) =>
+        setTimeout(() => resolve('unsettled'), 50),
+      ),
     ]);
-    expect(diffASettled).toBe(false);
+    expect(diffAResult).toStrictEqual({
+      status: 'rejected',
+      content: undefined,
+    });
 
     // Suppress unhandled rejection warnings for unsettled promises in test.
     void diffA.catch(() => {});

--- a/packages/ide-integration/src/ide/ide-client.test.ts
+++ b/packages/ide-integration/src/ide/ide-client.test.ts
@@ -15,6 +15,7 @@ import {
   type Mock,
 } from 'vitest';
 import { IdeClient, IDEConnectionStatus } from './ide-client.js';
+import { IdeContextNotificationSchema } from './ideContext.js';
 import * as fs from 'node:fs';
 import { getIdeProcessInfo } from './process-utils.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -66,11 +67,28 @@ describe('IdeClient', () => {
     });
     vi.mocked(os.tmpdir).mockReturnValue('/tmp');
 
-    // Mock MCP client and transports
+    // Mock MCP client and transports. The context notification handler is
+    // captured and invoked asynchronously (via microtask) so the client's
+    // context-receipt deferred resolves and connect succeeds.
+    let contextHandler:
+      | ((notification: { params: Record<string, unknown> }) => void)
+      | undefined = undefined;
     mockClient = {
       connect: vi.fn().mockResolvedValue(undefined),
+      ping: vi.fn().mockResolvedValue(undefined),
       close: vi.fn(),
-      setNotificationHandler: vi.fn(),
+      setNotificationHandler: vi.fn((schema, handler) => {
+        if (schema === IdeContextNotificationSchema) {
+          contextHandler = handler as typeof contextHandler;
+          // Simulate the server delivering initial context on the next
+          // microtask, so the context-receipt deferred resolves.
+          void Promise.resolve().then(() => {
+            contextHandler?.({
+              params: { workspaceState: { isTrusted: true } },
+            });
+          });
+        }
+      }),
       callTool: vi.fn(),
     } as unknown as Mocked<Client>;
     mockHttpTransport = {

--- a/packages/ide-integration/src/ide/ide-client.ts
+++ b/packages/ide-integration/src/ide/ide-client.ts
@@ -45,6 +45,18 @@ type ConnectionConfig = {
   stdio?: StdioConfig;
 };
 
+/**
+ * Tri-state result for a connection attempt within {@link establishConnection}.
+ *
+ * - `'connected'`: the attempt succeeded and set Connected state.
+ * - `'failed'`: the attempt genuinely failed (connect error, ping error,
+ *   context timeout). The caller may try the next fallback.
+ * - `'superseded'`: a newer connect/startNewAttempt displaced this attempt
+ *   while it was in-flight. The caller MUST NOT touch any shared state
+ *   (no setState) because the newer attempt owns the visible lifecycle.
+ */
+type EstablishConnectionResult = 'connected' | 'failed' | 'superseded';
+
 export type IDEConnectionState = {
   status: IDEConnectionStatus;
   details?: string; // User-facing
@@ -66,9 +78,107 @@ function getRealPath(path: string): string {
 }
 
 /**
+ * Cancellable timer with an explicit settle outcome. The promise resolves with
+ * `'elapsed'` when the timer fires, or `'cancelled'` if it was cleared before
+ * firing. Retaining the handle lets us clear it on early receipt, failure,
+ * supersession, and disconnect — preventing timer leaks.
+ */
+interface CancellableTimer {
+  promise: Promise<'elapsed' | 'cancelled'>;
+  cancel: () => void;
+}
+
+function createCancellableTimer(ms: number): CancellableTimer {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  let cancelFn: () => void = () => {};
+  const promise = new Promise<'elapsed' | 'cancelled'>((resolve) => {
+    timerId = setTimeout(() => resolve('elapsed'), ms);
+    cancelFn = () => {
+      if (timerId !== undefined) {
+        clearTimeout(timerId);
+        timerId = undefined;
+      }
+      resolve('cancelled');
+    };
+  });
+  return { promise, cancel: cancelFn };
+}
+
+/**
+ * Deferred that resolves to `void` on context receipt. Owned per attempt.
+ */
+interface ReceiptDeferred {
+  resolve: () => void;
+  promise: Promise<void>;
+}
+
+function createReceiptDeferred(): ReceiptDeferred {
+  let resolveFn: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    resolveFn = resolve;
+  });
+  return { resolve: resolveFn, promise };
+}
+
+/**
+ * Immutable per-connection-attempt ownership bundle. Each attempt captures its
+ * own Client, transport, context receipt deferred, and cancellable timeout.
+ * The monotonically increasing generation token (not Date.now alone) is
+ * collision-free and lets handlers/continuations verify they belong to the
+ * still-active attempt before mutating any shared state.
+ */
+class ConnectionAttempt {
+  readonly generation: number;
+  readonly client: Client;
+  readonly receiptDeferred: ReceiptDeferred;
+  readonly receiptTimer: CancellableTimer;
+  transport: StreamableHTTPClientTransport | undefined;
+
+  constructor(generation: number) {
+    this.generation = generation;
+    this.client = new Client({
+      name: 'streamable-http-client',
+      // Task(#3487): use the CLI version here.
+      version: '1.0.0',
+    });
+    this.receiptDeferred = createReceiptDeferred();
+    this.receiptTimer = createCancellableTimer(
+      IdeClient.CONTEXT_RECEIPT_TIMEOUT_MS,
+    );
+  }
+
+  /**
+   * Closes only the resources owned by THIS attempt. Must not touch the
+   * mutable `IdeClient.client` which may point to a different (newer) attempt.
+   */
+  async closeOwned(): Promise<void> {
+    this.receiptTimer.cancel();
+    try {
+      await this.client.close();
+    } catch (error) {
+      logger.debug('Failed to close attempt client:', error);
+    }
+    if (this.transport) {
+      try {
+        await this.transport.close();
+      } catch (error) {
+        logger.debug('Failed to close attempt transport:', error);
+      }
+    }
+  }
+}
+
+/**
  * Manages the connection to and interaction with the IDE server.
  */
 export class IdeClient {
+  /**
+   * Bounded timeout (ms) for waiting on initial IDE context receipt after a
+   * successful ping. If the context notification does not arrive within this
+   * window, the connection is considered failed (Disconnected).
+   */
+  static readonly CONTEXT_RECEIPT_TIMEOUT_MS = 5000;
+
   private static instance: IdeClient | undefined;
   private client: Client | undefined = undefined;
   private state: IDEConnectionState = {
@@ -85,6 +195,35 @@ export class IdeClient {
   private diffResponses = new Map<string, (result: DiffUpdateResult) => void>();
   private statusListeners = new Set<(state: IDEConnectionState) => void>();
   private trustChangeListeners = new Set<(isTrusted: boolean) => void>();
+
+  /**
+   * Monotonically increasing generation counter for collision-free attempt
+   * tokens. Never reused, so a stale handler's generation can never match a
+   * newer attempt's generation.
+   */
+  private nextGeneration = 1;
+
+  /**
+   * Monotonically increasing lifecycle epoch. Every connect() and disconnect()
+   * invocation claims a unique epoch synchronously at its very start — BEFORE
+   * its first await — by writing `activeLifecycleEpoch = this.nextLifecycleEpoch++`
+   * with no intervening await. After every await that can be superseded by a
+   * newer connect()/disconnect(), the owning operation re-checks
+   * `this.activeLifecycleEpoch === myEpoch` before mutating any shared state
+   * (client, diff map, ideContext, connection status). This guarantees that a
+   * stale operation resuming after a newer operation can never clobber the
+   * newer operation's results, because its epoch no longer matches.
+   */
+  private nextLifecycleEpoch = 1;
+  private activeLifecycleEpoch = 0;
+
+  /**
+   * The currently active connection attempt, or undefined when none is active.
+   * Starting a fresh attempt supersedes (cancels and closes) the prior one.
+   * All handlers and post-await continuations verify ownership against this
+   * before mutating shared state.
+   */
+  private activeAttempt: ConnectionAttempt | undefined = undefined;
 
   private constructor() {}
 
@@ -136,9 +275,29 @@ export class IdeClient {
       return;
     }
 
+    // Claim lifecycle ownership SYNCHRONOUSLY, before the first await. This
+    // ensures that a disconnect() (or a newer connect()) issued immediately
+    // after `const p = connect();` — with no intervening await — invalidates
+    // this invocation: after our first await resumes, the epoch will no longer
+    // match and we abort without touching shared state.
+    const myEpoch = this.claimLifecycleEpoch();
+
+    // Supersede any prior in-flight attempt AFTER claiming ownership, so that
+    // if a newer connect()/disconnect() starts while we await this close, our
+    // post-await continuation detects the stale epoch and aborts.
+    await this.supersedeActiveAttempt();
+    if (!this.isLifecycleActive(myEpoch)) {
+      return;
+    }
+
     this.setState(IDEConnectionStatus.Connecting);
 
     this.connectionConfig = await this.getConnectionConfigFromFile();
+
+    if (!this.isLifecycleActive(myEpoch)) {
+      return;
+    }
+
     this.authToken =
       this.connectionConfig?.authToken ??
       process.env['LLXPRT_CODE_IDE_AUTH_TOKEN'];
@@ -153,24 +312,34 @@ export class IdeClient {
     );
 
     if (!isValid) {
-      this.setState(IDEConnectionStatus.Disconnected, error, true);
+      if (this.isLifecycleActive(myEpoch)) {
+        this.setState(IDEConnectionStatus.Disconnected, error, true);
+      }
       return;
     }
 
     const portFromFile = this.connectionConfig?.port;
     if (portFromFile) {
-      const connected = await this.establishConnection(portFromFile);
-      if (connected) {
+      const result = await this.establishConnection(portFromFile, myEpoch);
+      if (result === 'connected' || result === 'superseded') {
         return;
       }
     }
 
+    if (!this.isLifecycleActive(myEpoch)) {
+      return;
+    }
+
     const portFromEnv = this.getPortFromEnv();
     if (portFromEnv) {
-      const connected = await this.establishConnection(portFromEnv);
-      if (connected) {
+      const result = await this.establishConnection(portFromEnv, myEpoch);
+      if (result === 'connected' || result === 'superseded') {
         return;
       }
+    }
+
+    if (!this.isLifecycleActive(myEpoch)) {
+      return;
     }
 
     this.setState(
@@ -261,18 +430,96 @@ export class IdeClient {
   }
 
   async disconnect() {
-    if (this.state.status === IDEConnectionStatus.Disconnected) {
-      return;
+    // Claim lifecycle ownership SYNCHRONOUSLY before any await. This makes a
+    // reconnect that starts while we are awaiting closeDiff()/closeOwned()
+    // claim a newer epoch, which we detect on resume so we never clobber the
+    // newer connection's client/context/state.
+    const myEpoch = this.claimLifecycleEpoch();
+
+    const attempt = this.activeAttempt;
+    this.activeAttempt = undefined;
+
+    // Snapshot the disconnect-owned client and pending diff paths BEFORE the
+    // first await. We must not iterate the live shared diffResponses Map or
+    // dereference mutable this.client after an await, because a reconnect may
+    // have installed a new client and/or added new diff entries. Calling
+    // this.closeDiff() would dereference the (possibly new) this.client and
+    // could send closeDiff for new-lifecycle diffs through the wrong client.
+    const ownedClient = this.client;
+    const ownedDiffPaths: string[] = [];
+    if (
+      this.state.status !== IDEConnectionStatus.Disconnected &&
+      ownedClient !== undefined
+    ) {
+      for (const filePath of this.diffResponses.keys()) {
+        ownedDiffPaths.push(filePath);
+      }
     }
-    for (const filePath of this.diffResponses.keys()) {
-      await this.closeDiff(filePath);
+
+    for (const filePath of ownedDiffPaths) {
+      // After every await, check that this disconnect still owns the lifecycle
+      // and that the owned client is still available. A reconnect that
+      // completed during the prior closeDiff await claims a newer epoch; once
+      // stale, stop issuing tool calls and do not mutate shared state/maps.
+      // (ownedDiffPaths is only populated when ownedClient was defined, but
+      // TypeScript cannot narrow across the loop boundary.)
+      if (!this.isLifecycleActive(myEpoch) || ownedClient === undefined) {
+        break;
+      }
+      try {
+        await IdeClient.closeDiffViaClient(ownedClient, filePath);
+      } catch (error) {
+        logger.debug(`disconnect closeDiff for ${filePath} failed:`, error);
+      }
     }
-    this.diffResponses.clear();
-    this.setState(
-      IDEConnectionStatus.Disconnected,
-      'IDE integration disabled. To enable it again, run /ide enable.',
-    );
-    void this.client?.close();
+
+    // Only clear shared diff state, settle resolvers, and transition to
+    // Disconnected if this disconnect is still the active lifecycle operation.
+    // A newer lifecycle may have added entries to the shared map; we must not
+    // delete or settle those.
+    if (this.isLifecycleActive(myEpoch)) {
+      for (const filePath of ownedDiffPaths) {
+        const resolver = this.diffResponses.get(filePath);
+        if (resolver) {
+          resolver({ status: 'rejected', content: undefined });
+          this.diffResponses.delete(filePath);
+        }
+      }
+      this.setState(
+        IDEConnectionStatus.Disconnected,
+        'IDE integration disabled. To enable it again, run /ide enable.',
+      );
+      this.client = undefined;
+    }
+
+    if (attempt) {
+      await attempt.closeOwned();
+    }
+  }
+
+  /**
+   * Calls closeDiff directly on a specific client, bypassing the mutable
+   * this.client reference. Used by disconnect cleanup so that a stale
+   * disconnect never sends tool calls through a newer lifecycle's client.
+   * Preserves the same tool arguments and logging conventions as closeDiff().
+   */
+  private static async closeDiffViaClient(
+    client: Client,
+    filePath: string,
+  ): Promise<void> {
+    logger.debug(`closeDiff -> tools/call closeDiff for ${filePath}`);
+    const result = await client.callTool({
+      name: 'closeDiff',
+      arguments: {
+        filePath,
+        suppressNotification: true,
+      },
+    });
+    try {
+      CloseDiffResponseSchema.parse(result);
+    } catch {
+      // Result parsing is best-effort during cleanup.
+    }
   }
 
   getCurrentIde(): IdeInfo | undefined {
@@ -457,40 +704,21 @@ export class IdeClient {
     };
   }
 
-  private registerClientHandlers() {
-    if (!this.client) {
-      return;
-    }
-
-    this.client.setNotificationHandler(
-      IdeContextNotificationSchema,
-      (notification) => {
-        ideContext.setIdeContext(notification.params);
-        const isTrusted = notification.params.workspaceState?.isTrusted;
-        if (isTrusted !== undefined) {
-          for (const listener of this.trustChangeListeners) {
-            listener(isTrusted);
-          }
-        }
-      },
-    );
-    this.client.onerror = (_error) => {
-      this.setState(
-        IDEConnectionStatus.Disconnected,
-        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable`,
-        true,
-      );
-    };
-    this.client.onclose = () => {
-      this.setState(
-        IDEConnectionStatus.Disconnected,
-        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable`,
-        true,
-      );
-    };
-    this.client.setNotificationHandler(
+  /**
+   * Registers the diff-related notification handlers (accepted, rejected,
+   * and the backwards-compatible closed variant). Each resolves the diff
+   * response callback for the given file path, if a pending resolver exists.
+   */
+  private registerDiffHandlers(
+    client: Client,
+    isStillActive: () => boolean,
+  ): void {
+    client.setNotificationHandler(
       IdeDiffAcceptedNotificationSchema,
       (notification) => {
+        if (!isStillActive()) {
+          return;
+        }
         const { filePath, content } = notification.params;
         const resolver = this.diffResponses.get(filePath);
         if (resolver) {
@@ -502,9 +730,12 @@ export class IdeClient {
       },
     );
 
-    this.client.setNotificationHandler(
+    client.setNotificationHandler(
       IdeDiffRejectedNotificationSchema,
       (notification) => {
+        if (!isStillActive()) {
+          return;
+        }
         const { filePath } = notification.params;
         const resolver = this.diffResponses.get(filePath);
         if (resolver) {
@@ -518,9 +749,12 @@ export class IdeClient {
 
     // For backwards compatibility. Newer extension versions will only send
     // IdeDiffRejectedNotificationSchema.
-    this.client.setNotificationHandler(
+    client.setNotificationHandler(
       IdeDiffClosedNotificationSchema,
       (notification) => {
+        if (!isStillActive()) {
+          return;
+        }
         const { filePath } = notification.params;
         const resolver = this.diffResponses.get(filePath);
         if (resolver) {
@@ -533,15 +767,83 @@ export class IdeClient {
     );
   }
 
-  private async establishConnection(port: string): Promise<boolean> {
-    let transport: StreamableHTTPClientTransport | undefined;
+  /**
+   * Registers notification and lifecycle handlers on the attempt's own Client.
+   * Every handler captures the attempt's generation token and first checks that
+   * it is still the active attempt before mutating any shared state (ideContext,
+   * connection state, or diff resolvers). Stale attempt events are ignored.
+   */
+  private registerClientHandlers(attempt: ConnectionAttempt) {
+    const client = attempt.client;
+
+    const isStillActive = () => this.activeAttempt === attempt;
+
+    client.setNotificationHandler(
+      IdeContextNotificationSchema,
+      (notification) => {
+        // Stale attempt events must be ignored and must not mutate ideContext
+        // or current state/receipt.
+        if (!isStillActive()) {
+          return;
+        }
+        ideContext.setIdeContext(notification.params);
+        // Acknowledge receipt before invoking external listeners so a throwing
+        // listener cannot prevent establishConnection from recognizing that
+        // context was received (which would cause a spurious timeout).
+        attempt.receiptDeferred.resolve();
+        const isTrusted = notification.params.workspaceState?.isTrusted;
+        if (isTrusted !== undefined) {
+          for (const listener of this.trustChangeListeners) {
+            try {
+              listener(isTrusted);
+            } catch (error) {
+              logger.debug('Trust change listener threw:', error);
+            }
+          }
+        }
+      },
+    );
+    client.onerror = (_error) => {
+      if (!isStillActive()) {
+        return;
+      }
+      this.setState(
+        IDEConnectionStatus.Disconnected,
+        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable`,
+        true,
+      );
+    };
+    client.onclose = () => {
+      if (!isStillActive()) {
+        return;
+      }
+      this.setState(
+        IDEConnectionStatus.Disconnected,
+        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable`,
+        true,
+      );
+    };
+
+    this.registerDiffHandlers(client, isStillActive);
+  }
+
+  private async establishConnection(
+    port: string,
+    epoch: number,
+  ): Promise<EstablishConnectionResult> {
+    const attempt = await this.startNewAttempt(epoch);
+    if (attempt === undefined) {
+      // A newer lifecycle operation superseded this one while it awaited the
+      // prior attempt's close. Abort without touching shared state.
+      return 'superseded';
+    }
     try {
-      this.client = new Client({
-        name: 'streamable-http-client',
-        // Task(#3487): use the CLI version here.
-        version: '1.0.0',
-      });
-      transport = new StreamableHTTPClientTransport(
+      // Register notification handlers (including the IdeContextNotificationSchema
+      // handler that resolves THIS attempt's deferred) before Client.connect so
+      // we never miss the initial context notification.
+      this.registerClientHandlers(attempt);
+
+      attempt.transport = new StreamableHTTPClientTransport(
         new URL(`http://${getIdeServerHost()}:${port}/mcp`),
         {
           fetch: this.createProxyAwareFetch(),
@@ -552,21 +854,140 @@ export class IdeClient {
           },
         },
       );
-      await this.client.connect(transport);
-      this.registerClientHandlers();
-      this.setState(IDEConnectionStatus.Connected);
-      return true;
-    } catch {
-      // Connection failed; cleanup transport if created.
-      if (transport) {
-        try {
-          await transport.close();
-        } catch (closeError) {
-          logger.debug('Failed to close transport:', closeError);
-        }
+      await attempt.client.connect(attempt.transport);
+
+      // Post-await continuation must verify the attempt is still active before
+      // proceeding; a superseding attempt may have started during the await.
+      if (!this.isAttemptActive(attempt)) {
+        await attempt.closeOwned();
+        return 'superseded';
       }
-      return false;
+
+      // Issue a standard MCP ping after initialization. The companion server
+      // intercepts this ping to synchronously deliver the initial IDE context
+      // notification before the ping response is sent. If the server cannot
+      // deliver context, the ping fails (JSON-RPC error) and we disconnect.
+      await attempt.client.ping();
+
+      // Post-await continuation must verify the attempt is still active.
+      if (!this.isAttemptActive(attempt)) {
+        await attempt.closeOwned();
+        return 'superseded';
+      }
+
+      // Ping success alone is NOT acknowledgment — only the real notification
+      // handler resolving the deferred proves the context was received. Await
+      // the context receipt with a bounded, cancellable timeout. If no context
+      // arrives (including a new client against a default-ping-only server),
+      // connect must end Disconnected.
+      const receiptResult = await Promise.race([
+        attempt.receiptDeferred.promise.then(() => 'received' as const),
+        attempt.receiptTimer.promise,
+      ]);
+
+      // Clear the timer on early receipt (it may have been resolved by the
+      // notification before the timer elapsed).
+      attempt.receiptTimer.cancel();
+
+      if (!this.isAttemptActive(attempt)) {
+        await attempt.closeOwned();
+        return 'superseded';
+      }
+
+      if (receiptResult !== 'received') {
+        throw new Error(
+          'Timed out waiting for initial IDE context notification',
+        );
+      }
+
+      this.setState(IDEConnectionStatus.Connected);
+      return 'connected';
+    } catch {
+      // Connection failed or context was not received. If this attempt is
+      // still active, invalidate it and close owned resources. If a newer
+      // attempt has already superseded it, close resources but report
+      // 'superseded' so the caller does not overwrite the newer attempt's
+      // state.
+      const wasActive = this.activeAttempt === attempt;
+      if (wasActive) {
+        this.activeAttempt = undefined;
+        ideContext.clearIdeContext();
+      }
+      await attempt.closeOwned();
+
+      if (!wasActive || !this.isLifecycleActive(epoch)) {
+        return 'superseded';
+      }
+      return 'failed';
     }
+  }
+
+  /**
+   * Starts a new connection attempt with a fresh monotonic generation token.
+   * The prior active attempt (if any) is superseded — awaited, not
+   * fire-and-forget — so installation only proceeds for the still-owning
+   * lifecycle operation. This prevents an older connect() that resumes after a
+   * newer connect() from installing itself and claiming ownership.
+   *
+   * Returns `undefined` if the owning operation was superseded while awaiting
+   * the prior attempt's close, signalling the caller to abort.
+   */
+  private async startNewAttempt(
+    epoch: number,
+  ): Promise<ConnectionAttempt | undefined> {
+    // AWAIT supersession rather than fire-and-forget. This serializes the
+    // prior close before installation and lets a superseding operation win.
+    await this.supersedeActiveAttempt();
+
+    // If a newer connect()/disconnect() started while we awaited the prior
+    // close, this operation no longer owns the lifecycle and must not install.
+    if (!this.isLifecycleActive(epoch)) {
+      return undefined;
+    }
+
+    const generation = this.nextGeneration++;
+    const attempt = new ConnectionAttempt(generation);
+    this.activeAttempt = attempt;
+    this.client = attempt.client;
+    ideContext.clearIdeContext();
+    return attempt;
+  }
+
+  /**
+   * Supersedes (cancels and closes) the currently active attempt, if any.
+   * The prior attempt's generation is invalidated so its handlers/continuations
+   * become no-ops, and its owned Client/transport/timer are closed.
+   */
+  private async supersedeActiveAttempt(): Promise<void> {
+    const prior = this.activeAttempt;
+    if (prior === undefined) {
+      return;
+    }
+    this.activeAttempt = undefined;
+    this.client = undefined;
+    ideContext.clearIdeContext();
+    await prior.closeOwned();
+  }
+
+  private isAttemptActive(attempt: ConnectionAttempt): boolean {
+    return this.activeAttempt === attempt;
+  }
+
+  /**
+   * Claims the next lifecycle epoch synchronously (no await between reading
+   * and writing), returning the claimed value. Both connect() and disconnect()
+   * call this as their very first action so a competing operation issued
+   * immediately afterward is guaranteed a newer epoch.
+   */
+  private claimLifecycleEpoch(): number {
+    const epoch = this.nextLifecycleEpoch;
+    this.nextLifecycleEpoch += 1;
+    this.activeLifecycleEpoch = epoch;
+    return epoch;
+  }
+
+  private isLifecycleActive(epoch: number): boolean {
+    return this.activeLifecycleEpoch === epoch;
   }
 }
 

--- a/packages/ide-integration/src/ide/ide-client.ts
+++ b/packages/ide-integration/src/ide/ide-client.ts
@@ -131,8 +131,13 @@ class ConnectionAttempt {
   readonly generation: number;
   readonly client: Client;
   readonly receiptDeferred: ReceiptDeferred;
-  readonly receiptTimer: CancellableTimer;
   transport: StreamableHTTPClientTransport | undefined;
+
+  /**
+   * Lazily created only after a successful ping, so a slow connect/ping does
+   * not consume the post-ping receipt budget. Undefined before ping resolves.
+   */
+  receiptTimer: CancellableTimer | undefined;
 
   constructor(generation: number) {
     this.generation = generation;
@@ -142,9 +147,25 @@ class ConnectionAttempt {
       version: '1.0.0',
     });
     this.receiptDeferred = createReceiptDeferred();
-    this.receiptTimer = createCancellableTimer(
-      IdeClient.CONTEXT_RECEIPT_TIMEOUT_MS,
-    );
+  }
+
+  /**
+   * Starts the context-receipt timeout. Must be called only after a successful
+   * ping so the receipt window measures the wait for the context notification,
+   * not connect/ping latency. Safe to call once per attempt.
+   */
+  startReceiptTimer(): CancellableTimer {
+    const timer = createCancellableTimer(IdeClient.CONTEXT_RECEIPT_TIMEOUT_MS);
+    this.receiptTimer = timer;
+    return timer;
+  }
+
+  /**
+   * Cancels the receipt timer if one was started. A no-op when the timer was
+   * never created (e.g. attempt superseded before ping resolved).
+   */
+  cancelReceiptTimer(): void {
+    this.receiptTimer?.cancel();
   }
 
   /**
@@ -152,7 +173,7 @@ class ConnectionAttempt {
    * mutable `IdeClient.client` which may point to a different (newer) attempt.
    */
   async closeOwned(): Promise<void> {
-    this.receiptTimer.cancel();
+    this.cancelReceiptTimer();
     try {
       await this.client.close();
     } catch (error) {
@@ -877,17 +898,20 @@ export class IdeClient {
 
       // Ping success alone is NOT acknowledgment — only the real notification
       // handler resolving the deferred proves the context was received. Await
-      // the context receipt with a bounded, cancellable timeout. If no context
-      // arrives (including a new client against a default-ping-only server),
-      // connect must end Disconnected.
+      // the context receipt with a bounded, cancellable timeout. The timer is
+      // started only now (after ping resolved) so slow connect/ping latency
+      // does not consume the receipt budget. If no context arrives (including
+      // a new client against a default-ping-only server), connect must end
+      // Disconnected.
+      const receiptTimer = attempt.startReceiptTimer();
       const receiptResult = await Promise.race([
         attempt.receiptDeferred.promise.then(() => 'received' as const),
-        attempt.receiptTimer.promise,
+        receiptTimer.promise,
       ]);
 
       // Clear the timer on early receipt (it may have been resolved by the
       // notification before the timer elapsed).
-      attempt.receiptTimer.cancel();
+      receiptTimer.cancel();
 
       if (!this.isAttemptActive(attempt)) {
         await attempt.closeOwned();

--- a/packages/ide-integration/src/ide/ide-client.ts
+++ b/packages/ide-integration/src/ide/ide-client.ts
@@ -92,7 +92,10 @@ function createCancellableTimer(ms: number): CancellableTimer {
   let timerId: ReturnType<typeof setTimeout> | undefined;
   let cancelFn: () => void = () => {};
   const promise = new Promise<'elapsed' | 'cancelled'>((resolve) => {
-    timerId = setTimeout(() => resolve('elapsed'), ms);
+    timerId = setTimeout(() => {
+      timerId = undefined;
+      resolve('elapsed');
+    }, ms);
     cancelFn = () => {
       if (timerId !== undefined) {
         clearTimeout(timerId);
@@ -199,6 +202,12 @@ export class IdeClient {
    * window, the connection is considered failed (Disconnected).
    */
   static readonly CONTEXT_RECEIPT_TIMEOUT_MS = 5000;
+
+  /**
+   * Message shown when the IDE connection is lost unexpectedly (onerror /
+   * onclose). Used in both handlers to avoid an inline duplicated string.
+   */
+  private static readonly CONNECTION_LOST_MESSAGE = `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable`;
 
   private static instance: IdeClient | undefined;
   private client: Client | undefined = undefined;
@@ -467,22 +476,31 @@ export class IdeClient {
     // this.closeDiff() would dereference the (possibly new) this.client and
     // could send closeDiff for new-lifecycle diffs through the wrong client.
     const ownedClient = this.client;
-    const ownedDiffPaths: string[] = [];
+    // Snapshot BOTH the filePath AND its resolver BEFORE the first await. We
+    // must not iterate the live shared diffResponses Map after an await,
+    // because a reconnect may install a new client and/or add new diff entries.
+    // Capturing the resolver reference lets us settle it unconditionally (so
+    // awaiters never hang) while identity-guarding map deletion so a newer
+    // lifecycle's entry for the same path is never clobbered.
+    const ownedDiffs: Array<{
+      filePath: string;
+      resolver: (result: DiffUpdateResult) => void;
+    }> = [];
     if (
       this.state.status !== IDEConnectionStatus.Disconnected &&
       ownedClient !== undefined
     ) {
-      for (const filePath of this.diffResponses.keys()) {
-        ownedDiffPaths.push(filePath);
+      for (const [filePath, resolver] of this.diffResponses) {
+        ownedDiffs.push({ filePath, resolver });
       }
     }
 
-    for (const filePath of ownedDiffPaths) {
+    for (const { filePath } of ownedDiffs) {
       // After every await, check that this disconnect still owns the lifecycle
       // and that the owned client is still available. A reconnect that
       // completed during the prior closeDiff await claims a newer epoch; once
       // stale, stop issuing tool calls and do not mutate shared state/maps.
-      // (ownedDiffPaths is only populated when ownedClient was defined, but
+      // (ownedDiffs is only populated when ownedClient was defined, but
       // TypeScript cannot narrow across the loop boundary.)
       if (!this.isLifecycleActive(myEpoch) || ownedClient === undefined) {
         break;
@@ -494,18 +512,26 @@ export class IdeClient {
       }
     }
 
-    // Only clear shared diff state, settle resolvers, and transition to
-    // Disconnected if this disconnect is still the active lifecycle operation.
-    // A newer lifecycle may have added entries to the shared map; we must not
-    // delete or settle those.
-    if (this.isLifecycleActive(myEpoch)) {
-      for (const filePath of ownedDiffPaths) {
-        const resolver = this.diffResponses.get(filePath);
-        if (resolver) {
-          resolver({ status: 'rejected', content: undefined });
-          this.diffResponses.delete(filePath);
-        }
+    // ALWAYS settle every captured resolver — unconditionally, outside the
+    // isLifecycleActive guard. If a reconnect claimed a newer epoch mid-loop,
+    // the loop broke but these old diff awaiters would otherwise hang forever
+    // (closeDiffViaClient uses suppressNotification:true, so no IDE
+    // notification will ever settle them). Settling a resolver twice is a
+    // no-op, so this is safe even if a notification already settled it. Map
+    // deletion is identity-guarded so a newer lifecycle's entry for the same
+    // filePath is never clobbered.
+    for (const { filePath, resolver } of ownedDiffs) {
+      resolver({ status: 'rejected', content: undefined });
+      if (this.diffResponses.get(filePath) === resolver) {
+        this.diffResponses.delete(filePath);
       }
+    }
+
+    // The state transition and client clearing remain epoch-guarded: only the
+    // active lifecycle operation may flip connection status or clear
+    // this.client. A newer lifecycle may have reconnected; we must not
+    // overwrite its state.
+    if (this.isLifecycleActive(myEpoch)) {
       this.setState(
         IDEConnectionStatus.Disconnected,
         'IDE integration disabled. To enable it again, run /ide enable.',
@@ -830,7 +856,7 @@ export class IdeClient {
       }
       this.setState(
         IDEConnectionStatus.Disconnected,
-        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable`,
+        IdeClient.CONNECTION_LOST_MESSAGE,
         true,
       );
     };
@@ -840,7 +866,7 @@ export class IdeClient {
       }
       this.setState(
         IDEConnectionStatus.Disconnected,
-        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable`,
+        IdeClient.CONNECTION_LOST_MESSAGE,
         true,
       );
     };

--- a/packages/vscode-ide-companion/src/ide-client-integration.test.ts
+++ b/packages/vscode-ide-companion/src/ide-client-integration.test.ts
@@ -1,0 +1,629 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import {
+  IdeClient,
+  IDEConnectionStatus,
+  ideContext,
+  type IdeContext,
+} from '@vybestack/llxprt-code-ide-integration';
+import { DiffContentProvider, DiffManager } from './diff-manager.js';
+import { IDEServer } from './ide-server.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { IdeContextNotificationSchema } from './ide-schemas.js';
+import * as path from 'node:path';
+import * as http from 'node:http';
+import { fileURLToPath } from 'node:url';
+
+const companionFile = fileURLToPath(import.meta.url);
+// companionFile: packages/vscode-ide-companion/src/<this file>
+const srcDir = path.dirname(companionFile);
+const companionDir = path.dirname(srcDir);
+const packagesDir = path.dirname(companionDir);
+const repositoryRoot = path.dirname(packagesDir);
+const readmePath = path.join(repositoryRoot, 'README.md');
+
+vi.mock('vscode', () => {
+  class TestEventEmitter<T> {
+    private readonly listeners = new Set<(event: T) => unknown>();
+
+    readonly event = (listener: (event: T) => unknown) => {
+      this.listeners.add(listener);
+      return { dispose: () => this.listeners.delete(listener) };
+    };
+
+    fire(event: T): void {
+      for (const listener of this.listeners) {
+        listener(event);
+      }
+    }
+
+    dispose(): void {
+      this.listeners.clear();
+    }
+  }
+
+  const createUri = (scheme: string, filePath: string, query = '') => ({
+    scheme,
+    fsPath: filePath,
+    path: filePath,
+    query,
+    toString: () => `${scheme}:${filePath}${query === '' ? '' : `?${query}`}`,
+  });
+  const disposable = () => ({ dispose: () => undefined });
+
+  return {
+    EventEmitter: TestEventEmitter,
+    Uri: {
+      file: (filePath: string) => createUri('file', filePath),
+      from: ({
+        scheme,
+        path: filePath,
+        query,
+      }: {
+        scheme: string;
+        path: string;
+        query?: string;
+      }) => createUri(scheme, filePath, query),
+      parse: (value: string) => createUri('file', value),
+    },
+    window: {
+      activeTextEditor: undefined,
+      onDidChangeActiveTextEditor: disposable,
+      onDidChangeTextEditorSelection: disposable,
+      tabGroups: { all: [], close: () => Promise.resolve(true) },
+    },
+    workspace: {
+      fs: { stat: () => Promise.resolve({}) },
+      isTrusted: true,
+      workspaceFolders: undefined,
+      onDidCloseTextDocument: disposable,
+      onDidDeleteFiles: disposable,
+      onDidGrantWorkspaceTrust: disposable,
+      onDidRenameFiles: disposable,
+      openTextDocument: () => Promise.resolve({ getText: () => '' }),
+    },
+    commands: {
+      executeCommand: () => Promise.resolve(undefined),
+    },
+  };
+});
+
+const IDE_ENVIRONMENT_VARIABLES = [
+  'LLXPRT_CODE_IDE_SERVER_PORT',
+  'LLXPRT_CODE_IDE_WORKSPACE_PATH',
+  'LLXPRT_CODE_IDE_AUTH_TOKEN',
+] as const;
+
+function seedActiveEditor(): void {
+  const selection = {
+    active: { line: 0, character: 11 },
+    anchor: { line: 0, character: 0 },
+  };
+  Object.defineProperty(vscode.window, 'activeTextEditor', {
+    configurable: true,
+    value: {
+      document: {
+        uri: vscode.Uri.file(readmePath),
+        getText: () => 'LLxprt Code',
+      },
+      selection,
+      selections: [selection],
+    },
+  });
+  Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+    configurable: true,
+    value: [{ uri: vscode.Uri.file(repositoryRoot) }],
+  });
+}
+
+function createExtensionContext(): vscode.ExtensionContext {
+  const environmentVariables = new Set<string>();
+  return {
+    subscriptions: [],
+    environmentVariableCollection: {
+      replace: (variable: string, value: string) => {
+        environmentVariables.add(variable);
+        vi.stubEnv(variable, value);
+      },
+      clear: () => {
+        for (const variable of environmentVariables) {
+          delete process.env[variable];
+        }
+        environmentVariables.clear();
+      },
+    },
+  } as unknown as vscode.ExtensionContext;
+}
+
+async function buildConnectedStack(): Promise<{
+  ideClient: IdeClient;
+  ideServer: IDEServer;
+  diffManager: DiffManager;
+  context: vscode.ExtensionContext;
+}> {
+  vi.stubEnv('TERM_PROGRAM', 'vscode');
+  seedActiveEditor();
+  const context = createExtensionContext();
+  const diffManager = new DiffManager(
+    () => undefined,
+    new DiffContentProvider(),
+  );
+  const ideServer = new IDEServer(() => undefined, diffManager);
+  await ideServer.start(context);
+  const ideClient = await IdeClient.getInstance();
+  return { ideClient, ideServer, diffManager, context };
+}
+
+describe('IdeClient with the VS Code companion server', () => {
+  let ideClient: IdeClient | undefined;
+  let ideServer: IDEServer | undefined;
+  let diffManager: DiffManager | undefined;
+  let context: vscode.ExtensionContext | undefined;
+  let externalHttpServers: http.Server[] = [];
+  // Raw MCP clients/transports created directly by tests (not via IdeClient).
+  // These must be closed in afterEach so sessions/timers do not leak.
+  let rawClients: Client[] = [];
+  let rawClientTransports: StreamableHTTPClientTransport[] = [];
+
+  afterEach(async () => {
+    // Close raw clients first (sends delete/close to their sessions) before
+    // tearing down the shared IDEServer.
+    for (const client of rawClients) {
+      try {
+        await client.close();
+      } catch {
+        // Best-effort teardown.
+      }
+    }
+    rawClients = [];
+    for (const transport of rawClientTransports) {
+      try {
+        await transport.close();
+      } catch {
+        // Best-effort teardown.
+      }
+    }
+    rawClientTransports = [];
+    if (ideClient !== undefined) {
+      await ideClient.disconnect();
+    }
+    if (ideServer !== undefined) {
+      await ideServer.stop();
+    }
+    for (const srv of externalHttpServers) {
+      await new Promise<void>((resolve) => srv.close(() => resolve()));
+    }
+    externalHttpServers = [];
+    diffManager?.dispose();
+    for (const subscription of context?.subscriptions ?? []) {
+      subscription.dispose();
+    }
+    ideContext.clearIdeContext();
+    IdeClient.resetInstance();
+    for (const variable of IDE_ENVIRONMENT_VARIABLES) {
+      delete process.env[variable];
+    }
+    Object.defineProperty(vscode.window, 'activeTextEditor', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+      configurable: true,
+      value: undefined,
+    });
+    vi.unstubAllEnvs();
+  });
+
+  it('stores initial editor context before connect resolves (no polling)', async () => {
+    const stack = await buildConnectedStack();
+    ideClient = stack.ideClient;
+    ideServer = stack.ideServer;
+    diffManager = stack.diffManager;
+    context = stack.context;
+
+    await ideClient.connect();
+
+    // Assert synchronously-immediately after connect resolves, with NO wait.
+    const receivedContext = ideContext.getIdeContext();
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+    expect(receivedContext).toMatchObject({
+      workspaceState: {
+        isTrusted: true,
+        openFiles: [
+          {
+            path: readmePath,
+            isActive: true,
+            selectedText: 'LLxprt Code',
+            cursor: { line: 1, character: 12 },
+          },
+        ],
+      },
+    });
+  });
+
+  it('reflects incremental context updates after the initial sync', async () => {
+    const stack = await buildConnectedStack();
+    ideClient = stack.ideClient;
+    ideServer = stack.ideServer;
+    diffManager = stack.diffManager;
+    context = stack.context;
+
+    await ideClient.connect();
+    // Drain the synchronous initial value first.
+    expect(ideContext.getIdeContext()).toBeDefined();
+
+    const secondUpdate = new Promise<IdeContext>((resolve) => {
+      const unsubscribe = ideContext.subscribeToIdeContext((next) => {
+        if (next !== undefined) {
+          unsubscribe();
+          resolve(next);
+        }
+      });
+    });
+    stack.ideServer.broadcastIdeContextUpdate();
+
+    const updated = await secondUpdate;
+    // broadcastIdeContextUpdate re-sends openFilesManager.state (the same
+    // workspaceState shape seeded by seedActiveEditor), so the incremental
+    // update must carry the active README file.
+    expect(updated).toMatchObject({
+      workspaceState: {
+        isTrusted: true,
+        openFiles: [
+          {
+            path: readmePath,
+            isActive: true,
+            selectedText: 'LLxprt Code',
+            cursor: { line: 1, character: 12 },
+          },
+        ],
+      },
+    });
+  });
+
+  it('disconnect closes the MCP client and session transport resources', async () => {
+    const stack = await buildConnectedStack();
+    ideClient = stack.ideClient;
+    ideServer = stack.ideServer;
+    diffManager = stack.diffManager;
+    context = stack.context;
+
+    await ideClient.connect();
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    await ideClient.disconnect();
+    // Client is visibly disconnected after disconnect resolves.
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+
+    await ideServer.stop();
+    ideServer = undefined;
+    ideClient = undefined;
+  });
+
+  it('server.stop resolves promptly while a client is still connected and closes the endpoint', async () => {
+    const stack = await buildConnectedStack();
+    ideClient = stack.ideClient;
+    ideServer = stack.ideServer;
+    diffManager = stack.diffManager;
+    context = stack.context;
+
+    await ideClient.connect();
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Connected,
+    );
+
+    // Capture the port before stop clears the env.
+    const port = process.env['LLXPRT_CODE_IDE_SERVER_PORT'] ?? 'unknown';
+
+    // Stop the server FIRST while the client is still connected. This must
+    // resolve within a bounded time — proving active SSE streams and keep-alive
+    // timers are torn down rather than lingering for the 60-second interval.
+    const stopResult = await Promise.race([
+      ideServer.stop().then(() => 'stopped'),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve('timeout'), 5000),
+      ),
+    ]);
+    expect(stopResult).toBe('stopped');
+
+    // The former endpoint no longer accepts connections.
+    const endpointCheck = await new Promise<string>((resolve) => {
+      const req = http.request(
+        `http://127.0.0.1:${port}/mcp`,
+        { method: 'POST' },
+        (res) => {
+          res.destroy();
+          resolve(`responded-${res.statusCode}`);
+        },
+      );
+      req.on('error', () => resolve('rejected'));
+      req.end();
+    });
+    expect(endpointCheck).toBe('rejected');
+
+    // The client can still be disconnected without hanging.
+    await ideClient.disconnect();
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+
+    // Prevent afterEach from double-stopping.
+    ideServer = undefined;
+    ideClient = undefined;
+  });
+
+  it('ends Disconnected when a default-ping server completes initialize/ping but never sends ide/contextUpdate', async () => {
+    // Core regression guard for issue #2650: a genuine MCP server that
+    // completes initialize and ping but NEVER delivers ide/contextUpdate must
+    // NOT cause a false Connected state. The client must end Disconnected.
+    // The test timeout must exceed the client's internal context-receipt
+    // timeout (5s) so the Disconnected result is observable.
+    vi.stubEnv('TERM_PROGRAM', 'vscode');
+    seedActiveEditor();
+
+    // Create a bare MCP server (no ping interception, no ide/contextUpdate).
+    const bareMcpServer = new McpServer(
+      { name: 'bare-ping-only-server', version: '1.0.0' },
+      { capabilities: { logging: {} } },
+    );
+    const express = (await import('express')).default;
+    const { randomUUID } = await import('node:crypto');
+    const authToken = 'bare-test-token';
+
+    const app = express();
+    app.use(express.json({ limit: '10mb' }));
+    app.use((req, res, next) => {
+      const authHeader = req.headers['authorization'];
+      if (!authHeader || authHeader !== `Bearer ${authToken}`) {
+        res.status(401).send('Unauthorized');
+        return;
+      }
+      next();
+    });
+
+    const bareTransports = new Map<string, StreamableHTTPServerTransport>();
+    app.post('/mcp', (req, res) => {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      const existing = sessionId ? bareTransports.get(sessionId) : undefined;
+      if (existing) {
+        existing.handleRequest(req, res, req.body).catch(() => {
+          if (!res.headersSent) {
+            res.status(500).json({ error: 'error' });
+          }
+        });
+        return;
+      }
+      const transport: StreamableHTTPServerTransport =
+        new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (id) => {
+            bareTransports.set(id, transport);
+          },
+        });
+      void bareMcpServer.connect(transport).catch(() => {
+        // Best-effort: a bare server connect failure must not produce an
+        // unhandled rejection that fails the test process.
+      });
+      transport.handleRequest(req, res, req.body).catch(() => {
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'error' });
+        }
+      });
+    });
+
+    const bareServer = http.createServer(app);
+    await new Promise<void>((resolve) =>
+      bareServer.listen(0, '127.0.0.1', resolve),
+    );
+    externalHttpServers.push(bareServer);
+    const bareAddress = bareServer.address();
+    const barePort =
+      typeof bareAddress === 'object' && bareAddress ? bareAddress.port : 0;
+
+    // Make IdeClient connect to the bare server via env (no port file).
+    vi.stubEnv('LLXPRT_CODE_IDE_SERVER_PORT', String(barePort));
+    vi.stubEnv('LLXPRT_CODE_IDE_AUTH_TOKEN', authToken);
+    vi.stubEnv('LLXPRT_CODE_IDE_WORKSPACE_PATH', repositoryRoot);
+
+    IdeClient.resetInstance();
+    ideClient = await IdeClient.getInstance();
+    await ideClient.connect();
+
+    // The client must be Disconnected — the bare server completes initialize
+    // and ping but never sends ide/contextUpdate, so the client's context
+    // receipt deferred must time out.
+    expect(ideClient.getConnectionStatus().status).toBe(
+      IDEConnectionStatus.Disconnected,
+    );
+    expect(ideContext.getIdeContext()).toBeUndefined();
+
+    // Best-effort close of bare server-side transports so their SSE/timers
+    // cannot leak even if an assertion above were to fail.
+    for (const transport of bareTransports.values()) {
+      try {
+        await transport.close();
+      } catch {
+        // Best-effort teardown.
+      }
+    }
+    bareTransports.clear();
+
+    ideClient = undefined;
+  }, 10000);
+
+  it('delivers initial context to a client that opens a GET stream without a custom ping', async () => {
+    // Regression guard for the GET fallback: a standard MCP client opens a GET
+    // SSE stream automatically after the `notifications/initialized` message.
+    // The server should push initial context on that stream even if the client
+    // does not send a custom application ping.
+    const stack = await buildConnectedStack();
+    ideServer = stack.ideServer;
+    context = stack.context;
+    diffManager = stack.diffManager;
+    seedActiveEditor();
+
+    const port = process.env['LLXPRT_CODE_IDE_SERVER_PORT']!;
+    const authToken = process.env['LLXPRT_CODE_IDE_AUTH_TOKEN']!;
+
+    // Use a real MCP Client that connects normally. The SDK transport
+    // automatically opens a GET SSE stream after notifications/initialized.
+    const client = new Client({
+      name: 'get-stream-client',
+      version: '1.0.0',
+    });
+    // Register immediately so afterEach cleans up on failure.
+    rawClients.push(client);
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+      {
+        requestInit: {
+          headers: { Authorization: `Bearer ${authToken}` },
+        },
+      },
+    );
+    // Register immediately so afterEach cleans up on failure.
+    rawClientTransports.push(transport);
+
+    // Register a notification handler for ide/contextUpdate BEFORE connecting.
+    let receivedContext = false;
+    let contextUpdateCount = 0;
+    client.setNotificationHandler(IdeContextNotificationSchema, () => {
+      receivedContext = true;
+      contextUpdateCount++;
+    });
+
+    await client.connect(transport);
+
+    // The client opens a GET stream automatically after initialized. The
+    // server should push initial context on it within a bounded time.
+    const result = await new Promise<boolean>((resolve) => {
+      const timeout = setTimeout(() => resolve(false), 5000);
+      const check = () => {
+        if (receivedContext) {
+          clearTimeout(timeout);
+          resolve(true);
+        } else {
+          setTimeout(check, 100);
+        }
+      };
+      setTimeout(check, 100);
+    });
+
+    // Close explicitly here (idempotent in the SDK); afterEach will also
+    // attempt a best-effort close.
+    try {
+      await client.close();
+    } catch {
+      // ignore
+    }
+
+    expect(result).toBe(true);
+    // Exactly one client-visible ide/contextUpdate notification was delivered.
+    expect(contextUpdateCount).toBe(1);
+  });
+
+  it('supports a second client connecting while a first client remains active (per-session server)', async () => {
+    // Regression guard for issue #2650: the server used to share a single
+    // McpServer across every session transport. A McpServer can only be
+    // connected to one transport at a time, so a second client's initialize
+    // established TCP but the server-side connect() never resolved, hanging
+    // until the client's ~60s timeout. This test connects two real MCP
+    // Clients to one real IDEServer and asserts both initialize, the second
+    // can ping, and closing the second does not break the first.
+    const stack = await buildConnectedStack();
+    ideServer = stack.ideServer;
+    context = stack.context;
+    diffManager = stack.diffManager;
+    seedActiveEditor();
+
+    const port = process.env['LLXPRT_CODE_IDE_SERVER_PORT']!;
+    const authToken = process.env['LLXPRT_CODE_IDE_AUTH_TOKEN']!;
+
+    // --- Client A: connect and keep active. ---
+    const clientA = new Client({
+      name: 'two-client-A',
+      version: '1.0.0',
+    });
+    const transportA = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+      {
+        requestInit: {
+          headers: { Authorization: `Bearer ${authToken}` },
+        },
+      },
+    );
+    let clientAReceivedContext = false;
+    clientA.setNotificationHandler(IdeContextNotificationSchema, () => {
+      clientAReceivedContext = true;
+    });
+    rawClients.push(clientA);
+    rawClientTransports.push(transportA);
+    await clientA.connect(transportA);
+    await clientA.ping();
+    expect(clientAReceivedContext).toBe(true);
+
+    // --- Client B: connect while A is still active. Race with a short
+    //     timeout so a hung shared-server connect fails the test fast. ---
+    const clientB = new Client({
+      name: 'two-client-B',
+      version: '1.0.0',
+    });
+    const transportB = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+      {
+        requestInit: {
+          headers: { Authorization: `Bearer ${authToken}` },
+        },
+      },
+    );
+    let clientBReceivedContext = false;
+    clientB.setNotificationHandler(IdeContextNotificationSchema, () => {
+      clientBReceivedContext = true;
+    });
+    rawClients.push(clientB);
+    rawClientTransports.push(transportB);
+
+    const connectOutcome = await Promise.race([
+      clientB.connect(transportB).then(() => 'connected'),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve('timeout'), 5000),
+      ),
+    ]);
+    expect(connectOutcome).toBe('connected');
+
+    // A ping is the authoritative initial-context synchronization point.
+    await clientB.ping();
+    expect(clientBReceivedContext).toBe(true);
+
+    // Close only client B. A must remain usable.
+    try {
+      await clientB.close();
+    } catch {
+      // Best-effort.
+    }
+    // Remove B from raw cleanup (already closed) so afterEach does not
+    // double-close a closed transport.
+    rawClients = rawClients.filter((c) => c !== clientB);
+    rawClientTransports = rawClientTransports.filter((t) => t !== transportB);
+
+    // A must still be able to ping — closing B must not have torn down the
+    // shared protocol that A depends on.
+    await clientA.ping();
+    expect(clientAReceivedContext).toBe(true);
+  }, 10000);
+});

--- a/packages/vscode-ide-companion/src/ide-server-concurrency.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server-concurrency.test.ts
@@ -1,0 +1,506 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { DiffContentProvider, DiffManager } from './diff-manager.js';
+import { IDEServer } from './ide-server.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type {
+  JSONRPCMessage,
+  RequestId,
+} from '@modelcontextprotocol/sdk/types.js';
+import * as path from 'node:path';
+import * as http from 'node:http';
+import { fileURLToPath } from 'node:url';
+
+const companionFile = fileURLToPath(import.meta.url);
+const srcDir = path.dirname(companionFile);
+const companionDir = path.dirname(srcDir);
+const packagesDir = path.dirname(companionDir);
+const repositoryRoot = path.dirname(packagesDir);
+const readmePath = path.join(repositoryRoot, 'README.md');
+
+vi.mock('vscode', () => {
+  class TestEventEmitter<T> {
+    private readonly listeners = new Set<(event: T) => unknown>();
+
+    readonly event = (listener: (event: T) => unknown) => {
+      this.listeners.add(listener);
+      return { dispose: () => this.listeners.delete(listener) };
+    };
+
+    fire(event: T): void {
+      for (const listener of this.listeners) {
+        listener(event);
+      }
+    }
+
+    dispose(): void {
+      this.listeners.clear();
+    }
+  }
+
+  const createUri = (scheme: string, filePath: string) => ({
+    scheme,
+    fsPath: filePath,
+    path: filePath,
+    toString: () => `${scheme}:${filePath}`,
+  });
+  const disposable = () => ({ dispose: () => undefined });
+
+  return {
+    EventEmitter: TestEventEmitter,
+    Uri: {
+      file: (filePath: string) => createUri('file', filePath),
+      from: ({ scheme, path: filePath }: { scheme: string; path: string }) =>
+        createUri(scheme, filePath),
+      parse: (value: string) => createUri('file', value),
+    },
+    window: {
+      activeTextEditor: undefined,
+      onDidChangeActiveTextEditor: disposable,
+      onDidChangeTextEditorSelection: disposable,
+      tabGroups: { all: [], close: () => Promise.resolve(true) },
+    },
+    workspace: {
+      fs: { stat: () => Promise.resolve({}) },
+      isTrusted: true,
+      workspaceFolders: undefined,
+      onDidCloseTextDocument: disposable,
+      onDidDeleteFiles: disposable,
+      onDidGrantWorkspaceTrust: disposable,
+      onDidRenameFiles: disposable,
+      openTextDocument: () => Promise.resolve({ getText: () => '' }),
+    },
+    commands: {
+      executeCommand: () => Promise.resolve(undefined),
+    },
+  };
+});
+
+function seedActiveEditor(): void {
+  const selection = {
+    active: { line: 0, character: 11 },
+    anchor: { line: 0, character: 0 },
+  };
+  Object.defineProperty(vscode.window, 'activeTextEditor', {
+    configurable: true,
+    value: {
+      document: {
+        uri: vscode.Uri.file(readmePath),
+        getText: () => 'LLxprt Code',
+      },
+      selection,
+      selections: [selection],
+    },
+  });
+  Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+    configurable: true,
+    value: [{ uri: vscode.Uri.file(repositoryRoot) }],
+  });
+}
+
+function createExtensionContext(): vscode.ExtensionContext {
+  const environmentVariables = new Set<string>();
+  return {
+    subscriptions: [],
+    environmentVariableCollection: {
+      replace: (variable: string, value: string) => {
+        environmentVariables.add(variable);
+        vi.stubEnv(variable, value);
+      },
+      clear: () => {
+        for (const variable of environmentVariables) {
+          delete process.env[variable];
+        }
+        environmentVariables.clear();
+      },
+    },
+  } as unknown as vscode.ExtensionContext;
+}
+
+const IDE_ENVIRONMENT_VARIABLES = [
+  'LLXPRT_CODE_IDE_SERVER_PORT',
+  'LLXPRT_CODE_IDE_WORKSPACE_PATH',
+  'LLXPRT_CODE_IDE_AUTH_TOKEN',
+] as const;
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  id: string | number;
+  result?: unknown;
+  error?: { code: number; message: string };
+  sessionId?: string;
+}
+
+const NEWLINE = '\n';
+
+/**
+ * Parses a single SSE "data:" line into a JSON-RPC message, or undefined if
+ * the line is not a data line or is malformed.
+ */
+function parseSseDataLine(line: string): JsonRpcResponse | undefined {
+  if (!line.startsWith('data:')) {
+    return undefined;
+  }
+  const jsonText = line.slice(5).trim();
+  if (jsonText === '') {
+    return undefined;
+  }
+  try {
+    return JSON.parse(jsonText) as JsonRpcResponse;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Parses a response body that may be either raw JSON or an SSE stream of
+ * "event: message" / "data: {...}" lines. Extracts the JSON-RPC message and
+ * pairs it with the mcp-session-id response header.
+ */
+function parseResponseBody(
+  data: string,
+  sessionIdHeader: string | string[] | undefined,
+  expectedId?: string | number,
+): JsonRpcResponse {
+  const trimmed = data.trim();
+  const result: JsonRpcResponse = { jsonrpc: '2.0', id: 0 };
+  if (typeof sessionIdHeader === 'string') {
+    result.sessionId = sessionIdHeader;
+  }
+  // Notifications (e.g. notifications/initialized) return an empty 202 body.
+  if (trimmed === '') {
+    return result;
+  }
+  if (trimmed.startsWith('event:') || trimmed.startsWith('data:')) {
+    const messages: JsonRpcResponse[] = [];
+    for (const line of trimmed.split(NEWLINE)) {
+      const parsed = parseSseDataLine(line);
+      if (parsed !== undefined) {
+        messages.push(parsed);
+      }
+    }
+    if (messages.length > 0) {
+      const match =
+        expectedId !== undefined
+          ? messages.find((m) => m.id === expectedId)
+          : undefined;
+      const chosen = match ?? messages[messages.length - 1];
+      if (typeof sessionIdHeader === 'string') {
+        chosen.sessionId = sessionIdHeader;
+      }
+      return chosen;
+    }
+    return result;
+  }
+  const parsed = JSON.parse(trimmed) as JsonRpcResponse;
+  if (typeof sessionIdHeader === 'string') {
+    parsed.sessionId = sessionIdHeader;
+  }
+  return parsed;
+}
+
+/**
+ * Sends a raw JSON-RPC request over HTTP to the IDE server's /mcp endpoint and
+ * returns the parsed response body and the mcp-session-id header. Used to
+ * drive initialize/ping sequencing deterministically without the SDK client's
+ * automatic GET-stream behavior interfering with the precise overlap under
+ * test.
+ */
+function sendJsonRpc(
+  port: number,
+  authToken: string,
+  body: { id?: string | number; [key: string]: unknown },
+  sessionId?: string,
+): Promise<JsonRpcResponse> {
+  const expectedId = body.id;
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Authorization: `Bearer ${authToken}`,
+    };
+    if (sessionId !== undefined) {
+      headers['mcp-session-id'] = sessionId;
+    }
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      `http://127.0.0.1:${port}/mcp`,
+      {
+        method: 'POST',
+        headers: { ...headers, 'Content-Length': Buffer.byteLength(payload) },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer | string) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve(
+              parseResponseBody(
+                data,
+                res.headers['mcp-session-id'],
+                expectedId,
+              ),
+            );
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+/**
+ * Opens a GET SSE stream against /mcp for a session. Returns the underlying
+ * request and a function to collect notification events from the stream. The
+ * standalone GET triggers non-authoritative initial-context delivery on the
+ * server.
+ */
+function openGetStream(
+  port: number,
+  authToken: string,
+  sessionId: string,
+): {
+  close: () => void;
+  notificationEvents: string[];
+} {
+  const notificationEvents: string[] = [];
+  const req = http.request(
+    `http://127.0.0.1:${port}/mcp`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'text/event-stream',
+        Authorization: `Bearer ${authToken}`,
+        'mcp-session-id': sessionId,
+      },
+    },
+    (res) => {
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => {
+        if (chunk.includes('ide/contextUpdate')) {
+          notificationEvents.push('ide/contextUpdate');
+        }
+      });
+    },
+  );
+  req.on('error', () => {
+    // Stream errors during teardown are expected; ignored.
+  });
+  req.end();
+  return {
+    close: () => req.destroy(),
+    notificationEvents,
+  };
+}
+
+/**
+ * Wraps StreamableHTTPServerTransport.send so ide/contextUpdate notifications
+ * are gated behind a controllable promise. This forces the GET's non-
+ * authoritative send to remain in-flight while the authoritative ping arrives,
+ * reproducing the concurrency race fixed in deliverInitialContext.
+ */
+function createGatedSendSpy(): {
+  contextSendCount: () => number;
+  gateRelease: () => void;
+  waitForGateEntry: () => Promise<void>;
+  restore: () => void;
+} {
+  const realSend = StreamableHTTPServerTransport.prototype.send;
+  let contextSendCalls = 0;
+  let gateEntered = false;
+  let gateResolve!: () => void;
+  const gateEnteredPromise = new Promise<void>((resolve) => {
+    gateResolve = resolve;
+  });
+  let releaseGate!: () => void;
+  const releaseGatePromise = new Promise<void>((resolve) => {
+    releaseGate = resolve;
+  });
+
+  const spy = vi
+    .spyOn(StreamableHTTPServerTransport.prototype, 'send')
+    .mockImplementation(function (
+      this: unknown,
+      notification: JSONRPCMessage,
+      options?: { relatedRequestId?: RequestId },
+    ) {
+      if (
+        'method' in notification &&
+        notification.method === 'ide/contextUpdate'
+      ) {
+        contextSendCalls++;
+        if (!gateEntered) {
+          gateEntered = true;
+          gateResolve();
+        }
+        return releaseGatePromise.then(() =>
+          realSend.call(this, notification, options),
+        );
+      }
+      return realSend.call(this, notification, options);
+    });
+
+  return {
+    contextSendCount: () => contextSendCalls,
+    gateRelease: () => releaseGate(),
+    waitForGateEntry: () => gateEnteredPromise,
+    restore: () => spy.mockRestore(),
+  };
+}
+
+describe('IDEServer initial-context delivery concurrency', () => {
+  let ideServer: IDEServer | undefined;
+  let diffManager: DiffManager | undefined;
+  let context: vscode.ExtensionContext | undefined;
+
+  beforeEach(() => {
+    seedActiveEditor();
+  });
+
+  afterEach(async () => {
+    try {
+      if (ideServer !== undefined) {
+        await ideServer.stop();
+      }
+    } finally {
+      // Always restore mocks and tear down diffManager/subscriptions/env/vscode
+      // state even if ideServer.stop() rejects, so no global prototype spy or
+      // stubbed env leaks into subsequent tests.
+      vi.restoreAllMocks();
+      diffManager?.dispose();
+      for (const subscription of context?.subscriptions ?? []) {
+        subscription.dispose();
+      }
+      for (const variable of IDE_ENVIRONMENT_VARIABLES) {
+        delete process.env[variable];
+      }
+      Object.defineProperty(vscode.window, 'activeTextEditor', {
+        configurable: true,
+        value: undefined,
+      });
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        configurable: true,
+        value: undefined,
+      });
+      vi.unstubAllEnvs();
+      ideServer = undefined;
+    }
+  });
+
+  it('marks the session delivered when an authoritative ping awaits a GET-created in-flight send', async () => {
+    // Regression for the concurrency bug: deliverInitialContext captured
+    // `authoritative` in the closure that creates the shared in-flight
+    // promise. If a non-authoritative GET created the promise and an
+    // authoritative ping awaited it, successful completion left the session
+    // pending forever. This test forces GET-first/ping-second overlap and
+    // proves durable delivered state (no duplicate send on a subsequent ping).
+    const gate = createGatedSendSpy();
+
+    diffManager = new DiffManager(() => undefined, new DiffContentProvider());
+    ideServer = new IDEServer(() => undefined, diffManager);
+    context = createExtensionContext();
+    await ideServer.start(context);
+
+    const port = Number(process.env['LLXPRT_CODE_IDE_SERVER_PORT']);
+    const authToken = process.env['LLXPRT_CODE_IDE_AUTH_TOKEN']!;
+
+    // 1. Initialize to create a session.
+    const initResponse = await sendJsonRpc(port, authToken, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'concurrency-test-client', version: '1.0.0' },
+      },
+    });
+    const resolvedSessionId = initResponse.sessionId;
+    expect(resolvedSessionId).toBeTruthy();
+
+    // Send notifications/initialized to complete the handshake.
+    await sendJsonRpc(
+      port,
+      authToken,
+      {
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      },
+      resolvedSessionId,
+    );
+
+    // 2. Open the GET stream (non-authoritative). This creates the shared
+    //    in-flight send promise. The gated spy holds it in-flight.
+    const getStream = openGetStream(port, authToken, resolvedSessionId!);
+
+    try {
+      // Wait until the GET's send has entered the gate (in-flight promise
+      // created by the non-authoritative path).
+      await gate.waitForGateEntry();
+      // Yield so the in-flight promise can register in the session map before
+      // the authoritative ping arrives. setImmediate is a macrotask yield only;
+      // the gate (releaseGatePromise) is the authoritative synchronization
+      // point that actually holds the send in-flight.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // 3. Issue the authoritative ping while the GET send is still in-flight.
+      //    The ping must await the SAME shared in-flight promise created by GET.
+      const pingPromise = sendJsonRpc(
+        port,
+        authToken,
+        { jsonrpc: '2.0', id: 2, method: 'ping' },
+        resolvedSessionId,
+      );
+
+      // Let the ping reach the server and attach to the shared in-flight promise.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // 4. Release the gate: the shared send completes successfully.
+      gate.gateRelease();
+
+      const pingResult = await pingPromise;
+      // Ping must succeed (the shared send returned true), so no JSON-RPC error.
+      expect(pingResult.error).toBeUndefined();
+      expect(pingResult.result).toStrictEqual({});
+
+      // Exactly one ide/contextUpdate send occurred (shared, not duplicated).
+      expect(gate.contextSendCount()).toStrictEqual(1);
+
+      // 5. A subsequent ping must NOT re-send: the session is durably delivered.
+      const secondPing = await sendJsonRpc(
+        port,
+        authToken,
+        { jsonrpc: '2.0', id: 3, method: 'ping' },
+        resolvedSessionId,
+      );
+      expect(secondPing.error).toBeUndefined();
+      // No additional context send — durable delivered state prevents a
+      // duplicate notification.
+      expect(gate.contextSendCount()).toStrictEqual(1);
+
+      // The client-visible GET stream must have received exactly one
+      // ide/contextUpdate notification, matching the internal send count.
+      expect(getStream.notificationEvents).toStrictEqual(['ide/contextUpdate']);
+    } finally {
+      // Release the gate so no in-flight mocked send remains hanging, close
+      // the raw GET request, and restore the global prototype spy explicitly
+      // rather than relying solely on afterEach.
+      gate.gateRelease();
+      getStream.close();
+      gate.restore();
+    }
+  }, 15000);
+});

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { IdeContextNotificationSchema } from './ide-schemas.js';
 import { z } from 'zod';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { PingRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import express, {
@@ -36,6 +37,25 @@ const MCP_SESSION_ID_HEADER = 'mcp-session-id';
 const IDE_SERVER_PORT_ENV_VAR = 'LLXPRT_CODE_IDE_SERVER_PORT';
 const IDE_WORKSPACE_PATH_ENV_VAR = 'LLXPRT_CODE_IDE_WORKSPACE_PATH';
 const IDE_AUTH_TOKEN_ENV_VAR = 'LLXPRT_CODE_IDE_AUTH_TOKEN';
+
+/**
+ * Tracks the initial `ide/contextUpdate` delivery for each session atomically.
+ *
+ * - `pending`: a delivery attempt is in-flight (shared boolean promise).
+ * - `delivered`: the initial context notification was confirmed sent via the
+ *   authoritative ping-associated path.
+ * - `undefined`: no delivery has been attempted yet for this session.
+ *
+ * The in-flight promise (`Promise<boolean>`) ensures concurrent ping/GET
+ * delivery attempts share a single send with compatible boolean result
+ * semantics. A failed attempt clears only its own in-flight entry so it
+ * remains retryable.
+ */
+interface SessionDeliveryEntry {
+  status: 'pending' | 'delivered';
+  inFlight?: Promise<boolean>;
+}
+type SessionContextDelivery = Map<string, SessionDeliveryEntry>;
 
 interface WritePortAndWorkspaceArgs {
   context: vscode.ExtensionContext;
@@ -92,23 +112,41 @@ async function writePortAndWorkspace({
   }
 }
 
-function sendIdeContextUpdateNotification(
+async function sendIdeContextUpdateNotification(
   transport: StreamableHTTPServerTransport,
   log: (message: string) => void,
   openFilesManager: OpenFilesManager,
-) {
+  relatedRequestId?: string | number,
+): Promise<boolean> {
   const ideContext = openFilesManager.state;
 
-  const notification = IdeContextNotificationSchema.parse({
-    jsonrpc: '2.0',
-    method: 'ide/contextUpdate',
-    params: ideContext,
-  });
+  try {
+    const notification = IdeContextNotificationSchema.parse({
+      jsonrpc: '2.0',
+      method: 'ide/contextUpdate',
+      params: ideContext,
+    });
 
-  void transport.send(notification);
+    await transport.send(
+      notification,
+      relatedRequestId === undefined ? undefined : { relatedRequestId },
+    );
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`Failed to send ide/contextUpdate notification: ${message}`);
+    return false;
+  }
 }
 
 export class IDEServer {
+  /**
+   * Maximum time (ms) to wait for a single transport's close() to resolve
+   * during shutdown. The SDK's close() can hang when an active SSE GET stream
+   * is still open, so we bound it to prevent server.stop() from deadlocking.
+   */
+  static readonly TRANSPORT_CLOSE_TIMEOUT_MS = 2000;
+
   private server: HTTPServer | undefined;
   private context: vscode.ExtensionContext | undefined;
   private log: (message: string) => void;
@@ -128,7 +166,7 @@ export class IDEServer {
     return new Promise((resolve, reject) => {
       this.context = context;
       this.authToken = randomUUID();
-      const sessionsWithInitialNotification = new Set<string>();
+      const sessionContextDelivery: SessionContextDelivery = new Map();
       const app = express();
       app.use(express.json({ limit: '10mb' }));
 
@@ -136,10 +174,9 @@ export class IDEServer {
       this.registerHostValidation(app);
       this.registerAuthorization(app);
 
-      const mcpServer = createMcpServer(this.diffManager, this.log);
       this.openFilesManager = new OpenFilesManager(context);
       this.registerIdeChangeSubscriptions(context);
-      this.registerMcpRoutes(app, mcpServer, sessionsWithInitialNotification);
+      this.registerMcpRoutes(app, sessionContextDelivery);
       this.registerErrorHandler(app);
       this.startHttpServer(app, context, resolve, reject);
     });
@@ -198,6 +235,168 @@ export class IDEServer {
     });
   }
 
+  /**
+   * Synchronizes the initial IDE context with a client-initiated `ping`
+   * request that arrives after MCP initialization.
+   *
+   * The client issues a standard `ping` immediately after `initialize`. We
+   * intercept it here: if the session has not yet received its initial
+   * `ide/contextUpdate`, we send the notification (awaited, associated with
+   * the ping's request id so it is delivered in the same response stream)
+   * before letting the ping response go out. This guarantees the context is
+   * stored on the client before `connect()` resolves, without sending custom
+   * notifications during the `initialize` handshake (which would violate MCP
+   * lifecycle ordering).
+   *
+   * If the initial delivery fails (missing transport, send returns false, or
+   * send throws), the session entry is cleared so a later ping can retry, and
+   * we throw an error so the ping response is a JSON-RPC error — the client
+   * MUST NOT treat a successful ping as context-receipt acknowledgment.
+   */
+  private registerPingSynchronization(
+    mcpServer: McpServer,
+    sessionContextDelivery: SessionContextDelivery,
+  ) {
+    mcpServer.server.setRequestHandler(PingRequestSchema, (_request, extra) =>
+      this.deliverInitialContextOnPing(
+        extra.sessionId,
+        extra.requestId,
+        sessionContextDelivery,
+      ),
+    );
+  }
+
+  private async deliverInitialContextOnPing(
+    sessionId: string | undefined,
+    requestId: string | number,
+    sessionContextDelivery: SessionContextDelivery,
+  ): Promise<Record<string, never>> {
+    if (sessionId === undefined) {
+      throw new Error('Cannot deliver initial IDE context: missing session id');
+    }
+
+    // Ping delivery is authoritative: a successful ping-associated send marks
+    // the session delivered. A false/rejection must propagate as a JSON-RPC
+    // error so the client does not treat a successful ping as context-receipt
+    // acknowledgment.
+    const delivered = await this.deliverInitialContext(
+      sessionId,
+      sessionContextDelivery,
+      { relatedRequestId: requestId, authoritative: true },
+    );
+    if (!delivered) {
+      throw new Error('Failed to deliver initial IDE context notification');
+    }
+    return {};
+  }
+
+  /**
+   * Atomically delivers the initial context for a session through a single
+   * typed boolean delivery state machine. Concurrent calls (e.g. overlapping
+   * ping and GET) share the exact same `Promise<boolean>`. The boolean result
+   * is compatible across both paths: true means sent, false means failed and
+   * retryable.
+   *
+   * `authoritative`: when true (ping path), a successful send permanently marks
+   * the session delivered — REGARDLESS of which caller created the shared
+   * in-flight promise. The authoritative caller upgrades the session to
+   * delivered AFTER awaiting the shared promise, rather than relying on the
+   * promise closure, so that a non-authoritative GET creating the in-flight
+   * promise cannot leave a concurrently-awaiting ping with a permanently
+   * pending session on success. When false (standalone GET path), a successful
+   * send does NOT permanently mark delivered, because the SDK standalone GET
+   * send may resolve despite the notification not actually reaching the client
+   * on an active response stream. This leaves the session retryable by a later
+   * ping.
+   *
+   * On false/rejection, the in-flight promise clears only its own entry so the
+   * session remains retryable without losing a concurrent caller's result.
+   */
+  private async deliverInitialContext(
+    sessionId: string,
+    sessionContextDelivery: SessionContextDelivery,
+    options: { relatedRequestId?: string | number; authoritative: boolean },
+  ): Promise<boolean> {
+    const { relatedRequestId, authoritative } = options;
+    const entry = sessionContextDelivery.get(sessionId);
+    if (entry?.status === 'delivered') {
+      return true;
+    }
+
+    const transport = this.transports.get(sessionId);
+    if (transport === undefined || this.openFilesManager === undefined) {
+      return false;
+    }
+
+    if (entry?.inFlight) {
+      // Concurrent callers share the exact boolean promise — no casting. The
+      // shared promise only manages the in-flight lifecycle (clearing its own
+      // entry on completion); authoritative upgrading is applied by the
+      // caller after awaiting.
+      const delivered = await entry.inFlight;
+      // An authoritative caller upgrades the session to delivered after a
+      // successful shared send, even if a non-authoritative caller created the
+      // promise. This closes the race where GET creates the in-flight promise
+      // (capturing authoritative=false) and a concurrent ping awaits it.
+      if (delivered && authoritative) {
+        sessionContextDelivery.set(sessionId, { status: 'delivered' });
+      }
+      return delivered;
+    }
+
+    // Create the in-flight boolean promise and register it BEFORE awaiting so
+    // concurrent callers share it. The closure only manages the in-flight
+    // lifecycle; it does NOT capture `authoritative`, so the creating caller's
+    // authority cannot leak into (or be absent from) concurrent awaiters.
+    const inFlight = sendIdeContextUpdateNotification(
+      transport,
+      this.log.bind(this),
+      this.openFilesManager,
+      relatedRequestId,
+    )
+      .then((delivered) => {
+        if (!delivered) {
+          // Clear only THIS in-flight attempt so it remains retryable.
+          const current = sessionContextDelivery.get(sessionId);
+          if (current?.inFlight === inFlight) {
+            sessionContextDelivery.delete(sessionId);
+          }
+        }
+        return delivered;
+      })
+      .catch(() => {
+        // Clear only THIS in-flight attempt so it remains retryable.
+        const current = sessionContextDelivery.get(sessionId);
+        if (current?.inFlight === inFlight) {
+          sessionContextDelivery.delete(sessionId);
+        }
+        return false;
+      });
+
+    sessionContextDelivery.set(sessionId, { status: 'pending', inFlight });
+    const delivered = await inFlight;
+
+    if (delivered) {
+      if (authoritative) {
+        // The authoritative creating caller upgrades the session to delivered
+        // on a successful send.
+        sessionContextDelivery.set(sessionId, { status: 'delivered' });
+      } else {
+        // Non-authoritative success: leave as pending (retryable) and clear
+        // the resolved in-flight promise so a later ping creates a FRESH send
+        // rather than awaiting this already-resolved one. This matters because
+        // the SDK standalone GET send may resolve true without the
+        // notification actually reaching the client; a later ping must be able
+        // to attempt a real authoritative send.
+        const current = sessionContextDelivery.get(sessionId);
+        if (current?.inFlight === inFlight) {
+          sessionContextDelivery.set(sessionId, { status: 'pending' });
+        }
+      }
+    }
+    return delivered;
+  }
+
   private registerIdeChangeSubscriptions(context: vscode.ExtensionContext) {
     const onDidChangeSubscription = this.openFilesManager!.onDidChange(() => {
       this.broadcastIdeContextUpdate();
@@ -206,7 +405,11 @@ export class IDEServer {
     const onDidChangeDiffSubscription = this.diffManager.onDidChange(
       (notification) => {
         for (const transport of this.transports.values()) {
-          void transport.send(notification);
+          void transport.send(notification).catch((error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            this.log(`Failed to broadcast diff notification: ${message}`);
+          });
         }
       },
     );
@@ -215,40 +418,28 @@ export class IDEServer {
 
   private registerMcpRoutes(
     app: Express,
-    mcpServer: McpServer,
-    sessionsWithInitialNotification: Set<string>,
+    sessionContextDelivery: SessionContextDelivery,
   ) {
     app.post('/mcp', (req: Request, res: Response, next: NextFunction) => {
-      this.handleMcpPostRequest(
-        req,
-        res,
-        mcpServer,
-        sessionsWithInitialNotification,
-      ).catch(next);
+      this.handleMcpPostRequest(req, res, sessionContextDelivery).catch(next);
     });
 
     app.get('/mcp', (req: Request, res: Response, next: NextFunction) => {
-      this.handleSessionRequest(
-        req,
-        res,
-        sessionsWithInitialNotification,
-      ).catch(next);
+      this.handleSessionRequest(req, res, sessionContextDelivery).catch(next);
     });
   }
 
   private async handleMcpPostRequest(
     req: Request,
     res: Response,
-    mcpServer: McpServer,
-    sessionsWithInitialNotification: Set<string>,
+    sessionContextDelivery: SessionContextDelivery,
   ) {
     const sessionId = req.headers[MCP_SESSION_ID_HEADER] as string | undefined;
     const transport = this.resolvePostTransport(
       req,
       res,
-      mcpServer,
       sessionId,
-      sessionsWithInitialNotification,
+      sessionContextDelivery,
     );
     if (transport === undefined) {
       return;
@@ -268,20 +459,19 @@ export class IDEServer {
         });
       }
     }
-
-    this.sendInitialSessionNotification(
-      transport,
-      sessionId,
-      sessionsWithInitialNotification,
-    );
+    // Initial context delivery is handled exclusively by the ping
+    // synchronization handler, which associates the notification with the
+    // ping request id so it is delivered in the same response stream
+    // before the client's connect() resolves. Sending it here (after the
+    // initialize response) is unreliable because the notification would be
+    // routed to a standalone SSE stream that the client has not opened yet.
   }
 
   private resolvePostTransport(
     req: Request,
     res: Response,
-    mcpServer: McpServer,
     sessionId: string | undefined,
-    sessionsWithInitialNotification: Set<string>,
+    sessionContextDelivery: SessionContextDelivery,
   ): StreamableHTTPServerTransport | undefined {
     const transportForSession =
       sessionId === undefined ? undefined : this.transports.get(sessionId);
@@ -289,10 +479,7 @@ export class IDEServer {
       return transportForSession;
     }
     if (isInitializeRequest(req.body)) {
-      return this.createSessionTransport(
-        mcpServer,
-        sessionsWithInitialNotification,
-      );
+      return this.createSessionTransport(sessionContextDelivery);
     }
 
     this.log(
@@ -311,25 +498,30 @@ export class IDEServer {
   }
 
   private createSessionTransport(
-    mcpServer: McpServer,
-    sessionsWithInitialNotification: Set<string>,
+    sessionContextDelivery: SessionContextDelivery,
   ): StreamableHTTPServerTransport {
+    const mcpServer = createMcpServer(this.diffManager, this.log);
+    this.registerPingSynchronization(mcpServer, sessionContextDelivery);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (newSessionId) => {
         this.log(`New session initialized: ${newSessionId}`);
         this.transports.set(newSessionId, transport);
+        sessionContextDelivery.set(newSessionId, { status: 'pending' });
       },
     });
 
-    this.configureKeepAlive(transport, sessionsWithInitialNotification);
-    void mcpServer.connect(transport);
+    this.configureKeepAlive(transport, sessionContextDelivery);
+    void mcpServer.connect(transport).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`Error connecting MCP server to transport: ${message}`);
+    });
     return transport;
   }
 
   private configureKeepAlive(
     transport: StreamableHTTPServerTransport,
-    sessionsWithInitialNotification: Set<string>,
+    sessionContextDelivery: SessionContextDelivery,
   ) {
     let missedPings = 0;
     const keepAlive = setInterval(() => {
@@ -357,7 +549,7 @@ export class IDEServer {
       clearInterval(keepAlive);
       if (transport.sessionId) {
         this.log(`Session closed: ${transport.sessionId}`);
-        sessionsWithInitialNotification.delete(transport.sessionId);
+        sessionContextDelivery.delete(transport.sessionId);
         this.transports.delete(transport.sessionId);
       }
     };
@@ -366,7 +558,7 @@ export class IDEServer {
   private async handleSessionRequest(
     req: Request,
     res: Response,
-    sessionsWithInitialNotification: Set<string>,
+    sessionContextDelivery: SessionContextDelivery,
   ) {
     const sessionId = req.headers[MCP_SESSION_ID_HEADER] as string | undefined;
     const transport = sessionId ? this.transports.get(sessionId) : undefined;
@@ -376,8 +568,35 @@ export class IDEServer {
       return;
     }
 
+    // Start the GET request handling WITHOUT awaiting first. The SDK's
+    // handleGetRequest sets up the standalone SSE stream mapping
+    // synchronously before returning the Response, so by the time this
+    // call yields, the mapping is active. We then send the initial context
+    // while the GET SSE stream is live, and finally await the request
+    // lifecycle.
+    const handlePromise = transport.handleRequest(req, res);
+
     try {
-      await transport.handleRequest(req, res);
+      // Deliver initial context on the standalone SSE stream (no
+      // relatedRequestId). The GET mapping is active because handleGetRequest
+      // set it up synchronously before this point.
+      //
+      // GET delivery is non-authoritative: the SDK standalone GET send may
+      // resolve despite the notification not actually reaching the client on
+      // an active response stream. We share the same typed boolean delivery
+      // state machine as the ping path so concurrent ping/GET overlap shares
+      // the exact boolean promise without incompatible result semantics.
+      await this.deliverInitialContext(sessionId, sessionContextDelivery, {
+        authoritative: false,
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.log(`Error delivering initial context on GET: ${errorMessage}`);
+    }
+
+    try {
+      await handlePromise;
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
@@ -385,31 +604,6 @@ export class IDEServer {
       if (!res.headersSent) {
         res.status(400).send('Bad Request');
       }
-    }
-
-    this.sendInitialSessionNotification(
-      transport,
-      sessionId,
-      sessionsWithInitialNotification,
-    );
-  }
-
-  private sendInitialSessionNotification(
-    transport: StreamableHTTPServerTransport,
-    sessionId: string | undefined,
-    sessionsWithInitialNotification: Set<string>,
-  ) {
-    if (
-      this.openFilesManager &&
-      sessionId &&
-      !sessionsWithInitialNotification.has(sessionId)
-    ) {
-      sendIdeContextUpdateNotification(
-        transport,
-        this.log.bind(this),
-        this.openFilesManager,
-      );
-      sessionsWithInitialNotification.add(sessionId);
     }
   }
 
@@ -488,7 +682,7 @@ export class IDEServer {
       return;
     }
     for (const transport of this.transports.values()) {
-      sendIdeContextUpdateNotification(
+      void sendIdeContextUpdateNotification(
         transport,
         this.log.bind(this),
         this.openFilesManager,
@@ -515,9 +709,16 @@ export class IDEServer {
   }
 
   async stop(): Promise<void> {
+    // Close and clear all tracked session transports first so their
+    // keep-alive timers and session state are released promptly rather than
+    // lingering for the 60-second keep-alive interval.
+    await this.closeAllTransports();
+
     if (this.server) {
+      const server = this.server;
+      this.server = undefined;
       await new Promise<void>((resolve, reject) => {
-        this.server!.close((err?: Error) => {
+        server.close((err?: Error) => {
           if (err) {
             this.log(`Error shutting down IDE server: ${err.message}`);
             reject(err);
@@ -526,8 +727,8 @@ export class IDEServer {
           this.log(`IDE server shut down`);
           resolve();
         });
+        server.closeAllConnections();
       });
-      this.server = undefined;
     }
 
     if (this.context !== undefined) {
@@ -540,6 +741,36 @@ export class IDEServer {
         // File may not exist; cleanup is best-effort.
       }
     }
+  }
+
+  private async closeAllTransports(): Promise<void> {
+    const transports = [...this.transports.values()];
+    // Close all transports first; each transport's onclose handler removes
+    // itself from the map and clears its keep-alive interval. We do not
+    // clear the map before closing so onclose can find entries robustly.
+    //
+    // Each close is guarded by a bounded timeout: the SDK's close() can hang
+    // when an active SSE GET stream is still open (the stream handler's
+    // internal promise may not resolve until the client disconnects). We must
+    // not let a single stuck transport block server shutdown indefinitely.
+    await Promise.all(
+      transports.map(async (transport) => {
+        try {
+          await Promise.race([
+            transport.close(),
+            new Promise<void>((resolve) =>
+              setTimeout(resolve, IDEServer.TRANSPORT_CLOSE_TIMEOUT_MS),
+            ),
+          ]);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          this.log(`Error closing session transport: ${message}`);
+        }
+      }),
+    );
+    // Ensure the map is empty even if an onclose handler was missing.
+    this.transports.clear();
   }
 }
 

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -770,7 +770,10 @@ export class IDEServer {
       transports.map(async (transport) => {
         try {
           await Promise.race([
-            transport.close(),
+            // Pre-attached catch prevents a late rejection of the abandoned
+            // close() (when the timeout wins the race) from surfacing as an
+            // unhandled rejection in the extension host.
+            transport.close().catch(() => {}),
             new Promise<void>((resolve) =>
               setTimeout(resolve, IDEServer.TRANSPORT_CLOSE_TIMEOUT_MS),
             ),

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -572,9 +572,22 @@ export class IDEServer {
     // handleGetRequest sets up the standalone SSE stream mapping
     // synchronously before returning the Response, so by the time this
     // call yields, the mapping is active. We then send the initial context
-    // while the GET SSE stream is live, and finally await the request
-    // lifecycle.
+    // while the GET SSE stream is live, and finally observe the request
+    // lifecycle outcome.
     const handlePromise = transport.handleRequest(req, res);
+
+    // Capture the settled outcome synchronously so a client-abort rejection
+    // that fires while deliverInitialContext is in-flight can never become a
+    // transient unhandled rejection. The captured result is observed (and any
+    // error propagated to the existing handler) after context delivery, so
+    // request/SSE lifecycle semantics are unchanged.
+    const handleSettled = handlePromise.then<
+      { ok: true },
+      { ok: false; error: unknown }
+    >(
+      () => ({ ok: true }),
+      (error: unknown) => ({ ok: false, error }),
+    );
 
     try {
       // Deliver initial context on the standalone SSE stream (no
@@ -595,9 +608,9 @@ export class IDEServer {
       this.log(`Error delivering initial context on GET: ${errorMessage}`);
     }
 
-    try {
-      await handlePromise;
-    } catch (error) {
+    const settled = await handleSettled;
+    if (!settled.ok) {
+      const error = settled.error;
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
       this.log(`Error handling session request: ${errorMessage}`);

--- a/packages/vscode-ide-companion/vitest.config.ts
+++ b/packages/vscode-ide-companion/vitest.config.ts
@@ -7,9 +7,19 @@
 /// <reference types="vitest" />
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 const require = createRequire(import.meta.url);
+const configDir = dirname(fileURLToPath(import.meta.url));
+
+// Resolve the IDE integration workspace dependency to its TypeScript source
+// public entry so tests exercise changed source directly rather than a stale
+// dist build. This keeps regression tests honest without a prebuild step.
+const ideIntegrationSourceEntry = resolve(
+  configDir,
+  '../ide-integration/index.ts',
+);
 
 // Resolve ajv/fdir dynamically rather than hardcoding nested node_modules
 // paths. npm may hoist or nest these differently depending on the rest of the
@@ -32,6 +42,9 @@ const workspaceDependencyAliasPlugin = {
    * @pseudocode verification.md lines 19-22
    */
   resolveId(source: string) {
+    if (source === '@vybestack/llxprt-code-ide-integration') {
+      return ideIntegrationSourceEntry;
+    }
     if (source === 'ajv') {
       return ajvCjsEntry;
     }


### PR DESCRIPTION
## TLDR

Fixes the VS Code IDE companion's initial-context loss and ~60-second reconnect/disconnect behavior by giving every Streamable HTTP MCP session its own `McpServer`, synchronizing initial editor context on a standard client ping, and preventing stale client lifecycle work from clobbering newer connections.

The implementation was reproduced and validated against a real VS Code Extension Development Host, not only mocks: the companion remained connected for 75.9 seconds across the prior failure boundary, reported active `README.md` with the exact selection `LLxprt Code`, and `gpt56high` replied exactly `IDE_OK|README.md|LLxprt Code` using IDE context.

## Dive Deeper

### Root cause

The companion previously reused one MCP SDK `McpServer`/`Protocol` instance across multiple `StreamableHTTPServerTransport` sessions. The SDK protocol supports one attached transport; a later client's initialization could therefore hang until the client-side timeout, which manifested as context loss and a disconnect near 60 seconds.

The original issue also exposed a notification-order race: the client could become `connected` before a real initial `ide/contextUpdate` had been received.

### Changes

- Create one `McpServer` per transport session while preserving shared IDE/diff managers.
- Register an MCP ping synchronization handler that sends initial `ide/contextUpdate` on the ping response stream and only acknowledges a connection after the client receives the notification.
- Keep standalone GET delivery as a retryable, non-authoritative fallback and serialize overlapping GET/ping delivery through per-session state.
- Bound transport shutdown and force-close active HTTP connections so extension/server stop cannot hang on an open SSE stream.
- Introduce per-attempt resource ownership and monotonic lifecycle epochs in `IdeClient` so stale connect/disconnect continuations, errors, close events, timers, and diff cleanup cannot mutate a newer connection.
- Make disconnect diff cleanup use the disconnect-owned client and a snapshot of old paths; cleanup failures are isolated and cannot close a newly opened diff on a reconnected client.
- Acknowledge initial context before invoking trust listeners and isolate listener exceptions.
- Add real client/server, two-client, GET/ping concurrency, bounded-shutdown, false-connected, and lifecycle-race regressions.

### Review and verification notes

- GLM implementation audit: approved, no blocking findings.
- Hard lifecycle review findings were remediated with red-first behavioral tests.
- Open Code Review ran detached with the required 20-minute floor. Its concrete trust-listener and test cleanup findings were addressed; the remaining production high finding was misattributed and would incorrectly time out a legitimate long-lived SSE GET stream.
- The unrelated local `README_CN.md` modification is not part of this PR.

## Reviewer Test Plan

1. Run the focused IDE client lifecycle tests:
   ```text
   npm run test --workspace packages/ide-integration -- src/ide/ide-client.test.ts src/ide/ide-client-lifecycle.test.ts
   ```
   Expected: 22/22 tests pass.

2. Run the real companion integration/concurrency tests:
   ```text
   npm run test --workspace packages/vscode-ide-companion -- src/ide-client-integration.test.ts src/ide-server-concurrency.test.ts
   ```
   Expected: 8/8 tests pass, including:
   - initial `README.md` context exists when `connect()` resolves;
   - a default-ping-only server never produces a false `Connected` state;
   - a second real MCP client connects while the first remains independently usable;
   - GET-first/ping-second overlap sends exactly one initial context update;
   - server stop is bounded with an active client.

3. Run static/build checks:
   ```text
   npm run typecheck
   npm run format
   npm run build
   ```

4. Optional real VS Code validation:
   - Build/install the companion VSIX.
   - Open `README.md`, select `LLxprt Code`, and start a fresh integrated terminal after activation.
   - Run LLxprt with IDE mode and ask it to return `IDE_OK|README.md|LLxprt Code` using only IDE context.
   - Leave the connection active beyond 60 seconds and verify it remains connected with the same active file/selection.

### Local verification results

- `npm run typecheck`: pass.
- `npm run format`: pass.
- `npm run build`: pass.
- Changed-file ESLint: pass for all seven PR files.
- Focused IDE tests: 22/22 pass.
- Focused companion tests: 8/8 pass.
- Real VS Code Extension Development Host: connected for 75.9 seconds; exact file/selection received; model response exactly `IDE_OK|README.md|LLxprt Code`.
- Full `npm run test`: attempted; this Windows checkout has unrelated pre-existing Windows path/permission/LSP/provider failures and exceeded the 900-second command window. No issue-focused failures were observed.
- Full `npm run lint`: attempted repeatedly; root ESLint exceeded 9 GB working set and was killed by host memory constraints. All changed PR files lint clean, and the companion build's package lint passes.
- Required `stepfun-37` smoke: attempted, but that profile is not configured on this machine (`Profile 'stepfun-37' not found`). The configured `gpt56high` profile passed the real IDE-context smoke instead.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ✅  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IDE connection reliability during rapid reconnects, disconnects, and overlapping connection attempts using safer lifecycle handling.
  - Ensured initial and incremental workspace context is delivered consistently, with no duplicate, stale, or superseded notifications.
  - Prevented stale close/disconnect events from impacting active diff/tool state after reconnects, even when close operations fail.
  - Improved robustness when trust/context handling throws during setup and when MCP servers don’t send expected updates.
- **Tests**
  - Added/expanded Vitest coverage for connection supersession, IDE server concurrency, SSE/GET streaming behavior, and shutdown/teardown correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->