### PR TITLE
Restore IDE diff view for write_file and ast_edit (Fixes #2664)

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -1,7 +1,10 @@
-# LLxprt Code
+<h1>
+  <img src="docs/assets/llxprt.svg" alt="LLxprt 标志" width="42" />
+  <a href="https://vybestack.dev/llxprt-code.html">LLxprt Code</a>
+</h1>
 
 [![LLxprt Code CI](https://github.com/vybestack/llxprt-code/actions/workflows/ci.yml/badge.svg)](https://github.com/vybestack/llxprt-code/actions/workflows/ci.yml)
-&nbsp;[![Mentioned in Awesome Gemini CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/Piebald-AI/awesome-gemini-cli)&nbsp;[![Discord Server](https://dcbadge.limes.pink/api/server/https://discord.gg/Wc6dZqWWYv?style=flat)](https://discord.gg/Wc6dZqWWYv)
+&nbsp;[![Discord Server](https://dcbadge.limes.pink/api/server/https://discord.gg/Wc6dZqWWYv?style=flat)](https://discord.gg/Wc6dZqWWYv)&nbsp;
 
 ![LLxprt Code Screenshot](./docs/assets/llxprt-screenshot.png)
 
@@ -12,40 +15,55 @@
 立即开始使用强大的LLM选项：
 
 ```bash
-# 免费的Gemini模型
+# Gemini（Google账户或API密钥）
 /auth gemini enable
 /provider gemini
 /model gemini-2.5-flash
 
-# 免费的Qwen模型
-/auth qwen enable
-/provider qwen
-/model qwen-3-coder
-
 # 您的Claude Pro / Max订阅
 /auth anthropic enable
 /provider anthropic
-/model claude-sonnet-4-5
+/model claude-opus-4-8
+
+# 您的ChatGPT Plus / Pro订阅（Codex）
+/auth codex enable
+/provider codex
+/model gpt-5.5
+
+# Kimi订阅（Kimi K3，1M上下文，原生视觉，思考模式始终开启）
+/provider kimi
+/key **************
+/model kimi-for-coding
 ```
 
 ## 为什么选择LLxprt Code？
 
-- **免费层级支持**：立即使用Gemini、Qwen或您现有的Claude账户开始编码
-- **提供商灵活性**：在任何Anthropic、Gemini或OpenAI兼容的提供商之间切换
-- **顶尖开源模型**：与GLM 4.6、MiniMax-2和Qwen 3 Coder无缝工作
+- **使用您现有的订阅**：通过OAuth直接使用Claude Pro/Max、ChatGPT Plus/Pro（Codex）。通过密钥使用Kimi/Synthetic/Chutes订阅
+- **多账户故障转移**：配置多个OAuth账户，在达到速率限制时自动故障转移
+- **负载均衡配置文件**：在提供商或账户之间平衡请求，并自动故障转移
+- **免费与低成本层级**：从Google账户（Gemini）或Qwen账户开始 — 有关当前层级可用性，请参阅[身份验证](./docs/cli/authentication.md)
+- **提供商灵活性**：在任何Anthropic、Gemini、OpenAI、Kimi或OpenAI兼容的提供商之间切换
+- **顶尖开源模型**：与GLM 5.2、Kimi K3、MiniMax M3和Qwen 3 Coder Next无缝工作
 - **本地模型**：使用LM Studio、llama.cpp本地运行模型以获得完全隐私
 - **隐私优先**：默认不收集遥测数据，可进行本地处理
 - **子代理灵活性**：创建具有不同模型、提供商或设置的代理
-- **[ACTION] 实时**：具有美观主题的交互式REPL
+- **交互式REPL**：具有多种主题的美观终端UI
 - **Zed集成**：原生Zed编辑器集成，实现无缝工作流
 
 ```bash
-# 安装并开始使用
+# macOS（Homebrew）
+brew tap vybestack/homebrew-tap
+brew update
+brew install llxprt-code
+
+# npm
 npm install -g @vybestack/llxprt-code
+
+# 开始编码
 llxprt
 
 # 无需安装尝试
-npx @vybestack/llxprt-code --provider synthetic --model hf:zai-org/GLM-4.6 --keyfile ~/.synthetic_key "简化README.md"
+npx @vybestack/llxprt-code --provider synthetic --model hf:zai-org/GLM-4.7 --keyfile ~/.synthetic_key "简化README.md"
 ```
 
 ## 什么是LLxprt Code？
@@ -62,16 +80,51 @@ LLxprt Code是一个专为希望在终端内获得强大LLM功能的开发者设
 
 ## 快速开始
 
-1. **先决条件：** 安装Node.js 24+
+1. **先决条件：** 安装Node.js 24+（Homebrew安装不需要）
+
+   > **注意：** LLxprt Code在底层运行于[Bun](https://bun.sh)运行时。Node.js仍然是调用的兼容性目标 — 下面的npm/npx/Homebrew安装命令保持不变。发布的包将Bun捆绑为依赖项，因此大多数用户永远不需要单独安装Bun。如果Bun缺失，请参阅[Bun回退](#bun运行时与安装回退)部分。
+
 2. **安装：**
+
    ```bash
+   # macOS（Homebrew）
+   brew tap vybestack/homebrew-tap
+   brew update
+   brew install llxprt-code
+
+   # npm
    npm install -g @vybestack/llxprt-code
    # 或者无需安装尝试：
    npx @vybestack/llxprt-code
    ```
+
 3. **运行：** `llxprt`
 4. **选择提供商：** 使用`/provider`选择您首选的LLM服务
 5. **开始编码：** 提问、生成代码或分析项目
+
+### Bun运行时与安装回退
+
+LLxprt Code由[Bun](https://bun.sh)运行时驱动。当您运行`llxprt`时，平台原生启动器（`packages/cli/bin/llxprt`）会解析包捆绑的Bun并直接执行TypeScript入口点（`packages/cli/index.ts`）— 在已安装的命令路径上不会启动Node进程。CLI的运行路径不需要预编译的CLI `dist/`工件或已停用的`bundle/llxprt.js`工件。
+
+**Bun解析（生产启动器）：**
+
+1. 包本地：`<package>/node_modules/bun/bin/bun.exe`（包固定的Bun依赖项）
+2. 提升（仅限已安装的包）：外层的`node_modules/bun/bin/bun.exe`（npm/Bun提升），在外层`node_modules`边界处停止 — 永远不会爬升到消费者的上级目录
+3. 工作区根目录（仅限源工作区）：当包不在`node_modules`下且仓库根目录是经过验证的llxprt-code工作区（其清单引用此包）时，使用该经过验证的根目录的`node_modules/bun/bin/bun.exe`
+
+启动器永远不会扫描`.bin`符号链接，也永远不会回退到`PATH`上的全局`bun`。当包的`package.json`声明了精确的Bun固定版本（例如`1.3.14`）时，`package.json`/版本缺失或不匹配的候选项将被拒绝。
+
+如果未找到包本地的Bun运行时，启动器会打印可操作的错误（退出码43）：
+
+> LLxprt Code: bundled Bun runtime was not found. Reinstall the package with "npm install @vybestack/llxprt-code" to restore the bundled Bun dependency, or visit https://bun.sh
+
+解决方法：
+
+- **npm用户：** 重新运行`npm install @vybestack/llxprt-code`（或`npm install -g @vybestack/llxprt-code`）以恢复捆绑的Bun依赖项。
+- **Homebrew用户：** 运行`brew upgrade llxprt-code`获取最新配方，或运行`brew reinstall llxprt-code`恢复损坏的安装。
+- **所有用户：** 如果无法恢复捆绑的Bun依赖项，重新安装包是受支持的路径。启动器不会使用单独安装的全局Bun。
+
+**Windows pty注意事项：** 在Windows上，`node-pty`模块存在已知的终端调整大小竞争条件（`Cannot resize a pty that has already exited`）。CLI在进程级别静默此特定错误。在POSIX系统上，Bun下使用专用的`bun-pty`适配器（`packages/core/src/utils/bunPtyAdapter.ts`）代替`node-pty`以解决Bun挂起问题。Windows使用`@lydell/node-pty`（以`node-pty`作为回退），而不是Bun适配器。如果您在Windows上遇到终端大小调整问题，请使用兼容的终端模拟器；调整大小竞争在`node-pty`本身中，而不是Bun运行时中。
 
 **首次会话示例：**
 
@@ -85,9 +138,12 @@ llxprt
 
 ## 主要功能
 
-- **免费与订阅选项** - Gemini、Qwen（免费）、Claude Pro/Max（订阅）
-- **广泛的提供商支持** - 任何Anthropic、Gemini或OpenAI兼容的提供商 [**提供商指南 →**](./docs/providers/quick-reference.md)
-- **顶尖开源模型** - GLM 4.6、MiniMax-2、Qwen 3 Coder
+- **订阅OAuth** - 直接使用Claude Pro/Max、ChatGPT Plus/Pro（Codex）或Kimi订阅
+- **免费与低成本层级** - Gemini（Google账户）和Qwen — 有关当前可用性，请参阅[身份验证](./docs/cli/authentication.md)
+- **多账户故障转移** - 配置多个OAuth存储桶，在达到速率限制时自动故障转移
+- **负载均衡配置文件** - 使用roundrobin或failover策略在提供商/账户之间平衡
+- **广泛的提供商支持** - Anthropic、Gemini、OpenAI、Kimi以及任何OpenAI兼容的提供商 [**提供商指南 →**](./docs/providers/quick-reference.md)
+- **顶尖开源模型** - GLM 5.2、Kimi K3、MiniMax M3、Qwen 3 Coder Next
 - **本地模型支持** - LM Studio、llama.cpp、Ollama以获得完全隐私
 - **配置文件系统** - 保存提供商配置和模型设置
 - **高级子代理** - 具有不同模型/提供商的隔离AI助手
@@ -114,34 +170,57 @@ llxprt
 
 ```bash
 # 带有即时响应的单个命令
-llxprt --profile-load zai-glm46 "重构这个函数以提高可读性"
+llxprt --profile-load zai-glm5 "重构这个函数以提高可读性"
 llxprt "为支付模块生成单元测试" > tests/payment.test.js
 ```
 
 ## 顶尖开源权重模型
 
-LLxprt Code与最佳开源权重模型无缝工作：
+LLxprt Code与最佳开源权重模型无缝工作。以下规格是说明性的供应商能力，不一定是内置的提供商默认值 — 有关LLxprt附带的模型ID和上下文限制，请参阅[提供商快速参考](./docs/providers/quick-reference.md)。
 
-### GLM 4.6
+### Kimi K3
 
-- **上下文窗口**：200,000令牌
-- **架构**：具有355B总参数（32B活动）的专家混合模型
-- **优势**：编码、多步骤规划、工具集成
-- **相比上一代减少15%的令牌**，用于等效任务
+- **上下文窗口**：1,000,000令牌（1M）
+- **架构**：具有始终开启思考模式的前沿MoE
+- **优势**：长视野代理编码、多步骤工具编排、原生视觉（图像和视频）
+- **特殊**：思考模式始终开启且无法禁用；`reasoning.effort`接受`low` / `high` / `max`（默认`max`）
+- **视觉**：原生支持，但需要base64或`ms://<file-id>`输入（不支持公共图像URL）
 
-### MiniMax-2
+```bash
+# 订阅提供的模型（Kimi Code订阅）
+/provider kimi
+/model kimi-for-coding
 
-- **上下文窗口**：约204,800令牌
-- **架构**：具有230B总参数（10B活动）的MoE
-- **优势**：编码工作流、多步骤代理、工具调用
-- **成本**：仅为Claude Sonnet的8%，速度约快2倍
+# 或在Moonshot API上按令牌付费（模型ID：kimi-k3）
+/provider kimi
+/baseurl https://api.moonshot.ai/v1
+/keyfile ~/.moonshot_key
+/model kimi-k3
 
-### Qwen 3 Coder
+# 或通过Synthetic/Chutes：
+/provider synthetic
+/model hf:moonshotai/Kimi-K3
+```
 
-- **上下文窗口**：256,000令牌（可扩展至1M）
-- **架构**：具有480B总参数（35B活动）的MoE
+### GLM 5.2
+
+- **上下文窗口**：1M令牌（API密钥）
+- **最大输出**：131,072令牌
+- **架构**：具有744B总参数（40B活动）的专家混合模型
+- **优势**：长视野编码、多步骤规划、灵活的思考力度（High/Max）
+
+### MiniMax M3
+
+- **上下文窗口**：1M令牌（API密钥）
+- **架构**：具有428B总参数（23B活动）的MoE
+- **优势**：编码工作流、多步骤代理、工具调用、原生多模态输入
+
+### Qwen 3 Coder Next
+
+- **上下文窗口**：262,144令牌（256K原生，通过YaRN可扩展至约1M）
+- **架构**：具有80B总参数（3B活动）的混合注意力MoE
 - **优势**：代理编码、浏览器自动化、工具使用
-- **性能**：在SWE-bench Verified上达到最先进的水平（69.6%）
+- **性能**：在SWE-bench Verified上表现强劲（约70%）
 
 ## 本地模型
 
@@ -153,9 +232,10 @@ LLxprt Code与最佳开源权重模型无缝工作：
 /baseurl http://localhost:1234/v1/
 /model your-local-model
 
-# 使用Ollama
-/provider ollama
-/model codellama:13b
+# 使用Ollama（OpenAI兼容端点）
+/provider openai
+/baseurl http://localhost:11434/v1/
+/model qwen2.5-coder
 ```
 
 支持的本地提供商：
@@ -179,7 +259,7 @@ LLxprt Code与最佳开源权重模型无缝工作：
 每个子代理可以配置：
 
 - **不同的提供商**（Gemini vs Anthropic vs Qwen vs 本地）
-- **不同的模型**（Flash vs Sonnet vs GLM 4.6 vs 自定义）
+- **不同的模型**（Flash vs Sonnet vs GLM 5 vs 自定义）
 - **不同的工具访问权限**（限制或允许特定工具）
 - **不同的设置**（温度、超时、最大轮次）
 - **隔离的运行时上下文**（没有内存或状态交叉）
@@ -195,22 +275,27 @@ LLxprt Code与最佳开源权重模型无缝工作：
 
 ## Zed集成
 
-原生Zed编辑器支持，实现无缝开发工作流：
+LLxprt Code使用代理通信协议（ACP）与[Zed编辑器](https://zed.dev)集成：
 
-```bash
-# 安装Zed扩展
-zed:install llxprt-code
-
-# 在Zed内使用
-# （有关Zed集成设置，请参阅文档）
+```json
+{
+  "agent_servers": {
+    "llxprt": {
+      "command": "/opt/homebrew/bin/llxprt",
+      "args": ["--experimental-acp", "--profile-load", "my-profile", "--yolo"]
+    }
+  }
+}
 ```
+
+在Zed的`settings.json`中的`agent_servers`下进行配置。使用`which llxprt`查找您的二进制文件路径。
 
 功能：
 
 - **编辑器内聊天**：直接在Zed内进行AI交互，无需离开
 - **代码选择**：询问特定代码选择
-- **内联建议**：在输入时获得AI帮助
 - **项目感知**：打开工作区的完整上下文
+- **多提供商**：为Claude、OpenAI、Gemini等配置不同的代理
 
 **[Zed集成指南 →](./docs/zed-integration.md)**
 

--- a/packages/core/src/config/toolRegistryFactory.ts
+++ b/packages/core/src/config/toolRegistryFactory.ts
@@ -353,6 +353,17 @@ function registerStandardTools(
     storageServiceAdapter.getGlobalDataDir(),
   );
 
+  // Editing tools that need both IDE diff and LSP diagnostic adapters share
+  // the same registration shape; collapsed here to keep this function within
+  // the max-lines-per-function limit.
+  const registerIdeLspTool = (ToolClass: ToolConstructor): void =>
+    registerCoreTool(
+      ToolClass,
+      toolHostAdapter,
+      ideServiceAdapter,
+      lspServiceAdapter,
+    );
+
   registerCoreTool(LSTool, toolHostAdapter);
   registerCoreTool(ReadFileTool, toolHostAdapter);
 
@@ -363,38 +374,18 @@ function registerStandardTools(
   }
 
   registerCoreTool(GlobTool, toolHostAdapter);
-  registerCoreTool(
-    EditTool,
-    toolHostAdapter,
-    ideServiceAdapter,
-    lspServiceAdapter,
-  );
-  registerCoreTool(ASTEditTool, toolHostAdapter, lspServiceAdapter);
-  registerCoreTool(WriteFileTool, toolHostAdapter);
+  registerIdeLspTool(EditTool);
+  registerIdeLspTool(ASTEditTool);
+  registerCoreTool(WriteFileTool, toolHostAdapter, ideServiceAdapter);
   registerCoreTool(ReadManyFilesTool, toolHostAdapter);
   registerCoreTool(ReadLineRangeTool, toolHostAdapter);
   registerCoreTool(ASTReadFileTool, toolHostAdapter);
   // @plan PLAN-20260211-ASTGREP.P05
   registerCoreTool(AstGrepTool, toolHostAdapter);
   registerCoreTool(StructuralAnalysisTool, toolHostAdapter);
-  registerCoreTool(
-    DeleteLineRangeTool,
-    toolHostAdapter,
-    ideServiceAdapter,
-    lspServiceAdapter,
-  );
-  registerCoreTool(
-    InsertAtLineTool,
-    toolHostAdapter,
-    ideServiceAdapter,
-    lspServiceAdapter,
-  );
-  registerCoreTool(
-    ApplyPatchTool,
-    toolHostAdapter,
-    ideServiceAdapter,
-    lspServiceAdapter,
-  );
+  registerIdeLspTool(DeleteLineRangeTool);
+  registerIdeLspTool(InsertAtLineTool);
+  registerIdeLspTool(ApplyPatchTool);
   registerCoreTool(
     ShellTool,
     new CoreShellToolHostAdapter(config),

--- a/packages/tools/src/tools/ast-edit.ide.test.ts
+++ b/packages/tools/src/tools/ast-edit.ide.test.ts
@@ -1,0 +1,227 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ASTEditTool } from './ast-edit.js';
+import { createDefaultToolHost } from './edit-utils.js';
+import type {
+  IToolHost,
+  IIdeService,
+  DiffParams,
+  DiffUpdateResult,
+  IDEConnectionStatus,
+} from '../interfaces/index.js';
+import type { ToolEditConfirmationDetails } from './tools.js';
+import { ToolConfirmationOutcome } from './tools.js';
+
+/**
+ * A recording fake IIdeService. Behavioral: applyDiff resolves with the
+ * configured outcome and records the params it was called with.
+ */
+function fakeIdeService(
+  status: IDEConnectionStatus,
+  outcome: DiffUpdateResult = { status: 'accepted', content: undefined },
+): IIdeService & { applyDiffCalls: DiffParams[] } {
+  const applyDiffCalls: DiffParams[] = [];
+  return {
+    applyDiffCalls,
+    getConnectionStatus: () => status,
+    applyDiff: async (params: DiffParams) => {
+      applyDiffCalls.push(params);
+      return outcome;
+    },
+    openDiff: async () => {},
+  };
+}
+
+describe('ASTEditTool IDE diff integration', () => {
+  let tmpDir: string;
+  let host: IToolHost;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ast-edit-ide-'));
+    host = {
+      ...createDefaultToolHost(),
+      getTargetDir: () => tmpDir,
+      getWorkspaceRoots: () => [tmpDir],
+      // Manual approval so shouldConfirmExecute produces confirmation details.
+      getApprovalMode: () => 'default',
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Builds an ast_edit invocation in execution mode (force: true) and returns
+   * its confirmation details (or false).
+   */
+  async function getConfirmation(
+    tool: ASTEditTool,
+    filePath: string,
+    oldString: string,
+    newString: string,
+  ): Promise<ToolEditConfirmationDetails | false> {
+    const invocation = tool.build({
+      file_path: filePath,
+      old_string: oldString,
+      new_string: newString,
+      force: true,
+    });
+    return (await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    )) as ToolEditConfirmationDetails | false;
+  }
+
+  it('opens an IDE diff (applyDiff) when the IDE service is connected', async () => {
+    const ide = fakeIdeService('connected');
+    // ASTEditTool signature: (host, ideService, lspService)
+    const tool = new ASTEditTool(host, ide);
+    const filePath = path.join(tmpDir, 'greeting.ts');
+    fs.writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+
+    const confirmation = await getConfirmation(
+      tool,
+      filePath,
+      'const greeting = "hello";',
+      'const greeting = "world";',
+    );
+
+    expect(confirmation).not.toBe(false);
+    const details = confirmation as ToolEditConfirmationDetails;
+    expect(details.ideConfirmation).toBeDefined();
+    expect(ide.applyDiffCalls).toHaveLength(1);
+    expect(ide.applyDiffCalls[0].filePath).toBe(filePath);
+    expect(ide.applyDiffCalls[0].diff).toBe('const greeting = "world";\n');
+  });
+
+  it('does NOT open an IDE diff when the IDE service is disconnected', async () => {
+    const ide = fakeIdeService('disconnected');
+    const tool = new ASTEditTool(host, ide);
+    const filePath = path.join(tmpDir, 'greeting.ts');
+    fs.writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+
+    const confirmation = await getConfirmation(
+      tool,
+      filePath,
+      'const greeting = "hello";',
+      'const greeting = "world";',
+    );
+
+    expect(confirmation).not.toBe(false);
+    const details = confirmation as ToolEditConfirmationDetails;
+    expect(details.ideConfirmation).toBeUndefined();
+    expect(ide.applyDiffCalls).toHaveLength(0);
+  });
+
+  it('does NOT open an IDE diff when no IDE service is provided', async () => {
+    const tool = new ASTEditTool(host);
+    const filePath = path.join(tmpDir, 'greeting.ts');
+    fs.writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+
+    const confirmation = await getConfirmation(
+      tool,
+      filePath,
+      'const greeting = "hello";',
+      'const greeting = "world";',
+    );
+
+    expect(confirmation).not.toBe(false);
+    const details = confirmation as ToolEditConfirmationDetails;
+    expect(details.ideConfirmation).toBeUndefined();
+  });
+
+  it('writes the IDE-modified content when the user edits in the diff view', async () => {
+    const ide = fakeIdeService('connected', {
+      status: 'accepted',
+      content: 'const greeting = "user-edited";\n',
+    });
+    const tool = new ASTEditTool(host, ide);
+    const filePath = path.join(tmpDir, 'edited.ts');
+    fs.writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+
+    const invocation = tool.build({
+      file_path: filePath,
+      old_string: 'const greeting = "hello";',
+      new_string: 'const greeting = "world";',
+      force: true,
+    });
+    const confirmation = (await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    )) as ToolEditConfirmationDetails;
+    expect(confirmation.ideConfirmation).toBeDefined();
+
+    await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(
+      'const greeting = "user-edited";\n',
+    );
+  });
+
+  it('writes the model content when the IDE accepts without modification', async () => {
+    const ide = fakeIdeService('connected', {
+      status: 'accepted',
+      content: undefined,
+    });
+    const tool = new ASTEditTool(host, ide);
+    const filePath = path.join(tmpDir, 'unmodified.ts');
+    fs.writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+
+    const invocation = tool.build({
+      file_path: filePath,
+      old_string: 'const greeting = "hello";',
+      new_string: 'const greeting = "world";',
+      force: true,
+    });
+    const confirmation = (await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    )) as ToolEditConfirmationDetails;
+
+    await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(
+      'const greeting = "world";\n',
+    );
+  });
+
+  it('writes the model content when the IDE rejects the diff', async () => {
+    const ide = fakeIdeService('connected', {
+      status: 'rejected',
+      content: undefined,
+    });
+    const tool = new ASTEditTool(host, ide);
+    const filePath = path.join(tmpDir, 'rejected.ts');
+    fs.writeFileSync(filePath, 'const greeting = "hello";\n', 'utf-8');
+
+    const invocation = tool.build({
+      file_path: filePath,
+      old_string: 'const greeting = "hello";',
+      new_string: 'const greeting = "world";',
+      force: true,
+    });
+    const confirmation = (await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    )) as ToolEditConfirmationDetails;
+    expect(confirmation.ideConfirmation).toBeDefined();
+
+    await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    // Rejected diff must not override the model-computed content.
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(
+      'const greeting = "world";\n',
+    );
+  });
+});

--- a/packages/tools/src/tools/ast-edit.ts
+++ b/packages/tools/src/tools/ast-edit.ts
@@ -19,7 +19,11 @@ import fs from 'fs';
 import type { ToolInvocation } from './tools.js';
 import { BaseDeclarativeTool, Kind, type ToolResult } from './tools.js';
 import { isNodeError } from '../utils/errors.js';
-import type { IToolHost, ILspService } from '../interfaces/index.js';
+import type {
+  IToolHost,
+  IIdeService,
+  ILspService,
+} from '../interfaces/index.js';
 import { hasWorkspaceContextCap } from '../interfaces/host-capabilities.js';
 import type {
   ModifiableDeclarativeTool,
@@ -99,6 +103,7 @@ export class ASTEditTool
 
   constructor(
     private readonly host: IToolHost,
+    private readonly ideService?: IIdeService,
     private readonly lspService?: ILspService,
   ) {
     super(
@@ -167,6 +172,7 @@ export class ASTEditTool
       params,
       this.contextCollector,
       this.lspService,
+      this.ideService,
     );
   }
 

--- a/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
+++ b/packages/tools/src/tools/ast-edit/ast-edit-invocation.ts
@@ -25,8 +25,10 @@ import { makeRelative, shortenPath } from '../../utils/paths.js';
 import type {
   Diagnostic,
   IToolHost,
+  IIdeService,
   ILspService,
 } from '../../interfaces/index.js';
+import { toIdeConnectionStatus } from '../edit-utils.js';
 import { hasLspCap } from '../../interfaces/host-capabilities.js';
 import { DEFAULT_CREATE_PATCH_OPTIONS } from '../../utils/diffOptions.js';
 import { collectLspDiagnosticsBlock } from '../../utils/lsp-diagnostics-helper.js';
@@ -53,11 +55,20 @@ function normalizeSeverity(severity: unknown): string {
 export class ASTEditToolInvocation
   implements ToolInvocation<ASTEditToolParams, ToolResult>
 {
+  /**
+   * When the IDE diff view accepts user-modified content, that full file
+   * content overrides the model-computed replacement on write (mirrors
+   * write_file). Undefined when there is no IDE confirmation or the user
+   * rejected the diff.
+   */
+  private ideAcceptedContent: string | undefined;
+
   constructor(
     private readonly host: IToolHost,
     public params: ASTEditToolParams,
     private readonly contextCollector: ASTContextCollector,
     private readonly lspService?: ILspService,
+    private readonly ideService?: IIdeService,
   ) {}
 
   toolLocations(): ToolLocation[] {
@@ -98,6 +109,16 @@ export class ASTEditToolInvocation
       DEFAULT_CREATE_PATCH_OPTIONS,
     );
 
+    const ideConfirmation =
+      this.ideService !== undefined &&
+      toIdeConnectionStatus(this.ideService.getConnectionStatus()) ===
+        'connected'
+        ? this.ideService.applyDiff({
+            filePath: this.params.file_path,
+            diff: editData.newContent,
+          })
+        : undefined;
+
     const confirmationDetails: ToolEditConfirmationDetails = {
       type: 'edit',
       title: `Confirm Edit: ${shortenPath(makeRelative(this.params.file_path, this.host.getTargetDir()))}`,
@@ -110,7 +131,17 @@ export class ASTEditToolInvocation
         if (outcome === ToolConfirmationOutcome.ProceedAlways) {
           this.host.setApprovalMode('auto');
         }
+
+        if (ideConfirmation) {
+          const result = await ideConfirmation;
+          if (result.status === 'accepted' && result.content !== undefined) {
+            // The IDE returns the full file content the user reviewed (and
+            // possibly edited) in the diff view; write exactly that.
+            this.ideAcceptedContent = result.content;
+          }
+        }
       },
+      ideConfirmation,
       metadata: {
         astValidation: editData.astValidation,
         fileFreshness: editData.fileFreshness,
@@ -355,10 +386,15 @@ export class ASTEditToolInvocation
 
   private async writeEditResult(editData: CalculatedEdit): Promise<ToolResult> {
     try {
+      // When the user accepted (and possibly edited) content in the IDE diff
+      // view, that full-file content takes precedence over the model-computed
+      // replacement — mirrors write_file/edit behavior.
+      const contentToWrite = this.ideAcceptedContent ?? editData.newContent;
+
       await ensureParentDirectoriesExist(this.params.file_path);
       await fsPromises.writeFile(
         this.params.file_path,
-        editData.newContent,
+        contentToWrite,
         'utf-8',
       );
 
@@ -366,7 +402,7 @@ export class ASTEditToolInvocation
       const fileDiff = Diff.createPatch(
         fileName,
         editData.currentContent ?? '',
-        editData.newContent,
+        contentToWrite,
         'Current',
         'Applied',
         DEFAULT_CREATE_PATCH_OPTIONS,
@@ -376,7 +412,7 @@ export class ASTEditToolInvocation
         fileDiff,
         fileName,
         originalContent: editData.currentContent,
-        newContent: editData.newContent,
+        newContent: contentToWrite,
         applied: true,
         metadata: { astValidation: editData.astValidation },
       };

--- a/packages/tools/src/tools/write-file.test.ts
+++ b/packages/tools/src/tools/write-file.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { WriteFileTool } from './write-file.js';
+import { createDefaultToolHost } from './edit-utils.js';
+import type {
+  IToolHost,
+  IIdeService,
+  DiffParams,
+  DiffUpdateResult,
+  IDEConnectionStatus,
+} from '../interfaces/index.js';
+import type { ToolEditConfirmationDetails } from './tools.js';
+import { ToolConfirmationOutcome } from './tools.js';
+
+/**
+ * A recording fake IIdeService. Behavioral: applyDiff resolves with the
+ * configured outcome and records the params it was called with.
+ */
+function fakeIdeService(
+  status: IDEConnectionStatus,
+  outcome: DiffUpdateResult = { status: 'accepted', content: undefined },
+): IIdeService & { applyDiffCalls: DiffParams[] } {
+  const applyDiffCalls: DiffParams[] = [];
+  return {
+    applyDiffCalls,
+    getConnectionStatus: () => status,
+    applyDiff: async (params: DiffParams) => {
+      applyDiffCalls.push(params);
+      return outcome;
+    },
+    openDiff: async () => {},
+  };
+}
+
+describe('WriteFileTool IDE diff integration', () => {
+  let tmpDir: string;
+  let host: IToolHost;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'write-file-ide-'));
+    host = {
+      ...createDefaultToolHost(),
+      getTargetDir: () => tmpDir,
+      getWorkspaceRoots: () => [tmpDir],
+      // Manual approval so shouldConfirmExecute produces confirmation details.
+      getApprovalMode: () => 'default',
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function getConfirmation(
+    tool: WriteFileTool,
+    filePath: string,
+    content: string,
+  ): Promise<ToolEditConfirmationDetails | false> {
+    const invocation = tool.build({ absolute_path: filePath, content });
+    return (await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    )) as ToolEditConfirmationDetails | false;
+  }
+
+  it('opens an IDE diff (applyDiff) when the IDE service is connected', async () => {
+    const ide = fakeIdeService('connected');
+    const tool = new WriteFileTool(host, ide);
+    const filePath = path.join(tmpDir, 'greeting.txt');
+
+    const confirmation = await getConfirmation(tool, filePath, 'hello ide\n');
+
+    expect(confirmation).not.toBe(false);
+    const details = confirmation as ToolEditConfirmationDetails;
+    expect(details.ideConfirmation).toBeDefined();
+    expect(ide.applyDiffCalls).toHaveLength(1);
+    expect(ide.applyDiffCalls[0].filePath).toBe(filePath);
+    expect(ide.applyDiffCalls[0].diff).toBe('hello ide\n');
+  });
+
+  it('does NOT open an IDE diff when the IDE service is disconnected', async () => {
+    const ide = fakeIdeService('disconnected');
+    const tool = new WriteFileTool(host, ide);
+    const filePath = path.join(tmpDir, 'greeting.txt');
+
+    const confirmation = await getConfirmation(tool, filePath, 'hello\n');
+
+    expect(confirmation).not.toBe(false);
+    const details = confirmation as ToolEditConfirmationDetails;
+    expect(details.ideConfirmation).toBeUndefined();
+    expect(ide.applyDiffCalls).toHaveLength(0);
+  });
+
+  it('does NOT open an IDE diff when no IDE service is provided', async () => {
+    const tool = new WriteFileTool(host);
+    const filePath = path.join(tmpDir, 'greeting.txt');
+
+    const confirmation = await getConfirmation(tool, filePath, 'hello\n');
+
+    expect(confirmation).not.toBe(false);
+    const details = confirmation as ToolEditConfirmationDetails;
+    expect(details.ideConfirmation).toBeUndefined();
+  });
+
+  it('writes the IDE-modified content when the user edits in the diff view', async () => {
+    const ide = fakeIdeService('connected', {
+      status: 'accepted',
+      content: 'user-edited content\n',
+    });
+    const tool = new WriteFileTool(host, ide);
+    const filePath = path.join(tmpDir, 'edited.txt');
+
+    const invocation = tool.build({
+      absolute_path: filePath,
+      content: 'model content\n',
+    });
+    const confirmation = (await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    )) as ToolEditConfirmationDetails;
+    expect(confirmation.ideConfirmation).toBeDefined();
+
+    await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('user-edited content\n');
+  });
+
+  it('writes the original content when the IDE accepts without modification', async () => {
+    const ide = fakeIdeService('connected', {
+      status: 'accepted',
+      content: undefined,
+    });
+    const tool = new WriteFileTool(host, ide);
+    const filePath = path.join(tmpDir, 'unmodified.txt');
+
+    const invocation = tool.build({
+      absolute_path: filePath,
+      content: 'model content\n',
+    });
+    const confirmation = (await invocation.shouldConfirmExecute(
+      new AbortController().signal,
+    )) as ToolEditConfirmationDetails;
+
+    await confirmation.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('model content\n');
+  });
+});

--- a/packages/tools/src/tools/write-file.ts
+++ b/packages/tools/src/tools/write-file.ts
@@ -19,7 +19,12 @@ import {
   ToolConfirmationOutcome,
 } from './tools.js';
 import { ToolErrorType } from '../types/tool-error.js';
-import type { IToolHost, IToolMessageBus } from '../interfaces/index.js';
+import type {
+  IToolHost,
+  IToolMessageBus,
+  IIdeService,
+} from '../interfaces/index.js';
+import { resolveConstructorArguments } from './edit-utils.js';
 import { makeRelative, shortenPath } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';
 import {
@@ -121,6 +126,7 @@ class WriteFileToolInvocation extends BaseToolInvocation<
 > {
   constructor(
     private readonly host: IToolHost,
+    private readonly ideService: IIdeService | undefined,
     params: WriteFileToolParams,
     messageBus: IToolMessageBus,
     toolName?: string,
@@ -188,6 +194,11 @@ class WriteFileToolInvocation extends BaseToolInvocation<
       DEFAULT_CREATE_PATCH_OPTIONS,
     );
 
+    const ideConfirmation =
+      this.ideService?.getConnectionStatus() === 'connected'
+        ? this.ideService.applyDiff({ filePath, diff: newContent })
+        : undefined;
+
     return {
       type: 'edit',
       title: 'Confirm Write File',
@@ -202,7 +213,17 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         } else {
           await this.publishPolicyUpdate(outcome);
         }
+
+        if (ideConfirmation) {
+          const result = await ideConfirmation;
+          if (result.status === 'accepted' && result.content !== undefined) {
+            // The IDE returns the full file content the user reviewed (and
+            // possibly edited) in the diff view; write exactly that.
+            this.params.content = result.content;
+          }
+        }
       },
+      ideConfirmation,
     };
   }
 
@@ -381,11 +402,19 @@ export class WriteFileTool
   implements ModifiableDeclarativeTool<WriteFileToolParams>
 {
   static readonly Name: string = 'write_file';
+  private readonly ideService?: IIdeService;
 
   constructor(
     private host: IToolHost,
-    messageBus?: IToolMessageBus,
+    messageBusOrIdeService?: IToolMessageBus | IIdeService,
+    ideService?: IIdeService,
   ) {
+    const resolved = resolveConstructorArguments(
+      host,
+      messageBusOrIdeService,
+      ideService,
+      undefined,
+    );
     super(
       WriteFileTool.Name,
       'WriteFile',
@@ -415,8 +444,9 @@ export class WriteFileTool
       },
       true,
       false,
-      messageBus,
+      resolved.messageBus,
     );
+    this.ideService = resolved.ideService;
   }
 
   protected override validateToolParamValues(
@@ -469,6 +499,7 @@ export class WriteFileTool
     }
     return new WriteFileToolInvocation(
       this.host,
+      this.ideService,
       normalizedParams,
       messageBus as IToolMessageBus,
       toolName ?? this.name,


### PR DESCRIPTION
## Summary

Fixes #2664 — restores the native IDE diff view for `write_file` **and** `ast_edit` tool confirmations, both lost in the #1585 tools-package extraction.

## Root cause (same two breaks, two tools)

1. **Missing IDE wiring in the extracted tools.** The pre-#1585 implementations opened the IDE diff from `shouldConfirmExecute` and honored the accept/reject/modified-content result. The extracted `write-file.ts` and `ast-edit.ts` had no `IIdeService` usage at all.
2. **Missing registration.** In `toolRegistryFactory.ts`, the other editing tools (Edit, DeleteLineRange, InsertAtLine, ApplyPatch) are constructed with the `ideServiceAdapter` — `WriteFileTool` and `ASTEditTool` were not, so even IDE-aware code would never get the service.

Net effect: in an IDE-connected session those tools fell back to the terminal confirmation and edits made in the diff editor were silently ignored. An audit of all registered tools confirmed these were the only two affected; the remaining editing tools were wired correctly during extraction, read-only tools need no diff, and the ACP/Zed path (which renders diffs via its own permission UI from confirmation details) is untouched and correctly bypassed by the connected-gate.

## Changes

- **packages/tools/src/tools/write-file.ts** — thread `IIdeService` through tool + invocation; `shouldConfirmExecute` opens the native diff view when connected; user-edited diff content is what lands on disk.
- **packages/tools/src/tools/ast-edit.ts** + **ast-edit/ast-edit-invocation.ts** — identical treatment, following the `edit.ts` pattern (`toIdeConnectionStatus` gating, `ideConfirmation` attached to confirmation details, accepted content carried into `writeEditResult` so the display diff also reflects what was written).
- **packages/core/src/config/toolRegistryFactory.ts** — register both tools with the `ideServiceAdapter`; introduced a `registerIdeLspTool` helper collapsing the five identical ide+lsp registrations (also keeps `registerStandardTools` under the max-lines lint limit).
- **packages/tools/src/tools/write-file.test.ts** (new, 5 tests) and **packages/tools/src/tools/ast-edit.ide.test.ts** (new, 6 tests) — behavioral coverage: connected opens diff, disconnected/no-service do not, user-modified diff content lands on disk (asserted via real file reads), accepted-unmodified writes model content, rejected diff does not apply IDE content.
- **README_CN.md** — sync with the current English README (Codex/Kimi subscription auth, Bun runtime + install-fallback section, Homebrew install, current model lineup, ACP-based Zed config). Verified using the restored write_file diff-view flow itself.

## Verification

- `npm run typecheck` — pass (all workspaces)
- `npm run lint` — pass (0 errors, 0 warnings)
- `npm run build` — pass
- `npm run format` — no churn
- Targeted behavioral tests: write-file 5/5, ast-edit 11/11 (6 new IDE + 5 existing preview)
- Full `npm run test`: all observed failures are pre-existing on clean main in this Windows environment (a2a-server symlink EPERM, test-utils SIGTERM semantics, lsp fake-server spawn timeouts) — verified by A/B running the identical suites on unmodified main. Zero deltas from this change.
- CLI smoke (haiku prompt via `bun scripts/start.ts`) — pass
- **Live E2E** (write_file): verified against a real VS Code companion server — diff view opens, accept/reject/user-edit results flow back; confirmed interactively after a CLI restart.

## Relation to other work

Found while investigating #2650 (IDE reconnect, PR #2660) but kept separate since it is an independent #1585 regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IDE-assisted editing for both write-file and AST-based edits, enabling users to review IDE-proposed diffs before changes are applied.
  * Refreshed Chinese documentation with updated setup/rollback guidance, provider enable commands, model examples, local configuration, subagent options, and Zed integration instructions.

* **Bug Fixes**
  * Ensured IDE-reviewed content is correctly written when the IDE is connected and accepts changes, while disconnected or missing IDE services continue to fall back to the model’s output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->