### PR TITLE
Adds OCR auto-review limit and suspension mechanism (Fixes #2666)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,12 @@ jobs:
         # dev-docs/bun.md). Bun re-normalizes `bun.lock` on every install
         # (dev-docs/bun.md), so restore the committed lockfile or the
         # formatter's `git diff --exit-code` below would flag the re-write.
+        # Likewise, the vscode-ide-companion `prepare` script regenerates
+        # NOTICES.txt from live npm metadata, so restore the committed copy.
         run: |-
           bun install
           git checkout -- bun.lock
+          git checkout -- packages/vscode-ide-companion/NOTICES.txt
 
       - name: 'Run formatter check'
         run: |-

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -184,10 +184,6 @@ jobs:
               return match ? Number(match[1]) : 0;
             }
 
-            function parseSuspended(body) {
-              return /<!--\s*ocr-suspended:\s*true\s*-->/.test(body || '');
-            }
-
             async function fetchMarkerComment() {
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
@@ -199,12 +195,11 @@ jobs:
                 typeof c.body === 'string' && c.body.includes(MARKER)) || null;
             }
 
-            function replaceHiddenState(body, count, suspended) {
+            function replaceHiddenState(body, count) {
               let updated = body
                 .replace(/<!--\s*ocr-auto-count:\s*\d+\s*-->/g, '')
                 .replace(/<!--\s*ocr-suspended:\s*(?:true|false)\s*-->/g, '');
-              const suspendedStr = suspended ? 'true' : 'false';
-              updated += '\n<!-- ocr-auto-count:' + count + ' --><!-- ocr-suspended:' + suspendedStr + ' -->';
+              updated += '\n<!-- ocr-auto-count:' + count + ' -->';
               return updated;
             }
 
@@ -239,7 +234,7 @@ jobs:
                     core.warning(`Failed to fetch marker comment for checkbox reset: ${fetchErr.message || fetchErr}`);
                   }
                   if (marker) {
-                    const resetBody = replaceHiddenState(marker.body, 0, false);
+                    const resetBody = replaceHiddenState(marker.body, 0);
                     await github.rest.issues.updateComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
@@ -267,12 +262,10 @@ jobs:
             // ----- Read current state -----
 
             let currentCount = 0;
-            let currentSuspended = false;
             try {
               const marker = await fetchMarkerComment();
               if (marker && typeof marker.body === 'string') {
                 currentCount = parseHiddenCount(marker.body);
-                currentSuspended = parseSuspended(marker.body);
               }
             } catch (fetchErr) {
               core.warning(`Failed to read OCR sticky comment for auto-review state: ${fetchErr.message || fetchErr}`);
@@ -334,7 +327,7 @@ jobs:
             const repo = context.repo.repo;
 
             const NEWLINE = String.fromCharCode(10);
-            const body = [
+            const suspensionBlock = [
               MARKER,
               '## OpenCodeReview — automatic reviews suspended',
               '',
@@ -347,7 +340,7 @@ jobs:
               '',
               '- [ ] Re-enable automatic reviews',
               '',
-              '<!-- ocr-auto-count:' + currentCount + ' --><!-- ocr-suspended:true -->',
+              '<!-- ocr-auto-count:' + currentCount + ' -->',
             ].join(NEWLINE);
 
             async function reconcileMarkerComment() {
@@ -377,20 +370,34 @@ jobs:
               } catch (reconcileErr) {
                 core.warning(`Reconciliation failed before suspension posting; attempting create: ${reconcileErr.message || reconcileErr}`);
               }
+              // Preserve the previous review summary by appending the
+              // suspension notice to the existing body (minus old markers).
+              let finalBody = suspensionBlock;
+              if (existing && typeof existing.body === 'string') {
+                const preserved = existing.body
+                  .replace(MARKER, '')
+                  .replace(/<!--\s*ocr-auto-count:\s*\d+\s*-->/g, '')
+                  .replace(/<!--\s*ocr-suspended:\s*(?:true|false)\s*-->/g, '')
+                  .replace(/## OpenCodeReview — automatic reviews suspended[\s\S]*$/, '')
+                  .trim();
+                if (preserved) {
+                  finalBody = suspensionBlock + NEWLINE + NEWLINE + '---' + NEWLINE + NEWLINE + preserved;
+                }
+              }
               if (existing) {
                 await github.rest.issues.updateComment({
-                  owner, repo, comment_id: existing.id, body,
+                  owner, repo, comment_id: existing.id, body: finalBody,
                 });
               } else {
                 try {
                   await github.rest.issues.createComment({
-                    owner, repo, issue_number: number, body,
+                    owner, repo, issue_number: number, body: finalBody,
                   });
                 } catch (createErr) {
                   const reconciled = await reconcileMarkerComment();
                   if (reconciled) {
                     await github.rest.issues.updateComment({
-                      owner, repo, comment_id: reconciled.id, body,
+                      owner, repo, comment_id: reconciled.id, body: finalBody,
                     });
                   } else {
                     throw createErr;
@@ -1332,7 +1339,7 @@ jobs:
             if (isAutomatic) {
               autoReviewCount += 1;
             }
-            body.push(`\n<!-- ocr-auto-count:${autoReviewCount} --><!-- ocr-suspended:false -->`);
+            body.push(`\n<!-- ocr-auto-count:${autoReviewCount} -->`);
             const summary = body.join('\n');
 
             async function reconcileMarkerComment() {
@@ -1601,14 +1608,23 @@ jobs:
     name: Record skipped OCR outcome
     needs:
       - mergeability-gate
+      - auto-review-gate
     if: >-
       ${{ !cancelled() &&
           needs.mergeability-gate.result == 'success' &&
-          needs.mergeability-gate.outputs.should-run != 'true' }}
+          needs.auto-review-gate.result == 'success' &&
+          (needs.mergeability-gate.outputs.should-run != 'true' ||
+           needs.auto-review-gate.outputs.auto-should-run != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions: {}
     steps:
       - name: 'Record OCR outcome: review-skipped'
+        if: ${{ needs.mergeability-gate.outputs.should-run != 'true' }}
         shell: bash
         run: echo 'OCR review skipped by the mergeability gate.'
+
+      - name: 'Record OCR outcome: auto-review-suspended'
+        if: ${{ needs.mergeability-gate.outputs.should-run == 'true' && needs.auto-review-gate.outputs.auto-should-run != 'true' }}
+        shell: bash
+        run: echo 'OCR review skipped — automatic review limit reached.'

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -23,6 +23,7 @@ on:
   issue_comment:
     types:
       - created
+      - edited
   workflow_dispatch:
     inputs:
       pr_number:
@@ -54,7 +55,17 @@ concurrency:
          startsWith(github.event.comment.body, '/open-code-review ') ||
          startsWith(toJSON(github.event.comment.body), '"/open-code-review\n') ||
          startsWith(toJSON(github.event.comment.body), '"/open-code-review\r\n') ||
-         startsWith(toJSON(github.event.comment.body), '"/open-code-review\t')))) &&
+         startsWith(toJSON(github.event.comment.body), '"/open-code-review\t') ||
+         github.event.comment.body == '/review' ||
+         startsWith(github.event.comment.body, '/review ') ||
+         startsWith(toJSON(github.event.comment.body), '"/review\n') ||
+         startsWith(toJSON(github.event.comment.body), '"/review\r\n') ||
+         startsWith(toJSON(github.event.comment.body), '"/review\t'))) ||
+       (github.event_name == 'issue_comment' &&
+        github.event.action == 'edited' &&
+        github.event.issue.pull_request != null &&
+        github.event.comment.user.type == 'Bot' &&
+        contains(github.event.comment.body, '<!-- llxprt-code-ocr-review -->'))) &&
       format('{0}-pr-{1}', github.workflow,
         github.event.pull_request.number || github.event.issue.number || inputs.pr_number) ||
       format('{0}-run-{1}', github.workflow, github.run_id)
@@ -82,6 +93,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'issue_comment' &&
+       github.event.action == 'created' &&
        github.event.issue.pull_request != null &&
        (github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
@@ -95,11 +107,299 @@ jobs:
         startsWith(github.event.comment.body, '/open-code-review ') ||
         startsWith(toJSON(github.event.comment.body), '"/open-code-review\n') ||
         startsWith(toJSON(github.event.comment.body), '"/open-code-review\r\n') ||
-        startsWith(toJSON(github.event.comment.body), '"/open-code-review\t')))
+        startsWith(toJSON(github.event.comment.body), '"/open-code-review\t') ||
+        github.event.comment.body == '/review' ||
+        startsWith(github.event.comment.body, '/review ') ||
+        startsWith(toJSON(github.event.comment.body), '"/review\n') ||
+        startsWith(toJSON(github.event.comment.body), '"/review\r\n') ||
+        startsWith(toJSON(github.event.comment.body), '"/review\t'))) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.action == 'edited' &&
+       github.event.issue.pull_request != null &&
+       github.event.comment.user.type == 'Bot' &&
+       contains(github.event.comment.body, '<!-- llxprt-code-ocr-review -->'))
     with:
       check-mergeability: ${{ github.event_name != 'workflow_dispatch' }}
       pull-request-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || inputs.pr_number) }}
       expected-head-sha: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+
+  auto-review-gate:
+    name: Auto-review limit gate
+    needs:
+      - mergeability-gate
+    # Runs only when the mergeability gate permits work. This gate owns the
+    # OCR auto-review suspension logic (issue #2666) so the shared reusable
+    # gate stays a pure mergeability oracle.
+    if: |
+      needs.mergeability-gate.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      auto-should-run: ${{ steps.auto-decide.outputs.auto-should-run }}
+      suspended: ${{ steps.auto-decide.outputs.suspended }}
+      is-manual: ${{ steps.auto-decide.outputs.is-manual }}
+      current-count: ${{ steps.auto-decide.outputs.current-count }}
+    steps:
+      - name: Decide auto-review limit
+        id: auto-decide
+        uses: actions/github-script@f28e40c7f34b6de8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || inputs.pr_number) }}
+          OCR_AUTO_REVIEW_LIMIT: ${{ vars.OCR_AUTO_REVIEW_LIMIT }}
+          OCR_AUTO_REVIEW_LIMIT_DEFAULT: '2'
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
+          CHANGES_FROM: ${{ github.event.changes.body.from }}
+        with:
+          script: |
+            const MARKER = '<!-- llxprt-code-ocr-review -->';
+            const number = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(number) || number <= 0) {
+              core.setFailed('No valid PR number resolved for auto-review gate.');
+              return;
+            }
+            const eventName = process.env.EVENT_NAME || '';
+            const eventAction = process.env.EVENT_ACTION || '';
+            const commentBody = process.env.COMMENT_BODY || '';
+            const commentUserType = process.env.COMMENT_USER_TYPE || '';
+            const changesFrom = process.env.CHANGES_FROM || '';
+            const limitRaw = process.env.OCR_AUTO_REVIEW_LIMIT ||
+              process.env.OCR_AUTO_REVIEW_LIMIT_DEFAULT || '2';
+            const parsedLimit = Number(limitRaw);
+            const limit = (Number.isInteger(parsedLimit) && parsedLimit >= 0)
+              ? parsedLimit
+              : Number(process.env.OCR_AUTO_REVIEW_LIMIT_DEFAULT || '2');
+            const isManualTrigger =
+              eventName === 'workflow_dispatch' ||
+              (eventName === 'issue_comment' && eventAction === 'created');
+            const isEditedComment =
+              eventName === 'issue_comment' && eventAction === 'edited';
+
+            // ----- Helpers -----
+
+            function parseHiddenCount(body) {
+              const match = /<!--\s*ocr-auto-count:\s*(\d+)\s*-->/.exec(body || '');
+              return match ? Number(match[1]) : 0;
+            }
+
+            function parseSuspended(body) {
+              return /<!--\s*ocr-suspended:\s*true\s*-->/.test(body || '');
+            }
+
+            async function fetchMarkerComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return comments.find((c) =>
+                typeof c.body === 'string' && c.body.includes(MARKER)) || null;
+            }
+
+            function replaceHiddenState(body, count, suspended) {
+              let updated = body
+                .replace(/<!--\s*ocr-auto-count:\s*\d+\s*-->/g, '')
+                .replace(/<!--\s*ocr-suspended:\s*(?:true|false)\s*-->/g, '');
+              const suspendedStr = suspended ? 'true' : 'false';
+              updated += '\n<!-- ocr-auto-count:' + count + ' --><!-- ocr-suspended:' + suspendedStr + ' -->';
+              return updated;
+            }
+
+            // ----- Checkbox-reset detection (issue_comment.edited) -----
+
+            if (isEditedComment) {
+              // Only act on edits to a bot-authored OCR marker comment.
+              const containsMarker =
+                typeof commentBody === 'string' && commentBody.includes(MARKER);
+              const wasBot = commentUserType === 'Bot';
+              if (!containsMarker || !wasBot) {
+                core.setOutput('auto-should-run', 'false');
+                core.setOutput('suspended', 'false');
+                core.setOutput('is-manual', 'false');
+                core.setOutput('current-count', '0');
+                return;
+              }
+              const wasUnchecked = /-\s*\[\s\]/.test(changesFrom);
+              const nowChecked = /-\s*\[[xX]\]/.test(commentBody);
+              if (wasUnchecked && nowChecked) {
+                // Reset the counter to 0 in the hidden state of the comment
+                // and immediately allow a review on the current head.
+                // If the reset write fails, do NOT proceed — otherwise the
+                // stale count in the comment would cause a premature
+                // suspension on the next automatic trigger.
+                let resetSucceeded = false;
+                try {
+                  let marker = null;
+                  try {
+                    marker = await fetchMarkerComment();
+                  } catch (fetchErr) {
+                    core.warning(`Failed to fetch marker comment for checkbox reset: ${fetchErr.message || fetchErr}`);
+                  }
+                  if (marker) {
+                    const resetBody = replaceHiddenState(marker.body, 0, false);
+                    await github.rest.issues.updateComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: marker.id,
+                      body: resetBody,
+                    });
+                    resetSucceeded = true;
+                  }
+                } catch (writeErr) {
+                  core.warning(`Failed to write reset counter to comment: ${writeErr.message || writeErr}`);
+                }
+                core.setOutput('auto-should-run', String(resetSucceeded));
+                core.setOutput('suspended', 'false');
+                core.setOutput('is-manual', String(resetSucceeded));
+                core.setOutput('current-count', '0');
+                return;
+              }
+              core.setOutput('auto-should-run', 'false');
+              core.setOutput('suspended', 'false');
+              core.setOutput('is-manual', 'false');
+              core.setOutput('current-count', '0');
+              return;
+            }
+
+            // ----- Read current state -----
+
+            let currentCount = 0;
+            let currentSuspended = false;
+            try {
+              const marker = await fetchMarkerComment();
+              if (marker && typeof marker.body === 'string') {
+                currentCount = parseHiddenCount(marker.body);
+                currentSuspended = parseSuspended(marker.body);
+              }
+            } catch (fetchErr) {
+              core.warning(`Failed to read OCR sticky comment for auto-review state: ${fetchErr.message || fetchErr}`);
+            }
+
+            // ----- Decision -----
+
+            if (isManualTrigger) {
+              core.setOutput('auto-should-run', 'true');
+              core.setOutput('suspended', 'false');
+              core.setOutput('is-manual', 'true');
+              core.setOutput('current-count', String(currentCount));
+              return;
+            }
+
+            const suspended = currentCount >= limit;
+            core.setOutput('auto-should-run', suspended ? 'false' : 'true');
+            core.setOutput('suspended', suspended ? 'true' : 'false');
+            core.setOutput('is-manual', 'false');
+            core.setOutput('current-count', String(currentCount));
+
+  post-suspension:
+    name: Post OCR suspension message
+    needs:
+      - mergeability-gate
+      - auto-review-gate
+    # Runs only when the auto-review gate determined that reviews should be
+    # suspended on an automatic trigger. This posts a sticky suspension
+    # message with a re-enable checkbox and /review instructions.
+    if: |
+      needs.mergeability-gate.outputs.should-run == 'true' &&
+      needs.auto-review-gate.outputs.suspended == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post OCR suspension message
+        uses: actions/github-script@f28e40c7f34b6de8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || inputs.pr_number) }}
+          CURRENT_COUNT: ${{ needs.auto-review-gate.outputs.current-count }}
+          OCR_AUTO_REVIEW_LIMIT: ${{ vars.OCR_AUTO_REVIEW_LIMIT }}
+          OCR_AUTO_REVIEW_LIMIT_DEFAULT: '2'
+        with:
+          script: |
+            const MARKER = '<!-- llxprt-code-ocr-review -->';
+            const number = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(number) || number <= 0) {
+              core.setFailed('No valid PR number resolved for suspension message.');
+              return;
+            }
+            const currentCount = Number(process.env.CURRENT_COUNT || '0');
+            const limitRaw = process.env.OCR_AUTO_REVIEW_LIMIT ||
+              process.env.OCR_AUTO_REVIEW_LIMIT_DEFAULT || '2';
+            const parsedLimit = Number(limitRaw);
+            const limit = (Number.isInteger(parsedLimit) && parsedLimit >= 0)
+              ? parsedLimit
+              : Number(process.env.OCR_AUTO_REVIEW_LIMIT_DEFAULT || '2');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const NEWLINE = String.fromCharCode(10);
+            const body = [
+              MARKER,
+              '## OpenCodeReview — automatic reviews suspended',
+              '',
+              'Automatic OCR reviews are **suspended** for this PR after ' + currentCount + ' of ' + limit + ' automatic reviews.',
+              '',
+              'To get more reviews you can:',
+              '',
+              '- Check the box below to re-enable automatic reviews (resets the counter), or',
+              '- Comment `/review`, `/ocr`, or `/open-code-review` to request a single review on demand.',
+              '',
+              '- [ ] Re-enable automatic reviews',
+              '',
+              '<!-- ocr-auto-count:' + currentCount + ' --><!-- ocr-suspended:true -->',
+            ].join(NEWLINE);
+
+            async function reconcileMarkerComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: number, per_page: 100,
+              });
+              const markerComments = comments.filter((comment) =>
+                comment.body && comment.body.includes(MARKER));
+              const existing = markerComments[0];
+              for (const duplicate of markerComments.slice(1)) {
+                try {
+                  await github.rest.issues.deleteComment({
+                    owner, repo, comment_id: duplicate.id,
+                  });
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                } catch (duplicateError) {
+                  core.warning(`Failed to delete duplicate OCR marker comment ${duplicate.id}: ${duplicateError.message || duplicateError}`);
+                }
+              }
+              return existing || null;
+            }
+
+            try {
+              let existing = null;
+              try {
+                existing = await reconcileMarkerComment();
+              } catch (reconcileErr) {
+                core.warning(`Reconciliation failed before suspension posting; attempting create: ${reconcileErr.message || reconcileErr}`);
+              }
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body,
+                });
+              } else {
+                try {
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: number, body,
+                  });
+                } catch (createErr) {
+                  const reconciled = await reconcileMarkerComment();
+                  if (reconciled) {
+                    await github.rest.issues.updateComment({
+                      owner, repo, comment_id: reconciled.id, body,
+                    });
+                  } else {
+                    throw createErr;
+                  }
+                }
+              }
+            } catch (summaryError) {
+              core.warning(`Failed to post OCR suspension message; continuing without failing the workflow: ${summaryError.message || summaryError}`);
+            }
 
   code-review:
     name: OpenCodeReview
@@ -111,11 +411,14 @@ jobs:
     outputs:
       infrastructure_failure: ${{ steps.ocr-classification.outputs.infrastructure_failure }}
       policy_failure: ${{ steps.ocr-classification.outputs.policy_failure }}
-    # The code-review job runs only when the mergeability gate permits it.
+    # The code-review job runs only when the mergeability gate and the
+    # auto-review gate both permit it.
     needs:
       - mergeability-gate
+      - auto-review-gate
     if: |
-      needs.mergeability-gate.outputs.should-run == 'true'
+      needs.mergeability-gate.outputs.should-run == 'true' &&
+      needs.auto-review-gate.outputs.auto-should-run == 'true'
     steps:
       - name: Resolve PR context
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
@@ -568,11 +871,14 @@ jobs:
 
       - name: Post OCR results
         if: always()
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34b6de8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         env:
           BASE_SHA: ${{ env.BASE_SHA }}
           HEAD_SHA: ${{ env.HEAD_SHA }}
           PR_NUMBER: ${{ steps.pr-context.outputs.number }}
+          # Whether this run is an automatic (pull_request_target) trigger.
+          # Automatic runs increment the auto-review counter; manual runs do not.
+          IS_AUTOMATIC: ${{ needs.auto-review-gate.outputs.is-manual == 'false' }}
           # Exact OCR endpoint/credential values are provided only for redaction;
           # do not log process.env from this step.
           OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
@@ -994,6 +1300,31 @@ jobs:
                 body.push(`- ${where}${text}`);
               }
             }
+            const isAutomatic = process.env.IS_AUTOMATIC === 'true';
+
+            // Read the current auto-review count from the existing sticky
+            // comment so it can be incremented (issue #2666). Manual triggers
+            // do not increment the counter.
+            let autoReviewCount = 0;
+            try {
+              const preComments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: number, per_page: 100,
+              });
+              const preMarker = preComments.find((c) =>
+                typeof c.body === 'string' && c.body.includes(MARKER));
+              if (preMarker) {
+                const match = /<!--\s*ocr-auto-count:\s*(\d+)\s*-->/.exec(preMarker.body);
+                if (match) {
+                  autoReviewCount = Number(match[1]);
+                }
+              }
+            } catch (preFetchErr) {
+              core.warning(redactSecretDiagnostics(`Could not read existing OCR comment for auto-review count: ${preFetchErr.message || preFetchErr}`));
+            }
+            if (isAutomatic) {
+              autoReviewCount += 1;
+            }
+            body.push(`\n<!-- ocr-auto-count:${autoReviewCount} --><!-- ocr-suspended:false -->`);
             const summary = body.join('\n');
 
             async function reconcileMarkerComment() {

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -142,7 +142,7 @@ jobs:
     steps:
       - name: Decide auto-review limit
         id: auto-decide
-        uses: actions/github-script@f28e40c7f34b6de8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         env:
           PR_NUMBER: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || inputs.pr_number) }}
           OCR_AUTO_REVIEW_LIMIT: ${{ vars.OCR_AUTO_REVIEW_LIMIT }}
@@ -309,7 +309,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Post OCR suspension message
-        uses: actions/github-script@f28e40c7f34b6de8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         env:
           PR_NUMBER: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || inputs.pr_number) }}
           CURRENT_COUNT: ${{ needs.auto-review-gate.outputs.current-count }}
@@ -871,7 +871,7 @@ jobs:
 
       - name: Post OCR results
         if: always()
-        uses: actions/github-script@f28e40c7f34b6de8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         env:
           BASE_SHA: ${{ env.BASE_SHA }}
           HEAD_SHA: ${{ env.HEAD_SHA }}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -217,8 +217,8 @@ jobs:
                 core.setOutput('current-count', '0');
                 return;
               }
-              const wasUnchecked = /-\s*\[\s\]/.test(changesFrom);
-              const nowChecked = /-\s*\[[xX]\]/.test(commentBody);
+              const wasUnchecked = /-\s*\[\s\]\s*Re-enable automatic reviews/.test(changesFrom);
+              const nowChecked = /-\s*\[[xX]\]\s*Re-enable automatic reviews/.test(commentBody);
               if (wasUnchecked && nowChecked) {
                 // Reset the counter to 0 in the hidden state of the comment
                 // and immediately allow a review on the current head.
@@ -1319,22 +1319,25 @@ jobs:
 
             // Read the current auto-review count from the existing sticky
             // comment so it can be incremented (issue #2666). Manual triggers
-            // do not increment the counter.
-            let autoReviewCount = 0;
+            // do not increment the counter. Fetch the comment list once and
+            // reuse it for both count parsing and reconciliation below.
+            let markerComments = [];
             try {
-              const preComments = await github.paginate(github.rest.issues.listComments, {
+              const allComments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: number, per_page: 100,
               });
-              const preMarker = preComments.find((c) =>
+              markerComments = allComments.filter((c) =>
                 typeof c.body === 'string' && c.body.includes(MARKER));
-              if (preMarker) {
-                const match = /<!--\s*ocr-auto-count:\s*(\d+)\s*-->/.exec(preMarker.body);
-                if (match) {
-                  autoReviewCount = Number(match[1]);
-                }
-              }
             } catch (preFetchErr) {
-              core.warning(redactSecretDiagnostics(`Could not read existing OCR comment for auto-review count: ${preFetchErr.message || preFetchErr}`));
+              core.warning(redactSecretDiagnostics(`Could not list OCR comments for auto-review count: ${preFetchErr.message || preFetchErr}`));
+            }
+            let autoReviewCount = 0;
+            const preMarker = markerComments[0];
+            if (preMarker) {
+              const match = /<!--\s*ocr-auto-count:\s*(\d+)\s*-->/.exec(preMarker.body);
+              if (match) {
+                autoReviewCount = Number(match[1]);
+              }
             }
             if (isAutomatic) {
               autoReviewCount += 1;
@@ -1342,14 +1345,10 @@ jobs:
             body.push(`\n<!-- ocr-auto-count:${autoReviewCount} -->`);
             const summary = body.join('\n');
 
-            async function reconcileMarkerComment() {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner, repo, issue_number: number, per_page: 100,
-              });
-              const markerComments = comments.filter((comment) =>
-                comment.body && comment.body.includes(MARKER));
-              const existing = markerComments[0];
-              for (const duplicate of markerComments.slice(1)) {
+            async function reconcileMarkerComment(existingComments) {
+              const comments = existingComments || markerComments;
+              const existing = comments[0];
+              for (const duplicate of comments.slice(1)) {
                 try {
                   await github.rest.issues.deleteComment({
                     owner, repo, comment_id: duplicate.id,
@@ -1380,7 +1379,10 @@ jobs:
                   owner, repo, issue_number: number, body: summary,
                 });
               } catch (createErr) {
-                const reconciled = await reconcileMarkerComment();
+                // After a failed create (e.g. a race where a marker was just
+                // posted), re-list comments fresh to reconcile, since the
+                // pre-fetched list is stale at this point.
+                const reconciled = await reconcileMarkerComment(null);
                 if (reconciled) {
                   await github.rest.issues.updateComment({
                     owner, repo, comment_id: reconciled.id, body: summary,

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,9 @@
 node_modules/
 bower_components
 
+# Generated license/notice files (third-party, must not be reformatted)
+**/NOTICES.txt
+
 # Git submodules
 packages/opentui/
 

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -436,7 +436,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ============================================================
 which@2.0.2
-(https://github.com/isaacs/node-which.git)
+(git://github.com/isaacs/node-which.git)
 
 The ISC License
 
@@ -478,7 +478,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ============================================================
 eventsource@3.0.7
-(https://github.com/EventSource/eventsource.git)
+(git://git@github.com/EventSource/eventsource.git)
 
 The MIT License
 
@@ -738,7 +738,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ============================================================
 debug@4.4.3
-(https://github.com/debug-js/debug.git)
+(git://github.com/debug-js/debug.git)
 
 (The MIT License)
 
@@ -1172,7 +1172,7 @@ SOFTWARE.
 
 ============================================================
 object-inspect@1.13.4
-(https://github.com/inspect-js/object-inspect.git)
+(git://github.com/inspect-js/object-inspect.git)
 
 MIT License
 
@@ -1468,7 +1468,7 @@ SOFTWARE.
 
 ============================================================
 has-symbols@1.1.0
-(https://github.com/inspect-js/has-symbols.git)
+(git://github.com/inspect-js/has-symbols.git)
 
 MIT License
 
@@ -1965,7 +1965,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ============================================================
 once@1.4.0
-(https://github.com/isaacs/once)
+(git://github.com/isaacs/once)
 
 The ISC License
 
@@ -2283,7 +2283,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ============================================================
 ip-address@10.2.0
-(https://github.com/beaugunderson/ip-address.git)
+(git://github.com/beaugunderson/ip-address.git)
 
 Copyright (C) 2011 by Beau Gunderson
 
@@ -4800,7 +4800,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ============================================================
 require-directory@2.1.1
-(https://github.com/troygoode/node-require-directory.git)
+(git://github.com/troygoode/node-require-directory.git)
 
 The MIT License (MIT)
 

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -436,7 +436,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ============================================================
 which@2.0.2
-(git://github.com/isaacs/node-which.git)
+(https://github.com/isaacs/node-which.git)
 
 The ISC License
 
@@ -478,7 +478,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ============================================================
 eventsource@3.0.7
-(git://git@github.com/EventSource/eventsource.git)
+(https://github.com/EventSource/eventsource.git)
 
 The MIT License
 
@@ -738,7 +738,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ============================================================
 debug@4.4.3
-(git://github.com/debug-js/debug.git)
+(https://github.com/debug-js/debug.git)
 
 (The MIT License)
 
@@ -1172,7 +1172,7 @@ SOFTWARE.
 
 ============================================================
 object-inspect@1.13.4
-(git://github.com/inspect-js/object-inspect.git)
+(https://github.com/inspect-js/object-inspect.git)
 
 MIT License
 
@@ -1468,7 +1468,7 @@ SOFTWARE.
 
 ============================================================
 has-symbols@1.1.0
-(git://github.com/inspect-js/has-symbols.git)
+(https://github.com/inspect-js/has-symbols.git)
 
 MIT License
 
@@ -1965,7 +1965,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ============================================================
 once@1.4.0
-(git://github.com/isaacs/once)
+(https://github.com/isaacs/once)
 
 The ISC License
 
@@ -2283,7 +2283,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ============================================================
 ip-address@10.2.0
-(git://github.com/beaugunderson/ip-address.git)
+(https://github.com/beaugunderson/ip-address.git)
 
 Copyright (C) 2011 by Beau Gunderson
 
@@ -4800,7 +4800,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ============================================================
 require-directory@2.1.1
-(git://github.com/troygoode/node-require-directory.git)
+(https://github.com/troygoode/node-require-directory.git)
 
 The MIT License (MIT)
 

--- a/project-plans/issue-2666-ocr-auto-review-limit.md
+++ b/project-plans/issue-2666-ocr-auto-review-limit.md
@@ -1,0 +1,51 @@
+# Issue #2666 — OCR Auto-Review Limit & Suspension Mechanism
+
+## Scope Ledger
+
+### In scope
+- `.github/workflows/ocr-review.yml`: auto-review-limit decision, suspension message, counter increment, `/review` alias, `issue_comment.edited` trigger
+- New behavioral test file under `scripts/tests/`
+- Minimal updates to existing workflow-wiring tests to accommodate new job structure
+
+### Explicit non-goals
+- NOT modifying `.github/workflows/_pr-mergeability-gate.yml` (shared pure mergeability oracle used by 3 workflows; has only `pull-requests: read`, no `issues: read`)
+- NOT modifying `pr-review.yml` or `e2e.yml`
+- NOT adding PR labels (Approach B) — deferred; Approach A (hidden comment data) is primary
+- NOT implementing incremental reviews (#2649 is complementary)
+- NOT implementing a `resume` slash command beyond checkbox + existing manual commands
+- NOT changing the fork-safety model or trusted-base checkout
+
+### Hard scope budget
+- Target: ≤ 4 files, ≤ 600 net changed lines (well under 25-file / 1500-line ceiling)
+
+## Architectural decision
+
+The shared gate stays a **pure mergeability oracle**. Auto-review-limit is an
+**OCR-owned concern** implemented as a new job in `ocr-review.yml`:
+
+```
+mergeability-gate (unchanged, shared) → auto-review-gate (NEW, OCR) → code-review / post-suspension
+```
+
+State storage: **Approach A** — hidden HTML comments in the sticky summary comment:
+- `<!-- ocr-auto-count:N -->`
+- `<!-- ocr-suspended:true -->`
+
+## Acceptance Matrix
+
+| AC | Behavior | Trigger / State | Expected outcome |
+|----|----------|-----------------|------------------|
+| 1 | After 2 auto reviews, 3rd sync skips OCR | pull_request_target synchronize, count=2 | code-review skipped; suspended=true |
+| 2 | Suspension message posted | suspended=true | sticky comment: header, count/limit, checkbox `[ ]`, `/review` instructions |
+| 3 | Checkbox edit resets counter | issue_comment.edited, `[ ]`→`[x]` on bot OCR comment | counter→0, review runs |
+| 4 | Post-reset push allows 2 more | count=0 | reviews 1,2 run; 3rd suspends |
+| 5 | Manual commands always run | issue_comment /ocr /open-code-review /review | should-run=true regardless of suspension |
+| 6 | Manual reviews don't increment counter | manual trigger | counter unchanged |
+| 7 | Configurable via OCR_AUTO_REVIEW_LIMIT | var=3 | limit=3 enforced |
+| 8 | Counter persists across runs | multiple runs | read from sticky comment |
+| 9 | Suspension message clear & actionable | — | header + count + limit + checkbox + instructions |
+
+## Bounded vertical slices
+1. **Slice 1**: auto-review-gate decision logic (count vs limit, manual bypass) + tests
+2. **Slice 2**: suspension message rendering + counter increment + tests
+3. **Slice 3**: `issue_comment.edited` checkbox reset + `/review` alias + tests

--- a/scripts/tests/ocr-auto-review-limit.test.js
+++ b/scripts/tests/ocr-auto-review-limit.test.js
@@ -457,9 +457,7 @@ describe('.github/workflows/ocr-review.yml — auto-review limit (issue #2666)',
     // The counter is reset in the comment
     expect(result.updateCalls).toHaveLength(1);
     expect(result.updateCalls[0].body).toContain('<!-- ocr-auto-count:0 -->');
-    expect(result.updateCalls[0].body).toContain(
-      '<!-- ocr-suspended:false -->',
-    );
+    expect(result.updateCalls[0].body).not.toContain('ocr-suspended');
   });
 
   it('checkbox edit without change does not reset counter', async () => {
@@ -544,7 +542,11 @@ describe('.github/workflows/ocr-review.yml — auto-review limit (issue #2666)',
     expect(postSuspensionScript).toContain('/ocr');
     expect(postSuspensionScript).toContain(MARKER);
     expect(postSuspensionScript).toContain('<!-- ocr-auto-count:');
-    expect(postSuspensionScript).toContain('<!-- ocr-suspended:true');
+    // The suspension state is derived from count >= limit at runtime,
+    // not stored as a separate hidden flag (issue #2666 CodeRabbit Fix3).
+    // The script may contain a backward-compat cleanup regex for old markers,
+    // but must not WRITE a new ocr-suspended:true marker.
+    expect(postSuspensionScript).not.toContain("'<!-- ocr-suspended:true'");
   });
 
   it('post-suspension writes the count and limit into the message', () => {
@@ -570,9 +572,14 @@ describe('.github/workflows/ocr-review.yml — auto-review limit (issue #2666)',
 
   // ---- Wiring tests: skip/outcome recording ----
 
-  it('record-skipped-ocr-outcome accommodates suspension skips', () => {
+  it('record-skipped-ocr-outcome fires on both mergeability skip and suspension skip', () => {
     const skippedJob = workflow.jobs?.['record-skipped-ocr-outcome'];
     expect(skippedJob).toBeTruthy();
     expect(skippedJob.needs).toContain('mergeability-gate');
+    expect(skippedJob.needs).toContain('auto-review-gate');
+    const skippedIf = normalize(skippedJob.if);
+    expect(skippedIf).toContain(
+      normalize("needs.auto-review-gate.outputs.auto-should-run != 'true'"),
+    );
   });
 });

--- a/scripts/tests/ocr-auto-review-limit.test.js
+++ b/scripts/tests/ocr-auto-review-limit.test.js
@@ -1,0 +1,578 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import vm from 'vm';
+import yaml from 'js-yaml';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  normalize,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.js';
+
+const MARKER = '<!-- llxprt-code-ocr-review -->';
+
+/**
+ * Load and parse the OCR review workflow, extracting the auto-review-gate
+ * and post-suspension job scripts for behavioral execution.
+ */
+function loadAutoReviewScripts() {
+  const source = readRootFile(WORKFLOW_PATH);
+  const parsed = yaml.load(source);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`${WORKFLOW_PATH} did not parse to a YAML mapping`);
+  }
+  const autoReviewJob = parsed.jobs?.['auto-review-gate'];
+  const postSuspensionJob = parsed.jobs?.['post-suspension'];
+  const codeReviewJob = parsed.jobs?.['code-review'];
+  return { source, parsed, autoReviewJob, postSuspensionJob, codeReviewJob };
+}
+
+/**
+ * Find the github-script step in a job and return its script body.
+ */
+function scriptFromJob(job, stepName) {
+  const step = stepNamed(job, stepName);
+  const script = step.with?.script;
+  if (typeof script !== 'string' || script.trim().length === 0) {
+    throw new Error(`${stepName} should have a non-empty github-script body`);
+  }
+  return { step, script };
+}
+
+/**
+ * Execute the real auto-review-gate script in an isolated VM sandbox with
+ * faked GitHub infrastructure. Only Octokit REST and context are faked —
+ * the actual decision logic runs unchanged.
+ */
+async function executeAutoReviewGate({
+  script,
+  eventName = 'pull_request_target',
+  eventAction = 'synchronize',
+  prNumber = '42',
+  autoReviewLimit = '',
+  commentBody = '',
+  changesFrom = '',
+  commentUserType = 'Bot',
+  listComments = [],
+  updateCommentResult = null,
+}) {
+  const outputs = {};
+  const warnings = [];
+  const updateCalls = [];
+  let failure = null;
+
+  const fakeGithub = {
+    paginate: async (fn, options) => {
+      const result = await fn(options);
+      return result.data;
+    },
+    rest: {
+      issues: {
+        listComments: async () => ({ data: listComments }),
+        updateComment: async (opts) => {
+          updateCalls.push(opts);
+          if (updateCommentResult instanceof Error) throw updateCommentResult;
+          return updateCommentResult || { status: 200 };
+        },
+      },
+    },
+  };
+
+  const fakeCore = {
+    setOutput: (name, value) => {
+      outputs[name] = String(value);
+    },
+    warning: (message) => {
+      warnings.push(String(message));
+    },
+    info: () => {},
+    setFailed: (message) => {
+      failure = String(message);
+    },
+  };
+
+  const fakeContext = {
+    repo: { owner: 'test-owner', repo: 'test-repo' },
+    eventName,
+    payload: {
+      action: eventAction,
+      issue: { number: Number(prNumber), pull_request: {} },
+      comment: commentBody
+        ? { body: commentBody, user: { type: commentUserType }, id: 999 }
+        : undefined,
+      changes: changesFrom ? { body: { from: changesFrom } } : undefined,
+    },
+  };
+
+  const sandbox = {
+    github: fakeGithub,
+    core: fakeCore,
+    context: fakeContext,
+    process: {
+      env: {
+        PR_NUMBER: prNumber,
+        OCR_AUTO_REVIEW_LIMIT: autoReviewLimit,
+        OCR_AUTO_REVIEW_LIMIT_DEFAULT: '2',
+        EVENT_NAME: eventName,
+        EVENT_ACTION: eventAction,
+        COMMENT_BODY: commentBody,
+        COMMENT_USER_TYPE: commentUserType,
+        CHANGES_FROM: changesFrom,
+      },
+    },
+    setTimeout: (fn) => {
+      fn();
+      return 0;
+    },
+    clearTimeout: () => {},
+    console: { log: () => {}, warn: (m) => warnings.push(String(m)) },
+    AbortSignal,
+    Number,
+    String,
+    Boolean,
+    Math,
+    JSON,
+    Error,
+    Promise,
+    Date,
+    Array,
+    Object,
+    parseInt,
+    RegExp,
+  };
+
+  const promise = vm.runInNewContext(`(async () => { ${script} })()`, sandbox);
+  await promise;
+
+  return { outputs, warnings, updateCalls, failure };
+}
+
+describe('.github/workflows/ocr-review.yml — auto-review limit (issue #2666)', () => {
+  let workflow;
+  let autoReviewJob;
+  let postSuspensionJob;
+  let codeReviewJob;
+  let mergeabilityGateJob;
+  let autoGateScript;
+  let postSuspensionScript;
+
+  beforeAll(() => {
+    const loaded = loadAutoReviewScripts();
+    workflow = loaded.parsed;
+    autoReviewJob = loaded.autoReviewJob;
+    postSuspensionJob = loaded.postSuspensionJob;
+    codeReviewJob = loaded.codeReviewJob;
+    mergeabilityGateJob = workflow.jobs?.['mergeability-gate'];
+
+    expect(
+      autoReviewJob,
+      'workflow should contain an auto-review-gate job',
+    ).toBeTruthy();
+    expect(
+      postSuspensionJob,
+      'workflow should contain a post-suspension job',
+    ).toBeTruthy();
+
+    const autoGate = scriptFromJob(autoReviewJob, 'Decide auto-review limit');
+    autoGateScript = autoGate.script;
+    const postSusp = scriptFromJob(
+      postSuspensionJob,
+      'Post OCR suspension message',
+    );
+    postSuspensionScript = postSusp.script;
+  });
+
+  // ---- YAML structural tests ----
+
+  it('adds issue_comment.edited to the trigger types', () => {
+    const types = workflow.on?.issue_comment?.types ?? [];
+    expect(types).toContain('created');
+    expect(types).toContain('edited');
+  });
+
+  it('adds /review to the concurrency group authorized commands', () => {
+    const concurrencyGroup = normalize(workflow.concurrency?.group);
+    expect(concurrencyGroup).toContain(
+      "github.event.comment.body == '/review'",
+    );
+    expect(concurrencyGroup).toContain(
+      "startsWith(github.event.comment.body, '/review ')",
+    );
+  });
+
+  it('adds /review to the mergeability-gate if filter', () => {
+    const gateIf = normalize(mergeabilityGateJob.if);
+    expect(gateIf).toContain("github.event.comment.body == '/review'");
+    expect(gateIf).toContain(
+      "startsWith(github.event.comment.body, '/review ')",
+    );
+  });
+
+  it('adds edited-comment conditions to the mergeability-gate if filter', () => {
+    const gateIf = normalize(mergeabilityGateJob.if);
+    expect(gateIf).toContain("github.event.action == 'edited'");
+    expect(gateIf).toContain('contains(github.event.comment.body');
+    expect(gateIf).toContain("github.event.comment.user.type == 'Bot'");
+  });
+
+  it('adds an auto-review-gate job that needs mergeability-gate', () => {
+    expect(autoReviewJob.needs).toContain('mergeability-gate');
+    expect(normalize(autoReviewJob.if)).toContain(
+      normalize("needs.mergeability-gate.outputs.should-run == 'true'"),
+    );
+  });
+
+  it('exposes auto-review-gate outputs', () => {
+    const outputs = autoReviewJob.outputs || {};
+    expect(outputs['auto-should-run']).toBeTruthy();
+    expect(outputs['suspended']).toBeTruthy();
+    expect(outputs['is-manual']).toBeTruthy();
+    expect(outputs['current-count']).toBeTruthy();
+  });
+
+  it('code-review needs auto-review-gate and runs when auto-should-run is true', () => {
+    expect(codeReviewJob.needs).toContain('auto-review-gate');
+    expect(codeReviewJob.needs).toContain('mergeability-gate');
+    expect(normalize(codeReviewJob.if)).toContain(
+      normalize("needs.auto-review-gate.outputs.auto-should-run == 'true'"),
+    );
+  });
+
+  it('post-suspension runs when suspended is true', () => {
+    expect(postSuspensionJob.needs).toContain('mergeability-gate');
+    expect(postSuspensionJob.needs).toContain('auto-review-gate');
+    expect(normalize(postSuspensionJob.if)).toContain(
+      normalize("needs.auto-review-gate.outputs.suspended == 'true'"),
+    );
+  });
+
+  it('reads OCR_AUTO_REVIEW_LIMIT from vars with a default of 2', () => {
+    const decideStep = stepNamed(autoReviewJob, 'Decide auto-review limit');
+    const limitEnv = decideStep.env?.OCR_AUTO_REVIEW_LIMIT;
+    expect(limitEnv).toBeTruthy();
+    expect(String(limitEnv)).toContain('vars.OCR_AUTO_REVIEW_LIMIT');
+    // YAML unquotes '2' to the string "2".
+    expect(String(decideStep.env?.OCR_AUTO_REVIEW_LIMIT_DEFAULT || '')).toBe(
+      '2',
+    );
+  });
+
+  // ---- Behavioral tests: auto-review-gate decision logic ----
+
+  it('permits automatic review when count is below the limit (AC 1, 8)', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      prNumber: '42',
+      autoReviewLimit: '2',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n## OpenCodeReview\n<!-- ocr-auto-count:0 --><!-- ocr-suspended:false -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.outputs['is-manual']).toBe('false');
+    expect(result.outputs['current-count']).toBe('0');
+  });
+
+  it('permits automatic review when count is 1 and limit is 2', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '2',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:1 --><!-- ocr-suspended:false -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.outputs['current-count']).toBe('1');
+  });
+
+  it('suspends when count reaches the limit on automatic trigger (AC 1)', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '2',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:false -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.outputs['suspended']).toBe('true');
+    expect(result.outputs['is-manual']).toBe('false');
+    expect(result.outputs['current-count']).toBe('2');
+  });
+
+  it('suspends when count exceeds the limit', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '2',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:5 --><!-- ocr-suspended:true -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.outputs['suspended']).toBe('true');
+  });
+
+  it('manual /review command always permits regardless of suspension (AC 5, 6)', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'created',
+      commentBody: '/review',
+      autoReviewLimit: '2',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:true -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.outputs['is-manual']).toBe('true');
+  });
+
+  it('workflow_dispatch always permits regardless of suspension (AC 5)', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'workflow_dispatch',
+      eventAction: '',
+      autoReviewLimit: '2',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:true -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.outputs['is-manual']).toBe('true');
+  });
+
+  it('defaults to limit 2 when OCR_AUTO_REVIEW_LIMIT is unset (AC 7)', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:false -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.outputs['suspended']).toBe('true');
+  });
+
+  it('respects a custom OCR_AUTO_REVIEW_LIMIT of 3 (AC 7)', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '3',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:false -->`,
+        },
+      ],
+    });
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+  });
+
+  it('defaults to count 0 and suspended false when no sticky comment exists (AC 8)', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '2',
+      listComments: [],
+    });
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.outputs['current-count']).toBe('0');
+  });
+
+  it('defaults to count 0 when sticky comment lacks hidden state', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '2',
+      listComments: [{ id: 1, body: `${MARKER}\n## Review without state` }],
+    });
+    expect(result.outputs['current-count']).toBe('0');
+    expect(result.outputs['auto-should-run']).toBe('true');
+  });
+
+  // ---- Behavioral tests: checkbox reset ----
+
+  it('checkbox edit from unchecked to checked resets counter to 0 (AC 3, 4)', async () => {
+    const oldBody = `${MARKER}\n## Suspended\n- [ ] Re-enable automatic reviews\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:true -->`;
+    const newBody = oldBody.replace('[ ]', '[x]');
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'edited',
+      autoReviewLimit: '2',
+      commentBody: newBody,
+      changesFrom: oldBody,
+      commentUserType: 'Bot',
+      listComments: [{ id: 999, body: newBody }],
+    });
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.outputs['is-manual']).toBe('true');
+    expect(result.outputs['current-count']).toBe('0');
+    // The counter is reset in the comment
+    expect(result.updateCalls).toHaveLength(1);
+    expect(result.updateCalls[0].body).toContain('<!-- ocr-auto-count:0 -->');
+    expect(result.updateCalls[0].body).toContain(
+      '<!-- ocr-suspended:false -->',
+    );
+  });
+
+  it('checkbox edit without change does not reset counter', async () => {
+    const body = `${MARKER}\n## Suspended\n- [ ] Re-enable automatic reviews\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:true -->`;
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'edited',
+      autoReviewLimit: '2',
+      commentBody: body,
+      changesFrom: body,
+      commentUserType: 'Bot',
+      listComments: [{ id: 999, body }],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.updateCalls).toHaveLength(0);
+  });
+
+  it('unchecking the box does not reset counter', async () => {
+    const checkedBody = `${MARKER}\n## Suspended\n- [x] Re-enable automatic reviews\n<!-- ocr-auto-count:2 --><!-- ocr-suspended:true -->`;
+    const uncheckedBody = checkedBody.replace('[x]', '[ ]');
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'edited',
+      autoReviewLimit: '2',
+      commentBody: uncheckedBody,
+      changesFrom: checkedBody,
+      commentUserType: 'Bot',
+      listComments: [{ id: 999, body: uncheckedBody }],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.updateCalls).toHaveLength(0);
+  });
+
+  it('edited comment without OCR marker is a no-op', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'edited',
+      autoReviewLimit: '2',
+      commentBody: 'Some random comment that was edited',
+      changesFrom: 'Some random comment',
+      commentUserType: 'User',
+      listComments: [],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.updateCalls).toHaveLength(0);
+  });
+
+  it('checkbox reset that fails to write does not proceed with stale count', async () => {
+    const oldBody = `${MARKER}
+## Suspended
+- [ ] Re-enable automatic reviews
+<!-- ocr-auto-count:2 --><!-- ocr-suspended:true -->`;
+    const newBody = oldBody.replace('[ ]', '[x]');
+    const writeError = new Error('API rate limit');
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'edited',
+      autoReviewLimit: '2',
+      commentBody: newBody,
+      changesFrom: oldBody,
+      commentUserType: 'Bot',
+      listComments: [{ id: 999, body: newBody }],
+      updateCommentResult: writeError,
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.outputs['suspended']).toBe('false');
+    expect(result.outputs['is-manual']).toBe('false');
+  });
+
+  // ---- Behavioral tests: suspension message rendering ----
+
+  it('renders a suspension message with header, count/limit, checkbox, and instructions (AC 2, 9)', () => {
+    expect(postSuspensionScript).toContain('suspended');
+    expect(postSuspensionScript).toContain('Re-enable automatic reviews');
+    expect(postSuspensionScript).toContain('- [ ]');
+    expect(postSuspensionScript).toContain('/review');
+    expect(postSuspensionScript).toContain('/ocr');
+    expect(postSuspensionScript).toContain(MARKER);
+    expect(postSuspensionScript).toContain('<!-- ocr-auto-count:');
+    expect(postSuspensionScript).toContain('<!-- ocr-suspended:true');
+  });
+
+  it('post-suspension writes the count and limit into the message', () => {
+    expect(postSuspensionScript).toContain('OCR_AUTO_REVIEW_LIMIT');
+    expect(postSuspensionScript).toContain('CURRENT_COUNT');
+  });
+
+  // ---- Behavioral tests: counter increment in Post OCR results ----
+
+  it('Post OCR results increments the counter for automatic triggers (AC 6)', () => {
+    const postStep = stepNamed(codeReviewJob, 'Post OCR results');
+    const postScript = commandText(postStep);
+    expect(postScript).toContain('ocr-auto-count');
+    expect(postScript).toContain('IS_AUTOMATIC');
+  });
+
+  it('manual reviews do not increment the counter (AC 6)', () => {
+    const postStep = stepNamed(codeReviewJob, 'Post OCR results');
+    const postScript = commandText(postStep);
+    // The increment should be conditional on the automatic flag
+    expect(postScript).toContain('isAutomatic');
+  });
+
+  // ---- Wiring tests: skip/outcome recording ----
+
+  it('record-skipped-ocr-outcome accommodates suspension skips', () => {
+    const skippedJob = workflow.jobs?.['record-skipped-ocr-outcome'];
+    expect(skippedJob).toBeTruthy();
+    expect(skippedJob.needs).toContain('mergeability-gate');
+  });
+});

--- a/scripts/tests/ocr-auto-review-limit.test.js
+++ b/scripts/tests/ocr-auto-review-limit.test.js
@@ -60,6 +60,7 @@ async function executeAutoReviewGate({
   changesFrom = '',
   commentUserType = 'Bot',
   listComments = [],
+  listCommentsError = null,
   updateCommentResult = null,
 }) {
   const outputs = {};
@@ -74,7 +75,10 @@ async function executeAutoReviewGate({
     },
     rest: {
       issues: {
-        listComments: async () => ({ data: listComments }),
+        listComments: async () => {
+          if (listCommentsError instanceof Error) throw listCommentsError;
+          return { data: listComments };
+        },
         updateComment: async (opts) => {
           updateCalls.push(opts);
           if (updateCommentResult instanceof Error) throw updateCommentResult;
@@ -148,7 +152,11 @@ async function executeAutoReviewGate({
   };
 
   const promise = vm.runInNewContext(`(async () => { ${script} })()`, sandbox);
-  await promise;
+  try {
+    await promise;
+  } catch (error) {
+    failure = String(error);
+  }
 
   return { outputs, warnings, updateCalls, failure };
 }
@@ -410,6 +418,54 @@ describe('.github/workflows/ocr-review.yml — auto-review limit (issue #2666)',
     expect(result.outputs['suspended']).toBe('false');
   });
 
+  it('falls back to the default limit when OCR_AUTO_REVIEW_LIMIT is not a number', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: 'not-a-number',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:2 -->`,
+        },
+      ],
+    });
+    // Default limit is 2; count 2 >= 2 means suspended.
+    expect(result.outputs['suspended']).toBe('true');
+    expect(result.outputs['auto-should-run']).toBe('false');
+  });
+
+  it('falls back to the default limit when OCR_AUTO_REVIEW_LIMIT is negative', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '-1',
+      listComments: [
+        {
+          id: 1,
+          body: `${MARKER}\n<!-- ocr-auto-count:1 -->`,
+        },
+      ],
+    });
+    // Negative limit falls back to default 2; count 1 < 2 means allowed.
+    expect(result.outputs['auto-should-run']).toBe('true');
+    expect(result.outputs['suspended']).toBe('false');
+  });
+
+  it('treats a limit of 0 as suspending every automatic review', async () => {
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'pull_request_target',
+      eventAction: 'synchronize',
+      autoReviewLimit: '0',
+      listComments: [],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.outputs['suspended']).toBe('true');
+  });
+
   it('defaults to count 0 and suspended false when no sticky comment exists (AC 8)', async () => {
     const result = await executeAutoReviewGate({
       script: autoGateScript,
@@ -494,19 +550,54 @@ describe('.github/workflows/ocr-review.yml — auto-review limit (issue #2666)',
     expect(result.updateCalls).toHaveLength(0);
   });
 
-  it('edited comment without OCR marker is a no-op', async () => {
+  it('edited bot comment without the OCR marker is a no-op', async () => {
     const result = await executeAutoReviewGate({
       script: autoGateScript,
       eventName: 'issue_comment',
       eventAction: 'edited',
       autoReviewLimit: '2',
-      commentBody: 'Some random comment that was edited',
-      changesFrom: 'Some random comment',
+      commentBody: 'Some random bot comment that was edited',
+      changesFrom: 'Some random bot comment',
+      commentUserType: 'Bot',
+      listComments: [],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.updateCalls).toHaveLength(0);
+  });
+
+  it('edited marker comment authored by a non-bot user is a no-op', async () => {
+    const oldBody = `${MARKER}\n- [ ] Re-enable automatic reviews\n<!-- ocr-auto-count:2 -->`;
+    const newBody = oldBody.replace('[ ]', '[x]');
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'edited',
+      autoReviewLimit: '2',
+      commentBody: newBody,
+      changesFrom: oldBody,
       commentUserType: 'User',
       listComments: [],
     });
     expect(result.outputs['auto-should-run']).toBe('false');
     expect(result.updateCalls).toHaveLength(0);
+  });
+
+  it('listComments API failure during edited-comment handling is non-fatal', async () => {
+    const oldBody = `${MARKER}\n- [ ] Re-enable automatic reviews\n<!-- ocr-auto-count:2 -->`;
+    const newBody = oldBody.replace('[ ]', '[x]');
+    const result = await executeAutoReviewGate({
+      script: autoGateScript,
+      eventName: 'issue_comment',
+      eventAction: 'edited',
+      autoReviewLimit: '2',
+      commentBody: newBody,
+      changesFrom: oldBody,
+      commentUserType: 'Bot',
+      listCommentsError: new Error('API rate limit'),
+      listComments: [],
+    });
+    expect(result.outputs['auto-should-run']).toBe('false');
+    expect(result.failure).toBeNull();
   });
 
   it('checkbox reset that fails to write does not proceed with stale count', async () => {

--- a/scripts/tests/ocr-notifier-classification.test.js
+++ b/scripts/tests/ocr-notifier-classification.test.js
@@ -267,7 +267,10 @@ describe('OCR workflow_run notification classification', () => {
     expect(outcomeJob?.permissions).toEqual({});
     expect(skippedJob?.permissions).toEqual({});
     expect(outcomeJob?.needs).toEqual(['mergeability-gate', 'code-review']);
-    expect(skippedJob?.needs).toEqual(['mergeability-gate']);
+    expect(skippedJob?.needs).toEqual([
+      'mergeability-gate',
+      'auto-review-gate',
+    ]);
     for (const scenario of truthTable.slice(0, 4)) {
       expect(stepNamed(outcomeJob, scenario.marker)).toBeTruthy();
     }

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -49,8 +49,8 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
     notifyRun = commandText(notifyStep);
   });
 
-  it('exposes a single OCR_VERSION env var set to 1.7.9 (Behavior 1)', () => {
-    expect(workflow.env?.OCR_VERSION).toBe('1.7.9');
+  it('exposes a single OCR_VERSION env var set to 1.7.16 (Behavior 1)', () => {
+    expect(workflow.env?.OCR_VERSION).toBe('1.7.16');
   });
 
   it('installs OpenCodeReview using the OCR_VERSION env var (Behavior 1)', () => {
@@ -61,7 +61,7 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
       '"@alibaba-group/open-code-review@${OCR_VERSION}"',
     );
     expect(installRun).not.toContain('1.6.1');
-    expect(installRun).not.toContain('@alibaba-group/open-code-review@1.7.9');
+    expect(installRun).not.toContain('@alibaba-group/open-code-review@1.7.16');
   });
 
   it('exposes a configurable OCR_CONCURRENCY env var set to 2 (Behavior 2)', () => {

--- a/scripts/tests/ocr-review-workflow-behaviors.test.js
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.js
@@ -156,8 +156,8 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
   it('reconciles ambiguous createComment by marker (Behavior 6)', () => {
     expectContainsAll(postScript, [
       'async function createOrUpdateMarkerComment(summary)',
-      'async function reconcileMarkerComment()',
-      'comment.body && comment.body.includes(MARKER)',
+      'async function reconcileMarkerComment(existingComments)',
+      "typeof c.body === 'string' && c.body.includes(MARKER)",
     ]);
     const postFunctionSource = extractFunctionSource(
       postScript,
@@ -167,7 +167,7 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
       'existing = await reconcileMarkerComment()',
       'github.rest.issues.updateComment({',
       'github.rest.issues.createComment({',
-      'const reconciled = await reconcileMarkerComment()',
+      'const reconciled = await reconcileMarkerComment(null)',
       'if (reconciled)',
     ]);
   });

--- a/scripts/tests/pr-mergeability-workflow-wiring.test.js
+++ b/scripts/tests/pr-mergeability-workflow-wiring.test.js
@@ -29,6 +29,7 @@ const OCR_AUTHORIZATION_PREDICATE = `
   github.event_name == 'workflow_dispatch' ||
   github.event_name == 'pull_request_target' ||
   (github.event_name == 'issue_comment' &&
+   github.event.action == 'created' &&
    github.event.issue.pull_request != null &&
    (github.event.comment.author_association == 'OWNER' ||
     github.event.comment.author_association == 'MEMBER' ||
@@ -42,7 +43,17 @@ const OCR_AUTHORIZATION_PREDICATE = `
     startsWith(github.event.comment.body, '/open-code-review ') ||
     startsWith(toJSON(github.event.comment.body), '"/open-code-review\\n') ||
     startsWith(toJSON(github.event.comment.body), '"/open-code-review\\r\\n') ||
-    startsWith(toJSON(github.event.comment.body), '"/open-code-review\\t')))
+    startsWith(toJSON(github.event.comment.body), '"/open-code-review\\t') ||
+    github.event.comment.body == '/review' ||
+    startsWith(github.event.comment.body, '/review ') ||
+    startsWith(toJSON(github.event.comment.body), '"/review\\n') ||
+    startsWith(toJSON(github.event.comment.body), '"/review\\r\\n') ||
+    startsWith(toJSON(github.event.comment.body), '"/review\\t'))) ||
+  (github.event_name == 'issue_comment' &&
+   github.event.action == 'edited' &&
+   github.event.issue.pull_request != null &&
+   github.event.comment.user.type == 'Bot' &&
+   contains(github.event.comment.body, '<!-- llxprt-code-ocr-review -->'))
 `;
 
 const OCR_CONCURRENCY_GROUP = `
@@ -63,7 +74,17 @@ const OCR_CONCURRENCY_GROUP = `
        startsWith(github.event.comment.body, '/open-code-review ') ||
        startsWith(toJSON(github.event.comment.body), '"/open-code-review\\n') ||
        startsWith(toJSON(github.event.comment.body), '"/open-code-review\\r\\n') ||
-       startsWith(toJSON(github.event.comment.body), '"/open-code-review\\t')))) &&
+       startsWith(toJSON(github.event.comment.body), '"/open-code-review\\t') ||
+       github.event.comment.body == '/review' ||
+       startsWith(github.event.comment.body, '/review ') ||
+       startsWith(toJSON(github.event.comment.body), '"/review\\n') ||
+       startsWith(toJSON(github.event.comment.body), '"/review\\r\\n') ||
+       startsWith(toJSON(github.event.comment.body), '"/review\\t'))) ||
+     (github.event_name == 'issue_comment' &&
+      github.event.action == 'edited' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type == 'Bot' &&
+      contains(github.event.comment.body, '<!-- llxprt-code-ocr-review -->'))) &&
     format('{0}-pr-{1}', github.workflow,
       github.event.pull_request.number || github.event.issue.number || inputs.pr_number) ||
     format('{0}-run-{1}', github.workflow, github.run_id)
@@ -76,6 +97,7 @@ function evaluateOcrConcurrencyGroup(group, { github, inputs = {} }) {
     github,
     inputs,
     startsWith: (value, prefix) => String(value).startsWith(prefix),
+    contains: (value, fragment) => String(value).includes(String(fragment)),
     toJSON: (value) => JSON.stringify(value),
     format: (template, ...values) =>
       template.replace(/{(\d+)}/g, (_match, index) => values[Number(index)]),
@@ -91,6 +113,8 @@ function ocrConcurrencyContext({
   association = 'NONE',
   body = '',
   inputPrNumber = '',
+  action = 'created',
+  commentUserType = 'User',
 }) {
   return {
     github: {
@@ -98,6 +122,7 @@ function ocrConcurrencyContext({
       run_id: runId,
       event_name: eventName,
       event: {
+        action,
         pull_request: { number: pullRequestNumber },
         issue: {
           number: issueNumber,
@@ -106,6 +131,7 @@ function ocrConcurrencyContext({
         comment: {
           author_association: association,
           body,
+          user: { type: commentUserType },
         },
       },
     },
@@ -245,7 +271,12 @@ describe('OCR mergeability gate wiring (.github/workflows/ocr-review.yml)', () =
   it('keeps the sequential gate and review inside one workflow concurrency owner', () => {
     expect(gateJob.concurrency).toBeUndefined();
     expect(codeReviewJob.concurrency).toBeUndefined();
-    expect(codeReviewJob.needs).toEqual(['mergeability-gate']);
+    // code-review now depends on both the mergeability gate and the OCR
+    // auto-review limit gate (issue #2666).
+    expect(codeReviewJob.needs).toEqual([
+      'mergeability-gate',
+      'auto-review-gate',
+    ]);
     expect(parsed.jobs?.['notify-ocr-infrastructure-failure']).toBeUndefined();
   });
 

--- a/scripts/tests/pr-mergeability-workflow-wiring.test.js
+++ b/scripts/tests/pr-mergeability-workflow-wiring.test.js
@@ -272,11 +272,12 @@ describe('OCR mergeability gate wiring (.github/workflows/ocr-review.yml)', () =
     expect(gateJob.concurrency).toBeUndefined();
     expect(codeReviewJob.concurrency).toBeUndefined();
     // code-review now depends on both the mergeability gate and the OCR
-    // auto-review limit gate (issue #2666).
-    expect(codeReviewJob.needs).toEqual([
-      'mergeability-gate',
-      'auto-review-gate',
-    ]);
+    // auto-review limit gate (issue #2666). Assert membership and length
+    // independently rather than pinning YAML ordering, which Actions treats
+    // as a set.
+    expect(codeReviewJob.needs).toHaveLength(2);
+    expect(codeReviewJob.needs).toContain('mergeability-gate');
+    expect(codeReviewJob.needs).toContain('auto-review-gate');
     expect(parsed.jobs?.['notify-ocr-infrastructure-failure']).toBeUndefined();
   });
 


### PR DESCRIPTION
## Problem

The OCR workflow (`.github/workflows/ocr-review.yml`) runs a full code review on every `pull_request_target` synchronize event with no limit, creating a feedback loop where an AI agent addresses findings, pushes, triggers another review, and repeats indefinitely. On PR #2634 alone, OCR ran **11 times**, generating hundreds of duplicative comments and consuming significant LLM tokens and CI runner time.

## Solution

After 2 automatic reviews per PR (configurable via `OCR_AUTO_REVIEW_LIMIT`), OCR suspends itself and posts a sticky suspension comment with a checkbox for re-enabling and instructions for manual commands. This mirrors how CodeRabbit handles auto-review limits.

### Architecture decision

The shared `_pr-mergeability-gate.yml` is a **pure mergeability oracle** used by 3 workflows (`ocr-review`, `pr-review`, `e2e`) with only `pull-requests: read` permission. The auto-review-limit logic is **OCR-owned** within `ocr-review.yml` — the shared gate is unchanged.

### State tracking (Approach A)

State persists across workflow runs via hidden HTML comments in the sticky OCR summary comment (same marker `<!-- llxprt-code-ocr-review -->`):

    <!-- ocr-auto-count:N -->
    <!-- ocr-suspended:true|false -->

This is self-contained, needs no external dependencies, and survives repo resets.

## Changes

### New jobs in `ocr-review.yml`

1. **`auto-review-gate`** — Reads `OCR_AUTO_REVIEW_LIMIT` (default 2) from repository variables, parses hidden count/suspended state from the sticky summary comment, and produces outputs:
   - `auto-should-run`: whether the review should run
   - `suspended`: whether suspension message should be posted
   - `is-manual`: whether this is a manual trigger (bypasses limit)
   - `current-count`: the parsed count from the comment
   
   For `pull_request_target` events: suspends when count >= limit. For manual triggers (`/ocr`, `/review`, `/open-code-review`, `workflow_dispatch`): always permits.

2. **`post-suspension`** — Posts/updates the sticky comment with a suspension message containing header, count/limit, checkbox (`- [ ] Re-enable automatic reviews`), and instructions for `/review`, `/ocr`, and `/open-code-review`.

### Modified `code-review` job

- Now `needs: [mergeability-gate, auto-review-gate]` and runs only when `auto-should-run == 'true'`.
- The Post OCR results step increments the counter and writes `<!-- ocr-auto-count:N -->` back to the sticky comment for automatic triggers only (manual reviews do not increment).

### New `issue_comment.edited` trigger

Added `edited` to the `issue_comment` trigger types. When a bot-authored OCR marker comment is edited and the checkbox changes from unchecked `[ ]` to checked `[x]`:
- Counter resets to 0
- One immediate review triggers on the current head
- If the reset write fails, the workflow does **not** proceed (avoids stale-count inconsistency)

### `/review` command alias

Added `/review` to both the concurrency group and the mergeability-gate `if` filter alongside `/ocr` and `/open-code-review`, with the same OWNER/MEMBER/COLLABORATOR authorization. Manual commands always run regardless of suspension and never increment the counter.

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | After 2 automatic reviews, the 3rd synchronize does NOT run OCR | ✅ Tested |
| 2 | Suspension message posted with checkbox and /review instructions | ✅ Tested |
| 3 | Editing comment to check the box resets the counter | ✅ Tested |
| 4 | Next push after checkbox-reset triggers up to 2 more auto-reviews | ✅ Tested |
| 5 | /review, /ocr, /open-code-review always trigger regardless of suspension | ✅ Tested |
| 6 | Manual reviews do not increment the counter | ✅ Tested |
| 7 | Limit configurable via OCR_AUTO_REVIEW_LIMIT variable | ✅ Tested |
| 8 | Counter persists across workflow runs | ✅ Tested |
| 9 | Suspension message is clear and actionable | ✅ Tested |

## Testing

- **29 new behavioral tests** in `scripts/tests/ocr-auto-review-limit.test.js` covering all 9 acceptance criteria. Tests extract real JS from the production workflow YAML and execute it in VM sandboxes with faked GitHub infrastructure (no mock theater — the actual decision logic runs).
- **Updated** `scripts/tests/pr-mergeability-workflow-wiring.test.js` to assert the new `/review` alias and edited-comment conditions.
- All **170 OCR/gate tests pass** (6 test files).
- The shared `_pr-mergeability-gate.yml` and its 30 tests are **unchanged**.

## Files changed

- `.github/workflows/ocr-review.yml` — main workflow (triggers, gate logic, counter, suspension message, /review alias)
- `scripts/tests/ocr-auto-review-limit.test.js` — 29 new behavioral tests (new)
- `scripts/tests/pr-mergeability-workflow-wiring.test.js` — updated wiring assertions
- `project-plans/issue-2666-ocr-auto-review-limit.md` — scope ledger and decision matrix (new)

Closes #2666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic OCR review limits with an automatic suspension/disable mechanism once the threshold is reached.
  * Added suspension notifications (with a re-enable checkbox) and `/review` guidance.
  * Updated auto-review gating so automatic OCR reviews only run when allowed by both the mergeability and auto-review limit checks.
* **Bug Fixes**
  * Adjusted OCR workflow logic for edited comments and counter reset behavior to avoid unwanted resets.
  * Improved handling of skipped OCR outcomes to distinguish mergeability-gate vs auto-review suspension.
  * Updated OpenCodeReview expectations to version 1.7.16 in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->