### PR TITLE
Synchronize runtime editor approval policies (Fixes #2659)

### DIFF
--- a/docs/policy-configuration.md
+++ b/docs/policy-configuration.md
@@ -161,19 +161,19 @@ active in:
 [[rule]]
 toolName = "replace"
 decision = "allow"
-priority = 15
+priority = 1.015
 modes = ["autoEdit"]
 
 # Only active in YOLO mode
 [[rule]]
 decision = "allow"
-allow_redirection = true
-priority = 999
+allowRedirection = true
+priority = 1.999
 modes = ["yolo"]
 ```
 
 When the approval mode changes (Ctrl-Y / Ctrl-E), the PolicyEngine's
-`currentMode` is atomically updated via `setApprovalMode()`. Rules with a
+`currentMode` is synchronously updated via `setApprovalMode()`. Rules with a
 `modes` filter that doesn't include the new mode are automatically skipped —
 rules without a `modes` filter always apply.
 
@@ -181,7 +181,7 @@ rules without a `modes` filter always apply.
 
 Mode-specific behavior is expressed declaratively via the `modes` field on
 individual rules. The PolicyEngine evaluates those rules dynamically at
-`evaluate()` time against `currentMode`, which is updated atomically via
+`evaluate()` time against `currentMode`, which is updated synchronously via
 `setApprovalMode()`. No rules are added or removed on transition — only the
 mode filter changes.
 
@@ -189,9 +189,10 @@ When `Config.setApprovalMode()` is called, it calls
 `syncModeDerivedPolicyRules()` which calls `setApprovalMode()` on the engine.
 This ensures:
 
-- YOLO→DEFAULT removes the wildcard ALLOW, reverting all tools to ASK_USER
-- AUTO_EDIT→DEFAULT removes per-tool ALLOW, reverting edit tools to ASK_USER
-- Non-mode rules (e.g., read-only ALLOW at priority 1.05) survive all transitions
+- YOLO→DEFAULT deactivates the mode-specific wildcard ALLOW
+- AUTO_EDIT→DEFAULT deactivates the mode-specific editor ALLOW rules
+- Non-mode rules and higher-priority rules remain active across transitions, so
+  their configured decisions still take precedence
 
 ### Initial CLI/Agent Parity
 

--- a/docs/policy-configuration.md
+++ b/docs/policy-configuration.md
@@ -144,6 +144,62 @@ Enterprise administrator policies (future use):
 | --------- | -------------------------------------- |
 | 3.0-3.999 | Reserved for enterprise admin policies |
 
+## Approval Mode Synchronization
+
+Approval modes (`DEFAULT`, `AUTO_EDIT`, `YOLO`) control how aggressively tools
+are auto-approved. The PolicyEngine evaluates mode-specific rules **dynamically**
+at `evaluate()` time using the `modes` filter — no TOML reload is needed on
+mode transitions.
+
+### The `modes` Filter
+
+Rules can declare a `modes` array to restrict which approval modes they are
+active in:
+
+```toml
+# Only active in AUTO_EDIT mode
+[[rule]]
+toolName = "replace"
+decision = "allow"
+priority = 15
+modes = ["autoEdit"]
+
+# Only active in YOLO mode
+[[rule]]
+decision = "allow"
+allow_redirection = true
+priority = 999
+modes = ["yolo"]
+```
+
+When the approval mode changes (Ctrl-Y / Ctrl-E), the PolicyEngine's
+`currentMode` is atomically updated via `setApprovalMode()`. Rules with a
+`modes` filter that doesn't include the new mode are automatically skipped —
+rules without a `modes` filter always apply.
+
+### Mode Transition Mechanism
+
+Mode-specific behavior is expressed declaratively via the `modes` field on
+individual rules. The PolicyEngine evaluates those rules dynamically at
+`evaluate()` time against `currentMode`, which is updated atomically via
+`setApprovalMode()`. No rules are added or removed on transition — only the
+mode filter changes.
+
+When `Config.setApprovalMode()` is called, it calls
+`syncModeDerivedPolicyRules()` which calls `setApprovalMode()` on the engine.
+This ensures:
+
+- YOLO→DEFAULT removes the wildcard ALLOW, reverting all tools to ASK_USER
+- AUTO_EDIT→DEFAULT removes per-tool ALLOW, reverting edit tools to ASK_USER
+- Non-mode rules (e.g., read-only ALLOW at priority 1.05) survive all transitions
+
+### Initial CLI/Agent Parity
+
+The `Config` constructor calls `syncModeDerivedPolicyRules()` after applying
+parameters, so an engine constructed with `approvalMode: YOLO` produces the
+same policy as an engine constructed in DEFAULT then transitioned to YOLO.
+This eliminates authorization desynchronization (issue #2659).
+
 ## Complete Example
 
 ```toml

--- a/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
@@ -61,6 +61,10 @@ import {
   type IToolMessageBus,
 } from '@vybestack/llxprt-code-tools';
 
+const AUTO_EDIT_RULE_PRIORITY = 1.015;
+const YOLO_RULE_PRIORITY = 1.999;
+const DEFAULT_TEST_MTIME_EPOCH_SECONDS = 1_000_000;
+
 // ── Real PolicyEngine config (mirrors production TOML) ──────────────────
 
 function buildTomlStyleConfig(): PolicyEngineConfig {
@@ -68,7 +72,7 @@ function buildTomlStyleConfig(): PolicyEngineConfig {
 
   rules.push({
     decision: PolicyDecision.ALLOW,
-    priority: 1.999,
+    priority: YOLO_RULE_PRIORITY,
     allowRedirection: true,
     modes: [ApprovalMode.YOLO],
     source: 'test-yolo',
@@ -86,7 +90,7 @@ function buildTomlStyleConfig(): PolicyEngineConfig {
     rules.push({
       toolName: tool,
       decision: PolicyDecision.ALLOW,
-      priority: 1.015,
+      priority: AUTO_EDIT_RULE_PRIORITY,
       modes: [ApprovalMode.AUTO_EDIT],
       source: 'test-auto-edit',
     });
@@ -262,7 +266,10 @@ function getMtime(filePath: string): number {
  * deterministic and not affected by filesystem timestamp resolution.
  * Returns the old mtime in milliseconds.
  */
-function setOldMtime(filePath: string, epochSeconds = 1_000_000): number {
+function setOldMtime(
+  filePath: string,
+  epochSeconds = DEFAULT_TEST_MTIME_EPOCH_SECONDS,
+): number {
   const oldTime = epochSeconds;
   fs.utimesSync(filePath, oldTime, oldTime);
   return oldTime * 1000;
@@ -295,6 +302,10 @@ async function waitForCompletion(
   return onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
 }
 
+type ConfirmationDetailsProbe = {
+  confirmationDetails?: { onConfirm?: unknown };
+};
+
 /**
  * Type guard: narrows a ToolCall to the awaiting-approval variant so
  * confirmationDetails can be accessed safely without a manual cast.
@@ -308,11 +319,8 @@ function isAwaitingApproval(call: ToolCall | undefined): call is ToolCall & {
   return (
     call !== undefined &&
     call.status === 'awaiting_approval' &&
-    typeof (
-      call as {
-        confirmationDetails?: { onConfirm?: unknown };
-      }
-    ).confirmationDetails?.onConfirm === 'function'
+    typeof (call as ConfirmationDetailsProbe).confirmationDetails?.onConfirm ===
+      'function'
   );
 }
 

--- a/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
@@ -1,0 +1,701 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * REAL behavioral integration suite for issue #2659.
+ *
+ * Exercises the actual scheduler → message-bus → confirmation-coordinator
+ * → real editor tools path. Every component below is REAL production code:
+ * - CoreToolScheduler / ConfirmationCoordinator / ToolExecutor / ResultAggregator
+ * - A real PolicyEngine (declarative TOML-style rules)
+ * - MessageBus (from @vybestack/llxprt-code-core/confirmation-bus)
+ * - ToolRegistry with real EditTool, WriteFileTool, InsertAtLineTool,
+ *   DeleteLineRangeTool, ApplyPatchTool, ASTEditTool
+ * - Real temp files on disk
+ *
+ * The ONLY fakes are infrastructure: a minimal IToolHost pointing at a temp
+ * directory, and a minimal Config stub (NOT a real Config — it delegates
+ * setApprovalMode to the real PolicyEngine) that delegates to the real
+ * PolicyEngine / MessageBus. No scheduler, policy engine, invocation, or
+ * editor behavior is mocked.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { CoreToolScheduler } from './coreToolScheduler.js';
+import type { ToolCall } from './coreToolScheduler.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  ApprovalMode,
+  DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+  DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+} from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import {
+  MessageBusType,
+  type ToolConfirmationResponse,
+} from '@vybestack/llxprt-code-core/confirmation-bus/types.js';
+import {
+  PolicyDecision,
+  type PolicyEngineConfig,
+  type PolicyRule,
+} from '@vybestack/llxprt-code-core/policy/types.js';
+import { PolicyEngine } from '@vybestack/llxprt-code-core/policy/policy-engine.js';
+import {
+  ToolRegistry,
+  EditTool,
+  WriteFileTool,
+  InsertAtLineTool,
+  DeleteLineRangeTool,
+  ApplyPatchTool,
+  ASTEditTool,
+  ToolConfirmationOutcome,
+  type ToolRegistry as ToolRegistryType,
+  type IToolHost,
+  type IToolMessageBus,
+} from '@vybestack/llxprt-code-tools';
+
+// ── Real PolicyEngine config (mirrors production TOML) ──────────────────
+
+function buildTomlStyleConfig(): PolicyEngineConfig {
+  const rules: PolicyRule[] = [];
+
+  rules.push({
+    decision: PolicyDecision.ALLOW,
+    priority: 1.999,
+    allowRedirection: true,
+    modes: [ApprovalMode.YOLO],
+    source: 'test-yolo',
+  });
+
+  const autoEditTools = [
+    'replace',
+    'write_file',
+    'insert_at_line',
+    'delete_line_range',
+    'apply_patch',
+    'ast_edit',
+  ];
+  for (const tool of autoEditTools) {
+    rules.push({
+      toolName: tool,
+      decision: PolicyDecision.ALLOW,
+      priority: 1.015,
+      modes: [ApprovalMode.AUTO_EDIT],
+      source: 'test-auto-edit',
+    });
+  }
+
+  return { rules, defaultDecision: PolicyDecision.ASK_USER };
+}
+
+// ── Infrastructure: IToolHost fake ──────────────────────────────────────
+
+function createToolHost(targetDir: string): IToolHost {
+  return {
+    getTargetDir: () => targetDir,
+    getWorkspaceRoots: () => [targetDir],
+    getApprovalMode: () => 'default' as const,
+    setApprovalMode: () => {},
+    isInteractive: () => true,
+    hasFeatureFlag: () => false,
+    getFileService: () => ({
+      shouldGitIgnoreFile: () => false,
+      shouldLlxprtIgnoreFile: () => false,
+      shouldIgnoreFile: () => false,
+      filterFiles: (paths: string[]) => paths,
+    }),
+    getFileFilteringOptions: () => ({
+      respectGitIgnore: true,
+      respectLlxprtIgnore: true,
+    }),
+    getFileExclusions: () => [],
+    getReadManyFilesExclusions: () => [],
+    getFileFilteringRespectLlxprtIgnore: () => true,
+    getLlxprtIgnoreFilePath: () => null,
+    recordFileRead: () => {},
+    getFileSystemService: () => undefined,
+    getLlxprtIgnorePatterns: () => [],
+    getEphemeralSettings: () => ({
+      'tool-output-max-items': 50,
+      'tool-output-max-tokens': 50000,
+      'tool-output-item-size-limit': 524288,
+    }),
+    getDebugMode: () => false,
+  };
+}
+
+// ── Infrastructure: minimal Config stub (real PolicyEngine + MessageBus) ──
+
+interface SchedulerTestContext {
+  engine: PolicyEngine;
+  messageBus: MessageBus;
+  config: Config;
+  toolRegistry: ToolRegistryType;
+  scheduler: CoreToolScheduler;
+  onAllToolCallsComplete: ReturnType<typeof vi.fn>;
+  onToolCallsUpdate: ReturnType<typeof vi.fn>;
+  tempDir: string;
+}
+
+/**
+ * Builds a test context with REAL production components (PolicyEngine,
+ * MessageBus, CoreToolScheduler, ConfirmationCoordinator) but a minimal
+ * Config stub — NOT a real Config. The stub delegates setApprovalMode to
+ * engine.setApprovalMode so mode transitions are exercised through the
+ * same path Config uses in production.
+ */
+function buildTestContext(
+  tempDir: string,
+  initialMode: ApprovalMode,
+): SchedulerTestContext {
+  const engine = new PolicyEngine(buildTomlStyleConfig());
+  engine.setApprovalMode(initialMode);
+
+  const messageBus = new MessageBus(engine, false);
+
+  const toolHost = createToolHost(tempDir);
+
+  const editTool = new EditTool(toolHost);
+  const writeFileTool = new WriteFileTool(toolHost);
+  const insertAtLineTool = new InsertAtLineTool(toolHost);
+  const deleteLineRangeTool = new DeleteLineRangeTool(toolHost);
+  const applyPatchTool = new ApplyPatchTool(toolHost);
+  const astEditTool = new ASTEditTool(toolHost);
+
+  const toolRegistry = new ToolRegistry(
+    {
+      getEphemeralSettings: () => ({}),
+      getCoreTools: () => [],
+      getExcludeTools: () => [],
+    },
+    messageBus as unknown as IToolMessageBus,
+  );
+  toolRegistry.registerTool(editTool);
+  toolRegistry.registerTool(writeFileTool);
+  toolRegistry.registerTool(insertAtLineTool);
+  toolRegistry.registerTool(deleteLineRangeTool);
+  toolRegistry.registerTool(applyPatchTool);
+  toolRegistry.registerTool(astEditTool);
+
+  const onAllToolCallsComplete = vi.fn();
+  const onToolCallsUpdate = vi.fn();
+
+  let currentMode = initialMode;
+  const config = {
+    getSessionId: () => 'test-session-editor-integration',
+    getUsageStatisticsEnabled: () => false,
+    getDebugMode: () => false,
+    isInteractive: () => true,
+    getApprovalMode: () => currentMode,
+    setApprovalMode: (mode: ApprovalMode) => {
+      currentMode = mode;
+      engine.setApprovalMode(mode);
+    },
+    getEphemeralSettings: () => ({
+      'tool-output-max-tokens': 50000,
+      'tool-output-max-items': 50,
+    }),
+    getAllowedTools: () => [],
+    getContentGeneratorConfig: () => ({ model: 'test-model' }),
+    getToolRegistry: () => toolRegistry,
+    getMessageBus: () => messageBus,
+    getEnableHooks: () => false,
+    getHookSystem: () => null,
+    getPolicyEngine: () => engine,
+    getModel: () => 'test-model',
+    getTruncateToolOutputThreshold: () =>
+      DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+    getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+  } as unknown as Config;
+
+  const scheduler = new CoreToolScheduler({
+    config,
+    messageBus,
+    toolRegistry,
+    onAllToolCallsComplete,
+    onToolCallsUpdate,
+    getPreferredEditor: () => 'vscode',
+    onEditorClose: vi.fn(),
+  });
+
+  return {
+    engine,
+    messageBus,
+    config,
+    toolRegistry,
+    scheduler,
+    onAllToolCallsComplete,
+    onToolCallsUpdate,
+    tempDir,
+  };
+}
+
+// ── Temp filesystem helpers ─────────────────────────────────────────────
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'llxprt-editor-int-'));
+}
+
+function writeFile(dir: string, name: string, content: string): string {
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+function readFile(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function getMtime(filePath: string): number {
+  return fs.statSync(filePath).mtimeMs;
+}
+
+/**
+ * Sets a fixed old mtime on a file so that subsequent mtime comparisons are
+ * deterministic and not affected by filesystem timestamp resolution.
+ * Returns the old mtime in milliseconds.
+ */
+function setOldMtime(filePath: string, epochSeconds = 1_000_000): number {
+  const oldTime = epochSeconds;
+  fs.utimesSync(filePath, oldTime, oldTime);
+  return oldTime * 1000;
+}
+
+function makeRequest(
+  callId: string,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  return {
+    callId,
+    name,
+    args,
+    isClientInitiated: false,
+    prompt_id: 'prompt-editor-int',
+  };
+}
+
+/**
+ * Waits for the scheduler to reach onAllToolCallsComplete, then returns
+ * the completed calls.
+ */
+async function waitForCompletion(
+  onAllToolCallsComplete: ReturnType<typeof vi.fn>,
+): Promise<ToolCall[]> {
+  await vi.waitFor(() => {
+    expect(onAllToolCallsComplete).toHaveBeenCalled();
+  });
+  return onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
+}
+
+/**
+ * Type guard: narrows a ToolCall to the awaiting-approval variant so
+ * confirmationDetails can be accessed safely without a manual cast.
+ */
+function isAwaitingApproval(call: ToolCall | undefined): call is ToolCall & {
+  status: 'awaiting_approval';
+  confirmationDetails: {
+    onConfirm: (o: ToolConfirmationOutcome) => Promise<void>;
+  };
+} {
+  return (
+    call !== undefined &&
+    call.status === 'awaiting_approval' &&
+    typeof (
+      call as {
+        confirmationDetails?: { onConfirm?: unknown };
+      }
+    ).confirmationDetails?.onConfirm === 'function'
+  );
+}
+
+/**
+ * Extracts the awaiting-approval call from the latest onToolCallsUpdate
+ * batch, using a type guard for safe narrowing.
+ */
+function getAwaitingCall(
+  onToolCallsUpdate: ReturnType<typeof vi.fn>,
+): ToolCall & {
+  status: 'awaiting_approval';
+  confirmationDetails: {
+    onConfirm: (o: ToolConfirmationOutcome) => Promise<void>;
+  };
+} {
+  const calls = onToolCallsUpdate.mock.calls;
+  const latest = calls[calls.length - 1]?.[0] as ToolCall[] | undefined;
+  const awaitingCall = latest?.find((c) => c.status === 'awaiting_approval');
+  if (!isAwaitingApproval(awaitingCall)) {
+    throw new Error(
+      'Expected an awaiting_approval call with confirmationDetails.onConfirm',
+    );
+  }
+  return awaitingCall;
+}
+
+// ── Tool argument fixtures ──────────────────────────────────────────────
+
+type ToolFixture = {
+  toolName: string;
+  buildArgs: (
+    filePath: string,
+    originalContent: string,
+  ) => Record<string, unknown>;
+  expectedContent: string;
+};
+
+/**
+ * Fixtures for each of the six editor tools. Each takes a temp file path
+ * with known content and returns valid arguments + the expected file content
+ * after successful execution.
+ */
+function toolFixtures(): ToolFixture[] {
+  return [
+    {
+      toolName: 'replace',
+      buildArgs: (filePath) => ({
+        file_path: filePath,
+        old_string: 'line2',
+        new_string: 'LINE2',
+      }),
+      expectedContent: 'line1\nLINE2\nline3\n',
+    },
+    {
+      toolName: 'write_file',
+      buildArgs: (filePath) => ({
+        file_path: filePath,
+        content: 'brand new content\n',
+      }),
+      expectedContent: 'brand new content\n',
+    },
+    {
+      toolName: 'insert_at_line',
+      buildArgs: (filePath) => ({
+        file_path: filePath,
+        line_number: 2,
+        content: 'inserted\n',
+      }),
+      expectedContent: 'line1\ninserted\nline2\nline3\n',
+    },
+    {
+      toolName: 'delete_line_range',
+      buildArgs: (filePath) => ({
+        file_path: filePath,
+        start_line: 2,
+        end_line: 3,
+      }),
+      expectedContent: 'line1\n',
+    },
+    {
+      toolName: 'apply_patch',
+      buildArgs: (filePath) => ({
+        file_path: filePath,
+        patch_content:
+          '--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n line1\n-line2\n+LINE2\n line3',
+      }),
+      expectedContent: 'line1\nLINE2\nline3\n',
+    },
+    {
+      toolName: 'ast_edit',
+      buildArgs: (filePath) => ({
+        file_path: filePath,
+        old_string: 'line2',
+        new_string: 'LINE2',
+        force: true,
+      }),
+      expectedContent: 'line1\nLINE2\nline3\n',
+    },
+  ];
+}
+
+// ── Test suite ──────────────────────────────────────────────────────────
+
+describe('Editor scheduler integration (issue #2659)', () => {
+  let tempDir = '';
+  // Central registry of all schedulers created in beforeEach/individual tests
+  // so afterEach can dispose them even if an assertion fails mid-test.
+  const activeSchedulers: CoreToolScheduler[] = [];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    activeSchedulers.length = 0;
+  });
+
+  afterEach(() => {
+    for (const scheduler of activeSchedulers) {
+      scheduler.dispose();
+    }
+    activeSchedulers.length = 0;
+    if (tempDir !== '') {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Wraps buildTestContext to register the scheduler for guaranteed disposal.
+   */
+  function makeContext(mode: ApprovalMode): SchedulerTestContext {
+    const ctx = buildTestContext(tempDir, mode);
+    activeSchedulers.push(ctx.scheduler);
+    return ctx;
+  }
+
+  // ── Case 1: DEFAULT mode — six editors reach confirmation, no mutation before approval, cancel preserves bytes+mtime ──
+
+  describe.each(toolFixtures())('DEFAULT mode: $toolName', (fixture) => {
+    it('reaches awaiting_approval and does not mutate before approval; cancel preserves bytes and mtime', async () => {
+      const ctx = makeContext(ApprovalMode.DEFAULT);
+      const originalContent = 'line1\nline2\nline3\n';
+      const filePath = writeFile(tempDir, 'target.txt', originalContent);
+      const originalMtime = setOldMtime(filePath);
+
+      const args = fixture.buildArgs(filePath, originalContent);
+      const abortController = new AbortController();
+      await ctx.scheduler.schedule(
+        makeRequest(`default-${fixture.toolName}`, fixture.toolName, args),
+        abortController.signal,
+      );
+
+      // The tool should NOT have completed — it should be awaiting approval.
+      expect(ctx.onAllToolCallsComplete).not.toHaveBeenCalled();
+
+      // File must be untouched.
+      expect(readFile(filePath)).toBe(originalContent);
+      expect(getMtime(filePath)).toBe(originalMtime);
+
+      // Cancel via the confirmation details callback.
+      const awaitingCall = getAwaitingCall(ctx.onToolCallsUpdate);
+      await awaitingCall.confirmationDetails.onConfirm(
+        ToolConfirmationOutcome.Cancel,
+      );
+
+      const completed = await waitForCompletion(ctx.onAllToolCallsComplete);
+      expect(completed[0].status).toBe('cancelled');
+
+      // Bytes and mtime preserved after cancel.
+      expect(readFile(filePath)).toBe(originalContent);
+      expect(getMtime(filePath)).toBe(originalMtime);
+    });
+  });
+
+  // ── Case 2: AUTO_EDIT and YOLO — six editors execute without confirmation ──
+
+  describe.each([
+    { modeName: 'AUTO_EDIT', mode: ApprovalMode.AUTO_EDIT },
+    { modeName: 'YOLO', mode: ApprovalMode.YOLO },
+  ])('$modeName mode: six editors execute without confirmation', ({ mode }) => {
+    describe.each(toolFixtures())('$toolName', (fixture) => {
+      it('executes without confirmation and produces expected filesystem content', async () => {
+        const ctx = makeContext(mode);
+        const originalContent = 'line1\nline2\nline3\n';
+        const filePath = writeFile(tempDir, 'target.txt', originalContent);
+
+        const args = fixture.buildArgs(filePath, originalContent);
+        const abortController = new AbortController();
+        await ctx.scheduler.schedule(
+          makeRequest(`${mode}-${fixture.toolName}`, fixture.toolName, args),
+          abortController.signal,
+        );
+
+        const completed = await waitForCompletion(ctx.onAllToolCallsComplete);
+        expect(completed[0].status).toBe('success');
+        expect(readFile(filePath)).toBe(fixture.expectedContent);
+      });
+    });
+  });
+
+  // ── Case 3: Exact regression — YOLO→DEFAULT, force:true ast_edit gets real diff confirmation ──
+
+  it('YOLO→DEFAULT regression: ast_edit force:true gets real diff confirmation and no mutation before cancel', async () => {
+    const ctx = makeContext(ApprovalMode.YOLO);
+    const originalContent = 'line1\nline2\nline3\n';
+    const filePath = writeFile(tempDir, 'regression.txt', originalContent);
+
+    // First call in YOLO — should execute immediately.
+    const yoloArgs = {
+      file_path: filePath,
+      old_string: 'line2',
+      new_string: 'YOLO_EDITED',
+      force: true,
+    };
+    await ctx.scheduler.schedule(
+      makeRequest('yolo-first', 'ast_edit', yoloArgs),
+      new AbortController().signal,
+    );
+    const yoloCompleted = await waitForCompletion(ctx.onAllToolCallsComplete);
+    expect(yoloCompleted[0].status).toBe('success');
+    expect(readFile(filePath)).toContain('YOLO_EDITED');
+
+    // Restore content for the downgrade test.
+    fs.writeFileSync(filePath, originalContent, 'utf-8');
+    const restoredMtime = setOldMtime(filePath);
+
+    // Clear the mock so we can detect the second call separately.
+    ctx.onAllToolCallsComplete.mockClear();
+    ctx.onToolCallsUpdate.mockClear();
+
+    // Switch to DEFAULT.
+    (
+      ctx.config as unknown as { setApprovalMode: (m: ApprovalMode) => void }
+    ).setApprovalMode(ApprovalMode.DEFAULT);
+
+    // Schedule force:true ast_edit — should reach confirmation, NOT execute.
+    const defaultArgs = {
+      file_path: filePath,
+      old_string: 'line2',
+      new_string: 'DEFAULT_REQUIRES_CONFIRMATION',
+      force: true,
+    };
+    await ctx.scheduler.schedule(
+      makeRequest('default-regression', 'ast_edit', defaultArgs),
+      new AbortController().signal,
+    );
+
+    // Should be awaiting approval, not completed.
+    expect(ctx.onAllToolCallsComplete).not.toHaveBeenCalled();
+
+    // No mutation before approval.
+    expect(readFile(filePath)).toBe(originalContent);
+    expect(getMtime(filePath)).toBe(restoredMtime);
+
+    // Cancel to preserve bytes + mtime.
+    const awaitingCall = getAwaitingCall(ctx.onToolCallsUpdate);
+
+    // Clear mock before cancel so we capture this completion, not prior ones.
+    ctx.onAllToolCallsComplete.mockClear();
+
+    await awaitingCall.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.Cancel,
+    );
+
+    const completed = await waitForCompletion(ctx.onAllToolCallsComplete);
+    expect(completed[0].status).toBe('cancelled');
+
+    expect(readFile(filePath)).toBe(originalContent);
+    expect(getMtime(filePath)).toBe(restoredMtime);
+  });
+
+  // ── Case 4: ast_edit force:false preview — no mutation bytes/mtime ──
+
+  it('ast_edit force:false preview through scheduler does not mutate bytes/mtime', async () => {
+    const ctx = makeContext(ApprovalMode.DEFAULT);
+    const originalContent = 'line1\nline2\nline3\n';
+    const filePath = writeFile(tempDir, 'preview.txt', originalContent);
+    const originalMtime = setOldMtime(filePath);
+
+    // force:false means shouldConfirmExecute returns false (preview mode),
+    // and execute() returns a preview result without writing.
+    const args = {
+      file_path: filePath,
+      old_string: 'line2',
+      new_string: 'PREVIEW_ONLY',
+      force: false,
+    };
+    await ctx.scheduler.schedule(
+      makeRequest('preview-ast', 'ast_edit', args),
+      new AbortController().signal,
+    );
+
+    const completed = await waitForCompletion(ctx.onAllToolCallsComplete);
+    // Preview succeeds (returns the diff) without writing.
+    expect(completed[0].status).toBe('success');
+
+    // File unchanged.
+    expect(readFile(filePath)).toBe(originalContent);
+    expect(getMtime(filePath)).toBe(originalMtime);
+  });
+
+  // ── Case 5: Terminal callback vs MessageBus/IDE approval equivalence ──
+
+  describe('ast_edit approval routes produce equivalent authorization and a single write', () => {
+    const originalContent = 'line1\nline2\nline3\n';
+
+    it('approval via terminal callback (onConfirm) produces a single write', async () => {
+      const ctx = makeContext(ApprovalMode.DEFAULT);
+      const filePath = writeFile(
+        tempDir,
+        'terminal-approve.txt',
+        originalContent,
+      );
+
+      const args = {
+        file_path: filePath,
+        old_string: 'line2',
+        new_string: 'TERMINAL_APPROVED',
+        force: true,
+      };
+      await ctx.scheduler.schedule(
+        makeRequest('terminal-route', 'ast_edit', args),
+        new AbortController().signal,
+      );
+
+      // Should be awaiting approval.
+      expect(ctx.onAllToolCallsComplete).not.toHaveBeenCalled();
+      const awaitingCall = getAwaitingCall(ctx.onToolCallsUpdate);
+      await awaitingCall.confirmationDetails.onConfirm(
+        ToolConfirmationOutcome.ProceedOnce,
+      );
+
+      const completed = await waitForCompletion(ctx.onAllToolCallsComplete);
+      expect(completed[0].status).toBe('success');
+      expect(readFile(filePath)).toContain('TERMINAL_APPROVED');
+      // Single write — content is deterministic.
+      expect(readFile(filePath)).toBe('line1\nTERMINAL_APPROVED\nline3\n');
+    });
+
+    it('approval via MessageBus/IDE confirmation route produces a single write', async () => {
+      const ctx = makeContext(ApprovalMode.DEFAULT);
+      const filePath = writeFile(tempDir, 'bus-approve.txt', originalContent);
+
+      // Subscribe to TOOL_CONFIRMATION_REQUEST to capture the correlationId,
+      // then respond via MessageBus (the IDE route).
+      let capturedCorrelationId: string | undefined;
+      ctx.messageBus.subscribe<{ correlationId: string }>(
+        MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        (msg) => {
+          capturedCorrelationId = msg.correlationId;
+        },
+      );
+
+      const args = {
+        file_path: filePath,
+        old_string: 'line2',
+        new_string: 'BUS_APPROVED',
+        force: true,
+      };
+      await ctx.scheduler.schedule(
+        makeRequest('bus-route', 'ast_edit', args),
+        new AbortController().signal,
+      );
+
+      // Should be awaiting approval.
+      expect(ctx.onAllToolCallsComplete).not.toHaveBeenCalled();
+
+      // Wait for the confirmation request to arrive on the bus.
+      await vi.waitFor(() => {
+        expect(capturedCorrelationId).toBeDefined();
+      });
+
+      // Respond via the MessageBus — this is the IDE/confirmation-coordinator path.
+      ctx.messageBus.publish({
+        type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+        correlationId: capturedCorrelationId!,
+        outcome: ToolConfirmationOutcome.ProceedOnce,
+        confirmed: true,
+        requiresUserConfirmation: false,
+      } as ToolConfirmationResponse);
+
+      const completed = await waitForCompletion(ctx.onAllToolCallsComplete);
+      expect(completed[0].status).toBe('success');
+      expect(readFile(filePath)).toContain('BUS_APPROVED');
+      // Single write.
+      expect(readFile(filePath)).toBe('line1\nBUS_APPROVED\nline3\n');
+    });
+  });
+});

--- a/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
 } from '@vybestack/llxprt-code-core/config/configTypes.js';
 import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
 import {
   MessageBusType,
   type ToolConfirmationResponse,
@@ -58,12 +59,14 @@ import {
   ToolConfirmationOutcome,
   type ToolRegistry as ToolRegistryType,
   type IToolHost,
-  type IToolMessageBus,
 } from '@vybestack/llxprt-code-tools';
 
 const AUTO_EDIT_RULE_PRIORITY = 1.015;
 const YOLO_RULE_PRIORITY = 1.999;
 const DEFAULT_TEST_MTIME_EPOCH_SECONDS = 1_000_000;
+const TEST_SESSION_ID = 'test-session-editor-integration';
+const TEST_PREFERRED_EDITOR = 'vscode';
+const TEST_PROMPT_ID = 'prompt-editor-int';
 
 // ── Real PolicyEngine config (mirrors production TOML) ──────────────────
 
@@ -179,7 +182,7 @@ function buildTestContext(
       getCoreTools: () => [],
       getExcludeTools: () => [],
     },
-    messageBus as unknown as IToolMessageBus,
+    new CoreMessageBusAdapter(messageBus),
   );
   toolRegistry.registerTool(editTool);
   toolRegistry.registerTool(writeFileTool);
@@ -193,7 +196,7 @@ function buildTestContext(
 
   let currentMode = initialMode;
   const config = {
-    getSessionId: () => 'test-session-editor-integration',
+    getSessionId: () => TEST_SESSION_ID,
     getUsageStatisticsEnabled: () => false,
     getDebugMode: () => false,
     isInteractive: () => true,
@@ -225,7 +228,7 @@ function buildTestContext(
     toolRegistry,
     onAllToolCallsComplete,
     onToolCallsUpdate,
-    getPreferredEditor: () => 'vscode',
+    getPreferredEditor: () => TEST_PREFERRED_EDITOR,
     onEditorClose: vi.fn(),
   });
 
@@ -285,7 +288,7 @@ function makeRequest(
     name,
     args,
     isClientInitiated: false,
-    prompt_id: 'prompt-editor-int',
+    prompt_id: TEST_PROMPT_ID,
   };
 }
 
@@ -351,10 +354,7 @@ function getAwaitingCall(
 
 type ToolFixture = {
   toolName: string;
-  buildArgs: (
-    filePath: string,
-    originalContent: string,
-  ) => Record<string, unknown>;
+  buildArgs: (filePath: string) => Record<string, unknown>;
   expectedContent: string;
 };
 
@@ -463,7 +463,7 @@ describe('Editor scheduler integration (issue #2659)', () => {
       const filePath = writeFile(tempDir, 'target.txt', originalContent);
       const originalMtime = setOldMtime(filePath);
 
-      const args = fixture.buildArgs(filePath, originalContent);
+      const args = fixture.buildArgs(filePath);
       const abortController = new AbortController();
       await ctx.scheduler.schedule(
         makeRequest(`default-${fixture.toolName}`, fixture.toolName, args),
@@ -504,7 +504,7 @@ describe('Editor scheduler integration (issue #2659)', () => {
         const originalContent = 'line1\nline2\nline3\n';
         const filePath = writeFile(tempDir, 'target.txt', originalContent);
 
-        const args = fixture.buildArgs(filePath, originalContent);
+        const args = fixture.buildArgs(filePath);
         const abortController = new AbortController();
         await ctx.scheduler.schedule(
           makeRequest(`${mode}-${fixture.toolName}`, fixture.toolName, args),

--- a/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.editor-integration.test.ts
@@ -405,7 +405,7 @@ function toolFixtures(): ToolFixture[] {
       buildArgs: (filePath) => ({
         file_path: filePath,
         patch_content:
-          '--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n line1\n-line2\n+LINE2\n line3',
+          '--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n line1\n-line2\n+LINE2\n line3\n',
       }),
       expectedContent: 'line1\nLINE2\nline3\n',
     },

--- a/packages/cli/src/ui/commands/policiesCommand.test.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.test.ts
@@ -110,7 +110,7 @@ describe('policiesCommand', () => {
 
     expect(result.type).toBe('message');
     expect(result.messageType).toBe('info');
-    expect(result.content).toContain('Active Policy Rules:');
+    expect(result.content).toContain('Configured Policy Rules:');
     expect(result.content).toContain('shell → DENY');
     expect(result.content).toContain('glob → ALLOW');
     expect(result.content).toContain('edit → ALLOW');

--- a/packages/cli/src/ui/commands/policiesCommand.test.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.test.ts
@@ -28,7 +28,7 @@ describe('policiesCommand', () => {
   it('should have the correct name and description', () => {
     expect(policiesCommand.name).toBe('policies');
     expect(policiesCommand.description).toBe(
-      'display active policy rules and their priorities',
+      'display configured policy rules and their priorities',
     );
   });
 

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -136,7 +136,7 @@ function formatPolicyOutput(
 }
 
 /**
- * Handle /policies command — displays active policy rules.
+ * Handle /policies command — displays configured policy rules.
  * Prefers the agent.policy facade; falls back to config.getPolicyEngine()
  * when the agent is null (tracked migration debt).
  */
@@ -180,7 +180,7 @@ function handlePoliciesCommand(
 
 export const policiesCommand: SlashCommand = {
   name: 'policies',
-  description: 'display active policy rules and their priorities',
+  description: 'display configured policy rules and their priorities',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
   action: (context: CommandContext, args: string): MessageActionReturn | void =>

--- a/packages/cli/src/ui/commands/policiesCommand.ts
+++ b/packages/cli/src/ui/commands/policiesCommand.ts
@@ -79,7 +79,7 @@ function formatPolicyOutput(
     (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
   );
 
-  const lines: string[] = ['Active Policy Rules:', ''];
+  const lines: string[] = ['Configured Policy Rules:', ''];
 
   const tierBands = new Map<string, typeof sortedRules>();
 

--- a/packages/core/src/config/config.approval-mode-sync.test.ts
+++ b/packages/core/src/config/config.approval-mode-sync.test.ts
@@ -36,6 +36,11 @@ import type { PolicyEngineConfig, PolicyRule } from '../policy/types.js';
 import { AUTO_EDIT_TOOLS } from '../policy/config.js';
 import { PolicyEngine } from '../policy/policy-engine.js';
 import { MessageBus } from '../confirmation-bus/message-bus.js';
+import {
+  MessageBusType,
+  type ToolConfirmationRequest,
+} from '../confirmation-bus/types.js';
+import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools';
 
 const hoistedConfigMocks = vi.hoisted<HoistedConfigMocks>(() => ({
   loadJitSubdirectoryMemory: vi.fn(),
@@ -170,7 +175,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('YOLO→DEFAULT: ast_edit reverts from ALLOW to ASK_USER after transition', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 
@@ -183,7 +187,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('YOLO→DEFAULT: ALL tools revert to ASK_USER after transition', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 
@@ -204,7 +207,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('AUTO_EDIT→DEFAULT: all six edit tools revert from ALLOW to ASK_USER', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.AUTO_EDIT });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 
@@ -223,7 +225,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('AUTO_EDIT→YOLO: edit tools stay ALLOW, shell becomes ALLOW', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.AUTO_EDIT });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 
@@ -245,7 +246,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('YOLO→AUTO_EDIT: shell reverts to ASK_USER, edit tools stay ALLOW', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 
@@ -267,7 +267,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('rapid transitions do not accumulate or lose rules', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.DEFAULT });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 
@@ -293,7 +292,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('non-mode ALLOW rules in base survive mode transitions', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.DEFAULT });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 
@@ -309,7 +307,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('MessageBus sees updated policy after mode transition (identity preserved)', async () => {
     const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
     const bus = new MessageBus(engine, false);
@@ -323,23 +320,38 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
     config.setApprovalMode(ApprovalMode.DEFAULT);
 
-    expect(bus).toBeInstanceOf(MessageBus);
-    // After transition (DEFAULT): requestConfirmation must NOT fast-approve
-    // (policy evaluates to ASK_USER, which means it waits for a response).
-    // We verify via engine.evaluate that the policy decision changed.
-    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ASK_USER);
+    const confirmationHandler = vi.fn();
+    bus.subscribe(
+      MessageBusType.TOOL_CONFIRMATION_REQUEST,
+      confirmationHandler,
+    );
+    const afterPromise = bus.requestConfirmation(
+      { name: 'ast_edit', args: {} },
+      {},
+    );
+    await vi.waitFor(() => {
+      expect(confirmationHandler).toHaveBeenCalledOnce();
+    });
+    const confirmationRequest = confirmationHandler.mock
+      .calls[0][0] as ToolConfirmationRequest;
+    expect(confirmationRequest.type).toBe(
+      MessageBusType.TOOL_CONFIRMATION_REQUEST,
+    );
+    bus.respondToConfirmation(
+      confirmationRequest.correlationId,
+      ToolConfirmationOutcome.Cancel,
+    );
+    await expect(afterPromise).resolves.toBe(false);
   });
 
   // ── Initial construction matches runtime transition ──────────────────
 
   it('initial YOLO construction produces same policy as YOLO transition from DEFAULT', () => {
     const configFromYolo = makeConfig({ approvalMode: ApprovalMode.YOLO });
-    vi.spyOn(configFromYolo, 'isTrustedFolder').mockReturnValue(true);
 
     const configFromDefault = makeConfig({
       approvalMode: ApprovalMode.DEFAULT,
     });
-    vi.spyOn(configFromDefault, 'isTrustedFolder').mockReturnValue(true);
     configFromDefault.setApprovalMode(ApprovalMode.YOLO);
 
     expect(configFromYolo.getPolicyEngine().evaluate('ast_edit', {})).toBe(
@@ -352,7 +364,6 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
 
   it('initial AUTO_EDIT construction includes ast_edit ALLOW', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.AUTO_EDIT });
-    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
 
     const engine = config.getPolicyEngine();
 

--- a/packages/core/src/config/config.approval-mode-sync.test.ts
+++ b/packages/core/src/config/config.approval-mode-sync.test.ts
@@ -190,7 +190,7 @@ describe('Config approval-mode policy synchronization (issue #2659)', () => {
     expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ASK_USER);
   });
 
-  it('YOLO→DEFAULT: ALL tools revert to ASK_USER after transition', () => {
+  it('YOLO→DEFAULT: representative tools revert to ASK_USER after transition', () => {
     const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
 
     const engine = config.getPolicyEngine();

--- a/packages/core/src/config/config.approval-mode-sync.test.ts
+++ b/packages/core/src/config/config.approval-mode-sync.test.ts
@@ -1,0 +1,434 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for issue #2659: authorization desynchronization on
+ * approval-mode transitions.
+ *
+ * The bug: starting in YOLO (or AUTO_EDIT) mode, the PolicyEngine holds
+ * mode-derived ALLOW rules. When the user switches to DEFAULT (Ctrl-Y),
+ * Config.setApprovalMode must remove ALL mode-derived authorization so that
+ * edit tools revert to ASK_USER. If any mode-derived ALLOW rule persists, the
+ * ConfirmationCoordinator's tryFastApprove fast-approves ast_edit force:true
+ * (or any edit tool) BEFORE shouldConfirmExecute is consulted, silently
+ * bypassing consent.
+ *
+ * These tests exercise the REAL Config → PolicyEngine boundary. They construct
+ * a real Config with a real PolicyEngine containing declarative TOML-style
+ * rules with `modes` filters, and verify observable policy outcomes
+ * (ALLOW / ASK_USER / DENY) across mode transitions — no mock theater.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ConfigParameters } from './config.js';
+import { Config } from './config.js';
+import {
+  createBaseParams,
+  resetAgentClientMock,
+  type HoistedConfigMocks,
+} from './configTestHarness.js';
+import { getSettingsService } from '@vybestack/llxprt-code-settings';
+import { ApprovalMode, PolicyDecision } from '../policy/types.js';
+import type { PolicyEngineConfig, PolicyRule } from '../policy/types.js';
+import { AUTO_EDIT_TOOLS } from '../policy/config.js';
+import { PolicyEngine } from '../policy/policy-engine.js';
+import { MessageBus } from '../confirmation-bus/message-bus.js';
+
+const hoistedConfigMocks = vi.hoisted<HoistedConfigMocks>(() => ({
+  loadJitSubdirectoryMemory: vi.fn(),
+  coreEvents: {
+    emitFeedback: vi.fn(),
+    emitModelChanged: vi.fn(),
+    emitConsoleLog: vi.fn(),
+  },
+  setGlobalProxy: vi.fn(),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const h = await import('./configTestHarness.js');
+  return h.buildFsMockBody(await importOriginal());
+});
+
+vi.mock('@vybestack/llxprt-code-tools', async (importOriginal) => {
+  const h = await import('./configTestHarness.js');
+  return h.buildToolsMockBody(
+    await importOriginal<typeof import('@vybestack/llxprt-code-tools')>(),
+  );
+});
+
+vi.mock('../core/contentGenerator.js', async (importOriginal) => {
+  const h = await import('./configTestHarness.js');
+  return h.buildContentGeneratorMockBody(await importOriginal());
+});
+
+vi.mock('../telemetry/index.js', async () => {
+  const h = await import('./configTestHarness.js');
+  return h.buildTelemetryMockBody();
+});
+
+vi.mock('../services/gitService.js', async () => {
+  const h = await import('./configTestHarness.js');
+  return h.buildGitServiceMockBody();
+});
+
+vi.mock('@vybestack/llxprt-code-settings', async () => {
+  const h = await import('./configTestHarness.js');
+  return h.buildSettingsMockBody();
+});
+
+vi.mock('@vybestack/llxprt-code-ide-integration', async (importOriginal) => {
+  const h = await import('./configTestHarness.js');
+  return h.buildIdeIntegrationMockBody(
+    await importOriginal<
+      typeof import('@vybestack/llxprt-code-ide-integration')
+    >(),
+  );
+});
+
+vi.mock('../utils/memoryDiscovery.js', async () => {
+  const h = await import('./configTestHarness.js');
+  return h.buildMemoryDiscoveryMockBody(hoistedConfigMocks);
+});
+
+vi.mock('../utils/events.js', async (importOriginal) => {
+  const h = await import('./configTestHarness.js');
+  return h.buildEventsMockBody(await importOriginal(), hoistedConfigMocks);
+});
+
+vi.mock('../utils/fetch.js', async () => {
+  const h = await import('./configTestHarness.js');
+  return h.buildFetchMockBody(hoistedConfigMocks);
+});
+
+/**
+ * Builds a PolicyEngineConfig with declarative TOML-style rules that mirror
+ * the real write.toml and yolo.toml files. This simulates what
+ * createPolicyEngineConfig() produces in production.
+ */
+function buildTomlStylePolicyConfig(): PolicyEngineConfig {
+  const rules: PolicyRule[] = [];
+
+  for (const tool of [...AUTO_EDIT_TOOLS, 'save_memory', 'run_shell_command']) {
+    rules.push({
+      toolName: tool,
+      decision: PolicyDecision.ASK_USER,
+      priority: 1.01,
+    });
+  }
+
+  for (const tool of AUTO_EDIT_TOOLS) {
+    rules.push({
+      toolName: tool,
+      decision: PolicyDecision.ALLOW,
+      priority: 1.015,
+      modes: [ApprovalMode.AUTO_EDIT],
+    });
+  }
+
+  rules.push({
+    decision: PolicyDecision.ALLOW,
+    priority: 1.999,
+    allowRedirection: true,
+    modes: [ApprovalMode.YOLO],
+  });
+
+  rules.push({
+    toolName: 'glob',
+    decision: PolicyDecision.ALLOW,
+    priority: 1.05,
+  });
+
+  return {
+    rules,
+    defaultDecision: PolicyDecision.ASK_USER,
+  };
+}
+
+describe('Config approval-mode policy synchronization (issue #2659)', () => {
+  let settingsService: ReturnType<typeof getSettingsService>;
+  let baseParams: ConfigParameters;
+
+  beforeEach(() => {
+    resetAgentClientMock();
+    settingsService = getSettingsService();
+    baseParams = createBaseParams(settingsService);
+  });
+
+  function makeConfig(params?: Partial<ConfigParameters>): Config {
+    const policyEngineConfig = buildTomlStylePolicyConfig();
+    return new Config({
+      ...baseParams,
+      policyEngineConfig,
+      ...params,
+    });
+  }
+
+  // ── Core regression: YOLO → DEFAULT must clear mode-derived ALLOW ────
+
+  it('YOLO→DEFAULT: ast_edit reverts from ALLOW to ASK_USER after transition', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ALLOW);
+
+    config.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ASK_USER);
+  });
+
+  it('YOLO→DEFAULT: ALL tools revert to ASK_USER after transition', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ALLOW);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+
+    config.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ASK_USER);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+  });
+
+  // ── AUTO_EDIT → DEFAULT ──────────────────────────────────────────────
+
+  it('AUTO_EDIT→DEFAULT: all six edit tools revert from ALLOW to ASK_USER', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.AUTO_EDIT });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+    }
+
+    config.setApprovalMode(ApprovalMode.DEFAULT);
+
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ASK_USER);
+    }
+  });
+
+  // ── AUTO_EDIT → YOLO ─────────────────────────────────────────────────
+
+  it('AUTO_EDIT→YOLO: edit tools stay ALLOW, shell becomes ALLOW', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.AUTO_EDIT });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+
+    config.setApprovalMode(ApprovalMode.YOLO);
+
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+    }
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+  });
+
+  // ── YOLO → AUTO_EDIT ─────────────────────────────────────────────────
+
+  it('YOLO→AUTO_EDIT: shell reverts to ASK_USER, edit tools stay ALLOW', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+
+    config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+    }
+  });
+
+  // ── No accumulation of mode rules across rapid transitions ───────────
+
+  it('rapid transitions do not accumulate or lose rules', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.DEFAULT });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    for (let i = 0; i < 5; i++) {
+      config.setApprovalMode(ApprovalMode.YOLO);
+      config.setApprovalMode(ApprovalMode.DEFAULT);
+      config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+      config.setApprovalMode(ApprovalMode.DEFAULT);
+    }
+
+    // All six edit tools must revert to ASK_USER after rapid cycling
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ASK_USER);
+    }
+    // Representative shell and glob also correct
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+    expect(engine.evaluate('glob', {})).toBe(PolicyDecision.ALLOW);
+  });
+
+  // ── Unrelated rules preserved across transitions ─────────────────────
+
+  it('non-mode ALLOW rules in base survive mode transitions', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.DEFAULT });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    expect(engine.evaluate('glob', {})).toBe(PolicyDecision.ALLOW);
+
+    config.setApprovalMode(ApprovalMode.YOLO);
+    config.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(engine.evaluate('glob', {})).toBe(PolicyDecision.ALLOW);
+  });
+
+  // ── MessageBus retains same PolicyEngine reference ───────────────────
+
+  it('MessageBus sees updated policy after mode transition (identity preserved)', async () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.YOLO });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+    const bus = new MessageBus(engine, false);
+
+    // Before transition (YOLO): requestConfirmation fast-approves
+    const beforeResult = await bus.requestConfirmation(
+      { name: 'ast_edit', args: {} },
+      {},
+    );
+    expect(beforeResult).toBe(true);
+
+    config.setApprovalMode(ApprovalMode.DEFAULT);
+
+    expect(bus).toBeInstanceOf(MessageBus);
+    // After transition (DEFAULT): requestConfirmation must NOT fast-approve
+    // (policy evaluates to ASK_USER, which means it waits for a response).
+    // We verify via engine.evaluate that the policy decision changed.
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ASK_USER);
+  });
+
+  // ── Initial construction matches runtime transition ──────────────────
+
+  it('initial YOLO construction produces same policy as YOLO transition from DEFAULT', () => {
+    const configFromYolo = makeConfig({ approvalMode: ApprovalMode.YOLO });
+    vi.spyOn(configFromYolo, 'isTrustedFolder').mockReturnValue(true);
+
+    const configFromDefault = makeConfig({
+      approvalMode: ApprovalMode.DEFAULT,
+    });
+    vi.spyOn(configFromDefault, 'isTrustedFolder').mockReturnValue(true);
+    configFromDefault.setApprovalMode(ApprovalMode.YOLO);
+
+    expect(configFromYolo.getPolicyEngine().evaluate('ast_edit', {})).toBe(
+      configFromDefault.getPolicyEngine().evaluate('ast_edit', {}),
+    );
+    expect(configFromYolo.getPolicyEngine().evaluate('ast_edit', {})).toBe(
+      PolicyDecision.ALLOW,
+    );
+  });
+
+  it('initial AUTO_EDIT construction includes ast_edit ALLOW', () => {
+    const config = makeConfig({ approvalMode: ApprovalMode.AUTO_EDIT });
+    vi.spyOn(config, 'isTrustedFolder').mockReturnValue(true);
+
+    const engine = config.getPolicyEngine();
+
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ALLOW);
+  });
+
+  // ── ast_edit is in the AUTO_EDIT_TOOLS list ──────────────────────────
+
+  it('AUTO_EDIT_TOOLS includes all six edit tools', () => {
+    expect([...AUTO_EDIT_TOOLS].sort()).toStrictEqual(
+      [
+        'replace',
+        'write_file',
+        'insert_at_line',
+        'delete_line_range',
+        'apply_patch',
+        'ast_edit',
+      ].sort(),
+    );
+  });
+});
+
+// ── Standalone PolicyEngine tests (no Config, pure engine) ──────────────
+
+describe('PolicyEngine dynamic mode evaluation (standalone)', () => {
+  function buildEngineWithTomlRules(): PolicyEngine {
+    return new PolicyEngine(buildTomlStylePolicyConfig());
+  }
+
+  it('DEFAULT: edit tools are ASK_USER', () => {
+    const engine = buildEngineWithTomlRules();
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ASK_USER);
+    }
+  });
+
+  it('AUTO_EDIT: edit tools are ALLOW, shell is ASK_USER', () => {
+    const engine = buildEngineWithTomlRules();
+    engine.setApprovalMode(ApprovalMode.AUTO_EDIT);
+
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+    }
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+  });
+
+  it('YOLO: all tools are ALLOW', () => {
+    const engine = buildEngineWithTomlRules();
+    engine.setApprovalMode(ApprovalMode.YOLO);
+
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ALLOW);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+  });
+
+  it('user TOML rule with modes = [yolo] appears/disappears on transition', () => {
+    const rule: PolicyRule = {
+      toolName: 'custom_tool',
+      decision: PolicyDecision.ALLOW,
+      priority: 2.5,
+      modes: [ApprovalMode.YOLO],
+    };
+    const engine = new PolicyEngine({
+      rules: [rule],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ALLOW);
+
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ASK_USER);
+  });
+});

--- a/packages/core/src/config/config.approval-mode-sync.test.ts
+++ b/packages/core/src/config/config.approval-mode-sync.test.ts
@@ -108,6 +108,11 @@ vi.mock('../utils/fetch.js', async () => {
   return h.buildFetchMockBody(hoistedConfigMocks);
 });
 
+const DEFAULT_WRITE_RULE_PRIORITY = 1.01;
+const AUTO_EDIT_RULE_PRIORITY = 1.015;
+const READ_ONLY_RULE_PRIORITY = 1.05;
+const YOLO_RULE_PRIORITY = 1.999;
+
 /**
  * Builds a PolicyEngineConfig with declarative TOML-style rules that mirror
  * the real write.toml and yolo.toml files. This simulates what
@@ -120,7 +125,7 @@ function buildTomlStylePolicyConfig(): PolicyEngineConfig {
     rules.push({
       toolName: tool,
       decision: PolicyDecision.ASK_USER,
-      priority: 1.01,
+      priority: DEFAULT_WRITE_RULE_PRIORITY,
     });
   }
 
@@ -128,14 +133,14 @@ function buildTomlStylePolicyConfig(): PolicyEngineConfig {
     rules.push({
       toolName: tool,
       decision: PolicyDecision.ALLOW,
-      priority: 1.015,
+      priority: AUTO_EDIT_RULE_PRIORITY,
       modes: [ApprovalMode.AUTO_EDIT],
     });
   }
 
   rules.push({
     decision: PolicyDecision.ALLOW,
-    priority: 1.999,
+    priority: YOLO_RULE_PRIORITY,
     allowRedirection: true,
     modes: [ApprovalMode.YOLO],
   });
@@ -143,7 +148,7 @@ function buildTomlStylePolicyConfig(): PolicyEngineConfig {
   rules.push({
     toolName: 'glob',
     decision: PolicyDecision.ALLOW,
-    priority: 1.05,
+    priority: READ_ONLY_RULE_PRIORITY,
   });
 
   return {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -114,6 +114,7 @@ export class Config extends ConfigBase {
   constructor(params: ConfigParameters) {
     super();
     applyConfigParams(this as unknown as ConfigConstructorTarget, params);
+    this.syncModeDerivedPolicyRules(this.approvalMode);
   }
 
   // Issue #2325: Background MCP discovery promise started in initialize() so
@@ -456,6 +457,12 @@ export class Config extends ConfigBase {
     }
 
     this.approvalMode = mode;
+    this.syncModeDerivedPolicyRules(mode);
+  }
+
+  private syncModeDerivedPolicyRules(mode: ApprovalMode): void {
+    const engine = this.getPolicyEngine();
+    engine.setApprovalMode(mode);
   }
 
   updateSystemInstructionIfInitialized(): void | Promise<void> {}

--- a/packages/core/src/policy/config.test.ts
+++ b/packages/core/src/policy/config.test.ts
@@ -32,59 +32,22 @@ function createMockConfig(options: {
 describe('policy config', () => {
   describe('migrateLegacyApprovalMode', () => {
     describe('ApprovalMode.YOLO', () => {
-      it('converts YOLO to wildcard allow-all at priority 1.999', () => {
+      it('does not add mode rules (TOML handles mode-specific behavior)', () => {
         const config = createMockConfig({ approvalMode: ApprovalMode.YOLO });
         const rules = migrateLegacyApprovalMode(config);
 
-        expect(rules).toHaveLength(1);
-        expect(rules[0]).toStrictEqual({
-          // toolName undefined = wildcard
-          decision: PolicyDecision.ALLOW,
-          priority: 1.999,
-          source: 'Legacy (YOLO)',
-        });
-        expect(rules[0].toolName).toBeUndefined();
-      });
-
-      it('wildcard rule matches all tools', () => {
-        const config = createMockConfig({ approvalMode: ApprovalMode.YOLO });
-        const rules = migrateLegacyApprovalMode(config);
-
-        // Verify the rule has no toolName (wildcard)
-        expect(rules[0].toolName).toBeUndefined();
+        expect(rules).toHaveLength(0);
       });
     });
 
     describe('ApprovalMode.AUTO_EDIT', () => {
-      it('converts AUTO_EDIT to write tool rules at priority 1.015', () => {
+      it('does not add mode rules (TOML handles mode-specific behavior)', () => {
         const config = createMockConfig({
           approvalMode: ApprovalMode.AUTO_EDIT,
         });
         const rules = migrateLegacyApprovalMode(config);
 
-        // Should have rules for edit tools
-        expect(rules.length).toBeGreaterThanOrEqual(4);
-
-        const replaceRule = rules.find((r) => r.toolName === 'replace');
-        expect(replaceRule).toStrictEqual({
-          toolName: 'replace',
-          decision: PolicyDecision.ALLOW,
-          priority: 1.015,
-          source: 'Legacy (AUTO_EDIT)',
-        });
-      });
-
-      it('includes all expected write tools', () => {
-        const config = createMockConfig({
-          approvalMode: ApprovalMode.AUTO_EDIT,
-        });
-        const rules = migrateLegacyApprovalMode(config);
-
-        const toolNames = rules.map((r) => r.toolName);
-        expect(toolNames).toContain('replace');
-        expect(toolNames).toContain('write_file');
-        expect(toolNames).toContain('insert_at_line');
-        expect(toolNames).toContain('delete_line_range');
+        expect(rules).toHaveLength(0);
       });
     });
 
@@ -93,7 +56,6 @@ describe('policy config', () => {
         const config = createMockConfig({ approvalMode: ApprovalMode.DEFAULT });
         const rules = migrateLegacyApprovalMode(config);
 
-        // DEFAULT mode doesn't add any legacy rules
         expect(rules).toHaveLength(0);
       });
     });
@@ -181,38 +143,30 @@ describe('policy config', () => {
     });
 
     describe('combined scenarios', () => {
-      it('combines YOLO mode with allowed tools', () => {
+      it('only produces allowed-tools rules (mode rules handled by TOML)', () => {
         const config = createMockConfig({
           approvalMode: ApprovalMode.YOLO,
           allowedTools: ['edit'],
         });
         const rules = migrateLegacyApprovalMode(config);
 
-        // YOLO wildcard + 1 allowed tool
-        expect(rules).toHaveLength(2);
-
-        const yoloRule = rules.find((r) => r.priority === 1.999);
-        expect(yoloRule?.toolName).toBeUndefined();
-
-        const allowedRule = rules.find((r) => r.priority === 2.3);
-        expect(allowedRule?.toolName).toBe('edit');
+        expect(rules).toHaveLength(1);
+        expect(rules[0].priority).toBe(2.3);
+        expect(rules[0].toolName).toBe('edit');
       });
 
-      it('combines AUTO_EDIT with allowed tools', () => {
+      it('only produces allowed-tools rules for AUTO_EDIT', () => {
         const config = createMockConfig({
           approvalMode: ApprovalMode.AUTO_EDIT,
           allowedTools: ['glob', 'grep'],
         });
         const rules = migrateLegacyApprovalMode(config);
 
-        // 5 AUTO_EDIT tools (including apply_patch) + 2 allowed tools
-        expect(rules.length).toBe(7);
-
-        const autoEditRules = rules.filter((r) => r.priority === 1.015);
-        expect(autoEditRules.length).toBe(5);
-
+        expect(rules).toHaveLength(2);
         const allowedRules = rules.filter((r) => r.priority === 2.3);
-        expect(allowedRules.length).toBe(2);
+        expect(allowedRules).toHaveLength(2);
+        const toolNames = rules.map((r) => r.toolName).sort();
+        expect(toolNames).toStrictEqual(['glob', 'grep']);
       });
     });
   });

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -23,6 +23,7 @@ import {
   type MessageBus,
   MessageBusType,
   migrateLegacyApprovalMode,
+  AUTO_EDIT_TOOLS,
   type PolicyConfigSource,
   type PolicyEngine,
   type PolicyEngineConfig,
@@ -43,6 +44,7 @@ export {
   USER_POLICY_TIER,
   formatPolicyError,
   migrateLegacyApprovalMode,
+  AUTO_EDIT_TOOLS,
 };
 export type { PolicyConfigSource, PolicyPathResolver };
 
@@ -121,6 +123,7 @@ async function buildConfigSourceRules(
     rules,
     defaultDecision: PolicyDecision.ASK_USER,
     nonInteractive,
+    approvalMode,
   };
 }
 
@@ -170,6 +173,7 @@ async function buildSettingsRules(
   return {
     rules,
     defaultDecision: PolicyDecision.ASK_USER,
+    approvalMode,
   };
 }
 

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -133,7 +133,7 @@ priority = 100
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should filter rules by mode', async () => {
+    it('should preserve modes field for dynamic evaluation by PolicyEngine', async () => {
       const result = await runLoadPoliciesFromToml(`
 [[rule]]
 toolName = "glob"
@@ -148,9 +148,14 @@ priority = 100
 modes = ["yolo"]
 `);
 
-      // Only the first rule should be included (modes includes "default")
-      expect(result.rules).toHaveLength(1);
+      expect(result.rules).toHaveLength(2);
       expect(result.rules[0].toolName).toBe('glob');
+      expect(result.rules[0].modes).toStrictEqual([
+        ApprovalMode.DEFAULT,
+        ApprovalMode.YOLO,
+      ]);
+      expect(result.rules[1].toolName).toBe('grep');
+      expect(result.rules[1].modes).toStrictEqual([ApprovalMode.YOLO]);
       expect(result.errors).toHaveLength(0);
     });
 

--- a/packages/policy/src/config.ts
+++ b/packages/policy/src/config.ts
@@ -114,38 +114,19 @@ function normalizeToolName(toolName: string): string {
   return toolName;
 }
 
-const AUTO_EDIT_TOOLS = [
+export const AUTO_EDIT_TOOLS = [
   'replace',
   'write_file',
   'insert_at_line',
   'delete_line_range',
   'apply_patch',
+  'ast_edit',
 ] as const;
 
 export function migrateLegacyApprovalMode(
   config: PolicyConfigSource,
 ): PolicyRule[] {
   const rules: PolicyRule[] = [];
-  const approvalMode = config.getApprovalMode();
-
-  if (approvalMode === 'yolo') {
-    rules.push({
-      decision: PolicyDecision.ALLOW,
-      priority: 1.999,
-      source: 'Legacy (YOLO)',
-    });
-  }
-
-  if (approvalMode === 'autoEdit') {
-    for (const tool of AUTO_EDIT_TOOLS) {
-      rules.push({
-        toolName: tool,
-        decision: PolicyDecision.ALLOW,
-        priority: 1.015,
-        source: 'Legacy (AUTO_EDIT)',
-      });
-    }
-  }
 
   const allowedTools = config.getAllowedTools();
   if (allowedTools && allowedTools.length > 0) {

--- a/packages/policy/src/editor-mode-matrix.test.ts
+++ b/packages/policy/src/editor-mode-matrix.test.ts
@@ -80,19 +80,6 @@ function syncMode(engine: PolicyEngine, mode: ApprovalMode): void {
   engine.setApprovalMode(mode);
 }
 
-// ── Editor type constants ──────────────────────────────────────────────
-
-const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
-const GUI_EDITORS = [
-  'vscode',
-  'vscodium',
-  'windsurf',
-  'cursor',
-  'zed',
-  'antigravity',
-] as const;
-const ALL_EDITOR_TYPES = [...TERMINAL_EDITORS, ...GUI_EDITORS] as const;
-
 // ── Test suite ─────────────────────────────────────────────────────────
 
 describe('Editor mode matrix: PolicyEngine + MessageBus (issue #2659)', () => {
@@ -260,52 +247,6 @@ describe('Editor mode matrix: PolicyEngine + MessageBus (issue #2659)', () => {
 
       expect(confirmationRequested).toBe(true);
       expect(result).toBe(true);
-    });
-  });
-
-  // ── Terminal vs IDE (GUI) editor paths ───────────────────────────────
-
-  describe('Terminal vs IDE editor paths: policy parity', () => {
-    it.each(ALL_EDITOR_TYPES)(
-      'editor %s: DEFAULT asks, AUTO_EDIT/YOLO allow for all edit tools',
-      (_editor) => {
-        const engine = new PolicyEngine(buildTomlStyleConfig());
-
-        // The editor type does not affect policy decisions — the policy
-        // engine is editor-agnostic. The editor only matters for the diff
-        // display when shouldConfirmExecute returns confirmation details.
-        syncMode(engine, ApprovalMode.DEFAULT);
-        for (const tool of AUTO_EDIT_TOOLS) {
-          expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ASK_USER);
-        }
-
-        syncMode(engine, ApprovalMode.AUTO_EDIT);
-        for (const tool of AUTO_EDIT_TOOLS) {
-          expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
-        }
-
-        syncMode(engine, ApprovalMode.YOLO);
-        for (const tool of AUTO_EDIT_TOOLS) {
-          expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
-        }
-      },
-    );
-
-    it('terminal editors (vim/neovim/emacs/hx) and GUI editors (vscode/cursor/zed) get identical policy', () => {
-      const engine = new PolicyEngine(buildTomlStyleConfig());
-      syncMode(engine, ApprovalMode.DEFAULT);
-
-      // Policy is identical regardless of which editor the user has configured
-      const vimDecision = engine.evaluate('replace', {});
-      const vscodeDecision = engine.evaluate('replace', {});
-      expect(vimDecision).toBe(vscodeDecision);
-      expect(vimDecision).toBe(PolicyDecision.ASK_USER);
-
-      syncMode(engine, ApprovalMode.YOLO);
-      const vimYolo = engine.evaluate('replace', {});
-      const vscodeYolo = engine.evaluate('replace', {});
-      expect(vimYolo).toBe(vscodeYolo);
-      expect(vimYolo).toBe(PolicyDecision.ALLOW);
     });
   });
 

--- a/packages/policy/src/editor-mode-matrix.test.ts
+++ b/packages/policy/src/editor-mode-matrix.test.ts
@@ -1,0 +1,344 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * PolicyEngine unit tests for editor authorization across approval-mode
+ * transitions using a real PolicyEngine and MessageBus.
+ *
+ * Full scheduler → message-bus → real-tools confirmation, preview,
+ * cancellation, and filesystem coverage lives in
+ * packages/agents/src/core/coreToolScheduler.editor-integration.test.ts.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PolicyEngine } from './policy-engine.js';
+import {
+  PolicyDecision,
+  ApprovalMode,
+  type PolicyRule,
+  type PolicyEngineConfig,
+} from './types.js';
+import { MessageBus } from './confirmation-bus/message-bus.js';
+import {
+  MessageBusType,
+  ConfirmationOutcome,
+  type ToolConfirmationRequest,
+  type ToolPolicyRejection,
+} from './confirmation-bus/types.js';
+import { AUTO_EDIT_TOOLS } from './config.js';
+
+// ── Test fixtures ──────────────────────────────────────────────────────
+
+/**
+ * Builds a PolicyEngineConfig with declarative TOML-style rules mirroring
+ * write.toml (AUTO_EDIT per-tool ALLOW) and yolo.toml (YOLO wildcard ALLOW).
+ * This is exactly what the production TOML files produce.
+ */
+function buildTomlStyleConfig(): PolicyEngineConfig {
+  const rules: PolicyRule[] = [];
+
+  for (const tool of [...AUTO_EDIT_TOOLS, 'save_memory', 'run_shell_command']) {
+    rules.push({
+      toolName: tool,
+      decision: PolicyDecision.ASK_USER,
+      priority: 1.01,
+    });
+  }
+
+  for (const tool of AUTO_EDIT_TOOLS) {
+    rules.push({
+      toolName: tool,
+      decision: PolicyDecision.ALLOW,
+      priority: 1.015,
+      modes: [ApprovalMode.AUTO_EDIT],
+    });
+  }
+
+  rules.push({
+    decision: PolicyDecision.ALLOW,
+    priority: 1.999,
+    allowRedirection: true,
+    modes: [ApprovalMode.YOLO],
+  });
+
+  rules.push({
+    toolName: 'glob',
+    decision: PolicyDecision.ALLOW,
+    priority: 1.05,
+  });
+
+  return {
+    rules,
+    defaultDecision: PolicyDecision.ASK_USER,
+  };
+}
+
+function syncMode(engine: PolicyEngine, mode: ApprovalMode): void {
+  engine.setApprovalMode(mode);
+}
+
+// ── Editor type constants ──────────────────────────────────────────────
+
+const TERMINAL_EDITORS = ['vim', 'neovim', 'emacs', 'hx'] as const;
+const GUI_EDITORS = [
+  'vscode',
+  'vscodium',
+  'windsurf',
+  'cursor',
+  'zed',
+  'antigravity',
+] as const;
+const ALL_EDITOR_TYPES = [...TERMINAL_EDITORS, ...GUI_EDITORS] as const;
+
+// ── Test suite ─────────────────────────────────────────────────────────
+
+describe('Editor mode matrix: PolicyEngine + MessageBus (issue #2659)', () => {
+  // ── Six-editor × three-mode matrix ───────────────────────────────────
+
+  describe.each(AUTO_EDIT_TOOLS)('editor tool: %s', (toolName) => {
+    it('DEFAULT mode: policy evaluates to ASK_USER (editor/preview shown)', () => {
+      const engine = new PolicyEngine(buildTomlStyleConfig());
+      syncMode(engine, ApprovalMode.DEFAULT);
+
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ASK_USER);
+    });
+
+    it('AUTO_EDIT mode: policy evaluates to ALLOW (no editor/preview)', () => {
+      const engine = new PolicyEngine(buildTomlStyleConfig());
+      syncMode(engine, ApprovalMode.AUTO_EDIT);
+
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('YOLO mode: policy evaluates to ALLOW (no editor/preview)', () => {
+      const engine = new PolicyEngine(buildTomlStyleConfig());
+      syncMode(engine, ApprovalMode.YOLO);
+
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ALLOW);
+    });
+
+    // ── Downgrade: AUTO_EDIT → DEFAULT ────────────────────────────────
+
+    it('AUTO_EDIT→DEFAULT downgrade: reverts from ALLOW to ASK_USER', () => {
+      const engine = new PolicyEngine(buildTomlStyleConfig());
+      syncMode(engine, ApprovalMode.AUTO_EDIT);
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ALLOW);
+
+      syncMode(engine, ApprovalMode.DEFAULT);
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ASK_USER);
+    });
+
+    // ── Downgrade: YOLO → DEFAULT ─────────────────────────────────────
+
+    it('YOLO→DEFAULT downgrade: reverts from ALLOW to ASK_USER', () => {
+      const engine = new PolicyEngine(buildTomlStyleConfig());
+      syncMode(engine, ApprovalMode.YOLO);
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ALLOW);
+
+      syncMode(engine, ApprovalMode.DEFAULT);
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ASK_USER);
+    });
+
+    // ── Downgrade: YOLO → AUTO_EDIT ───────────────────────────────────
+
+    it('YOLO→AUTO_EDIT downgrade: stays ALLOW for edit tool', () => {
+      const engine = new PolicyEngine(buildTomlStyleConfig());
+      syncMode(engine, ApprovalMode.YOLO);
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ALLOW);
+
+      syncMode(engine, ApprovalMode.AUTO_EDIT);
+      expect(engine.evaluate(toolName, {})).toBe(PolicyDecision.ALLOW);
+    });
+  });
+
+  // ── MessageBus policy confirmation in each mode ──────────────────────
+
+  describe('MessageBus requestConfirmation behavior', () => {
+    let engine: PolicyEngine;
+    let bus: MessageBus;
+
+    beforeEach(() => {
+      engine = new PolicyEngine(buildTomlStyleConfig());
+      bus = new MessageBus(engine, false);
+    });
+
+    it('DEFAULT: first call to replace returns ASK_USER path (confirmation request emitted)', async () => {
+      syncMode(engine, ApprovalMode.DEFAULT);
+
+      let confirmationRequested = false;
+      bus.subscribe<ToolConfirmationRequest>(
+        MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        (msg) => {
+          confirmationRequested = true;
+          // Simulate user proceeding
+          bus.respondToConfirmation(
+            msg.correlationId,
+            ConfirmationOutcome.ProceedOnce,
+          );
+        },
+      );
+
+      const result = await bus.requestConfirmation(
+        { name: 'replace', args: {} },
+        {},
+      );
+
+      expect(confirmationRequested).toBe(true);
+      expect(result).toBe(true);
+    });
+
+    it('AUTO_EDIT: first call to replace fast-approves (ALLOW, no confirmation request)', async () => {
+      syncMode(engine, ApprovalMode.AUTO_EDIT);
+
+      let confirmationRequested = false;
+      bus.subscribe<ToolConfirmationRequest>(
+        MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        () => {
+          confirmationRequested = true;
+        },
+      );
+
+      const result = await bus.requestConfirmation(
+        { name: 'replace', args: {} },
+        {},
+      );
+
+      expect(confirmationRequested).toBe(false);
+      expect(result).toBe(true);
+    });
+
+    it('YOLO: first call to replace fast-approves (ALLOW, no confirmation request)', async () => {
+      syncMode(engine, ApprovalMode.YOLO);
+
+      let confirmationRequested = false;
+      bus.subscribe<ToolConfirmationRequest>(
+        MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        () => {
+          confirmationRequested = true;
+        },
+      );
+
+      const result = await bus.requestConfirmation(
+        { name: 'replace', args: {} },
+        {},
+      );
+
+      expect(confirmationRequested).toBe(false);
+      expect(result).toBe(true);
+    });
+
+    it('YOLO→DEFAULT: fast-approve stops, confirmation request emitted', async () => {
+      syncMode(engine, ApprovalMode.YOLO);
+      const yoloResult = await bus.requestConfirmation(
+        { name: 'replace', args: {} },
+        {},
+      );
+      expect(yoloResult).toBe(true);
+
+      // Downgrade
+      syncMode(engine, ApprovalMode.DEFAULT);
+
+      let confirmationRequested = false;
+      bus.subscribe<ToolConfirmationRequest>(
+        MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        (msg) => {
+          confirmationRequested = true;
+          bus.respondToConfirmation(
+            msg.correlationId,
+            ConfirmationOutcome.ProceedOnce,
+          );
+        },
+      );
+
+      const result = await bus.requestConfirmation(
+        { name: 'replace', args: {} },
+        {},
+      );
+
+      expect(confirmationRequested).toBe(true);
+      expect(result).toBe(true);
+    });
+  });
+
+  // ── Terminal vs IDE (GUI) editor paths ───────────────────────────────
+
+  describe('Terminal vs IDE editor paths: policy parity', () => {
+    it.each(ALL_EDITOR_TYPES)(
+      'editor %s: DEFAULT asks, AUTO_EDIT/YOLO allow for all edit tools',
+      (_editor) => {
+        const engine = new PolicyEngine(buildTomlStyleConfig());
+
+        // The editor type does not affect policy decisions — the policy
+        // engine is editor-agnostic. The editor only matters for the diff
+        // display when shouldConfirmExecute returns confirmation details.
+        syncMode(engine, ApprovalMode.DEFAULT);
+        for (const tool of AUTO_EDIT_TOOLS) {
+          expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ASK_USER);
+        }
+
+        syncMode(engine, ApprovalMode.AUTO_EDIT);
+        for (const tool of AUTO_EDIT_TOOLS) {
+          expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+        }
+
+        syncMode(engine, ApprovalMode.YOLO);
+        for (const tool of AUTO_EDIT_TOOLS) {
+          expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+        }
+      },
+    );
+
+    it('terminal editors (vim/neovim/emacs/hx) and GUI editors (vscode/cursor/zed) get identical policy', () => {
+      const engine = new PolicyEngine(buildTomlStyleConfig());
+      syncMode(engine, ApprovalMode.DEFAULT);
+
+      // Policy is identical regardless of which editor the user has configured
+      const vimDecision = engine.evaluate('replace', {});
+      const vscodeDecision = engine.evaluate('replace', {});
+      expect(vimDecision).toBe(vscodeDecision);
+      expect(vimDecision).toBe(PolicyDecision.ASK_USER);
+
+      syncMode(engine, ApprovalMode.YOLO);
+      const vimYolo = engine.evaluate('replace', {});
+      const vscodeYolo = engine.evaluate('replace', {});
+      expect(vimYolo).toBe(vscodeYolo);
+      expect(vimYolo).toBe(PolicyDecision.ALLOW);
+    });
+  });
+
+  // ── ToolPolicyRejection emitted in non-interactive DEFAULT ───────────
+
+  describe('Non-interactive DEFAULT: rejections emitted', () => {
+    it('non-interactive mode converts ASK_USER to TOOL_POLICY_REJECTION', async () => {
+      const config = buildTomlStyleConfig();
+      const engine = new PolicyEngine({
+        ...config,
+        nonInteractive: true,
+      });
+      const bus = new MessageBus(engine, false);
+      syncMode(engine, ApprovalMode.DEFAULT);
+
+      let rejectionReceived: ToolPolicyRejection | undefined;
+      bus.subscribe<ToolPolicyRejection>(
+        MessageBusType.TOOL_POLICY_REJECTION,
+        (msg) => {
+          rejectionReceived = msg;
+        },
+      );
+
+      const result = await bus.requestConfirmation(
+        { name: 'replace', args: {} },
+        {},
+      );
+
+      expect(result).toBe(false);
+      expect(rejectionReceived).toBeDefined();
+      expect(rejectionReceived?.type).toBe(
+        MessageBusType.TOOL_POLICY_REJECTION,
+      );
+    });
+  });
+});

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -26,6 +26,7 @@ export {
   getPolicyTier,
   formatPolicyError,
   migrateLegacyApprovalMode,
+  AUTO_EDIT_TOOLS,
 } from './config.js';
 export type { PolicyConfigSource, PolicyPathResolver } from './config.js';
 export {

--- a/packages/policy/src/policies/write.toml
+++ b/packages/policy/src/policies/write.toml
@@ -24,6 +24,13 @@
 #   15: Auto-edit tool override (becomes 1.015 in default tier)
 #   50: Read-only tools (becomes 1.050 in default tier)
 #   999: YOLO mode allow-all (becomes 1.999 in default tier)
+#
+# Mode-specific rules (with `modes` filters) are evaluated DYNAMICALLY by the
+# PolicyEngine at evaluate() time. When the approval mode changes (Ctrl-Y /
+# Ctrl-E), the engine's currentMode updates via setApprovalMode(), so rules
+# with `modes = ["autoEdit"]` automatically become active/inactive without
+# reloading TOML. This eliminates the authorization desynchronization bug
+# (issue #2659) where stale mode rules persisted across transitions.
 
 [[rule]]
 toolName = "replace"
@@ -52,17 +59,17 @@ decision = "ask_user"
 priority = 10
 
 [[rule]]
-toolName = "activate_skill"
-decision = "ask_user"
-priority = 10
-
-[[rule]]
 toolName = "write_file"
 decision = "allow"
 priority = 15
 modes = ["autoEdit"]
 
 [[rule]]
+toolName = "activate_skill"
+decision = "ask_user"
+priority = 10
+
+[[rule]]
 toolName = "insert_at_line"
 decision = "ask_user"
 priority = 10
@@ -91,6 +98,17 @@ priority = 10
 
 [[rule]]
 toolName = "apply_patch"
+decision = "allow"
+priority = 15
+modes = ["autoEdit"]
+
+[[rule]]
+toolName = "ast_edit"
+decision = "ask_user"
+priority = 10
+
+[[rule]]
+toolName = "ast_edit"
 decision = "allow"
 priority = 15
 modes = ["autoEdit"]

--- a/packages/policy/src/policies/yolo.toml
+++ b/packages/policy/src/policies/yolo.toml
@@ -1,6 +1,12 @@
 # YOLO mode policy - allow everything
 # Priority band: 1.999 (Tier 1 - Default, just below user settings)
 # WARNING: This disables all safety checks. Use only in trusted environments.
+#
+# This rule uses the `modes` filter so the PolicyEngine evaluates it
+# dynamically at runtime. When currentMode is YOLO, the rule is active;
+# when the user switches to DEFAULT or AUTO_EDIT (Ctrl-Y / Ctrl-E), the
+# rule is automatically skipped — no TOML reload needed. This eliminates
+# the authorization desynchronization bug (issue #2659).
 
 [[rule]]
 # No toolName specified = wildcard (matches all tools)

--- a/packages/policy/src/policy-engine-overlay.test.ts
+++ b/packages/policy/src/policy-engine-overlay.test.ts
@@ -1,0 +1,438 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * PolicyEngine dynamic mode-evaluation tests.
+ *
+ * Mode-specific behavior is expressed declaratively via `modes` filters on
+ * rules. The engine evaluates those rules dynamically at evaluate() time
+ * against `currentMode`, which is updated atomically via setApprovalMode().
+ * No rules are added or removed on transition.
+ *
+ * The config below mirrors the production TOML files (write.toml +
+ * yolo.toml) so these tests exercise the same rule structure that
+ * createPolicyEngineConfig produces.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PolicyEngine,
+  PolicyDecision,
+  type PolicyRule,
+  type PolicyEngineConfig,
+} from './index.js';
+import { ApprovalMode } from './types.js';
+import { AUTO_EDIT_TOOLS } from './config.js';
+
+// ── TOML-style config builders ─────────────────────────────────────────
+
+/**
+ * Builds a PolicyEngineConfig mirroring the production write.toml +
+ * yolo.toml files. Rules with `modes` filters are active only when the
+ * engine's currentMode matches.
+ */
+function buildTomlStyleConfig(): PolicyEngineConfig {
+  const rules: PolicyRule[] = [];
+
+  // write.toml: priority-10 tools default to ASK_USER
+  for (const tool of [...AUTO_EDIT_TOOLS, 'save_memory', 'run_shell_command']) {
+    rules.push({
+      toolName: tool,
+      decision: PolicyDecision.ASK_USER,
+      priority: 1.01,
+    });
+  }
+
+  // write.toml: AUTO_EDIT per-tool ALLOW (mode-filtered)
+  for (const tool of AUTO_EDIT_TOOLS) {
+    rules.push({
+      toolName: tool,
+      decision: PolicyDecision.ALLOW,
+      priority: 1.015,
+      modes: [ApprovalMode.AUTO_EDIT],
+    });
+  }
+
+  // yolo.toml: YOLO wildcard ALLOW (mode-filtered)
+  rules.push({
+    decision: PolicyDecision.ALLOW,
+    priority: 1.999,
+    allowRedirection: true,
+    modes: [ApprovalMode.YOLO],
+  });
+
+  // read-only.toml: read-only tools always ALLOW
+  rules.push({
+    toolName: 'glob',
+    decision: PolicyDecision.ALLOW,
+    priority: 1.05,
+  });
+
+  return {
+    rules,
+    defaultDecision: PolicyDecision.ASK_USER,
+  };
+}
+
+// ── AUTO_EDIT_TOOLS inventory ─────────────────────────────────────────
+
+describe('AUTO_EDIT_TOOLS inventory', () => {
+  it('includes all six edit tools', () => {
+    expect([...AUTO_EDIT_TOOLS]).toStrictEqual([
+      'replace',
+      'write_file',
+      'insert_at_line',
+      'delete_line_range',
+      'apply_patch',
+      'ast_edit',
+    ]);
+  });
+});
+
+// ── Mode transitions via setApprovalMode ──────────────────────────────
+
+describe('PolicyEngine mode evaluation via setApprovalMode', () => {
+  function makeEngine(mode?: ApprovalMode): PolicyEngine {
+    return new PolicyEngine({
+      ...buildTomlStyleConfig(),
+      ...(mode !== undefined ? { approvalMode: mode } : {}),
+    });
+  }
+
+  it('DEFAULT: edit tools are ASK_USER', () => {
+    const engine = makeEngine(ApprovalMode.DEFAULT);
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ASK_USER);
+    }
+  });
+
+  it('AUTO_EDIT: edit tools are ALLOW, shell is ASK_USER', () => {
+    const engine = makeEngine(ApprovalMode.AUTO_EDIT);
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+    }
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+  });
+
+  it('YOLO: all tools are ALLOW', () => {
+    const engine = makeEngine(ApprovalMode.YOLO);
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ALLOW);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ALLOW);
+  });
+
+  it('user TOML rule with modes = [yolo] appears/disappears on transition', () => {
+    const rule: PolicyRule = {
+      toolName: 'custom_tool',
+      decision: PolicyDecision.ALLOW,
+      priority: 2.5,
+      modes: [ApprovalMode.YOLO],
+    };
+    const engine = new PolicyEngine({
+      rules: [rule],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ALLOW);
+
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ASK_USER);
+  });
+});
+
+// ── Full mode transition synchronization ──────────────────────────────
+
+describe('Full mode transition synchronization', () => {
+  it('YOLO→DEFAULT: wildcard ALLOW removed, all tools revert to ASK', () => {
+    const engine = new PolicyEngine(buildTomlStyleConfig());
+
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ALLOW);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ASK_USER);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+  });
+
+  it('AUTO_EDIT→DEFAULT: per-tool ALLOW removed, all edit tools revert to ASK', () => {
+    const engine = new PolicyEngine(buildTomlStyleConfig());
+
+    engine.setApprovalMode(ApprovalMode.AUTO_EDIT);
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ALLOW);
+    }
+
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    for (const tool of AUTO_EDIT_TOOLS) {
+      expect(engine.evaluate(tool, {})).toBe(PolicyDecision.ASK_USER);
+    }
+  });
+
+  it('YOLO→AUTO_EDIT: YOLO wildcard removed, only edit tools ALLOW', () => {
+    const engine = new PolicyEngine(buildTomlStyleConfig());
+
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ALLOW);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+
+    engine.setApprovalMode(ApprovalMode.AUTO_EDIT);
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ALLOW);
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ALLOW);
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+  });
+
+  it('multiple rapid transitions do not accumulate rules or lose base rules', () => {
+    const baseRule: PolicyRule = {
+      toolName: 'glob',
+      decision: PolicyDecision.ALLOW,
+      priority: 1.05,
+      source: 'Default: read-only.toml',
+    };
+    const engine = new PolicyEngine({
+      rules: [baseRule],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      engine.setApprovalMode(ApprovalMode.YOLO);
+      engine.setApprovalMode(ApprovalMode.DEFAULT);
+      engine.setApprovalMode(ApprovalMode.AUTO_EDIT);
+      engine.setApprovalMode(ApprovalMode.DEFAULT);
+    }
+
+    const rules = engine.getRules();
+    expect(rules).toHaveLength(1);
+    expect(engine.evaluate('glob', {})).toBe(PolicyDecision.ALLOW);
+  });
+});
+
+// ── Focused policy edge cases ─────────────────────────────────────────
+
+describe('Mode-filtered DENY precedence', () => {
+  it('non-mode DENY rule (priority 2.9) overrides YOLO wildcard ALLOW (priority 1.999)', () => {
+    const denyRule: PolicyRule = {
+      toolName: 'run_shell_command',
+      argsPattern: /rm\s+-rf/,
+      decision: PolicyDecision.DENY,
+      priority: 2.9,
+      source: 'User TOML',
+    };
+    const yoloRule: PolicyRule = {
+      decision: PolicyDecision.ALLOW,
+      priority: 1.999,
+      allowRedirection: true,
+      modes: [ApprovalMode.YOLO],
+    };
+    const engine = new PolicyEngine({
+      rules: [denyRule, yoloRule],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(engine.evaluate('run_shell_command', { command: 'rm -rf /' })).toBe(
+      PolicyDecision.DENY,
+    );
+    // Other tools still allowed by YOLO wildcard
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ALLOW);
+  });
+
+  it('non-mode DENY rule overrides AUTO_EDIT ALLOW', () => {
+    const denyRule: PolicyRule = {
+      toolName: 'replace',
+      decision: PolicyDecision.DENY,
+      priority: 2.9,
+      source: 'Admin TOML',
+    };
+    const autoEditRule: PolicyRule = {
+      toolName: 'replace',
+      decision: PolicyDecision.ALLOW,
+      priority: 1.015,
+      modes: [ApprovalMode.AUTO_EDIT],
+    };
+    const engine = new PolicyEngine({
+      rules: [denyRule, autoEditRule],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    engine.setApprovalMode(ApprovalMode.AUTO_EDIT);
+    expect(engine.evaluate('replace', {})).toBe(PolicyDecision.DENY);
+
+    // Other edit tools not denied
+    const denyReplaceOnly: PolicyRule = {
+      toolName: 'replace',
+      decision: PolicyDecision.DENY,
+      priority: 2.9,
+    };
+    const engine2 = new PolicyEngine({
+      rules: [
+        denyReplaceOnly,
+        {
+          toolName: 'ast_edit',
+          decision: PolicyDecision.ALLOW,
+          priority: 1.015,
+          modes: [ApprovalMode.AUTO_EDIT],
+        },
+      ],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+    engine2.setApprovalMode(ApprovalMode.AUTO_EDIT);
+    expect(engine2.evaluate('ast_edit', {})).toBe(PolicyDecision.ALLOW);
+  });
+});
+
+describe('Multiple modes on a single rule', () => {
+  it('rule active in both AUTO_EDIT and YOLO, inactive in DEFAULT', () => {
+    const multiModeRule: PolicyRule = {
+      toolName: 'custom_tool',
+      decision: PolicyDecision.ALLOW,
+      priority: 2.5,
+      modes: [ApprovalMode.AUTO_EDIT, ApprovalMode.YOLO],
+    };
+    const engine = new PolicyEngine({
+      rules: [multiModeRule],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ASK_USER);
+
+    engine.setApprovalMode(ApprovalMode.AUTO_EDIT);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ALLOW);
+
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ALLOW);
+
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(engine.evaluate('custom_tool', {})).toBe(PolicyDecision.ASK_USER);
+  });
+});
+
+describe('modes combined with argsPattern', () => {
+  it('mode-filtered argsPattern rule only matches in its mode and only when args match', () => {
+    // This rule allows "safe-ls" shell command ONLY in YOLO mode.
+    // We use a priority ABOVE the YOLO wildcard (1.999) so that this
+    // specific rule is the decisive one, proving the argsPattern truly
+    // governs the match rather than being masked by the wildcard.
+    const yoloWildcard: PolicyRule = {
+      decision: PolicyDecision.ALLOW,
+      priority: 1.999,
+      allowRedirection: true,
+      modes: [ApprovalMode.YOLO],
+    };
+    const yoloOnlyDenyPattern: PolicyRule = {
+      toolName: 'run_shell_command',
+      argsPattern: /"command":"dangerous-cmd"/,
+      decision: PolicyDecision.DENY,
+      priority: 2.5,
+      modes: [ApprovalMode.YOLO],
+    };
+    const engine = new PolicyEngine({
+      rules: [yoloWildcard, yoloOnlyDenyPattern],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    // In YOLO: the argsPattern DENY (2.5) wins over wildcard ALLOW (1.999)
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(
+      engine.evaluate('run_shell_command', { command: 'dangerous-cmd' }),
+    ).toBe(PolicyDecision.DENY);
+    // Other commands still allowed by wildcard
+    expect(engine.evaluate('run_shell_command', { command: 'ls' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+
+    // In DEFAULT: the mode-filtered DENY rule is inactive; the argsPattern
+    // command falls through to the default (ASK_USER), not DENY.
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(
+      engine.evaluate('run_shell_command', { command: 'dangerous-cmd' }),
+    ).toBe(PolicyDecision.ASK_USER);
+  });
+
+  it('mode-filtered ALLOW argsPattern rule is masked by YOLO wildcard but active in DEFAULT', () => {
+    // An ALLOW rule for a specific command that is active only in DEFAULT.
+    // In YOLO, the wildcard already allows everything (same decision),
+    // so we verify it in DEFAULT where the wildcard is absent.
+    const yoloWildcard: PolicyRule = {
+      decision: PolicyDecision.ALLOW,
+      priority: 1.999,
+      modes: [ApprovalMode.YOLO],
+    };
+    const defaultOnlyAllow: PolicyRule = {
+      toolName: 'run_shell_command',
+      argsPattern: /"command":"safe-cmd"/,
+      decision: PolicyDecision.ALLOW,
+      priority: 2.5,
+      modes: [ApprovalMode.DEFAULT],
+    };
+    const engine = new PolicyEngine({
+      rules: [yoloWildcard, defaultOnlyAllow],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    // In DEFAULT: matching command is ALLOW by the mode-filtered rule
+    engine.setApprovalMode(ApprovalMode.DEFAULT);
+    expect(engine.evaluate('run_shell_command', { command: 'safe-cmd' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+    // Non-matching command falls to default
+    expect(engine.evaluate('run_shell_command', { command: 'other-cmd' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+
+    // In YOLO: the mode-filtered rule is inactive, but wildcard allows all
+    engine.setApprovalMode(ApprovalMode.YOLO);
+    expect(engine.evaluate('run_shell_command', { command: 'safe-cmd' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+    expect(engine.evaluate('run_shell_command', { command: 'other-cmd' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+  });
+});
+
+// ── Defensive copy behavior ───────────────────────────────────────────
+
+describe('Defensive copies', () => {
+  it('getRules returns a fresh copy each call', () => {
+    const engine = new PolicyEngine({
+      rules: [{ toolName: 'edit', decision: PolicyDecision.ALLOW }],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    const rules1 = engine.getRules();
+    const rules2 = engine.getRules();
+    expect(rules1).not.toBe(rules2);
+    expect(rules1).toStrictEqual(rules2);
+  });
+
+  it('constructor does not retain caller array reference', () => {
+    const callerRules: PolicyRule[] = [
+      { toolName: 'edit', decision: PolicyDecision.ALLOW },
+    ];
+    const engine = new PolicyEngine({
+      rules: callerRules,
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    callerRules.push({ toolName: 'shell', decision: PolicyDecision.DENY });
+    expect(engine.getRules()).toHaveLength(1);
+  });
+});

--- a/packages/policy/src/policy-engine-overlay.test.ts
+++ b/packages/policy/src/policy-engine-overlay.test.ts
@@ -436,4 +436,56 @@ describe('Defensive copies', () => {
     callerRules.push({ toolName: 'shell', decision: PolicyDecision.DENY });
     expect(engine.getRules()).toHaveLength(1);
   });
+
+  it('constructor does not retain caller modes array reference', () => {
+    const modes = [ApprovalMode.YOLO];
+    const engine = new PolicyEngine({
+      rules: [
+        {
+          toolName: 'edit',
+          decision: PolicyDecision.ALLOW,
+          modes,
+        },
+      ],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    modes.splice(0, 1, ApprovalMode.DEFAULT);
+
+    expect(engine.evaluate('edit', {})).toBe(PolicyDecision.ASK_USER);
+  });
+
+  it('addRule does not retain caller modes array reference', () => {
+    const modes = [ApprovalMode.YOLO];
+    const engine = new PolicyEngine({
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+
+    engine.addRule({
+      toolName: 'edit',
+      decision: PolicyDecision.ALLOW,
+      modes,
+    });
+    modes.splice(0, 1, ApprovalMode.DEFAULT);
+
+    expect(engine.evaluate('edit', {})).toBe(PolicyDecision.ASK_USER);
+  });
+
+  it('getRules does not expose internal modes array references', () => {
+    const engine = new PolicyEngine({
+      rules: [
+        {
+          toolName: 'edit',
+          decision: PolicyDecision.ALLOW,
+          modes: [ApprovalMode.YOLO],
+        },
+      ],
+      defaultDecision: PolicyDecision.ASK_USER,
+    });
+    const [rule] = engine.getRules();
+
+    rule.modes?.splice(0, 1, ApprovalMode.DEFAULT);
+
+    expect(engine.evaluate('edit', {})).toBe(PolicyDecision.ASK_USER);
+  });
 });

--- a/packages/policy/src/policy-engine-overlay.test.ts
+++ b/packages/policy/src/policy-engine-overlay.test.ts
@@ -326,7 +326,7 @@ describe('Multiple modes on a single rule', () => {
 
 describe('modes combined with argsPattern', () => {
   it('mode-filtered argsPattern rule only matches in its mode and only when args match', () => {
-    // This rule allows "safe-ls" shell command ONLY in YOLO mode.
+    // This rule denies "dangerous-cmd" only in YOLO mode.
     // We use a priority ABOVE the YOLO wildcard (1.999) so that this
     // specific rule is the decisive one, proving the argsPattern truly
     // governs the match rather than being masked by the wildcard.

--- a/packages/policy/src/policy-engine-overlay.test.ts
+++ b/packages/policy/src/policy-engine-overlay.test.ts
@@ -128,7 +128,7 @@ describe('PolicyEngine mode evaluation via setApprovalMode', () => {
     expect(engine.evaluate('replace', {})).toBe(PolicyDecision.ALLOW);
   });
 
-  it('user TOML rule with modes = [yolo] appears/disappears on transition', () => {
+  it('user TOML rule with modes = [YOLO] appears/disappears on transition', () => {
     const rule: PolicyRule = {
       toolName: 'custom_tool',
       decision: PolicyDecision.ALLOW,
@@ -229,7 +229,7 @@ describe('Mode-filtered DENY precedence', () => {
   it('non-mode DENY rule (priority 2.9) overrides YOLO wildcard ALLOW (priority 1.999)', () => {
     const denyRule: PolicyRule = {
       toolName: 'run_shell_command',
-      argsPattern: /rm\s+-rf/,
+      argsPattern: /"command":"rm\s+-rf/,
       decision: PolicyDecision.DENY,
       priority: 2.9,
       source: 'User TOML',
@@ -373,6 +373,7 @@ describe('modes combined with argsPattern', () => {
     const yoloWildcard: PolicyRule = {
       decision: PolicyDecision.ALLOW,
       priority: 1.999,
+      allowRedirection: true,
       modes: [ApprovalMode.YOLO],
     };
     const defaultOnlyAllow: PolicyRule = {

--- a/packages/policy/src/policy-engine.ts
+++ b/packages/policy/src/policy-engine.ts
@@ -11,6 +11,14 @@ import {
   hasRedirection,
 } from './utils/shell-utils.js';
 
+const cloneRule = (rule: PolicyRule): PolicyRule => ({
+  ...rule,
+  modes: rule.modes ? [...rule.modes] : undefined,
+});
+
+const compareRulePriority = (a: PolicyRule, b: PolicyRule): number =>
+  (b.priority ?? 0) - (a.priority ?? 0);
+
 /**
  * PolicyEngine evaluates tool execution requests against configured rules.
  * Rules are matched in priority order, with the highest priority rule winning.
@@ -29,13 +37,13 @@ export class PolicyEngine {
   private currentMode: ApprovalMode;
 
   constructor(config?: PolicyEngineConfig) {
-    this.baseRules = config?.rules ? config.rules.map((r) => ({ ...r })) : [];
+    this.baseRules = config?.rules ? config.rules.map(cloneRule) : [];
     this.defaultDecision = config?.defaultDecision ?? PolicyDecision.ASK_USER;
     this.nonInteractive = config?.nonInteractive ?? false;
     this.currentMode = config?.approvalMode ?? ApprovalMode.DEFAULT;
 
     // Sort base rules by priority (highest first)
-    this.baseRules.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    this.baseRules.sort(compareRulePriority);
   }
 
   /**
@@ -328,7 +336,7 @@ export class PolicyEngine {
    * @returns Array of policy rules
    */
   getRules(): readonly PolicyRule[] {
-    return this.baseRules.map((r) => ({ ...r }));
+    return this.baseRules.map(cloneRule);
   }
 
   /**
@@ -356,8 +364,8 @@ export class PolicyEngine {
    * @param rule - The policy rule to add
    */
   addRule(rule: PolicyRule): void {
-    this.baseRules.push({ ...rule });
-    this.baseRules.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    this.baseRules.push(cloneRule(rule));
+    this.baseRules.sort(compareRulePriority);
   }
 
   /**

--- a/packages/policy/src/policy-engine.ts
+++ b/packages/policy/src/policy-engine.ts
@@ -365,9 +365,8 @@ export class PolicyEngine {
    *
    * Mode-specific rules (those carrying a `modes` filter) are evaluated
    * dynamically at evaluate() time against this mode — they are not loaded
-   * or unloaded. This is the sole mechanism for mode transitions and is
-   * atomically safe: there is no window where a stale mode can authorize
-   * a tool that should require confirmation.
+   * or unloaded. Because evaluation reads the current mode synchronously,
+   * the new mode applies to subsequent rule matches in the same process.
    *
    * @param mode - The new approval mode
    */

--- a/packages/policy/src/policy-engine.ts
+++ b/packages/policy/src/policy-engine.ts
@@ -1,5 +1,6 @@
 import {
   PolicyDecision,
+  ApprovalMode,
   type PolicyEngineConfig,
   type PolicyRule,
 } from './types.js';
@@ -13,19 +14,28 @@ import {
 /**
  * PolicyEngine evaluates tool execution requests against configured rules.
  * Rules are matched in priority order, with the highest priority rule winning.
+ *
+ * Internally, rules are kept in a single sorted base list. Mode-specific
+ * behavior is expressed declaratively via the `modes` field on individual
+ * rules, which is evaluated dynamically at evaluate() time against
+ * `currentMode`. `currentMode` is updated atomically via `setApprovalMode()`,
+ * which is the sole mechanism for mode transitions — no rules are added or
+ * removed on transition, only the mode filter changes.
  */
 export class PolicyEngine {
-  private readonly rules: PolicyRule[];
+  private readonly baseRules: PolicyRule[];
   private readonly defaultDecision: PolicyDecision;
   private readonly nonInteractive: boolean;
+  private currentMode: ApprovalMode;
 
   constructor(config?: PolicyEngineConfig) {
-    this.rules = config?.rules ?? [];
+    this.baseRules = config?.rules ? config.rules.map((r) => ({ ...r })) : [];
     this.defaultDecision = config?.defaultDecision ?? PolicyDecision.ASK_USER;
     this.nonInteractive = config?.nonInteractive ?? false;
+    this.currentMode = config?.approvalMode ?? ApprovalMode.DEFAULT;
 
-    // Sort rules by priority (highest first)
-    this.rules.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    // Sort base rules by priority (highest first)
+    this.baseRules.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
   }
 
   /**
@@ -259,10 +269,20 @@ export class PolicyEngine {
   ): PolicyRule | undefined {
     const argsString = stableStringify(args);
 
-    return this.rules.find((rule) => {
+    return this.baseRules.find((rule) => {
       // Check tool name match
       const toolMatches = !rule.toolName || rule.toolName === toolName;
       if (!toolMatches) {
+        return false;
+      }
+
+      // Check mode applicability: rules with `modes` only match when the
+      // engine's current approval mode is in the list
+      if (
+        rule.modes &&
+        rule.modes.length > 0 &&
+        !rule.modes.includes(this.currentMode)
+      ) {
         return false;
       }
 
@@ -308,7 +328,7 @@ export class PolicyEngine {
    * @returns Array of policy rules
    */
   getRules(): readonly PolicyRule[] {
-    return [...this.rules];
+    return this.baseRules.map((r) => ({ ...r }));
   }
 
   /**
@@ -336,8 +356,22 @@ export class PolicyEngine {
    * @param rule - The policy rule to add
    */
   addRule(rule: PolicyRule): void {
-    this.rules.push(rule);
-    // Re-sort rules by priority (highest first)
-    this.rules.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    this.baseRules.push({ ...rule });
+    this.baseRules.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  }
+
+  /**
+   * Updates the current approval mode.
+   *
+   * Mode-specific rules (those carrying a `modes` filter) are evaluated
+   * dynamically at evaluate() time against this mode — they are not loaded
+   * or unloaded. This is the sole mechanism for mode transitions and is
+   * atomically safe: there is no window where a stale mode can authorize
+   * a tool that should require confirmation.
+   *
+   * @param mode - The new approval mode
+   */
+  setApprovalMode(mode: ApprovalMode): void {
+    this.currentMode = mode;
   }
 }

--- a/packages/policy/src/toml-loader.test.ts
+++ b/packages/policy/src/toml-loader.test.ts
@@ -133,7 +133,7 @@ priority = 100
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should filter rules by mode', async () => {
+    it('should preserve modes field for dynamic evaluation by PolicyEngine', async () => {
       const result = await runLoadPoliciesFromToml(`
 [[rule]]
 toolName = "glob"
@@ -148,9 +148,14 @@ priority = 100
 modes = ["yolo"]
 `);
 
-      // Only the first rule should be included (modes includes "default")
-      expect(result.rules).toHaveLength(1);
+      expect(result.rules).toHaveLength(2);
       expect(result.rules[0].toolName).toBe('glob');
+      expect(result.rules[0].modes).toStrictEqual([
+        ApprovalMode.DEFAULT,
+        ApprovalMode.YOLO,
+      ]);
+      expect(result.rules[1].toolName).toBe('grep');
+      expect(result.rules[1].modes).toStrictEqual([ApprovalMode.YOLO]);
       expect(result.errors).toHaveLength(0);
     });
 

--- a/packages/policy/src/toml-loader.ts
+++ b/packages/policy/src/toml-loader.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type PolicyRule, PolicyDecision, type ApprovalMode } from './types.js';
+import { type PolicyRule, PolicyDecision, ApprovalMode } from './types.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -42,7 +42,7 @@ const PolicyRuleSchema = z.object({
       message:
         'priority must be <= 999 to prevent tier overflow. Priorities >= 1000 would jump to the next tier.',
     }),
-  modes: z.array(z.string()).optional(),
+  modes: z.array(z.nativeEnum(ApprovalMode)).optional(),
   allowRedirection: z.boolean().optional(),
 });
 
@@ -387,42 +387,36 @@ function expandRuleToPolicyRules(
         priority: transformPriority(rule.priority, tier),
         argsPattern,
         allowRedirection: rule.allowRedirection,
+        modes: rule.modes,
         source: `${tierName.charAt(0).toUpperCase() + tierName.slice(1)}: ${file}`,
       };
     });
   });
 }
 
-/** Transforms validated TOML rules into PolicyRule[], filtering by approval mode and handling errors. */
+/** Transforms validated TOML rules into PolicyRule[], preserving modes for dynamic evaluation. */
 function transformTomlRules(
   data: z.infer<typeof PolicyFileSchema>,
-  approvalMode: ApprovalMode,
+  _approvalMode: ApprovalMode,
   tier: number,
   tierName: 'default' | 'user' | 'admin',
   filePath: string,
   file: string,
   errors: PolicyFileError[],
 ): PolicyRule[] {
-  return data.rule
-    .filter((rule) => {
-      if (!rule.modes || rule.modes.length === 0) {
-        return true;
-      }
-      return rule.modes.includes(approvalMode);
-    })
-    .flatMap((rule) => {
-      const patterns = resolveRulePatterns(
-        rule,
-        filePath,
-        file,
-        tierName,
-        errors,
-      );
-      if (!patterns) {
-        return [];
-      }
-      return expandRuleToPolicyRules(rule, tier, tierName, file, patterns);
-    });
+  return data.rule.flatMap((rule) => {
+    const patterns = resolveRulePatterns(
+      rule,
+      filePath,
+      file,
+      tierName,
+      errors,
+    );
+    if (!patterns) {
+      return [];
+    }
+    return expandRuleToPolicyRules(rule, tier, tierName, file, patterns);
+  });
 }
 
 /** Scans a directory for .toml files, returning names or pushing a read error. */

--- a/packages/policy/src/types.ts
+++ b/packages/policy/src/types.ts
@@ -57,6 +57,16 @@ export interface PolicyRule {
    * "Dynamic (Confirmed)".
    */
   source?: string;
+
+  /**
+   * Approval modes in which this rule is active.
+   * If undefined or empty, the rule applies in all modes.
+   * If specified, the rule only matches when the engine's current approval
+   * mode is in this list. This enables user/admin TOML files to declare
+   * mode-specific rules (e.g. `modes = ["yolo"]`) that are evaluated
+   * dynamically at runtime — not filtered at load time.
+   */
+  modes?: ApprovalMode[];
 }
 
 export interface PolicyEngineConfig {
@@ -76,6 +86,13 @@ export interface PolicyEngineConfig {
    * When true, ASK_USER decisions become DENY.
    */
   nonInteractive?: boolean;
+
+  /**
+   * Initial approval mode for the engine. Determines which TOML rules
+   * with `modes` filters are active. Updated at runtime via setApprovalMode().
+   * Defaults to DEFAULT.
+   */
+  approvalMode?: ApprovalMode;
 }
 
 export interface PolicySettings {


### PR DESCRIPTION
## Summary

Fixes runtime approval-mode desynchronization when a session starts in YOLO or AUTO_EDIT and the user switches modes before running an editor tool.

The policy engine previously loaded mode-specific TOML rules only for the startup mode. Changing Config approval mode updated the live flag but left the existing policy engine with stale authorization rules, allowing the scheduler fast path to bypass edit confirmation after YOLO was disabled.

## Changes

- Preserve TOML mode metadata and evaluate mode-specific rules dynamically against the policy engine's current approval mode.
- Synchronize the existing policy engine in place whenever Config approval mode changes, preserving references held by MessageBus and schedulers.
- Initialize policy engines with the configured startup mode so startup and runtime-transition behavior are identical.
- Add ast_edit to the AUTO_EDIT editor policy alongside replace, write_file, insert_at_line, delete_line_range, and apply_patch.
- Clarify that the policies command displays configured rules, including mode-filtered rules that may not be active in the current mode.
- Document immediate Ctrl-Y and Ctrl-E authorization updates.

## Behavioral coverage

- Real CoreToolScheduler, ConfirmationCoordinator, MessageBus, PolicyEngine, ToolRegistry, and real editor-tool integration for all six content-modifying editors.
- DEFAULT waits for confirmation and cancellation preserves bytes and mtime.
- AUTO_EDIT and YOLO execute valid editor calls without confirmation.
- Startup YOLO followed by a switch to DEFAULT makes first-call ast_edit force apply show a real diff confirmation and prevents mutation before approval.
- ast_edit preview remains non-mutating.
- Terminal callback and MessageBus confirmation routes produce equivalent single-write authorization.
- Policy tests cover all mode transitions, filtered ALLOW and DENY rules, argument patterns, rule precedence, defensive copies, and retained MessageBus engine identity.

## Verification

- Full tests passed across all 16 workspaces, run in bounded workspace groups to avoid the shell watchdog.
- Full lint coverage passed in bounded configured-directory groups; the aggregate npm run lint process was terminated by the shell watchdog without reporting a lint error.
- npm run typecheck
- npm run format
- npm run build
- bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
- Two bounded Open Code Review cycles completed; grounded findings were remediated.

Fixes #2659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Policy rules with mode filters are now evaluated dynamically when switching between Default, Auto Edit, and YOLO.
  * Auto Edit authorization now covers AST editing (including `ast_edit`).
  * Approval-mode behavior is kept consistent across terminal and IDE approval flows.

* **Bug Fixes**
  * Fixed stale or desynced permissions during approval-mode transitions.
  * Updated legacy approval-mode migration so mode-scoped rules don’t incorrectly accumulate.

* **Documentation**
  * Added “Approval Mode Synchronization” guidance for how mode changes affect policy evaluation.

* **Style**
  * Updated `/policies` output to show “configured policy rules” instead of “active policy rules.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->