### PR TITLE
Skip conflicted PR review workflows (Fixes #2587)

### DIFF
--- a/.github/workflows/_pr-mergeability-gate.yml
+++ b/.github/workflows/_pr-mergeability-gate.yml
@@ -106,7 +106,9 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: number,
-                request: { timeout: REQUEST_TIMEOUT_MS },
+                request: {
+                  signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+                },
               });
             let mergeable = null;
             let apiUncertain = false;

--- a/.github/workflows/_pr-mergeability-gate.yml
+++ b/.github/workflows/_pr-mergeability-gate.yml
@@ -1,0 +1,188 @@
+name: PR Mergeability Gate
+
+# Reusable read-only gate that decides whether expensive trusted-context
+# PR work should run.  It uses the GitHub REST API (authoritative for
+# mergeability) rather than the webhook payload, which is commonly null
+# while GitHub computes the result.  The gate never checks out PR code,
+# receives no provider/repository secrets, and has only pull-requests: read.
+
+on:
+  workflow_call:
+    inputs:
+      check-mergeability:
+        description: 'When false, the gate bypasses mergeability checking and permits work.'
+        required: true
+        type: boolean
+      pull-request-number:
+        description: 'The pull request number to check.'
+        required: true
+        type: string
+      expected-head-sha:
+        description: 'Optional event head SHA; skip stale event work if it differs from the current API head.'
+        required: false
+        type: string
+    outputs:
+      should-run:
+        description: "'true' when work is permitted; 'false' when it should be skipped."
+        value: ${{ jobs.gate.outputs.should-run }}
+      reason:
+        description: 'Stable diagnostic reason for the decision.'
+        value: ${{ jobs.gate.outputs.reason }}
+
+permissions:
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Mergeability gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should-run: ${{ steps.decide.outputs.should-run }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - name: Decide mergeability
+        id: decide
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        env:
+          CHECK_MERGEABILITY: ${{ inputs.check-mergeability }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected-head-sha }}
+        with:
+          script: |
+            const checkMergeability = process.env.CHECK_MERGEABILITY === 'true';
+            if (!checkMergeability) {
+              core.setOutput('should-run', 'true');
+              core.setOutput('reason', 'bypass');
+              return;
+            }
+            const rawNumber = process.env.PULL_REQUEST_NUMBER;
+            const number = Number(rawNumber);
+            if (!Number.isInteger(number) || number <= 0) {
+              core.setFailed(`Invalid pull request number for mergeability check: "${rawNumber}"`);
+              return;
+            }
+            const expectedHeadSha = process.env.EXPECTED_HEAD_SHA || '';
+            const MAX_POLLS = 5;
+            const POLL_DELAY_MS = 2000;
+            const REQUEST_TIMEOUT_MS = 10000;
+            const NETWORK_ERROR_CODES = new Set([
+              'EAI_AGAIN',
+              'ECONNABORTED',
+              'ECONNREFUSED',
+              'ECONNRESET',
+              'EHOSTUNREACH',
+              'ENETDOWN',
+              'ENETUNREACH',
+              'ENOTFOUND',
+              'EPIPE',
+              'ETIMEDOUT',
+              'UND_ERR_BODY_TIMEOUT',
+              'UND_ERR_CONNECT_TIMEOUT',
+              'UND_ERR_HEADERS_TIMEOUT',
+              'UND_ERR_SOCKET',
+            ]);
+            const isNetworkError = (error) => {
+              const seen = new Set();
+              let current = error;
+              while (
+                current &&
+                typeof current === 'object' &&
+                !seen.has(current)
+              ) {
+                seen.add(current);
+                if (
+                  typeof current.code === 'string' &&
+                  NETWORK_ERROR_CODES.has(current.code)
+                ) {
+                  return true;
+                }
+                current = current.cause;
+              }
+              return false;
+            };
+            const getPullWithTimeout = () =>
+              github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: number,
+                request: { timeout: REQUEST_TIMEOUT_MS },
+              });
+            let mergeable = null;
+            let apiUncertain = false;
+            for (let attempt = 0; attempt < MAX_POLLS; attempt++) {
+              let data;
+              try {
+                const response = await getPullWithTimeout();
+                data = response.data;
+              } catch (apiError) {
+                const status = Number(apiError && apiError.status);
+                const hasHttpStatus = Number.isInteger(status) && status > 0;
+                const retryableHttpStatus =
+                  status === 429 || (status >= 500 && status <= 599);
+                const retryableError = hasHttpStatus
+                  ? retryableHttpStatus
+                  : isNetworkError(apiError);
+                if (!retryableError) {
+                  if (hasHttpStatus) {
+                    core.setFailed(
+                      `GitHub REST API rejected the mergeability check for ` +
+                        `PR #${number} with status ${status}.`,
+                    );
+                  } else {
+                    core.setFailed(
+                      `GitHub REST API failed the mergeability check for ` +
+                        `PR #${number} with an unrecognized error.`,
+                    );
+                  }
+                  return;
+                }
+                apiUncertain = true;
+                mergeable = null;
+                if (attempt < MAX_POLLS - 1) {
+                  await new Promise((resolve) =>
+                    setTimeout(resolve, POLL_DELAY_MS),
+                  );
+                }
+                continue;
+              }
+              if (expectedHeadSha && data.head && data.head.sha && data.head.sha !== expectedHeadSha) {
+                core.setOutput('should-run', 'false');
+                core.setOutput('reason', 'stale-head');
+                return;
+              }
+              mergeable = data.mergeable;
+              if (mergeable === true) {
+                core.setOutput('should-run', 'true');
+                core.setOutput('reason', 'mergeable');
+                return;
+              }
+              if (mergeable === false) {
+                core.setOutput('should-run', 'false');
+                core.setOutput('reason', 'conflict');
+                return;
+              }
+              // mergeable is null — GitHub is still computing.  Poll.
+              if (attempt < MAX_POLLS - 1) {
+                await new Promise((resolve) =>
+                  setTimeout(resolve, POLL_DELAY_MS),
+                );
+              }
+            }
+            // Bounded polling exhausted without a definitive answer.
+            // Fail open so a valid PR is not stranded indefinitely.
+            if (apiUncertain) {
+              core.warning(
+                `Could not determine mergeability for PR #${number}: ` +
+                  `transient API uncertainty after ${MAX_POLLS} attempts. ` +
+                  `Failing open.`,
+              );
+            } else {
+              core.warning(
+                `Could not determine mergeability for PR #${number}: ` +
+                  `mergeable remained null after ${MAX_POLLS} polls. ` +
+                  `Failing open.`,
+              );
+            }
+            core.setOutput('should-run', 'true');
+            core.setOutput('reason', 'uncertain');

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,9 +9,11 @@ on:
     branches:
       - 'main'
       - 'release/**'
-  # This will run for PRs from forks when a label is added.
+  # This will run for PRs from forks when the approval label is added.
+  # A new fork head requires a new maintainer approval event.
   pull_request_target:
-    types: ['labeled']
+    types:
+      - 'labeled'
   merge_group:
   workflow_dispatch:
     inputs:
@@ -36,12 +38,32 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["workflow_dispatch", "merge_group"]'
+  mergeability-gate:
+    name: 'Mergeability gate'
+    needs:
+      - 'skip_check'
+    if: >-
+      ${{ needs.skip_check.result == 'success' &&
+          needs.skip_check.outputs.should_skip != 'true' &&
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'maintainer:e2e:ok' }}
+    uses: './.github/workflows/_pr-mergeability-gate.yml'
+    with:
+      check-mergeability: true
+      pull-request-number: "${{ format('{0}', github.event.pull_request.number) }}"
+      expected-head-sha: '${{ github.event.pull_request.head.sha }}'
   e2e_doc_change_filter:
     name: 'Detect doc-only changes for E2E'
     runs-on: 'ubuntu-latest'
     needs:
       - 'skip_check'
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    if: >-
+      ${{ needs.skip_check.result == 'success' &&
+          needs.skip_check.outputs.should_skip != 'true' &&
+          (github.event_name != 'pull_request_target' ||
+           (github.event.action == 'labeled' &&
+            github.event.label.name == 'maintainer:e2e:ok')) }}
     outputs:
       docs_only: '${{ steps.detect.outputs.docs_only }}'
     steps:
@@ -124,22 +146,36 @@ jobs:
     needs:
       - e2e_doc_change_filter
       - skip_check
+      - mergeability-gate
     concurrency:
       group: >-
         ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.branch_ref || github.ref }}-${{ matrix.sandbox }}
       cancel-in-progress: true
     if: |
-      (
-        github.event_name == 'push' ||
-        github.event_name == 'merge_group' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository) ||
-        (github.event_name == 'pull_request_target' &&
-          github.event.label.name == 'maintainer:e2e:ok')
-      ) &&
+      !cancelled() &&
+      needs.skip_check.result == 'success' &&
+      needs.e2e_doc_change_filter.result == 'success' &&
       needs.e2e_doc_change_filter.outputs.docs_only != 'true' &&
-      needs.skip_check.outputs.should_skip != 'true'
+      needs.skip_check.outputs.should_skip != 'true' &&
+      (
+        (
+          (
+            github.event_name == 'push' ||
+            github.event_name == 'merge_group' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.full_name == github.repository)
+          ) &&
+          needs.mergeability-gate.result == 'skipped'
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'maintainer:e2e:ok' &&
+          needs.mergeability-gate.result == 'success' &&
+          needs.mergeability-gate.outputs.should-run == 'true'
+        )
+      )
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
@@ -250,21 +286,35 @@ jobs:
     needs:
       - e2e_doc_change_filter
       - skip_check
+      - mergeability-gate
     concurrency:
       group: >-
         ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.branch_ref || github.ref }}-macos
       cancel-in-progress: true
     if: |
-      (
-        github.event_name == 'merge_group' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository) ||
-        (github.event_name == 'pull_request_target' &&
-          github.event.label.name == 'maintainer:e2e:ok')
-      ) &&
+      !cancelled() &&
+      needs.skip_check.result == 'success' &&
+      needs.e2e_doc_change_filter.result == 'success' &&
       needs.e2e_doc_change_filter.outputs.docs_only != 'true' &&
-      needs.skip_check.outputs.should_skip != 'true'
+      needs.skip_check.outputs.should_skip != 'true' &&
+      (
+        (
+          (
+            github.event_name == 'merge_group' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.full_name == github.repository)
+          ) &&
+          needs.mergeability-gate.result == 'skipped'
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'maintainer:e2e:ok' &&
+          needs.mergeability-gate.result == 'success' &&
+          needs.mergeability-gate.outputs.should-run == 'true'
+        )
+      )
     runs-on: 'macos-latest'
     continue-on-error: true
     steps:

--- a/.github/workflows/ocr-infrastructure-notifier.yml
+++ b/.github/workflows/ocr-infrastructure-notifier.yml
@@ -232,7 +232,7 @@ jobs:
             }
             if ! EXISTING_ISSUE="$(
               retry_gh gh issue list \
-                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
+                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-asc" \
                 --limit 30 \
                 --json number,title \
                 --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
@@ -258,7 +258,7 @@ jobs:
             fi
             if ! EXISTING_ISSUE="$(
               retry_gh gh issue list \
-                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
+                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-asc" \
                 --limit 30 \
                 --json number,title \
                 --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"

--- a/.github/workflows/ocr-infrastructure-notifier.yml
+++ b/.github/workflows/ocr-infrastructure-notifier.yml
@@ -1,0 +1,280 @@
+name: OCR Infrastructure Notifier
+
+on:
+  workflow_run:
+    workflows:
+      - OCR Review
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  classify-ocr-run:
+    name: Classify completed OCR run
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' ||
+          github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    outputs:
+      classification: ${{ steps.classify.outputs.classification }}
+    steps:
+      - name: Download OCR artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: ocr-review-output
+          path: ocr-review-output
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Classify completed OCR run
+        id: classify
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        env:
+          ARTIFACT_PATH: ocr-review-output
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const markerOutcomes = new Map([
+              ['Record OCR outcome: policy-failure', 'policy-failure'],
+              ['Record OCR outcome: infrastructure-failure', 'infrastructure-failure'],
+              ['Record OCR outcome: success', 'success'],
+              ['Record OCR outcome: unexpected-failure', 'unexpected-failure'],
+              ['Record OCR outcome: review-skipped', 'review-skipped'],
+            ]);
+            const runId = Number(process.env.RUN_ID);
+            if (!Number.isInteger(runId) || runId <= 0) {
+              core.setFailed('Completed OCR run id was invalid.');
+              return;
+            }
+            const response = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              filter: 'latest',
+              per_page: 100,
+            });
+            const durableOutcomes = new Set();
+            for (const job of response.data.jobs || []) {
+              for (const step of job.steps || []) {
+                if (
+                  step.conclusion === 'success' &&
+                  markerOutcomes.has(step.name)
+                ) {
+                  durableOutcomes.add(markerOutcomes.get(step.name));
+                }
+              }
+            }
+            if (durableOutcomes.size > 1) {
+              core.setFailed(
+                `Completed OCR run recorded multiple durable OCR outcomes: ${Array.from(durableOutcomes).join(', ')}.`,
+              );
+              return;
+            }
+            const artifactPath = process.env.ARTIFACT_PATH || '';
+            const readArtifact = (fileName) => {
+              if (!artifactPath) {
+                return null;
+              }
+              try {
+                return fs.readFileSync(path.join(artifactPath, fileName), 'utf8').trim();
+              } catch (error) {
+                if (error && error.code === 'ENOENT') {
+                  return null;
+                }
+                throw error;
+              }
+            };
+            const policyFailure = readArtifact('ocr-policy-failure.txt');
+            const infrastructureFailure = readArtifact(
+              'ocr-infrastructure-failure.txt',
+            );
+            const exitCode = readArtifact('ocr-exit-code.txt');
+            const result = readArtifact('ocr-result.json');
+            const runConclusion = process.env.RUN_CONCLUSION || '';
+            let artifactOutcome = null;
+            if (policyFailure) {
+              artifactOutcome = 'policy-failure';
+            } else if (runConclusion === 'failure') {
+              artifactOutcome = 'unexpected-failure';
+            } else if (infrastructureFailure) {
+              artifactOutcome = 'infrastructure-failure';
+            } else if (exitCode === '0' && result) {
+              artifactOutcome = 'success';
+            }
+            const durableOutcome = Array.from(durableOutcomes)[0] || null;
+            if (
+              durableOutcome &&
+              artifactOutcome &&
+              durableOutcome !== artifactOutcome
+            ) {
+              core.warning(
+                `OCR artifact classification ${artifactOutcome} disagreed with durable job classification ${durableOutcome}; using durable classification.`,
+              );
+            }
+            const classification =
+              durableOutcome ||
+              artifactOutcome ||
+              (runConclusion === 'failure'
+                ? 'unexpected-failure'
+                : 'not-run');
+            core.info(`Completed OCR run classified as ${classification}.`);
+            core.setOutput('classification', classification);
+
+  notify-ocr-infrastructure-failure:
+    name: Notify OCR infrastructure failure
+    needs: classify-ocr-run
+    if: >-
+      ${{ needs.classify-ocr-run.result == 'success' &&
+          (needs.classify-ocr-run.outputs.classification == 'infrastructure-failure' ||
+           needs.classify-ocr-run.outputs.classification == 'unexpected-failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: ocr-review-infrastructure-issue
+      cancel-in-progress: false
+    permissions:
+      issues: write
+    steps:
+      - name: Notify OCR infrastructure failure issue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          OCR_RUN_CLASSIFICATION: ${{ needs.classify-ocr-run.outputs.classification }}
+        run: |
+          set -uo pipefail
+          notify_ocr_infrastructure_failure() {
+            if ! command -v gh >/dev/null 2>&1; then
+              echo "::warning::GitHub CLI is unavailable; skipping OCR infrastructure issue notification."
+              printf '%s\n' '### OCR infrastructure notification skipped' '' 'GitHub CLI was unavailable; see workflow logs for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+              return 0
+            fi
+            if ! gh auth status >/dev/null 2>&1; then
+              echo "::warning::GitHub CLI is not authenticated; skipping OCR infrastructure issue notification."
+              printf '%s\n' '### OCR infrastructure notification skipped' '' 'GitHub CLI was not authenticated; see workflow logs for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+              return 0
+            fi
+            case "${OCR_RUN_CLASSIFICATION:-}" in
+              infrastructure-failure|unexpected-failure) ;;
+              *)
+                echo "::warning::Refusing notification for non-infrastructure OCR classification."
+                return 0
+                ;;
+            esac
+            ISSUE_TITLE="OCR review infrastructure failure"
+            retry_gh() {
+              local attempt
+              for attempt in 1 2 3 4; do
+                if "$@"; then
+                  return 0
+                fi
+                if [ "$attempt" -lt 4 ]; then
+                  sleep $(( attempt * 5 ))
+                fi
+              done
+              echo "All retries exhausted for: $*" >&2
+              return 1
+            }
+            create_infrastructure_issue() {
+              local issue_body_file
+              local create_stderr
+              issue_body_file="$1"
+              shift
+              create_stderr="$(mktemp)"
+              if gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"; then
+                rm -f "${create_stderr}"
+                return 0
+              fi
+              if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then
+                echo "::warning::OCR infrastructure issue label was unavailable; retrying without labels."
+                if gh issue create "$@" --body-file "$issue_body_file"; then
+                  rm -f "${create_stderr}"
+                  return 0
+                fi
+              fi
+              rm -f "${create_stderr}"
+              echo "::warning::Failed to create OCR infrastructure issue."
+              return 1
+            }
+            converge_duplicate_tracking_issues() {
+              local dup_issues
+              if ! dup_issues="$(
+                gh issue list \
+                  --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-asc" \
+                  --limit 30 \
+                  --json number,title \
+                  --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number]"
+              )"; then
+                echo "::warning::Failed to list duplicate tracking issues for convergence; duplicates may accumulate."
+                return 0
+              fi
+              local dup_count
+              dup_count="$(printf '%s' "$dup_issues" | jq 'length')"
+              if [ "$dup_count" -le 1 ]; then
+                return 0
+              fi
+              local KEEP_ISSUE
+              KEEP_ISSUE="$(printf '%s' "$dup_issues" | jq -r '.[0]')"
+              for dup in $(printf '%s' "$dup_issues" | jq -r '.[1:][]'); do
+                gh issue comment "${KEEP_ISSUE}" --body "Consolidated duplicate tracking issue #${dup} into this issue." || true
+                gh issue close "${dup}" || true
+              done
+            }
+            if ! EXISTING_ISSUE="$(
+              retry_gh gh issue list \
+                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
+                --limit 30 \
+                --json number,title \
+                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
+            )"; then
+              echo "::warning::Failed to search for existing OCR infrastructure issue."
+              return 0
+            fi
+            body="OCR review run was classified as ${OCR_RUN_CLASSIFICATION} on $(TZ=UTC date +'%Y-%m-%d'). Run: ${RUN_URL}. Review the trusted workflow logs and the redacted ocr-review-output artifact for diagnostics."
+            if ! body_file="$(mktemp)"; then
+              echo "::warning::Failed to create OCR infrastructure issue body file."
+              return 1
+            fi
+            trap 'rm -f "$body_file"' EXIT
+            if ! printf '%s\n' "$body" > "$body_file"; then
+              echo "::warning::Failed to write OCR infrastructure issue body file."
+              rm -f "$body_file"
+              return 1
+            fi
+            if [ -n "$EXISTING_ISSUE" ]; then
+              gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue."
+              converge_duplicate_tracking_issues
+              return 0
+            fi
+            if ! EXISTING_ISSUE="$(
+              retry_gh gh issue list \
+                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
+                --limit 30 \
+                --json number,title \
+                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
+            )"; then
+              echo "::warning::Failed to recheck for existing OCR infrastructure issue before create."
+              return 0
+            fi
+            if [ -n "$EXISTING_ISSUE" ]; then
+              gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue after recheck."
+              converge_duplicate_tracking_issues
+              return 0
+            fi
+            create_infrastructure_issue "$body_file" \
+              --title "${ISSUE_TITLE}"
+            converge_duplicate_tracking_issues
+            return 0
+          }
+          notify_ocr_infrastructure_failure || echo "::warning::OCR infrastructure issue notification failed; continuing."
+          exit 0

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -35,6 +35,32 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: >-
+    ${{
+      (github.event_name == 'workflow_dispatch' ||
+       github.event_name == 'pull_request_target' ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR') &&
+        (github.event.comment.body == '/ocr' ||
+         startsWith(github.event.comment.body, '/ocr ') ||
+         startsWith(toJSON(github.event.comment.body), '"/ocr\n') ||
+         startsWith(toJSON(github.event.comment.body), '"/ocr\r\n') ||
+         startsWith(toJSON(github.event.comment.body), '"/ocr\t') ||
+         github.event.comment.body == '/open-code-review' ||
+         startsWith(github.event.comment.body, '/open-code-review ') ||
+         startsWith(toJSON(github.event.comment.body), '"/open-code-review\n') ||
+         startsWith(toJSON(github.event.comment.body), '"/open-code-review\r\n') ||
+         startsWith(toJSON(github.event.comment.body), '"/open-code-review\t')))) &&
+      format('{0}-pr-{1}', github.workflow,
+        github.event.pull_request.number || github.event.issue.number || inputs.pr_number) ||
+      format('{0}-run-{1}', github.workflow, github.run_id)
+    }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   # Keep CI reviews deterministic by disabling OCR self-update checks.
@@ -46,22 +72,15 @@ env:
   OCR_CONCURRENCY: '2'
 
 jobs:
-  code-review:
-    name: OpenCodeReview
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    # Infrastructure failures are intentionally non-blocking for PR checks, but
-    # this output lets downstream jobs distinguish a completed OCR review from a
-    # review that could not run because of provider, install, or script issues.
-    outputs:
-      infrastructure_failure: ${{ steps.ocr-classification.outputs.infrastructure_failure }}
-      policy_failure: ${{ steps.ocr-classification.outputs.policy_failure }}
-    # For issue_comment, only run on PR comments requesting a review.
-    # The toJSON checks intentionally support LF, CRLF, and tab after the
-    # command; other whitespace is not matched to keep triggers predictable.
+  mergeability-gate:
+    name: Mergeability gate
+    uses: ./.github/workflows/_pr-mergeability-gate.yml
+    # The gate caller owns the exact authorized event/comment predicate so
+    # unauthorized and non-PR comments cannot enter the concurrency group.
+    # workflow_dispatch bypasses mergeability checking intentionally.
     if: |
-      github.event_name == 'pull_request_target' ||
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request_target' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        (github.event.comment.author_association == 'OWNER' ||
@@ -77,14 +96,26 @@ jobs:
         startsWith(toJSON(github.event.comment.body), '"/open-code-review\n') ||
         startsWith(toJSON(github.event.comment.body), '"/open-code-review\r\n') ||
         startsWith(toJSON(github.event.comment.body), '"/open-code-review\t')))
-    # Job-level concurrency is evaluated only for runs that pass this job if filter,
-    # so ordinary, unauthorized, and non-PR issue comments cannot cancel OCR.
-    # All authorized OCR triggers for the same PR share one workflow-scoped group
-    # so the latest run owns the sticky summary and inline-comment posting.
-    concurrency:
-      group: >-
-        ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
-      cancel-in-progress: true
+    with:
+      check-mergeability: ${{ github.event_name != 'workflow_dispatch' }}
+      pull-request-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || inputs.pr_number) }}
+      expected-head-sha: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+
+  code-review:
+    name: OpenCodeReview
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Infrastructure failures are intentionally non-blocking for PR checks, but
+    # this output lets downstream jobs distinguish a completed OCR review from a
+    # review that could not run because of provider, install, or script issues.
+    outputs:
+      infrastructure_failure: ${{ steps.ocr-classification.outputs.infrastructure_failure }}
+      policy_failure: ${{ steps.ocr-classification.outputs.policy_failure }}
+    # The code-review job runs only when the mergeability gate permits it.
+    needs:
+      - mergeability-gate
+    if: |
+      needs.mergeability-gate.outputs.should-run == 'true'
     steps:
       - name: Resolve PR context
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
@@ -1181,260 +1212,61 @@ jobs:
           set +e
           git config --file "${HOME}/.gitconfig" --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 
-  notify-ocr-infrastructure-failure:
-    name: Notify OCR infrastructure failure
+  record-ocr-outcome:
+    name: Record OCR outcome
+    needs:
+      - mergeability-gate
+      - code-review
+    if: >-
+      ${{ !cancelled() &&
+          needs.mergeability-gate.result == 'success' &&
+          needs.mergeability-gate.outputs.should-run == 'true' &&
+          (needs.code-review.result == 'success' ||
+           needs.code-review.result == 'failure') }}
     runs-on: ubuntu-latest
-    needs: code-review
-    # Skipped/cancelled superseded OCR runs should not create infrastructure issues;
-    # successful runs check artifacts because OCR runtime failures are non-blocking,
-    # and failed runs may still have artifacts from an unexpected later failure.
-    if: ${{ !cancelled() && (needs.code-review.result == 'success' || needs.code-review.result == 'failure') }}
-    timeout-minutes: 5
-    concurrency:
-      group: ocr-review-infrastructure-issue
-      cancel-in-progress: false
-    permissions:
-      actions: read
-      issues: write
+    timeout-minutes: 2
+    permissions: {}
     steps:
-      - name: Download OCR artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: ocr-review-output
-          path: ocr-review-output
-
-      - name: Notify OCR infrastructure failure issue
-        if: always()
+      - name: 'Record OCR outcome: policy-failure'
+        if: ${{ needs.code-review.outputs.policy_failure == 'true' }}
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CODE_REVIEW_RESULT: ${{ needs.code-review.result }}
-          CODE_REVIEW_POLICY_FAILURE: ${{ needs.code-review.outputs.policy_failure }}
-          CODE_REVIEW_INFRASTRUCTURE_FAILURE: ${{ needs.code-review.outputs.infrastructure_failure }}
-          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
-          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
-        run: |
-          set -uo pipefail
-          sanitize_diagnostics() {
-            local diagnostic
-            local exact_secret
-            local exact_url
-            diagnostic="$1"
-            exact_secret="${OCR_LLM_TOKEN:-}"
-            exact_url="${OCR_LLM_URL:-}"
-            OCR_EXACT_SECRET="$exact_secret" OCR_EXACT_URL="$exact_url" perl -0pe '
-              BEGIN {
-                $redaction = "[REDACTED]";
-                $secret = $ENV{"OCR_EXACT_SECRET"} // "";
-                $url = $ENV{"OCR_EXACT_URL"} // "";
-              }
-              if (length($secret) > 0) {
-                my $quoted_secret = quotemeta($secret);
-                s/$quoted_secret/$redaction/g;
-              }
-              if (length($url) > 0) {
-                my $quoted_url = quotemeta($url);
-                s/$quoted_url/$redaction/g;
-              }
-              s/\b(Authorization\s*:\s*(?:(?:Bearer|Basic|token|ApiKey)\s+)?)([^\s,;]+)/$1$redaction/gi;
-              s/\b(x-api-key\s*:\s*)([^\s,;]+)/$1$redaction/gi;
-              s/\b(api[_-]?key\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
-              s/([?&](?:key|api[_-]?key|token)=)([^\s,;&]+)/$1$redaction/gi;
-              s/\b(access[_-]?token\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
-              s/\b(refresh[_-]?token\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
-              s/\b(id[_-]?token\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
-              s/\b(token\s*[=:]\s*)([A-Za-z0-9_.\/+=:\@-]{16,})/$1$redaction/gi;
-              s/\b(secret\s*[=:]\s*)([A-Za-z0-9_.\/+=:\@-]{16,})/$1$redaction/gi;
-            ' <<< "$diagnostic" || return 1
-          }
-          notify_ocr_infrastructure_failure() {
-            if ! command -v gh >/dev/null 2>&1; then
-              echo "::warning::GitHub CLI is unavailable; skipping OCR infrastructure issue notification."
-              printf '%s\n' '### OCR infrastructure notification skipped' '' 'GitHub CLI was unavailable; see workflow warnings and artifacts for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-              return 0
-            fi
-            if ! gh auth status >/dev/null 2>&1; then
-              echo "::warning::GitHub CLI is not authenticated; skipping OCR infrastructure issue notification."
-              printf '%s\n' '### OCR infrastructure notification skipped' '' 'GitHub CLI was not authenticated; see workflow warnings and artifacts for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-              return 0
-            fi
-            exit_code="unknown"
-            phase="unknown"
-            infra_failure=""
-            policy_failure=""
-            if [ -d ocr-review-output ]; then
-              cd ocr-review-output || return 1
-              missing_diagnostics=""
-              for diagnostic_file in ocr-exit-code.txt ocr-phase.txt ocr-infrastructure-failure.txt ocr-policy-failure.txt; do
-                if [ ! -f "$diagnostic_file" ]; then
-                  missing_diagnostics="${missing_diagnostics}${diagnostic_file} "
-                fi
-              done
-              if [ -f ocr-exit-code.txt ] && [ -s ocr-exit-code.txt ]; then
-                raw_exit_code="$(cat ocr-exit-code.txt)"
-                case "$raw_exit_code" in
-                  ''|*[!0-9]*) exit_code="unknown" ;;
-                  *) exit_code="$raw_exit_code" ;;
-                esac
-              fi
-              if [ -f ocr-phase.txt ] && [ -s ocr-phase.txt ]; then
-                phase="$(cat ocr-phase.txt)"
-              fi
-              if [ -f ocr-infrastructure-failure.txt ]; then
-                infra_failure="$(cat ocr-infrastructure-failure.txt)"
-              fi
-              if [ -f ocr-policy-failure.txt ]; then
-                policy_failure="$(cat ocr-policy-failure.txt)"
-              fi
-              if [ -z "$policy_failure" ] && [ "${CODE_REVIEW_POLICY_FAILURE:-}" = "true" ]; then
-                policy_failure="policy failure recorded by code-review job output"
-              fi
-              if [ -z "$infra_failure" ] && [ -n "$missing_diagnostics" ] && [ "${CODE_REVIEW_RESULT:-}" = "failure" ]; then
-                phase="artifact"
-                infra_failure="phase=artifact; reason=OCR diagnostic artifact was incomplete: ${missing_diagnostics}"
-              fi
-              if [ -z "$infra_failure" ] && [ "$exit_code" = "0" ] && [ ! -s ocr-result.json ]; then
-                phase="artifact"
-                infra_failure="phase=artifact; reason=OCR result artifact was missing after a zero-exit review"
-              fi
-            elif [ "${CODE_REVIEW_RESULT:-}" = "failure" ] || [ "${CODE_REVIEW_INFRASTRUCTURE_FAILURE:-}" = "true" ]; then
-              if [ "${CODE_REVIEW_POLICY_FAILURE:-}" = "true" ]; then
-                echo "::notice::OCR policy failure output was set; skipping missing-artifact infrastructure notification."
-                return 0
-              fi
-              phase="artifact"
-              infra_failure="phase=artifact; reason=OCR artifacts were unavailable after code-review completed with failure or infrastructure diagnostics"
-              echo "::warning::OCR artifacts were unavailable after code-review completed with failure or infrastructure diagnostics; creating infrastructure notification."
-            else
-              echo "::warning::OCR artifacts were unavailable; cannot determine whether an infrastructure failure occurred."
-              printf '%s\n' '### OCR artifact diagnostics unavailable' '' 'The OCR artifact download failed, and the code-review job did not report a policy or infrastructure failure output. See workflow logs for details.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-              return 0
-            fi
-            if [ -n "$policy_failure" ]; then
-              echo "::notice::OCR policy failure detected; skipping infrastructure issue notification."
-              return 0
-            fi
-            if [ -z "$infra_failure" ]; then
-              return 0
-            fi
-            if ! command -v perl >/dev/null 2>&1; then
-              echo "::warning::Perl is unavailable; skipping OCR infrastructure issue notification."
-              printf '%s\n' '### OCR infrastructure notification skipped' '' 'Perl was unavailable, so the final issue-notification sanitizer could not run. See the redacted OCR artifacts and workflow warnings for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-              return 0
-            fi
-            # Keep ISSUE_TITLE as a simple repository-owned literal; it is used inside gh search strings below.
-            ISSUE_TITLE="OCR review infrastructure failure"
-            if ! sanitized_infra_failure="$(sanitize_diagnostics "$infra_failure")"; then
-              echo "::warning::Failed to sanitize OCR infrastructure diagnostic; skipping notification."
-              return 1
-            fi
-            retry_gh() {
-              local attempt
-              for attempt in 1 2 3 4; do
-                if "$@"; then
-                  return 0
-                fi
-                if [ "$attempt" -lt 4 ]; then
-                  sleep $(( attempt * 5 ))
-                fi
-              done
-              echo "All retries exhausted for: $*" >&2
-              return 1
-            }
-            create_infrastructure_issue() {
-              local issue_body_file
-              local create_stderr
-              issue_body_file="$1"
-              shift
-              create_stderr="$(mktemp)"
-              if gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"; then
-                rm -f "${create_stderr}"
-                return 0
-              fi
-              if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then
-                echo "::warning::OCR infrastructure issue label was unavailable; retrying without labels."
-                if gh issue create "$@" --body-file "$issue_body_file"; then
-                  rm -f "${create_stderr}"
-                  return 0
-                fi
-              fi
-              rm -f "${create_stderr}"
-              echo "::warning::Failed to create OCR infrastructure issue."
-              return 1
-            }
-            converge_duplicate_tracking_issues() {
-              local dup_issues
-              if ! dup_issues="$(
-                gh issue list \
-                  --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-asc" \
-                  --limit 30 \
-                  --json number,title \
-                  --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number]"
-              )"; then
-                echo "::warning::Failed to list duplicate tracking issues for convergence; duplicates may accumulate."
-                return 0
-              fi
-              local dup_count
-              dup_count="$(printf '%s' "$dup_issues" | jq 'length')"
-              if [ "$dup_count" -le 1 ]; then
-                return 0
-              fi
-              local KEEP_ISSUE
-              KEEP_ISSUE="$(printf '%s' "$dup_issues" | jq -r '.[0]')"
-              for dup in $(printf '%s' "$dup_issues" | jq -r '.[1:][]'); do
-                gh issue comment "${KEEP_ISSUE}" --body "Consolidated duplicate tracking issue #${dup} into this issue." || true
-                gh issue close "${dup}" || true
-              done
-            }
-            if ! EXISTING_ISSUE="$(
-              retry_gh gh issue list \
-                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
-                --limit 30 \
-                --json number,title \
-                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
-            )"; then
-              echo "::warning::Failed to search for existing OCR infrastructure issue."
-              return 0
-            fi
-            diagnostic_block="$(printf '%s\n' "$sanitized_infra_failure" | sed 's/^/    /')"
-            body="$(printf 'OCR review infrastructure failure on %s. Phase: %s. Exit code: %s. Artifact: ocr-review-output. Infrastructure diagnostic:\n\n%s\n\nRun: %s. Raw stderr remains available only in the workflow artifact.' "$(TZ=UTC date +'%Y-%m-%d')" "$phase" "$exit_code" "$diagnostic_block" "$RUN_URL")"
-            if ! body_file="$(mktemp)"; then
-              echo "::warning::Failed to create OCR infrastructure issue body file."
-              return 1
-            fi
-            trap 'rm -f "$body_file"' EXIT
-            if ! printf '%s\n' "$body" > "$body_file"; then
-              echo "::warning::Failed to write OCR infrastructure issue body file."
-              rm -f "$body_file"
-              return 1
-            fi
-            if [ -n "$EXISTING_ISSUE" ]; then
-              gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue."
-              converge_duplicate_tracking_issues
-              return 0
-            fi
-            if ! EXISTING_ISSUE="$(
-              retry_gh gh issue list \
-                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
-                --limit 30 \
-                --json number,title \
-                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
-            )"; then
-              echo "::warning::Failed to recheck for existing OCR infrastructure issue before create."
-              return 0
-            fi
-            if [ -n "$EXISTING_ISSUE" ]; then
-              gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue after recheck."
-              converge_duplicate_tracking_issues
-              return 0
-            fi
-            create_infrastructure_issue "$body_file" \
-              --title "${ISSUE_TITLE}"
-            converge_duplicate_tracking_issues
-            return 0
-          }
-          notify_ocr_infrastructure_failure || echo "::warning::OCR infrastructure issue notification failed; continuing."
-          exit 0
+        run: echo 'OCR policy failure recorded.'
+
+      - name: 'Record OCR outcome: infrastructure-failure'
+        if: >-
+          ${{ needs.code-review.result == 'success' &&
+              needs.code-review.outputs.policy_failure != 'true' &&
+              needs.code-review.outputs.infrastructure_failure == 'true' }}
+        shell: bash
+        run: echo 'Non-blocking OCR infrastructure failure recorded.'
+
+      - name: 'Record OCR outcome: success'
+        if: >-
+          ${{ needs.code-review.result == 'success' &&
+              needs.code-review.outputs.policy_failure != 'true' &&
+              needs.code-review.outputs.infrastructure_failure != 'true' }}
+        shell: bash
+        run: echo 'Successful OCR review recorded.'
+
+      - name: 'Record OCR outcome: unexpected-failure'
+        if: >-
+          ${{ needs.code-review.result == 'failure' &&
+              needs.code-review.outputs.policy_failure != 'true' }}
+        shell: bash
+        run: echo 'Unexpected OCR job failure recorded.'
+
+  record-skipped-ocr-outcome:
+    name: Record skipped OCR outcome
+    needs:
+      - mergeability-gate
+    if: >-
+      ${{ !cancelled() &&
+          needs.mergeability-gate.result == 'success' &&
+          needs.mergeability-gate.outputs.should-run != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    steps:
+      - name: 'Record OCR outcome: review-skipped'
+        shell: bash
+        run: echo 'OCR review skipped by the mergeability gate.'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -28,8 +28,19 @@ env:
   REPO: '${{ github.repository }}'
 
 jobs:
+  mergeability-gate:
+    name: 'Mergeability gate'
+    uses: './.github/workflows/_pr-mergeability-gate.yml'
+    with:
+      check-mergeability: true
+      pull-request-number: "${{ format('{0}', github.event.pull_request.number) }}"
+      expected-head-sha: '${{ github.event.pull_request.head.sha }}'
+
   review:
     name: 'Run LLxprt review'
+    needs:
+      - 'mergeability-gate'
+    if: ${{ needs.mergeability-gate.outputs.should-run == 'true' }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 60
     env:
@@ -64,6 +75,7 @@ jobs:
         env:
           HEAD_REF_VALUE: '${{ github.event.pull_request.head.ref }}'
           HEAD_REPO_VALUE: '${{ github.event.pull_request.head.repo.full_name }}'
+          EXPECTED_HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
         run: |
           set -euo pipefail
           pr_ref="refs/pr/${PR_NUMBER}"
@@ -83,6 +95,10 @@ jobs:
 
           base_sha='${{ github.event.pull_request.base.sha }}'
           head_sha="$(git rev-parse "${pr_ref}")"
+          if [[ "${head_sha}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "Fetched PR head changed from event SHA ${EXPECTED_HEAD_SHA} to ${head_sha}; aborting." >&2
+            exit 1
+          fi
 
           # Compute the merge-base so diffs only contain changes the PR
           # actually introduced, not unrelated main-branch activity.

--- a/project-plans/issue2587.md
+++ b/project-plans/issue2587.md
@@ -1,0 +1,229 @@
+# Plan: Skip expensive trusted-context PR work while merge conflicts are reported (Issue #2587)
+
+- **Issue:** https://github.com/vybestack/llxprt-code/issues/2587
+- **Parent:** https://github.com/vybestack/llxprt-code/issues/2658
+- **Branch:** `issue2587`
+- **Rules:** `dev-docs/RULES.md` — behavioral TDD is mandatory (RED → GREEN → REFACTOR), tests must exercise the real workflow scripts and YAML, and infrastructure adapters may be faked without testing mock calls.
+
+## 1. Verified platform behavior and scope
+
+GitHub does not run workflows triggered by `pull_request` while the pull request has a merge conflict. Converting those workflows to `pull_request_target` would weaken security and required-check integrity, so these remain unchanged:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/interactive-ui.yml`
+- `.github/workflows/windows-installed-command.yml`
+- The normal internal-PR `pull_request` leg of `.github/workflows/e2e.yml`
+
+The repository must explicitly gate expensive work that still starts in trusted context:
+
+- `.github/workflows/ocr-review.yml` on automatic `pull_request_target` and authorized PR comment commands. `workflow_dispatch` is an explicit operator override.
+- `.github/workflows/pr-review.yml` on `pull_request_target`.
+- `.github/workflows/e2e.yml` on the approved-fork `pull_request_target` path.
+
+`.github/workflows/auto-label-trusted-contributors.yml` remains ungated because it is cheap metadata automation. Events created by the repository `GITHUB_TOKEN` do not recursively start `labeled` workflows, so this auto-label workflow cannot resume E2E after a head update.
+
+CodeRabbit is an external GitHub App. Its current repository configuration has no mergeability predicate, so Actions cannot reliably prevent, cancel, or retrigger CodeRabbit reviews based on conflicts. `.coderabbit.yaml` remains unchanged.
+
+## 2. Binding architectural decisions
+
+### AD1 — One reusable mergeability gate
+
+Add `.github/workflows/_pr-mergeability-gate.yml` as a reusable `workflow_call` contract. It accepts:
+
+- `check-mergeability`: boolean; false is an explicit bypass.
+- `pull-request-number`: string.
+- `expected-head-sha`: optional string used to reject stale event work.
+
+It returns string outputs:
+
+- `should-run`: `true` or `false`.
+- `reason`: stable diagnostic reason.
+
+The gate has only `pull-requests: read`, does not check out code, receives no repository secrets, and uses the repository's pinned `actions/github-script` revision.
+
+### AD2 — Decide conflicts only from REST `mergeable`
+
+The webhook payload is not authoritative because `mergeable` is commonly null while GitHub computes the result. The gate calls `github.rest.pulls.get` and:
+
+- permits when `mergeable === true`;
+- skips when `mergeable === false`;
+- polls a bounded number of times when `mergeable === null`;
+- retries and may fail open only for statusless network errors, HTTP 429, and HTTP 5xx responses;
+- fails visibly with sanitized diagnostics for permanent HTTP errors, including 4xx authentication, authorization, not-found, and configuration failures;
+- fails visibly for invalid gate inputs;
+- skips stale event work when the current API head differs from `expected-head-sha`.
+
+Do not interpret `mergeable_state` values such as blocked, behind, or unstable as git conflicts.
+
+### AD3 — Keep workflows triggered; skip only expensive jobs
+
+Trusted-context workflows still create a cheap gate job. Their expensive jobs use `needs` and `if` to skip when the gate returns false. This preserves observable successful/skipped workflow conclusions and avoids expected checks being absent solely because of a workflow-level filter.
+
+### AD4 — Preserve authorization and cancellation
+
+- OCR's exact existing event/authorization predicate moves to the gate-caller job. Unauthorized and non-PR comments cannot enter its concurrency group.
+- OCR's gate and review jobs share the current per-PR concurrency group so a newer conflicting update can cancel stale review work before returning false.
+- PR Review retains its existing workflow-level per-PR cancellation.
+- E2E retains its job/matrix concurrency and trusted `maintainer:e2e:ok` boundary.
+
+### AD5 — New fork heads require fresh E2E approval
+
+Keep E2E's `pull_request_target` trigger limited to `labeled`. A persistent `maintainer:e2e:ok` label is not scoped to a particular head SHA, so `synchronize` must not authorize newly pushed fork code to receive repository secrets.
+
+After a conflict-resolution push changes the head, a maintainer must remove and re-add `maintainer:e2e:ok` after the head changes, or use manual `workflow_dispatch`. The fresh label event carries the new expected head SHA through the mergeability gate. This deliberately preserves security over automatic rerun convenience.
+
+## 3. Requirements
+
+### REQ-2587-1: Authoritative conflict decision
+
+- **GIVEN** an eligible trusted-context PR workflow event
+- **WHEN** GitHub's REST PR response reports `mergeable: false`
+- **THEN** the expensive review/test job is skipped and the gate succeeds with a conflict reason.
+
+### REQ-2587-2: Pending and uncertain state is safe
+
+- **GIVEN** REST mergeability is null or temporarily unavailable
+- **WHEN** bounded polling cannot obtain a boolean
+- **THEN** the gate warns and permits work rather than stranding a valid PR indefinitely.
+
+### REQ-2587-3: Stale event work does not run
+
+- **GIVEN** the event expected head differs from the current PR head
+- **WHEN** the gate resolves PR state
+- **THEN** it returns false with a stale-head reason so the newer synchronize run owns the work.
+
+### REQ-2587-4: Existing event contracts remain intact
+
+Push, merge-group, ordinary `pull_request`, and explicit workflow-dispatch behavior remain unchanged. Authorized OCR commands are mergeability-checked; OCR workflow dispatch bypasses the gate intentionally. Unauthorized comments still cannot cancel OCR.
+
+### REQ-2587-5: Security boundaries remain intact
+
+The mergeability gate has read-only PR access, never checks out PR code, receives no provider credentials, and does not convert native `pull_request` workflows to `pull_request_target`.
+
+### REQ-2587-6: Conflict resolution requires fresh fork E2E approval
+
+Normal conflict resolution updates the PR head and emits `synchronize`, so OCR and PR Review reevaluate mergeability. E2E does not authorize a new fork head from a persistent label. A maintainer must remove and re-add `maintainer:e2e:ok` or invoke `workflow_dispatch` explicitly.
+
+## 4. TDD phases
+
+### Phase 1 — Reusable gate behavior (RED then GREEN)
+
+**Create first:** `scripts/tests/pr-mergeability-gate.test.js`
+
+The test parses the real reusable workflow and executes the real `actions/github-script` body. Fake only the Octokit REST adapter and timer. Assert observable outputs/warnings, not adapter call counts.
+
+RED behaviors:
+
+1. Bypass allows without requiring a PR number.
+2. `mergeable: true` allows.
+3. `mergeable: false` skips with conflict reason.
+4. null followed by true allows.
+5. null followed by false skips.
+6. repeated null warns and allows.
+7. exhausted network, HTTP 429, and HTTP 5xx uncertainty warns and allows with sanitized diagnostics.
+8. permanent HTTP 401, 403, 404, and 422 errors fail visibly without exposing response details.
+9. current head different from expected head skips as stale.
+10. missing/malformed PR number with checking enabled fails visibly.
+11. Workflow permissions are exactly `pull-requests: read`; no checkout, shell step, or secrets contract exists.
+12. Script does not consume event-payload `mergeable` or `mergeable_state`.
+
+**GREEN:** Add `.github/workflows/_pr-mergeability-gate.yml` with the minimum implementation satisfying those tests.
+
+### Phase 2 — OCR wiring (RED then GREEN)
+
+**Create/extend first:** `scripts/tests/pr-mergeability-workflow-wiring.test.js` and the existing OCR workflow tests where they own authorization/concurrency behavior.
+
+RED behaviors:
+
+1. The mergeability caller carries the exact authorized event/comment predicate.
+2. Gate and code-review use the shared current per-PR concurrency group.
+3. Automatic target events and authorized comments check mergeability.
+4. Workflow dispatch bypasses mergeability.
+5. `code-review` needs the gate and runs only when `should-run` is true.
+6. Infrastructure notification cannot run for a conflict-skipped code-review job.
+7. Existing fork safety, trusted checkout, command syntax, permissions, outputs, and timeout remain unchanged.
+
+**GREEN:** Modify `.github/workflows/ocr-review.yml` minimally.
+
+### Phase 3 — PR Review wiring (RED then GREEN)
+
+RED behaviors:
+
+1. Existing trigger types and workflow-level concurrency remain unchanged.
+2. A read-only reusable gate runs before the expensive review.
+3. The gate receives the event PR number and head SHA.
+4. The review job needs the gate and runs only when permitted.
+5. Existing provider secrets remain scoped to the review job, not the gate.
+
+**GREEN:** Modify `.github/workflows/pr-review.yml` minimally.
+
+### Phase 4 — Approved fork E2E wiring (RED then GREEN)
+
+RED behaviors:
+
+1. Existing push, pull_request, merge_group, workflow_dispatch, and labeled target triggers remain.
+2. Target `synchronize` is not registered and cannot reuse a persistent approval label for a new fork head.
+3. Labeled target E2E requires the exact `maintainer:e2e:ok` label event.
+4. The mergeability gate and target setup run only for that eligible label event.
+5. Native and manual events continue only when the target gate is intentionally skipped.
+6. Target E2E requires successful duplicate-check and doc-filter dependencies plus a successful gate whose output is exactly true.
+7. Both Linux and macOS jobs preserve doc-only, duplicate-skip, matrix, continue-on-error, checkout, secret, and concurrency contracts.
+8. Auto-label remains ungated, but its `GITHUB_TOKEN` label write cannot recursively trigger E2E.
+
+**GREEN:** Modify `.github/workflows/e2e.yml` minimally.
+
+### Phase 5 — Regression and full verification
+
+Run focused tests, then all script tests. Validate YAML/action syntax through repository linting. Run the complete required suite:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+The smoke command must produce a haiku and no additional user-facing prose. Formatting changes must be reviewed and limited to intended files.
+
+## 5. Files
+
+### Create
+
+- `.github/workflows/_pr-mergeability-gate.yml`
+- `scripts/tests/pr-mergeability-gate.test.js`
+- `scripts/tests/pr-mergeability-workflow-wiring.test.js`
+
+### Modify
+
+- `.github/workflows/ocr-review.yml`
+- `.github/workflows/pr-review.yml`
+- `.github/workflows/e2e.yml`
+- `scripts/tests/ocr-review-workflow.test.js` if necessary to preserve its existing ownership of authorization/concurrency assertions
+- `scripts/tests/pr-workflow-concurrency.test.js` if necessary to preserve its existing ownership of concurrency assertions
+
+### Intentionally unchanged
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/interactive-ui.yml`
+- `.github/workflows/windows-installed-command.yml`
+- `.github/workflows/auto-label-trusted-contributors.yml`
+- `.coderabbit.yaml`
+- `.llxprt/**`
+
+## 6. Known limitation
+
+GitHub has no mergeability-changed Actions event. Normal conflict resolution modifies the PR head and emits `synchronize`, which retriggers OCR and PR Review. It intentionally does not trigger fork E2E: a persistent approval label is not head-scoped, and `GITHUB_TOKEN` label writes cannot recursively create the required `labeled` workflow run. A maintainer must remove and re-add the approval label after reviewing the new head, or use manual workflow dispatch. If mergeability changes solely because the base branch changes without a head update, no guaranteed event exists; operator workflow dispatch or rerun remains the fallback. CodeRabbit requires vendor-side mergeability support for exact equivalent behavior, so `.coderabbit.yaml` remains unchanged.
+
+## 7. Completion gate
+
+- [ ] Every production change was preceded by a failing behavioral test.
+- [ ] Explicit `mergeable: false` skips expensive trusted-context work.
+- [ ] Null and retryable network/429/5xx uncertainty fails open and is observable.
+- [ ] Permanent REST failures fail visibly with sanitized diagnostics.
+- [ ] Stale event heads cannot run expensive work.
+- [ ] Native pull-request workflow security remains unchanged.
+- [ ] New fork heads require a fresh label event or manual dispatch before E2E receives secrets.
+- [ ] OCR authorization and cancellation semantics remain intact.
+- [ ] All focused and full verification commands pass.

--- a/scripts/tests/ocr-notifier-classification.test.js
+++ b/scripts/tests/ocr-notifier-classification.test.js
@@ -1,0 +1,330 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import vm from 'node:vm';
+import { beforeAll, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  commandText,
+  normalize,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.js';
+
+const OCR_WORKFLOW_PATH = '.github/workflows/ocr-review.yml';
+const require = createRequire(import.meta.url);
+const NOTIFIER_WORKFLOW_PATH =
+  '.github/workflows/ocr-infrastructure-notifier.yml';
+
+function loadWorkflow(workflowPath) {
+  const source = readRootFile(workflowPath);
+  const parsed = yaml.load(source);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`${workflowPath} did not parse to a YAML mapping`);
+  }
+  return { source, parsed };
+}
+
+function loadClassificationScript(classifyJob) {
+  const classifyStep = stepNamed(classifyJob, 'Classify completed OCR run');
+  const script = commandText(classifyStep);
+  if (!script) {
+    throw new Error('OCR notifier classification script should not be empty');
+  }
+  return script;
+}
+
+async function executeClassificationScript({
+  script,
+  jobs,
+  runConclusion,
+  artifactFiles,
+}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'ocr-notifier-classification-'));
+  const artifactPath = path.join(root, 'ocr-review-output');
+  const outputs = {};
+  const warnings = [];
+  let failure = null;
+
+  try {
+    if (artifactFiles) {
+      mkdirSync(artifactPath);
+      for (const [fileName, contents] of Object.entries(artifactFiles)) {
+        writeFileSync(path.join(artifactPath, fileName), contents);
+      }
+    }
+
+    const sandbox = {
+      github: {
+        rest: {
+          actions: {
+            listJobsForWorkflowRun: async () => ({ data: { jobs } }),
+          },
+        },
+      },
+      context: {
+        repo: { owner: 'test-owner', repo: 'test-repo' },
+      },
+      core: {
+        setOutput: (name, value) => {
+          outputs[name] = String(value);
+        },
+        setFailed: (message) => {
+          failure = String(message);
+        },
+        warning: (message) => {
+          warnings.push(String(message));
+        },
+        info: () => {},
+      },
+      process: {
+        env: {
+          ARTIFACT_PATH: artifactPath,
+          RUN_CONCLUSION: runConclusion,
+          RUN_ID: '12345',
+        },
+      },
+      require,
+      console,
+      Array,
+      Boolean,
+      Error,
+      JSON,
+      Map,
+      Number,
+      Object,
+      Set,
+      String,
+    };
+
+    await vm.runInNewContext(`(async () => { ${script} })()`, sandbox);
+    return { outputs, warnings, failure };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function markerJob(stepName) {
+  return [
+    {
+      name: 'Record OCR outcome',
+      conclusion: 'success',
+      steps: [{ name: stepName, conclusion: 'success' }],
+    },
+  ];
+}
+
+function evaluateNotifyCondition(condition, classification) {
+  const wrappedExpression = String(condition).trim();
+  const expression = wrappedExpression
+    .slice(3, wrappedExpression.length - 2)
+    .trim()
+    .replaceAll('needs.classify-ocr-run', "needs['classify-ocr-run']")
+    .replaceAll('.outputs.classification', ".outputs['classification']");
+  return Boolean(
+    vm.runInNewContext(expression, {
+      needs: {
+        'classify-ocr-run': {
+          result: 'success',
+          outputs: { classification },
+        },
+      },
+    }),
+  );
+}
+
+describe('OCR workflow_run notification classification', () => {
+  let ocrWorkflow;
+  let notifierWorkflow;
+  let classifyJob;
+  let notifyJob;
+  let classificationScript;
+
+  beforeAll(() => {
+    ocrWorkflow = loadWorkflow(OCR_WORKFLOW_PATH).parsed;
+    notifierWorkflow = loadWorkflow(NOTIFIER_WORKFLOW_PATH).parsed;
+    classifyJob = notifierWorkflow.jobs?.['classify-ocr-run'];
+    notifyJob = notifierWorkflow.jobs?.['notify-ocr-infrastructure-failure'];
+    if (!classifyJob || !notifyJob) {
+      throw new Error(
+        'OCR notifier should contain separate classify-ocr-run and notify-ocr-infrastructure-failure jobs',
+      );
+    }
+    classificationScript = loadClassificationScript(classifyJob);
+  });
+
+  const truthTable = [
+    {
+      name: 'policy failure',
+      marker: 'Record OCR outcome: policy-failure',
+      conclusion: 'failure',
+      classification: 'policy-failure',
+      notify: false,
+    },
+    {
+      name: 'non-blocking infrastructure failure',
+      marker: 'Record OCR outcome: infrastructure-failure',
+      conclusion: 'success',
+      classification: 'infrastructure-failure',
+      notify: true,
+    },
+    {
+      name: 'ordinary success',
+      marker: 'Record OCR outcome: success',
+      conclusion: 'success',
+      classification: 'success',
+      notify: false,
+    },
+    {
+      name: 'unexpected job failure',
+      marker: 'Record OCR outcome: unexpected-failure',
+      conclusion: 'failure',
+      classification: 'unexpected-failure',
+      notify: true,
+    },
+    {
+      name: 'conflict-skipped review',
+      marker: 'Record OCR outcome: review-skipped',
+      conclusion: 'success',
+      classification: 'review-skipped',
+      notify: false,
+    },
+  ];
+
+  for (const scenario of truthTable) {
+    it(`classifies ${scenario.name} without an artifact and gates privileged notification`, async () => {
+      const result = await executeClassificationScript({
+        script: classificationScript,
+        jobs: markerJob(scenario.marker),
+        runConclusion: scenario.conclusion,
+      });
+
+      expect(result.failure).toBeNull();
+      expect(result.outputs.classification).toBe(scenario.classification);
+      expect(
+        evaluateNotifyCondition(notifyJob.if, result.outputs.classification),
+      ).toBe(scenario.notify);
+    });
+  }
+
+  const artifactFallbackTable = [
+    {
+      name: 'policy failure',
+      conclusion: 'failure',
+      files: { 'ocr-policy-failure.txt': 'scope policy failed\n' },
+      classification: 'policy-failure',
+    },
+    {
+      name: 'non-blocking infrastructure failure',
+      conclusion: 'success',
+      files: {
+        'ocr-infrastructure-failure.txt': 'phase=review; reason=timeout\n',
+      },
+      classification: 'infrastructure-failure',
+    },
+    {
+      name: 'ordinary success',
+      conclusion: 'success',
+      files: {
+        'ocr-exit-code.txt': '0\n',
+        'ocr-result.json': '{"comments":[]}\n',
+      },
+      classification: 'success',
+    },
+    {
+      name: 'unexpected job failure',
+      conclusion: 'failure',
+      files: {},
+      classification: 'unexpected-failure',
+    },
+  ];
+
+  for (const scenario of artifactFallbackTable) {
+    it(`uses artifact fallback to classify ${scenario.name}`, async () => {
+      const result = await executeClassificationScript({
+        script: classificationScript,
+        jobs: [],
+        runConclusion: scenario.conclusion,
+        artifactFiles: scenario.files,
+      });
+
+      expect(result.failure).toBeNull();
+      expect(result.outputs.classification).toBe(scenario.classification);
+    });
+  }
+
+  it('records durable trusted OCR outcomes in unprivileged source-workflow jobs', () => {
+    const outcomeJob = ocrWorkflow.jobs?.['record-ocr-outcome'];
+    const skippedJob = ocrWorkflow.jobs?.['record-skipped-ocr-outcome'];
+
+    expect(outcomeJob?.permissions).toEqual({});
+    expect(skippedJob?.permissions).toEqual({});
+    expect(outcomeJob?.needs).toEqual(['mergeability-gate', 'code-review']);
+    expect(skippedJob?.needs).toEqual(['mergeability-gate']);
+    for (const scenario of truthTable.slice(0, 4)) {
+      expect(stepNamed(outcomeJob, scenario.marker)).toBeTruthy();
+    }
+    expect(
+      stepNamed(skippedJob, 'Record OCR outcome: review-skipped'),
+    ).toBeTruthy();
+    expect(normalize(skippedJob.if)).toContain(
+      normalize("needs.mergeability-gate.outputs.should-run != 'true'"),
+    );
+    expect(JSON.stringify({ outcomeJob, skippedJob })).not.toContain(
+      'secrets.',
+    );
+  });
+
+  it('classifies job metadata and artifacts before entering the issues-write job', () => {
+    expect(notifierWorkflow.permissions).toEqual({});
+    expect(classifyJob.permissions).toEqual({ actions: 'read' });
+    expect(classifyJob.permissions?.issues).toBeUndefined();
+    expect(notifyJob.permissions).toEqual({ issues: 'write' });
+    expect(notifyJob.needs).toBe('classify-ocr-run');
+    expect(normalize(notifyJob.if)).toBe(
+      normalize(
+        "${{ needs.classify-ocr-run.result == 'success' && (needs.classify-ocr-run.outputs.classification == 'infrastructure-failure' || needs.classify-ocr-run.outputs.classification == 'unexpected-failure') }}",
+      ),
+    );
+
+    const downloadStep = stepNamed(classifyJob, 'Download OCR artifacts');
+    expect(downloadStep['continue-on-error']).toBe(true);
+    expect(downloadStep.with['run-id']).toBe(
+      '${{ github.event.workflow_run.id }}',
+    );
+    expect(
+      notifyJob.steps.some((step) => step.name === 'Download OCR artifacts'),
+    ).toBe(false);
+
+    const notifyStep = stepNamed(
+      notifyJob,
+      'Notify OCR infrastructure failure issue',
+    );
+    expect(notifyStep.if).toBeUndefined();
+    expect(JSON.stringify(notifyJob)).not.toContain('always()');
+    expect(JSON.stringify(notifyJob)).not.toContain('secrets.');
+    expect(JSON.stringify(notifyJob)).not.toContain('OCR_LLM_TOKEN');
+    expect(JSON.stringify(notifyJob)).not.toContain('OCR_LLM_URL');
+  });
+
+  it('fails closed instead of notifying when durable job metadata is contradictory', async () => {
+    const result = await executeClassificationScript({
+      script: classificationScript,
+      jobs: [
+        ...markerJob('Record OCR outcome: policy-failure'),
+        ...markerJob('Record OCR outcome: infrastructure-failure'),
+      ],
+      runConclusion: 'failure',
+    });
+
+    expect(result.failure).toContain('multiple durable OCR outcomes');
+    expect(result.outputs.classification).toBeUndefined();
+  });
+});

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -27,15 +27,19 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
 
   beforeAll(() => {
     workflowYml = readRootFile(WORKFLOW_PATH);
+    const notifierWorkflowYml = readRootFile(
+      '.github/workflows/ocr-infrastructure-notifier.yml',
+    );
     try {
       workflow = yaml.load(workflowYml);
+      const notifierWorkflow = yaml.load(notifierWorkflowYml);
+      notifyJob = notifierWorkflow.jobs?.['notify-ocr-infrastructure-failure'];
     } catch (error) {
-      throw new Error(`Failed to parse ${WORKFLOW_PATH}: ${error.message}`, {
+      throw new Error(`Failed to parse OCR workflows: ${error.message}`, {
         cause: error,
       });
     }
     codeReviewJob = workflow.jobs?.['code-review'];
-    notifyJob = workflow.jobs?.['notify-ocr-infrastructure-failure'];
     postStep = stepNamed(codeReviewJob, 'Post OCR results');
     postScript = commandText(postStep);
     notifyStep = stepNamed(

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -13,18 +13,22 @@ import {
   expectCommonCredentialsRedacted,
   expectContainsAll,
   extractFunctionSource,
-  hasBashAndPerl,
   makePostSanitizer,
   normalize,
   readRootFile,
-  runNotifySanitizer,
   stepNamed,
 } from './ocr-review-workflow-helpers.js';
 
+const NOTIFIER_WORKFLOW_PATH =
+  '.github/workflows/ocr-infrastructure-notifier.yml';
+
 describe('.github/workflows/ocr-review.yml', () => {
   let workflowYml;
+  let notifierWorkflowYml;
   let workflow;
+  let notifierWorkflow;
   let codeReviewJob;
+  let mergeabilityGateJob;
 
   let postStep;
   let postScript;
@@ -38,10 +42,12 @@ describe('.github/workflows/ocr-review.yml', () => {
       workflowYml.trim(),
       `${WORKFLOW_PATH} should have content`,
     ).toBeTruthy();
+    notifierWorkflowYml = readRootFile(NOTIFIER_WORKFLOW_PATH);
     try {
       workflow = yaml.load(workflowYml);
+      notifierWorkflow = yaml.load(notifierWorkflowYml);
     } catch (error) {
-      throw new Error(`Failed to parse ${WORKFLOW_PATH}: ${error.message}`, {
+      throw new Error(`Failed to parse OCR workflows: ${error.message}`, {
         cause: error,
       });
     }
@@ -49,15 +55,27 @@ describe('.github/workflows/ocr-review.yml', () => {
       workflow && typeof workflow === 'object',
       `${WORKFLOW_PATH} should parse to a YAML mapping`,
     ).toBeTruthy();
+    expect(
+      notifierWorkflow && typeof notifierWorkflow === 'object',
+      `${NOTIFIER_WORKFLOW_PATH} should parse to a YAML mapping`,
+    ).toBeTruthy();
     codeReviewJob = workflow.jobs?.['code-review'];
     expect(
       codeReviewJob,
       'workflow should contain job: code-review',
     ).toBeTruthy();
-    notifyJob = workflow.jobs?.['notify-ocr-infrastructure-failure'];
+    mergeabilityGateJob = workflow.jobs?.['mergeability-gate'];
+    expect(
+      mergeabilityGateJob,
+      'workflow should contain job: mergeability-gate',
+    ).toBeTruthy();
+    expect(
+      workflow.jobs?.['notify-ocr-infrastructure-failure'],
+    ).toBeUndefined();
+    notifyJob = notifierWorkflow.jobs?.['notify-ocr-infrastructure-failure'];
     expect(
       notifyJob,
-      'workflow should contain job: notify-ocr-infrastructure-failure',
+      'notifier workflow should contain job: notify-ocr-infrastructure-failure',
     ).toBeTruthy();
     postStep = stepNamed(codeReviewJob, 'Post OCR results');
     postScript = commandText(postStep);
@@ -76,12 +94,13 @@ describe('.github/workflows/ocr-review.yml', () => {
     );
   });
 
-  it('uses job-level concurrency so skipped issue comments cannot cancel OCR', () => {
-    const group = codeReviewJob.concurrency?.group;
+  it('uses authorization-aware workflow concurrency around the complete run', () => {
+    const group = workflow.concurrency?.group;
     const normalizedGroup = normalize(group);
-    const normalizedJobIf = normalize(codeReviewJob.if);
+    const normalizedCodeReviewIf = normalize(codeReviewJob.if);
+    const normalizedGateIf = normalize(mergeabilityGateJob.if);
 
-    expect(workflow.concurrency).toBeUndefined();
+    expect(workflow.concurrency?.['cancel-in-progress']).toBe(true);
     expect(codeReviewJob['timeout-minutes']).toBe(60);
     expect(codeReviewJob.outputs?.infrastructure_failure).toBe(
       '${{ steps.ocr-classification.outputs.infrastructure_failure }}',
@@ -89,40 +108,25 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(codeReviewJob.outputs?.policy_failure).toBe(
       '${{ steps.ocr-classification.outputs.policy_failure }}',
     );
-    expect(codeReviewJob.concurrency?.['cancel-in-progress']).toBe(true);
-    expect(normalizedGroup).toContain(normalize('${{ github.workflow }}'));
-    expect(group).toContain(
-      'github.event.pull_request.number || github.event.issue.number || inputs.pr_number',
+    expect(mergeabilityGateJob.concurrency).toBeUndefined();
+    expect(codeReviewJob.concurrency).toBeUndefined();
+    expect(normalizedGroup).toContain("format('{0}-pr-{1}', github.workflow,");
+    expect(normalizedGroup).toContain(
+      "format('{0}-run-{1}', github.workflow, github.run_id)",
     );
-    expect(group).not.toContain('ocr-review-');
-    expect(group).not.toContain("github.event_name == 'issue_comment'");
-    expect(group).not.toContain("'command'");
-    expect(group).not.toContain("'automatic'");
-    expect(group).not.toContain('github.event.action');
-    expect(group).not.toContain('github.event.comment.author_association');
-    expect(group).not.toContain('github.event.comment.body');
-    expect(group).not.toContain(
-      "format('comment-{0}', github.event.comment.id)",
+    expect(normalizedCodeReviewIf).toContain(
+      normalize("needs.mergeability-gate.outputs.should-run == 'true'"),
     );
-    expect(normalizedJobIf).toContain(
+    expect(normalizedGateIf).toContain(
       normalize("github.event_name == 'issue_comment'"),
-    );
-    expect(normalizedGroup).not.toContain(
-      normalize('github.event.comment.author_association'),
-    );
-    expect(workflowYml).toContain(
-      'Job-level concurrency is evaluated only for runs that pass this job if filter',
-    );
-    expect(workflowYml).toContain(
-      'All authorized OCR triggers for the same PR share one workflow-scoped group',
-    );
-    expect(workflowYml).toContain(
-      'run owns the sticky summary and inline-comment posting',
     );
   });
 
   it('keeps the job filter responsible for authorized command issue comments', () => {
-    const normalizedJobIf = normalize(codeReviewJob.if);
+    // The authorization predicate has moved to the mergeability-gate job;
+    // code-review's if only checks the gate's should-run output.
+    const normalizedGateIf = normalize(mergeabilityGateJob.if);
+    const normalizedCodeReviewIf = normalize(codeReviewJob.if);
     const issueCommentFragments = [
       "github.event_name == 'issue_comment'",
       'github.event.issue.pull_request != null',
@@ -142,8 +146,11 @@ describe('.github/workflows/ocr-review.yml', () => {
     ];
 
     for (const fragment of issueCommentFragments) {
-      expect(normalizedJobIf).toContain(normalize(fragment));
+      expect(normalizedGateIf).toContain(normalize(fragment));
     }
+    expect(normalizedCodeReviewIf).toContain(
+      normalize("needs.mergeability-gate.outputs.should-run == 'true'"),
+    );
     expect(workflowYml).not.toContain(
       'Keep this predicate in sync with the code-review job if filter',
     );
@@ -453,121 +460,6 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(sanitized).toBe('first [REDACTED] second [REDACTED]');
     expect(sanitized).not.toContain(secret);
   });
-  it.skipIf(!hasBashAndPerl())(
-    'redacts exact OCR secrets with regex metacharacters and backslashes in notify diagnostics',
-    () => {
-      // Include Perl's \E escape marker to prove quotemeta prevents it from ending literal matching early.
-      const secret = String.raw`tok$^.*+?()[]{}|\slash\Eend`;
-
-      const sanitized = runNotifySanitizer(
-        notifyRun,
-        `first ${secret} second ${secret}`,
-        secret,
-      );
-
-      expect(sanitized).toBe('first [REDACTED] second [REDACTED]');
-      expect(sanitized).not.toContain(secret);
-    },
-  );
-
-  it.skipIf(!hasBashAndPerl())(
-    'redacts common credential patterns in notify diagnostics',
-    () => {
-      const diagnostic = [
-        'Error: OCR review failed for packages/agents/src/core/TurnProcessor.ts:266',
-        'snippet: for await (const event of stream) handle(event);',
-      ].join('\n');
-
-      const sanitized = runNotifySanitizer(
-        notifyRun,
-        [commonCredentialInput(), diagnostic].join('\n'),
-        'unused-secret',
-      );
-
-      expectCommonCredentialsRedacted(sanitized);
-      expect(sanitized).toContain(diagnostic);
-    },
-  );
-
-  it.skipIf(!hasBashAndPerl())(
-    'does not redact short generic token and secret diagnostic words in notify diagnostics',
-    () => {
-      const diagnostic =
-        'token=expired secret=enabled while auth_token_value remains visible';
-
-      expect(runNotifySanitizer(notifyRun, diagnostic, 'unused-secret')).toBe(
-        diagnostic,
-      );
-    },
-  );
-
-  it.skipIf(!hasBashAndPerl())(
-    'redacts the configured OCR LLM URL from notify diagnostics',
-    () => {
-      const url = 'https://llm.example.test/v1/messages?api_key=sk-url-secret';
-
-      const sanitized = runNotifySanitizer(
-        notifyRun,
-        `request failed for ${url}`,
-        'unused-secret',
-        { OCR_LLM_URL: url },
-      );
-
-      expect(sanitized).toBe('request failed for [REDACTED]');
-      expect(sanitized).not.toContain(url);
-    },
-  );
-
-  it.skipIf(!hasBashAndPerl())(
-    'fails closed with process details when notify diagnostic sanitization fails',
-    () => {
-      const secret = 'must-not-leak';
-
-      expect(() =>
-        runNotifySanitizer(notifyRun, `diagnostic ${secret}`, secret, {
-          PERL5OPT: '-MNo::Such::Module',
-        }),
-      ).toThrow(/status: .*\ncode: .*\nsignal: .*\nstderr:/);
-    },
-  );
-  it('sanitizes notify-job OCR diagnostics before issue bodies', () => {
-    expect(notifyStep.env?.OCR_LLM_TOKEN).toBe(
-      '${{ secrets.OCR_LLM_AUTH_TOKEN }}',
-    );
-    expect(notifyStep.env?.OCR_LLM_URL).toBe('${{ vars.OCR_LLM_URL }}');
-    expect(notifyStep.shell).toBe('bash');
-    expectContainsAll(notifyRun, [
-      'sanitize_diagnostics() {',
-      'local diagnostic',
-      'diagnostic="$1"',
-      'exact_secret="${OCR_LLM_TOKEN:-}"',
-      'exact_url="${OCR_LLM_URL:-}"',
-      'OCR_EXACT_SECRET="$exact_secret" OCR_EXACT_URL="$exact_url"',
-      '$url = $ENV{"OCR_EXACT_URL"} // "";',
-      'REDACTED',
-      'quotemeta($secret)',
-      'quotemeta($url)',
-      'Authorization\\s*:\\s*(?:(?:Bearer|Basic|token|ApiKey)\\s+)?',
-      'x-api-key\\s*:\\s*',
-      'api[_-]?key\\s*[=:]\\s*',
-      '[?&](?:key|api[_-]?key|token)=',
-      'access[_-]?token\\s*[=:]\\s*',
-      'refresh[_-]?token\\s*[=:]\\s*',
-      'id[_-]?token\\s*[=:]\\s*',
-      'token\\s*[=:]\\s*',
-      'secret\\s*[=:]\\s*',
-      '[A-Za-z0-9_.\\/+=:\\@-]{16,}',
-      'if ! command -v perl >/dev/null 2>&1; then',
-      'sanitize_diagnostics "$infra_failure"',
-      'diagnostic_block="$(printf \'%s\\n\' "$sanitized_infra_failure" | sed \'s/^/    /\')"',
-    ]);
-    expect(notifyRun).toContain(
-      'if ! sanitized_infra_failure="$(sanitize_diagnostics "$infra_failure")"; then',
-    );
-    expect(notifyRun).not.toContain(
-      'Infrastructure diagnostic: ${infra_failure}.',
-    );
-  });
 
   it('marks changed-test scope guard failures as policy failures with exit-code artifacts', () => {
     const initializeRun = commandText(
@@ -659,7 +551,7 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(postScript).not.toContain('body.splice(12, 0');
   });
 
-  it('surfaces zero-exit parse failures in PR and infrastructure diagnostics', () => {
+  it('surfaces zero-exit parse failures in PR and redacted artifact diagnostics', () => {
     expectContainsAll(postScript, [
       'diagnosticPhase = markerPhase;',
       "fs.writeFileSync('ocr-phase.txt', `${markerPhase}\\n`);",
@@ -668,7 +560,9 @@ describe('.github/workflows/ocr-review.yml', () => {
       '`- Infrastructure diagnostic: \\`${sanitizedInfrastructureFailure.replace(/`/g, "\\\\`")}\\``',
     ]);
     expect(postScript).toContain('Phase: \\`${diagnosticPhase}\\`');
-    expect(notifyRun).toContain('phase="$(cat ocr-phase.txt)"');
+    expect(notifyRun).toContain(
+      'Review the trusted workflow logs and the redacted ocr-review-output artifact for diagnostics.',
+    );
   });
 
   it('preserves native failure phase in diagnostics', () => {
@@ -703,71 +597,39 @@ describe('.github/workflows/ocr-review.yml', () => {
     expect(uploadStep.with?.['if-no-files-found']).toBe('warn');
   });
 
-  it('notifies a deduplicated ci/cd issue for OCR infrastructure errors', () => {
-    expect(notifyJob?.needs).toBe('code-review');
+  it('notifies a deduplicated ci/cd issue only for classified infrastructure errors', () => {
+    expect(notifyJob?.needs).toBe('classify-ocr-run');
     expect(notifyJob?.['timeout-minutes']).toBe(5);
     expect(notifyJob?.concurrency?.group).toBe(
       'ocr-review-infrastructure-issue',
     );
     expect(notifyJob?.concurrency?.['cancel-in-progress']).toBe(false);
-    expect(notifyJob.if).toBe(
-      "${{ !cancelled() && (needs.code-review.result == 'success' || needs.code-review.result == 'failure') }}",
+    expect(normalize(notifyJob.if)).toBe(
+      normalize(
+        "${{ needs.classify-ocr-run.result == 'success' && (needs.classify-ocr-run.outputs.classification == 'infrastructure-failure' || needs.classify-ocr-run.outputs.classification == 'unexpected-failure') }}",
+      ),
     );
-    expect(notifyStep.if).toContain('always()');
+    expect(notifyStep.if).toBeUndefined();
     expect(notifyStep.env?.GH_TOKEN).toBe('${{ github.token }}');
-    expect(notifyStep.env?.CODE_REVIEW_POLICY_FAILURE).toBe(
-      '${{ needs.code-review.outputs.policy_failure }}',
-    );
-    expect(notifyStep.env?.CODE_REVIEW_INFRASTRUCTURE_FAILURE).toBe(
-      '${{ needs.code-review.outputs.infrastructure_failure }}',
-    );
     expect(notifyStep.env?.GH_REPO).toBe('${{ github.repository }}');
     expect(notifyStep.env?.RUN_URL).toBe(
-      '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+      '${{ github.event.workflow_run.html_url }}',
     );
-    expect(notifyStep.env?.CODE_REVIEW_RESULT).toBe(
-      '${{ needs.code-review.result }}',
+    expect(notifyStep.env?.OCR_RUN_CLASSIFICATION).toBe(
+      '${{ needs.classify-ocr-run.outputs.classification }}',
     );
-    const downloadStep = stepNamed(notifyJob, 'Download OCR artifacts');
-    expect(downloadStep.uses).toContain(
-      'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093',
+    expect(notifierWorkflowYml).toContain(
+      'ratchet:actions/download-artifact@v4',
     );
-    expect(workflowYml).toContain('ratchet:actions/download-artifact@v4');
-    expect(downloadStep['continue-on-error']).toBe(true);
     expectContainsAll(notifyRun, [
       'notify_ocr_infrastructure_failure() {',
-      'OCR artifacts were unavailable after code-review completed with failure or infrastructure diagnostics; creating infrastructure notification.',
-      'CODE_REVIEW_INFRASTRUCTURE_FAILURE',
-      'CODE_REVIEW_POLICY_FAILURE',
-      'policy failure recorded by code-review job output',
-      'OCR policy failure output was set; skipping missing-artifact infrastructure notification.',
-      'OCR artifacts were unavailable; cannot determine whether an infrastructure failure occurred.',
-      'cd ocr-review-output || return 1',
-      'missing_diagnostics=""',
-      'for diagnostic_file in ocr-exit-code.txt ocr-phase.txt ocr-infrastructure-failure.txt ocr-policy-failure.txt; do',
-      'phase="artifact"',
-      'OCR diagnostic artifact was incomplete: ${missing_diagnostics}',
-      'OCR result artifact was missing after a zero-exit review',
-      'OCR artifacts were unavailable after code-review completed with failure or infrastructure diagnostics',
-      'OCR artifact diagnostics unavailable',
-      'exit_code="unknown"',
-      'if [ -f ocr-exit-code.txt ] && [ -s ocr-exit-code.txt ]; then',
-      'raw_exit_code="$(cat ocr-exit-code.txt)"',
-      '\'\'|*[!0-9]*) exit_code="unknown" ;;',
-      'if [ -f ocr-phase.txt ] && [ -s ocr-phase.txt ]; then',
-      'infra_failure=""',
-      'infra_failure="$(cat ocr-infrastructure-failure.txt)"',
-      'if [ -n "$policy_failure" ]; then',
-      'OCR policy failure detected; skipping infrastructure issue notification.',
-      'if [ -z "$infra_failure" ]; then',
-      'return 0',
+      'case "${OCR_RUN_CLASSIFICATION:-}" in',
+      'infrastructure-failure|unexpected-failure)',
+      'Refusing notification for non-infrastructure OCR classification.',
       'command -v gh >/dev/null 2>&1',
       'gh auth status >/dev/null 2>&1',
-      'Keep ISSUE_TITLE as a simple repository-owned literal',
       'ISSUE_TITLE="OCR review infrastructure failure"',
-      'Artifact: ocr-review-output.',
-      'diagnostic_block="$(printf \'%s\\n\' "$sanitized_infra_failure" | sed \'s/^/    /\')"',
-      'Raw stderr remains available only in the workflow artifact.',
+      'OCR review run was classified as ${OCR_RUN_CLASSIFICATION}',
       'gh issue list',
       '--search "' +
         String.raw`\"` +
@@ -788,13 +650,8 @@ describe('.github/workflows/ocr-review.yml', () => {
       'Failed to comment on OCR infrastructure issue after recheck.',
     ]);
     expect(notifyRun).not.toContain('trap \'rm -f "$body_file"\' EXIT RETURN');
-    expect(notifyRun).toContain(
-      'policy_failure="$(cat ocr-policy-failure.txt)"',
-    );
-    expect(notifyRun).not.toContain(
-      'if [ -z "$infra_failure" ] && { [ -z "$exit_code" ] || [ "$exit_code" = "0" ]; }; then',
-    );
     expect(notifyRun).not.toContain('--label "bug"');
+    expect(JSON.stringify(notifyJob)).not.toContain('secrets.');
   });
 
   it('uses UTC dates, backoff retries, and label fallback for infrastructure issues', () => {

--- a/scripts/tests/ocr-review-workflow.test.js
+++ b/scripts/tests/ocr-review-workflow.test.js
@@ -635,7 +635,7 @@ describe('.github/workflows/ocr-review.yml', () => {
         String.raw`\"` +
         '${ISSUE_TITLE}' +
         String.raw`\"` +
-        ' in:title is:issue state:open sort:created-desc"',
+        ' in:title is:issue state:open sort:created-asc"',
       '--label "ci/cd"',
       'if ! body_file="$(mktemp)"; then',
       'Failed to create OCR infrastructure issue body file.',
@@ -649,6 +649,8 @@ describe('.github/workflows/ocr-review.yml', () => {
       'Failed to recheck for existing OCR infrastructure issue before create.',
       'Failed to comment on OCR infrastructure issue after recheck.',
     ]);
+    expect(notifyRun).not.toContain('sort:created-desc');
+    expect(notifyRun.match(/sort:created-asc/g)).toHaveLength(3);
     expect(notifyRun).not.toContain('trap \'rm -f "$body_file"\' EXIT RETURN');
     expect(notifyRun).not.toContain('--label "bug"');
     expect(JSON.stringify(notifyJob)).not.toContain('secrets.');

--- a/scripts/tests/pr-mergeability-gate.test.js
+++ b/scripts/tests/pr-mergeability-gate.test.js
@@ -1,0 +1,592 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import vm from 'vm';
+import yaml from 'js-yaml';
+import { readRootFile } from './ocr-review-workflow-helpers.js';
+
+const GATE_WORKFLOW_PATH = '.github/workflows/_pr-mergeability-gate.yml';
+
+/**
+ * Read, parse, and extract the real github-script body from the reusable
+ * gate workflow.  The test executes this exact production script with only
+ * network (Octokit REST) and timer (setTimeout) infrastructure faked.
+ */
+function loadGateScript() {
+  const source = readRootFile(GATE_WORKFLOW_PATH);
+  const parsed = yaml.load(source);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`${GATE_WORKFLOW_PATH} did not parse to a YAML mapping`);
+  }
+  const gateJob = parsed.jobs?.gate;
+  if (!gateJob) {
+    throw new Error(`${GATE_WORKFLOW_PATH} should contain a gate job`);
+  }
+  const steps = Array.isArray(gateJob.steps) ? gateJob.steps : [];
+  const scriptStep = steps.find(
+    (step) =>
+      typeof step.uses === 'string' &&
+      step.uses.startsWith('actions/github-script@'),
+  );
+  if (!scriptStep) {
+    throw new Error(
+      `${GATE_WORKFLOW_PATH} gate job should use actions/github-script`,
+    );
+  }
+  const script = scriptStep.with?.script;
+  if (typeof script !== 'string' || script.trim().length === 0) {
+    throw new Error(
+      `${GATE_WORKFLOW_PATH} github-script step should have a non-empty script`,
+    );
+  }
+  return { source, parsed, gateJob, scriptStep, script };
+}
+
+/**
+ * Execute the real gate script in an isolated VM sandbox with faked
+ * infrastructure.  Only Octokit REST and setTimeout are faked — the actual
+ * decision logic runs unchanged.
+ *
+ * @param {object} options
+ * @param {string} options.script - The real github-script body.
+ * @param {Record<string, string>} [options.env] - process.env values.
+ * @param {Array<object | Error>} [options.pullsGetSequence]
+ *   Sequence of mergeable responses or errors.
+ * @returns {Promise<object>} Captured outputs, warnings, request options, and failure state.
+ */
+async function executeGateScript({ script, env = {}, pullsGetSequence = [] }) {
+  const outputs = {};
+  const warnings = [];
+  const pullRequestOptions = [];
+  let failure = null;
+  let elapsedMs = 0;
+  let nextTimerId = 1;
+
+  const sequence = [...pullsGetSequence];
+  const timers = new Map();
+
+  const fakeGithub = {
+    rest: {
+      pulls: {
+        get: async (options) => {
+          pullRequestOptions.push(options);
+          const next = sequence.shift();
+          if (next === undefined) {
+            throw new Error(
+              'pulls.get was called more times than the fake sequence provided',
+            );
+          }
+          if (next instanceof Error) {
+            throw next;
+          }
+          return { data: next };
+        },
+      },
+    },
+  };
+
+  const fakeCore = {
+    setOutput: (name, value) => {
+      outputs[name] = String(value);
+    },
+    warning: (message) => {
+      warnings.push(String(message));
+    },
+    info: () => {},
+    setFailed: (message) => {
+      failure = String(message);
+    },
+  };
+
+  const fakeContext = {
+    repo: { owner: 'test-owner', repo: 'test-repo' },
+    payload: {},
+  };
+
+  const sandbox = {
+    github: fakeGithub,
+    core: fakeCore,
+    context: fakeContext,
+    process: { env: { ...env } },
+    setTimeout: (fn, delay = 0) => {
+      const timerId = nextTimerId;
+      nextTimerId += 1;
+      const timer = setTimeout(() => {
+        timers.delete(timerId);
+        elapsedMs += Number(delay);
+        fn();
+      }, 0);
+      timers.set(timerId, timer);
+      return timerId;
+    },
+    clearTimeout: (timerId) => {
+      const timer = timers.get(timerId);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timers.delete(timerId);
+      }
+    },
+    console: {
+      log: () => {},
+      warn: (message) => warnings.push(String(message)),
+    },
+    Number,
+    String,
+    Boolean,
+    Math,
+    JSON,
+    Error,
+    Promise,
+    Date,
+    Array,
+    Object,
+    parseInt,
+  };
+
+  const promise = vm.runInNewContext(`(async () => { ${script} })()`, sandbox);
+  await promise;
+
+  return { outputs, warnings, pullRequestOptions, failure, elapsedMs };
+}
+
+describe('.github/workflows/_pr-mergeability-gate.yml — gate behavior', () => {
+  let gate;
+  let workflowSource;
+  let workflowParsed;
+
+  beforeAll(() => {
+    gate = loadGateScript();
+    workflowSource = gate.source;
+    workflowParsed = gate.parsed;
+  });
+
+  it('defines a reusable workflow_call contract with required inputs and outputs', () => {
+    const wfCall = workflowParsed.on?.workflow_call ?? workflowParsed.true;
+    expect(wfCall, 'should define workflow_call trigger').toBeTruthy();
+    expect(wfCall.inputs?.['check-mergeability']?.type).toBe('boolean');
+    expect(wfCall.inputs?.['check-mergeability']?.required).toBe(true);
+    expect(wfCall.inputs?.['pull-request-number']?.type).toBe('string');
+    expect(wfCall.inputs?.['pull-request-number']?.required).toBe(true);
+    expect(wfCall.inputs?.['expected-head-sha']?.type).toBe('string');
+    expect(wfCall.inputs?.['expected-head-sha']?.required).toBe(false);
+    expect(wfCall.outputs?.['should-run']?.value).toContain(
+      'jobs.gate.outputs.should-run',
+    );
+    expect(wfCall.outputs?.['reason']?.value).toContain(
+      'jobs.gate.outputs.reason',
+    );
+  });
+
+  it('uses the repository-pinned actions/github-script SHA', () => {
+    expect(gate.scriptStep.uses).toBe(
+      'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b',
+    );
+    // The ratchet comment is stripped by YAML parsing; verify from raw source.
+    expect(workflowSource).toContain(
+      'actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7',
+    );
+  });
+
+  it('has exactly pull-requests: read permission and no other permissions', () => {
+    const permissions = workflowParsed.permissions;
+    expect(permissions).toEqual({ 'pull-requests': 'read' });
+  });
+
+  it('does not check out code, run shell steps, or receive secrets', () => {
+    const wfCall = workflowParsed.on?.workflow_call ?? workflowParsed.true;
+    expect(wfCall.secrets).toBeUndefined();
+    const steps = gate.gateJob.steps ?? [];
+    for (const step of steps) {
+      expect(step.uses, 'no checkout step').not.toContain('actions/checkout');
+      expect(step.run, 'no shell run step').toBeUndefined();
+    }
+    const scriptEnv = gate.scriptStep.env ?? {};
+    const envKeys = Object.keys(scriptEnv);
+    for (const key of envKeys) {
+      expect(scriptEnv[key]).not.toContain('secrets.');
+    }
+  });
+
+  it('bypass allows without requiring a PR number when check-mergeability is false', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'false',
+        PULL_REQUEST_NUMBER: '',
+      },
+      pullsGetSequence: [],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('true');
+    expect(result.outputs['reason']).toBe('bypass');
+  });
+
+  it('permits when REST mergeable is true', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: [{ mergeable: true, head: { sha: 'aaa111' } }],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('true');
+    expect(result.outputs['reason']).toBe('mergeable');
+  });
+
+  it('skips with conflict reason when REST mergeable is false', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: [{ mergeable: false, head: { sha: 'aaa111' } }],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('false');
+    expect(result.outputs['reason']).toBe('conflict');
+  });
+
+  it('permits when null is followed by true', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: [
+        { mergeable: null, head: { sha: 'aaa111' } },
+        { mergeable: true, head: { sha: 'aaa111' } },
+      ],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('true');
+    expect(result.outputs['reason']).toBe('mergeable');
+  });
+
+  it('settles on the fifth poll after exactly four delays', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: [
+        { mergeable: null, head: { sha: 'aaa111' } },
+        { mergeable: null, head: { sha: 'aaa111' } },
+        { mergeable: null, head: { sha: 'aaa111' } },
+        { mergeable: null, head: { sha: 'aaa111' } },
+        { mergeable: true, head: { sha: 'aaa111' } },
+      ],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs).toEqual({
+      'should-run': 'true',
+      reason: 'mergeable',
+    });
+    expect(result.elapsedMs).toBe(8000);
+  });
+
+  it('skips with conflict reason when null is followed by false', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: [
+        { mergeable: null, head: { sha: 'aaa111' } },
+        { mergeable: false, head: { sha: 'aaa111' } },
+      ],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('false');
+    expect(result.outputs['reason']).toBe('conflict');
+  });
+
+  it('warns and fails open when mergeable remains null after bounded polling', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: Array.from({ length: 5 }, () => ({
+        mergeable: null,
+        head: { sha: 'aaa111' },
+      })),
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('true');
+    expect(result.outputs['reason']).toBe('uncertain');
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.elapsedMs).toBe(8000);
+  });
+
+  it('passes a bounded timeout to every Octokit request and treats timeout as transient', async () => {
+    const timeoutErrors = Array.from({ length: 5 }, () =>
+      Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' }),
+    );
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: timeoutErrors,
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs).toEqual({
+      'should-run': 'true',
+      reason: 'uncertain',
+    });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('transient API uncertainty');
+    expect(result.pullRequestOptions).toHaveLength(5);
+    for (const requestOptions of result.pullRequestOptions) {
+      expect(requestOptions.request).toEqual({ timeout: 10000 });
+    }
+    expect(result.elapsedMs).toBe(8000);
+  });
+
+  for (const status of [401, 403, 404, 422]) {
+    it(`fails visibly without failing open for permanent REST ${status}`, async () => {
+      const apiError = new Error(
+        `request rejected with Authorization: Bearer super-secret-${status}`,
+      );
+      apiError.status = status;
+      const result = await executeGateScript({
+        script: gate.script,
+        env: {
+          CHECK_MERGEABILITY: 'true',
+          PULL_REQUEST_NUMBER: '42',
+        },
+        pullsGetSequence: [apiError],
+      });
+
+      expect(result.failure).toBe(
+        `GitHub REST API rejected the mergeability check for PR #42 with status ${status}.`,
+      );
+      expect(result.failure).not.toContain('super-secret');
+      expect(result.outputs['should-run']).toBeUndefined();
+      expect(result.outputs['reason']).toBeUndefined();
+      expect(result.warnings).toEqual([]);
+    });
+  }
+
+  for (const errorCase of [
+    { name: 'REST 429', status: 429 },
+    { name: 'REST 500', status: 500 },
+    { name: 'REST 503', status: 503 },
+  ]) {
+    it(`warns and fails open after ${errorCase.name} uncertainty is exhausted`, async () => {
+      const pullsGetSequence = Array.from({ length: 5 }, () => {
+        const apiError = new Error(
+          'request failed with x-api-key: super-secret-retry-token',
+        );
+        apiError.status = errorCase.status;
+        return apiError;
+      });
+      const result = await executeGateScript({
+        script: gate.script,
+        env: {
+          CHECK_MERGEABILITY: 'true',
+          PULL_REQUEST_NUMBER: '42',
+        },
+        pullsGetSequence,
+      });
+
+      expect(result.failure).toBeNull();
+      expect(result.outputs['should-run']).toBe('true');
+      expect(result.outputs['reason']).toBe('uncertain');
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).not.toContain('super-secret');
+      expect(result.elapsedMs).toBe(8000);
+    });
+  }
+
+  it('gives a permanent HTTP status precedence over a nested network code', async () => {
+    const apiError = Object.assign(
+      new Error('request rejected', {
+        cause: Object.assign(new Error('socket reset'), {
+          code: 'ECONNRESET',
+        }),
+      }),
+      { status: 401 },
+    );
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+      },
+      pullsGetSequence: [apiError],
+    });
+
+    expect(result.failure).toBe(
+      'GitHub REST API rejected the mergeability check for PR #42 with status 401.',
+    );
+    expect(result.outputs).toEqual({});
+    expect(result.warnings).toEqual([]);
+    expect(result.elapsedMs).toBe(0);
+  });
+
+  for (const errorCase of [
+    {
+      name: 'a direct ECONNRESET network failure',
+      create: () =>
+        Object.assign(new Error('socket disconnected with secret-token'), {
+          code: 'ECONNRESET',
+        }),
+    },
+    {
+      name: 'an Undici connect timeout in a cause chain',
+      create: () =>
+        new TypeError('fetch failed with secret-token', {
+          cause: Object.assign(new Error('connect timed out'), {
+            code: 'UND_ERR_CONNECT_TIMEOUT',
+          }),
+        }),
+    },
+  ]) {
+    it(`warns and fails open after ${errorCase.name} is exhausted`, async () => {
+      const result = await executeGateScript({
+        script: gate.script,
+        env: {
+          CHECK_MERGEABILITY: 'true',
+          PULL_REQUEST_NUMBER: '42',
+        },
+        pullsGetSequence: Array.from({ length: 5 }, errorCase.create),
+      });
+
+      expect(result.failure).toBeNull();
+      expect(result.outputs).toEqual({
+        'should-run': 'true',
+        reason: 'uncertain',
+      });
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).not.toContain('secret-token');
+      expect(result.elapsedMs).toBe(8000);
+    });
+  }
+
+  for (const errorCase of [
+    {
+      name: 'an unknown TypeError',
+      create: () =>
+        new TypeError('invalid runtime configuration: secret-token'),
+    },
+    {
+      name: 'an unknown statusless Error',
+      create: () => new Error('invalid action configuration: secret-token'),
+    },
+  ]) {
+    it(`fails visibly for ${errorCase.name}`, async () => {
+      const result = await executeGateScript({
+        script: gate.script,
+        env: {
+          CHECK_MERGEABILITY: 'true',
+          PULL_REQUEST_NUMBER: '42',
+        },
+        pullsGetSequence: [errorCase.create()],
+      });
+
+      expect(result.failure).toBe(
+        'GitHub REST API failed the mergeability check for PR #42 with an unrecognized error.',
+      );
+      expect(result.failure).not.toContain('secret-token');
+      expect(result.outputs).toEqual({});
+      expect(result.warnings).toEqual([]);
+      expect(result.elapsedMs).toBe(0);
+    });
+  }
+
+  it('skips stale event work when current API head differs from expected head', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+        EXPECTED_HEAD_SHA: 'expected-sha-000',
+      },
+      pullsGetSequence: [{ mergeable: true, head: { sha: 'current-sha-999' } }],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('false');
+    expect(result.outputs['reason']).toBe('stale-head');
+  });
+
+  it('permits when expected head matches current API head and mergeable is true', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '42',
+        EXPECTED_HEAD_SHA: 'matching-sha',
+      },
+      pullsGetSequence: [{ mergeable: true, head: { sha: 'matching-sha' } }],
+    });
+
+    expect(result.failure).toBeNull();
+    expect(result.outputs['should-run']).toBe('true');
+    expect(result.outputs['reason']).toBe('mergeable');
+  });
+
+  it('fails visibly when PR number is missing with checking enabled', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: '',
+      },
+      pullsGetSequence: [],
+    });
+
+    expect(result.failure).toBeTruthy();
+    expect(result.outputs['should-run']).toBeUndefined();
+  });
+
+  it('fails visibly when PR number is non-numeric with checking enabled', async () => {
+    const result = await executeGateScript({
+      script: gate.script,
+      env: {
+        CHECK_MERGEABILITY: 'true',
+        PULL_REQUEST_NUMBER: 'not-a-number',
+      },
+      pullsGetSequence: [],
+    });
+
+    expect(result.failure).toBeTruthy();
+    expect(result.outputs['should-run']).toBeUndefined();
+  });
+
+  it('does not consume event-payload mergeable or mergeable_state', () => {
+    const scriptText = gate.script;
+    expect(scriptText).not.toContain('mergeable_state');
+    expect(scriptText).not.toContain('context.payload.pull_request.mergeable');
+    expect(scriptText).not.toContain('payload.mergeable');
+  });
+
+  it('passes the PR number to pulls.get using the validated numeric value', () => {
+    const scriptText = gate.script;
+    expect(scriptText).toContain('github.rest.pulls.get');
+    expect(scriptText).toContain('pull_number');
+    expect(scriptText).toContain('context.repo.owner');
+    expect(scriptText).toContain('context.repo.repo');
+  });
+});

--- a/scripts/tests/pr-mergeability-gate.test.js
+++ b/scripts/tests/pr-mergeability-gate.test.js
@@ -134,6 +134,7 @@ async function executeGateScript({ script, env = {}, pullsGetSequence = [] }) {
       log: () => {},
       warn: (message) => warnings.push(String(message)),
     },
+    AbortSignal,
     Number,
     String,
     Boolean,
@@ -358,7 +359,7 @@ describe('.github/workflows/_pr-mergeability-gate.yml — gate behavior', () => 
     expect(result.warnings[0]).toContain('transient API uncertainty');
     expect(result.pullRequestOptions).toHaveLength(5);
     for (const requestOptions of result.pullRequestOptions) {
-      expect(requestOptions.request).toEqual({ timeout: 10000 });
+      expect(requestOptions.request.signal).toBeDefined();
     }
     expect(result.elapsedMs).toBe(8000);
   });

--- a/scripts/tests/pr-mergeability-workflow-test-helpers.js
+++ b/scripts/tests/pr-mergeability-workflow-test-helpers.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+function runGit(cwd, args) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(' ')} failed: ${result.stderr || result.stdout}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+export function runFetchHeadStepWithRealRepository(
+  step,
+  { expectedHeadSha } = {},
+) {
+  const root = mkdtempSync(path.join(tmpdir(), 'pr-review-real-head-'));
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const workspace = path.join(root, 'workspace');
+  const githubEnv = path.join(root, 'github-env');
+  const githubOutput = path.join(root, 'github-output');
+
+  try {
+    mkdirSync(seed);
+    runGit(root, ['init', '--bare', remote]);
+    runGit(seed, ['init', '--initial-branch=main']);
+    runGit(seed, ['config', 'user.name', 'Workflow Test']);
+    runGit(seed, ['config', 'user.email', 'workflow-test@example.com']);
+    writeFileSync(path.join(seed, 'base.txt'), 'base\n');
+    runGit(seed, ['add', 'base.txt']);
+    runGit(seed, ['commit', '-m', 'base']);
+    const baseSha = runGit(seed, ['rev-parse', 'HEAD']);
+    runGit(seed, ['remote', 'add', 'origin', remote]);
+    runGit(seed, ['push', 'origin', 'main']);
+    runGit(remote, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+    runGit(seed, ['checkout', '-b', 'feature-branch']);
+    writeFileSync(path.join(seed, 'feature.txt'), 'feature\n');
+    runGit(seed, ['add', 'feature.txt']);
+    runGit(seed, ['commit', '-m', 'feature']);
+    const headSha = runGit(seed, ['rev-parse', 'HEAD']);
+    runGit(seed, ['push', 'origin', 'feature-branch']);
+    runGit(root, ['clone', remote, workspace]);
+    writeFileSync(githubEnv, '');
+    writeFileSync(githubOutput, '');
+
+    const script = step.run.replace(
+      "'${{ github.event.pull_request.base.sha }}'",
+      `'${baseSha}'`,
+    );
+    const result = spawnSync('bash', ['-c', script], {
+      cwd: workspace,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PR_NUMBER: '42',
+        REPO: 'owner/repo',
+        GITHUB_TOKEN: 'test-token',
+        HEAD_REF_VALUE: 'feature-branch',
+        HEAD_REPO_VALUE: 'owner/repo',
+        EXPECTED_HEAD_SHA: expectedHeadSha ?? headSha,
+        GITHUB_ENV: githubEnv,
+        GITHUB_OUTPUT: githubOutput,
+      },
+    });
+
+    return {
+      status: result.status,
+      stderr: result.stderr,
+      baseSha,
+      headSha,
+      fetchedHeadSha: runGit(workspace, ['rev-parse', 'refs/pr/42']),
+      exportedEnvironment: readFileSync(githubEnv, 'utf8'),
+      exportedOutputs: readFileSync(githubOutput, 'utf8'),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/scripts/tests/pr-mergeability-workflow-wiring.test.js
+++ b/scripts/tests/pr-mergeability-workflow-wiring.test.js
@@ -1,0 +1,842 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import vm from 'vm';
+import yaml from 'js-yaml';
+import { normalize, readRootFile } from './ocr-review-workflow-helpers.js';
+import { runFetchHeadStepWithRealRepository } from './pr-mergeability-workflow-test-helpers.js';
+
+function loadWorkflow(path) {
+  const source = readRootFile(path);
+  try {
+    const parsed = yaml.load(source);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error(`${path} did not parse to a YAML mapping`);
+    }
+    return { source, parsed };
+  } catch (error) {
+    throw new Error(`Failed to parse ${path}: ${error.message}`, {
+      cause: error,
+    });
+  }
+}
+
+const OCR_AUTHORIZATION_PREDICATE = `
+  github.event_name == 'workflow_dispatch' ||
+  github.event_name == 'pull_request_target' ||
+  (github.event_name == 'issue_comment' &&
+   github.event.issue.pull_request != null &&
+   (github.event.comment.author_association == 'OWNER' ||
+    github.event.comment.author_association == 'MEMBER' ||
+    github.event.comment.author_association == 'COLLABORATOR') &&
+   (github.event.comment.body == '/ocr' ||
+    startsWith(github.event.comment.body, '/ocr ') ||
+    startsWith(toJSON(github.event.comment.body), '"/ocr\\n') ||
+    startsWith(toJSON(github.event.comment.body), '"/ocr\\r\\n') ||
+    startsWith(toJSON(github.event.comment.body), '"/ocr\\t') ||
+    github.event.comment.body == '/open-code-review' ||
+    startsWith(github.event.comment.body, '/open-code-review ') ||
+    startsWith(toJSON(github.event.comment.body), '"/open-code-review\\n') ||
+    startsWith(toJSON(github.event.comment.body), '"/open-code-review\\r\\n') ||
+    startsWith(toJSON(github.event.comment.body), '"/open-code-review\\t')))
+`;
+
+const OCR_CONCURRENCY_GROUP = `
+  \${{
+    (github.event_name == 'workflow_dispatch' ||
+     github.event_name == 'pull_request_target' ||
+     (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      (github.event.comment.body == '/ocr' ||
+       startsWith(github.event.comment.body, '/ocr ') ||
+       startsWith(toJSON(github.event.comment.body), '"/ocr\\n') ||
+       startsWith(toJSON(github.event.comment.body), '"/ocr\\r\\n') ||
+       startsWith(toJSON(github.event.comment.body), '"/ocr\\t') ||
+       github.event.comment.body == '/open-code-review' ||
+       startsWith(github.event.comment.body, '/open-code-review ') ||
+       startsWith(toJSON(github.event.comment.body), '"/open-code-review\\n') ||
+       startsWith(toJSON(github.event.comment.body), '"/open-code-review\\r\\n') ||
+       startsWith(toJSON(github.event.comment.body), '"/open-code-review\\t')))) &&
+    format('{0}-pr-{1}', github.workflow,
+      github.event.pull_request.number || github.event.issue.number || inputs.pr_number) ||
+    format('{0}-run-{1}', github.workflow, github.run_id)
+  }}
+`;
+
+function evaluateOcrConcurrencyGroup(group, { github, inputs = {} }) {
+  const expression = group.trim().slice(3, -2).trim();
+  return vm.runInNewContext(expression, {
+    github,
+    inputs,
+    startsWith: (value, prefix) => String(value).startsWith(prefix),
+    toJSON: (value) => JSON.stringify(value),
+    format: (template, ...values) =>
+      template.replace(/{(\d+)}/g, (_match, index) => values[Number(index)]),
+  });
+}
+
+function ocrConcurrencyContext({
+  eventName,
+  runId,
+  pullRequestNumber = null,
+  issueNumber = null,
+  issueIsPullRequest = false,
+  association = 'NONE',
+  body = '',
+  inputPrNumber = '',
+}) {
+  return {
+    github: {
+      workflow: 'OCR Review',
+      run_id: runId,
+      event_name: eventName,
+      event: {
+        pull_request: { number: pullRequestNumber },
+        issue: {
+          number: issueNumber,
+          pull_request: issueIsPullRequest ? {} : null,
+        },
+        comment: {
+          author_association: association,
+          body,
+        },
+      },
+    },
+    inputs: { pr_number: inputPrNumber },
+  };
+}
+
+const E2E_GATE_PREDICATE = `
+  \${{ needs.skip_check.result == 'success' &&
+      needs.skip_check.outputs.should_skip != 'true' &&
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'maintainer:e2e:ok' }}
+`;
+
+const E2E_DOC_FILTER_PREDICATE = `
+  \${{ needs.skip_check.result == 'success' &&
+      needs.skip_check.outputs.should_skip != 'true' &&
+      (github.event_name != 'pull_request_target' ||
+       (github.event.action == 'labeled' &&
+        github.event.label.name == 'maintainer:e2e:ok')) }}
+`;
+
+function evaluateE2ECondition(condition, context) {
+  const expression = condition
+    .replaceAll('needs.mergeability-gate', "needs['mergeability-gate']")
+    .replaceAll('.outputs.should-run', ".outputs['should-run']")
+    .trim();
+  return vm.runInNewContext(expression, {
+    ...context,
+    cancelled: () => context.cancelled ?? false,
+  });
+}
+
+function e2eContext({
+  eventName,
+  action = '',
+  label = '',
+  headRepository = 'vybestack/llxprt-code',
+  repository = 'vybestack/llxprt-code',
+  skipResult = 'success',
+  shouldSkip = 'false',
+  docResult = 'success',
+  docsOnly = 'false',
+  gateResult = 'skipped',
+  shouldRun,
+  cancelled = false,
+}) {
+  return {
+    cancelled,
+    github: {
+      event_name: eventName,
+      event: {
+        action,
+        label: { name: label },
+        pull_request: { head: { repo: { full_name: headRepository } } },
+      },
+      repository,
+    },
+    needs: {
+      skip_check: { result: skipResult, outputs: { should_skip: shouldSkip } },
+      e2e_doc_change_filter: {
+        result: docResult,
+        outputs: { docs_only: docsOnly },
+      },
+      'mergeability-gate': {
+        result: gateResult,
+        outputs: { 'should-run': shouldRun },
+      },
+    },
+  };
+}
+
+describe('OCR mergeability gate wiring (.github/workflows/ocr-review.yml)', () => {
+  let parsed;
+  let notifierParsed;
+  let gateJob;
+  let codeReviewJob;
+  let classifyJob;
+  let notifyJob;
+
+  beforeAll(() => {
+    const wf = loadWorkflow('.github/workflows/ocr-review.yml');
+    const notifier = loadWorkflow(
+      '.github/workflows/ocr-infrastructure-notifier.yml',
+    );
+    parsed = wf.parsed;
+    notifierParsed = notifier.parsed;
+    gateJob = parsed.jobs?.['mergeability-gate'];
+    codeReviewJob = parsed.jobs?.['code-review'];
+    classifyJob = notifierParsed.jobs?.['classify-ocr-run'];
+    notifyJob = notifierParsed.jobs?.['notify-ocr-infrastructure-failure'];
+  });
+
+  it('adds a mergeability-gate job that calls the reusable gate', () => {
+    expect(gateJob, 'should contain mergeability-gate job').toBeTruthy();
+    const uses = gateJob.uses;
+    expect(uses).toBe('./.github/workflows/_pr-mergeability-gate.yml');
+  });
+
+  it('gate job carries the exact authorized event/comment predicate', () => {
+    expect(normalize(gateJob.if)).toBe(normalize(OCR_AUTHORIZATION_PREDICATE));
+  });
+
+  it('gate job passes check-mergeability=false for workflow_dispatch bypass', () => {
+    const withInputs = gateJob.with;
+    // workflow_dispatch bypasses: check-mergeability is false for dispatch
+    // and true for all other authorized events.
+    expect(withInputs['check-mergeability']).toBe(
+      "${{ github.event_name != 'workflow_dispatch' }}",
+    );
+  });
+
+  it('formats the event/input PR number as the reusable string input', () => {
+    expect(gateJob.with['pull-request-number']).toBe(
+      "${{ format('{0}', github.event.pull_request.number || github.event.issue.number || inputs.pr_number) }}",
+    );
+  });
+
+  it('passes the event head only for automatic pull_request_target work', () => {
+    expect(gateJob.with['expected-head-sha']).toBe(
+      "${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}",
+    );
+  });
+
+  it('does not pass a secrets contract to the reusable workflow', () => {
+    expect(gateJob.secrets).toBeUndefined();
+  });
+
+  it('uses the exact authorization-aware workflow concurrency group', () => {
+    expect(normalize(parsed.concurrency?.group)).toBe(
+      normalize(OCR_CONCURRENCY_GROUP),
+    );
+    expect(parsed.concurrency?.['cancel-in-progress']).toBe(true);
+  });
+
+  it('keeps the sequential gate and review inside one workflow concurrency owner', () => {
+    expect(gateJob.concurrency).toBeUndefined();
+    expect(codeReviewJob.concurrency).toBeUndefined();
+    expect(codeReviewJob.needs).toEqual(['mergeability-gate']);
+    expect(parsed.jobs?.['notify-ocr-infrastructure-failure']).toBeUndefined();
+  });
+
+  it('isolates the notifier in a completed-workflow run that newer reviews cannot cancel', () => {
+    const workflowRun =
+      notifierParsed.on?.workflow_run ?? notifierParsed.true?.workflow_run;
+
+    expect(workflowRun.workflows).toEqual(['OCR Review']);
+    expect(workflowRun.types).toEqual(['completed']);
+    expect(notifierParsed.concurrency).toBeUndefined();
+    expect(classifyJob.concurrency).toBeUndefined();
+    expect(notifyJob.concurrency?.group).toBe(
+      'ocr-review-infrastructure-issue',
+    );
+    expect(notifyJob.concurrency?.['cancel-in-progress']).toBe(false);
+    expect(normalize(classifyJob.if)).toBe(
+      normalize(
+        "${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}",
+      ),
+    );
+    expect(normalize(notifyJob.if)).toContain(
+      normalize("needs.classify-ocr-run.result == 'success'"),
+    );
+  });
+
+  const authorizedScenarios = [
+    ocrConcurrencyContext({
+      eventName: 'pull_request_target',
+      runId: 101,
+      pullRequestNumber: 42,
+    }),
+    ocrConcurrencyContext({
+      eventName: 'issue_comment',
+      runId: 102,
+      issueNumber: 42,
+      issueIsPullRequest: true,
+      association: 'OWNER',
+      body: '/ocr',
+    }),
+    ocrConcurrencyContext({
+      eventName: 'issue_comment',
+      runId: 103,
+      issueNumber: 42,
+      issueIsPullRequest: true,
+      association: 'COLLABORATOR',
+      body: '/open-code-review details',
+    }),
+    ocrConcurrencyContext({
+      eventName: 'workflow_dispatch',
+      runId: 104,
+      inputPrNumber: '42',
+    }),
+  ];
+
+  for (const [index, scenario] of authorizedScenarios.entries()) {
+    it(`maps authorized PR trigger ${index + 1} to the shared per-PR group`, () => {
+      expect(
+        evaluateOcrConcurrencyGroup(parsed.concurrency.group, scenario),
+      ).toBe('OCR Review-pr-42');
+    });
+  }
+
+  const isolatedScenarios = [
+    {
+      context: ocrConcurrencyContext({
+        eventName: 'issue_comment',
+        runId: 201,
+        issueNumber: 42,
+        issueIsPullRequest: true,
+        association: 'NONE',
+        body: '/ocr',
+      }),
+      expected: 'OCR Review-run-201',
+    },
+    {
+      context: ocrConcurrencyContext({
+        eventName: 'issue_comment',
+        runId: 202,
+        issueNumber: 42,
+        issueIsPullRequest: true,
+        association: 'MEMBER',
+        body: 'please review',
+      }),
+      expected: 'OCR Review-run-202',
+    },
+    {
+      context: ocrConcurrencyContext({
+        eventName: 'issue_comment',
+        runId: 203,
+        issueNumber: 42,
+        association: 'OWNER',
+        body: '/ocr',
+      }),
+      expected: 'OCR Review-run-203',
+    },
+  ];
+
+  for (const scenario of isolatedScenarios) {
+    it(`isolates unauthorized or non-PR comments as ${scenario.expected}`, () => {
+      expect(
+        evaluateOcrConcurrencyGroup(parsed.concurrency.group, scenario.context),
+      ).toBe(scenario.expected);
+    });
+  }
+
+  it('code-review needs mergeability-gate and runs only when should-run is true', () => {
+    expect(codeReviewJob.needs).toContain('mergeability-gate');
+    const jobIf = normalize(codeReviewJob.if);
+    expect(jobIf).toContain(
+      normalize("needs.mergeability-gate.outputs.should-run == 'true'"),
+    );
+  });
+
+  it('unprivileged classification reads the completed OCR artifact before notification', () => {
+    const downloadStep = classifyJob.steps.find(
+      (step) => step.name === 'Download OCR artifacts',
+    );
+
+    expect(classifyJob.permissions).toEqual({ actions: 'read' });
+    expect(notifyJob.needs).toBe('classify-ocr-run');
+    expect(notifyJob.permissions).toEqual({ issues: 'write' });
+    expect(downloadStep.with['run-id']).toBe(
+      '${{ github.event.workflow_run.id }}',
+    );
+    expect(downloadStep.with['github-token']).toBe('${{ github.token }}');
+    expect(downloadStep.with.repository).toBe('${{ github.repository }}');
+    expect(
+      notifyJob.steps.some((step) => step.name === 'Download OCR artifacts'),
+    ).toBe(false);
+  });
+
+  it('preserves existing fork-safety, checkout, permissions, and command syntax', () => {
+    // The review job runs only when the gate permits; its own if is the
+    // should-run gate output, and the authorized predicate lives on the gate.
+    const codeReviewIf = normalize(codeReviewJob.if);
+    expect(codeReviewIf).toContain(
+      normalize("needs.mergeability-gate.outputs.should-run == 'true'"),
+    );
+    // Permissions unchanged
+    expect(parsed.permissions?.contents).toBe('read');
+    expect(parsed.permissions?.['pull-requests']).toBe('write');
+    expect(parsed.permissions?.issues).toBe('write');
+    // code-review still has the Resolve PR context step
+    expect(
+      codeReviewJob.steps.some((s) => s.name === 'Resolve PR context'),
+    ).toBe(true);
+    expect(codeReviewJob['timeout-minutes']).toBe(60);
+  });
+
+  it('the gate job has no checkout, no secrets, and no code execution', () => {
+    const steps = gateJob.steps ?? [];
+    expect(steps.length).toBe(0);
+    const withInputs = gateJob.with ?? {};
+    for (const value of Object.values(withInputs)) {
+      expect(String(value)).not.toContain('secrets.');
+    }
+    expect(gateJob.uses).not.toContain('actions/checkout');
+  });
+});
+
+describe('PR Review mergeability gate wiring (.github/workflows/pr-review.yml)', () => {
+  let parsed;
+  let gateJob;
+  let reviewJob;
+
+  beforeAll(() => {
+    const wf = loadWorkflow('.github/workflows/pr-review.yml');
+    parsed = wf.parsed;
+    gateJob = parsed.jobs?.['mergeability-gate'];
+    reviewJob = parsed.jobs?.review;
+  });
+
+  it('retains existing trigger types and workflow-level concurrency', () => {
+    const prt = parsed.on?.pull_request_target;
+    expect(prt.types).toContain('opened');
+    expect(prt.types).toContain('reopened');
+    expect(prt.types).toContain('synchronize');
+    expect(prt.types).toContain('ready_for_review');
+    expect(prt.types).toContain('edited');
+    expect(parsed.concurrency?.group).toContain(
+      'llxprt-pr-review-${{ github.event.pull_request.number }}',
+    );
+    expect(parsed.concurrency?.['cancel-in-progress']).toBe(true);
+  });
+
+  it('adds a read-only reusable gate before the expensive review', () => {
+    expect(gateJob, 'should contain mergeability-gate job').toBeTruthy();
+    expect(gateJob.uses).toBe('./.github/workflows/_pr-mergeability-gate.yml');
+  });
+
+  it('gate receives the string-formatted event PR number and head SHA', () => {
+    const withInputs = gateJob.with;
+    expect(withInputs['check-mergeability']).toBe(true);
+    expect(withInputs['pull-request-number']).toBe(
+      "${{ format('{0}', github.event.pull_request.number) }}",
+    );
+    expect(withInputs['expected-head-sha']).toBe(
+      '${{ github.event.pull_request.head.sha }}',
+    );
+  });
+
+  it('proceeds with a matching immutable head and exports real git results', () => {
+    const fetchStep = reviewJob.steps.find(
+      (step) => step.name === 'Fetch pull request head',
+    );
+    const result = runFetchHeadStepWithRealRepository(fetchStep);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('aborting');
+    expect(result.fetchedHeadSha).toBe(result.headSha);
+    expect(result.exportedEnvironment).toBe(
+      `PR_HEAD_REF=refs/pr/42\nPR_HEAD_SHA=${result.headSha}\nBASE_SHA=${result.baseSha}\nMERGE_BASE=${result.baseSha}\n`,
+    );
+    expect(result.exportedOutputs).toBe(
+      `head_sha=${result.headSha}\nbase_sha=${result.baseSha}\nmerge_base=${result.baseSha}\n`,
+    );
+  });
+
+  it('rejects a fetched branch tip that no longer matches the event head', () => {
+    const fetchStep = reviewJob.steps.find(
+      (step) => step.name === 'Fetch pull request head',
+    );
+
+    expect(fetchStep.env.EXPECTED_HEAD_SHA).toBe(
+      '${{ github.event.pull_request.head.sha }}',
+    );
+
+    const result = runFetchHeadStepWithRealRepository(fetchStep, {
+      expectedHeadSha: 'event-head-sha',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `Fetched PR head changed from event SHA event-head-sha to ${result.headSha}; aborting.`,
+    );
+    expect(result.exportedEnvironment).toBe('');
+    expect(result.exportedOutputs).toBe('');
+  });
+
+  it('does not pass a secrets contract to the reusable workflow', () => {
+    expect(gateJob.secrets).toBeUndefined();
+  });
+
+  it('review job needs the gate and runs only when permitted', () => {
+    expect(reviewJob.needs).toContain('mergeability-gate');
+    const reviewIf = normalize(reviewJob.if);
+    expect(reviewIf).toContain(
+      normalize("needs.mergeability-gate.outputs.should-run == 'true'"),
+    );
+  });
+
+  it('gate job does not receive provider secrets; only the review job does', () => {
+    const gateEnv = gateJob.env ?? {};
+    const gateWith = gateJob.with ?? {};
+    const gateSource = normalize(
+      JSON.stringify({ env: gateEnv, with: gateWith }),
+    );
+    expect(gateSource).not.toContain('OPENAI_API_KEY');
+    expect(gateSource).not.toContain('KEY_VAR_NAME');
+
+    // Review job should still have provider secrets
+    const reviewEnv = reviewJob.env ?? {};
+    const reviewEnvStr = JSON.stringify(reviewEnv);
+    expect(reviewEnvStr).toContain('OPENAI_API_KEY');
+  });
+});
+
+describe('E2E mergeability gate wiring (.github/workflows/e2e.yml)', () => {
+  let parsed;
+  let linuxJob;
+  let macJob;
+  let gateJob;
+  let docFilterJob;
+
+  beforeAll(() => {
+    const wf = loadWorkflow('.github/workflows/e2e.yml');
+    parsed = wf.parsed;
+    linuxJob = parsed.jobs?.e2e_linux;
+    macJob = parsed.jobs?.e2e_mac;
+    gateJob = parsed.jobs?.['mergeability-gate'];
+    docFilterJob = parsed.jobs?.e2e_doc_change_filter;
+  });
+
+  it('retains existing push, pull_request, merge_group, workflow_dispatch triggers', () => {
+    expect(parsed.on?.push).toBeTruthy();
+    expect(parsed.on?.pull_request).toBeTruthy();
+    expect(Object.prototype.hasOwnProperty.call(parsed.on, 'merge_group')).toBe(
+      true,
+    );
+    expect(parsed.on?.workflow_dispatch).toBeTruthy();
+  });
+
+  it('permits only labeled pull_request_target triggers', () => {
+    expect(parsed.on?.pull_request_target?.types).toEqual(['labeled']);
+  });
+
+  it('limits mergeability gate and target setup to the exact approved label event', () => {
+    expect(normalize(gateJob.if)).toBe(normalize(E2E_GATE_PREDICATE));
+    expect(normalize(docFilterJob.if)).toBe(
+      normalize(E2E_DOC_FILTER_PREDICATE),
+    );
+  });
+
+  it('passes no secrets contract to the target mergeability gate', () => {
+    expect(gateJob.secrets).toBeUndefined();
+  });
+
+  it('formats the event PR number as the reusable string input', () => {
+    expect(gateJob.with['pull-request-number']).toBe(
+      "${{ format('{0}', github.event.pull_request.number) }}",
+    );
+  });
+
+  const truthTable = [
+    {
+      name: 'push with intentionally skipped gate',
+      eventName: 'push',
+      linux: true,
+      mac: false,
+    },
+    {
+      name: 'merge group with intentionally skipped gate',
+      eventName: 'merge_group',
+      linux: true,
+      mac: true,
+    },
+    {
+      name: 'manual dispatch with intentionally skipped gate',
+      eventName: 'workflow_dispatch',
+      linux: true,
+      mac: true,
+    },
+    {
+      name: 'internal pull request with intentionally skipped gate',
+      eventName: 'pull_request',
+      linux: true,
+      mac: true,
+    },
+    {
+      name: 'fork pull request in native context',
+      eventName: 'pull_request',
+      headRepository: 'fork/repo',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'approved target event with successful true gate',
+      eventName: 'pull_request_target',
+      headRepository: 'fork/repo',
+      action: 'labeled',
+      label: 'maintainer:e2e:ok',
+      gateResult: 'success',
+      shouldRun: 'true',
+      linux: true,
+      mac: true,
+    },
+    {
+      name: 'approved internal target event',
+      eventName: 'pull_request_target',
+      headRepository: 'vybestack/llxprt-code',
+      action: 'labeled',
+      label: 'maintainer:e2e:ok',
+      gateResult: 'success',
+      shouldRun: 'true',
+      linux: true,
+      mac: true,
+    },
+    {
+      name: 'approved target event with false gate',
+      eventName: 'pull_request_target',
+      headRepository: 'fork/repo',
+      action: 'labeled',
+      label: 'maintainer:e2e:ok',
+      gateResult: 'success',
+      shouldRun: 'false',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'approved target event with failed gate',
+      eventName: 'pull_request_target',
+      headRepository: 'fork/repo',
+      action: 'labeled',
+      label: 'maintainer:e2e:ok',
+      gateResult: 'failure',
+      shouldRun: 'true',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'approved target event with skipped gate',
+      eventName: 'pull_request_target',
+      headRepository: 'fork/repo',
+      action: 'labeled',
+      label: 'maintainer:e2e:ok',
+      gateResult: 'skipped',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'unapproved target label',
+      eventName: 'pull_request_target',
+      headRepository: 'fork/repo',
+      action: 'labeled',
+      label: 'other',
+      gateResult: 'skipped',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'fork synchronize cannot reuse a persistent approval label',
+      eventName: 'pull_request_target',
+      headRepository: 'fork/repo',
+      action: 'synchronize',
+      gateResult: 'skipped',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'failed duplicate check',
+      eventName: 'merge_group',
+      skipResult: 'failure',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'duplicate content',
+      eventName: 'merge_group',
+      shouldSkip: 'true',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'failed doc filter',
+      eventName: 'merge_group',
+      docResult: 'failure',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'documentation-only change',
+      eventName: 'merge_group',
+      docsOnly: 'true',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'native event with failed gate',
+      eventName: 'merge_group',
+      gateResult: 'failure',
+      linux: false,
+      mac: false,
+    },
+    {
+      name: 'cancelled workflow',
+      eventName: 'merge_group',
+      cancelled: true,
+      linux: false,
+      mac: false,
+    },
+  ];
+
+  for (const scenario of truthTable) {
+    it(`enforces dependency and authorization truth table: ${scenario.name}`, () => {
+      const context = e2eContext(scenario);
+
+      expect(Boolean(evaluateE2ECondition(linuxJob.if, context))).toBe(
+        scenario.linux,
+      );
+      expect(Boolean(evaluateE2ECondition(macJob.if, context))).toBe(
+        scenario.mac,
+      );
+    });
+  }
+
+  it('models every target event with an explicit fork head plus preserved internal behavior', () => {
+    const targetScenarios = truthTable.filter(
+      (scenario) => scenario.eventName === 'pull_request_target',
+    );
+    const internalScenario = targetScenarios.find(
+      (scenario) => scenario.name === 'approved internal target event',
+    );
+
+    expect(internalScenario).toMatchObject({
+      headRepository: 'vybestack/llxprt-code',
+      linux: true,
+      mac: true,
+    });
+    for (const scenario of targetScenarios) {
+      expect(
+        Object.prototype.hasOwnProperty.call(scenario, 'headRepository'),
+        `${scenario.name} must declare its head repository`,
+      ).toBe(true);
+      if (scenario !== internalScenario) {
+        expect(scenario.headRepository).toBe('fork/repo');
+      }
+    }
+  });
+  it('requires the exact dependency conjunctions for both E2E jobs', () => {
+    for (const job of [linuxJob, macJob]) {
+      expect(job.needs).toEqual([
+        'e2e_doc_change_filter',
+        'skip_check',
+        'mergeability-gate',
+      ]);
+      const predicate = normalize(job.if);
+      expect(predicate).toContain(
+        normalize("needs.skip_check.result == 'success'"),
+      );
+      expect(predicate).toContain(
+        normalize("needs.e2e_doc_change_filter.result == 'success'"),
+      );
+      expect(predicate).toContain(
+        normalize("needs.mergeability-gate.result == 'success'"),
+      );
+      expect(predicate).toContain(
+        normalize("needs.mergeability-gate.outputs.should-run == 'true'"),
+      );
+      expect(predicate).toContain(
+        normalize("needs.mergeability-gate.result == 'skipped'"),
+      );
+      expect(predicate).not.toContain(
+        normalize("needs.mergeability-gate.outputs.should-run != 'false'"),
+      );
+    }
+  });
+
+  it('preserves Linux/macOS concurrency, docs-only skip, matrix, continue-on-error', () => {
+    expect(linuxJob.concurrency?.['cancel-in-progress']).toBe(true);
+    expect(macJob.concurrency?.['cancel-in-progress']).toBe(true);
+    expect(linuxJob.concurrency.group).toContain('${{ matrix.sandbox }}');
+    expect(macJob.continue_on_error ?? macJob['continue-on-error']).toBe(true);
+    expect(linuxJob.strategy?.matrix?.sandbox).toContain('sandbox:none');
+    expect(linuxJob.strategy?.matrix?.sandbox).toContain('sandbox:docker');
+  });
+
+  it('retains the duplicate-check action', () => {
+    const skipStep = parsed.jobs?.skip_check?.steps?.find(
+      (step) => step.id === 'skip_check',
+    );
+    expect(skipStep?.uses).toContain('skip-duplicate-actions');
+  });
+});
+
+describe('Intentionally unchanged native workflows', () => {
+  it('ci.yml does not reference the mergeability gate', () => {
+    const ci = readRootFile('.github/workflows/ci.yml');
+    expect(ci).not.toContain('_pr-mergeability-gate');
+    expect(ci).not.toContain('mergeability-gate');
+  });
+
+  it('interactive-ui.yml does not reference the mergeability gate', () => {
+    const ui = readRootFile('.github/workflows/interactive-ui.yml');
+    expect(ui).not.toContain('_pr-mergeability-gate');
+    expect(ui).not.toContain('mergeability-gate');
+  });
+
+  it('windows-installed-command.yml does not reference the mergeability gate', () => {
+    const win = readRootFile('.github/workflows/windows-installed-command.yml');
+    expect(win).not.toContain('_pr-mergeability-gate');
+    expect(win).not.toContain('mergeability-gate');
+  });
+
+  it('auto-label-trusted-contributors.yml does not reference the mergeability gate', () => {
+    const al = readRootFile(
+      '.github/workflows/auto-label-trusted-contributors.yml',
+    );
+    expect(al).not.toContain('_pr-mergeability-gate');
+    expect(al).not.toContain('mergeability-gate');
+  });
+
+  it('.coderabbit.yaml does not reference the mergeability gate', () => {
+    const cr = readRootFile('.coderabbit.yaml');
+    expect(cr).not.toContain('_pr-mergeability-gate');
+    expect(cr).not.toContain('mergeability-gate');
+  });
+});
+
+describe('Issue 2587 documented platform limitations', () => {
+  it('does not claim GITHUB_TOKEN auto-label writes trigger E2E recursively', () => {
+    const plan = readRootFile('project-plans/issue2587.md');
+    expect(plan).toContain(
+      'Events created by the repository `GITHUB_TOKEN` do not recursively start `labeled` workflows',
+    );
+    expect(plan).toContain(
+      'remove and re-add `maintainer:e2e:ok` after the head changes',
+    );
+    expect(plan).toContain('manual `workflow_dispatch`');
+    expect(plan).not.toContain(
+      'its `synchronize` behavior can apply the label that emits an authorized `labeled` event',
+    );
+    expect(plan).not.toContain('Approved fork E2E reevaluates mergeability');
+  });
+});


### PR DESCRIPTION
## Summary

- add a reusable, least-privilege pull request mergeability gate for trusted-context workflows
- skip OCR, LLxprt PR Review, and approved-fork E2E work while GitHub reports merge conflicts
- preserve fail-open behavior for transient mergeability uncertainty and fail visibly for permanent API/configuration errors
- bind automatic review work to the immutable event head so stale runs cannot review a newer branch tip
- preserve OCR authorization-aware cancellation while moving infrastructure notification into an independent workflow that survives superseding review runs
- require a fresh maintainer E2E approval event for changed fork heads rather than allowing a persistent label to authorize new code
- add behavioral workflow tests, real temporary-Git head-binding tests, notifier truth tables, and the implementation plan

## Scope decisions

GitHub already withholds ordinary pull_request workflows while conflicts exist, so CI, Interactive UI, Windows installed-command, and the internal-PR E2E path remain unchanged. Converting them to pull_request_target would weaken their security model.

CodeRabbit is an external GitHub App. The repository's current CodeRabbit configuration exposes no mergeability predicate that Actions can reliably use to prevent, cancel, and retrigger its reviews. This PR therefore leaves .coderabbit.yaml unchanged and documents that platform limitation.

## Security and behavior

- the reusable gate has only pull-requests read permission
- the gate checks out no code and receives no workflow-call secrets
- conflict decisions use the REST mergeable boolean, not webhook mergeability or mergeable_state
- null and transient API conditions use bounded polling and fail open
- permanent errors fail visibly with sanitized diagnostics
- stale expected-head events skip rather than running against a changed PR
- fork E2E remains limited to a fresh authorized labeled event and checks out the event's immutable head
- conflict-skipped OCR runs do not enter the privileged infrastructure-notification path

## Verification

- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
- actionlint 1.7.10 on all changed/new workflows
- Prettier checks on all changed/new files
- git diff --check
- 131 focused workflow tests plus 12 notifier-classification tests

Local yamllint was unavailable; actionlint and Prettier both successfully parsed and validated the workflow YAML.

Fixes #2587


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable mergeability gate to control whether PR reviews, E2E, and OCR code review run.
  * Added automated OCR infrastructure failure notification with issue creation/commenting and deduplication.
  * Strengthened mergeability gating for maintainer-approved E2E label events.
* **Bug Fixes**
  * Prevented reviews from proceeding when the PR head SHA changes during fetching.
  * Improved handling of uncertain vs permanent mergeability-check failures for safer CI decisions.
* **Tests**
  * Expanded Vitest coverage for mergeability gating, OCR notification classification/wiring, and workflow orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->